### PR TITLE
feature: 添加 EvoAgentX Prompt 受控进化闭环

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -309,6 +309,25 @@ cd client
 npm.cmd run build
 ```
 
+### 8.3 EvoAgentX Prompt Evolution 护栏
+
+- Evolution 只能修改固定 revision 下选定的 `workflow_agent.rolePrompt`、
+  `promptSuffix` 或单个 Prompt Profile `template`，不得修改图结构、模型、资源或中间件。
+- DatasetVersion 必须按固定 seed 拆分优化集和验证集；验证集正文不得进入候选生成上下文。
+- optimizer 每代最多一次生成和一次 JSON 修复；候选必须保留模板变量、通过敏感信息与长样例复制检查。
+- 候选执行必须调用 Evaluator 的内部固定快照入口，继续使用只读 fail-closed 预检和相同预算。
+- 最终 Proposal 只能由独立验证集的非退化门禁创建。目标 revision 漂移时必须标记 stale，禁止写回。
+- `prompt_profile_update` 批准后只更新 Profile 草稿；Xpert/Profile 均禁止自动发布。
+- RunRegistry checkpoint 不得保存完整 Prompt、用例正文、模型输出全文、隐藏推理、工具结果或密钥。
+- `server/Dockerfile` 必须复制 `evolutions/`；修改 Evolution 时至少运行：
+
+```bash
+python -m pytest server/tests/test_xpert_evolutions.py server/tests/test_xpert_evaluations.py -q
+python -m pytest server/tests/test_xpert_runtime_authoring.py server/tests/test_meta_agent.py -q
+cd client
+npm.cmd run build
+```
+
 ## 9. MCP 开发规则
 
 MCP 原生集成属于后端进程管理和工具执行能力，开发时必须：

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -30,6 +30,7 @@ import ToolsetsPage from "./pages/ToolsetsPage";
 import PromptProfilesPage from "./pages/PromptProfilesPage";
 import PluginsPage from "./pages/PluginsPage";
 import XpertEvaluationsPage from "./pages/XpertEvaluationsPage";
+import XpertEvolutionPage from "./pages/XpertEvolutionPage";
 
 export default function App() {
   return (
@@ -48,6 +49,8 @@ export default function App() {
       <Route element={<ConversationGoalsPage />} path="/agents/goals/:goalId" />
       <Route element={<XpertEvaluationsPage />} path="/agents/evaluations" />
       <Route element={<XpertEvaluationsPage />} path="/agents/evaluations/:runId" />
+      <Route element={<XpertEvolutionPage />} path="/agents/evolution" />
+      <Route element={<XpertEvolutionPage />} path="/agents/evolution/:runId" />
       <Route element={<AutomationsPage />} path="/agents/automations" />
       <Route element={<DataXHomePage />} path="/datax" />
       <Route element={<DataXInboxPage />} path="/datax/:projectId/inbox" />

--- a/client/src/components/authoring/AuthoringProposalPanel.tsx
+++ b/client/src/components/authoring/AuthoringProposalPanel.tsx
@@ -2,7 +2,12 @@ import { useCallback, useEffect, useState } from "react";
 
 interface ProposalSummary {
   proposal_id: string;
-  kind: "xpert_create" | "xpert_update" | "skill_create" | "skill_update";
+  kind:
+    | "xpert_create"
+    | "xpert_update"
+    | "prompt_profile_update"
+    | "skill_create"
+    | "skill_update";
   title: string;
   status: "pending" | "approved" | "rejected" | "cancelled" | "conflict";
   revision: number;
@@ -35,7 +40,7 @@ export default function AuthoringProposalPanel({
   targetId,
   title = "自编写提案",
 }: {
-  kindPrefix?: "xpert" | "skill";
+  kindPrefix?: "xpert" | "prompt_profile" | "skill";
   onApplied?: () => void;
   targetId?: string;
   title?: string;
@@ -153,7 +158,7 @@ export default function AuthoringProposalPanel({
         <div>
           <h2 className="text-sm font-semibold text-white">{title}</h2>
           <p className="mt-1 text-xs text-slate-400">
-            Agent 只能提交版本化提案；批准后仍不会自动发布 Xpert 或安装 Skill。
+            Agent 只能提交版本化提案；批准后仍不会自动发布 Xpert、Prompt 或安装 Skill。
           </p>
         </div>
         <div className="flex items-center gap-2">

--- a/client/src/pages/PromptProfilesPage.tsx
+++ b/client/src/pages/PromptProfilesPage.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
+import { Link, useSearchParams } from "react-router-dom";
+import AuthoringProposalPanel from "../components/authoring/AuthoringProposalPanel";
 import PageContainer from "../components/PageContainer";
 
 interface PromptVersion {
@@ -44,6 +46,7 @@ function splitValues(value: string) {
 }
 
 export default function PromptProfilesPage() {
+  const [searchParams] = useSearchParams();
   const [items, setItems] = useState<PromptProfile[]>([]);
   const [selectedId, setSelectedId] = useState("");
   const [draft, setDraft] = useState<PromptProfile | null>(null);
@@ -55,7 +58,8 @@ export default function PromptProfilesPage() {
   async function load(selectId?: string) {
     const payload = await request<{ items: PromptProfile[] }>("/api/prompt-profiles?limit=200");
     setItems(payload.items);
-    const nextId = selectId || selectedId || payload.items[0]?.id || "";
+    const requestedId = searchParams.get("profile_id") ?? "";
+    const nextId = selectId || selectedId || requestedId || payload.items[0]?.id || "";
     setSelectedId(nextId);
     setDraft(payload.items.find((item) => item.id === nextId) ?? null);
   }
@@ -216,6 +220,7 @@ export default function PromptProfilesPage() {
               ) : <p className="text-xs text-slate-500">发布后会在这里保留固定模板与命令别名。</p>}
             </div>
             <div className="flex flex-wrap items-center gap-2 border-t border-white/10 pt-4">
+              <Link className="rounded-md border border-violet-300/25 bg-violet-300/10 px-3 py-2 text-xs font-semibold text-violet-100" to={`/agents/evolution?prompt_profile_id=${draft.id}`}>优化模板</Link>
               <button className="rounded-md border border-white/10 px-3 py-2 text-xs font-semibold text-white" disabled={Boolean(busy)} onClick={() => void saveProfile()} type="button">保存草稿</button>
               <button className="rounded-md border border-white/10 px-3 py-2 text-xs font-semibold text-white" disabled={Boolean(busy)} onClick={() => void action("validate")} type="button">校验</button>
               <button className="rounded-md bg-emerald-300 px-3 py-2 text-xs font-semibold text-slate-950" disabled={Boolean(busy)} onClick={() => void action("publish")} type="button">发布版本</button>
@@ -225,6 +230,16 @@ export default function PromptProfilesPage() {
           </section>
         ) : null}
       </div>
+      {draft ? (
+        <div className="mt-5">
+          <AuthoringProposalPanel
+            kindPrefix="prompt_profile"
+            onApplied={() => void load(draft.id)}
+            targetId={draft.id}
+            title="Prompt 进化提案"
+          />
+        </div>
+      ) : null}
     </PageContainer>
   );
 }

--- a/client/src/pages/XpertEvolutionPage.tsx
+++ b/client/src/pages/XpertEvolutionPage.tsx
@@ -1,0 +1,768 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom";
+import {
+  AlertTriangle,
+  ArrowLeft,
+  Beaker,
+  CheckCircle2,
+  FlaskConical,
+  GitCompareArrows,
+  LoaderCircle,
+  Play,
+  RefreshCw,
+  ShieldCheck,
+  Sparkles,
+  Square,
+  TrendingUp,
+  XCircle,
+} from "lucide-react";
+import PageContainer from "../components/PageContainer";
+import { models } from "../data/models";
+import { getXpert, listXpertVersions, listXperts } from "../utils/xpertApi";
+import type { XpertDefinition, XpertSummary, XpertVersion } from "../types/xpert";
+
+interface Dataset {
+  dataset_id: string;
+  name: string;
+  status: string;
+  published_version: number | null;
+  case_count: number;
+}
+
+interface DatasetVersion {
+  dataset_id: string;
+  version: number;
+  case_count: number;
+  checksum: string;
+}
+
+interface PromptProfile {
+  id: string;
+  name: string;
+  status: string;
+  draft_revision: number;
+  published_version: number | null;
+  template: string;
+}
+
+interface Candidate {
+  candidate_id: string;
+  checksum: string;
+  fields: Record<string, string>;
+  summary: string;
+}
+
+interface Ranking {
+  candidate_id: string;
+  score: number;
+  failed_count: number;
+  estimated_tokens: number;
+  average_latency_ms: number;
+  metrics: Record<string, number>;
+}
+
+interface EvolutionRun {
+  run_id: string;
+  status: string;
+  phase: string;
+  target: {
+    kind: "xpert" | "prompt_profile";
+    target_id: string;
+    base_revision: number;
+    name: string;
+    selected_fields: string[];
+    baseline_prompts: Record<string, string>;
+  };
+  dataset: {
+    dataset_id: string;
+    version: number;
+    name: string;
+  };
+  request: {
+    generations: number;
+    population_size: number;
+    min_score_delta: number;
+    max_metric_regression: number;
+    model_policy: string;
+  };
+  train_case_ids: string[];
+  validation_case_ids: string[];
+  generations: Array<{
+    generation: number;
+    repair_used: boolean;
+    candidates: Candidate[];
+    ranking: Ranking[];
+  }>;
+  finalists: Array<{ candidate_id: string; checksum: string }>;
+  report: {
+    training_baseline?: Ranking;
+    validation?: {
+      targets?: Array<Ranking & { target_id: string; label: string }>;
+    };
+    gate?: {
+      passed: boolean;
+      reason: string;
+      best_candidate_id?: string;
+      baseline_score?: number;
+      candidate_score?: number;
+      score_delta?: number;
+      metric_regressions?: Record<string, number>;
+      new_failures?: boolean;
+    };
+  };
+  warnings: string[];
+  proposal_id?: string | null;
+  proposal_revision?: number | null;
+  stale: boolean;
+  error?: string | null;
+  created_at: number;
+  completed_at?: number | null;
+}
+
+type TargetKind = "xpert" | "prompt_profile";
+
+async function requestJson<T>(url: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(url, init);
+  const payload = await response.json().catch(() => null);
+  if (!response.ok) {
+    const detail = payload && typeof payload === "object"
+      ? (payload as { detail?: unknown }).detail
+      : null;
+    throw new Error(typeof detail === "string" ? detail : `请求失败：${response.status}`);
+  }
+  return payload as T;
+}
+
+function postJson(body: unknown): RequestInit {
+  return {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  };
+}
+
+function score(value?: number) {
+  return value == null ? "-" : `${(value * 100).toFixed(1)}%`;
+}
+
+function statusTone(status: string) {
+  if (status === "completed") return "border-emerald-300/30 bg-emerald-300/10 text-emerald-100";
+  if (status === "no_improvement" || status === "stale") return "border-amber-300/30 bg-amber-300/10 text-amber-100";
+  if (status === "failed" || status === "cancelled") return "border-rose-300/30 bg-rose-300/10 text-rose-100";
+  return "border-cyan-300/30 bg-cyan-300/10 text-cyan-100";
+}
+
+export default function XpertEvolutionPage() {
+  const { runId = "" } = useParams();
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const [targetKind, setTargetKind] = useState<TargetKind>(
+    searchParams.get("prompt_profile_id") ? "prompt_profile" : "xpert",
+  );
+  const [xperts, setXperts] = useState<XpertSummary[]>([]);
+  const [profiles, setProfiles] = useState<PromptProfile[]>([]);
+  const [datasets, setDatasets] = useState<Dataset[]>([]);
+  const [datasetVersions, setDatasetVersions] = useState<DatasetVersion[]>([]);
+  const [selectedXpertId, setSelectedXpertId] = useState(searchParams.get("xpert_id") ?? "");
+  const [selectedProfileId, setSelectedProfileId] = useState(searchParams.get("prompt_profile_id") ?? "");
+  const [selectedXpert, setSelectedXpert] = useState<XpertDefinition | null>(null);
+  const [hostXpertId, setHostXpertId] = useState("");
+  const [hostVersions, setHostVersions] = useState<XpertVersion[]>([]);
+  const [hostVersion, setHostVersion] = useState(0);
+  const [promptFields, setPromptFields] = useState<string[]>([]);
+  const [datasetId, setDatasetId] = useState("");
+  const [datasetVersion, setDatasetVersion] = useState(0);
+  const [optimizerModelId, setOptimizerModelId] = useState(models[0]?.id ?? "");
+  const [modelPolicy, setModelPolicy] = useState<"snapshot" | "override">("snapshot");
+  const [overrideModelId, setOverrideModelId] = useState(models[0]?.id ?? "");
+  const [judgeModelId, setJudgeModelId] = useState(models[0]?.id ?? "");
+  const [generations, setGenerations] = useState(2);
+  const [populationSize, setPopulationSize] = useState(4);
+  const [seed, setSeed] = useState(42);
+  const [run, setRun] = useState<EvolutionRun | null>(null);
+  const [runs, setRuns] = useState<EvolutionRun[]>([]);
+  const [selectedCandidateId, setSelectedCandidateId] = useState("");
+  const [preflight, setPreflight] = useState<Record<string, unknown> | null>(null);
+  const [busy, setBusy] = useState("");
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    document.title = "模镜 - Prompt 受控进化";
+    void loadOptions();
+  }, []);
+
+  useEffect(() => {
+    if (runId) void loadRun(runId);
+  }, [runId]);
+
+  useEffect(() => {
+    if (!run || !["queued", "running"].includes(run.status)) return;
+    const timer = window.setInterval(() => void loadRun(run.run_id, true), 1500);
+    return () => window.clearInterval(timer);
+  }, [run]);
+
+  useEffect(() => {
+    if (!selectedXpertId) {
+      setSelectedXpert(null);
+      return;
+    }
+    void getXpert(selectedXpertId)
+      .then((item) => {
+        setSelectedXpert(item);
+        const available = promptOptions(item);
+        setPromptFields((current) => current.filter((field) => available.some((option) => option.key === field)));
+      })
+      .catch((caught) => setError(caught instanceof Error ? caught.message : "Xpert 加载失败"));
+  }, [selectedXpertId]);
+
+  useEffect(() => {
+    if (!hostXpertId) {
+      setHostVersions([]);
+      setHostVersion(0);
+      return;
+    }
+    void listXpertVersions(hostXpertId)
+      .then((items) => {
+        setHostVersions(items);
+        setHostVersion(items[0]?.version || 0);
+      })
+      .catch((caught) => setError(caught instanceof Error ? caught.message : "宿主版本加载失败"));
+  }, [hostXpertId]);
+
+  useEffect(() => {
+    if (!datasetId) {
+      setDatasetVersions([]);
+      setDatasetVersion(0);
+      return;
+    }
+    void requestJson<{ items: DatasetVersion[] }>(`/api/xpert-evaluations/datasets/${datasetId}/versions`)
+      .then((payload) => {
+        setDatasetVersions(payload.items ?? []);
+        setDatasetVersion(payload.items?.[0]?.version || 0);
+      })
+      .catch((caught) => setError(caught instanceof Error ? caught.message : "数据集版本加载失败"));
+  }, [datasetId]);
+
+  const availablePromptFields = useMemo(
+    () => selectedXpert ? promptOptions(selectedXpert) : [],
+    [selectedXpert],
+  );
+
+  const selectedProfile = profiles.find((item) => item.id === selectedProfileId) ?? null;
+  const allCandidates = useMemo(
+    () => run?.generations.flatMap((generation) => generation.candidates) ?? [],
+    [run],
+  );
+  const selectedCandidate = allCandidates.find((item) => item.candidate_id === selectedCandidateId)
+    ?? allCandidates.find((item) => item.candidate_id === run?.report.gate?.best_candidate_id)
+    ?? allCandidates[0]
+    ?? null;
+
+  async function loadOptions() {
+    try {
+      const [xpertPayload, profilePayload, datasetPayload, runPayload] = await Promise.all([
+        listXperts({ limit: 200 }),
+        requestJson<{ items: PromptProfile[] }>("/api/prompt-profiles?limit=200"),
+        requestJson<{ items: Dataset[] }>("/api/xpert-evaluations/datasets"),
+        requestJson<{ items: EvolutionRun[] }>("/api/xpert-evolutions/runs?limit=50"),
+      ]);
+      setXperts(xpertPayload.items);
+      setProfiles(profilePayload.items ?? []);
+      setDatasets(datasetPayload.items ?? []);
+      setRuns(runPayload.items ?? []);
+      setSelectedXpertId((current) => current || xpertPayload.items[0]?.id || "");
+      setSelectedProfileId((current) => current || profilePayload.items?.[0]?.id || "");
+      setHostXpertId((current) => current || xpertPayload.items.find((item) => item.published_version)?.id || "");
+      setDatasetId((current) => current || datasetPayload.items?.find((item) => item.published_version)?.dataset_id || "");
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "进化工作台加载失败");
+    }
+  }
+
+  async function loadRun(id: string, quiet = false) {
+    if (!quiet) setBusy("load");
+    try {
+      const payload = await requestJson<EvolutionRun>(`/api/xpert-evolutions/runs/${id}`);
+      setRun(payload);
+      setSelectedCandidateId((current) => current || payload.report.gate?.best_candidate_id || "");
+      setError("");
+    } catch (caught) {
+      if (!quiet) setError(caught instanceof Error ? caught.message : "进化运行加载失败");
+    } finally {
+      if (!quiet) setBusy("");
+    }
+  }
+
+  function requestPayload() {
+    const target = targetKind === "xpert" ? selectedXpert : selectedProfile;
+    if (!target) throw new Error("请选择进化目标");
+    if (!datasetId || !datasetVersion) throw new Error("请选择已发布评测集版本");
+    return {
+      target_kind: targetKind,
+      target_id: targetKind === "xpert" ? selectedXpert!.id : selectedProfile!.id,
+      target_revision: targetKind === "xpert" ? selectedXpert!.draft_revision : selectedProfile!.draft_revision,
+      prompt_fields: targetKind === "xpert" ? promptFields : [],
+      host_xpert_id: targetKind === "prompt_profile" ? hostXpertId : null,
+      host_xpert_version: targetKind === "prompt_profile" ? hostVersion : null,
+      dataset_id: datasetId,
+      dataset_version: datasetVersion,
+      optimizer_model_id: optimizerModelId,
+      model_policy: modelPolicy,
+      override_model_id: modelPolicy === "override" ? overrideModelId : null,
+      judge_model_id: judgeModelId || null,
+      seed,
+      generations,
+      population_size: populationSize,
+      min_score_delta: 0.01,
+      max_metric_regression: 0.02,
+      budget: {
+        repetitions: 1,
+        max_concurrency: 2,
+        case_timeout_seconds: 120,
+        max_model_calls: 16,
+        max_tool_calls: 24,
+        max_estimated_tokens: 64000,
+        max_output_chars: 20000,
+      },
+    };
+  }
+
+  async function runPreflight() {
+    setBusy("preflight");
+    setError("");
+    try {
+      const payload = await requestJson<Record<string, unknown>>(
+        "/api/xpert-evolutions/preflight",
+        postJson(requestPayload()),
+      );
+      setPreflight(payload);
+      if (payload.valid === false) {
+        const issues = payload.issues as Array<{ message?: string }> | undefined;
+        throw new Error(issues?.map((item) => item.message).filter(Boolean).join("；") || "预检未通过");
+      }
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "预检失败");
+    } finally {
+      setBusy("");
+    }
+  }
+
+  async function startRun() {
+    setBusy("start");
+    setError("");
+    try {
+      const payload = await requestJson<EvolutionRun>(
+        "/api/xpert-evolutions/runs",
+        postJson(requestPayload()),
+      );
+      navigate(`/agents/evolution/${payload.run_id}`);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "启动失败");
+    } finally {
+      setBusy("");
+    }
+  }
+
+  async function cancelRun() {
+    if (!run) return;
+    setBusy("cancel");
+    try {
+      await requestJson(`/api/xpert-evolutions/runs/${run.run_id}/cancel`, postJson({}));
+      await loadRun(run.run_id);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "取消失败");
+    } finally {
+      setBusy("");
+    }
+  }
+
+  return (
+    <PageContainer>
+      <header className="mb-5 flex flex-col gap-4 border-b border-white/10 pb-5 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase text-cyan-200">EvoAgentX Evolution</p>
+          <h1 className="mt-2 text-2xl font-semibold text-white">Prompt 受控进化</h1>
+          <p className="mt-1 max-w-3xl text-sm text-slate-400">
+            固定草稿与数据集，按同预算生成、评测和验证候选。通过非退化门禁后只创建待审批 Proposal。
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {runId ? (
+            <Link className="inline-flex items-center gap-2 rounded-md border border-white/10 px-3 py-2 text-xs text-slate-200 hover:bg-white/[0.05]" to="/agents/evolution">
+              <ArrowLeft className="h-4 w-4" /> 新建运行
+            </Link>
+          ) : null}
+          <Link className="inline-flex items-center gap-2 rounded-md border border-white/10 px-3 py-2 text-xs text-slate-200 hover:bg-white/[0.05]" to="/agents/evaluations">
+            <Beaker className="h-4 w-4" /> 评测集
+          </Link>
+        </div>
+      </header>
+
+      {error ? (
+        <div className="mb-4 flex items-start gap-2 border border-rose-300/25 bg-rose-300/10 p-3 text-sm text-rose-100">
+          <XCircle className="mt-0.5 h-4 w-4 shrink-0" /> {error}
+        </div>
+      ) : null}
+
+      {runId ? (
+        <RunDetail
+          busy={busy}
+          onCancel={() => void cancelRun()}
+          onRefresh={() => void loadRun(runId)}
+          run={run}
+          selectedCandidate={selectedCandidate}
+          selectedCandidateId={selectedCandidateId}
+          setSelectedCandidateId={setSelectedCandidateId}
+        />
+      ) : (
+        <div className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_340px]">
+          <main className="space-y-5">
+            <section className="border border-white/10 bg-ink-950/55 p-4">
+              <div className="mb-4 flex items-center gap-2">
+                <Sparkles className="h-4 w-4 text-cyan-200" />
+                <h2 className="text-sm font-semibold text-white">进化目标</h2>
+              </div>
+              <div className="mb-4 inline-flex border border-white/10 bg-black/20 p-1">
+                {(["xpert", "prompt_profile"] as TargetKind[]).map((kind) => (
+                  <button
+                    className={`px-3 py-1.5 text-xs ${targetKind === kind ? "bg-cyan-300 text-slate-950" : "text-slate-400 hover:text-white"}`}
+                    key={kind}
+                    onClick={() => {
+                      setTargetKind(kind);
+                      setPreflight(null);
+                    }}
+                    type="button"
+                  >
+                    {kind === "xpert" ? "Xpert Agent Prompt" : "Prompt Profile"}
+                  </button>
+                ))}
+              </div>
+              {targetKind === "xpert" ? (
+                <>
+                  <label className="block text-xs text-slate-400">
+                    Xpert 草稿
+                    <select className="mt-1 w-full border border-white/10 bg-ink-950 px-3 py-2 text-sm text-white" onChange={(event) => setSelectedXpertId(event.target.value)} value={selectedXpertId}>
+                      {xperts.map((item) => <option key={item.id} value={item.id}>{item.name} · r{item.draft_revision}</option>)}
+                    </select>
+                  </label>
+                  <div className="mt-4">
+                    <p className="text-xs text-slate-400">选择 1–3 个字段联合优化</p>
+                    <div className="mt-2 grid gap-2 md:grid-cols-2">
+                      {availablePromptFields.map((option) => {
+                        const checked = promptFields.includes(option.key);
+                        return (
+                          <label className={`flex cursor-pointer items-start gap-3 border p-3 ${checked ? "border-cyan-300/40 bg-cyan-300/10" : "border-white/10 bg-white/[0.02]"}`} key={option.key}>
+                            <input
+                              checked={checked}
+                              className="mt-1"
+                              onChange={() => setPromptFields((current) => checked
+                                ? current.filter((value) => value !== option.key)
+                                : current.length < 3 ? [...current, option.key] : current)}
+                              type="checkbox"
+                            />
+                            <span>
+                              <span className="block text-xs font-semibold text-white">{option.label}</span>
+                              <span className="mt-1 line-clamp-2 block text-[11px] text-slate-500">{option.preview || "当前为空"}</span>
+                            </span>
+                          </label>
+                        );
+                      })}
+                    </div>
+                  </div>
+                </>
+              ) : (
+                <div className="grid gap-4 md:grid-cols-2">
+                  <label className="block text-xs text-slate-400">
+                    Prompt Profile 草稿
+                    <select className="mt-1 w-full border border-white/10 bg-ink-950 px-3 py-2 text-sm text-white" onChange={(event) => setSelectedProfileId(event.target.value)} value={selectedProfileId}>
+                      {profiles.map((item) => <option key={item.id} value={item.id}>{item.name} · r{item.draft_revision}</option>)}
+                    </select>
+                  </label>
+                  <label className="block text-xs text-slate-400">
+                    固定评测宿主 Xpert
+                    <select className="mt-1 w-full border border-white/10 bg-ink-950 px-3 py-2 text-sm text-white" onChange={(event) => setHostXpertId(event.target.value)} value={hostXpertId}>
+                      {xperts.filter((item) => item.published_version).map((item) => <option key={item.id} value={item.id}>{item.name} · v{item.published_version}</option>)}
+                    </select>
+                  </label>
+                  <label className="block text-xs text-slate-400">
+                    宿主版本
+                    <select className="mt-1 w-full border border-white/10 bg-ink-950 px-3 py-2 text-sm text-white" onChange={(event) => setHostVersion(Number(event.target.value))} value={hostVersion}>
+                      {hostVersions.map((item) => <option key={item.version} value={item.version}>v{item.version} · {item.checksum.slice(0, 10)}</option>)}
+                    </select>
+                  </label>
+                  <div className="border border-white/10 bg-white/[0.02] p-3 text-xs text-slate-400">
+                    每条用例的 message 会作为 <code className="text-cyan-200">{"{{args}}"}</code> 渲染输入，宿主版本和资源保持不变。
+                  </div>
+                </div>
+              )}
+            </section>
+
+            <section className="grid gap-4 border border-white/10 bg-ink-950/55 p-4 md:grid-cols-2">
+              <div>
+                <div className="mb-3 flex items-center gap-2">
+                  <FlaskConical className="h-4 w-4 text-amber-200" />
+                  <h2 className="text-sm font-semibold text-white">数据隔离</h2>
+                </div>
+                <label className="block text-xs text-slate-400">
+                  已发布 Dataset
+                  <select className="mt-1 w-full border border-white/10 bg-ink-950 px-3 py-2 text-sm text-white" onChange={(event) => setDatasetId(event.target.value)} value={datasetId}>
+                    {datasets.filter((item) => item.published_version).map((item) => <option key={item.dataset_id} value={item.dataset_id}>{item.name} · {item.case_count} cases</option>)}
+                  </select>
+                </label>
+                <label className="mt-3 block text-xs text-slate-400">
+                  固定版本
+                  <select className="mt-1 w-full border border-white/10 bg-ink-950 px-3 py-2 text-sm text-white" onChange={(event) => setDatasetVersion(Number(event.target.value))} value={datasetVersion}>
+                    {datasetVersions.map((item) => <option key={item.version} value={item.version}>v{item.version} · {item.case_count} cases</option>)}
+                  </select>
+                </label>
+                <label className="mt-3 block text-xs text-slate-400">
+                  拆分 seed
+                  <input className="mt-1 w-full border border-white/10 bg-ink-950 px-3 py-2 text-sm text-white" min={0} onChange={(event) => setSeed(Number(event.target.value))} type="number" value={seed} />
+                </label>
+              </div>
+              <div>
+                <div className="mb-3 flex items-center gap-2">
+                  <GitCompareArrows className="h-4 w-4 text-violet-200" />
+                  <h2 className="text-sm font-semibold text-white">搜索边界</h2>
+                </div>
+                <label className="block text-xs text-slate-400">
+                  代数：{generations}
+                  <input className="mt-2 w-full accent-cyan-300" max={3} min={1} onChange={(event) => setGenerations(Number(event.target.value))} type="range" value={generations} />
+                </label>
+                <label className="mt-4 block text-xs text-slate-400">
+                  每代候选：{populationSize}
+                  <input className="mt-2 w-full accent-cyan-300" max={5} min={2} onChange={(event) => setPopulationSize(Number(event.target.value))} type="range" value={populationSize} />
+                </label>
+                <div className="mt-4 border border-emerald-300/20 bg-emerald-300/[0.06] p-3 text-xs leading-5 text-emerald-100">
+                  验证分至少提升 1%，且任一指标不得回退超过 2%。不允许新增超时、预算或安全错误。
+                </div>
+              </div>
+            </section>
+
+            <section className="grid gap-4 border border-white/10 bg-ink-950/55 p-4 md:grid-cols-2">
+              <label className="block text-xs text-slate-400">
+                Optimizer 模型
+                <select className="mt-1 w-full border border-white/10 bg-ink-950 px-3 py-2 text-sm text-white" onChange={(event) => setOptimizerModelId(event.target.value)} value={optimizerModelId}>
+                  {models.map((item) => <option key={item.id} value={item.id}>{item.name}</option>)}
+                </select>
+              </label>
+              <label className="block text-xs text-slate-400">
+                Rubric Judge 模型
+                <select className="mt-1 w-full border border-white/10 bg-ink-950 px-3 py-2 text-sm text-white" onChange={(event) => setJudgeModelId(event.target.value)} value={judgeModelId}>
+                  {models.map((item) => <option key={item.id} value={item.id}>{item.name}</option>)}
+                </select>
+              </label>
+              <label className="block text-xs text-slate-400">
+                Evaluator 模型策略
+                <select className="mt-1 w-full border border-white/10 bg-ink-950 px-3 py-2 text-sm text-white" onChange={(event) => setModelPolicy(event.target.value as "snapshot" | "override")} value={modelPolicy}>
+                  <option value="snapshot">使用目标快照模型</option>
+                  <option value="override">统一替换模型</option>
+                </select>
+              </label>
+              {modelPolicy === "override" ? (
+                <label className="block text-xs text-slate-400">
+                  统一模型
+                  <select className="mt-1 w-full border border-white/10 bg-ink-950 px-3 py-2 text-sm text-white" onChange={(event) => setOverrideModelId(event.target.value)} value={overrideModelId}>
+                    {models.map((item) => <option key={item.id} value={item.id}>{item.name}</option>)}
+                  </select>
+                </label>
+              ) : null}
+            </section>
+
+            <div className="flex flex-wrap items-center justify-end gap-2">
+              <button className="inline-flex items-center gap-2 rounded-md border border-white/10 px-4 py-2 text-sm text-slate-200 hover:bg-white/[0.05] disabled:opacity-50" disabled={Boolean(busy)} onClick={() => void runPreflight()} type="button">
+                {busy === "preflight" ? <LoaderCircle className="h-4 w-4 animate-spin" /> : <ShieldCheck className="h-4 w-4" />}
+                只读预检
+              </button>
+              <button className="inline-flex items-center gap-2 rounded-md bg-cyan-300 px-4 py-2 text-sm font-semibold text-slate-950 hover:bg-cyan-200 disabled:opacity-50" disabled={Boolean(busy)} onClick={() => void startRun()} type="button">
+                {busy === "start" ? <LoaderCircle className="h-4 w-4 animate-spin" /> : <Play className="h-4 w-4" />}
+                启动受控进化
+              </button>
+            </div>
+            {preflight?.valid === true ? (
+              <div className="flex items-center gap-2 border border-emerald-300/25 bg-emerald-300/10 p-3 text-xs text-emerald-100">
+                <CheckCircle2 className="h-4 w-4" /> 预检通过，优化集与验证集已按 seed 固定。
+              </div>
+            ) : null}
+          </main>
+
+          <aside className="border border-white/10 bg-ink-950/55 p-4">
+            <div className="mb-3 flex items-center justify-between">
+              <h2 className="text-sm font-semibold text-white">最近运行</h2>
+              <button className="text-slate-500 hover:text-white" onClick={() => void loadOptions()} title="刷新" type="button"><RefreshCw className="h-4 w-4" /></button>
+            </div>
+            <div className="space-y-2">
+              {runs.map((item) => (
+                <Link className="block border border-white/10 bg-white/[0.02] p-3 hover:border-cyan-300/30" key={item.run_id} to={`/agents/evolution/${item.run_id}`}>
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="truncate text-xs font-semibold text-white">{item.target.name}</span>
+                    <span className={`border px-2 py-0.5 text-[10px] ${statusTone(item.status)}`}>{item.status}</span>
+                  </div>
+                  <p className="mt-2 text-[11px] text-slate-500">{item.phase} · {item.target.kind}</p>
+                </Link>
+              ))}
+              {!runs.length ? <p className="border border-dashed border-white/10 p-5 text-center text-xs text-slate-500">尚无进化运行</p> : null}
+            </div>
+          </aside>
+        </div>
+      )}
+    </PageContainer>
+  );
+}
+
+function RunDetail({
+  run,
+  busy,
+  selectedCandidate,
+  selectedCandidateId,
+  setSelectedCandidateId,
+  onRefresh,
+  onCancel,
+}: {
+  run: EvolutionRun | null;
+  busy: string;
+  selectedCandidate: Candidate | null;
+  selectedCandidateId: string;
+  setSelectedCandidateId: (value: string) => void;
+  onRefresh: () => void;
+  onCancel: () => void;
+}) {
+  if (!run) {
+    return <div className="flex min-h-64 items-center justify-center text-sm text-slate-500"><LoaderCircle className="mr-2 h-4 w-4 animate-spin" />加载运行...</div>;
+  }
+  const active = ["queued", "running"].includes(run.status);
+  const gate = run.report.gate;
+  return (
+    <div className="space-y-5">
+      <section className="grid gap-4 border border-white/10 bg-ink-950/55 p-4 md:grid-cols-[1fr_auto]">
+        <div>
+          <div className="flex flex-wrap items-center gap-2">
+            <h2 className="text-lg font-semibold text-white">{run.target.name}</h2>
+            <span className={`border px-2 py-1 text-[11px] ${statusTone(run.status)}`}>{run.status}</span>
+            {run.stale ? <span className="border border-amber-300/30 bg-amber-300/10 px-2 py-1 text-[11px] text-amber-100">revision stale</span> : null}
+          </div>
+          <p className="mt-2 text-xs text-slate-400">
+            {run.phase} · Dataset {run.dataset.name} v{run.dataset.version} · train {run.train_case_ids.length} / validation {run.validation_case_ids.length}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button className="rounded-md border border-white/10 p-2 text-slate-300 hover:bg-white/[0.05]" onClick={onRefresh} title="刷新" type="button"><RefreshCw className="h-4 w-4" /></button>
+          {active ? <button className="inline-flex items-center gap-2 rounded-md border border-rose-300/25 px-3 py-2 text-xs text-rose-100" disabled={Boolean(busy)} onClick={onCancel} type="button"><Square className="h-4 w-4" />取消</button> : null}
+        </div>
+      </section>
+
+      {run.warnings.length ? (
+        <div className="space-y-1 border border-amber-300/25 bg-amber-300/[0.07] p-3 text-xs text-amber-100">
+          {run.warnings.map((warning) => <p className="flex gap-2" key={warning}><AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />{warning}</p>)}
+        </div>
+      ) : null}
+
+      <div className="grid gap-5 xl:grid-cols-[minmax(0,1.35fr)_minmax(320px,0.65fr)]">
+        <main className="space-y-5">
+          {run.generations.map((generation) => (
+            <section className="border border-white/10 bg-ink-950/55 p-4" key={generation.generation}>
+              <div className="mb-3 flex items-center justify-between">
+                <div>
+                  <h3 className="text-sm font-semibold text-white">Generation {generation.generation}</h3>
+                  <p className="mt-1 text-[11px] text-slate-500">{generation.candidates.length} 个安全候选{generation.repair_used ? " · 使用一次 JSON 修复" : ""}</p>
+                </div>
+                <TrendingUp className="h-4 w-4 text-cyan-200" />
+              </div>
+              <div className="overflow-x-auto">
+                <table className="w-full min-w-[680px] text-left text-xs">
+                  <thead className="border-b border-white/10 text-slate-500">
+                    <tr><th className="py-2">排名</th><th>候选</th><th>训练分</th><th>失败</th><th>Tokens</th><th>延迟</th><th></th></tr>
+                  </thead>
+                  <tbody>
+                    {generation.ranking.map((ranking, index) => {
+                      const candidate = generation.candidates.find((item) => item.candidate_id === ranking.candidate_id);
+                      return (
+                        <tr className="border-b border-white/[0.06] text-slate-300" key={ranking.candidate_id}>
+                          <td className="py-2 text-slate-500">#{index + 1}</td>
+                          <td><p className="font-medium text-white">{ranking.candidate_id}</p><p className="max-w-sm truncate text-[10px] text-slate-500">{candidate?.summary}</p></td>
+                          <td>{score(ranking.score)}</td><td>{ranking.failed_count}</td><td>{ranking.estimated_tokens}</td><td>{Math.round(ranking.average_latency_ms)} ms</td>
+                          <td><button className="text-cyan-200 hover:text-cyan-100" onClick={() => setSelectedCandidateId(ranking.candidate_id)} type="button">查看 diff</button></td>
+                        </tr>
+                      );
+                    })}
+                    {!generation.ranking.length ? <tr><td className="py-4 text-slate-500" colSpan={7}>正在生成或评测本代候选...</td></tr> : null}
+                  </tbody>
+                </table>
+              </div>
+            </section>
+          ))}
+
+          {gate ? (
+            <section className={`border p-4 ${gate.passed ? "border-emerald-300/25 bg-emerald-300/[0.06]" : "border-amber-300/25 bg-amber-300/[0.06]"}`}>
+              <div className="flex items-start gap-3">
+                {gate.passed ? <CheckCircle2 className="mt-0.5 h-5 w-5 text-emerald-200" /> : <AlertTriangle className="mt-0.5 h-5 w-5 text-amber-200" />}
+                <div>
+                  <h3 className="text-sm font-semibold text-white">{gate.passed ? "非退化门禁通过" : "未通过非退化门禁"}</h3>
+                  <p className="mt-1 text-xs text-slate-300">{gate.reason}</p>
+                  <div className="mt-3 flex flex-wrap gap-4 text-xs text-slate-400">
+                    <span>基线 {score(gate.baseline_score)}</span>
+                    <span>候选 {score(gate.candidate_score)}</span>
+                    <span>差值 {score(gate.score_delta)}</span>
+                  </div>
+                </div>
+              </div>
+            </section>
+          ) : null}
+
+          {run.proposal_id ? (
+            <section className="flex flex-col gap-3 border border-cyan-300/25 bg-cyan-300/[0.06] p-4 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <h3 className="text-sm font-semibold text-white">待审批 Proposal 已创建</h3>
+                <p className="mt-1 text-xs text-slate-400">{run.proposal_id} · 审批后只更新草稿，不自动发布。</p>
+              </div>
+              <Link
+                className="rounded-md bg-cyan-300 px-3 py-2 text-xs font-semibold text-slate-950"
+                to={
+                  run.target.kind === "xpert"
+                    ? `/agents/meta-agent?proposal_id=${run.proposal_id}`
+                    : `/prompts?profile_id=${run.target.target_id}&proposal_id=${run.proposal_id}`
+                }
+              >
+                进入审批
+              </Link>
+            </section>
+          ) : null}
+          {run.error ? <div className="border border-rose-300/25 bg-rose-300/10 p-3 text-xs text-rose-100">{run.error}</div> : null}
+        </main>
+
+        <aside className="border border-white/10 bg-ink-950/55 p-4">
+          <div className="mb-3 flex items-center gap-2">
+            <GitCompareArrows className="h-4 w-4 text-violet-200" />
+            <h3 className="text-sm font-semibold text-white">Prompt Diff</h3>
+          </div>
+          <select className="mb-4 w-full border border-white/10 bg-ink-950 px-3 py-2 text-xs text-white" onChange={(event) => setSelectedCandidateId(event.target.value)} value={selectedCandidateId || selectedCandidate?.candidate_id || ""}>
+            {run.generations.flatMap((generation) => generation.candidates).map((candidate) => <option key={candidate.candidate_id} value={candidate.candidate_id}>{candidate.candidate_id}</option>)}
+          </select>
+          {selectedCandidate ? Object.entries(selectedCandidate.fields).map(([field, value]) => (
+            <div className="mb-4" key={field}>
+              <p className="mb-2 text-[11px] font-semibold text-cyan-200">{field}</p>
+              <p className="mb-1 text-[10px] uppercase text-slate-600">Baseline</p>
+              <pre className="max-h-48 overflow-auto whitespace-pre-wrap border border-rose-300/15 bg-rose-300/[0.04] p-3 text-[11px] leading-5 text-slate-400">{run.target.baseline_prompts[field]}</pre>
+              <p className="mb-1 mt-3 text-[10px] uppercase text-slate-600">Candidate</p>
+              <pre className="max-h-64 overflow-auto whitespace-pre-wrap border border-emerald-300/15 bg-emerald-300/[0.04] p-3 text-[11px] leading-5 text-slate-200">{value}</pre>
+            </div>
+          )) : <p className="text-xs text-slate-500">候选生成后可查看差异。</p>}
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+function promptOptions(xpert: XpertDefinition) {
+  return xpert.draft.workflow.nodes.flatMap((node) => {
+    const data = node.data as Record<string, unknown>;
+    const kind = String(data.kind ?? node.type ?? "");
+    if (kind !== "workflow_agent") return [];
+    const title = String(data.label ?? data.title ?? node.id);
+    return (["rolePrompt", "promptSuffix"] as const).map((field) => ({
+      key: `${node.id}.${field}`,
+      label: `${title} · ${field}`,
+      preview: String(data[field] ?? ""),
+    }));
+  });
+}

--- a/client/src/pages/XpertStudioPage.tsx
+++ b/client/src/pages/XpertStudioPage.tsx
@@ -286,6 +286,9 @@ export default function XpertStudioPage() {
             </div>
           </div>
           <div className="flex shrink-0 flex-wrap gap-2">
+            <Link className="rounded-full border border-violet-300/25 bg-violet-300/10 px-3 py-2 text-xs font-semibold text-violet-100 transition hover:bg-violet-300/20" to={`/agents/evolution?xpert_id=${xpert.id}`}>
+              优化 Prompt
+            </Link>
             <button className="rounded-full border border-white/10 bg-white/[0.05] px-3 py-2 text-xs font-semibold text-slate-200 transition hover:border-hire-300/35" disabled={Boolean(busy)} onClick={() => void saveMetadata()} type="button">
               {busy === "metadata" ? "保存中..." : "保存信息"}
             </button>

--- a/docs/EVOAGENTX_ALIGNMENT.md
+++ b/docs/EVOAGENTX_ALIGNMENT.md
@@ -152,7 +152,22 @@ Meta Planner V2 必须：
 Evaluator 不批准 Proposal、不写 Xpert 草稿、不发布版本。完整契约见
 [EVOAGENTX_EVALUATOR.md](./EVOAGENTX_EVALUATOR.md)。
 
-### 下一步：`EVOAGENTX-EVOLUTION-03A`
+### `EVOAGENTX-EVOLUTION-03A`：已实现
 
-下一轮只生成 Prompt 候选，在同一 DatasetVersion、目标快照和固定预算下比较。
-排名结果必须写成带差异与评估报告的 Authoring Proposal，并继续禁止自动批准或发布。
+`EVOAGENTX-EVOLUTION-03A` 已形成受控闭环：
+
+- 固定 Xpert 或 Prompt Profile 草稿 revision、DatasetVersion、模型策略、seed 和预算。
+- Xpert 模式仅修改最多三个 `workflow_agent.rolePrompt/promptSuffix` 字段。
+- Profile 模式只修改 `template`，并使用固定 XpertVersion 作为评测宿主。
+- 五条及以上用例采用互斥 80/20 Holdout；小数据集显式标记过拟合风险。
+- 每代候选由有界 JSON 生成和最多一次修复产生，并经过变量保持、敏感信息和样例复制检查。
+- 训练与验证均复用现有 Evaluator 内部固定快照入口，不扩展公开 Evaluation Target。
+- 验证集总分提升、单指标非退化和错误不增加后，才创建 pending Authoring Proposal。
+- Proposal 批准只更新草稿，发布继续由用户显式完成。
+
+完整契约见 [EVOAGENTX_EVOLUTION.md](./EVOAGENTX_EVOLUTION.md)。
+
+### 下一步：`EVOAGENTX-EVOLUTION-03B`
+
+下一轮只开放类型化工作流结构 mutation。每个 mutation 必须先通过图、资源、
+循环和发布预检，再由同一 Evaluator 与固定基线比较；仍禁止自动批准和发布。

--- a/docs/EVOAGENTX_AUDIT_V014.md
+++ b/docs/EVOAGENTX_AUDIT_V014.md
@@ -227,3 +227,18 @@ Evaluator 或 Optimizer 若需要逐文件复用，必须另行补充 SHA-256、
 只读安全预检、classic runner capture、资源固定、预算、RunRegistry、API 和前端。
 EvoAgentX 中与 WorkFlow、AgentManager、任意代码 Benchmark 或第三方数据集耦合的实现
 未引入。详细契约见 [EVOAGENTX_EVALUATOR.md](./EVOAGENTX_EVALUATOR.md)。
+
+## 13. 第三次适配记录：Prompt Evolution
+
+本轮参考 `evoagentx/optimizers/evoprompt_optimizer.py` 中 population、mutation、
+selection 与 early-stop 的分层概念，判定为 `adapt`。
+
+- 未复制 EvoPrompt Runtime、日志、Benchmark、模型 Provider 或候选对象。
+- ModelMirror 使用自有 `XpertEvolutionStore` 持久化代际状态。
+- 候选执行继续由 `server/evaluations/` 的只读安全快照和固定预算完成。
+- 训练与验证数据按固定 seed 隔离，optimizer 不读取验证集。
+- 最优候选只有通过非退化门禁后才进入 `AuthoringProposalStore`。
+- 新增 `prompt_profile_update` 仍受草稿 revision 和显式发布边界约束。
+
+对应测试为 `server/tests/test_xpert_evolutions.py`，归因记录位于
+`server/meta_agent/NOTICE.md`。逐文件源码复用数量仍为零。

--- a/docs/EVOAGENTX_EVALUATOR.md
+++ b/docs/EVOAGENTX_EVALUATOR.md
@@ -174,3 +174,18 @@ npm.cmd run build
 
 变更安全预检或 runner capture 时，还必须覆盖 Toolset、Knowledge、Data X、
 Authoring、App 和 RunRegistry 回归。
+
+## 11. Evolution 内部复用
+
+Prompt Evolution 通过 Evaluator 的内部固定快照入口复用相同的只读安全预检、
+执行预算、指标和报告计算。它不会创建临时 Authoring Proposal，也不会扩展公开
+Evaluation Target 类型。
+
+- 每代训练评测只接收固定 DatasetVersion 的优化集。
+- 最终基线与 finalist 比较只接收验证集。
+- 每个临时快照固定 workflow、资源、模型策略和 checksum。
+- Evolution 取消时同时取消当前子评测；重启后跳过已经完成的子评测工作项。
+- Evaluator 仍不审批 Proposal、不写草稿、不发布版本。
+
+Prompt 搜索、非退化门禁和 Proposal 契约见
+[EVOAGENTX_EVOLUTION.md](./EVOAGENTX_EVOLUTION.md)。

--- a/docs/EVOAGENTX_EVOLUTION.md
+++ b/docs/EVOAGENTX_EVOLUTION.md
@@ -1,0 +1,100 @@
+# EvoAgentX Prompt 受控进化
+
+## 1. 边界
+
+`EVOAGENTX-EVOLUTION-03A` 在 Meta Planner V2 和 Xpert Evaluator 之上提供
+Prompt 候选搜索。它只允许修改以下内容：
+
+- 一个 Xpert 草稿中最多三个 `workflow_agent.rolePrompt` 或
+  `workflow_agent.promptSuffix` 字段。
+- 一个 Prompt Profile 草稿的 `template`。
+
+节点、边、模型、资源绑定、中间件、Toolset、Knowledge 和 Plugin 均被冻结。
+Evolution 不批准 Proposal、不写草稿、不发布版本，也不替换线上 Xpert。
+
+## 2. 固定快照
+
+每个 run 固定以下输入：
+
+- 目标 ID 与草稿 revision。
+- 已发布 DatasetVersion。
+- Prompt 字段集合，或 Prompt Profile 的固定评测宿主 XpertVersion。
+- optimizer、Evaluator model policy、judge model、seed 和执行预算。
+- `min_score_delta` 与 `max_metric_regression` 门禁。
+
+Xpert 候选使用完整临时 Xpert 快照执行。Prompt Profile 候选只改变传给固定
+宿主版本的 `{{args}}` 渲染模板。两种模式都复用 Evaluator 的只读
+fail-closed 预检和 classic workflow runner，不创建临时 Authoring Proposal。
+
+## 3. 数据隔离
+
+- 用例不少于五条时，按固定 seed 做互斥的 80/20 优化集与验证集拆分。
+- 用例少于五条时允许共用，但报告必须保留高过拟合风险 warning。
+- optimizer 只能看到优化集及前一轮的安全失败摘要。
+- 验证集仅用于最终基线与最多三个 finalist 的比较。
+- DatasetVersion 在运行期间不可漂移。
+
+## 4. 有界搜索
+
+默认搜索为两代、每代四个候选。允许范围为一至三代、每代二至五个候选。
+每一代最多调用 optimizer 一次，并在 JSON 契约无效时修复一次。
+
+候选必须：
+
+- 精确保留每个字段原有的模板变量集合。
+- Prompt Profile 精确保留一个 `{{args}}`。
+- 不包含凭据、本地路径、隐藏推理请求或长评测样例复制。
+- 通过 Xpert 发布预检和 Evaluator 只读安全预检。
+
+候选按规范化 hash 去重。训练排名依次使用总分、失败数、estimated token、
+延迟和 checksum，保证结果稳定。达到满分或本代无提升时可以早停。
+
+## 5. 非退化门禁
+
+最终验证默认要求：
+
+- 总分相对基线至少提升 `0.01`。
+- 任一指标回退不超过 `0.02`。
+- 不新增失败、超时、预算耗尽或安全错误。
+- 目标草稿 revision 未发生变化。
+
+通过后只创建一个 pending Proposal：
+
+- Xpert 模式：`xpert_update`。
+- Prompt Profile 模式：`prompt_profile_update`。
+
+批准 Proposal 只写目标草稿。用户仍需在 Xpert Studio 或 Prompt 页面显式发布。
+未通过时 run 进入 `no_improvement`，保留候选、diff 和评测报告，不创建 Proposal。
+
+## 6. API
+
+```text
+GET  /api/xpert-evolutions/capabilities
+POST /api/xpert-evolutions/preflight
+GET  /api/xpert-evolutions/runs
+POST /api/xpert-evolutions/runs
+GET  /api/xpert-evolutions/runs/{run_id}
+POST /api/xpert-evolutions/runs/{run_id}/cancel
+```
+
+管理侧 run detail 可以查看 Prompt diff。RunRegistry checkpoint 只保存候选 ID、
+hash、分数、长度、预算和错误摘要，不保存完整 Prompt、样例正文或模型隐藏推理。
+
+## 7. 恢复与取消
+
+`XpertEvolutionStore` 使用 Runtime 持久化目录和原子 JSON 写入。每一代候选、
+Evaluator run ID、排名和最终门禁均持久化。容器重启后：
+
+- 已完成的 optimizer 生成不会重复。
+- 已存在的 Evaluator run 继续由 Evaluator 恢复。
+- 已完成候选不会重新执行。
+- 取消会向当前子评测传播，且不会误建 Proposal。
+
+## 8. 上游归因
+
+本轮仅适配 EvoAgentX `v0.1.4@aad19b9` 中 EvoPrompt 的有界 mutation、
+selection 和 early-stop 概念。ModelMirror 独立实现 Store、模型网关、Evaluator、
+Runtime、日志、数据集和审批；未复制 EvoAgentX Runtime 或第三方优化器实现。
+
+下一步 `EVOAGENTX-EVOLUTION-03B` 只允许类型化的工作流结构 mutation，并继续
+使用同一 Evaluator 与人工审批门禁。

--- a/docs/META_AGENT.md
+++ b/docs/META_AGENT.md
@@ -155,3 +155,29 @@ Meta Planner V2 的 pending Proposal 可以从候选面板直接进入
 Evaluator 只读运行候选并生成报告，不调用 Proposal approve，也不会创建 Xpert 草稿
 或发布版本。安全、预算和报告契约见
 [EVOAGENTX_EVALUATOR.md](./EVOAGENTX_EVALUATOR.md)。
+
+## Prompt 受控进化
+
+`EVOAGENTX-EVOLUTION-03A` 在 Evaluator 之上增加了有界 Prompt 搜索，但不扩展
+Meta Planner 的发布权限。入口为：
+
+- `GET /api/xpert-evolutions/capabilities`
+- `POST /api/xpert-evolutions/preflight`
+- `GET/POST /api/xpert-evolutions/runs`
+- `GET /api/xpert-evolutions/runs/{run_id}`
+- `POST /api/xpert-evolutions/runs/{run_id}/cancel`
+
+Xpert 模式一次只固定一个草稿 revision，并最多联合优化三个
+`workflow_agent.rolePrompt` 或 `promptSuffix` 字段。Prompt Profile 模式固定 Profile
+草稿 revision 和一个已发布 XpertVersion 作为评测宿主，只优化单一 `{{args}}`
+模板。节点、边、模型、资源绑定和中间件均不允许变化。
+
+DatasetVersion 按 seed 进行 80/20 优化集与验证集拆分。候选生成器只能看到优化集的
+安全失败摘要；最终排名只使用独立验证集。少于五条用例时允许共享样例，但运行、
+报告和 Proposal 都会标记高过拟合风险。
+
+只有验证集总分提升、单指标没有越过退化上限且没有新增超时、预算或安全错误时，
+系统才创建 pending `xpert_update` 或 `prompt_profile_update` Proposal。运行期间目标
+revision 变化会使结果变为 stale，并阻止 Proposal 创建。批准 Proposal 只更新草稿，
+发布仍需用户在 Studio 或 Prompt 页面显式完成。完整契约见
+[EVOAGENTX_EVOLUTION.md](./EVOAGENTX_EVOLUTION.md)。

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@
 | [XPERT_APP_API.md](./XPERT_APP_API.md) | Xpert App 部署、分享、兼容 API、凭据、配额和回滚。 |
 | [XPERT_FREEZE.md](./XPERT_FREEZE.md) | Xpert 冻结快照、维护边界、延期项、技术债和回归入口。 |
 | [EVOAGENTX_ALIGNMENT.md](./EVOAGENTX_ALIGNMENT.md) | EvoAgentX 主线、Meta Planner、Evaluator 与候选进化路线。 |
+| [EVOAGENTX_EVOLUTION.md](./EVOAGENTX_EVOLUTION.md) | Prompt 候选搜索、Holdout、非退化门禁与审批边界。 |
 | [EVOAGENTX_AUDIT_V014.md](./EVOAGENTX_AUDIT_V014.md) | 官方 EvoAgentX v0.1.4 的逐模块来源、许可证和复用判定。 |
 | [EVOAGENTX_EVALUATOR.md](./EVOAGENTX_EVALUATOR.md) | 版本化 Xpert 评测集、只读执行、固定预算与基线报告契约。 |
 | [META_AGENT.md](./META_AGENT.md) | 当前 MetaAgent 边界与 Meta Planner V2 固定契约。 |

--- a/docs/XPERT_RUNTIME.md
+++ b/docs/XPERT_RUNTIME.md
@@ -282,6 +282,26 @@ checkpoints store only truncated outputs, safe citations, counts, timing and err
 Evaluator never approves a Proposal, writes an Xpert draft or publishes a version. See
 `docs/EVOAGENTX_EVALUATOR.md`.
 
+## Prompt Evolution Runtime
+
+`XpertEvolutionExecutor` is a persistent, bounded optimizer layered on the internal
+Evaluator snapshot entry. A run fixes one Xpert or Prompt Profile draft revision, one
+DatasetVersion, a deterministic train/validation split, model policy and execution budget.
+It never changes the workflow graph, model selection, resource bindings or middleware.
+
+Each generation creates deduplicated Prompt candidates, evaluates them with the same
+read-only safety preflight and budget, and records only hashes, scores, lengths and safe
+errors in checkpoints. Candidate generation receives training-case failure summaries only.
+Finalists are compared with the original Prompt on the validation split; the validation
+cases are never included in optimizer context.
+
+The non-degradation gate requires a minimum total-score improvement, limits every weighted
+metric regression and rejects new failures, timeouts, budget exhaustion or safety errors.
+Passing creates one pending Authoring Proposal. Failing produces a `no_improvement` report.
+A changed target revision marks the run stale and prevents Proposal creation. Proposal
+approval updates a draft only and cannot publish either an Xpert or Prompt Profile. See
+`docs/EVOAGENTX_EVOLUTION.md`.
+
 ## Data X Runtime
 
 `DataXStore` atomically persists project, source snapshot, import job, semantic model, indicator, immutable version, proposal, and result-artifact metadata. Each project owns a separate DuckDB file. Imported source bytes are fixed by SHA-256 and never exposed through API paths.

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -32,6 +32,7 @@ COPY prompts ./prompts
 COPY plugins ./plugins
 COPY xperts ./xperts
 COPY evaluations ./evaluations
+COPY evolutions ./evolutions
 COPY workflow_native ./workflow_native
 COPY xpert_runtime ./xpert_runtime
 COPY client_extension ./client_extension

--- a/server/evaluations/__init__.py
+++ b/server/evaluations/__init__.py
@@ -1,6 +1,8 @@
 from .api import (
     configure_xpert_evaluations,
     get_xpert_evaluation_executor,
+    get_xpert_evaluation_service,
+    get_xpert_evaluation_store,
     router,
 )
 from .executor import XpertEvaluationExecutor
@@ -24,5 +26,7 @@ __all__ = [
     "configure_xpert_evaluations",
     "evaluate_case_metrics",
     "get_xpert_evaluation_executor",
+    "get_xpert_evaluation_service",
+    "get_xpert_evaluation_store",
     "router",
 ]

--- a/server/evaluations/api.py
+++ b/server/evaluations/api.py
@@ -74,6 +74,14 @@ def get_xpert_evaluation_executor() -> XpertEvaluationExecutor:
     return _executor
 
 
+def get_xpert_evaluation_service() -> XpertEvaluationService:
+    return _require_service()
+
+
+def get_xpert_evaluation_store() -> XpertEvaluationStore:
+    return _require_store()
+
+
 def _require_store() -> XpertEvaluationStore:
     if _store is None:
         raise RuntimeError("Xpert Evaluator is not configured.")

--- a/server/evaluations/service.py
+++ b/server/evaluations/service.py
@@ -268,6 +268,127 @@ class XpertEvaluationService:
             "warnings": list(dict.fromkeys(warnings)),
         }
 
+    def snapshot_xpert_draft(
+        self,
+        xpert: XpertDefinition,
+        *,
+        source: dict[str, Any],
+        label: str,
+        model_policy: str,
+        override_model_id: str | None,
+        target_id: str,
+        input_template: str | None = None,
+    ) -> tuple[dict[str, Any], list[str]]:
+        """Create an internal read-only snapshot without a temporary proposal."""
+        validation, workflow, prompt_profiles = self.prompt_preflight(xpert)
+        errors = [
+            issue.message
+            for issue in validation.issues
+            if getattr(issue, "severity", "error") == "error"
+        ]
+        if errors:
+            raise EvaluationStateError(
+                "Evolution candidate cannot be evaluated: " + "; ".join(errors[:10])
+            )
+        workflow = workflow.model_copy(deep=True)
+        if model_policy == "override":
+            clean_model = str(override_model_id or "").strip()
+            if not clean_model:
+                raise EvaluationStateError("Override model is required.")
+            for node in workflow.nodes:
+                data = node.data if isinstance(node.data, dict) else {}
+                node_kind = str(data.get("kind") or node.type or "")
+                if node_kind in {"llm", "workflow_agent"}:
+                    data["modelId"] = clean_model
+                    node.data = data
+        issues, warnings, resources = self._safe_preflight(
+            workflow,
+            recursion_path=(xpert.id,),
+        )
+        graph_validation = validate_workflow_graph(workflow)
+        issues.extend(
+            {
+                "code": issue.code,
+                "message": issue.message,
+                "node_id": issue.node_id,
+            }
+            for issue in graph_validation.issues
+            if issue.severity == "error"
+        )
+        if issues:
+            raise EvaluationStateError(
+                "Evaluation safety preflight failed: "
+                + "; ".join(str(item["message"]) for item in issues[:10])
+            )
+        snapshot = {
+            "target_id": str(target_id)[:240],
+            "label": str(label)[:160],
+            "source": copy.deepcopy(source),
+            "xpert": {
+                "id": xpert.id,
+                "slug": xpert.slug,
+                "name": xpert.name,
+                "description": xpert.description,
+            },
+            "workflow": workflow.model_dump(mode="json"),
+            "input_variable": xpert.draft.input_variable,
+            "history_variable": xpert.draft.history_variable,
+            "output_variable": xpert.draft.output_variable,
+            "agent_config": (
+                xpert.draft.agent_config.model_dump(mode="json")
+                if xpert.draft.agent_config is not None
+                else None
+            ),
+            "features": (
+                xpert.draft.features.model_dump(mode="json")
+                if xpert.draft.features is not None
+                else None
+            ),
+            "prompt_profiles": [
+                item.model_dump(mode="json") for item in prompt_profiles
+            ],
+            "input_template": str(input_template or "")[:20_000] or None,
+            "checksum": self._checksum(
+                {
+                    "workflow": workflow.model_dump(mode="json"),
+                    "source": source,
+                    "resources": resources,
+                    "model_policy": model_policy,
+                    "override_model_id": override_model_id,
+                    "input_template": input_template,
+                }
+            ),
+            "resources": resources,
+            "warnings": warnings,
+            "created_at": time.time(),
+        }
+        return snapshot, warnings
+
+    def create_run_from_snapshots(
+        self,
+        *,
+        dataset_version: dict[str, Any],
+        cases: list[dict[str, Any]],
+        baseline: dict[str, Any] | None,
+        candidates: list[dict[str, Any]],
+        config: dict[str, Any],
+        warnings: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Internal optimizer entry that keeps public Evaluation targets unchanged."""
+        if not candidates:
+            raise EvaluationStateError("At least one candidate snapshot is required.")
+        selected = [copy.deepcopy(item) for item in cases]
+        if not selected:
+            raise EvaluationStateError("No evaluation cases were selected.")
+        return self.store.create_run(
+            dataset_version=copy.deepcopy(dataset_version),
+            cases=selected,
+            baseline=copy.deepcopy(baseline),
+            candidates=copy.deepcopy(candidates),
+            config=copy.deepcopy(config),
+            warnings=list(dict.fromkeys(warnings or [])),
+        )
+
     def create_run(self, payload: dict[str, Any]) -> dict[str, Any]:
         dataset = self.store.get_dataset_version(
             str(payload["dataset_id"]),

--- a/server/evolutions/__init__.py
+++ b/server/evolutions/__init__.py
@@ -1,0 +1,25 @@
+from .api import (
+    configure_xpert_evolutions,
+    get_xpert_evolution_executor,
+    router,
+)
+from .executor import XpertEvolutionExecutor
+from .service import XpertEvolutionService
+from .store import (
+    EvolutionConflictError,
+    EvolutionNotFoundError,
+    EvolutionStateError,
+    XpertEvolutionStore,
+)
+
+__all__ = [
+    "EvolutionConflictError",
+    "EvolutionNotFoundError",
+    "EvolutionStateError",
+    "XpertEvolutionExecutor",
+    "XpertEvolutionService",
+    "XpertEvolutionStore",
+    "configure_xpert_evolutions",
+    "get_xpert_evolution_executor",
+    "router",
+]

--- a/server/evolutions/api.py
+++ b/server/evolutions/api.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+
+from .executor import OptimizerRunner, XpertEvolutionExecutor
+from .models import EvolutionPreflightRequest, EvolutionRunRequest
+from .service import XpertEvolutionService
+from .store import (
+    EvolutionConflictError,
+    EvolutionNotFoundError,
+    EvolutionStateError,
+    XpertEvolutionStore,
+)
+
+
+router = APIRouter(prefix="/api/xpert-evolutions", tags=["xpert-evolutions"])
+_store: XpertEvolutionStore | None = None
+_service: XpertEvolutionService | None = None
+_executor: XpertEvolutionExecutor | None = None
+
+
+def configure_xpert_evolutions(
+    *,
+    storage_dir: str | Path | None,
+    evaluation_store: Any,
+    evaluation_service: Any,
+    evaluation_executor: Any,
+    xpert_store: Any,
+    prompt_store: Any,
+    proposal_store: Any,
+    optimizer_runner: OptimizerRunner,
+    run_registry: Any,
+) -> XpertEvolutionExecutor:
+    global _store, _service, _executor
+    _store = XpertEvolutionStore(storage_dir)
+    _service = XpertEvolutionService(
+        _store,
+        evaluation_store=evaluation_store,
+        evaluation_service=evaluation_service,
+        xpert_store=xpert_store,
+        prompt_store=prompt_store,
+        proposal_store=proposal_store,
+    )
+    _executor = XpertEvolutionExecutor(
+        _store,
+        _service,
+        evaluation_service=evaluation_service,
+        evaluation_store=evaluation_store,
+        evaluation_executor=evaluation_executor,
+        optimizer_runner=optimizer_runner,
+        run_registry=run_registry,
+    )
+    return _executor
+
+
+def get_xpert_evolution_executor() -> XpertEvolutionExecutor:
+    if _executor is None:
+        raise RuntimeError("Xpert Evolution is not configured.")
+    return _executor
+
+
+def _require_store() -> XpertEvolutionStore:
+    if _store is None:
+        raise RuntimeError("Xpert Evolution is not configured.")
+    return _store
+
+
+def _require_service() -> XpertEvolutionService:
+    if _service is None:
+        raise RuntimeError("Xpert Evolution is not configured.")
+    return _service
+
+
+@router.get("/capabilities")
+async def capabilities() -> dict[str, Any]:
+    return _require_service().capabilities()
+
+
+@router.post("/preflight")
+async def preflight(payload: EvolutionPreflightRequest) -> dict[str, Any]:
+    try:
+        return await _to_thread(_require_service().preflight, payload)
+    except (EvolutionConflictError, EvolutionStateError, ValueError) as exc:
+        return {
+            "valid": False,
+            "target": None,
+            "dataset": None,
+            "warnings": [],
+            "issues": [{"code": "evolution_preflight", "message": str(exc)[:500]}],
+        }
+
+
+@router.get("/runs")
+async def list_runs(status: str | None = None, limit: int = 100) -> dict[str, Any]:
+    items = await _to_thread(
+        _require_store().list_runs,
+        status=status,
+        limit=max(1, min(limit, 200)),
+    )
+    return {"items": items, "total": len(items)}
+
+
+@router.post("/runs")
+async def create_run(payload: EvolutionRunRequest) -> dict[str, Any]:
+    try:
+        run = await _to_thread(_require_service().create_run, payload)
+        get_xpert_evolution_executor().wake()
+        return _sanitize(run)
+    except EvolutionConflictError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except (EvolutionStateError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.get("/runs/{run_id}")
+async def get_run(run_id: str) -> dict[str, Any]:
+    try:
+        return _sanitize(
+            await _to_thread(_require_service().run_detail, run_id)
+        )
+    except EvolutionNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.post("/runs/{run_id}/cancel")
+async def cancel_run(run_id: str) -> dict[str, Any]:
+    try:
+        return _sanitize(await _to_thread(_require_store().cancel, run_id))
+    except EvolutionNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+async def _to_thread(function: Any, *args: Any, **kwargs: Any) -> Any:
+    import asyncio
+
+    return await asyncio.to_thread(function, *args, **kwargs)
+
+
+def _sanitize(run: dict[str, Any]) -> dict[str, Any]:
+    payload = copy.deepcopy(run)
+    dataset = dict(payload.get("dataset") or {})
+    dataset.pop("cases", None)
+    payload["dataset"] = dataset
+    target = dict(payload.get("target") or {})
+    target.pop("baseline_xpert", None)
+    target.pop("baseline_snapshot", None)
+    target.pop("baseline_profile", None)
+    payload["target"] = target
+    for generation in payload.get("generations") or []:
+        for candidate in generation.get("candidates") or []:
+            candidate.pop("snapshot", None)
+            candidate.pop("xpert", None)
+    return payload

--- a/server/evolutions/executor.py
+++ b/server/evolutions/executor.py
@@ -1,0 +1,807 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import copy
+import json
+import time
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from .service import XpertEvolutionService
+from .store import EvolutionConflictError, EvolutionStateError, XpertEvolutionStore
+
+
+OptimizerRunner = Callable[
+    [str, str, str, float, int],
+    Awaitable[str],
+]
+
+
+class _RunCancelled(Exception):
+    pass
+
+
+class XpertEvolutionExecutor:
+    """Restart-safe bounded Prompt search orchestrated through Evaluator runs."""
+
+    def __init__(
+        self,
+        store: XpertEvolutionStore,
+        service: XpertEvolutionService,
+        *,
+        evaluation_service: Any,
+        evaluation_store: Any,
+        evaluation_executor: Any,
+        optimizer_runner: OptimizerRunner,
+        run_registry: Any | None = None,
+        poll_seconds: float = 0.5,
+    ) -> None:
+        self.store = store
+        self.service = service
+        self.evaluation_service = evaluation_service
+        self.evaluation_store = evaluation_store
+        self.evaluation_executor = evaluation_executor
+        self.optimizer_runner = optimizer_runner
+        self.run_registry = run_registry
+        self.poll_seconds = max(0.1, float(poll_seconds))
+        self._wake = asyncio.Event()
+        self._task: asyncio.Task[None] | None = None
+        self._stopping = False
+
+    def start(self) -> None:
+        if self._task is not None and not self._task.done():
+            return
+        self.store.recover()
+        self._stopping = False
+        self._task = asyncio.create_task(self._loop())
+
+    async def stop(self) -> None:
+        self._stopping = True
+        self._wake.set()
+        if self._task is not None:
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
+        self._task = None
+
+    def wake(self) -> None:
+        self._wake.set()
+
+    async def _loop(self) -> None:
+        while not self._stopping:
+            run = await asyncio.to_thread(self.store.claim_next)
+            if run is None:
+                self._wake.clear()
+                try:
+                    await asyncio.wait_for(self._wake.wait(), timeout=self.poll_seconds)
+                except TimeoutError:
+                    pass
+                continue
+            try:
+                await self._execute(run)
+            except asyncio.CancelledError:
+                raise
+            except _RunCancelled:
+                continue
+            except Exception as exc:
+                failed = await asyncio.to_thread(
+                    self.store.fail, run["run_id"], str(exc)
+                )
+                await self._checkpoint(
+                    failed,
+                    "xpert_evolution.failed",
+                    "Prompt evolution failed",
+                    str(exc)[:500],
+                    severity="error",
+                )
+                await self._finish_registry(failed, "failed", error=str(exc)[:500])
+
+    async def _execute(self, claimed: dict[str, Any]) -> None:
+        run = await asyncio.to_thread(self.store.require, claimed["run_id"])
+        await self._ensure_registry_run(run)
+        if await self._cancelled(run):
+            return
+        baseline = self.service.baseline_candidate(run)
+        baseline_eval_id = run.get("baseline_evaluation_run_id")
+        if not baseline_eval_id:
+            baseline_eval = await asyncio.to_thread(
+                self.evaluation_service.create_run_from_snapshots,
+                dataset_version=run["dataset"],
+                cases=self.service.selected_cases(run, "train"),
+                baseline=None,
+                candidates=[baseline["snapshot"]],
+                config=self._evaluation_config(run),
+                warnings=["Prompt evolution training baseline."],
+            )
+            baseline_eval_id = baseline_eval["run_id"]
+            run = await asyncio.to_thread(
+                self.store.mutate,
+                run["run_id"],
+                lambda item: item.update(
+                    {
+                        "baseline_evaluation_run_id": baseline_eval_id,
+                        "phase": "baseline_evaluation",
+                    }
+                ),
+            )
+            self.evaluation_executor.wake()
+        baseline_eval = await self._await_evaluation(run, baseline_eval_id)
+        baseline_summary = self._target_summary(
+            baseline_eval, baseline["snapshot"]["target_id"]
+        )
+        if not baseline_summary:
+            raise EvolutionStateError("Baseline evaluation produced no target summary.")
+
+        previous_best = baseline
+        previous_summary = baseline_summary
+        configured_generations = int(run["request"]["generations"])
+        for generation_number in range(1, configured_generations + 1):
+            run = await asyncio.to_thread(self.store.require, run["run_id"])
+            if await self._cancelled(run):
+                return
+            generation = next(
+                (
+                    item
+                    for item in run.get("generations") or []
+                    if int(item.get("generation") or 0) == generation_number
+                ),
+                None,
+            )
+            if generation is None:
+                fields_payload, repair_used = await self._generate_candidates(
+                    run,
+                    generation_number,
+                    previous_best,
+                    previous_summary,
+                    baseline,
+                    (
+                        baseline_eval_id
+                        if generation_number == 1
+                        else str(
+                            next(
+                                value
+                                for value in run.get("generations") or []
+                                if int(value.get("generation") or 0)
+                                == generation_number - 1
+                            ).get("evaluation_run_id")
+                            or ""
+                        )
+                    ),
+                )
+                candidates: list[dict[str, Any]] = []
+                seen = {
+                    baseline["checksum"],
+                    *(
+                        str(candidate.get("checksum") or "")
+                        for previous in run.get("generations") or []
+                        for candidate in previous.get("candidates") or []
+                    ),
+                }
+                for index, raw in enumerate(fields_payload, start=1):
+                    try:
+                        candidate = self.service.build_candidate(
+                            run,
+                            fields=dict(raw.get("fields") or {}),
+                            generation=generation_number,
+                            index=index,
+                            summary=str(raw.get("summary") or ""),
+                        )
+                    except EvolutionStateError:
+                        continue
+                    if candidate["checksum"] in seen:
+                        continue
+                    seen.add(candidate["checksum"])
+                    candidates.append(candidate)
+                if len(candidates) < 1:
+                    raise EvolutionStateError(
+                        "Optimizer did not produce any unique safe Prompt candidates."
+                    )
+                generation = {
+                    "generation": generation_number,
+                    "repair_used": repair_used,
+                    "candidates": candidates,
+                    "evaluation_run_id": None,
+                    "ranking": [],
+                    "created_at": time.time(),
+                }
+
+                def add_generation(item: dict[str, Any]) -> None:
+                    if not any(
+                        int(value.get("generation") or 0) == generation_number
+                        for value in item.get("generations") or []
+                    ):
+                        item.setdefault("generations", []).append(generation)
+                    item["phase"] = f"generation_{generation_number}_generated"
+
+                run = await asyncio.to_thread(
+                    self.store.mutate, run["run_id"], add_generation
+                )
+                generation = next(
+                    item
+                    for item in run["generations"]
+                    if int(item["generation"]) == generation_number
+                )
+
+            eval_id = generation.get("evaluation_run_id")
+            if not eval_id:
+                evaluation = await asyncio.to_thread(
+                    self.evaluation_service.create_run_from_snapshots,
+                    dataset_version=run["dataset"],
+                    cases=self.service.selected_cases(run, "train"),
+                    baseline=baseline["snapshot"],
+                    candidates=[
+                        item["snapshot"] for item in generation["candidates"]
+                    ],
+                    config=self._evaluation_config(run),
+                    warnings=[f"Prompt evolution generation {generation_number}."],
+                )
+                eval_id = evaluation["run_id"]
+
+                def set_eval(item: dict[str, Any]) -> None:
+                    for value in item.get("generations") or []:
+                        if int(value.get("generation") or 0) == generation_number:
+                            value["evaluation_run_id"] = eval_id
+                            break
+                    item["phase"] = f"generation_{generation_number}_evaluation"
+
+                run = await asyncio.to_thread(
+                    self.store.mutate, run["run_id"], set_eval
+                )
+                self.evaluation_executor.wake()
+            evaluation = await self._await_evaluation(run, eval_id)
+            ranking = self._rank_generation(generation["candidates"], evaluation)
+            if not ranking:
+                raise EvolutionStateError(
+                    f"Generation {generation_number} produced no evaluation ranking."
+                )
+
+            def save_ranking(item: dict[str, Any]) -> None:
+                for value in item.get("generations") or []:
+                    if int(value.get("generation") or 0) == generation_number:
+                        value["ranking"] = copy.deepcopy(ranking)
+                        break
+                item["phase"] = f"generation_{generation_number}_ranked"
+
+            run = await asyncio.to_thread(
+                self.store.mutate, run["run_id"], save_ranking
+            )
+            best_id = ranking[0]["candidate_id"]
+            prior_best_score = float(previous_summary.get("score") or 0)
+            previous_best = next(
+                item for item in generation["candidates"] if item["candidate_id"] == best_id
+            )
+            previous_summary = ranking[0]
+            await self._checkpoint(
+                run,
+                "xpert_evolution.generation.completed",
+                f"Prompt evolution generation {generation_number} completed",
+                f"{len(ranking)} candidates ranked",
+                metadata={
+                    "generation": generation_number,
+                    "best_candidate_id": best_id,
+                    "best_score": ranking[0]["score"],
+                    "repair_used": bool(generation.get("repair_used")),
+                },
+            )
+            if (
+                float(previous_summary.get("score") or 0) >= 0.999999
+                or float(previous_summary.get("score") or 0)
+                <= prior_best_score
+            ):
+                break
+
+        run = await asyncio.to_thread(self.store.require, run["run_id"])
+        finalists = self._select_finalists(run)
+        if not finalists:
+            await self._finish_no_improvement(
+                run, "No generated candidate improved the training baseline."
+            )
+            return
+        validation_eval_id = run.get("validation_evaluation_run_id")
+        if not validation_eval_id:
+            validation = await asyncio.to_thread(
+                self.evaluation_service.create_run_from_snapshots,
+                dataset_version=run["dataset"],
+                cases=self.service.selected_cases(run, "validation"),
+                baseline=baseline["snapshot"],
+                candidates=[item["snapshot"] for item in finalists],
+                config=self._evaluation_config(run),
+                warnings=["Prompt evolution isolated validation holdout."],
+            )
+            validation_eval_id = validation["run_id"]
+            run = await asyncio.to_thread(
+                self.store.mutate,
+                run["run_id"],
+                lambda item: item.update(
+                    {
+                        "validation_evaluation_run_id": validation_eval_id,
+                        "finalists": [
+                            {
+                                "candidate_id": candidate["candidate_id"],
+                                "checksum": candidate["checksum"],
+                            }
+                            for candidate in finalists
+                        ],
+                        "phase": "validation",
+                    }
+                ),
+            )
+            self.evaluation_executor.wake()
+        validation = await self._await_evaluation(run, validation_eval_id)
+        gate = self._gate(run, baseline, finalists, validation)
+        best = next(
+            (
+                candidate
+                for candidate in finalists
+                if candidate["candidate_id"] == gate.get("best_candidate_id")
+            ),
+            None,
+        )
+        report = {
+            "training_baseline": baseline_summary,
+            "validation": copy.deepcopy(validation.get("report") or {}),
+            "gate": gate,
+        }
+        run = await asyncio.to_thread(
+            self.store.mutate,
+            run["run_id"],
+            lambda item: item.update({"report": report, "phase": "gate"}),
+        )
+        if self.service.is_stale(run):
+            stale = await asyncio.to_thread(
+                self.store.mutate,
+                run["run_id"],
+                lambda item: item.update(
+                    {
+                        "status": "stale",
+                        "stale": True,
+                        "completed_at": time.time(),
+                        "error": "Target draft changed during evolution.",
+                    }
+                ),
+            )
+            await self._checkpoint(
+                stale,
+                "xpert_evolution.stale",
+                "Prompt evolution result is stale",
+                "Target draft changed during evolution",
+                severity="warning",
+            )
+            await self._finish_registry(stale, "completed")
+            return
+        if not gate["passed"] or best is None:
+            await self._finish_no_improvement(run, gate["reason"])
+            return
+        proposal = await asyncio.to_thread(self.service.create_proposal, run, best)
+        run = await asyncio.to_thread(
+            self.store.mutate,
+            run["run_id"],
+            lambda item: item.update(
+                {
+                    "status": "completed",
+                    "phase": "completed",
+                    "proposal_id": proposal.proposal_id,
+                    "proposal_revision": proposal.revision,
+                    "completed_at": time.time(),
+                }
+            ),
+        )
+        await self._checkpoint(
+            run,
+            "xpert_evolution.completed",
+            "Prompt evolution completed",
+            f"Proposal {proposal.proposal_id}",
+            metadata={
+                "candidate_id": best["candidate_id"],
+                "proposal_id": proposal.proposal_id,
+                "score_delta": gate["score_delta"],
+            },
+        )
+        await self._finish_registry(run, "completed")
+
+    async def _generate_candidates(
+        self,
+        run: dict[str, Any],
+        generation: int,
+        previous_best: dict[str, Any],
+        previous_summary: dict[str, Any],
+        baseline: dict[str, Any],
+        prior_evaluation_run_id: str,
+    ) -> tuple[list[dict[str, Any]], bool]:
+        train_cases = self.service.selected_cases(run, "train")
+        requested = int(run["request"]["population_size"])
+        system_prompt = (
+            "You optimize assistant prompts under a strict bounded experiment. "
+            "Return JSON only. Do not reveal hidden reasoning. Preserve every template "
+            "variable exactly. Never copy long evaluation examples, credentials, paths, "
+            "or resource identifiers into prompts."
+        )
+        user_payload = {
+            "generation": generation,
+            "candidate_count": requested,
+            "selected_fields": list(run["target"]["selected_fields"]),
+            "original_prompts": baseline["fields"],
+            "previous_best_prompts": previous_best["fields"],
+            "previous_best_score": previous_summary.get("score"),
+            "failure_summary": await self._failure_digest(
+                prior_evaluation_run_id
+            ),
+            "training_cases": [
+                {
+                    "case_id": case.get("case_id"),
+                    "message": str(case.get("message") or "")[:2_000],
+                    "expected": case.get("expected") or {},
+                }
+                for case in train_cases
+            ],
+            "contract": {
+                "candidates": [
+                    {
+                        "fields": {
+                            field: "complete replacement prompt"
+                            for field in run["target"]["selected_fields"]
+                        },
+                        "summary": "public change summary, no hidden reasoning",
+                    }
+                ]
+            },
+        }
+        raw = await self.optimizer_runner(
+            str(run["request"]["optimizer_model_id"]),
+            system_prompt,
+            json.dumps(user_payload, ensure_ascii=False),
+            0.2,
+            6_000,
+        )
+        try:
+            return self._parse_generation(raw, requested), False
+        except Exception as first_error:
+            repair = await self.optimizer_runner(
+                str(run["request"]["optimizer_model_id"]),
+                system_prompt,
+                (
+                    "Repair the response to the exact JSON contract. Return JSON only. "
+                    f"Validation error: {str(first_error)[:500]}\n\n"
+                    f"Invalid response:\n{str(raw)[:12_000]}"
+                ),
+                0.0,
+                6_000,
+            )
+            return self._parse_generation(repair, requested), True
+
+    async def _failure_digest(self, evaluation_run_id: str) -> list[dict[str, Any]]:
+        if not evaluation_run_id:
+            return []
+        evaluation = await asyncio.to_thread(
+            self.evaluation_store.require_run, evaluation_run_id
+        )
+        digest = []
+        for item in evaluation.get("items") or []:
+            failed_metrics = [
+                {
+                    "kind": metric.get("kind"),
+                    "score": metric.get("score"),
+                    "reason": str(metric.get("reason") or "")[:300],
+                }
+                for metric in item.get("metrics") or []
+                if not metric.get("passed")
+            ]
+            if (
+                item.get("status") == "completed"
+                and float(item.get("score") or 0) >= 0.999999
+                and not failed_metrics
+            ):
+                continue
+            digest.append(
+                {
+                    "case_id": item.get("case_id"),
+                    "score": item.get("score", 0),
+                    "failed_metrics": failed_metrics[:10],
+                    "error": str(item.get("error") or "")[:300],
+                    "output_excerpt": str(item.get("output") or "")[:500],
+                }
+            )
+        return digest[:50]
+
+    @staticmethod
+    def _parse_generation(raw: str, requested: int) -> list[dict[str, Any]]:
+        text = str(raw or "").strip()
+        start = text.find("{")
+        end = text.rfind("}")
+        if start < 0 or end <= start:
+            raise EvolutionStateError("Optimizer did not return a JSON object.")
+        payload = json.loads(text[start : end + 1])
+        candidates = payload.get("candidates") if isinstance(payload, dict) else None
+        if not isinstance(candidates, list) or not candidates:
+            raise EvolutionStateError("Optimizer candidates must be a non-empty array.")
+        result = []
+        for item in candidates[:requested]:
+            if not isinstance(item, dict) or not isinstance(item.get("fields"), dict):
+                raise EvolutionStateError("Each optimizer candidate requires fields.")
+            result.append(
+                {
+                    "fields": dict(item["fields"]),
+                    "summary": str(item.get("summary") or "")[:500],
+                }
+            )
+        return result
+
+    async def _await_evaluation(
+        self, run: dict[str, Any], evaluation_run_id: str
+    ) -> dict[str, Any]:
+        while True:
+            current = await asyncio.to_thread(
+                self.evaluation_store.require_run, evaluation_run_id
+            )
+            if current.get("status") in {"completed", "cancelled", "failed"}:
+                if current.get("status") != "completed":
+                    raise EvolutionStateError(
+                        "Evaluator run did not complete: "
+                        + str(current.get("error") or current.get("status"))
+                    )
+                return current
+            latest = await asyncio.to_thread(self.store.require, run["run_id"])
+            if latest.get("cancel_requested"):
+                await asyncio.to_thread(
+                    self.evaluation_store.cancel_run, evaluation_run_id
+                )
+                await self._cancelled(latest)
+                raise _RunCancelled()
+            await asyncio.sleep(self.poll_seconds)
+
+    @staticmethod
+    def _target_summary(
+        evaluation: dict[str, Any], target_id: str
+    ) -> dict[str, Any] | None:
+        return next(
+            (
+                copy.deepcopy(item)
+                for item in (evaluation.get("report") or {}).get("targets") or []
+                if item.get("target_id") == target_id
+            ),
+            None,
+        )
+
+    def _rank_generation(
+        self,
+        candidates: list[dict[str, Any]],
+        evaluation: dict[str, Any],
+    ) -> list[dict[str, Any]]:
+        summaries = {
+            item["target_id"]: item
+            for item in (evaluation.get("report") or {}).get("targets") or []
+        }
+        ranking = []
+        for candidate in candidates:
+            summary = summaries.get(candidate["snapshot"]["target_id"])
+            if not summary:
+                continue
+            ranking.append(
+                {
+                    "candidate_id": candidate["candidate_id"],
+                    "checksum": candidate["checksum"],
+                    **copy.deepcopy(summary),
+                }
+            )
+        ranking.sort(
+            key=lambda item: (
+                -float(item.get("score") or 0),
+                int(item.get("failed_count") or 0),
+                int(item.get("estimated_tokens") or 0),
+                float(item.get("average_latency_ms") or 0),
+                str(item.get("checksum") or ""),
+            )
+        )
+        return ranking
+
+    @staticmethod
+    def _select_finalists(run: dict[str, Any]) -> list[dict[str, Any]]:
+        candidates: dict[str, dict[str, Any]] = {}
+        scores: dict[str, dict[str, Any]] = {}
+        for generation in run.get("generations") or []:
+            for candidate in generation.get("candidates") or []:
+                candidates[candidate["candidate_id"]] = candidate
+            for item in generation.get("ranking") or []:
+                scores[item["candidate_id"]] = item
+        ordered = sorted(
+            scores.values(),
+            key=lambda item: (
+                -float(item.get("score") or 0),
+                int(item.get("failed_count") or 0),
+                int(item.get("estimated_tokens") or 0),
+                float(item.get("average_latency_ms") or 0),
+                str(item.get("checksum") or ""),
+            ),
+        )
+        return [candidates[item["candidate_id"]] for item in ordered[:3]]
+
+    def _gate(
+        self,
+        run: dict[str, Any],
+        baseline: dict[str, Any],
+        finalists: list[dict[str, Any]],
+        evaluation: dict[str, Any],
+    ) -> dict[str, Any]:
+        summaries = {
+            item["target_id"]: item
+            for item in (evaluation.get("report") or {}).get("targets") or []
+        }
+        baseline_summary = summaries.get(baseline["snapshot"]["target_id"])
+        if not baseline_summary:
+            return {"passed": False, "reason": "Validation baseline is missing."}
+        ranked = []
+        for candidate in finalists:
+            summary = summaries.get(candidate["snapshot"]["target_id"])
+            if summary:
+                ranked.append((candidate, summary))
+        ranked.sort(
+            key=lambda item: (
+                -float(item[1].get("score") or 0),
+                int(item[1].get("failed_count") or 0),
+                int(item[1].get("estimated_tokens") or 0),
+                float(item[1].get("average_latency_ms") or 0),
+                item[0]["checksum"],
+            )
+        )
+        if not ranked:
+            return {"passed": False, "reason": "No finalist completed validation."}
+        candidate, summary = ranked[0]
+        score_delta = float(summary.get("score") or 0) - float(
+            baseline_summary.get("score") or 0
+        )
+        regressions = {}
+        for name, baseline_score in (baseline_summary.get("metrics") or {}).items():
+            delta = float((summary.get("metrics") or {}).get(name, 0)) - float(
+                baseline_score
+            )
+            if delta < -float(run["request"]["max_metric_regression"]):
+                regressions[name] = round(delta, 6)
+        new_failures = int(summary.get("failed_count") or 0) > int(
+            baseline_summary.get("failed_count") or 0
+        )
+        passed = (
+            score_delta >= float(run["request"]["min_score_delta"])
+            and not regressions
+            and not new_failures
+        )
+        reasons = []
+        if score_delta < float(run["request"]["min_score_delta"]):
+            reasons.append("validation score improvement is below the configured gate")
+        if regressions:
+            reasons.append("one or more weighted metrics regressed")
+        if new_failures:
+            reasons.append("candidate introduced evaluation failures")
+        return {
+            "passed": passed,
+            "reason": "; ".join(reasons) if reasons else "Non-degradation gate passed.",
+            "best_candidate_id": candidate["candidate_id"],
+            "baseline_score": baseline_summary.get("score"),
+            "candidate_score": summary.get("score"),
+            "score_delta": round(score_delta, 6),
+            "metric_regressions": regressions,
+            "new_failures": new_failures,
+        }
+
+    def _evaluation_config(self, run: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "model_policy": run["request"]["model_policy"],
+            "override_model_id": run["request"].get("override_model_id"),
+            "judge_model_id": run["request"].get("judge_model_id"),
+            "seed": int(run["request"].get("seed") or 0),
+            "budget": copy.deepcopy(run["request"].get("budget") or {}),
+        }
+
+    async def _cancelled(self, run: dict[str, Any]) -> bool:
+        if not run.get("cancel_requested"):
+            return False
+        result = await asyncio.to_thread(
+            self.store.mutate,
+            run["run_id"],
+            lambda item: item.update(
+                {
+                    "status": "cancelled",
+                    "phase": "cancelled",
+                    "completed_at": time.time(),
+                }
+            ),
+        )
+        await self._checkpoint(
+            result,
+            "xpert_evolution.cancelled",
+            "Prompt evolution cancelled",
+            "The evolution run was cancelled before completion",
+            severity="warning",
+        )
+        await self._finish_registry(result, "cancelled")
+        return True
+
+    async def _finish_no_improvement(
+        self, run: dict[str, Any], reason: str
+    ) -> None:
+        result = await asyncio.to_thread(
+            self.store.mutate,
+            run["run_id"],
+            lambda item: item.update(
+                {
+                    "status": "no_improvement",
+                    "phase": "completed",
+                    "completed_at": time.time(),
+                    "error": str(reason)[:500],
+                }
+            ),
+        )
+        await self._checkpoint(
+            result,
+            "xpert_evolution.no_improvement",
+            "Prompt evolution found no safe improvement",
+            str(reason)[:500],
+            severity="warning",
+        )
+        await self._finish_registry(result, "completed")
+
+    async def _ensure_registry_run(self, run: dict[str, Any]) -> None:
+        if self.run_registry is None or run.get("run_registry_id"):
+            return
+        registry = await self.run_registry.create_run(
+            "xpert_evolution",
+            f"Prompt evolution {run['target']['name']}",
+            status="running",
+            source_id=run["run_id"],
+            metadata={
+                "target_kind": run["target"]["kind"],
+                "target_id": run["target"]["target_id"],
+                "dataset_id": run["dataset"]["dataset_id"],
+                "dataset_version": run["dataset"]["version"],
+            },
+        )
+        await asyncio.to_thread(
+            self.store.mutate,
+            run["run_id"],
+            lambda item: item.update({"run_registry_id": registry.run_id}),
+        )
+
+    async def _finish_registry(
+        self,
+        run: dict[str, Any],
+        status: str,
+        *,
+        error: str | None = None,
+    ) -> None:
+        if self.run_registry is None:
+            return
+        registry_id = run.get("run_registry_id")
+        if not registry_id and run.get("run_id"):
+            latest = await asyncio.to_thread(self.store.require, run["run_id"])
+            registry_id = latest.get("run_registry_id")
+        if not registry_id:
+            return
+        await self.run_registry.update_run(
+            registry_id,
+            status=status,
+            error=error,
+        )
+
+    async def _checkpoint(
+        self,
+        run: dict[str, Any],
+        event_type: str,
+        title: str,
+        summary: str,
+        *,
+        severity: str = "info",
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        if self.run_registry is None:
+            return
+        latest = await asyncio.to_thread(self.store.require, run["run_id"])
+        if not latest.get("run_registry_id"):
+            return
+        await self.run_registry.record_checkpoint(
+            latest["run_registry_id"],
+            event_type=event_type,
+            title=title,
+            summary=summary[:500],
+            severity=severity,
+            metadata=metadata or {},
+        )

--- a/server/evolutions/models.py
+++ b/server/evolutions/models.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class EvolutionBudget(BaseModel):
+    repetitions: int = Field(default=1, ge=1, le=3)
+    max_concurrency: int = Field(default=2, ge=1, le=4)
+    case_timeout_seconds: int = Field(default=120, ge=10, le=600)
+    max_model_calls: int = Field(default=16, ge=1, le=64)
+    max_tool_calls: int = Field(default=24, ge=0, le=100)
+    max_estimated_tokens: int = Field(default=64_000, ge=1_000, le=500_000)
+    max_output_chars: int = Field(default=20_000, ge=1_000, le=20_000)
+
+
+class EvolutionRunRequest(BaseModel):
+    target_kind: Literal["xpert", "prompt_profile"]
+    target_id: str = Field(min_length=1, max_length=200)
+    target_revision: int = Field(ge=1)
+    prompt_fields: list[str] = Field(default_factory=list, max_length=3)
+    host_xpert_id: str | None = Field(default=None, max_length=200)
+    host_xpert_version: int | None = Field(default=None, ge=1)
+    dataset_id: str = Field(min_length=1, max_length=200)
+    dataset_version: int = Field(ge=1)
+    optimizer_model_id: str = Field(min_length=1, max_length=240)
+    model_policy: Literal["snapshot", "override"] = "snapshot"
+    override_model_id: str | None = Field(default=None, max_length=240)
+    judge_model_id: str | None = Field(default=None, max_length=240)
+    seed: int = Field(default=42, ge=0, le=2_147_483_647)
+    generations: int = Field(default=2, ge=1, le=3)
+    population_size: int = Field(default=4, ge=2, le=5)
+    min_score_delta: float = Field(default=0.01, ge=0, le=1)
+    max_metric_regression: float = Field(default=0.02, ge=0, le=1)
+    budget: EvolutionBudget = Field(default_factory=EvolutionBudget)
+
+    @model_validator(mode="after")
+    def validate_target(self) -> "EvolutionRunRequest":
+        if self.target_kind == "xpert":
+            if not self.prompt_fields:
+                raise ValueError("Xpert evolution requires at least one Prompt field.")
+            if len(set(self.prompt_fields)) != len(self.prompt_fields):
+                raise ValueError("Prompt fields must be unique.")
+            if self.host_xpert_id or self.host_xpert_version:
+                raise ValueError("Xpert evolution does not use a host Xpert.")
+        else:
+            if self.prompt_fields:
+                raise ValueError("Prompt Profile evolution does not accept prompt_fields.")
+            if not self.host_xpert_id or not self.host_xpert_version:
+                raise ValueError(
+                    "Prompt Profile evolution requires a published host Xpert version."
+                )
+        if self.model_policy == "override" and not self.override_model_id:
+            raise ValueError("override_model_id is required for override model policy.")
+        return self
+
+
+class EvolutionPreflightRequest(EvolutionRunRequest):
+    pass

--- a/server/evolutions/service.py
+++ b/server/evolutions/service.py
@@ -1,0 +1,466 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import random
+import re
+import time
+from typing import Any
+
+try:
+    from server.xperts.models import XpertDefinition, XpertDraft
+except ModuleNotFoundError:
+    from xperts.models import XpertDefinition, XpertDraft
+
+from .models import EvolutionRunRequest
+from .store import EvolutionConflictError, EvolutionStateError, XpertEvolutionStore
+
+
+PLACEHOLDER_PATTERN = re.compile(r"{{\s*([^{}]+?)\s*}}")
+SENSITIVE_PATTERNS = [
+    re.compile(r"\b(?:sk|rk|pk)-[A-Za-z0-9_-]{12,}\b"),
+    re.compile(r"(?i)\b(?:api[_ -]?key|token|secret|password)\s*[:=]\s*\S+"),
+    re.compile(r"(?i)\b(?:chain[- ]of[- ]thought|hidden reasoning|隐藏推理|思维链)\b"),
+    re.compile(r"(?:[A-Za-z]:\\|/(?:home|Users|var|etc)/)[^\s]+"),
+]
+
+
+class XpertEvolutionService:
+    """Builds immutable Prompt baselines and guarded candidate snapshots."""
+
+    def __init__(
+        self,
+        store: XpertEvolutionStore,
+        *,
+        evaluation_store: Any,
+        evaluation_service: Any,
+        xpert_store: Any,
+        prompt_store: Any,
+        proposal_store: Any,
+    ) -> None:
+        self.store = store
+        self.evaluation_store = evaluation_store
+        self.evaluation_service = evaluation_service
+        self.xpert_store = xpert_store
+        self.prompt_store = prompt_store
+        self.proposal_store = proposal_store
+
+    def capabilities(self) -> dict[str, Any]:
+        return {
+            "version": "evoagentx-prompt-evolution-v1",
+            "target_kinds": ["xpert", "prompt_profile"],
+            "xpert_fields": ["rolePrompt", "promptSuffix"],
+            "limits": {
+                "max_prompt_fields": 3,
+                "generations": [1, 3],
+                "population_size": [2, 5],
+                "max_finalists": 3,
+            },
+            "default_gate": {
+                "min_score_delta": 0.01,
+                "max_metric_regression": 0.02,
+            },
+            "approval": "authoring_proposal_only",
+        }
+
+    def preflight(self, request: EvolutionRunRequest) -> dict[str, Any]:
+        prepared = self._prepare(request)
+        return {
+            "valid": True,
+            "target": self._public_target(prepared["target"]),
+            "dataset": {
+                key: prepared["dataset"].get(key)
+                for key in ("dataset_id", "version", "name", "case_count", "checksum")
+            },
+            "train_case_count": len(prepared["train_case_ids"]),
+            "validation_case_count": len(prepared["validation_case_ids"]),
+            "warnings": prepared["warnings"],
+        }
+
+    def create_run(self, request: EvolutionRunRequest) -> dict[str, Any]:
+        prepared = self._prepare(request)
+        return self.store.create_run(
+            request=request.model_dump(mode="json"),
+            target=prepared["target"],
+            dataset=prepared["dataset"],
+            train_case_ids=prepared["train_case_ids"],
+            validation_case_ids=prepared["validation_case_ids"],
+            warnings=prepared["warnings"],
+        )
+
+    def run_detail(self, run_id: str) -> dict[str, Any]:
+        run = self.store.require(run_id)
+        run["stale"] = self.is_stale(run)
+        return self.store.payload(run, include_detail=True)
+
+    def is_stale(self, run: dict[str, Any]) -> bool:
+        target = dict(run.get("target") or {})
+        try:
+            if target.get("kind") == "xpert":
+                current = self.xpert_store.get_xpert(str(target["target_id"]))
+                return current.draft_revision != int(target["base_revision"])
+            current = self.prompt_store.get_profile(str(target["target_id"]))
+            return current.draft_revision != int(target["base_revision"])
+        except Exception:
+            return True
+
+    def build_candidate(
+        self,
+        run: dict[str, Any],
+        *,
+        fields: dict[str, str],
+        generation: int,
+        index: int,
+        summary: str,
+    ) -> dict[str, Any]:
+        target = dict(run["target"])
+        baseline = dict(target["baseline_prompts"])
+        unknown = sorted(set(fields) - set(baseline))
+        missing = sorted(set(baseline) - set(fields))
+        if unknown or missing:
+            raise EvolutionStateError(
+                "Candidate fields must exactly match the selected Prompt fields."
+            )
+        clean_fields = {key: str(value or "").strip() for key, value in fields.items()}
+        self._validate_prompt_safety(
+            baseline=baseline,
+            candidate=clean_fields,
+            train_cases=self.selected_cases(run, "train"),
+            profile=target.get("kind") == "prompt_profile",
+        )
+        checksum = self.prompt_checksum(clean_fields)
+        candidate_id = f"g{generation}-c{index}-{checksum[:10]}"
+        if target["kind"] == "xpert":
+            xpert = XpertDefinition.model_validate(target["baseline_xpert"])
+            self.apply_xpert_fields(xpert, clean_fields)
+            snapshot, warnings = self.evaluation_service.snapshot_xpert_draft(
+                xpert,
+                source={
+                    "kind": "evolution_candidate",
+                    "evolution_run_id": run["run_id"],
+                    "generation": generation,
+                    "candidate_id": candidate_id,
+                    "base_revision": target["base_revision"],
+                },
+                label=f"Generation {generation} candidate {index}",
+                model_policy=run["request"]["model_policy"],
+                override_model_id=run["request"].get("override_model_id"),
+                target_id=f"evolution:{run['run_id']}:{candidate_id}",
+            )
+            xpert_payload = xpert.model_dump(mode="json")
+        else:
+            snapshot = copy.deepcopy(target["baseline_snapshot"])
+            snapshot["target_id"] = f"evolution:{run['run_id']}:{candidate_id}"
+            snapshot["label"] = f"Generation {generation} candidate {index}"
+            snapshot["input_template"] = clean_fields["template"]
+            snapshot["source"] = {
+                "kind": "evolution_candidate",
+                "evolution_run_id": run["run_id"],
+                "generation": generation,
+                "candidate_id": candidate_id,
+                "base_revision": target["base_revision"],
+            }
+            snapshot["checksum"] = self.checksum(
+                {
+                    "host": target["baseline_snapshot"]["checksum"],
+                    "template": clean_fields["template"],
+                }
+            )
+            warnings = list(snapshot.get("warnings") or [])
+            xpert_payload = None
+        return {
+            "candidate_id": candidate_id,
+            "generation": generation,
+            "fields": clean_fields,
+            "summary": str(summary or "")[:500],
+            "checksum": checksum,
+            "snapshot": snapshot,
+            "xpert": xpert_payload,
+            "warnings": warnings,
+            "created_at": time.time(),
+        }
+
+    def baseline_candidate(self, run: dict[str, Any]) -> dict[str, Any]:
+        target = run["target"]
+        return {
+            "candidate_id": "baseline",
+            "generation": 0,
+            "fields": copy.deepcopy(target["baseline_prompts"]),
+            "summary": "Original Prompt baseline",
+            "checksum": self.prompt_checksum(target["baseline_prompts"]),
+            "snapshot": copy.deepcopy(target["baseline_snapshot"]),
+            "xpert": copy.deepcopy(target.get("baseline_xpert")),
+            "warnings": list(target["baseline_snapshot"].get("warnings") or []),
+        }
+
+    def selected_cases(self, run: dict[str, Any], split: str) -> list[dict[str, Any]]:
+        selected = set(
+            run["train_case_ids"] if split == "train" else run["validation_case_ids"]
+        )
+        return [
+            copy.deepcopy(case)
+            for case in run["dataset"].get("cases") or []
+            if str(case.get("case_id")) in selected
+        ]
+
+    def create_proposal(
+        self,
+        run: dict[str, Any],
+        candidate: dict[str, Any],
+    ) -> Any:
+        if self.is_stale(run):
+            raise EvolutionConflictError(
+                "Target draft changed while evolution was running."
+            )
+        target = run["target"]
+        if target["kind"] == "xpert":
+            payload = {
+                "xpert_id": target["target_id"],
+                "patch": {"draft": candidate["xpert"]["draft"]},
+                "evolution_report": self.safe_report(run, candidate),
+            }
+            kind = "xpert_update"
+        else:
+            payload = {
+                "profile_id": target["target_id"],
+                "patch": {"template": candidate["fields"]["template"]},
+                "evolution_report": self.safe_report(run, candidate),
+            }
+            kind = "prompt_profile_update"
+        return self.proposal_store.create(
+            kind=kind,
+            title=f"Prompt evolution: {target['name']}",
+            payload=payload,
+            source_type="prompt_evolution",
+            source_id=run["run_id"],
+            source_run_id=run["run_id"],
+            target_id=target["target_id"],
+            base_revision=int(target["base_revision"]),
+        )
+
+    @staticmethod
+    def safe_report(run: dict[str, Any], candidate: dict[str, Any]) -> dict[str, Any]:
+        report = dict(run.get("report") or {})
+        return {
+            "run_id": run["run_id"],
+            "dataset_id": run["dataset"].get("dataset_id"),
+            "dataset_version": run["dataset"].get("version"),
+            "candidate_id": candidate["candidate_id"],
+            "candidate_checksum": candidate["checksum"],
+            "gate": copy.deepcopy(report.get("gate") or {}),
+            "validation": copy.deepcopy(report.get("validation") or {}),
+        }
+
+    @staticmethod
+    def apply_xpert_fields(xpert: XpertDefinition, fields: dict[str, str]) -> None:
+        nodes = {node.id: node for node in xpert.draft.workflow.nodes}
+        for path, value in fields.items():
+            node_id, field_name = XpertEvolutionService.parse_field_path(path)
+            node = nodes.get(node_id)
+            if node is None:
+                raise EvolutionStateError(f"Workflow Agent node not found: {node_id}")
+            data = node.data if isinstance(node.data, dict) else {}
+            data[field_name] = value
+            node.data = data
+
+    @staticmethod
+    def parse_field_path(path: str) -> tuple[str, str]:
+        node_id, separator, field_name = str(path).rpartition(".")
+        if not separator or field_name not in {"rolePrompt", "promptSuffix"}:
+            raise EvolutionStateError(f"Invalid Prompt field: {path}")
+        return node_id, field_name
+
+    def _prepare(self, request: EvolutionRunRequest) -> dict[str, Any]:
+        dataset = self.evaluation_store.get_dataset_version(
+            request.dataset_id, request.dataset_version
+        )
+        cases = list(dataset.get("cases") or [])
+        train_ids, validation_ids, split_warnings = self.split_cases(
+            cases, request.seed
+        )
+        if request.target_kind == "xpert":
+            xpert = self.xpert_store.get_xpert(request.target_id)
+            if xpert.draft_revision != request.target_revision:
+                raise EvolutionConflictError(
+                    "Xpert draft changed. Reload before starting evolution."
+                )
+            prompts: dict[str, str] = {}
+            nodes = {node.id: node for node in xpert.draft.workflow.nodes}
+            for path in request.prompt_fields:
+                node_id, field_name = self.parse_field_path(path)
+                node = nodes.get(node_id)
+                data = node.data if node is not None and isinstance(node.data, dict) else {}
+                kind = str(data.get("kind") or (node.type if node is not None else ""))
+                if node is None or kind != "workflow_agent":
+                    raise EvolutionStateError(
+                        f"Prompt field must belong to workflow_agent: {path}"
+                    )
+                prompts[path] = str(data.get(field_name) or "")
+            baseline_snapshot, snapshot_warnings = (
+                self.evaluation_service.snapshot_xpert_draft(
+                    xpert.model_copy(deep=True),
+                    source={
+                        "kind": "evolution_baseline",
+                        "xpert_id": xpert.id,
+                        "draft_revision": xpert.draft_revision,
+                    },
+                    label=f"{xpert.name} draft r{xpert.draft_revision}",
+                    model_policy=request.model_policy,
+                    override_model_id=request.override_model_id,
+                    target_id=f"evolution-baseline:{xpert.id}:r{xpert.draft_revision}",
+                )
+            )
+            target = {
+                "kind": "xpert",
+                "target_id": xpert.id,
+                "base_revision": xpert.draft_revision,
+                "name": xpert.name,
+                "selected_fields": list(request.prompt_fields),
+                "baseline_prompts": prompts,
+                "baseline_xpert": xpert.model_dump(mode="json"),
+                "baseline_snapshot": baseline_snapshot,
+            }
+        else:
+            profile = self.prompt_store.get_profile(request.target_id)
+            if profile.draft_revision != request.target_revision:
+                raise EvolutionConflictError(
+                    "Prompt Profile draft changed. Reload before starting evolution."
+                )
+            profile_variables = sorted(PLACEHOLDER_PATTERN.findall(profile.template))
+            if profile_variables != ["args"]:
+                raise EvolutionStateError(
+                    "Prompt Profile must contain exactly one {{args}} placeholder."
+                )
+            host_ref = {
+                "kind": "xpert_version",
+                "xpert_id": request.host_xpert_id,
+                "version": request.host_xpert_version,
+                "label": f"Prompt host {request.host_xpert_id} v{request.host_xpert_version}",
+            }
+            baseline_snapshot, snapshot_warnings = (
+                self.evaluation_service.snapshot_target(
+                    host_ref,
+                    model_policy=request.model_policy,
+                    override_model_id=request.override_model_id,
+                )
+            )
+            baseline_snapshot["target_id"] = (
+                f"evolution-baseline:{profile.id}:r{profile.draft_revision}"
+            )
+            baseline_snapshot["input_template"] = profile.template
+            baseline_snapshot["checksum"] = self.checksum(
+                {"host": baseline_snapshot["checksum"], "template": profile.template}
+            )
+            target = {
+                "kind": "prompt_profile",
+                "target_id": profile.id,
+                "base_revision": profile.draft_revision,
+                "name": profile.name,
+                "selected_fields": ["template"],
+                "baseline_prompts": {"template": profile.template},
+                "baseline_profile": profile.model_dump(mode="json"),
+                "baseline_snapshot": baseline_snapshot,
+                "host_xpert_id": request.host_xpert_id,
+                "host_xpert_version": request.host_xpert_version,
+            }
+        return {
+            "target": target,
+            "dataset": dataset,
+            "train_case_ids": train_ids,
+            "validation_case_ids": validation_ids,
+            "warnings": list(dict.fromkeys([*split_warnings, *snapshot_warnings])),
+        }
+
+    @staticmethod
+    def split_cases(
+        cases: list[dict[str, Any]], seed: int
+    ) -> tuple[list[str], list[str], list[str]]:
+        ids = [str(case.get("case_id") or "") for case in cases]
+        if not ids:
+            raise EvolutionStateError("Published DatasetVersion has no cases.")
+        shuffled = list(ids)
+        random.Random(seed).shuffle(shuffled)
+        if len(shuffled) < 5:
+            return (
+                shuffled,
+                shuffled,
+                [
+                    "Dataset has fewer than five cases; optimization and validation "
+                    "share cases, so overfitting risk is high."
+                ],
+            )
+        validation_count = max(1, round(len(shuffled) * 0.2))
+        validation = shuffled[:validation_count]
+        train = shuffled[validation_count:]
+        return train, validation, []
+
+    def _validate_prompt_safety(
+        self,
+        *,
+        baseline: dict[str, str],
+        candidate: dict[str, str],
+        train_cases: list[dict[str, Any]],
+        profile: bool,
+    ) -> None:
+        for field, value in candidate.items():
+            if not value:
+                raise EvolutionStateError(f"Candidate Prompt is empty: {field}")
+            baseline_variables = sorted(PLACEHOLDER_PATTERN.findall(baseline[field]))
+            candidate_variables = sorted(PLACEHOLDER_PATTERN.findall(value))
+            if baseline_variables != candidate_variables:
+                raise EvolutionStateError(
+                    f"Candidate changed template variables for {field}."
+                )
+            if profile and candidate_variables != ["args"]:
+                raise EvolutionStateError(
+                    "Prompt Profile candidates must retain the {{args}} contract."
+                )
+            for pattern in SENSITIVE_PATTERNS:
+                if pattern.search(value):
+                    raise EvolutionStateError(
+                        f"Candidate failed Prompt safety checks: {field}."
+                    )
+            normalized = " ".join(value.casefold().split())
+            for case in train_cases:
+                corpus = [
+                    str(case.get("message") or ""),
+                    json.dumps(case.get("expected") or {}, ensure_ascii=False),
+                ]
+                for text in corpus:
+                    sample = " ".join(text.casefold().split())
+                    if len(sample) >= 160 and sample[:160] in normalized:
+                        raise EvolutionStateError(
+                            "Candidate appears to copy a long evaluation sample."
+                        )
+
+    @staticmethod
+    def _public_target(target: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "kind": target["kind"],
+            "target_id": target["target_id"],
+            "base_revision": target["base_revision"],
+            "name": target["name"],
+            "selected_fields": list(target["selected_fields"]),
+            "baseline_checksum": XpertEvolutionService.prompt_checksum(
+                target["baseline_prompts"]
+            ),
+        }
+
+    @staticmethod
+    def prompt_checksum(fields: dict[str, str]) -> str:
+        normalized = {
+            str(key): "\n".join(
+                line.rstrip()
+                for line in str(value or "").replace("\r\n", "\n").split("\n")
+            ).strip()
+            for key, value in fields.items()
+        }
+        return XpertEvolutionService.checksum(normalized)
+
+    @staticmethod
+    def checksum(value: Any) -> str:
+        encoded = json.dumps(
+            value, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+        )
+        return hashlib.sha256(encoded.encode("utf-8")).hexdigest()

--- a/server/evolutions/store.py
+++ b/server/evolutions/store.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import copy
+import json
+import os
+import threading
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Callable
+
+
+class EvolutionError(RuntimeError):
+    pass
+
+
+class EvolutionNotFoundError(EvolutionError):
+    pass
+
+
+class EvolutionConflictError(EvolutionError):
+    pass
+
+
+class EvolutionStateError(EvolutionError):
+    pass
+
+
+class XpertEvolutionStore:
+    """Atomic file-backed state for bounded Prompt evolution runs."""
+
+    TERMINAL_STATUSES = {
+        "completed",
+        "no_improvement",
+        "failed",
+        "cancelled",
+        "stale",
+    }
+
+    def __init__(self, storage_dir: str | Path | None = None) -> None:
+        root = Path(
+            storage_dir
+            or os.getenv("XPERT_EVOLUTION_STORAGE_DIR", "").strip()
+            or os.getenv("AGENT_TASK_STORAGE_DIR", "").strip()
+            or Path(__file__).resolve().parent / "storage"
+        )
+        self.storage_dir = root
+        self.path = root / "xpert_evolutions.json"
+        self._lock = threading.RLock()
+        self._data = self._load()
+
+    def create_run(
+        self,
+        *,
+        request: dict[str, Any],
+        target: dict[str, Any],
+        dataset: dict[str, Any],
+        train_case_ids: list[str],
+        validation_case_ids: list[str],
+        warnings: list[str],
+    ) -> dict[str, Any]:
+        now = time.time()
+        run = {
+            "run_id": f"xevo_run_{uuid.uuid4().hex}",
+            "status": "queued",
+            "phase": "baseline",
+            "request": copy.deepcopy(request),
+            "target": copy.deepcopy(target),
+            "dataset": copy.deepcopy(dataset),
+            "train_case_ids": list(train_case_ids),
+            "validation_case_ids": list(validation_case_ids),
+            "warnings": [str(item)[:500] for item in warnings[:50]],
+            "baseline_evaluation_run_id": None,
+            "generations": [],
+            "validation_evaluation_run_id": None,
+            "finalists": [],
+            "report": {},
+            "proposal_id": None,
+            "proposal_revision": None,
+            "stale": False,
+            "cancel_requested": False,
+            "run_registry_id": None,
+            "error": None,
+            "created_at": now,
+            "updated_at": now,
+            "completed_at": None,
+        }
+        with self._lock:
+            self._data["runs"][run["run_id"]] = run
+            self._save_unlocked()
+        return copy.deepcopy(run)
+
+    def list_runs(self, *, status: str | None = None, limit: int = 100) -> list[dict[str, Any]]:
+        with self._lock:
+            items = list(self._data["runs"].values())
+        if status:
+            items = [item for item in items if item.get("status") == status]
+        items.sort(key=lambda item: float(item.get("created_at") or 0), reverse=True)
+        return [self.payload(item, include_detail=False) for item in items[:limit]]
+
+    def require(self, run_id: str) -> dict[str, Any]:
+        with self._lock:
+            return copy.deepcopy(self._require_unlocked(run_id))
+
+    def claim_next(self) -> dict[str, Any] | None:
+        with self._lock:
+            items = [
+                item
+                for item in self._data["runs"].values()
+                if item.get("status") == "queued"
+            ]
+            if not items:
+                return None
+            item = min(items, key=lambda value: float(value.get("created_at") or 0))
+            item["status"] = "running"
+            item["updated_at"] = time.time()
+            self._save_unlocked()
+            return copy.deepcopy(item)
+
+    def recover(self) -> int:
+        recovered = 0
+        with self._lock:
+            for item in self._data["runs"].values():
+                if item.get("status") == "running":
+                    item["status"] = "queued"
+                    item["updated_at"] = time.time()
+                    recovered += 1
+            if recovered:
+                self._save_unlocked()
+        return recovered
+
+    def mutate(
+        self,
+        run_id: str,
+        callback: Callable[[dict[str, Any]], None],
+    ) -> dict[str, Any]:
+        with self._lock:
+            item = self._require_unlocked(run_id)
+            callback(item)
+            item["updated_at"] = time.time()
+            self._save_unlocked()
+            return copy.deepcopy(item)
+
+    def cancel(self, run_id: str) -> dict[str, Any]:
+        def apply(item: dict[str, Any]) -> None:
+            if item.get("status") in self.TERMINAL_STATUSES:
+                return
+            item["cancel_requested"] = True
+            if item.get("status") == "queued":
+                item["status"] = "cancelled"
+                item["completed_at"] = time.time()
+
+        return self.mutate(run_id, apply)
+
+    def fail(self, run_id: str, error: str) -> dict[str, Any]:
+        def apply(item: dict[str, Any]) -> None:
+            item["status"] = "failed"
+            item["error"] = str(error)[:500]
+            item["completed_at"] = time.time()
+
+        return self.mutate(run_id, apply)
+
+    @staticmethod
+    def payload(item: dict[str, Any], *, include_detail: bool) -> dict[str, Any]:
+        payload = copy.deepcopy(item)
+        payload["generation_count"] = len(payload.get("generations") or [])
+        payload["candidate_count"] = sum(
+            len(generation.get("candidates") or [])
+            for generation in payload.get("generations") or []
+        )
+        if not include_detail:
+            payload.pop("dataset", None)
+            target = dict(payload.get("target") or {})
+            target.pop("baseline_xpert", None)
+            target.pop("baseline_snapshot", None)
+            target.pop("baseline_prompts", None)
+            payload["target"] = target
+            for generation in payload.get("generations") or []:
+                for candidate in generation.get("candidates") or []:
+                    candidate.pop("snapshot", None)
+                    candidate.pop("xpert", None)
+        return payload
+
+    def _load(self) -> dict[str, Any]:
+        if not self.path.exists():
+            return {"schema_version": 1, "runs": {}}
+        try:
+            raw = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return {"schema_version": 1, "runs": {}}
+        return {"schema_version": 1, "runs": dict(raw.get("runs") or {})}
+
+    def _save_unlocked(self) -> None:
+        self.storage_dir.mkdir(parents=True, exist_ok=True)
+        temp = self.path.with_suffix(".tmp")
+        temp.write_text(
+            json.dumps(self._data, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+        os.replace(temp, self.path)
+
+    def _require_unlocked(self, run_id: str) -> dict[str, Any]:
+        item = self._data["runs"].get(run_id)
+        if not isinstance(item, dict):
+            raise EvolutionNotFoundError("Evolution run not found.")
+        return item

--- a/server/main.py
+++ b/server/main.py
@@ -51,13 +51,30 @@ try:
     from server.evaluations import (
         configure_xpert_evaluations,
         get_xpert_evaluation_executor,
+        get_xpert_evaluation_service,
+        get_xpert_evaluation_store,
         router as xpert_evaluations_router,
     )
 except ModuleNotFoundError:
     from evaluations import (
         configure_xpert_evaluations,
         get_xpert_evaluation_executor,
+        get_xpert_evaluation_service,
+        get_xpert_evaluation_store,
         router as xpert_evaluations_router,
+    )
+
+try:
+    from server.evolutions import (
+        configure_xpert_evolutions,
+        get_xpert_evolution_executor,
+        router as xpert_evolutions_router,
+    )
+except ModuleNotFoundError:
+    from evolutions import (
+        configure_xpert_evolutions,
+        get_xpert_evolution_executor,
+        router as xpert_evolutions_router,
     )
 
 try:
@@ -660,6 +677,7 @@ app.include_router(toolsets_router)
 app.include_router(prompt_profiles_router)
 app.include_router(plugins_router)
 app.include_router(xpert_evaluations_router)
+app.include_router(xpert_evolutions_router)
 
 request_windows: dict[str, deque[float]] = defaultdict(deque)
 mcp_connect_windows: dict[str, deque[float]] = defaultdict(deque)
@@ -772,6 +790,7 @@ authoring_service = AuthoringService(
     authoring_proposal_store,
     get_xpert_store(),
     get_skill_draft_store(),
+    get_prompt_profile_store(),
     xpert_preflight=preview_xpert_for_publish,
 )
 workflow_xpert_authoring_provider = AuthoringToolsetProvider(
@@ -12072,6 +12091,9 @@ async def run_xpert_evaluation_target(
     ]
     history_json = json.dumps(history, ensure_ascii=False)
     message = str(case.get("message") or "")[:20_000]
+    input_template = str(target.get("input_template") or "")
+    if input_template:
+        message = re.sub(r"{{\s*args\s*}}", message, input_template)[:20_000]
     inputs = {
         str(target.get("input_variable") or "user_input"): message,
         str(target.get("history_variable") or "conversation_history"): history_json,
@@ -12238,6 +12260,37 @@ configure_xpert_evaluations(
 )
 
 
+async def run_xpert_evolution_optimizer(
+    model_id: str,
+    system_prompt: str,
+    user_prompt: str,
+    temperature: float,
+    max_tokens: int,
+) -> str:
+    return await collect_chat_completion_text(
+        model_id,
+        [
+            ChatMessage(role="system", content=system_prompt),
+            ChatMessage(role="user", content=user_prompt),
+        ],
+        temperature=temperature,
+        max_tokens=max_tokens,
+    )
+
+
+configure_xpert_evolutions(
+    storage_dir=AGENT_TASK_STORAGE_DIR or None,
+    evaluation_store=get_xpert_evaluation_store(),
+    evaluation_service=get_xpert_evaluation_service(),
+    evaluation_executor=get_xpert_evaluation_executor(),
+    xpert_store=get_xpert_store(),
+    prompt_store=get_prompt_profile_store(),
+    proposal_store=authoring_proposal_store,
+    optimizer_runner=run_xpert_evolution_optimizer,
+    run_registry=run_registry,
+)
+
+
 @app.on_event("startup")
 async def start_mcp_ttl_cleanup() -> None:
     await asyncio.to_thread(datax_service.recover_import_jobs)
@@ -12251,6 +12304,7 @@ async def start_mcp_ttl_cleanup() -> None:
     get_pipeline_executor().start()
     get_evaluation_executor().start()
     get_xpert_evaluation_executor().start()
+    get_xpert_evolution_executor().start()
     get_handoff_executor().start()
     get_goal_coordinator().start()
     get_approval_coordinator().start()
@@ -12262,6 +12316,7 @@ async def start_mcp_ttl_cleanup() -> None:
 async def shutdown_mcp_sessions() -> None:
     await get_pipeline_executor().stop()
     await get_evaluation_executor().stop()
+    await get_xpert_evolution_executor().stop()
     await get_xpert_evaluation_executor().stop()
     if goal_coordinator is not None:
         await goal_coordinator.stop()

--- a/server/meta_agent/NOTICE.md
+++ b/server/meta_agent/NOTICE.md
@@ -25,6 +25,16 @@ audited in:
 - `evoagentx/benchmark/benchmark.py`
 - `evoagentx/benchmark/metrics.py`
 
+Prompt Evolution independently adapts the bounded mutation, selection, and
+early-stop concepts audited in:
+
+- `evoagentx/optimizers/evoprompt_optimizer.py`
+
+It does not copy EvoPrompt's runtime, logging, benchmark integration, or model
+provider implementation. ModelMirror candidates execute through the existing
+read-only Xpert Evaluator and can only create revision-bound authoring
+proposals after an isolated validation gate.
+
 The adapted concepts are task decomposition, capability-aware workflow
 generation, and separate agent configuration generation. ModelMirror's
 implementation uses its own Pydantic contracts, Workflow Node Registry,
@@ -43,5 +53,6 @@ Canonical audit and roadmap:
 
 - `docs/EVOAGENTX_AUDIT_V014.md`
 - `docs/EVOAGENTX_ALIGNMENT.md`
+- `docs/EVOAGENTX_EVOLUTION.md`
 - `docs/META_AGENT.md`
 - `docs/XPERT_FREEZE.md`

--- a/server/tests/test_xpert_evolutions.py
+++ b/server/tests/test_xpert_evolutions.py
@@ -1,0 +1,370 @@
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from server.evolutions.executor import XpertEvolutionExecutor
+from server.evolutions.service import XpertEvolutionService
+from server.evolutions.store import (
+    EvolutionConflictError,
+    EvolutionStateError,
+    XpertEvolutionStore,
+)
+from server.prompts.store import PromptProfileStore
+from server.skills.draft_store import WorkspaceSkillDraftStore
+from server.xpert_runtime.authoring_service import AuthoringService
+from server.xpert_runtime.authoring_store import AuthoringProposalStore
+from server.xperts import XpertStore
+
+
+class _EvaluationStore:
+    def __init__(self, cases: list[dict[str, Any]]) -> None:
+        self.version = {
+            "dataset_id": "dataset-one",
+            "version": 1,
+            "name": "Prompt benchmark",
+            "case_count": len(cases),
+            "checksum": "dataset-checksum",
+            "cases": cases,
+        }
+
+    def get_dataset_version(self, dataset_id: str, version: int) -> dict[str, Any]:
+        assert dataset_id == "dataset-one"
+        assert version == 1
+        return copy.deepcopy(self.version)
+
+
+class _EvaluationService:
+    def snapshot_xpert_draft(
+        self,
+        xpert: Any,
+        *,
+        source: dict[str, Any],
+        label: str,
+        model_policy: str,
+        override_model_id: str | None,
+        target_id: str,
+    ) -> tuple[dict[str, Any], list[str]]:
+        return (
+            {
+                "target_id": target_id,
+                "label": label,
+                "source": source,
+                "xpert": {"id": xpert.id, "name": xpert.name},
+                "workflow": xpert.draft.workflow.model_dump(mode="json"),
+                "input_variable": xpert.draft.input_variable,
+                "history_variable": xpert.draft.history_variable,
+                "output_variable": xpert.draft.output_variable,
+                "checksum": target_id,
+                "resources": {},
+                "warnings": [],
+            },
+            [],
+        )
+
+
+def _cases(count: int = 10) -> list[dict[str, Any]]:
+    return [
+        {
+            "case_id": f"case-{index}",
+            "message": f"Question {index}",
+            "expected": {"contains": [f"answer-{index}"]},
+        }
+        for index in range(count)
+    ]
+
+
+def _service(tmp_path: Path, *, case_count: int = 10) -> tuple[XpertEvolutionService, Any]:
+    xperts = XpertStore(tmp_path / "xperts")
+    xpert = xperts.create_xpert(name="Prompt Worker")
+    workflow = xpert.draft.workflow.model_copy(deep=True)
+    agent = next(
+        node
+        for node in workflow.nodes
+        if str((node.data or {}).get("kind") or node.type) == "workflow_agent"
+    )
+    agent.data["rolePrompt"] = "Use {{user_input}} and answer clearly."
+    agent.data["promptSuffix"] = "Keep the response concise."
+    xpert = xperts.update_xpert(xpert.id, {"draft": {"workflow": workflow}})
+    proposal_store = AuthoringProposalStore(tmp_path / "runtime")
+    service = XpertEvolutionService(
+        XpertEvolutionStore(tmp_path / "evolutions"),
+        evaluation_store=_EvaluationStore(_cases(case_count)),
+        evaluation_service=_EvaluationService(),
+        xpert_store=xperts,
+        prompt_store=PromptProfileStore(tmp_path / "prompts"),
+        proposal_store=proposal_store,
+    )
+    return service, xpert
+
+
+def test_holdout_split_is_seeded_and_isolated() -> None:
+    cases = _cases(10)
+    first = XpertEvolutionService.split_cases(cases, 42)
+    second = XpertEvolutionService.split_cases(cases, 42)
+    different = XpertEvolutionService.split_cases(cases, 7)
+
+    assert first == second
+    assert set(first[0]).isdisjoint(first[1])
+    assert len(first[0]) == 8
+    assert len(first[1]) == 2
+    assert first != different
+
+
+def test_small_dataset_shares_cases_with_overfitting_warning() -> None:
+    train, validation, warnings = XpertEvolutionService.split_cases(_cases(4), 42)
+
+    assert train == validation
+    assert len(train) == 4
+    assert "overfitting" in warnings[0]
+
+
+def test_xpert_preflight_fixes_revision_and_selected_fields(tmp_path: Path) -> None:
+    service, xpert = _service(tmp_path)
+    agent = next(
+        node
+        for node in xpert.draft.workflow.nodes
+        if str((node.data or {}).get("kind") or node.type) == "workflow_agent"
+    )
+    request = {
+        "target_kind": "xpert",
+        "target_id": xpert.id,
+        "target_revision": xpert.draft_revision,
+        "prompt_fields": [f"{agent.id}.rolePrompt", f"{agent.id}.promptSuffix"],
+        "dataset_id": "dataset-one",
+        "dataset_version": 1,
+        "optimizer_model_id": "model-one",
+    }
+    from server.evolutions.models import EvolutionRunRequest
+
+    result = service.preflight(EvolutionRunRequest.model_validate(request))
+
+    assert result["valid"] is True
+    assert result["target"]["base_revision"] == xpert.draft_revision
+    assert result["target"]["selected_fields"] == request["prompt_fields"]
+    assert result["train_case_count"] == 8
+    assert result["validation_case_count"] == 2
+
+
+def test_candidate_preserves_variables_and_rejects_sample_copy(tmp_path: Path) -> None:
+    service, xpert = _service(tmp_path)
+    agent = next(
+        node
+        for node in xpert.draft.workflow.nodes
+        if str((node.data or {}).get("kind") or node.type) == "workflow_agent"
+    )
+    from server.evolutions.models import EvolutionRunRequest
+
+    run = service.create_run(
+        EvolutionRunRequest(
+            target_kind="xpert",
+            target_id=xpert.id,
+            target_revision=xpert.draft_revision,
+            prompt_fields=[f"{agent.id}.rolePrompt"],
+            dataset_id="dataset-one",
+            dataset_version=1,
+            optimizer_model_id="model-one",
+        )
+    )
+    with pytest.raises(EvolutionStateError, match="template variables"):
+        service.build_candidate(
+            run,
+            fields={f"{agent.id}.rolePrompt": "Answer without the input variable."},
+            generation=1,
+            index=1,
+            summary="Removed variable",
+        )
+
+
+def test_evolution_store_recovers_running_run(tmp_path: Path) -> None:
+    service, xpert = _service(tmp_path)
+    from server.evolutions.models import EvolutionRunRequest
+
+    agent = next(
+        node
+        for node in xpert.draft.workflow.nodes
+        if str((node.data or {}).get("kind") or node.type) == "workflow_agent"
+    )
+    run = service.create_run(
+        EvolutionRunRequest(
+            target_kind="xpert",
+            target_id=xpert.id,
+            target_revision=xpert.draft_revision,
+            prompt_fields=[f"{agent.id}.rolePrompt"],
+            dataset_id="dataset-one",
+            dataset_version=1,
+            optimizer_model_id="model-one",
+        )
+    )
+    claimed = service.store.claim_next()
+    assert claimed and claimed["status"] == "running"
+
+    restored = XpertEvolutionStore(tmp_path / "evolutions")
+    assert restored.recover() == 1
+    assert restored.require(run["run_id"])["status"] == "queued"
+
+
+def test_non_degradation_gate_rejects_metric_regression(tmp_path: Path) -> None:
+    service, _xpert = _service(tmp_path)
+    executor = XpertEvolutionExecutor(
+        service.store,
+        service,
+        evaluation_service=None,
+        evaluation_store=None,
+        evaluation_executor=None,
+        optimizer_runner=None,  # type: ignore[arg-type]
+    )
+    baseline = {"snapshot": {"target_id": "baseline"}}
+    finalist = {
+        "candidate_id": "candidate",
+        "checksum": "checksum",
+        "snapshot": {"target_id": "candidate"},
+    }
+    run = {
+        "request": {
+            "min_score_delta": 0.01,
+            "max_metric_regression": 0.02,
+        }
+    }
+    evaluation = {
+        "report": {
+            "targets": [
+                {
+                    "target_id": "baseline",
+                    "score": 0.7,
+                    "metrics": {"contains": 0.9, "rubric_judge": 0.5},
+                    "failed_count": 0,
+                },
+                {
+                    "target_id": "candidate",
+                    "score": 0.75,
+                    "metrics": {"contains": 0.8, "rubric_judge": 0.7},
+                    "failed_count": 0,
+                },
+            ]
+        }
+    }
+
+    gate = executor._gate(run, baseline, [finalist], evaluation)
+
+    assert gate["passed"] is False
+    assert gate["metric_regressions"]["contains"] == pytest.approx(-0.1)
+
+
+def test_optimizer_generation_parser_is_json_only_and_bounded() -> None:
+    parsed = XpertEvolutionExecutor._parse_generation(
+        """
+        {"candidates": [
+          {"fields": {"node.rolePrompt": "first"}, "summary": "one"},
+          {"fields": {"node.rolePrompt": "second"}, "summary": "two"},
+          {"fields": {"node.rolePrompt": "third"}, "summary": "three"}
+        ]}
+        """,
+        2,
+    )
+
+    assert [item["fields"]["node.rolePrompt"] for item in parsed] == [
+        "first",
+        "second",
+    ]
+    with pytest.raises(EvolutionStateError, match="JSON object"):
+        XpertEvolutionExecutor._parse_generation("not-json", 2)
+    with pytest.raises(EvolutionStateError, match="requires fields"):
+        XpertEvolutionExecutor._parse_generation(
+            '{"candidates": [{"summary": "missing fields"}]}',
+            2,
+        )
+
+
+def test_prompt_checksum_normalizes_line_endings_and_trailing_space() -> None:
+    first = XpertEvolutionService.prompt_checksum(
+        {"node.rolePrompt": "Use {{user_input}}.\r\nReturn evidence.   "}
+    )
+    second = XpertEvolutionService.prompt_checksum(
+        {"node.rolePrompt": "Use {{user_input}}.\nReturn evidence."}
+    )
+
+    assert first == second
+
+
+def test_stale_target_revision_blocks_proposal_creation(tmp_path: Path) -> None:
+    service, xpert = _service(tmp_path)
+    agent = next(
+        node
+        for node in xpert.draft.workflow.nodes
+        if str((node.data or {}).get("kind") or node.type) == "workflow_agent"
+    )
+    from server.evolutions.models import EvolutionRunRequest
+
+    run = service.create_run(
+        EvolutionRunRequest(
+            target_kind="xpert",
+            target_id=xpert.id,
+            target_revision=xpert.draft_revision,
+            prompt_fields=[f"{agent.id}.rolePrompt"],
+            dataset_id="dataset-one",
+            dataset_version=1,
+            optimizer_model_id="model-one",
+        )
+    )
+    candidate = service.build_candidate(
+        run,
+        fields={
+            f"{agent.id}.rolePrompt": (
+                "Use {{user_input}}, verify the answer, and respond clearly."
+            )
+        },
+        generation=1,
+        index=1,
+        summary="Add verification",
+    )
+    service.xpert_store.update_xpert(
+        xpert.id,
+        {"description": "Human edit", "draft": xpert.draft.model_dump(mode="json")},
+    )
+
+    assert service.is_stale(run) is True
+    with pytest.raises(EvolutionConflictError, match="changed"):
+        service.create_proposal(run, candidate)
+
+
+def test_prompt_profile_proposal_updates_draft_only(tmp_path: Path) -> None:
+    proposal_store = AuthoringProposalStore(tmp_path / "runtime")
+    prompt_store = PromptProfileStore(tmp_path / "prompts")
+    profile = prompt_store.create_profile(
+        name="Review",
+        aliases=["review"],
+        template="Review this:\n{{args}}",
+    )
+    service = AuthoringService(
+        proposal_store,
+        XpertStore(tmp_path / "xperts"),
+        WorkspaceSkillDraftStore(tmp_path / "runtime"),
+        prompt_store,
+    )
+    proposal = proposal_store.create(
+        kind="prompt_profile_update",
+        title="Improve Review Prompt",
+        payload={
+            "profile_id": profile.id,
+            "patch": {"template": "Review carefully and return evidence:\n{{args}}"},
+        },
+        source_type="prompt_evolution",
+        source_id="xevo-run",
+        target_id=profile.id,
+        base_revision=profile.draft_revision,
+    )
+
+    approved = service.approve(
+        proposal.proposal_id,
+        revision=proposal.revision,
+        operator="tester",
+    )
+    updated = prompt_store.get_profile(profile.id)
+
+    assert approved.status == "approved"
+    assert "evidence" in updated.template
+    assert updated.published_version is None

--- a/server/xpert_runtime/authoring_service.py
+++ b/server/xpert_runtime/authoring_service.py
@@ -6,11 +6,13 @@ from collections.abc import Callable
 from typing import Any
 
 try:
+    from server.prompts.store import PromptProfileStore
     from server.skills.draft_store import WorkspaceSkillDraftStore
     from server.xperts.models import XpertDefinition, XpertDraft
     from server.xperts.store import XpertStore, default_xpert_workflow
     from server.xperts.validation import validate_xpert_definition
 except ModuleNotFoundError:
+    from prompts.store import PromptProfileStore
     from skills.draft_store import WorkspaceSkillDraftStore
     from xperts.models import XpertDefinition, XpertDraft
     from xperts.store import XpertStore, default_xpert_workflow
@@ -28,18 +30,30 @@ class AuthoringService:
     """Validates and applies approved proposals to draft-only resource layers."""
 
     XPERT_PATCH_FIELDS = {"name", "description", "tags", "starters", "draft"}
+    PROMPT_PROFILE_PATCH_FIELDS = {
+        "name",
+        "slug",
+        "description",
+        "aliases",
+        "template",
+        "argument_hint",
+        "tags",
+        "public_app_allowed",
+    }
 
     def __init__(
         self,
         proposal_store: AuthoringProposalStore,
         xpert_store: XpertStore,
         skill_draft_store: WorkspaceSkillDraftStore,
+        prompt_profile_store: PromptProfileStore | None = None,
         *,
         xpert_preflight: Callable[[XpertDefinition], Any] | None = None,
     ) -> None:
         self.proposal_store = proposal_store
         self.xpert_store = xpert_store
         self.skill_draft_store = skill_draft_store
+        self.prompt_profile_store = prompt_profile_store
         self.xpert_preflight = xpert_preflight
         self._apply_lock = threading.RLock()
 
@@ -180,6 +194,41 @@ class AuthoringService:
             result = self._validate_xpert_candidate(candidate)
             return {"resource_kind": "xpert", "node_count": result.node_count}
 
+        if proposal.kind == "prompt_profile_update":
+            if self.prompt_profile_store is None:
+                raise AuthoringProposalValidationError(
+                    "Prompt Profile authoring is not configured."
+                )
+            target_id = proposal.target_id or str(payload.get("profile_id") or "")
+            if not target_id:
+                raise AuthoringProposalValidationError(
+                    "Target Prompt Profile is required."
+                )
+            current = self.prompt_profile_store.get_profile(target_id)
+            if proposal.base_revision != current.draft_revision:
+                raise AuthoringProposalConflictError(
+                    "Target Prompt Profile changed after this proposal was created."
+                )
+            patch = dict(payload.get("patch") or {})
+            unknown = sorted(set(patch) - self.PROMPT_PROFILE_PATCH_FIELDS)
+            if unknown:
+                raise AuthoringProposalValidationError(
+                    "Unsupported Prompt Profile patch fields: " + ", ".join(unknown)
+                )
+            if not patch:
+                raise AuthoringProposalValidationError(
+                    "Prompt Profile patch cannot be empty."
+                )
+            if "template" in patch:
+                PromptProfileStore._validate_template(patch["template"])
+            if "aliases" in patch:
+                PromptProfileStore._clean_aliases(patch["aliases"])
+            return {
+                "resource_kind": "prompt_profile",
+                "profile_id": current.id,
+                "base_revision": current.draft_revision,
+            }
+
         skill = dict(payload.get("skill") or payload)
         target_draft = None
         if proposal.kind == "skill_update":
@@ -249,6 +298,19 @@ class AuthoringService:
             target_id = proposal.target_id or str(payload.get("xpert_id") or "")
             item = self.xpert_store.update_xpert(
                 target_id, dict(payload.get("patch") or {})
+            )
+            return item.id
+
+        if proposal.kind == "prompt_profile_update":
+            if self.prompt_profile_store is None:
+                raise AuthoringProposalValidationError(
+                    "Prompt Profile authoring is not configured."
+                )
+            target_id = proposal.target_id or str(payload.get("profile_id") or "")
+            item = self.prompt_profile_store.update_profile(
+                target_id,
+                revision=int(proposal.base_revision or 0),
+                patch=dict(payload.get("patch") or {}),
             )
             return item.id
 

--- a/server/xpert_runtime/authoring_store.py
+++ b/server/xpert_runtime/authoring_store.py
@@ -13,6 +13,7 @@ from typing import Any, Literal
 ProposalKind = Literal[
     "xpert_create",
     "xpert_update",
+    "prompt_profile_update",
     "skill_create",
     "skill_update",
 ]
@@ -98,6 +99,7 @@ class AuthoringProposalStore:
         if kind not in {
             "xpert_create",
             "xpert_update",
+            "prompt_profile_update",
             "skill_create",
             "skill_update",
         }:

--- a/server/xpert_runtime/run_registry.py
+++ b/server/xpert_runtime/run_registry.py
@@ -21,6 +21,7 @@ RuntimeRunType = Literal[
     "automation",
     "meta_planner",
     "xpert_evaluation",
+    "xpert_evolution",
 ]
 RuntimeRunStatus = Literal[
     "pending",


### PR DESCRIPTION
## Summary

- add restart-safe Prompt evolution runs for Xpert Agent prompts and Prompt Profiles
- reuse the Evaluator for seeded train/holdout ranking under fixed snapshots and budgets
- enforce non-regression gates and create revision-bound approval proposals without auto-publishing
- add the evolution workspace, Studio/Profile entry points, proposal review, tests, and EvoAgentX attribution/docs

## Safety

- evolution runs are read-only and fail closed through the existing Evaluator preflight
- Prompt candidates preserve template variables and are filtered for sensitive or dataset-copy leakage
- passing candidates only create pending proposals; approval updates drafts and never publishes versions

## Validation

- client production build passed
- targeted evolution/evaluation/authoring suite: 23 passed
- full backend suite: 480 passed
- Docker Compose rebuilt; health, capabilities, environment summary, and frontend routes passed
- in-app browser QA passed with no console errors
- staged diff secret/path scan and git diff --check passed