### PR TITLE
feature: 添加智能体中间件节点原型

### DIFF
--- a/client/src/components/workflow/NodePalette.tsx
+++ b/client/src/components/workflow/NodePalette.tsx
@@ -1,3 +1,9 @@
+import { useEffect, useState } from "react";
+
+import {
+  fetchRuntimeMiddlewareNodes,
+  type RuntimeMiddlewareNode,
+} from "../../types/runtimeMiddleware";
 import { type WorkflowNodeKind } from "../../types/workflow";
 
 interface PaletteItem {
@@ -124,7 +130,52 @@ const paletteItems: PaletteItem[] = [
   },
 ];
 
+const middlewareIconMap: Record<string, string> = {
+  Activity: "〽",
+  ClipboardList: "▦",
+  MessageSquare: "◇",
+  Puzzle: "▣",
+  Shield: "◇",
+};
+
+function MiddlewareIcon({ icon }: { icon: string }) {
+  return <span aria-hidden="true">{middlewareIconMap[icon] ?? "▣"}</span>;
+}
+
 export default function NodePalette() {
+  const [middlewareNodes, setMiddlewareNodes] = useState<RuntimeMiddlewareNode[]>([]);
+  const [middlewareLoading, setMiddlewareLoading] = useState(false);
+  const [middlewareError, setMiddlewareError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+    setMiddlewareLoading(true);
+    fetchRuntimeMiddlewareNodes()
+      .then((nodes) => {
+        if (!isMounted) {
+          return;
+        }
+        setMiddlewareNodes(nodes.filter((node) => node.enabled));
+        setMiddlewareError(null);
+      })
+      .catch((error) => {
+        console.error("Failed to load middleware nodes:", error);
+        if (!isMounted) {
+          return;
+        }
+        setMiddlewareError("加载中间件节点失败");
+      })
+      .finally(() => {
+        if (isMounted) {
+          setMiddlewareLoading(false);
+        }
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
   return (
     <div className="space-y-3">
       {paletteItems.map((item) => (
@@ -153,6 +204,68 @@ export default function NodePalette() {
           </span>
         </button>
       ))}
+
+      <div className="pt-3">
+        <div className="mb-2 flex items-center justify-between">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+            智能体中间件
+          </h3>
+          {middlewareLoading ? (
+            <span className="text-[11px] text-slate-500">加载中...</span>
+          ) : null}
+        </div>
+
+        {middlewareError ? (
+          <p className="rounded-lg border border-amber-300/20 bg-amber-300/10 px-3 py-2 text-xs leading-5 text-amber-100">
+            {middlewareError}，原有节点可继续使用。
+          </p>
+        ) : null}
+
+        {!middlewareError && middlewareNodes.length > 0 ? (
+          <div className="space-y-3">
+            {middlewareNodes.map((node) => (
+              <button
+                className="group w-full rounded-lg border border-white/10 bg-white/[0.045] p-3 text-left transition duration-200 hover:-translate-y-0.5 hover:border-hire-300/35 hover:bg-hire-300/10"
+                draggable
+                key={node.id}
+                onDragStart={(event) => {
+                  const payload = {
+                    kind: "runtime_middleware",
+                    runtimeMiddlewareId: node.id,
+                    runtimeMiddlewareKind: node.kind,
+                    title: node.title,
+                    description: node.description,
+                    fields: node.fields,
+                    metadata: node.metadata ?? {},
+                  };
+                  const serialized = JSON.stringify(payload);
+                  event.dataTransfer.setData("application/modelmirror-node", serialized);
+                  event.dataTransfer.setData(
+                    "application/modelmirror-runtime-middleware",
+                    serialized,
+                  );
+                  event.dataTransfer.effectAllowed = "move";
+                }}
+                type="button"
+              >
+                <span className="flex items-start gap-3">
+                  <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-hire-300/25 bg-hire-300/10 text-hire-100">
+                    <MiddlewareIcon icon={node.icon} />
+                  </span>
+                  <span className="min-w-0">
+                    <span className="block text-sm font-semibold text-white">
+                      {node.title}
+                    </span>
+                    <span className="mt-1 block text-xs leading-5 text-slate-400">
+                      {node.description}
+                    </span>
+                  </span>
+                </span>
+              </button>
+            ))}
+          </div>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/client/src/components/workflow/WorkflowEditor.tsx
+++ b/client/src/components/workflow/WorkflowEditor.tsx
@@ -28,6 +28,7 @@ import {
   type WorkflowNodeData,
   type WorkflowNodeKind,
 } from "../../types/workflow";
+import { type RuntimeMiddlewareField } from "../../types/runtimeMiddleware";
 import { readStoredWorkflow, saveStoredWorkflow } from "../../utils/workflowStorage";
 import NodePalette from "./NodePalette";
 import WorkflowNodeCard from "./WorkflowNodeCard";
@@ -37,7 +38,90 @@ const nodeTypes = {
   workflowNode: WorkflowNodeCard,
 };
 
-function createNodeData(kind: WorkflowNodeKind): WorkflowNodeData {
+interface RuntimeMiddlewareDragPayload {
+  kind: "runtime_middleware";
+  runtimeMiddlewareId?: string;
+  runtimeMiddlewareKind?: string;
+  title?: string;
+  description?: string;
+  fields?: RuntimeMiddlewareField[];
+  metadata?: Record<string, unknown>;
+}
+
+const runtimeMiddlewareFieldTypes = new Set([
+  "text",
+  "textarea",
+  "select",
+  "boolean",
+  "number",
+  "json",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isRuntimeMiddlewareField(value: unknown): value is RuntimeMiddlewareField {
+  return (
+    isRecord(value) &&
+    typeof value.name === "string" &&
+    typeof value.label === "string" &&
+    typeof value.type === "string" &&
+    runtimeMiddlewareFieldTypes.has(value.type)
+  );
+}
+
+function parseRuntimeMiddlewarePayload(
+  raw: string,
+): RuntimeMiddlewareDragPayload | null {
+  if (!raw.trim().startsWith("{")) {
+    return null;
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!isRecord(parsed) || parsed.kind !== "runtime_middleware") {
+      return null;
+    }
+
+    return {
+      kind: "runtime_middleware",
+      runtimeMiddlewareId:
+        typeof parsed.runtimeMiddlewareId === "string"
+          ? parsed.runtimeMiddlewareId
+          : undefined,
+      runtimeMiddlewareKind:
+        typeof parsed.runtimeMiddlewareKind === "string"
+          ? parsed.runtimeMiddlewareKind
+          : undefined,
+      title: typeof parsed.title === "string" ? parsed.title : undefined,
+      description:
+        typeof parsed.description === "string" ? parsed.description : undefined,
+      fields: Array.isArray(parsed.fields)
+        ? parsed.fields.filter(isRuntimeMiddlewareField)
+        : [],
+      metadata: isRecord(parsed.metadata) ? parsed.metadata : {},
+    };
+  } catch {
+    return null;
+  }
+}
+
+function createRuntimeMiddlewareConfig(
+  fields: RuntimeMiddlewareField[],
+): Record<string, unknown> {
+  return fields.reduce<Record<string, unknown>>((config, field) => {
+    if (field.default !== undefined) {
+      config[field.name] = field.default;
+    }
+    return config;
+  }, {});
+}
+
+function createNodeData(
+  kind: WorkflowNodeKind,
+  payload?: RuntimeMiddlewareDragPayload,
+): WorkflowNodeData {
   if (kind === "input") {
     return {
       kind,
@@ -252,6 +336,23 @@ function createNodeData(kind: WorkflowNodeKind): WorkflowNodeData {
     };
   }
 
+  if (kind === "runtime_middleware") {
+    const fields = payload?.fields ?? [];
+    const middlewareId = payload?.runtimeMiddlewareId ?? "unknown";
+    const middlewareKind =
+      payload?.runtimeMiddlewareKind ?? "runtime_middleware.unknown";
+    return {
+      kind,
+      title: payload?.title ?? "中间件节点",
+      description: payload?.description ?? "运行时中间件原型节点。",
+      runtimeMiddlewareId: middlewareId,
+      runtimeMiddlewareKind: middlewareKind,
+      runtimeMiddlewareFields: fields,
+      runtimeMiddlewareMetadata: payload?.metadata ?? {},
+      runtimeMiddlewareConfig: createRuntimeMiddlewareConfig(fields),
+    };
+  }
+
   return {
     kind,
     title: "最终交付",
@@ -260,12 +361,17 @@ function createNodeData(kind: WorkflowNodeKind): WorkflowNodeData {
   };
 }
 
-function createNode(kind: WorkflowNodeKind, x: number, y: number): WorkflowNode {
+function createNode(
+  kind: WorkflowNodeKind,
+  x: number,
+  y: number,
+  payload?: RuntimeMiddlewareDragPayload,
+): WorkflowNode {
   return {
     id: `${kind}-${Date.now()}-${Math.random().toString(16).slice(2, 7)}`,
     type: "workflowNode",
     position: { x, y },
-    data: createNodeData(kind),
+    data: createNodeData(kind, payload),
   };
 }
 
@@ -330,6 +436,47 @@ function Field({
 
 function textInputClass() {
   return "w-full rounded-lg border border-white/10 bg-white/[0.055] px-3 py-2 text-sm text-white outline-none transition placeholder:text-slate-500 focus:border-brand-300/50 focus:ring-4 focus:ring-brand-300/10";
+}
+
+function runtimeMiddlewareFieldValue(
+  config: Record<string, unknown> | undefined,
+  field: RuntimeMiddlewareField,
+): unknown {
+  if (config && Object.prototype.hasOwnProperty.call(config, field.name)) {
+    return config[field.name];
+  }
+  return field.default;
+}
+
+function runtimeMiddlewareStringValue(
+  config: Record<string, unknown> | undefined,
+  field: RuntimeMiddlewareField,
+): string {
+  const value = runtimeMiddlewareFieldValue(config, field);
+  if (value === undefined || value === null) {
+    return "";
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return JSON.stringify(value, null, 2);
+}
+
+function runtimeMiddlewareBooleanValue(
+  config: Record<string, unknown> | undefined,
+  field: RuntimeMiddlewareField,
+): boolean {
+  const value = runtimeMiddlewareFieldValue(config, field);
+  if (typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value === "string") {
+    return value.toLowerCase() === "true";
+  }
+  return false;
 }
 
 interface RegistryToolOption {
@@ -399,6 +546,13 @@ function NodeConfig({ node, onChange }: NodeConfigProps) {
 
   const data = node.data;
   const update = (patch: Partial<WorkflowNodeData>) => onChange(node.id, patch);
+  const updateRuntimeMiddlewareConfig = (fieldName: string, value: unknown) =>
+    update({
+      runtimeMiddlewareConfig: {
+        ...(data.runtimeMiddlewareConfig ?? {}),
+        [fieldName]: value,
+      },
+    });
 
   return (
     <div className="space-y-4">
@@ -1211,6 +1365,169 @@ function NodeConfig({ node, onChange }: NodeConfigProps) {
         </>
       ) : null}
 
+      {data.kind === "runtime_middleware" ? (
+        <div className="space-y-4">
+          <div className="rounded-lg border border-indigo-300/25 bg-indigo-300/10 px-3 py-2 text-xs leading-5 text-indigo-50">
+            当前为中间件原型节点：运行时会记录并跳过实际编排，下一轮接入真实 MiddlewarePipeline。
+          </div>
+          <div className="rounded-lg border border-white/10 bg-white/[0.035] px-3 py-2">
+            <p className="text-xs font-semibold text-slate-200">
+              {data.runtimeMiddlewareKind ?? "runtime_middleware.unknown"}
+            </p>
+            <p className="mt-1 text-[11px] leading-5 text-slate-500">
+              ID：{data.runtimeMiddlewareId ?? "unknown"}
+            </p>
+          </div>
+          {(data.runtimeMiddlewareFields ?? []).length === 0 ? (
+            <p className="rounded-lg border border-dashed border-white/15 bg-white/[0.035] px-3 py-4 text-sm leading-6 text-slate-400">
+              此中间件暂无可配置字段。
+            </p>
+          ) : (
+            <>
+              <p className="text-xs font-semibold text-slate-300">中间件配置</p>
+              {(data.runtimeMiddlewareFields ?? []).map((field) => (
+                <Field
+                  key={field.name}
+                  label={`${field.label}${field.required ? " *" : ""}`}
+                >
+                  {field.type === "text" ? (
+                    <input
+                      className={textInputClass()}
+                      onChange={(event) =>
+                        updateRuntimeMiddlewareConfig(
+                          field.name,
+                          event.target.value,
+                        )
+                      }
+                      placeholder={field.placeholder}
+                      value={runtimeMiddlewareStringValue(
+                        data.runtimeMiddlewareConfig,
+                        field,
+                      )}
+                    />
+                  ) : null}
+
+                  {field.type === "textarea" ? (
+                    <textarea
+                      className={`${textInputClass()} min-h-24 resize-none leading-6`}
+                      onChange={(event) =>
+                        updateRuntimeMiddlewareConfig(
+                          field.name,
+                          event.target.value,
+                        )
+                      }
+                      placeholder={field.placeholder}
+                      rows={field.rows ?? 3}
+                      value={runtimeMiddlewareStringValue(
+                        data.runtimeMiddlewareConfig,
+                        field,
+                      )}
+                    />
+                  ) : null}
+
+                  {field.type === "boolean" ? (
+                    <label className="flex items-start gap-3 rounded-lg border border-white/10 bg-white/[0.045] px-3 py-2 text-sm text-slate-200">
+                      <input
+                        checked={runtimeMiddlewareBooleanValue(
+                          data.runtimeMiddlewareConfig,
+                          field,
+                        )}
+                        className="mt-1 h-4 w-4 rounded border-white/20 bg-slate-950 text-brand-300"
+                        onChange={(event) =>
+                          updateRuntimeMiddlewareConfig(
+                            field.name,
+                            event.target.checked,
+                          )
+                        }
+                        type="checkbox"
+                      />
+                      <span className="leading-6">
+                        {field.description ?? field.label}
+                      </span>
+                    </label>
+                  ) : null}
+
+                  {field.type === "number" ? (
+                    <input
+                      className={textInputClass()}
+                      max={field.maxValue ?? field.max_value}
+                      min={field.minValue ?? field.min_value}
+                      onChange={(event) =>
+                        updateRuntimeMiddlewareConfig(
+                          field.name,
+                          event.target.value === ""
+                            ? ""
+                            : Number(event.target.value),
+                        )
+                      }
+                      placeholder={field.placeholder}
+                      type="number"
+                      value={runtimeMiddlewareStringValue(
+                        data.runtimeMiddlewareConfig,
+                        field,
+                      )}
+                    />
+                  ) : null}
+
+                  {field.type === "select" ? (
+                    <select
+                      className={textInputClass()}
+                      onChange={(event) =>
+                        updateRuntimeMiddlewareConfig(
+                          field.name,
+                          event.target.value,
+                        )
+                      }
+                      value={runtimeMiddlewareStringValue(
+                        data.runtimeMiddlewareConfig,
+                        field,
+                      )}
+                    >
+                      <option className="bg-slate-950" value="">
+                        请选择
+                      </option>
+                      {(field.options ?? []).map((option) => (
+                        <option
+                          className="bg-slate-950"
+                          key={option}
+                          value={option}
+                        >
+                          {option}
+                        </option>
+                      ))}
+                    </select>
+                  ) : null}
+
+                  {field.type === "json" ? (
+                    <textarea
+                      className={`${textInputClass()} min-h-28 resize-none font-mono text-xs leading-5`}
+                      onChange={(event) =>
+                        updateRuntimeMiddlewareConfig(
+                          field.name,
+                          event.target.value,
+                        )
+                      }
+                      placeholder={field.placeholder ?? '{"key":"value"}'}
+                      rows={field.rows ?? 4}
+                      value={runtimeMiddlewareStringValue(
+                        data.runtimeMiddlewareConfig,
+                        field,
+                      )}
+                    />
+                  ) : null}
+
+                  {field.description && field.type !== "boolean" ? (
+                    <p className="mt-2 text-xs leading-5 text-slate-500">
+                      {field.description}
+                    </p>
+                  ) : null}
+                </Field>
+              ))}
+            </>
+          )}
+        </div>
+      ) : null}
+
       {data.kind === "output" ? (
         <Field label="最终输出变量">
           <input
@@ -1348,15 +1665,46 @@ function WorkflowCanvas({ workflowId }: WorkflowCanvasProps) {
 
   function onDrop(event: React.DragEvent<HTMLDivElement>) {
     event.preventDefault();
-    const kind = event.dataTransfer.getData(
-      "application/modelmirror-node",
-    ) as WorkflowNodeKind;
-    if (!kind) return;
-
     const position = screenToFlowPosition({
       x: event.clientX,
       y: event.clientY,
     });
+
+    const runtimeMiddlewareRaw = event.dataTransfer.getData(
+      "application/modelmirror-runtime-middleware",
+    );
+    const runtimeMiddlewarePayload = runtimeMiddlewareRaw
+      ? parseRuntimeMiddlewarePayload(runtimeMiddlewareRaw)
+      : null;
+    if (runtimeMiddlewarePayload) {
+      const nextNode = createNode(
+        "runtime_middleware",
+        position.x,
+        position.y,
+        runtimeMiddlewarePayload,
+      );
+      setNodes((currentNodes) => [...currentNodes, nextNode]);
+      setSelectedNodeId(nextNode.id);
+      return;
+    }
+
+    const rawKind = event.dataTransfer.getData("application/modelmirror-node");
+    const fallbackPayload = parseRuntimeMiddlewarePayload(rawKind);
+    if (fallbackPayload) {
+      const nextNode = createNode(
+        "runtime_middleware",
+        position.x,
+        position.y,
+        fallbackPayload,
+      );
+      setNodes((currentNodes) => [...currentNodes, nextNode]);
+      setSelectedNodeId(nextNode.id);
+      return;
+    }
+
+    const kind = rawKind as WorkflowNodeKind;
+    if (!kind) return;
+
     const nextNode = createNode(kind, position.x, position.y);
     setNodes((currentNodes) => [...currentNodes, nextNode]);
     setSelectedNodeId(nextNode.id);

--- a/client/src/components/workflow/WorkflowNodeCard.tsx
+++ b/client/src/components/workflow/WorkflowNodeCard.tsx
@@ -128,6 +128,13 @@ const nodeMeta = {
     bg: "bg-violet-300/10",
     text: "text-violet-100",
   },
+  runtime_middleware: {
+    icon: "▣",
+    label: "中间件",
+    border: "border-indigo-300/40",
+    bg: "bg-indigo-300/10",
+    text: "text-indigo-100",
+  },
   output: {
     icon: "📤",
     label: "交付工位",
@@ -184,6 +191,9 @@ function outputName(data: WorkflowNode["data"]) {
   }
   if (data.kind === "iteration") {
     return `${data.inputVariable ?? "items"} as ${data.iterationVariable ?? "item"} -> ${data.outputVariable ?? "iteration_output"}`;
+  }
+  if (data.kind === "runtime_middleware") {
+    return `${data.runtimeMiddlewareId ?? "middleware"} → ${data.runtimeMiddlewareKind ?? "runtime"}`;
   }
   if (data.kind === "output") return data.outputVariable ?? "final_output";
   return data.outputVariable ?? "llm_output";

--- a/client/src/types/runtimeMiddleware.ts
+++ b/client/src/types/runtimeMiddleware.ts
@@ -1,0 +1,48 @@
+export type RuntimeMiddlewareFieldType =
+  | "text"
+  | "textarea"
+  | "select"
+  | "boolean"
+  | "number"
+  | "json";
+
+export interface RuntimeMiddlewareField {
+  name: string;
+  label: string;
+  type: RuntimeMiddlewareFieldType;
+  required?: boolean;
+  default?: unknown;
+  options?: string[];
+  placeholder?: string;
+  description?: string;
+  min_value?: number;
+  max_value?: number;
+  minValue?: number;
+  maxValue?: number;
+  rows?: number;
+}
+
+export interface RuntimeMiddlewareNode {
+  id: string;
+  kind: string;
+  title: string;
+  description: string;
+  category: string;
+  icon: string;
+  fields: RuntimeMiddlewareField[];
+  enabled: boolean;
+  tags?: string[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface RuntimeMiddlewareNodesResponse {
+  nodes: RuntimeMiddlewareNode[];
+}
+
+export async function fetchRuntimeMiddlewareNodes(): Promise<RuntimeMiddlewareNode[]> {
+  const response = await fetch("/api/runtime/middleware-nodes");
+  if (!response.ok) {
+    throw new Error(`Failed to fetch middleware nodes: ${response.status}`);
+  }
+  return response.json() as Promise<RuntimeMiddlewareNode[]>;
+}

--- a/client/src/types/workflow.ts
+++ b/client/src/types/workflow.ts
@@ -1,4 +1,5 @@
 import { type Edge, type Node } from "@xyflow/react";
+import { type RuntimeMiddlewareField } from "./runtimeMiddleware";
 
 export type WorkflowNodeKind =
   | "input"
@@ -19,6 +20,7 @@ export type WorkflowNodeKind =
   | "http_request"
   | "list_operation"
   | "iteration"
+  | "runtime_middleware"
   | "output";
 
 export type ConditionOperator = "equals" | "contains";
@@ -80,6 +82,11 @@ export interface WorkflowNodeData extends Record<string, unknown> {
   joinSeparator?: string;
   iterationVariable?: string;
   itemTemplate?: string;
+  runtimeMiddlewareId?: string;
+  runtimeMiddlewareKind?: string;
+  runtimeMiddlewareFields?: RuntimeMiddlewareField[];
+  runtimeMiddlewareMetadata?: Record<string, unknown>;
+  runtimeMiddlewareConfig?: Record<string, unknown>;
 }
 
 export type WorkflowNode = Node<WorkflowNodeData, "workflowNode">;

--- a/docs/workflow-native-design.md
+++ b/docs/workflow-native-design.md
@@ -2,7 +2,7 @@
 
 workflow-native 是模镜自研工作流引擎的渐进式实验线。它不会替换当前稳定的 `/workflow` Dify iframe 入口，也不会改动 `/rag`。当前阶段提供静态图校验能力，并在 classic 运行器中试点少量本地节点执行，让团队先把数据模型、API 契约、错误模型和测试流程立起来。
 
-最后更新日期：2026-06-17  
+最后更新日期：2026-06-24  
 维护人：模镜团队
 
 ## 目标与边界
@@ -412,6 +412,22 @@ curl http://localhost:8000/api/workflow/run/<task_id>/status
 - `mcp_tool` 字段：`toolName`、`argumentsJson`、`outputVariable`。运行前需要先在 `/mcps` 连接 MCP Server，工具进入全局注册表后才能被调用。`argumentsJson` 支持 `{{variable}}` 模板，模板替换后必须仍是 JSON 对象。
 - `time_tool` 字段：`operation`、`formatString`、`outputVariable`。`operation` 支持 `now_iso`、`now_epoch`、`format`。
 - 安全边界：`mcp_tool` 可通过 `WORKFLOW_MCP_TOOL_ENABLED=False` 降级为 no-op；`time_tool` 可通过 `WORKFLOW_TIME_TOOL_ENABLED=False` 降级为 no-op。工具调用失败时写入空字符串并继续后续节点。
+
+`mcp_tool` 当前已通过 Runtime Toolset Capability 调用工具：`MCPToolsetProvider` 作为薄封装复用 `ToolRegistry` 的全局去重列表和 `MCPClientManager.call_tool()` 的会话执行能力，再经由 `MiddlewarePipeline.run_tool_call()` 进入 `wrap_tool_call` 中间件链。这个链路为工具审计、日志、权限与后续聊天 Agent / 多 Agent 复用预留统一入口。
+
+工具调用会记录轻量运行时事件：`tool.call.started`、`tool.call.finished`、`tool.call.failed`。事件只保存工具名、参数数量、输出长度、content types 和错误摘要，不写入完整工具输出，避免泄露敏感内容。
+
+Runtime Toolset 还提供了内存态的 `ToolPermissionPolicy` 与 `InMemoryToolAuditStore`。当前 workflow 默认使用 `allow_by_default=True`，因此不会改变既有 `mcp_tool` 行为；审计记录只保存工具名、状态、耗时、输出长度、content types 与错误摘要。后续可在此基础上扩展用户级权限、持久化审计和 tool preference。
+
+为对齐 Xpert 的“智能体中间件”画布菜单，后端新增了 `server/xpert_runtime/middleware_registry.py` 与只读接口 `GET /api/runtime/middleware-nodes`。当前 registry 先暴露 5 个可拖拽元数据节点：`system_prompt_injector`、`event_recorder`、`tool_policy`、`tool_audit`、`mcp_tools`。本轮只提供 schema 与 metadata；下一步前端 `NodePalette` 可从该接口拉取分组、字段、图标和搜索内容，渲染“智能体中间件”拖拽菜单。再下一步才会把拖入画布的 `runtime_middleware.xxx` 节点接入 workflow validate 和 runner。
+
+前端 `NodePalette` 已新增“智能体中间件”分组，并从 `/api/runtime/middleware-nodes` 拉取 metadata 渲染内置 middleware 节点。中间件拖拽 payload 使用 JSON 字符串，包含 `kind="runtime_middleware"`、`runtimeMiddlewareId`、`runtimeMiddlewareKind`、`fields` 与 `metadata`；下一步 `WorkflowEditor` 会解析该 payload 并生成可配置的 `runtime_middleware` 节点，再后续接入 NodeConfig 字段表单与 runner 语义。
+
+### 运行时中间件节点（Runtime Middleware Node）
+
+`runtime_middleware` 当前是可视化 + no-op 原型阶段：前端支持从 `NodePalette` 拖拽“智能体中间件”节点到画布，右侧配置面板会根据 `RuntimeMiddlewareField` 动态渲染 `text`、`textarea`、`boolean`、`number`、`select`、`json` 六类基础字段。后端 validate 已最小支持 `runtimeMiddlewareId` 与 `runtimeMiddlewareKind`，classic `workflow_stream` 执行时会发出 `node_delta` 并跳过真实 middleware 编排逻辑。
+
+后续路线是将该节点接入 `MiddlewarePipeline`，让 `system_prompt_injector`、`event_recorder`、`tool_policy`、`tool_audit`、`mcp_tools` 等 registry 节点逐步具备真实运行效果。当前先以 no-op 方式完成拖拽、配置、保存、运行的护栏验收，避免在前端体验未稳定前叠加编排语义。
 
 ## 2026-06-17 增量：Agent 节点
 

--- a/server/main.py
+++ b/server/main.py
@@ -10,6 +10,7 @@ import time
 import uuid
 from collections.abc import AsyncIterator
 from collections import defaultdict, deque
+from dataclasses import asdict
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Literal
@@ -94,15 +95,35 @@ except ModuleNotFoundError:
 
 try:
     from server.xpert_runtime import (
+        CapabilityRegistry,
+        InMemoryToolAuditStore,
+        MCPToolsetProvider,
+        MiddlewareContext,
+        MiddlewarePipeline,
         ModelCallRequest,
         ModelCallResponse,
+        RuntimeToolCall,
+        ToolPermissionPolicy,
         create_default_runtime,
+        event_recorder,
+        run_tool_with_runtime,
+        runtime_middleware_registry,
     )
 except ModuleNotFoundError:
     from xpert_runtime import (
+        CapabilityRegistry,
+        InMemoryToolAuditStore,
+        MCPToolsetProvider,
+        MiddlewareContext,
+        MiddlewarePipeline,
         ModelCallRequest,
         ModelCallResponse,
+        RuntimeToolCall,
+        ToolPermissionPolicy,
         create_default_runtime,
+        event_recorder,
+        run_tool_with_runtime,
+        runtime_middleware_registry,
     )
 
 load_dotenv()
@@ -209,6 +230,16 @@ mcp_connect_windows: dict[str, deque[float]] = defaultdict(deque)
 mcp_manager = MCPClientManager()
 mcp_installer = MCPInstaller()
 tool_registry = ToolRegistry()
+workflow_mcp_provider = MCPToolsetProvider(tool_registry, mcp_manager)
+runtime_capabilities = CapabilityRegistry()
+workflow_mcp_pipeline = MiddlewarePipeline([event_recorder])
+workflow_tool_policy = ToolPermissionPolicy(allow_by_default=True)
+workflow_tool_audit_store = InMemoryToolAuditStore()
+runtime_capabilities.register(
+    "mcp_tools",
+    workflow_mcp_provider,
+    description="MCP tools runtime capability for workflow and agents.",
+)
 workflow_task_store: dict[str, dict[str, Any]] = {}
 
 
@@ -2817,18 +2848,9 @@ async def run_workflow(payload: WorkflowRunRequest, request: Request):
                                 }
                             )
                         else:
-                            registered_tools = await tool_registry.list_tools()
-                            matched_tool = next(
-                                (
-                                    tool
-                                    for tool in registered_tools
-                                    if str(tool.get("name") or "") == tool_name
-                                ),
-                                None,
-                            )
+                            matched_tool = await workflow_mcp_provider.find_tool(tool_name)
                             if not matched_tool:
                                 raise ValueError(f"MCP 工具未注册：{tool_name}")
-                            session_id = str(matched_tool.get("session_id") or "")
                             raw_arguments = render_workflow_template(
                                 str(node.data.get("argumentsJson") or "{}"),
                                 variables,
@@ -2836,25 +2858,38 @@ async def run_workflow(payload: WorkflowRunRequest, request: Request):
                             arguments = json.loads(raw_arguments)
                             if not isinstance(arguments, dict):
                                 raise ValueError("MCP 工具参数必须是 JSON 对象。")
-                            call_result = await mcp_manager.call_tool(
-                                session_id,
-                                tool_name,
-                                arguments,
+                            call_result = await run_tool_with_runtime(
+                                RuntimeToolCall(
+                                    tool_name=tool_name,
+                                    arguments=arguments,
+                                    metadata={
+                                        "session_id": matched_tool.session_id,
+                                        "server_id": matched_tool.server_id,
+                                        "node_id": node.id,
+                                    },
+                                ),
+                                runtime_capabilities,
+                                workflow_mcp_pipeline,
+                                MiddlewareContext(
+                                    task_id=task_id,
+                                    trace_id=task_id,
+                                    capabilities=runtime_capabilities,
+                                    metadata={
+                                        "node_id": node.id,
+                                        "node_title": title,
+                                        "workflow": True,
+                                    },
+                                ),
+                                policy=workflow_tool_policy,
+                                audit_store=workflow_tool_audit_store,
                             )
-                            text_parts: list[str] = []
-                            non_text_types: list[str] = []
-                            for part in getattr(call_result, "content", []) or []:
-                                if isinstance(part, dict):
-                                    part_type = str(part.get("type") or "other")
-                                    part_text = part.get("text")
-                                else:
-                                    part_type = str(getattr(part, "type", "other"))
-                                    part_text = getattr(part, "text", None)
-                                if part_type == "text":
-                                    text_parts.append(str(part_text or ""))
-                                else:
-                                    non_text_types.append(part_type)
-                            output = "\n".join(text_parts).strip()
+                            content_types = call_result.metadata.get("content_types", [])
+                            non_text_types = [
+                                str(content_type)
+                                for content_type in content_types
+                                if str(content_type) != "text"
+                            ]
+                            output = call_result.output.strip()
                             variables[output_variable] = output
                             if non_text_types:
                                 yield sse_payload(
@@ -2943,6 +2978,28 @@ async def run_workflow(payload: WorkflowRunRequest, request: Request):
                                 "message": str(exc),
                             }
                         )
+
+                elif kind == "runtime_middleware":
+                    middleware_id = str(
+                        node.data.get("runtimeMiddlewareId") or "unknown"
+                    )
+                    middleware_kind = str(
+                        node.data.get("runtimeMiddlewareKind")
+                        or "runtime_middleware.unknown"
+                    )
+                    output = (
+                        f"[原型节点] {title}（{middleware_kind} / {middleware_id}）"
+                        "已跳过实际执行。"
+                    )
+                    yield sse_payload(
+                        {
+                            "event": "node_delta",
+                            "node_id": node.id,
+                            "node_title": title,
+                            "node_type": kind,
+                            "output": output,
+                        }
+                    )
 
                 elif kind == "output":
                     output_variable = str(node.data.get("outputVariable") or "llm_output")
@@ -3542,6 +3599,13 @@ async def list_registered_tools():
             for tool in await tool_registry.list_tools()
         ]
     )
+
+
+@app.get("/api/runtime/middleware-nodes", response_model=list[dict[str, Any]])
+async def list_runtime_middleware_nodes():
+    """Return runtime middleware node metadata for the canvas palette."""
+
+    return [asdict(node) for node in runtime_middleware_registry.list()]
 
 
 @app.get("/api/mcp/{session_id}/tools", response_model=MCPToolsResponse)

--- a/server/tests/test_workflow_mcp_tool_runtime.py
+++ b/server/tests/test_workflow_mcp_tool_runtime.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from server.main import render_workflow_template
+from server.xpert_runtime import (
+    MCPToolsetProvider,
+    RuntimeToolCall,
+    RuntimeToolResult,
+)
+
+
+async def _call_runtime_mcp_tool(
+    provider: MCPToolsetProvider,
+    *,
+    tool_name: str,
+    arguments_json: str,
+    variables: dict[str, str],
+) -> RuntimeToolResult:
+    matched_tool = await provider.find_tool(tool_name)
+    if not matched_tool:
+        raise ValueError(f"MCP 工具未注册：{tool_name}")
+
+    raw_arguments = render_workflow_template(arguments_json, variables)
+    arguments = json.loads(raw_arguments)
+    if not isinstance(arguments, dict):
+        raise ValueError("MCP 工具参数必须是 JSON 对象。")
+
+    return await provider.call_tool(
+        RuntimeToolCall(tool_name=tool_name, arguments=arguments)
+    )
+
+
+def _provider_with_call_result(result: RuntimeToolResult) -> MCPToolsetProvider:
+    tool_registry = SimpleNamespace(
+        list_tools=AsyncMock(
+            return_value=[
+                {
+                    "name": "fetch",
+                    "description": "Fetch URL content",
+                    "input_schema": {"type": "object"},
+                    "server_id": "fetch-server",
+                    "session_id": "session-1",
+                    "registered_at": 1234567890.0,
+                }
+            ]
+        )
+    )
+    mcp_manager = SimpleNamespace(
+        call_tool=AsyncMock(return_value=SimpleNamespace(content=result.content))
+    )
+    return MCPToolsetProvider(tool_registry, mcp_manager)
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_calls_provider_with_correct_arguments() -> None:
+    provider = _provider_with_call_result(
+        RuntimeToolResult(
+            output="hello",
+            content=[{"type": "text", "text": "hello"}],
+            metadata={"content_types": ["text"]},
+        )
+    )
+
+    output = await _call_runtime_mcp_tool(
+        provider,
+        tool_name="fetch",
+        arguments_json='{"url": "{{url}}"}',
+        variables={"url": "https://example.com"},
+    )
+
+    assert output.output == "hello"
+    provider.mcp_manager.call_tool.assert_awaited_once_with(
+        "session-1",
+        "fetch",
+        {"url": "https://example.com"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_text_output_writes_to_output_variable() -> None:
+    provider = _provider_with_call_result(
+        RuntimeToolResult(
+            output="result text",
+            content=[{"type": "text", "text": "result text"}],
+            metadata={"content_types": ["text"]},
+        )
+    )
+    variables: dict[str, str] = {}
+
+    result = await _call_runtime_mcp_tool(
+        provider,
+        tool_name="fetch",
+        arguments_json="{}",
+        variables=variables,
+    )
+    variables["mcp_output"] = result.output.strip()
+
+    assert variables["mcp_output"] == "result text"
+    assert isinstance(variables["mcp_output"], str)
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_non_text_content_does_not_crash() -> None:
+    provider = _provider_with_call_result(
+        RuntimeToolResult(
+            output="",
+            content=[
+                {"type": "image", "data": "..."},
+                {"type": "resource", "uri": "file://doc.txt"},
+            ],
+            metadata={"content_types": ["image", "resource"]},
+        )
+    )
+
+    result = await _call_runtime_mcp_tool(
+        provider,
+        tool_name="fetch",
+        arguments_json="{}",
+        variables={},
+    )
+    non_text_types = [
+        content_type
+        for content_type in result.metadata.get("content_types", [])
+        if content_type != "text"
+    ]
+
+    assert result.output == ""
+    assert set(non_text_types) == {"image", "resource"}
+    assert result.is_error is False
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_not_found_degrades_gracefully() -> None:
+    provider = MCPToolsetProvider(
+        SimpleNamespace(list_tools=AsyncMock(return_value=[])),
+        SimpleNamespace(call_tool=AsyncMock()),
+    )
+    variables: dict[str, str] = {}
+
+    with pytest.raises(ValueError):
+        await _call_runtime_mcp_tool(
+            provider,
+            tool_name="missing",
+            arguments_json="{}",
+            variables=variables,
+        )
+
+    variables["mcp_output"] = ""
+    assert variables["mcp_output"] == ""
+
+
+def test_mcp_tool_arguments_template_and_json_parse() -> None:
+    assert json.loads(render_workflow_template("{}", {})) == {}
+
+    parsed = json.loads(
+        render_workflow_template(
+            '{"a": "{{x}}", "b": "{{y}}"}',
+            {"x": "1", "y": "2"},
+        )
+    )
+    assert parsed == {"a": "1", "b": "2"}
+
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(render_workflow_template("{invalid}", {}))

--- a/server/tests/test_workflow_native_validate.py
+++ b/server/tests/test_workflow_native_validate.py
@@ -668,6 +668,58 @@ async def test_validate_agent_invalid_mode(client: httpx.AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
+async def test_validate_runtime_middleware_ok(client: httpx.AsyncClient) -> None:
+    workflow = linear_workflow()
+    workflow["nodes"][1] = {
+        "id": "middleware",
+        "type": "runtime_middleware",
+        "data": {
+            "kind": "runtime_middleware",
+            "title": "系统提示词注入器",
+            "description": "运行时中间件原型节点。",
+            "runtimeMiddlewareId": "system_prompt_injector",
+            "runtimeMiddlewareKind": "runtime_middleware.system_prompt_injector",
+            "runtimeMiddlewareConfig": {"system_prompt": "你是助手。"},
+        },
+    }
+    workflow["nodes"][2]["data"]["outputVariable"] = "user_input"
+    workflow["edges"] = [
+        {"id": "e1", "source": "input", "target": "middleware"},
+        {"id": "e2", "source": "middleware", "target": "output"},
+    ]
+
+    data = await validate(client, workflow)
+
+    assert data["valid"] is True
+
+
+@pytest.mark.asyncio
+async def test_validate_runtime_middleware_missing_metadata(
+    client: httpx.AsyncClient,
+) -> None:
+    workflow = linear_workflow()
+    workflow["nodes"][1] = {
+        "id": "middleware",
+        "type": "runtime_middleware",
+        "data": {
+            "kind": "runtime_middleware",
+            "title": "中间件节点",
+        },
+    }
+    workflow["edges"] = [
+        {"id": "e1", "source": "input", "target": "middleware"},
+        {"id": "e2", "source": "middleware", "target": "output"},
+    ]
+
+    data = await validate(client, workflow)
+
+    assert data["valid"] is False
+    codes = issue_codes(data)
+    assert "missing_runtime_middleware_id" in codes
+    assert "missing_runtime_middleware_kind" in codes
+
+
+@pytest.mark.asyncio
 async def test_templates_endpoint_returns_starter_template(
     client: httpx.AsyncClient,
 ) -> None:

--- a/server/tests/test_xpert_runtime_middleware_registry.py
+++ b/server/tests/test_xpert_runtime_middleware_registry.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from server.xpert_runtime import (
+    RuntimeMiddlewareNode,
+    RuntimeMiddlewareRegistry,
+    register_builtin_middleware_nodes,
+)
+
+
+def _registry() -> RuntimeMiddlewareRegistry:
+    registry = RuntimeMiddlewareRegistry()
+    register_builtin_middleware_nodes(registry)
+    return registry
+
+
+def test_registry_list_returns_builtin_nodes() -> None:
+    registry = _registry()
+    nodes = registry.list()
+
+    assert len(nodes) == 5
+    for node in nodes:
+        assert node.id
+        assert node.kind.startswith("runtime_middleware.")
+        assert node.title
+        assert node.category
+        assert isinstance(node.fields, list)
+        assert isinstance(node.metadata, dict)
+
+
+def test_registry_get_by_id() -> None:
+    registry = _registry()
+    first = registry.list()[0]
+
+    assert registry.get(first.id) == first
+    assert registry.get("nonexistent") is None
+
+
+def test_registry_categories_returns_unique() -> None:
+    registry = _registry()
+    categories = registry.categories()
+
+    assert len(categories) == len(set(categories))
+    assert "agent" in categories
+    assert "tool" in categories
+
+
+def test_registry_by_category_groups_correctly() -> None:
+    registry = _registry()
+    grouped = registry.by_category()
+
+    assert isinstance(grouped, dict)
+    assert all(isinstance(category, str) for category in grouped)
+    assert all(
+        isinstance(node, RuntimeMiddlewareNode)
+        for nodes in grouped.values()
+        for node in nodes
+    )
+    assert sum(len(nodes) for nodes in grouped.values()) == len(registry.list())

--- a/server/tests/test_xpert_runtime_tool_policy.py
+++ b/server/tests/test_xpert_runtime_tool_policy.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from server.xpert_runtime import (
+    CapabilityRegistry,
+    InMemoryToolAuditStore,
+    MiddlewareContext,
+    MiddlewarePipeline,
+    RuntimeToolCall,
+    RuntimeToolError,
+    RuntimeToolResult,
+    ToolPermissionPolicy,
+    run_tool_with_runtime,
+)
+
+
+def _registry_with_provider(provider: MagicMock) -> CapabilityRegistry:
+    registry = CapabilityRegistry()
+    registry.register("mcp_tools", provider)
+    return registry
+
+
+@pytest.mark.asyncio
+async def test_policy_allow_by_default() -> None:
+    provider = MagicMock()
+    provider.call_tool = AsyncMock(
+        return_value=RuntimeToolResult(
+            output="ok",
+            content=[{"type": "text", "text": "ok"}],
+            metadata={"content_types": ["text"]},
+        )
+    )
+    audit_store = InMemoryToolAuditStore()
+
+    result = await run_tool_with_runtime(
+        RuntimeToolCall(tool_name="echo", arguments={"message": "hi"}),
+        _registry_with_provider(provider),
+        MiddlewarePipeline([]),
+        MiddlewareContext(),
+        policy=ToolPermissionPolicy(allow_by_default=True),
+        audit_store=audit_store,
+    )
+
+    assert result.output == "ok"
+    provider.call_tool.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_policy_deny_blocks_tool_call() -> None:
+    provider = MagicMock()
+    provider.call_tool = AsyncMock(
+        return_value=RuntimeToolResult(output="should not run")
+    )
+    audit_store = InMemoryToolAuditStore()
+
+    with pytest.raises(RuntimeToolError) as exc_info:
+        await run_tool_with_runtime(
+            RuntimeToolCall(tool_name="evil_tool", arguments={}),
+            _registry_with_provider(provider),
+            MiddlewarePipeline([]),
+            MiddlewareContext(),
+            policy=ToolPermissionPolicy(
+                denied_tools={"evil_tool"},
+                allow_by_default=True,
+            ),
+            audit_store=audit_store,
+        )
+
+    assert exc_info.value.code == "tool_denied"
+    provider.call_tool.assert_not_awaited()
+    records = await audit_store.list_records()
+    assert len(records) == 1
+    assert records[0].tool_name == "evil_tool"
+    assert records[0].status == "denied"
+
+
+@pytest.mark.asyncio
+async def test_audit_records_success() -> None:
+    provider = MagicMock()
+    provider.call_tool = AsyncMock(
+        return_value=RuntimeToolResult(
+            output="hello world",
+            content=[{"type": "text", "text": "hello world"}],
+            metadata={"content_types": ["text"]},
+        )
+    )
+    audit_store = InMemoryToolAuditStore()
+
+    await run_tool_with_runtime(
+        RuntimeToolCall(tool_name="echo", arguments={}),
+        _registry_with_provider(provider),
+        MiddlewarePipeline([]),
+        MiddlewareContext(),
+        policy=ToolPermissionPolicy(allow_by_default=True),
+        audit_store=audit_store,
+    )
+
+    records = await audit_store.list_records()
+    assert len(records) == 1
+    record = records[0]
+    assert record.tool_name == "echo"
+    assert record.status == "succeeded"
+    assert record.output_length == 11
+    assert record.content_types == ["text"]
+    assert record.duration_ms is not None and record.duration_ms >= 0
+    assert record.finished_at is not None
+    assert record.error is None
+
+
+@pytest.mark.asyncio
+async def test_audit_records_failure() -> None:
+    provider = MagicMock()
+    provider.call_tool = AsyncMock(
+        side_effect=RuntimeToolError(
+            "echo",
+            "something went wrong",
+            code="tool_error",
+        )
+    )
+    audit_store = InMemoryToolAuditStore()
+
+    with pytest.raises(RuntimeToolError):
+        await run_tool_with_runtime(
+            RuntimeToolCall(tool_name="echo", arguments={}),
+            _registry_with_provider(provider),
+            MiddlewarePipeline([]),
+            MiddlewareContext(),
+            policy=ToolPermissionPolicy(allow_by_default=True),
+            audit_store=audit_store,
+        )
+
+    records = await audit_store.list_records()
+    assert len(records) == 1
+    record = records[0]
+    assert record.status == "failed"
+    assert record.error is not None
+    assert "something went wrong" in record.error
+    assert record.finished_at is not None
+    assert record.duration_ms is not None

--- a/server/tests/test_xpert_runtime_tool_runner.py
+++ b/server/tests/test_xpert_runtime_tool_runner.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from server.xpert_runtime import (
+    AgentMiddleware,
+    CapabilityRegistry,
+    MiddlewareContext,
+    MiddlewarePipeline,
+    RuntimeEventStore,
+    RuntimeToolCall,
+    RuntimeToolResult,
+    ToolCallResponse,
+    event_recorder,
+    run_tool_with_runtime,
+)
+
+
+@pytest.mark.asyncio
+async def test_run_tool_with_registered_capability() -> None:
+    provider = MagicMock()
+    provider.call_tool = AsyncMock(
+        return_value=RuntimeToolResult(
+            output="hello",
+            content=[{"type": "text", "text": "hello"}],
+            metadata={"content_types": ["text"]},
+            is_error=False,
+        )
+    )
+    registry = CapabilityRegistry()
+    registry.register("mcp_tools", provider)
+
+    result = await run_tool_with_runtime(
+        RuntimeToolCall(tool_name="echo", arguments={"msg": "hi"}),
+        registry,
+        MiddlewarePipeline([]),
+        MiddlewareContext(),
+    )
+
+    assert result.output == "hello"
+    assert result.is_error is False
+    provider.call_tool.assert_awaited_once()
+    called = provider.call_tool.await_args.args[0]
+    assert called.tool_name == "echo"
+    assert called.arguments == {"msg": "hi"}
+
+
+@pytest.mark.asyncio
+async def test_wrap_tool_call_middleware_is_invoked() -> None:
+    provider = MagicMock()
+    provider.call_tool = AsyncMock(
+        return_value=RuntimeToolResult(
+            output="original",
+            content=[{"type": "text", "text": "original"}],
+            metadata={"content_types": ["text"]},
+        )
+    )
+    calls = {"count": 0}
+
+    async def wrap_tool_call(request, handler, context):
+        calls["count"] += 1
+        response = await handler(request)
+        return response.with_updates(output=f"[wrapped] {response.output}")
+
+    registry = CapabilityRegistry()
+    registry.register("mcp_tools", provider)
+
+    result = await run_tool_with_runtime(
+        RuntimeToolCall(tool_name="echo", arguments={}),
+        registry,
+        MiddlewarePipeline(
+            [AgentMiddleware(name="wrap-test", wrap_tool_call=wrap_tool_call)]
+        ),
+        MiddlewareContext(),
+    )
+
+    assert result.output == "[wrapped] original"
+    assert calls["count"] == 1
+    provider.call_tool.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_middleware_error_falls_back_to_direct_call() -> None:
+    provider = MagicMock()
+    provider.call_tool = AsyncMock(
+        return_value=RuntimeToolResult(
+            output="fallback result",
+            content=[{"type": "text", "text": "fallback result"}],
+            metadata={"content_types": ["text"]},
+        )
+    )
+
+    async def broken_wrap_tool_call(request, handler, context) -> ToolCallResponse:
+        raise RuntimeError("middleware broken")
+
+    registry = CapabilityRegistry()
+    registry.register("mcp_tools", provider)
+
+    result = await run_tool_with_runtime(
+        RuntimeToolCall(tool_name="echo", arguments={}),
+        registry,
+        MiddlewarePipeline(
+            [AgentMiddleware(name="broken", wrap_tool_call=broken_wrap_tool_call)]
+        ),
+        MiddlewareContext(),
+    )
+
+    assert result.output == "fallback result"
+    provider.call_tool.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_tool_call_events_are_recorded() -> None:
+    provider = MagicMock()
+    provider.call_tool = AsyncMock(
+        return_value=RuntimeToolResult(
+            output="event test",
+            content=[{"type": "text", "text": "event test"}],
+            metadata={"content_types": ["text"]},
+        )
+    )
+    registry = CapabilityRegistry()
+    registry.register("mcp_tools", provider)
+    store = RuntimeEventStore()
+    task = await store.create_task("tool_test")
+
+    await run_tool_with_runtime(
+        RuntimeToolCall(tool_name="echo", arguments={"msg": "hi"}),
+        registry,
+        MiddlewarePipeline([event_recorder]),
+        MiddlewareContext(task_id=task.id, store=store),
+    )
+
+    events = await store.list_events(task.id)
+    event_types = [event.type for event in events]
+    assert "tool.call.started" in event_types
+    assert "tool.call.finished" in event_types
+
+    started = next(event for event in events if event.type == "tool.call.started")
+    finished = next(event for event in events if event.type == "tool.call.finished")
+    assert started.payload["tool_name"] == "echo"
+    assert started.payload["arguments_count"] == 1
+    assert finished.payload["output_length"] == len("event test")

--- a/server/workflow_native/schemas.py
+++ b/server/workflow_native/schemas.py
@@ -24,6 +24,7 @@ NativeNodeKind = Literal[
     "http_request",
     "list_operation",
     "iteration",
+    "runtime_middleware",
     "output",
 ]
 IssueSeverity = Literal["error", "warning"]

--- a/server/workflow_native/validate.py
+++ b/server/workflow_native/validate.py
@@ -53,6 +53,8 @@ NODE_KIND_ALIASES = {
     "list-operation": "list_operation",
     "list-operator": "list_operation",
     "iteration": "iteration",
+    "runtime_middleware": "runtime_middleware",
+    "runtime-middleware": "runtime_middleware",
     "end": "output",
     "answer": "output",
     "output": "output",
@@ -78,6 +80,7 @@ SUPPORTED_NODE_KINDS = {
     "http_request",
     "list_operation",
     "iteration",
+    "runtime_middleware",
     "output",
 }
 
@@ -924,6 +927,26 @@ def validate_node_configuration(
                 ValidationIssue(
                     code="missing_output_variable",
                     message="Output node needs data.outputVariable.",
+                    node_id=node.id,
+                )
+            )
+
+    if kind == "runtime_middleware":
+        middleware_id = str(data.get("runtimeMiddlewareId") or "").strip()
+        if not middleware_id:
+            issues.append(
+                ValidationIssue(
+                    code="missing_runtime_middleware_id",
+                    message="runtime_middleware node needs data.runtimeMiddlewareId.",
+                    node_id=node.id,
+                )
+            )
+        middleware_kind = str(data.get("runtimeMiddlewareKind") or "").strip()
+        if not middleware_kind:
+            issues.append(
+                ValidationIssue(
+                    code="missing_runtime_middleware_kind",
+                    message="runtime_middleware node needs data.runtimeMiddlewareKind.",
                     node_id=node.id,
                 )
             )

--- a/server/xpert_runtime/__init__.py
+++ b/server/xpert_runtime/__init__.py
@@ -9,6 +9,13 @@ from .capabilities import CapabilityRegistry, RuntimeCapability
 from .defaults import create_default_runtime, event_recorder, system_prompt_injector
 from .events import RuntimeEventStore
 from .middleware import AgentMiddleware, MiddlewarePipeline
+from .middleware_registry import (
+    RuntimeMiddlewareField,
+    RuntimeMiddlewareNode,
+    RuntimeMiddlewareRegistry,
+    register_builtin_middleware_nodes,
+    runtime_middleware_registry,
+)
 from .models import (
     MiddlewareContext,
     ModelCallRequest,
@@ -17,6 +24,12 @@ from .models import (
     RuntimeTask,
     ToolCallRequest,
     ToolCallResponse,
+)
+from .tool_policy import (
+    InMemoryToolAuditStore,
+    ToolAuditRecord,
+    ToolAuditStatus,
+    ToolPermissionPolicy,
 )
 from .toolset import (
     MCPToolsetProvider,
@@ -27,12 +40,14 @@ from .toolset import (
     ToolsetProvider,
     register_mcp_toolset_capability,
 )
+from .tool_runner import run_tool_with_runtime
 
 __all__ = [
     "AgentMiddleware",
     "CapabilityRegistry",
     "create_default_runtime",
     "event_recorder",
+    "InMemoryToolAuditStore",
     "MCPToolsetProvider",
     "MiddlewareContext",
     "MiddlewarePipeline",
@@ -41,14 +56,23 @@ __all__ = [
     "RuntimeCapability",
     "RuntimeEvent",
     "RuntimeEventStore",
+    "RuntimeMiddlewareField",
+    "RuntimeMiddlewareNode",
+    "RuntimeMiddlewareRegistry",
     "RuntimeTask",
     "RuntimeTool",
     "RuntimeToolCall",
     "RuntimeToolError",
     "RuntimeToolResult",
+    "run_tool_with_runtime",
+    "runtime_middleware_registry",
     "system_prompt_injector",
     "ToolCallRequest",
     "ToolCallResponse",
+    "ToolAuditRecord",
+    "ToolAuditStatus",
     "ToolsetProvider",
+    "ToolPermissionPolicy",
+    "register_builtin_middleware_nodes",
     "register_mcp_toolset_capability",
 ]

--- a/server/xpert_runtime/defaults.py
+++ b/server/xpert_runtime/defaults.py
@@ -6,7 +6,13 @@ from typing import Any
 
 from .events import RuntimeEventStore
 from .middleware import AgentMiddleware, MiddlewarePipeline
-from .models import MiddlewareContext, ModelCallRequest, ModelCallResponse
+from .models import (
+    MiddlewareContext,
+    ModelCallRequest,
+    ModelCallResponse,
+    ToolCallRequest,
+    ToolCallResponse,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -127,6 +133,45 @@ async def _record_chat_finished(
         logger.warning("Xpert chat.finished middleware failed: %s", exc)
 
 
+async def _record_tool_call(
+    request: ToolCallRequest,
+    handler: Any,
+    context: MiddlewareContext,
+) -> ToolCallResponse:
+    try:
+        await _record_event(
+            context,
+            "tool.call.started",
+            {
+                "tool_name": request.tool_name,
+                "arguments_count": len(request.arguments or {}),
+            },
+        )
+        response = await handler(request)
+        await _record_event(
+            context,
+            "tool.call.finished",
+            {
+                "tool_name": request.tool_name,
+                "output_length": len(response.output or ""),
+                "content_types": response.metadata.get("content_types", []),
+                "is_error": bool(response.metadata.get("is_error")),
+            },
+        )
+        return response
+    except Exception as exc:
+        await _record_event(
+            context,
+            "tool.call.failed",
+            {
+                "tool_name": request.tool_name,
+                "error": str(exc)[:200],
+            },
+            severity="error",
+        )
+        raise
+
+
 system_prompt_injector = AgentMiddleware(
     name="system_prompt_injector",
     before_model=_inject_system_prompt,
@@ -138,6 +183,7 @@ event_recorder = AgentMiddleware(
     before_model=_record_model_started,
     after_model=_record_model_finished,
     after_agent=_record_chat_finished,
+    wrap_tool_call=_record_tool_call,
 )
 
 

--- a/server/xpert_runtime/middleware_registry.py
+++ b/server/xpert_runtime/middleware_registry.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+
+FieldType = Literal["text", "textarea", "select", "boolean", "number", "json"]
+
+
+@dataclass(slots=True)
+class RuntimeMiddlewareField:
+    """A canvas-renderable field definition for runtime middleware nodes."""
+
+    name: str
+    label: str
+    type: FieldType
+    required: bool = False
+    default: Any | None = None
+    options: list[str] | None = None
+    placeholder: str | None = None
+    description: str | None = None
+    min_value: float | None = None
+    max_value: float | None = None
+    rows: int | None = None
+
+
+@dataclass(slots=True)
+class RuntimeMiddlewareNode:
+    """Metadata for one Xpert-style runtime middleware palette node."""
+
+    id: str
+    kind: str
+    title: str
+    description: str
+    category: str
+    icon: str
+    fields: list[RuntimeMiddlewareField] = field(default_factory=list)
+    enabled: bool = True
+    tags: list[str] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class RuntimeMiddlewareRegistry:
+    """In-memory registry of middleware nodes available to the canvas palette."""
+
+    def __init__(self) -> None:
+        self._nodes: dict[str, RuntimeMiddlewareNode] = {}
+
+    def register(self, node: RuntimeMiddlewareNode) -> None:
+        self._nodes[node.id] = node
+
+    def list(self) -> list[RuntimeMiddlewareNode]:
+        return list(self._nodes.values())
+
+    def get(self, node_id: str) -> RuntimeMiddlewareNode | None:
+        return self._nodes.get(node_id)
+
+    def categories(self) -> list[str]:
+        return sorted({node.category for node in self._nodes.values()})
+
+    def by_category(self) -> dict[str, list[RuntimeMiddlewareNode]]:
+        grouped: dict[str, list[RuntimeMiddlewareNode]] = {}
+        for node in self._nodes.values():
+            grouped.setdefault(node.category, []).append(node)
+        return grouped
+
+
+def register_builtin_middleware_nodes(
+    registry: RuntimeMiddlewareRegistry,
+) -> None:
+    """Register ModelMirror's first built-in runtime middleware node metadata."""
+
+    registry.register(
+        RuntimeMiddlewareNode(
+            id="system_prompt_injector",
+            kind="runtime_middleware.system_prompt_injector",
+            title="系统提示词注入器",
+            description="在模型调用前自动注入系统提示词，支持覆盖或追加模式。",
+            category="agent",
+            icon="MessageSquare",
+            fields=[
+                RuntimeMiddlewareField(
+                    name="system_prompt",
+                    label="系统提示词",
+                    type="textarea",
+                    required=True,
+                    rows=4,
+                    placeholder="你是一个专业的...",
+                ),
+                RuntimeMiddlewareField(
+                    name="override",
+                    label="覆盖已有系统提示词",
+                    type="boolean",
+                    default=False,
+                    description="开启后替换消息列表首条 system message。",
+                ),
+            ],
+            tags=["agent", "prompt", "before_model"],
+            metadata={
+                "middleware_name": "system_prompt_injector",
+                "runtime_hook": "before_model",
+            },
+        )
+    )
+
+    registry.register(
+        RuntimeMiddlewareNode(
+            id="event_recorder",
+            kind="runtime_middleware.event_recorder",
+            title="事件记录器",
+            description="记录 chat/model/tool 生命周期事件到 Runtime Event Store，用于追踪和调试。",
+            category="agent",
+            icon="Activity",
+            tags=["observability", "events"],
+            metadata={
+                "middleware_name": "event_recorder",
+                "runtime_hook": "lifecycle",
+            },
+        )
+    )
+
+    registry.register(
+        RuntimeMiddlewareNode(
+            id="tool_policy",
+            kind="runtime_middleware.tool_policy",
+            title="工具权限策略",
+            description="基于 allow/deny 列表控制哪些工具可以被调用。",
+            category="tool",
+            icon="Shield",
+            fields=[
+                RuntimeMiddlewareField(
+                    name="allowed_tools",
+                    label="允许的工具（每行一个）",
+                    type="textarea",
+                    placeholder="fetch\necho\nsearch",
+                    description="留空表示不限制。白名单模式下仅允许列表中的工具。",
+                    rows=4,
+                ),
+                RuntimeMiddlewareField(
+                    name="denied_tools",
+                    label="禁止的工具（每行一个）",
+                    type="textarea",
+                    placeholder="delete\neval",
+                    description="优先级高于 allowed_tools。",
+                    rows=4,
+                ),
+                RuntimeMiddlewareField(
+                    name="allow_by_default",
+                    label="默认放行",
+                    type="boolean",
+                    default=True,
+                ),
+            ],
+            tags=["tool", "policy", "permission"],
+            metadata={
+                "middleware_name": "tool_policy",
+                "runtime_hook": "tool_policy",
+            },
+        )
+    )
+
+    registry.register(
+        RuntimeMiddlewareNode(
+            id="tool_audit",
+            kind="runtime_middleware.tool_audit",
+            title="工具审计记录器",
+            description="结构化记录工具调用：工具名、状态、耗时、输出长度、错误信息。",
+            category="tool",
+            icon="ClipboardList",
+            fields=[
+                RuntimeMiddlewareField(
+                    name="max_records",
+                    label="最大记录数",
+                    type="number",
+                    default=10000,
+                    min_value=100,
+                    max_value=100000,
+                ),
+            ],
+            tags=["tool", "audit", "observability"],
+            metadata={
+                "middleware_name": "tool_audit",
+                "runtime_hook": "tool_audit",
+            },
+        )
+    )
+
+    registry.register(
+        RuntimeMiddlewareNode(
+            id="mcp_tools",
+            kind="runtime_middleware.mcp_tools",
+            title="MCP 工具集",
+            description="通过 Runtime Toolset Capability 调用已注册的 MCP 工具。",
+            category="tool",
+            icon="Puzzle",
+            fields=[
+                RuntimeMiddlewareField(
+                    name="capability_name",
+                    label="Capability 名称",
+                    type="text",
+                    default="mcp_tools",
+                ),
+                RuntimeMiddlewareField(
+                    name="capability_required",
+                    label="Capability 必须存在",
+                    type="boolean",
+                    default=True,
+                ),
+            ],
+            tags=["tool", "mcp", "capability"],
+            metadata={
+                "capability_name": "mcp_tools",
+                "runtime_hook": "capability",
+            },
+        )
+    )
+
+
+runtime_middleware_registry = RuntimeMiddlewareRegistry()
+register_builtin_middleware_nodes(runtime_middleware_registry)

--- a/server/xpert_runtime/tool_policy.py
+++ b/server/xpert_runtime/tool_policy.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from .toolset import RuntimeToolError
+
+logger = logging.getLogger(__name__)
+
+ToolAuditStatus = Literal["started", "succeeded", "failed", "denied"]
+
+
+@dataclass(slots=True)
+class ToolAuditRecord:
+    """Structured runtime audit metadata for a single tool call."""
+
+    record_id: str
+    tool_name: str
+    status: ToolAuditStatus
+    started_at: float
+    finished_at: float | None = None
+    duration_ms: float | None = None
+    output_length: int | None = None
+    content_types: list[str] = field(default_factory=list)
+    error: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class ToolPermissionPolicy:
+    """Small allow/deny policy for runtime tool calls."""
+
+    def __init__(
+        self,
+        *,
+        allowed_tools: set[str] | None = None,
+        denied_tools: set[str] | None = None,
+        allow_by_default: bool = True,
+    ) -> None:
+        self.allowed_tools = set(allowed_tools or set())
+        self.denied_tools = set(denied_tools or set())
+        self.allow_by_default = allow_by_default
+
+    async def check(self, tool_name: str) -> None:
+        if not self.is_allowed(tool_name):
+            raise RuntimeToolError(
+                tool_name,
+                "Tool is denied by policy",
+                code="tool_denied",
+            )
+
+    def is_allowed(self, tool_name: str) -> bool:
+        if tool_name in self.denied_tools:
+            return False
+        if self.allowed_tools:
+            return tool_name in self.allowed_tools
+        return self.allow_by_default
+
+
+class InMemoryToolAuditStore:
+    """Bounded in-memory audit store for runtime tool calls."""
+
+    def __init__(self, max_records: int = 10000) -> None:
+        self._lock = asyncio.Lock()
+        self._records: list[ToolAuditRecord] = []
+        self._max_records = max(1, max_records)
+
+    async def record_started(
+        self,
+        tool_name: str,
+        *,
+        metadata: dict[str, Any] | None = None,
+    ) -> str:
+        record_id = uuid.uuid4().hex
+        record = ToolAuditRecord(
+            record_id=record_id,
+            tool_name=tool_name,
+            status="started",
+            started_at=time.time(),
+            metadata=dict(metadata or {}),
+        )
+        async with self._lock:
+            self._records.append(record)
+            self._trim_locked()
+        return record_id
+
+    async def record_finished(
+        self,
+        record_id: str,
+        *,
+        output_length: int,
+        content_types: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        async with self._lock:
+            record = self._find_locked(record_id)
+            if record is None:
+                logger.warning("Tool audit record not found: %s", record_id)
+                return
+            now = time.time()
+            record.status = "succeeded"
+            record.finished_at = now
+            record.duration_ms = max(0.0, (now - record.started_at) * 1000)
+            record.output_length = output_length
+            record.content_types = list(content_types or [])
+            record.metadata.update(metadata or {})
+
+    async def record_failed(
+        self,
+        record_id: str,
+        *,
+        error: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        async with self._lock:
+            record = self._find_locked(record_id)
+            if record is None:
+                logger.warning("Tool audit record not found: %s", record_id)
+                return
+            now = time.time()
+            record.status = "failed"
+            record.finished_at = now
+            record.duration_ms = max(0.0, (now - record.started_at) * 1000)
+            record.error = error[:200]
+            record.metadata.update(metadata or {})
+
+    async def record_denied(
+        self,
+        tool_name: str,
+        *,
+        metadata: dict[str, Any] | None = None,
+    ) -> str:
+        now = time.time()
+        record_id = uuid.uuid4().hex
+        record = ToolAuditRecord(
+            record_id=record_id,
+            tool_name=tool_name,
+            status="denied",
+            started_at=now,
+            finished_at=now,
+            duration_ms=0.0,
+            error="Tool is denied by policy",
+            metadata=dict(metadata or {}),
+        )
+        async with self._lock:
+            self._records.append(record)
+            self._trim_locked()
+        return record_id
+
+    async def list_records(
+        self,
+        *,
+        tool_name: str | None = None,
+        status: ToolAuditStatus | None = None,
+    ) -> list[ToolAuditRecord]:
+        async with self._lock:
+            records = list(self._records)
+        if tool_name is not None:
+            records = [record for record in records if record.tool_name == tool_name]
+        if status is not None:
+            records = [record for record in records if record.status == status]
+        return records
+
+    def _find_locked(self, record_id: str) -> ToolAuditRecord | None:
+        for record in self._records:
+            if record.record_id == record_id:
+                return record
+        return None
+
+    def _trim_locked(self) -> None:
+        overflow = len(self._records) - self._max_records
+        if overflow > 0:
+            del self._records[:overflow]

--- a/server/xpert_runtime/tool_runner.py
+++ b/server/xpert_runtime/tool_runner.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from .capabilities import CapabilityRegistry
+from .middleware import MiddlewarePipeline
+from .models import MiddlewareContext, ToolCallRequest, ToolCallResponse
+from .tool_policy import InMemoryToolAuditStore, ToolPermissionPolicy
+from .toolset import RuntimeToolCall, RuntimeToolError, RuntimeToolResult
+
+logger = logging.getLogger(__name__)
+
+
+async def run_tool_with_runtime(
+    tool_call: RuntimeToolCall,
+    capability_registry: CapabilityRegistry,
+    pipeline: MiddlewarePipeline,
+    context: MiddlewareContext,
+    *,
+    capability_name: str = "mcp_tools",
+    policy: ToolPermissionPolicy | None = None,
+    audit_store: InMemoryToolAuditStore | None = None,
+) -> RuntimeToolResult:
+    """Run a runtime tool call through capability lookup and middleware hooks."""
+
+    if not capability_registry.has(capability_name):
+        raise RuntimeToolError(
+            tool_call.tool_name,
+            f"Runtime capability is not registered: {capability_name}",
+            code="capability_not_found",
+        )
+
+    if policy is not None:
+        try:
+            await policy.check(tool_call.tool_name)
+        except RuntimeToolError as exc:
+            if exc.code == "tool_denied":
+                await _safe_record_denied(
+                    audit_store,
+                    tool_call.tool_name,
+                    metadata={
+                        "capability": capability_name,
+                        **dict(tool_call.metadata or {}),
+                    },
+                )
+            raise
+        except Exception as exc:
+            logger.warning("Tool policy check failed, allowing by default: %s", exc)
+
+    provider = capability_registry.require(capability_name).implementation
+    request = _to_tool_call_request(tool_call)
+    provider_called = False
+    provider_response: ToolCallResponse | None = None
+    audit_record_id: str | None = None
+
+    async def handler(req: ToolCallRequest) -> ToolCallResponse:
+        nonlocal provider_called, provider_response, audit_record_id
+        provider_called = True
+        if audit_record_id is None:
+            audit_record_id = await _safe_record_started(
+                audit_store,
+                req.tool_name,
+                metadata={
+                    "capability": capability_name,
+                    **dict(req.metadata or {}),
+                },
+            )
+        try:
+            inner_result = await provider.call_tool(
+                RuntimeToolCall(
+                    tool_name=req.tool_name,
+                    arguments=dict(req.arguments or {}),
+                    metadata=dict(req.metadata or {}),
+                )
+            )
+        except Exception as exc:
+            await _safe_record_failed(audit_store, audit_record_id, error=str(exc))
+            raise
+
+        await _safe_record_finished(
+            audit_store,
+            audit_record_id,
+            output_length=len(inner_result.output or ""),
+            content_types=_content_types(inner_result),
+        )
+        provider_response = ToolCallResponse(
+            output=inner_result.output,
+            raw=inner_result.content,
+            metadata={
+                **dict(inner_result.metadata or {}),
+                "is_error": inner_result.is_error,
+            },
+        )
+        return provider_response
+
+    try:
+        response = await pipeline.run_tool_call(request, handler, context)
+    except RuntimeToolError:
+        raise
+    except Exception as exc:
+        logger.warning("Runtime tool middleware failed, falling back: %s", exc)
+        if provider_called and provider_response is not None:
+            response = provider_response
+        elif provider_called:
+            raise
+        else:
+            response = await handler(request)
+
+    return _to_runtime_result(response)
+
+
+def _to_tool_call_request(tool_call: RuntimeToolCall) -> ToolCallRequest:
+    metadata = dict(tool_call.metadata or {})
+    return ToolCallRequest(
+        tool_name=tool_call.tool_name,
+        arguments=dict(tool_call.arguments or {}),
+        session_id=_optional_str(metadata.get("session_id")),
+        metadata=metadata,
+    )
+
+
+def _to_runtime_result(response: ToolCallResponse) -> RuntimeToolResult:
+    content = response.raw if isinstance(response.raw, list) else []
+    metadata = dict(response.metadata or {})
+    return RuntimeToolResult(
+        output=response.output,
+        content=[_ensure_dict(item) for item in content],
+        metadata=metadata,
+        is_error=bool(metadata.get("is_error", False)),
+    )
+
+
+def _ensure_dict(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return dict(value)
+    if hasattr(value, "model_dump"):
+        try:
+            return dict(value.model_dump())
+        except Exception:
+            return {"raw": str(value)}
+    if hasattr(value, "__dict__"):
+        return dict(vars(value))
+    return {"raw": str(value)}
+
+
+def _optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value)
+    return text or None
+
+
+async def _safe_record_started(
+    audit_store: InMemoryToolAuditStore | None,
+    tool_name: str,
+    *,
+    metadata: dict[str, Any],
+) -> str | None:
+    if audit_store is None:
+        return None
+    try:
+        return await audit_store.record_started(tool_name, metadata=metadata)
+    except Exception as exc:
+        logger.warning("Tool audit record_started failed: %s", exc)
+        return None
+
+
+async def _safe_record_finished(
+    audit_store: InMemoryToolAuditStore | None,
+    record_id: str | None,
+    *,
+    output_length: int,
+    content_types: list[str],
+) -> None:
+    if audit_store is None or record_id is None:
+        return
+    try:
+        await audit_store.record_finished(
+            record_id,
+            output_length=output_length,
+            content_types=content_types,
+        )
+    except Exception as exc:
+        logger.warning("Tool audit record_finished failed: %s", exc)
+
+
+async def _safe_record_failed(
+    audit_store: InMemoryToolAuditStore | None,
+    record_id: str | None,
+    *,
+    error: str,
+) -> None:
+    if audit_store is None or record_id is None:
+        return
+    try:
+        await audit_store.record_failed(record_id, error=error)
+    except Exception as exc:
+        logger.warning("Tool audit record_failed failed: %s", exc)
+
+
+async def _safe_record_denied(
+    audit_store: InMemoryToolAuditStore | None,
+    tool_name: str,
+    *,
+    metadata: dict[str, Any],
+) -> None:
+    if audit_store is None:
+        return
+    try:
+        await audit_store.record_denied(tool_name, metadata=metadata)
+    except Exception as exc:
+        logger.warning("Tool audit record_denied failed: %s", exc)
+
+
+def _content_types(result: RuntimeToolResult) -> list[str]:
+    content_types = result.metadata.get("content_types", [])
+    if isinstance(content_types, list):
+        return [str(content_type) for content_type in content_types]
+    return []


### PR DESCRIPTION
## Summary
- 添加智能体中间件节点原型：NodePalette 动态加载 runtime middleware 元数据，WorkflowEditor 支持拖入并配置 runtime_middleware 节点。
- 后端补齐 runtime_middleware 的 NativeNodeKind、静态校验和 workflow_stream no-op 执行分支。
- 完成 Runtime Toolset / tool runner / policy / audit / middleware registry 的增量底座与测试。

## Validation
- `cd client && npm.cmd run build`
- `python -m py_compile server/main.py server/workflow_native/schemas.py server/workflow_native/validate.py`
- `python -m pytest server/tests/test_workflow_native_validate.py -q`
- `python -m pytest server/tests/ -q`
- `docker compose -p modelmirror up -d --build --force-recreate`
- `curl http://localhost:8000/api/health`
- `curl http://localhost:8000/api/runtime/middleware-nodes`

## Notes
- `runtime_middleware` 当前是可视化 + 可配置 + 可运行 no-op 原型，真实 MiddlewarePipeline 编排留给下一轮。