### PR TITLE
feature: 增强 Handoff 前端观测闭环

### DIFF
--- a/client/src/components/workflow/WorkflowRun.tsx
+++ b/client/src/components/workflow/WorkflowRun.tsx
@@ -158,6 +158,16 @@ function observationPayloadSummary(payload: Record<string, unknown>) {
   return parts.join(" · ");
 }
 
+function runMetadataText(
+  metadata: Record<string, unknown> | undefined,
+  key: string,
+) {
+  const value = metadata?.[key];
+  if (typeof value === "string" && value.trim()) return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  return "";
+}
+
 function buildRunSteps(events: WorkflowRunEvent[]) {
   const steps: WorkflowRunStep[] = [];
   const byNodeId = new Map<string, WorkflowRunStep>();
@@ -247,6 +257,8 @@ export default function WorkflowRun({
   const [observationLoading, setObservationLoading] = useState(false);
   const [runSummary, setRunSummary] = useState<RuntimeRunSummary | null>(null);
   const [runSummaryLoading, setRunSummaryLoading] = useState(false);
+  const [childRuns, setChildRuns] = useState<RuntimeRunSummary[]>([]);
+  const [childRunsLoading, setChildRunsLoading] = useState(false);
 
   const inputVariable = useMemo(() => {
     const inputNode = definition.nodes.find((node) => node.data.kind === "input");
@@ -281,6 +293,8 @@ export default function WorkflowRun({
     setObservationLoading(false);
     setRunSummary(null);
     setRunSummaryLoading(false);
+    setChildRuns([]);
+    setChildRunsLoading(false);
     setIsRunning(true);
 
     try {
@@ -408,6 +422,7 @@ export default function WorkflowRun({
     if (!taskId) return;
     setObservationLoading(true);
     setRunSummaryLoading(Boolean(runId));
+    setChildRunsLoading(Boolean(runId));
     try {
       const response = await fetch(`/api/workflow/runtime-events/${taskId}`);
       if (response.ok) {
@@ -420,12 +435,21 @@ export default function WorkflowRun({
           const runPayload = (await runResponse.json()) as RuntimeRunSummary;
           setRunSummary(runPayload);
         }
+        const childRunsResponse = await fetch(
+          `/api/runtime/runs?parent_run_id=${encodeURIComponent(runId)}&limit=80`,
+        );
+        if (childRunsResponse.ok) {
+          const childRunPayload =
+            (await childRunsResponse.json()) as RuntimeRunSummary[];
+          setChildRuns(childRunPayload);
+        }
       }
     } catch {
       // Observability is best-effort; workflow execution output remains primary.
     } finally {
       setObservationLoading(false);
       setRunSummaryLoading(false);
+      setChildRunsLoading(false);
     }
   }
 
@@ -436,7 +460,8 @@ export default function WorkflowRun({
         next &&
         taskId &&
         ((!observationData && !observationLoading) ||
-          (runId && !runSummary && !runSummaryLoading))
+          (runId && !runSummary && !runSummaryLoading) ||
+          (runId && childRuns.length === 0 && !childRunsLoading))
       ) {
         void fetchObservation();
       }
@@ -614,6 +639,66 @@ export default function WorkflowRun({
                         <p className="mt-2 text-[11px] text-slate-500">
                           暂无 run 摘要。
                         </p>
+                      )}
+                    </div>
+                  ) : null}
+
+                  {runId ? (
+                    <div className="rounded-lg border border-white/10 bg-white/[0.035] p-3">
+                      <div className="flex items-center justify-between gap-3">
+                        <p className="text-xs font-semibold text-slate-200">
+                          子 Run
+                        </p>
+                        <span className="text-[11px] text-slate-500">
+                          {childRunsLoading ? "..." : childRuns.length}
+                        </span>
+                      </div>
+                      {childRunsLoading ? (
+                        <p className="mt-2 text-xs text-slate-500">
+                          正在读取 AgentTask / Handoff 子 run...
+                        </p>
+                      ) : childRuns.length === 0 ? (
+                        <p className="mt-2 text-xs text-slate-500">
+                          暂无子 run。
+                        </p>
+                      ) : (
+                        <div className="mt-2 max-h-44 space-y-1 overflow-y-auto">
+                          {childRuns.slice(0, 30).map((run) => {
+                            const agentTaskId = runMetadataText(
+                              run.metadata,
+                              "agent_task_id",
+                            );
+                            const handoffId = runMetadataText(
+                              run.metadata,
+                              "handoff_id",
+                            );
+                            const targetAgent = runMetadataText(
+                              run.metadata,
+                              "target_agent",
+                            );
+                            return (
+                              <div
+                                className="rounded-md bg-slate-950/35 px-2 py-1.5"
+                                key={run.run_id}
+                              >
+                                <div className="flex items-center justify-between gap-2">
+                                  <span className="truncate text-[11px] font-semibold text-slate-200">
+                                    {run.title || run.run_type}
+                                  </span>
+                                  <span className="shrink-0 rounded-full border border-white/10 bg-white/[0.045] px-2 py-0.5 text-[10px] uppercase text-slate-400">
+                                    {run.status}
+                                  </span>
+                                </div>
+                                <p className="mt-1 truncate text-[11px] text-slate-500">
+                                  {run.run_type}
+                                  {targetAgent ? ` · target=${targetAgent}` : ""}
+                                  {agentTaskId ? ` · task=${agentTaskId}` : ""}
+                                  {handoffId ? ` · handoff=${handoffId}` : ""}
+                                </p>
+                              </div>
+                            );
+                          })}
+                        </div>
                       )}
                     </div>
                   ) : null}

--- a/client/src/pages/MetaAgentPage.tsx
+++ b/client/src/pages/MetaAgentPage.tsx
@@ -90,6 +90,18 @@ interface AgentTaskDetail extends AgentTaskSummary {
   metadata: Record<string, unknown>;
 }
 
+interface AgentHandoffSummary {
+  handoff_id: string;
+  task_id: string;
+  source_agent: string;
+  target_agent: string;
+  reason: string;
+  status: string;
+  metadata: Record<string, unknown>;
+  created_at: number;
+  updated_at: number;
+}
+
 const nodeTypes = {
   workflowNode: WorkflowNodeCard,
 };
@@ -164,6 +176,23 @@ function taskStatusClass(status: string) {
   if (status === "failed") return "border-rose-300/25 bg-rose-300/10 text-rose-100";
   if (status === "cancelled") return "border-slate-400/20 bg-slate-400/10 text-slate-300";
   if (status === "running") return "border-cyan-300/25 bg-cyan-300/10 text-cyan-100";
+  return "border-hire-300/25 bg-hire-300/10 text-hire-100";
+}
+
+function handoffStatusLabel(status: string) {
+  const labels: Record<string, string> = {
+    pending: "待处理",
+    accepted: "已接受",
+    rejected: "已拒绝",
+    completed: "已完成",
+  };
+  return labels[status] ?? status;
+}
+
+function handoffStatusClass(status: string) {
+  if (status === "completed") return "border-emerald-300/25 bg-emerald-300/10 text-emerald-100";
+  if (status === "rejected") return "border-rose-300/25 bg-rose-300/10 text-rose-100";
+  if (status === "accepted") return "border-cyan-300/25 bg-cyan-300/10 text-cyan-100";
   return "border-hire-300/25 bg-hire-300/10 text-hire-100";
 }
 
@@ -274,6 +303,12 @@ export default function MetaAgentPage() {
   const [tasksError, setTasksError] = useState("");
   const [taskActionError, setTaskActionError] = useState("");
   const [cancellingTaskId, setCancellingTaskId] = useState<string | null>(null);
+  const [selectedTaskHandoffs, setSelectedTaskHandoffs] = useState<
+    AgentHandoffSummary[]
+  >([]);
+  const [handoffInbox, setHandoffInbox] = useState<AgentHandoffSummary[]>([]);
+  const [handoffError, setHandoffError] = useState("");
+  const [handoffActionId, setHandoffActionId] = useState<string | null>(null);
 
   useEffect(() => {
     document.title = "模镜 - 元智能体工作台";
@@ -281,7 +316,51 @@ export default function MetaAgentPage() {
 
   useEffect(() => {
     void loadAgentTasks();
+    void loadHandoffInbox();
   }, []);
+
+  async function loadAgentTaskHandoffs(taskId: string) {
+    try {
+      const response = await fetch(`/api/runtime/agent-tasks/${taskId}/handoffs`);
+      const payload = (await response.json().catch(() => null)) as
+        | AgentHandoffSummary[]
+        | { error?: string; detail?: unknown }
+        | null;
+      if (!response.ok || !Array.isArray(payload)) {
+        throw new Error(errorMessage(payload, "Handoff records failed to load."));
+      }
+      setSelectedTaskHandoffs(payload);
+      setHandoffError("");
+    } catch (handoffLoadError) {
+      setSelectedTaskHandoffs([]);
+      setHandoffError(
+        handoffLoadError instanceof Error
+          ? handoffLoadError.message
+          : "Handoff records failed to load.",
+      );
+    }
+  }
+
+  async function loadHandoffInbox() {
+    try {
+      const response = await fetch("/api/runtime/agent-handoffs?limit=20");
+      const payload = (await response.json().catch(() => null)) as
+        | AgentHandoffSummary[]
+        | { error?: string; detail?: unknown }
+        | null;
+      if (!response.ok || !Array.isArray(payload)) {
+        throw new Error(errorMessage(payload, "Handoff Inbox failed to load."));
+      }
+      setHandoffInbox(payload);
+      setHandoffError("");
+    } catch (handoffLoadError) {
+      setHandoffError(
+        handoffLoadError instanceof Error
+          ? handoffLoadError.message
+          : "Handoff Inbox failed to load.",
+      );
+    }
+  }
 
   async function loadAgentTask(taskId: string) {
     try {
@@ -294,6 +373,7 @@ export default function MetaAgentPage() {
         throw new Error(errorMessage(payload, "任务详情加载失败。"));
       }
       setSelectedTask(payload as AgentTaskDetail);
+      await loadAgentTaskHandoffs(taskId);
       setTaskActionError("");
     } catch (taskError) {
       setTaskActionError(
@@ -391,6 +471,88 @@ export default function MetaAgentPage() {
     } finally {
       setCancellingTaskId(null);
     }
+  }
+
+  async function updateHandoffStatus(
+    handoff: AgentHandoffSummary,
+    action: "accept" | "reject" | "complete",
+  ) {
+    setHandoffActionId(handoff.handoff_id);
+    try {
+      const body =
+        action === "reject"
+          ? { reason: "Rejected in MetaAgent handoff inbox." }
+          : action === "complete"
+            ? { result: "Completed in MetaAgent handoff inbox." }
+            : {};
+      const response = await fetch(
+        `/api/runtime/agent-handoffs/${handoff.handoff_id}/${action}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        },
+      );
+      const payload = (await response.json().catch(() => null)) as
+        | AgentHandoffSummary
+        | { error?: string; detail?: unknown }
+        | null;
+      if (!response.ok) {
+        throw new Error(errorMessage(payload, "Handoff status update failed."));
+      }
+      setHandoffError("");
+      await loadHandoffInbox();
+      if (selectedTask?.task_id) {
+        await loadAgentTask(selectedTask.task_id);
+      }
+    } catch (handoffActionError) {
+      setHandoffError(
+        handoffActionError instanceof Error
+          ? handoffActionError.message
+          : "Handoff status update failed.",
+      );
+    } finally {
+      setHandoffActionId(null);
+    }
+  }
+
+  function renderHandoffActions(handoff: AgentHandoffSummary) {
+    const busy = handoffActionId === handoff.handoff_id;
+    if (handoff.status === "pending") {
+      return (
+        <div className="mt-2 flex gap-2">
+          <button
+            className="rounded-full border border-cyan-300/25 bg-cyan-300/10 px-2.5 py-1 text-[11px] font-semibold text-cyan-100 transition hover:bg-cyan-300/15 disabled:opacity-50"
+            disabled={busy}
+            onClick={() => void updateHandoffStatus(handoff, "accept")}
+            type="button"
+          >
+            接受
+          </button>
+          <button
+            className="rounded-full border border-rose-300/25 bg-rose-300/10 px-2.5 py-1 text-[11px] font-semibold text-rose-100 transition hover:bg-rose-300/15 disabled:opacity-50"
+            disabled={busy}
+            onClick={() => void updateHandoffStatus(handoff, "reject")}
+            type="button"
+          >
+            拒绝
+          </button>
+        </div>
+      );
+    }
+    if (handoff.status === "accepted") {
+      return (
+        <button
+          className="mt-2 rounded-full border border-emerald-300/25 bg-emerald-300/10 px-2.5 py-1 text-[11px] font-semibold text-emerald-100 transition hover:bg-emerald-300/15 disabled:opacity-50"
+          disabled={busy}
+          onClick={() => void updateHandoffStatus(handoff, "complete")}
+          type="button"
+        >
+          完成
+        </button>
+      );
+    }
+    return null;
   }
 
   async function generateWorkflow() {
@@ -638,6 +800,11 @@ export default function MetaAgentPage() {
                 {taskActionError}
               </div>
             ) : null}
+            {handoffError ? (
+              <div className="mt-3 rounded-lg border border-amber-300/25 bg-amber-300/10 px-3 py-2 text-xs leading-5 text-amber-100">
+                {handoffError}
+              </div>
+            ) : null}
 
             <div className="mt-3 max-h-48 space-y-2 overflow-y-auto pr-1">
               {tasksLoading && agentTasks.length === 0 ? (
@@ -725,6 +892,47 @@ export default function MetaAgentPage() {
                     </p>
                   </div>
                 </div>
+                <div className="mt-3 rounded-md border border-white/10 bg-slate-950/25 p-2">
+                  <div className="flex items-center justify-between gap-2">
+                    <p className="text-[11px] font-semibold text-slate-300">
+                      Handoff records
+                    </p>
+                    <span className="text-[10px] text-slate-500">
+                      {selectedTaskHandoffs.length}
+                    </span>
+                  </div>
+                  {selectedTaskHandoffs.length === 0 ? (
+                    <p className="mt-2 text-[11px] text-slate-500">
+                      No handoff records for this task.
+                    </p>
+                  ) : (
+                    <div className="mt-2 max-h-40 space-y-2 overflow-y-auto pr-1">
+                      {selectedTaskHandoffs.map((handoff) => (
+                        <div
+                          className="rounded-md border border-white/10 bg-white/[0.035] px-2 py-1.5"
+                          key={handoff.handoff_id}
+                        >
+                          <div className="flex items-center justify-between gap-2">
+                            <p className="min-w-0 truncate text-[11px] font-semibold text-slate-200">
+                              {handoff.source_agent} -&gt; {handoff.target_agent}
+                            </p>
+                            <span
+                              className={`shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-semibold ${handoffStatusClass(
+                                handoff.status,
+                              )}`}
+                            >
+                              {handoffStatusLabel(handoff.status)}
+                            </span>
+                          </div>
+                          <p className="mt-1 line-clamp-2 text-[11px] leading-5 text-slate-500">
+                            {handoff.reason}
+                          </p>
+                          {renderHandoffActions(handoff)}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
                 {selectedTask.error ? (
                   <p className="mt-2 rounded-md border border-rose-300/25 bg-rose-300/10 px-2 py-1.5 text-xs text-rose-100">
                     {selectedTask.error}
@@ -743,6 +951,65 @@ export default function MetaAgentPage() {
                 </button>
               </div>
             ) : null}
+          </section>
+
+          <section className="surface-panel rounded-lg p-4">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <p className="text-sm font-semibold text-white">
+                  Handoff Inbox Beta
+                </p>
+                <p className="mt-1 text-xs text-slate-400">
+                  Manual accept / reject / complete
+                </p>
+              </div>
+              <button
+                className="rounded-full border border-white/10 bg-white/[0.055] px-2.5 py-1 text-xs font-semibold text-slate-300 transition hover:border-hire-300/35 hover:text-hire-100"
+                onClick={() => void loadHandoffInbox()}
+                type="button"
+              >
+                刷新
+              </button>
+            </div>
+            <div className="mt-3 max-h-64 space-y-2 overflow-y-auto pr-1">
+              {handoffInbox.length === 0 ? (
+                <p className="rounded-lg border border-dashed border-white/15 bg-white/[0.025] px-3 py-3 text-xs leading-5 text-slate-400">
+                  No recent handoffs.
+                </p>
+              ) : (
+                handoffInbox.map((handoff) => (
+                  <article
+                    className="rounded-lg border border-white/10 bg-white/[0.045] p-3"
+                    key={handoff.handoff_id}
+                  >
+                    <div className="flex items-start justify-between gap-2">
+                      <div className="min-w-0">
+                        <p className="truncate text-xs font-semibold text-white">
+                          {handoff.source_agent} -&gt; {handoff.target_agent}
+                        </p>
+                        <p className="mt-1 break-all font-mono text-[10px] text-slate-500">
+                          {handoff.handoff_id}
+                        </p>
+                      </div>
+                      <span
+                        className={`shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-semibold ${handoffStatusClass(
+                          handoff.status,
+                        )}`}
+                      >
+                        {handoffStatusLabel(handoff.status)}
+                      </span>
+                    </div>
+                    <p className="mt-2 line-clamp-2 text-xs leading-5 text-slate-400">
+                      {handoff.reason}
+                    </p>
+                    <p className="mt-1 break-all text-[11px] text-slate-500">
+                      task: {handoff.task_id}
+                    </p>
+                    {renderHandoffActions(handoff)}
+                  </article>
+                ))
+              )}
+            </div>
           </section>
 
           <section className="surface-panel rounded-lg p-4">

--- a/docs/META_AGENT.md
+++ b/docs/META_AGENT.md
@@ -1,6 +1,6 @@
 # 元智能体集成说明
 
-最后更新日期：2026-06-26  
+最后更新日期：2026-07-06  
 维护人：模镜团队
 
 ## 定位
@@ -15,6 +15,7 @@
 - 后端生成接口：`POST /api/meta-agent/generate-workflow`。
 - 后端模块：`server/meta_agent/`。
 - 任务运行时：复用 `POST /api/runtime/agent-tasks`、`GET /api/runtime/agent-tasks`、`GET /api/runtime/agent-tasks/{task_id}`、`POST /api/runtime/agent-tasks/{task_id}/cancel`。
+- Handoff 观测：任务工作台会查询 `GET /api/runtime/agent-tasks/{task_id}/handoffs` 展示选中任务的移交记录，并通过 `GET /api/runtime/agent-handoffs?limit=20` 提供 Handoff Inbox Beta；pending 移交支持手动接受/拒绝，accepted 移交支持手动完成。
 - 输出目标：生成 `WorkflowDefinition`，可导入经典自研画布并通过 `/api/workflow/run` 执行。
 - 校验路径：生成后的工作流会调用 `workflow_native.validate_workflow_graph` 做静态校验。
 
@@ -23,7 +24,7 @@
 - planner、schema 和 prompt 放在 `server/meta_agent/`，不要继续堆进 `server/main.py`。
 - 生成接口依赖模型网关；测试必须 mock `collect_chat_completion_text`，不能请求真实模型。
 - 前端负责提交目标、展示任务拆解、创建 AgentTask 记录、展示任务工作台和导入经典画布。
-- 当前只做任务可见和取消，不做队列分派、专家协作、自动执行或持久化调度。
+- 当前只做任务可见、取消、handoff 观测和手动状态操作，不做队列分派、专家协作、自动执行或持久化调度。
 - Docker 镜像必须复制 `server/meta_agent/`，否则 `server/main.py` 导入会失败。
 
 ## 请求示例

--- a/docs/XPERT_ALIGNMENT.md
+++ b/docs/XPERT_ALIGNMENT.md
@@ -1,5 +1,7 @@
 # Xpert 对齐总纲
 
+> 2026-07-06 状态补充：Handoff 前端观测已进入“部分实现”。Workflow 运行观测可以按 `parent_run_id` 拉取 `agent_task` / `agent_handoff` 子 run；MetaAgent 任务工作台可以查看任务 handoff 记录，并通过 Handoff Inbox Beta 手动 accept / reject / complete。当前仍不做真实多 Agent 调度、队列分派、数据库持久化或目标 Agent 自动执行。
+
 > 2026-07-05 状态补充：RunRegistry 已进入最小可观测闭环阶段，详见文末“RunRegistry 最小可观测闭环”。
 
 ## 2026-07-05 增量：RunRegistry 最小可观测闭环
@@ -16,7 +18,7 @@ Classic workflow 运行时会创建 workflow run，并在 `workflow_meta` / `wor
 
 当前边界：RunRegistry 仅为内存态可观测索引，不是持久化调度器；取消 run 只更新 registry 状态，不中断真实 workflow、AgentTask 或 Handoff 执行。下一步可在此基础上继续补齐 Handoff 前端观测、RunRegistry 页面、checkpoint、死信与持久化存储。
 
-最后更新日期：2026-07-05
+最后更新日期：2026-07-06
 维护人：模镜团队
 
 ## 对齐原则

--- a/docs/workflow-native-design.md
+++ b/docs/workflow-native-design.md
@@ -1,5 +1,7 @@
 # workflow-native 自研工作流设计
 
+> 2026-07-06 状态补充：Handoff 观测前端进入最小闭环。`GET /api/runtime/runs` 支持按 `parent_run_id` / `source_id` 查询，`WorkflowRun` 的“运行观测”可展示 workflow 下的 `agent_task` 与 `agent_handoff` 子 run；新增 `GET /api/runtime/agent-handoffs?task_id=&status=&target_agent=&limit=` 供 MetaAgent Handoff Inbox 查询。当前只做观测和手动状态操作，不做真实调度、队列或持久化。
+
 > 2026-07-05 状态补充：classic workflow 已接入 RunRegistry 最小可观测闭环，并恢复 `/workflow` 画布的节点库浮层与配置/运行 tabs 布局。
 
 ## 2026-07-05 增量：RunRegistry 与工作流运行观测
@@ -20,7 +22,7 @@ Classic workflow 每次运行会登记一条 `workflow` run，并在 `workflow_m
 
 workflow-native 是模镜自研工作流引擎的渐进式实验线。它不会替换当前稳定的 `/workflow` Dify iframe 入口，也不会改动 `/rag`。当前阶段提供静态图校验能力，并在 classic 运行器中试点少量本地节点执行，让团队先把数据模型、API 契约、错误模型和测试流程立起来。
 
-最后更新日期：2026-07-05
+最后更新日期：2026-07-06
 维护人：模镜团队
 
 ## 目标与边界

--- a/server/main.py
+++ b/server/main.py
@@ -3654,6 +3654,8 @@ async def update_runtime_runs_for_source(
 async def list_runtime_runs(
     run_type: str | None = None,
     status: str | None = None,
+    parent_run_id: str | None = None,
+    source_id: str | None = None,
     limit: int = 50,
 ):
     valid_run_types = {"workflow", "agent_task", "agent_handoff"}
@@ -3665,6 +3667,8 @@ async def list_runtime_runs(
     runs = await run_registry.list_runs(
         run_type=run_type,  # type: ignore[arg-type]
         status=status,  # type: ignore[arg-type]
+        parent_run_id=parent_run_id,
+        source_id=source_id,
         limit=max(1, min(limit, 200)),
     )
     return [runtime_run_to_payload(run) for run in runs]
@@ -4258,6 +4262,29 @@ async def list_agent_tasks(status: str | None = None, limit: int = 50):
         }
         for task in tasks
     ]
+
+
+@app.get("/api/runtime/agent-handoffs")
+async def list_agent_handoffs_global(
+    task_id: str | None = None,
+    status: str | None = None,
+    target_agent: str | None = None,
+    limit: int = 50,
+):
+    valid_statuses = {"pending", "accepted", "rejected", "completed"}
+    if status is not None and status not in valid_statuses:
+        raise HTTPException(status_code=400, detail="Invalid agent handoff status.")
+    handoffs = await agent_task_store.list_handoffs(task_id=task_id)
+    if status is not None:
+        handoffs = [handoff for handoff in handoffs if handoff.status == status]
+    if target_agent is not None:
+        handoffs = [
+            handoff
+            for handoff in handoffs
+            if handoff.target_agent == target_agent
+        ]
+    capped_limit = max(1, min(limit, 200))
+    return [agent_handoff_to_payload(handoff) for handoff in handoffs[:capped_limit]]
 
 
 @app.post("/api/runtime/agent-tasks/{task_id}/handoffs")

--- a/server/tests/test_workflow_agent_task_node.py
+++ b/server/tests/test_workflow_agent_task_node.py
@@ -224,6 +224,20 @@ async def test_workflow_agent_handoff_node_creates_runtime_handoff_and_runs(
     assert handoff_run["metadata"]["agent_task_id"] == task_id
     assert handoff_run["metadata"]["target_agent"] == "review-agent"
 
+    child_runs_response = await client.get(
+        f"/api/runtime/runs?parent_run_id={workflow_run_id}&limit=50",
+    )
+    assert child_runs_response.status_code == 200, child_runs_response.text
+    child_runs = child_runs_response.json()
+    assert any(
+        item["run_type"] == "agent_task" and item["source_id"] == task_id
+        for item in child_runs
+    )
+    assert any(
+        item["run_type"] == "agent_handoff" and item["source_id"] == handoff_id
+        for item in child_runs
+    )
+
 
 def _parse_sse_events(sse_text: str) -> list[dict]:
     events: list[dict] = []

--- a/server/tests/test_xpert_runtime_agent_tasks.py
+++ b/server/tests/test_xpert_runtime_agent_tasks.py
@@ -276,6 +276,55 @@ async def test_api_create_and_list_handoffs(client: httpx.AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
+async def test_api_global_handoff_list_filters(client: httpx.AsyncClient) -> None:
+    task_a = await client.post(
+        "/api/runtime/agent-tasks",
+        json={"title": "Handoff Filter A", "input": "x", "assigned_agent": "a"},
+    )
+    task_b = await client.post(
+        "/api/runtime/agent-tasks",
+        json={"title": "Handoff Filter B", "input": "x", "assigned_agent": "b"},
+    )
+    task_a_id = task_a.json()["task_id"]
+    task_b_id = task_b.json()["task_id"]
+
+    handoff_a = await client.post(
+        f"/api/runtime/agent-tasks/{task_a_id}/handoffs",
+        json={"target_agent": "review-agent", "reason": "review this"},
+    )
+    handoff_b = await client.post(
+        f"/api/runtime/agent-tasks/{task_b_id}/handoffs",
+        json={"target_agent": "qa-agent", "reason": "qa this"},
+    )
+    assert handoff_a.status_code == 200, handoff_a.text
+    assert handoff_b.status_code == 200, handoff_b.text
+    handoff_a_id = handoff_a.json()["handoff_id"]
+
+    await client.post(f"/api/runtime/agent-handoffs/{handoff_a_id}/accept")
+
+    task_filter = await client.get(
+        f"/api/runtime/agent-handoffs?task_id={task_a_id}&limit=20",
+    )
+    assert task_filter.status_code == 200, task_filter.text
+    assert [item["task_id"] for item in task_filter.json()] == [task_a_id]
+
+    status_filter = await client.get(
+        "/api/runtime/agent-handoffs?status=accepted&limit=20",
+    )
+    assert status_filter.status_code == 200, status_filter.text
+    assert any(item["handoff_id"] == handoff_a_id for item in status_filter.json())
+    assert all(item["status"] == "accepted" for item in status_filter.json())
+
+    target_filter = await client.get(
+        "/api/runtime/agent-handoffs?target_agent=qa-agent&limit=1",
+    )
+    assert target_filter.status_code == 200, target_filter.text
+    target_handoffs = target_filter.json()
+    assert len(target_handoffs) == 1
+    assert target_handoffs[0]["target_agent"] == "qa-agent"
+
+
+@pytest.mark.asyncio
 async def test_api_handoff_status_transitions(client: httpx.AsyncClient) -> None:
     create_response = await client.post(
         "/api/runtime/agent-tasks",
@@ -315,6 +364,14 @@ async def test_api_handoff_status_transitions(client: httpx.AsyncClient) -> None
     handoff_run = next(item for item in runs if item["source_id"] == handoff_id)
     assert handoff_run["status"] == "completed"
     assert handoff_run["metadata"]["handoff_status"] == "completed"
+
+    list_response = await client.get(
+        f"/api/runtime/agent-handoffs?task_id={task_id}&status=completed",
+    )
+    assert list_response.status_code == 200, list_response.text
+    listed = list_response.json()
+    assert any(item["handoff_id"] == handoff_id for item in listed)
+    assert all(item["status"] == "completed" for item in listed)
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_xpert_runtime_run_registry.py
+++ b/server/tests/test_xpert_runtime_run_registry.py
@@ -59,6 +59,30 @@ async def test_run_registry_list_filters_and_limit() -> None:
 
 
 @pytest.mark.asyncio
+async def test_run_registry_filters_by_parent_and_source() -> None:
+    registry = RunRegistry()
+    parent = await registry.create_run("workflow", "Parent", status="running")
+    child = await registry.create_run(
+        "agent_handoff",
+        "Child handoff",
+        parent_run_id=parent.run_id,
+        source_id="handoff-filter-source",
+    )
+    await registry.create_run(
+        "agent_task",
+        "Other child",
+        parent_run_id="other-parent",
+        source_id="other-source",
+    )
+
+    children = await registry.list_runs(parent_run_id=parent.run_id)
+    assert [run.run_id for run in children] == [child.run_id]
+
+    source_runs = await registry.list_runs(source_id="handoff-filter-source")
+    assert [run.run_id for run in source_runs] == [child.run_id]
+
+
+@pytest.mark.asyncio
 async def test_run_registry_cancel_run_updates_status() -> None:
     registry = RunRegistry()
     run = await registry.create_run("agent_handoff", "handoff", status="pending")
@@ -102,3 +126,44 @@ async def test_runtime_run_api_list_and_cancel(client: httpx.AsyncClient) -> Non
     cancelled = cancel_response.json()
     assert cancelled["status"] == "cancelled"
     assert cancelled["error"] == "api test"
+
+
+@pytest.mark.asyncio
+async def test_runtime_run_api_filters_parent_and_source(
+    client: httpx.AsyncClient,
+) -> None:
+    from server.main import run_registry
+
+    parent = await run_registry.create_run(
+        "workflow",
+        "API parent workflow",
+        status="running",
+        source_id="api-parent-workflow",
+    )
+    child = await run_registry.create_run(
+        "agent_task",
+        "API child task",
+        parent_run_id=parent.run_id,
+        source_id="api-child-source",
+    )
+    await run_registry.create_run(
+        "agent_handoff",
+        "API unrelated handoff",
+        parent_run_id="different-parent",
+        source_id="api-unrelated-source",
+    )
+
+    parent_response = await client.get(
+        f"/api/runtime/runs?parent_run_id={parent.run_id}&limit=20",
+    )
+    assert parent_response.status_code == 200, parent_response.text
+    parent_runs = parent_response.json()
+    assert any(item["run_id"] == child.run_id for item in parent_runs)
+    assert all(item["parent_run_id"] == parent.run_id for item in parent_runs)
+
+    source_response = await client.get(
+        "/api/runtime/runs?source_id=api-child-source&limit=20",
+    )
+    assert source_response.status_code == 200, source_response.text
+    source_runs = source_response.json()
+    assert [item["run_id"] for item in source_runs] == [child.run_id]

--- a/server/xpert_runtime/run_registry.py
+++ b/server/xpert_runtime/run_registry.py
@@ -69,6 +69,8 @@ class RunRegistry:
         *,
         run_type: RuntimeRunType | None = None,
         status: RuntimeRunStatus | None = None,
+        parent_run_id: str | None = None,
+        source_id: str | None = None,
         limit: int = 50,
     ) -> list[RuntimeRun]:
         async with self._lock:
@@ -77,6 +79,10 @@ class RunRegistry:
             runs = [run for run in runs if run.run_type == run_type]
         if status is not None:
             runs = [run for run in runs if run.status == status]
+        if parent_run_id is not None:
+            runs = [run for run in runs if run.parent_run_id == parent_run_id]
+        if source_id is not None:
+            runs = [run for run in runs if run.source_id == source_id]
         runs.sort(key=lambda run: run.created_at, reverse=True)
         return runs[: max(1, limit)]
 


### PR DESCRIPTION
## Summary
- 扩展 RunRegistry 查询，支持 parent_run_id/source_id 过滤，便于 workflow 运行观测读取子 run。
- 新增 GET /api/runtime/agent-handoffs 列表 API，支持 task/status/target/limit 过滤。
- WorkflowRun 运行观测展示 workflow run 的 agent_task / agent_handoff 子 run。
- MetaAgent 任务工作台展示任务 handoff 记录，并新增 Handoff Inbox Beta，可手动 accept/reject/complete。
- 更新 Xpert 对齐、workflow-native 和 MetaAgent 文档。

## Boundaries
- 不做真实多 Agent 调度、队列分派、数据库持久化或目标 Agent 自动执行。
- 不改变 SSE 协议、节点数据结构或现有 handoff 状态 API。
- 未提交 package.json、package-lock.json、模镜.apk 等无关未跟踪文件。

## Verification
- npm.cmd run build
- py_compile: server/main.py server/xpert_runtime/run_registry.py server/xpert_runtime/agent_tasks.py server/workflow_native/schemas.py server/workflow_native/validate.py
- docker compose -p modelmirror up -d --build --force-recreate
- curl http://localhost:8000/api/health
- docker pytest: /app/server/tests/test_xpert_runtime_agent_tasks.py -q (18 passed)
- docker pytest: /app/server/tests/test_xpert_runtime_run_registry.py -q (7 passed)
- docker pytest: /app/server/tests/test_workflow_agent_task_node.py -q (2 passed)
- docker full pytest: /app/server/tests/ -q (130 passed)
