### PR TITLE
feature: 增强 Chat 观测与知识流水线

### DIFF
--- a/client/src/components/workflow/NodePalette.tsx
+++ b/client/src/components/workflow/NodePalette.tsx
@@ -69,6 +69,12 @@ const paletteItems: PaletteItem[] = [
     description: "查询本地 RAG 资料库，把相关段落写入变量。",
   },
   {
+    kind: "knowledge_citation",
+    icon: "🔖",
+    title: "知识引用锚点",
+    description: "查询本地 RAG，输出 CitationAnchor JSON 供下游节点引用。",
+  },
+  {
     kind: "document_extractor",
     icon: "📄",
     title: "文档提取器",

--- a/client/src/components/workflow/WorkflowEditor.tsx
+++ b/client/src/components/workflow/WorkflowEditor.tsx
@@ -222,6 +222,18 @@ function createNodeData(
     };
   }
 
+  if (kind === "knowledge_citation") {
+    return {
+      kind,
+      title: "知识引用锚点",
+      description: "把本地 RAG 检索结果转换为 CitationAnchor JSON。",
+      queryVariable: "user_input",
+      knowledgeBaseId: "",
+      top_k: "4",
+      outputVariable: "citation_anchors_json",
+    };
+  }
+
   if (kind === "document_extractor") {
     return {
       kind,
@@ -930,6 +942,47 @@ function NodeConfig({ node, onChange }: NodeConfigProps) {
               onChange={(event) => update({ top_k: event.target.value })}
               type="number"
               value={data.top_k ?? "3"}
+            />
+          </Field>
+          <Field label="输出变量">
+            <input
+              className={textInputClass()}
+              onChange={(event) => update({ outputVariable: event.target.value })}
+              value={data.outputVariable ?? ""}
+            />
+          </Field>
+        </>
+      ) : null}
+
+      {data.kind === "knowledge_citation" ? (
+        <>
+          <div className="rounded-lg border border-teal-300/25 bg-teal-300/10 px-3 py-2 text-xs leading-5 text-teal-50">
+            输出为 JSON 字符串，包含 citations 与 citation_count；不返回本地文件路径或向量内容。
+          </div>
+          <Field label="查询变量">
+            <input
+              className={textInputClass()}
+              onChange={(event) => update({ queryVariable: event.target.value })}
+              value={data.queryVariable ?? ""}
+            />
+          </Field>
+          <Field label="知识库 ID（可选）">
+            <input
+              className={textInputClass()}
+              onChange={(event) => update({ knowledgeBaseId: event.target.value })}
+              placeholder="留空时使用第一个知识库"
+              value={data.knowledgeBaseId ?? ""}
+            />
+          </Field>
+          <Field label="返回引用数 Top K">
+            <input
+              className={textInputClass()}
+              inputMode="numeric"
+              max={10}
+              min={1}
+              onChange={(event) => update({ top_k: event.target.value })}
+              type="number"
+              value={data.top_k ?? "4"}
             />
           </Field>
           <Field label="输出变量">

--- a/client/src/components/workflow/WorkflowNodeCard.tsx
+++ b/client/src/components/workflow/WorkflowNodeCard.tsx
@@ -65,6 +65,13 @@ const nodeMeta = {
     bg: "bg-teal-300/10",
     text: "text-teal-100",
   },
+  knowledge_citation: {
+    icon: "🔖",
+    label: "引用锚点",
+    border: "border-teal-200/40",
+    bg: "bg-teal-200/10",
+    text: "text-teal-100",
+  },
   document_extractor: {
     icon: "📄",
     label: "文档工位",
@@ -192,6 +199,9 @@ function outputName(data: WorkflowNode["data"]) {
   }
   if (data.kind === "knowledge_retrieval") {
     return `${data.queryVariable ?? "query"} top ${data.top_k ?? "3"} -> ${data.outputVariable ?? "rag_context"}`;
+  }
+  if (data.kind === "knowledge_citation") {
+    return `${data.queryVariable ?? "query"} top ${data.top_k ?? "4"} -> ${data.outputVariable ?? "citation_anchors_json"}`;
   }
   if (data.kind === "document_extractor") {
     return `${data.sourcePathVariable ?? "path"} -> ${data.outputVariable ?? "document_text"}`;

--- a/client/src/pages/ChatPage.tsx
+++ b/client/src/pages/ChatPage.tsx
@@ -33,6 +33,7 @@ import {
   fetchChatStream,
   type ChatApiMessage,
   type ChatMessageContent,
+  type ChatRuntimeMeta,
   type ChatRole,
 } from "../utils/fetchChatStream";
 
@@ -95,6 +96,74 @@ interface InstalledSkillsResponse {
 interface SkillContentResponse {
   skill_id: string;
   content: string;
+}
+
+interface RuntimeRunPayload {
+  run_id: string;
+  run_type: string;
+  status: string;
+  title: string;
+  metadata: Record<string, unknown>;
+  error: string | null;
+}
+
+interface RuntimeCheckpointPayload {
+  checkpoint_id: string;
+  event_type: string;
+  title: string;
+  summary: string;
+  severity: string;
+  created_at: number;
+}
+
+interface ChatRuntimeEventPayload {
+  id: string;
+  type: string;
+  severity: string;
+  payload: Record<string, unknown>;
+  created_at: number;
+}
+
+interface ChatToolAuditPayload {
+  record_id: string;
+  tool_name: string;
+  status: string;
+  duration_ms: number | null;
+  output_length: number | null;
+  error: string | null;
+}
+
+interface ChatRuntimeEventsResponse {
+  task_id: string;
+  run_id: string | null;
+  events: ChatRuntimeEventPayload[];
+  event_count: number;
+  tool_audit_records: ChatToolAuditPayload[];
+  tool_audit_count: number;
+}
+
+interface ChatRuntimeObservation {
+  run: RuntimeRunPayload | null;
+  checkpoints: RuntimeCheckpointPayload[];
+  events: ChatRuntimeEventPayload[];
+  auditRecords: ChatToolAuditPayload[];
+  eventCount: number;
+  auditCount: number;
+}
+
+function shortRuntimeId(value: string | null | undefined) {
+  if (!value) return "未登记";
+  return value.length > 12 ? `${value.slice(0, 8)}...${value.slice(-4)}` : value;
+}
+
+function formatRuntimeTimestamp(value: number | null | undefined) {
+  if (!value) return "";
+  return new Date(value * 1000).toLocaleTimeString("zh-CN", {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  });
 }
 
 const modalityLabels: Record<string, string> = {
@@ -491,6 +560,11 @@ export default function ChatPage() {
   const [runtimeToolNames, setRuntimeToolNames] = useState("");
   const [runtimeMaxToolIterations, setRuntimeMaxToolIterations] = useState("5");
   const [runtimePromptSuffix, setRuntimePromptSuffix] = useState("");
+  const [runtimeMeta, setRuntimeMeta] = useState<ChatRuntimeMeta | null>(null);
+  const [runtimeObservation, setRuntimeObservation] =
+    useState<ChatRuntimeObservation | null>(null);
+  const [runtimeObservationLoading, setRuntimeObservationLoading] = useState(false);
+  const [runtimeObservationError, setRuntimeObservationError] = useState("");
   const [knowledgeBases, setKnowledgeBases] = useState<KnowledgeBase[]>([]);
   const [selectedKnowledgeBaseId, setSelectedKnowledgeBaseId] = useState("");
   const [isLoadingKnowledgeBases, setIsLoadingKnowledgeBases] = useState(false);
@@ -690,6 +764,45 @@ export default function ChatPage() {
     }
   }
 
+  async function loadRuntimeObservation(meta: ChatRuntimeMeta | null = runtimeMeta) {
+    if (!meta?.taskId || !meta.runId) return;
+    setRuntimeObservationLoading(true);
+    setRuntimeObservationError("");
+    try {
+      const [runResponse, checkpointResponse, eventsResponse] = await Promise.all([
+        fetch(`/api/runtime/runs/${meta.runId}`),
+        fetch(`/api/runtime/runs/${meta.runId}/checkpoints?limit=30`),
+        fetch(`/api/chat/runtime-events/${meta.taskId}`),
+      ]);
+      if (!runResponse.ok) throw new Error(await readApiError(runResponse));
+      if (!checkpointResponse.ok) {
+        throw new Error(await readApiError(checkpointResponse));
+      }
+      if (!eventsResponse.ok) throw new Error(await readApiError(eventsResponse));
+
+      const run = (await runResponse.json()) as RuntimeRunPayload;
+      const checkpoints =
+        (await checkpointResponse.json()) as RuntimeCheckpointPayload[];
+      const eventsData = (await eventsResponse.json()) as ChatRuntimeEventsResponse;
+      setRuntimeObservation({
+        run,
+        checkpoints,
+        events: eventsData.events,
+        auditRecords: eventsData.tool_audit_records,
+        eventCount: eventsData.event_count,
+        auditCount: eventsData.tool_audit_count,
+      });
+    } catch (loadError) {
+      setRuntimeObservationError(
+        loadError instanceof Error
+          ? loadError.message
+          : "运行观测加载失败",
+      );
+    } finally {
+      setRuntimeObservationLoading(false);
+    }
+  }
+
   async function loadSkillContent(skillId: string) {
     if (!skillId) return "";
     const cached = skillContentCache[skillId];
@@ -793,7 +906,13 @@ export default function ChatPage() {
     if (!overrideText) setUploadedImages([]);
     setError("");
     setIsSending(true);
+    if (runtimeToolsEnabled) {
+      setRuntimeMeta(null);
+      setRuntimeObservation(null);
+      setRuntimeObservationError("");
+    }
 
+    let activeRuntimeMeta: ChatRuntimeMeta | null = null;
     try {
       if (selectedKnowledgeBaseId && rawText) {
         const ragQuestion = activeSkillContent
@@ -841,6 +960,12 @@ export default function ChatPage() {
           Math.max(1, Number(runtimeMaxToolIterations) || 5),
         ),
         promptSuffix: runtimePromptSuffix,
+        onRuntimeMeta: (meta) => {
+          activeRuntimeMeta = meta;
+          setRuntimeMeta(meta);
+          setRuntimeObservation(null);
+          setRuntimeObservationError("");
+        },
         onDelta: (delta) => {
           setMessages((current) =>
             current.map((message) =>
@@ -858,6 +983,9 @@ export default function ChatPage() {
           );
         },
       });
+      if (activeRuntimeMeta) {
+        await loadRuntimeObservation(activeRuntimeMeta);
+      }
 
       setMessages((current) =>
         current.map((message) =>
@@ -871,6 +999,9 @@ export default function ChatPage() {
         ),
       );
     } catch (streamError) {
+      if (activeRuntimeMeta) {
+        await loadRuntimeObservation(activeRuntimeMeta);
+      }
       const message =
         streamError instanceof Error && streamError.message
           ? streamError.message
@@ -1328,6 +1459,106 @@ export default function ChatPage() {
                     </div>
                   ) : null}
                 </div>
+                {runtimeToolsEnabled &&
+                (runtimeMeta || runtimeObservation || runtimeObservationError) ? (
+                  <div className="mb-3 rounded-lg border border-cyan-300/15 bg-cyan-300/[0.055] px-3 py-3">
+                    <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                      <div>
+                        <p className="text-xs font-semibold text-cyan-100">
+                          运行观测 Beta
+                        </p>
+                        <p className="mt-1 text-xs leading-5 text-slate-400">
+                          run {shortRuntimeId(runtimeMeta?.runId)} · task{" "}
+                          {shortRuntimeId(runtimeMeta?.taskId)}
+                        </p>
+                      </div>
+                      <button
+                        className="rounded-full border border-cyan-300/20 px-3 py-1.5 text-xs font-semibold text-cyan-100 transition hover:border-cyan-300/45 hover:bg-cyan-300/10 disabled:cursor-not-allowed disabled:opacity-60"
+                        disabled={runtimeObservationLoading || !runtimeMeta}
+                        onClick={() => void loadRuntimeObservation()}
+                        type="button"
+                      >
+                        {runtimeObservationLoading ? "加载中" : "刷新观测"}
+                      </button>
+                    </div>
+                    {runtimeObservationError ? (
+                      <p className="mt-3 rounded-lg border border-rose-300/20 bg-rose-400/10 px-3 py-2 text-xs text-rose-100">
+                        {runtimeObservationError}
+                      </p>
+                    ) : null}
+                    {runtimeObservation ? (
+                      <div className="mt-3 grid gap-3 xl:grid-cols-3">
+                        <div className="rounded-lg border border-white/10 bg-ink-950/55 p-3">
+                          <p className="text-[11px] font-semibold text-slate-400">
+                            Run 状态
+                          </p>
+                          <p className="mt-1 text-sm font-semibold text-white">
+                            {runtimeObservation.run?.status ?? "unknown"}
+                          </p>
+                          {runtimeObservation.run?.error ? (
+                            <p className="mt-1 truncate text-xs leading-5 text-rose-100">
+                              {runtimeObservation.run.error}
+                            </p>
+                          ) : (
+                            <p className="mt-1 text-xs leading-5 text-slate-400">
+                              事件 {runtimeObservation.eventCount} 条，审计{" "}
+                              {runtimeObservation.auditCount} 条。
+                            </p>
+                          )}
+                        </div>
+                        <div className="rounded-lg border border-white/10 bg-ink-950/55 p-3">
+                          <p className="text-[11px] font-semibold text-slate-400">
+                            Checkpoint
+                          </p>
+                          <div className="mt-2 space-y-2">
+                            {runtimeObservation.checkpoints.slice(0, 4).map((item) => (
+                              <div key={item.checkpoint_id}>
+                                <p className="truncate text-xs font-semibold text-slate-100">
+                                  {item.event_type}
+                                </p>
+                                <p className="truncate text-[11px] text-slate-400">
+                                  {formatRuntimeTimestamp(item.created_at)}
+                                  {item.summary ? ` · ${item.summary}` : ""}
+                                </p>
+                              </div>
+                            ))}
+                            {runtimeObservation.checkpoints.length === 0 ? (
+                              <p className="text-xs text-slate-500">暂无 checkpoint。</p>
+                            ) : null}
+                          </div>
+                        </div>
+                        <div className="rounded-lg border border-white/10 bg-ink-950/55 p-3">
+                          <p className="text-[11px] font-semibold text-slate-400">
+                            Tool 事件 / 审计
+                          </p>
+                          <div className="mt-2 space-y-2">
+                            {runtimeObservation.auditRecords.slice(0, 3).map((item) => (
+                              <div key={item.record_id}>
+                                <p className="truncate text-xs font-semibold text-slate-100">
+                                  {item.tool_name} · {item.status}
+                                </p>
+                                <p className="truncate text-[11px] text-slate-400">
+                                  {item.duration_ms != null
+                                    ? `${item.duration_ms.toFixed(0)}ms`
+                                    : "无耗时"}
+                                  {item.output_length != null
+                                    ? ` · ${item.output_length} chars`
+                                    : ""}
+                                  {item.error ? ` · ${item.error}` : ""}
+                                </p>
+                              </div>
+                            ))}
+                            {runtimeObservation.auditRecords.length === 0 ? (
+                              <p className="text-xs text-slate-500">
+                                暂无工具审计记录。
+                              </p>
+                            ) : null}
+                          </div>
+                        </div>
+                      </div>
+                    ) : null}
+                  </div>
+                ) : null}
                 <div
                   className={`rounded-lg border p-2 transition ${
                     superPromptMode

--- a/client/src/pages/RagPage.tsx
+++ b/client/src/pages/RagPage.tsx
@@ -26,6 +26,37 @@ interface DocumentListResponse {
   documents: RagDocument[];
 }
 
+interface PipelineAsset {
+  file_asset_id: string;
+  document_id: string;
+  knowledge_base_id: string;
+  filename: string;
+  size: number;
+  extension: string;
+  mime_type?: string | null;
+  created_at: number;
+}
+
+interface PipelineAssetListResponse {
+  assets: PipelineAsset[];
+  asset_count: number;
+}
+
+interface PipelineArtifact {
+  artifact_id: string;
+  file_asset_id: string;
+  document_id: string;
+  knowledge_base_id: string;
+  title: string;
+  chunk_count: number;
+  created_at: number;
+}
+
+interface PipelineArtifactListResponse {
+  artifacts: PipelineArtifact[];
+  artifact_count: number;
+}
+
 const MAX_FILE_BYTES = 10 * 1024 * 1024;
 const SUPPORTED_EXTENSIONS = [".txt", ".md", ".markdown", ".pdf"];
 
@@ -80,11 +111,21 @@ export default function RagPage() {
   const [notice, setNotice] = useState("");
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [newKbName, setNewKbName] = useState("");
+  const [isPipelineOpen, setIsPipelineOpen] = useState(false);
+  const [isLoadingPipeline, setIsLoadingPipeline] = useState(false);
+  const [pipelineError, setPipelineError] = useState("");
+  const [pipelineAssets, setPipelineAssets] = useState<PipelineAsset[]>([]);
+  const [pipelineArtifacts, setPipelineArtifacts] = useState<PipelineArtifact[]>([]);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const selectedKnowledgeBase = useMemo(
     () => knowledgeBases.find((item) => item.id === selectedKbId) ?? null,
     [knowledgeBases, selectedKbId],
+  );
+
+  const pipelineChunkCount = useMemo(
+    () => pipelineArtifacts.reduce((total, artifact) => total + artifact.chunk_count, 0),
+    [pipelineArtifacts],
   );
 
   useEffect(() => {
@@ -95,10 +136,14 @@ export default function RagPage() {
   useEffect(() => {
     if (!selectedKbId) {
       setDocuments([]);
+      setPipelineAssets([]);
+      setPipelineArtifacts([]);
+      setPipelineError("");
       return;
     }
     void loadDocuments(selectedKbId);
-  }, [selectedKbId]);
+    if (isPipelineOpen) void loadPipeline(selectedKbId);
+  }, [isPipelineOpen, selectedKbId]);
 
   async function loadKnowledgeBases(nextSelectedId?: string) {
     setIsLoadingKbs(true);
@@ -137,6 +182,30 @@ export default function RagPage() {
       setError(loadError instanceof Error ? loadError.message : "文档列表加载失败。");
     } finally {
       setIsLoadingDocs(false);
+    }
+  }
+
+  async function loadPipeline(kbId: string) {
+    setIsLoadingPipeline(true);
+    setPipelineError("");
+    try {
+      const query = new URLSearchParams({ kb_id: kbId }).toString();
+      const [assetsResponse, artifactsResponse] = await Promise.all([
+        fetch(`/api/rag/pipeline/assets?${query}`),
+        fetch(`/api/rag/pipeline/artifacts?${query}`),
+      ]);
+      if (!assetsResponse.ok) throw new Error(await readError(assetsResponse));
+      if (!artifactsResponse.ok) throw new Error(await readError(artifactsResponse));
+      const assetsData = (await assetsResponse.json()) as PipelineAssetListResponse;
+      const artifactsData = (await artifactsResponse.json()) as PipelineArtifactListResponse;
+      setPipelineAssets(assetsData.assets);
+      setPipelineArtifacts(artifactsData.artifacts);
+    } catch (loadError) {
+      setPipelineError(
+        loadError instanceof Error ? loadError.message : "知识流水线加载失败。",
+      );
+    } finally {
+      setIsLoadingPipeline(false);
     }
   }
 
@@ -208,6 +277,7 @@ export default function RagPage() {
       const uploaded = (await response.json()) as RagDocument;
       setNotice(`文档「${uploaded.filename}」已入库，切成 ${uploaded.chunk_count} 个片段。`);
       await Promise.all([loadDocuments(selectedKbId), loadKnowledgeBases(selectedKbId)]);
+      if (isPipelineOpen) await loadPipeline(selectedKbId);
     } catch (uploadError) {
       setError(uploadError instanceof Error ? uploadError.message : "上传文档失败。");
     } finally {
@@ -227,6 +297,7 @@ export default function RagPage() {
       if (!response.ok) throw new Error(await readError(response));
       setNotice(`文档「${document.filename}」已删除。`);
       await Promise.all([loadDocuments(selectedKbId), loadKnowledgeBases(selectedKbId)]);
+      if (isPipelineOpen) await loadPipeline(selectedKbId);
     } catch (deleteError) {
       setError(deleteError instanceof Error ? deleteError.message : "删除文档失败。");
     }
@@ -418,6 +489,109 @@ export default function RagPage() {
                   {isUploading ? "处理中" : "选择文件"}
                 </button>
               </div>
+
+              <section className="mt-5 overflow-hidden rounded-lg border border-white/10 bg-white/[0.035]">
+                <button
+                  className="flex w-full flex-col gap-3 px-4 py-3 text-left transition hover:bg-white/[0.04] sm:flex-row sm:items-center sm:justify-between"
+                  onClick={() => setIsPipelineOpen((value) => !value)}
+                  type="button"
+                >
+                  <span>
+                    <span className="block text-sm font-semibold text-white">
+                      知识流水线 Beta
+                    </span>
+                    <span className="mt-1 block text-xs leading-5 text-slate-400">
+                      FileAsset → Artifact → Chunk → CitationAnchor 只读元数据视图
+                    </span>
+                  </span>
+                  <span className="rounded-full border border-hire-300/25 bg-hire-300/10 px-3 py-1 text-xs font-semibold text-hire-100">
+                    {isPipelineOpen ? "收起" : "展开"}
+                  </span>
+                </button>
+
+                {isPipelineOpen ? (
+                  <div className="border-t border-white/10 px-4 py-4">
+                    {isLoadingPipeline ? (
+                      <p className="text-sm text-slate-400">正在读取知识流水线元数据...</p>
+                    ) : pipelineError ? (
+                      <p className="text-sm text-rose-100">{pipelineError}</p>
+                    ) : (
+                      <>
+                        <div className="grid gap-3 sm:grid-cols-3">
+                          <div className="rounded-lg border border-white/10 bg-ink-950/35 p-3">
+                            <p className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+                              FileAssets
+                            </p>
+                            <p className="mt-2 text-2xl font-semibold text-white">
+                              {pipelineAssets.length}
+                            </p>
+                          </div>
+                          <div className="rounded-lg border border-white/10 bg-ink-950/35 p-3">
+                            <p className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+                              Artifacts
+                            </p>
+                            <p className="mt-2 text-2xl font-semibold text-white">
+                              {pipelineArtifacts.length}
+                            </p>
+                          </div>
+                          <div className="rounded-lg border border-white/10 bg-ink-950/35 p-3">
+                            <p className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+                              Chunks
+                            </p>
+                            <p className="mt-2 text-2xl font-semibold text-white">
+                              {pipelineChunkCount}
+                            </p>
+                          </div>
+                        </div>
+
+                        <div className="mt-4">
+                          <div className="flex items-center justify-between gap-3">
+                            <p className="text-xs font-semibold text-slate-300">
+                              最近 Artifacts
+                            </p>
+                            <button
+                              className="text-xs font-semibold text-hire-100 transition hover:text-hire-50"
+                              onClick={(event) => {
+                                event.stopPropagation();
+                                void loadPipeline(selectedKbId);
+                              }}
+                              type="button"
+                            >
+                              刷新
+                            </button>
+                          </div>
+                          {pipelineArtifacts.length === 0 ? (
+                            <p className="mt-3 rounded-lg border border-dashed border-white/10 p-3 text-sm text-slate-400">
+                              当前资料库还没有可观察的文档产物。
+                            </p>
+                          ) : (
+                            <div className="mt-3 divide-y divide-white/10 overflow-hidden rounded-lg border border-white/10">
+                              {pipelineArtifacts.slice(0, 5).map((artifact) => (
+                                <div
+                                  className="grid gap-2 bg-ink-950/30 p-3 text-sm sm:grid-cols-[minmax(0,1fr)_auto]"
+                                  key={artifact.artifact_id}
+                                >
+                                  <div className="min-w-0">
+                                    <p className="truncate font-semibold text-white">
+                                      {artifact.title}
+                                    </p>
+                                    <p className="mt-1 text-xs text-slate-400">
+                                      {artifact.artifact_id}
+                                    </p>
+                                  </div>
+                                  <p className="text-xs font-semibold text-hire-100">
+                                    {artifact.chunk_count} chunks
+                                  </p>
+                                </div>
+                              ))}
+                            </div>
+                          )}
+                        </div>
+                      </>
+                    )}
+                  </div>
+                ) : null}
+              </section>
 
               <div className="mt-6">
                 <div className="flex items-center justify-between">

--- a/client/src/types/workflow-native.ts
+++ b/client/src/types/workflow-native.ts
@@ -10,6 +10,7 @@ export type NativeNodeKind =
   | "variable_aggregator"
   | "parameter_extractor"
   | "knowledge_retrieval"
+  | "knowledge_citation"
   | "document_extractor"
   | "human_intervention"
   | "question_classifier"
@@ -32,6 +33,7 @@ export type DifyConceptNodeKind =
   | "variable-aggregator"
   | "parameter-extractor"
   | "knowledge-retrieval"
+  | "knowledge-citation"
   | "document-extractor"
   | "human-in-the-loop"
   | "question-classifier"
@@ -94,6 +96,11 @@ export const difyNodeMappings: DifyNodeMapping[] = [
     native: "knowledge_retrieval",
     dify: "knowledge-retrieval",
     note: "Native retrieval queries the local RAG service when a knowledge base exists.",
+  },
+  {
+    native: "knowledge_citation",
+    dify: "knowledge-citation",
+    note: "Native citation maps local RAG retrieval results into CitationAnchor JSON.",
   },
   {
     native: "document_extractor",

--- a/client/src/types/workflow.ts
+++ b/client/src/types/workflow.ts
@@ -11,6 +11,7 @@ export type WorkflowNodeKind =
   | "variable_aggregator"
   | "parameter_extractor"
   | "knowledge_retrieval"
+  | "knowledge_citation"
   | "document_extractor"
   | "human_intervention"
   | "question_classifier"
@@ -58,6 +59,7 @@ export interface WorkflowNodeData extends Record<string, unknown> {
   outputTemplate?: string;
   schema?: string;
   queryVariable?: string;
+  knowledgeBaseId?: string;
   top_k?: string;
   sourcePathVariable?: string;
   categories?: string;

--- a/client/src/utils/fetchChatStream.ts
+++ b/client/src/utils/fetchChatStream.ts
@@ -19,6 +19,12 @@ export interface ChatApiMessage {
   content: ChatMessageContent;
 }
 
+export interface ChatRuntimeMeta {
+  runId: string;
+  taskId: string;
+  toolMode: string;
+}
+
 interface FetchChatStreamOptions {
   modelId: string;
   messages: ChatApiMessage[];
@@ -32,6 +38,7 @@ interface FetchChatStreamOptions {
   maxToolIterations?: number;
   promptSuffix?: string;
   signal?: AbortSignal;
+  onRuntimeMeta?: (meta: ChatRuntimeMeta) => void;
   onDelta: (text: string) => void;
 }
 
@@ -206,6 +213,7 @@ export async function fetchChatStream({
   maxToolIterations = 5,
   promptSuffix = "",
   signal,
+  onRuntimeMeta,
   onDelta,
 }: FetchChatStreamOptions) {
   const response = await fetch("/api/chat", {
@@ -242,6 +250,17 @@ export async function fetchChatStream({
       error: errorPayload,
     });
     throw new Error(message);
+  }
+
+  const runtimeRunId = response.headers.get("X-ModelMirror-Runtime-Run-Id") ?? "";
+  const runtimeTaskId = response.headers.get("X-ModelMirror-Runtime-Task-Id") ?? "";
+  const runtimeToolMode = response.headers.get("X-ModelMirror-Tool-Mode") ?? "";
+  if (onRuntimeMeta && (runtimeRunId || runtimeTaskId)) {
+    onRuntimeMeta({
+      runId: runtimeRunId,
+      taskId: runtimeTaskId,
+      toolMode: runtimeToolMode,
+    });
   }
 
   const reader = response.body?.getReader();

--- a/docs/RAG_INTEGRATION.md
+++ b/docs/RAG_INTEGRATION.md
@@ -2,7 +2,17 @@
 
 本文件说明模镜本地 RAG 模块的架构、API、扩展方式和测试方法。该模块位于 `server/rag/`，前端入口为 `/rag`，聊天页可选择知识库进行检索增强问答。
 
-最后更新日期：2026-06-16  
+最后更新日期：2026-07-08
+
+## 2026-07-08 增量：Workflow CitationAnchor 节点
+
+Classic workflow 已新增 `knowledge_citation` 节点，复用本地 RAG Knowledge Pipeline 的 citation 生成能力。节点读取 `queryVariable` 中的文本，使用可选 `knowledgeBaseId` 和 `top_k` 调用 `RagService.create_pipeline_citations(...)`，并把结果写入 `outputVariable`：
+
+```json
+{"citations":[...],"citation_count":1}
+```
+
+该节点只输出 CitationAnchor 摘要，包括 `chunk_id`、`document_name`、`score`、`snippet` 等字段；不会返回本地文件绝对路径、embedding、完整上传文件内容或密钥。它不改变上传、切分、检索、向量存储、`/api/rag/query` 或聊天 RAG 行为，只是让 workflow 和后续 Agent 能引用同一套只读知识元数据视图。
 维护人：模镜团队
 
 ## 1. 概述
@@ -291,3 +301,29 @@ python -m pytest server/tests/test_rag.py -q
 4. 验证 `answer` 和 `sources`。
 5. 清理文档和知识库。
 
+
+## 2026-07-08 增量：知识流水线 Beta
+
+本地 RAG 现在额外提供一层只读 Knowledge Pipeline 元数据视图，用于对齐 Xpert 的知识产物模型。该层不会改变上传、切分、embedding、向量存储、检索测试或 `/api/rag/query` 响应协议。
+
+新增模型映射：
+
+- `FileAsset`：由已上传 document 派生，包含文件名、大小、扩展名、mime、知识库 ID 与 document ID，不返回 `stored_path`。
+- `Artifact`：由 document 派生，表示可被检索和引用的文档产物，包含 `file_asset_id`、标题和 `chunk_count`。
+- `KnowledgeChunk`：由向量索引中的 chunk 派生，只返回 chunk ID、序号、文本摘要和字符长度，不返回 embedding。
+- `CitationAnchor`：由现有检索结果派生，包含 chunk ID、document 名称、score 和 snippet。
+
+新增只读 API：
+
+```bash
+curl 'http://localhost:8000/api/rag/pipeline/assets?kb_id=kb_xxx'
+curl 'http://localhost:8000/api/rag/pipeline/artifacts?kb_id=kb_xxx'
+curl 'http://localhost:8000/api/rag/pipeline/artifacts/artifact_doc_xxx/chunks'
+curl -X POST http://localhost:8000/api/rag/pipeline/citations \
+  -H 'Content-Type: application/json' \
+  -d '{"kb_id":"kb_xxx","question":"如何使用资料？","top_k":4}'
+```
+
+前端 `/rag` 新增“知识流水线 Beta”折叠区，展示当前知识库的 assets / artifacts / chunks 计数和最近 artifacts。后续知识类工作流节点、Agent 引用和 citation 面板会基于这层 schema 继续扩展。
+
+最后更新日期：2026-07-08

--- a/docs/XPERT_ALIGNMENT.md
+++ b/docs/XPERT_ALIGNMENT.md
@@ -1,5 +1,6 @@
 # Xpert 对齐总纲
 
+> 2026-07-08 状态补充：Chat Toolset 运行观测已进入“部分实现”。`tool_mode=mcp_tools` 的聊天请求会登记 `chat` run，响应 header 暴露 runtime run/task id，并记录 `chat.started/model_decision/tool_call/answer/failed` checkpoint；聊天页会展示轻量“运行观测 Beta”。普通聊天仍不创建 chat run，SSE 格式不变。
 > 2026-07-08 状态补充：Chat Agent Toolset 已进入“部分实现”。`/api/chat` 新增默认关闭的 `tool_mode=mcp_tools`，显式开启后使用轻量 JSON 决策协议调用 MCP 工具，并复用 `MCPToolsetProvider`、`run_tool_with_runtime`、`tool_policy` 与 `tool_audit`。普通聊天请求保持 `tool_mode=none`，SSE wire format 不变；当前不是 OpenAI function calling，不做 Handoff 自动调度或真实多 Agent 协作。
 > 2026-07-08 状态补充：Handoff Router 已进入“部分实现”。Classic workflow 新增 `handoff_router` 节点，可读取 `workflow_agent` 等上游节点输出，创建 AgentTask，并向目标 Agent 创建 pending Handoff，让结果进入 MetaAgent Handoff Inbox。当前不自动 accept、不执行目标 Agent、不接队列 worker 或持久化。
 > 2026-07-07 状态补充：RunRegistry Trace 已进入“部分实现”。`RuntimeRun` 现在可挂载内存态 checkpoint，记录 workflow、workflow_agent、agent_task、agent_handoff 的关键执行时间线；新增 `GET /api/runtime/runs/{run_id}/checkpoints` 供前端运行观测读取。当前仍不做持久化、自动重试、队列调度或 checkpoint resume。
@@ -29,6 +30,12 @@ Classic workflow 运行时会创建 workflow run，并在 `workflow_meta` / `wor
 当前边界：RunRegistry 仅为内存态可观测索引，不是持久化调度器；取消 run 只更新 registry 状态，不中断真实 workflow、AgentTask 或 Handoff 执行。Checkpoint 只保存摘要与元信息，不保存完整 prompt、工具输出、模型输出或密钥。下一步可在此基础上继续补齐 Handoff 自动编排、RunRegistry 页面、死信与持久化存储。
 
 最后更新日期：2026-07-08
+
+## 2026-07-08 增量：Knowledge Citation 工作流节点
+
+Classic workflow 新增 `knowledge_citation` 节点，作为 Knowledge Pipeline 进入工作流的最小闭环。节点字段包括 `queryVariable`、`knowledgeBaseId`、`top_k` 与 `outputVariable`；`knowledgeBaseId` 留空时沿用本地 RAG 默认策略，使用第一个知识库。运行时会调用 `RagService.create_pipeline_citations(...)`，把结果写入 JSON 字符串：`{"citations":[...],"citation_count":N}`。
+
+该节点同步登记 `knowledge_citation` 子 run，`parent_run_id` 指向 workflow run，并记录 `knowledge_citation.started/completed/failed` checkpoint。metadata 只保存 `workflow_task_id`、`node_id`、`kb_id`、`query_variable`、`output_variable`、`citation_count` 等摘要；不保存完整 query、chunk 全文、embedding、本地文件路径或密钥。当前不改 `/api/rag/query`、聊天 RAG、上传、切分、向量存储或 embedding 策略。
 维护人：模镜团队
 
 ## 对齐原则
@@ -53,7 +60,7 @@ EvoAgentX 只保留为历史参考：此前元智能体曾借鉴其 `goal -> sub
 ## 当前已落地能力
 
 - Runtime Middleware：已具备 `before_agent`、`before_model`、`wrap_model_call`、`after_model`、`after_agent`、`wrap_tool_call` 生命周期。
-- Chat Runtime：`/api/chat` 已接入默认 runtime pipeline，支持 system prompt 注入和模型调用事件记录；显式设置 `tool_mode=mcp_tools` 时可进入 Runtime Toolset 工具循环，默认仍保持普通聊天路径。
+- Chat Runtime：`/api/chat` 已接入默认 runtime pipeline，支持 system prompt 注入和模型调用事件记录；显式设置 `tool_mode=mcp_tools` 时可进入 Runtime Toolset 工具循环，并登记 `chat` run、checkpoint、tool events 与审计摘要。默认仍保持普通聊天路径。
 - Toolset / MCP：`mcp_tool` 已通过 `MCPToolsetProvider`、`CapabilityRegistry`、`run_tool_with_runtime` 调用工具。
 - Tool Policy / Audit：`tool_policy` 可影响 workflow 内 MCP 工具调用，`InMemoryToolAuditStore` 提供最小审计记录。
 - Runtime Middleware Node：前端可拖入 `runtime_middleware` 节点，`system_prompt_injector`、`tool_policy`、`event_recorder`、`tool_audit` 已逐步进入真实执行或可见状态。
@@ -67,7 +74,7 @@ EvoAgentX 只保留为历史参考：此前元智能体曾借鉴其 `goal -> sub
 
 1. **RunRegistry Trace 增强**：补齐 workflow_agent / handoff 的 trace、checkpoint、失败摘要与重试入口。
 2. **Handoff 自动编排雏形**：将 workflow_agent 输出与 handoff queue 连接，但仍保持人工可控。
-3. **Chat Agent Toolset 观测增强**：补齐聊天工具模式的任务级 trace、工具偏好和更细粒度安全提示。
+3. **Chat Agent Toolset 安全增强**：补齐聊天工具偏好、工具 schema 提示和更细粒度安全提示。
 4. **知识流水线底座**：拆分本地 RAG 的文件元数据，建立 FileAsset -> Artifact -> Chunk -> CitationAnchor 的最小模型。
 
 ## 2026-07-07 增量：RunRegistry Trace / Checkpoint
@@ -91,3 +98,15 @@ RunRegistry 现在提供内存态 checkpoint：每条 `RuntimeRun` 可记录 `ev
 - 前端构建：涉及前端时运行 `cd client && npm.cmd run build`。
 - Docker smoke：影响主路径时运行 `docker compose -p modelmirror up -d --build --force-recreate` 和 `/api/health`。
 - 文档更新：同步更新本文件或相关模块文档，说明状态、边界和下一步。
+
+## 2026-07-08 增量：Knowledge Pipeline 元数据视图
+
+Knowledge Pipeline 已从“待实现”进入“部分实现”。当前在本地 RAG 之上新增只读元数据层，将既有知识库、文档与 chunk 映射为 `FileAsset -> Artifact -> KnowledgeChunk -> CitationAnchor`：
+
+- `GET /api/rag/pipeline/assets?kb_id=` 返回上传文件视图，不暴露本地绝对路径。
+- `GET /api/rag/pipeline/artifacts?kb_id=` 返回可检索文档产物与 chunk 计数。
+- `GET /api/rag/pipeline/artifacts/{artifact_id}/chunks` 返回 chunk 摘要、长度和稳定 ID，不返回 embedding。
+- `POST /api/rag/pipeline/citations` 复用现有检索路径返回 citation anchors。
+- `/rag` 新增“知识流水线 Beta”折叠区，可查看当前知识库的 assets / artifacts / chunks 摘要。
+
+边界：本轮不迁移 Chroma/LocalJsonVectorStore，不改变上传、切分、embedding、检索、RAG 问答或聊天协议；该层只是 Xpert Knowledge Pipeline 的本地可观测 schema 底座。

--- a/docs/workflow-native-design.md
+++ b/docs/workflow-native-design.md
@@ -1,5 +1,6 @@
 # workflow-native 自研工作流设计
 
+> 2026-07-08 状态补充：Chat Toolset 运行观测进入最小闭环。`tool_mode=mcp_tools` 的聊天请求会登记 `chat` run，响应 header 返回 `X-ModelMirror-Runtime-Run-Id` / `X-ModelMirror-Runtime-Task-Id`；前端聊天页展示 run 状态、checkpoint、tool events 与 audit 摘要。普通聊天仍不创建 chat run，SSE wire format 不变。
 > 2026-07-08 状态补充：`/api/chat` 已接入默认关闭的 Runtime Toolset 工具模式。前端聊天页可显式开启 MCP 工具循环，后端复用 `run_tool_with_runtime`、`tool_policy` 与 `tool_audit`，并继续使用现有 OpenAI SSE delta 结构输出最终答案。当前不是 OpenAI function calling，不自动创建 Handoff，也不改变 workflow、RAG、Skill 或 MCP 连接主路径。
 > 2026-07-07 状态补充：RunRegistry Trace / Checkpoint 进入最小闭环。Workflow run、`workflow_agent`、`agent_task`、`agent_handoff` 会写入内存态 checkpoint；前端“运行观测”会读取 `GET /api/runtime/runs/{run_id}/checkpoints` 展示当前 run 与子 run 的时间线摘要。当前不做持久化、自动重试、队列调度或 checkpoint resume。
 > 2026-07-07 状态补充：`workflow_agent` 已支持 Runtime Toolset 工具模式。`toolMode=none` 保持单步模型执行；`toolMode=mcp_tools` 使用轻量 JSON 决策协议调用 MCP 工具，并复用 `run_tool_with_runtime`、`tool_policy`、`tool_audit`。旧 `agent.tool_first` 也已收敛到同一条 runtime toolset 路径。当前不是 OpenAI function calling，不做自动 Handoff 或真实多 Agent 协作。
@@ -531,6 +532,20 @@ Classic workflow 新增 handoff_router 节点，作为 workflow_agent -> Handoff
 
 工具调用统一经过 `MCPToolsetProvider`、`run_tool_with_runtime` 与 `MiddlewarePipeline.wrap_tool_call`，因此现有 `tool_policy`、`tool_audit` 和 `event_recorder` 可复用到聊天工具循环。`tool_names` 提供逗号或换行分隔的白名单，留空代表允许当前已注册 MCP 工具；`max_tool_iterations` 限制为 1-20，避免无限工具循环。
 
+本轮补齐最小运行观测：工具模式请求会在内存态 RunRegistry 中创建 `chat` run，并通过响应 header 暴露 run/task id。后端新增 `GET /api/chat/runtime-events/{task_id}` 返回本次聊天的 runtime events 与 per-chat audit 摘要；前端“Runtime 工具模式 Beta”区域展示 run 状态、checkpoint、tool event 和审计摘要。
+
 当前边界：不是 OpenAI function calling，不自动创建 Handoff，不接真实多 Agent 调度，也不保存完整 prompt、工具输出、模型回答或 API key 到运行元数据中。
 
 最后更新日期：2026-07-08
+
+## 2026-07-08 增量：Knowledge Citation 工作流节点
+
+Classic workflow 新增 `knowledge_citation` 节点，用于把本地 RAG Knowledge Pipeline 的 `CitationAnchor` 变成可拖拽、可配置、可运行、可观测的工作流能力。前端字段为 `queryVariable`、`knowledgeBaseId`、`top_k`、`outputVariable`；`knowledgeBaseId` 留空时使用第一个知识库，`top_k` 静态校验范围为 1-10。
+
+运行时读取 `variables[queryVariable]` 作为检索问题，调用 `RagService.create_pipeline_citations(kb_id, query_text, top_k=...)`，并将输出变量写成 JSON 字符串：
+
+```json
+{"citations":[{"chunk_id":"...","document_name":"...","score":0.91,"snippet":"..."}],"citation_count":1}
+```
+
+节点会登记 `knowledge_citation` 子 run，`parent_run_id` 指向 workflow run，并写入 `knowledge_citation.started/completed/failed` checkpoint。metadata 只保存知识库 ID、变量名、输出变量、引用数量等摘要，不返回本地文件路径、embedding、完整上传文件内容或密钥。该节点与既有 `knowledge_retrieval` 并存，不改变 `/api/rag/query`、聊天 RAG 或向量库行为。

--- a/server/main.py
+++ b/server/main.py
@@ -28,9 +28,9 @@ except ModuleNotFoundError:
     from api.dify_proxy import router as dify_router
 
 try:
-    from server.rag.api import router as rag_router
+    from server.rag.api import get_rag_service, router as rag_router
 except ModuleNotFoundError:
-    from rag.api import router as rag_router
+    from rag.api import get_rag_service, router as rag_router
 
 try:
     from server.skills.api import router as skills_router
@@ -224,6 +224,12 @@ app.add_middleware(
     allow_credentials=True,
     allow_methods=["GET", "POST", "DELETE", "OPTIONS"],
     allow_headers=["*"],
+    expose_headers=[
+        "X-ModelMirror-Actual-Model",
+        "X-ModelMirror-Tool-Mode",
+        "X-ModelMirror-Runtime-Run-Id",
+        "X-ModelMirror-Runtime-Task-Id",
+    ],
 )
 
 app.include_router(dify_router)
@@ -250,6 +256,7 @@ runtime_capabilities.register(
     description="MCP tools runtime capability for workflow and agents.",
 )
 workflow_task_store: dict[str, dict[str, Any]] = {}
+chat_runtime_task_store: dict[str, dict[str, Any]] = {}
 
 
 class TextContentPart(BaseModel):
@@ -418,6 +425,7 @@ WorkflowNodeType = Literal[
     "variable_aggregator",
     "parameter_extractor",
     "knowledge_retrieval",
+    "knowledge_citation",
     "document_extractor",
     "human_intervention",
     "question_classifier",
@@ -959,6 +967,30 @@ def runtime_tool_result_text(call_result: Any) -> str:
     return output_text
 
 
+async def record_chat_checkpoint(
+    run_id: str | None,
+    *,
+    event_type: str,
+    title: str,
+    summary: str = "",
+    severity: str = "info",
+    metadata: dict[str, Any] | None = None,
+) -> None:
+    if not run_id:
+        return
+    try:
+        await run_registry.record_checkpoint(
+            run_id,
+            event_type=event_type,
+            title=title,
+            summary=summary,
+            severity=severity,
+            metadata=metadata,
+        )
+    except Exception as exc:
+        logger.warning("Chat runtime checkpoint recording failed: %s", exc)
+
+
 async def collect_chat_completion_text(
     model_id: str,
     messages: list[ChatMessage],
@@ -1000,6 +1032,8 @@ async def stream_chat_toolset_text(
     *,
     runtime_pipeline: MiddlewarePipeline,
     runtime_context: MiddlewareContext,
+    run_id: str | None = None,
+    audit_store: InMemoryToolAuditStore | None = None,
 ) -> AsyncIterator[str]:
     requested_tools = parse_chat_tool_names(payload.tool_names)
     all_tools = await workflow_mcp_provider.list_tools()
@@ -1050,13 +1084,52 @@ async def stream_chat_toolset_text(
             )
         ).strip()
         decision = extract_json_decision(raw_response)
+        decision_type = "raw"
+        if isinstance(decision, dict):
+            if isinstance(decision.get("answer"), str) and str(decision.get("answer")).strip():
+                decision_type = "answer"
+            elif str(decision.get("tool") or "").strip():
+                decision_type = "tool"
+        await record_chat_checkpoint(
+            run_id,
+            event_type="chat.model_decision",
+            title="Model decision",
+            summary=f"iteration={iteration_index + 1}, type={decision_type}",
+            metadata={
+                "iteration": iteration_index + 1,
+                "decision_type": decision_type,
+                "raw_length": len(raw_response),
+            },
+        )
         if decision is None:
+            await record_chat_checkpoint(
+                run_id,
+                event_type="chat.answer",
+                title="Final answer",
+                summary=f"length={len(raw_response)}",
+                metadata={
+                    "iteration": iteration_index + 1,
+                    "answer_length": len(raw_response),
+                    "fallback_raw": True,
+                },
+            )
             yield raw_response
             return
 
         answer = decision.get("answer")
         if isinstance(answer, str) and answer.strip():
-            yield answer.strip()
+            answer_text = answer.strip()
+            await record_chat_checkpoint(
+                run_id,
+                event_type="chat.answer",
+                title="Final answer",
+                summary=f"length={len(answer_text)}",
+                metadata={
+                    "iteration": iteration_index + 1,
+                    "answer_length": len(answer_text),
+                },
+            )
+            yield answer_text
             return
 
         tool_name = str(decision.get("tool") or "").strip()
@@ -1104,9 +1177,26 @@ async def stream_chat_toolset_text(
             runtime_pipeline,
             tool_context,
             policy=workflow_tool_policy,
-            audit_store=workflow_tool_audit_store,
+            audit_store=audit_store or workflow_tool_audit_store,
         )
         tool_result_text = runtime_tool_result_text(call_result)
+        await record_chat_checkpoint(
+            run_id,
+            event_type="chat.tool_call",
+            title="Tool call",
+            summary=f"{tool_name} output_length={len(tool_result_text)}",
+            metadata={
+                "iteration": iteration_index + 1,
+                "tool_name": tool_name,
+                "output_length": len(tool_result_text),
+                "content_types": getattr(call_result, "metadata", {}).get(
+                    "content_types",
+                    [],
+                )
+                if isinstance(getattr(call_result, "metadata", {}), dict)
+                else [],
+            },
+        )
         yield (
             f"\n[Runtime 工具调用 {iteration_index + 1}/{payload.max_tool_iterations}] "
             f"{tool_name} 完成，结果预览：{tool_result_text[:240]}\n"
@@ -1421,6 +1511,7 @@ def workflow_node_kind(node: WorkflowNodePayload) -> WorkflowNodeType:
         "variable_aggregator",
         "parameter_extractor",
         "knowledge_retrieval",
+        "knowledge_citation",
         "document_extractor",
         "human_intervention",
         "question_classifier",
@@ -2898,6 +2989,182 @@ async def run_workflow(payload: WorkflowRunRequest, request: Request):
                             }
                         )
 
+                elif kind == "knowledge_citation":
+                    output_variable = str(
+                        node.data.get("outputVariable") or "citation_anchors_json"
+                    )
+                    output = json.dumps(
+                        {"citations": [], "citation_count": 0},
+                        ensure_ascii=False,
+                    )
+                    citation_run = None
+                    try:
+                        query_variable = str(
+                            node.data.get("queryVariable") or "user_input"
+                        ).strip()
+                        query_text = variables.get(query_variable, "")
+                        knowledge_base_id = str(
+                            node.data.get("knowledgeBaseId") or ""
+                        ).strip()
+                        try:
+                            top_k = int(str(node.data.get("top_k") or "4"))
+                        except ValueError:
+                            top_k = 4
+                        top_k = max(1, min(top_k, 10))
+
+                        service = get_rag_service()
+                        if not knowledge_base_id:
+                            knowledge_bases = service.list_knowledge_bases()
+                            if knowledge_bases:
+                                knowledge_base_id = str(knowledge_bases[0]["id"])
+
+                        citation_run = await run_registry.create_run(
+                            "knowledge_citation",
+                            title,
+                            status="running",
+                            source_id=f"{task_id}:{node.id}",
+                            parent_run_id=workflow_run.run_id,
+                            metadata={
+                                "workflow_id": payload.workflow.id,
+                                "workflow_title": payload.workflow.title,
+                                "workflow_task_id": task_id,
+                                "node_id": node.id,
+                                "node_title": title,
+                                "kb_id": knowledge_base_id,
+                                "query_variable": query_variable,
+                                "output_variable": output_variable,
+                                "top_k": top_k,
+                            },
+                        )
+                        await run_registry.record_checkpoint(
+                            citation_run.run_id,
+                            event_type="knowledge_citation.started",
+                            title="Knowledge citation started",
+                            summary=f"query_variable={query_variable}, top_k={top_k}",
+                            metadata={
+                                "node_id": node.id,
+                                "kb_id": knowledge_base_id,
+                                "query_variable": query_variable,
+                                "output_variable": output_variable,
+                                "top_k": top_k,
+                            },
+                        )
+
+                        if not knowledge_base_id:
+                            variables[output_variable] = output
+                            await run_registry.update_run(
+                                citation_run.run_id,
+                                status="completed",
+                                metadata={"citation_count": 0},
+                            )
+                            await run_registry.record_checkpoint(
+                                citation_run.run_id,
+                                event_type="knowledge_citation.completed",
+                                title="Knowledge citation completed",
+                                summary="citation_count=0",
+                                metadata={
+                                    "node_id": node.id,
+                                    "citation_count": 0,
+                                },
+                            )
+                            yield sse_payload(
+                                {
+                                    "event": "error",
+                                    "node_id": node.id,
+                                    "message": "RAG 索引尚未就绪，暂无可查询知识库。",
+                                }
+                            )
+                            yield sse_payload(
+                                {
+                                    "event": "node_delta",
+                                    "node_id": node.id,
+                                    "node_title": title,
+                                    "node_type": kind,
+                                    "output": "未找到可查询知识库，已写入空 CitationAnchor JSON。",
+                                    "variable": output_variable,
+                                    "run_id": citation_run.run_id,
+                                    "citation_count": 0,
+                                }
+                            )
+                        else:
+                            citations = await service.create_pipeline_citations(
+                                knowledge_base_id,
+                                query_text,
+                                top_k=top_k,
+                            )
+                            payload_json = {
+                                "citations": citations,
+                                "citation_count": len(citations),
+                            }
+                            output = json.dumps(payload_json, ensure_ascii=False)
+                            variables[output_variable] = output
+                            await run_registry.update_run(
+                                citation_run.run_id,
+                                status="completed",
+                                metadata={
+                                    "kb_id": knowledge_base_id,
+                                    "citation_count": len(citations),
+                                    "output_length": len(output),
+                                },
+                            )
+                            await run_registry.record_checkpoint(
+                                citation_run.run_id,
+                                event_type="knowledge_citation.completed",
+                                title="Knowledge citation completed",
+                                summary=f"citation_count={len(citations)}",
+                                metadata={
+                                    "node_id": node.id,
+                                    "kb_id": knowledge_base_id,
+                                    "citation_count": len(citations),
+                                    "output_variable": output_variable,
+                                },
+                            )
+                            yield sse_payload(
+                                {
+                                    "event": "node_delta",
+                                    "node_id": node.id,
+                                    "node_title": title,
+                                    "node_type": kind,
+                                    "output": (
+                                        f"已生成 {len(citations)} 个 CitationAnchor，"
+                                        f"写入 {output_variable}。"
+                                    ),
+                                    "variable": output_variable,
+                                    "run_id": citation_run.run_id,
+                                    "citation_count": len(citations),
+                                }
+                            )
+                    except Exception as exc:
+                        logger.warning("Workflow knowledge_citation node failed: %s", exc)
+                        variables[output_variable] = output
+                        if citation_run is not None:
+                            try:
+                                await run_registry.record_checkpoint(
+                                    citation_run.run_id,
+                                    event_type="knowledge_citation.failed",
+                                    title="Knowledge citation failed",
+                                    summary=str(exc),
+                                    severity="error",
+                                    metadata={"node_id": node.id},
+                                )
+                                await run_registry.update_run(
+                                    citation_run.run_id,
+                                    status="failed",
+                                    error=str(exc),
+                                )
+                            except Exception:
+                                logger.warning(
+                                    "Failed to update knowledge_citation run status",
+                                    exc_info=True,
+                                )
+                        yield sse_payload(
+                            {
+                                "event": "error",
+                                "node_id": node.id,
+                                "message": str(exc),
+                            }
+                        )
+
                 elif kind == "document_extractor":
                     try:
                         output_variable = str(
@@ -4277,6 +4544,32 @@ async def get_workflow_task_status(task_id: str):
     )
 
 
+def runtime_event_to_payload(event: Any) -> dict[str, Any]:
+    return {
+        "id": event.id,
+        "type": event.type,
+        "payload": dict(event.payload or {}),
+        "task_id": event.task_id,
+        "trace_id": event.trace_id,
+        "severity": event.severity,
+        "created_at": event.created_at,
+    }
+
+
+def tool_audit_record_to_payload(record: Any) -> dict[str, Any]:
+    return {
+        "record_id": record.record_id,
+        "tool_name": record.tool_name,
+        "status": record.status,
+        "started_at": record.started_at,
+        "finished_at": record.finished_at,
+        "duration_ms": record.duration_ms,
+        "output_length": record.output_length,
+        "content_types": record.content_types,
+        "error": record.error,
+    }
+
+
 @app.get("/api/workflow/runtime-events/{task_id}")
 async def get_workflow_runtime_events(task_id: str):
     task = get_workflow_task_or_none(task_id)
@@ -4287,18 +4580,7 @@ async def get_workflow_runtime_events(task_id: str):
     events: list[dict[str, Any]] = []
     if isinstance(event_store, RuntimeEventStore):
         event_list = await event_store.list_events(task_id=task_id)
-        events = [
-            {
-                "id": event.id,
-                "type": event.type,
-                "payload": dict(event.payload or {}),
-                "task_id": event.task_id,
-                "trace_id": event.trace_id,
-                "severity": event.severity,
-                "created_at": event.created_at,
-            }
-            for event in event_list
-        ]
+        events = [runtime_event_to_payload(event) for event in event_list]
 
     audit_store = task.get("tool_audit_store")
     if not isinstance(audit_store, InMemoryToolAuditStore):
@@ -4306,25 +4588,45 @@ async def get_workflow_runtime_events(task_id: str):
     audit_records: list[dict[str, Any]] = []
     try:
         record_list = await audit_store.list_records()
-        audit_records = [
-            {
-                "record_id": record.record_id,
-                "tool_name": record.tool_name,
-                "status": record.status,
-                "started_at": record.started_at,
-                "finished_at": record.finished_at,
-                "duration_ms": record.duration_ms,
-                "output_length": record.output_length,
-                "content_types": record.content_types,
-                "error": record.error,
-            }
-            for record in record_list
-        ]
+        audit_records = [tool_audit_record_to_payload(record) for record in record_list]
     except Exception as exc:
         logger.warning("Workflow runtime audit listing failed: %s", exc)
 
     return {
         "task_id": task_id,
+        "events": events,
+        "event_count": len(events),
+        "tool_audit_records": audit_records,
+        "tool_audit_count": len(audit_records),
+    }
+
+
+@app.get("/api/chat/runtime-events/{task_id}")
+async def get_chat_runtime_events(task_id: str):
+    task = chat_runtime_task_store.get(task_id)
+    if task is None:
+        raise HTTPException(status_code=404, detail="Chat runtime task not found.")
+
+    event_store = task.get("runtime_event_store")
+    events: list[dict[str, Any]] = []
+    if isinstance(event_store, RuntimeEventStore):
+        event_list = await event_store.list_events(task_id=task_id)
+        events = [runtime_event_to_payload(event) for event in event_list]
+
+    audit_store = task.get("tool_audit_store")
+    audit_records: list[dict[str, Any]] = []
+    if isinstance(audit_store, InMemoryToolAuditStore):
+        try:
+            record_list = await audit_store.list_records()
+            audit_records = [
+                tool_audit_record_to_payload(record) for record in record_list
+            ]
+        except Exception as exc:
+            logger.warning("Chat runtime audit listing failed: %s", exc)
+
+    return {
+        "task_id": task_id,
+        "run_id": task.get("run_id"),
         "events": events,
         "event_count": len(events),
         "tool_audit_records": audit_records,
@@ -4431,7 +4733,14 @@ async def list_runtime_runs(
     source_id: str | None = None,
     limit: int = 50,
 ):
-    valid_run_types = {"workflow", "workflow_agent", "agent_task", "agent_handoff"}
+    valid_run_types = {
+        "workflow",
+        "workflow_agent",
+        "agent_task",
+        "agent_handoff",
+        "chat",
+        "knowledge_citation",
+    }
     valid_statuses = {"pending", "running", "completed", "failed", "cancelled"}
     if run_type is not None and run_type not in valid_run_types:
         raise HTTPException(status_code=400, detail="Invalid runtime run type.")
@@ -5490,17 +5799,67 @@ async def chat(payload: ChatRequest, request: Request):
             logger.warning("Xpert runtime chat finalize failed: %s", exc)
 
     if payload.tool_mode == "mcp_tools":
+        chat_event_store = RuntimeEventStore()
+        chat_audit_store = InMemoryToolAuditStore()
+        requested_tools = parse_chat_tool_names(payload.tool_names)
+        chat_run = await run_registry.create_run(
+            "chat",
+            "Chat Runtime Toolset",
+            status="running",
+            source_id=runtime_task_id,
+            metadata={
+                "model_id": payload.model_id,
+                "tool_mode": payload.tool_mode,
+                "message_count": len(payload.messages),
+                "tool_names": sorted(requested_tools),
+                "max_tool_iterations": payload.max_tool_iterations,
+            },
+        )
+        chat_runtime_task_store[runtime_task_id] = {
+            "run_id": chat_run.run_id,
+            "created_at": time.time(),
+            "runtime_event_store": chat_event_store,
+            "tool_audit_store": chat_audit_store,
+            "model_id": payload.model_id,
+        }
+
         if runtime_pipeline is None or runtime_context is None:
             runtime_pipeline, runtime_context = create_default_runtime(
+                store=chat_event_store,
                 middlewares=[event_recorder]
             )
-            runtime_context.task_id = runtime_task_id
-            runtime_context.trace_id = request.headers.get("x-trace-id") or runtime_task_id
-            runtime_context.metadata = {
+        else:
+            runtime_context.store = chat_event_store
+        runtime_context.task_id = runtime_task_id
+        runtime_context.trace_id = request.headers.get("x-trace-id") or runtime_task_id
+        runtime_context.metadata = {
+            "model_id": payload.model_id,
+            "message_count": len(payload.messages),
+            "tool_mode": payload.tool_mode,
+            "run_id": chat_run.run_id,
+        }
+        try:
+            await runtime_pipeline.before_agent(
+                {
+                    "model_id": payload.model_id,
+                    "messages": chat_messages_json(payload.messages),
+                    "tool_mode": payload.tool_mode,
+                },
+                runtime_context,
+            )
+        except Exception as exc:
+            logger.warning("Chat runtime tool mode start event failed: %s", exc)
+        await record_chat_checkpoint(
+            chat_run.run_id,
+            event_type="chat.started",
+            title="Chat toolset started",
+            summary=f"model={payload.model_id}, tools={len(requested_tools) or 'all'}",
+            metadata={
                 "model_id": payload.model_id,
-                "message_count": len(payload.messages),
-                "tool_mode": payload.tool_mode,
-            }
+                "tool_names_count": len(requested_tools),
+                "max_tool_iterations": payload.max_tool_iterations,
+            },
+        )
 
         async def stream_tool_response():
             accumulated_chunks: list[str] = []
@@ -5511,6 +5870,8 @@ async def chat(payload: ChatRequest, request: Request):
                     payload,
                     runtime_pipeline=runtime_pipeline,
                     runtime_context=runtime_context,
+                    run_id=chat_run.run_id,
+                    audit_store=chat_audit_store,
                 ):
                     accumulated_chunks.append(delta)
                     yield chat_sse_delta(delta)
@@ -5519,8 +5880,36 @@ async def chat(payload: ChatRequest, request: Request):
                 runtime_status = "error"
                 runtime_error = str(exc)
                 logger.warning("Runtime chat toolset failed: %s", exc)
+                await record_chat_checkpoint(
+                    chat_run.run_id,
+                    event_type="chat.failed",
+                    title="Chat toolset failed",
+                    summary=str(exc)[:500],
+                    severity="error",
+                    metadata={"model_id": payload.model_id},
+                )
+                try:
+                    await run_registry.update_run(
+                        chat_run.run_id,
+                        status="failed",
+                        error=runtime_error,
+                        metadata={"output_length": len("".join(accumulated_chunks))},
+                    )
+                except Exception as update_exc:
+                    logger.warning("Chat runtime run failure update failed: %s", update_exc)
                 yield chat_sse_error(str(exc))
             finally:
+                if runtime_status == "completed":
+                    try:
+                        await run_registry.update_run(
+                            chat_run.run_id,
+                            status="completed",
+                            metadata={
+                                "output_length": len("".join(accumulated_chunks)),
+                            },
+                        )
+                    except Exception as update_exc:
+                        logger.warning("Chat runtime run completion update failed: %s", update_exc)
                 await client.aclose()
                 await finalize_runtime(
                     runtime_status,
@@ -5537,6 +5926,8 @@ async def chat(payload: ChatRequest, request: Request):
                 "Connection": "keep-alive",
                 "X-ModelMirror-Actual-Model": payload.model_id,
                 "X-ModelMirror-Tool-Mode": "mcp_tools",
+                "X-ModelMirror-Runtime-Run-Id": chat_run.run_id,
+                "X-ModelMirror-Runtime-Task-Id": runtime_task_id,
             },
         )
 

--- a/server/rag/api.py
+++ b/server/rag/api.py
@@ -67,6 +67,75 @@ class RagQueryResponse(BaseModel):
     sources: list[RagSourcePayload]
 
 
+class FileAssetPayload(BaseModel):
+    file_asset_id: str
+    document_id: str
+    knowledge_base_id: str
+    filename: str
+    size: int
+    extension: str
+    mime_type: str | None = None
+    created_at: float
+
+
+class FileAssetListResponse(BaseModel):
+    assets: list[FileAssetPayload]
+    asset_count: int
+
+
+class ArtifactPayload(BaseModel):
+    artifact_id: str
+    file_asset_id: str
+    document_id: str
+    knowledge_base_id: str
+    title: str
+    chunk_count: int
+    created_at: float
+
+
+class ArtifactListResponse(BaseModel):
+    artifacts: list[ArtifactPayload]
+    artifact_count: int
+
+
+class KnowledgeChunkPayload(BaseModel):
+    chunk_id: str
+    artifact_id: str
+    knowledge_base_id: str
+    document_id: str
+    index: int
+    text_preview: str
+    text_length: int
+
+
+class KnowledgeChunkListResponse(BaseModel):
+    artifact_id: str
+    chunks: list[KnowledgeChunkPayload]
+    chunk_count: int
+
+
+class CitationAnchorPayload(BaseModel):
+    citation_id: str
+    chunk_id: str
+    artifact_id: str
+    document_id: str
+    document_name: str
+    score: float
+    snippet: str
+
+
+class CitationAnchorRequest(BaseModel):
+    kb_id: str = Field(min_length=1, max_length=160)
+    question: str = Field(min_length=1, max_length=20_000)
+    top_k: int = Field(default=4, ge=1, le=10)
+
+
+class CitationAnchorResponse(BaseModel):
+    kb_id: str
+    citations: list[CitationAnchorPayload]
+    citation_count: int
+
+
 def get_rag_service() -> RagService:
     """Return the process-wide RAG service."""
 
@@ -145,6 +214,62 @@ async def delete_document(doc_id: str) -> dict[str, bool]:
         return {"ok": True}
     except DocumentNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.get("/pipeline/assets", response_model=FileAssetListResponse)
+async def list_pipeline_assets(kb_id: str | None = None) -> FileAssetListResponse:
+    try:
+        assets = get_rag_service().list_pipeline_assets(kb_id=kb_id)
+        return FileAssetListResponse(
+            assets=[FileAssetPayload.model_validate(item) for item in assets],
+            asset_count=len(assets),
+        )
+    except KnowledgeBaseNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.get("/pipeline/artifacts", response_model=ArtifactListResponse)
+async def list_pipeline_artifacts(kb_id: str | None = None) -> ArtifactListResponse:
+    try:
+        artifacts = get_rag_service().list_pipeline_artifacts(kb_id=kb_id)
+        return ArtifactListResponse(
+            artifacts=[ArtifactPayload.model_validate(item) for item in artifacts],
+            artifact_count=len(artifacts),
+        )
+    except KnowledgeBaseNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.get("/pipeline/artifacts/{artifact_id}/chunks", response_model=KnowledgeChunkListResponse)
+async def list_pipeline_artifact_chunks(artifact_id: str) -> KnowledgeChunkListResponse:
+    try:
+        chunks = get_rag_service().list_pipeline_artifact_chunks(artifact_id)
+        return KnowledgeChunkListResponse(
+            artifact_id=artifact_id,
+            chunks=[KnowledgeChunkPayload.model_validate(item) for item in chunks],
+            chunk_count=len(chunks),
+        )
+    except DocumentNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.post("/pipeline/citations", response_model=CitationAnchorResponse)
+async def create_pipeline_citations(payload: CitationAnchorRequest) -> CitationAnchorResponse:
+    try:
+        citations = await get_rag_service().create_pipeline_citations(
+            payload.kb_id,
+            payload.question,
+            top_k=payload.top_k,
+        )
+        return CitationAnchorResponse(
+            kb_id=payload.kb_id,
+            citations=[CitationAnchorPayload.model_validate(item) for item in citations],
+            citation_count=len(citations),
+        )
+    except KnowledgeBaseNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 @router.post("/query", response_model=RagQueryResponse)

--- a/server/rag/rag_service.py
+++ b/server/rag/rag_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import mimetypes
 import os
 import re
 import shutil
@@ -181,6 +182,75 @@ class RagService:
         ]
         return sorted(documents, key=lambda item: item["created_at"], reverse=True)
 
+    def list_pipeline_assets(self, kb_id: str | None = None) -> list[dict[str, Any]]:
+        """Return FileAsset views derived from uploaded documents."""
+
+        metadata = self._read_metadata()
+        self._ensure_kb_exists(metadata, kb_id)
+        assets = [
+            self._file_asset_payload(document)
+            for document in metadata["documents"].values()
+            if kb_id is None or document["kb_id"] == kb_id
+        ]
+        return sorted(assets, key=lambda item: item["created_at"], reverse=True)
+
+    def list_pipeline_artifacts(self, kb_id: str | None = None) -> list[dict[str, Any]]:
+        """Return Artifact views derived from uploaded documents."""
+
+        metadata = self._read_metadata()
+        self._ensure_kb_exists(metadata, kb_id)
+        artifacts = [
+            self._artifact_payload(document)
+            for document in metadata["documents"].values()
+            if kb_id is None or document["kb_id"] == kb_id
+        ]
+        return sorted(artifacts, key=lambda item: item["created_at"], reverse=True)
+
+    def list_pipeline_artifact_chunks(self, artifact_id: str) -> list[dict[str, Any]]:
+        """Return chunk metadata for one artifact without exposing embeddings."""
+
+        document = self._document_for_artifact_id(artifact_id)
+        chunks = self.vector_store.list_document_chunks(document["id"])
+        return [
+            {
+                "chunk_id": chunk.chunk_id,
+                "artifact_id": self._artifact_id(document["id"]),
+                "knowledge_base_id": chunk.kb_id or document["kb_id"],
+                "document_id": document["id"],
+                "index": chunk.chunk_index,
+                "text_preview": _preview_text(chunk.text),
+                "text_length": len(chunk.text),
+            }
+            for chunk in chunks
+        ]
+
+    async def create_pipeline_citations(
+        self,
+        kb_id: str,
+        question: str,
+        *,
+        top_k: int = 4,
+    ) -> list[dict[str, Any]]:
+        """Return citation anchors using the existing RAG retrieval path."""
+
+        result = await self.query(kb_id, question, top_k=top_k)
+        citations: list[dict[str, Any]] = []
+        for source in result.get("sources", []):
+            chunk_id = str(source.get("chunk_id", ""))
+            doc_id = str(source.get("doc_id", ""))
+            citations.append(
+                {
+                    "citation_id": f"citation_{chunk_id}" if chunk_id else f"citation_{len(citations)}",
+                    "chunk_id": chunk_id,
+                    "artifact_id": self._artifact_id(doc_id) if doc_id else "",
+                    "document_id": doc_id,
+                    "document_name": str(source.get("document_name", "")),
+                    "score": float(source.get("score", 0.0)),
+                    "snippet": _preview_text(str(source.get("text", ""))),
+                }
+            )
+        return citations
+
     def delete_document(self, doc_id: str) -> None:
         """Delete one document and its vector chunks."""
 
@@ -328,7 +398,57 @@ class RagService:
             "created_at": document["created_at"],
         }
 
+    def _ensure_kb_exists(self, metadata: dict[str, Any], kb_id: str | None) -> None:
+        if kb_id is not None and kb_id not in metadata["knowledge_bases"]:
+            raise KnowledgeBaseNotFoundError("知识库不存在。")
+
+    def _document_for_artifact_id(self, artifact_id: str) -> dict[str, Any]:
+        doc_id = artifact_id.removeprefix("artifact_")
+        metadata = self._read_metadata()
+        document = metadata["documents"].get(doc_id)
+        if not document:
+            raise DocumentNotFoundError("文档不存在。")
+        return document
+
+    def _file_asset_payload(self, document: dict[str, Any]) -> dict[str, Any]:
+        extension = Path(document["filename"]).suffix.lower()
+        mime_type, _ = mimetypes.guess_type(document["filename"])
+        return {
+            "file_asset_id": self._file_asset_id(document["id"]),
+            "document_id": document["id"],
+            "knowledge_base_id": document["kb_id"],
+            "filename": document["filename"],
+            "size": document["size"],
+            "extension": extension,
+            "mime_type": mime_type,
+            "created_at": document["created_at"],
+        }
+
+    def _artifact_payload(self, document: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "artifact_id": self._artifact_id(document["id"]),
+            "file_asset_id": self._file_asset_id(document["id"]),
+            "document_id": document["id"],
+            "knowledge_base_id": document["kb_id"],
+            "title": document["filename"],
+            "chunk_count": document["chunk_count"],
+            "created_at": document["created_at"],
+        }
+
+    def _artifact_id(self, document_id: str) -> str:
+        return f"artifact_{document_id}"
+
+    def _file_asset_id(self, document_id: str) -> str:
+        return f"file_{document_id}"
+
 
 def _safe_filename(filename: str) -> str:
     cleaned = Path(filename).name.strip() or "document.txt"
     return re.sub(r"[^A-Za-z0-9._\-\u4e00-\u9fff]+", "_", cleaned)
+
+
+def _preview_text(text: str, limit: int = 240) -> str:
+    normalized = " ".join(text.split())
+    if len(normalized) <= limit:
+        return normalized
+    return f"{normalized[:limit].rstrip()}..."

--- a/server/rag/vector_store.py
+++ b/server/rag/vector_store.py
@@ -31,6 +31,16 @@ class SearchResult:
     score: float
 
 
+@dataclass(slots=True)
+class StoredVectorChunk:
+    chunk_id: str
+    kb_id: str
+    doc_id: str
+    document_name: str
+    text: str
+    chunk_index: int
+
+
 class VectorStore(Protocol):
     """Protocol implemented by vector-store backends."""
 
@@ -45,6 +55,9 @@ class VectorStore(Protocol):
 
     def delete_knowledge_base(self, kb_id: str) -> None:
         """Delete all chunks for a knowledge base."""
+
+    def list_document_chunks(self, doc_id: str) -> list[StoredVectorChunk]:
+        """List stored chunks for one document without exposing embeddings."""
 
 
 class LocalJsonVectorStore:
@@ -90,6 +103,21 @@ class LocalJsonVectorStore:
         self._write_records(
             [record for record in self._read_records() if record.get("kb_id") != kb_id]
         )
+
+    def list_document_chunks(self, doc_id: str) -> list[StoredVectorChunk]:
+        chunks = [
+            StoredVectorChunk(
+                chunk_id=str(record["id"]),
+                kb_id=str(record["kb_id"]),
+                doc_id=str(record["doc_id"]),
+                document_name=str(record["document_name"]),
+                text=str(record["text"]),
+                chunk_index=int(record.get("chunk_index", 0)),
+            )
+            for record in self._read_records()
+            if record.get("doc_id") == doc_id
+        ]
+        return sorted(chunks, key=lambda item: item.chunk_index)
 
     def _read_records(self) -> list[dict[str, Any]]:
         if not self.storage_path.exists():
@@ -172,6 +200,31 @@ class ChromaVectorStore:
 
     def delete_knowledge_base(self, kb_id: str) -> None:
         self._collection.delete(where={"kb_id": kb_id})
+
+    def list_document_chunks(self, doc_id: str) -> list[StoredVectorChunk]:
+        response = self._collection.get(
+            where={"doc_id": doc_id},
+            include=["documents", "metadatas"],
+        )
+        ids = response.get("ids") or []
+        documents = response.get("documents") or []
+        metadatas = response.get("metadatas") or []
+
+        chunks: list[StoredVectorChunk] = []
+        for index, chunk_id in enumerate(ids):
+            metadata = metadatas[index] if index < len(metadatas) else {}
+            metadata = metadata or {}
+            chunks.append(
+                StoredVectorChunk(
+                    chunk_id=str(chunk_id),
+                    kb_id=str(metadata.get("kb_id", "")),
+                    doc_id=str(metadata.get("doc_id", doc_id)),
+                    document_name=str(metadata.get("document_name", "")),
+                    text=str(documents[index] if index < len(documents) else ""),
+                    chunk_index=int(metadata.get("chunk_index", index)),
+                )
+            )
+        return sorted(chunks, key=lambda item: item.chunk_index)
 
 
 def create_vector_store(storage_dir: Path) -> VectorStore:

--- a/server/tests/test_rag_pipeline.py
+++ b/server/tests/test_rag_pipeline.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from server.main import app
+from server.rag.api import set_rag_service_for_tests
+from server.rag.embedder import EmbeddingClient
+from server.rag.rag_service import RagService
+from server.rag.vector_store import LocalJsonVectorStore
+
+
+@pytest_asyncio.fixture
+async def client(tmp_path: Path):
+    service = RagService(
+        storage_dir=tmp_path / "storage",
+        uploads_dir=tmp_path / "uploads",
+        embedder=EmbeddingClient(api_key="", dimension=128),
+        vector_store=LocalJsonVectorStore(tmp_path / "storage" / "vectors.json"),
+        llm_enabled=False,
+    )
+    set_rag_service_for_tests(service)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://testserver",
+    ) as async_client:
+        yield async_client
+    set_rag_service_for_tests(None)
+
+
+async def create_kb(client: httpx.AsyncClient, name: str = "pipeline") -> str:
+    response = await client.post("/api/rag/knowledge_bases", json={"name": name})
+    assert response.status_code == 200, response.text
+    return response.json()["id"]
+
+
+async def upload_pipeline_document(client: httpx.AsyncClient, kb_id: str) -> dict:
+    response = await client.post(
+        f"/api/rag/knowledge_bases/{kb_id}/documents",
+        files={
+            "file": (
+                "pipeline.txt",
+                b"ModelMirror Knowledge Pipeline maps uploaded files into artifacts, chunks, and citations.",
+                "text/plain",
+            )
+        },
+    )
+    assert response.status_code == 200, response.text
+    return response.json()
+
+
+@pytest.mark.asyncio
+async def test_rag_pipeline_assets_artifacts_and_chunks(client: httpx.AsyncClient) -> None:
+    kb_id = await create_kb(client, "pipeline metadata")
+    document = await upload_pipeline_document(client, kb_id)
+
+    assets_response = await client.get(f"/api/rag/pipeline/assets?kb_id={kb_id}")
+    assert assets_response.status_code == 200, assets_response.text
+    assets_data = assets_response.json()
+    assert assets_data["asset_count"] == 1
+    asset = assets_data["assets"][0]
+    assert asset["document_id"] == document["id"]
+    assert asset["knowledge_base_id"] == kb_id
+    assert asset["filename"] == "pipeline.txt"
+    assert asset["extension"] == ".txt"
+    assert "stored_path" not in asset
+
+    artifacts_response = await client.get(f"/api/rag/pipeline/artifacts?kb_id={kb_id}")
+    assert artifacts_response.status_code == 200, artifacts_response.text
+    artifacts_data = artifacts_response.json()
+    assert artifacts_data["artifact_count"] == 1
+    artifact = artifacts_data["artifacts"][0]
+    assert artifact["artifact_id"] == f"artifact_{document['id']}"
+    assert artifact["file_asset_id"] == asset["file_asset_id"]
+    assert artifact["chunk_count"] == document["chunk_count"]
+
+    chunks_response = await client.get(
+        f"/api/rag/pipeline/artifacts/{artifact['artifact_id']}/chunks"
+    )
+    assert chunks_response.status_code == 200, chunks_response.text
+    chunks_data = chunks_response.json()
+    assert chunks_data["chunk_count"] == document["chunk_count"]
+    assert chunks_data["chunks"][0]["artifact_id"] == artifact["artifact_id"]
+    assert chunks_data["chunks"][0]["text_length"] > 0
+    assert "Knowledge Pipeline" in chunks_data["chunks"][0]["text_preview"]
+
+
+@pytest.mark.asyncio
+async def test_rag_pipeline_citations(client: httpx.AsyncClient) -> None:
+    kb_id = await create_kb(client, "pipeline citations")
+    document = await upload_pipeline_document(client, kb_id)
+
+    response = await client.post(
+        "/api/rag/pipeline/citations",
+        json={
+            "kb_id": kb_id,
+            "question": "What does the Knowledge Pipeline map?",
+            "top_k": 2,
+        },
+    )
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["kb_id"] == kb_id
+    assert data["citation_count"] >= 1
+    citation = data["citations"][0]
+    assert citation["document_id"] == document["id"]
+    assert citation["document_name"] == "pipeline.txt"
+    assert citation["chunk_id"].startswith(document["id"])
+    assert "artifacts" in citation["snippet"]
+    assert isinstance(citation["score"], float)
+
+
+@pytest.mark.asyncio
+async def test_rag_pipeline_missing_resources_return_404(client: httpx.AsyncClient) -> None:
+    assets_response = await client.get("/api/rag/pipeline/assets?kb_id=missing")
+    assert assets_response.status_code == 404
+
+    artifacts_response = await client.get("/api/rag/pipeline/artifacts?kb_id=missing")
+    assert artifacts_response.status_code == 404
+
+    chunks_response = await client.get("/api/rag/pipeline/artifacts/artifact_missing/chunks")
+    assert chunks_response.status_code == 404

--- a/server/tests/test_workflow_knowledge_citation_node.py
+++ b/server/tests/test_workflow_knowledge_citation_node.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from server.main import app
+from server.rag.api import set_rag_service_for_tests
+from server.rag.embedder import EmbeddingClient
+from server.rag.rag_service import RagService
+from server.rag.vector_store import LocalJsonVectorStore
+
+
+@pytest_asyncio.fixture
+async def client(tmp_path: Path):
+    service = RagService(
+        storage_dir=tmp_path / "storage",
+        uploads_dir=tmp_path / "uploads",
+        embedder=EmbeddingClient(api_key="", dimension=128),
+        vector_store=LocalJsonVectorStore(tmp_path / "storage" / "vectors.json"),
+        llm_enabled=False,
+    )
+    set_rag_service_for_tests(service)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://testserver",
+    ) as async_client:
+        yield async_client
+    set_rag_service_for_tests(None)
+
+
+async def _create_kb_with_document(client: httpx.AsyncClient) -> str:
+    kb_response = await client.post(
+        "/api/rag/knowledge_bases",
+        json={"name": "workflow citation test"},
+    )
+    assert kb_response.status_code == 200, kb_response.text
+    kb_id = kb_response.json()["id"]
+
+    upload_response = await client.post(
+        f"/api/rag/knowledge_bases/{kb_id}/documents",
+        files={
+            "file": (
+                "workflow-citation.txt",
+                (
+                    b"ModelMirror Knowledge Pipeline creates FileAsset, "
+                    b"Artifact, Chunk, and CitationAnchor records for workflow use."
+                ),
+                "text/plain",
+            )
+        },
+    )
+    assert upload_response.status_code == 200, upload_response.text
+    return kb_id
+
+
+@pytest.mark.asyncio
+async def test_workflow_knowledge_citation_outputs_json_and_run_trace(
+    client: httpx.AsyncClient,
+) -> None:
+    kb_id = await _create_kb_with_document(client)
+    workflow = {
+        "id": "knowledge-citation-workflow",
+        "title": "knowledge citation workflow",
+        "nodes": [
+            {
+                "id": "input",
+                "type": "input",
+                "data": {"kind": "input", "variableName": "user_input"},
+            },
+            {
+                "id": "knowledge_citation",
+                "type": "knowledge_citation",
+                "data": {
+                    "kind": "knowledge_citation",
+                    "title": "Knowledge citations",
+                    "queryVariable": "user_input",
+                    "knowledgeBaseId": kb_id,
+                    "top_k": "2",
+                    "outputVariable": "citation_anchors_json",
+                },
+            },
+            {
+                "id": "output",
+                "type": "output",
+                "data": {"kind": "output", "outputVariable": "citation_anchors_json"},
+            },
+        ],
+        "edges": [
+            {"id": "e1", "source": "input", "target": "knowledge_citation"},
+            {"id": "e2", "source": "knowledge_citation", "target": "output"},
+        ],
+    }
+
+    response = await client.post(
+        "/api/workflow/run",
+        json={
+            "workflow": workflow,
+            "inputs": {"user_input": "What does the Knowledge Pipeline create?"},
+        },
+    )
+    assert response.status_code == 200, response.text
+
+    events = _parse_sse_events(response.text)
+    workflow_meta = next(event for event in events if event.get("event") == "workflow_meta")
+    workflow_run_id = workflow_meta["run_id"]
+
+    citation_delta = next(
+        event
+        for event in events
+        if event.get("event") == "node_delta"
+        and event.get("node_id") == "knowledge_citation"
+    )
+    assert "CitationAnchor" in citation_delta["output"]
+    assert citation_delta["citation_count"] >= 1
+
+    citation_end = next(
+        event
+        for event in events
+        if event.get("event") == "node_end"
+        and event.get("node_id") == "knowledge_citation"
+    )
+    citation_payload = json.loads(citation_end["output"])
+    assert citation_payload["citation_count"] >= 1
+    citation = citation_payload["citations"][0]
+    assert citation["chunk_id"]
+    assert citation["document_name"] == "workflow-citation.txt"
+    assert isinstance(citation["score"], float)
+    assert "CitationAnchor" in citation["snippet"]
+    assert "stored_path" not in citation
+
+    child_runs_response = await client.get(
+        f"/api/runtime/runs?run_type=knowledge_citation&parent_run_id={workflow_run_id}&limit=20"
+    )
+    assert child_runs_response.status_code == 200, child_runs_response.text
+    citation_runs = child_runs_response.json()
+    citation_run = next(
+        item for item in citation_runs if item["metadata"]["node_id"] == "knowledge_citation"
+    )
+    assert citation_run["status"] == "completed"
+    assert citation_run["metadata"]["kb_id"] == kb_id
+    assert citation_run["metadata"]["citation_count"] >= 1
+
+    checkpoints_response = await client.get(
+        f"/api/runtime/runs/{citation_run['run_id']}/checkpoints"
+    )
+    assert checkpoints_response.status_code == 200, checkpoints_response.text
+    checkpoint_types = {
+        checkpoint["event_type"] for checkpoint in checkpoints_response.json()
+    }
+    assert "knowledge_citation.started" in checkpoint_types
+    assert "knowledge_citation.completed" in checkpoint_types
+
+
+def _parse_sse_events(sse_text: str) -> list[dict]:
+    events: list[dict] = []
+    for line in sse_text.splitlines():
+        if not line.startswith("data:"):
+            continue
+        try:
+            payload = json.loads(line[5:].strip())
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            events.append(payload)
+    return events

--- a/server/tests/test_workflow_native_validate.py
+++ b/server/tests/test_workflow_native_validate.py
@@ -400,6 +400,133 @@ async def test_validate_knowledge_retrieval_top_k(client: httpx.AsyncClient) -> 
 
 
 @pytest.mark.asyncio
+async def test_validate_knowledge_citation_node_ok(client: httpx.AsyncClient) -> None:
+    workflow = linear_workflow()
+    workflow["nodes"][1] = {
+        "id": "citation",
+        "type": "knowledge_citation",
+        "data": {
+            "kind": "knowledge_citation",
+            "queryVariable": "user_input",
+            "knowledgeBaseId": "",
+            "top_k": "4",
+            "outputVariable": "citation_anchors_json",
+        },
+    }
+    workflow["nodes"][2]["data"]["outputVariable"] = "citation_anchors_json"
+    workflow["edges"] = [
+        {"id": "e1", "source": "input", "target": "citation"},
+        {"id": "e2", "source": "citation", "target": "output"},
+    ]
+
+    data = await validate(client, workflow)
+
+    assert data["valid"] is True
+    assert data["issues"] == []
+
+
+@pytest.mark.asyncio
+async def test_validate_knowledge_citation_required_fields(
+    client: httpx.AsyncClient,
+) -> None:
+    workflow = linear_workflow()
+    workflow["nodes"][1] = {
+        "id": "citation",
+        "type": "knowledge_citation",
+        "data": {
+            "kind": "knowledge_citation",
+            "queryVariable": "",
+            "top_k": "11",
+            "outputVariable": "",
+        },
+    }
+    workflow["edges"] = [
+        {"id": "e1", "source": "input", "target": "citation"},
+        {"id": "e2", "source": "citation", "target": "output"},
+    ]
+
+    data = await validate(client, workflow)
+    codes = issue_codes(data)
+
+    assert data["valid"] is False
+    assert "missing_knowledge_citation_query_variable" in codes
+    assert "invalid_knowledge_citation_top_k" in codes
+    assert "missing_knowledge_citation_output_variable" in codes
+
+
+@pytest.mark.asyncio
+async def test_knowledge_citation_query_variable_must_be_declared(
+    client: httpx.AsyncClient,
+) -> None:
+    workflow = linear_workflow()
+    workflow["nodes"][1] = {
+        "id": "citation",
+        "type": "knowledge_citation",
+        "data": {
+            "kind": "knowledge_citation",
+            "queryVariable": "missing_query",
+            "top_k": "3",
+            "outputVariable": "citation_anchors_json",
+        },
+    }
+    workflow["nodes"][2]["data"]["outputVariable"] = "citation_anchors_json"
+    workflow["edges"] = [
+        {"id": "e1", "source": "input", "target": "citation"},
+        {"id": "e2", "source": "citation", "target": "output"},
+    ]
+
+    data = await validate(client, workflow)
+
+    assert data["valid"] is False
+    assert "missing_knowledge_citation_query_variable_reference" in issue_codes(data)
+
+
+@pytest.mark.asyncio
+async def test_knowledge_citation_output_variable_is_declared(
+    client: httpx.AsyncClient,
+) -> None:
+    workflow = linear_workflow()
+    workflow["nodes"][1] = {
+        "id": "citation",
+        "type": "knowledge_citation",
+        "data": {
+            "kind": "knowledge_citation",
+            "queryVariable": "user_input",
+            "top_k": "2",
+            "outputVariable": "citation_anchors_json",
+        },
+    }
+    workflow["nodes"][2] = {
+        "id": "template",
+        "type": "template_transform",
+        "data": {
+            "kind": "template_transform",
+            "template": "Citations: {{citation_anchors_json}}",
+            "outputVariable": "final_text",
+        },
+    }
+    workflow["nodes"].append(
+        {
+            "id": "output",
+            "type": "output",
+            "data": {
+                "kind": "output",
+                "outputVariable": "final_text",
+            },
+        }
+    )
+    workflow["edges"] = [
+        {"id": "e1", "source": "input", "target": "citation"},
+        {"id": "e2", "source": "citation", "target": "template"},
+        {"id": "e3", "source": "template", "target": "output"},
+    ]
+
+    data = await validate(client, workflow)
+
+    assert data["valid"] is True
+
+
+@pytest.mark.asyncio
 async def test_validate_document_extractor_required_fields(
     client: httpx.AsyncClient,
 ) -> None:

--- a/server/tests/test_xpert_runtime_chat.py
+++ b/server/tests/test_xpert_runtime_chat.py
@@ -271,6 +271,36 @@ async def test_chat_tool_mode_calls_runtime_toolset(
     assert len(provider.calls) == 1
     assert provider.calls[0].tool_name == "fetch"
     assert provider.calls[0].arguments == {"query": "hello"}
+    run_id = response.headers.get("x-modelmirror-runtime-run-id")
+    task_id = response.headers.get("x-modelmirror-runtime-task-id")
+    assert run_id
+    assert task_id
+
+    run_response = await client.get(f"/api/runtime/runs/{run_id}")
+    assert run_response.status_code == 200, run_response.text
+    run_payload = run_response.json()
+    assert run_payload["run_type"] == "chat"
+    assert run_payload["status"] == "completed"
+
+    checkpoints_response = await client.get(
+        f"/api/runtime/runs/{run_id}/checkpoints",
+    )
+    assert checkpoints_response.status_code == 200, checkpoints_response.text
+    checkpoint_types = [item["event_type"] for item in checkpoints_response.json()]
+    assert "chat.started" in checkpoint_types
+    assert "chat.model_decision" in checkpoint_types
+    assert "chat.tool_call" in checkpoint_types
+    assert "chat.answer" in checkpoint_types
+
+    events_response = await client.get(f"/api/chat/runtime-events/{task_id}")
+    assert events_response.status_code == 200, events_response.text
+    events_payload = events_response.json()
+    event_types = [item["type"] for item in events_payload["events"]]
+    assert "chat.started" in event_types
+    assert "tool.call.started" in event_types
+    assert "tool.call.finished" in event_types
+    assert events_payload["tool_audit_count"] == 1
+    assert events_payload["tool_audit_records"][0]["tool_name"] == "fetch"
 
 
 @pytest.mark.asyncio
@@ -323,6 +353,109 @@ async def test_chat_tool_mode_invalid_payload_returns_validation_error(
     )
 
     assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_chat_runtime_events_missing_task_returns_404(
+    client: httpx.AsyncClient,
+) -> None:
+    response = await client.get("/api/chat/runtime-events/missing-chat-task")
+
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_chat_tool_mode_failure_records_failed_run(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider, restore_provider = _install_fake_chat_tool_provider()
+
+    async def fake_collect_chat_completion_text(*args, **kwargs):
+        return '{"tool":"search","arguments":{"query":"blocked"}}'
+
+    monkeypatch.setattr(main_module, "get_llm_gateway_config", lambda: ("http://mock", "key"))
+    monkeypatch.setattr(
+        main_module,
+        "collect_chat_completion_text",
+        fake_collect_chat_completion_text,
+    )
+    monkeypatch.setattr(main_module, "workflow_mcp_provider", provider)
+    try:
+        response = await client.post(
+            "/api/chat",
+            json={
+                "model_id": "mock-model",
+                "messages": [{"role": "user", "content": "hi"}],
+                "tool_mode": "mcp_tools",
+                "tool_names": "fetch",
+            },
+        )
+    finally:
+        restore_provider()
+
+    assert response.status_code == 200, response.text
+    assert provider.calls == []
+    run_id = response.headers.get("x-modelmirror-runtime-run-id")
+    assert run_id
+    run_response = await client.get(f"/api/runtime/runs/{run_id}")
+    assert run_response.status_code == 200, run_response.text
+    assert run_response.json()["status"] == "failed"
+    checkpoints_response = await client.get(
+        f"/api/runtime/runs/{run_id}/checkpoints",
+    )
+    assert checkpoints_response.status_code == 200, checkpoints_response.text
+    checkpoint_types = [item["event_type"] for item in checkpoints_response.json()]
+    assert "chat.failed" in checkpoint_types
+    assert "run.failed" in checkpoint_types
+
+
+@pytest.mark.asyncio
+async def test_chat_tool_mode_none_does_not_create_chat_run(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    before = {
+        run.run_id
+        for run in await main_module.run_registry.list_runs(run_type="chat", limit=200)
+    }
+
+    class FakeUpstreamClient:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        def build_request(self, *args, **kwargs):
+            return httpx.Request("POST", "http://mock")
+
+        async def send(self, request, *, stream: bool = False):
+            return httpx.Response(
+                200,
+                content=b'data: {"choices":[{"delta":{"content":"ok"}}]}\n\n',
+                request=httpx.Request("POST", "http://mock"),
+            )
+
+        async def aclose(self) -> None:
+            return None
+
+    monkeypatch.setattr(main_module, "get_llm_gateway_config", lambda: ("http://mock", "key"))
+    monkeypatch.setattr(main_module.httpx, "AsyncClient", FakeUpstreamClient)
+
+    response = await client.post(
+        "/api/chat",
+        json={
+            "model_id": "mock-model",
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    assert _read_sse_text(response.text) == "ok"
+    assert response.headers.get("x-modelmirror-runtime-run-id") is None
+    after = {
+        run.run_id
+        for run in await main_module.run_registry.list_runs(run_type="chat", limit=200)
+    }
+    assert after == before
 
 
 class FakeChatToolProvider:

--- a/server/tests/test_xpert_runtime_run_registry.py
+++ b/server/tests/test_xpert_runtime_run_registry.py
@@ -49,17 +49,22 @@ async def test_run_registry_list_filters_and_limit() -> None:
     await registry.create_run("workflow_agent", "Agent", status="completed")
     await registry.create_run("agent_task", "B", status="pending")
     await registry.create_run("agent_task", "C", status="completed")
+    await registry.create_run("chat", "Chat", status="completed")
 
     agent_runs = await registry.list_runs(run_type="agent_task")
     assert len(agent_runs) == 2
     assert all(run.run_type == "agent_task" for run in agent_runs)
 
     completed_runs = await registry.list_runs(status="completed")
-    assert len(completed_runs) == 3
+    assert len(completed_runs) == 4
 
     workflow_agent_runs = await registry.list_runs(run_type="workflow_agent")
     assert len(workflow_agent_runs) == 1
     assert workflow_agent_runs[0].title == "Agent"
+
+    chat_runs = await registry.list_runs(run_type="chat")
+    assert len(chat_runs) == 1
+    assert chat_runs[0].title == "Chat"
 
     limited = await registry.list_runs(limit=1)
     assert len(limited) == 1

--- a/server/workflow_native/schemas.py
+++ b/server/workflow_native/schemas.py
@@ -15,6 +15,7 @@ NativeNodeKind = Literal[
     "variable_aggregator",
     "parameter_extractor",
     "knowledge_retrieval",
+    "knowledge_citation",
     "document_extractor",
     "human_intervention",
     "question_classifier",

--- a/server/workflow_native/validate.py
+++ b/server/workflow_native/validate.py
@@ -33,6 +33,8 @@ NODE_KIND_ALIASES = {
     "parameter-extractor": "parameter_extractor",
     "knowledge_retrieval": "knowledge_retrieval",
     "knowledge-retrieval": "knowledge_retrieval",
+    "knowledge_citation": "knowledge_citation",
+    "knowledge-citation": "knowledge_citation",
     "document_extractor": "document_extractor",
     "document-extractor": "document_extractor",
     "human_intervention": "human_intervention",
@@ -79,6 +81,7 @@ SUPPORTED_NODE_KINDS = {
     "variable_aggregator",
     "parameter_extractor",
     "knowledge_retrieval",
+    "knowledge_citation",
     "document_extractor",
     "human_intervention",
     "question_classifier",
@@ -438,6 +441,55 @@ def validate_node_configuration(
                 ValidationIssue(
                     code="invalid_knowledge_retrieval_output_variable",
                     message="Knowledge retrieval outputVariable must be an identifier.",
+                    node_id=node.id,
+                )
+            )
+
+    if kind == "knowledge_citation":
+        query_variable = str(data.get("queryVariable") or "").strip()
+        if not query_variable:
+            issues.append(
+                ValidationIssue(
+                    code="missing_knowledge_citation_query_variable",
+                    message="Knowledge citation node needs data.queryVariable.",
+                    node_id=node.id,
+                )
+            )
+        elif not is_variable_name(query_variable):
+            issues.append(
+                ValidationIssue(
+                    code="invalid_knowledge_citation_query_variable",
+                    message="Knowledge citation queryVariable must be an identifier.",
+                    node_id=node.id,
+                )
+            )
+        top_k = str(data.get("top_k") or "4").strip()
+        try:
+            top_k_int = int(top_k)
+        except ValueError:
+            top_k_int = 0
+        if top_k_int < 1 or top_k_int > 10:
+            issues.append(
+                ValidationIssue(
+                    code="invalid_knowledge_citation_top_k",
+                    message="Knowledge citation top_k must be an integer between 1 and 10.",
+                    node_id=node.id,
+                )
+            )
+        output_variable = str(data.get("outputVariable") or "").strip()
+        if not output_variable:
+            issues.append(
+                ValidationIssue(
+                    code="missing_knowledge_citation_output_variable",
+                    message="Knowledge citation node needs data.outputVariable.",
+                    node_id=node.id,
+                )
+            )
+        elif not is_variable_name(output_variable):
+            issues.append(
+                ValidationIssue(
+                    code="invalid_knowledge_citation_output_variable",
+                    message="Knowledge citation outputVariable must be an identifier.",
                     node_id=node.id,
                 )
             )
@@ -1301,6 +1353,7 @@ def collect_declared_variables(
             "variable_aggregator",
             "parameter_extractor",
             "knowledge_retrieval",
+            "knowledge_citation",
             "document_extractor",
             "human_intervention",
             "question_classifier",
@@ -1457,6 +1510,17 @@ def validate_variable_references(
                 ValidationIssue(
                     code="missing_knowledge_retrieval_query_variable_reference",
                     message=f"Knowledge retrieval references undefined variable '{query_variable}'.",
+                    node_id=node.id,
+                )
+            )
+
+    if kind == "knowledge_citation":
+        query_variable = str(data.get("queryVariable") or "").strip()
+        if query_variable and query_variable not in available_variables:
+            issues.append(
+                ValidationIssue(
+                    code="missing_knowledge_citation_query_variable_reference",
+                    message=f"Knowledge citation references undefined variable '{query_variable}'.",
                     node_id=node.id,
                 )
             )

--- a/server/xpert_runtime/run_registry.py
+++ b/server/xpert_runtime/run_registry.py
@@ -6,7 +6,14 @@ import uuid
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
-RuntimeRunType = Literal["workflow", "workflow_agent", "agent_task", "agent_handoff"]
+RuntimeRunType = Literal[
+    "workflow",
+    "workflow_agent",
+    "agent_task",
+    "agent_handoff",
+    "chat",
+    "knowledge_citation",
+]
 RuntimeRunStatus = Literal["pending", "running", "completed", "failed", "cancelled"]
 
 


### PR DESCRIPTION
﻿## Summary
- Chat Runtime Toolset 增加运行观测：tool mode 下登记 chat run、checkpoint、runtime events 和 audit 摘要，并在聊天页展示观测面板。
- 本地 RAG 增加 Knowledge Pipeline 只读元数据视图：FileAsset、Artifact、KnowledgeChunk、CitationAnchor API 和 /rag Beta 展示。
- Classic workflow 新增 knowledge_citation 节点，可拖拽、配置、运行，输出 CitationAnchor JSON，并登记 knowledge_citation 子 run/checkpoint。

## Boundaries
- 普通聊天默认行为不变，tool_mode=none 不创建 chat run。
- 不改变 /api/rag/query、聊天 RAG、上传、切分、embedding 或向量存储协议。
- 不接数据库、Redis、真实队列或 OpenAI function calling。
- 不提交 package.json、package-lock.json、模镜.apk。

## Validation
- npm.cmd run build：通过。
- py_compile：通过。
- 聚焦测试：77 passed。
- 全量后端测试：163 passed。
- docker compose -p modelmirror up -d --build --force-recreate：通过。
- curl http://localhost:8000/api/health：返回 {"status":"ok"}。
- /workflow 与 /rag：HTTP 200。
