### PR TITLE
feature: 工作流运行观测面板与 runtime events

### DIFF
--- a/client/src/components/workflow/WorkflowRun.tsx
+++ b/client/src/components/workflow/WorkflowRun.tsx
@@ -4,6 +4,36 @@ import {
   type WorkflowRunEvent,
 } from "../../types/workflow";
 
+interface WorkflowObservationEvent {
+  id: string;
+  type: string;
+  payload: Record<string, unknown>;
+  task_id?: string | null;
+  trace_id?: string | null;
+  severity: string;
+  created_at: number;
+}
+
+interface WorkflowToolAuditRecord {
+  record_id: string;
+  tool_name: string;
+  status: string;
+  started_at: number;
+  finished_at: number | null;
+  duration_ms: number | null;
+  output_length: number | null;
+  content_types?: string[];
+  error: string | null;
+}
+
+interface WorkflowObservationData {
+  task_id: string;
+  events: WorkflowObservationEvent[];
+  event_count: number;
+  tool_audit_records: WorkflowToolAuditRecord[];
+  tool_audit_count: number;
+}
+
 interface WorkflowRunProps {
   definition: WorkflowDefinition;
 }
@@ -86,6 +116,32 @@ function statusClass(status: RunStepStatus) {
   return "border-hire-300/25 bg-hire-300/10 text-hire-100";
 }
 
+function formatObservationTime(value: number | null | undefined) {
+  if (!value) return "";
+  return new Date(value * 1000).toLocaleTimeString();
+}
+
+function observationPayloadSummary(payload: Record<string, unknown>) {
+  const toolName = payload.tool_name;
+  const outputLength = payload.output_length;
+  const contentTypes = payload.content_types;
+  const error = payload.error;
+  const parts: string[] = [];
+  if (typeof toolName === "string" && toolName) {
+    parts.push(`tool=${toolName}`);
+  }
+  if (typeof outputLength === "number") {
+    parts.push(`output=${outputLength}`);
+  }
+  if (Array.isArray(contentTypes) && contentTypes.length > 0) {
+    parts.push(`types=${contentTypes.join(",")}`);
+  }
+  if (typeof error === "string" && error) {
+    parts.push(`error=${error}`);
+  }
+  return parts.join(" · ");
+}
+
 function buildRunSteps(events: WorkflowRunEvent[]) {
   const steps: WorkflowRunStep[] = [];
   const byNodeId = new Map<string, WorkflowRunStep>();
@@ -164,6 +220,10 @@ export default function WorkflowRun({ definition }: WorkflowRunProps) {
     useState<PendingHumanIntervention | null>(null);
   const [humanInput, setHumanInput] = useState("");
   const [isResuming, setIsResuming] = useState(false);
+  const [showObservation, setShowObservation] = useState(false);
+  const [observationData, setObservationData] =
+    useState<WorkflowObservationData | null>(null);
+  const [observationLoading, setObservationLoading] = useState(false);
 
   const inputVariable = useMemo(() => {
     const inputNode = definition.nodes.find((node) => node.data.kind === "input");
@@ -191,6 +251,9 @@ export default function WorkflowRun({ definition }: WorkflowRunProps) {
     setTaskId(null);
     setPendingHuman(null);
     setHumanInput("");
+    setShowObservation(false);
+    setObservationData(null);
+    setObservationLoading(false);
     setIsRunning(true);
 
     try {
@@ -308,6 +371,31 @@ export default function WorkflowRun({ definition }: WorkflowRunProps) {
     }
   }
 
+  async function fetchObservation() {
+    if (!taskId) return;
+    setObservationLoading(true);
+    try {
+      const response = await fetch(`/api/workflow/runtime-events/${taskId}`);
+      if (!response.ok) return;
+      const payload = (await response.json()) as WorkflowObservationData;
+      setObservationData(payload);
+    } catch {
+      // Observability is best-effort; workflow execution output remains primary.
+    } finally {
+      setObservationLoading(false);
+    }
+  }
+
+  function toggleObservation() {
+    setShowObservation((current) => {
+      const next = !current;
+      if (next && taskId && !observationData && !observationLoading) {
+        void fetchObservation();
+      }
+      return next;
+    });
+  }
+
   return (
     <aside className="surface-panel flex min-h-0 flex-col rounded-lg">
       <div className="border-b border-white/10 p-4">
@@ -415,6 +503,125 @@ export default function WorkflowRun({ definition }: WorkflowRunProps) {
           )}
         </div>
       </div>
+
+      {taskId ? (
+        <div className="border-t border-white/10">
+          <button
+            className="flex w-full items-center justify-between px-4 py-3 text-left text-xs font-semibold text-slate-300 transition hover:bg-white/5"
+            onClick={toggleObservation}
+            type="button"
+          >
+            <span>运行观测</span>
+            <span className="text-[11px] text-slate-500">
+              {showObservation ? "收起" : "展开"}
+            </span>
+          </button>
+          {showObservation ? (
+            <div className="space-y-3 px-4 pb-4">
+              {observationLoading ? (
+                <p className="rounded-lg border border-white/10 bg-white/[0.035] px-3 py-2 text-xs text-slate-400">
+                  加载中...
+                </p>
+              ) : observationData ? (
+                <>
+                  <div className="rounded-lg border border-white/10 bg-white/[0.035] p-3">
+                    <div className="flex items-center justify-between gap-3">
+                      <p className="text-xs font-semibold text-slate-200">
+                        运行事件
+                      </p>
+                      <span className="text-[11px] text-slate-500">
+                        {observationData.event_count}
+                      </span>
+                    </div>
+                    {observationData.events.length === 0 ? (
+                      <p className="mt-2 text-xs text-slate-500">暂无事件。</p>
+                    ) : (
+                      <div className="mt-2 max-h-44 space-y-1 overflow-y-auto">
+                        {observationData.events.slice(0, 30).map((event) => {
+                          const summary = observationPayloadSummary(event.payload);
+                          return (
+                            <div
+                              className="rounded-md bg-slate-950/35 px-2 py-1.5"
+                              key={event.id}
+                            >
+                              <div className="flex items-center justify-between gap-2">
+                                <span className="truncate text-[11px] font-semibold text-hire-100">
+                                  {event.type}
+                                </span>
+                                <span className="shrink-0 text-[10px] uppercase text-slate-500">
+                                  {event.severity}
+                                </span>
+                              </div>
+                              <p className="mt-1 truncate text-[11px] text-slate-500">
+                                {formatObservationTime(event.created_at)}
+                                {summary ? ` · ${summary}` : ""}
+                              </p>
+                            </div>
+                          );
+                        })}
+                        {observationData.event_count > 30 ? (
+                          <p className="text-[11px] text-slate-500">
+                            仅展示前 30 条，共 {observationData.event_count} 条。
+                          </p>
+                        ) : null}
+                      </div>
+                    )}
+                  </div>
+
+                  <div className="rounded-lg border border-white/10 bg-white/[0.035] p-3">
+                    <div className="flex items-center justify-between gap-3">
+                      <p className="text-xs font-semibold text-slate-200">
+                        工具调用审计
+                      </p>
+                      <span className="text-[11px] text-slate-500">
+                        {observationData.tool_audit_count}
+                      </span>
+                    </div>
+                    {observationData.tool_audit_records.length === 0 ? (
+                      <p className="mt-2 text-xs text-slate-500">
+                        暂无工具调用记录。
+                      </p>
+                    ) : (
+                      <div className="mt-2 max-h-40 space-y-1 overflow-y-auto">
+                        {observationData.tool_audit_records
+                          .slice(0, 20)
+                          .map((record) => (
+                            <div
+                              className="rounded-md bg-slate-950/35 px-2 py-1.5"
+                              key={record.record_id}
+                            >
+                              <div className="flex items-center justify-between gap-2">
+                                <span className="truncate text-[11px] font-semibold text-slate-200">
+                                  {record.tool_name}
+                                </span>
+                                <span className="shrink-0 text-[10px] uppercase text-slate-500">
+                                  {record.status}
+                                </span>
+                              </div>
+                              <p className="mt-1 truncate text-[11px] text-slate-500">
+                                {record.duration_ms != null
+                                  ? `${record.duration_ms.toFixed(0)}ms`
+                                  : "duration n/a"}
+                                {record.output_length != null
+                                  ? ` · ${record.output_length} chars`
+                                  : ""}
+                                {record.error ? ` · ${record.error}` : ""}
+                              </p>
+                            </div>
+                          ))}
+                      </div>
+                    )}
+                  </div>
+                </>
+              ) : (
+                <p className="rounded-lg border border-white/10 bg-white/[0.035] px-3 py-2 text-xs text-slate-400">
+                  展开后会读取本次运行的 runtime events 和工具审计摘要。
+                </p>
+              )}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
 
       {finalOutput ? (
         <div className="border-t border-white/10 p-4">

--- a/docs/workflow-native-design.md
+++ b/docs/workflow-native-design.md
@@ -427,9 +427,13 @@ Runtime Toolset 还提供了内存态的 `ToolPermissionPolicy` 与 `InMemoryToo
 
 `runtime_middleware` 当前是可视化 + 渐进执行阶段：前端支持从 `NodePalette` 拖拽“智能体中间件”节点到画布，右侧配置面板会根据 `RuntimeMiddlewareField` 动态渲染 `text`、`textarea`、`boolean`、`number`、`select`、`json` 六类基础字段。后端 validate 已最小支持 `runtimeMiddlewareId` 与 `runtimeMiddlewareKind`，classic `workflow_stream` 会为中间件节点发出 `node_delta`，并按已支持的 middleware id 逐步启用真实效果。
 
-`system_prompt_injector` 已具备最小真实执行：节点读取 `runtimeMiddlewareConfig.system_prompt`，先用当前 workflow 变量渲染 `{{variable}}` 模板，再写入运行态上下文；后续 `llm` 节点调用模型时会 prepend 一条 `system` message。若同一条路径上出现多个系统提示词注入器，后执行的节点覆盖前一个。`event_recorder`、`tool_audit`、`mcp_tools` 等中间件节点仍保持 no-op 原型，后续再接入 `MiddlewarePipeline` 的真实编排与审计能力。
+`system_prompt_injector` 已具备最小真实执行：节点读取 `runtimeMiddlewareConfig.system_prompt`，先用当前 workflow 变量渲染 `{{variable}}` 模板，再写入运行态上下文；后续 `llm` 节点调用模型时会 prepend 一条 `system` message。若同一条路径上出现多个系统提示词注入器，后执行的节点覆盖前一个。`mcp_tools` 等中间件节点仍保持 no-op 原型，后续再接入 `MiddlewarePipeline` 的真实编排能力。
 
 `tool_policy` 已进入最小真实执行：节点读取 `runtimeMiddlewareConfig.denied_tools`、`allowed_tools` 与 `allow_by_default`，支持换行或逗号分隔工具名，并创建 `ToolPermissionPolicy` 写入 `workflow_runtime_context`。后续 `mcp_tool` 节点优先使用 workflow 级 policy；无 `tool_policy` 节点时回退全局 `workflow_tool_policy`（默认 `allow_by_default=True`）。当 `denied_tools` 命中或 `allow_by_default=False` 且工具不在白名单时，`run_tool_with_runtime` 会抛出 `RuntimeToolError(code="tool_denied")`，classic workflow 记录 error event、写入空输出并继续后续节点。当前作用范围仅 classic workflow 的 `mcp_tool`，不做持久化权限系统或用户级/workspace 级权限。
+
+`event_recorder` 已进入最小真实可见状态：classic workflow 每个 task 会创建独立 `RuntimeEventStore`，`mcp_tool` 节点通过 `MiddlewareContext.store` 将该 store 传入 `MiddlewarePipeline`，因此 `event_recorder.wrap_tool_call` 会记录 `tool.call.started`、`tool.call.finished`、`tool.call.failed`。事件按 `task_id` 隔离，并可通过 `GET /api/workflow/runtime-events/{task_id}` 查询；前端 `WorkflowRun` 的“运行观测”折叠区会展示事件类型、severity、工具名、输出长度和错误摘要。
+
+`tool_audit` 当前是原型可见状态：每个 workflow task 默认拥有独立 `InMemoryToolAuditStore`，工具调用会记录 `tool_name`、`status`、`started_at`、`finished_at`、`duration_ms`、`output_length`、`content_types` 与 `error`。`runtime_middleware.tool_audit` 节点可读取 `runtimeMiddlewareConfig.max_records`，为本次运行重建指定上限的审计 store；观测 API 返回当前 task 的审计记录。该能力仍为内存态，后续再扩展 per-user/per-workspace 过滤、持久化审计与图形化 trace。
 
 ## 2026-06-17 增量：Agent 节点
 

--- a/server/main.py
+++ b/server/main.py
@@ -102,6 +102,7 @@ try:
         MiddlewarePipeline,
         ModelCallRequest,
         ModelCallResponse,
+        RuntimeEventStore,
         RuntimeToolCall,
         ToolPermissionPolicy,
         create_default_runtime,
@@ -118,6 +119,7 @@ except ModuleNotFoundError:
         MiddlewarePipeline,
         ModelCallRequest,
         ModelCallResponse,
+        RuntimeEventStore,
         RuntimeToolCall,
         ToolPermissionPolicy,
         create_default_runtime,
@@ -1764,6 +1766,8 @@ async def run_workflow(payload: WorkflowRunRequest, request: Request):
         "paused_node_id": None,
         "created_at": time.monotonic(),
         "ttl": WORKFLOW_TASK_TTL_SECONDS,
+        "runtime_event_store": RuntimeEventStore(),
+        "tool_audit_store": InMemoryToolAuditStore(),
     }
     workflow_task_store[task_id] = task_state
 
@@ -2928,6 +2932,7 @@ async def run_workflow(payload: WorkflowRunRequest, request: Request):
                                     task_id=task_id,
                                     trace_id=task_id,
                                     capabilities=runtime_capabilities,
+                                    store=task_state["runtime_event_store"],
                                     metadata={
                                         "node_id": node.id,
                                         "node_title": title,
@@ -2938,7 +2943,10 @@ async def run_workflow(payload: WorkflowRunRequest, request: Request):
                                     workflow_runtime_context.get("tool_policy")
                                     or workflow_tool_policy
                                 ),
-                                audit_store=workflow_tool_audit_store,
+                                audit_store=(
+                                    task_state.get("tool_audit_store")
+                                    or workflow_tool_audit_store
+                                ),
                             )
                             content_types = call_result.metadata.get("content_types", [])
                             non_text_types = [
@@ -3081,6 +3089,23 @@ async def run_workflow(payload: WorkflowRunRequest, request: Request):
                             "已启用工具权限策略"
                             f"（{allowed_info}；{denied_info}；{default_info}）"
                         )
+                    elif middleware_id == "tool_audit":
+                        raw_max_records = middleware_config.get("max_records")
+                        try:
+                            max_records = int(raw_max_records or 10000)
+                        except (TypeError, ValueError):
+                            max_records = 10000
+                        max_records = max(100, min(max_records, 100000))
+                        task_state["tool_audit_store"] = InMemoryToolAuditStore(
+                            max_records=max_records
+                        )
+                        workflow_runtime_context["active_middlewares"].append(
+                            middleware_id
+                        )
+                        output = (
+                            "已启用工具审计记录器"
+                            f"（本次运行最多保留 {max_records} 条工具记录）"
+                        )
                     elif middleware_id == "system_prompt_injector":
                         raw_system_prompt = str(
                             middleware_config.get("system_prompt")
@@ -3173,7 +3198,7 @@ async def run_workflow(payload: WorkflowRunRequest, request: Request):
             logger.exception("Workflow run failed workflow=%s", payload.workflow.id)
             yield sse_payload({"event": "error", "message": str(exc)})
         finally:
-            workflow_task_store.pop(task_id, None)
+            task_state["completed_at"] = time.monotonic()
 
     return StreamingResponse(
         workflow_stream(),
@@ -3228,6 +3253,61 @@ async def get_workflow_task_status(task_id: str):
         created_at=created_at,
         ttl_seconds_left=ttl_seconds_left,
     )
+
+
+@app.get("/api/workflow/runtime-events/{task_id}")
+async def get_workflow_runtime_events(task_id: str):
+    task = get_workflow_task_or_none(task_id)
+    if task is None:
+        raise HTTPException(status_code=404, detail="工作流任务不存在或已过期。")
+
+    event_store = task.get("runtime_event_store")
+    events: list[dict[str, Any]] = []
+    if isinstance(event_store, RuntimeEventStore):
+        event_list = await event_store.list_events(task_id=task_id)
+        events = [
+            {
+                "id": event.id,
+                "type": event.type,
+                "payload": dict(event.payload or {}),
+                "task_id": event.task_id,
+                "trace_id": event.trace_id,
+                "severity": event.severity,
+                "created_at": event.created_at,
+            }
+            for event in event_list
+        ]
+
+    audit_store = task.get("tool_audit_store")
+    if not isinstance(audit_store, InMemoryToolAuditStore):
+        audit_store = workflow_tool_audit_store
+    audit_records: list[dict[str, Any]] = []
+    try:
+        record_list = await audit_store.list_records()
+        audit_records = [
+            {
+                "record_id": record.record_id,
+                "tool_name": record.tool_name,
+                "status": record.status,
+                "started_at": record.started_at,
+                "finished_at": record.finished_at,
+                "duration_ms": record.duration_ms,
+                "output_length": record.output_length,
+                "content_types": record.content_types,
+                "error": record.error,
+            }
+            for record in record_list
+        ]
+    except Exception as exc:
+        logger.warning("Workflow runtime audit listing failed: %s", exc)
+
+    return {
+        "task_id": task_id,
+        "events": events,
+        "event_count": len(events),
+        "tool_audit_records": audit_records,
+        "tool_audit_count": len(audit_records),
+    }
 
 
 @app.post("/api/fusion/chat")

--- a/server/tests/test_workflow_runtime_events.py
+++ b/server/tests/test_workflow_runtime_events.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from server.main import app
+from server.xpert_runtime.events import RuntimeEventStore
+
+
+@pytest_asyncio.fixture
+async def client():
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://testserver",
+    ) as async_client:
+        yield async_client
+
+
+@pytest.mark.asyncio
+async def test_runtime_events_missing_task_returns_404(
+    client: httpx.AsyncClient,
+) -> None:
+    response = await client.get("/api/workflow/runtime-events/nonexistent")
+
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_runtime_event_store_record_and_list() -> None:
+    store = RuntimeEventStore()
+
+    await store.record_event(
+        "tool.call.started",
+        task_id="t1",
+        payload={"tool_name": "fetch"},
+    )
+
+    events = await store.list_events(task_id="t1")
+    assert len(events) == 1
+    assert events[0].type == "tool.call.started"
+    assert events[0].task_id == "t1"
+    assert events[0].payload == {"tool_name": "fetch"}
+
+    all_events = await store.list_events()
+    assert len(all_events) == 1
+
+    other_events = await store.list_events(task_id="other")
+    assert other_events == []
+
+
+@pytest.mark.asyncio
+async def test_workflow_run_creates_task_with_event_store(
+    client: httpx.AsyncClient,
+) -> None:
+    workflow = {
+        "id": "obs-test",
+        "title": "obs test",
+        "nodes": [
+            {
+                "id": "input",
+                "type": "input",
+                "data": {"kind": "input", "variableName": "user_input"},
+            },
+            {
+                "id": "output",
+                "type": "output",
+                "data": {"kind": "output", "outputVariable": "user_input"},
+            },
+        ],
+        "edges": [{"id": "e1", "source": "input", "target": "output"}],
+    }
+
+    response = await client.post(
+        "/api/workflow/run",
+        json={
+            "workflow": workflow,
+            "inputs": {"user_input": "hello"},
+        },
+    )
+    assert response.status_code == 200, response.text
+
+    task_id = _extract_task_id(response.text)
+    assert task_id is not None, response.text[:500]
+
+    event_response = await client.get(f"/api/workflow/runtime-events/{task_id}")
+    assert event_response.status_code == 200, event_response.text
+    payload = event_response.json()
+
+    assert payload["task_id"] == task_id
+    assert isinstance(payload["events"], list)
+    assert isinstance(payload["event_count"], int)
+    assert isinstance(payload["tool_audit_records"], list)
+    assert isinstance(payload["tool_audit_count"], int)
+
+
+def _extract_task_id(sse_text: str) -> str | None:
+    for line in sse_text.splitlines():
+        if not line.startswith("data:"):
+            continue
+        try:
+            payload = json.loads(line[5:].strip())
+        except json.JSONDecodeError:
+            continue
+        if payload.get("event") == "workflow_meta":
+            task_id = payload.get("task_id")
+            return task_id if isinstance(task_id, str) else None
+    return None


### PR DESCRIPTION
Summary: 为 classic workflow task 增加 per-task RuntimeEventStore，mcp_tool 通过 MiddlewareContext.store 记录 tool.call.*；新增 /api/workflow/runtime-events/{task_id}；WorkflowRun 增加运行观测折叠区；tool_audit 支持 per-task max_records；补充测试和文档。 Verification: npm.cmd run build passed; py_compile passed; test_workflow_runtime_events passed; test_xpert_runtime_tool_policy passed; full backend tests passed; docker compose rebuild passed; /api/health and /api/runtime/middleware-nodes passed.