### PR TITLE
feature: 增强 RunRegistry Trace 观测闭环

### DIFF
--- a/client/src/components/workflow/WorkflowEditor.tsx
+++ b/client/src/components/workflow/WorkflowEditor.tsx
@@ -285,6 +285,10 @@ function createNodeData(
       modelId: "deepseek/deepseek-chat",
       rolePrompt: "你是负责执行当前工作流步骤的智能体，请直接输出结果。",
       taskInput: "{{user_input}}",
+      toolMode: "none",
+      toolNames: "",
+      maxIterations: "5",
+      promptSuffix: "",
       outputVariable: "agent_output",
     };
   }
@@ -1191,7 +1195,7 @@ function NodeConfig({ node, onChange }: NodeConfigProps) {
       {data.kind === "workflow_agent" ? (
         <>
           <div className="rounded-lg border border-cyan-300/25 bg-cyan-300/10 px-3 py-2 text-xs leading-5 text-cyan-50">
-            该节点会以角色提示词调用模型执行一个工作流步骤，并将结果写入输出变量；当前不接工具和真实多智能体调度。
+            该节点会以角色提示词调用模型执行一个工作流步骤；启用 MCP 工具时会复用 runtime toolset、权限策略和审计。
           </div>
           <Field label="智能体名称">
             <input
@@ -1232,6 +1236,57 @@ function NodeConfig({ node, onChange }: NodeConfigProps) {
               className={`${textInputClass()} min-h-32 resize-none leading-6`}
               onChange={(event) => update({ taskInput: event.target.value })}
               value={data.taskInput ?? ""}
+            />
+          </Field>
+          <Field label="工具模式">
+            <select
+              className={textInputClass()}
+              onChange={(event) => update({ toolMode: event.target.value })}
+              value={data.toolMode ?? "none"}
+            >
+              <option className="bg-slate-950" value="none">
+                none：直接调用模型
+              </option>
+              <option className="bg-slate-950" value="mcp_tools">
+                mcp_tools：允许调用 MCP 工具
+              </option>
+            </select>
+          </Field>
+          {data.toolMode === "mcp_tools" ? (
+            <>
+              <Field label="允许工具名（逗号分隔，留空代表全部已注册工具）">
+                <input
+                  className={textInputClass()}
+                  onChange={(event) => update({ toolNames: event.target.value })}
+                  placeholder={
+                    registryTools.length
+                      ? registryTools.map((tool) => tool.name).slice(0, 3).join(", ")
+                      : "先在 MCP 页面连接工具 Server"
+                  }
+                  value={data.toolNames ?? ""}
+                />
+              </Field>
+              <Field label="最大工具循环次数">
+                <input
+                  className={textInputClass()}
+                  inputMode="numeric"
+                  max={20}
+                  min={1}
+                  onChange={(event) =>
+                    update({ maxIterations: event.target.value })
+                  }
+                  type="number"
+                  value={data.maxIterations ?? "5"}
+                />
+              </Field>
+            </>
+          ) : null}
+          <Field label="补充提示词（可选，支持 {{变量}}）">
+            <textarea
+              className={`${textInputClass()} min-h-24 resize-none leading-6`}
+              onChange={(event) => update({ promptSuffix: event.target.value })}
+              placeholder="可加入输出格式、语气或额外约束。"
+              value={data.promptSuffix ?? ""}
             />
           </Field>
           <Field label="输出变量">

--- a/client/src/components/workflow/WorkflowNodeCard.tsx
+++ b/client/src/components/workflow/WorkflowNodeCard.tsx
@@ -199,7 +199,7 @@ function outputName(data: WorkflowNode["data"]) {
     return `🤖 ${data.agentMode ?? "tool_first"} → ${data.outputVariable ?? "agent_output"}`;
   }
   if (data.kind === "workflow_agent") {
-    return `${data.agentName ?? "workflow-agent"} · ${data.modelId ?? "model"} → ${data.outputVariable ?? "agent_output"}`;
+    return `${data.agentName ?? "workflow-agent"} · ${data.toolMode ?? "none"} → ${data.outputVariable ?? "agent_output"}`;
   }
   if (data.kind === "agent_task") {
     return `${data.assignedAgent ?? "workflow-planner"} → ${data.outputVariable ?? "agent_task_id"}`;

--- a/client/src/components/workflow/WorkflowRun.tsx
+++ b/client/src/components/workflow/WorkflowRun.tsx
@@ -48,6 +48,17 @@ interface RuntimeRunSummary {
   error: string | null;
 }
 
+interface RuntimeRunCheckpoint {
+  checkpoint_id: string;
+  run_id: string;
+  event_type: string;
+  title: string;
+  summary: string;
+  severity: string;
+  metadata: Record<string, unknown>;
+  created_at: number;
+}
+
 interface WorkflowRunProps {
   definition: WorkflowDefinition;
   embedded?: boolean;
@@ -168,6 +179,61 @@ function runMetadataText(
   return "";
 }
 
+function checkpointSeverityClass(severity: string) {
+  if (severity === "error") return "text-rose-200";
+  if (severity === "warning") return "text-amber-200";
+  return "text-slate-300";
+}
+
+function RuntimeCheckpointList({
+  checkpoints,
+  limit = 6,
+}: {
+  checkpoints: RuntimeRunCheckpoint[];
+  limit?: number;
+}) {
+  if (checkpoints.length === 0) {
+    return (
+      <p className="mt-2 rounded-md bg-slate-950/25 px-2 py-1.5 text-[11px] text-slate-500">
+        暂无 checkpoint。
+      </p>
+    );
+  }
+
+  return (
+    <div className="mt-2 max-h-44 space-y-1 overflow-y-auto">
+      {checkpoints.slice(0, limit).map((checkpoint) => (
+        <div
+          className="rounded-md bg-slate-950/35 px-2 py-1.5"
+          key={checkpoint.checkpoint_id}
+        >
+          <div className="flex items-center justify-between gap-2">
+            <span
+              className={`truncate text-[11px] font-semibold ${checkpointSeverityClass(
+                checkpoint.severity,
+              )}`}
+            >
+              {checkpoint.title || checkpoint.event_type}
+            </span>
+            <span className="shrink-0 text-[10px] text-slate-500">
+              {formatObservationTime(checkpoint.created_at)}
+            </span>
+          </div>
+          <p className="mt-1 truncate text-[11px] text-slate-500">
+            {checkpoint.event_type}
+            {checkpoint.summary ? ` · ${checkpoint.summary}` : ""}
+          </p>
+        </div>
+      ))}
+      {checkpoints.length > limit ? (
+        <p className="text-[11px] text-slate-500">
+          仅展示最近 {limit} 条，共 {checkpoints.length} 条。
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
 function buildRunSteps(events: WorkflowRunEvent[]) {
   const steps: WorkflowRunStep[] = [];
   const byNodeId = new Map<string, WorkflowRunStep>();
@@ -259,6 +325,10 @@ export default function WorkflowRun({
   const [runSummaryLoading, setRunSummaryLoading] = useState(false);
   const [childRuns, setChildRuns] = useState<RuntimeRunSummary[]>([]);
   const [childRunsLoading, setChildRunsLoading] = useState(false);
+  const [runCheckpoints, setRunCheckpoints] = useState<
+    Record<string, RuntimeRunCheckpoint[]>
+  >({});
+  const [runCheckpointsLoading, setRunCheckpointsLoading] = useState(false);
 
   const inputVariable = useMemo(() => {
     const inputNode = definition.nodes.find((node) => node.data.kind === "input");
@@ -295,6 +365,8 @@ export default function WorkflowRun({
     setRunSummaryLoading(false);
     setChildRuns([]);
     setChildRunsLoading(false);
+    setRunCheckpoints({});
+    setRunCheckpointsLoading(false);
     setIsRunning(true);
 
     try {
@@ -423,6 +495,7 @@ export default function WorkflowRun({
     setObservationLoading(true);
     setRunSummaryLoading(Boolean(runId));
     setChildRunsLoading(Boolean(runId));
+    setRunCheckpointsLoading(Boolean(runId));
     try {
       const response = await fetch(`/api/workflow/runtime-events/${taskId}`);
       if (response.ok) {
@@ -430,6 +503,7 @@ export default function WorkflowRun({
         setObservationData(payload);
       }
       if (runId) {
+        const checkpointRunIds = [runId];
         const runResponse = await fetch(`/api/runtime/runs/${runId}`);
         if (runResponse.ok) {
           const runPayload = (await runResponse.json()) as RuntimeRunSummary;
@@ -442,7 +516,24 @@ export default function WorkflowRun({
           const childRunPayload =
             (await childRunsResponse.json()) as RuntimeRunSummary[];
           setChildRuns(childRunPayload);
+          checkpointRunIds.push(
+            ...childRunPayload.map((run) => run.run_id).filter(Boolean),
+          );
         }
+        const checkpointPairs = await Promise.all(
+          checkpointRunIds.map(async (checkpointRunId) => {
+            const checkpointsResponse = await fetch(
+              `/api/runtime/runs/${checkpointRunId}/checkpoints?limit=30`,
+            );
+            if (!checkpointsResponse.ok) {
+              return [checkpointRunId, []] as const;
+            }
+            const checkpoints =
+              (await checkpointsResponse.json()) as RuntimeRunCheckpoint[];
+            return [checkpointRunId, checkpoints] as const;
+          }),
+        );
+        setRunCheckpoints(Object.fromEntries(checkpointPairs));
       }
     } catch {
       // Observability is best-effort; workflow execution output remains primary.
@@ -450,6 +541,7 @@ export default function WorkflowRun({
       setObservationLoading(false);
       setRunSummaryLoading(false);
       setChildRunsLoading(false);
+      setRunCheckpointsLoading(false);
     }
   }
 
@@ -461,7 +553,10 @@ export default function WorkflowRun({
         taskId &&
         ((!observationData && !observationLoading) ||
           (runId && !runSummary && !runSummaryLoading) ||
-          (runId && childRuns.length === 0 && !childRunsLoading))
+          (runId && childRuns.length === 0 && !childRunsLoading) ||
+          (runId &&
+            Object.keys(runCheckpoints).length === 0 &&
+            !runCheckpointsLoading))
       ) {
         void fetchObservation();
       }
@@ -640,6 +735,22 @@ export default function WorkflowRun({
                           暂无 run 摘要。
                         </p>
                       )}
+                      <div className="mt-3 border-t border-white/10 pt-2">
+                        <div className="flex items-center justify-between gap-3">
+                          <p className="text-[11px] font-semibold text-slate-300">
+                            Checkpoints
+                          </p>
+                          <span className="text-[10px] text-slate-500">
+                            {runCheckpointsLoading
+                              ? "..."
+                              : runCheckpoints[runId]?.length ?? 0}
+                          </span>
+                        </div>
+                        <RuntimeCheckpointList
+                          checkpoints={runCheckpoints[runId] ?? []}
+                          limit={8}
+                        />
+                      </div>
                     </div>
                   ) : null}
 
@@ -712,6 +823,10 @@ export default function WorkflowRun({
                                     {result ? `result=${result}` : ""}
                                   </p>
                                 ) : null}
+                                <RuntimeCheckpointList
+                                  checkpoints={runCheckpoints[run.run_id] ?? []}
+                                  limit={3}
+                                />
                               </div>
                             );
                           })}

--- a/client/src/types/workflow.ts
+++ b/client/src/types/workflow.ts
@@ -67,6 +67,7 @@ export interface WorkflowNodeData extends Record<string, unknown> {
   llmFallbackPrompt?: string;
   agentName?: string;
   agentMode?: string;
+  toolMode?: string;
   rolePrompt?: string;
   taskTitle?: string;
   taskInput?: string;

--- a/docs/XPERT_ALIGNMENT.md
+++ b/docs/XPERT_ALIGNMENT.md
@@ -1,5 +1,8 @@
 # Xpert 对齐总纲
 
+> 2026-07-07 状态补充：RunRegistry Trace 已进入“部分实现”。`RuntimeRun` 现在可挂载内存态 checkpoint，记录 workflow、workflow_agent、agent_task、agent_handoff 的关键执行时间线；新增 `GET /api/runtime/runs/{run_id}/checkpoints` 供前端运行观测读取。当前仍不做持久化、自动重试、队列调度或 checkpoint resume。
+> 2026-07-07 状态补充：Workflow Agent Toolset 已进入“部分实现”。`workflow_agent` 现在支持 `toolMode=none/mcp_tools`，启用 MCP 工具时复用 Runtime Toolset、`tool_policy` 与 `tool_audit`；旧 `agent.tool_first` 也收敛到同一条 `run_tool_with_runtime` 路径。当前仍是轻量 JSON 决策协议，不做 OpenAI function calling、自动 Handoff 或真实多 Agent 调度。
+
 > 2026-07-06 状态补充：Workflow Agent 节点已进入“部分实现”。Classic workflow 现在可拖入 `workflow_agent` 节点，用角色提示词和任务输入调用模型，输出结果到变量，并登记 `workflow_agent` 子 run。当前仍是单步模型执行，不接工具调用、Handoff 自动调度或真实多 Agent 协作。
 
 > 2026-07-06 状态补充：Handoff Queue 已进入“部分实现”。Handoff metadata 现在记录 accepted/rejected/completed 的处理者、时间和结果/原因；MetaAgent Handoff Inbox 支持按状态和目标 Agent 筛选，并可填写完成结果。当前仍是内存态人工处理闭环，不做真实调度、worker 队列或持久化。
@@ -18,9 +21,10 @@ Classic workflow 运行时会创建 workflow run，并在 `workflow_meta` / `wor
 
 - `GET /api/runtime/runs?run_type=&status=&limit=`
 - `GET /api/runtime/runs/{run_id}`
+- `GET /api/runtime/runs/{run_id}/checkpoints`
 - `POST /api/runtime/runs/{run_id}/cancel`
 
-当前边界：RunRegistry 仅为内存态可观测索引，不是持久化调度器；取消 run 只更新 registry 状态，不中断真实 workflow、AgentTask 或 Handoff 执行。下一步可在此基础上继续补齐 Handoff 前端观测、RunRegistry 页面、checkpoint、死信与持久化存储。
+当前边界：RunRegistry 仅为内存态可观测索引，不是持久化调度器；取消 run 只更新 registry 状态，不中断真实 workflow、AgentTask 或 Handoff 执行。Checkpoint 只保存摘要与元信息，不保存完整 prompt、工具输出、模型输出或密钥。下一步可在此基础上继续补齐 Handoff 自动编排、RunRegistry 页面、死信与持久化存储。
 
 最后更新日期：2026-07-06
 维护人：模镜团队
@@ -36,9 +40,9 @@ EvoAgentX 只保留为历史参考：此前元智能体曾借鉴其 `goal -> sub
 | 能力域 | Xpert 对齐目标 | 当前状态 | 下一步 |
 | --- | --- | --- | --- |
 | Runtime / Execution | 中间件生命周期、任务注册、事件记录、运行观测 | 部分实现 | 建立 Handoff / RunRegistry 闭环 |
-| Agent / Handoff | AgentTask、任务移交、子 Agent、主管-专家协作 | 部分实现 | 将 workflow_agent 接入工具与 Handoff 编排 |
-| Workflow | Xpert 节点类型、Agent 节点、工具节点、知识流水线节点 | 部分实现 | 扩展 workflow_agent toolset、subflow、知识类节点 |
-| Toolset / MCP | 统一 Toolset Provider、权限、审计、偏好 | 部分实现 | 将聊天 Agent 和工作流 Agent 统一接入 toolset capability |
+| Agent / Handoff | AgentTask、任务移交、子 Agent、主管-专家协作 | 部分实现 | 将 workflow_agent 输出与 Handoff 编排连接 |
+| Workflow | Xpert 节点类型、Agent 节点、工具节点、知识流水线节点 | 部分实现 | 扩展 subflow、知识类节点与 Agent trace |
+| Toolset / MCP | 统一 Toolset Provider、权限、审计、偏好 | 部分实现 | 将聊天 Agent 继续收敛到 toolset capability |
 | Knowledge Pipeline | FileAsset、Artifact、Chunk、CitationAnchor、Embedding | 待实现 | 从本地 RAG 元数据模型开始拆分 |
 | Claw / Skill | 用户偏好、工作区 Skill、会话临时选择 | 待实现 | 在 Xpert workspace / skill 抽象稳定后接入 |
 | Environment / Sandbox | 工作区文件、受限执行、浏览器/终端能力 | 待实现 | 先做受限文件 API 和 workspace volume |
@@ -51,17 +55,23 @@ EvoAgentX 只保留为历史参考：此前元智能体曾借鉴其 `goal -> sub
 - Toolset / MCP：`mcp_tool` 已通过 `MCPToolsetProvider`、`CapabilityRegistry`、`run_tool_with_runtime` 调用工具。
 - Tool Policy / Audit：`tool_policy` 可影响 workflow 内 MCP 工具调用，`InMemoryToolAuditStore` 提供最小审计记录。
 - Runtime Middleware Node：前端可拖入 `runtime_middleware` 节点，`system_prompt_injector`、`tool_policy`、`event_recorder`、`tool_audit` 已逐步进入真实执行或可见状态。
-- Workflow Agent Node：classic workflow 可拖入 `workflow_agent` 节点，使用 `rolePrompt` 作为该节点 system prompt、`taskInput` 作为用户输入调用模型，结果写入 `outputVariable`，并登记 `workflow_agent` 子 run。
+- Workflow Agent Node：classic workflow 可拖入 `workflow_agent` 节点，使用 `rolePrompt` 作为该节点 system prompt、`taskInput` 作为用户输入调用模型，结果写入 `outputVariable`，并登记 `workflow_agent` 子 run；启用 `toolMode=mcp_tools` 时可通过 Runtime Toolset 调用 MCP 工具。
 - Agent Task Runtime：已提供 `AgentTaskStore`、最小 AgentTask API、MetaAgent 任务工作台，以及 classic workflow `agent_task` 节点；该节点当前负责创建任务并输出 `task_id`，暂不做真实多 Agent 调度。
 - Handoff API：已提供 handoff 创建、按任务查询、接受、拒绝、完成的内存态 API，状态转移限定为 `pending -> accepted/rejected`、`accepted -> completed`，并写入 `agent.handoff.created/accepted/rejected/completed` runtime events。
 - 运行观测：classic workflow 可查询 per-task runtime events 和 tool audit records，前端 `WorkflowRun` 已提供“运行观测”折叠区。
 
 ## 近期交付顺序
 
-1. **Workflow Agent Toolset**：让 `workflow_agent` 可选择 MCP Toolset，复用 tool policy / audit。
-2. **RunRegistry Trace 增强**：补齐 workflow_agent / handoff 的 trace、checkpoint、失败摘要与重试入口。
-3. **Handoff 自动编排雏形**：将 workflow_agent 输出与 handoff queue 连接，但仍保持人工可控。
+1. **RunRegistry Trace 增强**：补齐 workflow_agent / handoff 的 trace、checkpoint、失败摘要与重试入口。
+2. **Handoff 自动编排雏形**：将 workflow_agent 输出与 handoff queue 连接，但仍保持人工可控。
+3. **Chat Agent Toolset 收敛**：将聊天 Agent 的工具调用继续迁入 Runtime Toolset capability。
 4. **知识流水线底座**：拆分本地 RAG 的文件元数据，建立 FileAsset -> Artifact -> Chunk -> CitationAnchor 的最小模型。
+
+## 2026-07-07 增量：RunRegistry Trace / Checkpoint
+
+RunRegistry 现在提供内存态 checkpoint：每条 `RuntimeRun` 可记录 `event_type`、标题、摘要、severity、metadata 与创建时间。Workflow 运行、`workflow_agent` 模型/工具步骤、`agent_task` 创建、`agent_handoff` 创建与手动状态变更都会写入 checkpoint。新增 API `GET /api/runtime/runs/{run_id}/checkpoints`，前端 `WorkflowRun` 的“运行观测”会展示当前 run 与子 run 的 checkpoint 摘要。
+
+边界：checkpoint 只保存摘要和元信息，不保存完整 prompt、模型输出、工具结果、API key 或用户隐私内容；当前仍是内存态可观测索引，不做持久化、自动重试、队列调度或 checkpoint resume。
 
 ## 源码与协议策略
 

--- a/docs/workflow-native-design.md
+++ b/docs/workflow-native-design.md
@@ -1,5 +1,8 @@
 # workflow-native 自研工作流设计
 
+> 2026-07-07 状态补充：RunRegistry Trace / Checkpoint 进入最小闭环。Workflow run、`workflow_agent`、`agent_task`、`agent_handoff` 会写入内存态 checkpoint；前端“运行观测”会读取 `GET /api/runtime/runs/{run_id}/checkpoints` 展示当前 run 与子 run 的时间线摘要。当前不做持久化、自动重试、队列调度或 checkpoint resume。
+> 2026-07-07 状态补充：`workflow_agent` 已支持 Runtime Toolset 工具模式。`toolMode=none` 保持单步模型执行；`toolMode=mcp_tools` 使用轻量 JSON 决策协议调用 MCP 工具，并复用 `run_tool_with_runtime`、`tool_policy`、`tool_audit`。旧 `agent.tool_first` 也已收敛到同一条 runtime toolset 路径。当前不是 OpenAI function calling，不做自动 Handoff 或真实多 Agent 协作。
+
 > 2026-07-06 状态补充：classic workflow 新增 `workflow_agent` 节点。该节点使用 `rolePrompt` 作为该节点 system prompt、`taskInput` 作为用户输入调用模型，流式输出结果并写入 `outputVariable`，同时登记 `workflow_agent` 子 run。当前是单步模型智能体执行，不接 MCP 工具、Handoff 自动调度或真实多 Agent 协作。
 
 > 2026-07-06 状态补充：Handoff Queue 进入人工处理闭环。`accept/reject/complete` 会记录处理者、处理时间和结果/原因摘要，并同步到 `agent_handoff` run metadata；`WorkflowRun` 子 run 摘要会展示 handler/result。当前不做自动调度、目标 Agent 执行、持久化队列或权限系统。
@@ -16,9 +19,10 @@ Classic workflow 每次运行会登记一条 `workflow` run，并在 `workflow_m
 
 - `GET /api/runtime/runs?run_type=&status=&limit=`
 - `GET /api/runtime/runs/{run_id}`
+- `GET /api/runtime/runs/{run_id}/checkpoints`
 - `POST /api/runtime/runs/{run_id}/cancel`
 
-当前 RunRegistry 是内存态索引，不是调度器；取消 run 仅更新观测状态，不中断正在执行的 workflow、AgentTask 或 Handoff。前端 `WorkflowRun` 的“运行观测”折叠区会展示当前 `run_id` 与 RunRegistry 摘要，并继续展示 runtime events 与 tool audit records。
+当前 RunRegistry 是内存态索引，不是调度器；取消 run 仅更新观测状态，不中断正在执行的 workflow、AgentTask 或 Handoff。Checkpoint 仅保存摘要和元信息，不保存完整 prompt、模型输出、工具结果或密钥。前端 `WorkflowRun` 的“运行观测”折叠区会展示当前 `run_id`、RunRegistry 摘要、当前 run 与子 run checkpoint，并继续展示 runtime events 与 tool audit records。
 
 ## 2026-07-05 增量：`/workflow` 画布布局恢复
 
@@ -477,7 +481,9 @@ Agent Task Runtime 包含三层：
 
 classic workflow 已新增 `agent_task` 节点，作为 Xpert Agent/Handoff 对齐的第一步闭环。前端可从节点调色板拖入“智能体任务”，配置 `taskTitle`、`taskInput`、`assignedAgent` 与 `outputVariable`；运行时会渲染 `{{变量}}` 模板，调用 `AgentTaskStore.create_task(...)` 创建一条 AgentTask，并将新任务的 `task_id` 写入 `outputVariable`。该节点当前只负责创建任务和输出 ID，不做真实队列分派、专家协作或任务执行；完整任务详情继续通过现有 Agent Task API 查询。
 
-classic workflow 已新增 `workflow_agent` 节点，作为 Xpert Workflow Agent 的最小执行闭环。前端可从节点调色板拖入“工作流智能体”，配置 `agentName`、`modelId`、`rolePrompt`、`taskInput` 与 `outputVariable`；运行时会先渲染 `{{变量}}`，再以 `rolePrompt` 作为该节点 system prompt、`taskInput` 作为用户输入调用现有工作流 LLM 流式函数，最终把模型输出写入 `outputVariable`。该节点会登记 `workflow_agent` 子 run，便于运行观测查看；当前不接 MCP Toolset、不做 Handoff 自动调度、不实现真实多 Agent 协作。
+classic workflow 已新增 `workflow_agent` 节点，作为 Xpert Workflow Agent 的最小执行闭环。前端可从节点调色板拖入“工作流智能体”，配置 `agentName`、`modelId`、`rolePrompt`、`taskInput`、`toolMode`、`toolNames`、`maxIterations`、`promptSuffix` 与 `outputVariable`；运行时会先渲染 `{{变量}}`，再以 `rolePrompt` 作为该节点 system prompt、`taskInput` 作为用户输入执行。
+
+`toolMode=none` 时，节点直接调用现有工作流 LLM 流式函数，最终把模型输出写入 `outputVariable`。`toolMode=mcp_tools` 时，节点进入 ReAct-Lite 工具循环：模型每轮必须返回 `{"tool":"工具名","arguments":{...}}` 或 `{"answer":"最终答案"}`；工具调用统一经过 `run_tool_with_runtime`、`MCPToolsetProvider` 和 `MiddlewarePipeline.wrap_tool_call`，因此 workflow 中的 `tool_policy` 与 `tool_audit` 会对 `workflow_agent` 生效。该节点会登记 `workflow_agent` 子 run，便于运行观测查看；当前不使用 OpenAI function calling、不做 Handoff 自动调度、不实现真实多 Agent 协作。
 
 ## 2026-06-17 增量：Agent 节点
 

--- a/server/main.py
+++ b/server/main.py
@@ -1835,6 +1835,18 @@ async def run_workflow(payload: WorkflowRunRequest, request: Request):
             "edge_count": len(payload.workflow.edges),
         },
     )
+    await run_registry.record_checkpoint(
+        workflow_run.run_id,
+        event_type="workflow.started",
+        title="Workflow started",
+        summary=payload.workflow.title,
+        metadata={
+            "workflow_id": payload.workflow.id,
+            "workflow_task_id": task_id,
+            "node_count": len(payload.workflow.nodes),
+            "edge_count": len(payload.workflow.edges),
+        },
+    )
     initial_queue = deque(sorted(start_node_ids, key=lambda node_id: order_index[node_id]))
     task_state: dict[str, Any] = {
         "task_id": task_id,
@@ -1869,6 +1881,317 @@ async def run_workflow(payload: WorkflowRunRequest, request: Request):
             "active_middlewares": [],
             "tool_policy": None,
         }
+
+        def selected_workflow_tool_policy() -> ToolPermissionPolicy:
+            policy = workflow_runtime_context.get("tool_policy")
+            return policy if isinstance(policy, ToolPermissionPolicy) else workflow_tool_policy
+
+        def selected_workflow_tool_audit_store() -> InMemoryToolAuditStore:
+            audit_store = task_state.get("tool_audit_store")
+            return (
+                audit_store
+                if isinstance(audit_store, InMemoryToolAuditStore)
+                else workflow_tool_audit_store
+            )
+
+        async def call_workflow_runtime_tool(
+            *,
+            tool_name: str,
+            arguments: dict[str, Any],
+            node: WorkflowNodePayload,
+            title: str,
+            metadata: dict[str, Any] | None = None,
+        ):
+            matched_tool = await workflow_mcp_provider.find_tool(tool_name)
+            if not matched_tool:
+                raise ValueError(f"MCP 工具未注册：{tool_name}")
+            return await run_tool_with_runtime(
+                RuntimeToolCall(
+                    tool_name=tool_name,
+                    arguments=arguments,
+                    metadata={
+                        "session_id": matched_tool.session_id,
+                        "server_id": matched_tool.server_id,
+                        "node_id": node.id,
+                        **dict(metadata or {}),
+                    },
+                ),
+                runtime_capabilities,
+                workflow_mcp_pipeline,
+                MiddlewareContext(
+                    task_id=task_id,
+                    trace_id=task_id,
+                    capabilities=runtime_capabilities,
+                    store=task_state["runtime_event_store"],
+                    metadata={
+                        "node_id": node.id,
+                        "node_title": title,
+                        "workflow": True,
+                    },
+                ),
+                policy=selected_workflow_tool_policy(),
+                audit_store=selected_workflow_tool_audit_store(),
+            )
+
+        def runtime_tool_result_text(call_result: Any) -> str:
+            content_types = call_result.metadata.get("content_types", [])
+            non_text_types = [
+                str(content_type)
+                for content_type in content_types
+                if str(content_type) != "text"
+            ]
+            output_text = str(call_result.output or "").strip()
+            if non_text_types:
+                output_text = (
+                    output_text
+                    + "\n"
+                    + "非文本结果已省略："
+                    + ", ".join(non_text_types)
+                ).strip()
+            return output_text
+
+        async def workflow_available_tools(tool_names_raw: Any) -> list[Any]:
+            tools = await workflow_mcp_provider.list_tools()
+            requested_tool_names = {
+                item.strip()
+                for item in str(tool_names_raw or "").split(",")
+                if item.strip()
+            }
+            if not requested_tool_names:
+                return tools
+            return [tool for tool in tools if tool.name in requested_tool_names]
+
+        async def run_react_lite_agent(
+            *,
+            node: WorkflowNodePayload,
+            title: str,
+            kind: str,
+            model_id: str,
+            system_prompt: str,
+            user_prompt: str,
+            tool_names_raw: Any,
+            max_iterations: int,
+            temperature: float,
+            output_variable: str,
+            run_id: str | None = None,
+        ) -> tuple[str, list[dict[str, Any]]]:
+            available_tools = await workflow_available_tools(tool_names_raw)
+            events: list[dict[str, Any]] = []
+            if not available_tools:
+                events.append(
+                    {
+                        "event": "node_delta",
+                        "node_id": node.id,
+                        "node_title": title,
+                        "node_type": kind,
+                        "output": "Agent 切换为直接回答：没有可用 MCP 工具",
+                        "variable": output_variable,
+                    }
+                )
+                if run_id:
+                    events[-1]["run_id"] = run_id
+                    await run_registry.record_checkpoint(
+                        run_id,
+                        event_type="workflow_agent.direct_fallback",
+                        title="Direct answer fallback",
+                        summary="No MCP tools were available for this agent run.",
+                        metadata={
+                            "node_id": node.id,
+                            "model_id": model_id,
+                            "output_variable": output_variable,
+                        },
+                    )
+                return (
+                    await collect_chat_completion_text(
+                        model_id,
+                        [ChatMessage(role="system", content=system_prompt), ChatMessage(role="user", content=user_prompt)],
+                        temperature=temperature,
+                        max_tokens=WORKFLOW_AGENT_MAX_TOKENS,
+                    ),
+                    events,
+                )
+
+            tool_by_name = {tool.name: tool for tool in available_tools if tool.name}
+            tool_descriptions = "\n".join(
+                (
+                    f"- {name}: {tool.description or '无描述'} "
+                    f"schema={json.dumps(tool.input_schema or {}, ensure_ascii=False)}"
+                )
+                for name, tool in tool_by_name.items()
+            )
+            react_system_prompt = (
+                f"{system_prompt}\n\n"
+                "你可以选择调用一个工具，或给出最终答案。"
+                "每次回复必须是 JSON，且只能使用以下两种格式之一："
+                '{"tool":"工具名","arguments":{...}} 或 {"answer":"最终答案"}。'
+                "不要输出 JSON 以外的文字。\n\n可用工具：\n"
+                f"{tool_descriptions}"
+            )
+            messages: list[ChatMessage] = [
+                ChatMessage(role="system", content=react_system_prompt),
+                ChatMessage(role="user", content=user_prompt),
+            ]
+            output_text = ""
+            for iteration_index in range(max_iterations):
+                if not get_llm_gateway_config()[0]:
+                    raise ValueError(LLM_GATEWAY_NOT_CONFIGURED_MESSAGE)
+                raw_response = (
+                    await collect_chat_completion_text(
+                        model_id,
+                        messages,
+                        temperature=temperature,
+                        max_tokens=WORKFLOW_AGENT_MAX_TOKENS,
+                    )
+                ).strip()
+                json_text = raw_response
+                fenced = re.search(
+                    r"```(?:json)?\s*\n?(.*?)\n?```",
+                    raw_response,
+                    re.DOTALL,
+                )
+                if fenced:
+                    json_text = fenced.group(1).strip()
+                try:
+                    decision = json.loads(json_text)
+                except ValueError:
+                    output_text = raw_response
+                    if run_id:
+                        await run_registry.record_checkpoint(
+                            run_id,
+                            event_type="workflow_agent.model_decision",
+                            title="Model returned plain text",
+                            summary="The agent treated the model response as final text.",
+                            metadata={"iteration": iteration_index + 1},
+                        )
+                    break
+                if not isinstance(decision, dict):
+                    output_text = raw_response
+                    if run_id:
+                        await run_registry.record_checkpoint(
+                            run_id,
+                            event_type="workflow_agent.model_decision",
+                            title="Model returned non-object JSON",
+                            summary="The agent treated the model response as final text.",
+                            metadata={"iteration": iteration_index + 1},
+                        )
+                    break
+                answer = decision.get("answer")
+                if isinstance(answer, str) and answer.strip():
+                    output_text = answer.strip()
+                    if run_id:
+                        await run_registry.record_checkpoint(
+                            run_id,
+                            event_type="workflow_agent.model_answer",
+                            title="Model produced final answer",
+                            summary=f"answer_length={len(output_text)}",
+                            metadata={"iteration": iteration_index + 1},
+                        )
+                    break
+                tool_name = str(decision.get("tool") or "").strip()
+                arguments = decision.get("arguments")
+                if not tool_name:
+                    output_text = raw_response
+                    if run_id:
+                        await run_registry.record_checkpoint(
+                            run_id,
+                            event_type="workflow_agent.model_decision",
+                            title="Model decision missing tool name",
+                            summary="The agent treated the response as final text.",
+                            severity="warning",
+                            metadata={"iteration": iteration_index + 1},
+                        )
+                    break
+                if not isinstance(arguments, dict):
+                    arguments = {}
+                matched_tool = tool_by_name.get(tool_name)
+                if not matched_tool:
+                    tool_result_text = f"工具不可用：{tool_name}"
+                    if run_id:
+                        await run_registry.record_checkpoint(
+                            run_id,
+                            event_type="workflow_agent.tool_missing",
+                            title="Tool unavailable",
+                            summary=tool_name,
+                            severity="warning",
+                            metadata={"iteration": iteration_index + 1},
+                        )
+                else:
+                    call_result = await call_workflow_runtime_tool(
+                        tool_name=tool_name,
+                        arguments=arguments,
+                        node=node,
+                        title=title,
+                        metadata={
+                            "agent_kind": kind,
+                            "agent_node_id": node.id,
+                            "iteration": iteration_index + 1,
+                        },
+                    )
+                    tool_result_text = runtime_tool_result_text(call_result)
+                    if run_id:
+                        await run_registry.record_checkpoint(
+                            run_id,
+                            event_type="workflow_agent.tool_call",
+                            title="Tool call completed",
+                            summary=f"{tool_name} result_length={len(tool_result_text)}",
+                            metadata={
+                                "iteration": iteration_index + 1,
+                                "tool_name": tool_name,
+                                "result_length": len(tool_result_text),
+                            },
+                        )
+                event = {
+                    "event": "node_delta",
+                    "node_id": node.id,
+                    "node_title": title,
+                    "node_type": kind,
+                    "output": (
+                        f"[{iteration_index + 1}/{max_iterations}] 调用工具 "
+                        f"{tool_name}，结果预览：{tool_result_text[:300]}"
+                    ),
+                    "variable": output_variable,
+                }
+                if run_id:
+                    event["run_id"] = run_id
+                    await run_registry.record_checkpoint(
+                        run_id,
+                        event_type="workflow_agent.iteration_limit",
+                        title="Iteration limit reached",
+                        summary=f"max_iterations={max_iterations}",
+                        severity="warning",
+                        metadata={"max_iterations": max_iterations},
+                    )
+                events.append(event)
+                messages.append(
+                    ChatMessage(
+                        role="assistant",
+                        content=json.dumps(decision, ensure_ascii=False),
+                    )
+                )
+                messages.append(
+                    ChatMessage(
+                        role="user",
+                        content=(
+                            f"工具 {tool_name} 的执行结果：\n"
+                            f"{tool_result_text}\n\n"
+                            "请继续用 JSON 决策下一步。"
+                        ),
+                    )
+                )
+            else:
+                event = {
+                    "event": "node_delta",
+                    "node_id": node.id,
+                    "node_title": title,
+                    "node_type": kind,
+                    "output": f"Agent 达到最大循环次数 {max_iterations}，未得到最终答案。",
+                    "variable": output_variable,
+                }
+                if run_id:
+                    event["run_id"] = run_id
+                events.append(event)
+                output_text = ""
+            return output_text, events
 
         try:
             yield sse_payload(
@@ -2759,208 +3082,31 @@ async def run_workflow(payload: WorkflowRunRequest, request: Request):
                                     }
                                 )
                             elif agent_mode == "tool_first":
-                                registered_tools = await tool_registry.list_tools()
-                                requested_tool_names = [
-                                    item.strip()
-                                    for item in str(node.data.get("toolNames") or "").split(",")
-                                    if item.strip()
-                                ]
-                                if requested_tool_names:
-                                    allowed_names = set(requested_tool_names)
-                                    available_tools = [
-                                        tool
-                                        for tool in registered_tools
-                                        if str(tool.get("name") or "") in allowed_names
-                                    ]
-                                else:
-                                    available_tools = registered_tools
-
-                                if not available_tools:
-                                    yield sse_payload(
-                                        {
-                                            "event": "node_delta",
-                                            "node_id": node.id,
-                                            "node_title": title,
-                                            "node_type": kind,
-                                            "output": "Agent 切换为直接回答：没有可用 MCP 工具",
-                                            "variable": output_variable,
-                                        }
-                                    )
-                                    output = await run_direct_agent()
-                                    variables[output_variable] = output
-                                    yield sse_payload(
-                                        {
-                                            "event": "node_delta",
-                                            "node_id": node.id,
-                                            "node_title": title,
-                                            "node_type": kind,
-                                            "output": output[:500],
-                                            "variable": output_variable,
-                                        }
-                                    )
-                                else:
-                                    tool_by_name = {
-                                        str(tool.get("name") or ""): tool
-                                        for tool in available_tools
-                                        if str(tool.get("name") or "")
+                                output, agent_events = await run_react_lite_agent(
+                                    node=node,
+                                    title=title,
+                                    kind=kind,
+                                    model_id=model_id,
+                                    system_prompt="你是模镜工作流中的 ReAct-Lite Agent。",
+                                    user_prompt=instruction,
+                                    tool_names_raw=node.data.get("toolNames"),
+                                    max_iterations=max_iterations,
+                                    temperature=temperature,
+                                    output_variable=output_variable,
+                                )
+                                variables[output_variable] = output
+                                for agent_event in agent_events:
+                                    yield sse_payload(agent_event)
+                                yield sse_payload(
+                                    {
+                                        "event": "node_delta",
+                                        "node_id": node.id,
+                                        "node_title": title,
+                                        "node_type": kind,
+                                        "output": output[:500],
+                                        "variable": output_variable,
                                     }
-                                    tool_descriptions = "\n".join(
-                                        (
-                                            f"- {name}: "
-                                            f"{tool.get('description') or '无描述'} "
-                                            f"schema={json.dumps(tool.get('input_schema') or {}, ensure_ascii=False)}"
-                                        )
-                                        for name, tool in tool_by_name.items()
-                                    )
-                                    system_prompt = (
-                                        "你是模镜工作流中的 ReAct-Lite Agent。"
-                                        "你可以选择调用一个工具，或给出最终答案。"
-                                        "每次回复必须是 JSON，且只能使用以下两种格式之一："
-                                        '{"tool":"工具名","arguments":{...}} 或 {"answer":"最终答案"}。'
-                                        "不要输出 JSON 以外的文字。\n\n可用工具：\n"
-                                        f"{tool_descriptions}"
-                                    )
-                                    messages: list[ChatMessage] = [
-                                        ChatMessage(role="system", content=system_prompt),
-                                        ChatMessage(role="user", content=instruction),
-                                    ]
-                                    for iteration_index in range(max_iterations):
-                                        if not get_llm_gateway_config()[0]:
-                                            raise ValueError(LLM_GATEWAY_NOT_CONFIGURED_MESSAGE)
-                                        raw_response = (
-                                            await collect_chat_completion_text(
-                                                model_id,
-                                                messages,
-                                                temperature=temperature,
-                                                max_tokens=WORKFLOW_AGENT_MAX_TOKENS,
-                                            )
-                                        ).strip()
-                                        json_text = raw_response
-                                        fenced = re.search(
-                                            r"```(?:json)?\s*\n?(.*?)\n?```",
-                                            raw_response,
-                                            re.DOTALL,
-                                        )
-                                        if fenced:
-                                            json_text = fenced.group(1).strip()
-                                        try:
-                                            decision = json.loads(json_text)
-                                        except ValueError:
-                                            output = raw_response
-                                            break
-                                        if not isinstance(decision, dict):
-                                            output = raw_response
-                                            break
-                                        answer = decision.get("answer")
-                                        if isinstance(answer, str) and answer.strip():
-                                            output = answer.strip()
-                                            break
-                                        tool_name = str(decision.get("tool") or "").strip()
-                                        arguments = decision.get("arguments")
-                                        if not tool_name:
-                                            output = raw_response
-                                            break
-                                        if not isinstance(arguments, dict):
-                                            arguments = {}
-                                        matched_tool = tool_by_name.get(tool_name)
-                                        if not matched_tool:
-                                            tool_result_text = f"工具不可用：{tool_name}"
-                                            yield sse_payload(
-                                                {
-                                                    "event": "node_delta",
-                                                    "node_id": node.id,
-                                                    "node_title": title,
-                                                    "node_type": kind,
-                                                    "output": tool_result_text,
-                                                    "variable": output_variable,
-                                                }
-                                            )
-                                        else:
-                                            call_result = await mcp_manager.call_tool(
-                                                str(matched_tool.get("session_id") or ""),
-                                                tool_name,
-                                                arguments,
-                                            )
-                                            text_parts: list[str] = []
-                                            non_text_types: list[str] = []
-                                            for part in getattr(call_result, "content", []) or []:
-                                                if isinstance(part, dict):
-                                                    part_type = str(part.get("type") or "other")
-                                                    part_text = part.get("text")
-                                                else:
-                                                    part_type = str(getattr(part, "type", "other"))
-                                                    part_text = getattr(part, "text", None)
-                                                if part_type == "text":
-                                                    text_parts.append(str(part_text or ""))
-                                                else:
-                                                    non_text_types.append(part_type)
-                                            tool_result_text = "\n".join(text_parts).strip()
-                                            if non_text_types:
-                                                tool_result_text = (
-                                                    tool_result_text
-                                                    + "\n"
-                                                    + "非文本结果已省略："
-                                                    + ", ".join(non_text_types)
-                                                ).strip()
-                                            yield sse_payload(
-                                                {
-                                                    "event": "node_delta",
-                                                    "node_id": node.id,
-                                                    "node_title": title,
-                                                    "node_type": kind,
-                                                    "output": (
-                                                        f"[{iteration_index + 1}/{max_iterations}] "
-                                                        f"调用工具 {tool_name}，结果预览："
-                                                        f"{tool_result_text[:300]}"
-                                                    ),
-                                                    "variable": output_variable,
-                                                }
-                                            )
-                                        messages.append(
-                                            ChatMessage(
-                                                role="assistant",
-                                                content=json.dumps(
-                                                    decision,
-                                                    ensure_ascii=False,
-                                                ),
-                                            )
-                                        )
-                                        messages.append(
-                                            ChatMessage(
-                                                role="user",
-                                                content=(
-                                                    f"工具 {tool_name} 的执行结果：\n"
-                                                    f"{tool_result_text}\n\n"
-                                                    "请继续用 JSON 决策下一步。"
-                                                ),
-                                            )
-                                        )
-                                    else:
-                                        yield sse_payload(
-                                            {
-                                                "event": "node_delta",
-                                                "node_id": node.id,
-                                                "node_title": title,
-                                                "node_type": kind,
-                                                "output": (
-                                                    f"Agent 达到最大循环次数 {max_iterations}，"
-                                                    "未得到最终答案。"
-                                                ),
-                                                "variable": output_variable,
-                                            }
-                                        )
-                                        output = ""
-                                    variables[output_variable] = output
-                                    yield sse_payload(
-                                        {
-                                            "event": "node_delta",
-                                            "node_id": node.id,
-                                            "node_title": title,
-                                            "node_type": kind,
-                                            "output": output[:500],
-                                            "variable": output_variable,
-                                        }
-                                    )
+                                )
                             else:
                                 raise ValueError(f"Agent 模式不支持：{agent_mode}")
                     except Exception as exc:
@@ -2995,10 +3141,29 @@ async def run_workflow(payload: WorkflowRunRequest, request: Request):
                             str(node.data.get("taskInput") or ""),
                             variables,
                         ).strip()
+                        prompt_suffix = render_workflow_template(
+                            str(node.data.get("promptSuffix") or ""),
+                            variables,
+                        ).strip()
+                        if prompt_suffix:
+                            task_input = f"{task_input}\n\n{prompt_suffix}".strip()
+                        tool_mode = str(node.data.get("toolMode") or "none").strip()
+                        try:
+                            max_iterations = int(
+                                str(
+                                    node.data.get("maxIterations")
+                                    or WORKFLOW_AGENT_MAX_ITERATIONS_DEFAULT
+                                )
+                            )
+                        except ValueError:
+                            max_iterations = WORKFLOW_AGENT_MAX_ITERATIONS_DEFAULT
+                        max_iterations = min(max(max_iterations, 1), 20)
                         if not role_prompt:
                             raise ValueError("workflow_agent 缺少角色提示词。")
                         if not task_input:
                             raise ValueError("workflow_agent 缺少任务输入。")
+                        if tool_mode not in {"none", "mcp_tools"}:
+                            raise ValueError(f"workflow_agent 工具模式不支持：{tool_mode}")
 
                         workflow_agent_run = await run_registry.create_run(
                             "workflow_agent",
@@ -3014,23 +3179,75 @@ async def run_workflow(payload: WorkflowRunRequest, request: Request):
                                 "node_title": title,
                                 "agent_name": agent_name,
                                 "model_id": model_id,
+                                "tool_mode": tool_mode,
+                                "output_variable": output_variable,
+                            },
+                        )
+                        await run_registry.record_checkpoint(
+                            workflow_agent_run.run_id,
+                            event_type="workflow_agent.started",
+                            title="Workflow agent started",
+                            summary=f"agent={agent_name}, tool_mode={tool_mode}",
+                            metadata={
+                                "node_id": node.id,
+                                "agent_name": agent_name,
+                                "model_id": model_id,
+                                "tool_mode": tool_mode,
                                 "output_variable": output_variable,
                             },
                         )
 
-                        async for delta in stream_workflow_llm_text(
-                            model_id,
-                            task_input,
-                            system_prompt=role_prompt,
-                        ):
-                            output += delta
+                        if tool_mode == "none":
+                            await run_registry.record_checkpoint(
+                                workflow_agent_run.run_id,
+                                event_type="workflow_agent.model_call",
+                                title="Model call started",
+                                summary=f"model={model_id}",
+                                metadata={
+                                    "node_id": node.id,
+                                    "model_id": model_id,
+                                },
+                            )
+                            async for delta in stream_workflow_llm_text(
+                                model_id,
+                                task_input,
+                                system_prompt=role_prompt,
+                            ):
+                                output += delta
+                                yield sse_payload(
+                                    {
+                                        "event": "node_delta",
+                                        "node_id": node.id,
+                                        "node_title": title,
+                                        "node_type": kind,
+                                        "output": delta,
+                                        "variable": output_variable,
+                                        "run_id": workflow_agent_run.run_id,
+                                    }
+                                )
+                        else:
+                            output, agent_events = await run_react_lite_agent(
+                                node=node,
+                                title=title,
+                                kind=kind,
+                                model_id=model_id,
+                                system_prompt=role_prompt,
+                                user_prompt=task_input,
+                                tool_names_raw=node.data.get("toolNames"),
+                                max_iterations=max_iterations,
+                                temperature=0.7,
+                                output_variable=output_variable,
+                                run_id=workflow_agent_run.run_id,
+                            )
+                            for agent_event in agent_events:
+                                yield sse_payload(agent_event)
                             yield sse_payload(
                                 {
                                     "event": "node_delta",
                                     "node_id": node.id,
                                     "node_title": title,
                                     "node_type": kind,
-                                    "output": delta,
+                                    "output": output[:500],
                                     "variable": output_variable,
                                     "run_id": workflow_agent_run.run_id,
                                 }
@@ -3042,6 +3259,16 @@ async def run_workflow(payload: WorkflowRunRequest, request: Request):
                             metadata={
                                 "output_length": len(output or ""),
                                 "variables_count": len(variables),
+                            },
+                        )
+                        await run_registry.record_checkpoint(
+                            workflow_agent_run.run_id,
+                            event_type="workflow_agent.completed",
+                            title="Workflow agent completed",
+                            summary=f"output_length={len(output or '')}",
+                            metadata={
+                                "node_id": node.id,
+                                "output_variable": output_variable,
                             },
                         )
                     except Exception as exc:
@@ -3117,6 +3344,18 @@ async def run_workflow(payload: WorkflowRunRequest, request: Request):
                                 "workflow_task_id": task_id,
                                 "node_id": node.id,
                                 "node_title": title,
+                                "agent_task_id": task.task_id,
+                                "assigned_agent": assigned_agent,
+                                "output_variable": output_variable,
+                            },
+                        )
+                        await run_registry.record_checkpoint(
+                            agent_task_run.run_id,
+                            event_type="agent_task.created",
+                            title="Agent task created",
+                            summary=task.title,
+                            metadata={
+                                "node_id": node.id,
                                 "agent_task_id": task.task_id,
                                 "assigned_agent": assigned_agent,
                                 "output_variable": output_variable,
@@ -3222,6 +3461,19 @@ async def run_workflow(payload: WorkflowRunRequest, request: Request):
                                 "target_agent": target_agent,
                                 "task_id_variable": task_id_variable,
                                 "output_variable": output_variable,
+                            },
+                        )
+                        await run_registry.record_checkpoint(
+                            handoff_run.run_id,
+                            event_type="agent_handoff.created",
+                            title="Agent handoff created",
+                            summary=f"{source_agent} -> {target_agent}",
+                            metadata={
+                                "node_id": node.id,
+                                "agent_task_id": handoff_task_id,
+                                "handoff_id": handoff.handoff_id,
+                                "source_agent": source_agent,
+                                "target_agent": target_agent,
                             },
                         )
                         output = handoff.handoff_id
@@ -3561,6 +3813,15 @@ async def run_workflow(payload: WorkflowRunRequest, request: Request):
                     "variables_count": len(variables),
                 },
             )
+            await run_registry.record_checkpoint(
+                workflow_run.run_id,
+                event_type="workflow.completed",
+                title="Workflow completed",
+                summary=f"final_output_length={len(final_output or '')}",
+                metadata={
+                    "variables_count": len(variables),
+                },
+            )
             yield sse_payload(
                 {
                     "event": "workflow_end",
@@ -3709,6 +3970,19 @@ def runtime_run_to_payload(run: Any) -> dict[str, Any]:
     }
 
 
+def runtime_run_checkpoint_to_payload(checkpoint: Any) -> dict[str, Any]:
+    return {
+        "checkpoint_id": checkpoint.checkpoint_id,
+        "run_id": checkpoint.run_id,
+        "event_type": checkpoint.event_type,
+        "title": checkpoint.title,
+        "summary": checkpoint.summary,
+        "severity": checkpoint.severity,
+        "metadata": dict(checkpoint.metadata or {}),
+        "created_at": checkpoint.created_at,
+    }
+
+
 async def first_runtime_run_for_source(
     source_id: str,
     run_type: str,
@@ -3745,6 +4019,32 @@ async def update_runtime_runs_for_source(
             )
 
 
+async def record_runtime_run_checkpoints_for_source(
+    source_id: str,
+    run_type: str,
+    *,
+    event_type: str,
+    title: str,
+    summary: str = "",
+    severity: str = "info",
+    metadata: dict[str, Any] | None = None,
+) -> None:
+    runs = await run_registry.list_runs(
+        run_type=run_type,  # type: ignore[arg-type]
+        limit=200,
+    )
+    for run in runs:
+        if run.source_id == source_id:
+            await run_registry.record_checkpoint(
+                run.run_id,
+                event_type=event_type,
+                title=title,
+                summary=summary,
+                severity=severity,
+                metadata=metadata,
+            )
+
+
 @app.get("/api/runtime/runs")
 async def list_runtime_runs(
     run_type: str | None = None,
@@ -3775,6 +4075,18 @@ async def get_runtime_run(run_id: str):
     if run is None:
         raise HTTPException(status_code=404, detail="Runtime run not found.")
     return runtime_run_to_payload(run)
+
+
+@app.get("/api/runtime/runs/{run_id}/checkpoints")
+async def list_runtime_run_checkpoints(run_id: str, limit: int = 50):
+    try:
+        checkpoints = await run_registry.list_checkpoints(
+            run_id,
+            limit=max(1, min(limit, 200)),
+        )
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="Runtime run not found.") from exc
+    return [runtime_run_checkpoint_to_payload(checkpoint) for checkpoint in checkpoints]
 
 
 @app.post("/api/runtime/runs/{run_id}/cancel")
@@ -4298,7 +4610,7 @@ async def create_agent_task(payload: dict[str, Any]):
         assigned_agent=payload.get("assigned_agent"),
         metadata=metadata,
     )
-    await run_registry.create_run(
+    agent_task_run = await run_registry.create_run(
         "agent_task",
         task.title,
         status="pending",
@@ -4310,6 +4622,17 @@ async def create_agent_task(payload: dict[str, Any]):
         ),
         metadata={
             **dict(metadata or {}),
+            "agent_task_id": task.task_id,
+            "source_agent": task.source_agent,
+            "assigned_agent": task.assigned_agent,
+        },
+    )
+    await run_registry.record_checkpoint(
+        agent_task_run.run_id,
+        event_type="agent_task.created",
+        title="Agent task created",
+        summary=task.title,
+        metadata={
             "agent_task_id": task.task_id,
             "source_agent": task.source_agent,
             "assigned_agent": task.assigned_agent,
@@ -4427,7 +4750,7 @@ async def create_agent_handoff(task_id: str, payload: dict[str, Any]):
         metadata=metadata,
     )
     task_run = await first_runtime_run_for_source(task_id, "agent_task")
-    await run_registry.create_run(
+    handoff_run = await run_registry.create_run(
         "agent_handoff",
         f"{source_agent or 'workflow'} -> {target_agent}",
         status="pending",
@@ -4439,6 +4762,18 @@ async def create_agent_handoff(task_id: str, payload: dict[str, Any]):
         ),
         metadata={
             **dict(metadata or {}),
+            "agent_task_id": task_id,
+            "handoff_id": handoff.handoff_id,
+            "source_agent": handoff.source_agent,
+            "target_agent": handoff.target_agent,
+        },
+    )
+    await run_registry.record_checkpoint(
+        handoff_run.run_id,
+        event_type="agent_handoff.created",
+        title="Agent handoff created",
+        summary=f"{handoff.source_agent} -> {handoff.target_agent}",
+        metadata={
             "agent_task_id": task_id,
             "handoff_id": handoff.handoff_id,
             "source_agent": handoff.source_agent,
@@ -4553,6 +4888,31 @@ async def update_agent_handoff_api(
             ),
             metadata={
                 "handoff_status": status,
+                **merged_metadata,
+            },
+        )
+        handler = (
+            merged_metadata.get("completed_by")
+            or merged_metadata.get("accepted_by")
+            or merged_metadata.get("rejected_by")
+            or ""
+        )
+        summary = str(
+            merged_metadata.get("result")
+            or merged_metadata.get("reason")
+            or handler
+            or status
+        )
+        await record_runtime_run_checkpoints_for_source(
+            handoff_id,
+            "agent_handoff",
+            event_type=f"agent_handoff.{status}",
+            title=f"Agent handoff {status}",
+            summary=summary,
+            severity="error" if status == "rejected" else "info",
+            metadata={
+                "handoff_id": handoff_id,
+                "status": status,
                 **merged_metadata,
             },
         )

--- a/server/tests/test_workflow_agent_task_node.py
+++ b/server/tests/test_workflow_agent_task_node.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import json
+from typing import Any
 
 import httpx
 import pytest
 import pytest_asyncio
 
+import server.main as main_module
 from server.main import app
+from server.xpert_runtime import RuntimeTool, RuntimeToolResult
 
 
 @pytest_asyncio.fixture
@@ -238,6 +241,24 @@ async def test_workflow_agent_handoff_node_creates_runtime_handoff_and_runs(
         for item in child_runs
     )
 
+    task_checkpoints_response = await client.get(
+        f"/api/runtime/runs/{task_run['run_id']}/checkpoints",
+    )
+    assert task_checkpoints_response.status_code == 200
+    assert any(
+        item["event_type"] == "agent_task.created"
+        for item in task_checkpoints_response.json()
+    )
+
+    handoff_checkpoints_response = await client.get(
+        f"/api/runtime/runs/{handoff_run['run_id']}/checkpoints",
+    )
+    assert handoff_checkpoints_response.status_code == 200
+    assert any(
+        item["event_type"] == "agent_handoff.created"
+        for item in handoff_checkpoints_response.json()
+    )
+
 
 @pytest.mark.asyncio
 async def test_workflow_agent_node_streams_output_and_registers_run(
@@ -348,6 +369,326 @@ async def test_workflow_agent_node_streams_output_and_registers_run(
     assert agent_run["metadata"]["model_id"] == "deepseek/deepseek-chat"
     assert agent_run["metadata"]["output_variable"] == "agent_output"
 
+    workflow_checkpoints_response = await client.get(
+        f"/api/runtime/runs/{workflow_run_id}/checkpoints",
+    )
+    assert workflow_checkpoints_response.status_code == 200
+    workflow_checkpoint_types = [
+        item["event_type"] for item in workflow_checkpoints_response.json()
+    ]
+    assert "workflow.started" in workflow_checkpoint_types
+    assert "workflow.completed" in workflow_checkpoint_types
+
+    agent_checkpoints_response = await client.get(
+        f"/api/runtime/runs/{agent_run['run_id']}/checkpoints",
+    )
+    assert agent_checkpoints_response.status_code == 200
+    agent_checkpoint_types = [
+        item["event_type"] for item in agent_checkpoints_response.json()
+    ]
+    assert "workflow_agent.started" in agent_checkpoint_types
+    assert "workflow_agent.model_call" in agent_checkpoint_types
+    assert "workflow_agent.completed" in agent_checkpoint_types
+
+
+@pytest.mark.asyncio
+async def test_workflow_agent_mcp_tool_mode_uses_runtime_toolset(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider, restore_provider = _install_fake_tool_provider()
+    responses = iter(
+        [
+            '{"tool":"fetch","arguments":{"query":"handoff queue"}}',
+            '{"answer":"final from tool"}',
+        ]
+    )
+
+    async def fake_collect_chat_completion_text(*args, **kwargs):
+        return next(responses)
+
+    monkeypatch.setattr(
+        main_module,
+        "get_llm_gateway_config",
+        lambda: ("http://test-gateway.local/v1/chat/completions", "test-key"),
+    )
+    monkeypatch.setattr(
+        main_module,
+        "collect_chat_completion_text",
+        fake_collect_chat_completion_text,
+    )
+    monkeypatch.setattr(main_module, "workflow_mcp_provider", provider)
+    try:
+        workflow = {
+            "id": "workflow-agent-tool-workflow",
+            "title": "workflow agent tool workflow",
+            "nodes": [
+                {
+                    "id": "input",
+                    "type": "input",
+                    "data": {"kind": "input", "variableName": "user_input"},
+                },
+                {
+                    "id": "workflow_agent",
+                    "type": "workflow_agent",
+                    "data": {
+                        "kind": "workflow_agent",
+                        "agentName": "tool-agent",
+                        "modelId": "deepseek/deepseek-chat",
+                        "rolePrompt": "你是工具智能体。",
+                        "taskInput": "请处理：{{user_input}}",
+                        "toolMode": "mcp_tools",
+                        "toolNames": "fetch",
+                        "maxIterations": "3",
+                        "outputVariable": "agent_output",
+                    },
+                },
+                {
+                    "id": "output",
+                    "type": "output",
+                    "data": {"kind": "output", "outputVariable": "agent_output"},
+                },
+            ],
+            "edges": [
+                {"id": "e1", "source": "input", "target": "workflow_agent"},
+                {"id": "e2", "source": "workflow_agent", "target": "output"},
+            ],
+        }
+
+        response = await client.post(
+            "/api/workflow/run",
+            json={
+                "workflow": workflow,
+                "inputs": {"user_input": "handoff queue"},
+            },
+        )
+    finally:
+        restore_provider()
+
+    assert response.status_code == 200, response.text
+    events = _parse_sse_events(response.text)
+    tool_deltas = [
+        event
+        for event in events
+        if event.get("event") == "node_delta"
+        and event.get("node_id") == "workflow_agent"
+        and "调用工具 fetch" in str(event.get("output"))
+    ]
+    assert tool_deltas
+
+    agent_end = next(
+        event
+        for event in events
+        if event.get("event") == "node_end" and event.get("node_id") == "workflow_agent"
+    )
+    assert agent_end["output"] == "final from tool"
+    assert agent_end["variables"]["agent_output"] == "final from tool"
+    assert len(provider.calls) == 1
+    assert provider.calls[0].tool_name == "fetch"
+    assert provider.calls[0].arguments == {"query": "handoff queue"}
+
+    workflow_meta = next(event for event in events if event.get("event") == "workflow_meta")
+    workflow_run_id = workflow_meta["run_id"]
+    child_runs_response = await client.get(
+        f"/api/runtime/runs?parent_run_id={workflow_run_id}&limit=20",
+    )
+    assert child_runs_response.status_code == 200, child_runs_response.text
+    workflow_agent_run = next(
+        item for item in child_runs_response.json() if item["run_type"] == "workflow_agent"
+    )
+    checkpoints_response = await client.get(
+        f"/api/runtime/runs/{workflow_agent_run['run_id']}/checkpoints",
+    )
+    assert checkpoints_response.status_code == 200, checkpoints_response.text
+    checkpoint_types = [item["event_type"] for item in checkpoints_response.json()]
+    assert "workflow_agent.tool_call" in checkpoint_types
+    assert "workflow_agent.model_answer" in checkpoint_types
+
+
+@pytest.mark.asyncio
+async def test_workflow_agent_tool_policy_denial_does_not_crash_workflow(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider, restore_provider = _install_fake_tool_provider()
+
+    async def fake_collect_chat_completion_text(*args, **kwargs):
+        return '{"tool":"fetch","arguments":{"query":"blocked"}}'
+
+    monkeypatch.setattr(
+        main_module,
+        "get_llm_gateway_config",
+        lambda: ("http://test-gateway.local/v1/chat/completions", "test-key"),
+    )
+    monkeypatch.setattr(
+        main_module,
+        "collect_chat_completion_text",
+        fake_collect_chat_completion_text,
+    )
+    monkeypatch.setattr(main_module, "workflow_mcp_provider", provider)
+    try:
+        workflow = {
+            "id": "workflow-agent-policy-workflow",
+            "title": "workflow agent policy workflow",
+            "nodes": [
+                {
+                    "id": "input",
+                    "type": "input",
+                    "data": {"kind": "input", "variableName": "user_input"},
+                },
+                {
+                    "id": "policy",
+                    "type": "runtime_middleware",
+                    "data": {
+                        "kind": "runtime_middleware",
+                        "runtimeMiddlewareId": "tool_policy",
+                        "runtimeMiddlewareKind": "runtime_middleware.tool_policy",
+                        "runtimeMiddlewareConfig": {
+                            "denied_tools": "fetch",
+                            "allow_by_default": True,
+                        },
+                    },
+                },
+                {
+                    "id": "workflow_agent",
+                    "type": "workflow_agent",
+                    "data": {
+                        "kind": "workflow_agent",
+                        "agentName": "tool-agent",
+                        "modelId": "deepseek/deepseek-chat",
+                        "rolePrompt": "你是工具智能体。",
+                        "taskInput": "请处理：{{user_input}}",
+                        "toolMode": "mcp_tools",
+                        "toolNames": "fetch",
+                        "maxIterations": "2",
+                        "outputVariable": "agent_output",
+                    },
+                },
+                {
+                    "id": "output",
+                    "type": "output",
+                    "data": {"kind": "output", "outputVariable": "agent_output"},
+                },
+            ],
+            "edges": [
+                {"id": "e1", "source": "input", "target": "policy"},
+                {"id": "e2", "source": "policy", "target": "workflow_agent"},
+                {"id": "e3", "source": "workflow_agent", "target": "output"},
+            ],
+        }
+
+        response = await client.post(
+            "/api/workflow/run",
+            json={
+                "workflow": workflow,
+                "inputs": {"user_input": "blocked"},
+            },
+        )
+    finally:
+        restore_provider()
+
+    assert response.status_code == 200, response.text
+    events = _parse_sse_events(response.text)
+    errors = [
+        event
+        for event in events
+        if event.get("event") == "error" and event.get("node_id") == "workflow_agent"
+    ]
+    assert errors
+    assert "denied" in str(errors[0].get("message")).lower()
+    agent_end = next(
+        event
+        for event in events
+        if event.get("event") == "node_end" and event.get("node_id") == "workflow_agent"
+    )
+    assert agent_end["output"] == ""
+    assert provider.calls == []
+
+
+@pytest.mark.asyncio
+async def test_legacy_agent_tool_first_uses_runtime_toolset(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider, restore_provider = _install_fake_tool_provider()
+    responses = iter(
+        [
+            '{"tool":"fetch","arguments":{"query":"legacy agent"}}',
+            '{"answer":"legacy final"}',
+        ]
+    )
+
+    async def fake_collect_chat_completion_text(*args, **kwargs):
+        return next(responses)
+
+    monkeypatch.setattr(
+        main_module,
+        "get_llm_gateway_config",
+        lambda: ("http://test-gateway.local/v1/chat/completions", "test-key"),
+    )
+    monkeypatch.setattr(
+        main_module,
+        "collect_chat_completion_text",
+        fake_collect_chat_completion_text,
+    )
+    monkeypatch.setattr(main_module, "workflow_mcp_provider", provider)
+    try:
+        workflow = {
+            "id": "legacy-agent-tool-workflow",
+            "title": "legacy agent tool workflow",
+            "nodes": [
+                {
+                    "id": "input",
+                    "type": "input",
+                    "data": {"kind": "input", "variableName": "user_input"},
+                },
+                {
+                    "id": "agent",
+                    "type": "agent",
+                    "data": {
+                        "kind": "agent",
+                        "agentMode": "tool_first",
+                        "instruction": "请处理：{{user_input}}",
+                        "modelId": "deepseek/deepseek-chat",
+                        "toolNames": "fetch",
+                        "maxIterations": "3",
+                        "temperature": "0.7",
+                        "outputVariable": "agent_output",
+                    },
+                },
+                {
+                    "id": "output",
+                    "type": "output",
+                    "data": {"kind": "output", "outputVariable": "agent_output"},
+                },
+            ],
+            "edges": [
+                {"id": "e1", "source": "input", "target": "agent"},
+                {"id": "e2", "source": "agent", "target": "output"},
+            ],
+        }
+
+        response = await client.post(
+            "/api/workflow/run",
+            json={
+                "workflow": workflow,
+                "inputs": {"user_input": "legacy agent"},
+            },
+        )
+    finally:
+        restore_provider()
+
+    assert response.status_code == 200, response.text
+    events = _parse_sse_events(response.text)
+    agent_end = next(
+        event
+        for event in events
+        if event.get("event") == "node_end" and event.get("node_id") == "agent"
+    )
+    assert agent_end["output"] == "legacy final"
+    assert len(provider.calls) == 1
+    assert provider.calls[0].tool_name == "fetch"
+
 
 def _parse_sse_events(sse_text: str) -> list[dict]:
     events: list[dict] = []
@@ -361,3 +702,46 @@ def _parse_sse_events(sse_text: str) -> list[dict]:
         if isinstance(payload, dict):
             events.append(payload)
     return events
+
+
+class FakeWorkflowToolProvider:
+    def __init__(self) -> None:
+        self.tools = [
+            RuntimeTool(
+                name="fetch",
+                description="Fetch test content",
+                input_schema={"type": "object"},
+                session_id="session-1",
+                server_id="server-1",
+            )
+        ]
+        self.calls = []
+
+    async def list_tools(self):
+        return list(self.tools)
+
+    async def find_tool(self, tool_name: str):
+        for tool in self.tools:
+            if tool.name == tool_name:
+                return tool
+        return None
+
+    async def call_tool(self, call):
+        self.calls.append(call)
+        return RuntimeToolResult(
+            output="tool response",
+            content=[{"type": "text", "text": "tool response"}],
+            metadata={"content_types": ["text"]},
+            is_error=False,
+        )
+
+
+def _install_fake_tool_provider() -> tuple[FakeWorkflowToolProvider, Any]:
+    provider = FakeWorkflowToolProvider()
+    original = main_module.runtime_capabilities.require("mcp_tools").implementation
+    main_module.runtime_capabilities.register("mcp_tools", provider)
+
+    def restore() -> None:
+        main_module.runtime_capabilities.register("mcp_tools", original)
+
+    return provider, restore

--- a/server/tests/test_workflow_native_validate.py
+++ b/server/tests/test_workflow_native_validate.py
@@ -1203,6 +1203,72 @@ async def test_workflow_agent_output_variable_is_available_downstream(
 
 
 @pytest.mark.asyncio
+async def test_workflow_agent_mcp_tool_mode_is_valid(
+    client: httpx.AsyncClient,
+) -> None:
+    workflow = linear_workflow()
+    workflow["nodes"][1] = {
+        "id": "workflow_agent",
+        "type": "workflow_agent",
+        "data": {
+            "kind": "workflow_agent",
+            "agentName": "tool-agent",
+            "modelId": "deepseek/deepseek-chat",
+            "rolePrompt": "你是工具智能体。",
+            "taskInput": "{{user_input}}",
+            "toolMode": "mcp_tools",
+            "toolNames": "fetch",
+            "maxIterations": "3",
+            "outputVariable": "agent_output",
+        },
+    }
+    workflow["nodes"][2]["data"]["outputVariable"] = "agent_output"
+    workflow["edges"] = [
+        {"id": "e1", "source": "input", "target": "workflow_agent"},
+        {"id": "e2", "source": "workflow_agent", "target": "output"},
+    ]
+
+    data = await validate(client, workflow)
+
+    assert data["valid"] is True
+    assert "invalid_workflow_agent_tool_mode" not in issue_codes(data)
+    assert "invalid_workflow_agent_max_iterations" not in issue_codes(data)
+
+
+@pytest.mark.asyncio
+async def test_workflow_agent_invalid_tool_mode_and_iterations(
+    client: httpx.AsyncClient,
+) -> None:
+    workflow = linear_workflow()
+    workflow["nodes"][1] = {
+        "id": "workflow_agent",
+        "type": "workflow_agent",
+        "data": {
+            "kind": "workflow_agent",
+            "agentName": "tool-agent",
+            "modelId": "deepseek/deepseek-chat",
+            "rolePrompt": "你是工具智能体。",
+            "taskInput": "{{user_input}}",
+            "toolMode": "unknown",
+            "maxIterations": "99",
+            "outputVariable": "agent_output",
+        },
+    }
+    workflow["nodes"][2]["data"]["outputVariable"] = "agent_output"
+    workflow["edges"] = [
+        {"id": "e1", "source": "input", "target": "workflow_agent"},
+        {"id": "e2", "source": "workflow_agent", "target": "output"},
+    ]
+
+    data = await validate(client, workflow)
+
+    codes = issue_codes(data)
+    assert data["valid"] is False
+    assert "invalid_workflow_agent_tool_mode" in codes
+    assert "invalid_workflow_agent_max_iterations" in codes
+
+
+@pytest.mark.asyncio
 async def test_validate_agent_handoff_node_ok(client: httpx.AsyncClient) -> None:
     workflow = linear_workflow()
     workflow["nodes"] = [

--- a/server/tests/test_xpert_runtime_run_registry.py
+++ b/server/tests/test_xpert_runtime_run_registry.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+
 import httpx
 import pytest
 import pytest_asyncio
@@ -88,16 +90,64 @@ async def test_run_registry_filters_by_parent_and_source() -> None:
 
 
 @pytest.mark.asyncio
+async def test_run_registry_record_and_list_checkpoints() -> None:
+    registry = RunRegistry()
+    run = await registry.create_run("workflow", "Trace workflow", status="running")
+
+    first = await registry.record_checkpoint(
+        run.run_id,
+        event_type="workflow.started",
+        title="Started",
+        summary="start summary",
+        metadata={"step": 1},
+    )
+    await asyncio.sleep(0.001)
+    second = await registry.record_checkpoint(
+        run.run_id,
+        event_type="workflow.completed",
+        title="Completed",
+        summary="done summary",
+        metadata={"step": 2},
+    )
+
+    checkpoints = await registry.list_checkpoints(run.run_id)
+    assert [checkpoint.checkpoint_id for checkpoint in checkpoints] == [
+        second.checkpoint_id,
+        first.checkpoint_id,
+    ]
+    assert checkpoints[0].event_type == "workflow.completed"
+    assert checkpoints[0].metadata["step"] == 2
+
+
+@pytest.mark.asyncio
+async def test_run_registry_checkpoint_missing_run_raises() -> None:
+    registry = RunRegistry()
+
+    with pytest.raises(KeyError):
+        await registry.record_checkpoint(
+            "missing-run",
+            event_type="workflow.started",
+            title="missing",
+        )
+
+    with pytest.raises(KeyError):
+        await registry.list_checkpoints("missing-run")
+
+
+@pytest.mark.asyncio
 async def test_run_registry_cancel_run_updates_status() -> None:
     registry = RunRegistry()
     run = await registry.create_run("agent_handoff", "handoff", status="pending")
 
     cancelled = await registry.cancel_run(run.run_id, reason="manual stop")
+    checkpoints = await registry.list_checkpoints(run.run_id)
 
     assert cancelled.status == "cancelled"
     assert cancelled.error == "manual stop"
     assert cancelled.cancelled_at is not None
     assert cancelled.metadata["cancel_reason"] == "manual stop"
+    assert checkpoints[0].event_type == "run.cancelled"
+    assert checkpoints[0].summary == "manual stop"
 
 
 @pytest.mark.asyncio
@@ -131,6 +181,13 @@ async def test_runtime_run_api_list_and_cancel(client: httpx.AsyncClient) -> Non
     cancelled = cancel_response.json()
     assert cancelled["status"] == "cancelled"
     assert cancelled["error"] == "api test"
+
+    checkpoints_response = await client.get(
+        f"/api/runtime/runs/{run['run_id']}/checkpoints",
+    )
+    assert checkpoints_response.status_code == 200, checkpoints_response.text
+    checkpoints = checkpoints_response.json()
+    assert any(item["event_type"] == "run.cancelled" for item in checkpoints)
 
 
 @pytest.mark.asyncio
@@ -218,3 +275,12 @@ async def test_handoff_status_updates_runtime_run_metadata(
     assert run["metadata"]["accepted_by"] == "queue-operator"
     assert run["metadata"]["completed_by"] == "queue-operator"
     assert run["metadata"]["result"] == "review complete"
+
+    checkpoints_response = await client.get(
+        f"/api/runtime/runs/{run['run_id']}/checkpoints",
+    )
+    assert checkpoints_response.status_code == 200, checkpoints_response.text
+    checkpoint_types = [item["event_type"] for item in checkpoints_response.json()]
+    assert "agent_handoff.created" in checkpoint_types
+    assert "agent_handoff.accepted" in checkpoint_types
+    assert "agent_handoff.completed" in checkpoint_types

--- a/server/workflow_native/validate.py
+++ b/server/workflow_native/validate.py
@@ -738,6 +738,31 @@ def validate_node_configuration(
                 )
             )
 
+        tool_mode = str(data.get("toolMode") or "none").strip()
+        if tool_mode not in {"none", "mcp_tools"}:
+            issues.append(
+                ValidationIssue(
+                    code="invalid_workflow_agent_tool_mode",
+                    message="Workflow agent toolMode must be none or mcp_tools.",
+                    node_id=node.id,
+                )
+            )
+
+        max_iterations = str(data.get("maxIterations") or "").strip()
+        if max_iterations:
+            try:
+                max_iterations_value = int(max_iterations)
+            except ValueError:
+                max_iterations_value = 0
+            if max_iterations_value < 1 or max_iterations_value > 20:
+                issues.append(
+                    ValidationIssue(
+                        code="invalid_workflow_agent_max_iterations",
+                        message="Workflow agent maxIterations must be between 1 and 20.",
+                        node_id=node.id,
+                    )
+                )
+
         output_variable = str(data.get("outputVariable") or "").strip()
         if not output_variable:
             issues.append(

--- a/server/xpert_runtime/__init__.py
+++ b/server/xpert_runtime/__init__.py
@@ -29,6 +29,7 @@ from .models import (
 from .run_registry import (
     RunRegistry,
     RuntimeRun,
+    RuntimeRunCheckpoint,
     RuntimeRunStatus,
     RuntimeRunType,
 )
@@ -70,6 +71,7 @@ __all__ = [
     "RuntimeMiddlewareNode",
     "RuntimeMiddlewareRegistry",
     "RuntimeRun",
+    "RuntimeRunCheckpoint",
     "RuntimeRunStatus",
     "RuntimeRunType",
     "RuntimeTask",

--- a/server/xpert_runtime/run_registry.py
+++ b/server/xpert_runtime/run_registry.py
@@ -30,12 +30,27 @@ class RuntimeRun:
         self.updated_at = time.time()
 
 
+@dataclass(slots=True)
+class RuntimeRunCheckpoint:
+    """Small trace item attached to a RuntimeRun."""
+
+    checkpoint_id: str
+    run_id: str
+    event_type: str
+    title: str
+    summary: str = ""
+    severity: str = "info"
+    metadata: dict[str, Any] = field(default_factory=dict)
+    created_at: float = field(default_factory=time.time)
+
+
 class RunRegistry:
     """Small in-memory RunRegistry for workflow, agent, task, and handoff runs."""
 
     def __init__(self) -> None:
         self._lock = asyncio.Lock()
         self._runs: dict[str, RuntimeRun] = {}
+        self._checkpoints: dict[str, list[RuntimeRunCheckpoint]] = {}
 
     async def create_run(
         self,
@@ -58,6 +73,7 @@ class RunRegistry:
         )
         async with self._lock:
             self._runs[run.run_id] = run
+            self._checkpoints[run.run_id] = []
         return run
 
     async def get_run(self, run_id: str) -> RuntimeRun | None:
@@ -86,6 +102,44 @@ class RunRegistry:
         runs.sort(key=lambda run: run.created_at, reverse=True)
         return runs[: max(1, limit)]
 
+    async def record_checkpoint(
+        self,
+        run_id: str,
+        *,
+        event_type: str,
+        title: str,
+        summary: str = "",
+        severity: str = "info",
+        metadata: dict[str, Any] | None = None,
+    ) -> RuntimeRunCheckpoint:
+        checkpoint = RuntimeRunCheckpoint(
+            checkpoint_id=str(uuid.uuid4()),
+            run_id=run_id,
+            event_type=event_type,
+            title=title,
+            summary=summary[:500],
+            severity=severity,
+            metadata=dict(metadata or {}),
+        )
+        async with self._lock:
+            if run_id not in self._runs:
+                raise KeyError(f"Runtime run not found: {run_id}")
+            self._checkpoints.setdefault(run_id, []).append(checkpoint)
+        return checkpoint
+
+    async def list_checkpoints(
+        self,
+        run_id: str,
+        *,
+        limit: int = 50,
+    ) -> list[RuntimeRunCheckpoint]:
+        async with self._lock:
+            if run_id not in self._runs:
+                raise KeyError(f"Runtime run not found: {run_id}")
+            checkpoints = list(self._checkpoints.get(run_id, []))
+        checkpoints.sort(key=lambda checkpoint: checkpoint.created_at, reverse=True)
+        return checkpoints[: max(1, limit)]
+
     async def update_run(
         self,
         run_id: str,
@@ -107,6 +161,30 @@ class RunRegistry:
             if metadata is not None:
                 run.metadata.update(metadata)
             run.touch()
+            if status == "failed":
+                self._checkpoints.setdefault(run_id, []).append(
+                    RuntimeRunCheckpoint(
+                        checkpoint_id=str(uuid.uuid4()),
+                        run_id=run_id,
+                        event_type="run.failed",
+                        title="Run failed",
+                        summary=str(error or run.error or "")[:500],
+                        severity="error",
+                        metadata={"status": status},
+                    )
+                )
+            elif status == "cancelled":
+                self._checkpoints.setdefault(run_id, []).append(
+                    RuntimeRunCheckpoint(
+                        checkpoint_id=str(uuid.uuid4()),
+                        run_id=run_id,
+                        event_type="run.cancelled",
+                        title="Run cancelled",
+                        summary=str(error or run.error or "")[:500],
+                        severity="warning",
+                        metadata={"status": status},
+                    )
+                )
             return run
 
     async def cancel_run(


### PR DESCRIPTION
Summary: Add in-memory RunRegistry checkpoints and checkpoint query API; record workflow, workflow_agent, agent_task, agent_handoff, and handoff status checkpoints; show checkpoints in the workflow runtime observation panel; update Xpert alignment and workflow design docs. Validation: npm.cmd run build passed; py_compile passed; focused pytest 67 passed; full pytest 143 passed; docker compose rebuild passed; /api/health returned {status:ok}. Boundaries: no database, queue, automatic retry, checkpoint resume, or scheduler changes; checkpoints store summaries and metadata only, not full prompts, tool outputs, model outputs, or secrets; untracked package files and APK are excluded.