### PR TITLE
feature: 添加 EvoAgentX Xpert Evaluator 闭环

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Do not use for: refactoring, writing scripts from scratch, debugging business lo
 
 本文件是模镜仓库内 AI Agent、人类开发者和自动化任务的项目级操作说明。任何代码生成、重构、测试、提交和发布都必须优先遵守本文档。
 
-最后更新日期：2026-07-23
+最后更新日期：2026-07-25
 维护人：模镜团队
 
 ## 1. 项目边界
@@ -278,6 +278,33 @@ Meta Planner V2 只生成候选 Xpert，并使用 Authoring Proposal 作为唯�
 
 ```bash
 python -m pytest server/tests/test_meta_planner_v2.py server/tests/test_meta_agent.py -q
+cd client
+npm.cmd run build
+```
+
+### 8.2 EvoAgentX Evaluator 护栏
+
+- Dataset 草稿必须使用 revision，Evaluation Run 只能引用不可变 DatasetVersion。
+- 基线和候选必须在创建 run 时固定 XpertVersion 或 Authoring Proposal revision、
+  workflow checksum、资源版本、模型策略、seed 和预算。
+- 评测只能使用 classic runner 的内部只读 capture；不得通过 HTTP 回环或复制第二套
+  Workflow Runtime。
+- 安全预检必须 fail-closed 拒绝等待、Handoff、Automation、HITL、Memory/Todo/
+  Knowledge/Data X/Authoring 写入、Browser、Client Tools、Sandbox 写入和不安全 Plugin。
+- Toolset 仅允许固定版本中 `read_only=true` 且 `sensitive=false` 的工具。External
+  Xpert 必须固定版本并递归通过同一预检。
+- Knowledge 查询必须固定 run 创建时的活动索引版本，不能在运行中漂移到新索引。
+- 预算必须覆盖 repetitions、并发、单用例超时、模型调用、工具调用、token 和输出长度。
+  usage 缺失时允许保守估算，但报告必须明确标记。
+- 重启恢复只能重跑未完成 work item；已完成项、终态工具和报告不得重复生成。
+- Evaluator 只能生成报告；不得批准 Proposal、写 Xpert 草稿、发布版本或改变线上资源。
+- `server/Dockerfile` 必须复制 `evaluations/`；新增后端包不能只依赖宿主机挂载或 pytest
+  的仓库根路径，必须通过重建镜像验证真实 import。
+- 修改 Evaluator 时至少运行：
+
+```bash
+python -m pytest server/tests/test_xpert_evaluations.py -q
+python -m pytest server/tests/test_meta_agent.py server/tests/test_xpert_publish.py -q
 cd client
 npm.cmd run build
 ```

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,6 +8,7 @@
         "@vitejs/plugin-react": "^5.0.0",
         "@xyflow/react": "^12.11.0",
         "autoprefixer": "^10.4.21",
+        "lucide-react": "^1.27.0",
         "postcss": "^8.5.6",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -2527,6 +2528,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.27.0.tgz",
+      "integrity": "sha512-rJicGl/3Fly/E0rOH1YmPZ6e49JCnKknh1ox1vpHnkfjujAkKA6sqUZvH3MTAaXXjgexyUwgNwTJzTtYuAFYJw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/markdown-table": {

--- a/client/package.json
+++ b/client/package.json
@@ -9,6 +9,7 @@
     "@vitejs/plugin-react": "^5.0.0",
     "@xyflow/react": "^12.11.0",
     "autoprefixer": "^10.4.21",
+    "lucide-react": "^1.27.0",
     "postcss": "^8.5.6",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -29,6 +29,7 @@ import DataXInboxPage from "./pages/DataXInboxPage";
 import ToolsetsPage from "./pages/ToolsetsPage";
 import PromptProfilesPage from "./pages/PromptProfilesPage";
 import PluginsPage from "./pages/PluginsPage";
+import XpertEvaluationsPage from "./pages/XpertEvaluationsPage";
 
 export default function App() {
   return (
@@ -45,6 +46,8 @@ export default function App() {
       <Route element={<XpertAppPage />} path="/apps/:appSlug" />
       <Route element={<ConversationGoalsPage />} path="/agents/goals" />
       <Route element={<ConversationGoalsPage />} path="/agents/goals/:goalId" />
+      <Route element={<XpertEvaluationsPage />} path="/agents/evaluations" />
+      <Route element={<XpertEvaluationsPage />} path="/agents/evaluations/:runId" />
       <Route element={<AutomationsPage />} path="/agents/automations" />
       <Route element={<DataXHomePage />} path="/datax" />
       <Route element={<DataXInboxPage />} path="/datax/:projectId/inbox" />

--- a/client/src/components/meta/MetaPlannerV2.tsx
+++ b/client/src/components/meta/MetaPlannerV2.tsx
@@ -772,6 +772,17 @@ export default function MetaPlannerV2() {
                   </label>
                   <div className="mt-3 flex flex-wrap gap-2">
                     <button
+                      className="rounded-md border border-violet-300/30 bg-violet-300/10 px-3 py-2 text-xs font-semibold text-violet-100 hover:bg-violet-300/15"
+                      onClick={() =>
+                        navigate(
+                          `/agents/evaluations?proposal_id=${proposal.proposal_id}&proposal_revision=${proposal.revision}`,
+                        )
+                      }
+                      type="button"
+                    >
+                      评测候选
+                    </button>
+                    <button
                       className="rounded-md border border-white/10 px-3 py-2 text-xs font-semibold text-slate-200 hover:bg-white/5"
                       disabled={isSaving}
                       onClick={() => void saveCandidate()}

--- a/client/src/pages/XpertEvaluationsPage.tsx
+++ b/client/src/pages/XpertEvaluationsPage.tsx
@@ -1,0 +1,845 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom";
+import {
+  AlertTriangle,
+  BarChart3,
+  Beaker,
+  CheckCircle2,
+  Clock3,
+  Database,
+  FileUp,
+  GitCompareArrows,
+  LoaderCircle,
+  Play,
+  Plus,
+  RefreshCw,
+  Save,
+  Square,
+  XCircle,
+} from "lucide-react";
+import PageContainer from "../components/PageContainer";
+import { models } from "../data/models";
+import { listXpertVersions, listXperts } from "../utils/xpertApi";
+
+type TargetKind = "xpert_version" | "proposal";
+
+interface EvaluationCase {
+  case_id?: string;
+  name?: string;
+  message: string;
+  messages?: Array<{ role: "system" | "user" | "assistant"; content: string }>;
+  tags?: string[];
+  expected?: {
+    exact_answer?: string;
+    contains?: string[];
+    json_schema?: Record<string, unknown>;
+    citation_ids?: string[];
+    chunk_ids?: string[];
+    document_names?: string[];
+    rubric?: string;
+  };
+  weights?: Record<string, number>;
+}
+
+interface DatasetSummary {
+  dataset_id: string;
+  name: string;
+  description: string;
+  status: string;
+  revision: number;
+  published_version: number | null;
+  case_count: number;
+  version_count: number;
+  updated_at: number;
+}
+
+interface DatasetDetail extends DatasetSummary {
+  cases: EvaluationCase[];
+}
+
+interface DatasetVersion {
+  dataset_id: string;
+  version: number;
+  case_count: number;
+  checksum: string;
+  published_at: number;
+}
+
+interface TargetOption {
+  key: string;
+  kind: TargetKind;
+  label: string;
+  xpert_id?: string;
+  version?: number;
+  proposal_id?: string;
+  proposal_revision?: number;
+}
+
+interface EvaluationItem {
+  item_id: string;
+  target_id: string;
+  target_label: string;
+  case_id: string;
+  repetition: number;
+  status: string;
+  output?: string;
+  score?: number;
+  metrics?: Array<{
+    kind: string;
+    score: number;
+    passed: boolean;
+    reason: string;
+  }>;
+  latency_ms?: number;
+  error?: string | null;
+  usage?: Record<string, number | boolean>;
+}
+
+interface EvaluationRun {
+  run_id: string;
+  status: string;
+  dataset: {
+    dataset_id: string;
+    version: number;
+    name: string;
+    cases?: EvaluationCase[];
+  };
+  targets: Array<{
+    target_id: string;
+    label: string;
+    source: Record<string, unknown>;
+    stale?: boolean;
+    warnings?: string[];
+  }>;
+  baseline_target_id?: string | null;
+  config: {
+    model_policy: "snapshot" | "override";
+    override_model_id?: string | null;
+    judge_model_id?: string | null;
+    budget: Record<string, number>;
+  };
+  item_count: number;
+  completed_item_count: number;
+  items?: EvaluationItem[];
+  warnings: string[];
+  report?: {
+    targets?: Array<{
+      target_id: string;
+      label: string;
+      score: number;
+      case_count: number;
+      completed_count: number;
+      failed_count: number;
+      metrics: Record<string, number>;
+      average_latency_ms: number;
+      p95_latency_ms: number;
+      model_calls: number;
+      tool_calls: number;
+      estimated_tokens: number;
+    }>;
+    comparisons?: Array<{
+      target_id: string;
+      baseline_target_id: string;
+      score_delta: number;
+      wins: number;
+      ties: number;
+      losses: number;
+    }>;
+  };
+  created_at: number;
+  completed_at?: number | null;
+  error?: string | null;
+}
+
+interface AuthoringProposalSummary {
+  proposal_id: string;
+  revision: number;
+  title: string;
+  kind: string;
+  status: string;
+}
+
+const defaultCases: EvaluationCase[] = [
+  {
+    name: "基础回答",
+    message: "请用一句话说明你的处理方案。",
+    expected: {
+      contains: ["方案"],
+    },
+  },
+];
+
+function readError(payload: unknown, fallback: string) {
+  if (payload && typeof payload === "object") {
+    const detail = (payload as { detail?: unknown }).detail;
+    if (typeof detail === "string") return detail;
+    const error = (payload as { error?: unknown }).error;
+    if (typeof error === "string") return error;
+  }
+  return fallback;
+}
+
+async function requestJson<T>(url: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(url, init);
+  const payload = await response.json().catch(() => null);
+  if (!response.ok) throw new Error(readError(payload, `请求失败：${response.status}`));
+  return payload as T;
+}
+
+function jsonInit(method: "POST" | "PATCH", body: unknown): RequestInit {
+  return {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  };
+}
+
+function formatTime(value?: number | null) {
+  if (!value) return "-";
+  return new Date(value * 1000).toLocaleString("zh-CN", { hour12: false });
+}
+
+function percent(value?: number) {
+  if (value == null || Number.isNaN(value)) return "-";
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+function statusTone(status: string) {
+  if (status === "completed") return "border-emerald-300/25 bg-emerald-300/10 text-emerald-100";
+  if (status === "failed") return "border-rose-300/25 bg-rose-300/10 text-rose-100";
+  if (status === "cancelled") return "border-slate-400/20 bg-slate-400/10 text-slate-300";
+  if (status === "running") return "border-cyan-300/25 bg-cyan-300/10 text-cyan-100";
+  return "border-amber-300/25 bg-amber-300/10 text-amber-100";
+}
+
+export default function XpertEvaluationsPage() {
+  const { runId = "" } = useParams();
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const importRef = useRef<HTMLInputElement>(null);
+  const [datasets, setDatasets] = useState<DatasetSummary[]>([]);
+  const [dataset, setDataset] = useState<DatasetDetail | null>(null);
+  const [datasetVersions, setDatasetVersions] = useState<DatasetVersion[]>([]);
+  const [runs, setRuns] = useState<EvaluationRun[]>([]);
+  const [run, setRun] = useState<EvaluationRun | null>(null);
+  const [targetOptions, setTargetOptions] = useState<TargetOption[]>([]);
+  const [selectedTargets, setSelectedTargets] = useState<string[]>([]);
+  const [baselineKey, setBaselineKey] = useState("");
+  const [datasetVersion, setDatasetVersion] = useState(0);
+  const [newDatasetName, setNewDatasetName] = useState("");
+  const [casesText, setCasesText] = useState(JSON.stringify(defaultCases, null, 2));
+  const [modelPolicy, setModelPolicy] = useState<"snapshot" | "override">("snapshot");
+  const [overrideModelId, setOverrideModelId] = useState(models[0]?.id ?? "");
+  const [judgeModelId, setJudgeModelId] = useState(models[0]?.id ?? "");
+  const [repetitions, setRepetitions] = useState(1);
+  const [maxConcurrency, setMaxConcurrency] = useState(2);
+  const [timeoutSeconds, setTimeoutSeconds] = useState(120);
+  const [maxModelCalls, setMaxModelCalls] = useState(16);
+  const [maxToolCalls, setMaxToolCalls] = useState(24);
+  const [selectedItemId, setSelectedItemId] = useState("");
+  const [busy, setBusy] = useState("");
+  const [error, setError] = useState("");
+  const [notice, setNotice] = useState("");
+
+  const selectedItem = useMemo(
+    () => run?.items?.find((item) => item.item_id === selectedItemId) ?? run?.items?.[0] ?? null,
+    [run, selectedItemId],
+  );
+
+  useEffect(() => {
+    document.title = "模镜 - Xpert 评测";
+    void loadWorkspace();
+  }, []);
+
+  useEffect(() => {
+    if (runId) void loadRun(runId);
+  }, [runId]);
+
+  useEffect(() => {
+    if (!run || !["queued", "running"].includes(run.status)) return;
+    const timer = window.setInterval(() => void loadRun(run.run_id, true), 1500);
+    return () => window.clearInterval(timer);
+  }, [run?.run_id, run?.status]);
+
+  useEffect(() => {
+    const proposalId = searchParams.get("proposal_id");
+    const proposalRevision = Number(searchParams.get("proposal_revision") || 0);
+    const xpertId = searchParams.get("xpert_id");
+    const version = Number(searchParams.get("version") || 0);
+    const key = proposalId && proposalRevision
+      ? `proposal:${proposalId}:${proposalRevision}`
+      : xpertId && version
+        ? `xpert:${xpertId}:${version}`
+        : "";
+    if (key && targetOptions.some((item) => item.key === key)) {
+      setSelectedTargets((current) => current.includes(key) ? current : [key, ...current]);
+    }
+  }, [searchParams, targetOptions]);
+
+  async function loadWorkspace() {
+    setError("");
+    try {
+      const [datasetPayload, runPayload, xperts, proposals] = await Promise.all([
+        requestJson<{ items: DatasetSummary[] }>("/api/xpert-evaluations/datasets"),
+        requestJson<{ items: EvaluationRun[] }>("/api/xpert-evaluations/runs?limit=50"),
+        listXperts({ status: "published", limit: 100 }),
+        requestJson<{ items: AuthoringProposalSummary[] }>(
+          "/api/runtime/authoring-proposals?status=pending&source_type=meta_planner&limit=100",
+        ).catch(() => ({ items: [] })),
+      ]);
+      setDatasets(datasetPayload.items ?? []);
+      setRuns(runPayload.items ?? []);
+      const versionGroups = await Promise.all(
+        xperts.items
+          .filter((item) => item.published_version)
+          .map(async (item) => ({
+            xpert: item,
+            versions: await listXpertVersions(item.id),
+          })),
+      );
+      const versionTargets = versionGroups.flatMap(({ xpert, versions }) =>
+        versions.map((version) => ({
+          key: `xpert:${xpert.id}:${version.version}`,
+          kind: "xpert_version" as const,
+          label: `${xpert.name} v${version.version}`,
+          xpert_id: xpert.id,
+          version: version.version,
+        })),
+      );
+      const proposalTargets = (proposals.items ?? [])
+        .filter((item) => ["xpert_create", "xpert_update"].includes(item.kind))
+        .map((item) => ({
+          key: `proposal:${item.proposal_id}:${item.revision}`,
+          kind: "proposal" as const,
+          label: `${item.title} · r${item.revision}`,
+          proposal_id: item.proposal_id,
+          proposal_revision: item.revision,
+        }));
+      setTargetOptions([...proposalTargets, ...versionTargets]);
+      const firstDataset = datasetPayload.items?.[0];
+      if (firstDataset) await selectDataset(firstDataset.dataset_id);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "评测工作台加载失败。");
+    }
+  }
+
+  async function selectDataset(datasetId: string) {
+    const [detail, versions] = await Promise.all([
+      requestJson<DatasetDetail>(`/api/xpert-evaluations/datasets/${datasetId}`),
+      requestJson<{ items: DatasetVersion[] }>(
+        `/api/xpert-evaluations/datasets/${datasetId}/versions`,
+      ),
+    ]);
+    setDataset(detail);
+    setDatasetVersions(versions.items ?? []);
+    setCasesText(JSON.stringify(detail.cases ?? [], null, 2));
+    const preferred = detail.published_version ?? versions.items?.[0]?.version ?? 0;
+    setDatasetVersion(preferred);
+  }
+
+  async function loadRun(id: string, silent = false) {
+    if (!silent) setBusy("run");
+    try {
+      const detail = await requestJson<EvaluationRun>(`/api/xpert-evaluations/runs/${id}`);
+      setRun(detail);
+      setRuns((current) => [detail, ...current.filter((item) => item.run_id !== id)]);
+      if (!selectedItemId && detail.items?.[0]) setSelectedItemId(detail.items[0].item_id);
+    } catch (caught) {
+      if (!silent) setError(caught instanceof Error ? caught.message : "评测运行加载失败。");
+    } finally {
+      if (!silent) setBusy("");
+    }
+  }
+
+  async function createDataset() {
+    if (!newDatasetName.trim()) return;
+    setBusy("dataset-create");
+    setError("");
+    try {
+      const created = await requestJson<DatasetDetail>(
+        "/api/xpert-evaluations/datasets",
+        jsonInit("POST", { name: newDatasetName.trim(), description: "" }),
+      );
+      setNewDatasetName("");
+      setDatasets((current) => [created, ...current]);
+      await selectDataset(created.dataset_id);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "数据集创建失败。");
+    } finally {
+      setBusy("");
+    }
+  }
+
+  async function saveCases() {
+    if (!dataset) return;
+    setBusy("cases");
+    setError("");
+    try {
+      const parsed = JSON.parse(casesText) as EvaluationCase[];
+      if (!Array.isArray(parsed) || parsed.length === 0) {
+        throw new Error("用例 JSON 必须是非空数组。");
+      }
+      const updated = await requestJson<DatasetDetail>(
+        `/api/xpert-evaluations/datasets/${dataset.dataset_id}/cases`,
+        jsonInit("POST", { revision: dataset.revision, cases: parsed, replace: true }),
+      );
+      setDataset(updated);
+      setDatasets((current) =>
+        current.map((item) => item.dataset_id === updated.dataset_id ? updated : item),
+      );
+      setCasesText(JSON.stringify(updated.cases ?? [], null, 2));
+      setNotice("评测用例草稿已保存。");
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "评测用例保存失败。");
+    } finally {
+      setBusy("");
+    }
+  }
+
+  async function publishDataset() {
+    if (!dataset) return;
+    setBusy("dataset-publish");
+    setError("");
+    try {
+      const published = await requestJson<DatasetVersion>(
+        `/api/xpert-evaluations/datasets/${dataset.dataset_id}/publish`,
+        jsonInit("POST", { revision: dataset.revision, release_notes: "Evaluation dataset snapshot" }),
+      );
+      await selectDataset(dataset.dataset_id);
+      setDatasetVersion(published.version);
+      setNotice(`数据集 v${published.version} 已发布，后续草稿修改不会影响该版本。`);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "数据集发布失败。");
+    } finally {
+      setBusy("");
+    }
+  }
+
+  async function importCases(file: File) {
+    if (!dataset) return;
+    setBusy("import");
+    setError("");
+    const form = new FormData();
+    form.append("file", file);
+    try {
+      const updated = await requestJson<DatasetDetail>(
+        `/api/xpert-evaluations/datasets/${dataset.dataset_id}/import?revision=${dataset.revision}`,
+        { method: "POST", body: form },
+      );
+      setDataset(updated);
+      setCasesText(JSON.stringify(updated.cases ?? [], null, 2));
+      setNotice(`已导入 ${file.name}。`);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "用例导入失败。");
+    } finally {
+      setBusy("");
+      if (importRef.current) importRef.current.value = "";
+    }
+  }
+
+  function targetPayload(key: string) {
+    const option = targetOptions.find((item) => item.key === key);
+    if (!option) throw new Error(`目标已失效：${key}`);
+    return option.kind === "proposal"
+      ? {
+          kind: option.kind,
+          proposal_id: option.proposal_id,
+          proposal_revision: option.proposal_revision,
+          label: option.label,
+        }
+      : {
+          kind: option.kind,
+          xpert_id: option.xpert_id,
+          version: option.version,
+          label: option.label,
+        };
+  }
+
+  async function startRun() {
+    if (!dataset || datasetVersion < 1) {
+      setError("请先发布并选择一个数据集版本。");
+      return;
+    }
+    if (selectedTargets.length === 0) {
+      setError("请至少选择一个候选目标。");
+      return;
+    }
+    setBusy("start");
+    setError("");
+    try {
+      const payload = {
+        dataset_id: dataset.dataset_id,
+        dataset_version: datasetVersion,
+        case_ids: [],
+        baseline: baselineKey ? targetPayload(baselineKey) : null,
+        candidates: selectedTargets.map(targetPayload),
+        model_policy: modelPolicy,
+        override_model_id: modelPolicy === "override" ? overrideModelId : null,
+        judge_model_id: judgeModelId || null,
+        seed: 0,
+        budget: {
+          repetitions,
+          max_concurrency: maxConcurrency,
+          case_timeout_seconds: timeoutSeconds,
+          max_model_calls: maxModelCalls,
+          max_tool_calls: maxToolCalls,
+          max_estimated_tokens: 64_000,
+          max_output_chars: 20_000,
+        },
+      };
+      const preflight = await requestJson<{ valid: boolean; issues?: Array<{ message: string }> }>(
+        "/api/xpert-evaluations/preflight",
+        jsonInit("POST", {
+          baseline: payload.baseline,
+          candidates: payload.candidates,
+          model_policy: payload.model_policy,
+          override_model_id: payload.override_model_id,
+        }),
+      );
+      if (!preflight.valid) {
+        throw new Error(preflight.issues?.map((item) => item.message).join("；") || "只读安全预检未通过。");
+      }
+      const created = await requestJson<EvaluationRun>(
+        "/api/xpert-evaluations/runs",
+        jsonInit("POST", payload),
+      );
+      setRun(created);
+      setRuns((current) => [created, ...current]);
+      navigate(`/agents/evaluations/${created.run_id}`, { replace: true });
+      setNotice("评测已排队，执行快照不会随草稿变化。");
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "评测启动失败。");
+    } finally {
+      setBusy("");
+    }
+  }
+
+  async function cancelRun() {
+    if (!run) return;
+    setBusy("cancel");
+    try {
+      const cancelled = await requestJson<EvaluationRun>(
+        `/api/xpert-evaluations/runs/${run.run_id}/cancel`,
+        { method: "POST" },
+      );
+      setRun(cancelled);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "取消评测失败。");
+    } finally {
+      setBusy("");
+    }
+  }
+
+  return (
+    <PageContainer activeResource="agents" hideSidebar maxWidthClassName="max-w-[1820px]">
+      <header className="mb-5 flex flex-col gap-4 border-b border-white/10 pb-5 xl:flex-row xl:items-end xl:justify-between">
+        <div>
+          <div className="flex items-center gap-2 text-xs font-semibold text-cyan-200">
+            <Beaker className="h-4 w-4" />
+            EVOAGENTX EVALUATOR
+          </div>
+          <h1 className="mt-2 text-2xl font-semibold text-white">Xpert 版本评测</h1>
+          <p className="mt-1 max-w-3xl text-sm leading-6 text-slate-400">
+            用不可变数据集和固定执行快照比较基线、已发布版本及 Meta Planner 候选。评测只生成报告，不修改草稿或发布状态。
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Link className="rounded-md border border-white/10 bg-white/[0.04] px-3 py-2 text-xs font-semibold text-slate-200 hover:border-cyan-300/30" to="/agents/meta-agent">
+            Meta Planner
+          </Link>
+          <button className="inline-flex items-center gap-2 rounded-md border border-white/10 bg-white/[0.04] px-3 py-2 text-xs font-semibold text-slate-200 hover:border-cyan-300/30" onClick={() => void loadWorkspace()} type="button">
+            <RefreshCw className="h-3.5 w-3.5" />刷新
+          </button>
+        </div>
+      </header>
+
+      {error || notice ? (
+        <div className={`mb-4 rounded-md border px-3 py-2 text-sm ${error ? "border-rose-300/25 bg-rose-300/10 text-rose-100" : "border-emerald-300/25 bg-emerald-300/10 text-emerald-100"}`}>
+          {error || notice}
+        </div>
+      ) : null}
+
+      <div className="grid min-w-0 gap-5 2xl:grid-cols-[280px_minmax(0,1fr)_minmax(420px,0.9fr)]">
+        <aside className="min-w-0 border-r border-white/10 pr-5">
+          <div className="flex items-center gap-2 text-sm font-semibold text-white">
+            <Database className="h-4 w-4 text-cyan-200" />评测集
+          </div>
+          <div className="mt-3 flex gap-2">
+            <input className="min-w-0 flex-1 rounded-md border border-white/10 bg-white/[0.04] px-3 py-2 text-sm text-white outline-none focus:border-cyan-300/40" onChange={(event) => setNewDatasetName(event.target.value)} placeholder="新数据集名称" value={newDatasetName} />
+            <button aria-label="创建数据集" className="grid h-9 w-9 shrink-0 place-items-center rounded-md bg-cyan-300 text-ink-950 disabled:opacity-50" disabled={!newDatasetName.trim() || Boolean(busy)} onClick={() => void createDataset()} title="创建数据集" type="button">
+              <Plus className="h-4 w-4" />
+            </button>
+          </div>
+          <div className="mt-4 space-y-2">
+            {datasets.map((item) => (
+              <button className={`w-full rounded-md border p-3 text-left transition ${dataset?.dataset_id === item.dataset_id ? "border-cyan-300/35 bg-cyan-300/10" : "border-white/10 bg-white/[0.025] hover:border-white/20"}`} key={item.dataset_id} onClick={() => void selectDataset(item.dataset_id)} type="button">
+                <div className="flex items-start justify-between gap-2">
+                  <span className="truncate text-sm font-semibold text-slate-100">{item.name}</span>
+                  <span className="shrink-0 text-[10px] text-slate-500">r{item.revision}</span>
+                </div>
+                <div className="mt-2 flex items-center justify-between text-[11px] text-slate-500">
+                  <span>{item.case_count} 用例</span>
+                  <span>{item.published_version ? `v${item.published_version}` : "未发布"}</span>
+                </div>
+              </button>
+            ))}
+          </div>
+          <div className="mt-6 border-t border-white/10 pt-4">
+            <div className="mb-2 flex items-center gap-2 text-sm font-semibold text-white">
+              <Clock3 className="h-4 w-4 text-slate-400" />最近运行
+            </div>
+            <div className="space-y-2">
+              {runs.slice(0, 10).map((item) => (
+                <Link className="block rounded-md border border-white/10 bg-white/[0.025] p-3 hover:border-white/20" key={item.run_id} to={`/agents/evaluations/${item.run_id}`}>
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="truncate text-xs font-semibold text-slate-200">{item.dataset?.name ?? "Evaluation"}</span>
+                    <span className={`rounded border px-1.5 py-0.5 text-[10px] ${statusTone(item.status)}`}>{item.status}</span>
+                  </div>
+                  <p className="mt-1 text-[10px] text-slate-500">{formatTime(item.created_at)}</p>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </aside>
+
+        <section className="min-w-0 space-y-5">
+          <div className="border-b border-white/10 pb-4">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <h2 className="text-base font-semibold text-white">{dataset?.name ?? "选择评测集"}</h2>
+                <p className="mt-1 text-xs text-slate-500">草稿 revision 与发布版本相互隔离。</p>
+              </div>
+              {dataset ? (
+                <div className="flex gap-2">
+                  <input accept=".json,.csv" className="hidden" onChange={(event) => {
+                    const file = event.target.files?.[0];
+                    if (file) void importCases(file);
+                  }} ref={importRef} type="file" />
+                  <button className="inline-flex items-center gap-2 rounded-md border border-white/10 bg-white/[0.04] px-3 py-2 text-xs text-slate-200" onClick={() => importRef.current?.click()} type="button">
+                    <FileUp className="h-3.5 w-3.5" />JSON / CSV
+                  </button>
+                  <button className="inline-flex items-center gap-2 rounded-md border border-white/10 bg-white/[0.04] px-3 py-2 text-xs text-slate-200" disabled={Boolean(busy)} onClick={() => void saveCases()} type="button">
+                    <Save className="h-3.5 w-3.5" />保存草稿
+                  </button>
+                  <button className="inline-flex items-center gap-2 rounded-md bg-cyan-300 px-3 py-2 text-xs font-semibold text-ink-950 disabled:opacity-50" disabled={!dataset.case_count || Boolean(busy)} onClick={() => void publishDataset()} type="button">
+                    <CheckCircle2 className="h-3.5 w-3.5" />发布版本
+                  </button>
+                </div>
+              ) : null}
+            </div>
+          </div>
+
+          {dataset ? (
+            <>
+              <textarea className="min-h-[380px] w-full resize-y rounded-md border border-white/10 bg-ink-950/70 p-4 font-mono text-xs leading-6 text-slate-200 outline-none focus:border-cyan-300/40" onChange={(event) => setCasesText(event.target.value)} spellCheck={false} value={casesText} />
+              <div className="grid gap-3 sm:grid-cols-2">
+                <label className="text-xs font-semibold text-slate-300">
+                  固定数据集版本
+                  <select className="mt-1 h-10 w-full rounded-md border border-white/10 bg-ink-950 px-3 text-sm text-white" onChange={(event) => setDatasetVersion(Number(event.target.value))} value={datasetVersion}>
+                    <option value={0}>请选择已发布版本</option>
+                    {datasetVersions.map((item) => <option key={item.version} value={item.version}>v{item.version} · {item.case_count} 用例</option>)}
+                  </select>
+                </label>
+                <div className="rounded-md border border-white/10 bg-white/[0.025] p-3 text-xs leading-5 text-slate-400">
+                  运行创建后会固定 Dataset、Xpert、Proposal revision、知识索引和资源版本。外部 Provider 响应可能变化，报告会明确标记该限制。
+                </div>
+              </div>
+            </>
+          ) : (
+            <div className="grid min-h-[440px] place-items-center rounded-md border border-dashed border-white/10 text-sm text-slate-500">创建或选择一个评测集。</div>
+          )}
+        </section>
+
+        <aside className="min-w-0 space-y-5 border-l border-white/10 pl-5">
+          <section>
+            <div className="flex items-center gap-2 text-sm font-semibold text-white">
+              <GitCompareArrows className="h-4 w-4 text-cyan-200" />基线与候选
+            </div>
+            <label className="mt-3 block text-xs font-semibold text-slate-300">
+              基线（可选）
+              <select className="mt-1 h-10 w-full rounded-md border border-white/10 bg-ink-950 px-3 text-sm text-white" onChange={(event) => setBaselineKey(event.target.value)} value={baselineKey}>
+                <option value="">无基线，仅比较候选</option>
+                {targetOptions.filter((item) => item.kind === "xpert_version").map((item) => <option key={item.key} value={item.key}>{item.label}</option>)}
+              </select>
+            </label>
+            <div className="mt-3 max-h-56 space-y-2 overflow-y-auto pr-1">
+              {targetOptions.map((item) => (
+                <label className="flex cursor-pointer items-start gap-3 rounded-md border border-white/10 bg-white/[0.025] p-3" key={item.key}>
+                  <input checked={selectedTargets.includes(item.key)} className="mt-0.5 h-4 w-4 accent-cyan-300" onChange={(event) => setSelectedTargets((current) => event.target.checked ? [...current, item.key].slice(0, 5) : current.filter((key) => key !== item.key))} type="checkbox" />
+                  <span className="min-w-0">
+                    <span className="block truncate text-xs font-semibold text-slate-200">{item.label}</span>
+                    <span className="mt-1 block text-[10px] uppercase tracking-wide text-slate-500">{item.kind === "proposal" ? "Meta Planner Proposal" : "Published Xpert"}</span>
+                  </span>
+                </label>
+              ))}
+            </div>
+          </section>
+
+          <section className="border-t border-white/10 pt-4">
+            <div className="grid gap-3 sm:grid-cols-2">
+              <label className="text-xs font-semibold text-slate-300">
+                模型策略
+                <select className="mt-1 h-9 w-full rounded-md border border-white/10 bg-ink-950 px-2 text-xs text-white" onChange={(event) => setModelPolicy(event.target.value as "snapshot" | "override")} value={modelPolicy}>
+                  <option value="snapshot">固定快照模型</option>
+                  <option value="override">统一替换模型</option>
+                </select>
+              </label>
+              <label className="text-xs font-semibold text-slate-300">
+                重复次数
+                <input className="mt-1 h-9 w-full rounded-md border border-white/10 bg-ink-950 px-2 text-xs text-white" max={3} min={1} onChange={(event) => setRepetitions(Number(event.target.value))} type="number" value={repetitions} />
+              </label>
+            </div>
+            {modelPolicy === "override" ? (
+              <label className="mt-3 block text-xs font-semibold text-slate-300">
+                统一模型
+                <select className="mt-1 h-9 w-full rounded-md border border-white/10 bg-ink-950 px-2 text-xs text-white" onChange={(event) => setOverrideModelId(event.target.value)} value={overrideModelId}>
+                  {models.map((model) => <option key={model.id} value={model.id}>{model.name}</option>)}
+                </select>
+              </label>
+            ) : null}
+            <label className="mt-3 block text-xs font-semibold text-slate-300">
+              Rubric Judge 模型
+              <select className="mt-1 h-9 w-full rounded-md border border-white/10 bg-ink-950 px-2 text-xs text-white" onChange={(event) => setJudgeModelId(event.target.value)} value={judgeModelId}>
+                <option value="">不启用 Judge</option>
+                {models.map((model) => <option key={model.id} value={model.id}>{model.name}</option>)}
+              </select>
+            </label>
+            <div className="mt-3 grid grid-cols-2 gap-3">
+              {[
+                ["并发", maxConcurrency, setMaxConcurrency, 1, 4],
+                ["超时（秒）", timeoutSeconds, setTimeoutSeconds, 10, 600],
+                ["模型调用", maxModelCalls, setMaxModelCalls, 1, 64],
+                ["工具调用", maxToolCalls, setMaxToolCalls, 0, 100],
+              ].map(([label, value, setter, min, max]) => (
+                <label className="text-[11px] font-semibold text-slate-400" key={String(label)}>
+                  {String(label)}
+                  <input className="mt-1 h-9 w-full rounded-md border border-white/10 bg-ink-950 px-2 text-xs text-white" max={Number(max)} min={Number(min)} onChange={(event) => (setter as (value: number) => void)(Number(event.target.value))} type="number" value={Number(value)} />
+                </label>
+              ))}
+            </div>
+            <button className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-md bg-cyan-300 px-4 py-3 text-sm font-semibold text-ink-950 disabled:cursor-not-allowed disabled:opacity-50" disabled={busy === "start" || !datasetVersion || selectedTargets.length === 0} onClick={() => void startRun()} type="button">
+              {busy === "start" ? <LoaderCircle className="h-4 w-4 animate-spin" /> : <Play className="h-4 w-4" />}
+              安全预检并运行
+            </button>
+          </section>
+        </aside>
+      </div>
+
+      {run ? (
+        <section className="mt-7 border-t border-white/10 pt-6">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <div className="flex items-center gap-2">
+                <BarChart3 className="h-5 w-5 text-cyan-200" />
+                <h2 className="text-lg font-semibold text-white">评测报告</h2>
+                <span className={`rounded border px-2 py-0.5 text-[11px] ${statusTone(run.status)}`}>{run.status}</span>
+              </div>
+              <p className="mt-1 text-xs text-slate-500">{run.run_id} · {run.completed_item_count}/{run.item_count} 项</p>
+            </div>
+            <div className="flex gap-2">
+              {["queued", "running"].includes(run.status) ? (
+                <button className="inline-flex items-center gap-2 rounded-md border border-rose-300/25 bg-rose-300/10 px-3 py-2 text-xs font-semibold text-rose-100" onClick={() => void cancelRun()} type="button">
+                  <Square className="h-3.5 w-3.5" />取消
+                </button>
+              ) : null}
+              <button className="inline-flex items-center gap-2 rounded-md border border-white/10 bg-white/[0.04] px-3 py-2 text-xs text-slate-200" onClick={() => void loadRun(run.run_id)} type="button">
+                <RefreshCw className="h-3.5 w-3.5" />刷新报告
+              </button>
+            </div>
+          </div>
+
+          {run.targets.some((target) => target.stale) ? (
+            <div className="mt-4 flex items-start gap-2 rounded-md border border-amber-300/25 bg-amber-300/10 p-3 text-xs leading-5 text-amber-100">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+              Proposal revision 已变化。本报告仍准确描述原固定快照，但不代表当前候选。
+            </div>
+          ) : null}
+
+          <div className="mt-5 grid gap-4 lg:grid-cols-3">
+            {(run.report?.targets ?? []).map((target) => (
+              <article className="rounded-md border border-white/10 bg-white/[0.025] p-4" key={target.target_id}>
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <h3 className="text-sm font-semibold text-white">{target.label}</h3>
+                    <p className="mt-1 text-[11px] text-slate-500">{target.completed_count} 完成 · {target.failed_count} 失败</p>
+                  </div>
+                  <span className="text-xl font-semibold text-cyan-100">{percent(target.score)}</span>
+                </div>
+                <div className="mt-4 grid grid-cols-2 gap-2 text-[11px]">
+                  <div className="rounded bg-white/[0.035] p-2 text-slate-400">平均延迟<br /><strong className="text-slate-200">{Math.round(target.average_latency_ms)} ms</strong></div>
+                  <div className="rounded bg-white/[0.035] p-2 text-slate-400">P95<br /><strong className="text-slate-200">{Math.round(target.p95_latency_ms)} ms</strong></div>
+                  <div className="rounded bg-white/[0.035] p-2 text-slate-400">模型 / 工具<br /><strong className="text-slate-200">{target.model_calls} / {target.tool_calls}</strong></div>
+                  <div className="rounded bg-white/[0.035] p-2 text-slate-400">估算 Token<br /><strong className="text-slate-200">{target.estimated_tokens}</strong></div>
+                </div>
+                <div className="mt-3 space-y-1">
+                  {Object.entries(target.metrics).map(([name, score]) => (
+                    <div className="flex items-center justify-between text-[11px]" key={name}>
+                      <span className="text-slate-400">{name}</span>
+                      <span className="font-semibold text-slate-200">{percent(score)}</span>
+                    </div>
+                  ))}
+                </div>
+              </article>
+            ))}
+          </div>
+
+          {(run.report?.comparisons ?? []).length > 0 ? (
+            <div className="mt-4 flex flex-wrap gap-3">
+              {run.report?.comparisons?.map((item) => (
+                <div className="rounded-md border border-white/10 bg-white/[0.025] px-3 py-2 text-xs text-slate-300" key={item.target_id}>
+                  Δ <strong className={item.score_delta >= 0 ? "text-emerald-200" : "text-rose-200"}>{item.score_delta >= 0 ? "+" : ""}{percent(item.score_delta)}</strong>
+                  <span className="ml-3 text-slate-500">胜 {item.wins} · 平 {item.ties} · 负 {item.losses}</span>
+                </div>
+              ))}
+            </div>
+          ) : null}
+
+          <div className="mt-5 grid min-w-0 gap-4 xl:grid-cols-[360px_minmax(0,1fr)]">
+            <div className="max-h-[540px] space-y-2 overflow-y-auto pr-1">
+              {(run.items ?? []).map((item) => (
+                <button className={`w-full rounded-md border p-3 text-left ${selectedItem?.item_id === item.item_id ? "border-cyan-300/35 bg-cyan-300/10" : "border-white/10 bg-white/[0.025]"}`} key={item.item_id} onClick={() => setSelectedItemId(item.item_id)} type="button">
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="truncate text-xs font-semibold text-slate-200">{item.target_label}</span>
+                    {item.status === "completed" ? <CheckCircle2 className="h-4 w-4 text-emerald-300" /> : item.status === "failed" ? <XCircle className="h-4 w-4 text-rose-300" /> : <LoaderCircle className="h-4 w-4 animate-spin text-cyan-300" />}
+                  </div>
+                  <div className="mt-2 flex items-center justify-between text-[10px] text-slate-500">
+                    <span>{item.case_id} · #{item.repetition}</span>
+                    <span>{item.score == null ? "-" : percent(item.score)}</span>
+                  </div>
+                </button>
+              ))}
+            </div>
+            <div className="min-w-0 rounded-md border border-white/10 bg-ink-950/55 p-4">
+              {selectedItem ? (
+                <>
+                  <div className="flex flex-wrap items-center justify-between gap-3 border-b border-white/10 pb-3">
+                    <div>
+                      <h3 className="text-sm font-semibold text-white">{selectedItem.target_label}</h3>
+                      <p className="mt-1 text-[11px] text-slate-500">{selectedItem.case_id} · {Math.round(selectedItem.latency_ms ?? 0)} ms</p>
+                    </div>
+                    <span className={`rounded border px-2 py-0.5 text-[11px] ${statusTone(selectedItem.status)}`}>{selectedItem.status}</span>
+                  </div>
+                  {selectedItem.error ? <p className="mt-3 rounded border border-rose-300/20 bg-rose-300/10 p-3 text-xs text-rose-100">{selectedItem.error}</p> : null}
+                  <pre className="mt-4 max-h-72 overflow-auto whitespace-pre-wrap break-words rounded-md bg-black/20 p-3 text-xs leading-6 text-slate-200">{selectedItem.output || "暂无最终输出。"}</pre>
+                  <div className="mt-4 space-y-2">
+                    {(selectedItem.metrics ?? []).map((metricItem) => (
+                      <div className="rounded-md border border-white/10 bg-white/[0.025] p-3" key={metricItem.kind}>
+                        <div className="flex items-center justify-between">
+                          <span className="text-xs font-semibold text-slate-200">{metricItem.kind}</span>
+                          <span className={metricItem.passed ? "text-xs font-semibold text-emerald-200" : "text-xs font-semibold text-rose-200"}>{percent(metricItem.score)}</span>
+                        </div>
+                        <p className="mt-1 text-[11px] leading-5 text-slate-500">{metricItem.reason}</p>
+                      </div>
+                    ))}
+                  </div>
+                </>
+              ) : (
+                <div className="grid min-h-64 place-items-center text-sm text-slate-500">运行后选择一个样例查看结果。</div>
+              )}
+            </div>
+          </div>
+        </section>
+      ) : null}
+    </PageContainer>
+  );
+}

--- a/client/src/pages/XpertStudioPage.tsx
+++ b/client/src/pages/XpertStudioPage.tsx
@@ -237,6 +237,14 @@ export default function XpertStudioPage() {
               <span className="rounded-full border border-hire-300/25 bg-hire-300/10 px-2 py-0.5 font-semibold text-hire-100">
                 {xpert.published_version ? `已发布 v${xpert.published_version}` : "未发布"}
               </span>
+              {xpert.published_version ? (
+                <Link
+                  className="rounded-full border border-violet-300/25 bg-violet-300/10 px-2 py-0.5 font-semibold text-violet-100 hover:bg-violet-300/15"
+                  to={`/agents/evaluations?xpert_id=${xpert.id}&version=${xpert.published_version}`}
+                >
+                  版本回归评测
+                </Link>
+              ) : null}
             </div>
             <div className="mt-3 grid gap-3 lg:grid-cols-[minmax(220px,0.7fr)_minmax(320px,1.3fr)]">
               <input className="h-11 rounded-lg border border-white/10 bg-white/[0.055] px-3 text-lg font-semibold text-white outline-none focus:border-hire-300/60" maxLength={120} onChange={(event) => setName(event.target.value)} value={name} />

--- a/docs/EVOAGENTX_ALIGNMENT.md
+++ b/docs/EVOAGENTX_ALIGNMENT.md
@@ -33,7 +33,8 @@ EvoAgentX 的唯一复用基线是：
 与此同时，classic workflow 已支持可发布 Xpert、Goal、Handoff、资源绑定、
 Agent middleware、Toolset、Knowledge、Memory、Data X、Sandbox、Browser、
 Client Tools、Automation、Plugin 和 Prompt。Meta Planner V2 已补齐候选生成与当前
-执行面的主要契约；评测、基线比较和进化收益证明仍未实现。
+执行面的主要契约；Evaluator 已补齐版本化评测、固定预算和基线比较。当前尚未
+实现的是 Prompt 与结构候选的受控进化。
 
 ## 复用规则
 
@@ -59,8 +60,8 @@ Client Tools、Automation、Plugin 和 Prompt。Meta Planner V2 已补齐候选�
 | Workflow generation | V2 已生成当前 Agent DAG 与五类绑定边 | `adapt` | Meta Planner V2 已交付 |
 | Agent generation | V2 已覆盖当前 Agent 配置、资源与 middleware | `adapt` | 候选 Xpert 草稿已交付 |
 | Task planning | V2 已生成 1–8 个带依赖与契约的任务 | `adapt` | 结构化规划已交付 |
-| Evaluator | RAG 有专项评估，通用 Xpert 缺任务级基线 | `adapt` | 固定版本 Evaluator |
-| Benchmark | 无统一任务数据集与预算报告 | `adapt` | Benchmark Suite |
+| Evaluator | 已支持只读安全的固定版本/Proposal 快照评测 | `adapt` | Evaluator 已交付 |
+| Benchmark | 已支持版本化数据集、固定预算和基线报告 | `adapt` | Dataset/Report 已交付 |
 | Prompt optimizer | 仅人工编辑与版本化发布 | `rewrite` | Prompt 候选与对比报告 |
 | Workflow optimizer | 无受控结构进化 | `adapt/rewrite` | 结构候选 Xpert 草稿 |
 | Memory / RAG / Tool Runtime | 已有更完整 ModelMirror 实现 | `reject` | 继续复用现有 Runtime |
@@ -135,7 +136,23 @@ Meta Planner V2 必须：
 `workflow_generator.py`、`agent_generator.py` 的分层概念。没有复制上游源码，也没有
 引入 EvoAgentX Provider、RAG、Store、Workflow Runtime 或其他运行时依赖。
 
-### 下一步：`EVOAGENTX-EVALUATOR-02`
+### `EVOAGENTX-EVALUATOR-02`：已实现
 
-下一轮进入版本化评测集、固定基线与候选快照、可插拔指标、预算约束和退化报告。
-Evaluator 仍只能评价候选，不得写入 Xpert 草稿或发布版本。
+- 已实现 revision 化数据集草稿、JSON/CSV/会话导入和不可变版本发布。
+- 已固定 XpertVersion、Authoring Proposal revision、workflow、资源版本、
+  Knowledge 活动索引、模型策略、seed 和预算。
+- 已实现只读安全预检，副作用、等待、写入工具和不安全 Plugin 均 fail-closed。
+- 已复用 classic workflow runner，以 `xpert_evaluation` 根 run 运行并捕获最终输出、
+  Citation 和安全 usage。
+- 已实现 exact、contains、JSON Schema、Citation 和严格 JSON LLM Judge。
+- 已实现重启恢复、取消、并发/超时/模型调用/工具调用/token/输出预算。
+- 已实现基线 delta、win/tie/loss、延迟、错误和资源 warning 报告。
+- 已实现 `/agents/evaluations` 工作台，以及 Meta Planner 候选和 Studio 版本入口。
+
+Evaluator 不批准 Proposal、不写 Xpert 草稿、不发布版本。完整契约见
+[EVOAGENTX_EVALUATOR.md](./EVOAGENTX_EVALUATOR.md)。
+
+### 下一步：`EVOAGENTX-EVOLUTION-03A`
+
+下一轮只生成 Prompt 候选，在同一 DatasetVersion、目标快照和固定预算下比较。
+排名结果必须写成带差异与评估报告的 Authoring Proposal，并继续禁止自动批准或发布。

--- a/docs/EVOAGENTX_AUDIT_V014.md
+++ b/docs/EVOAGENTX_AUDIT_V014.md
@@ -159,8 +159,8 @@ Benchmark、Core、Model、Storage 和 Workflow。
 | WorkFlowGenerator | `server/meta_agent/` | 分阶段规划、资源选择和校验，使用现有模型网关 |
 | Agent | `workflow_agent` + XpertDefinition/Version | 只生成配置和绑定，不创建第二套 Agent Runtime |
 | Tool/Toolkit | ToolsetVersion + RuntimeTool | 只引用固定资源，不导入上游工具 SDK |
-| Evaluator | 未来 Evaluation Store/Executor | 固定输入、版本、模型、资源和预算后运行 classic runner |
-| Benchmark | 未来 Dataset/Metric contract | 数据集许可证独立登记，代码执行进入 Sandbox |
+| Evaluator | `server/evaluations/` | 固定输入、版本、模型、资源和预算后运行 classic runner |
+| Benchmark | XpertEvaluationStore/DatasetVersion/metrics | 数据集版本化；代码执行继续被只读预检拒绝 |
 | Optimizer | 未来 Candidate Proposal | 只创建候选 Xpert/Prompt 草稿和评估报告 |
 | Memory | XpertContextStore/File Memory | 不迁移上游 Memory Manager |
 | HITL | ApprovalStore/WorkflowExecutionStore | 候选和发布继续人工审批 |
@@ -213,3 +213,17 @@ preflight 和 classic runner。
 来源基线仍固定为 `v0.1.4@aad19b912f640161ea07e8904d9237cd34fde5f1`。后续
 Evaluator 或 Optimizer 若需要逐文件复用，必须另行补充 SHA-256、版权头、第三方依赖
 和测试映射；本条适配记录不能作为整体引入 EvoAgentX 的授权。
+
+## 12. 第二次适配记录：Xpert Evaluator
+
+| 上游相对路径 | 判定 | 适配内容 | ModelMirror 实现 | 测试责任 |
+| --- | --- | --- | --- | --- |
+| `evoagentx/evaluators/evaluator.py` | `adapt` | 将目标执行与评分分离、批量聚合的概念 | `server/evaluations/executor.py`、`metrics.py` | executor 恢复、指标和基线比较 |
+| `evoagentx/evaluators/aflow_evaluator.py` | `rewrite` | 候选在同一数据与预算下比较的目标 | Evaluation Run snapshot/report | 预算、stale、win/tie/loss |
+| `evoagentx/benchmark/benchmark.py` | `adapt` | Dataset/Case/Metric 的边界 | `models.py`、`store.py` | revision、不可变版本、导入 |
+| `evoagentx/benchmark/metrics.py` | `adapt` | 独立指标接口与聚合概念 | `metrics.py` | exact/contains/schema/citation/judge |
+
+本次没有复制上游 evaluator 或 benchmark Runtime。ModelMirror 独立实现文件 Store、
+只读安全预检、classic runner capture、资源固定、预算、RunRegistry、API 和前端。
+EvoAgentX 中与 WorkFlow、AgentManager、任意代码 Benchmark 或第三方数据集耦合的实现
+未引入。详细契约见 [EVOAGENTX_EVALUATOR.md](./EVOAGENTX_EVALUATOR.md)。

--- a/docs/EVOAGENTX_EVALUATOR.md
+++ b/docs/EVOAGENTX_EVALUATOR.md
@@ -1,0 +1,176 @@
+# EvoAgentX Xpert Evaluator
+
+最后更新日期：2026-07-25
+
+## 1. 定位
+
+`EVOAGENTX-EVALUATOR-02` 为 Meta Planner V2 和后续 Evolution 提供只读、
+可恢复的评测闭环：
+
+```text
+DatasetVersion
+  -> baseline/candidate snapshot
+  -> read-only preflight
+  -> bounded classic workflow execution
+  -> metrics and budget aggregation
+  -> immutable comparison report
+```
+
+Evaluator 只评价固定快照。它不会批准 Authoring Proposal、修改 Xpert 草稿、
+发布版本或改变线上资源。
+
+实现位于：
+
+- `server/evaluations/models.py`
+- `server/evaluations/store.py`
+- `server/evaluations/service.py`
+- `server/evaluations/executor.py`
+- `server/evaluations/metrics.py`
+- `server/evaluations/api.py`
+- `client/src/pages/XpertEvaluationsPage.tsx`
+
+## 2. 版本化数据集
+
+数据集草稿使用 revision 乐观并发，发布后生成不可变递增版本。单数据集最多
+500 条用例，单次运行最多选择 100 条。用例支持：
+
+- 当前用户消息和最多 20 条 `system/user/assistant` 历史消息。
+- 标签。
+- 精确答案。
+- 必须包含的文本。
+- JSON Schema。
+- Citation ID、chunk ID 或文档名。
+- LLM Judge rubric。
+- 指标权重。
+
+数据可通过管理页面人工编辑、JSON/CSV 导入，或从用户显式选择的 Xpert 会话
+导入。会话导入不复制附件、记忆、物理路径或内部 Runtime 上下文。
+
+## 3. 固定快照
+
+每次 Evaluation Run 固定：
+
+- Dataset ID、版本、checksum 和选中的用例。
+- 可选的已发布 XpertVersion 基线。
+- 1–5 个已发布 XpertVersion 或固定 revision 的 Authoring Proposal 候选。
+- 完整 workflow、资源固定版本、配置 checksum 和 Proposal revision。
+- 创建时的 Knowledge 活动索引版本。
+- Data X 已发布资源及外部 Xpert 固定版本。
+- seed、模型策略、Judge 模型和预算。
+
+`snapshot` 模式保留每个目标自己的模型配置。`override` 模式只在评测临时快照中
+替换模型，不修改 Xpert、Proposal 或已发布版本。
+
+Proposal 在运行后发生变化时，旧报告标记为 `stale`，但运行快照和已完成结果
+保持不变。
+
+## 4. 只读安全预检
+
+评测执行复用 classic workflow runner，不通过 HTTP 回环。进入 runner 前必须通过
+fail-closed 预检：
+
+- 禁止 Handoff、Automation、HITL、Human Intervention 和等待型执行。
+- 禁止 Memory、Todo、Knowledge/Data X/Authoring 写入。
+- 禁止 Browser、Client Tools、Sandbox 写入和 Skill/Plugin Hook。
+- Toolset 只允许已发布版本中 `read_only=true` 且 `sensitive=false` 的工具。
+- External Xpert 必须固定版本，并递归通过同一预检。
+- Knowledge 查询固定到运行创建时的活动索引版本。
+- Plugin 只有在展开后的 Toolset、middleware 和 Skill 均为只读安全能力时才允许。
+
+评测模式不会创建会话、写记忆、生成提案或进入人工审批队列。任何
+`RuntimeInterrupt` 或等待事件都按该样例失败处理。
+
+## 5. 执行预算与恢复
+
+`XpertEvaluationExecutor` 是单进程文件型后台执行器。每个 run 按
+用例、目标和 repetition 保存工作项状态；容器重启后只重置未完成项，已完成项
+不会重复执行。
+
+预算范围：
+
+- repetitions：1–3。
+- max concurrency：1–4。
+- 单用例 timeout：10–600 秒。
+- 单目标用例模型调用、工具调用和估算 token 上限。
+- 最终输出最大保存 20,000 字符。
+
+模型和工具调用继续通过 `execution_operation` 计数。网关提供 usage 时优先使用；
+否则报告明确使用保守 token 估算。单个样例失败、超时或耗尽预算时计 0 分，不影响
+其他工作项。
+
+RunRegistry 根类型为 `xpert_evaluation`，目标 Xpert 和节点 run 继续挂在其下。
+checkpoint 仅记录 ID、状态、数量、耗时和安全错误摘要。
+
+## 6. 指标与报告
+
+内置指标：
+
+- `exact_match`
+- `contains`
+- `json_schema`
+- `citation_hit`
+- `rubric_judge`
+
+LLM Judge 使用固定模型、温度 0 和严格 JSON，只保存 0–1 分数、通过状态与最多
+500 字符理由，不保存隐藏推理。
+
+报告包含：
+
+- 各目标加权总分和各指标分数。
+- 候选相对基线的 score delta 和 win/tie/loss。
+- 失败、超时和预算错误分布。
+- 平均与 P95 延迟。
+- 模型调用、工具调用和实际或估算 token。
+- 资源漂移与外部 Provider 不完全可复现 warning。
+- 逐样例截断输入、预期、最终输出和安全错误摘要。
+
+## 7. API
+
+```text
+GET/POST /api/xpert-evaluations/datasets
+GET/PATCH /api/xpert-evaluations/datasets/{dataset_id}
+POST      /api/xpert-evaluations/datasets/{dataset_id}/cases
+POST      /api/xpert-evaluations/datasets/{dataset_id}/import
+POST      /api/xpert-evaluations/datasets/{dataset_id}/import-conversations
+POST      /api/xpert-evaluations/datasets/{dataset_id}/publish
+GET       /api/xpert-evaluations/datasets/{dataset_id}/versions
+POST      /api/xpert-evaluations/preflight
+GET/POST  /api/xpert-evaluations/runs
+GET       /api/xpert-evaluations/runs/{run_id}
+POST      /api/xpert-evaluations/runs/{run_id}/cancel
+GET       /api/xpert-evaluations/capabilities
+```
+
+列表只返回摘要。可信管理面的 detail 会移除 workflow、Prompt、完整 Tool 配置和
+私有 feature，只返回评测所需的截断内容。
+
+## 8. 前端入口
+
+- `/agents/evaluations`
+- `/agents/evaluations/:runId`
+
+Meta Planner V2 候选提供“评测候选”入口，并固定当前 Proposal revision。
+Xpert Studio 的已发布版本提供“版本回归评测”入口。工作台支持数据集编辑/导入、
+发布、基线与候选选择、模型策略、预算、预检、运行、取消和报告查看。
+
+## 9. 安全边界
+
+- 不执行真实副作用、附件、持久写入或交互审批。
+- 不返回完整 prompt、工具原始输出、密钥、物理路径或 Runtime Store。
+- 不把外部 Provider 可变响应描述为完全确定性结果。
+- 不允许报告自动改变 Proposal 或 Xpert 状态。
+- 不允许 Evaluator 成为线上流量入口。
+
+## 10. 回归
+
+最小验证：
+
+```bash
+python -m pytest server/tests/test_xpert_evaluations.py -q
+python -m pytest server/tests/test_meta_agent.py server/tests/test_xpert_publish.py -q
+cd client
+npm.cmd run build
+```
+
+变更安全预检或 runner capture 时，还必须覆盖 Toolset、Knowledge、Data X、
+Authoring、App 和 RunRegistry 回归。

--- a/docs/META_AGENT.md
+++ b/docs/META_AGENT.md
@@ -102,7 +102,7 @@ curl http://localhost:5173/agents/meta-agent
    [EVOAGENTX_AUDIT_V014.md](./EVOAGENTX_AUDIT_V014.md)。
 2. `EVOAGENTX-META-PLANNER-01`：已完成，按上述固定契约生成当前
    WorkflowNodeKind、资源绑定边、Agent middleware 与发布配置。
-3. `EVOAGENTX-EVALUATOR-02`：增加任务数据集、可插拔指标、候选执行和基线对比。
+3. `EVOAGENTX-EVALUATOR-02`：已完成版本化数据集、只读候选执行、固定预算和基线对比。
 4. `EVOAGENTX-EVOLUTION-03`：先做 Prompt 优化，再做工作流结构优化；输出候选草稿与评估报告，必须人工批准后才能发布。
 
 完整路线见 [EVOAGENTX_ALIGNMENT.md](./EVOAGENTX_ALIGNMENT.md)。
@@ -145,3 +145,13 @@ python -m pytest server/tests/test_meta_planner_v2.py server/tests/test_meta_age
 cd client
 npm.cmd run build
 ```
+
+## 候选评测
+
+Meta Planner V2 的 pending Proposal 可以从候选面板直接进入
+`/agents/evaluations`。入口固定当前 `proposal_id + revision`，评测运行会保存完整
+不可变快照；之后继续编辑 Proposal 只会把旧报告标记为 stale，不会改变已完成结果。
+
+Evaluator 只读运行候选并生成报告，不调用 Proposal approve，也不会创建 Xpert 草稿
+或发布版本。安全、预算和报告契约见
+[EVOAGENTX_EVALUATOR.md](./EVOAGENTX_EVALUATOR.md)。

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@
 | [XPERT_FREEZE.md](./XPERT_FREEZE.md) | Xpert 冻结快照、维护边界、延期项、技术债和回归入口。 |
 | [EVOAGENTX_ALIGNMENT.md](./EVOAGENTX_ALIGNMENT.md) | EvoAgentX 主线、Meta Planner、Evaluator 与候选进化路线。 |
 | [EVOAGENTX_AUDIT_V014.md](./EVOAGENTX_AUDIT_V014.md) | 官方 EvoAgentX v0.1.4 的逐模块来源、许可证和复用判定。 |
+| [EVOAGENTX_EVALUATOR.md](./EVOAGENTX_EVALUATOR.md) | 版本化 Xpert 评测集、只读执行、固定预算与基线报告契约。 |
 | [META_AGENT.md](./META_AGENT.md) | 当前 MetaAgent 边界与 Meta Planner V2 固定契约。 |
 | [SKILL_INTEGRATION.md](./SKILL_INTEGRATION.md) | Skill 扩展包安装、管理、聊天注入和测试指南。 |
 | [workflow-native-design.md](./workflow-native-design.md) | 自研工作流 native 实验线的设计、API 契约和回退方案。 |

--- a/docs/XPERT_RUNTIME.md
+++ b/docs/XPERT_RUNTIME.md
@@ -264,6 +264,24 @@ The Todo capability exposes scope-bound `todo_list`, `todo_create`, and `todo_up
 
 Ralph Loop performs bounded continuation and strict verification before the Agent output is committed. Knowledge Writer creates pending proposals only and retains the existing Inbox, pipeline, evaluation, and promotion gates. Plugin Hooks stage an installed Skill's explicit manifest into the offline Sandbox and execute argv only. Public Xpert Apps reject all private automation middleware. See `docs/XPERT_AUTOMATION.md`.
 
+## Xpert Evaluation Runtime
+
+`XpertEvaluationExecutor` reuses the classic workflow runner in an internal capture mode and
+creates a `xpert_evaluation` RunRegistry parent. Every run fixes its DatasetVersion,
+XpertVersion or Authoring Proposal revision, workflow checksum, resource versions, model
+policy, seed and budget before any sample executes.
+
+Evaluation mode is read-only and fail-closed. It blocks waiting, Handoff, Automation,
+interactive approval, persistent writes, Browser, Client Tools, Sandbox writes and unsafe
+Toolset/Plugin capabilities. Knowledge queries are pinned to the active index observed when
+the run is created. External Xperts recurse through the same preflight.
+
+The executor persists work items and resumes only unfinished items after restart. Budget
+counters cover model calls, tool calls and actual or explicitly estimated tokens. Reports and
+checkpoints store only truncated outputs, safe citations, counts, timing and error summaries.
+Evaluator never approves a Proposal, writes an Xpert draft or publishes a version. See
+`docs/EVOAGENTX_EVALUATOR.md`.
+
 ## Data X Runtime
 
 `DataXStore` atomically persists project, source snapshot, import job, semantic model, indicator, immutable version, proposal, and result-artifact metadata. Each project owns a separate DuckDB file. Imported source bytes are fixed by SHA-256 and never exposed through API paths.

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -31,6 +31,7 @@ COPY skills ./skills
 COPY prompts ./prompts
 COPY plugins ./plugins
 COPY xperts ./xperts
+COPY evaluations ./evaluations
 COPY workflow_native ./workflow_native
 COPY xpert_runtime ./xpert_runtime
 COPY client_extension ./client_extension

--- a/server/evaluations/__init__.py
+++ b/server/evaluations/__init__.py
@@ -1,0 +1,28 @@
+from .api import (
+    configure_xpert_evaluations,
+    get_xpert_evaluation_executor,
+    router,
+)
+from .executor import XpertEvaluationExecutor
+from .metrics import aggregate_evaluation_report, evaluate_case_metrics
+from .service import XpertEvaluationService
+from .store import (
+    EvaluationConflictError,
+    EvaluationNotFoundError,
+    EvaluationStateError,
+    XpertEvaluationStore,
+)
+
+__all__ = [
+    "EvaluationConflictError",
+    "EvaluationNotFoundError",
+    "EvaluationStateError",
+    "XpertEvaluationExecutor",
+    "XpertEvaluationService",
+    "XpertEvaluationStore",
+    "aggregate_evaluation_report",
+    "configure_xpert_evaluations",
+    "evaluate_case_metrics",
+    "get_xpert_evaluation_executor",
+    "router",
+]

--- a/server/evaluations/api.py
+++ b/server/evaluations/api.py
@@ -1,0 +1,379 @@
+from __future__ import annotations
+
+import csv
+import io
+import json
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, File, HTTPException, UploadFile
+
+from .executor import JudgeRunner, TargetRunner, XpertEvaluationExecutor
+from .models import (
+    ConversationImportRequest,
+    DatasetCasesRequest,
+    DatasetCreateRequest,
+    DatasetPublishRequest,
+    DatasetUpdateRequest,
+    EvaluationPreflightRequest,
+    EvaluationRunRequest,
+)
+from .service import XpertEvaluationService
+from .store import (
+    EvaluationConflictError,
+    EvaluationNotFoundError,
+    EvaluationStateError,
+    XpertEvaluationStore,
+)
+
+
+router = APIRouter(prefix="/api/xpert-evaluations", tags=["xpert-evaluations"])
+_store: XpertEvaluationStore | None = None
+_service: XpertEvaluationService | None = None
+_executor: XpertEvaluationExecutor | None = None
+
+
+def configure_xpert_evaluations(
+    *,
+    storage_dir: str | Path | None,
+    xpert_store: Any,
+    proposal_store: Any,
+    prompt_preflight: Any,
+    toolset_store: Any,
+    plugin_store: Any,
+    rag_service: Any,
+    context_store: Any,
+    target_runner: TargetRunner,
+    judge_runner: JudgeRunner | None,
+    run_registry: Any,
+) -> XpertEvaluationExecutor:
+    global _store, _service, _executor
+    _store = XpertEvaluationStore(storage_dir)
+    _service = XpertEvaluationService(
+        _store,
+        xpert_store=xpert_store,
+        proposal_store=proposal_store,
+        prompt_preflight=prompt_preflight,
+        toolset_store=toolset_store,
+        plugin_store=plugin_store,
+        rag_service=rag_service,
+        context_store=context_store,
+    )
+    _executor = XpertEvaluationExecutor(
+        _store,
+        target_runner=target_runner,
+        judge_runner=judge_runner,
+        run_registry=run_registry,
+    )
+    return _executor
+
+
+def get_xpert_evaluation_executor() -> XpertEvaluationExecutor:
+    if _executor is None:
+        raise RuntimeError("Xpert Evaluator is not configured.")
+    return _executor
+
+
+def _require_store() -> XpertEvaluationStore:
+    if _store is None:
+        raise RuntimeError("Xpert Evaluator is not configured.")
+    return _store
+
+
+def _require_service() -> XpertEvaluationService:
+    if _service is None:
+        raise RuntimeError("Xpert Evaluator is not configured.")
+    return _service
+
+
+@router.get("/capabilities")
+async def get_capabilities() -> dict[str, Any]:
+    return {
+        "version": "evoagentx-xpert-evaluator-v1",
+        "metrics": [
+            "exact_match",
+            "contains",
+            "json_schema",
+            "citation_hit",
+            "rubric_judge",
+        ],
+        "dataset_limits": {"max_cases": 500, "max_cases_per_run": 100},
+        "budget_limits": {
+            "repetitions": [1, 3],
+            "max_concurrency": [1, 4],
+            "case_timeout_seconds": [10, 600],
+            "max_model_calls": 64,
+            "max_tool_calls": 100,
+        },
+        "model_policies": ["snapshot", "override"],
+        "safe_mode": "read_only_fail_closed",
+    }
+
+
+@router.get("/datasets")
+async def list_datasets(status: str | None = None) -> dict[str, Any]:
+    items = await _to_thread(_require_store().list_datasets, status=status)
+    return {"items": items, "total": len(items)}
+
+
+@router.post("/datasets")
+async def create_dataset(payload: DatasetCreateRequest) -> dict[str, Any]:
+    return await _to_thread(
+        _require_store().create_dataset,
+        payload.name,
+        payload.description,
+    )
+
+
+@router.get("/datasets/{dataset_id}")
+async def get_dataset(dataset_id: str) -> dict[str, Any]:
+    try:
+        item = await _to_thread(_require_store().require_dataset, dataset_id)
+        return _require_store().dataset_payload(item, include_cases=True)
+    except EvaluationNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.patch("/datasets/{dataset_id}")
+async def update_dataset(
+    dataset_id: str,
+    payload: DatasetUpdateRequest,
+) -> dict[str, Any]:
+    try:
+        return await _to_thread(
+            _require_store().update_dataset,
+            dataset_id,
+            revision=payload.revision,
+            name=payload.name,
+            description=payload.description,
+            status=payload.status,
+        )
+    except EvaluationConflictError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except (EvaluationNotFoundError, EvaluationStateError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.post("/datasets/{dataset_id}/cases")
+async def put_dataset_cases(
+    dataset_id: str,
+    payload: DatasetCasesRequest,
+) -> dict[str, Any]:
+    try:
+        return await _to_thread(
+            _require_store().put_cases,
+            dataset_id,
+            revision=payload.revision,
+            cases=[item.model_dump(mode="json") for item in payload.cases],
+            replace=payload.replace,
+        )
+    except EvaluationConflictError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except (EvaluationNotFoundError, EvaluationStateError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.post("/datasets/{dataset_id}/import")
+async def import_dataset_cases(
+    dataset_id: str,
+    revision: int,
+    file: UploadFile = File(...),
+) -> dict[str, Any]:
+    content = await file.read()
+    if len(content) > 5 * 1024 * 1024:
+        raise HTTPException(status_code=413, detail="Evaluation import exceeds 5 MB.")
+    try:
+        cases = _parse_import(file.filename or "", content)
+        return await _to_thread(
+            _require_store().put_cases,
+            dataset_id,
+            revision=revision,
+            cases=cases,
+        )
+    except EvaluationConflictError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except (ValueError, EvaluationNotFoundError, EvaluationStateError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.post("/datasets/{dataset_id}/import-conversations")
+async def import_conversations(
+    dataset_id: str,
+    payload: ConversationImportRequest,
+) -> dict[str, Any]:
+    try:
+        return await _to_thread(
+            _require_service().import_conversations,
+            dataset_id,
+            revision=payload.revision,
+            selections=[
+                item.model_dump(mode="json") for item in payload.selections
+            ],
+        )
+    except EvaluationConflictError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except (EvaluationNotFoundError, EvaluationStateError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.post("/datasets/{dataset_id}/publish")
+async def publish_dataset(
+    dataset_id: str,
+    payload: DatasetPublishRequest,
+) -> dict[str, Any]:
+    try:
+        return await _to_thread(
+            _require_store().publish_dataset,
+            dataset_id,
+            revision=payload.revision,
+            release_notes=payload.release_notes,
+        )
+    except EvaluationConflictError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except (EvaluationNotFoundError, EvaluationStateError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.get("/datasets/{dataset_id}/versions")
+async def list_dataset_versions(dataset_id: str) -> dict[str, Any]:
+    try:
+        items = await _to_thread(
+            _require_store().list_dataset_versions, dataset_id
+        )
+        return {"items": items, "total": len(items)}
+    except EvaluationNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.post("/preflight")
+async def preflight(payload: EvaluationPreflightRequest) -> dict[str, Any]:
+    try:
+        return await _to_thread(
+            _require_service().preflight,
+            baseline=(
+                payload.baseline.model_dump(mode="json")
+                if payload.baseline
+                else None
+            ),
+            candidates=[
+                item.model_dump(mode="json") for item in payload.candidates
+            ],
+            model_policy=payload.model_policy,
+            override_model_id=payload.override_model_id,
+        )
+    except (EvaluationConflictError, EvaluationStateError, ValueError) as exc:
+        return {
+            "valid": False,
+            "baseline": None,
+            "candidates": [],
+            "targets": [],
+            "warnings": [],
+            "issues": [{"code": "evaluation_preflight", "message": str(exc)[:500]}],
+        }
+
+
+@router.get("/runs")
+async def list_runs(status: str | None = None, limit: int = 100) -> dict[str, Any]:
+    items = await _to_thread(
+        _require_store().list_runs,
+        status=status,
+        limit=max(1, min(limit, 200)),
+    )
+    return {"items": items, "total": len(items)}
+
+
+@router.post("/runs")
+async def create_run(payload: EvaluationRunRequest) -> dict[str, Any]:
+    try:
+        run = await _to_thread(
+            _require_service().create_run,
+            payload.model_dump(mode="json"),
+        )
+        get_xpert_evaluation_executor().wake()
+        return _sanitize_run_detail(run)
+    except EvaluationConflictError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except (EvaluationNotFoundError, EvaluationStateError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.get("/runs/{run_id}")
+async def get_run(run_id: str) -> dict[str, Any]:
+    try:
+        item = await _to_thread(_require_service().run_detail, run_id)
+        return _sanitize_run_detail(item)
+    except EvaluationNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.post("/runs/{run_id}/cancel")
+async def cancel_run(run_id: str) -> dict[str, Any]:
+    try:
+        return _sanitize_run_detail(
+            await _to_thread(_require_store().cancel_run, run_id)
+        )
+    except EvaluationNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+async def _to_thread(function: Any, *args: Any, **kwargs: Any) -> Any:
+    import asyncio
+
+    return await asyncio.to_thread(function, *args, **kwargs)
+
+
+def _parse_import(filename: str, content: bytes) -> list[dict[str, Any]]:
+    suffix = Path(filename).suffix.lower()
+    text = content.decode("utf-8-sig")
+    if suffix == ".json":
+        payload = json.loads(text)
+        raw_cases = payload.get("cases") if isinstance(payload, dict) else payload
+        if not isinstance(raw_cases, list):
+            raise ValueError("JSON import must be an array or contain a cases array.")
+        return [dict(item) for item in raw_cases if isinstance(item, dict)]
+    if suffix == ".csv":
+        result: list[dict[str, Any]] = []
+        for row in csv.DictReader(io.StringIO(text)):
+            expected: dict[str, Any] = {}
+            if row.get("exact_answer"):
+                expected["exact_answer"] = row["exact_answer"]
+            if row.get("contains"):
+                expected["contains"] = [
+                    item.strip() for item in row["contains"].split("|") if item.strip()
+                ]
+            if row.get("rubric"):
+                expected["rubric"] = row["rubric"]
+            if row.get("json_schema"):
+                expected["json_schema"] = json.loads(row["json_schema"])
+            result.append(
+                {
+                    "case_id": row.get("case_id") or None,
+                    "name": row.get("name") or "",
+                    "message": row.get("message") or "",
+                    "tags": [
+                        item.strip()
+                        for item in str(row.get("tags") or "").split("|")
+                        if item.strip()
+                    ],
+                    "expected": expected,
+                }
+            )
+        return result
+    raise ValueError("Evaluation import must be JSON or CSV.")
+
+
+def _sanitize_run_detail(run: dict[str, Any]) -> dict[str, Any]:
+    payload = json.loads(json.dumps(run, ensure_ascii=False))
+    dataset = dict(payload.get("dataset") or {})
+    for case in dataset.get("cases") or []:
+        case["message"] = str(case.get("message") or "")[:20_000]
+        case["messages"] = list(case.get("messages") or [])[-20:]
+    payload["dataset"] = dataset
+    for target in payload.get("targets") or []:
+        target.pop("workflow", None)
+        target.pop("prompt_profiles", None)
+        target.pop("features", None)
+        target.pop("agent_config", None)
+    for item in payload.get("items") or []:
+        item["output"] = str(item.get("output") or "")[:20_000]
+    return payload

--- a/server/evaluations/executor.py
+++ b/server/evaluations/executor.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import time
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from .metrics import aggregate_evaluation_report, evaluate_case_metrics
+from .store import XpertEvaluationStore
+
+
+TargetRunner = Callable[
+    [dict[str, Any], dict[str, Any], dict[str, Any], str | None],
+    Awaitable[dict[str, Any]],
+]
+JudgeRunner = Callable[[str, str, str, str], Awaitable[dict[str, Any]]]
+
+
+class XpertEvaluationExecutor:
+    """Restart-safe single-process evaluator for immutable Xpert snapshots."""
+
+    def __init__(
+        self,
+        store: XpertEvaluationStore,
+        *,
+        target_runner: TargetRunner,
+        judge_runner: JudgeRunner | None = None,
+        run_registry: Any | None = None,
+        poll_seconds: float = 0.5,
+    ) -> None:
+        self.store = store
+        self.target_runner = target_runner
+        self.judge_runner = judge_runner
+        self.run_registry = run_registry
+        self.poll_seconds = max(0.1, float(poll_seconds))
+        self._task: asyncio.Task[None] | None = None
+        self._wake = asyncio.Event()
+        self._stopping = False
+
+    def start(self) -> None:
+        if self._task is not None and not self._task.done():
+            return
+        self.store.recover_runs()
+        self._stopping = False
+        self._task = asyncio.create_task(self._loop())
+
+    async def stop(self) -> None:
+        self._stopping = True
+        self._wake.set()
+        if self._task is not None:
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
+        self._task = None
+
+    def wake(self) -> None:
+        self._wake.set()
+
+    async def _loop(self) -> None:
+        while not self._stopping:
+            run = await asyncio.to_thread(self.store.claim_next_run)
+            if run is None:
+                self._wake.clear()
+                try:
+                    await asyncio.wait_for(self._wake.wait(), timeout=self.poll_seconds)
+                except TimeoutError:
+                    pass
+                continue
+            try:
+                await self._execute_run(run)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                await asyncio.to_thread(self.store.fail_run, run["run_id"], str(exc))
+                if self.run_registry is not None:
+                    failed = await asyncio.to_thread(
+                        self.store.require_run, run["run_id"]
+                    )
+                    registry_run_id = failed.get("run_registry_id")
+                    if registry_run_id:
+                        await self.run_registry.update_run(
+                            registry_run_id,
+                            status="failed",
+                            error=str(exc)[:500],
+                        )
+                        await self.run_registry.record_checkpoint(
+                            registry_run_id,
+                            event_type="xpert_evaluation.failed",
+                            title="Xpert evaluation failed",
+                            summary=str(exc)[:500],
+                            severity="error",
+                            metadata={"run_id": run["run_id"]},
+                        )
+
+    async def _execute_run(self, run: dict[str, Any]) -> None:
+        registry_run = None
+        if self.run_registry is not None:
+            registry_run = await self.run_registry.create_run(
+                "xpert_evaluation",
+                f"Xpert evaluation {run['run_id']}",
+                status="running",
+                source_id=run["run_id"],
+                metadata={
+                    "dataset_id": run["dataset"]["dataset_id"],
+                    "dataset_version": run["dataset"]["version"],
+                    "target_count": len(run["targets"]),
+                    "case_count": len(run["selected_case_ids"]),
+                },
+            )
+            await asyncio.to_thread(
+                self.store.set_run_registry_id,
+                run["run_id"],
+                registry_run.run_id,
+            )
+        budget = dict(run.get("config", {}).get("budget") or {})
+        concurrency = max(1, min(int(budget.get("max_concurrency") or 2), 4))
+        semaphore = asyncio.Semaphore(concurrency)
+        targets = {item["target_id"]: item for item in run["targets"]}
+        cases = {
+            item["case_id"]: item
+            for item in run["dataset"].get("cases") or []
+            if item["case_id"] in run["selected_case_ids"]
+        }
+
+        async def execute_item(item: dict[str, Any]) -> None:
+            async with semaphore:
+                current = await asyncio.to_thread(self.store.require_run, run["run_id"])
+                if current.get("cancel_requested"):
+                    await asyncio.to_thread(
+                        self.store.record_item_result,
+                        run["run_id"],
+                        item["item_id"],
+                        result={"status": "cancelled", "error": "Run cancelled."},
+                    )
+                    return
+                target = targets[item["target_id"]]
+                case = cases[item["case_id"]]
+                started = time.perf_counter()
+                try:
+                    timeout = max(
+                        10, min(int(budget.get("case_timeout_seconds") or 120), 600)
+                    )
+                    async with asyncio.timeout(timeout):
+                        result = await self.target_runner(
+                            target,
+                            case,
+                            {
+                                **dict(run.get("config") or {}),
+                                "repetition": item["repetition"],
+                            },
+                            registry_run.run_id if registry_run else None,
+                        )
+                    output = str(result.get("output") or "")[
+                        : int(budget.get("max_output_chars") or 20_000)
+                    ]
+                    metrics = await evaluate_case_metrics(
+                        case=case,
+                        output=output,
+                        citations=dict(result.get("citations") or {}),
+                        judge=self.judge_runner,
+                        judge_model_id=run.get("config", {}).get("judge_model_id"),
+                    )
+                    payload = {
+                        "status": "completed",
+                        "output": output,
+                        "citations": dict(result.get("citations") or {}),
+                        "usage": dict(result.get("usage") or {}),
+                        "latency_ms": round(
+                            (time.perf_counter() - started) * 1000, 3
+                        ),
+                        **metrics,
+                        "runtime_run_id": result.get("runtime_run_id"),
+                        "error": None,
+                    }
+                except Exception as exc:
+                    payload = {
+                        "status": "failed",
+                        "output": "",
+                        "citations": {},
+                        "usage": {},
+                        "score": 0.0,
+                        "metrics": [],
+                        "latency_ms": round(
+                            (time.perf_counter() - started) * 1000, 3
+                        ),
+                        "error": str(exc)[:500],
+                    }
+                await asyncio.to_thread(
+                    self.store.record_item_result,
+                    run["run_id"],
+                    item["item_id"],
+                    result=payload,
+                )
+
+        while True:
+            current = await asyncio.to_thread(self.store.require_run, run["run_id"])
+            if current.get("cancel_requested"):
+                break
+            claimed = await asyncio.to_thread(
+                self.store.claim_items, run["run_id"], concurrency
+            )
+            if not claimed:
+                break
+            await asyncio.gather(*(execute_item(item) for item in claimed))
+
+        completed = await asyncio.to_thread(self.store.require_run, run["run_id"])
+        report = aggregate_evaluation_report(
+            list(completed.get("items") or []),
+            baseline_target_id=completed.get("baseline_target_id"),
+        )
+        report["warnings"] = list(completed.get("warnings") or [])
+        result = await asyncio.to_thread(
+            self.store.complete_run, run["run_id"], report
+        )
+        if registry_run is not None:
+            await self.run_registry.update_run(
+                registry_run.run_id,
+                status=(
+                    "cancelled" if result.get("status") == "cancelled" else "completed"
+                ),
+                metadata={
+                    "target_count": len(report.get("targets") or []),
+                    "comparison_count": len(report.get("comparisons") or []),
+                },
+            )
+            await self.run_registry.record_checkpoint(
+                registry_run.run_id,
+                event_type="xpert_evaluation.completed",
+                title="Xpert evaluation completed",
+                summary=f"{len(result.get('items') or [])} work items",
+                metadata={
+                    "run_id": run["run_id"],
+                    "status": result.get("status"),
+                },
+            )

--- a/server/evaluations/metrics.py
+++ b/server/evaluations/metrics.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import json
+import math
+from statistics import mean
+from typing import Any, Awaitable, Callable
+
+from jsonschema import Draft202012Validator
+
+
+JudgeCallback = Callable[[str, str, str, str], Awaitable[dict[str, Any]]]
+
+
+async def evaluate_case_metrics(
+    *,
+    case: dict[str, Any],
+    output: str,
+    citations: dict[str, list[str]],
+    judge: JudgeCallback | None = None,
+    judge_model_id: str | None = None,
+) -> dict[str, Any]:
+    expected = dict(case.get("expected") or {})
+    weights = dict(case.get("weights") or {})
+    metrics: list[dict[str, Any]] = []
+
+    exact = expected.get("exact_answer")
+    if isinstance(exact, str):
+        metrics.append(
+            _metric(
+                "exact_match",
+                1.0 if _normalize(output) == _normalize(exact) else 0.0,
+                "Normalized final output matched the expected answer."
+                if _normalize(output) == _normalize(exact)
+                else "Normalized final output did not match the expected answer.",
+                weights,
+            )
+        )
+
+    contains = [
+        str(item).strip()
+        for item in list(expected.get("contains") or [])
+        if str(item).strip()
+    ]
+    if contains:
+        normalized = _normalize(output)
+        hits = sum(1 for item in contains if _normalize(item) in normalized)
+        metrics.append(
+            _metric(
+                "contains",
+                hits / len(contains),
+                f"Matched {hits} of {len(contains)} required text fragments.",
+                weights,
+            )
+        )
+
+    schema = expected.get("json_schema")
+    if isinstance(schema, dict):
+        score = 0.0
+        reason = "Final output was not valid JSON."
+        try:
+            parsed = json.loads(output)
+            Draft202012Validator.check_schema(schema)
+            Draft202012Validator(schema).validate(parsed)
+            score = 1.0
+            reason = "Final output satisfied the configured JSON Schema."
+        except Exception as exc:
+            reason = f"JSON Schema validation failed: {str(exc)[:300]}"
+        metrics.append(_metric("json_schema", score, reason, weights))
+
+    expected_citations = {
+        "citation_ids": _string_set(expected.get("citation_ids")),
+        "chunk_ids": _string_set(expected.get("chunk_ids")),
+        "document_names": {
+            item.casefold() for item in _string_set(expected.get("document_names"))
+        },
+    }
+    citation_total = sum(len(values) for values in expected_citations.values())
+    if citation_total:
+        actual = {
+            "citation_ids": _string_set(citations.get("citation_ids")),
+            "chunk_ids": _string_set(citations.get("chunk_ids")),
+            "document_names": {
+                item.casefold()
+                for item in _string_set(citations.get("document_names"))
+            },
+        }
+        matched = sum(
+            len(expected_citations[key] & actual[key]) for key in expected_citations
+        )
+        metrics.append(
+            _metric(
+                "citation_hit",
+                matched / citation_total,
+                f"Matched {matched} of {citation_total} expected citation references.",
+                weights,
+            )
+        )
+
+    rubric = expected.get("rubric")
+    if isinstance(rubric, str) and rubric.strip():
+        if judge is None or not judge_model_id:
+            metrics.append(
+                _metric(
+                    "rubric_judge",
+                    0.0,
+                    "Rubric judge was requested but no judge model was configured.",
+                    weights,
+                )
+            )
+        else:
+            judged = await judge(
+                judge_model_id,
+                str(case.get("message") or "")[:20_000],
+                output[:20_000],
+                rubric[:4_000],
+            )
+            metrics.append(
+                _metric(
+                    "rubric_judge",
+                    max(0.0, min(float(judged.get("score") or 0.0), 1.0)),
+                    str(judged.get("reason") or "")[:500],
+                    weights,
+                    passed=bool(judged.get("passed")),
+                )
+            )
+
+    total_weight = sum(float(item["weight"]) for item in metrics)
+    total_score = (
+        sum(float(item["score"]) * float(item["weight"]) for item in metrics)
+        / total_weight
+        if total_weight
+        else 0.0
+    )
+    return {
+        "score": round(total_score, 6),
+        "metrics": metrics,
+        "metric_count": len(metrics),
+    }
+
+
+def aggregate_evaluation_report(
+    items: list[dict[str, Any]],
+    *,
+    baseline_target_id: str | None,
+) -> dict[str, Any]:
+    by_target: dict[str, list[dict[str, Any]]] = {}
+    for item in items:
+        by_target.setdefault(str(item.get("target_id") or ""), []).append(item)
+
+    targets: list[dict[str, Any]] = []
+    for target_id, target_items in by_target.items():
+        completed = [item for item in target_items if item.get("status") == "completed"]
+        scores = [float(item.get("score") or 0.0) for item in target_items]
+        latencies = sorted(float(item.get("latency_ms") or 0.0) for item in target_items)
+        per_metric: dict[str, list[float]] = {}
+        for item in completed:
+            for metric in list(item.get("metrics") or []):
+                per_metric.setdefault(str(metric.get("kind") or ""), []).append(
+                    float(metric.get("score") or 0.0)
+                )
+        targets.append(
+            {
+                "target_id": target_id,
+                "label": str(target_items[0].get("target_label") or target_id),
+                "score": round(mean(scores), 6) if scores else 0.0,
+                "case_count": len(target_items),
+                "completed_count": len(completed),
+                "failed_count": len(target_items) - len(completed),
+                "metrics": {
+                    name: round(mean(values), 6)
+                    for name, values in sorted(per_metric.items())
+                },
+                "average_latency_ms": round(mean(latencies), 3) if latencies else 0.0,
+                "p95_latency_ms": round(_percentile(latencies, 0.95), 3),
+                "model_calls": sum(
+                    int((item.get("usage") or {}).get("model_calls") or 0)
+                    for item in target_items
+                ),
+                "tool_calls": sum(
+                    int((item.get("usage") or {}).get("tool_calls") or 0)
+                    for item in target_items
+                ),
+                "estimated_tokens": sum(
+                    int((item.get("usage") or {}).get("estimated_tokens") or 0)
+                    for item in target_items
+                ),
+            }
+        )
+    targets.sort(key=lambda item: (-float(item["score"]), item["target_id"]))
+
+    comparisons: list[dict[str, Any]] = []
+    if baseline_target_id and baseline_target_id in by_target:
+        baseline_by_case = _case_scores(by_target[baseline_target_id])
+        for target in targets:
+            if target["target_id"] == baseline_target_id:
+                continue
+            candidate_by_case = _case_scores(by_target.get(target["target_id"], []))
+            wins = ties = losses = 0
+            for case_key, baseline_score in baseline_by_case.items():
+                candidate_score = candidate_by_case.get(case_key, 0.0)
+                if candidate_score > baseline_score + 1e-9:
+                    wins += 1
+                elif candidate_score < baseline_score - 1e-9:
+                    losses += 1
+                else:
+                    ties += 1
+            baseline_target = next(
+                item for item in targets if item["target_id"] == baseline_target_id
+            )
+            comparisons.append(
+                {
+                    "target_id": target["target_id"],
+                    "baseline_target_id": baseline_target_id,
+                    "score_delta": round(
+                        float(target["score"]) - float(baseline_target["score"]), 6
+                    ),
+                    "wins": wins,
+                    "ties": ties,
+                    "losses": losses,
+                }
+            )
+    return {"targets": targets, "comparisons": comparisons}
+
+
+def _metric(
+    kind: str,
+    score: float,
+    reason: str,
+    weights: dict[str, Any],
+    *,
+    passed: bool | None = None,
+) -> dict[str, Any]:
+    normalized = max(0.0, min(float(score), 1.0))
+    return {
+        "kind": kind,
+        "score": round(normalized, 6),
+        "weight": max(0.0, min(float(weights.get(kind, 1.0)), 10.0)),
+        "passed": normalized >= 0.999 if passed is None else passed,
+        "reason": reason[:500],
+    }
+
+
+def _normalize(value: str) -> str:
+    return " ".join(str(value).strip().casefold().split())
+
+
+def _string_set(value: Any) -> set[str]:
+    return {str(item).strip() for item in list(value or []) if str(item).strip()}
+
+
+def _percentile(values: list[float], quantile: float) -> float:
+    if not values:
+        return 0.0
+    index = max(0, min(math.ceil(len(values) * quantile) - 1, len(values) - 1))
+    return values[index]
+
+
+def _case_scores(items: list[dict[str, Any]]) -> dict[str, float]:
+    grouped: dict[str, list[float]] = {}
+    for item in items:
+        key = str(item.get("case_id") or "")
+        grouped.setdefault(key, []).append(float(item.get("score") or 0.0))
+    return {key: mean(values) for key, values in grouped.items()}

--- a/server/evaluations/models.py
+++ b/server/evaluations/models.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field, model_validator
+
+
+MetricKind = Literal[
+    "exact_match",
+    "contains",
+    "json_schema",
+    "citation_hit",
+    "rubric_judge",
+]
+
+
+class EvaluationMessage(BaseModel):
+    role: Literal["system", "user", "assistant"]
+    content: str = Field(min_length=1, max_length=20_000)
+
+
+class EvaluationExpectation(BaseModel):
+    exact_answer: str | None = Field(default=None, max_length=20_000)
+    contains: list[str] = Field(default_factory=list, max_length=20)
+    json_schema: dict[str, Any] | None = None
+    citation_ids: list[str] = Field(default_factory=list, max_length=50)
+    chunk_ids: list[str] = Field(default_factory=list, max_length=50)
+    document_names: list[str] = Field(default_factory=list, max_length=50)
+    rubric: str | None = Field(default=None, max_length=4_000)
+
+
+class EvaluationCaseInput(BaseModel):
+    case_id: str | None = Field(default=None, max_length=120)
+    name: str = Field(default="", max_length=160)
+    message: str = Field(min_length=1, max_length=20_000)
+    messages: list[EvaluationMessage] = Field(default_factory=list, max_length=20)
+    tags: list[str] = Field(default_factory=list, max_length=20)
+    expected: EvaluationExpectation = Field(default_factory=EvaluationExpectation)
+    weights: dict[MetricKind, float] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def normalize_weights(self) -> "EvaluationCaseInput":
+        for key, value in self.weights.items():
+            if not 0 <= float(value) <= 10:
+                raise ValueError(f"Metric weight must be between 0 and 10: {key}")
+        return self
+
+
+class DatasetCreateRequest(BaseModel):
+    name: str = Field(min_length=1, max_length=160)
+    description: str = Field(default="", max_length=2_000)
+
+
+class DatasetUpdateRequest(BaseModel):
+    revision: int = Field(ge=1)
+    name: str | None = Field(default=None, min_length=1, max_length=160)
+    description: str | None = Field(default=None, max_length=2_000)
+    status: Literal["draft", "archived"] | None = None
+
+
+class DatasetCasesRequest(BaseModel):
+    revision: int = Field(ge=1)
+    cases: list[EvaluationCaseInput] = Field(min_length=1, max_length=500)
+    replace: bool = False
+
+
+class DatasetPublishRequest(BaseModel):
+    revision: int = Field(ge=1)
+    release_notes: str = Field(default="", max_length=2_000)
+
+
+class ConversationImportSelection(BaseModel):
+    xpert_id: str = Field(min_length=1, max_length=200)
+    conversation_id: str = Field(min_length=1, max_length=200)
+    message_ids: list[str] = Field(default_factory=list, max_length=100)
+
+
+class ConversationImportRequest(BaseModel):
+    revision: int = Field(ge=1)
+    selections: list[ConversationImportSelection] = Field(min_length=1, max_length=50)
+
+
+class EvaluationTargetRequest(BaseModel):
+    kind: Literal["xpert_version", "proposal"]
+    xpert_id: str | None = Field(default=None, max_length=200)
+    version: int | None = Field(default=None, ge=1)
+    proposal_id: str | None = Field(default=None, max_length=200)
+    proposal_revision: int | None = Field(default=None, ge=1)
+    label: str = Field(default="", max_length=160)
+
+    @model_validator(mode="after")
+    def validate_reference(self) -> "EvaluationTargetRequest":
+        if self.kind == "xpert_version":
+            if not self.xpert_id or self.version is None:
+                raise ValueError("xpert_id and version are required for xpert_version.")
+        elif not self.proposal_id or self.proposal_revision is None:
+            raise ValueError(
+                "proposal_id and proposal_revision are required for proposal."
+            )
+        return self
+
+
+class EvaluationBudget(BaseModel):
+    repetitions: int = Field(default=1, ge=1, le=3)
+    max_concurrency: int = Field(default=2, ge=1, le=4)
+    case_timeout_seconds: int = Field(default=120, ge=10, le=600)
+    max_model_calls: int = Field(default=16, ge=1, le=64)
+    max_tool_calls: int = Field(default=24, ge=0, le=100)
+    max_estimated_tokens: int = Field(default=64_000, ge=1_000, le=500_000)
+    max_output_chars: int = Field(default=20_000, ge=1_000, le=50_000)
+
+
+class EvaluationRunRequest(BaseModel):
+    dataset_id: str = Field(min_length=1, max_length=200)
+    dataset_version: int = Field(ge=1)
+    case_ids: list[str] = Field(default_factory=list, max_length=100)
+    baseline: EvaluationTargetRequest | None = None
+    candidates: list[EvaluationTargetRequest] = Field(min_length=1, max_length=5)
+    model_policy: Literal["snapshot", "override"] = "snapshot"
+    override_model_id: str | None = Field(default=None, max_length=300)
+    judge_model_id: str | None = Field(default=None, max_length=300)
+    seed: int = Field(default=0, ge=0, le=2_147_483_647)
+    budget: EvaluationBudget = Field(default_factory=EvaluationBudget)
+
+    @model_validator(mode="after")
+    def validate_model_policy(self) -> "EvaluationRunRequest":
+        if self.model_policy == "override" and not self.override_model_id:
+            raise ValueError("override_model_id is required for override policy.")
+        return self
+
+
+class EvaluationPreflightRequest(BaseModel):
+    baseline: EvaluationTargetRequest | None = None
+    candidates: list[EvaluationTargetRequest] = Field(min_length=1, max_length=5)
+    model_policy: Literal["snapshot", "override"] = "snapshot"
+    override_model_id: str | None = Field(default=None, max_length=300)

--- a/server/evaluations/service.py
+++ b/server/evaluations/service.py
@@ -1,0 +1,645 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import time
+from typing import Any, Callable
+
+try:
+    from server.workflow_native.schemas import NativeWorkflowDefinition
+    from server.workflow_native.validate import validate_workflow_graph
+    from server.xperts.models import (
+        XpertDefinition,
+        XpertDraft,
+        XpertVersion,
+    )
+except ModuleNotFoundError:
+    from workflow_native.schemas import NativeWorkflowDefinition
+    from workflow_native.validate import validate_workflow_graph
+    from xperts.models import XpertDefinition, XpertDraft, XpertVersion
+
+from .store import (
+    EvaluationConflictError,
+    EvaluationStateError,
+    XpertEvaluationStore,
+)
+
+
+UNSAFE_NODE_KINDS = {
+    "agent_handoff",
+    "handoff_router",
+    "human_intervention",
+}
+UNSAFE_MIDDLEWARE_IDS = {
+    "human_in_the_loop",
+    "todo_planner",
+    "sandbox_files",
+    "sandbox_shell",
+    "skills_runtime",
+    "browser_automation",
+    "client_tools",
+    "office_automation",
+    "scheduler",
+    "ralph_loop",
+    "knowledge_writer",
+    "plugin_hooks",
+    "xpert_authoring",
+    "skill_creator",
+}
+
+
+class XpertEvaluationService:
+    """Freezes safe evaluation targets without mutating Xpert resources."""
+
+    def __init__(
+        self,
+        store: XpertEvaluationStore,
+        *,
+        xpert_store: Any,
+        proposal_store: Any,
+        prompt_preflight: Callable[[XpertDefinition], Any],
+        toolset_store: Any,
+        plugin_store: Any,
+        rag_service: Any,
+        context_store: Any,
+    ) -> None:
+        self.store = store
+        self.xpert_store = xpert_store
+        self.proposal_store = proposal_store
+        self.prompt_preflight = prompt_preflight
+        self.toolset_store = toolset_store
+        self.plugin_store = plugin_store
+        self.rag_service = rag_service
+        self.context_store = context_store
+
+    def snapshot_target(
+        self,
+        reference: dict[str, Any],
+        *,
+        model_policy: str,
+        override_model_id: str | None,
+        recursion_path: tuple[str, ...] = (),
+    ) -> tuple[dict[str, Any], list[str]]:
+        kind = str(reference.get("kind") or "")
+        if kind == "xpert_version":
+            xpert_id = str(reference.get("xpert_id") or "")
+            version_number = int(reference.get("version") or 0)
+            xpert = self.xpert_store.get_xpert(xpert_id)
+            version = self.xpert_store.get_version(xpert.id, version_number)
+            source = {
+                "kind": kind,
+                "xpert_id": xpert.id,
+                "version": version.version,
+                "proposal_id": None,
+                "proposal_revision": None,
+            }
+            label = str(reference.get("label") or f"{xpert.name} v{version.version}")
+        elif kind == "proposal":
+            proposal_id = str(reference.get("proposal_id") or "")
+            expected_revision = int(reference.get("proposal_revision") or 0)
+            proposal = self.proposal_store.require(proposal_id)
+            if proposal.revision != expected_revision:
+                raise EvaluationConflictError(
+                    "Authoring Proposal changed before the evaluation snapshot was created."
+                )
+            if proposal.kind not in {"xpert_create", "xpert_update"}:
+                raise EvaluationStateError("Only Xpert authoring proposals can be evaluated.")
+            xpert = self._candidate_from_proposal(proposal)
+            validation, workflow, prompt_profiles = self.prompt_preflight(xpert)
+            errors = [
+                issue.message
+                for issue in validation.issues
+                if getattr(issue, "severity", "error") == "error"
+            ]
+            if errors:
+                raise EvaluationStateError(
+                    "Proposal cannot be evaluated: " + "; ".join(errors[:10])
+                )
+            version = XpertVersion(
+                version=max(1, int(xpert.published_version or 0) + 1),
+                draft_revision=xpert.draft_revision,
+                workflow=workflow,
+                input_variable=xpert.draft.input_variable,
+                history_variable=xpert.draft.history_variable,
+                output_variable=xpert.draft.output_variable,
+                agent_config=xpert.draft.agent_config,
+                features=xpert.draft.features,
+                prompt_profiles=prompt_profiles,
+                release_notes="Ephemeral evaluation snapshot",
+                checksum=self._checksum(
+                    {
+                        "workflow": workflow.model_dump(mode="json"),
+                        "revision": proposal.revision,
+                    }
+                ),
+                published_at=time.time(),
+            )
+            source = {
+                "kind": kind,
+                "xpert_id": xpert.id,
+                "version": None,
+                "proposal_id": proposal.proposal_id,
+                "proposal_revision": proposal.revision,
+            }
+            label = str(reference.get("label") or proposal.title)
+        else:
+            raise EvaluationStateError("Unsupported evaluation target kind.")
+
+        if xpert.id in recursion_path:
+            raise EvaluationStateError(
+                "External Xpert collaboration cycle detected in evaluation target."
+            )
+        workflow = version.workflow.model_copy(deep=True)
+        if model_policy == "override":
+            clean_model = str(override_model_id or "").strip()
+            if not clean_model:
+                raise EvaluationStateError("Override model is required.")
+            for node in workflow.nodes:
+                data = node.data if isinstance(node.data, dict) else {}
+                node_kind = str(data.get("kind") or node.type or "")
+                if node_kind in {"llm", "workflow_agent"}:
+                    data["modelId"] = clean_model
+                    node.data = data
+
+        issues, warnings, resources = self._safe_preflight(
+            workflow,
+            recursion_path=(*recursion_path, xpert.id),
+        )
+        validation = validate_workflow_graph(workflow)
+        issues.extend(
+            {
+                "code": issue.code,
+                "message": issue.message,
+                "node_id": issue.node_id,
+            }
+            for issue in validation.issues
+            if issue.severity == "error"
+        )
+        if issues:
+            raise EvaluationStateError(
+                "Evaluation safety preflight failed: "
+                + "; ".join(str(item["message"]) for item in issues[:10])
+            )
+
+        target_id = (
+            f"xpert:{source['xpert_id']}:v{source['version']}"
+            if kind == "xpert_version"
+            else f"proposal:{source['proposal_id']}:r{source['proposal_revision']}"
+        )
+        snapshot = {
+            "target_id": target_id,
+            "label": label[:160],
+            "source": source,
+            "xpert": {
+                "id": xpert.id,
+                "slug": xpert.slug,
+                "name": xpert.name,
+                "description": xpert.description,
+            },
+            "workflow": workflow.model_dump(mode="json"),
+            "input_variable": version.input_variable,
+            "history_variable": version.history_variable,
+            "output_variable": version.output_variable,
+            "agent_config": (
+                version.agent_config.model_dump(mode="json")
+                if version.agent_config is not None
+                else None
+            ),
+            "features": (
+                version.features.model_dump(mode="json")
+                if version.features is not None
+                else None
+            ),
+            "prompt_profiles": [
+                item.model_dump(mode="json") for item in version.prompt_profiles
+            ],
+            "checksum": self._checksum(
+                {
+                    "workflow": workflow.model_dump(mode="json"),
+                    "source": source,
+                    "resources": resources,
+                    "model_policy": model_policy,
+                    "override_model_id": override_model_id,
+                }
+            ),
+            "resources": resources,
+            "warnings": warnings,
+            "created_at": time.time(),
+        }
+        return snapshot, warnings
+
+    def preflight(
+        self,
+        *,
+        baseline: dict[str, Any] | None,
+        candidates: list[dict[str, Any]],
+        model_policy: str,
+        override_model_id: str | None,
+    ) -> dict[str, Any]:
+        snapshots: list[dict[str, Any]] = []
+        warnings: list[str] = []
+        baseline_snapshot = None
+        if baseline:
+            baseline_snapshot, target_warnings = self.snapshot_target(
+                baseline,
+                model_policy=model_policy,
+                override_model_id=override_model_id,
+            )
+            warnings.extend(target_warnings)
+            snapshots.append(self.public_target_payload(baseline_snapshot))
+        candidate_snapshots = []
+        for reference in candidates:
+            snapshot, target_warnings = self.snapshot_target(
+                reference,
+                model_policy=model_policy,
+                override_model_id=override_model_id,
+            )
+            candidate_snapshots.append(snapshot)
+            snapshots.append(self.public_target_payload(snapshot))
+            warnings.extend(target_warnings)
+        return {
+            "valid": True,
+            "baseline": self.public_target_payload(baseline_snapshot)
+            if baseline_snapshot
+            else None,
+            "candidates": [self.public_target_payload(item) for item in candidate_snapshots],
+            "targets": snapshots,
+            "warnings": list(dict.fromkeys(warnings)),
+        }
+
+    def create_run(self, payload: dict[str, Any]) -> dict[str, Any]:
+        dataset = self.store.get_dataset_version(
+            str(payload["dataset_id"]),
+            int(payload["dataset_version"]),
+        )
+        selected_ids = {
+            str(item) for item in list(payload.get("case_ids") or []) if str(item)
+        }
+        cases = [
+            case
+            for case in dataset.get("cases") or []
+            if not selected_ids or str(case.get("case_id")) in selected_ids
+        ]
+        if not cases:
+            raise EvaluationStateError("No evaluation cases were selected.")
+        if len(cases) > self.store.MAX_RUN_CASES:
+            raise EvaluationStateError("A run may select at most 100 cases.")
+        model_policy = str(payload.get("model_policy") or "snapshot")
+        override_model_id = payload.get("override_model_id")
+        warnings: list[str] = []
+        baseline_snapshot = None
+        if payload.get("baseline"):
+            baseline_snapshot, current = self.snapshot_target(
+                dict(payload["baseline"]),
+                model_policy=model_policy,
+                override_model_id=override_model_id,
+            )
+            warnings.extend(current)
+        candidate_snapshots = []
+        for reference in payload.get("candidates") or []:
+            snapshot, current = self.snapshot_target(
+                dict(reference),
+                model_policy=model_policy,
+                override_model_id=override_model_id,
+            )
+            candidate_snapshots.append(snapshot)
+            warnings.extend(current)
+        return self.store.create_run(
+            dataset_version=dataset,
+            cases=cases,
+            baseline=baseline_snapshot,
+            candidates=candidate_snapshots,
+            config={
+                "model_policy": model_policy,
+                "override_model_id": override_model_id,
+                "judge_model_id": payload.get("judge_model_id"),
+                "seed": int(payload.get("seed") or 0),
+                "budget": copy.deepcopy(payload.get("budget") or {}),
+            },
+            warnings=list(dict.fromkeys(warnings)),
+        )
+
+    def run_detail(self, run_id: str) -> dict[str, Any]:
+        run = self.store.require_run(run_id)
+        for target in run.get("targets") or []:
+            source = dict(target.get("source") or {})
+            if source.get("kind") == "proposal":
+                try:
+                    current = self.proposal_store.require(str(source["proposal_id"]))
+                    target["stale"] = (
+                        current.revision != int(source.get("proposal_revision") or 0)
+                    )
+                except Exception:
+                    target["stale"] = True
+            else:
+                target["stale"] = False
+        return self.store.run_payload(run, include_detail=True)
+
+    def import_conversations(
+        self,
+        dataset_id: str,
+        *,
+        revision: int,
+        selections: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        cases: list[dict[str, Any]] = []
+        for selection in selections:
+            conversation = self.context_store.get_conversation(
+                str(selection["xpert_id"]),
+                str(selection["conversation_id"]),
+            )
+            selected = set(selection.get("message_ids") or [])
+            history: list[dict[str, str]] = []
+            for message in conversation.messages:
+                if selected and message.message_id not in selected:
+                    history.append({"role": message.role, "content": message.content})
+                    continue
+                if message.role != "user":
+                    history.append({"role": message.role, "content": message.content})
+                    continue
+                cases.append(
+                    {
+                        "name": message.content[:80],
+                        "message": message.content,
+                        "messages": history[-20:],
+                        "tags": ["conversation-import"],
+                        "expected": {},
+                    }
+                )
+                history.append({"role": message.role, "content": message.content})
+        if not cases:
+            raise EvaluationStateError("No selected user messages were found.")
+        return self.store.put_cases(
+            dataset_id,
+            revision=revision,
+            cases=cases,
+        )
+
+    @staticmethod
+    def public_target_payload(target: dict[str, Any] | None) -> dict[str, Any] | None:
+        if target is None:
+            return None
+        return {
+            "target_id": target["target_id"],
+            "label": target["label"],
+            "source": copy.deepcopy(target["source"]),
+            "xpert": copy.deepcopy(target["xpert"]),
+            "checksum": target["checksum"],
+            "resources": copy.deepcopy(target.get("resources") or {}),
+            "warnings": list(target.get("warnings") or []),
+            "stale": bool(target.get("stale", False)),
+        }
+
+    def _candidate_from_proposal(self, proposal: Any) -> XpertDefinition:
+        payload = dict(proposal.payload or {})
+        if proposal.kind == "xpert_create":
+            draft = XpertDraft.model_validate(payload.get("draft"))
+            return XpertDefinition(
+                id=f"proposal-{proposal.proposal_id}",
+                slug=str(payload.get("slug") or f"proposal-{proposal.proposal_id}")[:64],
+                name=str(payload.get("name") or proposal.title),
+                description=str(payload.get("description") or ""),
+                tags=list(payload.get("tags") or []),
+                starters=list(payload.get("starters") or []),
+                draft_revision=proposal.revision,
+                draft=draft,
+                created_at=proposal.created_at,
+                updated_at=proposal.updated_at,
+            )
+        target_id = proposal.target_id or str(payload.get("xpert_id") or "")
+        current = self.xpert_store.get_xpert(target_id)
+        if current.draft_revision != proposal.base_revision:
+            raise EvaluationConflictError(
+                "Target Xpert draft changed after this proposal was created."
+            )
+        candidate = current.model_copy(deep=True)
+        patch = dict(payload.get("patch") or {})
+        for field in ("name", "description", "tags", "starters"):
+            if field in patch:
+                setattr(candidate, field, copy.deepcopy(patch[field]))
+        if "draft" in patch:
+            candidate.draft = XpertDraft.model_validate(patch["draft"])
+        candidate.draft_revision = proposal.revision
+        return candidate
+
+    def _safe_preflight(
+        self,
+        workflow: NativeWorkflowDefinition,
+        *,
+        recursion_path: tuple[str, ...],
+    ) -> tuple[list[dict[str, Any]], list[str], dict[str, Any]]:
+        issues: list[dict[str, Any]] = []
+        warnings: list[str] = []
+        resources: dict[str, Any] = {
+            "toolsets": [],
+            "knowledge_versions": [],
+            "external_xperts": [],
+            "plugins": [],
+        }
+        for node in workflow.nodes:
+            data = node.data if isinstance(node.data, dict) else {}
+            kind = str(data.get("kind") or node.type or "")
+            if kind in UNSAFE_NODE_KINDS:
+                issues.append(
+                    {
+                        "code": "evaluation_unsafe_node",
+                        "message": f"Evaluation does not allow node kind: {kind}.",
+                        "node_id": node.id,
+                    }
+                )
+            if kind == "runtime_middleware":
+                middleware_id = str(data.get("runtimeMiddlewareId") or "")
+                config = dict(data.get("runtimeMiddlewareConfig") or {})
+                if middleware_id in UNSAFE_MIDDLEWARE_IDS:
+                    issues.append(
+                        {
+                            "code": "evaluation_unsafe_middleware",
+                            "message": (
+                                "Evaluation does not allow side-effect or waiting middleware: "
+                                f"{middleware_id}."
+                            ),
+                            "node_id": node.id,
+                        }
+                    )
+                if middleware_id == "xpert_file_memory" and bool(
+                    config.get("writeback_enabled")
+                ):
+                    issues.append(
+                        {
+                            "code": "evaluation_memory_write",
+                            "message": "Evaluation disables Xpert memory writeback.",
+                            "node_id": node.id,
+                        }
+                    )
+            if kind == "workflow_agent":
+                if self._truthy(data.get("memoryWriteEnabled")):
+                    issues.append(
+                        {
+                            "code": "evaluation_memory_write",
+                            "message": "Evaluation disables memory writes.",
+                            "node_id": node.id,
+                        }
+                    )
+                if self._truthy(data.get("knowledgeWriteEnabled")):
+                    issues.append(
+                        {
+                            "code": "evaluation_knowledge_write",
+                            "message": "Evaluation disables knowledge proposals.",
+                            "node_id": node.id,
+                        }
+                    )
+            if kind == "toolset_resource":
+                try:
+                    toolset_id = str(data.get("toolsetId") or "").strip()
+                    version_number = int(data.get("pinnedVersion") or 0)
+                    snapshot = self.toolset_store.get_version(toolset_id, version_number)
+                    unsafe = [
+                        tool.exposed_name
+                        for tool in snapshot.tools
+                        if tool.enabled and (not tool.read_only or tool.sensitive)
+                    ]
+                    if unsafe:
+                        raise ValueError(
+                            "Toolset includes mutable or sensitive tools: "
+                            + ", ".join(unsafe[:10])
+                        )
+                    resources["toolsets"].append(
+                        {
+                            "toolset_id": toolset_id,
+                            "version": version_number,
+                            "schema_hash": snapshot.schema_hash,
+                        }
+                    )
+                except Exception as exc:
+                    issues.append(
+                        {
+                            "code": "evaluation_toolset_unsafe",
+                            "message": str(exc),
+                            "node_id": node.id,
+                        }
+                    )
+            if kind == "knowledge_base":
+                kb_id = str(data.get("knowledgeBaseId") or "").strip()
+                try:
+                    active = self.rag_service.get_active_pipeline_version(kb_id)
+                    if not active:
+                        warnings.append(
+                            f"Knowledge base {kb_id} has no active pipeline version."
+                        )
+                    resources["knowledge_versions"].append(
+                        {
+                            "knowledge_base_id": kb_id,
+                            "version_id": (
+                                str(active.get("version_id") or "") if active else None
+                            ),
+                        }
+                    )
+                    data["evaluationPinnedVersionId"] = (
+                        str(active.get("version_id") or "") if active else ""
+                    )
+                    node.data = data
+                except Exception as exc:
+                    issues.append(
+                        {
+                            "code": "evaluation_knowledge_invalid",
+                            "message": str(exc),
+                            "node_id": node.id,
+                        }
+                    )
+            if kind == "external_xpert":
+                try:
+                    target_id = str(data.get("xpertId") or "").strip()
+                    target_version = int(data.get("pinnedVersion") or 0)
+                    target = self.xpert_store.get_xpert(target_id)
+                    if target.id in recursion_path:
+                        raise ValueError("External Xpert evaluation cycle detected.")
+                    version = self.xpert_store.get_version(target.id, target_version)
+                    nested_issues, nested_warnings, _ = self._safe_preflight(
+                        version.workflow.model_copy(deep=True),
+                        recursion_path=(*recursion_path, target.id),
+                    )
+                    issues.extend(nested_issues)
+                    warnings.extend(nested_warnings)
+                    resources["external_xperts"].append(
+                        {
+                            "xpert_id": target.id,
+                            "version": version.version,
+                            "checksum": version.checksum,
+                        }
+                    )
+                except Exception as exc:
+                    issues.append(
+                        {
+                            "code": "evaluation_external_xpert_unsafe",
+                            "message": str(exc),
+                            "node_id": node.id,
+                        }
+                    )
+            if kind == "plugin_resource":
+                self._inspect_plugin(node, data, issues, resources)
+        return issues, warnings, resources
+
+    def _inspect_plugin(
+        self,
+        node: Any,
+        data: dict[str, Any],
+        issues: list[dict[str, Any]],
+        resources: dict[str, Any],
+    ) -> None:
+        try:
+            plugin_id = str(data.get("pluginId") or "").strip()
+            version_number = int(data.get("pinnedVersion") or 0)
+            snapshot = self.plugin_store.get_version(plugin_id, version_number)
+            if snapshot.skills or snapshot.installed_skill_ids:
+                raise ValueError("Evaluation does not allow Plugin Skill execution.")
+            unsafe_presets = [
+                item.middleware_id
+                for item in snapshot.middleware_presets
+                if item.middleware_id in UNSAFE_MIDDLEWARE_IDS
+            ]
+            if unsafe_presets:
+                raise ValueError(
+                    "Plugin contains unsafe middleware: "
+                    + ", ".join(unsafe_presets[:10])
+                )
+            for reference in snapshot.toolsets:
+                toolset = self.toolset_store.get_version(
+                    reference.toolset_id, reference.version
+                )
+                unsafe = [
+                    tool.exposed_name
+                    for tool in toolset.tools
+                    if tool.enabled and (not tool.read_only or tool.sensitive)
+                ]
+                if unsafe:
+                    raise ValueError(
+                        "Plugin Toolset contains mutable or sensitive tools: "
+                        + ", ".join(unsafe[:10])
+                    )
+            resources["plugins"].append(
+                {
+                    "plugin_id": plugin_id,
+                    "version": version_number,
+                    "checksum": snapshot.package_checksum,
+                }
+            )
+        except Exception as exc:
+            issues.append(
+                {
+                    "code": "evaluation_plugin_unsafe",
+                    "message": str(exc),
+                    "node_id": node.id,
+                }
+            )
+
+    @staticmethod
+    def _truthy(value: Any) -> bool:
+        if isinstance(value, str):
+            return value.strip().lower() in {"1", "true", "yes", "on"}
+        return bool(value)
+
+    @staticmethod
+    def _checksum(value: Any) -> str:
+        payload = json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()

--- a/server/evaluations/store.py
+++ b/server/evaluations/store.py
@@ -1,0 +1,489 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import os
+import threading
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+
+class EvaluationError(RuntimeError):
+    pass
+
+
+class EvaluationNotFoundError(EvaluationError):
+    pass
+
+
+class EvaluationConflictError(EvaluationError):
+    pass
+
+
+class EvaluationStateError(EvaluationError):
+    pass
+
+
+class XpertEvaluationStore:
+    """Atomic file-backed datasets, immutable versions, and resumable runs."""
+
+    MAX_DATASET_CASES = 500
+    MAX_RUN_CASES = 100
+
+    def __init__(self, storage_dir: str | Path | None = None) -> None:
+        root = Path(
+            storage_dir
+            or os.getenv("XPERT_EVALUATION_STORAGE_DIR", "").strip()
+            or os.getenv("AGENT_TASK_STORAGE_DIR", "").strip()
+            or Path(__file__).resolve().parent / "storage"
+        )
+        self.storage_dir = root
+        self.path = root / "xpert_evaluations.json"
+        self._lock = threading.RLock()
+        self._data = self._load()
+
+    def create_dataset(self, name: str, description: str = "") -> dict[str, Any]:
+        now = time.time()
+        dataset = {
+            "dataset_id": f"xeval_dataset_{uuid.uuid4().hex}",
+            "name": self._required(name, "name", 160),
+            "description": str(description or "").strip()[:2_000],
+            "status": "draft",
+            "revision": 1,
+            "published_version": None,
+            "cases": [],
+            "versions": [],
+            "created_at": now,
+            "updated_at": now,
+        }
+        with self._lock:
+            self._data["datasets"][dataset["dataset_id"]] = dataset
+            self._save_unlocked()
+        return copy.deepcopy(dataset)
+
+    def list_datasets(self, *, status: str | None = None) -> list[dict[str, Any]]:
+        with self._lock:
+            items = list(self._data["datasets"].values())
+        if status:
+            items = [item for item in items if item.get("status") == status]
+        items.sort(key=lambda item: float(item.get("updated_at") or 0), reverse=True)
+        return [self.dataset_payload(item, include_cases=False) for item in items]
+
+    def require_dataset(self, dataset_id: str) -> dict[str, Any]:
+        with self._lock:
+            item = self._data["datasets"].get(dataset_id)
+            if not isinstance(item, dict):
+                raise EvaluationNotFoundError("Evaluation dataset not found.")
+            return copy.deepcopy(item)
+
+    def update_dataset(
+        self,
+        dataset_id: str,
+        *,
+        revision: int,
+        name: str | None = None,
+        description: str | None = None,
+        status: str | None = None,
+    ) -> dict[str, Any]:
+        with self._lock:
+            item = self._dataset_unlocked(dataset_id)
+            self._check_revision(item, revision)
+            if name is not None:
+                item["name"] = self._required(name, "name", 160)
+            if description is not None:
+                item["description"] = str(description).strip()[:2_000]
+            if status is not None:
+                if status not in {"draft", "archived"}:
+                    raise EvaluationStateError("Dataset status must be draft or archived.")
+                item["status"] = status
+            self._touch(item)
+            self._save_unlocked()
+            return copy.deepcopy(item)
+
+    def put_cases(
+        self,
+        dataset_id: str,
+        *,
+        revision: int,
+        cases: list[dict[str, Any]],
+        replace: bool = False,
+    ) -> dict[str, Any]:
+        normalized = [self.normalize_case(item) for item in cases]
+        with self._lock:
+            item = self._dataset_unlocked(dataset_id)
+            self._check_revision(item, revision)
+            if item.get("status") == "archived":
+                raise EvaluationStateError("Archived datasets cannot be edited.")
+            existing = [] if replace else list(item.get("cases") or [])
+            by_id = {str(case["case_id"]): case for case in existing}
+            for case in normalized:
+                by_id[str(case["case_id"])] = case
+            if len(by_id) > self.MAX_DATASET_CASES:
+                raise EvaluationStateError("A dataset may contain at most 500 cases.")
+            item["cases"] = list(by_id.values())
+            self._touch(item)
+            self._save_unlocked()
+            return copy.deepcopy(item)
+
+    def publish_dataset(
+        self,
+        dataset_id: str,
+        *,
+        revision: int,
+        release_notes: str = "",
+    ) -> dict[str, Any]:
+        with self._lock:
+            item = self._dataset_unlocked(dataset_id)
+            self._check_revision(item, revision)
+            if not item.get("cases"):
+                raise EvaluationStateError("Dataset must contain at least one case.")
+            version_number = len(item.get("versions") or []) + 1
+            cases = copy.deepcopy(item["cases"])
+            version = {
+                "dataset_id": dataset_id,
+                "version": version_number,
+                "draft_revision": int(item["revision"]),
+                "name": item["name"],
+                "description": item.get("description") or "",
+                "cases": cases,
+                "case_count": len(cases),
+                "release_notes": str(release_notes or "").strip()[:2_000],
+                "checksum": self._checksum(cases),
+                "published_at": time.time(),
+            }
+            item.setdefault("versions", []).append(version)
+            item["published_version"] = version_number
+            self._touch(item)
+            self._save_unlocked()
+            return copy.deepcopy(version)
+
+    def list_dataset_versions(self, dataset_id: str) -> list[dict[str, Any]]:
+        item = self.require_dataset(dataset_id)
+        versions = list(item.get("versions") or [])
+        versions.sort(key=lambda version: int(version.get("version") or 0), reverse=True)
+        return [
+            {key: value for key, value in version.items() if key != "cases"}
+            for version in versions
+        ]
+
+    def get_dataset_version(self, dataset_id: str, version: int) -> dict[str, Any]:
+        item = self.require_dataset(dataset_id)
+        for snapshot in item.get("versions") or []:
+            if int(snapshot.get("version") or 0) == int(version):
+                return copy.deepcopy(snapshot)
+        raise EvaluationNotFoundError("Evaluation dataset version not found.")
+
+    def create_run(
+        self,
+        *,
+        dataset_version: dict[str, Any],
+        cases: list[dict[str, Any]],
+        baseline: dict[str, Any] | None,
+        candidates: list[dict[str, Any]],
+        config: dict[str, Any],
+        warnings: list[str],
+    ) -> dict[str, Any]:
+        if not 1 <= len(cases) <= self.MAX_RUN_CASES:
+            raise EvaluationStateError("A run must contain between 1 and 100 cases.")
+        now = time.time()
+        targets = ([baseline] if baseline else []) + list(candidates)
+        items: list[dict[str, Any]] = []
+        repetitions = int((config.get("budget") or {}).get("repetitions") or 1)
+        for target in targets:
+            for case in cases:
+                for repetition in range(1, repetitions + 1):
+                    items.append(
+                        {
+                            "item_id": f"xeval_item_{uuid.uuid4().hex}",
+                            "target_id": target["target_id"],
+                            "target_label": target["label"],
+                            "case_id": case["case_id"],
+                            "repetition": repetition,
+                            "status": "pending",
+                            "attempts": 0,
+                            "created_at": now,
+                            "updated_at": now,
+                        }
+                    )
+        run = {
+            "run_id": f"xeval_run_{uuid.uuid4().hex}",
+            "status": "queued",
+            "dataset": copy.deepcopy(dataset_version),
+            "selected_case_ids": [case["case_id"] for case in cases],
+            "baseline_target_id": baseline["target_id"] if baseline else None,
+            "targets": copy.deepcopy(targets),
+            "config": copy.deepcopy(config),
+            "warnings": [str(item)[:500] for item in warnings[:50]],
+            "items": items,
+            "report": {},
+            "cancel_requested": False,
+            "run_registry_id": None,
+            "error": None,
+            "created_at": now,
+            "updated_at": now,
+            "completed_at": None,
+        }
+        with self._lock:
+            self._data["runs"][run["run_id"]] = run
+            self._save_unlocked()
+        return copy.deepcopy(run)
+
+    def list_runs(self, *, status: str | None = None, limit: int = 100) -> list[dict[str, Any]]:
+        with self._lock:
+            runs = list(self._data["runs"].values())
+        if status:
+            runs = [item for item in runs if item.get("status") == status]
+        runs.sort(key=lambda item: float(item.get("created_at") or 0), reverse=True)
+        return [self.run_payload(item, include_detail=False) for item in runs[:limit]]
+
+    def require_run(self, run_id: str) -> dict[str, Any]:
+        with self._lock:
+            item = self._data["runs"].get(run_id)
+            if not isinstance(item, dict):
+                raise EvaluationNotFoundError("Evaluation run not found.")
+            return copy.deepcopy(item)
+
+    def claim_next_run(self) -> dict[str, Any] | None:
+        with self._lock:
+            queued = [
+                run
+                for run in self._data["runs"].values()
+                if run.get("status") == "queued"
+            ]
+            if not queued:
+                return None
+            run = min(queued, key=lambda item: float(item.get("created_at") or 0))
+            run["status"] = "running"
+            run["updated_at"] = time.time()
+            self._save_unlocked()
+            return copy.deepcopy(run)
+
+    def recover_runs(self) -> int:
+        recovered = 0
+        with self._lock:
+            for run in self._data["runs"].values():
+                if run.get("status") == "running":
+                    run["status"] = "queued"
+                    run["updated_at"] = time.time()
+                    for item in run.get("items") or []:
+                        if item.get("status") == "running":
+                            item["status"] = "pending"
+                            item["updated_at"] = time.time()
+                    recovered += 1
+            if recovered:
+                self._save_unlocked()
+        return recovered
+
+    def set_run_registry_id(self, run_id: str, registry_id: str) -> None:
+        with self._lock:
+            run = self._run_unlocked(run_id)
+            run["run_registry_id"] = registry_id
+            run["updated_at"] = time.time()
+            self._save_unlocked()
+
+    def claim_items(self, run_id: str, limit: int) -> list[dict[str, Any]]:
+        claimed: list[dict[str, Any]] = []
+        with self._lock:
+            run = self._run_unlocked(run_id)
+            if run.get("cancel_requested"):
+                return []
+            for item in run.get("items") or []:
+                if item.get("status") != "pending":
+                    continue
+                item["status"] = "running"
+                item["attempts"] = int(item.get("attempts") or 0) + 1
+                item["updated_at"] = time.time()
+                claimed.append(copy.deepcopy(item))
+                if len(claimed) >= max(1, limit):
+                    break
+            if claimed:
+                run["updated_at"] = time.time()
+                self._save_unlocked()
+        return claimed
+
+    def record_item_result(
+        self,
+        run_id: str,
+        item_id: str,
+        *,
+        result: dict[str, Any],
+    ) -> None:
+        with self._lock:
+            run = self._run_unlocked(run_id)
+            item = self._item_unlocked(run, item_id)
+            if item.get("status") not in {"running", "pending"}:
+                return
+            item.update(copy.deepcopy(result))
+            item["status"] = str(result.get("status") or "completed")
+            item["updated_at"] = time.time()
+            run["updated_at"] = time.time()
+            self._save_unlocked()
+
+    def complete_run(self, run_id: str, report: dict[str, Any]) -> dict[str, Any]:
+        with self._lock:
+            run = self._run_unlocked(run_id)
+            if run.get("cancel_requested"):
+                run["status"] = "cancelled"
+            else:
+                run["status"] = "completed"
+            run["report"] = copy.deepcopy(report)
+            run["completed_at"] = time.time()
+            run["updated_at"] = run["completed_at"]
+            self._save_unlocked()
+            return copy.deepcopy(run)
+
+    def fail_run(self, run_id: str, error: str) -> None:
+        with self._lock:
+            run = self._run_unlocked(run_id)
+            run["status"] = "failed"
+            run["error"] = str(error)[:500]
+            run["completed_at"] = time.time()
+            run["updated_at"] = run["completed_at"]
+            self._save_unlocked()
+
+    def cancel_run(self, run_id: str) -> dict[str, Any]:
+        with self._lock:
+            run = self._run_unlocked(run_id)
+            if run.get("status") in {"completed", "failed", "cancelled"}:
+                return copy.deepcopy(run)
+            run["cancel_requested"] = True
+            if run.get("status") == "queued":
+                run["status"] = "cancelled"
+                run["completed_at"] = time.time()
+            for item in run.get("items") or []:
+                if item.get("status") == "pending":
+                    item["status"] = "cancelled"
+            run["updated_at"] = time.time()
+            self._save_unlocked()
+            return copy.deepcopy(run)
+
+    @staticmethod
+    def dataset_payload(item: dict[str, Any], *, include_cases: bool) -> dict[str, Any]:
+        payload = copy.deepcopy(item)
+        payload["case_count"] = len(payload.get("cases") or [])
+        payload["version_count"] = len(payload.get("versions") or [])
+        payload.pop("versions", None)
+        if not include_cases:
+            payload.pop("cases", None)
+        return payload
+
+    @staticmethod
+    def run_payload(item: dict[str, Any], *, include_detail: bool) -> dict[str, Any]:
+        payload = copy.deepcopy(item)
+        payload["item_count"] = len(payload.get("items") or [])
+        payload["completed_item_count"] = sum(
+            1
+            for result in payload.get("items") or []
+            if result.get("status") in {"completed", "failed", "cancelled"}
+        )
+        if not include_detail:
+            dataset = dict(payload.get("dataset") or {})
+            dataset.pop("cases", None)
+            payload["dataset"] = dataset
+            for target in payload.get("targets") or []:
+                target.pop("workflow", None)
+                target.pop("xpert", None)
+            payload.pop("items", None)
+        return payload
+
+    @staticmethod
+    def normalize_case(raw: dict[str, Any]) -> dict[str, Any]:
+        case = copy.deepcopy(raw)
+        case_id = str(case.get("case_id") or "").strip() or f"case_{uuid.uuid4().hex}"
+        message = str(case.get("message") or "").strip()
+        if not message:
+            raise EvaluationStateError("Evaluation case message is required.")
+        messages = []
+        total_history = 0
+        for item in list(case.get("messages") or [])[-20:]:
+            if not isinstance(item, dict):
+                continue
+            role = str(item.get("role") or "").strip()
+            content = str(item.get("content") or "").strip()
+            if role not in {"system", "user", "assistant"} or not content:
+                continue
+            remaining = 40_000 - total_history
+            if remaining <= 0:
+                break
+            content = content[:remaining]
+            total_history += len(content)
+            messages.append({"role": role, "content": content})
+        return {
+            "case_id": case_id[:120],
+            "name": str(case.get("name") or message[:80]).strip()[:160],
+            "message": message[:20_000],
+            "messages": messages,
+            "tags": [
+                str(item).strip()[:80]
+                for item in list(case.get("tags") or [])[:20]
+                if str(item).strip()
+            ],
+            "expected": copy.deepcopy(case.get("expected") or {}),
+            "weights": copy.deepcopy(case.get("weights") or {}),
+        }
+
+    def _load(self) -> dict[str, Any]:
+        if not self.path.exists():
+            return {"schema_version": 1, "datasets": {}, "runs": {}}
+        try:
+            raw = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return {"schema_version": 1, "datasets": {}, "runs": {}}
+        return {
+            "schema_version": 1,
+            "datasets": dict(raw.get("datasets") or {}),
+            "runs": dict(raw.get("runs") or {}),
+        }
+
+    def _save_unlocked(self) -> None:
+        self.storage_dir.mkdir(parents=True, exist_ok=True)
+        temp = self.path.with_suffix(".tmp")
+        temp.write_text(
+            json.dumps(self._data, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+        os.replace(temp, self.path)
+
+    def _dataset_unlocked(self, dataset_id: str) -> dict[str, Any]:
+        item = self._data["datasets"].get(dataset_id)
+        if not isinstance(item, dict):
+            raise EvaluationNotFoundError("Evaluation dataset not found.")
+        return item
+
+    def _run_unlocked(self, run_id: str) -> dict[str, Any]:
+        item = self._data["runs"].get(run_id)
+        if not isinstance(item, dict):
+            raise EvaluationNotFoundError("Evaluation run not found.")
+        return item
+
+    @staticmethod
+    def _item_unlocked(run: dict[str, Any], item_id: str) -> dict[str, Any]:
+        for item in run.get("items") or []:
+            if item.get("item_id") == item_id:
+                return item
+        raise EvaluationNotFoundError("Evaluation work item not found.")
+
+    @staticmethod
+    def _check_revision(item: dict[str, Any], revision: int) -> None:
+        if int(item.get("revision") or 0) != int(revision):
+            raise EvaluationConflictError("Resource changed. Reload before saving.")
+
+    @staticmethod
+    def _touch(item: dict[str, Any]) -> None:
+        item["revision"] = int(item.get("revision") or 0) + 1
+        item["updated_at"] = time.time()
+
+    @staticmethod
+    def _required(value: Any, name: str, limit: int) -> str:
+        clean = str(value or "").strip()
+        if not clean:
+            raise EvaluationStateError(f"{name} is required.")
+        return clean[:limit]
+
+    @staticmethod
+    def _checksum(value: Any) -> str:
+        payload = json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()

--- a/server/main.py
+++ b/server/main.py
@@ -48,6 +48,19 @@ except ModuleNotFoundError:
     )
 
 try:
+    from server.evaluations import (
+        configure_xpert_evaluations,
+        get_xpert_evaluation_executor,
+        router as xpert_evaluations_router,
+    )
+except ModuleNotFoundError:
+    from evaluations import (
+        configure_xpert_evaluations,
+        get_xpert_evaluation_executor,
+        router as xpert_evaluations_router,
+    )
+
+try:
     from server.skills.api import (
         get_skill_draft_store,
         get_skill_manager,
@@ -646,6 +659,7 @@ app.include_router(runtime_authoring_router)
 app.include_router(toolsets_router)
 app.include_router(prompt_profiles_router)
 app.include_router(plugins_router)
+app.include_router(xpert_evaluations_router)
 
 request_windows: dict[str, deque[float]] = defaultdict(deque)
 mcp_connect_windows: dict[str, deque[float]] = defaultdict(deque)
@@ -3572,7 +3586,7 @@ async def _run_workflow_response(
     )
     execution_budget: XpertExecutionBudget | None = None
     raw_agent_config = run_metadata.get("xpert_agent_config")
-    if runtime_run_type in {"xpert", "xpert_app"} and isinstance(
+    if runtime_run_type in {"xpert", "xpert_app", "xpert_evaluation"} and isinstance(
         raw_agent_config, dict
     ):
         restored_budget = resume_state.get("execution_budget")
@@ -3585,6 +3599,26 @@ async def _run_workflow_response(
             max_concurrency=int(raw_agent_config.get("max_concurrency") or 4),
             recursion_limit=int(raw_agent_config.get("recursion_limit") or 1000),
             steps_used=restored_steps,
+            max_model_calls=(
+                int(raw_agent_config["max_model_calls"])
+                if raw_agent_config.get("max_model_calls") is not None
+                else None
+            ),
+            max_tool_calls=(
+                int(raw_agent_config["max_tool_calls"])
+                if raw_agent_config.get("max_tool_calls") is not None
+                else None
+            ),
+            model_calls=(
+                int(restored_budget.get("model_calls") or 0)
+                if isinstance(restored_budget, dict)
+                else 0
+            ),
+            tool_calls=(
+                int(restored_budget.get("tool_calls") or 0)
+                if isinstance(restored_budget, dict)
+                else 0
+            ),
         )
     task_state: dict[str, Any] = {
         "task_id": task_id,
@@ -4505,6 +4539,26 @@ async def _run_workflow_response(
                 raise PermissionError("Xpert App authoring tools are disabled.")
             if not matched_tool:
                 raise ValueError(f"MCP 工具未注册：{tool_name}")
+            if runtime_run_type == "xpert_evaluation":
+                blocked_evaluation_capabilities = {
+                    "memory_tools",
+                    "todo_tools",
+                    "sandbox_tools",
+                    "browser_tools",
+                    "client_tools",
+                    "office_tools",
+                    "automation_tools",
+                    "xpert_authoring_tools",
+                    "skill_creator_tools",
+                }
+                if capability_name in blocked_evaluation_capabilities:
+                    raise RuntimeMiddlewareFatalError(
+                        "Xpert evaluation blocks stateful or side-effect Runtime tools."
+                    )
+                if not matched_tool.read_only or matched_tool.sensitive:
+                    raise RuntimeMiddlewareFatalError(
+                        "Xpert evaluation only permits non-sensitive read-only tools."
+                    )
             if matched_tool.requires_approval or matched_tool.sensitive:
                 hitl_spec = (
                     middleware_spec(middleware_specs, "human_in_the_loop")
@@ -7300,6 +7354,12 @@ async def _run_workflow_response(
                                             1.0,
                                         ),
                                     ),
+                                    "evaluation_version_id": str(
+                                        resource_data.get(
+                                            "evaluationPinnedVersionId"
+                                        )
+                                        or ""
+                                    ).strip(),
                                 }
                             )
                         if knowledge_resource_configs:
@@ -9777,6 +9837,8 @@ async def _run_workflow_response(
                 "execution_budget": (
                     {
                         "steps_used": task_state["execution_budget"].steps_used,
+                        "model_calls": task_state["execution_budget"].model_calls,
+                        "tool_calls": task_state["execution_budget"].tool_calls,
                     }
                     if isinstance(
                         task_state.get("execution_budget"),
@@ -11957,6 +12019,225 @@ async def team_chat(payload: TeamChatRequest, request: Request):
     )
 
 
+def evaluation_citation_summary(value: Any) -> dict[str, list[str]]:
+    result: dict[str, set[str]] = {
+        "citation_ids": set(),
+        "chunk_ids": set(),
+        "document_names": set(),
+    }
+    stack = [value]
+    visited = 0
+    while stack and visited < 5_000:
+        visited += 1
+        current = stack.pop()
+        if isinstance(current, dict):
+            for key, item in current.items():
+                normalized = str(key).strip().casefold()
+                if normalized in {"citation_id", "citationid"} and item:
+                    result["citation_ids"].add(str(item)[:300])
+                elif normalized in {"chunk_id", "chunkid"} and item:
+                    result["chunk_ids"].add(str(item)[:300])
+                elif normalized in {
+                    "document_name",
+                    "documentname",
+                    "file_name",
+                    "filename",
+                    "source_name",
+                } and item:
+                    result["document_names"].add(str(item)[:500])
+                elif isinstance(item, (dict, list, tuple)):
+                    stack.append(item)
+        elif isinstance(current, (list, tuple)):
+            stack.extend(current)
+    return {
+        key: sorted(values)
+        for key, values in result.items()
+    }
+
+
+async def run_xpert_evaluation_target(
+    target: dict[str, Any],
+    case: dict[str, Any],
+    config: dict[str, Any],
+    parent_run_id: str | None,
+) -> dict[str, Any]:
+    workflow = WorkflowPayload.model_validate(target["workflow"])
+    history = [
+        {
+            "role": str(item.get("role") or "user"),
+            "content": str(item.get("content") or "")[:20_000],
+        }
+        for item in list(case.get("messages") or [])[-20:]
+        if isinstance(item, dict) and str(item.get("content") or "").strip()
+    ]
+    history_json = json.dumps(history, ensure_ascii=False)
+    message = str(case.get("message") or "")[:20_000]
+    inputs = {
+        str(target.get("input_variable") or "user_input"): message,
+        str(target.get("history_variable") or "conversation_history"): history_json,
+        "user_input": message,
+        "conversation_history": history_json,
+        "xpert_file_context": "",
+        "xpert_memory_context": "",
+    }
+    budget = dict(config.get("budget") or {})
+    agent_config = dict(target.get("agent_config") or {})
+    agent_config.update(
+        {
+            "max_concurrency": max(
+                1,
+                min(
+                    int(agent_config.get("max_concurrency") or 4),
+                    int(budget.get("max_concurrency") or 2),
+                ),
+            ),
+            "recursion_limit": int(agent_config.get("recursion_limit") or 1000),
+            "max_model_calls": int(budget.get("max_model_calls") or 16),
+            "max_tool_calls": int(budget.get("max_tool_calls") or 24),
+        }
+    )
+    source = dict(target.get("source") or {})
+    xpert = dict(target.get("xpert") or {})
+    runtime_metadata = {
+        "xpert_id": xpert.get("id"),
+        "xpert_slug": xpert.get("slug"),
+        "xpert_name": xpert.get("name"),
+        "xpert_version": source.get("version"),
+        "xpert_proposal_id": source.get("proposal_id"),
+        "xpert_proposal_revision": source.get("proposal_revision"),
+        "xpert_checksum": target.get("checksum"),
+        "xpert_agent_config": agent_config,
+        "xpert_features": {},
+        "evaluation_mode": "read_only",
+        "evaluation_target_id": target.get("target_id"),
+        "evaluation_resources": dict(target.get("resources") or {}),
+        "evaluation_seed": int(config.get("seed") or 0),
+        "memory_write_enabled": False,
+        "knowledge_write_enabled": False,
+    }
+    response = await _run_workflow_response(
+        WorkflowRunRequest(workflow=workflow, inputs=inputs),
+        None,
+        runtime_run_type="xpert_evaluation",
+        runtime_source_id=str(target.get("target_id") or ""),
+        runtime_metadata=runtime_metadata,
+        runtime_parent_run_id=parent_run_id,
+    )
+    task_id = str(
+        getattr(response, "headers", {}).get("X-ModelMirror-Runtime-Task-Id") or ""
+    )
+    runtime_run_id = str(
+        getattr(response, "headers", {}).get("X-ModelMirror-Runtime-Run-Id") or ""
+    )
+    final_event = await consume_workflow_stream(response)
+    if final_event.get("event") != "workflow_end":
+        raise RuntimeError(
+            "Evaluation target attempted to wait for an interactive Runtime action."
+        )
+    output = str(final_event.get("final_output") or "")
+    usage: dict[str, Any] = {}
+    task_state = workflow_task_store.get(task_id)
+    execution_budget = (
+        task_state.get("execution_budget")
+        if isinstance(task_state, dict)
+        else None
+    )
+    if isinstance(execution_budget, XpertExecutionBudget):
+        usage.update(execution_budget.usage())
+    estimated_tokens = max(
+        1,
+        (
+            len(message)
+            + len(history_json)
+            + len(output)
+            + 3
+        )
+        // 4,
+    )
+    usage.update(
+        {
+            "estimated_tokens": estimated_tokens,
+            "token_estimate": True,
+        }
+    )
+    if estimated_tokens > int(budget.get("max_estimated_tokens") or 64_000):
+        raise RuntimeError(
+            "Evaluation estimated-token budget was exhausted for this target case."
+        )
+    citation_value: Any = {
+        "output": output,
+        "variables": final_event.get("variables") or {},
+    }
+    try:
+        citation_value["parsed_output"] = json.loads(output)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        pass
+    return {
+        "output": output,
+        "citations": evaluation_citation_summary(citation_value),
+        "usage": usage,
+        "runtime_run_id": runtime_run_id or None,
+    }
+
+
+async def run_xpert_evaluation_judge(
+    model_id: str,
+    user_input: str,
+    output: str,
+    rubric: str,
+) -> dict[str, Any]:
+    prompt = (
+        "Evaluate the assistant answer against the rubric. Return JSON only with "
+        'keys "score" (number 0-1), "passed" (boolean), and "reason" '
+        "(at most 500 characters). Do not include hidden reasoning.\n\n"
+        f"Rubric:\n{rubric[:4_000]}\n\n"
+        f"User input:\n{user_input[:20_000]}\n\n"
+        f"Assistant answer:\n{output[:20_000]}"
+    )
+    raw = await collect_chat_completion_text(
+        model_id,
+        [
+            ChatMessage(
+                role="system",
+                content=(
+                    "You are a strict evaluation scorer. Follow the JSON contract "
+                    "and provide only a short reader-facing reason."
+                ),
+            ),
+            ChatMessage(role="user", content=prompt),
+        ],
+        temperature=0,
+        max_tokens=700,
+    )
+    json_text = extract_json_object_text(raw)
+    if not json_text:
+        raise RuntimeError("Rubric judge did not return a JSON object.")
+    parsed = json.loads(json_text)
+    if not isinstance(parsed, dict):
+        raise RuntimeError("Rubric judge returned an invalid JSON object.")
+    score = max(0.0, min(float(parsed.get("score") or 0.0), 1.0))
+    return {
+        "score": score,
+        "passed": bool(parsed.get("passed", score >= 0.5)),
+        "reason": str(parsed.get("reason") or "")[:500],
+    }
+
+
+configure_xpert_evaluations(
+    storage_dir=AGENT_TASK_STORAGE_DIR or None,
+    xpert_store=get_xpert_store(),
+    proposal_store=authoring_proposal_store,
+    prompt_preflight=preview_xpert_for_publish,
+    toolset_store=toolset_store,
+    plugin_store=get_plugin_store(),
+    rag_service=get_rag_service(),
+    context_store=xpert_context_store,
+    target_runner=run_xpert_evaluation_target,
+    judge_runner=run_xpert_evaluation_judge,
+    run_registry=run_registry,
+)
+
+
 @app.on_event("startup")
 async def start_mcp_ttl_cleanup() -> None:
     await asyncio.to_thread(datax_service.recover_import_jobs)
@@ -11969,6 +12250,7 @@ async def start_mcp_ttl_cleanup() -> None:
         logger.warning("Toolset auto-start failed: %s", warning)
     get_pipeline_executor().start()
     get_evaluation_executor().start()
+    get_xpert_evaluation_executor().start()
     get_handoff_executor().start()
     get_goal_coordinator().start()
     get_approval_coordinator().start()
@@ -11980,6 +12262,7 @@ async def start_mcp_ttl_cleanup() -> None:
 async def shutdown_mcp_sessions() -> None:
     await get_pipeline_executor().stop()
     await get_evaluation_executor().stop()
+    await get_xpert_evaluation_executor().stop()
     if goal_coordinator is not None:
         await goal_coordinator.stop()
     if handoff_executor is not None:

--- a/server/meta_agent/NOTICE.md
+++ b/server/meta_agent/NOTICE.md
@@ -17,6 +17,14 @@ files:
 - `evoagentx/workflow/workflow_generator.py`
 - `evoagentx/workflow/agent_generator.py`
 
+Xpert Evaluator independently adapts the separation and aggregation concepts
+audited in:
+
+- `evoagentx/evaluators/evaluator.py`
+- `evoagentx/evaluators/aflow_evaluator.py`
+- `evoagentx/benchmark/benchmark.py`
+- `evoagentx/benchmark/metrics.py`
+
 The adapted concepts are task decomposition, capability-aware workflow
 generation, and separate agent configuration generation. ModelMirror's
 implementation uses its own Pydantic contracts, Workflow Node Registry,

--- a/server/rag/rag_service.py
+++ b/server/rag/rag_service.py
@@ -2534,17 +2534,28 @@ class RagService:
         *,
         top_k: int = 5,
         retrieval: dict[str, Any] | None = None,
+        version_id: str | None = None,
     ) -> dict[str, Any]:
-        """Retrieve from the active namespace without generating an answer."""
+        """Retrieve from an active or explicitly fixed namespace."""
 
         metadata = self._read_metadata()
         self._ensure_kb_exists(metadata, kb_id)
-        active_version_id = metadata["pipeline_active_versions"].get(kb_id)
+        active_version_id = (
+            str(version_id)
+            if version_id
+            else metadata["pipeline_active_versions"].get(kb_id)
+        )
         version = (
             metadata["pipeline_versions"].get(active_version_id)
             if active_version_id
             else None
         )
+        if version_id and (
+            not isinstance(version, dict) or str(version.get("kb_id") or "") != kb_id
+        ):
+            raise PipelineVersionNotFoundError(
+                "Fixed knowledge pipeline version was not found."
+            )
         namespace = str(version.get("namespace") or kb_id) if isinstance(version, dict) else kb_id
         config = self._retrieval_config_for_version(
             version if isinstance(version, dict) else None,
@@ -2564,17 +2575,33 @@ class RagService:
         result["version_id"] = version_id
         return result
 
-    def get_knowledge_chunk(self, kb_id: str, chunk_id: str) -> dict[str, Any]:
-        """Read one chunk from the active namespace only."""
+    def get_knowledge_chunk(
+        self,
+        kb_id: str,
+        chunk_id: str,
+        *,
+        version_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Read one chunk from an active or explicitly fixed namespace."""
 
         metadata = self._read_metadata()
         self._ensure_kb_exists(metadata, kb_id)
-        active_version_id = metadata["pipeline_active_versions"].get(kb_id)
+        active_version_id = (
+            str(version_id)
+            if version_id
+            else metadata["pipeline_active_versions"].get(kb_id)
+        )
         version = (
             metadata["pipeline_versions"].get(active_version_id)
             if active_version_id
             else None
         )
+        if version_id and (
+            not isinstance(version, dict) or str(version.get("kb_id") or "") != kb_id
+        ):
+            raise PipelineVersionNotFoundError(
+                "Fixed knowledge pipeline version was not found."
+            )
         namespace = str(version.get("namespace") or kb_id) if isinstance(version, dict) else kb_id
         chunk = self.vector_store.get_chunk(namespace, chunk_id)
         if chunk is None:

--- a/server/tests/test_xpert_evaluations.py
+++ b/server/tests/test_xpert_evaluations.py
@@ -1,0 +1,351 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from server.evaluations import api as evaluation_api
+from server.evaluations.executor import XpertEvaluationExecutor
+from server.evaluations.metrics import (
+    aggregate_evaluation_report,
+    evaluate_case_metrics,
+)
+from server.evaluations.service import XpertEvaluationService
+from server.evaluations.store import (
+    EvaluationConflictError,
+    XpertEvaluationStore,
+)
+from server.workflow_native.schemas import NativeWorkflowDefinition
+from server.xperts import XpertStore
+
+
+class _EmptyStore:
+    def get_version(self, *_args: Any, **_kwargs: Any) -> Any:
+        raise KeyError("resource not found")
+
+
+class _RagStub:
+    def get_active_pipeline_version(self, kb_id: str) -> dict[str, Any] | None:
+        if kb_id == "kb-ready":
+            return {"version_id": "pipeline-v2"}
+        return None
+
+
+def _dataset_with_case(store: XpertEvaluationStore) -> tuple[dict[str, Any], dict[str, Any]]:
+    dataset = store.create_dataset("Regression")
+    dataset = store.put_cases(
+        dataset["dataset_id"],
+        revision=dataset["revision"],
+        cases=[
+            {
+                "case_id": "case-one",
+                "name": "Simple answer",
+                "message": "Say hello",
+                "expected": {
+                    "contains": ["hello"],
+                    "json_schema": {
+                        "type": "object",
+                        "required": ["answer"],
+                        "properties": {"answer": {"type": "string"}},
+                    },
+                },
+            }
+        ],
+    )
+    version = store.publish_dataset(
+        dataset["dataset_id"],
+        revision=dataset["revision"],
+    )
+    return dataset, version
+
+
+def _target(target_id: str = "candidate") -> dict[str, Any]:
+    return {
+        "target_id": target_id,
+        "label": target_id.title(),
+        "source": {
+            "kind": "xpert_version",
+            "xpert_id": "xpert-one",
+            "version": 1,
+        },
+        "xpert": {
+            "id": "xpert-one",
+            "slug": "xpert-one",
+            "name": "Xpert One",
+            "description": "",
+        },
+        "workflow": {"id": "wf", "title": "Workflow", "nodes": [], "edges": []},
+        "input_variable": "user_input",
+        "history_variable": "conversation_history",
+        "output_variable": "agent_output",
+        "agent_config": {"max_concurrency": 2, "recursion_limit": 1000},
+        "features": {},
+        "prompt_profiles": [],
+        "checksum": "checksum",
+        "resources": {},
+        "warnings": [],
+    }
+
+
+def test_dataset_versions_are_immutable_and_survive_reload(tmp_path: Path) -> None:
+    store = XpertEvaluationStore(tmp_path)
+    dataset, first = _dataset_with_case(store)
+    changed = store.put_cases(
+        dataset["dataset_id"],
+        revision=dataset["revision"] + 1,
+        cases=[
+            {
+                "case_id": "case-two",
+                "message": "A later draft case",
+                "expected": {"exact_answer": "later"},
+            }
+        ],
+    )
+
+    assert first["case_count"] == 1
+    assert store.get_dataset_version(dataset["dataset_id"], 1)["cases"][0][
+        "case_id"
+    ] == "case-one"
+    assert len(changed["cases"]) == 2
+    restored = XpertEvaluationStore(tmp_path)
+    assert restored.get_dataset_version(dataset["dataset_id"], 1)["checksum"] == first[
+        "checksum"
+    ]
+
+    with pytest.raises(EvaluationConflictError):
+        restored.put_cases(
+            dataset["dataset_id"],
+            revision=dataset["revision"],
+            cases=[{"message": "stale"}],
+        )
+
+
+@pytest.mark.asyncio
+async def test_metrics_and_baseline_comparison_are_stable() -> None:
+    async def judge(
+        _model_id: str,
+        _message: str,
+        _output: str,
+        _rubric: str,
+    ) -> dict[str, Any]:
+        return {"score": 0.75, "passed": True, "reason": "Useful and concise."}
+
+    result = await evaluate_case_metrics(
+        case={
+            "message": "Return JSON",
+            "expected": {
+                "contains": ["hello"],
+                "json_schema": {
+                    "type": "object",
+                    "required": ["answer"],
+                    "properties": {"answer": {"type": "string"}},
+                },
+                "citation_ids": ["cite-1"],
+                "rubric": "The answer is concise.",
+            },
+        },
+        output='{"answer":"hello"}',
+        citations={"citation_ids": ["cite-1"]},
+        judge=judge,
+        judge_model_id="judge-model",
+    )
+    assert result["metric_count"] == 4
+    assert result["score"] == pytest.approx(0.9375)
+
+    report = aggregate_evaluation_report(
+        [
+            {
+                "target_id": "baseline",
+                "target_label": "Baseline",
+                "case_id": "case-one",
+                "repetition": 1,
+                "status": "completed",
+                "score": 0.5,
+                "metrics": [],
+                "latency_ms": 100,
+                "usage": {},
+            },
+            {
+                "target_id": "candidate",
+                "target_label": "Candidate",
+                "case_id": "case-one",
+                "repetition": 1,
+                "status": "completed",
+                "score": 0.9,
+                "metrics": [],
+                "latency_ms": 80,
+                "usage": {},
+            },
+        ],
+        baseline_target_id="baseline",
+    )
+    assert report["comparisons"] == [
+        {
+            "target_id": "candidate",
+            "baseline_target_id": "baseline",
+            "score_delta": 0.4,
+            "wins": 1,
+            "ties": 0,
+            "losses": 0,
+        }
+    ]
+
+
+def test_safe_preflight_pins_knowledge_and_blocks_waiting_nodes(tmp_path: Path) -> None:
+    xpert_store = XpertStore(tmp_path / "xperts")
+    service = XpertEvaluationService(
+        XpertEvaluationStore(tmp_path / "evaluations"),
+        xpert_store=xpert_store,
+        proposal_store=_EmptyStore(),
+        prompt_preflight=lambda _xpert: None,
+        toolset_store=_EmptyStore(),
+        plugin_store=_EmptyStore(),
+        rag_service=_RagStub(),
+        context_store=_EmptyStore(),
+    )
+    workflow = NativeWorkflowDefinition.model_validate(
+        {
+            "id": "safe-check",
+            "title": "Safe check",
+            "nodes": [
+                {
+                    "id": "kb",
+                    "type": "knowledge_base",
+                    "data": {
+                        "kind": "knowledge_base",
+                        "knowledgeBaseId": "kb-ready",
+                    },
+                },
+                {
+                    "id": "human",
+                    "type": "human_intervention",
+                    "data": {"kind": "human_intervention"},
+                },
+            ],
+            "edges": [],
+        }
+    )
+
+    issues, _warnings, resources = service._safe_preflight(
+        workflow,
+        recursion_path=("root",),
+    )
+    assert any(item["code"] == "evaluation_unsafe_node" for item in issues)
+    assert workflow.nodes[0].data["evaluationPinnedVersionId"] == "pipeline-v2"
+    assert resources["knowledge_versions"] == [
+        {"knowledge_base_id": "kb-ready", "version_id": "pipeline-v2"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_executor_persists_results_and_resumes_unfinished_items(
+    tmp_path: Path,
+) -> None:
+    store = XpertEvaluationStore(tmp_path)
+    _dataset, version = _dataset_with_case(store)
+    run = store.create_run(
+        dataset_version=version,
+        cases=version["cases"],
+        baseline=None,
+        candidates=[_target()],
+        config={
+            "budget": {
+                "repetitions": 1,
+                "max_concurrency": 2,
+                "case_timeout_seconds": 30,
+                "max_output_chars": 20_000,
+            }
+        },
+        warnings=[],
+    )
+
+    async def runner(
+        _target_payload: dict[str, Any],
+        _case: dict[str, Any],
+        _config: dict[str, Any],
+        _parent_run_id: str | None,
+    ) -> dict[str, Any]:
+        return {
+            "output": '{"answer":"hello"}',
+            "citations": {},
+            "usage": {"model_calls": 1, "tool_calls": 0, "estimated_tokens": 10},
+        }
+
+    claimed = store.claim_next_run()
+    assert claimed is not None
+    executor = XpertEvaluationExecutor(store, target_runner=runner)
+    await executor._execute_run(claimed)
+    completed = store.require_run(run["run_id"])
+    assert completed["status"] == "completed"
+    assert completed["items"][0]["status"] == "completed"
+    assert completed["report"]["targets"][0]["model_calls"] == 1
+
+    completed["status"] = "running"
+    completed["items"][0]["status"] = "running"
+    store._data["runs"][run["run_id"]] = completed
+    store._save_unlocked()
+    assert XpertEvaluationStore(tmp_path).recover_runs() == 1
+    recovered = XpertEvaluationStore(tmp_path).require_run(run["run_id"])
+    assert recovered["status"] == "queued"
+    assert recovered["items"][0]["status"] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_evaluation_api_exposes_safe_dataset_and_run_contract(
+    tmp_path: Path,
+) -> None:
+    async def runner(
+        _target_payload: dict[str, Any],
+        _case: dict[str, Any],
+        _config: dict[str, Any],
+        _parent_run_id: str | None,
+    ) -> dict[str, Any]:
+        return {"output": "hello", "citations": {}, "usage": {}}
+
+    evaluation_api._store = XpertEvaluationStore(tmp_path)
+    evaluation_api._executor = XpertEvaluationExecutor(
+        evaluation_api._store,
+        target_runner=runner,
+    )
+    app = FastAPI()
+    app.include_router(evaluation_api.router)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://testserver",
+    ) as client:
+        capabilities = await client.get("/api/xpert-evaluations/capabilities")
+        assert capabilities.status_code == 200
+        assert capabilities.json()["safe_mode"] == "read_only_fail_closed"
+
+        created = await client.post(
+            "/api/xpert-evaluations/datasets",
+            json={"name": "API dataset", "description": "Safe contract"},
+        )
+        assert created.status_code == 200
+        dataset = created.json()
+        cases = await client.post(
+            f"/api/xpert-evaluations/datasets/{dataset['dataset_id']}/cases",
+            json={
+                "revision": dataset["revision"],
+                "cases": [
+                    {
+                        "message": "Hello",
+                        "expected": {"contains": ["hello"]},
+                    }
+                ],
+            },
+        )
+        assert cases.status_code == 200
+        published = await client.post(
+            f"/api/xpert-evaluations/datasets/{dataset['dataset_id']}/publish",
+            json={"revision": cases.json()["revision"], "release_notes": "v1"},
+        )
+        assert published.status_code == 200
+        serialized = json.dumps(published.json(), ensure_ascii=False)
+        assert "OPENROUTER_API_KEY" not in serialized
+        assert "stored_path" not in serialized

--- a/server/xpert_runtime/execution_budget.py
+++ b/server/xpert_runtime/execution_budget.py
@@ -16,6 +16,10 @@ class XpertExecutionBudget:
     max_concurrency: int
     recursion_limit: int
     steps_used: int = 0
+    max_model_calls: int | None = None
+    max_tool_calls: int | None = None
+    model_calls: int = 0
+    tool_calls: int = 0
     _semaphore: asyncio.Semaphore = field(init=False, repr=False)
     _step_lock: asyncio.Lock = field(init=False, repr=False)
 
@@ -23,18 +27,54 @@ class XpertExecutionBudget:
         self.max_concurrency = max(1, min(int(self.max_concurrency), 100))
         self.recursion_limit = max(100, min(int(self.recursion_limit), 10_000))
         self.steps_used = max(0, int(self.steps_used))
+        self.max_model_calls = (
+            max(1, int(self.max_model_calls))
+            if self.max_model_calls is not None
+            else None
+        )
+        self.max_tool_calls = (
+            max(0, int(self.max_tool_calls))
+            if self.max_tool_calls is not None
+            else None
+        )
+        self.model_calls = max(0, int(self.model_calls))
+        self.tool_calls = max(0, int(self.tool_calls))
         self._semaphore = asyncio.Semaphore(self.max_concurrency)
         self._step_lock = asyncio.Lock()
 
     async def charge(self, kind: str) -> int:
-        del kind
         async with self._step_lock:
             if self.steps_used >= self.recursion_limit:
                 raise XpertExecutionBudgetExceeded(
                     f"Xpert global recursion limit reached ({self.recursion_limit})."
                 )
+            if kind == "model_call":
+                if (
+                    self.max_model_calls is not None
+                    and self.model_calls >= self.max_model_calls
+                ):
+                    raise XpertExecutionBudgetExceeded(
+                        f"Evaluation model-call budget reached ({self.max_model_calls})."
+                    )
+                self.model_calls += 1
+            elif kind == "tool_call":
+                if (
+                    self.max_tool_calls is not None
+                    and self.tool_calls >= self.max_tool_calls
+                ):
+                    raise XpertExecutionBudgetExceeded(
+                        f"Evaluation tool-call budget reached ({self.max_tool_calls})."
+                    )
+                self.tool_calls += 1
             self.steps_used += 1
             return self.steps_used
+
+    def usage(self) -> dict[str, int]:
+        return {
+            "steps_used": self.steps_used,
+            "model_calls": self.model_calls,
+            "tool_calls": self.tool_calls,
+        }
 
 
 _execution_budgets: ContextVar[tuple[XpertExecutionBudget, ...]] = ContextVar(

--- a/server/xpert_runtime/knowledge_toolset.py
+++ b/server/xpert_runtime/knowledge_toolset.py
@@ -123,7 +123,11 @@ class KnowledgeToolsetProvider:
                 chunk_id = str(call.arguments.get("chunk_id") or "").strip()
                 if not chunk_id:
                     raise ValueError("chunk_id is required.")
-                item = self.service.get_knowledge_chunk(kb_id, chunk_id)
+                item = self.service.get_knowledge_chunk(
+                    kb_id,
+                    chunk_id,
+                    version_id=self._fixed_version(call, kb_id),
+                )
                 return RuntimeToolResult(
                     output=json.dumps(item, ensure_ascii=False),
                     metadata={
@@ -138,7 +142,11 @@ class KnowledgeToolsetProvider:
                 chunk_id = str(call.arguments.get("chunk_id") or "").strip()
                 if not chunk_id:
                     raise ValueError("chunk_id is required.")
-                item = self.service.get_knowledge_chunk(kb_id, chunk_id)
+                item = self.service.get_knowledge_chunk(
+                    kb_id,
+                    chunk_id,
+                    version_id=self._fixed_version(call, kb_id),
+                )
                 anchor = {
                     "citation_id": f"citation_{chunk_id}",
                     "kb_id": kb_id,
@@ -247,6 +255,7 @@ class KnowledgeToolsetProvider:
                     kb_id,
                     query,
                     top_k=target_top_k,
+                    version_id=self._fixed_version(call, kb_id),
                 )
             except Exception as exc:
                 warnings.append(f"{kb_id}: {str(exc)[:180]}")
@@ -338,6 +347,11 @@ class KnowledgeToolsetProvider:
                 code="knowledge_scope_invalid",
             )
         return result
+
+    def _fixed_version(self, call: RuntimeToolCall, kb_id: str) -> str | None:
+        config = self._resource_configs(call).get(kb_id, {})
+        value = str(config.get("evaluation_version_id") or "").strip()
+        return value or None
 
     def _required_allowed_kb(self, call: RuntimeToolCall, allowed: list[str]) -> str:
         requested = str(call.arguments.get("kb_id") or "").strip()

--- a/server/xpert_runtime/run_registry.py
+++ b/server/xpert_runtime/run_registry.py
@@ -20,6 +20,7 @@ RuntimeRunType = Literal[
     "knowledge_evaluation",
     "automation",
     "meta_planner",
+    "xpert_evaluation",
 ]
 RuntimeRunStatus = Literal[
     "pending",


### PR DESCRIPTION
## Summary

- 新增版本化 Xpert Evaluation Dataset，支持 JSON、CSV 与会话样例导入
- 固定已发布 XpertVersion 或 Meta Planner Proposal revision，提供 snapshot/override 模型策略
- 增加只读 fail-closed 安全预检，阻断副作用、交互等待与不安全资源
- 新增可恢复后台执行器、并发/超时/模型与工具调用预算、取消和重启续跑
- 支持 exact、contains、JSON Schema、Citation 与严格 JSON LLM Judge 指标
- 提供基线差异、win/tie/loss、退化项、延迟、错误和预算报告
- 新增 `/agents/evaluations` 工作台，并接入 Meta Planner V2 与 Xpert Studio
- 更新 EvoAgentX 审计、Runtime、MetaAgent、Harness 与 NOTICE 文档

## Safety

- 评测不会批准 Proposal、写入 Xpert 草稿或发布版本
- 不创建会话，不写入 Memory、Todo、Knowledge/Data X 或 Authoring Proposal
- Toolset 仅允许 `read_only=true` 且 `sensitive=false` 的工具
- 外部 Xpert 与 Knowledge 索引均在运行快照中固定
- API、报告和 checkpoint 不保存 prompt、工具原始结果、密钥或物理路径

## Validation

- `npm.cmd run build`
- Evaluator tests: `5 passed`
- Cross-module regression: `160 passed`
- Full backend suite: `470 passed, 4 warnings`
- `git diff --check`
- Docker Compose full rebuild and health checks
- `GET /api/xpert-evaluations/capabilities`
- Visual QA: `http://localhost:5173/agents/evaluations`

## Notes

- Docker 首次重建发现缺少 `COPY evaluations ./evaluations`，已补齐并重新完成全量重建
- 现有 FastAPI `on_event` deprecation warnings 未在本轮扩大处理范围
