### PR TITLE
feature: 完成 Xpert MCP Toolset 运行闭环

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ server/skills/tmp/
 server/xperts/storage/
 server/xpert_runtime/storage/
 server/datax/storage/
+server/toolsets/storage/
 server/mcp/installed/
 server/workflow_sandboxes/
 server/office_host/certs/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -391,13 +391,18 @@ Office 自动化是高风险客户端副作用路径。修改 `server/xpert_runt
 
 ## 22. Workflow 资源绑定与 EvoAgentX 复用规则
 
-- `external_xpert`、`knowledge_base` 与未来 `toolset_resource` 必须通过专用 binding handle 连接 `workflow_agent`；资源边不得进入控制流拓扑、变量传播或节点调度。
+- `external_xpert`、`knowledge_base` 与 `toolset_resource` 必须通过专用 binding handle 连接 `workflow_agent`；资源边不得进入控制流拓扑、变量传播或节点调度。
 - 同一资源节点只能绑定一个 Agent，且不得混用控制流边。新增资源类型必须同步更新 schema、validate、topological order、runner、registry、前端 handle 和专门测试。
 - 外部 Xpert 草稿可跟随当前发布版，但 Xpert 发布时必须解析为具体不可变版本；运行时禁止自身调用、协作循环和超过 4 层嵌套。
 - 外部 Xpert 必须复用 classic runner，不得通过本服务 HTTP 回环；调用继续经过 Tool Policy、HITL、Audit、middleware 和 RunRegistry 父子链。
 - 知识资源只能访问显式绑定的知识库和活动索引；无活动版本时安全返回空结果，不得回退到其他知识库。审批写入仍走 Knowledge Inbox。
 - 公开 Xpert App 必须拒绝 `external_xpert`；知识资源继续受 `allow_knowledge_read` 与 Tool Policy 双门禁。
 - 修改资源节点至少运行 `test_workflow_resource_nodes.py`、workflow validate、Xpert publish、Knowledge Toolset、App preflight 和前端生产构建。
+- MCP Toolset 草稿与发布版本必须分离。Xpert 发布时 `latest` 必须解析为具体 Toolset 版本；新发现工具、草稿别名和 Schema 变化不得静默扩展已发布 Xpert。
+- Stdio Toolset 只接受 argv，工作目录必须位于 MCP sandbox；远程 Toolset 默认阻断私网、回环、元数据和 URL credentials，旧 SSE 仅作兼容。
+- Toolset Header、环境变量和 Provider key 只能引用加密 Credential ID。普通 API、版本 JSON、日志、audit 和 checkpoint 不得返回明文；主密钥错误时必须 fail-closed。
+- 管理侧工具测试也必须经过参数 Schema、Tool Policy 和 Audit。固定版本遇到工具消失或必填参数不兼容漂移时必须拒绝调用。
+- 修改 Toolset Runtime 至少运行 `test_toolset_store.py`、`test_toolset_service.py`、`test_toolset_api.py`、`test_workflow_toolset_resource.py`、MCP/Toolset/Workflow/Xpert/App 回归和前端生产构建。
 - EvoAgentX 只允许选择性移植已锁定 commit 且许可证审计通过的 MIT 文件；必须保留版权和 NOTICE，并在 `docs/EVOAGENTX_ALIGNMENT.md` 记录来源。
 - EvoAgentX optimizer 或 planner 只能产生候选 Xpert 草稿与评估报告，不得静默发布、覆盖人工草稿或修改不可变线上版本。
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -27,6 +27,7 @@ import AutomationsPage from "./pages/AutomationsPage";
 import DataXHomePage from "./pages/DataXHomePage";
 import DataXProjectPage from "./pages/DataXProjectPage";
 import DataXInboxPage from "./pages/DataXInboxPage";
+import ToolsetsPage from "./pages/ToolsetsPage";
 
 export default function App() {
   return (
@@ -50,6 +51,7 @@ export default function App() {
       <Route element={<MatrixOasisPage />} path="/matrix-oasis" />
       <Route element={<ExpertTeamPage />} path="/expert-team" />
       <Route element={<McpBrowserPage />} path="/mcps" />
+      <Route element={<ToolsetsPage />} path="/toolsets" />
       <Route element={<SkillBrowserPage />} path="/skills" />
       <Route element={<RuntimeOpsPage />} path="/runtime" />
       <Route element={<ComingSoonPage resource="prompts" />} path="/prompts" />

--- a/client/src/components/workflow/WorkflowEditor.tsx
+++ b/client/src/components/workflow/WorkflowEditor.tsx
@@ -364,6 +364,17 @@ function createNodeData(
     };
   }
 
+  if (kind === "toolset_resource") {
+    return {
+      kind,
+      title: "MCP Toolset",
+      description: "将已发布的 MCP Toolset 版本绑定到当前智能体。",
+      toolsetId: "",
+      versionPolicy: "current_published",
+      pinnedVersion: "",
+    };
+  }
+
   if (kind === "agent_task") {
     return {
       kind,
@@ -1371,7 +1382,11 @@ function AgentStudioPanel({
                   type="button"
                 >
                   <span className="flex h-7 w-7 items-center justify-center rounded-md bg-cyan-300/15 text-[10px] font-semibold text-cyan-100">
-                    {resource.data.kind === "external_xpert" ? "XP" : "KB"}
+                    {resource.data.kind === "external_xpert"
+                      ? "XP"
+                      : resource.data.kind === "knowledge_base"
+                        ? "KB"
+                        : "TS"}
                   </span>
                   <span className="min-w-0 flex-1">
                     <span className="block truncate text-xs font-semibold text-cyan-50">
@@ -1380,7 +1395,9 @@ function AgentStudioPanel({
                     <span className="block truncate text-[11px] text-cyan-200/70">
                       {resource.data.kind === "external_xpert"
                         ? String(resource.data.toolName || "external_xpert")
-                        : String(resource.data.knowledgeBaseId || "未选择知识库")}
+                        : resource.data.kind === "knowledge_base"
+                          ? String(resource.data.knowledgeBaseId || "未选择知识库")
+                          : String(resource.data.toolsetId || "未选择 Toolset")}
                     </span>
                   </span>
                 </button>
@@ -1388,7 +1405,7 @@ function AgentStudioPanel({
             </div>
           ) : (
             <p className="rounded-lg border border-dashed border-white/15 bg-white/[0.035] px-3 py-3 text-xs leading-5 text-slate-400">
-              从节点库拖入外部 Xpert 或知识库，再用专用端口绑定到当前智能体。
+              从节点库拖入外部 Xpert、知识库或 Toolset，再用专用端口绑定到当前智能体。
             </p>
           )}
         </ConfigSection>
@@ -1406,6 +1423,7 @@ interface WorkflowResourceOption {
   published_version?: number | null;
   active_version_id?: string | null;
   document_count?: number;
+  tool_count?: number;
 }
 
 function ResourceNodeConfig({
@@ -1418,7 +1436,11 @@ function ResourceNodeConfig({
   const [options, setOptions] = useState<WorkflowResourceOption[]>([]);
   const [loadError, setLoadError] = useState("");
   const resourceKind =
-    data.kind === "external_xpert" ? "external_xpert" : "knowledge_base";
+    data.kind === "external_xpert"
+      ? "external_xpert"
+      : data.kind === "toolset_resource"
+        ? "toolset"
+        : "knowledge_base";
 
   useEffect(() => {
     let cancelled = false;
@@ -1533,6 +1555,97 @@ function ResourceNodeConfig({
             />
           </Field>
         ) : null}
+        {loadError ? (
+          <p className="text-xs leading-5 text-amber-200">{loadError}</p>
+        ) : null}
+      </ConfigSection>
+    );
+  }
+
+  if (data.kind === "toolset_resource") {
+    return (
+      <ConfigSection
+        description="草稿可跟随当前发布版本；发布 Xpert 时会解析并固定不可变 Toolset 版本。"
+        title="MCP Toolset"
+      >
+        <Field label="已发布 Toolset">
+          <select
+            className={textInputClass()}
+            onChange={(event) => {
+              const selected = options.find(
+                (item) => item.id === event.target.value,
+              );
+              update({
+                toolsetId: event.target.value,
+                description: selected?.description || data.description,
+                pinnedVersion:
+                  data.versionPolicy === "pinned"
+                    ? String(selected?.published_version ?? "")
+                    : data.pinnedVersion,
+              });
+            }}
+            value={data.toolsetId ?? ""}
+          >
+            <option className="bg-slate-950" value="">
+              选择 Toolset
+            </option>
+            {options.map((item) => (
+              <option
+                className="bg-slate-950"
+                disabled={item.status !== "published"}
+                key={item.id}
+                value={item.id}
+              >
+                {item.name} · {item.status} · v{item.published_version ?? "-"} ·{" "}
+                {item.tool_count ?? 0} tools
+              </option>
+            ))}
+          </select>
+        </Field>
+        <Field label="版本策略">
+          <select
+            className={textInputClass()}
+            onChange={(event) =>
+              update({
+                versionPolicy: event.target.value,
+                pinnedVersion:
+                  event.target.value === "pinned"
+                    ? String(
+                        options.find((item) => item.id === data.toolsetId)
+                          ?.published_version ?? "",
+                      )
+                    : "",
+              })
+            }
+            value={data.versionPolicy ?? "current_published"}
+          >
+            <option className="bg-slate-950" value="current_published">
+              草稿跟随当前发布版本
+            </option>
+            <option className="bg-slate-950" value="pinned">
+              草稿固定版本
+            </option>
+          </select>
+        </Field>
+        {data.versionPolicy === "pinned" ? (
+          <Field label="固定版本">
+            <input
+              className={textInputClass()}
+              min={1}
+              onChange={(event) =>
+                update({ pinnedVersion: event.target.value })
+              }
+              type="number"
+              value={data.pinnedVersion ?? ""}
+            />
+          </Field>
+        ) : null}
+        <a
+          className="inline-flex text-xs font-semibold text-cyan-200 hover:text-cyan-100"
+          href="/toolsets"
+        >
+          打开 Toolset 管理页
+        </a>
         {loadError ? (
           <p className="text-xs leading-5 text-amber-200">{loadError}</p>
         ) : null}
@@ -1734,13 +1847,16 @@ function NodeConfig({
           .filter(
             (edge) =>
               edge.target === node.id &&
-              ["expert", "knowledge"].includes(edge.targetHandle ?? ""),
+              ["expert", "knowledge", "toolset"].includes(
+                edge.targetHandle ?? "",
+              ),
           )
           .map((edge) => nodes.find((candidate) => candidate.id === edge.source))
           .filter(
             (candidate): candidate is WorkflowNode =>
               candidate?.data.kind === "external_xpert" ||
-              candidate?.data.kind === "knowledge_base",
+              candidate?.data.kind === "knowledge_base" ||
+              candidate?.data.kind === "toolset_resource",
           )
       : [];
   const updateRuntimeMiddlewareConfig = (fieldName: string, value: unknown) =>
@@ -2280,7 +2396,9 @@ function NodeConfig({
         </>
       ) : null}
 
-      {data.kind === "external_xpert" || data.kind === "knowledge_base" ? (
+      {data.kind === "external_xpert" ||
+      data.kind === "knowledge_base" ||
+      data.kind === "toolset_resource" ? (
         <ResourceNodeConfig data={data} update={update} />
       ) : null}
 
@@ -2949,7 +3067,8 @@ function WorkflowCanvas({
       const middlewareBinding = connection.targetHandle === "middleware";
       const resourceBinding =
         connection.targetHandle === "expert" ||
-        connection.targetHandle === "knowledge";
+        connection.targetHandle === "knowledge" ||
+        connection.targetHandle === "toolset";
       if (resourceBinding) {
         const expected =
           connection.targetHandle === "expert"
@@ -2958,11 +3077,17 @@ function WorkflowCanvas({
                 sourceHandle: "expert-binding",
                 color: "#93c5fd",
               }
-            : {
+            : connection.targetHandle === "knowledge"
+              ? {
                 sourceKind: "knowledge_base",
                 sourceHandle: "knowledge-binding",
                 color: "#5eead4",
-              };
+                }
+              : {
+                  sourceKind: "toolset_resource",
+                  sourceHandle: "toolset-binding",
+                  color: "#fcd34d",
+                };
         if (
           connection.sourceHandle !== expected.sourceHandle ||
           sourceNode?.data.kind !== expected.sourceKind ||
@@ -3007,11 +3132,12 @@ function WorkflowCanvas({
         return;
       }
       if (
-        ["expert-binding", "knowledge-binding"].includes(
+        ["expert-binding", "knowledge-binding", "toolset-binding"].includes(
           connection.sourceHandle ?? "",
         ) ||
         sourceNode?.data.kind === "external_xpert" ||
-        sourceNode?.data.kind === "knowledge_base"
+        sourceNode?.data.kind === "knowledge_base" ||
+        sourceNode?.data.kind === "toolset_resource"
       ) {
         setSaveNotice("资源节点只能通过专用端口绑定到 workflow_agent。");
         return;

--- a/client/src/components/workflow/WorkflowNodeCard.tsx
+++ b/client/src/components/workflow/WorkflowNodeCard.tsx
@@ -121,6 +121,13 @@ const nodeMeta = {
     bg: "bg-teal-300/10",
     text: "text-teal-100",
   },
+  toolset_resource: {
+    icon: "TS",
+    label: "Toolset 资源",
+    border: "border-amber-300/40",
+    bg: "bg-amber-300/10",
+    text: "text-amber-100",
+  },
   agent_task: {
     icon: "▣",
     label: "Agent Task",
@@ -242,6 +249,13 @@ function outputName(data: WorkflowNode["data"]) {
   if (data.kind === "knowledge_base") {
     return `${data.knowledgeBaseId || "选择知识库"} · top ${data.topK ?? "5"}`;
   }
+  if (data.kind === "toolset_resource") {
+    const version =
+      data.versionPolicy === "pinned"
+        ? `v${data.pinnedVersion ?? "?"}`
+        : "current";
+    return `${data.toolsetId || "选择 Toolset"} -> ${version}`;
+  }
   if (data.kind === "agent_task") {
     return `${data.assignedAgent ?? "workflow-planner"} → ${data.outputVariable ?? "agent_task_id"}`;
   }
@@ -291,14 +305,14 @@ export default function WorkflowNodeCard({ data, selected }: NodeProps<WorkflowN
           <Handle
             className="!h-3 !w-3 !border-2 !border-surface-900 !bg-slate-200"
             position={Position.Left}
-            style={{ top: "38%" }}
+            style={{ top: "24%" }}
             type="target"
           />
           <Handle
             className="!h-3 !w-3 !border-2 !border-surface-900 !bg-indigo-300"
             id="middleware"
             position={Position.Left}
-            style={{ top: "72%" }}
+            style={{ top: "88%" }}
             title="绑定 Agent 中间件"
             type="target"
           />
@@ -306,7 +320,7 @@ export default function WorkflowNodeCard({ data, selected }: NodeProps<WorkflowN
             className="!h-3 !w-3 !border-2 !border-surface-900 !bg-blue-300"
             id="expert"
             position={Position.Left}
-            style={{ top: "52%" }}
+            style={{ top: "40%" }}
             title="绑定外部 Xpert"
             type="target"
           />
@@ -314,15 +328,25 @@ export default function WorkflowNodeCard({ data, selected }: NodeProps<WorkflowN
             className="!h-3 !w-3 !border-2 !border-surface-900 !bg-teal-300"
             id="knowledge"
             position={Position.Left}
-            style={{ top: "88%" }}
+            style={{ top: "56%" }}
             title="绑定知识库"
             type="target"
           />
-          <div className="pointer-events-none absolute -left-14 top-[66%] text-[10px] font-semibold text-indigo-200">
-            middleware
-          </div>
+          <Handle
+            className="!h-3 !w-3 !border-2 !border-surface-900 !bg-amber-300"
+            id="toolset"
+            position={Position.Left}
+            style={{ top: "72%" }}
+            title="绑定 Toolset"
+            type="target"
+          />
         </>
-      ) : !["input", "external_xpert", "knowledge_base"].includes(data.kind) ? (
+      ) : ![
+          "input",
+          "external_xpert",
+          "knowledge_base",
+          "toolset_resource",
+        ].includes(data.kind) ? (
         <Handle
           className="!h-3 !w-3 !border-2 !border-surface-900 !bg-slate-200"
           position={Position.Left}
@@ -413,6 +437,14 @@ export default function WorkflowNodeCard({ data, selected }: NodeProps<WorkflowN
           id="knowledge-binding"
           position={Position.Right}
           title="绑定到 workflow_agent 的 knowledge 入口"
+          type="source"
+        />
+      ) : data.kind === "toolset_resource" ? (
+        <Handle
+          className="!h-3 !w-3 !border-2 !border-surface-900 !bg-amber-300"
+          id="toolset-binding"
+          position={Position.Right}
+          title="绑定到 workflow_agent 的 toolset 入口"
           type="source"
         />
       ) : data.kind !== "output" ? (

--- a/client/src/components/workflow/workflowNodeRegistry.ts
+++ b/client/src/components/workflow/workflowNodeRegistry.ts
@@ -211,6 +211,13 @@ export const workflowPaletteSections: WorkflowPaletteSection[] = [
         description: "将知识库的检索、原文和引用能力绑定到工作流智能体。",
         tags: ["knowledge", "rag", "resource", "binding"],
       },
+      {
+        kind: "toolset_resource",
+        icon: "TS",
+        title: "MCP Toolset",
+        description: "将已发布的固定版本 MCP Toolset 绑定到工作流智能体。",
+        tags: ["mcp", "toolset", "resource", "binding"],
+      },
     ],
   },
   {

--- a/client/src/pages/StudioHomePage.tsx
+++ b/client/src/pages/StudioHomePage.tsx
@@ -648,7 +648,7 @@ export default function StudioHomePage() {
             ],
         loading: mcpSessions.loading || registryTools.loading,
         metricLabel: "已注册工具",
-        primaryAction: { href: "/mcps", label: "连接 MCP" },
+        primaryAction: { href: "/toolsets", label: "管理 Toolset" },
         secondaryAction: { href: "/runtime", label: "查看运维" },
         status: "部分实现",
         tags: ["runnable", "creatable", "observable", "xpert"],

--- a/client/src/pages/ToolsetsPage.tsx
+++ b/client/src/pages/ToolsetsPage.tsx
@@ -1,0 +1,1274 @@
+import { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import PageContainer from "../components/PageContainer";
+
+type Transport = "stdio" | "streamable_http" | "legacy_sse";
+type CredentialKind = "header" | "environment" | "provider_key" | "generic";
+
+interface CredentialSummary {
+  credential_id: string;
+  name: string;
+  kind: CredentialKind;
+  prefix: string;
+  masked_value: string;
+  status: string;
+}
+
+interface SecretBinding {
+  name: string;
+  credential_id: string;
+}
+
+interface ConnectionProfile {
+  transport: Transport;
+  command: string[];
+  url: string;
+  headers: SecretBinding[];
+  environment: SecretBinding[];
+  installed_project_id: string;
+  working_directory: string;
+  auto_start: boolean;
+  auto_reconnect: boolean;
+  reconnect_attempts: number;
+  tool_prefix: string;
+  network_policy: "public_only" | "trusted_private";
+  timeout_seconds: number;
+}
+
+interface ToolDefinition {
+  original_name: string;
+  alias: string;
+  description: string;
+  input_schema: Record<string, unknown>;
+  default_arguments: Record<string, unknown>;
+  enabled: boolean;
+  order: number;
+  schema_hash: string;
+}
+
+interface ToolsetVersion {
+  version: number;
+  draft_revision: number;
+  schema_hash: string;
+  release_notes: string;
+  published_at: number;
+  tools: ToolDefinition[];
+}
+
+interface ToolsetDefinition {
+  id: string;
+  name: string;
+  description: string;
+  tags: string[];
+  privacy_policy: string;
+  disclaimer: string;
+  status: "draft" | "published" | "archived";
+  revision: number;
+  published_version: number | null;
+  connection: ConnectionProfile;
+  tools: ToolDefinition[];
+  versions: ToolsetVersion[];
+  runtime_status: string;
+  runtime_session_id: string | null;
+  runtime_error: string;
+  updated_at: number;
+}
+
+interface InstalledMCPProject {
+  project_id: string;
+  server_command?: string[];
+  install_type?: string;
+  npm_package?: string;
+}
+
+const emptyConnection: ConnectionProfile = {
+  transport: "stdio",
+  command: [],
+  url: "",
+  headers: [],
+  environment: [],
+  installed_project_id: "",
+  working_directory: "",
+  auto_start: false,
+  auto_reconnect: true,
+  reconnect_attempts: 2,
+  tool_prefix: "",
+  network_policy: "public_only",
+  timeout_seconds: 30,
+};
+
+const inputClass =
+  "w-full rounded-md border border-white/10 bg-ink-950 px-3 py-2 text-sm text-white outline-none transition focus:border-cyan-300 disabled:cursor-not-allowed disabled:opacity-50";
+const secondaryButton =
+  "rounded-md border border-white/10 px-3 py-2 text-sm font-semibold text-slate-200 transition hover:bg-white/5 disabled:cursor-not-allowed disabled:opacity-45";
+const primaryButton =
+  "rounded-md bg-cyan-300 px-3 py-2 text-sm font-semibold text-slate-950 transition hover:bg-cyan-200 disabled:cursor-not-allowed disabled:opacity-45";
+
+async function requestJson<T>(url: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(url, init);
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    const detail = (payload as { detail?: unknown }).detail;
+    throw new Error(typeof detail === "string" ? detail : `请求失败：${response.status}`);
+  }
+  return payload as T;
+}
+
+function parseJsonObject(value: string, label: string): Record<string, unknown> {
+  const parsed = JSON.parse(value || "{}") as unknown;
+  if (!parsed || Array.isArray(parsed) || typeof parsed !== "object") {
+    throw new Error(`${label}必须是 JSON 对象。`);
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function formatTime(value: number): string {
+  return new Date(value * 1000).toLocaleString("zh-CN");
+}
+
+function StatusDot({ status }: { status: string }) {
+  const color =
+    status === "connected" || status === "published"
+      ? "bg-emerald-300"
+      : status === "error"
+        ? "bg-rose-300"
+        : "bg-slate-500";
+  return <span aria-hidden="true" className={`h-2 w-2 rounded-full ${color}`} />;
+}
+
+function InlineMessage({
+  tone,
+  children,
+  onClose,
+}: {
+  tone: "error" | "success";
+  children: string;
+  onClose: () => void;
+}) {
+  const colors =
+    tone === "error" ? "bg-rose-500/10 text-rose-100" : "bg-emerald-400/10 text-emerald-100";
+  return (
+    <div className={`mt-4 flex items-start justify-between gap-3 rounded-md px-3 py-2 text-sm ${colors}`}>
+      <span>{children}</span>
+      <button className="font-semibold" onClick={onClose} type="button">
+        关闭
+      </button>
+    </div>
+  );
+}
+
+export default function ToolsetsPage() {
+  const [toolsets, setToolsets] = useState<ToolsetDefinition[]>([]);
+  const [credentials, setCredentials] = useState<CredentialSummary[]>([]);
+  const [installedProjects, setInstalledProjects] = useState<InstalledMCPProject[]>([]);
+  const [selectedId, setSelectedId] = useState("");
+  const [draft, setDraft] = useState<ToolsetDefinition | null>(null);
+  const [commandText, setCommandText] = useState("[]");
+  const [newName, setNewName] = useState("");
+  const [newDescription, setNewDescription] = useState("");
+  const [credentialName, setCredentialName] = useState("");
+  const [credentialKind, setCredentialKind] = useState<CredentialKind>("header");
+  const [credentialValue, setCredentialValue] = useState("");
+  const [releaseNotes, setReleaseNotes] = useState("");
+  const [activeTool, setActiveTool] = useState("");
+  const [toolArguments, setToolArguments] = useState("{}");
+  const [toolResult, setToolResult] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState("");
+  const [notice, setNotice] = useState("");
+  const [error, setError] = useState("");
+
+  const selected = useMemo(
+    () => toolsets.find((item) => item.id === selectedId) ?? null,
+    [selectedId, toolsets],
+  );
+  const activeToolDefinition = useMemo(
+    () => draft?.tools.find((tool) => tool.original_name === activeTool) ?? null,
+    [activeTool, draft],
+  );
+  const counts = useMemo(
+    () => ({
+      connected: toolsets.filter((item) => item.runtime_status === "connected").length,
+      published: toolsets.filter((item) => item.status === "published").length,
+      enabledTools: toolsets.reduce(
+        (sum, item) => sum + item.tools.filter((tool) => tool.enabled).length,
+        0,
+      ),
+    }),
+    [toolsets],
+  );
+
+  const loadAll = useCallback(async (preferredId?: string) => {
+    setLoading(true);
+    try {
+      const [toolsetPayload, credentialPayload, installedPayload] = await Promise.all([
+        requestJson<{ toolsets: ToolsetDefinition[] }>("/api/toolsets"),
+        requestJson<{ credentials: CredentialSummary[] }>("/api/runtime/credentials"),
+        requestJson<{ installed: InstalledMCPProject[] }>("/api/mcp/installed"),
+      ]);
+      setToolsets(toolsetPayload.toolsets);
+      setCredentials(credentialPayload.credentials);
+      setInstalledProjects(installedPayload.installed);
+      setSelectedId((current) => {
+        const wanted = preferredId || current;
+        return toolsetPayload.toolsets.some((item) => item.id === wanted)
+          ? wanted
+          : toolsetPayload.toolsets[0]?.id || "";
+      });
+      setError("");
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : "Toolset 加载失败。");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadAll();
+  }, [loadAll]);
+
+  useEffect(() => {
+    if (!selected) {
+      setDraft(null);
+      return;
+    }
+    setDraft(structuredClone(selected));
+    setCommandText(JSON.stringify(selected.connection.command, null, 2));
+    setActiveTool((current) =>
+      selected.tools.some((tool) => tool.original_name === current)
+        ? current
+        : selected.tools[0]?.original_name || "",
+    );
+    setToolResult("");
+  }, [selected]);
+
+  function patchDraft(patch: Partial<ToolsetDefinition>) {
+    setDraft((current) => (current ? { ...current, ...patch } : current));
+  }
+
+  function patchConnection(patch: Partial<ConnectionProfile>) {
+    setDraft((current) =>
+      current ? { ...current, connection: { ...current.connection, ...patch } } : current,
+    );
+  }
+
+  async function createToolset(event: FormEvent) {
+    event.preventDefault();
+    if (!newName.trim()) return;
+    setBusy("create");
+    try {
+      const created = await requestJson<ToolsetDefinition>("/api/toolsets", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: newName.trim(),
+          description: newDescription.trim(),
+          connection: emptyConnection,
+        }),
+      });
+      setNewName("");
+      setNewDescription("");
+      setNotice("Toolset 草稿已创建。");
+      await loadAll(created.id);
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : "创建失败。");
+    } finally {
+      setBusy("");
+    }
+  }
+
+  async function saveDraft(): Promise<ToolsetDefinition | null> {
+    if (!draft) return null;
+    setBusy("save");
+    try {
+      let command: string[] = [];
+      if (draft.connection.transport === "stdio") {
+        const parsed = JSON.parse(commandText) as unknown;
+        if (!Array.isArray(parsed) || !parsed.every((item) => typeof item === "string")) {
+          throw new Error("Stdio 命令必须是字符串数组。");
+        }
+        command = parsed;
+      }
+      const updated = await requestJson<ToolsetDefinition>(`/api/toolsets/${draft.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          revision: draft.revision,
+          patch: {
+            name: draft.name,
+            description: draft.description,
+            tags: draft.tags,
+            privacy_policy: draft.privacy_policy,
+            disclaimer: draft.disclaimer,
+            connection: { ...draft.connection, command },
+          },
+        }),
+      });
+      setNotice("Toolset 草稿已保存。");
+      await loadAll(updated.id);
+      return updated;
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : "保存失败。");
+      return null;
+    } finally {
+      setBusy("");
+    }
+  }
+
+  async function runConnection(action: "connect" | "disconnect") {
+    if (!draft) return;
+    setBusy(action);
+    try {
+      let revision = draft.revision;
+      if (action === "connect") {
+        const saved = await saveDraft();
+        if (!saved) return;
+        revision = saved.revision;
+      }
+      const current = await requestJson<ToolsetDefinition>(
+        `/api/toolsets/${draft.id}/${action}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ revision }),
+        },
+      );
+      setNotice(
+        action === "connect"
+          ? "连接成功，工具 Schema 已刷新。新发现工具默认关闭。"
+          : "连接已断开。",
+      );
+      await loadAll(current.id);
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : "连接操作失败。");
+    } finally {
+      setBusy("");
+    }
+  }
+
+  async function createCredential(event: FormEvent) {
+    event.preventDefault();
+    if (!credentialName.trim() || !credentialValue) return;
+    setBusy("credential");
+    try {
+      await requestJson("/api/runtime/credentials", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: credentialName.trim(),
+          kind: credentialKind,
+          value: credentialValue,
+        }),
+      });
+      setCredentialName("");
+      setCredentialValue("");
+      setNotice("凭据已加密保存，后续只显示掩码。");
+      await loadAll(draft?.id);
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : "凭据保存失败。");
+    } finally {
+      setBusy("");
+    }
+  }
+
+  function updateBinding(
+    field: "headers" | "environment",
+    index: number,
+    patch: Partial<SecretBinding>,
+  ) {
+    if (!draft) return;
+    const next = [...draft.connection[field]];
+    next[index] = { ...next[index], ...patch };
+    patchConnection({ [field]: next });
+  }
+
+  function addBinding(field: "headers" | "environment") {
+    if (!draft) return;
+    patchConnection({
+      [field]: [
+        ...draft.connection[field],
+        {
+          name: "",
+          credential_id:
+            credentials.find((item) => item.status === "active")?.credential_id || "",
+        },
+      ],
+    });
+  }
+
+  function removeBinding(field: "headers" | "environment", index: number) {
+    if (!draft) return;
+    patchConnection({
+      [field]: draft.connection[field].filter((_, position) => position !== index),
+    });
+  }
+
+  async function updateTool(patch: Partial<ToolDefinition>) {
+    if (!draft || !activeToolDefinition) return;
+    setBusy("tool");
+    try {
+      const updated = await requestJson<ToolsetDefinition>(
+        `/api/toolsets/${draft.id}/tools/${encodeURIComponent(activeToolDefinition.original_name)}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ revision: draft.revision, patch }),
+        },
+      );
+      setNotice("工具配置已保存。");
+      await loadAll(updated.id);
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : "工具配置保存失败。");
+    } finally {
+      setBusy("");
+    }
+  }
+
+  async function testTool() {
+    if (!draft || !activeToolDefinition) return;
+    setBusy("test");
+    try {
+      const result = await requestJson<{
+        output: string;
+        is_error: boolean;
+        metadata: Record<string, unknown>;
+      }>(
+        `/api/toolsets/${draft.id}/tools/${encodeURIComponent(activeToolDefinition.original_name)}/test`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            arguments: parseJsonObject(toolArguments, "测试参数"),
+          }),
+        },
+      );
+      setToolResult(result.output || JSON.stringify(result.metadata, null, 2));
+      setNotice(result.is_error ? "工具返回了错误结果。" : "工具测试完成。");
+    } catch (reason) {
+      setToolResult("");
+      setError(reason instanceof Error ? reason.message : "工具测试失败。");
+    } finally {
+      setBusy("");
+    }
+  }
+
+  async function publishToolset() {
+    if (!draft) return;
+    setBusy("publish");
+    try {
+      const version = await requestJson<ToolsetVersion>(`/api/toolsets/${draft.id}/publish`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          revision: draft.revision,
+          release_notes: releaseNotes.trim(),
+        }),
+      });
+      setReleaseNotes("");
+      setNotice(`Toolset v${version.version} 已发布。`);
+      await loadAll(draft.id);
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : "发布失败。");
+    } finally {
+      setBusy("");
+    }
+  }
+
+  return (
+    <PageContainer activeResource="mcps" hideSidebar maxWidthClassName="max-w-[1720px]">
+      <div className="px-1 py-2 sm:px-2">
+        <header className="flex flex-col gap-4 border-b border-white/10 pb-5 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <div className="flex items-center gap-2 text-xs font-semibold text-cyan-200">
+              <span className="h-2 w-2 rounded-full bg-cyan-300" />
+              Runtime Toolset
+            </div>
+            <h1 className="mt-2 text-2xl font-semibold text-white">MCP Toolset 管理</h1>
+            <p className="mt-1 max-w-3xl text-sm leading-6 text-slate-400">
+              配置连接与凭据，发现并测试工具，然后发布不可变版本供 Agent 绑定。
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="rounded-full bg-white/5 px-3 py-1.5 text-xs text-slate-300">
+              {toolsets.length} 个 Toolset
+            </span>
+            <span className="rounded-full bg-emerald-300/10 px-3 py-1.5 text-xs text-emerald-200">
+              {counts.connected} 个已连接
+            </span>
+            <span className="rounded-full bg-cyan-300/10 px-3 py-1.5 text-xs text-cyan-100">
+              {counts.published} 个已发布 · {counts.enabledTools} 个工具
+            </span>
+            <Link className={secondaryButton} to="/mcps">
+              发现 MCP 项目
+            </Link>
+            <button className={secondaryButton} onClick={() => void loadAll()} type="button">
+              刷新
+            </button>
+          </div>
+        </header>
+
+        <nav aria-label="Toolset 类型" className="mt-4 flex gap-1 border-b border-white/10">
+          <button
+            className="border-b-2 border-cyan-300 px-3 py-2 text-sm font-semibold text-cyan-100"
+            type="button"
+          >
+            我的 Toolset
+          </button>
+          <button className="cursor-not-allowed px-3 py-2 text-sm text-slate-500" disabled type="button">
+            内置 Provider（下一轮）
+          </button>
+          <button className="cursor-not-allowed px-3 py-2 text-sm text-slate-500" disabled type="button">
+            API Toolset（下一轮）
+          </button>
+        </nav>
+
+        {error ? <InlineMessage onClose={() => setError("")} tone="error">{error}</InlineMessage> : null}
+        {notice ? <InlineMessage onClose={() => setNotice("")} tone="success">{notice}</InlineMessage> : null}
+
+        <div className="mt-5 grid min-h-[720px] gap-5 xl:grid-cols-[260px_minmax(420px,0.9fr)_minmax(420px,1.1fr)]">
+          <aside className="border-r border-white/10 pr-5">
+            <form className="border-b border-white/10 pb-5" onSubmit={createToolset}>
+              <h2 className="text-sm font-semibold text-white">创建 MCP Toolset</h2>
+              <label className="mt-3 block text-xs font-semibold text-slate-300">
+                名称
+                <input
+                  className={`${inputClass} mt-1`}
+                  maxLength={160}
+                  onChange={(event) => setNewName(event.target.value)}
+                  placeholder="研究工具集"
+                  value={newName}
+                />
+              </label>
+              <label className="mt-3 block text-xs font-semibold text-slate-300">
+                说明
+                <textarea
+                  className={`${inputClass} mt-1 min-h-20 resize-y`}
+                  maxLength={2000}
+                  onChange={(event) => setNewDescription(event.target.value)}
+                  placeholder="工具用途和使用边界"
+                  value={newDescription}
+                />
+              </label>
+              <button
+                className={`${primaryButton} mt-3 w-full`}
+                disabled={busy === "create" || !newName.trim()}
+                type="submit"
+              >
+                {busy === "create" ? "创建中..." : "创建草稿"}
+              </button>
+            </form>
+
+            <div className="pt-4">
+              <div className="mb-2 flex items-center justify-between text-xs text-slate-500">
+                <span>Toolset</span>
+                <span>{toolsets.length}</span>
+              </div>
+              <div className="divide-y divide-white/10 border-y border-white/10">
+                {loading ? <p className="py-5 text-center text-xs text-slate-500">正在加载...</p> : null}
+                {!loading && !toolsets.length ? (
+                  <p className="py-7 text-center text-xs leading-5 text-slate-500">
+                    创建第一个 Toolset 后，在这里连接 MCP 并选择工具。
+                  </p>
+                ) : null}
+                {toolsets.map((item) => (
+                  <button
+                    className={`w-full px-2 py-3 text-left transition ${
+                      item.id === selectedId ? "bg-cyan-300/10" : "hover:bg-white/[0.035]"
+                    }`}
+                    key={item.id}
+                    onClick={() => setSelectedId(item.id)}
+                    type="button"
+                  >
+                    <span className="flex items-center gap-2 text-sm font-semibold text-white">
+                      <StatusDot status={item.runtime_status} />
+                      <span className="truncate">{item.name}</span>
+                    </span>
+                    <span className="mt-1 flex justify-between gap-2 text-[11px] text-slate-500">
+                      <span>{item.connection.transport}</span>
+                      <span>{item.published_version ? `v${item.published_version}` : "未发布"}</span>
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          </aside>
+
+          {!draft ? (
+            <section className="col-span-2 flex min-h-[560px] items-center justify-center border border-dashed border-white/10">
+              <div className="max-w-sm text-center">
+                <h2 className="text-base font-semibold text-white">选择一个 Toolset</h2>
+                <p className="mt-2 text-sm leading-6 text-slate-500">
+                  连接成功后会发现 MCP 工具，启用至少一个工具即可发布版本。
+                </p>
+              </div>
+            </section>
+          ) : (
+            <>
+              <section className="min-w-0 border-r border-white/10 pr-5">
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <h2 className="text-base font-semibold text-white">连接与版本</h2>
+                    <p className="mt-1 flex items-center gap-2 text-xs text-slate-500">
+                      <StatusDot status={draft.runtime_status} />
+                      {draft.runtime_status}
+                      {draft.runtime_error ? ` · ${draft.runtime_error}` : ""}
+                    </p>
+                  </div>
+                  <div className="flex gap-2">
+                    <button
+                      className={secondaryButton}
+                      disabled={busy !== ""}
+                      onClick={() => void runConnection("disconnect")}
+                      type="button"
+                    >
+                      断开
+                    </button>
+                    <button
+                      className={primaryButton}
+                      disabled={busy !== ""}
+                      onClick={() => void runConnection("connect")}
+                      type="button"
+                    >
+                      {busy === "connect" ? "连接中..." : "保存并连接"}
+                    </button>
+                  </div>
+                </div>
+
+                <div className="mt-5 space-y-4">
+                  <label className="block text-xs font-semibold text-slate-300">
+                    名称
+                    <input
+                      className={`${inputClass} mt-1`}
+                      onChange={(event) => patchDraft({ name: event.target.value })}
+                      value={draft.name}
+                    />
+                  </label>
+                  <label className="block text-xs font-semibold text-slate-300">
+                    说明
+                    <textarea
+                      className={`${inputClass} mt-1 min-h-20 resize-y`}
+                      onChange={(event) => patchDraft({ description: event.target.value })}
+                      value={draft.description}
+                    />
+                  </label>
+                  <label className="block text-xs font-semibold text-slate-300">
+                    标签（逗号分隔）
+                    <input
+                      className={`${inputClass} mt-1`}
+                      onChange={(event) =>
+                        patchDraft({
+                          tags: event.target.value
+                            .split(",")
+                            .map((item) => item.trim())
+                            .filter(Boolean),
+                        })
+                      }
+                      value={draft.tags.join(", ")}
+                    />
+                  </label>
+
+                  <fieldset>
+                    <legend className="text-xs font-semibold text-slate-300">传输</legend>
+                    <div className="mt-2 grid grid-cols-3 gap-1 rounded-md bg-white/5 p-1">
+                      {([
+                        ["stdio", "Stdio"],
+                        ["streamable_http", "HTTP"],
+                        ["legacy_sse", "旧 SSE"],
+                      ] as Array<[Transport, string]>).map(([value, label]) => (
+                        <button
+                          className={`rounded px-2 py-2 text-xs font-semibold transition ${
+                            draft.connection.transport === value
+                              ? "bg-cyan-300 text-slate-950"
+                              : "text-slate-400 hover:bg-white/5 hover:text-white"
+                          }`}
+                          key={value}
+                          onClick={() => patchConnection({ transport: value })}
+                          type="button"
+                        >
+                          {label}
+                        </button>
+                      ))}
+                    </div>
+                  </fieldset>
+
+                  {draft.connection.transport === "stdio" ? (
+                    <>
+                      <label className="block text-xs font-semibold text-slate-300">
+                        已安装 MCP 项目（可选）
+                        <select
+                          className={`${inputClass} mt-1`}
+                          onChange={(event) => {
+                            const project = installedProjects.find(
+                              (item) => item.project_id === event.target.value,
+                            );
+                            patchConnection({
+                              installed_project_id: event.target.value,
+                            });
+                            if (project?.server_command?.length) {
+                              setCommandText(
+                                JSON.stringify(project.server_command, null, 2),
+                              );
+                            }
+                          }}
+                          value={draft.connection.installed_project_id}
+                        >
+                          <option className="bg-slate-950" value="">
+                            手动配置启动命令
+                          </option>
+                          {installedProjects.map((project) => (
+                            <option
+                              className="bg-slate-950"
+                              key={project.project_id}
+                              value={project.project_id}
+                            >
+                              {project.project_id}
+                              {project.npm_package ? ` · ${project.npm_package}` : ""}
+                            </option>
+                          ))}
+                        </select>
+                        <span className="mt-1 block font-normal leading-5 text-slate-500">
+                          选择 `/mcps` 已安装项目后，发布版本会固定解析后的 argv。
+                        </span>
+                      </label>
+                      <label className="block text-xs font-semibold text-slate-300">
+                        启动命令（argv JSON）
+                        <textarea
+                          className={`${inputClass} mt-1 min-h-24 resize-y font-mono text-xs`}
+                          onChange={(event) => setCommandText(event.target.value)}
+                          placeholder='["npx", "-y", "@modelcontextprotocol/server-everything"]'
+                          value={commandText}
+                        />
+                      </label>
+                      <label className="block text-xs font-semibold text-slate-300">
+                        MCP Sandbox 子目录（可选）
+                        <input
+                          className={`${inputClass} mt-1`}
+                          onChange={(event) =>
+                            patchConnection({ working_directory: event.target.value })
+                          }
+                          placeholder="project-a"
+                          value={draft.connection.working_directory}
+                        />
+                      </label>
+                    </>
+                  ) : (
+                    <>
+                      <label className="block text-xs font-semibold text-slate-300">
+                        MCP URL
+                        <input
+                          className={`${inputClass} mt-1`}
+                          onChange={(event) => patchConnection({ url: event.target.value })}
+                          placeholder="https://mcp.example.com/mcp"
+                          type="url"
+                          value={draft.connection.url}
+                        />
+                      </label>
+                      <label className="block text-xs font-semibold text-slate-300">
+                        网络策略
+                        <select
+                          className={`${inputClass} mt-1`}
+                          onChange={(event) =>
+                            patchConnection({
+                              network_policy: event.target
+                                .value as ConnectionProfile["network_policy"],
+                            })
+                          }
+                          value={draft.connection.network_policy}
+                        >
+                          <option className="bg-slate-950" value="public_only">
+                            仅公网，阻断私网与本机
+                          </option>
+                          <option className="bg-slate-950" value="trusted_private">
+                            受控私网（可信管理面）
+                          </option>
+                        </select>
+                      </label>
+                    </>
+                  )}
+
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <label className="block text-xs font-semibold text-slate-300">
+                      工具名前缀
+                      <input
+                        className={`${inputClass} mt-1`}
+                        onChange={(event) =>
+                          patchConnection({ tool_prefix: event.target.value })
+                        }
+                        placeholder="research"
+                        value={draft.connection.tool_prefix}
+                      />
+                    </label>
+                    <label className="block text-xs font-semibold text-slate-300">
+                      调用超时（秒）
+                      <input
+                        className={`${inputClass} mt-1`}
+                        max={300}
+                        min={5}
+                        onChange={(event) =>
+                          patchConnection({ timeout_seconds: Number(event.target.value) })
+                        }
+                        type="number"
+                        value={draft.connection.timeout_seconds}
+                      />
+                    </label>
+                  </div>
+
+                  <div className="grid gap-2 sm:grid-cols-2">
+                    <label className="flex items-center gap-2 rounded-md bg-white/[0.035] px-3 py-2 text-xs text-slate-300">
+                      <input
+                        checked={draft.connection.auto_reconnect}
+                        onChange={(event) =>
+                          patchConnection({ auto_reconnect: event.target.checked })
+                        }
+                        type="checkbox"
+                      />
+                      自动重连
+                    </label>
+                    <label className="flex items-center gap-2 rounded-md bg-white/[0.035] px-3 py-2 text-xs text-slate-300">
+                      <input
+                        checked={draft.connection.auto_start}
+                        onChange={(event) =>
+                          patchConnection({ auto_start: event.target.checked })
+                        }
+                        type="checkbox"
+                      />
+                      发布后自动恢复
+                    </label>
+                  </div>
+
+                  <BindingEditor
+                    bindings={draft.connection.headers}
+                    credentials={credentials}
+                    kind="headers"
+                    label="Headers"
+                    onAdd={() => addBinding("headers")}
+                    onRemove={(index) => removeBinding("headers", index)}
+                    onUpdate={(index, patch) => updateBinding("headers", index, patch)}
+                  />
+                  <BindingEditor
+                    bindings={draft.connection.environment}
+                    credentials={credentials}
+                    kind="environment"
+                    label="环境变量"
+                    onAdd={() => addBinding("environment")}
+                    onRemove={(index) => removeBinding("environment", index)}
+                    onUpdate={(index, patch) => updateBinding("environment", index, patch)}
+                  />
+
+                  <details className="border-t border-white/10 pt-4">
+                    <summary className="cursor-pointer text-xs font-semibold text-slate-300">
+                      隐私协议与免责声明
+                    </summary>
+                    <label className="mt-3 block text-xs font-semibold text-slate-300">
+                      隐私协议
+                      <textarea
+                        className={`${inputClass} mt-1 min-h-20 resize-y`}
+                        onChange={(event) =>
+                          patchDraft({ privacy_policy: event.target.value })
+                        }
+                        value={draft.privacy_policy}
+                      />
+                    </label>
+                    <label className="mt-3 block text-xs font-semibold text-slate-300">
+                      免责声明
+                      <textarea
+                        className={`${inputClass} mt-1 min-h-20 resize-y`}
+                        onChange={(event) => patchDraft({ disclaimer: event.target.value })}
+                        value={draft.disclaimer}
+                      />
+                    </label>
+                  </details>
+
+                  <button
+                    className={`${secondaryButton} w-full`}
+                    disabled={busy !== ""}
+                    onClick={() => void saveDraft()}
+                    type="button"
+                  >
+                    {busy === "save" ? "保存中..." : `保存草稿 r${draft.revision}`}
+                  </button>
+                </div>
+
+                <div className="mt-7 border-t border-white/10 pt-5">
+                  <h3 className="text-sm font-semibold text-white">凭据保险箱</h3>
+                  <p className="mt-1 text-xs leading-5 text-slate-500">
+                    Header 与环境变量只引用加密凭据 ID，Toolset 版本不保存明文。
+                  </p>
+                  <form className="mt-3 space-y-2" onSubmit={createCredential}>
+                    <div className="grid gap-2 sm:grid-cols-2">
+                      <input
+                        className={inputClass}
+                        onChange={(event) => setCredentialName(event.target.value)}
+                        placeholder="凭据名称"
+                        value={credentialName}
+                      />
+                      <select
+                        className={inputClass}
+                        onChange={(event) =>
+                          setCredentialKind(event.target.value as CredentialKind)
+                        }
+                        value={credentialKind}
+                      >
+                        <option className="bg-slate-950" value="header">Header</option>
+                        <option className="bg-slate-950" value="environment">环境变量</option>
+                        <option className="bg-slate-950" value="provider_key">Provider Key</option>
+                        <option className="bg-slate-950" value="generic">通用秘密</option>
+                      </select>
+                    </div>
+                    <input
+                      autoComplete="new-password"
+                      className={inputClass}
+                      onChange={(event) => setCredentialValue(event.target.value)}
+                      placeholder="凭据值，仅本次提交"
+                      type="password"
+                      value={credentialValue}
+                    />
+                    <button
+                      className={`${secondaryButton} w-full`}
+                      disabled={
+                        busy === "credential" || !credentialName.trim() || !credentialValue
+                      }
+                      type="submit"
+                    >
+                      加密保存凭据
+                    </button>
+                  </form>
+                  <div className="mt-3 divide-y divide-white/10 border-y border-white/10">
+                    {credentials.map((item) => (
+                      <div
+                        className="flex items-center justify-between gap-3 py-2 text-xs"
+                        key={item.credential_id}
+                      >
+                        <span className="min-w-0">
+                          <span className="block truncate font-semibold text-slate-200">
+                            {item.name}
+                          </span>
+                          <span className="text-slate-500">
+                            {item.kind} · {item.masked_value}
+                          </span>
+                        </span>
+                        <span
+                          className={
+                            item.status === "active" ? "text-emerald-200" : "text-rose-200"
+                          }
+                        >
+                          {item.status}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </section>
+
+              <section className="min-w-0">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                  <div>
+                    <h2 className="text-base font-semibold text-white">工具配置与测试</h2>
+                    <p className="mt-1 text-xs text-slate-500">
+                      {draft.tools.length} 个已发现，{draft.tools.filter((tool) => tool.enabled).length} 个已启用
+                    </p>
+                  </div>
+                  <span className="text-xs text-slate-500">Schema 仅在连接时刷新</span>
+                </div>
+
+                <div className="mt-4 grid gap-4 lg:grid-cols-[210px_minmax(0,1fr)]">
+                  <div className="divide-y divide-white/10 border-y border-white/10">
+                    {!draft.tools.length ? (
+                      <p className="px-2 py-10 text-center text-xs leading-5 text-slate-500">
+                        保存配置并连接 MCP Server 后，工具列表会显示在这里。
+                      </p>
+                    ) : null}
+                    {[...draft.tools]
+                      .sort(
+                        (left, right) =>
+                          left.order - right.order ||
+                          left.original_name.localeCompare(right.original_name),
+                      )
+                      .map((tool) => (
+                        <button
+                          className={`w-full px-2 py-3 text-left transition ${
+                            activeTool === tool.original_name
+                              ? "bg-cyan-300/10"
+                              : "hover:bg-white/[0.035]"
+                          }`}
+                          key={tool.original_name}
+                          onClick={() => {
+                            setActiveTool(tool.original_name);
+                            setToolArguments(
+                              JSON.stringify(tool.default_arguments || {}, null, 2),
+                            );
+                            setToolResult("");
+                          }}
+                          type="button"
+                        >
+                          <span className="flex items-center justify-between gap-2">
+                            <span className="truncate text-xs font-semibold text-white">
+                              {tool.alias || tool.original_name}
+                            </span>
+                            <span
+                              className={`h-2 w-2 rounded-full ${
+                                tool.enabled ? "bg-emerald-300" : "bg-slate-600"
+                              }`}
+                            />
+                          </span>
+                          <span className="mt-1 block truncate font-mono text-[10px] text-slate-500">
+                            {tool.original_name}
+                          </span>
+                        </button>
+                      ))}
+                  </div>
+
+                  {activeToolDefinition ? (
+                    <div className="min-w-0 space-y-4">
+                      <div className="flex items-center justify-between gap-3">
+                        <div className="min-w-0">
+                          <h3 className="truncate text-sm font-semibold text-white">
+                            {activeToolDefinition.alias || activeToolDefinition.original_name}
+                          </h3>
+                          <p className="mt-1 truncate font-mono text-[11px] text-slate-500">
+                            {activeToolDefinition.original_name}
+                          </p>
+                        </div>
+                        <label className="flex items-center gap-2 text-xs font-semibold text-slate-300">
+                          <input
+                            checked={activeToolDefinition.enabled}
+                            disabled={busy !== ""}
+                            onChange={(event) =>
+                              void updateTool({ enabled: event.target.checked })
+                            }
+                            type="checkbox"
+                          />
+                          启用
+                        </label>
+                      </div>
+                      <label className="block text-xs font-semibold text-slate-300">
+                        Agent 别名
+                        <input
+                          className={`${inputClass} mt-1`}
+                          defaultValue={activeToolDefinition.alias}
+                          key={`${activeToolDefinition.original_name}:alias:${draft.revision}`}
+                          onBlur={(event) => {
+                            if (event.target.value !== activeToolDefinition.alias) {
+                              void updateTool({ alias: event.target.value });
+                            }
+                          }}
+                          placeholder={activeToolDefinition.original_name}
+                        />
+                      </label>
+                      <label className="block text-xs font-semibold text-slate-300">
+                        描述覆盖
+                        <textarea
+                          className={`${inputClass} mt-1 min-h-20 resize-y`}
+                          defaultValue={activeToolDefinition.description}
+                          key={`${activeToolDefinition.original_name}:description:${draft.revision}`}
+                          onBlur={(event) => {
+                            if (event.target.value !== activeToolDefinition.description) {
+                              void updateTool({ description: event.target.value });
+                            }
+                          }}
+                        />
+                      </label>
+                      <div>
+                        <p className="text-xs font-semibold text-slate-300">参数 Schema</p>
+                        <pre className="mt-1 max-h-56 overflow-auto rounded-md bg-black/25 p-3 text-[11px] leading-5 text-slate-300">
+                          {JSON.stringify(activeToolDefinition.input_schema, null, 2)}
+                        </pre>
+                      </div>
+                      <label className="block text-xs font-semibold text-slate-300">
+                        默认参数 JSON
+                        <textarea
+                          className={`${inputClass} mt-1 min-h-24 resize-y font-mono text-xs`}
+                          defaultValue={JSON.stringify(
+                            activeToolDefinition.default_arguments || {},
+                            null,
+                            2,
+                          )}
+                          key={`${activeToolDefinition.original_name}:defaults:${draft.revision}`}
+                          onBlur={(event) => {
+                            try {
+                              const value = parseJsonObject(event.target.value, "默认参数");
+                              if (
+                                JSON.stringify(value) !==
+                                JSON.stringify(activeToolDefinition.default_arguments)
+                              ) {
+                                void updateTool({ default_arguments: value });
+                              }
+                            } catch (reason) {
+                              setError(
+                                reason instanceof Error ? reason.message : "默认参数无效。",
+                              );
+                            }
+                          }}
+                        />
+                      </label>
+                      <label className="block text-xs font-semibold text-slate-300">
+                        测试参数 JSON
+                        <textarea
+                          className={`${inputClass} mt-1 min-h-24 resize-y font-mono text-xs`}
+                          onChange={(event) => setToolArguments(event.target.value)}
+                          value={toolArguments}
+                        />
+                      </label>
+                      <button
+                        className={`${primaryButton} w-full`}
+                        disabled={busy !== "" || draft.runtime_status !== "connected"}
+                        onClick={() => void testTool()}
+                        type="button"
+                      >
+                        {busy === "test" ? "测试中..." : "通过 Runtime Policy 测试工具"}
+                      </button>
+                      {toolResult ? (
+                        <div>
+                          <p className="text-xs font-semibold text-slate-300">安全结果摘要</p>
+                          <pre className="mt-1 max-h-44 overflow-auto rounded-md bg-black/25 p-3 text-[11px] leading-5 text-slate-300">
+                            {toolResult}
+                          </pre>
+                        </div>
+                      ) : null}
+                    </div>
+                  ) : (
+                    <div className="flex min-h-72 items-center justify-center border border-dashed border-white/10 px-6 text-center text-xs leading-5 text-slate-500">
+                      选择一个工具以查看 Schema、设置别名和执行测试。
+                    </div>
+                  )}
+                </div>
+
+                <div className="mt-7 border-t border-white/10 pt-5">
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+                    <label className="min-w-0 flex-1 text-xs font-semibold text-slate-300">
+                      发布说明
+                      <input
+                        className={`${inputClass} mt-1`}
+                        onChange={(event) => setReleaseNotes(event.target.value)}
+                        placeholder="本版本启用的工具和用途"
+                        value={releaseNotes}
+                      />
+                    </label>
+                    <button
+                      className={primaryButton}
+                      disabled={
+                        busy !== "" ||
+                        draft.runtime_status !== "connected" ||
+                        !draft.tools.some((tool) => tool.enabled)
+                      }
+                      onClick={() => void publishToolset()}
+                      type="button"
+                    >
+                      {busy === "publish" ? "发布中..." : "发布不可变版本"}
+                    </button>
+                  </div>
+                  <div className="mt-4 divide-y divide-white/10 border-y border-white/10">
+                    {[...draft.versions].reverse().map((version) => (
+                      <div
+                        className="grid gap-2 py-3 text-xs sm:grid-cols-[70px_minmax(0,1fr)_150px]"
+                        key={version.version}
+                      >
+                        <span className="font-semibold text-cyan-100">v{version.version}</span>
+                        <span className="truncate text-slate-300">
+                          {version.release_notes || "无发布说明"} · {version.tools.length} tools
+                        </span>
+                        <time className="text-slate-500">
+                          {formatTime(version.published_at)}
+                        </time>
+                      </div>
+                    ))}
+                    {!draft.versions.length ? (
+                      <p className="py-5 text-center text-xs text-slate-500">
+                        尚未发布版本。
+                      </p>
+                    ) : null}
+                  </div>
+                </div>
+              </section>
+            </>
+          )}
+        </div>
+      </div>
+    </PageContainer>
+  );
+}
+
+function BindingEditor({
+  bindings,
+  credentials,
+  kind,
+  label,
+  onAdd,
+  onRemove,
+  onUpdate,
+}: {
+  bindings: SecretBinding[];
+  credentials: CredentialSummary[];
+  kind: "headers" | "environment";
+  label: string;
+  onAdd: () => void;
+  onRemove: (index: number) => void;
+  onUpdate: (index: number, patch: Partial<SecretBinding>) => void;
+}) {
+  return (
+    <div>
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-xs font-semibold text-slate-300">{label}</p>
+        <button
+          className="text-xs font-semibold text-cyan-200 hover:text-cyan-100"
+          onClick={onAdd}
+          type="button"
+        >
+          添加引用
+        </button>
+      </div>
+      <div className="mt-2 space-y-2">
+        {bindings.map((binding, index) => (
+          <div
+            className="grid grid-cols-[minmax(90px,0.8fr)_minmax(130px,1.2fr)_34px] gap-2"
+            key={`${kind}:${index}`}
+          >
+            <input
+              aria-label={`${label} 名称`}
+              className={inputClass}
+              onChange={(event) => onUpdate(index, { name: event.target.value })}
+              placeholder={kind === "headers" ? "Authorization" : "API_KEY"}
+              value={binding.name}
+            />
+            <select
+              aria-label={`${label} 凭据`}
+              className={inputClass}
+              onChange={(event) =>
+                onUpdate(index, { credential_id: event.target.value })
+              }
+              value={binding.credential_id}
+            >
+              <option className="bg-slate-950" value="">
+                选择加密凭据
+              </option>
+              {credentials
+                .filter((item) => item.status === "active")
+                .map((credential) => (
+                  <option
+                    className="bg-slate-950"
+                    key={credential.credential_id}
+                    value={credential.credential_id}
+                  >
+                    {credential.name} · {credential.masked_value}
+                  </option>
+                ))}
+            </select>
+            <button
+              aria-label={`删除 ${label} 引用`}
+              className="rounded-md border border-white/10 text-slate-400 hover:bg-rose-500/10 hover:text-rose-200"
+              onClick={() => onRemove(index)}
+              type="button"
+            >
+              ×
+            </button>
+          </div>
+        ))}
+        {!bindings.length ? (
+          <p className="rounded-md bg-white/[0.025] px-3 py-2 text-xs text-slate-500">
+            未配置。连接时不会注入任何 {label}。
+          </p>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/client/src/types/workflow.ts
+++ b/client/src/types/workflow.ts
@@ -19,6 +19,7 @@ export type WorkflowNodeKind =
   | "workflow_agent"
   | "external_xpert"
   | "knowledge_base"
+  | "toolset_resource"
   | "agent_task"
   | "agent_handoff"
   | "handoff_router"
@@ -62,6 +63,7 @@ export interface WorkflowNodeData extends Record<string, unknown> {
   schema?: string;
   queryVariable?: string;
   knowledgeBaseId?: string;
+  toolsetId?: string;
   xpertId?: string;
   versionPolicy?: string;
   pinnedVersion?: string;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,6 +119,7 @@ services:
       XPERT_STORAGE_DIR: /app/xperts/storage
       AGENT_TASK_STORAGE_DIR: /app/xpert_runtime/storage
       DATAX_STORAGE_DIR: /app/datax/storage
+      TOOLSET_STORAGE_DIR: /app/toolsets/storage
       HANDOFF_EXECUTOR_ENABLED: "true"
       HANDOFF_EXECUTOR_MAX_CONCURRENCY: "2"
       GOAL_COORDINATOR_ENABLED: "true"
@@ -135,6 +136,7 @@ services:
       - ./server/xperts/storage:/app/xperts/storage
       - ./server/xpert_runtime/storage:/app/xpert_runtime/storage
       - ./server/datax/storage:/app/datax/storage
+      - ./server/toolsets/storage:/app/toolsets/storage
       - sandbox_socket:/run/modelmirror-sandbox
       - sandbox_workspaces:/app/sandbox-workspaces:ro
       - browser_socket:/run/modelmirror-browser

--- a/docs/MCP_INTEGRATION.md
+++ b/docs/MCP_INTEGRATION.md
@@ -5,7 +5,19 @@
 
 ## 1. 概述
 
-MCP（Model Context Protocol）是一套让 AI 应用通过标准协议连接外部工具、资源和上下文的机制。模镜当前实现的是 **stdio MCP Server 原生集成**：后端负责启动 MCP Server 子进程、建立官方 SDK 的 `ClientSession`，前端负责连接、展示工具 schema、渲染动态参数表单并执行工具。
+MCP（Model Context Protocol）是一套让 AI 应用通过标准协议连接外部工具、资源和上下文的机制。模镜保留原 `/mcps` 即时连接入口，并新增 `/toolsets` 的版本化 MCP Runtime。后者支持 **Stdio、Streamable HTTP 与旧 SSE 兼容**：连接后发现工具 Schema，用户显式启停和配置工具，再发布不可变版本供 Workflow、Xpert、Goal 与 Handoff 绑定。
+
+### 1.1 版本化 MCP Toolset
+
+- 草稿包含连接类型、URL 或 argv、凭据引用、重连策略、超时、工具前缀和逐工具配置。
+- Stdio 可以直接填写 argv，也可以选择 `/mcps` 已安装项目；发布时会把解析后的 argv 固定进版本快照。
+- Streamable HTTP 是远程 MCP 的主路径；旧 SSE 仅用于兼容旧服务。
+- Headers 和环境变量只引用 `CredentialStore` ID。创建或轮换时明文只返回一次，定义、版本与普通 API 均不保存或返回明文。
+- 连接后新发现工具默认关闭。别名、描述覆盖、默认参数、顺序和启用状态都属于草稿。
+- 发布至少需要连接成功并启用一个工具。新工具不会自动进入旧版本，远端发生不兼容 Schema 漂移时旧版本调用会 fail-closed。
+- 管理侧测试调用也必须经过参数校验、Tool Policy 和 Audit。
+
+Agent 画布使用 `toolset_resource -> workflow_agent` 的 `toolset` 绑定边。该边不属于控制流，Xpert 发布会把 Toolset 固定到具体版本。旧 `mcp_tool` 和全局 Tool Registry 继续兼容。
 
 架构图：
 
@@ -325,7 +337,10 @@ python server/mcp/test_manager.py
 
 | 文件 | 说明 |
 | --- | --- |
-| `server/mcp/manager.py` | MCPClientManager，负责 stdio session 生命周期。 |
+| `server/mcp/manager.py` | MCPClientManager，负责 Stdio、Streamable HTTP 与旧 SSE session 生命周期。 |
+| `server/toolsets/` | Toolset/凭据 Store、版本发布、Schema 漂移与固定版本 Provider。 |
+| `client/src/pages/ToolsetsPage.tsx` | MCP Toolset 创建、连接、工具配置、测试和发布管理页。 |
+| `server/tests/test_toolset_*.py` | Toolset Store、API、连接、固定版本与安全回归。 |
 | `server/mcp/test_manager.py` | 外部 fetch server smoke 脚本。 |
 | `server/registry/tool_registry.py` | 内存级全局工具注册表。 |
 | `server/tests/mock_mcp_server.py` | 本地 mock MCP Server。 |

--- a/docs/XPERT_ALIGNMENT.md
+++ b/docs/XPERT_ALIGNMENT.md
@@ -1,11 +1,22 @@
 # Xpert 对齐总纲
 
+## 2026-07-23 增量：XPERT-TOOLSET-MCP-02A
+
+Toolset 收尾路线已从“命名白名单打包”修正为完整运行闭环：
+
+1. `XPERT-TOOLSET-MCP-02A`：本轮已实现 MCP Toolset 草稿、加密凭据、Stdio / Streamable HTTP / 旧 SSE 连接、工具发现与 Schema 配置、受策略约束的测试调用、不可变版本发布和 Agent 资源绑定。
+2. `XPERT-TOOLSET-API-02B`：下一轮实现 OpenAPI 3.x 与 OData v4 导入、鉴权和受控 HTTP 执行。
+3. `XPERT-TOOLSET-SEMANTICS-02C`：随后补内置 Provider、工具敏感/终点/记忆语义、并行调用、并发和递归预算。
+4. `XPERT-AGENT-FEATURES-02D`：最后收口开场白、问题建议、标题/摘要、文件与记忆能力和显式音频模型。
+
+`toolset_resource -> workflow_agent` 使用 `targetHandle="toolset"`，不进入控制流、变量传播或节点调度。Xpert 发布会把 `latest` 解析为具体 Toolset 版本；运行时只暴露该快照中启用的工具，Schema 发生不兼容漂移时拒绝调用。公开 App 在工具级公共安全策略完成前继续禁止此资源。
+
 ## 2026-07-22 路线切换：资源节点收尾与 EvoAgentX 主线
 
 Xpert 对齐进入收尾阶段。当前优先补齐真实画布语义，而不是继续扩展企业治理、远程市场或运维目录：
 
 1. `XPERT-RESOURCE-NODES-01`：新增 `external_xpert` 与 `knowledge_base` 资源节点，通过 `expert` / `knowledge` 特殊绑定边向单个 `workflow_agent` 提供同步协作者工具和限定知识工具。绑定边不参与控制流、变量传播或节点调度；外部 Xpert 在发布时固定不可变版本，知识库继续消费活动索引。
-2. `XPERT-TOOLSET-BINDING-02`：把命名 MCP/Runtime 工具组合收口为可绑定 Agent 的稳定 `toolset_resource`，不建设企业 Provider 治理。
+2. `XPERT-TOOLSET-RUNTIME-02`：按 MCP、API、工具语义、Agent Features 四轮补齐完整 Toolset；MCP 02A 已进入真实运行闭环。
 3. `XPERT-PLUGIN-PROMPT-03`：交付可信本地插件清单与版本化 Prompt Profile 的编辑、发布、Agent 绑定和斜杠命令最小闭环，不建设远程市场、计费或组织权限。
 4. `XPERT-ALIGNMENT-FREEZE-04`：形成 Xpert 已实现、延期与冻结清单；GraphRAG、企业权限、多租户、市场治理和剩余 UI 像素对齐暂缓。
 5. `EVOAGENTX-ALIGNMENT-AUDIT-01`：转向 EvoAgentX 元智能体、评估、benchmark、optimizer、自进化和记忆模块审计，并从审计过的 MIT 代码中选择性移植。
@@ -249,7 +260,7 @@ EvoAgentX 曾只作为 `goal -> sub_tasks -> inferred edges` 的历史参考。X
 | RunRegistry / Trace | 部分实现 | workflow/xpert/chat/goal/agent_task/agent_handoff run、checkpoint、workflow/chat/Xpert/Goal 观测与 `/runtime` 运维总览 | 内存态，可观测索引，不是调度器；Goal 重启恢复会创建 recovery run | 为文件、记忆与知识执行提供护栏 |
 | Workflow Agent | 部分实现 | `workflow_agent` 节点、模型执行、Runtime Toolset、文件理解、结构化输出、类型化记忆召回/候选写回、失败重试、备用模型与异常策略 | 轻量 JSON 决策，不是 function calling；并行工具调用仍未接入 | 基于真实任务反馈收敛 Agent 执行契约 |
 | Chat Toolset | 部分实现 | `/api/chat` 可选 MCP 工具模式，chat run 与 checkpoint | 默认关闭，不改变普通聊天；无自动 handoff | 补工具偏好、安全提示和观测 UI |
-| Toolset / MCP | 部分实现 | `MCPToolsetProvider`、`run_tool_with_runtime`、tool policy/audit、MCP 管理基础、`/runtime` MCP Runtime 状态细分与只读运维，`/studio` 已提供 MCP 与 Runtime 入口 | 缺可固定命名工具组合并绑定 Agent 的 Toolset 资源；Runtime Ops 不执行 MCP start/stop | `XPERT-TOOLSET-BINDING-02` |
+| Toolset / MCP | 部分实现 | `/toolsets` 支持 MCP Toolset 草稿、加密凭据、三种传输、发现/启停/别名/默认参数/测试、不可变发布版本和 `toolset_resource` Agent 绑定；固定版本调用继续经过 policy/HITL/audit | API Toolset、内置 Provider、工具级敏感/终点/记忆语义和受限并行调用尚未实现；公开 App 暂禁 Toolset 资源 | `XPERT-TOOLSET-API-02B` |
 | Plugin / Skill | 部分实现 | `/skills`、安装运行时、Workspace Skill 草稿、审批后显式安装、Sandbox staging 与显式 Skill Plugin Hooks | Agent 只能提案；草稿安装不会覆盖既有 Skill；Hook 仅支持离线 manifest，不提供组织权限 | 基于真实 Skill 草稿与 Hook 使用反馈收敛协议 |
 | Knowledge Pipeline | 已实现 | FileAsset/Artifact/Chunk/CitationAnchor、结构感知 Processor、General/QA/Summary、可执行 Graph、逐文档/逐视觉页恢复、图片与扫描 PDF 的 OCR/VLM、版本化 ingestion job、递归与父子分块、向量/FTS5 双索引、混合检索、Rerank、离线评估、Promotion Gate、Knowledge Toolset、审批写入、预览、激活/回滚 | 成熟 RAG 基础闭环完成；仍为本地单进程 worker，旧上传保留 legacy index；评估标签需人工维护；图片向量、版面坐标与 GraphRAG 暂缓 | 真实使用反馈与技术债审计 |
 | Prompt / Slash Command | 下一步 | 仅有提示词资源页雏形和聊天 prompt 使用 | 尚无版本化 Prompt Profile、Agent 绑定和 slash command | `XPERT-PLUGIN-PROMPT-03` 后冻结 Xpert 对齐 |

--- a/docs/XPERT_RUNTIME.md
+++ b/docs/XPERT_RUNTIME.md
@@ -253,3 +253,13 @@ Ralph Loop performs bounded continuation and strict verification before the Agen
 Queries do not accept SQL. `DataXService` compiles a bounded DSL of published indicators, dimensions, parameterized filters, time ranges, ordering, and limits. Draft edits do not affect the immutable published snapshot used by runtime queries. Derived expressions are evaluated from published metric results with a restricted arithmetic AST.
 
 The `datax_indicators` Agent middleware compiles explicit project/model scopes into `datax_tools`. Workflow, Xpert Chat, Goal, Handoff, and Automation share this provider. Agent writes are proposal-only; approval creates a draft and explicit publication remains a separate operation. Public Apps require `allow_datax_read`, an active tool policy, and valid project/model scope, and never receive proposal tools. See `docs/XPERT_DATAX.md`.
+
+## Versioned MCP Toolset Runtime
+
+`ToolsetStore` persists editable MCP Toolset definitions and immutable published versions. A version fixes the transport profile, credential references, enabled tools, aliases, default arguments, JSON Schema hashes, prefix, and release metadata. Xpert publication resolves `latest` to a concrete Toolset version; later discovery or draft edits cannot expand an already published Xpert.
+
+Stdio profiles accept argv only and run inside the MCP sandbox boundary. Streamable HTTP is the preferred remote transport and legacy SSE remains compatibility-only. Remote transports reject URL credentials and, under the default policy, resolve and block loopback, private, link-local, reserved, multicast, Docker-local, and metadata targets. Reconnect attempts and operation timeouts are bounded.
+
+Secrets are referenced by credential ID. The encrypted credential file never stores plaintext; create and rotate responses reveal a value only once, while normal APIs return mask, prefix, kind, and status. Losing or replacing the local master key marks existing credentials unavailable and never falls back to plaintext.
+
+`toolset_resource` is a non-control binding into `workflow_agent`. The runtime exposes only tools enabled in the fixed version. Calls merge versioned default arguments, validate the resulting object against the fixed JSON Schema, then enter the existing permission policy, durable HITL, audit, middleware, and checkpoint path. A missing tool or newly required remote parameter is a hard Schema-drift failure; compatible optional additions produce a warning. Public Xpert Apps reject MCP Toolset resources until the later public tool-policy round.

--- a/docs/workflow-native-design.md
+++ b/docs/workflow-native-design.md
@@ -1,5 +1,7 @@
 # workflow-native 自研工作流设计
 
+> 2026-07-23 MCP Toolset Runtime：`toolset_resource` 已成为真实资源节点，通过 `toolset-binding -> toolset` 绑定单个 `workflow_agent`。节点引用可发布的 MCP Toolset；Xpert 发布时固定具体版本，运行时只暴露版本中启用的工具，并复用 Tool Policy、HITL、Audit 与 checkpoint。绑定边不进入控制流和变量可达性，公开 App 暂时禁止此资源。
+
 > 2026-07-22 Resource Nodes：新增 `external_xpert` 与 `knowledge_base`。资源节点通过 `sourceHandle="expert-binding" -> targetHandle="expert"` 或 `sourceHandle="knowledge-binding" -> targetHandle="knowledge"` 绑定单个 `workflow_agent`，不参与控制流、变量可达性或节点调度。发布 Xpert 时外部专家解析为不可变版本；知识库继续读取活动索引。同步专家调用与异步 Handoff 是两套明确语义。
 
 > 2026-07-19 Office Automation：`office_automation` 可通过 middleware binding 绑定到 `workflow_agent`，复用 `wait_kind=client_tool` 的持久暂停和恢复语义。22 个 Word/Excel/PowerPoint 工具由用户主动绑定的 Office.js Task Pane 执行；绑定边不参与控制流，修改工具必须有 HITL 覆盖，公开 App/API 禁止该中间件。完整契约见 `docs/XPERT_OFFICE_AUTOMATION.md`。
@@ -51,7 +53,7 @@
 | --- | --- | --- |
 | `external_xpert` | `expert-binding -> expert` | 调用发布时固定版本的外部 Xpert；复用 classic runner，不通过 HTTP 回环 |
 | `knowledge_base` | `knowledge-binding -> knowledge` | 向目标 Agent 暴露限定知识库的 `knowledge_search/get/cite`；使用活动 Retrieval Profile |
-| `toolset_resource` | `toolset-binding -> toolset` | 下一轮交付命名 Toolset 资源；当前不生成该节点 |
+| `toolset_resource` | `toolset-binding -> toolset` | 调用发布时固定的 MCP Toolset 版本；工具 Schema、别名、默认参数和白名单来自不可变快照 |
 | `runtime_middleware` | `middleware-binding -> middleware` | 编译目标 Agent 的 middleware pipeline |
 
 共同约束：

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -23,6 +23,7 @@ COPY main.py .
 COPY data ./data
 COPY api ./api
 COPY mcp ./mcp
+COPY toolsets ./toolsets
 COPY registry ./registry
 COPY rag ./rag
 COPY datax ./datax

--- a/server/main.py
+++ b/server/main.py
@@ -173,6 +173,27 @@ except ModuleNotFoundError:
     from registry.tool_registry import ToolRegistry
 
 try:
+    from server.toolsets import (
+        CredentialStore,
+        DraftMCPToolTestProvider,
+        PublishedMCPToolsetProvider,
+        ToolsetService,
+        ToolsetStore,
+        configure_toolsets,
+        toolsets_router,
+    )
+except ModuleNotFoundError:
+    from toolsets import (
+        CredentialStore,
+        DraftMCPToolTestProvider,
+        PublishedMCPToolsetProvider,
+        ToolsetService,
+        ToolsetStore,
+        configure_toolsets,
+        toolsets_router,
+    )
+
+try:
     from server.xpert_runtime import (
         AgentTaskStore,
         AutomationCoordinator,
@@ -566,6 +587,7 @@ app.include_router(runtime_browser_router)
 app.include_router(runtime_client_tool_router)
 app.include_router(runtime_automation_router)
 app.include_router(runtime_authoring_router)
+app.include_router(toolsets_router)
 
 request_windows: dict[str, deque[float]] = defaultdict(deque)
 mcp_connect_windows: dict[str, deque[float]] = defaultdict(deque)
@@ -573,6 +595,17 @@ mcp_manager = MCPClientManager()
 mcp_installer = MCPInstaller()
 tool_registry = ToolRegistry()
 workflow_mcp_provider = MCPToolsetProvider(tool_registry, mcp_manager)
+toolset_store = ToolsetStore()
+toolset_credential_store = CredentialStore(toolset_store.storage_dir)
+toolset_service = ToolsetService(
+    toolset_store,
+    toolset_credential_store,
+    mcp_manager,
+    installed_project_resolver=mcp_installer.get_installed,
+)
+configure_toolsets(toolset_service)
+workflow_published_toolset_provider = PublishedMCPToolsetProvider(toolset_service)
+workflow_draft_toolset_test_provider = DraftMCPToolTestProvider(toolset_service)
 xpert_context_store = get_xpert_context_store()
 workflow_memory_provider = MemoryToolsetProvider(xpert_context_store)
 workflow_knowledge_provider = KnowledgeToolsetProvider(get_rag_service)
@@ -691,6 +724,16 @@ runtime_capabilities.register(
     workflow_knowledge_provider,
     description="Active knowledge retrieval and approval-gated write tools.",
 )
+runtime_capabilities.register(
+    "published_mcp_toolsets",
+    workflow_published_toolset_provider,
+    description="Fixed-version MCP Toolsets bound to workflow agents.",
+)
+runtime_capabilities.register(
+    "draft_mcp_toolset_test",
+    workflow_draft_toolset_test_provider,
+    description="Trusted management-plane MCP Toolset test calls.",
+)
 register_external_xpert_toolset_capability(
     runtime_capabilities,
     workflow_external_xpert_provider,
@@ -703,6 +746,28 @@ register_authoring_toolset_capabilities(
 )
 
 
+async def run_draft_toolset_test(call: RuntimeToolCall) -> RuntimeToolResult:
+    context = MiddlewareContext(
+        task_id=f"toolset-test-{uuid.uuid4().hex}",
+        metadata={
+            "run_type": "toolset_test",
+            "toolset_id": call.metadata.get("toolset_id"),
+        },
+    )
+    return await run_tool_with_runtime(
+        call,
+        runtime_capabilities,
+        workflow_mcp_pipeline,
+        context,
+        capability_name="draft_mcp_toolset_test",
+        policy=workflow_tool_policy,
+        audit_store=workflow_tool_audit_store,
+    )
+
+
+toolset_service.set_tool_test_runner(run_draft_toolset_test)
+
+
 async def validate_runtime_approval_decision(
     approval: RuntimeApprovalRequest,
     decision_payload: Any,
@@ -713,24 +778,34 @@ async def validate_runtime_approval_decision(
     if not isinstance(edited_arguments, dict):
         raise HTTPException(status_code=400, detail="编辑后的工具参数必须是 JSON 对象。")
     tool_name = str(approval.tool_name or "").strip()
-    matched_tool = None
-    for provider in (
-        workflow_mcp_provider,
-        workflow_memory_provider,
-        workflow_knowledge_provider,
-        workflow_datax_provider,
-        workflow_todo_provider,
-        workflow_sandbox_provider,
-        workflow_browser_provider,
-        workflow_xpert_authoring_provider,
-        workflow_skill_creator_provider,
-    ):
-        matched_tool = await provider.find_tool(tool_name)
-        if matched_tool is not None:
-            break
-    if matched_tool is None:
-        raise HTTPException(status_code=400, detail=f"工具已不可用：{tool_name}")
-    schema = matched_tool.input_schema
+    schema = approval.metadata.get("tool_input_schema")
+    if not isinstance(schema, dict):
+        matched_tool = None
+        toolset_resources = approval.metadata.get("toolset_resources")
+        if isinstance(toolset_resources, list):
+            matched_tool = await workflow_published_toolset_provider.find_tool(
+                tool_name,
+                toolset_resources,
+            )
+        for provider in (
+            workflow_mcp_provider,
+            workflow_memory_provider,
+            workflow_knowledge_provider,
+            workflow_datax_provider,
+            workflow_todo_provider,
+            workflow_sandbox_provider,
+            workflow_browser_provider,
+            workflow_xpert_authoring_provider,
+            workflow_skill_creator_provider,
+        ):
+            if matched_tool is not None:
+                break
+            matched_tool = await provider.find_tool(tool_name)
+            if matched_tool is not None:
+                break
+        if matched_tool is None:
+            raise HTTPException(status_code=400, detail=f"工具已不可用：{tool_name}")
+        schema = matched_tool.input_schema
     if isinstance(schema, dict) and schema:
         try:
             from jsonschema import Draft202012Validator
@@ -2315,7 +2390,7 @@ def workflow_topological_order(
         node.id
         for node in nodes
         if workflow_node_kind(node)
-        in {"external_xpert", "knowledge_base"}
+        in {"external_xpert", "knowledge_base", "toolset_resource"}
     )
     node_ids = all_node_ids - bound_resource_node_ids
     indegree = {node_id: 0 for node_id in node_ids}
@@ -3749,8 +3824,19 @@ async def _run_workflow_response(
             middleware_context: MiddlewareContext | None = None,
             middleware_specs: list[RuntimeMiddlewareSpec] | None = None,
         ):
-            matched_tool = await workflow_mcp_provider.find_tool(tool_name)
-            capability_name = "mcp_tools"
+            toolset_resources = (
+                middleware_context.metadata.get("toolset_resources")
+                if middleware_context is not None
+                else None
+            )
+            matched_tool = await workflow_published_toolset_provider.find_tool(
+                tool_name,
+                toolset_resources if isinstance(toolset_resources, list) else None,
+            )
+            capability_name = "published_mcp_toolsets"
+            if not matched_tool:
+                matched_tool = await workflow_mcp_provider.find_tool(tool_name)
+                capability_name = "mcp_tools"
             if not matched_tool:
                 matched_tool = await workflow_memory_provider.find_tool(tool_name)
                 capability_name = "memory_tools"
@@ -3805,6 +3891,11 @@ async def _run_workflow_response(
                 "allow_tools"
             ):
                 raise PermissionError("Xpert App tool access is disabled.")
+            if (
+                capability_name == "published_mcp_toolsets"
+                and runtime_run_type == "xpert_app"
+            ):
+                raise PermissionError("Xpert App bound Toolset access is disabled.")
             if capability_name == "memory_tools" and not app_capability_allowed(
                 "allow_xpert_memory"
             ):
@@ -3911,6 +4002,10 @@ async def _run_workflow_response(
                             )
                             or []
                         ),
+                        "toolset_resources": list(
+                            effective_context.metadata.get("toolset_resources") or []
+                        ),
+                        "tool_input_schema": dict(matched_tool.input_schema or {}),
                         "sandbox_config": effective_context.metadata.get("sandbox_config") or {},
                         "skills_config": effective_context.metadata.get("skills_config") or {},
                         "browser_config": effective_context.metadata.get("browser_config") or {},
@@ -3973,6 +4068,7 @@ async def _run_workflow_response(
             include_knowledge_read: bool = False,
             include_knowledge_write: bool = False,
             external_xpert_tools: list[dict[str, Any]] | None = None,
+            toolset_resources: list[dict[str, Any]] | None = None,
             include_datax: bool = False,
             include_datax_proposals: bool = False,
             include_todo: bool = False,
@@ -4037,6 +4133,23 @@ async def _run_workflow_response(
                         external_xpert_tools
                     )
                 )
+            if toolset_resources and runtime_run_type != "xpert_app":
+                bound_toolset_tools = (
+                    await workflow_published_toolset_provider.list_tools(
+                        toolset_resources
+                    )
+                )
+                conflicts = sorted(
+                    {str(tool.name) for tool in tools}.intersection(
+                        str(tool.name) for tool in bound_toolset_tools
+                    )
+                )
+                if conflicts:
+                    raise ValueError(
+                        "Bound Toolset names conflict with other Runtime tools: "
+                        + ", ".join(conflicts)
+                    )
+                tools.extend(bound_toolset_tools)
             datax_tools = await workflow_datax_provider.list_tools()
             if include_datax and app_capability_allowed("allow_datax_read"):
                 tools.extend(tool for tool in datax_tools if tool.name not in {
@@ -4120,6 +4233,7 @@ async def _run_workflow_response(
                         "memory": "memory_tools",
                         "knowledge": "knowledge_tools",
                         "external_xpert": "external_xpert_tools",
+                        "published_mcp_toolset": "published_mcp_toolsets",
                         "datax": "datax_tools",
                         "todo": "todo_tools",
                         "sandbox": "sandbox_tools",
@@ -4162,6 +4276,7 @@ async def _run_workflow_response(
             include_knowledge_write: bool = False,
             knowledge_base_ids: list[str] | None = None,
             external_xpert_tools: list[dict[str, Any]] | None = None,
+            toolset_resources: list[dict[str, Any]] | None = None,
             include_datax: bool = False,
             include_datax_proposals: bool = False,
             include_todo: bool = False,
@@ -4190,6 +4305,7 @@ async def _run_workflow_response(
                 include_knowledge_read=include_knowledge_read,
                 include_knowledge_write=include_knowledge_write,
                 external_xpert_tools=external_xpert_tools,
+                toolset_resources=toolset_resources,
                 include_datax=include_datax,
                 include_datax_proposals=include_datax_proposals,
                 include_todo=include_todo,
@@ -4444,6 +4560,7 @@ async def _run_workflow_response(
                     "knowledge_write_enabled": include_knowledge_write,
                     "knowledge_base_ids": list(knowledge_base_ids or []),
                     "external_xpert_tools": list(external_xpert_tools or []),
+                    "toolset_resources": list(toolset_resources or []),
                 }
                 if isinstance(approval_payload, dict):
                     resume_metadata["resolved_approval"] = approval_payload
@@ -4596,6 +4713,9 @@ async def _run_workflow_response(
                                 "knowledge_base_ids": list(knowledge_base_ids or []),
                                 "external_xpert_tools": list(
                                     external_xpert_tools or []
+                                ),
+                                "toolset_resources": list(
+                                    toolset_resources or []
                                 ),
                             },
                             pipeline=pipeline,
@@ -6253,6 +6373,73 @@ async def _run_workflow_response(
                                     "pinned_version": pinned_version,
                                 }
                             )
+                        toolset_resources: list[dict[str, Any]] = []
+                        for resource_node in bound_resource_nodes(
+                            nodes_by_id,
+                            payload.workflow.edges,
+                            node.id,
+                            "toolset",
+                        ):
+                            resource_data = (
+                                resource_node.data
+                                if isinstance(resource_node.data, dict)
+                                else {}
+                            )
+                            toolset_id = str(
+                                resource_data.get("toolsetId") or ""
+                            ).strip()
+                            toolset = toolset_store.get_toolset(toolset_id)
+                            version_policy = str(
+                                resource_data.get("versionPolicy")
+                                or "current_published"
+                            ).strip()
+                            pinned_version = (
+                                int(resource_data.get("pinnedVersion") or 0)
+                                if version_policy == "pinned"
+                                else int(toolset.published_version or 0)
+                            )
+                            if toolset.status != "published" or pinned_version < 1:
+                                raise ValueError(
+                                    f"Bound Toolset must be published: {toolset_id}"
+                                )
+                            snapshot = toolset_store.get_version(
+                                toolset.id,
+                                pinned_version,
+                            )
+                            toolset_resources.append(
+                                {
+                                    "node_id": resource_node.id,
+                                    "toolset_id": toolset.id,
+                                    "name": toolset.name,
+                                    "pinned_version": snapshot.version,
+                                    "schema_hash": snapshot.schema_hash,
+                                }
+                            )
+                        if toolset_resources:
+                            bound_tools = (
+                                await workflow_published_toolset_provider.list_tools(
+                                    toolset_resources
+                                )
+                            )
+                            bound_names = [tool.name for tool in bound_tools]
+                            if len(bound_names) != len(set(bound_names)):
+                                raise ValueError(
+                                    "Bound Toolsets expose conflicting tool names."
+                                )
+                            inline_names = {
+                                item.strip()
+                                for item in re.split(
+                                    r"[,\n]",
+                                    str(node.data.get("toolNames") or ""),
+                                )
+                                if item.strip()
+                            }
+                            conflict = sorted(inline_names.intersection(bound_names))
+                            if conflict:
+                                raise ValueError(
+                                    "Bound Toolset names conflict with inline MCP tools: "
+                                    + ", ".join(conflict)
+                                )
                         if knowledge_writer_spec is not None:
                             writer_kb_id = str(
                                 knowledge_writer_spec.config.get("knowledge_base_id") or ""
@@ -6271,10 +6458,11 @@ async def _run_workflow_response(
                             knowledge_read_enabled
                             or knowledge_write_enabled
                             or external_xpert_tools
+                            or toolset_resources
                         ):
                             if tool_mode != "mcp_tools":
                                 raise ValueError(
-                                    "Bound knowledge and external Xpert resources require Runtime tool mode."
+                                    "Bound knowledge, external Xpert, and Toolset resources require Runtime tool mode."
                                 )
                         if knowledge_read_enabled or knowledge_write_enabled:
                             if not 1 <= len(knowledge_base_ids) <= 5:
@@ -6443,6 +6631,7 @@ async def _run_workflow_response(
                                 "knowledge_write_enabled": knowledge_write_enabled,
                                 "knowledge_base_ids": knowledge_base_ids,
                                 "external_xpert_count": len(external_xpert_tools),
+                                "toolset_count": len(toolset_resources),
                             },
                         )
                         (
@@ -6459,6 +6648,7 @@ async def _run_workflow_response(
                         agent_context.metadata.update(
                             {
                                 "external_xpert_tools": external_xpert_tools,
+                                "toolset_resources": toolset_resources,
                                 "knowledge_resource_configs": knowledge_resource_configs,
                             }
                         )
@@ -6892,6 +7082,7 @@ async def _run_workflow_response(
                                         ),
                                         knowledge_base_ids=knowledge_base_ids,
                                         external_xpert_tools=external_xpert_tools,
+                                        toolset_resources=toolset_resources,
                                         include_datax=datax_enabled,
                                         include_datax_proposals=datax_allow_proposals,
                                         include_todo=todo_spec is not None,
@@ -6989,6 +7180,7 @@ async def _run_workflow_response(
                                             ),
                                             knowledge_base_ids=knowledge_base_ids,
                                             external_xpert_tools=external_xpert_tools,
+                                            toolset_resources=toolset_resources,
                                             include_datax=datax_enabled,
                                             include_datax_proposals=datax_allow_proposals,
                                             include_todo=todo_spec is not None,
@@ -10359,6 +10551,9 @@ async def team_chat(payload: TeamChatRequest, request: Request):
 async def start_mcp_ttl_cleanup() -> None:
     await asyncio.to_thread(datax_service.recover_import_jobs)
     mcp_manager.start_ttl_cleanup(on_cleanup=tool_registry.unregister_sessions)
+    toolset_warnings = await toolset_service.autostart()
+    for warning in toolset_warnings:
+        logger.warning("Toolset auto-start failed: %s", warning)
     get_pipeline_executor().start()
     get_evaluation_executor().start()
     get_handoff_executor().start()
@@ -10382,6 +10577,7 @@ async def shutdown_mcp_sessions() -> None:
         await client_tool_coordinator.stop()
     if automation_coordinator is not None:
         await automation_coordinator.stop()
+    await toolset_service.close()
     await mcp_manager.stop_ttl_cleanup()
     await mcp_manager.close_all()
     await tool_registry.clear()
@@ -10463,7 +10659,7 @@ async def list_workflow_node_registry():
 
 @app.get("/api/workflow/resource-options", response_model=dict[str, Any])
 async def list_workflow_resource_options(
-    kind: Literal["external_xpert", "knowledge_base"],
+    kind: Literal["external_xpert", "knowledge_base", "toolset"],
 ):
     if kind == "external_xpert":
         items = await asyncio.to_thread(
@@ -10484,6 +10680,30 @@ async def list_workflow_resource_options(
                     "published_version": item.published_version,
                 }
                 for item in items
+            ],
+        }
+    if kind == "toolset":
+        return {
+            "kind": kind,
+            "items": [
+                {
+                    "id": item.id,
+                    "name": item.name,
+                    "description": item.description,
+                    "status": item.status,
+                    "published_version": item.published_version,
+                    "tool_count": (
+                        len(
+                            toolset_store.get_version(
+                                item.id,
+                                int(item.published_version),
+                            ).tools
+                        )
+                        if item.published_version
+                        else 0
+                    ),
+                }
+                for item in toolset_store.list_toolsets()
             ],
         }
 

--- a/server/mcp/manager.py
+++ b/server/mcp/manager.py
@@ -10,11 +10,13 @@ worker task. Public manager methods communicate with that task through an
 from __future__ import annotations
 
 import asyncio
+import ipaddress
 import json
 import os
 import re
 import shlex
 import shutil
+import socket
 import subprocess
 import time
 import uuid
@@ -24,8 +26,12 @@ from pathlib import Path
 from typing import Any, Awaitable, Callable, Literal
 
 from mcp.client.session import ClientSession
+from mcp.client.sse import sse_client
 from mcp.client.stdio import StdioServerParameters, stdio_client
+from mcp.client.streamable_http import streamable_http_client
 from mcp.types import CallToolResult, Tool
+import httpx
+from urllib.parse import urlparse
 
 
 class MCPClientError(RuntimeError):
@@ -79,13 +85,21 @@ class SessionCommand:
 
 @dataclass(slots=True)
 class ManagedMCPSession:
-    """A live MCP stdio session controlled by an owner task."""
+    """A live MCP session controlled by an owner task."""
 
     session_id: str
     command: list[str]
     created_at: float
     created_monotonic_at: float
     last_used_at: float
+    transport: str = "stdio"
+    url: str = ""
+    headers: dict[str, str] = field(default_factory=dict)
+    environment: dict[str, str] = field(default_factory=dict)
+    network_policy: str = "public_only"
+    reconnect_attempts: int = 1
+    operation_timeout: float = 30.0
+    working_directory: str = ""
     queue: asyncio.Queue[SessionCommand] = field(default_factory=asyncio.Queue)
     task: asyncio.Task[None] | None = None
     tools_count: int = 0
@@ -123,10 +137,48 @@ class MCPClientManager:
 
         validate_server_command(server_command)
         managed = self._new_managed_session(server_command)
+        return await self._start_managed_session(managed)
+
+    async def connect_profile(
+        self,
+        *,
+        transport: str,
+        server_command: list[str] | None = None,
+        url: str = "",
+        headers: dict[str, str] | None = None,
+        environment: dict[str, str] | None = None,
+        network_policy: str = "public_only",
+        reconnect_attempts: int = 1,
+        operation_timeout: float | None = None,
+        working_directory: str = "",
+    ) -> str:
+        """Connect an MCP profile without exposing credentials in summaries."""
+
+        if transport not in {"stdio", "streamable_http", "legacy_sse"}:
+            raise ValueError(f"Unsupported MCP transport: {transport}")
+        command = list(server_command or [])
+        if transport == "stdio":
+            validate_server_command(command)
+        else:
+            await validate_remote_mcp_url(url, network_policy=network_policy)
+        managed = self._new_managed_session(
+            command,
+            transport=transport,
+            url=url,
+            headers=dict(headers or {}),
+            environment=dict(environment or {}),
+            network_policy=network_policy,
+            reconnect_attempts=reconnect_attempts,
+            operation_timeout=operation_timeout,
+            working_directory=working_directory,
+        )
+        return await self._start_managed_session(managed)
+
+    async def _start_managed_session(self, managed: ManagedMCPSession) -> str:
         ready: asyncio.Future[None] = asyncio.get_running_loop().create_future()
         managed.task = asyncio.create_task(self._session_worker(managed, ready))
         try:
-            await asyncio.wait_for(ready, timeout=self.operation_timeout)
+            await asyncio.wait_for(ready, timeout=managed.operation_timeout)
         except Exception:
             if managed.task:
                 managed.task.cancel()
@@ -196,7 +248,11 @@ class MCPClientManager:
         return [
             {
                 "session_id": managed.session_id,
-                "server_command": list(managed.command),
+                "server_command": (
+                    list(managed.command) if managed.transport == "stdio" else []
+                ),
+                "transport": managed.transport,
+                "url": sanitize_remote_url(managed.url),
                 "status": managed.status,
                 "created_at": managed.created_at,
                 "uptime_seconds": max(0, now_mono - managed.created_monotonic_at),
@@ -264,12 +320,31 @@ class MCPClientManager:
         *,
         session_id: str | None = None,
         restart_count: int = 0,
+        transport: str = "stdio",
+        url: str = "",
+        headers: dict[str, str] | None = None,
+        environment: dict[str, str] | None = None,
+        network_policy: str = "public_only",
+        reconnect_attempts: int = 1,
+        operation_timeout: float | None = None,
+        working_directory: str = "",
     ) -> ManagedMCPSession:
         now_epoch = time.time()
         now_mono = time.monotonic()
         return ManagedMCPSession(
             session_id=session_id or uuid.uuid4().hex,
             command=list(server_command),
+            transport=transport,
+            url=url,
+            headers=dict(headers or {}),
+            environment=dict(environment or {}),
+            network_policy=network_policy,
+            reconnect_attempts=max(0, min(5, reconnect_attempts)),
+            operation_timeout=max(
+                5.0,
+                min(float(operation_timeout or self.operation_timeout), 300.0),
+            ),
+            working_directory=str(working_directory or "").strip(),
             created_at=now_epoch,
             created_monotonic_at=now_mono,
             last_used_at=now_mono,
@@ -282,23 +357,79 @@ class MCPClientManager:
         ready: asyncio.Future[None],
     ) -> None:
         try:
-            command, *args = managed.command
-            params = StdioServerParameters(
-                command=command,
-                args=args,
-                env=self._child_env(),
-                cwd=str(self.sandbox_root),
-            )
             async with AsyncExitStack() as exit_stack:
-                read_stream, write_stream = await exit_stack.enter_async_context(
-                    stdio_client(params)
-                )
+                if managed.transport == "stdio":
+                    command, *args = managed.command
+                    params = StdioServerParameters(
+                        command=command,
+                        args=args,
+                        env=self._child_env(managed.environment),
+                        cwd=str(
+                            self._resolve_working_directory(
+                                managed.working_directory
+                            )
+                        ),
+                    )
+                    read_stream, write_stream = await exit_stack.enter_async_context(
+                        stdio_client(params)
+                    )
+                else:
+                    await validate_remote_mcp_url(
+                        managed.url,
+                        network_policy=managed.network_policy,
+                    )
+                    timeout = httpx.Timeout(
+                        connect=min(10.0, managed.operation_timeout),
+                        read=managed.operation_timeout,
+                        write=managed.operation_timeout,
+                        pool=min(10.0, managed.operation_timeout),
+                    )
+                    if managed.transport == "streamable_http":
+                        http_client = await exit_stack.enter_async_context(
+                            httpx.AsyncClient(
+                                headers=managed.headers,
+                                timeout=timeout,
+                                follow_redirects=False,
+                                trust_env=False,
+                            )
+                        )
+                        transport_result = await exit_stack.enter_async_context(
+                            streamable_http_client(
+                                managed.url,
+                                http_client=http_client,
+                            )
+                        )
+                        read_stream, write_stream = transport_result[:2]
+                    else:
+                        def safe_http_client_factory(
+                            *,
+                            headers: dict[str, str] | None = None,
+                            timeout: httpx.Timeout | None = None,
+                            auth: httpx.Auth | None = None,
+                        ) -> httpx.AsyncClient:
+                            return httpx.AsyncClient(
+                                headers=headers,
+                                timeout=timeout,
+                                auth=auth,
+                                follow_redirects=False,
+                                trust_env=False,
+                            )
+
+                        read_stream, write_stream = await exit_stack.enter_async_context(
+                            sse_client(
+                                managed.url,
+                                headers=managed.headers,
+                                timeout=min(10.0, managed.operation_timeout),
+                                sse_read_timeout=managed.operation_timeout,
+                                httpx_client_factory=safe_http_client_factory,
+                            )
+                        )
                 client_session = await exit_stack.enter_async_context(
                     ClientSession(read_stream, write_stream)
                 )
                 await asyncio.wait_for(
                     client_session.initialize(),
-                    timeout=self.operation_timeout,
+                    timeout=managed.operation_timeout,
                 )
                 managed.status = "connected"
                 if not ready.done():
@@ -317,7 +448,7 @@ class MCPClientManager:
                         if command_item.operation == "list_tools":
                             result = await asyncio.wait_for(
                                 client_session.list_tools(),
-                                timeout=self.operation_timeout,
+                                timeout=managed.operation_timeout,
                             )
                             tools = list(result.tools)
                             managed.tools_count = len(tools)
@@ -328,7 +459,7 @@ class MCPClientManager:
                                     command_item.tool_name or "",
                                     command_item.arguments or {},
                                 ),
-                                timeout=self.operation_timeout,
+                                timeout=managed.operation_timeout,
                             )
                             command_item.future.set_result(result)
                     except Exception as exc:
@@ -336,8 +467,9 @@ class MCPClientManager:
                             command_item.future.set_exception(exc)
         except FileNotFoundError as exc:
             managed.status = "error"
+            executable = managed.command[0] if managed.command else managed.transport
             friendly_error = MCPClientError(
-                f"MCP Server 启动失败：服务器缺少 `{managed.command[0]}` 命令；请确认后端容器已安装对应运行时。"
+                f"MCP Server 启动失败：运行时 `{executable}` 不可用。"
             )
             if not ready.done():
                 ready.set_exception(friendly_error)
@@ -374,14 +506,17 @@ class MCPClientManager:
                 arguments=arguments,
             )
         )
-        return await asyncio.wait_for(future, timeout=self.operation_timeout + 5)
+        return await asyncio.wait_for(
+            future,
+            timeout=managed.operation_timeout + 5,
+        )
 
     async def _restart_once(
         self,
         managed: ManagedMCPSession,
         original_error: Exception,
     ) -> ManagedMCPSession:
-        if managed.restart_count >= 1:
+        if managed.restart_count >= managed.reconnect_attempts:
             raise MCPClientError(
                 f"MCP session 已重启过一次，仍然失败：{original_error}"
             ) from original_error
@@ -393,10 +528,18 @@ class MCPClientManager:
             command,
             session_id=old_session_id,
             restart_count=managed.restart_count + 1,
+            transport=managed.transport,
+            url=managed.url,
+            headers=managed.headers,
+            environment=managed.environment,
+            network_policy=managed.network_policy,
+            reconnect_attempts=managed.reconnect_attempts,
+            operation_timeout=managed.operation_timeout,
+            working_directory=managed.working_directory,
         )
         ready: asyncio.Future[None] = asyncio.get_running_loop().create_future()
         restarted.task = asyncio.create_task(self._session_worker(restarted, ready))
-        await asyncio.wait_for(ready, timeout=self.operation_timeout)
+        await asyncio.wait_for(ready, timeout=restarted.operation_timeout)
         async with self._lock:
             self._sessions[old_session_id] = restarted
         return restarted
@@ -437,7 +580,7 @@ class MCPClientManager:
                     # cleanup fails. The next sweep can retry stale resources.
                     pass
 
-    def _child_env(self) -> dict[str, str]:
+    def _child_env(self, extra: dict[str, str] | None = None) -> dict[str, str]:
         allowed_keys = {
             "PATH",
             "SystemRoot",
@@ -453,8 +596,100 @@ class MCPClientManager:
             "NPM_CONFIG_PREFIX",
         }
         env = {key: value for key, value in os.environ.items() if key in allowed_keys}
+        for key, value in (extra or {}).items():
+            if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]{0,127}", key):
+                raise MCPClientError(f"Invalid MCP environment variable name: {key}")
+            env[key] = str(value)
         env.setdefault("NO_COLOR", "1")
         return env
+
+    def _resolve_working_directory(self, relative_path: str) -> Path:
+        clean = str(relative_path or "").strip()
+        if not clean:
+            return self.sandbox_root
+        candidate = (self.sandbox_root / clean).resolve()
+        sandbox_root = self.sandbox_root.resolve()
+        try:
+            candidate.relative_to(sandbox_root)
+        except ValueError as exc:
+            raise MCPClientError(
+                "MCP working directory must stay inside the MCP sandbox."
+            ) from exc
+        candidate.mkdir(parents=True, exist_ok=True)
+        return candidate
+
+
+BLOCKED_REMOTE_HOSTS = {
+    "localhost",
+    "host.docker.internal",
+    "server",
+    "new-api",
+    "sandbox",
+    "browser",
+    "169.254.169.254",
+}
+
+
+def sanitize_remote_url(url: str) -> str:
+    if not url:
+        return ""
+    parsed = urlparse(url)
+    host = parsed.hostname or ""
+    port = f":{parsed.port}" if parsed.port else ""
+    return f"{parsed.scheme}://{host}{port}{parsed.path or '/'}"
+
+
+async def validate_remote_mcp_url(
+    url: str,
+    *,
+    network_policy: str = "public_only",
+) -> None:
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        raise ValueError("Remote MCP URL must use http or https.")
+    if parsed.username or parsed.password:
+        raise ValueError("Remote MCP URL credentials are not allowed.")
+    if network_policy == "trusted_private":
+        return
+    if network_policy != "public_only":
+        raise ValueError("Invalid MCP network policy.")
+    hostname = parsed.hostname.rstrip(".").lower()
+    if (
+        hostname in BLOCKED_REMOTE_HOSTS
+        or hostname.endswith(".local")
+        or hostname.endswith(".internal")
+    ):
+        raise ValueError("Remote MCP URL points to a blocked host.")
+
+    def resolve() -> list[str]:
+        return sorted(
+            {
+                item[4][0]
+                for item in socket.getaddrinfo(
+                    hostname,
+                    parsed.port or (443 if parsed.scheme == "https" else 80),
+                    type=socket.SOCK_STREAM,
+                )
+            }
+        )
+
+    try:
+        addresses = await asyncio.to_thread(resolve)
+    except socket.gaierror as exc:
+        raise ValueError("Remote MCP host could not be resolved.") from exc
+    if not addresses:
+        raise ValueError("Remote MCP host could not be resolved.")
+    for address in addresses:
+        ip = ipaddress.ip_address(address)
+        if (
+            ip.is_private
+            or ip.is_loopback
+            or ip.is_link_local
+            or ip.is_reserved
+            or ip.is_multicast
+            or ip.is_unspecified
+        ):
+            raise ValueError("Remote MCP URL resolved to a blocked address.")
 
 
 class MCPInstaller:
@@ -545,6 +780,31 @@ class MCPInstaller:
             except Exception:
                 continue
         return records
+
+    def get_installed(self, project_id: str) -> dict[str, Any] | None:
+        """Return one installed project record without exposing storage paths."""
+
+        safe_project_id = self._safe_project_id(project_id)
+        installed_file = self.installed_root / safe_project_id / "installed.json"
+        if not installed_file.is_file():
+            return None
+        try:
+            data = json.loads(installed_file.read_text(encoding="utf-8"))
+        except Exception:
+            return None
+        if not isinstance(data, dict):
+            return None
+        return {
+            "project_id": str(data.get("project_id") or safe_project_id),
+            "server_command": [
+                str(part)
+                for part in list(data.get("server_command") or [])
+                if isinstance(part, str)
+            ],
+            "install_type": str(data.get("install_type") or ""),
+            "npm_package": str(data.get("npm_package") or ""),
+            "installed_at": data.get("installed_at"),
+        }
 
     def _safe_project_id(self, project_id: str) -> str:
         safe = project_id.strip()

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -14,5 +14,6 @@ PyPDF2==3.0.1
 pypdfium2==4.30.0
 Pillow==11.3.0
 jsonschema==4.25.1
+cryptography==45.0.7
 duckdb==1.4.1
 openpyxl==3.1.5

--- a/server/tests/test_toolset_api.py
+++ b/server/tests/test_toolset_api.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+import server.main as main_module
+from server.toolsets import (
+    CredentialStore,
+    ToolsetService,
+    ToolsetStore,
+    configure_toolsets,
+)
+
+
+class APIFakeMCPManager:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, dict[str, Any]]] = []
+        self.counter = 0
+
+    async def connect_profile(self, **kwargs: Any) -> str:
+        self.counter += 1
+        return f"api-session-{self.counter}"
+
+    async def list_tools(self, session_id: str) -> list[Any]:
+        return [
+            SimpleNamespace(
+                name="echo",
+                description="Echo a message.",
+                inputSchema={
+                    "type": "object",
+                    "properties": {"message": {"type": "string"}},
+                    "required": ["message"],
+                    "additionalProperties": False,
+                },
+            )
+        ]
+
+    async def call_tool(
+        self,
+        session_id: str,
+        tool_name: str,
+        arguments: dict[str, Any],
+    ) -> Any:
+        self.calls.append((session_id, tool_name, dict(arguments)))
+        return SimpleNamespace(
+            content=[{"type": "text", "text": arguments["message"]}],
+            isError=False,
+        )
+
+    async def disconnect(self, session_id: str) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_toolset_api_create_discover_configure_test_and_publish(
+    tmp_path: Path,
+) -> None:
+    original = main_module.toolset_service
+    manager = APIFakeMCPManager()
+    storage = tmp_path / "toolsets"
+    service = ToolsetService(
+        ToolsetStore(storage),
+        CredentialStore(storage),
+        manager,  # type: ignore[arg-type]
+    )
+    configure_toolsets(service)
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=main_module.app),
+            base_url="http://test",
+        ) as client:
+            credential_response = await client.post(
+                "/api/runtime/credentials",
+                json={
+                    "name": "MCP Authorization",
+                    "kind": "header",
+                    "value": "one-time-secret",
+                },
+            )
+            assert credential_response.status_code == 201
+            credential = credential_response.json()
+            assert credential["secret_value"] == "one-time-secret"
+            assert credential["secret_value_visible_once"] is True
+
+            listed_credentials = await client.get("/api/runtime/credentials")
+            assert listed_credentials.status_code == 200
+            credential_text = listed_credentials.text
+            assert "one-time-secret" not in credential_text
+            assert "ciphertext" not in credential_text
+
+            created_response = await client.post(
+                "/api/toolsets",
+                json={
+                    "name": "API test Toolset",
+                    "connection": {
+                        "transport": "stdio",
+                        "command": ["python", "-m", "echo_mcp"],
+                    },
+                },
+            )
+            assert created_response.status_code == 201
+            created = created_response.json()
+
+            resources_response = await client.get("/api/toolsets/resources")
+            assert resources_response.status_code == 200
+            resources = resources_response.json()
+            assert resources["version"] == "modelmirror-toolset-resources-v2"
+            assert resources["summary"]["toolset_count"] == 1
+            assert resources["toolsets"][0]["id"] == created["id"]
+            assert "connection" not in resources["toolsets"][0]
+
+            connected_response = await client.post(
+                f"/api/toolsets/{created['id']}/connect",
+            )
+            assert connected_response.status_code == 200
+            connected = connected_response.json()
+            assert connected["runtime_status"] == "connected"
+            assert connected["tools"][0]["enabled"] is False
+
+            configured_response = await client.patch(
+                f"/api/toolsets/{created['id']}/tools/echo",
+                json={
+                    "revision": connected["revision"],
+                    "patch": {
+                        "enabled": True,
+                        "alias": "say",
+                        "default_arguments": {"message": "default"},
+                    },
+                },
+            )
+            assert configured_response.status_code == 200
+            configured = configured_response.json()
+
+            tested_response = await client.post(
+                f"/api/toolsets/{created['id']}/tools/echo/test",
+                json={"arguments": {"message": "hello"}},
+            )
+            assert tested_response.status_code == 200
+            assert tested_response.json()["output"] == "hello"
+
+            published_response = await client.post(
+                f"/api/toolsets/{created['id']}/publish",
+                json={
+                    "revision": configured["revision"],
+                    "release_notes": "First stable version.",
+                },
+            )
+            assert published_response.status_code == 200
+            published = published_response.json()
+            assert published["version"] == 1
+            assert [tool["alias"] for tool in published["tools"]] == ["say"]
+
+            versions_response = await client.get(
+                f"/api/toolsets/{created['id']}/versions/1"
+            )
+            assert versions_response.status_code == 200
+            assert versions_response.json()["schema_hash"] == published["schema_hash"]
+
+        persisted = (storage / "credentials.json").read_text(encoding="utf-8")
+        assert "one-time-secret" not in persisted
+        assert json.loads(persisted)["credentials"][0]["ciphertext"]
+    finally:
+        configure_toolsets(original)

--- a/server/tests/test_toolset_service.py
+++ b/server/tests/test_toolset_service.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from server.toolsets.credentials import CredentialStore
+from server.toolsets.service import (
+    PublishedMCPToolsetProvider,
+    ToolsetService,
+)
+from server.toolsets.store import ToolsetStore, ToolsetValidationError
+from server.xpert_runtime.toolset import RuntimeToolCall, RuntimeToolError
+
+
+@dataclass
+class FakeTool:
+    name: str
+    description: str
+    inputSchema: dict[str, Any]
+
+
+class FakeMCPManager:
+    def __init__(self) -> None:
+        self.tools = [
+            FakeTool(
+                name="search",
+                description="Search sources.",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string"},
+                        "limit": {"type": "integer"},
+                    },
+                    "required": ["query"],
+                },
+            )
+        ]
+        self.connect_calls: list[dict[str, Any]] = []
+        self.tool_calls: list[tuple[str, str, dict[str, Any]]] = []
+        self.disconnected: list[str] = []
+        self._counter = 0
+
+    async def connect_profile(self, **kwargs: Any) -> str:
+        self.connect_calls.append(dict(kwargs))
+        self._counter += 1
+        return f"session-{self._counter}"
+
+    async def list_tools(self, session_id: str) -> list[FakeTool]:
+        return list(self.tools)
+
+    async def call_tool(
+        self,
+        session_id: str,
+        tool_name: str,
+        arguments: dict[str, Any],
+    ) -> Any:
+        self.tool_calls.append((session_id, tool_name, dict(arguments)))
+        return SimpleNamespace(
+            content=[{"type": "text", "text": f"result:{arguments['query']}"}],
+            isError=False,
+        )
+
+    async def disconnect(self, session_id: str) -> None:
+        self.disconnected.append(session_id)
+
+
+def _service(tmp_path: Path) -> tuple[ToolsetService, FakeMCPManager]:
+    manager = FakeMCPManager()
+    storage_dir = tmp_path / "toolsets"
+    service = ToolsetService(
+        ToolsetStore(storage_dir),
+        CredentialStore(storage_dir),
+        manager,  # type: ignore[arg-type]
+    )
+    return service, manager
+
+
+@pytest.mark.asyncio
+async def test_mcp_toolset_connect_publish_and_fixed_version_call(
+    tmp_path: Path,
+) -> None:
+    service, manager = _service(tmp_path)
+    credential, _ = service.credentials.create(
+        name="Authorization",
+        kind="header",
+        value="secret-token",
+    )
+    created = service.store.create_toolset(
+        name="Research",
+        connection={
+            "transport": "streamable_http",
+            "url": "https://mcp.example.test/mcp",
+            "headers": [
+                {
+                    "name": "Authorization",
+                    "credential_id": credential.credential_id,
+                }
+            ],
+            "tool_prefix": "research",
+            "auto_reconnect": False,
+        },
+    )
+    connected = await service.connect(created.id)
+    assert connected.runtime_status == "connected"
+    assert manager.connect_calls[0]["headers"] == {
+        "Authorization": "Bearer secret-token"
+    }
+    assert manager.connect_calls[0]["reconnect_attempts"] == 0
+
+    enabled = service.store.update_tool(
+        created.id,
+        "search",
+        revision=connected.revision,
+        patch={
+            "enabled": True,
+            "alias": "find",
+            "default_arguments": {"limit": 3},
+        },
+    )
+    version = await service.publish(
+        created.id,
+        expected_revision=enabled.revision,
+    )
+    provider = PublishedMCPToolsetProvider(service)
+    resources = [
+        {"toolset_id": created.id, "pinned_version": version.version}
+    ]
+    tools = await provider.list_tools(resources)
+    assert [tool.name for tool in tools] == ["research_find"]
+
+    result = await provider.call_tool(
+        RuntimeToolCall(
+            tool_name="research_find",
+            arguments={"query": "alpha"},
+            metadata={"toolset_resources": resources},
+        )
+    )
+    assert result.output == "result:alpha"
+    assert manager.tool_calls[-1][1:] == (
+        "search",
+        {"limit": 3, "query": "alpha"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_fixed_version_detects_compatible_and_breaking_schema_drift(
+    tmp_path: Path,
+) -> None:
+    service, manager = _service(tmp_path)
+    created = service.store.create_toolset(
+        name="Schema drift",
+        connection={"transport": "stdio", "command": ["python", "server.py"]},
+    )
+    connected = await service.connect(created.id)
+    enabled = service.store.update_tool(
+        created.id,
+        "search",
+        revision=connected.revision,
+        patch={"enabled": True},
+    )
+    version = await service.publish(
+        created.id,
+        expected_revision=enabled.revision,
+    )
+
+    manager.tools[0].inputSchema["properties"]["language"] = {"type": "string"}
+    result = await service.call_published_tool(
+        toolset_id=created.id,
+        version=version.version,
+        exposed_name="search",
+        arguments={"query": "beta"},
+    )
+    assert result.metadata["schema_warnings"]
+
+    manager.tools[0].inputSchema["required"].append("language")
+    with pytest.raises(RuntimeToolError) as error:
+        await service.call_published_tool(
+            toolset_id=created.id,
+            version=version.version,
+            exposed_name="search",
+            arguments={"query": "gamma"},
+        )
+    assert error.value.code == "toolset_call_failed"
+
+
+@pytest.mark.asyncio
+async def test_installed_project_is_resolved_and_frozen_in_version(
+    tmp_path: Path,
+) -> None:
+    projects = {
+        "local-search": {
+            "project_id": "local-search",
+            "server_command": ["python", "-m", "local_search_mcp"],
+        }
+    }
+    manager = FakeMCPManager()
+    storage_dir = tmp_path / "toolsets"
+    service = ToolsetService(
+        ToolsetStore(storage_dir),
+        CredentialStore(storage_dir),
+        manager,  # type: ignore[arg-type]
+        installed_project_resolver=projects.get,
+    )
+    created = service.store.create_toolset(
+        name="Installed project",
+        connection={
+            "transport": "stdio",
+            "installed_project_id": "local-search",
+        },
+    )
+    connected = await service.connect(created.id)
+    assert manager.connect_calls[0]["server_command"] == [
+        "python",
+        "-m",
+        "local_search_mcp",
+    ]
+    enabled = service.store.update_tool(
+        created.id,
+        "search",
+        revision=connected.revision,
+        patch={"enabled": True},
+    )
+    version = await service.publish(
+        created.id,
+        expected_revision=enabled.revision,
+    )
+    assert version.connection.command == [
+        "python",
+        "-m",
+        "local_search_mcp",
+    ]
+
+    projects["local-search"]["server_command"] = ["python", "-m", "changed"]
+    service._draft_sessions.clear()
+    await service.ensure_version_session(created.id, version.version)
+    assert manager.connect_calls[-1]["server_command"] == [
+        "python",
+        "-m",
+        "local_search_mcp",
+    ]

--- a/server/tests/test_toolset_store.py
+++ b/server/tests/test_toolset_store.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from cryptography.fernet import Fernet
+
+from server.toolsets.credentials import (
+    CredentialStore,
+    CredentialUnavailableError,
+)
+from server.toolsets.store import (
+    ToolsetConflictError,
+    ToolsetStore,
+    ToolsetValidationError,
+)
+
+
+TOOL_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "query": {"type": "string"},
+        "limit": {"type": "integer", "minimum": 1},
+    },
+    "required": ["query"],
+    "additionalProperties": False,
+}
+
+
+def _connected_toolset(store: ToolsetStore):
+    created = store.create_toolset(
+        name="Research tools",
+        connection={
+            "transport": "stdio",
+            "command": ["python", "-m", "research_server"],
+            "tool_prefix": "research",
+        },
+    )
+    discovered = store.replace_discovered_tools(
+        created.id,
+        tools=[
+            {
+                "original_name": "search",
+                "description": "Search a local corpus.",
+                "input_schema": TOOL_SCHEMA,
+            }
+        ],
+    )
+    enabled = store.update_tool(
+        created.id,
+        "search",
+        revision=discovered.revision,
+        patch={
+            "enabled": True,
+            "alias": "find_sources",
+            "default_arguments": {"limit": 5},
+        },
+    )
+    return store.set_runtime_state(
+        created.id,
+        status="connected",
+        session_id="session-draft",
+    ), enabled
+
+
+def test_toolset_store_persists_drafts_and_immutable_versions(
+    tmp_path: Path,
+) -> None:
+    store = ToolsetStore(tmp_path / "toolsets")
+    connected, _ = _connected_toolset(store)
+
+    version_one = store.publish(connected.id, revision=connected.revision)
+    changed = store.update_toolset(
+        connected.id,
+        revision=connected.revision,
+        patch={"description": "Changed after version one."},
+    )
+    changed = store.update_tool(
+        connected.id,
+        "search",
+        revision=changed.revision,
+        patch={"description": "New draft description."},
+    )
+    changed = store.set_runtime_state(
+        connected.id,
+        status="connected",
+        session_id="session-draft-2",
+    )
+    version_two = store.publish(changed.id, revision=changed.revision)
+
+    reloaded = ToolsetStore(store.storage_dir)
+    persisted = reloaded.get_toolset(connected.id)
+    assert persisted.published_version == 2
+    assert version_one.version == 1
+    assert version_two.version == 2
+    assert reloaded.get_version(connected.id, 1).tools[0].description == (
+        "Search a local corpus."
+    )
+    assert reloaded.get_version(connected.id, 2).tools[0].description == (
+        "New draft description."
+    )
+
+
+def test_toolset_store_enforces_revision_and_publish_contract(
+    tmp_path: Path,
+) -> None:
+    store = ToolsetStore(tmp_path / "toolsets")
+    created = store.create_toolset(name="Draft")
+
+    with pytest.raises(ToolsetConflictError):
+        store.update_toolset(
+            created.id,
+            revision=created.revision + 1,
+            patch={"description": "stale"},
+        )
+    with pytest.raises(ToolsetValidationError):
+        store.publish(created.id, revision=created.revision)
+
+
+def test_credentials_are_encrypted_rotatable_and_report_key_loss(
+    tmp_path: Path,
+) -> None:
+    storage_dir = tmp_path / "credentials"
+    store = CredentialStore(storage_dir, master_key=Fernet.generate_key())
+    record, visible_once = store.create(
+        name="Authorization",
+        kind="header",
+        value="super-secret-token",
+    )
+
+    assert visible_once == "super-secret-token"
+    assert record.ciphertext == ""
+    assert store.resolve(record.credential_id) == "super-secret-token"
+    persisted = (storage_dir / "credentials.json").read_text(encoding="utf-8")
+    assert "super-secret-token" not in persisted
+    assert json.loads(persisted)["credentials"][0]["ciphertext"]
+
+    rotated, visible_once = store.rotate(
+        record.credential_id,
+        value="replacement-secret",
+    )
+    assert visible_once == "replacement-secret"
+    assert rotated.ciphertext == ""
+    assert store.resolve(record.credential_id) == "replacement-secret"
+
+    wrong_key_store = CredentialStore(
+        storage_dir,
+        master_key=Fernet.generate_key(),
+    )
+    assert wrong_key_store.list()[0].status == "unavailable"
+    with pytest.raises(CredentialUnavailableError):
+        wrong_key_store.resolve(record.credential_id)

--- a/server/tests/test_workflow_toolset_resource.py
+++ b/server/tests/test_workflow_toolset_resource.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import server.main as main_module
+from server.workflow_native.schemas import NativeWorkflowDefinition
+from server.workflow_native.validate import validate_workflow_graph
+from server.xperts.app_api import _deployment_preflight
+from server.xperts.app_models import XpertAppPolicy
+from server.xperts.models import XpertVersion
+
+
+def _workflow(tool_mode: str = "mcp_tools") -> NativeWorkflowDefinition:
+    return NativeWorkflowDefinition.model_validate(
+        {
+            "id": "toolset-workflow",
+            "title": "Toolset workflow",
+            "nodes": [
+                {
+                    "id": "input",
+                    "type": "input",
+                    "data": {
+                        "kind": "input",
+                        "variableName": "user_input",
+                    },
+                },
+                {
+                    "id": "agent",
+                    "type": "workflow_agent",
+                    "data": {
+                        "kind": "workflow_agent",
+                        "agentName": "Manager",
+                        "modelId": "test-model",
+                        "rolePrompt": "Use the available tools.",
+                        "taskInput": "{{user_input}}",
+                        "outputVariable": "agent_output",
+                        "toolMode": tool_mode,
+                        "maxIterations": "5",
+                    },
+                },
+                {
+                    "id": "output",
+                    "type": "output",
+                    "data": {
+                        "kind": "output",
+                        "outputVariable": "agent_output",
+                    },
+                },
+                {
+                    "id": "toolset",
+                    "type": "toolset_resource",
+                    "data": {
+                        "kind": "toolset_resource",
+                        "toolsetId": "toolset-research",
+                        "versionPolicy": "pinned",
+                        "pinnedVersion": "2",
+                    },
+                },
+            ],
+            "edges": [
+                {"id": "input-agent", "source": "input", "target": "agent"},
+                {"id": "agent-output", "source": "agent", "target": "output"},
+                {
+                    "id": "bind-toolset",
+                    "source": "toolset",
+                    "target": "agent",
+                    "sourceHandle": "toolset-binding",
+                    "targetHandle": "toolset",
+                },
+            ],
+        }
+    )
+
+
+def test_toolset_binding_is_not_part_of_control_flow() -> None:
+    workflow = _workflow()
+    validation = validate_workflow_graph(workflow)
+    order = main_module.workflow_topological_order(
+        list(workflow.nodes),
+        list(workflow.edges),
+    )
+
+    assert validation.valid is True
+    assert "toolset" not in validation.order
+    assert "toolset" not in order
+    assert order == ["input", "agent", "output"]
+
+
+def test_toolset_binding_requires_runtime_tool_mode() -> None:
+    validation = validate_workflow_graph(_workflow("none"))
+    assert "resource_binding_requires_runtime_tool_mode" in {
+        issue.code for issue in validation.issues
+    }
+
+
+def test_toolset_resource_cannot_mix_control_and_binding_edges() -> None:
+    payload = _workflow().model_dump(mode="json")
+    payload["edges"].append(
+        {
+            "id": "bad-control-edge",
+            "source": "toolset",
+            "target": "output",
+        }
+    )
+    validation = validate_workflow_graph(
+        NativeWorkflowDefinition.model_validate(payload)
+    )
+    codes = {issue.code for issue in validation.issues}
+    assert "mixed_resource_binding_and_control_flow" in codes
+    assert "resource_node_in_control_flow" in codes
+
+
+def test_xpert_app_preflight_blocks_bound_toolsets() -> None:
+    preflight = _deployment_preflight(
+        XpertVersion(
+            version=1,
+            draft_revision=1,
+            workflow=_workflow(),
+            input_variable="user_input",
+            history_variable="conversation_history",
+            output_variable="agent_output",
+            checksum="test-checksum",
+            published_at=1.0,
+        ),
+        XpertAppPolicy(),
+    )
+    assert "app_toolset_resource_forbidden" in {
+        str(item.get("code")) for item in preflight["issues"]
+    }

--- a/server/toolsets/__init__.py
+++ b/server/toolsets/__init__.py
@@ -1,0 +1,39 @@
+from .api import configure_toolsets, get_toolset_service, router as toolsets_router
+from .credentials import CredentialStore
+from .models import (
+    CredentialRecord,
+    MCPConnectionProfile,
+    ToolDefinition,
+    ToolsetDefinition,
+    ToolsetVersion,
+)
+from .service import (
+    DraftMCPToolTestProvider,
+    PublishedMCPToolsetProvider,
+    ToolsetService,
+)
+from .store import (
+    ToolsetConflictError,
+    ToolsetNotFoundError,
+    ToolsetStore,
+    ToolsetValidationError,
+)
+
+__all__ = [
+    "CredentialRecord",
+    "CredentialStore",
+    "DraftMCPToolTestProvider",
+    "MCPConnectionProfile",
+    "PublishedMCPToolsetProvider",
+    "ToolDefinition",
+    "ToolsetConflictError",
+    "ToolsetDefinition",
+    "ToolsetNotFoundError",
+    "ToolsetService",
+    "ToolsetStore",
+    "ToolsetValidationError",
+    "ToolsetVersion",
+    "configure_toolsets",
+    "get_toolset_service",
+    "toolsets_router",
+]

--- a/server/toolsets/api.py
+++ b/server/toolsets/api.py
@@ -1,0 +1,361 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from .credentials import (
+    CredentialNotFoundError,
+    CredentialStoreError,
+    CredentialUnavailableError,
+)
+from .service import ToolsetService
+from .store import (
+    ToolsetConflictError,
+    ToolsetNotFoundError,
+    ToolsetValidationError,
+)
+
+
+router = APIRouter(tags=["toolsets"])
+_service: ToolsetService | None = None
+
+
+def configure_toolsets(service: ToolsetService) -> None:
+    global _service
+    _service = service
+
+
+def get_toolset_service() -> ToolsetService:
+    if _service is None:
+        raise RuntimeError("Toolset service is not configured.")
+    return _service
+
+
+def _error(exc: Exception) -> HTTPException:
+    if isinstance(exc, ToolsetNotFoundError):
+        return HTTPException(status_code=404, detail=str(exc))
+    if isinstance(exc, ToolsetConflictError):
+        return HTTPException(status_code=409, detail=str(exc))
+    if isinstance(exc, CredentialNotFoundError):
+        return HTTPException(status_code=404, detail=str(exc))
+    if isinstance(exc, CredentialUnavailableError):
+        return HTTPException(status_code=409, detail=str(exc))
+    if isinstance(
+        exc,
+        (ToolsetValidationError, CredentialStoreError, ValueError, TypeError),
+    ):
+        return HTTPException(status_code=400, detail=str(exc))
+    return HTTPException(status_code=500, detail="Toolset operation failed.")
+
+
+class ToolsetCreateRequest(BaseModel):
+    name: str = Field(min_length=1, max_length=160)
+    description: str = Field(default="", max_length=2000)
+    tags: list[str] = Field(default_factory=list, max_length=20)
+    privacy_policy: str = Field(default="", max_length=4000)
+    disclaimer: str = Field(default="", max_length=4000)
+    connection: dict[str, Any] = Field(default_factory=dict)
+
+
+class ToolsetPatchRequest(BaseModel):
+    revision: int = Field(ge=1)
+    patch: dict[str, Any]
+
+
+class ToolPatchRequest(BaseModel):
+    revision: int = Field(ge=1)
+    patch: dict[str, Any]
+
+
+class ToolTestRequest(BaseModel):
+    arguments: dict[str, Any] = Field(default_factory=dict)
+
+
+class PublishRequest(BaseModel):
+    revision: int = Field(ge=1)
+    release_notes: str = Field(default="", max_length=2000)
+
+
+class CredentialCreateRequest(BaseModel):
+    name: str = Field(min_length=1, max_length=160)
+    kind: Literal["header", "environment", "provider_key", "generic"] = "generic"
+    value: str = Field(min_length=1, max_length=20_000)
+
+
+class CredentialRotateRequest(BaseModel):
+    value: str = Field(min_length=1, max_length=20_000)
+
+
+@router.get("/api/toolsets")
+async def list_toolsets(status: str | None = None) -> dict[str, Any]:
+    service = get_toolset_service()
+    return {
+        "version": "modelmirror-toolsets-v1",
+        "toolsets": [
+            item.model_dump(mode="json")
+            for item in service.store.list_toolsets(status=status)
+        ],
+    }
+
+
+@router.post("/api/toolsets", status_code=201)
+async def create_toolset(request: ToolsetCreateRequest) -> dict[str, Any]:
+    try:
+        item = get_toolset_service().store.create_toolset(
+            name=request.name,
+            description=request.description,
+            tags=request.tags,
+            privacy_policy=request.privacy_policy,
+            disclaimer=request.disclaimer,
+            connection=request.connection,
+        )
+        return item.model_dump(mode="json")
+    except Exception as exc:
+        raise _error(exc) from exc
+
+
+@router.get("/api/toolsets/resources")
+async def list_toolset_resources() -> dict[str, Any]:
+    items = get_toolset_service().store.list_toolsets()
+    return {
+        "version": "modelmirror-toolset-resources-v2",
+        "tabs": [
+            {"id": "all", "label": "全部"},
+            {"id": "mcp", "label": "MCP"},
+            {"id": "builtin", "label": "内置工具"},
+            {"id": "api", "label": "API"},
+            {"id": "skill", "label": "Skill"},
+        ],
+        "summary": {
+            "toolset_count": len(items),
+            "connected_count": sum(
+                item.runtime_status == "connected" for item in items
+            ),
+            "published_count": sum(item.status == "published" for item in items),
+            "enabled_tool_count": sum(
+                tool.enabled for item in items for tool in item.tools
+            ),
+        },
+        "toolsets": [
+            {
+                "id": item.id,
+                "kind": "mcp",
+                "title": item.name,
+                "description": item.description,
+                "status": item.runtime_status,
+                "transport": item.connection.transport,
+                "published_version": item.published_version,
+                "tool_count": sum(tool.enabled for tool in item.tools),
+                "tags": list(item.tags),
+                "primary_action": {
+                    "label": "管理 Toolset",
+                    "href": "/toolsets",
+                },
+            }
+            for item in items
+        ],
+        "warnings": [],
+    }
+
+
+@router.get("/api/toolsets/{toolset_id}")
+async def get_toolset(toolset_id: str) -> dict[str, Any]:
+    try:
+        return get_toolset_service().store.get_toolset(toolset_id).model_dump(
+            mode="json"
+        )
+    except Exception as exc:
+        raise _error(exc) from exc
+
+
+@router.patch("/api/toolsets/{toolset_id}")
+async def patch_toolset(
+    toolset_id: str,
+    request: ToolsetPatchRequest,
+) -> dict[str, Any]:
+    try:
+        item = get_toolset_service().store.update_toolset(
+            toolset_id,
+            revision=request.revision,
+            patch=request.patch,
+        )
+        return item.model_dump(mode="json")
+    except Exception as exc:
+        raise _error(exc) from exc
+
+
+@router.post("/api/toolsets/{toolset_id}/connect")
+async def connect_toolset(toolset_id: str) -> dict[str, Any]:
+    try:
+        item = await get_toolset_service().connect(toolset_id)
+        return item.model_dump(mode="json")
+    except Exception as exc:
+        raise _error(exc) from exc
+
+
+@router.post("/api/toolsets/{toolset_id}/disconnect")
+async def disconnect_toolset(toolset_id: str) -> dict[str, Any]:
+    try:
+        item = await get_toolset_service().disconnect(toolset_id)
+        return item.model_dump(mode="json")
+    except Exception as exc:
+        raise _error(exc) from exc
+
+
+@router.get("/api/toolsets/{toolset_id}/tools")
+async def list_toolset_tools(toolset_id: str) -> dict[str, Any]:
+    try:
+        item = get_toolset_service().store.get_toolset(toolset_id)
+        return {
+            "toolset_id": item.id,
+            "revision": item.revision,
+            "runtime_status": item.runtime_status,
+            "tools": [tool.model_dump(mode="json") for tool in item.tools],
+        }
+    except Exception as exc:
+        raise _error(exc) from exc
+
+
+@router.patch("/api/toolsets/{toolset_id}/tools/{tool_name}")
+async def patch_toolset_tool(
+    toolset_id: str,
+    tool_name: str,
+    request: ToolPatchRequest,
+) -> dict[str, Any]:
+    try:
+        item = get_toolset_service().store.update_tool(
+            toolset_id,
+            tool_name,
+            revision=request.revision,
+            patch=request.patch,
+        )
+        return item.model_dump(mode="json")
+    except Exception as exc:
+        raise _error(exc) from exc
+
+
+@router.post("/api/toolsets/{toolset_id}/tools/{tool_name}/test")
+async def test_toolset_tool(
+    toolset_id: str,
+    tool_name: str,
+    request: ToolTestRequest,
+) -> dict[str, Any]:
+    try:
+        result = await get_toolset_service().test_tool(
+            toolset_id,
+            tool_name,
+            request.arguments,
+        )
+        return {
+            "output": result.output,
+            "is_error": result.is_error,
+            "metadata": result.metadata,
+            "content_types": sorted(
+                {
+                    str(item.get("type") or "unknown")
+                    for item in result.content
+                    if isinstance(item, dict)
+                }
+            ),
+        }
+    except Exception as exc:
+        raise _error(exc) from exc
+
+
+@router.post("/api/toolsets/{toolset_id}/publish")
+async def publish_toolset(
+    toolset_id: str,
+    request: PublishRequest,
+) -> dict[str, Any]:
+    try:
+        version = await get_toolset_service().publish(
+            toolset_id,
+            expected_revision=request.revision,
+            release_notes=request.release_notes,
+        )
+        return version.model_dump(mode="json")
+    except Exception as exc:
+        raise _error(exc) from exc
+
+
+@router.get("/api/toolsets/{toolset_id}/versions")
+async def list_toolset_versions(toolset_id: str) -> dict[str, Any]:
+    try:
+        item = get_toolset_service().store.get_toolset(toolset_id)
+        return {
+            "toolset_id": item.id,
+            "published_version": item.published_version,
+            "versions": [
+                version.model_dump(mode="json") for version in item.versions
+            ],
+        }
+    except Exception as exc:
+        raise _error(exc) from exc
+
+
+@router.get("/api/toolsets/{toolset_id}/versions/{version}")
+async def get_toolset_version(toolset_id: str, version: int) -> dict[str, Any]:
+    try:
+        return get_toolset_service().store.get_version(
+            toolset_id,
+            version,
+        ).model_dump(mode="json")
+    except Exception as exc:
+        raise _error(exc) from exc
+
+
+@router.get("/api/runtime/credentials")
+async def list_credentials() -> dict[str, Any]:
+    return {
+        "credentials": [
+            item.model_dump(mode="json", exclude={"ciphertext"})
+            for item in get_toolset_service().credentials.list()
+        ]
+    }
+
+
+@router.post("/api/runtime/credentials", status_code=201)
+async def create_credential(request: CredentialCreateRequest) -> dict[str, Any]:
+    try:
+        metadata, values = get_toolset_service().credentials.create(
+            name=request.name,
+            kind=request.kind,
+            value=request.value,
+        )
+        return {
+            **metadata.model_dump(mode="json", exclude={"ciphertext"}),
+            "secret_value": values,
+            "secret_value_visible_once": True,
+        }
+    except Exception as exc:
+        raise _error(exc) from exc
+
+
+@router.post("/api/runtime/credentials/{credential_id}/rotate")
+async def rotate_credential(
+    credential_id: str,
+    request: CredentialRotateRequest,
+) -> dict[str, Any]:
+    try:
+        metadata, values = get_toolset_service().credentials.rotate(
+            credential_id,
+            value=request.value,
+        )
+        return {
+            **metadata.model_dump(mode="json", exclude={"ciphertext"}),
+            "secret_value": values,
+            "secret_value_visible_once": True,
+        }
+    except Exception as exc:
+        raise _error(exc) from exc
+
+
+@router.delete("/api/runtime/credentials/{credential_id}")
+async def revoke_credential(credential_id: str) -> dict[str, Any]:
+    try:
+        item = get_toolset_service().credentials.revoke(credential_id)
+        return item.model_dump(mode="json", exclude={"ciphertext"})
+    except Exception as exc:
+        raise _error(exc) from exc

--- a/server/toolsets/credentials.py
+++ b/server/toolsets/credentials.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import threading
+import time
+import uuid
+from pathlib import Path
+from typing import Literal
+
+from cryptography.fernet import Fernet, InvalidToken
+
+from .models import CredentialRecord
+
+
+class CredentialStoreError(Exception):
+    """Base credential vault error."""
+
+
+class CredentialNotFoundError(CredentialStoreError):
+    """Raised when a credential reference does not exist."""
+
+
+class CredentialUnavailableError(CredentialStoreError):
+    """Raised when encrypted material cannot be decrypted."""
+
+
+class CredentialStore:
+    """Small authenticated local credential vault.
+
+    The persisted master key is runtime data and must live on the mounted storage
+    volume. Toolset definitions and versions only retain credential IDs.
+    """
+
+    def __init__(
+        self,
+        storage_dir: str | Path | None = None,
+        *,
+        master_key: str | bytes | None = None,
+    ) -> None:
+        package_dir = Path(__file__).resolve().parent
+        self.storage_dir = Path(
+            storage_dir
+            or os.getenv("TOOLSET_STORAGE_DIR", "").strip()
+            or os.getenv("XPERT_STORAGE_DIR", "").strip()
+            or package_dir / "storage"
+        )
+        self.storage_path = self.storage_dir / "credentials.json"
+        self.master_key_path = self.storage_dir / "credential-master.key"
+        self._lock = threading.RLock()
+        self._fernet = Fernet(self._resolve_master_key(master_key))
+        self._ensure_storage_unlocked()
+
+    def create(
+        self,
+        *,
+        name: str,
+        value: str,
+        kind: Literal["header", "environment", "provider_key", "generic"] = "generic",
+    ) -> tuple[CredentialRecord, str]:
+        clean_name = self._required_text(name, "name", 160)
+        clean_value = self._required_text(value, "value", 20_000)
+        now = time.time()
+        record = CredentialRecord(
+            credential_id=f"cred_{uuid.uuid4().hex}",
+            name=clean_name,
+            kind=kind,
+            prefix=self._prefix(clean_value),
+            masked_value=self._mask(clean_value),
+            ciphertext=self._fernet.encrypt(clean_value.encode("utf-8")).decode("ascii"),
+            created_at=now,
+            updated_at=now,
+        )
+        with self._lock:
+            items = self._read_unlocked()
+            items.append(record)
+            self._write_unlocked(items)
+        return self._public(record), clean_value
+
+    def list(self) -> list[CredentialRecord]:
+        with self._lock:
+            items = self._read_unlocked()
+        items.sort(key=lambda item: (-item.updated_at, item.credential_id))
+        return [self._public_with_runtime_status(item) for item in items]
+
+    def get_public(self, credential_id: str) -> CredentialRecord:
+        with self._lock:
+            record = self._find_unlocked(self._read_unlocked(), credential_id)
+        return self._public_with_runtime_status(record)
+
+    def resolve(self, credential_id: str) -> str:
+        with self._lock:
+            record = self._find_unlocked(self._read_unlocked(), credential_id)
+        if record.status != "active":
+            raise CredentialUnavailableError("Credential is not active.")
+        try:
+            return self._fernet.decrypt(record.ciphertext.encode("ascii")).decode("utf-8")
+        except (InvalidToken, ValueError, UnicodeDecodeError) as exc:
+            raise CredentialUnavailableError(
+                "Credential cannot be decrypted with the current master key."
+            ) from exc
+
+    def rotate(
+        self,
+        credential_id: str,
+        *,
+        value: str,
+    ) -> tuple[CredentialRecord, str]:
+        clean_value = self._required_text(value, "value", 20_000)
+        with self._lock:
+            items = self._read_unlocked()
+            record = self._find_unlocked(items, credential_id)
+            record.ciphertext = self._fernet.encrypt(
+                clean_value.encode("utf-8")
+            ).decode("ascii")
+            record.prefix = self._prefix(clean_value)
+            record.masked_value = self._mask(clean_value)
+            record.status = "active"
+            record.updated_at = time.time()
+            self._write_unlocked(items)
+            return self._public(record), clean_value
+
+    def revoke(self, credential_id: str) -> CredentialRecord:
+        with self._lock:
+            items = self._read_unlocked()
+            record = self._find_unlocked(items, credential_id)
+            record.status = "revoked"
+            record.updated_at = time.time()
+            self._write_unlocked(items)
+            return self._public(record)
+
+    def _resolve_master_key(self, supplied: str | bytes | None) -> bytes:
+        if supplied:
+            return self._normalize_key(supplied)
+        environment_key = os.getenv("MODEL_MIRROR_CREDENTIAL_MASTER_KEY", "").strip()
+        if environment_key:
+            return self._normalize_key(environment_key)
+        self.storage_dir.mkdir(parents=True, exist_ok=True)
+        if self.master_key_path.exists():
+            raw = self.master_key_path.read_bytes().strip()
+            return self._normalize_key(raw)
+        key = Fernet.generate_key()
+        temporary = self.master_key_path.with_suffix(".tmp")
+        temporary.write_bytes(key)
+        os.replace(temporary, self.master_key_path)
+        try:
+            os.chmod(self.master_key_path, 0o600)
+        except OSError:
+            pass
+        return key
+
+    @staticmethod
+    def _normalize_key(value: str | bytes) -> bytes:
+        raw = value.encode("utf-8") if isinstance(value, str) else bytes(value)
+        try:
+            Fernet(raw)
+            return raw
+        except ValueError:
+            digest = hashlib.sha256(raw).digest()
+            return base64.urlsafe_b64encode(digest)
+
+    def _ensure_storage_unlocked(self) -> None:
+        self.storage_dir.mkdir(parents=True, exist_ok=True)
+        if not self.storage_path.exists():
+            self._write_unlocked([])
+
+    def _read_unlocked(self) -> list[CredentialRecord]:
+        self._ensure_storage_unlocked()
+        try:
+            payload = json.loads(self.storage_path.read_text(encoding="utf-8"))
+            raw = payload.get("credentials", []) if isinstance(payload, dict) else []
+            return [CredentialRecord.model_validate(item) for item in raw]
+        except (OSError, json.JSONDecodeError, ValueError) as exc:
+            raise CredentialStoreError("Credential storage is unreadable.") from exc
+
+    def _write_unlocked(self, items: list[CredentialRecord]) -> None:
+        payload = {
+            "version": "modelmirror-credentials-v1",
+            "credentials": [item.model_dump(mode="json") for item in items],
+        }
+        temporary = self.storage_path.with_suffix(".tmp")
+        temporary.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+        os.replace(temporary, self.storage_path)
+
+    @staticmethod
+    def _find_unlocked(
+        items: list[CredentialRecord], credential_id: str
+    ) -> CredentialRecord:
+        for item in items:
+            if item.credential_id == credential_id:
+                return item
+        raise CredentialNotFoundError(f"Credential not found: {credential_id}")
+
+    @staticmethod
+    def _public(record: CredentialRecord) -> CredentialRecord:
+        clone = record.model_copy(deep=True)
+        clone.ciphertext = ""
+        return clone
+
+    def _public_with_runtime_status(
+        self,
+        record: CredentialRecord,
+    ) -> CredentialRecord:
+        clone = self._public(record)
+        if record.status != "active":
+            return clone
+        try:
+            self._fernet.decrypt(record.ciphertext.encode("ascii"))
+        except (InvalidToken, ValueError):
+            clone.status = "unavailable"
+        return clone
+
+    @staticmethod
+    def _prefix(value: str) -> str:
+        return value[:4] if len(value) > 8 else value[:2]
+
+    @staticmethod
+    def _mask(value: str) -> str:
+        if len(value) <= 4:
+            return "*" * len(value)
+        return f"{value[:2]}{'*' * min(12, len(value) - 4)}{value[-2:]}"
+
+    @staticmethod
+    def _required_text(value: str, field_name: str, limit: int) -> str:
+        text = str(value or "").strip()
+        if not text:
+            raise CredentialStoreError(f"{field_name} is required.")
+        if len(text) > limit:
+            raise CredentialStoreError(f"{field_name} exceeds {limit} characters.")
+        return text

--- a/server/toolsets/models.py
+++ b/server/toolsets/models.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+ToolsetStatus = Literal["draft", "published", "archived"]
+MCPTransport = Literal["stdio", "streamable_http", "legacy_sse"]
+MCPNetworkPolicy = Literal["public_only", "trusted_private"]
+
+
+class SecretBinding(BaseModel):
+    name: str = Field(min_length=1, max_length=128)
+    credential_id: str = Field(min_length=1, max_length=160)
+
+
+class MCPConnectionProfile(BaseModel):
+    transport: MCPTransport = "stdio"
+    command: list[str] = Field(default_factory=list, max_length=64)
+    url: str = Field(default="", max_length=2048)
+    headers: list[SecretBinding] = Field(default_factory=list, max_length=40)
+    environment: list[SecretBinding] = Field(default_factory=list, max_length=40)
+    installed_project_id: str = Field(default="", max_length=160)
+    working_directory: str = Field(default="", max_length=500)
+    auto_start: bool = False
+    auto_reconnect: bool = True
+    reconnect_attempts: int = Field(default=2, ge=0, le=5)
+    tool_prefix: str = Field(
+        default="",
+        max_length=80,
+        pattern=r"^$|^[A-Za-z_][A-Za-z0-9_]{0,79}$",
+    )
+    network_policy: MCPNetworkPolicy = "public_only"
+    timeout_seconds: int = Field(default=30, ge=5, le=300)
+
+
+class ToolDefinition(BaseModel):
+    original_name: str = Field(min_length=1, max_length=200)
+    alias: str = Field(default="", max_length=200)
+    description: str = Field(default="", max_length=4000)
+    input_schema: dict[str, Any] = Field(default_factory=dict)
+    default_arguments: dict[str, Any] = Field(default_factory=dict)
+    enabled: bool = False
+    order: int = Field(default=0, ge=0, le=10_000)
+    schema_hash: str = Field(default="", max_length=128)
+    discovered_at: float = 0.0
+
+    @property
+    def raw_name(self) -> str:
+        return self.original_name
+
+    @property
+    def exposed_name(self) -> str:
+        return self.alias.strip() or self.original_name
+
+    @property
+    def exposed_description(self) -> str:
+        return self.description
+
+
+class ToolsetVersion(BaseModel):
+    version: int = Field(ge=1)
+    draft_revision: int = Field(ge=1)
+    connection: MCPConnectionProfile
+    tools: list[ToolDefinition] = Field(default_factory=list)
+    schema_hash: str
+    release_notes: str = Field(default="", max_length=2000)
+    published_at: float
+
+
+class ToolsetDefinition(BaseModel):
+    id: str
+    name: str = Field(min_length=1, max_length=160)
+    description: str = Field(default="", max_length=4000)
+    tags: list[str] = Field(default_factory=list, max_length=30)
+    privacy_policy: str = Field(default="", max_length=4000)
+    disclaimer: str = Field(default="", max_length=4000)
+    status: ToolsetStatus = "draft"
+    revision: int = Field(default=1, ge=1)
+    published_version: int | None = None
+    connection: MCPConnectionProfile = Field(default_factory=MCPConnectionProfile)
+    tools: list[ToolDefinition] = Field(default_factory=list)
+    versions: list[ToolsetVersion] = Field(default_factory=list)
+    runtime_status: str = "disconnected"
+    runtime_session_id: str | None = None
+    runtime_error: str = ""
+    created_at: float
+    updated_at: float
+
+
+class CredentialRecord(BaseModel):
+    credential_id: str
+    name: str = Field(min_length=1, max_length=160)
+    kind: Literal["header", "environment", "provider_key", "generic"] = "generic"
+    prefix: str = ""
+    masked_value: str = ""
+    ciphertext: str
+    status: Literal["active", "unavailable", "revoked"] = "active"
+    created_at: float
+    updated_at: float

--- a/server/toolsets/service.py
+++ b/server/toolsets/service.py
@@ -1,0 +1,562 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+from copy import deepcopy
+from typing import Any, Awaitable, Callable
+
+from jsonschema import Draft202012Validator
+
+try:
+    from server.mcp.manager import MCPClientManager
+    from server.xpert_runtime.toolset import (
+        RuntimeTool,
+        RuntimeToolCall,
+        RuntimeToolError,
+        RuntimeToolResult,
+    )
+except ModuleNotFoundError:  # Docker copies server packages directly under /app.
+    from mcp.manager import MCPClientManager
+    from xpert_runtime.toolset import (
+        RuntimeTool,
+        RuntimeToolCall,
+        RuntimeToolError,
+        RuntimeToolResult,
+    )
+
+from .credentials import CredentialStore
+from .models import (
+    MCPConnectionProfile,
+    ToolDefinition,
+    ToolsetDefinition,
+    ToolsetVersion,
+)
+from .store import (
+    ToolsetNotFoundError,
+    ToolsetStore,
+    ToolsetValidationError,
+)
+
+
+ToolTestRunner = Callable[[RuntimeToolCall], Awaitable[RuntimeToolResult]]
+InstalledProjectResolver = Callable[[str], dict[str, Any] | None]
+
+
+def _schema_hash(schema: dict[str, Any]) -> str:
+    encoded = json.dumps(
+        schema,
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+class ToolsetService:
+    def __init__(
+        self,
+        store: ToolsetStore,
+        credentials: CredentialStore,
+        mcp_manager: MCPClientManager,
+        installed_project_resolver: InstalledProjectResolver | None = None,
+    ) -> None:
+        self.store = store
+        self.credentials = credentials
+        self.mcp_manager = mcp_manager
+        self.installed_project_resolver = installed_project_resolver
+        self._draft_sessions: dict[str, str] = {}
+        self._version_sessions: dict[tuple[str, int], str] = {}
+        self._version_warnings: dict[tuple[str, int], list[str]] = {}
+        self._locks: dict[str, asyncio.Lock] = {}
+        self._tool_test_runner: ToolTestRunner | None = None
+
+    def set_tool_test_runner(self, runner: ToolTestRunner) -> None:
+        self._tool_test_runner = runner
+
+    async def connect(self, toolset_id: str) -> ToolsetDefinition:
+        lock = self._locks.setdefault(toolset_id, asyncio.Lock())
+        async with lock:
+            item = self.store.get_toolset(toolset_id)
+            existing = self._draft_sessions.pop(toolset_id, None)
+            if existing:
+                await self._safe_disconnect(existing)
+            session_id: str | None = None
+            try:
+                session_id = await self._connect_profile(item.connection)
+                raw_tools = await self.mcp_manager.list_tools(session_id)
+                tools = [_normalize_tool(tool) for tool in raw_tools]
+                updated = self.store.replace_discovered_tools(
+                    toolset_id,
+                    tools=tools,
+                )
+                updated = self.store.set_runtime_state(
+                    toolset_id,
+                    status="connected",
+                    session_id=session_id,
+                )
+                self._draft_sessions[toolset_id] = session_id
+                return updated
+            except Exception as exc:
+                if session_id:
+                    await self._safe_disconnect(session_id)
+                self.store.set_runtime_state(
+                    toolset_id,
+                    status="error",
+                    session_id=None,
+                    error=str(exc),
+                )
+                raise
+
+    async def disconnect(self, toolset_id: str) -> ToolsetDefinition:
+        self.store.get_toolset(toolset_id)
+        session_id = self._draft_sessions.pop(toolset_id, None)
+        if session_id:
+            await self._safe_disconnect(session_id)
+        return self.store.set_runtime_state(
+            toolset_id,
+            status="disconnected",
+            session_id=None,
+        )
+
+    async def publish(
+        self,
+        toolset_id: str,
+        *,
+        expected_revision: int,
+        release_notes: str = "",
+    ) -> ToolsetVersion:
+        item = self.store.get_toolset(toolset_id)
+        connection = self._resolve_installed_project(item.connection)
+        return self.store.publish(
+            toolset_id,
+            revision=expected_revision,
+            release_notes=release_notes,
+            connection_override=connection,
+        )
+
+    async def test_tool(
+        self,
+        toolset_id: str,
+        raw_name: str,
+        arguments: dict[str, Any],
+    ) -> RuntimeToolResult:
+        item = self.store.get_toolset(toolset_id)
+        tool = next((row for row in item.tools if row.raw_name == raw_name), None)
+        if tool is None:
+            raise ToolsetNotFoundError(f"Tool not found: {raw_name}")
+        session_id = self._draft_sessions.get(toolset_id)
+        if not session_id:
+            raise ToolsetValidationError("Connect the Toolset before testing a tool.")
+        merged = {**deepcopy(tool.default_arguments), **dict(arguments)}
+        _validate_arguments(tool, merged)
+        call = RuntimeToolCall(
+            tool_name=tool.exposed_name,
+            arguments=merged,
+            metadata={
+                "toolset_test": True,
+                "toolset_id": toolset_id,
+                "toolset_raw_name": raw_name,
+                "toolset_session_id": session_id,
+            },
+        )
+        if self._tool_test_runner is not None:
+            return await self._tool_test_runner(call)
+        result = await self.mcp_manager.call_tool(session_id, raw_name, merged)
+        return _normalize_result(result, toolset_id=toolset_id, version=None)
+
+    async def autostart(self) -> list[str]:
+        warnings: list[str] = []
+        for item in self.store.list_toolsets(status="published"):
+            if not item.connection.auto_start or item.published_version is None:
+                continue
+            try:
+                await self.ensure_version_session(item.id, item.published_version)
+            except Exception as exc:
+                warnings.append(f"{item.id}: {str(exc)[:300]}")
+        return warnings
+
+    async def close(self) -> None:
+        session_ids = set(self._draft_sessions.values()) | set(
+            self._version_sessions.values()
+        )
+        self._draft_sessions.clear()
+        self._version_sessions.clear()
+        self._version_warnings.clear()
+        for session_id in session_ids:
+            await self._safe_disconnect(session_id)
+
+    async def ensure_version_session(self, toolset_id: str, version: int) -> str:
+        key = (toolset_id, version)
+        existing = self._version_sessions.get(key)
+        if existing:
+            try:
+                snapshot = self.store.get_version(toolset_id, version)
+                discovered = {
+                    tool.name: tool
+                    for tool in await self.mcp_manager.list_tools(existing)
+                }
+                hard_errors, warnings = _detect_schema_drift(snapshot, discovered)
+                if hard_errors:
+                    raise ToolsetValidationError("; ".join(hard_errors))
+                self._version_warnings[key] = warnings
+                return existing
+            except Exception:
+                self._version_sessions.pop(key, None)
+                self._version_warnings.pop(key, None)
+                await self._safe_disconnect(existing)
+        lock = self._locks.setdefault(f"{toolset_id}@{version}", asyncio.Lock())
+        async with lock:
+            existing = self._version_sessions.get(key)
+            if existing:
+                return existing
+            snapshot = self.store.get_version(toolset_id, version)
+            session_id: str | None = None
+            try:
+                session_id = await self._connect_profile(snapshot.connection)
+                discovered = {
+                    tool.name: tool
+                    for tool in await self.mcp_manager.list_tools(session_id)
+                }
+                hard_errors, warnings = _detect_schema_drift(snapshot, discovered)
+                if hard_errors:
+                    raise ToolsetValidationError("; ".join(hard_errors))
+            except Exception:
+                if session_id:
+                    await self._safe_disconnect(session_id)
+                raise
+            if session_id is None:
+                raise ToolsetValidationError("MCP Toolset session did not start.")
+            self._version_warnings[key] = warnings
+            self._version_sessions[key] = session_id
+            return session_id
+
+    async def call_published_tool(
+        self,
+        *,
+        toolset_id: str,
+        version: int,
+        exposed_name: str,
+        arguments: dict[str, Any],
+    ) -> RuntimeToolResult:
+        snapshot = self.store.get_version(toolset_id, version)
+        tool = next(
+            (row for row in snapshot.tools if row.exposed_name == exposed_name),
+            None,
+        )
+        if tool is None:
+            raise RuntimeToolError(
+                exposed_name,
+                "Tool is not enabled in the fixed Toolset version.",
+                code="toolset_scope_denied",
+            )
+        merged = {**deepcopy(tool.default_arguments), **dict(arguments)}
+        try:
+            _validate_arguments(tool, merged)
+            session_id = await self.ensure_version_session(toolset_id, version)
+            result = await self.mcp_manager.call_tool(
+                session_id,
+                tool.raw_name,
+                merged,
+            )
+        except RuntimeToolError:
+            raise
+        except Exception as exc:
+            raise RuntimeToolError(
+                exposed_name,
+                str(exc)[:500],
+                code="toolset_call_failed",
+            ) from exc
+        normalized = _normalize_result(
+            result,
+            toolset_id=toolset_id,
+            version=version,
+        )
+        warnings = self._version_warnings.get((toolset_id, version), [])
+        if warnings:
+            normalized.metadata["schema_warnings"] = list(warnings)
+        return normalized
+
+    async def _connect_profile(self, profile: Any) -> str:
+        profile = self._resolve_installed_project(profile)
+        headers: dict[str, str] = {}
+        environment: dict[str, str] = {}
+        for binding in profile.headers:
+            value = self.credentials.resolve(binding.credential_id)
+            headers[binding.name] = (
+                value
+                if binding.name.lower() != "authorization"
+                or value.lower().startswith(("bearer ", "basic "))
+                else f"Bearer {value}"
+            )
+        for binding in profile.environment:
+            environment[binding.name] = self.credentials.resolve(
+                binding.credential_id
+            )
+        return await self.mcp_manager.connect_profile(
+            transport=profile.transport,
+            server_command=profile.command,
+            url=profile.url,
+            headers=headers,
+            environment=environment,
+            network_policy=profile.network_policy,
+            reconnect_attempts=(
+                profile.reconnect_attempts if profile.auto_reconnect else 0
+            ),
+            operation_timeout=profile.timeout_seconds,
+            working_directory=profile.working_directory,
+        )
+
+    def _resolve_installed_project(
+        self,
+        profile: MCPConnectionProfile,
+    ) -> MCPConnectionProfile:
+        resolved = profile.model_copy(deep=True)
+        project_id = resolved.installed_project_id.strip()
+        if resolved.transport != "stdio" or not project_id:
+            return resolved
+        if resolved.command:
+            return resolved
+        if self.installed_project_resolver is None:
+            raise ToolsetValidationError(
+                "Installed MCP project resolver is unavailable."
+            )
+        project = self.installed_project_resolver(project_id)
+        if not project:
+            raise ToolsetValidationError(
+                f"Installed MCP project not found: {project_id}"
+            )
+        command = [
+            str(part)
+            for part in list(project.get("server_command") or [])
+            if isinstance(part, str) and part
+        ]
+        if not command:
+            raise ToolsetValidationError(
+                f"Installed MCP project is not runnable: {project_id}"
+            )
+        resolved.command = command
+        return resolved
+
+    async def _safe_disconnect(self, session_id: str) -> None:
+        try:
+            await self.mcp_manager.disconnect(session_id)
+        except Exception:
+            pass
+
+
+class PublishedMCPToolsetProvider:
+    provider_name = "published_mcp_toolset"
+
+    def __init__(self, service: ToolsetService) -> None:
+        self.service = service
+
+    async def list_tools(
+        self,
+        resources: list[dict[str, Any]] | None = None,
+    ) -> list[RuntimeTool]:
+        result: list[RuntimeTool] = []
+        for resource in resources or []:
+            toolset_id = str(resource.get("toolset_id") or "")
+            version = int(resource.get("pinned_version") or 0)
+            if not toolset_id or version < 1:
+                continue
+            snapshot = self.service.store.get_version(toolset_id, version)
+            prefix = snapshot.connection.tool_prefix
+            for tool in snapshot.tools:
+                exposed = tool.exposed_name
+                if prefix:
+                    exposed = f"{prefix}_{exposed}"
+                result.append(
+                    RuntimeTool(
+                        name=exposed,
+                        description=tool.exposed_description,
+                        input_schema=deepcopy(tool.input_schema),
+                        provider=self.provider_name,
+                        metadata={
+                            "toolset_id": toolset_id,
+                            "toolset_version": version,
+                            "toolset_raw_name": tool.raw_name,
+                            "toolset_exposed_name": tool.exposed_name,
+                        },
+                    )
+                )
+        return result
+
+    async def find_tool(
+        self,
+        tool_name: str,
+        resources: list[dict[str, Any]] | None = None,
+    ) -> RuntimeTool | None:
+        return next(
+            (tool for tool in await self.list_tools(resources) if tool.name == tool_name),
+            None,
+        )
+
+    async def call_tool(self, call: RuntimeToolCall) -> RuntimeToolResult:
+        resources = list(call.metadata.get("toolset_resources") or [])
+        matched = await self.find_tool(call.tool_name, resources)
+        if matched is None:
+            raise RuntimeToolError(
+                call.tool_name,
+                "Tool is outside the bound Toolset scope.",
+                code="toolset_scope_denied",
+            )
+        metadata = matched.metadata
+        return await self.service.call_published_tool(
+            toolset_id=str(metadata["toolset_id"]),
+            version=int(metadata["toolset_version"]),
+            exposed_name=str(metadata["toolset_exposed_name"]),
+            arguments=call.arguments,
+        )
+
+
+class DraftMCPToolTestProvider:
+    """Scoped provider used only by the trusted Toolset management test action."""
+
+    def __init__(self, service: ToolsetService) -> None:
+        self.service = service
+
+    async def call_tool(self, call: RuntimeToolCall) -> RuntimeToolResult:
+        if not call.metadata.get("toolset_test"):
+            raise RuntimeToolError(
+                call.tool_name,
+                "Draft Toolset test scope is missing.",
+                code="toolset_scope_denied",
+            )
+        session_id = str(call.metadata.get("toolset_session_id") or "")
+        raw_name = str(call.metadata.get("toolset_raw_name") or "")
+        toolset_id = str(call.metadata.get("toolset_id") or "")
+        if not session_id or not raw_name or not toolset_id:
+            raise RuntimeToolError(
+                call.tool_name,
+                "Draft Toolset test metadata is incomplete.",
+                code="toolset_scope_denied",
+            )
+        try:
+            result = await self.service.mcp_manager.call_tool(
+                session_id,
+                raw_name,
+                call.arguments,
+            )
+        except Exception as exc:
+            raise RuntimeToolError(
+                call.tool_name,
+                str(exc)[:500],
+                code="toolset_test_failed",
+            ) from exc
+        return _normalize_result(result, toolset_id=toolset_id, version=None)
+
+
+def _normalize_tool(tool: Any) -> ToolDefinition:
+    if hasattr(tool, "model_dump"):
+        data = tool.model_dump(by_alias=True)
+    elif isinstance(tool, dict):
+        data = dict(tool)
+    else:
+        data = vars(tool)
+    schema = data.get("inputSchema") or data.get("input_schema") or {}
+    return ToolDefinition(
+        original_name=str(data.get("name") or ""),
+        description=str(data.get("description") or ""),
+        input_schema=dict(schema) if isinstance(schema, dict) else {},
+        schema_hash=_schema_hash(schema if isinstance(schema, dict) else {}),
+    )
+
+
+def _validate_arguments(tool: ToolDefinition, arguments: dict[str, Any]) -> None:
+    try:
+        Draft202012Validator(tool.input_schema or {}).validate(arguments)
+    except Exception as exc:
+        raise ToolsetValidationError(
+            f"Arguments do not match {tool.exposed_name} schema: {str(exc)[:300]}"
+        ) from exc
+
+
+def _detect_schema_drift(
+    snapshot: ToolsetVersion,
+    discovered: dict[str, Any],
+) -> tuple[list[str], list[str]]:
+    hard_errors: list[str] = []
+    warnings: list[str] = []
+    for expected in snapshot.tools:
+        current_raw = discovered.get(expected.raw_name)
+        if current_raw is None:
+            hard_errors.append(f"Published tool disappeared: {expected.raw_name}")
+            continue
+        current = _normalize_tool(current_raw)
+        old_required = set(expected.input_schema.get("required") or [])
+        new_required = set(current.input_schema.get("required") or [])
+        added_required = sorted(new_required - old_required)
+        if added_required:
+            hard_errors.append(
+                f"{expected.raw_name} added required parameters: "
+                f"{', '.join(added_required)}"
+            )
+        old_properties = expected.input_schema.get("properties") or {}
+        new_properties = current.input_schema.get("properties") or {}
+        if isinstance(old_properties, dict) and isinstance(new_properties, dict):
+            changed_types = sorted(
+                name
+                for name, old_schema in old_properties.items()
+                if name in new_properties
+                and isinstance(old_schema, dict)
+                and isinstance(new_properties[name], dict)
+                and old_schema.get("type")
+                and new_properties[name].get("type")
+                and old_schema.get("type") != new_properties[name].get("type")
+            )
+            if changed_types:
+                hard_errors.append(
+                    f"{expected.raw_name} changed parameter types: "
+                    f"{', '.join(changed_types)}"
+                )
+        if (
+            not added_required
+            and not any(
+                message.startswith(
+                    f"{expected.raw_name} changed parameter types:"
+                )
+                for message in hard_errors
+            )
+            and current.schema_hash != expected.schema_hash
+        ):
+            warnings.append(f"{expected.raw_name} schema changed compatibly.")
+    return hard_errors, warnings
+
+
+def _normalize_result(
+    result: Any,
+    *,
+    toolset_id: str,
+    version: int | None,
+) -> RuntimeToolResult:
+    content_items = list(getattr(result, "content", []) or [])
+    content: list[dict[str, Any]] = []
+    text_parts: list[str] = []
+    for item in content_items:
+        if hasattr(item, "model_dump"):
+            value = dict(item.model_dump())
+        elif isinstance(item, dict):
+            value = dict(item)
+        else:
+            value = {"type": "unknown", "raw": str(item)}
+        content.append(value)
+        if value.get("type") == "text" and isinstance(value.get("text"), str):
+            text_parts.append(value["text"])
+    output = "\n\n".join(text_parts)
+    if len(output) > 65536:
+        output = output[:65536] + "\n...[truncated]"
+    return RuntimeToolResult(
+        output=output,
+        content=content[:50],
+        metadata={
+            "toolset_id": toolset_id,
+            "toolset_version": version,
+            "output_length": len(output),
+        },
+        is_error=bool(
+            getattr(result, "isError", False)
+            or getattr(result, "is_error", False)
+        ),
+    )

--- a/server/toolsets/store.py
+++ b/server/toolsets/store.py
@@ -1,0 +1,425 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import threading
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+from .models import (
+    MCPConnectionProfile,
+    ToolDefinition,
+    ToolsetDefinition,
+    ToolsetVersion,
+)
+
+
+TOOL_NAME_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_.:-]{0,199}$")
+
+
+class ToolsetStoreError(Exception):
+    """Base Toolset persistence error."""
+
+
+class ToolsetNotFoundError(ToolsetStoreError):
+    """Raised when a Toolset or version does not exist."""
+
+
+class ToolsetConflictError(ToolsetStoreError):
+    """Raised when a stale draft revision is submitted."""
+
+
+class ToolsetValidationError(ToolsetStoreError):
+    """Raised when Toolset data is not publishable."""
+
+
+class ToolsetStore:
+    """Atomic file-backed Toolset draft and immutable version store."""
+
+    def __init__(self, storage_dir: str | Path | None = None) -> None:
+        package_dir = Path(__file__).resolve().parent
+        self.storage_dir = Path(
+            storage_dir
+            or os.getenv("TOOLSET_STORAGE_DIR", "").strip()
+            or os.getenv("XPERT_STORAGE_DIR", "").strip()
+            or package_dir / "storage"
+        )
+        self.storage_path = self.storage_dir / "toolsets.json"
+        self._lock = threading.RLock()
+        self._ensure_storage_unlocked()
+
+    def list_toolsets(
+        self,
+        *,
+        status: str | None = None,
+        search: str = "",
+        limit: int = 100,
+    ) -> list[ToolsetDefinition]:
+        clean_search = search.strip().lower()
+        with self._lock:
+            items = self._read_unlocked()
+        if status:
+            items = [item for item in items if item.status == status]
+        if clean_search:
+            items = [
+                item
+                for item in items
+                if clean_search
+                in " ".join([item.name, item.description, *item.tags]).lower()
+            ]
+        items.sort(key=lambda item: (-item.updated_at, item.id))
+        return [item.model_copy(deep=True) for item in items[: max(1, min(limit, 500))]]
+
+    def create_toolset(
+        self,
+        *,
+        name: str,
+        description: str = "",
+        tags: list[str] | None = None,
+        privacy_policy: str = "",
+        disclaimer: str = "",
+        connection: dict[str, Any] | MCPConnectionProfile | None = None,
+    ) -> ToolsetDefinition:
+        now = time.time()
+        item = ToolsetDefinition(
+            id=f"toolset_{uuid.uuid4().hex}",
+            name=self._required_text(name, "name", 160),
+            description=str(description or "").strip()[:4000],
+            tags=self._clean_tags(tags),
+            privacy_policy=str(privacy_policy or "").strip()[:4000],
+            disclaimer=str(disclaimer or "").strip()[:4000],
+            connection=MCPConnectionProfile.model_validate(connection or {}),
+            created_at=now,
+            updated_at=now,
+        )
+        with self._lock:
+            items = self._read_unlocked()
+            items.append(item)
+            self._write_unlocked(items)
+        return item.model_copy(deep=True)
+
+    def get_toolset(self, toolset_id: str) -> ToolsetDefinition:
+        with self._lock:
+            return self._find_unlocked(self._read_unlocked(), toolset_id).model_copy(
+                deep=True
+            )
+
+    def update_toolset(
+        self,
+        toolset_id: str,
+        *,
+        revision: int,
+        patch: dict[str, Any],
+    ) -> ToolsetDefinition:
+        allowed = {
+            "name",
+            "description",
+            "tags",
+            "privacy_policy",
+            "disclaimer",
+            "connection",
+            "status",
+        }
+        unknown = set(patch) - allowed
+        if unknown:
+            raise ToolsetValidationError(
+                f"Unsupported Toolset fields: {', '.join(sorted(unknown))}."
+            )
+        with self._lock:
+            items = self._read_unlocked()
+            item = self._find_unlocked(items, toolset_id)
+            self._check_revision(item, revision)
+            if "name" in patch:
+                item.name = self._required_text(patch["name"], "name", 160)
+            if "description" in patch:
+                item.description = str(patch["description"] or "").strip()[:4000]
+            if "tags" in patch:
+                item.tags = self._clean_tags(patch["tags"])
+            if "privacy_policy" in patch:
+                item.privacy_policy = str(patch["privacy_policy"] or "").strip()[:4000]
+            if "disclaimer" in patch:
+                item.disclaimer = str(patch["disclaimer"] or "").strip()[:4000]
+            if "connection" in patch:
+                item.connection = MCPConnectionProfile.model_validate(
+                    patch["connection"] or {}
+                )
+            if "status" in patch:
+                status = str(patch["status"] or "").strip()
+                if status not in {"draft", "published", "archived"}:
+                    raise ToolsetValidationError("Unsupported Toolset status.")
+                if status == "published" and not item.versions:
+                    raise ToolsetValidationError("Publish through the publish endpoint.")
+                item.status = status  # type: ignore[assignment]
+            item.revision += 1
+            item.updated_at = time.time()
+            self._write_unlocked(items)
+            return item.model_copy(deep=True)
+
+    def replace_discovered_tools(
+        self,
+        toolset_id: str,
+        *,
+        tools: list[dict[str, Any] | ToolDefinition],
+    ) -> ToolsetDefinition:
+        now = time.time()
+        with self._lock:
+            items = self._read_unlocked()
+            item = self._find_unlocked(items, toolset_id)
+            current = {tool.original_name: tool for tool in item.tools}
+            discovered: list[ToolDefinition] = []
+            for index, raw in enumerate(tools):
+                candidate = (
+                    raw
+                    if isinstance(raw, ToolDefinition)
+                    else ToolDefinition.model_validate(raw)
+                )
+                if not TOOL_NAME_PATTERN.fullmatch(candidate.original_name):
+                    raise ToolsetValidationError(
+                        f"Invalid MCP tool name: {candidate.original_name}"
+                    )
+                previous = current.get(candidate.original_name)
+                candidate.alias = previous.alias if previous else candidate.alias
+                candidate.description = (
+                    previous.description
+                    if previous and previous.description
+                    else candidate.description
+                )
+                candidate.default_arguments = (
+                    dict(previous.default_arguments) if previous else {}
+                )
+                candidate.enabled = previous.enabled if previous else False
+                candidate.order = previous.order if previous else index
+                candidate.schema_hash = self.schema_hash(candidate.input_schema)
+                candidate.discovered_at = now
+                discovered.append(candidate)
+            item.tools = discovered
+            item.runtime_status = "connected"
+            item.runtime_error = ""
+            item.revision += 1
+            item.updated_at = now
+            self._write_unlocked(items)
+            return item.model_copy(deep=True)
+
+    def update_tool(
+        self,
+        toolset_id: str,
+        tool_name: str,
+        *,
+        revision: int,
+        patch: dict[str, Any],
+    ) -> ToolsetDefinition:
+        allowed = {"alias", "description", "default_arguments", "enabled", "order"}
+        unknown = set(patch) - allowed
+        if unknown:
+            raise ToolsetValidationError(
+                f"Unsupported tool fields: {', '.join(sorted(unknown))}."
+            )
+        with self._lock:
+            items = self._read_unlocked()
+            item = self._find_unlocked(items, toolset_id)
+            self._check_revision(item, revision)
+            tool = next(
+                (candidate for candidate in item.tools if candidate.original_name == tool_name),
+                None,
+            )
+            if tool is None:
+                raise ToolsetNotFoundError(f"Tool not found: {tool_name}")
+            if "alias" in patch:
+                alias = str(patch["alias"] or "").strip()
+                if alias and not TOOL_NAME_PATTERN.fullmatch(alias):
+                    raise ToolsetValidationError("Tool alias is invalid.")
+                tool.alias = alias
+            if "description" in patch:
+                tool.description = str(patch["description"] or "").strip()[:4000]
+            if "default_arguments" in patch:
+                if not isinstance(patch["default_arguments"], dict):
+                    raise ToolsetValidationError("default_arguments must be an object.")
+                tool.default_arguments = dict(patch["default_arguments"])
+            if "enabled" in patch:
+                tool.enabled = bool(patch["enabled"])
+            if "order" in patch:
+                tool.order = max(0, min(int(patch["order"]), 10_000))
+            self._ensure_unique_runtime_names(item.tools)
+            item.revision += 1
+            item.updated_at = time.time()
+            self._write_unlocked(items)
+            return item.model_copy(deep=True)
+
+    def set_runtime_state(
+        self,
+        toolset_id: str,
+        *,
+        status: str,
+        session_id: str | None,
+        error: str = "",
+    ) -> ToolsetDefinition:
+        with self._lock:
+            items = self._read_unlocked()
+            item = self._find_unlocked(items, toolset_id)
+            item.runtime_status = str(status or "disconnected")[:80]
+            item.runtime_session_id = session_id
+            item.runtime_error = str(error or "").strip()[:500]
+            item.updated_at = time.time()
+            self._write_unlocked(items)
+            return item.model_copy(deep=True)
+
+    def publish(
+        self,
+        toolset_id: str,
+        *,
+        revision: int,
+        release_notes: str = "",
+        connection_override: MCPConnectionProfile | None = None,
+    ) -> ToolsetVersion:
+        with self._lock:
+            items = self._read_unlocked()
+            item = self._find_unlocked(items, toolset_id)
+            self._check_revision(item, revision)
+            if item.runtime_status != "connected":
+                raise ToolsetValidationError("Toolset must be connected before publish.")
+            enabled = sorted(
+                (tool.model_copy(deep=True) for tool in item.tools if tool.enabled),
+                key=lambda tool: (tool.order, tool.original_name),
+            )
+            if not enabled:
+                raise ToolsetValidationError("Enable at least one discovered tool.")
+            self._ensure_unique_runtime_names(enabled)
+            version_connection = (
+                connection_override.model_copy(deep=True)
+                if connection_override is not None
+                else item.connection.model_copy(deep=True)
+            )
+            next_version = max((version.version for version in item.versions), default=0) + 1
+            canonical = json.dumps(
+                {
+                    "connection": version_connection.model_dump(mode="json"),
+                    "tools": [tool.model_dump(mode="json") for tool in enabled],
+                },
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            version = ToolsetVersion(
+                version=next_version,
+                draft_revision=item.revision,
+                connection=version_connection,
+                tools=enabled,
+                schema_hash=hashlib.sha256(canonical.encode("utf-8")).hexdigest(),
+                release_notes=str(release_notes or "").strip()[:2000],
+                published_at=time.time(),
+            )
+            item.versions.append(version)
+            item.published_version = version.version
+            item.status = "published"
+            item.updated_at = version.published_at
+            self._write_unlocked(items)
+            return version.model_copy(deep=True)
+
+    def get_version(
+        self, toolset_id: str, version: int | None = None
+    ) -> ToolsetVersion:
+        item = self.get_toolset(toolset_id)
+        target = version if version is not None else item.published_version
+        if target is None:
+            raise ToolsetNotFoundError("Toolset has not been published.")
+        for snapshot in item.versions:
+            if snapshot.version == target:
+                return snapshot.model_copy(deep=True)
+        raise ToolsetNotFoundError(f"Toolset version not found: {target}")
+
+    def list_versions(self, toolset_id: str) -> list[ToolsetVersion]:
+        item = self.get_toolset(toolset_id)
+        return [version.model_copy(deep=True) for version in reversed(item.versions)]
+
+    @staticmethod
+    def schema_hash(schema: dict[str, Any]) -> str:
+        canonical = json.dumps(
+            schema or {},
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def runtime_name(tool: ToolDefinition, prefix: str = "") -> str:
+        name = tool.alias.strip() or tool.original_name
+        return f"{prefix}_{name}" if prefix else name
+
+    @classmethod
+    def _ensure_unique_runtime_names(cls, tools: list[ToolDefinition]) -> None:
+        seen: set[str] = set()
+        for tool in tools:
+            if not tool.enabled:
+                continue
+            name = cls.runtime_name(tool)
+            if name in seen:
+                raise ToolsetValidationError(f"Duplicate enabled tool name: {name}")
+            seen.add(name)
+
+    def _ensure_storage_unlocked(self) -> None:
+        self.storage_dir.mkdir(parents=True, exist_ok=True)
+        if not self.storage_path.exists():
+            self._write_unlocked([])
+
+    def _read_unlocked(self) -> list[ToolsetDefinition]:
+        self._ensure_storage_unlocked()
+        try:
+            payload = json.loads(self.storage_path.read_text(encoding="utf-8"))
+            raw = payload.get("toolsets", []) if isinstance(payload, dict) else []
+            return [ToolsetDefinition.model_validate(item) for item in raw]
+        except (OSError, json.JSONDecodeError, ValueError) as exc:
+            raise ToolsetStoreError("Toolset storage is unreadable.") from exc
+
+    def _write_unlocked(self, items: list[ToolsetDefinition]) -> None:
+        self.storage_dir.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "version": "modelmirror-toolsets-v1",
+            "toolsets": [item.model_dump(mode="json") for item in items],
+        }
+        temporary = self.storage_path.with_suffix(".tmp")
+        temporary.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+        os.replace(temporary, self.storage_path)
+
+    @staticmethod
+    def _find_unlocked(
+        items: list[ToolsetDefinition], toolset_id: str
+    ) -> ToolsetDefinition:
+        for item in items:
+            if item.id == toolset_id:
+                return item
+        raise ToolsetNotFoundError(f"Toolset not found: {toolset_id}")
+
+    @staticmethod
+    def _check_revision(item: ToolsetDefinition, revision: int) -> None:
+        if item.revision != int(revision):
+            raise ToolsetConflictError(
+                f"Toolset revision conflict: expected {item.revision}."
+            )
+
+    @staticmethod
+    def _required_text(value: Any, field_name: str, limit: int) -> str:
+        text = str(value or "").strip()
+        if not text:
+            raise ToolsetValidationError(f"{field_name} is required.")
+        if len(text) > limit:
+            raise ToolsetValidationError(f"{field_name} exceeds {limit} characters.")
+        return text
+
+    @staticmethod
+    def _clean_tags(values: list[str] | None) -> list[str]:
+        tags: list[str] = []
+        for value in values or []:
+            clean = str(value or "").strip()[:80]
+            if clean and clean not in tags:
+                tags.append(clean)
+            if len(tags) >= 30:
+                break
+        return tags

--- a/server/workflow_native/schemas.py
+++ b/server/workflow_native/schemas.py
@@ -23,6 +23,7 @@ NativeNodeKind = Literal[
     "workflow_agent",
     "external_xpert",
     "knowledge_base",
+    "toolset_resource",
     "agent_task",
     "agent_handoff",
     "handoff_router",

--- a/server/workflow_native/validate.py
+++ b/server/workflow_native/validate.py
@@ -54,6 +54,8 @@ NODE_KIND_ALIASES = {
     "external-xpert": "external_xpert",
     "knowledge_base": "knowledge_base",
     "knowledge-base": "knowledge_base",
+    "toolset_resource": "toolset_resource",
+    "toolset-resource": "toolset_resource",
     "agent_task": "agent_task",
     "agent-task": "agent_task",
     "agent_handoff": "agent_handoff",
@@ -98,6 +100,7 @@ SUPPORTED_NODE_KINDS = {
     "workflow_agent",
     "external_xpert",
     "knowledge_base",
+    "toolset_resource",
     "agent_task",
     "agent_handoff",
     "handoff_router",
@@ -1119,6 +1122,42 @@ def validate_node_configuration(
                     node_id=node.id,
                 )
             )
+
+    if kind == "toolset_resource":
+        if not str(data.get("toolsetId") or "").strip():
+            issues.append(
+                ValidationIssue(
+                    code="missing_toolset_resource_id",
+                    message="Toolset resource needs data.toolsetId.",
+                    node_id=node.id,
+                )
+            )
+        version_policy = str(
+            data.get("versionPolicy") or "current_published"
+        ).strip()
+        if version_policy not in {"current_published", "pinned"}:
+            issues.append(
+                ValidationIssue(
+                    code="invalid_toolset_version_policy",
+                    message=(
+                        "Toolset versionPolicy must be current_published or pinned."
+                    ),
+                    node_id=node.id,
+                )
+            )
+        if version_policy == "pinned":
+            try:
+                pinned_version = int(data.get("pinnedVersion"))
+            except (TypeError, ValueError):
+                pinned_version = 0
+            if pinned_version < 1:
+                issues.append(
+                    ValidationIssue(
+                        code="invalid_toolset_pinned_version",
+                        message="Pinned Toolset resources require pinnedVersion >= 1.",
+                        node_id=node.id,
+                    )
+                )
 
     if kind == "agent_task":
         task_title = str(data.get("taskTitle") or "").strip()
@@ -2441,11 +2480,13 @@ def validate_edges(
                 "middleware": "runtime_middleware",
                 "expert": "external_xpert",
                 "knowledge": "knowledge_base",
+                "toolset": "toolset_resource",
             }.get(target_handle)
             expected_source_handle = {
                 "middleware": "middleware-binding",
                 "expert": "expert-binding",
                 "knowledge": "knowledge-binding",
+                "toolset": "toolset-binding",
             }.get(target_handle)
             if (
                 expected_source_kind is None
@@ -2469,6 +2510,7 @@ def validate_edges(
                 "middleware-binding",
                 "expert-binding",
                 "knowledge-binding",
+                "toolset-binding",
             }:
                 issues.append(
                     ValidationIssue(
@@ -2517,15 +2559,15 @@ def validate_edges(
             )
 
     for node_id, kind in kinds_by_id.items():
-        if kind not in {"external_xpert", "knowledge_base"}:
+        if kind not in {"external_xpert", "knowledge_base", "toolset_resource"}:
             continue
         if node_id not in bindings_by_source:
             issues.append(
                 ValidationIssue(
                     code="missing_resource_binding",
                     message=(
-                        "External Xpert and Knowledge Base nodes must bind to exactly "
-                        "one workflow_agent."
+                        "External Xpert, Knowledge Base, and Toolset nodes must bind "
+                        "to exactly one workflow_agent."
                     ),
                     node_id=node_id,
                 )
@@ -2560,7 +2602,11 @@ def validate_edges(
         expert_tool_names_by_agent[edge.target].add(tool_name)
 
     for edge in valid_edges:
-        if str(edge.targetHandle or "").strip() not in {"expert", "knowledge"}:
+        if str(edge.targetHandle or "").strip() not in {
+            "expert",
+            "knowledge",
+            "toolset",
+        }:
             continue
         target = nodes_by_id.get(edge.target)
         if (
@@ -2571,7 +2617,7 @@ def validate_edges(
                 ValidationIssue(
                     code="resource_binding_requires_runtime_tool_mode",
                     message=(
-                        "Bound External Xpert and Knowledge resources require "
+                        "Bound External Xpert, Knowledge, and Toolset resources require "
                         "workflow_agent toolMode=mcp_tools."
                     ),
                     node_id=target.id,

--- a/server/xpert_runtime/hitl_middleware.py
+++ b/server/xpert_runtime/hitl_middleware.py
@@ -75,6 +75,9 @@ def build_human_in_the_loop_middleware(
                     "middleware_priority": spec.priority,
                     "iteration": iteration,
                     "capability": request.metadata.get("capability"),
+                    "tool_input_schema": dict(
+                        request.metadata.get("tool_input_schema") or {}
+                    ),
                 },
             )
         except Exception as exc:

--- a/server/xpert_runtime/workflow_node_registry.py
+++ b/server/xpert_runtime/workflow_node_registry.py
@@ -339,6 +339,17 @@ def register_builtin_workflow_nodes(registry: WorkflowNodeRegistry) -> None:
                     category="resource",
                     tags=["knowledge", "rag", "resource", "binding"],
                 ),
+                WorkflowPaletteItem(
+                    kind="toolset_resource",
+                    icon="TS",
+                    title="MCP Toolset",
+                    description=(
+                        "Bind one immutable published MCP Toolset version to a "
+                        "workflow agent."
+                    ),
+                    category="resource",
+                    tags=["mcp", "toolset", "resource", "binding"],
+                ),
             ],
         )
     )

--- a/server/xperts/api.py
+++ b/server/xperts/api.py
@@ -109,6 +109,42 @@ def _prepare_published_resource_snapshot(
     for node in workflow.nodes:
         data = node.data if isinstance(node.data, dict) else {}
         kind = str(data.get("kind") or node.type or "")
+        if kind == "toolset_resource":
+            reference = str(data.get("toolsetId") or "").strip()
+            try:
+                try:
+                    from server.toolsets import get_toolset_service
+                except ModuleNotFoundError:
+                    from toolsets import get_toolset_service
+
+                toolset_service = get_toolset_service()
+                toolset = toolset_service.store.get_toolset(reference)
+                policy = str(
+                    data.get("versionPolicy") or "current_published"
+                ).strip()
+                version_number = (
+                    int(data.get("pinnedVersion") or 0)
+                    if policy == "pinned"
+                    else int(toolset.published_version or 0)
+                )
+                if toolset.status != "published" or version_number < 1:
+                    raise ValueError(
+                        f"Toolset must be published before Xpert publish: {reference}."
+                    )
+                toolset_service.store.get_version(toolset.id, version_number)
+                data["toolsetId"] = toolset.id
+                data["versionPolicy"] = "pinned"
+                data["pinnedVersion"] = version_number
+                node.data = data
+            except Exception as exc:
+                issues.append(
+                    ValidationIssue(
+                        code="xpert_toolset_resource_invalid",
+                        message=str(exc),
+                        node_id=node.id,
+                    )
+                )
+            continue
         if kind == "knowledge_base":
             kb_id = str(data.get("knowledgeBaseId") or "").strip()
             if not kb_id:
@@ -168,6 +204,58 @@ def _prepare_published_resource_snapshot(
                     node_id=node.id,
                 )
             )
+
+    nodes_by_id = {node.id: node for node in workflow.nodes}
+    names_by_agent: dict[str, set[str]] = {}
+    for edge in workflow.edges:
+        if str(edge.targetHandle or "") != "toolset":
+            continue
+        resource = nodes_by_id.get(edge.source)
+        agent = nodes_by_id.get(edge.target)
+        if resource is None or agent is None:
+            continue
+        resource_data = resource.data if isinstance(resource.data, dict) else {}
+        try:
+            try:
+                from server.toolsets import get_toolset_service
+            except ModuleNotFoundError:
+                from toolsets import get_toolset_service
+
+            toolset_service = get_toolset_service()
+            toolset_id = str(resource_data.get("toolsetId") or "")
+            version_number = int(resource_data.get("pinnedVersion") or 0)
+            snapshot = toolset_service.store.get_version(toolset_id, version_number)
+            prefix = snapshot.connection.tool_prefix
+            bound_names = {
+                f"{prefix}_{tool.exposed_name}" if prefix else tool.exposed_name
+                for tool in snapshot.tools
+            }
+            existing = names_by_agent.setdefault(edge.target, set())
+            duplicates = sorted(existing.intersection(bound_names))
+            inline_names = {
+                item.strip()
+                for item in re.split(
+                    r"[,\n]+",
+                    str(agent.data.get("toolNames") or ""),
+                )
+                if item.strip()
+            }
+            inline_conflicts = sorted(inline_names.intersection(bound_names))
+            if duplicates or inline_conflicts:
+                conflict_names = sorted(set(duplicates + inline_conflicts))
+                issues.append(
+                    ValidationIssue(
+                        code="xpert_toolset_name_conflict",
+                        message=(
+                            "Bound Toolset names conflict for this workflow_agent: "
+                            + ", ".join(conflict_names)
+                        ),
+                        node_id=resource.id,
+                    )
+                )
+            existing.update(bound_names)
+        except Exception:
+            continue
 
     def walk_dependencies(
         owner_id: str,

--- a/server/xperts/app_api.py
+++ b/server/xperts/app_api.py
@@ -135,6 +135,7 @@ def _deployment_preflight(version: XpertVersion, policy: XpertAppPolicy) -> dict
     has_datax_runtime = False
     has_datax_write = False
     has_external_xpert = False
+    has_toolset_resource = False
     datax_project_ids: set[str] = set()
     datax_model_ids: set[str] = set()
     contract_forbidden_middleware: set[str] = set()
@@ -166,6 +167,9 @@ def _deployment_preflight(version: XpertVersion, policy: XpertAppPolicy) -> dict
             has_tool_call = True
         if kind == "external_xpert":
             has_external_xpert = True
+            has_tool_call = True
+        if kind == "toolset_resource":
+            has_toolset_resource = True
             has_tool_call = True
         if kind == "knowledge_base":
             has_knowledge = True
@@ -288,6 +292,15 @@ def _deployment_preflight(version: XpertVersion, policy: XpertAppPolicy) -> dict
             {
                 "code": "app_external_xpert_forbidden",
                 "message": "Public Xpert Apps cannot deploy external Xpert collaborators.",
+            }
+        )
+    if has_toolset_resource:
+        issues.append(
+            {
+                "code": "app_toolset_resource_forbidden",
+                "message": (
+                    "Public Xpert Apps cannot deploy bound MCP Toolset resources yet."
+                ),
             }
         )
     if has_dynamic_knowledge_read and not policy.allow_knowledge_read:


### PR DESCRIPTION
## 变更概述

- 新增文件型 Toolset Store，支持 MCP Toolset 草稿、revision、不可变发布版本和容器重启恢复。
- 支持 Stdio、Streamable HTTP 和旧 SSE 三种 MCP 传输，并补齐远程地址安全校验、有限重连与 Schema 漂移检测。
- 新增加密 Credential Store，Headers、环境变量和 Provider Key 只通过 credential ID 引用，接口仅返回脱敏摘要。
- 支持工具发现、启停、别名、描述覆盖、默认参数、Schema 查看、测试调用和发布门禁。
- 新增 `toolset_resource -> workflow_agent` 绑定，发布 Xpert 时固定 Toolset 版本，并接入 Tool Policy、HITL、Audit 与 RunRegistry。
- 将 `/toolsets` 升级为完整 MCP Toolset 管理页，同时保留 `/mcps` 作为项目发现与安装入口。
- 更新 Xpert、MCP、Workflow 和 Harness 文档。

## 背景与影响

此前 Toolset 主要是现有工具的目录和白名单聚合，缺少连接、鉴权、发现、配置、测试、版本化与 Agent 绑定闭环。本 PR 完成首轮 MCP Runtime，使私有 Workflow、Xpert、Goal 和 Handoff 可以稳定消费固定版本 Toolset；公共 Xpert App 继续按安全策略阻断该资源。

## 验证

- `npm.cmd run build`
- 容器内 `python -m py_compile`
- 新增重点测试：11 passed
- Toolset/MCP/Workflow/Xpert App 重点回归：126 passed
- 全量后端测试：426 passed
- `docker compose -p modelmirror up -d --build --force-recreate`
- `GET /api/health` 返回 `{"status":"ok"}`
- `/toolsets` 浏览器检查通过，创建表单、空态与接口加载正常，无控制台错误

## 安全边界

- 未提交 `.env`、API key、Toolset Runtime storage、构建产物或 APK。
- 任意 Code/初始化脚本不在服务进程执行。
- 新 `toolset_resource` 暂不允许部署到公开 Xpert App。
