### PR TITLE
feature: 增强 Handoff Queue 并添加工作流智能体节点

### DIFF
--- a/client/src/components/workflow/NodePalette.tsx
+++ b/client/src/components/workflow/NodePalette.tsx
@@ -93,6 +93,12 @@ const paletteItems: PaletteItem[] = [
     description: "模型驱动的任务执行节点，支持工具循环和直接回答两种模式。",
   },
   {
+    kind: "workflow_agent",
+    icon: "🧭",
+    title: "工作流智能体",
+    description: "用角色提示词执行一个模型驱动的 Agent 步骤，并写入输出变量。",
+  },
+  {
     kind: "agent_task",
     icon: "▣",
     title: "智能体任务",

--- a/client/src/components/workflow/WorkflowEditor.tsx
+++ b/client/src/components/workflow/WorkflowEditor.tsx
@@ -276,6 +276,19 @@ function createNodeData(
     };
   }
 
+  if (kind === "workflow_agent") {
+    return {
+      kind,
+      title: "工作流智能体",
+      description: "模型驱动的单步智能体执行节点。",
+      agentName: "workflow-agent",
+      modelId: "deepseek/deepseek-chat",
+      rolePrompt: "你是负责执行当前工作流步骤的智能体，请直接输出结果。",
+      taskInput: "{{user_input}}",
+      outputVariable: "agent_output",
+    };
+  }
+
   if (kind === "agent_task") {
     return {
       kind,
@@ -1163,6 +1176,62 @@ function NodeConfig({ node, onChange }: NodeConfigProps) {
               onChange={(event) => update({ promptSuffix: event.target.value })}
               placeholder="可加入输出格式、语气或额外约束。"
               value={data.promptSuffix ?? ""}
+            />
+          </Field>
+          <Field label="输出变量">
+            <input
+              className={textInputClass()}
+              onChange={(event) => update({ outputVariable: event.target.value })}
+              value={data.outputVariable ?? ""}
+            />
+          </Field>
+        </>
+      ) : null}
+
+      {data.kind === "workflow_agent" ? (
+        <>
+          <div className="rounded-lg border border-cyan-300/25 bg-cyan-300/10 px-3 py-2 text-xs leading-5 text-cyan-50">
+            该节点会以角色提示词调用模型执行一个工作流步骤，并将结果写入输出变量；当前不接工具和真实多智能体调度。
+          </div>
+          <Field label="智能体名称">
+            <input
+              className={textInputClass()}
+              onChange={(event) => update({ agentName: event.target.value })}
+              value={data.agentName ?? ""}
+            />
+          </Field>
+          <Field label="调用模型">
+            <select
+              className={textInputClass()}
+              onChange={(event) => update({ modelId: event.target.value })}
+              value={data.modelId ?? ""}
+            >
+              <option className="bg-slate-950" value="">
+                请选择模型
+              </option>
+              {models.map((model) => (
+                <option
+                  className="bg-slate-950 text-white"
+                  key={model.id}
+                  value={model.id}
+                >
+                  {model.name}
+                </option>
+              ))}
+            </select>
+          </Field>
+          <Field label="角色提示词（支持 {{变量}}）">
+            <textarea
+              className={`${textInputClass()} min-h-32 resize-none leading-6`}
+              onChange={(event) => update({ rolePrompt: event.target.value })}
+              value={data.rolePrompt ?? ""}
+            />
+          </Field>
+          <Field label="任务输入（支持 {{变量}}）">
+            <textarea
+              className={`${textInputClass()} min-h-32 resize-none leading-6`}
+              onChange={(event) => update({ taskInput: event.target.value })}
+              value={data.taskInput ?? ""}
             />
           </Field>
           <Field label="输出变量">

--- a/client/src/components/workflow/WorkflowNodeCard.tsx
+++ b/client/src/components/workflow/WorkflowNodeCard.tsx
@@ -93,6 +93,13 @@ const nodeMeta = {
     bg: "bg-violet-400/10",
     text: "text-violet-100",
   },
+  workflow_agent: {
+    icon: "🧭",
+    label: "工作流智能体",
+    border: "border-cyan-300/40",
+    bg: "bg-cyan-300/10",
+    text: "text-cyan-100",
+  },
   agent_task: {
     icon: "▣",
     label: "Agent Task",
@@ -190,6 +197,9 @@ function outputName(data: WorkflowNode["data"]) {
   }
   if (data.kind === "agent") {
     return `🤖 ${data.agentMode ?? "tool_first"} → ${data.outputVariable ?? "agent_output"}`;
+  }
+  if (data.kind === "workflow_agent") {
+    return `${data.agentName ?? "workflow-agent"} · ${data.modelId ?? "model"} → ${data.outputVariable ?? "agent_output"}`;
   }
   if (data.kind === "agent_task") {
     return `${data.assignedAgent ?? "workflow-planner"} → ${data.outputVariable ?? "agent_task_id"}`;

--- a/client/src/components/workflow/WorkflowRun.tsx
+++ b/client/src/components/workflow/WorkflowRun.tsx
@@ -676,6 +676,16 @@ export default function WorkflowRun({
                               run.metadata,
                               "target_agent",
                             );
+                            const acceptedBy = runMetadataText(
+                              run.metadata,
+                              "accepted_by",
+                            );
+                            const completedBy = runMetadataText(
+                              run.metadata,
+                              "completed_by",
+                            );
+                            const result = runMetadataText(run.metadata, "result");
+                            const handler = completedBy || acceptedBy;
                             return (
                               <div
                                 className="rounded-md bg-slate-950/35 px-2 py-1.5"
@@ -695,6 +705,13 @@ export default function WorkflowRun({
                                   {agentTaskId ? ` · task=${agentTaskId}` : ""}
                                   {handoffId ? ` · handoff=${handoffId}` : ""}
                                 </p>
+                                {handler || result ? (
+                                  <p className="mt-1 truncate text-[11px] text-slate-500">
+                                    {handler ? `handler=${handler}` : ""}
+                                    {handler && result ? " 路 " : ""}
+                                    {result ? `result=${result}` : ""}
+                                  </p>
+                                ) : null}
                               </div>
                             );
                           })}

--- a/client/src/pages/MetaAgentPage.tsx
+++ b/client/src/pages/MetaAgentPage.tsx
@@ -196,6 +196,18 @@ function handoffStatusClass(status: string) {
   return "border-hire-300/25 bg-hire-300/10 text-hire-100";
 }
 
+function handoffMetaText(handoff: AgentHandoffSummary, key: string) {
+  const value = handoff.metadata?.[key];
+  if (typeof value === "string" && value.trim()) return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  return "";
+}
+
+function handoffMetaTime(handoff: AgentHandoffSummary, key: string) {
+  const value = handoff.metadata?.[key];
+  return typeof value === "number" ? formatTaskTime(value) : "";
+}
+
 function nodeColor(node: WorkflowNode) {
   const data = node.data as WorkflowNodeData;
   if (data.kind === "input") return "rgba(16,185,129,0.92)";
@@ -309,6 +321,13 @@ export default function MetaAgentPage() {
   const [handoffInbox, setHandoffInbox] = useState<AgentHandoffSummary[]>([]);
   const [handoffError, setHandoffError] = useState("");
   const [handoffActionId, setHandoffActionId] = useState<string | null>(null);
+  const [handoffStatusFilter, setHandoffStatusFilter] = useState("all");
+  const [handoffTargetFilter, setHandoffTargetFilter] = useState("");
+  const [handoffCompleteDrafts, setHandoffCompleteDrafts] = useState<
+    Record<string, string>
+  >({});
+  const [expandedCompleteHandoffId, setExpandedCompleteHandoffId] =
+    useState<string | null>(null);
 
   useEffect(() => {
     document.title = "模镜 - 元智能体工作台";
@@ -343,7 +362,15 @@ export default function MetaAgentPage() {
 
   async function loadHandoffInbox() {
     try {
-      const response = await fetch("/api/runtime/agent-handoffs?limit=20");
+      const params = new URLSearchParams({ limit: "20" });
+      if (handoffStatusFilter !== "all") {
+        params.set("status", handoffStatusFilter);
+      }
+      const targetFilter = handoffTargetFilter.trim();
+      if (targetFilter) {
+        params.set("target_agent", targetFilter);
+      }
+      const response = await fetch(`/api/runtime/agent-handoffs?${params}`);
       const payload = (await response.json().catch(() => null)) as
         | AgentHandoffSummary[]
         | { error?: string; detail?: unknown }
@@ -479,12 +506,22 @@ export default function MetaAgentPage() {
   ) {
     setHandoffActionId(handoff.handoff_id);
     try {
+      const operator = "meta-agent-operator";
+      const completionResult =
+        handoffCompleteDrafts[handoff.handoff_id]?.trim() ||
+        "Completed in MetaAgent handoff inbox.";
       const body =
         action === "reject"
-          ? { reason: "Rejected in MetaAgent handoff inbox." }
+          ? {
+              rejected_by: operator,
+              reason: "Rejected in MetaAgent handoff inbox.",
+            }
           : action === "complete"
-            ? { result: "Completed in MetaAgent handoff inbox." }
-            : {};
+            ? {
+                completed_by: operator,
+                result: completionResult,
+              }
+            : { accepted_by: operator };
       const response = await fetch(
         `/api/runtime/agent-handoffs/${handoff.handoff_id}/${action}`,
         {
@@ -505,6 +542,7 @@ export default function MetaAgentPage() {
       if (selectedTask?.task_id) {
         await loadAgentTask(selectedTask.task_id);
       }
+      setExpandedCompleteHandoffId(null);
     } catch (handoffActionError) {
       setHandoffError(
         handoffActionError instanceof Error
@@ -541,6 +579,52 @@ export default function MetaAgentPage() {
       );
     }
     if (handoff.status === "accepted") {
+      const expanded = expandedCompleteHandoffId === handoff.handoff_id;
+      return (
+        <div className="mt-2 space-y-2">
+          {expanded ? (
+            <textarea
+              className="min-h-16 w-full resize-none rounded-md border border-white/10 bg-slate-950/35 px-2 py-1.5 text-[11px] leading-5 text-slate-200 outline-none transition placeholder:text-slate-500 focus:border-emerald-300/45 focus:ring-2 focus:ring-emerald-300/10"
+              onChange={(event) =>
+                setHandoffCompleteDrafts((current) => ({
+                  ...current,
+                  [handoff.handoff_id]: event.target.value,
+                }))
+              }
+              placeholder="填写完成结果摘要"
+              value={handoffCompleteDrafts[handoff.handoff_id] ?? ""}
+            />
+          ) : null}
+          <div className="flex gap-2">
+            <button
+              className="rounded-full border border-emerald-300/25 bg-emerald-300/10 px-2.5 py-1 text-[11px] font-semibold text-emerald-100 transition hover:bg-emerald-300/15 disabled:opacity-50"
+              disabled={busy}
+              onClick={() => {
+                if (!expanded) {
+                  setExpandedCompleteHandoffId(handoff.handoff_id);
+                  return;
+                }
+                void updateHandoffStatus(handoff, "complete");
+              }}
+              type="button"
+            >
+              {expanded ? "提交完成" : "填写结果"}
+            </button>
+            {expanded ? (
+              <button
+                className="rounded-full border border-white/10 bg-white/[0.045] px-2.5 py-1 text-[11px] font-semibold text-slate-300 transition hover:bg-white/[0.07] disabled:opacity-50"
+                disabled={busy}
+                onClick={() => setExpandedCompleteHandoffId(null)}
+                type="button"
+              >
+                收起
+              </button>
+            ) : null}
+          </div>
+        </div>
+      );
+    }
+    if (false && handoff.status === "accepted") {
       return (
         <button
           className="mt-2 rounded-full border border-emerald-300/25 bg-emerald-300/10 px-2.5 py-1 text-[11px] font-semibold text-emerald-100 transition hover:bg-emerald-300/15 disabled:opacity-50"
@@ -553,6 +637,30 @@ export default function MetaAgentPage() {
       );
     }
     return null;
+  }
+
+  function renderHandoffMetaSummary(handoff: AgentHandoffSummary) {
+    const acceptedBy = handoffMetaText(handoff, "accepted_by");
+    const rejectedBy = handoffMetaText(handoff, "rejected_by");
+    const completedBy = handoffMetaText(handoff, "completed_by");
+    const result = handoffMetaText(handoff, "result");
+    const reason = handoffMetaText(handoff, "reason");
+    const time =
+      handoffMetaTime(handoff, "completed_at") ||
+      handoffMetaTime(handoff, "rejected_at") ||
+      handoffMetaTime(handoff, "accepted_at");
+    const handler = completedBy || rejectedBy || acceptedBy;
+    if (!handler && !result && !reason && !time) return null;
+    return (
+      <div className="mt-2 rounded-md border border-white/10 bg-slate-950/25 px-2 py-1.5 text-[11px] leading-5 text-slate-400">
+        {handler ? <p>处理者：{handler}</p> : null}
+        {time ? <p>处理时间：{time}</p> : null}
+        {result ? <p className="line-clamp-2">结果：{result}</p> : null}
+        {reason && handoff.status === "rejected" ? (
+          <p className="line-clamp-2">原因：{reason}</p>
+        ) : null}
+      </div>
+    );
   }
 
   async function generateWorkflow() {
@@ -927,6 +1035,7 @@ export default function MetaAgentPage() {
                           <p className="mt-1 line-clamp-2 text-[11px] leading-5 text-slate-500">
                             {handoff.reason}
                           </p>
+                          {renderHandoffMetaSummary(handoff)}
                           {renderHandoffActions(handoff)}
                         </div>
                       ))}
@@ -971,6 +1080,32 @@ export default function MetaAgentPage() {
                 刷新
               </button>
             </div>
+            <div className="mt-3 grid grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)_auto] gap-2">
+              <select
+                className="h-9 rounded-md border border-white/10 bg-slate-950/45 px-2 text-xs text-slate-200 outline-none transition focus:border-hire-300/45 focus:ring-2 focus:ring-hire-300/10"
+                onChange={(event) => setHandoffStatusFilter(event.target.value)}
+                value={handoffStatusFilter}
+              >
+                <option value="all">全部状态</option>
+                <option value="pending">待处理</option>
+                <option value="accepted">已接受</option>
+                <option value="rejected">已拒绝</option>
+                <option value="completed">已完成</option>
+              </select>
+              <input
+                className="h-9 rounded-md border border-white/10 bg-slate-950/45 px-2 text-xs text-slate-200 outline-none transition placeholder:text-slate-500 focus:border-hire-300/45 focus:ring-2 focus:ring-hire-300/10"
+                onChange={(event) => setHandoffTargetFilter(event.target.value)}
+                placeholder="target agent"
+                value={handoffTargetFilter}
+              />
+              <button
+                className="h-9 rounded-md border border-white/10 bg-white/[0.055] px-3 text-xs font-semibold text-slate-300 transition hover:border-hire-300/35 hover:text-hire-100"
+                onClick={() => void loadHandoffInbox()}
+                type="button"
+              >
+                应用
+              </button>
+            </div>
             <div className="mt-3 max-h-64 space-y-2 overflow-y-auto pr-1">
               {handoffInbox.length === 0 ? (
                 <p className="rounded-lg border border-dashed border-white/15 bg-white/[0.025] px-3 py-3 text-xs leading-5 text-slate-400">
@@ -1002,6 +1137,7 @@ export default function MetaAgentPage() {
                     <p className="mt-2 line-clamp-2 text-xs leading-5 text-slate-400">
                       {handoff.reason}
                     </p>
+                    {renderHandoffMetaSummary(handoff)}
                     <p className="mt-1 break-all text-[11px] text-slate-500">
                       task: {handoff.task_id}
                     </p>

--- a/client/src/types/workflow-native.ts
+++ b/client/src/types/workflow-native.ts
@@ -14,6 +14,7 @@ export type NativeNodeKind =
   | "human_intervention"
   | "question_classifier"
   | "agent"
+  | "workflow_agent"
   | "mcp_tool"
   | "time_tool"
   | "http_request"

--- a/client/src/types/workflow.ts
+++ b/client/src/types/workflow.ts
@@ -15,6 +15,7 @@ export type WorkflowNodeKind =
   | "human_intervention"
   | "question_classifier"
   | "agent"
+  | "workflow_agent"
   | "agent_task"
   | "agent_handoff"
   | "mcp_tool"
@@ -64,7 +65,9 @@ export interface WorkflowNodeData extends Record<string, unknown> {
   caseSensitive?: string;
   useLlmFallback?: string;
   llmFallbackPrompt?: string;
+  agentName?: string;
   agentMode?: string;
+  rolePrompt?: string;
   taskTitle?: string;
   taskInput?: string;
   assignedAgent?: string;

--- a/docs/META_AGENT.md
+++ b/docs/META_AGENT.md
@@ -15,7 +15,7 @@
 - 后端生成接口：`POST /api/meta-agent/generate-workflow`。
 - 后端模块：`server/meta_agent/`。
 - 任务运行时：复用 `POST /api/runtime/agent-tasks`、`GET /api/runtime/agent-tasks`、`GET /api/runtime/agent-tasks/{task_id}`、`POST /api/runtime/agent-tasks/{task_id}/cancel`。
-- Handoff 观测：任务工作台会查询 `GET /api/runtime/agent-tasks/{task_id}/handoffs` 展示选中任务的移交记录，并通过 `GET /api/runtime/agent-handoffs?limit=20` 提供 Handoff Inbox Beta；pending 移交支持手动接受/拒绝，accepted 移交支持手动完成。
+- Handoff Inbox：任务工作台会查询 `GET /api/runtime/agent-tasks/{task_id}/handoffs` 展示选中任务的移交记录，并通过 `GET /api/runtime/agent-handoffs?status=&target_agent=&limit=20` 提供 Handoff Inbox Beta；pending 移交支持手动接受/拒绝，accepted 移交支持填写完成结果并提交。
 - 输出目标：生成 `WorkflowDefinition`，可导入经典自研画布并通过 `/api/workflow/run` 执行。
 - 校验路径：生成后的工作流会调用 `workflow_native.validate_workflow_graph` 做静态校验。
 
@@ -24,7 +24,7 @@
 - planner、schema 和 prompt 放在 `server/meta_agent/`，不要继续堆进 `server/main.py`。
 - 生成接口依赖模型网关；测试必须 mock `collect_chat_completion_text`，不能请求真实模型。
 - 前端负责提交目标、展示任务拆解、创建 AgentTask 记录、展示任务工作台和导入经典画布。
-- 当前只做任务可见、取消、handoff 观测和手动状态操作，不做队列分派、专家协作、自动执行或持久化调度。
+- 当前只做任务可见、取消、handoff 观测、筛选和人工处理状态记录，不做真实队列分派、专家协作、自动执行、登录用户权限或持久化调度。
 - Docker 镜像必须复制 `server/meta_agent/`，否则 `server/main.py` 导入会失败。
 
 ## 请求示例

--- a/docs/XPERT_ALIGNMENT.md
+++ b/docs/XPERT_ALIGNMENT.md
@@ -1,14 +1,18 @@
 # Xpert 对齐总纲
 
+> 2026-07-06 状态补充：Workflow Agent 节点已进入“部分实现”。Classic workflow 现在可拖入 `workflow_agent` 节点，用角色提示词和任务输入调用模型，输出结果到变量，并登记 `workflow_agent` 子 run。当前仍是单步模型执行，不接工具调用、Handoff 自动调度或真实多 Agent 协作。
+
+> 2026-07-06 状态补充：Handoff Queue 已进入“部分实现”。Handoff metadata 现在记录 accepted/rejected/completed 的处理者、时间和结果/原因；MetaAgent Handoff Inbox 支持按状态和目标 Agent 筛选，并可填写完成结果。当前仍是内存态人工处理闭环，不做真实调度、worker 队列或持久化。
+
 > 2026-07-06 状态补充：Handoff 前端观测已进入“部分实现”。Workflow 运行观测可以按 `parent_run_id` 拉取 `agent_task` / `agent_handoff` 子 run；MetaAgent 任务工作台可以查看任务 handoff 记录，并通过 Handoff Inbox Beta 手动 accept / reject / complete。当前仍不做真实多 Agent 调度、队列分派、数据库持久化或目标 Agent 自动执行。
 
 > 2026-07-05 状态补充：RunRegistry 已进入最小可观测闭环阶段，详见文末“RunRegistry 最小可观测闭环”。
 
 ## 2026-07-05 增量：RunRegistry 最小可观测闭环
 
-RunRegistry 已从“下一步”进入“部分实现”。当前新增 `server/xpert_runtime/run_registry.py`，提供内存态 `RuntimeRun` 与 `RunRegistry`，统一登记 `workflow`、`agent_task`、`agent_handoff` 三类 run，支持创建、查询、过滤列表、状态更新和取消。
+RunRegistry 已从“下一步”进入“部分实现”。当前新增 `server/xpert_runtime/run_registry.py`，提供内存态 `RuntimeRun` 与 `RunRegistry`，统一登记 `workflow`、`workflow_agent`、`agent_task`、`agent_handoff` 四类 run，支持创建、查询、过滤列表、状态更新和取消。
 
-Classic workflow 运行时会创建 workflow run，并在 `workflow_meta` / `workflow_end` SSE 中携带 `run_id`；`agent_task` 节点创建任务时登记 agent_task run；`agent_handoff` 节点创建移交时登记 agent_handoff run。Run 之间通过 `parent_run_id` 和 metadata 关联，不强行合并现有 workflow `task_id`，避免破坏既有 SSE、status 和 resume 协议。
+Classic workflow 运行时会创建 workflow run，并在 `workflow_meta` / `workflow_end` SSE 中携带 `run_id`；`workflow_agent` 节点执行模型智能体步骤时登记 workflow_agent run；`agent_task` 节点创建任务时登记 agent_task run；`agent_handoff` 节点创建移交时登记 agent_handoff run。Run 之间通过 `parent_run_id` 和 metadata 关联，不强行合并现有 workflow `task_id`，避免破坏既有 SSE、status 和 resume 协议。
 
 新增 API：
 
@@ -32,8 +36,8 @@ EvoAgentX 只保留为历史参考：此前元智能体曾借鉴其 `goal -> sub
 | 能力域 | Xpert 对齐目标 | 当前状态 | 下一步 |
 | --- | --- | --- | --- |
 | Runtime / Execution | 中间件生命周期、任务注册、事件记录、运行观测 | 部分实现 | 建立 Handoff / RunRegistry 闭环 |
-| Agent / Handoff | AgentTask、任务移交、子 Agent、主管-专家协作 | 部分实现 | 增加 workflow handoff 节点与 handoff 观测 |
-| Workflow | Xpert 节点类型、Agent 节点、工具节点、知识流水线节点 | 部分实现 | 扩展 handoff、subflow、task 类节点 |
+| Agent / Handoff | AgentTask、任务移交、子 Agent、主管-专家协作 | 部分实现 | 将 workflow_agent 接入工具与 Handoff 编排 |
+| Workflow | Xpert 节点类型、Agent 节点、工具节点、知识流水线节点 | 部分实现 | 扩展 workflow_agent toolset、subflow、知识类节点 |
 | Toolset / MCP | 统一 Toolset Provider、权限、审计、偏好 | 部分实现 | 将聊天 Agent 和工作流 Agent 统一接入 toolset capability |
 | Knowledge Pipeline | FileAsset、Artifact、Chunk、CitationAnchor、Embedding | 待实现 | 从本地 RAG 元数据模型开始拆分 |
 | Claw / Skill | 用户偏好、工作区 Skill、会话临时选择 | 待实现 | 在 Xpert workspace / skill 抽象稳定后接入 |
@@ -47,15 +51,16 @@ EvoAgentX 只保留为历史参考：此前元智能体曾借鉴其 `goal -> sub
 - Toolset / MCP：`mcp_tool` 已通过 `MCPToolsetProvider`、`CapabilityRegistry`、`run_tool_with_runtime` 调用工具。
 - Tool Policy / Audit：`tool_policy` 可影响 workflow 内 MCP 工具调用，`InMemoryToolAuditStore` 提供最小审计记录。
 - Runtime Middleware Node：前端可拖入 `runtime_middleware` 节点，`system_prompt_injector`、`tool_policy`、`event_recorder`、`tool_audit` 已逐步进入真实执行或可见状态。
+- Workflow Agent Node：classic workflow 可拖入 `workflow_agent` 节点，使用 `rolePrompt` 作为该节点 system prompt、`taskInput` 作为用户输入调用模型，结果写入 `outputVariable`，并登记 `workflow_agent` 子 run。
 - Agent Task Runtime：已提供 `AgentTaskStore`、最小 AgentTask API、MetaAgent 任务工作台，以及 classic workflow `agent_task` 节点；该节点当前负责创建任务并输出 `task_id`，暂不做真实多 Agent 调度。
 - Handoff API：已提供 handoff 创建、按任务查询、接受、拒绝、完成的内存态 API，状态转移限定为 `pending -> accepted/rejected`、`accepted -> completed`，并写入 `agent.handoff.created/accepted/rejected/completed` runtime events。
 - 运行观测：classic workflow 可查询 per-task runtime events 和 tool audit records，前端 `WorkflowRun` 已提供“运行观测”折叠区。
 
 ## 近期交付顺序
 
-1. **Workflow Handoff 节点**：新增 `agent_handoff` 或扩展 `agent_task`，让工作流可显式发起 Agent 间移交。
-2. **RunRegistry 雏形**：为 workflow / agent task / handoff 建立统一运行记录、状态、取消和死信视图。
-3. **Handoff 前端观测**：在 MetaAgent / workflow 运行观测中展示 handoff 状态与事件。
+1. **Workflow Agent Toolset**：让 `workflow_agent` 可选择 MCP Toolset，复用 tool policy / audit。
+2. **RunRegistry Trace 增强**：补齐 workflow_agent / handoff 的 trace、checkpoint、失败摘要与重试入口。
+3. **Handoff 自动编排雏形**：将 workflow_agent 输出与 handoff queue 连接，但仍保持人工可控。
 4. **知识流水线底座**：拆分本地 RAG 的文件元数据，建立 FileAsset -> Artifact -> Chunk -> CitationAnchor 的最小模型。
 
 ## 源码与协议策略

--- a/docs/workflow-native-design.md
+++ b/docs/workflow-native-design.md
@@ -1,12 +1,16 @@
 # workflow-native 自研工作流设计
 
+> 2026-07-06 状态补充：classic workflow 新增 `workflow_agent` 节点。该节点使用 `rolePrompt` 作为该节点 system prompt、`taskInput` 作为用户输入调用模型，流式输出结果并写入 `outputVariable`，同时登记 `workflow_agent` 子 run。当前是单步模型智能体执行，不接 MCP 工具、Handoff 自动调度或真实多 Agent 协作。
+
+> 2026-07-06 状态补充：Handoff Queue 进入人工处理闭环。`accept/reject/complete` 会记录处理者、处理时间和结果/原因摘要，并同步到 `agent_handoff` run metadata；`WorkflowRun` 子 run 摘要会展示 handler/result。当前不做自动调度、目标 Agent 执行、持久化队列或权限系统。
+
 > 2026-07-06 状态补充：Handoff 观测前端进入最小闭环。`GET /api/runtime/runs` 支持按 `parent_run_id` / `source_id` 查询，`WorkflowRun` 的“运行观测”可展示 workflow 下的 `agent_task` 与 `agent_handoff` 子 run；新增 `GET /api/runtime/agent-handoffs?task_id=&status=&target_agent=&limit=` 供 MetaAgent Handoff Inbox 查询。当前只做观测和手动状态操作，不做真实调度、队列或持久化。
 
 > 2026-07-05 状态补充：classic workflow 已接入 RunRegistry 最小可观测闭环，并恢复 `/workflow` 画布的节点库浮层与配置/运行 tabs 布局。
 
 ## 2026-07-05 增量：RunRegistry 与工作流运行观测
 
-Classic workflow 每次运行会登记一条 `workflow` run，并在 `workflow_meta` / `workflow_end` SSE 中携带 `run_id`。`agent_task` 节点创建 AgentTask 时同步登记 `agent_task` run；`agent_handoff` 节点创建 Handoff 时同步登记 `agent_handoff` run。三类 run 通过 `parent_run_id` 与 metadata 互相关联，保留现有 workflow `task_id`、AgentTask `task_id` 与 Handoff `handoff_id` 协议不变。
+Classic workflow 每次运行会登记一条 `workflow` run，并在 `workflow_meta` / `workflow_end` SSE 中携带 `run_id`。`workflow_agent` 节点执行模型智能体步骤时同步登记 `workflow_agent` run；`agent_task` 节点创建 AgentTask 时同步登记 `agent_task` run；`agent_handoff` 节点创建 Handoff 时同步登记 `agent_handoff` run。四类 run 通过 `parent_run_id` 与 metadata 互相关联，保留现有 workflow `task_id`、AgentTask `task_id` 与 Handoff `handoff_id` 协议不变。
 
 新增 Runtime Run API 用于最小观测：
 
@@ -472,6 +476,8 @@ Agent Task Runtime 包含三层：
 后端已开放最小 API：`POST /api/runtime/agent-tasks` 创建任务，`GET /api/runtime/agent-tasks/{task_id}` 查询任务，`POST /api/runtime/agent-tasks/{task_id}/cancel` 取消任务，`GET /api/runtime/agent-tasks` 列出任务。Handoff 最小闭环也已开放：`POST /api/runtime/agent-tasks/{task_id}/handoffs` 创建移交，`GET /api/runtime/agent-tasks/{task_id}/handoffs` 查询任务下的移交记录，`POST /api/runtime/agent-handoffs/{handoff_id}/accept|reject|complete` 更新状态。状态转移限定为 `pending -> accepted/rejected` 与 `accepted -> completed`，非法转移返回 400；每次创建或状态变更会写入 `agent.handoff.created/accepted/rejected/completed` runtime events。当前不做真实多 Agent 编排、不接数据库、不接 Redis/Celery 队列；后续将继续扩展 workflow handoff 节点、handoff queue、agent selection、持久化与前端任务面板。
 
 classic workflow 已新增 `agent_task` 节点，作为 Xpert Agent/Handoff 对齐的第一步闭环。前端可从节点调色板拖入“智能体任务”，配置 `taskTitle`、`taskInput`、`assignedAgent` 与 `outputVariable`；运行时会渲染 `{{变量}}` 模板，调用 `AgentTaskStore.create_task(...)` 创建一条 AgentTask，并将新任务的 `task_id` 写入 `outputVariable`。该节点当前只负责创建任务和输出 ID，不做真实队列分派、专家协作或任务执行；完整任务详情继续通过现有 Agent Task API 查询。
+
+classic workflow 已新增 `workflow_agent` 节点，作为 Xpert Workflow Agent 的最小执行闭环。前端可从节点调色板拖入“工作流智能体”，配置 `agentName`、`modelId`、`rolePrompt`、`taskInput` 与 `outputVariable`；运行时会先渲染 `{{变量}}`，再以 `rolePrompt` 作为该节点 system prompt、`taskInput` 作为用户输入调用现有工作流 LLM 流式函数，最终把模型输出写入 `outputVariable`。该节点会登记 `workflow_agent` 子 run，便于运行观测查看；当前不接 MCP Toolset、不做 Handoff 自动调度、不实现真实多 Agent 协作。
 
 ## 2026-06-17 增量：Agent 节点
 

--- a/server/main.py
+++ b/server/main.py
@@ -418,6 +418,7 @@ WorkflowNodeType = Literal[
     "human_intervention",
     "question_classifier",
     "agent",
+    "workflow_agent",
     "agent_task",
     "agent_handoff",
     "mcp_tool",
@@ -1227,6 +1228,7 @@ def workflow_node_kind(node: WorkflowNodePayload) -> WorkflowNodeType:
         "human_intervention",
         "question_classifier",
         "agent",
+        "workflow_agent",
         "agent_task",
         "agent_handoff",
         "mcp_tool",
@@ -1788,7 +1790,7 @@ async def generate_meta_agent_workflow(
 async def run_workflow(payload: WorkflowRunRequest, request: Request):
     requires_model = any(
         (node.data.get("kind") if isinstance(node.data.get("kind"), str) else node.type)
-        == "llm"
+        in {"llm", "workflow_agent"}
         for node in payload.workflow.nodes
     )
     if requires_model and not get_llm_gateway_config()[0]:
@@ -2973,6 +2975,99 @@ async def run_workflow(payload: WorkflowRunRequest, request: Request):
                             }
                         )
 
+                elif kind == "workflow_agent":
+                    output_variable = str(
+                        node.data.get("outputVariable") or "agent_output"
+                    ).strip() or "agent_output"
+                    workflow_agent_run = None
+                    try:
+                        agent_name = str(
+                            node.data.get("agentName") or "workflow-agent"
+                        ).strip() or "workflow-agent"
+                        model_id = str(
+                            node.data.get("modelId") or TEXT_FALLBACK_MODEL
+                        ).strip() or TEXT_FALLBACK_MODEL
+                        role_prompt = render_workflow_template(
+                            str(node.data.get("rolePrompt") or ""),
+                            variables,
+                        ).strip()
+                        task_input = render_workflow_template(
+                            str(node.data.get("taskInput") or ""),
+                            variables,
+                        ).strip()
+                        if not role_prompt:
+                            raise ValueError("workflow_agent 缺少角色提示词。")
+                        if not task_input:
+                            raise ValueError("workflow_agent 缺少任务输入。")
+
+                        workflow_agent_run = await run_registry.create_run(
+                            "workflow_agent",
+                            agent_name,
+                            status="running",
+                            source_id=f"{task_id}:{node.id}",
+                            parent_run_id=workflow_run.run_id,
+                            metadata={
+                                "workflow_id": payload.workflow.id,
+                                "workflow_title": payload.workflow.title,
+                                "workflow_task_id": task_id,
+                                "node_id": node.id,
+                                "node_title": title,
+                                "agent_name": agent_name,
+                                "model_id": model_id,
+                                "output_variable": output_variable,
+                            },
+                        )
+
+                        async for delta in stream_workflow_llm_text(
+                            model_id,
+                            task_input,
+                            system_prompt=role_prompt,
+                        ):
+                            output += delta
+                            yield sse_payload(
+                                {
+                                    "event": "node_delta",
+                                    "node_id": node.id,
+                                    "node_title": title,
+                                    "node_type": kind,
+                                    "output": delta,
+                                    "variable": output_variable,
+                                    "run_id": workflow_agent_run.run_id,
+                                }
+                            )
+                        variables[output_variable] = output
+                        await run_registry.update_run(
+                            workflow_agent_run.run_id,
+                            status="completed",
+                            metadata={
+                                "output_length": len(output or ""),
+                                "variables_count": len(variables),
+                            },
+                        )
+                    except Exception as exc:
+                        logger.warning("Workflow workflow_agent node failed: %s", exc)
+                        output = ""
+                        variables[output_variable] = output
+                        if workflow_agent_run is not None:
+                            try:
+                                await run_registry.update_run(
+                                    workflow_agent_run.run_id,
+                                    status="failed",
+                                    error=str(exc),
+                                )
+                            except Exception:
+                                logger.warning(
+                                    "Failed to update workflow_agent run status",
+                                    exc_info=True,
+                                )
+                        yield sse_payload(
+                            {
+                                "event": "error",
+                                "node_id": node.id,
+                                "message": str(exc),
+                            }
+                        )
+
                 elif kind == "agent_task":
                     output_variable = str(
                         node.data.get("outputVariable") or "agent_task_id"
@@ -3658,7 +3753,7 @@ async def list_runtime_runs(
     source_id: str | None = None,
     limit: int = 50,
 ):
-    valid_run_types = {"workflow", "agent_task", "agent_handoff"}
+    valid_run_types = {"workflow", "workflow_agent", "agent_task", "agent_handoff"}
     valid_statuses = {"pending", "running", "completed", "failed", "cancelled"}
     if run_type is not None and run_type not in valid_run_types:
         raise HTTPException(status_code=400, detail="Invalid runtime run type.")
@@ -4268,7 +4363,9 @@ async def list_agent_tasks(status: str | None = None, limit: int = 50):
 async def list_agent_handoffs_global(
     task_id: str | None = None,
     status: str | None = None,
+    source_agent: str | None = None,
     target_agent: str | None = None,
+    created_after: float | None = None,
     limit: int = 50,
 ):
     valid_statuses = {"pending", "accepted", "rejected", "completed"}
@@ -4277,11 +4374,23 @@ async def list_agent_handoffs_global(
     handoffs = await agent_task_store.list_handoffs(task_id=task_id)
     if status is not None:
         handoffs = [handoff for handoff in handoffs if handoff.status == status]
+    if source_agent is not None:
+        handoffs = [
+            handoff
+            for handoff in handoffs
+            if handoff.source_agent == source_agent
+        ]
     if target_agent is not None:
         handoffs = [
             handoff
             for handoff in handoffs
             if handoff.target_agent == target_agent
+        ]
+    if created_after is not None:
+        handoffs = [
+            handoff
+            for handoff in handoffs
+            if handoff.created_at >= created_after
         ]
     capped_limit = max(1, min(limit, 200))
     return [agent_handoff_to_payload(handoff) for handoff in handoffs[:capped_limit]]
@@ -4377,12 +4486,46 @@ async def update_agent_handoff_api(
     if metadata is not None and not isinstance(metadata, dict):
         raise HTTPException(status_code=400, detail="Handoff metadata must be an object.")
     merged_metadata = dict(metadata or {})
+    operator = str(
+        (payload or {}).get("operator")
+        or (payload or {}).get("handled_by")
+        or (payload or {}).get("handledBy")
+        or ""
+    ).strip()
     reason = (payload or {}).get("reason")
     if reason is not None:
         merged_metadata["reason"] = str(reason)
     result = (payload or {}).get("result")
     if result is not None:
         merged_metadata["result"] = str(result)
+    now = time.time()
+    if status == "accepted":
+        accepted_by = str(
+            (payload or {}).get("accepted_by")
+            or (payload or {}).get("acceptedBy")
+            or operator
+            or "meta-agent-operator"
+        ).strip()
+        merged_metadata["accepted_by"] = accepted_by or "meta-agent-operator"
+        merged_metadata["accepted_at"] = now
+    elif status == "rejected":
+        rejected_by = str(
+            (payload or {}).get("rejected_by")
+            or (payload or {}).get("rejectedBy")
+            or operator
+            or "meta-agent-operator"
+        ).strip()
+        merged_metadata["rejected_by"] = rejected_by or "meta-agent-operator"
+        merged_metadata["rejected_at"] = now
+    elif status == "completed":
+        completed_by = str(
+            (payload or {}).get("completed_by")
+            or (payload or {}).get("completedBy")
+            or operator
+            or "meta-agent-operator"
+        ).strip()
+        merged_metadata["completed_by"] = completed_by or "meta-agent-operator"
+        merged_metadata["completed_at"] = now
     try:
         handoff = await agent_task_store.update_handoff_status(
             handoff_id,

--- a/server/tests/test_workflow_agent_task_node.py
+++ b/server/tests/test_workflow_agent_task_node.py
@@ -239,6 +239,116 @@ async def test_workflow_agent_handoff_node_creates_runtime_handoff_and_runs(
     )
 
 
+@pytest.mark.asyncio
+async def test_workflow_agent_node_streams_output_and_registers_run(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, str | None] = {}
+
+    async def fake_stream_workflow_llm_text(
+        model_id: str,
+        prompt: str,
+        *,
+        system_prompt: str | None = None,
+    ):
+        captured["model_id"] = model_id
+        captured["prompt"] = prompt
+        captured["system_prompt"] = system_prompt
+        yield "agent "
+        yield "result"
+
+    monkeypatch.setattr(
+        "server.main.get_llm_gateway_config",
+        lambda: ("http://test-gateway.local/v1/chat/completions", "test-key"),
+    )
+    monkeypatch.setattr(
+        "server.main.stream_workflow_llm_text",
+        fake_stream_workflow_llm_text,
+    )
+
+    workflow = {
+        "id": "workflow-agent-workflow",
+        "title": "workflow agent workflow",
+        "nodes": [
+            {
+                "id": "input",
+                "type": "input",
+                "data": {"kind": "input", "variableName": "user_input"},
+            },
+            {
+                "id": "workflow_agent",
+                "type": "workflow_agent",
+                "data": {
+                    "kind": "workflow_agent",
+                    "title": "Execute workflow agent",
+                    "agentName": "research-agent",
+                    "modelId": "deepseek/deepseek-chat",
+                    "rolePrompt": "你是研究智能体，任务来自 {{user_input}}。",
+                    "taskInput": "请处理：{{user_input}}",
+                    "outputVariable": "agent_output",
+                },
+            },
+            {
+                "id": "output",
+                "type": "output",
+                "data": {"kind": "output", "outputVariable": "agent_output"},
+            },
+        ],
+        "edges": [
+            {"id": "e1", "source": "input", "target": "workflow_agent"},
+            {"id": "e2", "source": "workflow_agent", "target": "output"},
+        ],
+    }
+
+    response = await client.post(
+        "/api/workflow/run",
+        json={
+            "workflow": workflow,
+            "inputs": {"user_input": "summarize handoff queue"},
+        },
+    )
+    assert response.status_code == 200, response.text
+
+    events = _parse_sse_events(response.text)
+    workflow_meta = next(event for event in events if event.get("event") == "workflow_meta")
+    workflow_run_id = workflow_meta.get("run_id")
+    assert isinstance(workflow_run_id, str)
+
+    deltas = [
+        event
+        for event in events
+        if event.get("event") == "node_delta" and event.get("node_id") == "workflow_agent"
+    ]
+    assert [event.get("output") for event in deltas] == ["agent ", "result"]
+
+    agent_end = next(
+        event
+        for event in events
+        if event.get("event") == "node_end" and event.get("node_id") == "workflow_agent"
+    )
+    assert agent_end["output"] == "agent result"
+    assert agent_end["variables"]["agent_output"] == "agent result"
+
+    assert captured["model_id"] == "deepseek/deepseek-chat"
+    assert captured["prompt"] == "请处理：summarize handoff queue"
+    assert captured["system_prompt"] == "你是研究智能体，任务来自 summarize handoff queue。"
+
+    agent_runs_response = await client.get(
+        "/api/runtime/runs?run_type=workflow_agent&limit=50",
+    )
+    assert agent_runs_response.status_code == 200, agent_runs_response.text
+    agent_runs = agent_runs_response.json()
+    agent_run = next(
+        item for item in agent_runs if item["source_id"].endswith(":workflow_agent")
+    )
+    assert agent_run["parent_run_id"] == workflow_run_id
+    assert agent_run["status"] == "completed"
+    assert agent_run["metadata"]["agent_name"] == "research-agent"
+    assert agent_run["metadata"]["model_id"] == "deepseek/deepseek-chat"
+    assert agent_run["metadata"]["output_variable"] == "agent_output"
+
+
 def _parse_sse_events(sse_text: str) -> list[dict]:
     events: list[dict] = []
     for line in sse_text.splitlines():

--- a/server/tests/test_workflow_native_validate.py
+++ b/server/tests/test_workflow_native_validate.py
@@ -1088,6 +1088,121 @@ async def test_agent_task_output_variable_is_available_downstream(
 
 
 @pytest.mark.asyncio
+async def test_validate_workflow_agent_node_ok(client: httpx.AsyncClient) -> None:
+    workflow = linear_workflow()
+    workflow["nodes"][1] = {
+        "id": "workflow_agent",
+        "type": "workflow_agent",
+        "data": {
+            "kind": "workflow_agent",
+            "agentName": "research-agent",
+            "modelId": "deepseek/deepseek-chat",
+            "rolePrompt": "你是研究智能体，输入来自 {{user_input}}。",
+            "taskInput": "请处理：{{user_input}}",
+            "outputVariable": "agent_output",
+        },
+    }
+    workflow["nodes"][2]["data"]["outputVariable"] = "agent_output"
+    workflow["edges"] = [
+        {"id": "e1", "source": "input", "target": "workflow_agent"},
+        {"id": "e2", "source": "workflow_agent", "target": "output"},
+    ]
+
+    data = await validate(client, workflow)
+
+    assert data["valid"] is True
+    assert data["issues"] == []
+
+
+@pytest.mark.asyncio
+async def test_workflow_agent_missing_required_fields(
+    client: httpx.AsyncClient,
+) -> None:
+    workflow = linear_workflow()
+    workflow["nodes"][1] = {
+        "id": "workflow_agent",
+        "type": "workflow_agent",
+        "data": {
+            "kind": "workflow_agent",
+            "agentName": "research-agent",
+            "modelId": "deepseek/deepseek-chat",
+            "rolePrompt": "你是研究智能体。",
+        },
+    }
+    workflow["nodes"][2]["data"]["outputVariable"] = "user_input"
+    workflow["edges"] = [
+        {"id": "e1", "source": "input", "target": "workflow_agent"},
+        {"id": "e2", "source": "workflow_agent", "target": "output"},
+    ]
+
+    data = await validate(client, workflow)
+
+    codes = issue_codes(data)
+    assert data["valid"] is False
+    assert "missing_workflow_agent_task_input" in codes
+    assert "missing_workflow_agent_output_variable" in codes
+
+
+@pytest.mark.asyncio
+async def test_workflow_agent_template_variable_must_be_declared(
+    client: httpx.AsyncClient,
+) -> None:
+    workflow = linear_workflow()
+    workflow["nodes"][1] = {
+        "id": "workflow_agent",
+        "type": "workflow_agent",
+        "data": {
+            "kind": "workflow_agent",
+            "agentName": "research-agent",
+            "modelId": "deepseek/deepseek-chat",
+            "rolePrompt": "你是研究智能体，引用 {{missing_role}}。",
+            "taskInput": "请处理：{{missing_task}}",
+            "outputVariable": "agent_output",
+        },
+    }
+    workflow["nodes"][2]["data"]["outputVariable"] = "agent_output"
+    workflow["edges"] = [
+        {"id": "e1", "source": "input", "target": "workflow_agent"},
+        {"id": "e2", "source": "workflow_agent", "target": "output"},
+    ]
+
+    data = await validate(client, workflow)
+
+    assert data["valid"] is False
+    codes = issue_codes(data)
+    assert "missing_workflow_agent_template_variable" in codes
+
+
+@pytest.mark.asyncio
+async def test_workflow_agent_output_variable_is_available_downstream(
+    client: httpx.AsyncClient,
+) -> None:
+    workflow = linear_workflow()
+    workflow["nodes"][1] = {
+        "id": "workflow_agent",
+        "type": "workflow_agent",
+        "data": {
+            "kind": "workflow_agent",
+            "agentName": "research-agent",
+            "modelId": "deepseek/deepseek-chat",
+            "rolePrompt": "你是研究智能体。",
+            "taskInput": "{{user_input}}",
+            "outputVariable": "agent_output",
+        },
+    }
+    workflow["nodes"][2]["data"]["outputVariable"] = "agent_output"
+    workflow["edges"] = [
+        {"id": "e1", "source": "input", "target": "workflow_agent"},
+        {"id": "e2", "source": "workflow_agent", "target": "output"},
+    ]
+
+    data = await validate(client, workflow)
+
+    assert data["valid"] is True
+    assert "missing_output_variable_reference" not in issue_codes(data)
+
+
+@pytest.mark.asyncio
 async def test_validate_agent_handoff_node_ok(client: httpx.AsyncClient) -> None:
     workflow = linear_workflow()
     workflow["nodes"] = [

--- a/server/tests/test_xpert_runtime_agent_tasks.py
+++ b/server/tests/test_xpert_runtime_agent_tasks.py
@@ -300,7 +300,10 @@ async def test_api_global_handoff_list_filters(client: httpx.AsyncClient) -> Non
     assert handoff_b.status_code == 200, handoff_b.text
     handoff_a_id = handoff_a.json()["handoff_id"]
 
-    await client.post(f"/api/runtime/agent-handoffs/{handoff_a_id}/accept")
+    await client.post(
+        f"/api/runtime/agent-handoffs/{handoff_a_id}/accept",
+        json={"accepted_by": "queue-operator"},
+    )
 
     task_filter = await client.get(
         f"/api/runtime/agent-handoffs?task_id={task_a_id}&limit=20",
@@ -323,6 +326,19 @@ async def test_api_global_handoff_list_filters(client: httpx.AsyncClient) -> Non
     assert len(target_handoffs) == 1
     assert target_handoffs[0]["target_agent"] == "qa-agent"
 
+    source_filter = await client.get(
+        "/api/runtime/agent-handoffs?source_agent=a&limit=20",
+    )
+    assert source_filter.status_code == 200, source_filter.text
+    assert any(item["handoff_id"] == handoff_a_id for item in source_filter.json())
+    assert all(item["source_agent"] == "a" for item in source_filter.json())
+
+    created_after_filter = await client.get(
+        "/api/runtime/agent-handoffs?created_after=9999999999&limit=20",
+    )
+    assert created_after_filter.status_code == 200, created_after_filter.text
+    assert created_after_filter.json() == []
+
 
 @pytest.mark.asyncio
 async def test_api_handoff_status_transitions(client: httpx.AsyncClient) -> None:
@@ -343,17 +359,23 @@ async def test_api_handoff_status_transitions(client: httpx.AsyncClient) -> None
 
     accept_response = await client.post(
         f"/api/runtime/agent-handoffs/{handoff_id}/accept",
+        json={"accepted_by": "queue-operator"},
     )
     assert accept_response.status_code == 200
-    assert accept_response.json()["status"] == "accepted"
+    accepted = accept_response.json()
+    assert accepted["status"] == "accepted"
+    assert accepted["metadata"]["accepted_by"] == "queue-operator"
+    assert isinstance(accepted["metadata"]["accepted_at"], float)
 
     complete_response = await client.post(
         f"/api/runtime/agent-handoffs/{handoff_id}/complete",
-        json={"result": "done"},
+        json={"completed_by": "queue-operator", "result": "done"},
     )
     assert complete_response.status_code == 200
     completed = complete_response.json()
     assert completed["status"] == "completed"
+    assert completed["metadata"]["completed_by"] == "queue-operator"
+    assert isinstance(completed["metadata"]["completed_at"], float)
     assert completed["metadata"]["result"] == "done"
 
     runs_response = await client.get(
@@ -364,6 +386,8 @@ async def test_api_handoff_status_transitions(client: httpx.AsyncClient) -> None
     handoff_run = next(item for item in runs if item["source_id"] == handoff_id)
     assert handoff_run["status"] == "completed"
     assert handoff_run["metadata"]["handoff_status"] == "completed"
+    assert handoff_run["metadata"]["completed_by"] == "queue-operator"
+    assert handoff_run["metadata"]["result"] == "done"
 
     list_response = await client.get(
         f"/api/runtime/agent-handoffs?task_id={task_id}&status=completed",
@@ -395,6 +419,17 @@ async def test_api_handoff_invalid_transition(client: httpx.AsyncClient) -> None
         f"/api/runtime/agent-handoffs/{handoff_id}/complete",
     )
     assert complete_response.status_code == 400
+
+    reject_response = await client.post(
+        f"/api/runtime/agent-handoffs/{handoff_id}/reject",
+        json={"rejected_by": "queue-operator", "reason": "not mine"},
+    )
+    assert reject_response.status_code == 200
+    rejected = reject_response.json()
+    assert rejected["status"] == "rejected"
+    assert rejected["metadata"]["rejected_by"] == "queue-operator"
+    assert isinstance(rejected["metadata"]["rejected_at"], float)
+    assert rejected["metadata"]["reason"] == "not mine"
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_xpert_runtime_run_registry.py
+++ b/server/tests/test_xpert_runtime_run_registry.py
@@ -44,6 +44,7 @@ async def test_run_registry_create_and_get_run() -> None:
 async def test_run_registry_list_filters_and_limit() -> None:
     registry = RunRegistry()
     await registry.create_run("workflow", "A", status="completed")
+    await registry.create_run("workflow_agent", "Agent", status="completed")
     await registry.create_run("agent_task", "B", status="pending")
     await registry.create_run("agent_task", "C", status="completed")
 
@@ -52,7 +53,11 @@ async def test_run_registry_list_filters_and_limit() -> None:
     assert all(run.run_type == "agent_task" for run in agent_runs)
 
     completed_runs = await registry.list_runs(status="completed")
-    assert len(completed_runs) == 2
+    assert len(completed_runs) == 3
+
+    workflow_agent_runs = await registry.list_runs(run_type="workflow_agent")
+    assert len(workflow_agent_runs) == 1
+    assert workflow_agent_runs[0].title == "Agent"
 
     limited = await registry.list_runs(limit=1)
     assert len(limited) == 1
@@ -167,3 +172,49 @@ async def test_runtime_run_api_filters_parent_and_source(
     assert source_response.status_code == 200, source_response.text
     source_runs = source_response.json()
     assert [item["run_id"] for item in source_runs] == [child.run_id]
+
+
+@pytest.mark.asyncio
+async def test_handoff_status_updates_runtime_run_metadata(
+    client: httpx.AsyncClient,
+) -> None:
+    create_task = await client.post(
+        "/api/runtime/agent-tasks",
+        json={"title": "Run metadata handoff", "input": "hello"},
+    )
+    assert create_task.status_code == 200, create_task.text
+    task_id = create_task.json()["task_id"]
+    create_handoff = await client.post(
+        f"/api/runtime/agent-tasks/{task_id}/handoffs",
+        json={
+            "source_agent": "planner",
+            "target_agent": "reviewer",
+            "reason": "review handoff metadata",
+        },
+    )
+    assert create_handoff.status_code == 200, create_handoff.text
+    handoff_id = create_handoff.json()["handoff_id"]
+
+    accept = await client.post(
+        f"/api/runtime/agent-handoffs/{handoff_id}/accept",
+        json={"accepted_by": "queue-operator"},
+    )
+    assert accept.status_code == 200, accept.text
+    complete = await client.post(
+        f"/api/runtime/agent-handoffs/{handoff_id}/complete",
+        json={"completed_by": "queue-operator", "result": "review complete"},
+    )
+    assert complete.status_code == 200, complete.text
+
+    runs_response = await client.get(
+        f"/api/runtime/runs?source_id={handoff_id}&limit=20",
+    )
+    assert runs_response.status_code == 200, runs_response.text
+    runs = runs_response.json()
+    assert len(runs) == 1
+    run = runs[0]
+    assert run["status"] == "completed"
+    assert run["metadata"]["handoff_status"] == "completed"
+    assert run["metadata"]["accepted_by"] == "queue-operator"
+    assert run["metadata"]["completed_by"] == "queue-operator"
+    assert run["metadata"]["result"] == "review complete"

--- a/server/workflow_native/schemas.py
+++ b/server/workflow_native/schemas.py
@@ -19,6 +19,7 @@ NativeNodeKind = Literal[
     "human_intervention",
     "question_classifier",
     "agent",
+    "workflow_agent",
     "agent_task",
     "agent_handoff",
     "mcp_tool",

--- a/server/workflow_native/validate.py
+++ b/server/workflow_native/validate.py
@@ -41,6 +41,8 @@ NODE_KIND_ALIASES = {
     "question_classifier": "question_classifier",
     "question-classifier": "question_classifier",
     "agent": "agent",
+    "workflow_agent": "workflow_agent",
+    "workflow-agent": "workflow_agent",
     "agent_task": "agent_task",
     "agent-task": "agent_task",
     "agent_handoff": "agent_handoff",
@@ -79,6 +81,7 @@ SUPPORTED_NODE_KINDS = {
     "human_intervention",
     "question_classifier",
     "agent",
+    "workflow_agent",
     "agent_task",
     "agent_handoff",
     "mcp_tool",
@@ -694,6 +697,65 @@ def validate_node_configuration(
                     )
                 )
 
+    if kind == "workflow_agent":
+        agent_name = str(data.get("agentName") or "").strip()
+        if not agent_name:
+            issues.append(
+                ValidationIssue(
+                    code="missing_workflow_agent_name",
+                    message="Workflow agent node needs data.agentName.",
+                    node_id=node.id,
+                )
+            )
+
+        model_id = str(data.get("modelId") or "").strip()
+        if not model_id:
+            issues.append(
+                ValidationIssue(
+                    code="missing_workflow_agent_model",
+                    message="Workflow agent node needs data.modelId.",
+                    node_id=node.id,
+                )
+            )
+
+        role_prompt = str(data.get("rolePrompt") or "").strip()
+        if not role_prompt:
+            issues.append(
+                ValidationIssue(
+                    code="missing_workflow_agent_role_prompt",
+                    message="Workflow agent node needs data.rolePrompt.",
+                    node_id=node.id,
+                )
+            )
+
+        task_input = str(data.get("taskInput") or "").strip()
+        if not task_input:
+            issues.append(
+                ValidationIssue(
+                    code="missing_workflow_agent_task_input",
+                    message="Workflow agent node needs data.taskInput.",
+                    node_id=node.id,
+                )
+            )
+
+        output_variable = str(data.get("outputVariable") or "").strip()
+        if not output_variable:
+            issues.append(
+                ValidationIssue(
+                    code="missing_workflow_agent_output_variable",
+                    message="Workflow agent node needs data.outputVariable.",
+                    node_id=node.id,
+                )
+            )
+        elif not is_variable_name(output_variable):
+            issues.append(
+                ValidationIssue(
+                    code="invalid_workflow_agent_output_variable",
+                    message="Workflow agent outputVariable must be an identifier.",
+                    node_id=node.id,
+                )
+            )
+
     if kind == "agent_task":
         task_title = str(data.get("taskTitle") or "").strip()
         if not task_title:
@@ -1148,6 +1210,7 @@ def collect_declared_variables(
             "human_intervention",
             "question_classifier",
             "agent",
+            "workflow_agent",
             "agent_task",
             "agent_handoff",
             "mcp_tool",
@@ -1373,6 +1436,22 @@ def validate_variable_references(
                         node_id=node.id,
                     )
                 )
+
+    if kind == "workflow_agent":
+        for field_name in ("rolePrompt", "taskInput"):
+            template = str(data.get(field_name) or "")
+            for variable in sorted(extract_template_variables(template)):
+                if variable not in available_variables:
+                    issues.append(
+                        ValidationIssue(
+                            code="missing_workflow_agent_template_variable",
+                            message=(
+                                f"Workflow agent {field_name} references undefined "
+                                f"variable '{variable}'."
+                            ),
+                            node_id=node.id,
+                        )
+                    )
 
     if kind == "agent_task":
         for field_name in ("taskTitle", "taskInput"):

--- a/server/xpert_runtime/run_registry.py
+++ b/server/xpert_runtime/run_registry.py
@@ -6,7 +6,7 @@ import uuid
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
-RuntimeRunType = Literal["workflow", "agent_task", "agent_handoff"]
+RuntimeRunType = Literal["workflow", "workflow_agent", "agent_task", "agent_handoff"]
 RuntimeRunStatus = Literal["pending", "running", "completed", "failed", "cancelled"]
 
 
@@ -31,7 +31,7 @@ class RuntimeRun:
 
 
 class RunRegistry:
-    """Small in-memory RunRegistry for workflow, AgentTask, and Handoff runs."""
+    """Small in-memory RunRegistry for workflow, agent, task, and handoff runs."""
 
     def __init__(self) -> None:
         self._lock = asyncio.Lock()


### PR DESCRIPTION
## Summary
- 增强 Handoff 前端观测与队列处理闭环，支持筛选、接受、拒绝和完成结果记录
- 新增 classic workflow 的 workflow_agent 节点，可配置 agentName/modelId/rolePrompt/taskInput/outputVariable
- workflow_agent 运行时调用现有工作流 LLM 流式函数，并登记 workflow_agent RunRegistry 子 run
- 更新 Xpert 对齐与 workflow-native 文档，明确当前仍不做真实多 Agent 调度、工具调用或持久化队列

## Tests
- npm.cmd run build
- python -m py_compile server/main.py server/xpert_runtime/*.py server/workflow_native/*.py（本地用显式文件列表，容器内通过 sh -lc 展开）
- docker compose -p modelmirror up -d --build --force-recreate
- curl http://localhost:8000/api/health
- docker run --rm -v <repo>:/workspace -w /workspace modelmirror-server python -m pytest server/tests/test_workflow_native_validate.py server/tests/test_workflow_agent_task_node.py server/tests/test_xpert_runtime_run_registry.py -q --basetemp /tmp/modelmirror-workflow-agent-focused（60 passed）
- docker run --rm -v <repo>:/workspace -w /workspace modelmirror-server python -m pytest server/tests/ -q --basetemp /tmp/modelmirror-workflow-agent-pytest（136 passed）

## Notes
- 未提交 .env、API key、package*.json、APK 或构建产物
- RunRegistry 仍是内存态观测索引
- Handoff Queue 仍是人工处理闭环，不接真实 worker/Redis/数据库