### PR TITLE
feature: Agent Task Runtime 底座

### DIFF
--- a/docs/workflow-native-design.md
+++ b/docs/workflow-native-design.md
@@ -435,6 +435,18 @@ Runtime Toolset 还提供了内存态的 `ToolPermissionPolicy` 与 `InMemoryToo
 
 `tool_audit` 当前是原型可见状态：每个 workflow task 默认拥有独立 `InMemoryToolAuditStore`，工具调用会记录 `tool_name`、`status`、`started_at`、`finished_at`、`duration_ms`、`output_length`、`content_types` 与 `error`。`runtime_middleware.tool_audit` 节点可读取 `runtimeMiddlewareConfig.max_records`，为本次运行重建指定上限的审计 store；观测 API 返回当前 task 的审计记录。该能力仍为内存态，后续再扩展 per-user/per-workspace 过滤、持久化审计与图形化 trace。
 
+### Agent Task Runtime（Xpert / EvoAgentX 对齐）
+
+当前为最小底座原型阶段，参考 EvoAgentX `AgentManager` 的 agent 状态管理思路，以及 `Environment` 的执行轨迹/任务历史思想，在 ModelMirror 内原生重写为 `server/xpert_runtime/agent_tasks.py`。源码策略是“参考架构，不复制实现”：不搬运 EvoAgentX 原文件，不保留原项目版权头，不引入不兼容协议代码。
+
+Agent Task Runtime 包含三层：
+
+- `AgentTask`：任务实体，包含 `title`、`input`、`status`、`result`、`error`、`source_agent`、`assigned_agent`、`metadata` 与时间戳。
+- `AgentHandoff`：Agent 间任务移交记录，包含 `source_agent`、`target_agent`、`reason`、`status` 与 metadata。
+- `AgentTaskStore`：内存态任务存储，支持 `create/get/list/update/cancel` 与 `create_handoff/list_handoffs`，并将 `agent.task.created`、`agent.task.updated`、`agent.task.cancelled`、`agent.handoff.created` 写入 `RuntimeEventStore`。
+
+后端已开放最小 API：`POST /api/runtime/agent-tasks` 创建任务，`GET /api/runtime/agent-tasks/{task_id}` 查询任务，`POST /api/runtime/agent-tasks/{task_id}/cancel` 取消任务，`GET /api/runtime/agent-tasks` 列出任务。当前不做真实多 Agent 编排、不接数据库、不接 Redis/Celery 队列；下一步再把 workflow `agent_task` 节点接入该 store，并逐步扩展 handoff queue、agent selection、持久化与前端任务面板。
+
 ## 2026-06-17 增量：Agent 节点
 
 `agent` 已进入 workflow-native / classic 共享实验线。它不是完整 Dify Agent 复刻，而是 ReAct-Lite MVP：模型要么直接返回答案，要么返回一个 JSON 工具调用决策，运行器再通过全局 MCP 工具注册表调用对应工具。

--- a/server/main.py
+++ b/server/main.py
@@ -95,6 +95,7 @@ except ModuleNotFoundError:
 
 try:
     from server.xpert_runtime import (
+        AgentTaskStore,
         CapabilityRegistry,
         InMemoryToolAuditStore,
         MCPToolsetProvider,
@@ -112,6 +113,7 @@ try:
     )
 except ModuleNotFoundError:
     from xpert_runtime import (
+        AgentTaskStore,
         CapabilityRegistry,
         InMemoryToolAuditStore,
         MCPToolsetProvider,
@@ -237,6 +239,8 @@ runtime_capabilities = CapabilityRegistry()
 workflow_mcp_pipeline = MiddlewarePipeline([event_recorder])
 workflow_tool_policy = ToolPermissionPolicy(allow_by_default=True)
 workflow_tool_audit_store = InMemoryToolAuditStore()
+runtime_event_store = RuntimeEventStore()
+agent_task_store = AgentTaskStore(event_store=runtime_event_store)
 runtime_capabilities.register(
     "mcp_tools",
     workflow_mcp_provider,
@@ -3803,6 +3807,87 @@ async def list_registered_tools():
             for tool in await tool_registry.list_tools()
         ]
     )
+
+
+@app.post("/api/runtime/agent-tasks")
+async def create_agent_task(payload: dict[str, Any]):
+    title = str(payload.get("title") or "").strip()
+    if not title:
+        raise HTTPException(status_code=400, detail="Agent task title is required.")
+    input_text = str(payload.get("input") or "")
+    metadata = payload.get("metadata")
+    if metadata is not None and not isinstance(metadata, dict):
+        raise HTTPException(status_code=400, detail="Agent task metadata must be an object.")
+    task = await agent_task_store.create_task(
+        title=title,
+        input_text=input_text,
+        source_agent=payload.get("source_agent"),
+        assigned_agent=payload.get("assigned_agent"),
+        metadata=metadata,
+    )
+    return {
+        "task_id": task.task_id,
+        "title": task.title,
+        "status": task.status,
+        "created_at": task.created_at,
+    }
+
+
+@app.get("/api/runtime/agent-tasks")
+async def list_agent_tasks(status: str | None = None, limit: int = 50):
+    valid_statuses = {"pending", "running", "completed", "failed", "cancelled"}
+    if status is not None and status not in valid_statuses:
+        raise HTTPException(status_code=400, detail="Invalid agent task status.")
+    tasks = await agent_task_store.list_tasks(
+        status=status,  # type: ignore[arg-type]
+        limit=max(1, min(limit, 200)),
+    )
+    return [
+        {
+            "task_id": task.task_id,
+            "title": task.title,
+            "status": task.status,
+            "assigned_agent": task.assigned_agent,
+            "created_at": task.created_at,
+            "updated_at": task.updated_at,
+        }
+        for task in tasks
+    ]
+
+
+@app.get("/api/runtime/agent-tasks/{task_id}")
+async def get_agent_task(task_id: str):
+    task = await agent_task_store.get_task(task_id)
+    if task is None:
+        raise HTTPException(status_code=404, detail="Agent task not found.")
+    return {
+        "task_id": task.task_id,
+        "title": task.title,
+        "input": task.input,
+        "status": task.status,
+        "result": task.result,
+        "error": task.error,
+        "source_agent": task.source_agent,
+        "assigned_agent": task.assigned_agent,
+        "metadata": task.metadata,
+        "created_at": task.created_at,
+        "updated_at": task.updated_at,
+    }
+
+
+@app.post("/api/runtime/agent-tasks/{task_id}/cancel")
+async def cancel_agent_task(task_id: str, payload: dict[str, Any] | None = None):
+    task = await agent_task_store.get_task(task_id)
+    if task is None:
+        raise HTTPException(status_code=404, detail="Agent task not found.")
+    reason = str((payload or {}).get("reason") or "cancelled")
+    cancelled = await agent_task_store.cancel_task(task_id, reason=reason)
+    return {
+        "task_id": cancelled.task_id,
+        "status": cancelled.status,
+        "error": cancelled.error,
+        "updated_at": cancelled.updated_at,
+    }
 
 
 @app.get("/api/runtime/middleware-nodes", response_model=list[dict[str, Any]])

--- a/server/tests/test_xpert_runtime_agent_tasks.py
+++ b/server/tests/test_xpert_runtime_agent_tasks.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from server.xpert_runtime import AgentTaskStore, RuntimeEventStore
+
+
+@pytest.mark.asyncio
+async def test_create_and_get_task() -> None:
+    store = AgentTaskStore()
+    task = await store.create_task("Test Task", "do something")
+
+    assert task.task_id
+    assert task.title == "Test Task"
+    assert task.input == "do something"
+    assert task.status == "pending"
+
+    got = await store.get_task(task.task_id)
+    assert got is not None
+    assert got.task_id == task.task_id
+
+    assert await store.get_task("nonexistent") is None
+
+
+@pytest.mark.asyncio
+async def test_update_task() -> None:
+    store = AgentTaskStore()
+    task = await store.create_task("T", "in")
+
+    updated = await store.update_task(task.task_id, status="running")
+    assert updated.status == "running"
+    assert updated.updated_at >= task.created_at
+
+    finished = await store.update_task(
+        task.task_id,
+        status="completed",
+        result="done",
+    )
+    assert finished.status == "completed"
+    assert finished.result == "done"
+
+
+@pytest.mark.asyncio
+async def test_cancel_task() -> None:
+    store = AgentTaskStore()
+    task = await store.create_task("T", "in")
+
+    cancelled = await store.cancel_task(task.task_id, reason="user cancelled")
+
+    assert cancelled.status == "cancelled"
+    assert cancelled.error == "user cancelled"
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_with_status_filter() -> None:
+    store = AgentTaskStore()
+    t1 = await store.create_task("A", "a")
+    await store.create_task("B", "b")
+    await store.update_task(t1.task_id, status="completed")
+
+    all_tasks = await store.list_tasks()
+    assert len(all_tasks) == 2
+    assert all_tasks[0].created_at >= all_tasks[1].created_at
+
+    completed = await store.list_tasks(status="completed")
+    assert len(completed) == 1
+    assert completed[0].task_id == t1.task_id
+
+
+@pytest.mark.asyncio
+async def test_handoff_create_and_list() -> None:
+    store = AgentTaskStore()
+    task = await store.create_task("T", "in")
+
+    handoff = await store.create_handoff(
+        task.task_id,
+        source_agent="agent_a",
+        target_agent="agent_b",
+        reason="need expertise",
+    )
+
+    assert handoff.handoff_id
+    assert handoff.status == "pending"
+
+    all_handoffs = await store.list_handoffs()
+    assert len(all_handoffs) == 1
+
+    task_handoffs = await store.list_handoffs(task_id=task.task_id)
+    assert len(task_handoffs) == 1
+
+    other = await store.list_handoffs(task_id="other")
+    assert other == []
+
+
+@pytest.mark.asyncio
+async def test_event_store_records_task_events() -> None:
+    event_store = RuntimeEventStore()
+    store = AgentTaskStore(event_store=event_store)
+
+    task = await store.create_task("ET", "input")
+    await store.cancel_task(task.task_id)
+
+    events = await event_store.list_events()
+    event_types = [event.type for event in events]
+    assert "agent.task.created" in event_types
+    assert "agent.task.cancelled" in event_types
+    assert "agent.task.updated" in event_types
+
+
+from server.main import app
+
+
+@pytest_asyncio.fixture
+async def client():
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://testserver",
+    ) as async_client:
+        yield async_client
+
+
+@pytest.mark.asyncio
+async def test_api_create_task(client: httpx.AsyncClient) -> None:
+    response = await client.post(
+        "/api/runtime/agent-tasks",
+        json={"title": "API Task", "input": "hello"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["title"] == "API Task"
+    assert data["status"] == "pending"
+    assert "task_id" in data
+
+
+@pytest.mark.asyncio
+async def test_api_create_task_missing_title(client: httpx.AsyncClient) -> None:
+    response = await client.post(
+        "/api/runtime/agent-tasks",
+        json={"input": "hello"},
+    )
+
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_api_get_task_404(client: httpx.AsyncClient) -> None:
+    response = await client.get("/api/runtime/agent-tasks/nonexistent")
+
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_api_cancel_task(client: httpx.AsyncClient) -> None:
+    create_response = await client.post(
+        "/api/runtime/agent-tasks",
+        json={"title": "Cancel Test", "input": "x"},
+    )
+    task_id = create_response.json()["task_id"]
+
+    cancel_response = await client.post(
+        f"/api/runtime/agent-tasks/{task_id}/cancel",
+        json={"reason": "test cancel"},
+    )
+
+    assert cancel_response.status_code == 200
+    data = cancel_response.json()
+    assert data["status"] == "cancelled"
+    assert data["error"] == "test cancel"
+
+
+@pytest.mark.asyncio
+async def test_api_list_tasks(client: httpx.AsyncClient) -> None:
+    response = await client.get("/api/runtime/agent-tasks")
+
+    assert response.status_code == 200
+    assert isinstance(response.json(), list)

--- a/server/xpert_runtime/__init__.py
+++ b/server/xpert_runtime/__init__.py
@@ -6,6 +6,7 @@ runtime primitives without adding more orchestration logic to ``server/main.py``
 """
 
 from .capabilities import CapabilityRegistry, RuntimeCapability
+from .agent_tasks import AgentHandoff, AgentTask, AgentTaskStore
 from .defaults import create_default_runtime, event_recorder, system_prompt_injector
 from .events import RuntimeEventStore
 from .middleware import AgentMiddleware, MiddlewarePipeline
@@ -44,6 +45,9 @@ from .tool_runner import run_tool_with_runtime
 
 __all__ = [
     "AgentMiddleware",
+    "AgentHandoff",
+    "AgentTask",
+    "AgentTaskStore",
     "CapabilityRegistry",
     "create_default_runtime",
     "event_recorder",

--- a/server/xpert_runtime/agent_tasks.py
+++ b/server/xpert_runtime/agent_tasks.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from .events import RuntimeEventStore
+
+AgentTaskStatus = Literal["pending", "running", "completed", "failed", "cancelled"]
+AgentHandoffStatus = Literal["pending", "accepted", "rejected", "completed"]
+
+
+@dataclass(slots=True)
+class AgentTask:
+    task_id: str
+    title: str
+    input: str
+    status: AgentTaskStatus = "pending"
+    result: str | None = None
+    error: str | None = None
+    source_agent: str | None = None
+    assigned_agent: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    created_at: float = field(default_factory=time.time)
+    updated_at: float = field(default_factory=time.time)
+
+    def touch(self) -> None:
+        self.updated_at = time.time()
+
+
+@dataclass(slots=True)
+class AgentHandoff:
+    handoff_id: str
+    task_id: str
+    source_agent: str
+    target_agent: str
+    reason: str
+    status: AgentHandoffStatus = "pending"
+    metadata: dict[str, Any] = field(default_factory=dict)
+    created_at: float = field(default_factory=time.time)
+    updated_at: float = field(default_factory=time.time)
+
+    def touch(self) -> None:
+        self.updated_at = time.time()
+
+
+class AgentTaskStore:
+    """In-memory agent task store for Xpert/EvoAgentX-aligned runtime work."""
+
+    def __init__(self, event_store: RuntimeEventStore | None = None) -> None:
+        self._lock = asyncio.Lock()
+        self._tasks: dict[str, AgentTask] = {}
+        self._handoffs: list[AgentHandoff] = []
+        self._event_store = event_store
+
+    async def create_task(
+        self,
+        title: str,
+        input_text: str,
+        *,
+        source_agent: str | None = None,
+        assigned_agent: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> AgentTask:
+        task = AgentTask(
+            task_id=str(uuid.uuid4()),
+            title=title,
+            input=input_text,
+            source_agent=source_agent,
+            assigned_agent=assigned_agent,
+            metadata=dict(metadata or {}),
+        )
+        async with self._lock:
+            self._tasks[task.task_id] = task
+        await self._record(
+            "agent.task.created",
+            task_id=task.task_id,
+            payload={
+                "task_id": task.task_id,
+                "title": task.title,
+                "source_agent": source_agent,
+                "assigned_agent": assigned_agent,
+            },
+        )
+        return task
+
+    async def get_task(self, task_id: str) -> AgentTask | None:
+        async with self._lock:
+            return self._tasks.get(task_id)
+
+    async def list_tasks(
+        self,
+        *,
+        status: AgentTaskStatus | None = None,
+        limit: int = 50,
+    ) -> list[AgentTask]:
+        async with self._lock:
+            tasks = list(self._tasks.values())
+        if status is not None:
+            tasks = [task for task in tasks if task.status == status]
+        tasks.sort(key=lambda task: task.created_at, reverse=True)
+        return tasks[: max(1, limit)]
+
+    async def update_task(
+        self,
+        task_id: str,
+        *,
+        status: AgentTaskStatus | None = None,
+        result: str | None = None,
+        error: str | None = None,
+        assigned_agent: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> AgentTask:
+        async with self._lock:
+            task = self._tasks.get(task_id)
+            if task is None:
+                raise KeyError(f"Agent task not found: {task_id}")
+            if status is not None:
+                task.status = status
+            if result is not None:
+                task.result = result
+            if error is not None:
+                task.error = error
+            if assigned_agent is not None:
+                task.assigned_agent = assigned_agent
+            if metadata is not None:
+                task.metadata.update(metadata)
+            task.touch()
+            updated = task
+        await self._record(
+            "agent.task.updated",
+            task_id=task_id,
+            payload={
+                "task_id": task_id,
+                "status": updated.status,
+                "has_result": updated.result is not None,
+                "has_error": updated.error is not None,
+            },
+        )
+        return updated
+
+    async def cancel_task(self, task_id: str, reason: str = "cancelled") -> AgentTask:
+        task = await self.update_task(task_id, status="cancelled", error=reason)
+        await self._record(
+            "agent.task.cancelled",
+            task_id=task_id,
+            payload={"task_id": task_id, "reason": reason},
+        )
+        return task
+
+    async def create_handoff(
+        self,
+        task_id: str,
+        source_agent: str,
+        target_agent: str,
+        reason: str,
+        *,
+        metadata: dict[str, Any] | None = None,
+    ) -> AgentHandoff:
+        handoff = AgentHandoff(
+            handoff_id=str(uuid.uuid4()),
+            task_id=task_id,
+            source_agent=source_agent,
+            target_agent=target_agent,
+            reason=reason,
+            metadata=dict(metadata or {}),
+        )
+        async with self._lock:
+            self._handoffs.append(handoff)
+        await self._record(
+            "agent.handoff.created",
+            task_id=task_id,
+            payload={
+                "handoff_id": handoff.handoff_id,
+                "task_id": task_id,
+                "source_agent": source_agent,
+                "target_agent": target_agent,
+            },
+        )
+        return handoff
+
+    async def list_handoffs(self, task_id: str | None = None) -> list[AgentHandoff]:
+        async with self._lock:
+            handoffs = list(self._handoffs)
+        if task_id is not None:
+            handoffs = [handoff for handoff in handoffs if handoff.task_id == task_id]
+        handoffs.sort(key=lambda handoff: handoff.created_at, reverse=True)
+        return handoffs
+
+    async def _record(
+        self,
+        event_type: str,
+        *,
+        task_id: str | None = None,
+        payload: dict[str, Any] | None = None,
+    ) -> None:
+        if self._event_store is None:
+            return
+        try:
+            await self._event_store.record_event(
+                event_type,
+                task_id=task_id,
+                payload=payload or {},
+                severity="info",
+            )
+        except Exception:
+            return


### PR DESCRIPTION
Summary: 新增 server/xpert_runtime/agent_tasks.py，提供 AgentTask、AgentHandoff、AgentTaskStore 内存态底座；新增 /api/runtime/agent-tasks 创建、列表、查询、取消接口；AgentTaskStore 写入 RuntimeEventStore 事件 agent.task.created/updated/cancelled 与 agent.handoff.created；补充 11 个单元/API 测试；文档说明参考 EvoAgentX AgentManager/Environment 思路但 ModelMirror 原生重写，不复制源码。 Note: 后续前端多 Agent/任务体验应在现有 /agents/meta-agent 元智能体雏形上迭代，不新建重复入口。 Verification: py_compile passed; test_xpert_runtime_agent_tasks 11 passed; test_xpert_runtime_foundation 5 passed; full backend tests 100 passed; docker compose rebuild passed; /api/health and /api/runtime/agent-tasks passed; POST/GET/CANCEL smoke passed via Invoke-RestMethod.