### PR TITLE
chore: 清理根目录临时构建产物

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,8 @@ server/workflow_sandboxes/
 .tmp-*/
 .tmp-*
 artifacts/
+
+# Root-level local packaging artifacts
+/package.json
+/package-lock.json
+/*.apk


### PR DESCRIPTION
## 改动摘要

- 忽略仓库根目录误生成的 package.json 和 package-lock.json
- 忽略仓库根目录 Android APK 构建产物
- 规则仅作用于根目录，不影响 client/package.json 与 client/package-lock.json

## 恢复审计结论

旧工作区中的 Knowledge Pipeline 草稿/预检、Runtime Ops 环境观测和模型目录更新均已进入 main，未重复提交旧版本；纯换行变化、临时 npm 文件和 APK 均未纳入提交。

## 验证

- git diff --cached --check
- git check-ignore -v --no-index package.json package-lock.json 模镜.apk

## 回退方案

回滚本提交即可恢复原忽略行为。