### PR TITLE
[codex] feature: 增加 Handoff API 并优化工作流体验

### DIFF
--- a/client/src/components/workflow/NodePalette.tsx
+++ b/client/src/components/workflow/NodePalette.tsx
@@ -93,6 +93,12 @@ const paletteItems: PaletteItem[] = [
     description: "模型驱动的任务执行节点，支持工具循环和直接回答两种模式。",
   },
   {
+    kind: "agent_task",
+    icon: "▣",
+    title: "智能体任务",
+    description: "创建 Agent Task Runtime 任务，输出 task_id 供后续节点引用。",
+  },
+  {
     kind: "mcp_tool",
     icon: "🔧",
     title: "MCP Tool",

--- a/client/src/components/workflow/WorkflowEditor.tsx
+++ b/client/src/components/workflow/WorkflowEditor.tsx
@@ -276,6 +276,18 @@ function createNodeData(
     };
   }
 
+  if (kind === "agent_task") {
+    return {
+      kind,
+      title: "智能体任务",
+      description: "创建 Agent Task Runtime 任务，并把 task_id 写入变量。",
+      taskTitle: "工作流任务：{{user_input}}",
+      taskInput: "{{user_input}}",
+      assignedAgent: "workflow-planner",
+      outputVariable: "agent_task_id",
+    };
+  }
+
   if (kind === "mcp_tool") {
     return {
       kind,
@@ -1150,6 +1162,42 @@ function NodeConfig({ node, onChange }: NodeConfigProps) {
         </>
       ) : null}
 
+      {data.kind === "agent_task" ? (
+        <>
+          <div className="rounded-lg border border-violet-300/25 bg-violet-300/10 px-3 py-2 text-xs leading-5 text-violet-50">
+            该节点会在运行时创建 Agent Task，并将新任务的 task_id 写入输出变量；当前不做真实多 Agent 调度。
+          </div>
+          <Field label="任务标题（支持 {{变量}}）">
+            <input
+              className={textInputClass()}
+              onChange={(event) => update({ taskTitle: event.target.value })}
+              value={data.taskTitle ?? ""}
+            />
+          </Field>
+          <Field label="任务输入（支持 {{变量}}）">
+            <textarea
+              className={`${textInputClass()} min-h-32 resize-none leading-6`}
+              onChange={(event) => update({ taskInput: event.target.value })}
+              value={data.taskInput ?? ""}
+            />
+          </Field>
+          <Field label="指派智能体">
+            <input
+              className={textInputClass()}
+              onChange={(event) => update({ assignedAgent: event.target.value })}
+              value={data.assignedAgent ?? ""}
+            />
+          </Field>
+          <Field label="输出变量">
+            <input
+              className={textInputClass()}
+              onChange={(event) => update({ outputVariable: event.target.value })}
+              value={data.outputVariable ?? ""}
+            />
+          </Field>
+        </>
+      ) : null}
+
       {data.kind === "mcp_tool" ? (
         <>
           <div className="rounded-lg border border-emerald-300/25 bg-emerald-300/10 px-3 py-2 text-xs leading-5 text-emerald-50">
@@ -1548,6 +1596,8 @@ interface WorkflowCanvasProps {
   workflowId: string;
 }
 
+type WorkflowWorkspaceTab = "config" | "run";
+
 function WorkflowCanvas({ workflowId }: WorkflowCanvasProps) {
   const loadedDefinition = useMemo(() => loadDefinition(workflowId), [workflowId]);
   const [title, setTitle] = useState(loadedDefinition.title);
@@ -1560,6 +1610,9 @@ function WorkflowCanvas({ workflowId }: WorkflowCanvasProps) {
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   const [selectedEdgeId, setSelectedEdgeId] = useState<string | null>(null);
   const [saveNotice, setSaveNotice] = useState("");
+  const [isNodePaletteOpen, setIsNodePaletteOpen] = useState(false);
+  const [workspaceTab, setWorkspaceTab] =
+    useState<WorkflowWorkspaceTab>("config");
   const { screenToFlowPosition } = useReactFlow();
 
   const definition = useMemo<WorkflowDefinition>(
@@ -1688,6 +1741,7 @@ function WorkflowCanvas({ workflowId }: WorkflowCanvasProps) {
       );
       setNodes((currentNodes) => [...currentNodes, nextNode]);
       setSelectedNodeId(nextNode.id);
+      setIsNodePaletteOpen(false);
       return;
     }
 
@@ -1702,6 +1756,7 @@ function WorkflowCanvas({ workflowId }: WorkflowCanvasProps) {
       );
       setNodes((currentNodes) => [...currentNodes, nextNode]);
       setSelectedNodeId(nextNode.id);
+      setIsNodePaletteOpen(false);
       return;
     }
 
@@ -1711,6 +1766,7 @@ function WorkflowCanvas({ workflowId }: WorkflowCanvasProps) {
     const nextNode = createNode(kind, position.x, position.y);
     setNodes((currentNodes) => [...currentNodes, nextNode]);
     setSelectedNodeId(nextNode.id);
+    setIsNodePaletteOpen(false);
   }
 
   useEffect(() => {
@@ -1720,8 +1776,8 @@ function WorkflowCanvas({ workflowId }: WorkflowCanvasProps) {
   }, [nodes]);
 
   return (
-    <div className="grid min-h-[calc(100vh-8rem)] gap-5 xl:grid-cols-[260px_minmax(0,1fr)_360px]">
-      <aside className="surface-panel rounded-lg p-4">
+    <div className="grid min-h-[calc(100vh-8rem)] gap-5 xl:grid-cols-[minmax(0,1fr)_380px]">
+      <aside className="hidden">
         <p className="text-sm font-semibold text-white">工位库</p>
         <p className="mt-1 text-xs leading-5 text-slate-400">
           拖拽节点到画布，像安排招聘会工位一样搭建 AI 流水线。
@@ -1731,7 +1787,7 @@ function WorkflowCanvas({ workflowId }: WorkflowCanvasProps) {
         </div>
       </aside>
 
-      <section className="min-w-0 overflow-hidden rounded-lg border border-white/10 bg-ink-950/80 shadow-prism">
+      <section className="relative min-w-0 rounded-lg border border-white/10 bg-ink-950/80 shadow-prism">
         <div className="flex flex-col gap-3 border-b border-white/10 bg-surface-900/90 p-4 lg:flex-row lg:items-center lg:justify-between">
           <div className="min-w-0">
             <input
@@ -1743,7 +1799,19 @@ function WorkflowCanvas({ workflowId }: WorkflowCanvasProps) {
               线性 + 条件分支 MVP，支持本地保存和后端流式试运行。
             </p>
           </div>
-          <div className="flex flex-wrap items-center gap-2">
+          <div className="relative flex flex-wrap items-center gap-2">
+            <button
+              className="rounded-full border border-hire-300/30 bg-hire-300/10 px-4 py-2 text-sm font-semibold text-hire-100 transition hover:border-hire-200/50 hover:bg-hire-300/20"
+              onClick={() => setIsNodePaletteOpen((current) => !current)}
+              type="button"
+            >
+              节点库
+            </button>
+            {isNodePaletteOpen ? (
+              <div className="absolute right-0 top-full z-30 mt-3 max-h-[72vh] w-[min(22rem,calc(100vw-2rem))] overflow-y-auto rounded-lg border border-white/10 bg-surface-900/95 p-4 shadow-2xl shadow-ink-950/50 backdrop-blur">
+                <NodePalette />
+              </div>
+            ) : null}
             {saveNotice ? (
               <span className="rounded-full border border-emerald-300/25 bg-emerald-300/10 px-3 py-1.5 text-xs font-semibold text-emerald-100">
                 {saveNotice}
@@ -1760,7 +1828,7 @@ function WorkflowCanvas({ workflowId }: WorkflowCanvasProps) {
         </div>
 
         <div
-          className="h-[640px] min-h-[520px]"
+          className="h-[640px] min-h-[520px] overflow-hidden rounded-b-lg"
           onDragOver={(event) => {
             event.preventDefault();
             event.dataTransfer.dropEffect = "move";
@@ -1816,8 +1884,47 @@ function WorkflowCanvas({ workflowId }: WorkflowCanvasProps) {
         </div>
       </section>
 
-      <aside className="grid min-h-0 gap-5 xl:grid-rows-[minmax(0,1fr)_minmax(360px,0.95fr)]">
-        <section className="surface-panel min-h-0 overflow-y-auto rounded-lg p-4">
+      <aside className="surface-panel flex min-h-[520px] flex-col rounded-lg p-4">
+        <div className="flex items-start justify-between gap-3 border-b border-white/10 pb-3">
+          <div>
+            <p className="text-sm font-semibold text-white">工作台</p>
+            <p className="mt-1 text-xs leading-5 text-slate-400">
+              在同一侧栏内切换节点配置与试运行，减少页面纵向滚动。
+            </p>
+          </div>
+          <div className="flex shrink-0 rounded-full border border-white/10 bg-white/[0.04] p-1">
+            <button
+              className={`rounded-full px-3 py-1.5 text-xs font-semibold transition ${
+                workspaceTab === "config"
+                  ? "bg-hire-300 text-ink-950"
+                  : "text-slate-400 hover:text-slate-100"
+              }`}
+              onClick={() => setWorkspaceTab("config")}
+              type="button"
+            >
+              配置
+            </button>
+            <button
+              className={`rounded-full px-3 py-1.5 text-xs font-semibold transition ${
+                workspaceTab === "run"
+                  ? "bg-hire-300 text-ink-950"
+                  : "text-slate-400 hover:text-slate-100"
+              }`}
+              onClick={() => setWorkspaceTab("run")}
+              type="button"
+            >
+              运行
+            </button>
+          </div>
+        </div>
+
+        <section
+          className={
+            workspaceTab === "config"
+              ? "min-h-0 flex-1 overflow-y-auto pt-4"
+              : "hidden"
+          }
+        >
           <p className="text-sm font-semibold text-white">工位配置</p>
           <p className="mt-1 text-xs leading-5 text-slate-400">
             节点配置会立即写入画布，下次运行直接生效。
@@ -1827,7 +1934,19 @@ function WorkflowCanvas({ workflowId }: WorkflowCanvasProps) {
           </div>
         </section>
 
-        <WorkflowRun definition={definition} />
+        <div
+          className={
+            workspaceTab === "run"
+              ? "min-h-0 flex flex-1 flex-col pt-4"
+              : "hidden"
+          }
+        >
+          <WorkflowRun
+            definition={definition}
+            embedded
+            onRunStart={() => setWorkspaceTab("run")}
+          />
+        </div>
       </aside>
     </div>
   );

--- a/client/src/components/workflow/WorkflowNodeCard.tsx
+++ b/client/src/components/workflow/WorkflowNodeCard.tsx
@@ -93,6 +93,13 @@ const nodeMeta = {
     bg: "bg-violet-400/10",
     text: "text-violet-100",
   },
+  agent_task: {
+    icon: "▣",
+    label: "Agent Task",
+    border: "border-purple-300/40",
+    bg: "bg-purple-300/10",
+    text: "text-purple-100",
+  },
   mcp_tool: {
     icon: "🔧",
     label: "MCP Tool",
@@ -176,6 +183,9 @@ function outputName(data: WorkflowNode["data"]) {
   }
   if (data.kind === "agent") {
     return `🤖 ${data.agentMode ?? "tool_first"} → ${data.outputVariable ?? "agent_output"}`;
+  }
+  if (data.kind === "agent_task") {
+    return `${data.assignedAgent ?? "workflow-planner"} → ${data.outputVariable ?? "agent_task_id"}`;
   }
   if (data.kind === "mcp_tool") {
     return `🔧 ${data.toolName ?? "未选择"} → ${data.outputVariable ?? "mcp_output"}`;

--- a/client/src/components/workflow/WorkflowRun.tsx
+++ b/client/src/components/workflow/WorkflowRun.tsx
@@ -36,6 +36,8 @@ interface WorkflowObservationData {
 
 interface WorkflowRunProps {
   definition: WorkflowDefinition;
+  embedded?: boolean;
+  onRunStart?: () => void;
 }
 
 interface PendingHumanIntervention {
@@ -210,7 +212,11 @@ function buildRunSteps(events: WorkflowRunEvent[]) {
   return steps;
 }
 
-export default function WorkflowRun({ definition }: WorkflowRunProps) {
+export default function WorkflowRun({
+  definition,
+  embedded = false,
+  onRunStart,
+}: WorkflowRunProps) {
   const [input, setInput] = useState("请帮我把这个需求拆成三步执行计划。");
   const [events, setEvents] = useState<WorkflowRunEvent[]>([]);
   const [isRunning, setIsRunning] = useState(false);
@@ -246,6 +252,7 @@ export default function WorkflowRun({ definition }: WorkflowRunProps) {
   const runSteps = useMemo(() => buildRunSteps(events), [events]);
 
   async function runWorkflow() {
+    onRunStart?.();
     setEvents([]);
     setError("");
     setTaskId(null);
@@ -397,7 +404,13 @@ export default function WorkflowRun({ definition }: WorkflowRunProps) {
   }
 
   return (
-    <aside className="surface-panel flex min-h-0 flex-col rounded-lg">
+    <aside
+      className={
+        embedded
+          ? "flex min-h-0 flex-1 flex-col"
+          : "surface-panel flex min-h-0 flex-col rounded-lg"
+      }
+    >
       <div className="border-b border-white/10 p-4">
         <p className="text-sm font-semibold text-white">流水线试运行</p>
         <p className="mt-1 text-xs leading-5 text-slate-400">

--- a/client/src/types/workflow.ts
+++ b/client/src/types/workflow.ts
@@ -15,6 +15,7 @@ export type WorkflowNodeKind =
   | "human_intervention"
   | "question_classifier"
   | "agent"
+  | "agent_task"
   | "mcp_tool"
   | "time_tool"
   | "http_request"
@@ -63,6 +64,9 @@ export interface WorkflowNodeData extends Record<string, unknown> {
   useLlmFallback?: string;
   llmFallbackPrompt?: string;
   agentMode?: string;
+  taskTitle?: string;
+  taskInput?: string;
+  assignedAgent?: string;
   instruction?: string;
   toolNames?: string;
   maxIterations?: string;

--- a/docs/XPERT_ALIGNMENT.md
+++ b/docs/XPERT_ALIGNMENT.md
@@ -14,8 +14,8 @@ EvoAgentX 只保留为历史参考：此前元智能体曾借鉴其 `goal -> sub
 | 能力域 | Xpert 对齐目标 | 当前状态 | 下一步 |
 | --- | --- | --- | --- |
 | Runtime / Execution | 中间件生命周期、任务注册、事件记录、运行观测 | 部分实现 | 建立 Handoff / RunRegistry 闭环 |
-| Agent / Handoff | AgentTask、任务移交、子 Agent、主管-专家协作 | 部分实现 | 增加 handoff API 与 workflow `agent_task` 节点 |
-| Workflow | Xpert 节点类型、Agent 节点、工具节点、知识流水线节点 | 部分实现 | 扩展 `agent_task`、handoff、subflow、task 类节点 |
+| Agent / Handoff | AgentTask、任务移交、子 Agent、主管-专家协作 | 部分实现 | 增加 workflow handoff 节点与 handoff 观测 |
+| Workflow | Xpert 节点类型、Agent 节点、工具节点、知识流水线节点 | 部分实现 | 扩展 handoff、subflow、task 类节点 |
 | Toolset / MCP | 统一 Toolset Provider、权限、审计、偏好 | 部分实现 | 将聊天 Agent 和工作流 Agent 统一接入 toolset capability |
 | Knowledge Pipeline | FileAsset、Artifact、Chunk、CitationAnchor、Embedding | 待实现 | 从本地 RAG 元数据模型开始拆分 |
 | Claw / Skill | 用户偏好、工作区 Skill、会话临时选择 | 待实现 | 在 Xpert workspace / skill 抽象稳定后接入 |
@@ -29,16 +29,16 @@ EvoAgentX 只保留为历史参考：此前元智能体曾借鉴其 `goal -> sub
 - Toolset / MCP：`mcp_tool` 已通过 `MCPToolsetProvider`、`CapabilityRegistry`、`run_tool_with_runtime` 调用工具。
 - Tool Policy / Audit：`tool_policy` 可影响 workflow 内 MCP 工具调用，`InMemoryToolAuditStore` 提供最小审计记录。
 - Runtime Middleware Node：前端可拖入 `runtime_middleware` 节点，`system_prompt_injector`、`tool_policy`、`event_recorder`、`tool_audit` 已逐步进入真实执行或可见状态。
-- Agent Task Runtime：已提供 `AgentTaskStore`、最小 AgentTask API 和 MetaAgent 任务工作台；workflow `agent_task` 节点列为下一步闭环。
+- Agent Task Runtime：已提供 `AgentTaskStore`、最小 AgentTask API、MetaAgent 任务工作台，以及 classic workflow `agent_task` 节点；该节点当前负责创建任务并输出 `task_id`，暂不做真实多 Agent 调度。
+- Handoff API：已提供 handoff 创建、按任务查询、接受、拒绝、完成的内存态 API，状态转移限定为 `pending -> accepted/rejected`、`accepted -> completed`，并写入 `agent.handoff.created/accepted/rejected/completed` runtime events。
 - 运行观测：classic workflow 可查询 per-task runtime events 和 tool audit records，前端 `WorkflowRun` 已提供“运行观测”折叠区。
 
 ## 近期交付顺序
 
-1. **Workflow Agent Task 节点**：在经典工作流新增 `agent_task` 节点，让画布可创建 AgentTask 并输出 `task_id`。
-2. **Handoff 最小闭环**：开放 handoff 创建、查询、接受/拒绝/完成 API，并把事件写入 RuntimeEventStore。
-3. **Workflow Handoff 节点**：新增 `agent_handoff` 或扩展 `agent_task`，让工作流可显式发起 Agent 间移交。
-4. **RunRegistry 雏形**：为 workflow / agent task / handoff 建立统一运行记录、状态、取消和死信视图。
-5. **知识流水线底座**：拆分本地 RAG 的文件元数据，建立 FileAsset -> Artifact -> Chunk -> CitationAnchor 的最小模型。
+1. **Workflow Handoff 节点**：新增 `agent_handoff` 或扩展 `agent_task`，让工作流可显式发起 Agent 间移交。
+2. **RunRegistry 雏形**：为 workflow / agent task / handoff 建立统一运行记录、状态、取消和死信视图。
+3. **Handoff 前端观测**：在 MetaAgent / workflow 运行观测中展示 handoff 状态与事件。
+4. **知识流水线底座**：拆分本地 RAG 的文件元数据，建立 FileAsset -> Artifact -> Chunk -> CitationAnchor 的最小模型。
 
 ## 源码与协议策略
 

--- a/docs/workflow-native-design.md
+++ b/docs/workflow-native-design.md
@@ -2,7 +2,7 @@
 
 workflow-native 是模镜自研工作流引擎的渐进式实验线。它不会替换当前稳定的 `/workflow` Dify iframe 入口，也不会改动 `/rag`。当前阶段提供静态图校验能力，并在 classic 运行器中试点少量本地节点执行，让团队先把数据模型、API 契约、错误模型和测试流程立起来。
 
-最后更新日期：2026-06-25
+最后更新日期：2026-06-26
 维护人：模镜团队
 
 ## 目标与边界
@@ -435,6 +435,10 @@ Runtime Toolset 还提供了内存态的 `ToolPermissionPolicy` 与 `InMemoryToo
 
 `tool_audit` 当前是原型可见状态：每个 workflow task 默认拥有独立 `InMemoryToolAuditStore`，工具调用会记录 `tool_name`、`status`、`started_at`、`finished_at`、`duration_ms`、`output_length`、`content_types` 与 `error`。`runtime_middleware.tool_audit` 节点可读取 `runtimeMiddlewareConfig.max_records`，为本次运行重建指定上限的审计 store；观测 API 返回当前 task 的审计记录。该能力仍为内存态，后续再扩展 per-user/per-workspace 过滤、持久化审计与图形化 trace。
 
+### Classic 工作流布局优化
+
+`/workflow` 当前改为“画布 + 单一右侧工作台”的主布局：节点库不再作为常驻左侧长栏，而是在画布标题区提供“节点库”下拉浮层，拖入节点后自动收起；右侧工作台用 `配置 / 运行` tabs 承载 `NodeConfig` 与 `WorkflowRun`。该调整只改变布局，不改变节点数据结构、React Flow 拖拽协议、SSE 运行协议或后端执行逻辑。目标是让节点库、画布和运行结果集中在同一视野附近，避免窄屏或 Docker 本地验收时出现左侧节点库与右侧运行区纵向堆叠、需要大幅下滑的问题。
+
 ### Agent Task Runtime（Xpert 对齐）
 
 当前为最小底座原型阶段，主线对齐 Xpert 的 Agent/Handoff/RunRegistry 思路，并在 ModelMirror 内原生实现为 `server/xpert_runtime/agent_tasks.py`。源码策略是“参考协议与分层，原生改写实现”：不迁移 Xpert 的 Nx/NestJS/Angular 主框架，不整文件复制上游源码，也不引入不兼容协议代码。
@@ -445,7 +449,9 @@ Agent Task Runtime 包含三层：
 - `AgentHandoff`：Agent 间任务移交记录，包含 `source_agent`、`target_agent`、`reason`、`status` 与 metadata。
 - `AgentTaskStore`：内存态任务存储，支持 `create/get/list/update/cancel` 与 `create_handoff/list_handoffs`，并将 `agent.task.created`、`agent.task.updated`、`agent.task.cancelled`、`agent.handoff.created` 写入 `RuntimeEventStore`。
 
-后端已开放最小 API：`POST /api/runtime/agent-tasks` 创建任务，`GET /api/runtime/agent-tasks/{task_id}` 查询任务，`POST /api/runtime/agent-tasks/{task_id}/cancel` 取消任务，`GET /api/runtime/agent-tasks` 列出任务。当前不做真实多 Agent 编排、不接数据库、不接 Redis/Celery 队列；下一步再把经典工作流的 `agent_task` 节点接入该 store，并逐步扩展 handoff queue、agent selection、持久化与前端任务面板。
+后端已开放最小 API：`POST /api/runtime/agent-tasks` 创建任务，`GET /api/runtime/agent-tasks/{task_id}` 查询任务，`POST /api/runtime/agent-tasks/{task_id}/cancel` 取消任务，`GET /api/runtime/agent-tasks` 列出任务。Handoff 最小闭环也已开放：`POST /api/runtime/agent-tasks/{task_id}/handoffs` 创建移交，`GET /api/runtime/agent-tasks/{task_id}/handoffs` 查询任务下的移交记录，`POST /api/runtime/agent-handoffs/{handoff_id}/accept|reject|complete` 更新状态。状态转移限定为 `pending -> accepted/rejected` 与 `accepted -> completed`，非法转移返回 400；每次创建或状态变更会写入 `agent.handoff.created/accepted/rejected/completed` runtime events。当前不做真实多 Agent 编排、不接数据库、不接 Redis/Celery 队列；后续将继续扩展 workflow handoff 节点、handoff queue、agent selection、持久化与前端任务面板。
+
+classic workflow 已新增 `agent_task` 节点，作为 Xpert Agent/Handoff 对齐的第一步闭环。前端可从节点调色板拖入“智能体任务”，配置 `taskTitle`、`taskInput`、`assignedAgent` 与 `outputVariable`；运行时会渲染 `{{变量}}` 模板，调用 `AgentTaskStore.create_task(...)` 创建一条 AgentTask，并将新任务的 `task_id` 写入 `outputVariable`。该节点当前只负责创建任务和输出 ID，不做真实队列分派、专家协作或任务执行；完整任务详情继续通过现有 Agent Task API 查询。
 
 ## 2026-06-17 增量：Agent 节点
 

--- a/server/main.py
+++ b/server/main.py
@@ -415,11 +415,13 @@ WorkflowNodeType = Literal[
     "human_intervention",
     "question_classifier",
     "agent",
+    "agent_task",
     "mcp_tool",
     "time_tool",
     "http_request",
     "list_operation",
     "iteration",
+    "runtime_middleware",
     "output",
 ]
 
@@ -624,10 +626,18 @@ def upstream_error_message(status_code: int, body: bytes) -> str:
         message = error.get("message")
         if isinstance(message, str) and message.strip():
             lowered = message.lower()
+            if "user not found" in lowered:
+                return (
+                    "本地 newAPI 未找到对应用户或令牌无效。请在 newAPI 中配置用户/令牌，"
+                    "或设置 OPENROUTER_API_KEY 使用 OpenRouter 兜底。"
+                )
             if "not available in your region" in lowered:
                 return "当前模型在本地区暂不可用，请返回列表选择其他模型。"
             if "invalid api key" in lowered or "no auth credentials" in lowered:
-                return "服务认证失败，请检查后端密钥配置。"
+                return (
+                    "模型服务认证失败。请检查本地 newAPI 用户/渠道配置，"
+                    "或设置 OPENROUTER_API_KEY 使用 OpenRouter 兜底。"
+                )
             return message
     return fallback
 
@@ -663,6 +673,55 @@ def is_region_or_model_unavailable(
     return status_code in {403, 404, 429, 502, 503} and any(
         marker in lowered for marker in markers
     )
+
+
+def is_local_gateway_url(url: str) -> bool:
+    lowered = url.lower()
+    return any(
+        marker in lowered
+        for marker in (
+            "new-api",
+            "localhost:3000",
+            "127.0.0.1:3000",
+            ":3000/v1/chat/completions",
+        )
+    )
+
+
+def is_gateway_auth_or_user_error(
+    status_code: int,
+    message: str,
+    data: dict[str, Any] | None,
+) -> bool:
+    lowered = json.dumps(data or {}, ensure_ascii=False).lower()
+    lowered += f" {message.lower()}"
+    markers = (
+        "user not found",
+        "invalid api key",
+        "no auth credentials",
+        "unauthorized",
+        "invalid token",
+        "令牌无效",
+        "认证失败",
+    )
+    return status_code in {401, 403, 404} and any(
+        marker in lowered for marker in markers
+    )
+
+
+def should_fallback_gateway_to_openrouter(
+    status_code: int,
+    message: str,
+    data: dict[str, Any] | None,
+    primary_url: str,
+) -> bool:
+    if not OPENROUTER_API_KEY:
+        return False
+    if primary_url.rstrip("/") == CHAT_COMPLETIONS_URL.rstrip("/"):
+        return False
+    if not is_local_gateway_url(primary_url):
+        return False
+    return is_gateway_auth_or_user_error(status_code, message, data)
 
 
 def should_fallback_model(
@@ -1164,11 +1223,13 @@ def workflow_node_kind(node: WorkflowNodePayload) -> WorkflowNodeType:
         "human_intervention",
         "question_classifier",
         "agent",
+        "agent_task",
         "mcp_tool",
         "time_tool",
         "http_request",
         "list_operation",
         "iteration",
+        "runtime_middleware",
         "output",
     }:
         return data_kind  # type: ignore[return-value]
@@ -2892,6 +2953,70 @@ async def run_workflow(payload: WorkflowRunRequest, request: Request):
                             }
                         )
 
+                elif kind == "agent_task":
+                    output_variable = str(
+                        node.data.get("outputVariable") or "agent_task_id"
+                    ).strip()
+                    if not output_variable:
+                        output_variable = "agent_task_id"
+                    try:
+                        task_title = render_workflow_template(
+                            str(node.data.get("taskTitle") or "Workflow agent task"),
+                            variables,
+                        ).strip()
+                        task_input = render_workflow_template(
+                            str(node.data.get("taskInput") or ""),
+                            variables,
+                        )
+                        assigned_agent = str(
+                            node.data.get("assignedAgent") or "workflow-planner"
+                        ).strip()
+                        if not task_title:
+                            raise ValueError("agent_task 缺少任务标题。")
+                        if not task_input.strip():
+                            raise ValueError("agent_task 缺少任务输入。")
+
+                        task = await agent_task_store.create_task(
+                            title=task_title,
+                            input_text=task_input,
+                            source_agent="workflow",
+                            assigned_agent=assigned_agent or "workflow-planner",
+                            metadata={
+                                "workflow_id": payload.workflow.id,
+                                "workflow_title": payload.workflow.title,
+                                "workflow_task_id": task_id,
+                                "workflow_node_id": node.id,
+                                "workflow_node_title": title,
+                                "output_variable": output_variable,
+                            },
+                        )
+                        output = task.task_id
+                        variables[output_variable] = output
+                        yield sse_payload(
+                            {
+                                "event": "node_delta",
+                                "node_id": node.id,
+                                "node_title": title,
+                                "node_type": kind,
+                                "output": (
+                                    "已创建 Agent Task："
+                                    f"{task.title}（{task.task_id}）"
+                                ),
+                                "variable": output_variable,
+                            }
+                        )
+                    except Exception as exc:
+                        logger.warning("Workflow agent_task node failed: %s", exc)
+                        output = ""
+                        variables[output_variable] = output
+                        yield sse_payload(
+                            {
+                                "event": "error",
+                                "node_id": node.id,
+                                "message": str(exc),
+                            }
+                        )
+
                 elif kind == "mcp_tool":
                     output_variable = str(node.data.get("outputVariable") or "mcp_output")
                     try:
@@ -3833,6 +3958,20 @@ async def create_agent_task(payload: dict[str, Any]):
     }
 
 
+def agent_handoff_to_payload(handoff: Any) -> dict[str, Any]:
+    return {
+        "handoff_id": handoff.handoff_id,
+        "task_id": handoff.task_id,
+        "source_agent": handoff.source_agent,
+        "target_agent": handoff.target_agent,
+        "reason": handoff.reason,
+        "status": handoff.status,
+        "metadata": handoff.metadata,
+        "created_at": handoff.created_at,
+        "updated_at": handoff.updated_at,
+    }
+
+
 @app.get("/api/runtime/agent-tasks")
 async def list_agent_tasks(status: str | None = None, limit: int = 50):
     valid_statuses = {"pending", "running", "completed", "failed", "cancelled"}
@@ -3855,6 +3994,48 @@ async def list_agent_tasks(status: str | None = None, limit: int = 50):
     ]
 
 
+@app.post("/api/runtime/agent-tasks/{task_id}/handoffs")
+async def create_agent_handoff(task_id: str, payload: dict[str, Any]):
+    task = await agent_task_store.get_task(task_id)
+    if task is None:
+        raise HTTPException(status_code=404, detail="Agent task not found.")
+    target_agent = str(
+        payload.get("target_agent") or payload.get("targetAgent") or ""
+    ).strip()
+    if not target_agent:
+        raise HTTPException(status_code=400, detail="Handoff target_agent is required.")
+    reason = str(payload.get("reason") or "").strip()
+    if not reason:
+        raise HTTPException(status_code=400, detail="Handoff reason is required.")
+    source_agent = str(
+        payload.get("source_agent")
+        or payload.get("sourceAgent")
+        or task.assigned_agent
+        or task.source_agent
+        or "workflow"
+    ).strip()
+    metadata = payload.get("metadata")
+    if metadata is not None and not isinstance(metadata, dict):
+        raise HTTPException(status_code=400, detail="Handoff metadata must be an object.")
+    handoff = await agent_task_store.create_handoff(
+        task_id,
+        source_agent=source_agent or "workflow",
+        target_agent=target_agent,
+        reason=reason,
+        metadata=metadata,
+    )
+    return agent_handoff_to_payload(handoff)
+
+
+@app.get("/api/runtime/agent-tasks/{task_id}/handoffs")
+async def list_agent_handoffs(task_id: str):
+    task = await agent_task_store.get_task(task_id)
+    if task is None:
+        raise HTTPException(status_code=404, detail="Agent task not found.")
+    handoffs = await agent_task_store.list_handoffs(task_id=task_id)
+    return [agent_handoff_to_payload(handoff) for handoff in handoffs]
+
+
 @app.get("/api/runtime/agent-tasks/{task_id}")
 async def get_agent_task(task_id: str):
     task = await agent_task_store.get_task(task_id)
@@ -3873,6 +4054,58 @@ async def get_agent_task(task_id: str):
         "created_at": task.created_at,
         "updated_at": task.updated_at,
     }
+
+
+async def update_agent_handoff_api(
+    handoff_id: str,
+    status: str,
+    payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    metadata = (payload or {}).get("metadata")
+    if metadata is not None and not isinstance(metadata, dict):
+        raise HTTPException(status_code=400, detail="Handoff metadata must be an object.")
+    merged_metadata = dict(metadata or {})
+    reason = (payload or {}).get("reason")
+    if reason is not None:
+        merged_metadata["reason"] = str(reason)
+    result = (payload or {}).get("result")
+    if result is not None:
+        merged_metadata["result"] = str(result)
+    try:
+        handoff = await agent_task_store.update_handoff_status(
+            handoff_id,
+            status,  # type: ignore[arg-type]
+            metadata=merged_metadata or None,
+        )
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="Agent handoff not found.") from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return agent_handoff_to_payload(handoff)
+
+
+@app.post("/api/runtime/agent-handoffs/{handoff_id}/accept")
+async def accept_agent_handoff(
+    handoff_id: str,
+    payload: dict[str, Any] | None = None,
+):
+    return await update_agent_handoff_api(handoff_id, "accepted", payload)
+
+
+@app.post("/api/runtime/agent-handoffs/{handoff_id}/reject")
+async def reject_agent_handoff(
+    handoff_id: str,
+    payload: dict[str, Any] | None = None,
+):
+    return await update_agent_handoff_api(handoff_id, "rejected", payload)
+
+
+@app.post("/api/runtime/agent-handoffs/{handoff_id}/complete")
+async def complete_agent_handoff(
+    handoff_id: str,
+    payload: dict[str, Any] | None = None,
+):
+    return await update_agent_handoff_api(handoff_id, "completed", payload)
 
 
 @app.post("/api/runtime/agent-tasks/{task_id}/cancel")
@@ -4039,22 +4272,35 @@ async def chat(payload: ChatRequest, request: Request):
     async def send_prepared_to_upstream(
         model_id: str,
         request_payload: dict[str, Any],
+        *,
+        gateway_url: str = url,
+        gateway_key: str = key,
     ) -> httpx.Response:
-        logger.info("Sending chat request to model=%s", model_id)
+        logger.info("Sending chat request to model=%s gateway=%s", model_id, gateway_url)
         return await client.send(
             client.build_request(
                 "POST",
-                url,
-                headers=llm_gateway_headers(key),
+                gateway_url,
+                headers=llm_gateway_headers(gateway_key),
                 json=request_payload,
             ),
             stream=True,
         )
 
-    async def send_to_upstream(model_id: str) -> httpx.Response:
+    async def send_to_upstream(
+        model_id: str,
+        *,
+        gateway_url: str = url,
+        gateway_key: str = key,
+    ) -> httpx.Response:
         request_payload = build_upstream_payload(payload, model_id)
         if runtime_pipeline is None or runtime_context is None:
-            return await send_prepared_to_upstream(model_id, request_payload)
+            return await send_prepared_to_upstream(
+                model_id,
+                request_payload,
+                gateway_url=gateway_url,
+                gateway_key=gateway_key,
+            )
 
         handler_started = False
         try:
@@ -4089,6 +4335,8 @@ async def chat(payload: ChatRequest, request: Request):
                 upstream_response = await send_prepared_to_upstream(
                     request_for_model.model_id,
                     request_payload,
+                    gateway_url=gateway_url,
+                    gateway_key=gateway_key,
                 )
                 return ModelCallResponse(
                     text="",
@@ -4109,7 +4357,12 @@ async def chat(payload: ChatRequest, request: Request):
                 raise
             logger.warning("Xpert runtime chat prepare failed; using direct path: %s", exc)
 
-        return await send_prepared_to_upstream(model_id, request_payload)
+        return await send_prepared_to_upstream(
+            model_id,
+            request_payload,
+            gateway_url=gateway_url,
+            gateway_key=gateway_key,
+        )
 
     try:
         response = await send_to_upstream(actual_model_id)
@@ -4141,7 +4394,62 @@ async def chat(payload: ChatRequest, request: Request):
             body[:500].decode("utf-8", errors="replace"),
         )
 
-        if should_fallback_model(
+        if should_fallback_gateway_to_openrouter(
+            response.status_code,
+            message,
+            data,
+            url,
+        ):
+            try:
+                response = await send_to_upstream(
+                    actual_model_id,
+                    gateway_url=CHAT_COMPLETIONS_URL,
+                    gateway_key=OPENROUTER_API_KEY,
+                )
+                fallback_notice = (
+                    "提示：本地 newAPI 当前不可用，已自动切换到 OpenRouter 继续回答。\n\n"
+                )
+            except httpx.TimeoutException:
+                logger.exception("OpenRouter gateway fallback timed out model=%s", actual_model_id)
+                await finalize_runtime("error", actual_model_id, error="gateway fallback timeout")
+                await client.aclose()
+                return JSONResponse(
+                    status_code=504,
+                    content={"error": "OpenRouter 兜底模型响应超时，请稍后重试。"},
+                )
+            except httpx.HTTPError as exc:
+                logger.exception(
+                    "OpenRouter gateway fallback connection failed model=%s error=%s",
+                    actual_model_id,
+                    exc,
+                )
+                await finalize_runtime("error", actual_model_id, error=str(exc))
+                await client.aclose()
+                return JSONResponse(
+                    status_code=502,
+                    content={"error": "本地 newAPI 当前不可用，OpenRouter 兜底也暂时无法连接。"},
+                )
+
+            if response.status_code >= 400:
+                fallback_body = await response.aread()
+                await response.aclose()
+                fallback_message, _ = parse_upstream_error(
+                    response.status_code,
+                    fallback_body,
+                )
+                await finalize_runtime("error", actual_model_id, error=fallback_message)
+                await client.aclose()
+                return JSONResponse(
+                    status_code=response.status_code,
+                    content={
+                        "error": (
+                            "本地 newAPI 当前不可用；OpenRouter 兜底也暂不可用："
+                            f"{fallback_message}"
+                        )
+                    },
+                )
+
+        if response.status_code >= 400 and should_fallback_model(
             response.status_code,
             message,
             data,
@@ -4194,7 +4502,7 @@ async def chat(payload: ChatRequest, request: Request):
                     status_code=response.status_code,
                     content={"error": f"{message}；兜底模型也暂不可用：{fallback_message}"},
                 )
-        else:
+        elif response.status_code >= 400:
             await finalize_runtime("error", actual_model_id, error=message)
             await client.aclose()
             return JSONResponse(

--- a/server/tests/test_workflow_agent_task_node.py
+++ b/server/tests/test_workflow_agent_task_node.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from server.main import app
+
+
+@pytest_asyncio.fixture
+async def client():
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://testserver",
+    ) as async_client:
+        yield async_client
+
+
+@pytest.mark.asyncio
+async def test_workflow_agent_task_node_creates_runtime_task(
+    client: httpx.AsyncClient,
+) -> None:
+    workflow = {
+        "id": "agent-task-workflow",
+        "title": "agent task workflow",
+        "nodes": [
+            {
+                "id": "input",
+                "type": "input",
+                "data": {"kind": "input", "variableName": "user_input"},
+            },
+            {
+                "id": "agent_task",
+                "type": "agent_task",
+                "data": {
+                    "kind": "agent_task",
+                    "title": "Create agent task",
+                    "taskTitle": "Plan {{user_input}}",
+                    "taskInput": "Please plan: {{user_input}}",
+                    "assignedAgent": "workflow-planner",
+                    "outputVariable": "agent_task_id",
+                },
+            },
+            {
+                "id": "output",
+                "type": "output",
+                "data": {"kind": "output", "outputVariable": "agent_task_id"},
+            },
+        ],
+        "edges": [
+            {"id": "e1", "source": "input", "target": "agent_task"},
+            {"id": "e2", "source": "agent_task", "target": "output"},
+        ],
+    }
+
+    response = await client.post(
+        "/api/workflow/run",
+        json={
+            "workflow": workflow,
+            "inputs": {"user_input": "launch a support workflow"},
+        },
+    )
+    assert response.status_code == 200, response.text
+
+    events = _parse_sse_events(response.text)
+    agent_task_end = next(
+        event
+        for event in events
+        if event.get("event") == "node_end" and event.get("node_id") == "agent_task"
+    )
+    task_id = agent_task_end.get("output")
+    assert isinstance(task_id, str)
+    assert task_id
+    assert agent_task_end["variables"]["agent_task_id"] == task_id
+
+    deltas = [
+        event
+        for event in events
+        if event.get("event") == "node_delta" and event.get("node_id") == "agent_task"
+    ]
+    assert any("Agent Task" in str(event.get("output")) for event in deltas)
+
+    detail_response = await client.get(f"/api/runtime/agent-tasks/{task_id}")
+    assert detail_response.status_code == 200, detail_response.text
+    payload = detail_response.json()
+    assert payload["task_id"] == task_id
+    assert payload["title"] == "Plan launch a support workflow"
+    assert payload["input"] == "Please plan: launch a support workflow"
+    assert payload["source_agent"] == "workflow"
+    assert payload["assigned_agent"] == "workflow-planner"
+    assert payload["metadata"]["workflow_id"] == "agent-task-workflow"
+    assert payload["metadata"]["workflow_node_id"] == "agent_task"
+
+
+def _parse_sse_events(sse_text: str) -> list[dict]:
+    events: list[dict] = []
+    for line in sse_text.splitlines():
+        if not line.startswith("data:"):
+            continue
+        try:
+            payload = json.loads(line[5:].strip())
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            events.append(payload)
+    return events

--- a/server/tests/test_workflow_native_validate.py
+++ b/server/tests/test_workflow_native_validate.py
@@ -669,6 +669,116 @@ async def test_validate_agent_invalid_mode(client: httpx.AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
+async def test_validate_agent_task_ok(client: httpx.AsyncClient) -> None:
+    workflow = linear_workflow()
+    workflow["nodes"][1] = {
+        "id": "agent_task",
+        "type": "agent_task",
+        "data": {
+            "kind": "agent_task",
+            "taskTitle": "Plan {{user_input}}",
+            "taskInput": "Create a plan for {{user_input}}",
+            "assignedAgent": "workflow-planner",
+            "outputVariable": "agent_task_id",
+        },
+    }
+    workflow["nodes"][2]["data"]["outputVariable"] = "agent_task_id"
+    workflow["edges"] = [
+        {"id": "e1", "source": "input", "target": "agent_task"},
+        {"id": "e2", "source": "agent_task", "target": "output"},
+    ]
+
+    data = await validate(client, workflow)
+
+    assert data["valid"] is True
+    assert data["issues"] == []
+
+
+@pytest.mark.asyncio
+async def test_validate_agent_task_missing_input_and_output_variable(
+    client: httpx.AsyncClient,
+) -> None:
+    workflow = linear_workflow()
+    workflow["nodes"][1] = {
+        "id": "agent_task",
+        "type": "agent_task",
+        "data": {
+            "kind": "agent_task",
+            "taskTitle": "Plan {{user_input}}",
+            "assignedAgent": "workflow-planner",
+        },
+    }
+    workflow["edges"] = [
+        {"id": "e1", "source": "input", "target": "agent_task"},
+        {"id": "e2", "source": "agent_task", "target": "output"},
+    ]
+
+    data = await validate(client, workflow)
+
+    assert data["valid"] is False
+    assert {
+        "missing_agent_task_input",
+        "missing_agent_task_output_variable",
+    }.issubset(issue_codes(data))
+
+
+@pytest.mark.asyncio
+async def test_validate_agent_task_template_reference(
+    client: httpx.AsyncClient,
+) -> None:
+    workflow = linear_workflow()
+    workflow["nodes"][1] = {
+        "id": "agent_task",
+        "type": "agent_task",
+        "data": {
+            "kind": "agent_task",
+            "taskTitle": "Plan {{missing_value}}",
+            "taskInput": "Create a plan for {{user_input}}",
+            "assignedAgent": "workflow-planner",
+            "outputVariable": "agent_task_id",
+        },
+    }
+    workflow["nodes"][2]["data"]["outputVariable"] = "agent_task_id"
+    workflow["edges"] = [
+        {"id": "e1", "source": "input", "target": "agent_task"},
+        {"id": "e2", "source": "agent_task", "target": "output"},
+    ]
+
+    data = await validate(client, workflow)
+
+    assert data["valid"] is False
+    assert "missing_agent_task_template_variable" in issue_codes(data)
+
+
+@pytest.mark.asyncio
+async def test_validate_agent_task_output_can_be_used_downstream(
+    client: httpx.AsyncClient,
+) -> None:
+    workflow = linear_workflow()
+    workflow["nodes"][1] = {
+        "id": "agent_task",
+        "type": "agent_task",
+        "data": {
+            "kind": "agent_task",
+            "taskTitle": "Plan {{user_input}}",
+            "taskInput": "Create a plan for {{user_input}}",
+            "assignedAgent": "workflow-planner",
+            "outputVariable": "agent_task_id",
+        },
+    }
+    workflow["nodes"][2]["data"]["outputVariable"] = "agent_task_id"
+    workflow["edges"] = [
+        {"id": "e1", "source": "input", "target": "agent_task"},
+        {"id": "e2", "source": "agent_task", "target": "output"},
+    ]
+
+    data = await validate(client, workflow)
+
+    assert data["valid"] is True
+    assert "missing_output_variable_reference" not in issue_codes(data)
+
+
+@pytest.mark.asyncio
 async def test_validate_runtime_middleware_ok(client: httpx.AsyncClient) -> None:
     workflow = linear_workflow()
     workflow["nodes"][1] = {

--- a/server/tests/test_xpert_runtime_agent_tasks.py
+++ b/server/tests/test_xpert_runtime_agent_tasks.py
@@ -95,6 +95,76 @@ async def test_handoff_create_and_list() -> None:
 
 
 @pytest.mark.asyncio
+async def test_handoff_status_transitions() -> None:
+    store = AgentTaskStore()
+    task = await store.create_task("T", "in")
+    handoff = await store.create_handoff(
+        task.task_id,
+        source_agent="agent_a",
+        target_agent="agent_b",
+        reason="need expertise",
+    )
+
+    accepted = await store.update_handoff_status(
+        handoff.handoff_id,
+        "accepted",
+    )
+    assert accepted.status == "accepted"
+
+    completed = await store.update_handoff_status(
+        handoff.handoff_id,
+        "completed",
+        metadata={"result": "done"},
+    )
+    assert completed.status == "completed"
+    assert completed.metadata["result"] == "done"
+
+
+@pytest.mark.asyncio
+async def test_handoff_reject_and_invalid_transition() -> None:
+    store = AgentTaskStore()
+    task = await store.create_task("T", "in")
+    handoff = await store.create_handoff(
+        task.task_id,
+        source_agent="agent_a",
+        target_agent="agent_b",
+        reason="need expertise",
+    )
+
+    rejected = await store.update_handoff_status(
+        handoff.handoff_id,
+        "rejected",
+        metadata={"reason": "busy"},
+    )
+    assert rejected.status == "rejected"
+    assert rejected.metadata["reason"] == "busy"
+
+    with pytest.raises(ValueError):
+        await store.update_handoff_status(handoff.handoff_id, "completed")
+
+
+@pytest.mark.asyncio
+async def test_event_store_records_handoff_events() -> None:
+    event_store = RuntimeEventStore()
+    store = AgentTaskStore(event_store=event_store)
+    task = await store.create_task("T", "in")
+    handoff = await store.create_handoff(
+        task.task_id,
+        source_agent="agent_a",
+        target_agent="agent_b",
+        reason="need expertise",
+    )
+    await store.update_handoff_status(handoff.handoff_id, "accepted")
+    await store.update_handoff_status(handoff.handoff_id, "completed")
+
+    events = await event_store.list_events(task.task_id)
+    event_types = [event.type for event in events]
+    assert "agent.handoff.created" in event_types
+    assert "agent.handoff.accepted" in event_types
+    assert "agent.handoff.completed" in event_types
+
+
+@pytest.mark.asyncio
 async def test_event_store_records_task_events() -> None:
     event_store = RuntimeEventStore()
     store = AgentTaskStore(event_store=event_store)
@@ -170,6 +240,88 @@ async def test_api_cancel_task(client: httpx.AsyncClient) -> None:
     data = cancel_response.json()
     assert data["status"] == "cancelled"
     assert data["error"] == "test cancel"
+
+
+@pytest.mark.asyncio
+async def test_api_create_and_list_handoffs(client: httpx.AsyncClient) -> None:
+    create_response = await client.post(
+        "/api/runtime/agent-tasks",
+        json={"title": "Handoff API Task", "input": "x", "assigned_agent": "agent_a"},
+    )
+    task_id = create_response.json()["task_id"]
+
+    handoff_response = await client.post(
+        f"/api/runtime/agent-tasks/{task_id}/handoffs",
+        json={"target_agent": "agent_b", "reason": "need expertise"},
+    )
+
+    assert handoff_response.status_code == 200, handoff_response.text
+    handoff = handoff_response.json()
+    assert handoff["task_id"] == task_id
+    assert handoff["source_agent"] == "agent_a"
+    assert handoff["target_agent"] == "agent_b"
+    assert handoff["status"] == "pending"
+
+    list_response = await client.get(f"/api/runtime/agent-tasks/{task_id}/handoffs")
+    assert list_response.status_code == 200
+    handoffs = list_response.json()
+    assert any(item["handoff_id"] == handoff["handoff_id"] for item in handoffs)
+
+
+@pytest.mark.asyncio
+async def test_api_handoff_status_transitions(client: httpx.AsyncClient) -> None:
+    create_response = await client.post(
+        "/api/runtime/agent-tasks",
+        json={"title": "Handoff Transition", "input": "x"},
+    )
+    task_id = create_response.json()["task_id"]
+    handoff_response = await client.post(
+        f"/api/runtime/agent-tasks/{task_id}/handoffs",
+        json={
+            "source_agent": "agent_a",
+            "target_agent": "agent_b",
+            "reason": "need expertise",
+        },
+    )
+    handoff_id = handoff_response.json()["handoff_id"]
+
+    accept_response = await client.post(
+        f"/api/runtime/agent-handoffs/{handoff_id}/accept",
+    )
+    assert accept_response.status_code == 200
+    assert accept_response.json()["status"] == "accepted"
+
+    complete_response = await client.post(
+        f"/api/runtime/agent-handoffs/{handoff_id}/complete",
+        json={"result": "done"},
+    )
+    assert complete_response.status_code == 200
+    completed = complete_response.json()
+    assert completed["status"] == "completed"
+    assert completed["metadata"]["result"] == "done"
+
+
+@pytest.mark.asyncio
+async def test_api_handoff_invalid_transition(client: httpx.AsyncClient) -> None:
+    create_response = await client.post(
+        "/api/runtime/agent-tasks",
+        json={"title": "Handoff Invalid", "input": "x"},
+    )
+    task_id = create_response.json()["task_id"]
+    handoff_response = await client.post(
+        f"/api/runtime/agent-tasks/{task_id}/handoffs",
+        json={
+            "source_agent": "agent_a",
+            "target_agent": "agent_b",
+            "reason": "need expertise",
+        },
+    )
+    handoff_id = handoff_response.json()["handoff_id"]
+
+    complete_response = await client.post(
+        f"/api/runtime/agent-handoffs/{handoff_id}/complete",
+    )
+    assert complete_response.status_code == 400
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_xpert_runtime_chat.py
+++ b/server/tests/test_xpert_runtime_chat.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 import pytest
 
-from server.main import ChatMessage, sse_delta_text, stream_chat_text
+from server.main import (
+    ChatMessage,
+    parse_upstream_error,
+    sse_delta_text,
+    stream_chat_text,
+)
 from server.xpert_runtime import (
     MiddlewareContext,
     ModelCallRequest,
@@ -130,3 +135,42 @@ def test_sse_image_url_is_converted_to_markdown() -> None:
     )
 
     assert sse_delta_text(event) == ["\n![图片](https://example.com/cat.png)\n"]
+
+
+def test_user_not_found_error_is_mapped_to_actionable_message() -> None:
+    message, data = parse_upstream_error(
+        401,
+        b'{"error":{"message":"User not found."}}',
+    )
+
+    assert data is not None
+    assert "User not found" not in message
+    assert "newAPI" in message
+    assert "OPENROUTER_API_KEY" in message
+
+
+def test_newapi_user_error_can_fallback_to_openrouter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import server.main as main_module
+
+    monkeypatch.setattr(main_module, "OPENROUTER_API_KEY", "sk-test")
+
+    assert (
+        main_module.should_fallback_gateway_to_openrouter(
+            401,
+            "本地 newAPI 未找到对应用户或令牌无效。",
+            {"error": {"message": "User not found."}},
+            "http://new-api:3000/v1/chat/completions",
+        )
+        is True
+    )
+    assert (
+        main_module.should_fallback_gateway_to_openrouter(
+            401,
+            "本地 newAPI 未找到对应用户或令牌无效。",
+            {"error": {"message": "User not found."}},
+            main_module.CHAT_COMPLETIONS_URL,
+        )
+        is False
+    )

--- a/server/workflow_native/schemas.py
+++ b/server/workflow_native/schemas.py
@@ -19,6 +19,7 @@ NativeNodeKind = Literal[
     "human_intervention",
     "question_classifier",
     "agent",
+    "agent_task",
     "mcp_tool",
     "time_tool",
     "http_request",

--- a/server/workflow_native/validate.py
+++ b/server/workflow_native/validate.py
@@ -41,6 +41,8 @@ NODE_KIND_ALIASES = {
     "question_classifier": "question_classifier",
     "question-classifier": "question_classifier",
     "agent": "agent",
+    "agent_task": "agent_task",
+    "agent-task": "agent_task",
     "mcp_tool": "mcp_tool",
     "mcp-tool": "mcp_tool",
     "tool": "mcp_tool",
@@ -75,6 +77,7 @@ SUPPORTED_NODE_KINDS = {
     "human_intervention",
     "question_classifier",
     "agent",
+    "agent_task",
     "mcp_tool",
     "time_tool",
     "http_request",
@@ -688,6 +691,45 @@ def validate_node_configuration(
                     )
                 )
 
+    if kind == "agent_task":
+        task_title = str(data.get("taskTitle") or "").strip()
+        if not task_title:
+            issues.append(
+                ValidationIssue(
+                    code="missing_agent_task_title",
+                    message="Agent task node needs data.taskTitle.",
+                    node_id=node.id,
+                )
+            )
+
+        task_input = str(data.get("taskInput") or "").strip()
+        if not task_input:
+            issues.append(
+                ValidationIssue(
+                    code="missing_agent_task_input",
+                    message="Agent task node needs data.taskInput.",
+                    node_id=node.id,
+                )
+            )
+
+        output_variable = str(data.get("outputVariable") or "").strip()
+        if not output_variable:
+            issues.append(
+                ValidationIssue(
+                    code="missing_agent_task_output_variable",
+                    message="Agent task node needs data.outputVariable.",
+                    node_id=node.id,
+                )
+            )
+        elif not is_variable_name(output_variable):
+            issues.append(
+                ValidationIssue(
+                    code="invalid_agent_task_output_variable",
+                    message="Agent task outputVariable must be an identifier.",
+                    node_id=node.id,
+                )
+            )
+
     if kind == "mcp_tool":
         tool_name = str(data.get("toolName") or "").strip()
         if not tool_name:
@@ -1046,6 +1088,7 @@ def collect_declared_variables(
             "human_intervention",
             "question_classifier",
             "agent",
+            "agent_task",
             "mcp_tool",
             "time_tool",
             "http_request",
@@ -1269,6 +1312,22 @@ def validate_variable_references(
                         node_id=node.id,
                     )
                 )
+
+    if kind == "agent_task":
+        for field_name in ("taskTitle", "taskInput"):
+            template = str(data.get(field_name) or "")
+            for variable in sorted(extract_template_variables(template)):
+                if variable not in available_variables:
+                    issues.append(
+                        ValidationIssue(
+                            code="missing_agent_task_template_variable",
+                            message=(
+                                f"Agent task {field_name} references undefined "
+                                f"variable '{variable}'."
+                            ),
+                            node_id=node.id,
+                        )
+                    )
 
     if kind == "mcp_tool":
         arguments_json = str(data.get("argumentsJson") or "")

--- a/server/xpert_runtime/agent_tasks.py
+++ b/server/xpert_runtime/agent_tasks.py
@@ -10,6 +10,12 @@ from .events import RuntimeEventStore
 
 AgentTaskStatus = Literal["pending", "running", "completed", "failed", "cancelled"]
 AgentHandoffStatus = Literal["pending", "accepted", "rejected", "completed"]
+HANDOFF_TRANSITIONS: dict[AgentHandoffStatus, set[AgentHandoffStatus]] = {
+    "pending": {"accepted", "rejected"},
+    "accepted": {"completed"},
+    "rejected": set(),
+    "completed": set(),
+}
 
 
 @dataclass(slots=True)
@@ -188,6 +194,54 @@ class AgentTaskStore:
             handoffs = [handoff for handoff in handoffs if handoff.task_id == task_id]
         handoffs.sort(key=lambda handoff: handoff.created_at, reverse=True)
         return handoffs
+
+    async def get_handoff(self, handoff_id: str) -> AgentHandoff | None:
+        async with self._lock:
+            for handoff in self._handoffs:
+                if handoff.handoff_id == handoff_id:
+                    return handoff
+        return None
+
+    async def update_handoff_status(
+        self,
+        handoff_id: str,
+        status: AgentHandoffStatus,
+        *,
+        metadata: dict[str, Any] | None = None,
+    ) -> AgentHandoff:
+        async with self._lock:
+            handoff = next(
+                (
+                    item
+                    for item in self._handoffs
+                    if item.handoff_id == handoff_id
+                ),
+                None,
+            )
+            if handoff is None:
+                raise KeyError(f"Agent handoff not found: {handoff_id}")
+            allowed = HANDOFF_TRANSITIONS.get(handoff.status, set())
+            if status not in allowed:
+                raise ValueError(
+                    f"Invalid handoff transition: {handoff.status} -> {status}"
+                )
+            handoff.status = status
+            if metadata is not None:
+                handoff.metadata.update(metadata)
+            handoff.touch()
+            updated = handoff
+        await self._record(
+            f"agent.handoff.{status}",
+            task_id=updated.task_id,
+            payload={
+                "handoff_id": updated.handoff_id,
+                "task_id": updated.task_id,
+                "source_agent": updated.source_agent,
+                "target_agent": updated.target_agent,
+                "status": updated.status,
+            },
+        )
+        return updated
 
     async def _record(
         self,


### PR DESCRIPTION
## Summary

- Added the Xpert-aligned agent_task workflow node so classic workflows can create Agent Task Runtime tasks and output the created task_id.
- Added the minimal Agent Handoff API loop: create/list handoffs and accept/reject/complete status transitions with RuntimeEventStore events.
- Improved chat gateway resilience for local newAPI User not found/auth errors, including actionable Chinese messaging and OpenRouter fallback when configured.
- Reworked /workflow layout: node library is now a canvas-near dropdown, and config/run share one right-side workspace with tabs.
- Updated Xpert alignment and workflow design docs.

## Validation

- cd client && npm.cmd run build passed.
- Explicit Windows py_compile for server/main.py, workflow_native, and xpert_runtime passed.
- Focused tests passed: 62 passed.
- Full backend tests passed: 113 passed.
- Docker rebuilt with docker compose -p modelmirror up -d --build --force-recreate.
- Smoke checks passed: GET /api/health, GET /workflow, and Handoff create/list/accept/complete API smoke.

## Notes

- This remains an in-memory Handoff/AgentTask runtime foundation. It does not add a workflow handoff node or real multi-agent scheduling yet.
- No API keys or environment files are included.