### PR TITLE
feature: 添加 Handoff Router 工作流节点

### DIFF
--- a/client/src/components/workflow/NodePalette.tsx
+++ b/client/src/components/workflow/NodePalette.tsx
@@ -111,6 +111,12 @@ const paletteItems: PaletteItem[] = [
     description: "把 Agent Task 显式移交给另一个智能体，输出 handoff_id。",
   },
   {
+    kind: "handoff_router",
+    icon: "↪",
+    title: "移交路由器",
+    description: "读取智能体输出，创建 AgentTask 并投递到目标 Agent 的 Handoff Inbox。",
+  },
+  {
     kind: "mcp_tool",
     icon: "🔧",
     title: "MCP Tool",

--- a/client/src/components/workflow/WorkflowEditor.tsx
+++ b/client/src/components/workflow/WorkflowEditor.tsx
@@ -318,6 +318,20 @@ function createNodeData(
     };
   }
 
+  if (kind === "handoff_router") {
+    return {
+      kind,
+      title: "移交路由器",
+      description: "读取工作流智能体输出，创建 AgentTask 并投递 pending Handoff。",
+      sourceVariable: "agent_output",
+      taskTitle: "来自工作流智能体的任务",
+      targetAgent: "review-agent",
+      sourceAgent: "workflow-agent",
+      reasonTemplate: "请处理工作流智能体输出：{{agent_output}}",
+      outputVariable: "agent_handoff_id",
+    };
+  }
+
   if (kind === "mcp_tool") {
     return {
       kind,
@@ -1366,6 +1380,56 @@ function NodeConfig({ node, onChange }: NodeConfigProps) {
               className={`${textInputClass()} min-h-28 resize-none leading-6`}
               onChange={(event) => update({ reason: event.target.value })}
               value={data.reason ?? ""}
+            />
+          </Field>
+          <Field label="输出变量">
+            <input
+              className={textInputClass()}
+              onChange={(event) => update({ outputVariable: event.target.value })}
+              value={data.outputVariable ?? ""}
+            />
+          </Field>
+        </>
+      ) : null}
+
+      {data.kind === "handoff_router" ? (
+        <>
+          <div className="rounded-lg border border-fuchsia-300/25 bg-fuchsia-300/10 px-3 py-2 text-xs leading-5 text-fuchsia-50">
+            读取上游智能体输出，创建 AgentTask 并投递一条 pending Handoff；目标 Agent 仍需在 Inbox 中人工接受和完成。
+          </div>
+          <Field label="来源变量">
+            <input
+              className={textInputClass()}
+              onChange={(event) => update({ sourceVariable: event.target.value })}
+              value={data.sourceVariable ?? ""}
+            />
+          </Field>
+          <Field label="任务标题（支持 {{变量}}）">
+            <input
+              className={textInputClass()}
+              onChange={(event) => update({ taskTitle: event.target.value })}
+              value={data.taskTitle ?? ""}
+            />
+          </Field>
+          <Field label="来源智能体">
+            <input
+              className={textInputClass()}
+              onChange={(event) => update({ sourceAgent: event.target.value })}
+              value={data.sourceAgent ?? ""}
+            />
+          </Field>
+          <Field label="目标智能体">
+            <input
+              className={textInputClass()}
+              onChange={(event) => update({ targetAgent: event.target.value })}
+              value={data.targetAgent ?? ""}
+            />
+          </Field>
+          <Field label="移交理由模板（支持 {{变量}}）">
+            <textarea
+              className={`${textInputClass()} min-h-28 resize-none leading-6`}
+              onChange={(event) => update({ reasonTemplate: event.target.value })}
+              value={data.reasonTemplate ?? ""}
             />
           </Field>
           <Field label="输出变量">

--- a/client/src/components/workflow/WorkflowNodeCard.tsx
+++ b/client/src/components/workflow/WorkflowNodeCard.tsx
@@ -114,6 +114,13 @@ const nodeMeta = {
     bg: "bg-fuchsia-300/10",
     text: "text-fuchsia-100",
   },
+  handoff_router: {
+    icon: "↪",
+    label: "Handoff Router",
+    border: "border-pink-300/40",
+    bg: "bg-pink-300/10",
+    text: "text-pink-100",
+  },
   mcp_tool: {
     icon: "🔧",
     label: "MCP Tool",
@@ -206,6 +213,9 @@ function outputName(data: WorkflowNode["data"]) {
   }
   if (data.kind === "agent_handoff") {
     return `${data.taskIdVariable ?? "agent_task_id"} -> ${data.targetAgent ?? "review-agent"} -> ${data.outputVariable ?? "agent_handoff_id"}`;
+  }
+  if (data.kind === "handoff_router") {
+    return `${data.sourceVariable ?? "agent_output"} -> ${data.targetAgent ?? "review-agent"} -> ${data.outputVariable ?? "agent_handoff_id"}`;
   }
   if (data.kind === "mcp_tool") {
     return `🔧 ${data.toolName ?? "未选择"} → ${data.outputVariable ?? "mcp_output"}`;

--- a/client/src/types/workflow.ts
+++ b/client/src/types/workflow.ts
@@ -18,6 +18,7 @@ export type WorkflowNodeKind =
   | "workflow_agent"
   | "agent_task"
   | "agent_handoff"
+  | "handoff_router"
   | "mcp_tool"
   | "time_tool"
   | "http_request"
@@ -73,9 +74,11 @@ export interface WorkflowNodeData extends Record<string, unknown> {
   taskInput?: string;
   assignedAgent?: string;
   taskIdVariable?: string;
+  sourceVariable?: string;
   sourceAgent?: string;
   targetAgent?: string;
   reason?: string;
+  reasonTemplate?: string;
   instruction?: string;
   toolNames?: string;
   maxIterations?: string;

--- a/docs/XPERT_ALIGNMENT.md
+++ b/docs/XPERT_ALIGNMENT.md
@@ -1,5 +1,6 @@
 # Xpert 对齐总纲
 
+> 2026-07-08 状态补充：Handoff Router 已进入“部分实现”。Classic workflow 新增 `handoff_router` 节点，可读取 `workflow_agent` 等上游节点输出，创建 AgentTask，并向目标 Agent 创建 pending Handoff，让结果进入 MetaAgent Handoff Inbox。当前不自动 accept、不执行目标 Agent、不接队列 worker 或持久化。
 > 2026-07-07 状态补充：RunRegistry Trace 已进入“部分实现”。`RuntimeRun` 现在可挂载内存态 checkpoint，记录 workflow、workflow_agent、agent_task、agent_handoff 的关键执行时间线；新增 `GET /api/runtime/runs/{run_id}/checkpoints` 供前端运行观测读取。当前仍不做持久化、自动重试、队列调度或 checkpoint resume。
 > 2026-07-07 状态补充：Workflow Agent Toolset 已进入“部分实现”。`workflow_agent` 现在支持 `toolMode=none/mcp_tools`，启用 MCP 工具时复用 Runtime Toolset、`tool_policy` 与 `tool_audit`；旧 `agent.tool_first` 也收敛到同一条 `run_tool_with_runtime` 路径。当前仍是轻量 JSON 决策协议，不做 OpenAI function calling、自动 Handoff 或真实多 Agent 调度。
 
@@ -26,7 +27,7 @@ Classic workflow 运行时会创建 workflow run，并在 `workflow_meta` / `wor
 
 当前边界：RunRegistry 仅为内存态可观测索引，不是持久化调度器；取消 run 只更新 registry 状态，不中断真实 workflow、AgentTask 或 Handoff 执行。Checkpoint 只保存摘要与元信息，不保存完整 prompt、工具输出、模型输出或密钥。下一步可在此基础上继续补齐 Handoff 自动编排、RunRegistry 页面、死信与持久化存储。
 
-最后更新日期：2026-07-06
+最后更新日期：2026-07-08
 维护人：模镜团队
 
 ## 对齐原则
@@ -58,6 +59,7 @@ EvoAgentX 只保留为历史参考：此前元智能体曾借鉴其 `goal -> sub
 - Workflow Agent Node：classic workflow 可拖入 `workflow_agent` 节点，使用 `rolePrompt` 作为该节点 system prompt、`taskInput` 作为用户输入调用模型，结果写入 `outputVariable`，并登记 `workflow_agent` 子 run；启用 `toolMode=mcp_tools` 时可通过 Runtime Toolset 调用 MCP 工具。
 - Agent Task Runtime：已提供 `AgentTaskStore`、最小 AgentTask API、MetaAgent 任务工作台，以及 classic workflow `agent_task` 节点；该节点当前负责创建任务并输出 `task_id`，暂不做真实多 Agent 调度。
 - Handoff API：已提供 handoff 创建、按任务查询、接受、拒绝、完成的内存态 API，状态转移限定为 `pending -> accepted/rejected`、`accepted -> completed`，并写入 `agent.handoff.created/accepted/rejected/completed` runtime events。
+- Handoff Router Node：classic workflow 可拖入 `handoff_router` 节点，读取上游变量作为 AgentTask input，创建 AgentTask 后立即创建 pending Handoff，并登记 `agent_task` / `agent_handoff` 子 run 与 checkpoint；当前仍由 Handoff Inbox 人工处理，不做自动调度。
 - 运行观测：classic workflow 可查询 per-task runtime events 和 tool audit records，前端 `WorkflowRun` 已提供“运行观测”折叠区。
 
 ## 近期交付顺序

--- a/docs/workflow-native-design.md
+++ b/docs/workflow-native-design.md
@@ -515,3 +515,13 @@ classic workflow 已新增 `workflow_agent` 节点，作为 Xpert Workflow Agent
 2. 从 `client/src/data/studio.ts` 移除实验卡片。
 3. 后端可以保留 `/api/workflow-native/validate`，因为它不会影响稳定路径。
 4. `/workflow`、`/workflow/classic`、`/rag` 不需要变更。
+
+## 2026-07-08 增量：Handoff Router 工作流节点
+
+Classic workflow 新增 handoff_router 节点，作为 workflow_agent -> Handoff Inbox 的人工可控自动编排雏形。节点字段包括 sourceVariable、taskTitle、targetAgent、sourceAgent、reasonTemplate 与 outputVariable。
+
+运行时会读取 sourceVariable 的完整文本作为 AgentTask input，渲染 taskTitle 与 reasonTemplate，调用 AgentTaskStore.create_task(...) 创建任务，再调用 create_handoff(...) 创建 pending Handoff，并将 handoff_id 写入 outputVariable。节点会同步登记 agent_task 与 agent_handoff 子 run，并写入 checkpoint，供运行观测和 MetaAgent Handoff Inbox 查看。
+
+当前边界：只创建 pending Handoff，不自动 accept、不执行目标 Agent、不接队列 worker、不做持久化或权限系统。
+
+最后更新日期：2026-07-08

--- a/server/main.py
+++ b/server/main.py
@@ -421,6 +421,7 @@ WorkflowNodeType = Literal[
     "workflow_agent",
     "agent_task",
     "agent_handoff",
+    "handoff_router",
     "mcp_tool",
     "time_tool",
     "http_request",
@@ -1231,6 +1232,7 @@ def workflow_node_kind(node: WorkflowNodePayload) -> WorkflowNodeType:
         "workflow_agent",
         "agent_task",
         "agent_handoff",
+        "handoff_router",
         "mcp_tool",
         "time_tool",
         "http_request",
@@ -3496,6 +3498,186 @@ async def run_workflow(payload: WorkflowRunRequest, request: Request):
                         )
                     except Exception as exc:
                         logger.warning("Workflow agent_handoff node failed: %s", exc)
+                        output = ""
+                        variables[output_variable] = output
+                        yield sse_payload(
+                            {
+                                "event": "error",
+                                "node_id": node.id,
+                                "message": str(exc),
+                            }
+                        )
+
+                elif kind == "handoff_router":
+                    output_variable = str(
+                        node.data.get("outputVariable") or "agent_handoff_id"
+                    ).strip() or "agent_handoff_id"
+                    try:
+                        source_variable = str(
+                            node.data.get("sourceVariable") or "agent_output"
+                        ).strip()
+                        source_agent = str(
+                            node.data.get("sourceAgent") or "workflow-agent"
+                        ).strip() or "workflow-agent"
+                        target_agent = str(node.data.get("targetAgent") or "").strip()
+                        task_title_template = str(
+                            node.data.get("taskTitle") or "Workflow handoff task"
+                        )
+                        reason_template = str(
+                            node.data.get("reasonTemplate") or ""
+                        )
+
+                        if not source_variable:
+                            raise ValueError("handoff_router needs sourceVariable.")
+                        if not target_agent:
+                            raise ValueError("handoff_router needs targetAgent.")
+                        if not reason_template.strip():
+                            raise ValueError("handoff_router needs reasonTemplate.")
+
+                        source_value = str(variables.get(source_variable) or "")
+                        if not source_value.strip():
+                            raise ValueError(
+                                f"handoff_router could not read source variable: {source_variable}"
+                            )
+
+                        task_title = render_workflow_template(
+                            task_title_template,
+                            variables,
+                        ).strip()
+                        if not task_title:
+                            raise ValueError("handoff_router rendered taskTitle is empty.")
+
+                        reason = render_workflow_template(
+                            reason_template,
+                            variables,
+                        ).strip()
+                        if not reason:
+                            raise ValueError("handoff_router rendered reason is empty.")
+
+                        task = await agent_task_store.create_task(
+                            title=task_title,
+                            input_text=source_value,
+                            source_agent=source_agent,
+                            assigned_agent=target_agent,
+                            metadata={
+                                "workflow_id": payload.workflow.id,
+                                "workflow_title": payload.workflow.title,
+                                "workflow_task_id": task_id,
+                                "workflow_node_id": node.id,
+                                "workflow_node_title": title,
+                                "source_variable": source_variable,
+                                "source_length": len(source_value),
+                                "output_variable": output_variable,
+                                "router": "handoff_router",
+                            },
+                        )
+                        agent_task_run = await run_registry.create_run(
+                            "agent_task",
+                            task.title,
+                            status="pending",
+                            source_id=task.task_id,
+                            parent_run_id=workflow_run.run_id,
+                            metadata={
+                                "workflow_id": payload.workflow.id,
+                                "workflow_title": payload.workflow.title,
+                                "workflow_task_id": task_id,
+                                "node_id": node.id,
+                                "node_title": title,
+                                "agent_task_id": task.task_id,
+                                "source_agent": source_agent,
+                                "assigned_agent": target_agent,
+                                "source_variable": source_variable,
+                                "source_length": len(source_value),
+                                "output_variable": output_variable,
+                                "router": "handoff_router",
+                            },
+                        )
+                        await run_registry.record_checkpoint(
+                            agent_task_run.run_id,
+                            event_type="agent_task.created",
+                            title="Agent task created by handoff router",
+                            summary=task.title,
+                            metadata={
+                                "node_id": node.id,
+                                "agent_task_id": task.task_id,
+                                "assigned_agent": target_agent,
+                                "source_variable": source_variable,
+                                "source_length": len(source_value),
+                            },
+                        )
+
+                        handoff = await agent_task_store.create_handoff(
+                            task.task_id,
+                            source_agent=source_agent,
+                            target_agent=target_agent,
+                            reason=reason,
+                            metadata={
+                                "workflow_id": payload.workflow.id,
+                                "workflow_title": payload.workflow.title,
+                                "workflow_task_id": task_id,
+                                "workflow_node_id": node.id,
+                                "workflow_node_title": title,
+                                "agent_task_id": task.task_id,
+                                "source_variable": source_variable,
+                                "output_variable": output_variable,
+                                "router": "handoff_router",
+                            },
+                        )
+                        handoff_run = await run_registry.create_run(
+                            "agent_handoff",
+                            f"{source_agent} -> {target_agent}",
+                            status="pending",
+                            source_id=handoff.handoff_id,
+                            parent_run_id=workflow_run.run_id,
+                            metadata={
+                                "workflow_id": payload.workflow.id,
+                                "workflow_title": payload.workflow.title,
+                                "workflow_task_id": task_id,
+                                "node_id": node.id,
+                                "node_title": title,
+                                "agent_task_id": task.task_id,
+                                "handoff_id": handoff.handoff_id,
+                                "source_agent": source_agent,
+                                "target_agent": target_agent,
+                                "source_variable": source_variable,
+                                "output_variable": output_variable,
+                                "router": "handoff_router",
+                            },
+                        )
+                        await run_registry.record_checkpoint(
+                            handoff_run.run_id,
+                            event_type="agent_handoff.created",
+                            title="Agent handoff created by router",
+                            summary=f"{source_agent} -> {target_agent}",
+                            metadata={
+                                "node_id": node.id,
+                                "agent_task_id": task.task_id,
+                                "handoff_id": handoff.handoff_id,
+                                "source_agent": source_agent,
+                                "target_agent": target_agent,
+                            },
+                        )
+
+                        output = handoff.handoff_id
+                        variables[output_variable] = output
+                        yield sse_payload(
+                            {
+                                "event": "node_delta",
+                                "node_id": node.id,
+                                "node_title": title,
+                                "node_type": kind,
+                                "output": (
+                                    f"Created routed Handoff: task {task.task_id} -> "
+                                    f"{target_agent} ({handoff.handoff_id})"
+                                ),
+                                "variable": output_variable,
+                                "agent_task_id": task.task_id,
+                                "agent_handoff_id": handoff.handoff_id,
+                                "run_id": handoff_run.run_id,
+                            }
+                        )
+                    except Exception as exc:
+                        logger.warning("Workflow handoff_router node failed: %s", exc)
                         output = ""
                         variables[output_variable] = output
                         yield sse_payload(

--- a/server/tests/test_workflow_agent_task_node.py
+++ b/server/tests/test_workflow_agent_task_node.py
@@ -392,6 +392,165 @@ async def test_workflow_agent_node_streams_output_and_registers_run(
 
 
 @pytest.mark.asyncio
+async def test_workflow_handoff_router_creates_task_handoff_and_runs(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_stream_workflow_llm_text(
+        model_id: str,
+        prompt: str,
+        *,
+        system_prompt: str | None = None,
+    ):
+        yield "ready for review"
+
+    monkeypatch.setattr(
+        "server.main.get_llm_gateway_config",
+        lambda: ("http://test-gateway.local/v1/chat/completions", "test-key"),
+    )
+    monkeypatch.setattr(
+        "server.main.stream_workflow_llm_text",
+        fake_stream_workflow_llm_text,
+    )
+
+    workflow = {
+        "id": "handoff-router-workflow",
+        "title": "handoff router workflow",
+        "nodes": [
+            {
+                "id": "input",
+                "type": "input",
+                "data": {"kind": "input", "variableName": "user_input"},
+            },
+            {
+                "id": "workflow_agent",
+                "type": "workflow_agent",
+                "data": {
+                    "kind": "workflow_agent",
+                    "agentName": "router-agent",
+                    "modelId": "deepseek/deepseek-chat",
+                    "rolePrompt": "You prepare handoff input.",
+                    "taskInput": "{{user_input}}",
+                    "outputVariable": "agent_output",
+                },
+            },
+            {
+                "id": "router",
+                "type": "handoff_router",
+                "data": {
+                    "kind": "handoff_router",
+                    "sourceVariable": "agent_output",
+                    "taskTitle": "Review {{user_input}}",
+                    "sourceAgent": "workflow-agent",
+                    "targetAgent": "review-agent",
+                    "reasonTemplate": "Please review {{agent_output}}",
+                    "outputVariable": "agent_handoff_id",
+                },
+            },
+            {
+                "id": "output",
+                "type": "output",
+                "data": {"kind": "output", "outputVariable": "agent_handoff_id"},
+            },
+        ],
+        "edges": [
+            {"id": "e1", "source": "input", "target": "workflow_agent"},
+            {"id": "e2", "source": "workflow_agent", "target": "router"},
+            {"id": "e3", "source": "router", "target": "output"},
+        ],
+    }
+
+    response = await client.post(
+        "/api/workflow/run",
+        json={
+            "workflow": workflow,
+            "inputs": {"user_input": "handoff this summary"},
+        },
+    )
+    assert response.status_code == 200, response.text
+
+    events = _parse_sse_events(response.text)
+    workflow_meta = next(event for event in events if event.get("event") == "workflow_meta")
+    workflow_run_id = workflow_meta.get("run_id")
+    assert isinstance(workflow_run_id, str)
+
+    router_delta = next(
+        event
+        for event in events
+        if event.get("event") == "node_delta" and event.get("node_id") == "router"
+    )
+    assert "Created routed Handoff" in str(router_delta.get("output"))
+    task_id = router_delta.get("agent_task_id")
+    handoff_id = router_delta.get("agent_handoff_id")
+    assert isinstance(task_id, str)
+    assert isinstance(handoff_id, str)
+
+    router_end = next(
+        event
+        for event in events
+        if event.get("event") == "node_end" and event.get("node_id") == "router"
+    )
+    assert router_end["output"] == handoff_id
+    assert router_end["variables"]["agent_handoff_id"] == handoff_id
+
+    task_response = await client.get(f"/api/runtime/agent-tasks/{task_id}")
+    assert task_response.status_code == 200, task_response.text
+    task_payload = task_response.json()
+    assert task_payload["title"] == "Review handoff this summary"
+    assert task_payload["input"] == "ready for review"
+    assert task_payload["source_agent"] == "workflow-agent"
+    assert task_payload["assigned_agent"] == "review-agent"
+    assert task_payload["metadata"]["router"] == "handoff_router"
+
+    handoff_response = await client.get(
+        "/api/runtime/agent-handoffs?target_agent=review-agent&limit=50",
+    )
+    assert handoff_response.status_code == 200, handoff_response.text
+    handoffs = handoff_response.json()
+    handoff_payload = next(item for item in handoffs if item["handoff_id"] == handoff_id)
+    assert handoff_payload["task_id"] == task_id
+    assert handoff_payload["status"] == "pending"
+    assert handoff_payload["source_agent"] == "workflow-agent"
+    assert handoff_payload["target_agent"] == "review-agent"
+
+    child_runs_response = await client.get(
+        f"/api/runtime/runs?parent_run_id={workflow_run_id}&limit=50",
+    )
+    assert child_runs_response.status_code == 200, child_runs_response.text
+    child_runs = child_runs_response.json()
+    task_run = next(
+        item
+        for item in child_runs
+        if item["run_type"] == "agent_task" and item["source_id"] == task_id
+    )
+    handoff_run = next(
+        item
+        for item in child_runs
+        if item["run_type"] == "agent_handoff" and item["source_id"] == handoff_id
+    )
+    assert task_run["metadata"]["router"] == "handoff_router"
+    assert handoff_run["metadata"]["router"] == "handoff_router"
+
+    task_checkpoints_response = await client.get(
+        f"/api/runtime/runs/{task_run['run_id']}/checkpoints",
+    )
+    assert task_checkpoints_response.status_code == 200
+    assert any(
+        item["event_type"] == "agent_task.created"
+        for item in task_checkpoints_response.json()
+    )
+
+    handoff_checkpoints_response = await client.get(
+        f"/api/runtime/runs/{handoff_run['run_id']}/checkpoints",
+    )
+    assert handoff_checkpoints_response.status_code == 200
+    assert any(
+        item["event_type"] == "agent_handoff.created"
+        for item in handoff_checkpoints_response.json()
+    )
+
+
+@pytest.mark.asyncio
 async def test_workflow_agent_mcp_tool_mode_uses_runtime_toolset(
     client: httpx.AsyncClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/server/tests/test_workflow_native_validate.py
+++ b/server/tests/test_workflow_native_validate.py
@@ -1415,6 +1415,139 @@ async def test_agent_handoff_task_id_variable_must_be_declared(
 
 
 @pytest.mark.asyncio
+async def test_validate_handoff_router_node_ok(client: httpx.AsyncClient) -> None:
+    workflow = linear_workflow()
+    workflow["nodes"] = [
+        workflow["nodes"][0],
+        {
+            "id": "agent",
+            "type": "workflow_agent",
+            "data": {
+                "kind": "workflow_agent",
+                "agentName": "research-agent",
+                "modelId": "deepseek/deepseek-chat",
+                "rolePrompt": "You summarize input.",
+                "taskInput": "{{user_input}}",
+                "outputVariable": "agent_output",
+            },
+        },
+        {
+            "id": "router",
+            "type": "handoff_router",
+            "data": {
+                "kind": "handoff_router",
+                "sourceVariable": "agent_output",
+                "taskTitle": "Review {{user_input}}",
+                "targetAgent": "reviewer-agent",
+                "sourceAgent": "workflow-agent",
+                "reasonTemplate": "Please review {{agent_output}}",
+                "outputVariable": "agent_handoff_id",
+            },
+        },
+        {
+            "id": "output",
+            "type": "output",
+            "data": {"kind": "output", "outputVariable": "agent_handoff_id"},
+        },
+    ]
+    workflow["edges"] = [
+        {"id": "e1", "source": "input", "target": "agent"},
+        {"id": "e2", "source": "agent", "target": "router"},
+        {"id": "e3", "source": "router", "target": "output"},
+    ]
+
+    data = await validate(client, workflow)
+
+    assert data["valid"] is True
+    assert data["issues"] == []
+
+
+@pytest.mark.asyncio
+async def test_handoff_router_missing_required_fields(
+    client: httpx.AsyncClient,
+) -> None:
+    workflow = linear_workflow()
+    workflow["nodes"][1] = {
+        "id": "router",
+        "type": "handoff_router",
+        "data": {"kind": "handoff_router"},
+    }
+    workflow["nodes"][2]["data"]["outputVariable"] = "user_input"
+    workflow["edges"] = [
+        {"id": "e1", "source": "input", "target": "router"},
+        {"id": "e2", "source": "router", "target": "output"},
+    ]
+
+    data = await validate(client, workflow)
+
+    codes = issue_codes(data)
+    assert data["valid"] is False
+    assert "missing_handoff_router_source_variable" in codes
+    assert "missing_handoff_router_task_title" in codes
+    assert "missing_handoff_router_target_agent" in codes
+    assert "missing_handoff_router_reason_template" in codes
+    assert "missing_handoff_router_output_variable" in codes
+
+
+@pytest.mark.asyncio
+async def test_handoff_router_template_variable_must_be_declared(
+    client: httpx.AsyncClient,
+) -> None:
+    workflow = linear_workflow()
+    workflow["nodes"][1] = {
+        "id": "router",
+        "type": "handoff_router",
+        "data": {
+            "kind": "handoff_router",
+            "sourceVariable": "user_input",
+            "taskTitle": "Review {{missing_title}}",
+            "targetAgent": "reviewer-agent",
+            "reasonTemplate": "Please review {{missing_reason}}",
+            "outputVariable": "agent_handoff_id",
+        },
+    }
+    workflow["nodes"][2]["data"]["outputVariable"] = "agent_handoff_id"
+    workflow["edges"] = [
+        {"id": "e1", "source": "input", "target": "router"},
+        {"id": "e2", "source": "router", "target": "output"},
+    ]
+
+    data = await validate(client, workflow)
+
+    assert data["valid"] is False
+    assert "missing_handoff_router_template_variable" in issue_codes(data)
+
+
+@pytest.mark.asyncio
+async def test_handoff_router_output_variable_is_available_downstream(
+    client: httpx.AsyncClient,
+) -> None:
+    workflow = linear_workflow()
+    workflow["nodes"][1] = {
+        "id": "router",
+        "type": "handoff_router",
+        "data": {
+            "kind": "handoff_router",
+            "sourceVariable": "user_input",
+            "taskTitle": "Review {{user_input}}",
+            "targetAgent": "reviewer-agent",
+            "reasonTemplate": "Please review {{user_input}}",
+            "outputVariable": "agent_handoff_id",
+        },
+    }
+    workflow["nodes"][2]["data"]["outputVariable"] = "agent_handoff_id"
+    workflow["edges"] = [
+        {"id": "e1", "source": "input", "target": "router"},
+        {"id": "e2", "source": "router", "target": "output"},
+    ]
+
+    data = await validate(client, workflow)
+
+    assert data["valid"] is True
+    assert "missing_output_variable_reference" not in issue_codes(data)
+
+
+@pytest.mark.asyncio
 async def test_templates_endpoint_returns_starter_template(
     client: httpx.AsyncClient,
 ) -> None:

--- a/server/workflow_native/schemas.py
+++ b/server/workflow_native/schemas.py
@@ -22,6 +22,7 @@ NativeNodeKind = Literal[
     "workflow_agent",
     "agent_task",
     "agent_handoff",
+    "handoff_router",
     "mcp_tool",
     "time_tool",
     "http_request",

--- a/server/workflow_native/validate.py
+++ b/server/workflow_native/validate.py
@@ -47,6 +47,8 @@ NODE_KIND_ALIASES = {
     "agent-task": "agent_task",
     "agent_handoff": "agent_handoff",
     "agent-handoff": "agent_handoff",
+    "handoff_router": "handoff_router",
+    "handoff-router": "handoff_router",
     "mcp_tool": "mcp_tool",
     "mcp-tool": "mcp_tool",
     "tool": "mcp_tool",
@@ -84,6 +86,7 @@ SUPPORTED_NODE_KINDS = {
     "workflow_agent",
     "agent_task",
     "agent_handoff",
+    "handoff_router",
     "mcp_tool",
     "time_tool",
     "http_request",
@@ -877,6 +880,73 @@ def validate_node_configuration(
                 )
             )
 
+    if kind == "handoff_router":
+        source_variable = str(data.get("sourceVariable") or "").strip()
+        if not source_variable:
+            issues.append(
+                ValidationIssue(
+                    code="missing_handoff_router_source_variable",
+                    message="Handoff router node needs data.sourceVariable.",
+                    node_id=node.id,
+                )
+            )
+        elif not is_variable_name(source_variable):
+            issues.append(
+                ValidationIssue(
+                    code="invalid_handoff_router_source_variable",
+                    message="Handoff router sourceVariable must be an identifier.",
+                    node_id=node.id,
+                )
+            )
+
+        task_title = str(data.get("taskTitle") or "").strip()
+        if not task_title:
+            issues.append(
+                ValidationIssue(
+                    code="missing_handoff_router_task_title",
+                    message="Handoff router node needs data.taskTitle.",
+                    node_id=node.id,
+                )
+            )
+
+        target_agent = str(data.get("targetAgent") or "").strip()
+        if not target_agent:
+            issues.append(
+                ValidationIssue(
+                    code="missing_handoff_router_target_agent",
+                    message="Handoff router node needs data.targetAgent.",
+                    node_id=node.id,
+                )
+            )
+
+        reason_template = str(data.get("reasonTemplate") or "").strip()
+        if not reason_template:
+            issues.append(
+                ValidationIssue(
+                    code="missing_handoff_router_reason_template",
+                    message="Handoff router node needs data.reasonTemplate.",
+                    node_id=node.id,
+                )
+            )
+
+        output_variable = str(data.get("outputVariable") or "").strip()
+        if not output_variable:
+            issues.append(
+                ValidationIssue(
+                    code="missing_handoff_router_output_variable",
+                    message="Handoff router node needs data.outputVariable.",
+                    node_id=node.id,
+                )
+            )
+        elif not is_variable_name(output_variable):
+            issues.append(
+                ValidationIssue(
+                    code="invalid_handoff_router_output_variable",
+                    message="Handoff router outputVariable must be an identifier.",
+                    node_id=node.id,
+                )
+            )
+
     if kind == "mcp_tool":
         tool_name = str(data.get("toolName") or "").strip()
         if not tool_name:
@@ -1238,6 +1308,7 @@ def collect_declared_variables(
             "workflow_agent",
             "agent_task",
             "agent_handoff",
+            "handoff_router",
             "mcp_tool",
             "time_tool",
             "http_request",
@@ -1521,6 +1592,35 @@ def validate_variable_references(
                         node_id=node.id,
                     )
                 )
+
+    if kind == "handoff_router":
+        source_variable = str(data.get("sourceVariable") or "").strip()
+        if source_variable and source_variable not in available_variables:
+            issues.append(
+                ValidationIssue(
+                    code="missing_handoff_router_source_variable_reference",
+                    message=(
+                        "Handoff router sourceVariable references undefined "
+                        f"variable '{source_variable}'."
+                    ),
+                    node_id=node.id,
+                )
+            )
+
+        for field_name in ("taskTitle", "reasonTemplate"):
+            template = str(data.get(field_name) or "")
+            for variable in sorted(extract_template_variables(template)):
+                if variable not in available_variables:
+                    issues.append(
+                        ValidationIssue(
+                            code="missing_handoff_router_template_variable",
+                            message=(
+                                f"Handoff router {field_name} references undefined "
+                                f"variable '{variable}'."
+                            ),
+                            node_id=node.id,
+                        )
+                    )
 
     if kind == "mcp_tool":
         arguments_json = str(data.get("argumentsJson") or "")


### PR DESCRIPTION
﻿## Summary
- 新增 classic workflow 的 handoff_router 节点，连接 workflow_agent 输出到 AgentTask + pending Handoff。
- 前端支持节点库拖拽、配置表单和节点卡片摘要。
- 后端支持 NativeNodeKind、静态校验、workflow_stream 执行、RunRegistry 子 run 与 checkpoint。
- 文档更新 Xpert 对齐和 workflow-native 设计说明。

## Validation
- python py_compile: server/main.py, server/workflow_native/*.py, server/xpert_runtime/*.py passed.
- cd client && npm.cmd run build passed.
- focused docker pytest: 72 passed.
- full docker pytest: 148 passed, 4 warnings.
- docker compose -p modelmirror up -d --build --force-recreate passed.
- curl http://localhost:8000/api/health returned {"status":"ok"}.

## Scope Boundaries
- No automatic accept or target Agent execution.
- No queue worker, database, Redis, Celery, or persistence.
- Untracked package files and APK were not included.
