### PR TITLE
feature: 添加 Xpert 工作空间与节点库对齐

### DIFF
--- a/client/src/components/BrandLogo.tsx
+++ b/client/src/components/BrandLogo.tsx
@@ -11,9 +11,9 @@ export default function BrandLogo({
 }: BrandLogoProps) {
   return (
     <Link
-      aria-label="返回模镜 ModelMirror 模型列表"
+      aria-label="返回模镜 ModelMirror 工作空间"
       className={`group inline-flex items-center gap-3 ${className}`}
-      to="/models"
+      to="/studio"
     >
       <span className="relative flex h-11 w-11 shrink-0 items-center justify-center overflow-hidden rounded-lg border border-white/10 bg-white shadow-neon transition duration-200 group-hover:scale-[1.03]">
         <img

--- a/client/src/components/workflow/NodePalette.tsx
+++ b/client/src/components/workflow/NodePalette.tsx
@@ -1,163 +1,24 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import {
   fetchRuntimeMiddlewareNodes,
   type RuntimeMiddlewareNode,
 } from "../../types/runtimeMiddleware";
-import { type WorkflowNodeKind } from "../../types/workflow";
+import {
+  knowledgePipelineItems,
+  knowledgePipelinePlaceholders,
+  matchesWorkflowPaletteQuery,
+  type WorkflowPaletteItem,
+  type WorkflowPalettePlaceholder,
+  workflowPaletteSections,
+} from "./workflowNodeRegistry";
 
-interface PaletteItem {
-  kind: WorkflowNodeKind;
-  icon: string;
-  title: string;
-  description: string;
-}
+type PaletteTab = "workflow" | "middleware" | "knowledge";
 
-const paletteItems: PaletteItem[] = [
-  {
-    kind: "input",
-    icon: "📥",
-    title: "输入节点",
-    description: "定义流水线入口变量，默认 user_input。",
-  },
-  {
-    kind: "llm",
-    icon: "🤖",
-    title: "LLM 节点",
-    description: "安排模型工位处理提示词，可引用 {{变量}}。",
-  },
-  {
-    kind: "condition",
-    icon: "🔀",
-    title: "条件分支",
-    description: "按变量值判断，走“是/否”两条传送带。",
-  },
-  {
-    kind: "code",
-    icon: "🔧",
-    title: "代码节点",
-    description: "只支持安全的内置字符串加工函数。",
-  },
-  {
-    kind: "variable_assign",
-    icon: "🪄",
-    title: "变量赋值",
-    description: "把模板渲染成一个变量，适合整理中间结果。",
-  },
-  {
-    kind: "template_transform",
-    icon: "📝",
-    title: "模板转换",
-    description: "渲染长文本模板，适合生成报告或结构化草稿。",
-  },
-  {
-    kind: "variable_aggregator",
-    icon: "🔗",
-    title: "变量聚合器",
-    description: "把多个变量汇总为文本或 JSON 字符串。",
-  },
-  {
-    kind: "parameter_extractor",
-    icon: "🎯",
-    title: "参数提取器",
-    description: "调用模型从文本中提取字段，输出 JSON 字符串。",
-  },
-  {
-    kind: "knowledge_retrieval",
-    icon: "📚",
-    title: "知识检索",
-    description: "查询本地 RAG 资料库，把相关段落写入变量。",
-  },
-  {
-    kind: "knowledge_citation",
-    icon: "🔖",
-    title: "知识引用锚点",
-    description: "查询本地 RAG，输出 CitationAnchor JSON 供下游节点引用。",
-  },
-  {
-    kind: "document_extractor",
-    icon: "📄",
-    title: "文档提取器",
-    description: "从受限本地路径提取文本，供后续节点使用。",
-  },
-  {
-    kind: "human_intervention",
-    icon: "👤",
-    title: "人工介入",
-    description: "暂停流水线，等待用户补充文本后再继续执行。",
-  },
-  {
-    kind: "question_classifier",
-    icon: "🏷️",
-    title: "问题分类器",
-    description: "根据关键词规则把输入文本分类为预设类别。可与条件节点串联做分流。",
-  },
-  {
-    kind: "agent",
-    icon: "🤖",
-    title: "Agent 节点",
-    description: "模型驱动的任务执行节点，支持工具循环和直接回答两种模式。",
-  },
-  {
-    kind: "workflow_agent",
-    icon: "🧭",
-    title: "工作流智能体",
-    description: "用角色提示词执行一个模型驱动的 Agent 步骤，并写入输出变量。",
-  },
-  {
-    kind: "agent_task",
-    icon: "▣",
-    title: "智能体任务",
-    description: "创建 Agent Task Runtime 任务，输出 task_id 供后续节点引用。",
-  },
-  {
-    kind: "agent_handoff",
-    icon: "⇄",
-    title: "智能体移交",
-    description: "把 Agent Task 显式移交给另一个智能体，输出 handoff_id。",
-  },
-  {
-    kind: "handoff_router",
-    icon: "↪",
-    title: "移交路由器",
-    description: "读取智能体输出，创建 AgentTask 并投递到目标 Agent 的 Handoff Inbox。",
-  },
-  {
-    kind: "mcp_tool",
-    icon: "🔧",
-    title: "MCP Tool",
-    description: "调用已连接 MCP Server 暴露的工具，参数支持 {{变量}} 模板。",
-  },
-  {
-    kind: "time_tool",
-    icon: "🕒",
-    title: "时间工具",
-    description: "获取当前时间、时间戳或按格式输出日期文本。",
-  },
-  {
-    kind: "http_request",
-    icon: "🌐",
-    title: "HTTP 请求",
-    description: "调用 GET/POST 接口，把响应文本写入变量。",
-  },
-  {
-    kind: "list_operation",
-    icon: "📋",
-    title: "列表操作",
-    description: "对逗号分隔的列表做长度、拼接、首尾提取。",
-  },
-  {
-    kind: "iteration",
-    icon: "🔁",
-    title: "迭代处理",
-    description: "逐项渲染模板，汇总为一个 JSON 数组字符串。",
-  },
-  {
-    kind: "output",
-    icon: "📤",
-    title: "输出节点",
-    description: "收尾交付最终变量，展示运行结果。",
-  },
+const paletteTabs: Array<{ id: PaletteTab; label: string }> = [
+  { id: "workflow", label: "工作流" },
+  { id: "middleware", label: "中间件" },
+  { id: "knowledge", label: "知识流水线" },
 ];
 
 const middlewareIconMap: Record<string, string> = {
@@ -172,10 +33,101 @@ function MiddlewareIcon({ icon }: { icon: string }) {
   return <span aria-hidden="true">{middlewareIconMap[icon] ?? "▣"}</span>;
 }
 
+function paletteCardClass(disabled = false) {
+  if (disabled) {
+    return "w-full rounded-lg border border-dashed border-white/10 bg-white/[0.025] p-3 text-left opacity-70";
+  }
+  return "group w-full rounded-lg border border-white/10 bg-white/[0.045] p-3 text-left transition duration-200 hover:-translate-y-0.5 hover:border-hire-300/35 hover:bg-hire-300/10 focus:outline-none focus:ring-2 focus:ring-hire-300/35";
+}
+
+function NormalNodeButton({ item }: { item: WorkflowPaletteItem }) {
+  return (
+    <button
+      className={paletteCardClass()}
+      draggable
+      key={item.kind}
+      onDragStart={(event) => {
+        event.dataTransfer.setData("application/modelmirror-node", item.kind);
+        event.dataTransfer.effectAllowed = "move";
+      }}
+      type="button"
+    >
+      <span className="flex items-start gap-3">
+        <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-hire-300/25 bg-hire-300/10 text-[11px] font-semibold text-hire-100">
+          {item.icon}
+        </span>
+        <span className="min-w-0">
+          <span className="block text-sm font-semibold text-white">
+            {item.title}
+          </span>
+          <span className="mt-1 block text-xs leading-5 text-slate-400">
+            {item.description}
+          </span>
+        </span>
+      </span>
+    </button>
+  );
+}
+
+function PlaceholderCard({ item }: { item: WorkflowPalettePlaceholder }) {
+  return (
+    <div aria-disabled="true" className={paletteCardClass(true)}>
+      <span className="flex items-start gap-3">
+        <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-white/10 bg-white/[0.04] text-[10px] font-semibold text-slate-400">
+          {item.icon}
+        </span>
+        <span className="min-w-0">
+          <span className="flex items-center gap-2">
+            <span className="block text-sm font-semibold text-slate-300">
+              {item.title}
+            </span>
+            <span className="rounded-full border border-white/10 bg-white/[0.04] px-2 py-0.5 text-[10px] text-slate-500">
+              {item.statusLabel}
+            </span>
+          </span>
+          <span className="mt-1 block text-xs leading-5 text-slate-500">
+            {item.description}
+          </span>
+        </span>
+      </span>
+    </div>
+  );
+}
+
+function EmptyState({ children }: { children: string }) {
+  return (
+    <p className="rounded-lg border border-dashed border-white/10 bg-white/[0.025] px-3 py-5 text-center text-xs leading-5 text-slate-500">
+      {children}
+    </p>
+  );
+}
+
+function matchesMiddlewareNode(node: RuntimeMiddlewareNode, query: string) {
+  if (!query) {
+    return true;
+  }
+  const haystack = [
+    node.id,
+    node.kind,
+    node.title,
+    node.description,
+    node.category,
+    node.icon,
+    ...(node.tags ?? []),
+  ]
+    .join(" ")
+    .toLowerCase();
+  return haystack.includes(query);
+}
+
 export default function NodePalette() {
+  const [activeTab, setActiveTab] = useState<PaletteTab>("workflow");
+  const [searchQuery, setSearchQuery] = useState("");
   const [middlewareNodes, setMiddlewareNodes] = useState<RuntimeMiddlewareNode[]>([]);
   const [middlewareLoading, setMiddlewareLoading] = useState(false);
   const [middlewareError, setMiddlewareError] = useState<string | null>(null);
+
+  const normalizedSearch = searchQuery.trim().toLowerCase();
 
   useEffect(() => {
     let isMounted = true;
@@ -206,96 +158,221 @@ export default function NodePalette() {
     };
   }, []);
 
+  const filteredWorkflowSections = useMemo(
+    () =>
+      workflowPaletteSections
+        .map((section) => ({
+          ...section,
+          items: section.items.filter((item) =>
+            matchesWorkflowPaletteQuery(item, normalizedSearch),
+          ),
+          placeholders: (section.placeholders ?? []).filter((item) =>
+            matchesWorkflowPaletteQuery(item, normalizedSearch),
+          ),
+        }))
+        .filter(
+          (section) =>
+            section.items.length > 0 || (section.placeholders ?? []).length > 0,
+        ),
+    [normalizedSearch],
+  );
+
+  const filteredMiddlewareNodes = useMemo(
+    () =>
+      middlewareNodes.filter((node) =>
+        matchesMiddlewareNode(node, normalizedSearch),
+      ),
+    [middlewareNodes, normalizedSearch],
+  );
+
+  const filteredKnowledgeItems = useMemo(
+    () =>
+      knowledgePipelineItems.filter((item) =>
+        matchesWorkflowPaletteQuery(item, normalizedSearch),
+      ),
+    [normalizedSearch],
+  );
+
+  const filteredKnowledgePlaceholders = useMemo(
+    () =>
+      knowledgePipelinePlaceholders.filter((item) =>
+        matchesWorkflowPaletteQuery(item, normalizedSearch),
+      ),
+    [normalizedSearch],
+  );
+
   return (
     <div className="space-y-3">
-      {paletteItems.map((item) => (
-        <button
-          className="group w-full rounded-lg border border-white/10 bg-white/[0.045] p-3 text-left transition duration-200 hover:-translate-y-0.5 hover:border-hire-300/35 hover:bg-hire-300/10"
-          draggable
-          key={item.kind}
-          onDragStart={(event) => {
-            event.dataTransfer.setData("application/modelmirror-node", item.kind);
-            event.dataTransfer.effectAllowed = "move";
-          }}
-          type="button"
-        >
-          <span className="flex items-start gap-3">
-            <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-hire-300/25 bg-hire-300/10 text-lg">
-              {item.icon}
-            </span>
-            <span className="min-w-0">
-              <span className="block text-sm font-semibold text-white">
-                {item.title}
-              </span>
-              <span className="mt-1 block text-xs leading-5 text-slate-400">
-                {item.description}
-              </span>
-            </span>
-          </span>
-        </button>
-      ))}
+      <div className="space-y-2">
+        <label className="sr-only" htmlFor="workflow-node-palette-search">
+          搜索节点
+        </label>
+        <input
+          className="w-full rounded-lg border border-white/10 bg-white/[0.04] px-3 py-2 text-sm text-white outline-none transition placeholder:text-slate-500 focus:border-hire-300/45 focus:bg-white/[0.06]"
+          id="workflow-node-palette-search"
+          onChange={(event) => setSearchQuery(event.target.value)}
+          placeholder="搜索节点、分类或标签"
+          value={searchQuery}
+        />
+        <div className="grid grid-cols-3 gap-1 rounded-lg border border-white/10 bg-white/[0.035] p-1">
+          {paletteTabs.map((tab) => (
+            <button
+              className={`rounded-md px-2 py-1.5 text-xs font-semibold transition ${
+                activeTab === tab.id
+                  ? "bg-hire-300/20 text-hire-100 shadow-sm"
+                  : "text-slate-400 hover:bg-white/[0.05] hover:text-slate-200"
+              }`}
+              key={tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              type="button"
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+      </div>
 
-      <div className="pt-3">
-        <div className="mb-2 flex items-center justify-between">
-          <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
-            智能体中间件
-          </h3>
-          {middlewareLoading ? (
-            <span className="text-[11px] text-slate-500">加载中...</span>
+      {activeTab === "workflow" ? (
+        <div className="space-y-4">
+          {filteredWorkflowSections.length === 0 ? (
+            <EmptyState>没有匹配的工作流节点。</EmptyState>
+          ) : (
+            filteredWorkflowSections.map((section) => (
+              <section className="space-y-2" key={section.id}>
+                <div>
+                  <h3 className="text-sm font-semibold text-slate-200">
+                    {section.label}
+                  </h3>
+                  <p className="mt-0.5 text-xs leading-5 text-slate-500">
+                    {section.description}
+                  </p>
+                </div>
+                <div className="space-y-2">
+                  {section.items.map((item) => (
+                    <NormalNodeButton item={item} key={item.kind} />
+                  ))}
+                  {(section.placeholders ?? []).map((item) => (
+                    <PlaceholderCard item={item} key={item.id} />
+                  ))}
+                </div>
+              </section>
+            ))
+          )}
+        </div>
+      ) : null}
+
+      {activeTab === "middleware" ? (
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h3 className="text-sm font-semibold text-slate-200">
+              智能体中间件
+            </h3>
+            {middlewareLoading ? (
+              <span className="text-[11px] text-slate-500">加载中...</span>
+            ) : null}
+          </div>
+
+          {middlewareError ? (
+            <p className="rounded-lg border border-amber-300/20 bg-amber-300/10 px-3 py-2 text-xs leading-5 text-amber-100">
+              {middlewareError}，工作流节点可继续使用。
+            </p>
+          ) : null}
+
+          {!middlewareError && filteredMiddlewareNodes.length === 0 ? (
+            <EmptyState>
+              {middlewareLoading ? "正在加载中间件节点。" : "没有匹配的中间件节点。"}
+            </EmptyState>
+          ) : null}
+
+          {!middlewareError && filteredMiddlewareNodes.length > 0 ? (
+            <div className="space-y-2">
+              {filteredMiddlewareNodes.map((node) => (
+                <button
+                  className={paletteCardClass()}
+                  draggable
+                  key={node.id}
+                  onDragStart={(event) => {
+                    const payload = {
+                      kind: "runtime_middleware",
+                      runtimeMiddlewareId: node.id,
+                      runtimeMiddlewareKind: node.kind,
+                      title: node.title,
+                      description: node.description,
+                      fields: node.fields,
+                      metadata: node.metadata ?? {},
+                    };
+                    const serialized = JSON.stringify(payload);
+                    event.dataTransfer.setData(
+                      "application/modelmirror-node",
+                      serialized,
+                    );
+                    event.dataTransfer.setData(
+                      "application/modelmirror-runtime-middleware",
+                      serialized,
+                    );
+                    event.dataTransfer.effectAllowed = "move";
+                  }}
+                  type="button"
+                >
+                  <span className="flex items-start gap-3">
+                    <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-hire-300/25 bg-hire-300/10 text-hire-100">
+                      <MiddlewareIcon icon={node.icon} />
+                    </span>
+                    <span className="min-w-0">
+                      <span className="block text-sm font-semibold text-white">
+                        {node.title}
+                      </span>
+                      <span className="mt-1 block text-xs leading-5 text-slate-400">
+                        {node.description}
+                      </span>
+                    </span>
+                  </span>
+                </button>
+              ))}
+            </div>
           ) : null}
         </div>
+      ) : null}
 
-        {middlewareError ? (
-          <p className="rounded-lg border border-amber-300/20 bg-amber-300/10 px-3 py-2 text-xs leading-5 text-amber-100">
-            {middlewareError}，原有节点可继续使用。
-          </p>
-        ) : null}
+      {activeTab === "knowledge" ? (
+        <div className="space-y-4">
+          <section className="space-y-2">
+            <div>
+              <h3 className="text-sm font-semibold text-slate-200">
+                引用与检索
+              </h3>
+              <p className="mt-0.5 text-xs leading-5 text-slate-500">
+                当前先暴露可运行的 CitationAnchor 节点。
+              </p>
+            </div>
+            <div className="space-y-2">
+              {filteredKnowledgeItems.map((item) => (
+                <NormalNodeButton item={item} key={item.kind} />
+              ))}
+            </div>
+          </section>
 
-        {!middlewareError && middlewareNodes.length > 0 ? (
-          <div className="space-y-3">
-            {middlewareNodes.map((node) => (
-              <button
-                className="group w-full rounded-lg border border-white/10 bg-white/[0.045] p-3 text-left transition duration-200 hover:-translate-y-0.5 hover:border-hire-300/35 hover:bg-hire-300/10"
-                draggable
-                key={node.id}
-                onDragStart={(event) => {
-                  const payload = {
-                    kind: "runtime_middleware",
-                    runtimeMiddlewareId: node.id,
-                    runtimeMiddlewareKind: node.kind,
-                    title: node.title,
-                    description: node.description,
-                    fields: node.fields,
-                    metadata: node.metadata ?? {},
-                  };
-                  const serialized = JSON.stringify(payload);
-                  event.dataTransfer.setData("application/modelmirror-node", serialized);
-                  event.dataTransfer.setData(
-                    "application/modelmirror-runtime-middleware",
-                    serialized,
-                  );
-                  event.dataTransfer.effectAllowed = "move";
-                }}
-                type="button"
-              >
-                <span className="flex items-start gap-3">
-                  <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-hire-300/25 bg-hire-300/10 text-hire-100">
-                    <MiddlewareIcon icon={node.icon} />
-                  </span>
-                  <span className="min-w-0">
-                    <span className="block text-sm font-semibold text-white">
-                      {node.title}
-                    </span>
-                    <span className="mt-1 block text-xs leading-5 text-slate-400">
-                      {node.description}
-                    </span>
-                  </span>
-                </span>
-              </button>
-            ))}
-          </div>
-        ) : null}
-      </div>
+          <section className="space-y-2">
+            <div>
+              <h3 className="text-sm font-semibold text-slate-200">
+                流水线阶段
+              </h3>
+              <p className="mt-0.5 text-xs leading-5 text-slate-500">
+                与 Xpert 菜单对齐的草稿入口，暂不创建节点。
+              </p>
+            </div>
+            {filteredKnowledgePlaceholders.length === 0 ? (
+              <EmptyState>没有匹配的知识流水线条目。</EmptyState>
+            ) : (
+              <div className="space-y-2">
+                {filteredKnowledgePlaceholders.map((item) => (
+                  <PlaceholderCard item={item} key={item.id} />
+                ))}
+              </div>
+            )}
+          </section>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/client/src/components/workflow/workflowNodeRegistry.ts
+++ b/client/src/components/workflow/workflowNodeRegistry.ts
@@ -1,0 +1,334 @@
+import { type WorkflowNodeKind } from "../../types/workflow";
+
+export type WorkflowPaletteNodeKind = Exclude<WorkflowNodeKind, "runtime_middleware">;
+
+export type WorkflowPaletteCategoryId =
+  | "logic"
+  | "transform"
+  | "tool"
+  | "memory"
+  | "other";
+
+export interface WorkflowPaletteItem {
+  kind: WorkflowPaletteNodeKind;
+  icon: string;
+  title: string;
+  description: string;
+  tags?: string[];
+}
+
+export interface WorkflowPalettePlaceholder {
+  id: string;
+  icon: string;
+  title: string;
+  description: string;
+  statusLabel: string;
+  tags?: string[];
+}
+
+export interface WorkflowPaletteSection {
+  id: WorkflowPaletteCategoryId;
+  label: string;
+  description: string;
+  items: WorkflowPaletteItem[];
+  placeholders?: WorkflowPalettePlaceholder[];
+}
+
+export const workflowPaletteSections: WorkflowPaletteSection[] = [
+  {
+    id: "logic",
+    label: "逻辑",
+    description: "触发、路由、迭代和变量流转。",
+    items: [
+      {
+        kind: "input",
+        icon: "▶",
+        title: "触发器",
+        description: "定义流水线入口变量，默认 user_input。",
+        tags: ["input", "start", "trigger"],
+      },
+      {
+        kind: "condition",
+        icon: "⌁",
+        title: "路由",
+        description: "按变量值判断，走“是/否”两条传送带。",
+        tags: ["condition", "branch", "route"],
+      },
+      {
+        kind: "iteration",
+        icon: "↻",
+        title: "迭代",
+        description: "逐项渲染模板，汇总为一个 JSON 数组字符串。",
+        tags: ["loop", "iteration"],
+      },
+      {
+        kind: "list_operation",
+        icon: "▾",
+        title: "列表操作",
+        description: "对逗号分隔的列表做长度、拼接、首尾提取。",
+        tags: ["list", "operator"],
+      },
+      {
+        kind: "variable_aggregator",
+        icon: "⧉",
+        title: "变量聚合",
+        description: "把多个变量汇总为文本或 JSON 字符串。",
+        tags: ["aggregate", "variables"],
+      },
+      {
+        kind: "variable_assign",
+        icon: "=",
+        title: "变量赋值",
+        description: "把模板渲染成一个变量，适合整理中间结果。",
+        tags: ["assign", "variables"],
+      },
+    ],
+  },
+  {
+    id: "transform",
+    label: "转换",
+    description: "分类、检索、模板、代码和最终回答。",
+    items: [
+      {
+        kind: "question_classifier",
+        icon: "◇",
+        title: "问题分类器",
+        description: "根据关键词规则把输入文本分类为预设类别。",
+        tags: ["classifier", "question"],
+      },
+      {
+        kind: "knowledge_retrieval",
+        icon: "▥",
+        title: "知识检索",
+        description: "查询本地 RAG 资料库，把相关段落写入变量。",
+        tags: ["rag", "knowledge"],
+      },
+      {
+        kind: "code",
+        icon: "</>",
+        title: "代码执行",
+        description: "只支持安全的内置字符串加工函数。",
+        tags: ["code", "python", "transform"],
+      },
+      {
+        kind: "template_transform",
+        icon: "T",
+        title: "模板",
+        description: "渲染长文本模板，适合生成报告或结构化草稿。",
+        tags: ["template", "text"],
+      },
+      {
+        kind: "parameter_extractor",
+        icon: "{}",
+        title: "参数提取器",
+        description: "调用模型从文本中提取字段，输出 JSON 字符串。",
+        tags: ["json", "extract"],
+      },
+      {
+        kind: "document_extractor",
+        icon: "□",
+        title: "文档提取器",
+        description: "从受限本地路径提取文本，供后续节点使用。",
+        tags: ["document", "file"],
+      },
+      {
+        kind: "llm",
+        icon: "AI",
+        title: "LLM 节点",
+        description: "安排模型工位处理提示词，可引用 {{变量}}。",
+        tags: ["model", "llm"],
+      },
+      {
+        kind: "output",
+        icon: "↵",
+        title: "回答",
+        description: "收尾交付最终变量，展示运行结果。",
+        tags: ["output", "answer"],
+      },
+    ],
+    placeholders: [
+      {
+        id: "json_serialize",
+        icon: "JSON",
+        title: "JSON 序列化",
+        description: "待接入：把变量对象序列化为 JSON。",
+        statusLabel: "待接入",
+        tags: ["json", "serialize"],
+      },
+      {
+        id: "json_deserialize",
+        icon: "JSON",
+        title: "JSON 反序列化",
+        description: "待接入：把 JSON 字符串解析为结构化变量。",
+        statusLabel: "待接入",
+        tags: ["json", "deserialize"],
+      },
+    ],
+  },
+  {
+    id: "tool",
+    label: "工具",
+    description: "HTTP、MCP、智能体步骤和任务移交。",
+    items: [
+      {
+        kind: "http_request",
+        icon: "HTTP",
+        title: "HTTP",
+        description: "调用 GET/POST 接口，把响应文本写入变量。",
+        tags: ["http", "api"],
+      },
+      {
+        kind: "mcp_tool",
+        icon: "◆",
+        title: "工具调用",
+        description: "调用已连接 MCP Server 暴露的工具。",
+        tags: ["mcp", "tool"],
+      },
+      {
+        kind: "agent",
+        icon: "A",
+        title: "Agent 节点",
+        description: "模型驱动的任务执行节点，支持工具循环和直接回答。",
+        tags: ["agent", "toolset"],
+      },
+      {
+        kind: "workflow_agent",
+        icon: "WA",
+        title: "智能体工作流",
+        description: "执行一个模型驱动的 Agent 步骤，并写入输出变量。",
+        tags: ["workflow-agent", "agent"],
+      },
+      {
+        kind: "agent_task",
+        icon: "TASK",
+        title: "智能体任务",
+        description: "创建 Agent Task Runtime 任务，输出 task_id。",
+        tags: ["task", "agent-task"],
+      },
+      {
+        kind: "agent_handoff",
+        icon: "⇄",
+        title: "任务移交",
+        description: "把 Agent Task 显式移交给另一个智能体。",
+        tags: ["handoff", "agent"],
+      },
+      {
+        kind: "handoff_router",
+        icon: "↪",
+        title: "移交路由器",
+        description: "读取智能体输出，投递到目标 Agent 的 Handoff Inbox。",
+        tags: ["handoff", "router"],
+      },
+      {
+        kind: "time_tool",
+        icon: "⌚",
+        title: "时间工具",
+        description: "获取当前时间、时间戳或格式化日期文本。",
+        tags: ["time", "date"],
+      },
+      {
+        kind: "human_intervention",
+        icon: "人",
+        title: "人工介入",
+        description: "暂停流水线，等待用户补充文本后再继续执行。",
+        tags: ["human", "approval"],
+      },
+    ],
+  },
+  {
+    id: "memory",
+    label: "记忆",
+    description: "数据库、长期记忆和写入能力。",
+    items: [],
+    placeholders: [
+      {
+        id: "database_memory",
+        icon: "DB",
+        title: "数据库",
+        description: "待接入：读写结构化数据和长期记忆。",
+        statusLabel: "待接入",
+        tags: ["database", "memory"],
+      },
+    ],
+  },
+  {
+    id: "other",
+    label: "其他",
+    description: "画布辅助节点。",
+    items: [],
+    placeholders: [
+      {
+        id: "annotation",
+        icon: "※",
+        title: "注释",
+        description: "待接入：仅用于画布说明，不参与运行。",
+        statusLabel: "待接入",
+        tags: ["note", "annotation"],
+      },
+    ],
+  },
+];
+
+export const knowledgePipelineItems: WorkflowPaletteItem[] = [
+  {
+    kind: "knowledge_citation",
+    icon: "◇",
+    title: "知识引用锚点",
+    description: "查询本地 RAG，输出 CitationAnchor JSON。",
+    tags: ["citation", "rag", "knowledge-pipeline"],
+  },
+];
+
+export const knowledgePipelinePlaceholders: WorkflowPalettePlaceholder[] = [
+  {
+    id: "pipeline_source_default",
+    icon: "TXT",
+    title: "默认数据源",
+    description: "待接入：从知识流水线数据源读取文件。",
+    statusLabel: "待接入",
+    tags: ["source", "data"],
+  },
+  {
+    id: "pipeline_processor",
+    icon: "PX",
+    title: "处理器",
+    description: "待接入：清洗、解析和转换文档内容。",
+    statusLabel: "待接入",
+    tags: ["processor"],
+  },
+  {
+    id: "pipeline_splitter",
+    icon: "¶",
+    title: "分块器",
+    description: "待接入：递归字符、Markdown 或父子分块。",
+    statusLabel: "待接入",
+    tags: ["splitter", "chunk"],
+  },
+  {
+    id: "pipeline_vision",
+    icon: "眼",
+    title: "图像理解",
+    description: "待接入：视觉语言模型处理图片内容。",
+    statusLabel: "待接入",
+    tags: ["vision", "image"],
+  },
+];
+
+export function matchesWorkflowPaletteQuery(
+  item: WorkflowPaletteItem | WorkflowPalettePlaceholder,
+  query: string,
+) {
+  if (!query) {
+    return true;
+  }
+  const haystack = [
+    item.title,
+    item.description,
+    item.icon,
+    ...(item.tags ?? []),
+    "kind" in item ? item.kind : item.id,
+  ]
+    .join(" ")
+    .toLowerCase();
+  return haystack.includes(query);
+}

--- a/client/src/pages/StudioHomePage.tsx
+++ b/client/src/pages/StudioHomePage.tsx
@@ -1,158 +1,667 @@
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import PageContainer from "../components/PageContainer";
-import { readStudioState, type StudioAppRecord } from "../data/studio";
+import { agents } from "../data/agents";
+import { mcpProjects } from "../data/mcpProjects";
+import { skillProjects } from "../data/skillProjects";
 
-function statusCopy(status: StudioAppRecord["status"]) {
-  if (status === "stable") return "稳定接入";
-  if (status === "fallback") return "备用入口";
-  return "规划中";
+type WorkspaceCategory =
+  | "all"
+  | "agents"
+  | "workflow"
+  | "knowledge"
+  | "mcp"
+  | "skills"
+  | "prompts"
+  | "environment"
+  | "runs";
+
+type Tone = "ready" | "partial" | "planned" | "error";
+
+interface Loadable<T> {
+  data: T;
+  error: string;
+  loading: boolean;
 }
 
-function statusClass(status: StudioAppRecord["status"]) {
-  if (status === "stable") {
+interface KnowledgeBasePayload {
+  id: string;
+  name: string;
+}
+
+interface FileAssetPayload {
+  file_asset_id?: string;
+  file_name?: string;
+  filename?: string;
+  name?: string;
+}
+
+interface ArtifactPayload {
+  artifact_id: string;
+  title: string;
+  chunk_count?: number;
+}
+
+interface McpSessionPayload {
+  session_id: string;
+  server_name?: string | null;
+  server_id?: string | null;
+  status?: string | null;
+}
+
+interface RegistryToolPayload {
+  name: string;
+  server_id: string;
+}
+
+interface InstalledSkillPayload {
+  skill_id: string;
+  name: string;
+  description: string;
+}
+
+interface RuntimeRunPayload {
+  run_id: string;
+  run_type: string;
+  status: string;
+  title: string;
+  created_at: number;
+  updated_at: number;
+}
+
+interface ResourceCardModel {
+  actionLabel: string;
+  category: Exclude<WorkspaceCategory, "all">;
+  count: string;
+  description: string;
+  error?: string;
+  href: string;
+  icon: string;
+  id: string;
+  items: string[];
+  loading?: boolean;
+  metricLabel: string;
+  status: string;
+  title: string;
+  tone: Tone;
+}
+
+const categories: Array<{ key: WorkspaceCategory; label: string }> = [
+  { key: "all", label: "全部" },
+  { key: "agents", label: "数字专家" },
+  { key: "workflow", label: "工作流" },
+  { key: "knowledge", label: "知识库" },
+  { key: "mcp", label: "MCP 工具集" },
+  { key: "skills", label: "Skill" },
+  { key: "prompts", label: "提示词" },
+  { key: "environment", label: "环境" },
+  { key: "runs", label: "运行记录" },
+];
+
+const dateFormatter = new Intl.DateTimeFormat("zh-CN", {
+  month: "2-digit",
+  day: "2-digit",
+  hour: "2-digit",
+  minute: "2-digit",
+});
+
+function createLoadable<T>(data: T): Loadable<T> {
+  return { data, error: "", loading: true };
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`请求失败：${response.status}`);
+  }
+  return response.json() as Promise<T>;
+}
+
+function toneClass(tone: Tone) {
+  if (tone === "ready") {
     return "border-emerald-300/25 bg-emerald-300/10 text-emerald-100";
   }
-  if (status === "fallback") {
+  if (tone === "partial") {
     return "border-hire-300/30 bg-hire-300/10 text-hire-100";
+  }
+  if (tone === "error") {
+    return "border-rose-300/30 bg-rose-300/10 text-rose-100";
   }
   return "border-white/10 bg-white/[0.055] text-slate-300";
 }
 
-function formatDate(value: string) {
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return "刚刚";
-  return date.toLocaleDateString("zh-CN", {
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
+function formatRunTime(value: number) {
+  if (!Number.isFinite(value)) return "刚刚";
+  const timestamp = value > 10_000_000_000 ? value : value * 1000;
+  return dateFormatter.format(new Date(timestamp));
 }
 
-function StudioAppCard({ app }: { app: StudioAppRecord }) {
+function compactItems(items: string[]) {
+  return items.filter(Boolean).slice(0, 4);
+}
+
+function ResourceCard({ card }: { card: ResourceCardModel }) {
+  const visibleItems = compactItems(card.items);
+
   return (
-    <Link
-      className="block rounded-lg border border-white/10 bg-ink-950/72 p-4 shadow-prism transition duration-200 hover:-translate-y-0.5 hover:border-hire-300/40 hover:bg-surface-900/88"
-      to={app.href}
-    >
+    <article className="rounded-lg border border-white/10 bg-ink-950/72 p-4 shadow-prism transition duration-200 hover:-translate-y-0.5 hover:border-hire-300/35 hover:bg-surface-900/88">
       <div className="flex items-start justify-between gap-3">
         <div className="flex min-w-0 items-start gap-3">
-          <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg border border-hire-300/25 bg-hire-300/10 text-lg">
-            {app.icon}
+          <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-hire-300/25 bg-hire-300/10 text-sm font-semibold text-hire-100">
+            {card.icon}
           </span>
           <div className="min-w-0">
-            <h3 className="truncate text-sm font-semibold text-white">{app.name}</h3>
+            <h2 className="truncate text-sm font-semibold text-white">{card.title}</h2>
             <p className="mt-1 line-clamp-2 text-xs leading-5 text-slate-400">
-              {app.description}
+              {card.description}
             </p>
           </div>
         </div>
-        <span className={`shrink-0 rounded-full border px-2.5 py-1 text-[11px] font-semibold ${statusClass(app.status)}`}>
-          {statusCopy(app.status)}
+        <span
+          className={`shrink-0 rounded-full border px-2.5 py-1 text-[11px] font-semibold ${toneClass(
+            card.error ? "error" : card.tone,
+          )}`}
+        >
+          {card.error ? "暂不可用" : card.status}
         </span>
       </div>
 
-      <div className="mt-4 flex flex-wrap gap-2">
-        {app.tags.map((tag) => (
-          <span
-            className="rounded-full border border-white/10 bg-white/[0.055] px-2.5 py-1 text-[11px] text-slate-300"
-            key={tag}
-          >
-            {tag}
-          </span>
-        ))}
+      <div className="mt-4 grid grid-cols-[minmax(0,1fr)_auto] items-end gap-3 border-t border-white/10 pt-4">
+        <div>
+          <p className="text-[11px] text-slate-500">{card.metricLabel}</p>
+          <p className="mt-1 text-2xl font-semibold text-white">
+            {card.loading ? "..." : card.count}
+          </p>
+        </div>
+        <Link
+          className="rounded-full border border-hire-300/25 bg-hire-300/10 px-3 py-1.5 text-xs font-semibold text-hire-100 transition hover:bg-hire-300/20"
+          to={card.href}
+        >
+          {card.actionLabel}
+        </Link>
       </div>
-    </Link>
+
+      {card.error ? (
+        <p className="mt-3 rounded-lg border border-rose-300/20 bg-rose-300/10 px-3 py-2 text-xs leading-5 text-rose-100">
+          {card.error}
+        </p>
+      ) : visibleItems.length > 0 ? (
+        <ul className="mt-3 space-y-2">
+          {visibleItems.map((item) => (
+            <li className="truncate text-xs text-slate-400" key={item}>
+              {item}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="mt-3 rounded-lg border border-white/10 bg-white/[0.04] px-3 py-2 text-xs text-slate-400">
+          暂无最近项目，进入模块后可继续创建或连接资源。
+        </p>
+      )}
+    </article>
+  );
+}
+
+function WorkspaceSidebar() {
+  return (
+    <div>
+      <p className="text-sm font-semibold text-white">工作空间</p>
+      <p className="mt-2 text-sm leading-6 text-slate-400">
+        先把现有资源集中到一个入口，再逐步对齐 Xpert Studio、Toolset、知识流水线和运行运维。
+      </p>
+      <div className="mt-4 space-y-2">
+        <Link
+          className="block rounded-lg border border-hire-300/25 bg-hire-300/10 px-3 py-2 text-sm font-semibold text-hire-100 transition hover:bg-hire-300/20"
+          to="/workflow"
+        >
+          打开工作流画布
+        </Link>
+        <Link
+          className="block rounded-lg border border-white/10 bg-white/[0.045] px-3 py-2 text-sm font-semibold text-slate-200 transition hover:border-hire-300/35 hover:bg-hire-300/10"
+          to="/agents/meta-agent"
+        >
+          进入任务工作台
+        </Link>
+        <Link
+          className="block rounded-lg border border-white/10 bg-white/[0.045] px-3 py-2 text-sm font-semibold text-slate-200 transition hover:border-hire-300/35 hover:bg-hire-300/10"
+          to="/mcps"
+        >
+          管理 MCP 工具
+        </Link>
+      </div>
+    </div>
   );
 }
 
 export default function StudioHomePage() {
-  const state = useMemo(() => readStudioState(), []);
+  const [activeCategory, setActiveCategory] = useState<WorkspaceCategory>("all");
+  const [searchTerm, setSearchTerm] = useState("");
+  const [knowledgeBases, setKnowledgeBases] = useState(
+    createLoadable<KnowledgeBasePayload[]>([]),
+  );
+  const [fileAssets, setFileAssets] = useState(createLoadable<FileAssetPayload[]>([]));
+  const [artifacts, setArtifacts] = useState(createLoadable<ArtifactPayload[]>([]));
+  const [mcpSessions, setMcpSessions] = useState(createLoadable<McpSessionPayload[]>([]));
+  const [registryTools, setRegistryTools] = useState(
+    createLoadable<RegistryToolPayload[]>([]),
+  );
+  const [installedSkills, setInstalledSkills] = useState(
+    createLoadable<InstalledSkillPayload[]>([]),
+  );
+  const [runtimeRuns, setRuntimeRuns] = useState(createLoadable<RuntimeRunPayload[]>([]));
 
   useEffect(() => {
-    document.title = "模镜 - 工作台总览";
+    document.title = "模镜 - Xpert 工作空间";
   }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadKnowledge() {
+      try {
+        const [kbData, assetData, artifactData] = await Promise.all([
+          fetchJson<{ knowledge_bases: KnowledgeBasePayload[] }>(
+            "/api/rag/knowledge_bases",
+          ),
+          fetchJson<{ assets: FileAssetPayload[] }>("/api/rag/pipeline/assets"),
+          fetchJson<{ artifacts: ArtifactPayload[] }>("/api/rag/pipeline/artifacts"),
+        ]);
+        if (cancelled) return;
+        setKnowledgeBases({
+          data: kbData.knowledge_bases ?? [],
+          error: "",
+          loading: false,
+        });
+        setFileAssets({ data: assetData.assets ?? [], error: "", loading: false });
+        setArtifacts({ data: artifactData.artifacts ?? [], error: "", loading: false });
+      } catch (error) {
+        if (cancelled) return;
+        const message =
+          error instanceof Error ? error.message : "知识库资源加载失败";
+        setKnowledgeBases({ data: [], error: message, loading: false });
+        setFileAssets({ data: [], error: message, loading: false });
+        setArtifacts({ data: [], error: message, loading: false });
+      }
+    }
+
+    async function loadMcp() {
+      try {
+        const [sessionsData, toolsData] = await Promise.all([
+          fetchJson<{ sessions: McpSessionPayload[] }>("/api/mcp/sessions"),
+          fetchJson<{ tools: RegistryToolPayload[] }>("/api/registry/tools"),
+        ]);
+        if (cancelled) return;
+        setMcpSessions({ data: sessionsData.sessions ?? [], error: "", loading: false });
+        setRegistryTools({ data: toolsData.tools ?? [], error: "", loading: false });
+      } catch (error) {
+        if (cancelled) return;
+        const message = error instanceof Error ? error.message : "MCP 运行态加载失败";
+        setMcpSessions({ data: [], error: message, loading: false });
+        setRegistryTools({ data: [], error: message, loading: false });
+      }
+    }
+
+    async function loadSkills() {
+      try {
+        const data = await fetchJson<{ skills: InstalledSkillPayload[] }>(
+          "/api/skills/installed",
+        );
+        if (cancelled) return;
+        setInstalledSkills({ data: data.skills ?? [], error: "", loading: false });
+      } catch (error) {
+        if (cancelled) return;
+        setInstalledSkills({
+          data: [],
+          error: error instanceof Error ? error.message : "Skill 加载失败",
+          loading: false,
+        });
+      }
+    }
+
+    async function loadRuns() {
+      try {
+        const data = await fetchJson<RuntimeRunPayload[]>("/api/runtime/runs?limit=8");
+        if (cancelled) return;
+        setRuntimeRuns({ data: data ?? [], error: "", loading: false });
+      } catch (error) {
+        if (cancelled) return;
+        setRuntimeRuns({
+          data: [],
+          error: error instanceof Error ? error.message : "运行记录加载失败",
+          loading: false,
+        });
+      }
+    }
+
+    void loadKnowledge();
+    void loadMcp();
+    void loadSkills();
+    void loadRuns();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const resourceCards = useMemo<ResourceCardModel[]>(() => {
+    const knowledgeError =
+      knowledgeBases.error || fileAssets.error || artifacts.error || "";
+    const mcpError = mcpSessions.error || registryTools.error || "";
+
+    return [
+      {
+        actionLabel: "查看专家",
+        category: "agents",
+        count: String(agents.length),
+        description: "本地智能体市场与元智能体任务工作台入口。",
+        href: "/agents",
+        icon: "智",
+        id: "agents",
+        items: agents.slice(0, 4).map((agent) => agent.name),
+        metricLabel: "可用智能体",
+        status: "可用",
+        title: "数字专家",
+        tone: "ready",
+      },
+      {
+        actionLabel: "打开画布",
+        category: "workflow",
+        count: "2",
+        description: "经典画布与 native 实验线，承载 Agent、Handoff、Toolset 与 RAG 节点。",
+        href: "/workflow",
+        icon: "流",
+        id: "workflow",
+        items: ["classic /workflow", "workflow-native validate", "节点运行观测", "RunRegistry"],
+        metricLabel: "工作流入口",
+        status: "部分实现",
+        title: "工作流",
+        tone: "partial",
+      },
+      {
+        actionLabel: "打开知识库",
+        category: "knowledge",
+        count: knowledgeError ? "0" : String(knowledgeBases.data.length),
+        description: "本地 RAG 知识库、FileAsset、Artifact 与 CitationAnchor 只读视图。",
+        error: knowledgeError,
+        href: "/rag",
+        icon: "知",
+        id: "knowledge",
+        items: knowledgeError
+          ? []
+          : [
+              ...knowledgeBases.data.map((kb) => kb.name),
+              `${fileAssets.data.length} 个 FileAsset`,
+              `${artifacts.data.length} 个 Artifact`,
+            ],
+        loading: knowledgeBases.loading || fileAssets.loading || artifacts.loading,
+        metricLabel: "知识库",
+        status: "部分实现",
+        title: "知识库",
+        tone: "partial",
+      },
+      {
+        actionLabel: "管理 MCP",
+        category: "mcp",
+        count: mcpError ? "0" : String(registryTools.data.length),
+        description: "MCP Server 会话、全局工具注册表和 Runtime Toolset 的入口。",
+        error: mcpError,
+        href: "/mcps",
+        icon: "MCP",
+        id: "mcp",
+        items: mcpError
+          ? []
+          : [
+              `${mcpSessions.data.length} 个运行会话`,
+              `${mcpProjects.length} 个候选工具箱`,
+              ...registryTools.data.map((tool) => tool.name),
+            ],
+        loading: mcpSessions.loading || registryTools.loading,
+        metricLabel: "已注册工具",
+        status: "部分实现",
+        title: "MCP 工具集",
+        tone: "partial",
+      },
+      {
+        actionLabel: "查看 Skill",
+        category: "skills",
+        count: installedSkills.error ? "0" : String(installedSkills.data.length),
+        description: "Skill 市场、已安装技能和仓库安装能力。",
+        error: installedSkills.error,
+        href: "/skills",
+        icon: "技",
+        id: "skills",
+        items: installedSkills.error
+          ? []
+          : [
+              ...installedSkills.data.map((skill) => skill.name),
+              `${skillProjects.length} 个市场候选技能`,
+            ],
+        loading: installedSkills.loading,
+        metricLabel: "已安装",
+        status: "部分实现",
+        title: "Skill",
+        tone: "partial",
+      },
+      {
+        actionLabel: "查看提示词",
+        category: "prompts",
+        count: "规划中",
+        description: "对齐 Xpert 提示词与 Slash Command 工作流，当前先保留入口。",
+        href: "/prompts",
+        icon: "词",
+        id: "prompts",
+        items: ["审查", "解释", "测试", "调试", "总结"],
+        metricLabel: "工作区提示词",
+        status: "待接入",
+        title: "提示词",
+        tone: "planned",
+      },
+      {
+        actionLabel: "进入设置",
+        category: "environment",
+        count: "Default",
+        description: "环境变量、模型网关和运行依赖入口，后续对齐 Xpert 环境页。",
+        href: "/settings",
+        icon: "ENV",
+        id: "environment",
+        items: ["OpenRouter / newAPI 网关", "Docker runtime", "MCP / Skill 依赖"],
+        metricLabel: "当前环境",
+        status: "规划中",
+        title: "环境",
+        tone: "planned",
+      },
+      {
+        actionLabel: "查看运行",
+        category: "runs",
+        count: runtimeRuns.error ? "0" : String(runtimeRuns.data.length),
+        description: "RunRegistry 内存态索引，汇总 workflow、chat、agent_task 与 handoff run。",
+        error: runtimeRuns.error,
+        href: "/workflow",
+        icon: "观",
+        id: "runs",
+        items: runtimeRuns.error
+          ? []
+          : runtimeRuns.data.map((run) => `${run.run_type} · ${run.status}`),
+        loading: runtimeRuns.loading,
+        metricLabel: "最近运行",
+        status: "可观测",
+        title: "运行记录",
+        tone: "partial",
+      },
+    ];
+  }, [
+    artifacts,
+    fileAssets,
+    installedSkills,
+    knowledgeBases,
+    mcpSessions,
+    registryTools,
+    runtimeRuns,
+  ]);
+
+  const filteredCards = useMemo(() => {
+    const normalizedSearch = searchTerm.trim().toLowerCase();
+    return resourceCards.filter((card) => {
+      const matchesCategory =
+        activeCategory === "all" || card.category === activeCategory;
+      const matchesSearch =
+        normalizedSearch.length === 0 ||
+        [card.title, card.description, card.status, card.count, ...card.items]
+          .join(" ")
+          .toLowerCase()
+          .includes(normalizedSearch);
+      return matchesCategory && matchesSearch;
+    });
+  }, [activeCategory, resourceCards, searchTerm]);
 
   return (
     <PageContainer
-      activeResource="agents"
       maxWidthClassName="max-w-[1760px]"
-      sidebar={
-        <div>
-          <p className="text-sm font-semibold text-white">工作台入口</p>
-          <p className="mt-2 text-sm leading-6 text-slate-400">
-            工作流默认使用经典自研画布，RAG本地知识库已开放，其他能力按模块持续扩展。
-          </p>
-          <div className="mt-4 space-y-2">
-            <Link
-              className="block rounded-lg border border-hire-300/25 bg-hire-300/10 px-3 py-2 text-sm font-semibold text-hire-100 transition hover:bg-hire-300/20"
-              to="/workflow"
-            >
-              进入经典工作流
-            </Link>
-            <Link
-              className="block rounded-lg border border-white/10 bg-white/[0.045] px-3 py-2 text-sm font-semibold text-slate-200 transition hover:border-hire-300/35 hover:bg-hire-300/10"
-              to="/rag"
-            >
-              打开本地知识库
-            </Link>
-          </div>
-        </div>
-      }
+      sidebar={<WorkspaceSidebar />}
     >
-      <header className="mb-6 overflow-hidden rounded-lg border border-hire-300/20 bg-[linear-gradient(135deg,rgba(67,20,7,0.76),rgba(6,9,22,0.94)_52%,rgba(8,51,68,0.42))] p-6 shadow-prism">
-        <p className="text-sm font-semibold text-hire-100">本地工作台</p>
-        <h1 className="mt-3 text-3xl font-semibold text-white sm:text-4xl">
-          模镜工作台已切换到本地能力
-        </h1>
-        <p className="mt-3 max-w-3xl text-sm leading-6 text-slate-300">
-          工作流由经典自研画布承载，RAG 资料库使用本地知识库链路。后续能力继续按模块推进，
-          保持独立测试和可回退开关。
-        </p>
-      </header>
-
-      <div className="grid gap-4 md:grid-cols-3">
-        {state.apps.map((app) => (
-          <StudioAppCard app={app} key={app.id} />
-        ))}
-      </div>
-
-      <section className="surface-card mt-6 rounded-lg p-5">
-        <div className="flex items-center justify-between gap-3">
-          <div>
-            <h2 className="text-xl font-semibold text-white">迭代记录</h2>
-            <p className="mt-1 text-sm text-slate-400">
-              这里记录本地工作流、RAG 与工具能力的推进状态。
+      <header className="mb-6 border-y border-hire-300/20 py-5">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="rounded-full border border-hire-300/30 bg-hire-300/10 px-3 py-1 text-xs font-semibold text-hire-100">
+                Xpert 对齐工作空间 Beta
+              </span>
+              <span className="rounded-full border border-white/10 bg-white/[0.055] px-3 py-1 text-xs text-slate-300">
+                React / FastAPI 原生实现
+              </span>
+            </div>
+            <h1 className="mt-3 text-2xl font-semibold text-white sm:text-3xl">
+              组织工作空间
+            </h1>
+            <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-400">
+              聚合智能体、知识库、工具集、Skill、提示词、环境和运行记录。这里先做只读总览，
+              后续再接 Xpert Studio 画布、节点注册表和配置侧栏。
             </p>
           </div>
-          <Link
-            className="rounded-full border border-hire-300/30 bg-hire-300/10 px-4 py-2 text-sm font-semibold text-hire-100 transition hover:bg-hire-300/20"
-            to="/workflow/classic"
-          >
-            查看经典画布
-          </Link>
-        </div>
-
-        <div className="mt-5 space-y-3">
-          {state.activities.map((activity) => (
-            <article
-              className="rounded-lg border border-white/10 bg-white/[0.045] p-4"
-              key={activity.id}
+          <div className="flex flex-wrap gap-2">
+            <Link
+              className="rounded-full bg-hire-300 px-4 py-2 text-sm font-semibold text-ink-950 transition hover:bg-hire-200"
+              to="/workflow"
             >
-              <div className="flex items-center justify-between gap-3">
-                <h3 className="text-sm font-semibold text-white">{activity.title}</h3>
-                <span className="rounded-full border border-white/10 bg-white/[0.055] px-2.5 py-1 text-[11px] text-slate-300">
-                  {formatDate(activity.at)}
-                </span>
-              </div>
-              <p className="mt-2 text-sm leading-6 text-slate-400">
-                {activity.detail}
-              </p>
-            </article>
+              创建工作流
+            </Link>
+            <Link
+              className="rounded-full border border-white/10 bg-white/[0.055] px-4 py-2 text-sm font-semibold text-slate-200 transition hover:border-hire-300/35 hover:bg-hire-300/10"
+              to="/agents/meta-agent"
+            >
+              打开任务工作台
+            </Link>
+          </div>
+        </div>
+      </header>
+
+      <section className="mb-5 grid gap-3 lg:grid-cols-[minmax(0,1fr)_320px] lg:items-center">
+        <div className="flex min-w-0 flex-wrap gap-2">
+          {categories.map((category) => (
+            <button
+              className={`rounded-full border px-3 py-2 text-sm font-semibold transition ${
+                activeCategory === category.key
+                  ? "border-hire-300 bg-hire-300 text-ink-950"
+                  : "border-white/10 bg-white/[0.045] text-slate-300 hover:border-hire-300/35 hover:bg-hire-300/10 hover:text-hire-100"
+              }`}
+              key={category.key}
+              onClick={() => setActiveCategory(category.key)}
+              type="button"
+            >
+              {category.label}
+            </button>
           ))}
         </div>
+        <label className="relative block">
+          <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-xs font-semibold text-slate-400">
+            搜索
+          </span>
+          <input
+            className="h-11 w-full rounded-lg border border-white/10 bg-ink-950/72 pl-12 pr-3 text-sm text-white outline-none transition placeholder:text-slate-500 hover:border-white/20 focus:border-hire-300/70 focus:ring-4 focus:ring-hire-300/10"
+            onChange={(event) => setSearchTerm(event.target.value)}
+            placeholder="资源、状态、运行类型"
+            type="search"
+            value={searchTerm}
+          />
+        </label>
       </section>
+
+      <div className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_360px]">
+        <section>
+          {filteredCards.length > 0 ? (
+            <div className="grid gap-4 md:grid-cols-2 2xl:grid-cols-3">
+              {filteredCards.map((card) => (
+                <ResourceCard card={card} key={card.id} />
+              ))}
+            </div>
+          ) : (
+            <div className="rounded-lg border border-white/10 bg-white/[0.045] p-8 text-center">
+              <p className="text-sm font-semibold text-white">没有匹配的资源</p>
+              <p className="mt-2 text-sm text-slate-400">
+                换一个分类或搜索词，资源入口仍然保留在顶部导航中。
+              </p>
+            </div>
+          )}
+        </section>
+
+        <aside className="space-y-4">
+          <section className="rounded-lg border border-white/10 bg-ink-950/72 p-4 shadow-prism">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <h2 className="text-sm font-semibold text-white">运行观测摘要</h2>
+                <p className="mt-1 text-xs text-slate-400">
+                  最近 8 条 RunRegistry 记录。
+                </p>
+              </div>
+              <span className={`rounded-full border px-2.5 py-1 text-[11px] font-semibold ${toneClass(runtimeRuns.error ? "error" : "partial")}`}>
+                {runtimeRuns.error ? "暂不可用" : "内存态"}
+              </span>
+            </div>
+            {runtimeRuns.error ? (
+              <p className="mt-4 rounded-lg border border-rose-300/20 bg-rose-300/10 px-3 py-2 text-xs leading-5 text-rose-100">
+                {runtimeRuns.error}
+              </p>
+            ) : runtimeRuns.loading ? (
+              <p className="mt-4 text-sm text-slate-400">运行记录加载中...</p>
+            ) : runtimeRuns.data.length > 0 ? (
+              <div className="mt-4 space-y-3">
+                {runtimeRuns.data.slice(0, 8).map((run) => (
+                  <article
+                    className="rounded-lg border border-white/10 bg-white/[0.045] p-3"
+                    key={run.run_id}
+                  >
+                    <div className="flex items-center justify-between gap-3">
+                      <p className="truncate text-xs font-semibold text-white">
+                        {run.title || run.run_type}
+                      </p>
+                      <span className="shrink-0 rounded-full border border-white/10 bg-white/[0.055] px-2 py-0.5 text-[11px] text-slate-300">
+                        {run.status}
+                      </span>
+                    </div>
+                    <p className="mt-2 text-xs text-slate-500">
+                      {run.run_type} · {formatRunTime(run.updated_at ?? run.created_at)}
+                    </p>
+                  </article>
+                ))}
+              </div>
+            ) : (
+              <p className="mt-4 rounded-lg border border-white/10 bg-white/[0.04] px-3 py-2 text-xs text-slate-400">
+                暂无运行记录。运行工作流或开启 Chat Toolset 后会出现在这里。
+              </p>
+            )}
+          </section>
+
+          <section className="rounded-lg border border-white/10 bg-white/[0.045] p-4">
+            <h2 className="text-sm font-semibold text-white">下一步对齐</h2>
+            <ol className="mt-3 space-y-2 text-xs leading-5 text-slate-400">
+              <li>1. 节点注册表与 Xpert 分类菜单</li>
+              <li>2. 智能体配置侧栏分区</li>
+              <li>3. 知识流水线可视化草稿</li>
+              <li>4. Runtime Ops 与环境观测</li>
+            </ol>
+          </section>
+        </aside>
+      </div>
     </PageContainer>
   );
 }

--- a/docs/XPERT_ALIGNMENT.md
+++ b/docs/XPERT_ALIGNMENT.md
@@ -1,112 +1,124 @@
 # Xpert 对齐总纲
 
-> 2026-07-08 状态补充：Chat Toolset 运行观测已进入“部分实现”。`tool_mode=mcp_tools` 的聊天请求会登记 `chat` run，响应 header 暴露 runtime run/task id，并记录 `chat.started/model_decision/tool_call/answer/failed` checkpoint；聊天页会展示轻量“运行观测 Beta”。普通聊天仍不创建 chat run，SSE 格式不变。
-> 2026-07-08 状态补充：Chat Agent Toolset 已进入“部分实现”。`/api/chat` 新增默认关闭的 `tool_mode=mcp_tools`，显式开启后使用轻量 JSON 决策协议调用 MCP 工具，并复用 `MCPToolsetProvider`、`run_tool_with_runtime`、`tool_policy` 与 `tool_audit`。普通聊天请求保持 `tool_mode=none`，SSE wire format 不变；当前不是 OpenAI function calling，不做 Handoff 自动调度或真实多 Agent 协作。
-> 2026-07-08 状态补充：Handoff Router 已进入“部分实现”。Classic workflow 新增 `handoff_router` 节点，可读取 `workflow_agent` 等上游节点输出，创建 AgentTask，并向目标 Agent 创建 pending Handoff，让结果进入 MetaAgent Handoff Inbox。当前不自动 accept、不执行目标 Agent、不接队列 worker 或持久化。
-> 2026-07-07 状态补充：RunRegistry Trace 已进入“部分实现”。`RuntimeRun` 现在可挂载内存态 checkpoint，记录 workflow、workflow_agent、agent_task、agent_handoff 的关键执行时间线；新增 `GET /api/runtime/runs/{run_id}/checkpoints` 供前端运行观测读取。当前仍不做持久化、自动重试、队列调度或 checkpoint resume。
-> 2026-07-07 状态补充：Workflow Agent Toolset 已进入“部分实现”。`workflow_agent` 现在支持 `toolMode=none/mcp_tools`，启用 MCP 工具时复用 Runtime Toolset、`tool_policy` 与 `tool_audit`；旧 `agent.tool_first` 也收敛到同一条 `run_tool_with_runtime` 路径。当前仍是轻量 JSON 决策协议，不做 OpenAI function calling、自动 Handoff 或真实多 Agent 调度。
-
-> 2026-07-06 状态补充：Workflow Agent 节点已进入“部分实现”。Classic workflow 现在可拖入 `workflow_agent` 节点，用角色提示词和任务输入调用模型，输出结果到变量，并登记 `workflow_agent` 子 run。当前仍是单步模型执行，不接工具调用、Handoff 自动调度或真实多 Agent 协作。
-
-> 2026-07-06 状态补充：Handoff Queue 已进入“部分实现”。Handoff metadata 现在记录 accepted/rejected/completed 的处理者、时间和结果/原因；MetaAgent Handoff Inbox 支持按状态和目标 Agent 筛选，并可填写完成结果。当前仍是内存态人工处理闭环，不做真实调度、worker 队列或持久化。
-
-> 2026-07-06 状态补充：Handoff 前端观测已进入“部分实现”。Workflow 运行观测可以按 `parent_run_id` 拉取 `agent_task` / `agent_handoff` 子 run；MetaAgent 任务工作台可以查看任务 handoff 记录，并通过 Handoff Inbox Beta 手动 accept / reject / complete。当前仍不做真实多 Agent 调度、队列分派、数据库持久化或目标 Agent 自动执行。
-
-> 2026-07-05 状态补充：RunRegistry 已进入最小可观测闭环阶段，详见文末“RunRegistry 最小可观测闭环”。
-
-## 2026-07-05 增量：RunRegistry 最小可观测闭环
-
-RunRegistry 已从“下一步”进入“部分实现”。当前新增 `server/xpert_runtime/run_registry.py`，提供内存态 `RuntimeRun` 与 `RunRegistry`，统一登记 `workflow`、`workflow_agent`、`agent_task`、`agent_handoff` 四类 run，支持创建、查询、过滤列表、状态更新和取消。
-
-Classic workflow 运行时会创建 workflow run，并在 `workflow_meta` / `workflow_end` SSE 中携带 `run_id`；`workflow_agent` 节点执行模型智能体步骤时登记 workflow_agent run；`agent_task` 节点创建任务时登记 agent_task run；`agent_handoff` 节点创建移交时登记 agent_handoff run。Run 之间通过 `parent_run_id` 和 metadata 关联，不强行合并现有 workflow `task_id`，避免破坏既有 SSE、status 和 resume 协议。
-
-新增 API：
-
-- `GET /api/runtime/runs?run_type=&status=&limit=`
-- `GET /api/runtime/runs/{run_id}`
-- `GET /api/runtime/runs/{run_id}/checkpoints`
-- `POST /api/runtime/runs/{run_id}/cancel`
-
-当前边界：RunRegistry 仅为内存态可观测索引，不是持久化调度器；取消 run 只更新 registry 状态，不中断真实 workflow、AgentTask 或 Handoff 执行。Checkpoint 只保存摘要与元信息，不保存完整 prompt、工具输出、模型输出或密钥。下一步可在此基础上继续补齐 Handoff 自动编排、RunRegistry 页面、死信与持久化存储。
-
 最后更新日期：2026-07-08
-
-## 2026-07-08 增量：Knowledge Citation 工作流节点
-
-Classic workflow 新增 `knowledge_citation` 节点，作为 Knowledge Pipeline 进入工作流的最小闭环。节点字段包括 `queryVariable`、`knowledgeBaseId`、`top_k` 与 `outputVariable`；`knowledgeBaseId` 留空时沿用本地 RAG 默认策略，使用第一个知识库。运行时会调用 `RagService.create_pipeline_citations(...)`，把结果写入 JSON 字符串：`{"citations":[...],"citation_count":N}`。
-
-该节点同步登记 `knowledge_citation` 子 run，`parent_run_id` 指向 workflow run，并记录 `knowledge_citation.started/completed/failed` checkpoint。metadata 只保存 `workflow_task_id`、`node_id`、`kb_id`、`query_variable`、`output_variable`、`citation_count` 等摘要；不保存完整 query、chunk 全文、embedding、本地文件路径或密钥。当前不改 `/api/rag/query`、聊天 RAG、上传、切分、向量存储或 embedding 策略。
 维护人：模镜团队
 
 ## 对齐原则
 
-模镜接下来以 `C:\Users\21547\Downloads\xpert-main\xpert-main` 为主要参考源，采用“原生移植 + 参考改写”的策略对齐 Xpert 的能力边界。项目继续保留现有 React、FastAPI、Pydantic、pytest 架构，不迁移 Xpert 的 Nx、NestJS、Angular 主框架，也不整文件复制上游源码。
+模镜接下来以 `C:\Users\21547\Downloads\xpert-main\xpert-main` 和真实 Xpert 前端界面作为主要参考源，采用“领域模型对齐 + 原生实现改写”的策略推进。项目继续保留现有 React、FastAPI、Pydantic、pytest 架构，不迁移 Xpert 的 Nx、NestJS、Angular 主框架，也不整文件复制上游源码。
 
-EvoAgentX 只保留为历史参考：此前元智能体曾借鉴其 `goal -> sub_tasks -> inferred edges` 的规划形态，但后续不再以 EvoAgentX 作为近期功能规划来源。未对齐的 EvoAgentX 能力会在 Xpert 架构主线稳定后再评估是否补齐。
+EvoAgentX 只保留为历史参考：此前元智能体曾借鉴其 `goal -> sub_tasks -> inferred edges` 的规划形态，但后续近期功能规划不再以 EvoAgentX 为来源。未对齐的 EvoAgentX 能力会在 Xpert 架构主线稳定后再评估。
 
-## 长期能力目标
+## 对齐主线
 
-| 能力域 | Xpert 对齐目标 | 当前状态 | 下一步 |
-| --- | --- | --- | --- |
-| Runtime / Execution | 中间件生命周期、任务注册、事件记录、运行观测 | 部分实现 | 建立 Handoff / RunRegistry 闭环 |
-| Agent / Handoff | AgentTask、任务移交、子 Agent、主管-专家协作 | 部分实现 | 将 workflow_agent 输出与 Handoff 编排连接 |
-| Workflow | Xpert 节点类型、Agent 节点、工具节点、知识流水线节点 | 部分实现 | 扩展 subflow、知识类节点与 Agent trace |
-| Toolset / MCP | 统一 Toolset Provider、权限、审计、偏好 | 部分实现 | 扩展 Chat 工具偏好、观测与安全边界 |
-| Knowledge Pipeline | FileAsset、Artifact、Chunk、CitationAnchor、Embedding | 待实现 | 从本地 RAG 元数据模型开始拆分 |
-| Claw / Skill | 用户偏好、工作区 Skill、会话临时选择 | 待实现 | 在 Xpert workspace / skill 抽象稳定后接入 |
-| Environment / Sandbox | 工作区文件、受限执行、浏览器/终端能力 | 待实现 | 先做受限文件 API 和 workspace volume |
-| Observability | trace、checkpoint、usage、事件查询面板 | 部分实现 | 运行观测从工具事件扩展到 Agent/Handoff |
+长期主线按产品骨架排序，而不是按单个节点或单个 API 随机扩展：
 
-## 当前已落地能力
+1. 工作空间资源：统一呈现智能体、知识库、MCP 工具集、API 工具、Skill、提示词、环境、运行记录。
+2. Xpert Studio 画布：对齐智能体画布、节点库、右侧配置面板、预览/发布/运行入口。
+3. Agent / Handoff / RunRegistry：建立任务、移交、运行记录、checkpoint、人工处理与未来调度的稳定底座。
+4. Toolset / MCP / Plugin / Skill：统一工具来源、工具权限、工具审计、插件市场和技能库。
+5. Knowledge Pipeline：把现有 RAG 逐步拆成 FileAsset、Artifact、Chunk、CitationAnchor、流水线草稿与执行观测。
+6. Environment / Sandbox / Memory / Observability：补齐环境变量、受限执行、文件工作区、记忆写入、日志与监测面板。
 
-- Runtime Middleware：已具备 `before_agent`、`before_model`、`wrap_model_call`、`after_model`、`after_agent`、`wrap_tool_call` 生命周期。
-- Chat Runtime：`/api/chat` 已接入默认 runtime pipeline，支持 system prompt 注入和模型调用事件记录；显式设置 `tool_mode=mcp_tools` 时可进入 Runtime Toolset 工具循环，并登记 `chat` run、checkpoint、tool events 与审计摘要。默认仍保持普通聊天路径。
-- Toolset / MCP：`mcp_tool` 已通过 `MCPToolsetProvider`、`CapabilityRegistry`、`run_tool_with_runtime` 调用工具。
-- Tool Policy / Audit：`tool_policy` 可影响 workflow 内 MCP 工具调用，`InMemoryToolAuditStore` 提供最小审计记录。
-- Runtime Middleware Node：前端可拖入 `runtime_middleware` 节点，`system_prompt_injector`、`tool_policy`、`event_recorder`、`tool_audit` 已逐步进入真实执行或可见状态。
-- Workflow Agent Node：classic workflow 可拖入 `workflow_agent` 节点，使用 `rolePrompt` 作为该节点 system prompt、`taskInput` 作为用户输入调用模型，结果写入 `outputVariable`，并登记 `workflow_agent` 子 run；启用 `toolMode=mcp_tools` 时可通过 Runtime Toolset 调用 MCP 工具。
-- Agent Task Runtime：已提供 `AgentTaskStore`、最小 AgentTask API、MetaAgent 任务工作台，以及 classic workflow `agent_task` 节点；该节点当前负责创建任务并输出 `task_id`，暂不做真实多 Agent 调度。
-- Handoff API：已提供 handoff 创建、按任务查询、接受、拒绝、完成的内存态 API，状态转移限定为 `pending -> accepted/rejected`、`accepted -> completed`，并写入 `agent.handoff.created/accepted/rejected/completed` runtime events。
-- Handoff Router Node：classic workflow 可拖入 `handoff_router` 节点，读取上游变量作为 AgentTask input，创建 AgentTask 后立即创建 pending Handoff，并登记 `agent_task` / `agent_handoff` 子 run 与 checkpoint；当前仍由 Handoff Inbox 人工处理，不做自动调度。
-- 运行观测：classic workflow 可查询 per-task runtime events 和 tool audit records，前端 `WorkflowRun` 已提供“运行观测”折叠区。
+## 能力矩阵
 
-## 近期交付顺序
+| 能力域 | 当前状态 | 已完成 | 当前边界 | 下一步 |
+| --- | --- | --- | --- | --- |
+| 工作空间资源 | 部分实现 | `/studio` 已作为 Xpert 式资源总览，聚合智能体、工作流、知识库、MCP、Skill、提示词、环境、运行记录 | 当前是只读聚合视图，不做 workspace 权限、持久化资源表或资源创建编排 | `XPERT-WORKSPACE-HUB-02` |
+| Xpert Studio 画布 | 部分实现 | classic `/workflow`、节点库浮层、配置/运行 tabs、前端节点 registry、Xpert 分类节点菜单、多个 Xpert 对齐节点 | 仍是 classic workflow 画布，不是完整 Xpert Studio；节点 registry 先放前端本地 | `XPERT-STUDIO-PANEL-01` |
+| Runtime Middleware | 部分实现 | middleware lifecycle、`event_recorder`、`system_prompt_injector`、`tool_policy`、`tool_audit` | 仍以内存态为主，部分 middleware 仅最小执行 | 继续挂到 Agent/Workflow 节点运行链 |
+| Agent Task | 部分实现 | AgentTask API、MetaAgent 任务工作台、workflow `agent_task` 节点 | 不做真实多 Agent 调度或持久化队列 | 与 Handoff/RunRegistry 继续闭环 |
+| Handoff | 部分实现 | Handoff API、workflow `agent_handoff`、`handoff_router`、MetaAgent Inbox 手动处理 | pending/accepted/completed 仍是人工内存态流程 | 后续做队列、死信、目标 Agent 执行 |
+| RunRegistry / Trace | 部分实现 | workflow/chat/agent_task/agent_handoff run，checkpoint，运行观测 | 内存态，可观测索引，不是调度器 | 增强 UI 汇总、失败摘要、重试入口 |
+| Workflow Agent | 部分实现 | `workflow_agent` 节点，模型执行，Runtime Toolset 工具模式 | 轻量 JSON 决策，不是 function calling，不自动 handoff | 对齐 Xpert Agent 配置侧栏 |
+| Chat Toolset | 部分实现 | `/api/chat` 可选 MCP 工具模式，chat run 与 checkpoint | 默认关闭，不改变普通聊天；无自动 handoff | 补工具偏好、安全提示和观测 UI |
+| Toolset / MCP | 部分实现 | `MCPToolsetProvider`、`run_tool_with_runtime`、tool policy/audit、MCP 管理基础 | 缺 Xpert 式 Toolset 资源模型与 MCP Runtime 运维页闭环 | `XPERT-RUNTIME-OPS-01` |
+| Plugin / Skill | 部分实现 | `/skills` 与 Skill 安装基础，Docker 已补 git/npm/npx 依赖 | 尚未形成 Xpert 插件市场/Skill 工作区统一模型 | 先建资源总览，再补市场与安装状态 |
+| Knowledge Pipeline | 部分实现 | RAG pipeline 只读元数据 API，`knowledge_citation` 工作流节点 | 不改上传、切分、向量库和聊天 RAG 主路径 | `XPERT-KNOWLEDGE-PIPELINE-02` |
+| Prompt / Slash Command | 下一步 | 仅有提示词资源页雏形和聊天 prompt 使用 | 尚无 Xpert 式工作区提示词/命令配置 | 放在工作空间资源后推进 |
+| Environment / Sandbox | 暂缓 | Docker/MCP/Skill 运行依赖逐步补齐 | 尚无 Xpert 环境变量、沙箱实例、文件工作区语义 | 等 Workspace Hub 和 Runtime Ops 稳定后推进 |
+| Memory / Logs / Monitor | 暂缓 | RunRegistry events/checkpoints/audit 摘要 | 尚无完整记忆写入、日志和监测页面 | 等 Agent 配置侧栏与运行观测稳定后推进 |
 
-1. **RunRegistry Trace 增强**：补齐 workflow_agent / handoff 的 trace、checkpoint、失败摘要与重试入口。
-2. **Handoff 自动编排雏形**：将 workflow_agent 输出与 handoff queue 连接，但仍保持人工可控。
-3. **Chat Agent Toolset 安全增强**：补齐聊天工具偏好、工具 schema 提示和更细粒度安全提示。
-4. **知识流水线底座**：拆分本地 RAG 的文件元数据，建立 FileAsset -> Artifact -> Chunk -> CitationAnchor 的最小模型。
+## 已实现基线
 
-## 2026-07-07 增量：RunRegistry Trace / Checkpoint
+- `/api/chat` 默认保持普通 SSE 聊天；显式启用 `tool_mode=mcp_tools` 时进入 Runtime Toolset 工具循环，登记 chat run、checkpoint、tool events 与审计摘要。
+- Classic workflow 已支持 `workflow_agent`、`agent_task`、`agent_handoff`、`handoff_router`、`knowledge_citation`、`mcp_tool`、`runtime_middleware` 等 Xpert 对齐节点。
+- `/workflow` 节点库已从平铺数组收敛为前端 `workflowNodeRegistry`，按工作流、中间件、知识流水线 tab 和逻辑、转换、工具、记忆、其他等 Xpert 分类渲染；拖拽协议和运行语义不变。
+- `MCPToolsetProvider`、`CapabilityRegistry`、`run_tool_with_runtime` 已成为 MCP 工具调用主路径。
+- `ToolPermissionPolicy` 与 `InMemoryToolAuditStore` 已对 workflow/chat 工具调用提供最小权限与审计。
+- AgentTask/Handoff API 已支持创建、查询、accept、reject、complete；MetaAgent 页面可查看任务和 Handoff Inbox。
+- RunRegistry 已支持 workflow、workflow_agent、agent_task、agent_handoff、chat 等 run 类型，并提供 checkpoint 查询。
+- 本地 RAG 之上已有 Knowledge Pipeline 只读元数据视图：FileAsset、Artifact、KnowledgeChunk、CitationAnchor。
+- `/studio` 已成为 Xpert 对齐工作空间入口，前端以软降级方式读取现有 RAG、MCP、Skill 与 RunRegistry API，展示资源卡片、分类筛选、搜索和最近运行摘要。
 
-RunRegistry 现在提供内存态 checkpoint：每条 `RuntimeRun` 可记录 `event_type`、标题、摘要、severity、metadata 与创建时间。Workflow 运行、`workflow_agent` 模型/工具步骤、`agent_task` 创建、`agent_handoff` 创建与手动状态变更都会写入 checkpoint。新增 API `GET /api/runtime/runs/{run_id}/checkpoints`，前端 `WorkflowRun` 的“运行观测”会展示当前 run 与子 run 的 checkpoint 摘要。
+## Xpert UI 证据摘要
 
-边界：checkpoint 只保存摘要和元信息，不保存完整 prompt、模型输出、工具结果、API key 或用户隐私内容；当前仍是内存态可观测索引，不做持久化、自动重试、队列调度或 checkpoint resume。
+详见 `docs/XPERT_UI_REFERENCE.md`。本轮截图与源码侦察确认 Xpert 的产品骨架主要包括：
 
-## 源码与协议策略
+- Xpert Studio：左侧工作区导航、中心画布、右侧节点配置、顶部预览/发布/功能入口。
+- 节点库菜单：工作流、中间件、知识流水线、工具集分别有清晰分类。
+- 智能体配置侧栏：参数、中间件、知识库、工具、失败重试、备用模型、异常处理、输出结构、记忆写入。
+- 工作空间资源：数字专家、内置工具、MCP 工具集、API 工具、知识库、数据库、Skill、提示词、环境。
+- 运维与市场：MCP Runtime 运维、插件市场、技能市场、提示词工作流、环境变量面板。
 
-- Xpert：仅参考协议、领域模型、运行时分层和测试思路；默认参考改写，不整文件复制。
-- EvoAgentX：保留历史归因说明，不继续扩展其 runtime、optimizer、RAG、MCP toolkit 或 dependency graph。
-- 第三方协议：任何复制片段前必须确认许可证兼容，并在文档中记录来源；默认不复制源码。
+## 分阶段路线
+
+### 阶段 1：资源与导航归拢
+
+目标：先让用户能从一个 Xpert 式工作空间入口理解系统中有哪些资源，而不是继续在分散页面之间跳转。
+
+- `XPERT-WORKSPACE-HUB-01`：已完成第一版工作空间资源总览，聚合智能体、知识库、MCP、Skill、提示词、环境、Run 入口。
+- 当前边界：只读聚合、软降级、不破坏现有入口；暂不引入 workspace 权限、资源创建编排或后端聚合 API。
+
+### 阶段 2：画布节点体系收敛
+
+目标：把 classic workflow 节点从散落的静态列表收敛为 Xpert 分类节点注册表。
+
+- `XPERT-WORKFLOW-PALETTE-01`：已完成第一版前端节点 registry，按逻辑、转换、工具、记忆、其他、中间件、知识流水线分类渲染节点库。
+- 当前边界：registry 先放前端本地；未实现的数据库、注释、知识流水线 stage 只显示禁用占位，不生成节点；拖拽 payload、validate、runner 和 SSE 协议保持不变。
+
+### 阶段 3：智能体配置面板对齐
+
+目标：把当前节点配置表单升级为 Xpert 式智能体配置侧栏，但不一次性实现全部高级语义。
+
+- `XPERT-STUDIO-PANEL-01`：补齐参数、中间件、知识库、工具、失败重试、备用模型、异常处理、输出结构、记忆写入等 UI 分区。
+- 验收重点：先做可见与配置存储，执行语义按后续小步接入。
+
+### 阶段 4：知识流水线从只读到草稿
+
+目标：从当前 RAG 元数据视图推进到可视化知识流水线草稿。
+
+- `XPERT-KNOWLEDGE-PIPELINE-02`：引入数据源、处理器、分块器、图像理解四类 stage 的草稿 schema 与 UI。
+- 验收重点：不迁移向量库，不改变 `/api/rag/query`，只新增可观测草稿层。
+
+### 阶段 5：运行与工具运维收口
+
+目标：补齐 Xpert 的运行、插件、工具、环境和观测管理体验。
+
+- `XPERT-RUNTIME-OPS-01`：MCP Runtime 运维页、插件/Skill 市场、环境变量与运行观测统一入口。
+- 验收重点：只显示元信息，不暴露密钥；MCP/Skill 安装主路径不回归。
+
+## 近期 5 步工程顺序
+
+1. `XPERT-STUDIO-PANEL-01`：智能体配置侧栏对齐，补齐参数、中间件、知识库、工具、重试、输出结构、记忆等分区。
+2. `XPERT-KNOWLEDGE-PIPELINE-02`：从只读 Citation/Artifact 视图推进到可视化知识流水线草稿。
+3. `XPERT-RUNTIME-OPS-01`：MCP Runtime 运维、插件/Skill 市场、环境与运行观测统一收口。
+4. `XPERT-WORKSPACE-HUB-02`：在工作空间 Hub 上接入资源创建入口、标签过滤和更完整的运行摘要。
+5. `XPERT-WORKFLOW-REGISTRY-API-01`：评估是否把前端节点 registry 升级为后端统一 registry API，避免未来前后端元数据漂移。
 
 ## 验收护栏
 
 每个后续对齐任务至少包含：
 
-- 后端语法检查：`python -m py_compile server/main.py server/xpert_runtime/*.py`
-- 相关 pytest：按模块新增 `server/tests/test_xpert_runtime_*.py` 或 workflow 节点测试。
+- 后端语法检查：`python -m py_compile server/main.py server/xpert_runtime/*.py server/workflow_native/*.py`
+- 相关 pytest：按模块新增或更新 `server/tests/test_xpert_runtime_*.py`、workflow 节点测试或 RAG 测试。
 - 前端构建：涉及前端时运行 `cd client && npm.cmd run build`。
-- Docker smoke：影响主路径时运行 `docker compose -p modelmirror up -d --build --force-recreate` 和 `/api/health`。
-- 文档更新：同步更新本文件或相关模块文档，说明状态、边界和下一步。
+- Docker smoke：影响主路径时运行 `docker compose -p modelmirror up -d --build --force-recreate` 与 `/api/health`。
+- 文档更新：同步更新本总纲或相关模块文档，说明状态、边界和下一步。
+- 安全检查：不得提交 `.env`、真实 API key、完整工具输出、完整 prompt、embedding、本地绝对文件路径或密钥。
 
-## 2026-07-08 增量：Knowledge Pipeline 元数据视图
+## 开源与参考边界
 
-Knowledge Pipeline 已从“待实现”进入“部分实现”。当前在本地 RAG 之上新增只读元数据层，将既有知识库、文档与 chunk 映射为 `FileAsset -> Artifact -> KnowledgeChunk -> CitationAnchor`：
-
-- `GET /api/rag/pipeline/assets?kb_id=` 返回上传文件视图，不暴露本地绝对路径。
-- `GET /api/rag/pipeline/artifacts?kb_id=` 返回可检索文档产物与 chunk 计数。
-- `GET /api/rag/pipeline/artifacts/{artifact_id}/chunks` 返回 chunk 摘要、长度和稳定 ID，不返回 embedding。
-- `POST /api/rag/pipeline/citations` 复用现有检索路径返回 citation anchors。
-- `/rag` 新增“知识流水线 Beta”折叠区，可查看当前知识库的 assets / artifacts / chunks 摘要。
-
-边界：本轮不迁移 Chroma/LocalJsonVectorStore，不改变上传、切分、embedding、检索、RAG 问答或聊天协议；该层只是 Xpert Knowledge Pipeline 的本地可观测 schema 底座。
+- Xpert：只参考领域模型、交互结构、文案分类、运行时分层和测试思路；默认参考改写，不复制源码。
+- EvoAgentX：只保留历史归因说明，不继续扩展其 runtime、optimizer、RAG、MCP toolkit 或 dependency graph。
+- 第三方仓库：可用于确认公开能力边界和术语，但不得直接搬运实现；如必须引用片段，先确认许可证兼容并在文档记录来源。

--- a/docs/XPERT_UI_REFERENCE.md
+++ b/docs/XPERT_UI_REFERENCE.md
@@ -1,0 +1,186 @@
+# Xpert UI 参考记录
+
+最后更新日期：2026-07-08
+维护人：模镜团队
+
+## 目的
+
+本文记录 2026-07-08 对真实 Xpert 前端界面与本地 `xpert-main` 源码的观察结果，用于指导 ModelMirror 后续对齐。本文只记录概念、字段、交互和源码参考位置，不复制 Xpert 源码实现。
+
+## 参考来源
+
+- 本地源码：`C:\Users\21547\Downloads\xpert-main\xpert-main`
+- 本地真实界面：`http://localhost:8088/xpert/w/2b9d44a2-b95e-44e2-8a76-97e0d9bb86be`
+- 用户提供的 2026-07-08 Xpert 前端截图
+- 主要源码参考点：
+  - `apps/cloud/src/assets/i18n/zh-Hans.json`
+  - `apps/cloud/src/app/features/xpert`
+  - `apps/cloud/src/app/features/xpert/studio`
+  - `apps/cloud/src/app/features/xpert/knowledge`
+  - `apps/cloud/src/app/features/operations/mcp-runtimes.component.*`
+  - `apps/cloud/src/app/features/setting/plugins`
+  - `packages/plugin-sdk/src/lib/workflow`
+  - `packages/plugin-sdk/src/lib/toolset`
+  - `packages/server-ai/src/xpert-toolset`
+  - `packages/server-ai/src/xpert-workspace`
+
+## 产品骨架
+
+Xpert 的核心不是单个工作流节点，而是一套工作空间级产品骨架：
+
+1. 工作空间资源首页：统一展示数字专家、内置工具、MCP 工具集、API 工具、知识库、数据库、Skill、提示词、环境。
+2. Xpert Studio：左侧资源/设置导航，中间画布，右侧节点配置，顶部预览、环境、功能、发布入口。
+3. 节点库：通过浮层菜单添加智能体、外部专家、知识库、工具集、中间件、工作流、知识流水线。
+4. Runtime 运维：MCP Runtime 运维页展示实例统计、筛选器、空态和刷新入口。
+5. 市场与资产：插件市场、技能市场、智能体广场、提示词工作流、环境变量面板。
+
+## 画布与节点库
+
+### 顶层菜单
+
+截图中的画布左下菜单包含：
+
+- 新建智能体
+- 添加外部专家
+- 添加知识库
+- 添加工具集
+- 添加中间件
+- 添加工作流
+- 添加知识流水线
+- 删除
+- 粘贴到这里
+
+ModelMirror 对齐策略：先在 classic `/workflow` 中完成节点注册表和分类菜单，不一次性复制完整 Xpert Studio。
+
+### 工作流节点分类
+
+Xpert “添加工作流”菜单按以下分类组织：
+
+| 分类 | 节点 |
+| --- | --- |
+| 逻辑 | 触发器、路由、迭代、子流程、列表操作、变量聚合、变量赋值 |
+| 转换 | 问题分类器、知识检索、代码执行、模板、JSON 序列化、JSON 反序列化、回答 |
+| 工具 | HTTP、工具调用、智能体工作流、任务移交 |
+| 记忆 | 数据库 |
+| 其他 | 注释 |
+
+ModelMirror 已有对应基础：`input`、`condition`、`iteration`、`list_operation`、`variable_aggregator`、`variable_assign`、`question_classifier`、`knowledge_retrieval`、`code`、`template_transform`、`mcp_tool`、`workflow_agent`、`agent_task`、`agent_handoff`、`handoff_router`、`knowledge_citation`、`output`。
+
+`XPERT-WORKFLOW-PALETTE-01` 已完成第一版本地映射：ModelMirror 在前端建立 `workflowNodeRegistry`，并让 `/workflow` 节点库以“工作流 / 中间件 / 知识流水线”三个 tab 呈现。工作流 tab 内按 Xpert 的逻辑、转换、工具、记忆、其他分类渲染；中间件 tab 继续读取 `/api/runtime/middleware-nodes`；知识流水线 tab 先暴露可运行的 `knowledge_citation`，并以禁用占位呈现数据源、处理器、分块器、图像理解等后续 stage。
+
+当前映射边界：
+
+- 普通工作流节点仍使用原有 `application/modelmirror-node = kind` 拖拽协议。
+- runtime middleware 仍使用现有 JSON payload，不改变 `WorkflowEditor` 解析逻辑。
+- 数据库、注释、JSON 序列化/反序列化、知识流水线 stage 等 Xpert 节点暂不创建真实节点，只显示“待接入”占位，避免用户拖入无法运行的节点。
+- registry 先放在前端本地，后续如节点元数据继续扩张，再评估后端统一 registry API。
+
+## 中间件菜单
+
+截图中的“添加中间件”菜单包括：
+
+- Xpert 编写中间件
+- 知识库写入器
+- 技能中间件
+- 技能创建中间件
+- 沙箱服务
+- 沙箱命令行工具
+- Xpert 文件记忆
+- 浏览器自动化
+- 客户端工具中间件
+- 上下文压缩中间件
+- 人机协同中间件
+- Office 自动化
+- Ralph 循环
+- 定时任务
+- 插件 Hooks
+- Data X 指标管理
+- 待办事项中间件
+- LLM 工具选择器
+- 客户端副作用中间件
+- 沙箱文件工具
+- 结构化输出事件中间件
+
+ModelMirror 已有最小底座：`system_prompt_injector`、`event_recorder`、`tool_policy`、`tool_audit`、`mcp_tools`。后续不要直接追逐完整列表，应先补齐中间件 registry、配置表单、运行链路和观测。
+
+## 知识流水线菜单
+
+截图中的“添加知识流水线”菜单按 stage 分类：
+
+| 分类 | 示例 |
+| --- | --- |
+| 数据源 | 默认、PDF 图文、文本 |
+| 处理器 | 处理器类节点 |
+| 分块器 | 递归字符、Markdown 递归、父子关系 |
+| 图像理解 | 视觉语言模型 |
+
+ModelMirror 当前只完成只读 Knowledge Pipeline 元数据视图和 `knowledge_citation` 节点。后续 `XPERT-KNOWLEDGE-PIPELINE-02` 应先做 stage 草稿 schema 与 UI，不迁移向量库和 embedding 策略。
+
+## 工具集菜单与市场
+
+截图中的工具集菜单有 Provider、内置、MCP、API 四个页签，示例包括对话 BI、对话数据库、指标管理、语义模型管理、规划、Tavily、SearchApi、电子邮件、Bing、钉钉、Slack、Discord、Serper。
+
+ModelMirror 已有 MCP Server、ToolRegistry、MCPToolsetProvider、Skill 页面和部分安装能力。后续应把这些入口收口为 Xpert 式 Toolset 资源模型，再补 MCP Runtime 运维和插件市场。
+
+## 智能体配置侧栏
+
+截图中的右侧配置侧栏包含：
+
+- 节点基础信息：标题、描述、模型、提示词。
+- 节点开关：禁用输出、文件理解、并行工具调用。
+- 参数：名称、可选、操作。
+- 中间件：已添加中间件列表。
+- 知识库：召回设置与知识库列表。
+- 工具：工具卡片列表。
+- 运行策略：失败时重试、备用模型、异常处理。
+- 输出结构：content/string 等结构化输出。
+- 记忆写入：将结果写入记忆或文件工作区。
+- 消息历史、附件和文件变量。
+
+ModelMirror 当前的 `NodeConfig` 仍偏节点表单。后续 `XPERT-STUDIO-PANEL-01` 应先做 UI 分区和配置存储，不急于实现所有执行语义。
+
+## 运维与资源页面
+
+截图中已确认的 Xpert 资源/运维页：
+
+- MCP Runtime 运维：总实例数、活跃、失败、已关闭、筛选器、空态。
+- 插件市场：已安装、探索插件市场、标签/来源筛选、插件卡片。
+- 技能页：已安装技能、文件树、文件内容、上传/仓库注册。
+- 提示词页：工作流列表、创建表单、标签、模板。
+- 数据库页：表列表、状态、版本、激活时间、消息。
+- 环境页：环境列表与变量表。
+
+ModelMirror 后续应先做 `XPERT-WORKSPACE-HUB-01`，再分步补 Runtime Ops，而不是直接散改每个页面。
+
+## ModelMirror `/studio` 第一版映射
+
+`/studio` 已作为 Xpert 工作空间资源首页的第一版本地映射。它不复制 Xpert 页面实现，只对齐资源组织方式：
+
+- 数字专家：链接 `/agents` 与 `/agents/meta-agent`，展示本地智能体数量和样例。
+- 工作流：链接 classic `/workflow`，提示当前承载 workflow agent、AgentTask、Handoff、Toolset 与 RunRegistry。
+- 知识库：读取 `/api/rag/knowledge_bases`、`/api/rag/pipeline/assets`、`/api/rag/pipeline/artifacts`，展示知识库、FileAsset、Artifact 摘要。
+- MCP 工具集：读取 `/api/mcp/sessions` 与 `/api/registry/tools`，展示运行会话与全局工具注册表数量。
+- Skill：读取 `/api/skills/installed`，并结合本地 Skill 市场候选数据展示安装状态。
+- 提示词、环境：当前为规划中入口，分别指向 `/prompts` 与 `/settings`。
+- 运行记录：读取 `/api/runtime/runs?limit=8`，展示 workflow/chat/agent/handoff 等最近 run 摘要。
+
+该页采用独立资源加载和软降级策略：任一资源 API 失败时，只在对应卡片显示“暂不可用”，不影响工作空间首页和其他入口。
+
+## 对齐风险
+
+- 风险：继续按单个节点补功能，会导致 UI、运行器、文档和资源模型继续发散。  
+  缓解：下一步先做工作空间资源总览，再做节点注册表。
+
+- 风险：直接复制 Xpert Angular/NestJS 代码会带来许可证、架构和技术债。  
+  缓解：只参考领域模型、交互结构和文案分类，ModelMirror 内用 React/FastAPI 原生实现。
+
+- 风险：Knowledge Pipeline、Toolset、Plugin、Skill 同时推进会互相污染边界。  
+  缓解：按资源总览、节点 registry、配置侧栏、知识流水线、Runtime Ops 的顺序推进。
+
+## 下一步建议
+
+1. `XPERT-WORKFLOW-PALETTE-01`：建立工作流节点 registry 与 Xpert 分类菜单。
+2. `XPERT-STUDIO-PANEL-01`：对齐智能体配置侧栏结构。
+3. `XPERT-KNOWLEDGE-PIPELINE-02`：把知识流水线从只读元数据推进到可视化草稿。
+4. `XPERT-RUNTIME-OPS-01`：补齐 MCP Runtime 运维、插件/Skill 市场与环境观测。
+5. `XPERT-WORKSPACE-HUB-02`：继续增强 `/studio` 的资源创建、标签过滤和运行观测摘要。

--- a/docs/workflow-native-design.md
+++ b/docs/workflow-native-design.md
@@ -1,5 +1,50 @@
 # workflow-native 自研工作流设计
 
+> 2026-07-08 路线重整：classic `/workflow` 后续节点规划改为按 Xpert 真实菜单分类推进。下一步不再盲目追加单点节点，而是先做节点注册表、调色板分类和右侧配置面板对齐；已有执行语义保持不变。
+> 2026-07-08 工作空间入口：`/studio` 已纳入 Xpert 式工作空间资源 Hub，统一展示工作流、知识库、MCP、Skill、提示词、环境与 RunRegistry 摘要。Classic `/workflow` 仍是画布主入口，后续节点与配置面板对齐会从该 Hub 进入。
+
+## Xpert 工作流节点规划
+
+真实 Xpert 画布把节点入口分成工作流、中间件、知识流水线、工具集等菜单。ModelMirror 后续仍基于现有 React/FastAPI classic workflow 迭代，但节点规划按 Xpert 分类收敛。
+
+### 工作流节点分类
+
+| Xpert 分类 | Xpert 菜单示例 | ModelMirror 已有/对应节点 | 下一步 |
+| --- | --- | --- | --- |
+| 逻辑 | 触发器、路由、迭代、子流程、列表操作、变量聚合、变量赋值 | `input`、`condition`、`iteration`、`list_operation`、`variable_aggregator`、`variable_assign` | 用节点 registry 统一分类与元数据 |
+| 转换 | 问题分类器、知识检索、代码执行、模板、JSON 序列化、JSON 反序列化、回答 | `question_classifier`、`knowledge_retrieval`、`knowledge_citation`、`code`、`template_transform`、`output` | 补 JSON 序列化/反序列化节点前先统一 registry |
+| 工具 | HTTP、工具调用、智能体工作流、任务移交 | `http_request`、`mcp_tool`、`workflow_agent`、`agent_task`、`agent_handoff`、`handoff_router` | 继续收敛到 Runtime Toolset 与 RunRegistry |
+| 记忆 | 数据库 | 暂无完整数据库/记忆节点，仅有 RunRegistry 与 RAG 元数据 | 等工作空间资源与记忆模型稳定后推进 |
+| 其他 | 注释 | 暂无 | 作为 UI-only 节点，低优先级 |
+
+### 中间件分类
+
+当前已注册/实现的最小中间件包括 `system_prompt_injector`、`event_recorder`、`tool_policy`、`tool_audit`、`mcp_tools`。Xpert 真实菜单还包含文件记忆、浏览器自动化、上下文压缩、人机协同、插件 Hooks、结构化输出事件等。后续不直接追完整列表，先保证 middleware registry、配置表单、运行链路和观测一致。
+
+### 知识流水线分类
+
+Xpert 知识流水线菜单按数据源、处理器、分块器、图像理解组织。ModelMirror 当前只有 RAG pipeline 只读元数据和 `knowledge_citation` 节点；下一阶段先做可视化草稿层，不迁移向量库、不改变 `/api/rag/query`、不改上传/切分/embedding 主路径。
+
+### 对齐顺序
+
+1. `XPERT-WORKFLOW-PALETTE-01`：节点注册表与 Xpert 分类菜单。
+2. `XPERT-STUDIO-PANEL-01`：右侧配置面板按参数、中间件、知识库、工具、重试、输出结构、记忆等分区。
+3. `XPERT-KNOWLEDGE-PIPELINE-02`：知识流水线草稿 schema 与 stage UI。
+4. `XPERT-RUNTIME-OPS-01`：MCP Runtime、工具集、插件/Skill、环境和运行观测入口。
+5. `XPERT-WORKSPACE-HUB-02`：在 `/studio` 上继续补资源创建、标签过滤和运行摘要。
+
+### 2026-07-08 增量：Xpert 分类节点库
+
+`/workflow` 节点库已从平铺静态数组迁移为前端 `workflowNodeRegistry` 分类渲染。节点库仍位于画布顶部附近的浮层中，不恢复为常驻左栏；右侧仍使用 `配置 / 运行` tabs，避免节点库、配置和运行结果纵向堆叠。
+
+当前节点库分为三个 tab：
+
+- `工作流`：按逻辑、转换、工具、记忆、其他分组展示现有可运行节点。
+- `中间件`：继续从 `GET /api/runtime/middleware-nodes` 拉取 runtime middleware metadata，并保持现有 JSON 拖拽 payload。
+- `知识流水线`：先暴露可运行的 `knowledge_citation` 节点，并用禁用占位展示数据源、处理器、分块器、图像理解等后续 stage。
+
+本轮不新增后端节点类型，不修改 `NativeNodeKind`、validate、classic runner、SSE 协议或 React Flow 拖拽协议。数据库、注释、JSON 序列化/反序列化和知识流水线 stage 仅显示“待接入”占位，不会生成无法运行的画布节点。
+
 > 2026-07-08 状态补充：Chat Toolset 运行观测进入最小闭环。`tool_mode=mcp_tools` 的聊天请求会登记 `chat` run，响应 header 返回 `X-ModelMirror-Runtime-Run-Id` / `X-ModelMirror-Runtime-Task-Id`；前端聊天页展示 run 状态、checkpoint、tool events 与 audit 摘要。普通聊天仍不创建 chat run，SSE wire format 不变。
 > 2026-07-08 状态补充：`/api/chat` 已接入默认关闭的 Runtime Toolset 工具模式。前端聊天页可显式开启 MCP 工具循环，后端复用 `run_tool_with_runtime`、`tool_policy` 与 `tool_audit`，并继续使用现有 OpenAI SSE delta 结构输出最终答案。当前不是 OpenAI function calling，不自动创建 Handoff，也不改变 workflow、RAG、Skill 或 MCP 连接主路径。
 > 2026-07-07 状态补充：RunRegistry Trace / Checkpoint 进入最小闭环。Workflow run、`workflow_agent`、`agent_task`、`agent_handoff` 会写入内存态 checkpoint；前端“运行观测”会读取 `GET /api/runtime/runs/{run_id}/checkpoints` 展示当前 run 与子 run 的时间线摘要。当前不做持久化、自动重试、队列调度或 checkpoint resume。


### PR DESCRIPTION
## Summary
- 将 /studio 升级为 Xpert 式工作空间资源 Hub，聚合智能体、工作流、知识库、MCP、Skill、提示词、环境与 RunRegistry 入口
- 将 /workflow 节点库从平铺列表升级为 Xpert 分类菜单，新增前端 workflowNodeRegistry
- 更新 Xpert 对齐总纲、UI 参考文档和 workflow-native 设计文档

## Validation
- cd client && npm.cmd run build ✅
- py_compile server/main.py + server/xpert_runtime/*.py + server/workflow_native/*.py + server/rag/*.py + server/skills/*.py ✅
- Docker rebuild: docker compose -p modelmirror up -d --build --force-recreate ✅
- curl http://localhost:8000/api/health ✅
- curl -I http://localhost:5173/workflow ✅
- container pytest server/tests/test_workflow_native_validate.py -q: 59 passed ✅
- container pytest server/tests/test_xpert_runtime_run_registry.py -q: 10 passed ✅
- container full pytest server/tests/ -q --basetemp /tmp/modelmirror-workflow-palette-pytest: 163 passed ✅

## Notes
- 本轮不改后端节点协议、validate、runner 或 SSE 协议
- 普通节点拖拽仍传 kind，runtime middleware 仍传现有 JSON payload
- 未暂存无关文件：package.json、package-lock.json、模镜.apk、server/tests/test_rag_integration.py
