### PR TITLE
feature: 聊天入口接入 Runtime Toolset

### DIFF
--- a/client/src/pages/ChatPage.tsx
+++ b/client/src/pages/ChatPage.tsx
@@ -487,6 +487,10 @@ export default function ChatPage() {
   const [advancedParams, setAdvancedParams] = useState<ChatAdvancedParams>(() =>
     defaultAdvancedParams(),
   );
+  const [runtimeToolsEnabled, setRuntimeToolsEnabled] = useState(false);
+  const [runtimeToolNames, setRuntimeToolNames] = useState("");
+  const [runtimeMaxToolIterations, setRuntimeMaxToolIterations] = useState("5");
+  const [runtimePromptSuffix, setRuntimePromptSuffix] = useState("");
   const [knowledgeBases, setKnowledgeBases] = useState<KnowledgeBase[]>([]);
   const [selectedKnowledgeBaseId, setSelectedKnowledgeBaseId] = useState("");
   const [isLoadingKnowledgeBases, setIsLoadingKnowledgeBases] = useState(false);
@@ -830,6 +834,13 @@ export default function ChatPage() {
           ? Number(advancedParams.seed)
           : undefined,
         stop: parseStopSequences(advancedParams.stopSequences),
+        toolMode: runtimeToolsEnabled ? "mcp_tools" : "none",
+        toolNames: runtimeToolNames,
+        maxToolIterations: Math.min(
+          20,
+          Math.max(1, Number(runtimeMaxToolIterations) || 5),
+        ),
+        promptSuffix: runtimePromptSuffix,
         onDelta: (delta) => {
           setMessages((current) =>
             current.map((message) =>
@@ -1252,6 +1263,70 @@ export default function ChatPage() {
                       {isLoadingKnowledgeBases ? "刷新中" : "刷新"}
                     </button>
                   </div>
+                </div>
+                <div className="mb-3 rounded-lg border border-white/10 bg-white/[0.045] px-3 py-3">
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                      <p className="text-xs font-semibold text-cyan-100">
+                        Runtime 工具模式 Beta
+                      </p>
+                      <p className="mt-1 text-xs leading-5 text-slate-400">
+                        开启后，聊天会按 JSON 决策调用已注册 MCP 工具；默认关闭。
+                      </p>
+                    </div>
+                    <label className="flex items-center gap-2 text-xs font-semibold text-slate-200">
+                      <input
+                        checked={runtimeToolsEnabled}
+                        className="h-4 w-4 rounded border-white/20 bg-ink-950 text-cyan-300 focus:ring-cyan-300/30"
+                        disabled={isSending}
+                        onChange={(event) =>
+                          setRuntimeToolsEnabled(event.target.checked)
+                        }
+                        type="checkbox"
+                      />
+                      启用 MCP 工具
+                    </label>
+                  </div>
+                  {runtimeToolsEnabled ? (
+                    <div className="mt-3 grid gap-3 lg:grid-cols-[1fr_140px]">
+                      <label className="flex flex-col gap-1 text-xs font-semibold text-slate-300">
+                        工具白名单
+                        <input
+                          className="rounded-lg border border-white/10 bg-ink-950/80 px-3 py-2 text-xs text-white outline-none transition placeholder:text-slate-500 focus:border-cyan-300/50 focus:ring-4 focus:ring-cyan-300/10"
+                          disabled={isSending}
+                          onChange={(event) => setRuntimeToolNames(event.target.value)}
+                          placeholder="fetch, search；留空代表全部已注册工具"
+                          value={runtimeToolNames}
+                        />
+                      </label>
+                      <label className="flex flex-col gap-1 text-xs font-semibold text-slate-300">
+                        最大循环
+                        <input
+                          className="rounded-lg border border-white/10 bg-ink-950/80 px-3 py-2 text-xs text-white outline-none transition focus:border-cyan-300/50 focus:ring-4 focus:ring-cyan-300/10"
+                          disabled={isSending}
+                          max={20}
+                          min={1}
+                          onChange={(event) =>
+                            setRuntimeMaxToolIterations(event.target.value)
+                          }
+                          type="number"
+                          value={runtimeMaxToolIterations}
+                        />
+                      </label>
+                      <label className="flex flex-col gap-1 text-xs font-semibold text-slate-300 lg:col-span-2">
+                        补充约束
+                        <textarea
+                          className="min-h-20 resize-none rounded-lg border border-white/10 bg-ink-950/80 px-3 py-2 text-xs leading-5 text-white outline-none transition placeholder:text-slate-500 focus:border-cyan-300/50 focus:ring-4 focus:ring-cyan-300/10"
+                          disabled={isSending}
+                          onChange={(event) =>
+                            setRuntimePromptSuffix(event.target.value)
+                          }
+                          placeholder="例如：工具结果不足时直接说明，不要猜测。"
+                          value={runtimePromptSuffix}
+                        />
+                      </label>
+                    </div>
+                  ) : null}
                 </div>
                 <div
                   className={`rounded-lg border p-2 transition ${

--- a/client/src/utils/fetchChatStream.ts
+++ b/client/src/utils/fetchChatStream.ts
@@ -27,6 +27,10 @@ interface FetchChatStreamOptions {
   maxTokens?: number;
   seed?: number;
   stop?: string[];
+  toolMode?: "none" | "mcp_tools";
+  toolNames?: string;
+  maxToolIterations?: number;
+  promptSuffix?: string;
   signal?: AbortSignal;
   onDelta: (text: string) => void;
 }
@@ -197,6 +201,10 @@ export async function fetchChatStream({
   maxTokens = 2048,
   seed,
   stop,
+  toolMode = "none",
+  toolNames = "",
+  maxToolIterations = 5,
+  promptSuffix = "",
   signal,
   onDelta,
 }: FetchChatStreamOptions) {
@@ -211,6 +219,10 @@ export async function fetchChatStream({
       max_tokens: maxTokens,
       seed,
       stop,
+      tool_mode: toolMode,
+      tool_names: toolNames,
+      max_tool_iterations: maxToolIterations,
+      prompt_suffix: promptSuffix,
     }),
     signal,
   });

--- a/docs/XPERT_ALIGNMENT.md
+++ b/docs/XPERT_ALIGNMENT.md
@@ -1,5 +1,6 @@
 # Xpert 对齐总纲
 
+> 2026-07-08 状态补充：Chat Agent Toolset 已进入“部分实现”。`/api/chat` 新增默认关闭的 `tool_mode=mcp_tools`，显式开启后使用轻量 JSON 决策协议调用 MCP 工具，并复用 `MCPToolsetProvider`、`run_tool_with_runtime`、`tool_policy` 与 `tool_audit`。普通聊天请求保持 `tool_mode=none`，SSE wire format 不变；当前不是 OpenAI function calling，不做 Handoff 自动调度或真实多 Agent 协作。
 > 2026-07-08 状态补充：Handoff Router 已进入“部分实现”。Classic workflow 新增 `handoff_router` 节点，可读取 `workflow_agent` 等上游节点输出，创建 AgentTask，并向目标 Agent 创建 pending Handoff，让结果进入 MetaAgent Handoff Inbox。当前不自动 accept、不执行目标 Agent、不接队列 worker 或持久化。
 > 2026-07-07 状态补充：RunRegistry Trace 已进入“部分实现”。`RuntimeRun` 现在可挂载内存态 checkpoint，记录 workflow、workflow_agent、agent_task、agent_handoff 的关键执行时间线；新增 `GET /api/runtime/runs/{run_id}/checkpoints` 供前端运行观测读取。当前仍不做持久化、自动重试、队列调度或 checkpoint resume。
 > 2026-07-07 状态补充：Workflow Agent Toolset 已进入“部分实现”。`workflow_agent` 现在支持 `toolMode=none/mcp_tools`，启用 MCP 工具时复用 Runtime Toolset、`tool_policy` 与 `tool_audit`；旧 `agent.tool_first` 也收敛到同一条 `run_tool_with_runtime` 路径。当前仍是轻量 JSON 决策协议，不做 OpenAI function calling、自动 Handoff 或真实多 Agent 调度。
@@ -43,7 +44,7 @@ EvoAgentX 只保留为历史参考：此前元智能体曾借鉴其 `goal -> sub
 | Runtime / Execution | 中间件生命周期、任务注册、事件记录、运行观测 | 部分实现 | 建立 Handoff / RunRegistry 闭环 |
 | Agent / Handoff | AgentTask、任务移交、子 Agent、主管-专家协作 | 部分实现 | 将 workflow_agent 输出与 Handoff 编排连接 |
 | Workflow | Xpert 节点类型、Agent 节点、工具节点、知识流水线节点 | 部分实现 | 扩展 subflow、知识类节点与 Agent trace |
-| Toolset / MCP | 统一 Toolset Provider、权限、审计、偏好 | 部分实现 | 将聊天 Agent 继续收敛到 toolset capability |
+| Toolset / MCP | 统一 Toolset Provider、权限、审计、偏好 | 部分实现 | 扩展 Chat 工具偏好、观测与安全边界 |
 | Knowledge Pipeline | FileAsset、Artifact、Chunk、CitationAnchor、Embedding | 待实现 | 从本地 RAG 元数据模型开始拆分 |
 | Claw / Skill | 用户偏好、工作区 Skill、会话临时选择 | 待实现 | 在 Xpert workspace / skill 抽象稳定后接入 |
 | Environment / Sandbox | 工作区文件、受限执行、浏览器/终端能力 | 待实现 | 先做受限文件 API 和 workspace volume |
@@ -52,7 +53,7 @@ EvoAgentX 只保留为历史参考：此前元智能体曾借鉴其 `goal -> sub
 ## 当前已落地能力
 
 - Runtime Middleware：已具备 `before_agent`、`before_model`、`wrap_model_call`、`after_model`、`after_agent`、`wrap_tool_call` 生命周期。
-- Chat Runtime：`/api/chat` 已接入默认 runtime pipeline，支持 system prompt 注入和模型调用事件记录。
+- Chat Runtime：`/api/chat` 已接入默认 runtime pipeline，支持 system prompt 注入和模型调用事件记录；显式设置 `tool_mode=mcp_tools` 时可进入 Runtime Toolset 工具循环，默认仍保持普通聊天路径。
 - Toolset / MCP：`mcp_tool` 已通过 `MCPToolsetProvider`、`CapabilityRegistry`、`run_tool_with_runtime` 调用工具。
 - Tool Policy / Audit：`tool_policy` 可影响 workflow 内 MCP 工具调用，`InMemoryToolAuditStore` 提供最小审计记录。
 - Runtime Middleware Node：前端可拖入 `runtime_middleware` 节点，`system_prompt_injector`、`tool_policy`、`event_recorder`、`tool_audit` 已逐步进入真实执行或可见状态。
@@ -66,7 +67,7 @@ EvoAgentX 只保留为历史参考：此前元智能体曾借鉴其 `goal -> sub
 
 1. **RunRegistry Trace 增强**：补齐 workflow_agent / handoff 的 trace、checkpoint、失败摘要与重试入口。
 2. **Handoff 自动编排雏形**：将 workflow_agent 输出与 handoff queue 连接，但仍保持人工可控。
-3. **Chat Agent Toolset 收敛**：将聊天 Agent 的工具调用继续迁入 Runtime Toolset capability。
+3. **Chat Agent Toolset 观测增强**：补齐聊天工具模式的任务级 trace、工具偏好和更细粒度安全提示。
 4. **知识流水线底座**：拆分本地 RAG 的文件元数据，建立 FileAsset -> Artifact -> Chunk -> CitationAnchor 的最小模型。
 
 ## 2026-07-07 增量：RunRegistry Trace / Checkpoint

--- a/docs/workflow-native-design.md
+++ b/docs/workflow-native-design.md
@@ -1,5 +1,6 @@
 # workflow-native 自研工作流设计
 
+> 2026-07-08 状态补充：`/api/chat` 已接入默认关闭的 Runtime Toolset 工具模式。前端聊天页可显式开启 MCP 工具循环，后端复用 `run_tool_with_runtime`、`tool_policy` 与 `tool_audit`，并继续使用现有 OpenAI SSE delta 结构输出最终答案。当前不是 OpenAI function calling，不自动创建 Handoff，也不改变 workflow、RAG、Skill 或 MCP 连接主路径。
 > 2026-07-07 状态补充：RunRegistry Trace / Checkpoint 进入最小闭环。Workflow run、`workflow_agent`、`agent_task`、`agent_handoff` 会写入内存态 checkpoint；前端“运行观测”会读取 `GET /api/runtime/runs/{run_id}/checkpoints` 展示当前 run 与子 run 的时间线摘要。当前不做持久化、自动重试、队列调度或 checkpoint resume。
 > 2026-07-07 状态补充：`workflow_agent` 已支持 Runtime Toolset 工具模式。`toolMode=none` 保持单步模型执行；`toolMode=mcp_tools` 使用轻量 JSON 决策协议调用 MCP 工具，并复用 `run_tool_with_runtime`、`tool_policy`、`tool_audit`。旧 `agent.tool_first` 也已收敛到同一条 runtime toolset 路径。当前不是 OpenAI function calling，不做自动 Handoff 或真实多 Agent 协作。
 
@@ -523,5 +524,13 @@ Classic workflow 新增 handoff_router 节点，作为 workflow_agent -> Handoff
 运行时会读取 sourceVariable 的完整文本作为 AgentTask input，渲染 taskTitle 与 reasonTemplate，调用 AgentTaskStore.create_task(...) 创建任务，再调用 create_handoff(...) 创建 pending Handoff，并将 handoff_id 写入 outputVariable。节点会同步登记 agent_task 与 agent_handoff 子 run，并写入 checkpoint，供运行观测和 MetaAgent Handoff Inbox 查看。
 
 当前边界：只创建 pending Handoff，不自动 accept、不执行目标 Agent、不接队列 worker、不做持久化或权限系统。
+
+## 2026-07-08 增量：Chat Runtime Toolset
+
+聊天入口新增默认关闭的 Runtime 工具模式。旧请求仍走普通 `/api/chat` 流式上游路径；只有请求显式传入 `tool_mode=mcp_tools` 时，后端才要求模型输出轻量 JSON 决策：`{"tool":"工具名","arguments":{...}}` 或 `{"answer":"最终答案"}`。
+
+工具调用统一经过 `MCPToolsetProvider`、`run_tool_with_runtime` 与 `MiddlewarePipeline.wrap_tool_call`，因此现有 `tool_policy`、`tool_audit` 和 `event_recorder` 可复用到聊天工具循环。`tool_names` 提供逗号或换行分隔的白名单，留空代表允许当前已注册 MCP 工具；`max_tool_iterations` 限制为 1-20，避免无限工具循环。
+
+当前边界：不是 OpenAI function calling，不自动创建 Handoff，不接真实多 Agent 调度，也不保存完整 prompt、工具输出、模型回答或 API key 到运行元数据中。
 
 最后更新日期：2026-07-08

--- a/server/main.py
+++ b/server/main.py
@@ -282,6 +282,10 @@ class ChatRequest(BaseModel):
     max_tokens: int = Field(default=2048, ge=1, le=128000)
     seed: int | None = None
     stop: list[str] | None = Field(default=None, max_length=8)
+    tool_mode: Literal["none", "mcp_tools"] = "none"
+    tool_names: str = Field(default="", max_length=2_000)
+    max_tool_iterations: int = Field(default=5, ge=1, le=20)
+    prompt_suffix: str = Field(default="", max_length=4_000)
 
 
 class AgentRecord(BaseModel):
@@ -900,6 +904,61 @@ def completion_text_from_payload(payload: dict[str, Any]) -> str:
     return ""
 
 
+def chat_sse_delta(text: str) -> bytes:
+    payload = json.dumps(
+        {"choices": [{"delta": {"content": text}}]},
+        ensure_ascii=False,
+    )
+    return f"data: {payload}\n\n".encode("utf-8")
+
+
+def chat_sse_error(message: str) -> bytes:
+    payload = json.dumps(
+        {"error": {"message": message}},
+        ensure_ascii=False,
+    )
+    return f"data: {payload}\n\n".encode("utf-8")
+
+
+def parse_chat_tool_names(value: str | None) -> set[str]:
+    return {
+        item.strip()
+        for item in re.split(r"[,\n]+", value or "")
+        if item.strip()
+    }
+
+
+def extract_json_decision(raw_response: str) -> dict[str, Any] | None:
+    json_text = raw_response.strip()
+    fenced = re.search(r"```(?:json)?\s*\n?(.*?)\n?```", json_text, re.DOTALL)
+    if fenced:
+        json_text = fenced.group(1).strip()
+    try:
+        decision = json.loads(json_text)
+    except ValueError:
+        return None
+    return decision if isinstance(decision, dict) else None
+
+
+def runtime_tool_result_text(call_result: Any) -> str:
+    metadata = getattr(call_result, "metadata", {}) or {}
+    content_types = metadata.get("content_types", [])
+    non_text_types = [
+        str(content_type)
+        for content_type in content_types
+        if str(content_type) != "text"
+    ]
+    output_text = str(getattr(call_result, "output", "") or "").strip()
+    if non_text_types:
+        output_text = (
+            output_text
+            + "\n"
+            + "非文本工具结果已省略："
+            + ", ".join(non_text_types)
+        ).strip()
+    return output_text
+
+
 async def collect_chat_completion_text(
     model_id: str,
     messages: list[ChatMessage],
@@ -934,6 +993,143 @@ async def collect_chat_completion_text(
         if not text.strip():
             raise RuntimeError("模型没有返回可用内容。")
         return text
+
+
+async def stream_chat_toolset_text(
+    payload: ChatRequest,
+    *,
+    runtime_pipeline: MiddlewarePipeline,
+    runtime_context: MiddlewareContext,
+) -> AsyncIterator[str]:
+    requested_tools = parse_chat_tool_names(payload.tool_names)
+    all_tools = await workflow_mcp_provider.list_tools()
+    available_tools = [
+        tool
+        for tool in all_tools
+        if not requested_tools or tool.name in requested_tools
+    ]
+    if not available_tools:
+        if requested_tools:
+            raise ValueError(
+                "Runtime 工具模式未找到这些 MCP 工具，请先在 MCP 页面连接工具，或检查工具白名单："
+                + ", ".join(sorted(requested_tools))
+            )
+        raise ValueError("Runtime 工具模式当前没有可用 MCP 工具，请先连接 MCP Server。")
+
+    tool_by_name = {tool.name: tool for tool in available_tools if tool.name}
+    tool_descriptions = "\n".join(
+        (
+            f"- {name}: {tool.description or '无描述'} "
+            f"schema={json.dumps(tool.input_schema or {}, ensure_ascii=False)}"
+        )
+        for name, tool in tool_by_name.items()
+    )
+    suffix = str(payload.prompt_suffix or "").strip()
+    tool_system_prompt = (
+        "你是 ModelMirror 的 Runtime Toolset 聊天智能体。"
+        "你可以选择调用一个工具，或者给出最终答案。"
+        "每次回复必须是 JSON，且只能使用以下两种格式之一："
+        '{"tool":"工具名","arguments":{...}} 或 {"answer":"最终答案"}。'
+        "不要输出 JSON 以外的文字。\n\n"
+        f"可用工具：\n{tool_descriptions}"
+    )
+    if suffix:
+        tool_system_prompt = f"{tool_system_prompt}\n\n补充约束：\n{suffix}"
+
+    messages: list[ChatMessage] = [
+        ChatMessage(role="system", content=tool_system_prompt),
+        *payload.messages,
+    ]
+    for iteration_index in range(payload.max_tool_iterations):
+        raw_response = (
+            await collect_chat_completion_text(
+                payload.model_id,
+                messages,
+                temperature=payload.temperature,
+                max_tokens=payload.max_tokens,
+            )
+        ).strip()
+        decision = extract_json_decision(raw_response)
+        if decision is None:
+            yield raw_response
+            return
+
+        answer = decision.get("answer")
+        if isinstance(answer, str) and answer.strip():
+            yield answer.strip()
+            return
+
+        tool_name = str(decision.get("tool") or "").strip()
+        if not tool_name:
+            yield raw_response
+            return
+
+        if requested_tools and tool_name not in requested_tools:
+            raise ValueError(
+                f"工具 {tool_name} 不在本次聊天允许列表中，请检查 Runtime 工具白名单。"
+            )
+        matched_tool = tool_by_name.get(tool_name)
+        if matched_tool is None:
+            raise ValueError(
+                f"工具 {tool_name} 当前未注册或未连接，请先在 MCP 页面连接对应 Server。"
+            )
+
+        arguments = decision.get("arguments")
+        if not isinstance(arguments, dict):
+            arguments = {}
+
+        tool_context = MiddlewareContext(
+            task_id=runtime_context.task_id,
+            trace_id=runtime_context.trace_id,
+            capabilities=runtime_capabilities,
+            store=runtime_context.store,
+            metadata={
+                "chat": True,
+                "model_id": payload.model_id,
+                "iteration": iteration_index + 1,
+            },
+        )
+        call_result = await run_tool_with_runtime(
+            RuntimeToolCall(
+                tool_name=tool_name,
+                arguments=arguments,
+                metadata={
+                    "session_id": matched_tool.session_id,
+                    "server_id": matched_tool.server_id,
+                    "chat": True,
+                    "iteration": iteration_index + 1,
+                },
+            ),
+            runtime_capabilities,
+            runtime_pipeline,
+            tool_context,
+            policy=workflow_tool_policy,
+            audit_store=workflow_tool_audit_store,
+        )
+        tool_result_text = runtime_tool_result_text(call_result)
+        yield (
+            f"\n[Runtime 工具调用 {iteration_index + 1}/{payload.max_tool_iterations}] "
+            f"{tool_name} 完成，结果预览：{tool_result_text[:240]}\n"
+        )
+        messages.append(
+            ChatMessage(
+                role="assistant",
+                content=json.dumps(decision, ensure_ascii=False),
+            )
+        )
+        messages.append(
+            ChatMessage(
+                role="user",
+                content=(
+                    f"工具 {tool_name} 的执行结果：\n{tool_result_text}\n\n"
+                    "请继续用 JSON 决策下一步。"
+                ),
+            )
+        )
+
+    raise ValueError(
+        f"Runtime 工具模式已达到最大循环次数 {payload.max_tool_iterations}，但模型没有给出最终答案。"
+    )
 
 
 async def stream_chat_text(
@@ -5292,6 +5488,57 @@ async def chat(payload: ChatRequest, request: Request):
             )
         except Exception as exc:
             logger.warning("Xpert runtime chat finalize failed: %s", exc)
+
+    if payload.tool_mode == "mcp_tools":
+        if runtime_pipeline is None or runtime_context is None:
+            runtime_pipeline, runtime_context = create_default_runtime(
+                middlewares=[event_recorder]
+            )
+            runtime_context.task_id = runtime_task_id
+            runtime_context.trace_id = request.headers.get("x-trace-id") or runtime_task_id
+            runtime_context.metadata = {
+                "model_id": payload.model_id,
+                "message_count": len(payload.messages),
+                "tool_mode": payload.tool_mode,
+            }
+
+        async def stream_tool_response():
+            accumulated_chunks: list[str] = []
+            runtime_status = "completed"
+            runtime_error: str | None = None
+            try:
+                async for delta in stream_chat_toolset_text(
+                    payload,
+                    runtime_pipeline=runtime_pipeline,
+                    runtime_context=runtime_context,
+                ):
+                    accumulated_chunks.append(delta)
+                    yield chat_sse_delta(delta)
+                    await asyncio.sleep(0)
+            except Exception as exc:
+                runtime_status = "error"
+                runtime_error = str(exc)
+                logger.warning("Runtime chat toolset failed: %s", exc)
+                yield chat_sse_error(str(exc))
+            finally:
+                await client.aclose()
+                await finalize_runtime(
+                    runtime_status,
+                    payload.model_id,
+                    "".join(accumulated_chunks),
+                    runtime_error,
+                )
+
+        return StreamingResponse(
+            stream_tool_response(),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "Connection": "keep-alive",
+                "X-ModelMirror-Actual-Model": payload.model_id,
+                "X-ModelMirror-Tool-Mode": "mcp_tools",
+            },
+        )
 
     async def send_prepared_to_upstream(
         model_id: str,

--- a/server/tests/test_xpert_runtime_chat.py
+++ b/server/tests/test_xpert_runtime_chat.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
 import pytest
+import httpx
+import pytest_asyncio
 
+import server.main as main_module
 from server.main import (
     ChatMessage,
+    app,
     parse_upstream_error,
     sse_delta_text,
     stream_chat_text,
@@ -12,10 +16,22 @@ from server.xpert_runtime import (
     MiddlewareContext,
     ModelCallRequest,
     ModelCallResponse,
+    RuntimeTool,
+    RuntimeToolResult,
     RuntimeEventStore,
     create_default_runtime,
     event_recorder,
 )
+
+
+@pytest_asyncio.fixture
+async def client():
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://testserver",
+    ) as async_client:
+        yield async_client
 
 
 @pytest.mark.asyncio
@@ -174,3 +190,209 @@ def test_newapi_user_error_can_fallback_to_openrouter(
         )
         is False
     )
+
+
+@pytest.mark.asyncio
+async def test_chat_tool_mode_answer_streams_final_text(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider, restore_provider = _install_fake_chat_tool_provider()
+
+    async def fake_collect_chat_completion_text(*args, **kwargs):
+        return '{"answer":"final"}'
+
+    monkeypatch.setattr(main_module, "get_llm_gateway_config", lambda: ("http://mock", "key"))
+    monkeypatch.setattr(
+        main_module,
+        "collect_chat_completion_text",
+        fake_collect_chat_completion_text,
+    )
+    monkeypatch.setattr(main_module, "workflow_mcp_provider", provider)
+    try:
+        response = await client.post(
+            "/api/chat",
+            json={
+                "model_id": "mock-model",
+                "messages": [{"role": "user", "content": "hi"}],
+                "tool_mode": "mcp_tools",
+                "tool_names": "fetch",
+            },
+        )
+    finally:
+        restore_provider()
+
+    assert response.status_code == 200, response.text
+    assert _read_sse_text(response.text) == "final"
+    assert provider.calls == []
+
+
+@pytest.mark.asyncio
+async def test_chat_tool_mode_calls_runtime_toolset(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider, restore_provider = _install_fake_chat_tool_provider()
+    responses = iter(
+        [
+            '{"tool":"fetch","arguments":{"query":"hello"}}',
+            '{"answer":"final from tool"}',
+        ]
+    )
+
+    async def fake_collect_chat_completion_text(*args, **kwargs):
+        return next(responses)
+
+    monkeypatch.setattr(main_module, "get_llm_gateway_config", lambda: ("http://mock", "key"))
+    monkeypatch.setattr(
+        main_module,
+        "collect_chat_completion_text",
+        fake_collect_chat_completion_text,
+    )
+    monkeypatch.setattr(main_module, "workflow_mcp_provider", provider)
+    try:
+        response = await client.post(
+            "/api/chat",
+            json={
+                "model_id": "mock-model",
+                "messages": [{"role": "user", "content": "hi"}],
+                "tool_mode": "mcp_tools",
+                "tool_names": "fetch",
+                "max_tool_iterations": 3,
+            },
+        )
+    finally:
+        restore_provider()
+
+    assert response.status_code == 200, response.text
+    text = _read_sse_text(response.text)
+    assert "Runtime 工具调用" in text
+    assert "final from tool" in text
+    assert len(provider.calls) == 1
+    assert provider.calls[0].tool_name == "fetch"
+    assert provider.calls[0].arguments == {"query": "hello"}
+
+
+@pytest.mark.asyncio
+async def test_chat_tool_mode_rejects_tool_outside_allowlist(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider, restore_provider = _install_fake_chat_tool_provider()
+
+    async def fake_collect_chat_completion_text(*args, **kwargs):
+        return '{"tool":"search","arguments":{"query":"blocked"}}'
+
+    monkeypatch.setattr(main_module, "get_llm_gateway_config", lambda: ("http://mock", "key"))
+    monkeypatch.setattr(
+        main_module,
+        "collect_chat_completion_text",
+        fake_collect_chat_completion_text,
+    )
+    monkeypatch.setattr(main_module, "workflow_mcp_provider", provider)
+    try:
+        response = await client.post(
+            "/api/chat",
+            json={
+                "model_id": "mock-model",
+                "messages": [{"role": "user", "content": "hi"}],
+                "tool_mode": "mcp_tools",
+                "tool_names": "fetch",
+            },
+        )
+    finally:
+        restore_provider()
+
+    assert response.status_code == 200, response.text
+    assert "不在本次聊天允许列表" in _read_sse_error(response.text)
+    assert provider.calls == []
+
+
+@pytest.mark.asyncio
+async def test_chat_tool_mode_invalid_payload_returns_validation_error(
+    client: httpx.AsyncClient,
+) -> None:
+    response = await client.post(
+        "/api/chat",
+        json={
+            "model_id": "mock-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tool_mode": "bad-mode",
+            "max_tool_iterations": 99,
+        },
+    )
+
+    assert response.status_code == 422
+
+
+class FakeChatToolProvider:
+    def __init__(self) -> None:
+        self.calls = []
+
+    async def list_tools(self):
+        return [
+            RuntimeTool(
+                name="fetch",
+                description="Fetch content",
+                input_schema={"type": "object"},
+                session_id="session-1",
+                server_id="server-1",
+            )
+        ]
+
+    async def find_tool(self, tool_name: str):
+        for tool in await self.list_tools():
+            if tool.name == tool_name:
+                return tool
+        return None
+
+    async def call_tool(self, call):
+        self.calls.append(call)
+        return RuntimeToolResult(
+            output="tool result",
+            content=[{"type": "text", "text": "tool result"}],
+            metadata={"content_types": ["text"]},
+            is_error=False,
+        )
+
+
+def _install_fake_chat_tool_provider():
+    provider = FakeChatToolProvider()
+    original = main_module.runtime_capabilities.require("mcp_tools").implementation
+    main_module.runtime_capabilities.register("mcp_tools", provider)
+
+    def restore_provider() -> None:
+        main_module.runtime_capabilities.register("mcp_tools", original)
+
+    return provider, restore_provider
+
+
+def _read_sse_text(text: str) -> str:
+    chunks: list[str] = []
+    for line in text.splitlines():
+        if not line.startswith("data:"):
+            continue
+        payload = line[5:].strip()
+        if not payload or payload == "[DONE]":
+            continue
+        data = __import__("json").loads(payload)
+        if "error" in data:
+            continue
+        choices = data.get("choices") or []
+        if choices:
+            chunks.append(str(choices[0].get("delta", {}).get("content") or ""))
+    return "".join(chunks)
+
+
+def _read_sse_error(text: str) -> str:
+    for line in text.splitlines():
+        if not line.startswith("data:"):
+            continue
+        payload = line[5:].strip()
+        if not payload or payload == "[DONE]":
+            continue
+        data = __import__("json").loads(payload)
+        error = data.get("error")
+        if isinstance(error, dict):
+            return str(error.get("message") or "")
+    return ""


### PR DESCRIPTION
## Summary
- Extend /api/chat with a default-off Runtime Toolset mode for MCP tool loops.
- Add ChatPage controls for MCP tool mode, whitelist, max iterations, and prompt suffix.
- Reuse MCPToolsetProvider, run_tool_with_runtime, tool policy, and tool audit for chat tool calls.
- Keep tool_mode=none as the default path so existing chat SSE behavior remains unchanged.

## Validation
- npm.cmd run build
- python -m py_compile server/main.py server/xpert_runtime/*.py server/workflow_native/*.py
- docker run focused runtime/chat/tool tests: 24 passed
- docker run full backend tests: 152 passed
- docker compose -p modelmirror up -d --build --force-recreate
- curl http://localhost:8000/api/health -> {"status":"ok"}

## Notes
- This is not OpenAI function calling.
- This does not add Handoff automation, database persistence, Redis, Celery, or a real multi-agent scheduler.
- Untracked package.json, package-lock.json, and 模镜.apk were intentionally excluded.
