### PR TITLE
feature: 添加原生智能调度与上下文优化灰度底座

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,14 @@ OMNIROUTE_API_KEY=
 MODEL_ROUTER_DEFAULT=newapi
 OMNIROUTE_BUDGET_HEADERS_ENABLED=false
 
+# 原生智能调度灰度由设置页持久化。仅在紧急回退时取消下一行注释；
+# 显式 sidecar 会覆盖数据库中的运行方式，删除或留空后恢复设置页策略。
+# MODEL_ROUTER_ENGINE=sidecar
+MODEL_ROUTER_CANARY_PERCENT=0
+MODEL_ROUTER_TENANT_ID=local
+# 仅限灾备或已完成独立审计的运维覆盖。普通设置界面仍执行 14 天/500 次门禁。
+MODEL_ROUTER_ALLOW_NATIVE_OVERRIDE=false
+
 # Optional: keep persistent bind-mounted data in a stable directory while
 # building source from another Git worktree.
 MODELMIRROR_DATA_ROOT=.

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ server/prompts/storage/
 server/xpert_runtime/storage/
 server/datax/storage/
 server/toolsets/storage/
+server/model_router/storage/
 server/mcp/installed/
 server/workflow_sandboxes/
 server/office_host/certs/

--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@
 
 模镜是一个 AI 资源浏览与协作平台，面向模型、智能体、MCP、Skill、提示词、工作流、RAG 和聊天场景。项目主题是“AI 牛马招聘会”：把模型与智能体看成候选人，把工具和能力看成岗位技能，让用户可以快速发现、比较、调用和组合 AI 能力。
 
-最后更新日期：2026-07-13
+最后更新日期：2026-07-27
 维护人：模镜团队
 
 ## 当前能力
 
 - 模型招聘会：模型筛选、价格展示、能力标签和聊天入口。
+- 智能调度：`/chat/auto` 支持六种策略、稳定会话灰度、健康熔断、预算回执和上下文优化；默认仍可回退 OmniRoute 侧车。
 - 面试间：OpenAI 兼容流式聊天、图片输入、高级参数、提示词助手、模型输出图片预览。
 - 图片生成模型：支持 `content` 多模态 parts、`delta.images` / `message.images`、`image_url` 和 `data:image/...` 输出；前端会转成图片卡片并接入 Lightbox 放大与下载。
 - AI 人才市场：智能体角色浏览、面试入口、专家团能力。
@@ -109,4 +110,6 @@ curl -N -X POST http://localhost:8000/api/chat ^
 
 ## 文档
 
-项目文档入口见 [docs/README.md](docs/README.md)。开发前请先阅读 [AGENTS.md](AGENTS.md) 和 [docs/HARNESS_ENGINEERING.md](docs/HARNESS_ENGINEERING.md)。
+项目文档入口见 [docs/README.md](docs/README.md)。原生调度的状态、门禁和回退见
+[docs/MODEL_ROUTER_NATIVE.md](docs/MODEL_ROUTER_NATIVE.md)。开发前请先阅读
+[AGENTS.md](AGENTS.md) 和 [docs/HARNESS_ENGINEERING.md](docs/HARNESS_ENGINEERING.md)。

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -20,7 +20,30 @@ immutable `3.8.48` image while the adapter is audited against the
 `release/v3.8.49` API contract. Replace the image only after repeating catalog,
 streaming, budget, telemetry and rollback checks.
 
-No OmniRoute source code is vendored into ModelMirror.
+No OmniRoute source code is vendored into ModelMirror. The native migration
+keeps a behavior-only fixture at
+`server/model_router/fixtures/omniroute-v3.8.49-routing.json`; it records the
+audited release, commit, documented default score factors and safety
+invariants. It does not contain executable OmniRoute source. Any future direct
+port must be listed here with its upstream path, commit and preserved license
+header before it can enter a production path.
+
+The following ModelMirror modules are independent Python behavioral
+reimplementations, not direct source copies:
+
+- `server/model_router/routing.py`: references the behavior, score-factor
+  defaults and mode packs documented/implemented by upstream
+  `open-sse/services/autoCombo/scoring.ts` at commit `36f8fd10052f`.
+- `server/model_router/repository.py` and `engine.py`: ModelMirror-native
+  SQLite, tenant, circuit-breaker, LKGP and dispatch implementation; only the
+  externally observable Auto-Combo behavior is aligned.
+- `server/context_engine/core.py`: ModelMirror-native deterministic context
+  optimizer inspired by the RTK/Caveman feature description. No OmniRoute
+  compression source was copied.
+
+If any of these modules is later replaced by a direct port, the individual
+file must preserve the upstream copyright/license header and this notice must
+be changed from “behavioral reimplementation” to “direct port”.
 
 ### MIT License
 

--- a/client/src/components/FederationRouterCard.tsx
+++ b/client/src/components/FederationRouterCard.tsx
@@ -59,7 +59,7 @@ export default function FederationRouterCard() {
         <div className="mt-auto flex flex-wrap items-center gap-2 pt-5">
           <Link
             className="rounded-full bg-hire-300 px-4 py-2 text-sm font-semibold text-ink-950 shadow-[0_0_24px_rgba(251,146,60,0.22)] transition duration-200 hover:bg-hire-200 active:scale-[0.98]"
-            to="/chat/auto?gateway=omniroute"
+            to="/chat/auto"
           >
             交给智能路由
           </Link>

--- a/client/src/components/settings/ModelServiceConnections.tsx
+++ b/client/src/components/settings/ModelServiceConnections.tsx
@@ -1,0 +1,521 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  CheckCircle2,
+  CircleAlert,
+  LoaderCircle,
+  Plug,
+  RefreshCw,
+  Server,
+} from "lucide-react";
+
+type ConnectionKind = "openrouter" | "newapi" | "openai_compatible";
+type ConnectionHealth = "untested" | "online" | "offline" | "disabled";
+
+interface RouterConnection {
+  id: string;
+  name: string;
+  kind: ConnectionKind;
+  base_url: string;
+  masked_key: string;
+  enabled: boolean;
+  health: ConnectionHealth;
+  model_count: number;
+  last_checked_at?: string | null;
+  last_error_hint?: string | null;
+}
+
+interface ConnectionTestResult {
+  ok: boolean;
+  health: ConnectionHealth;
+  model_count: number;
+  models_preview: string[];
+  message: string;
+  checked_at: string;
+}
+
+interface ConnectionForm {
+  kind: ConnectionKind;
+  name: string;
+  base_url: string;
+  api_key: string;
+}
+
+const PROVIDERS: Record<
+  ConnectionKind,
+  { label: string; name: string; baseUrl: string; hint: string }
+> = {
+  openrouter: {
+    label: "OpenRouter",
+    name: "OpenRouter",
+    baseUrl: "https://openrouter.ai/api/v1",
+    hint: "适合直接使用 OpenRouter 的统一模型目录。",
+  },
+  newapi: {
+    label: "newAPI",
+    name: "本地 newAPI",
+    baseUrl: "http://localhost:3000/v1",
+    hint: "适合已经在模镜中配置好的本地模型渠道。",
+  },
+  openai_compatible: {
+    label: "其他 OpenAI 兼容服务",
+    name: "自定义模型服务",
+    baseUrl: "",
+    hint: "适合带有 /v1/models 与 /v1/chat/completions 接口的服务。",
+  },
+};
+
+const INITIAL_FORM: ConnectionForm = {
+  kind: "openrouter",
+  name: PROVIDERS.openrouter.name,
+  base_url: PROVIDERS.openrouter.baseUrl,
+  api_key: "",
+};
+
+function healthLabel(health: ConnectionHealth) {
+  if (health === "online") return "可用";
+  if (health === "offline") return "需检查";
+  if (health === "disabled") return "已停用";
+  return "未测试";
+}
+
+function healthClass(health: ConnectionHealth) {
+  if (health === "online") {
+    return "border-emerald-300/25 bg-emerald-300/10 text-emerald-200";
+  }
+  if (health === "offline") {
+    return "border-rose-300/25 bg-rose-300/10 text-rose-200";
+  }
+  return "border-white/10 bg-white/[0.045] text-slate-300";
+}
+
+async function readError(response: Response) {
+  try {
+    const payload = await response.json();
+    const detail = payload?.detail;
+    if (typeof detail === "string") return detail;
+    if (typeof detail?.message === "string") return detail.message;
+  } catch {
+    // Fall through to the stable, user-facing fallback.
+  }
+  return "操作未完成，请检查服务状态后重试。";
+}
+
+export default function ModelServiceConnections() {
+  const [connections, setConnections] = useState<RouterConnection[]>([]);
+  const [form, setForm] = useState<ConnectionForm>(INITIAL_FORM);
+  const [testResult, setTestResult] = useState<ConnectionTestResult | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [testing, setTesting] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [error, setError] = useState("");
+
+  const provider = PROVIDERS[form.kind];
+  const canTest = Boolean(
+    form.name.trim() && form.base_url.trim() && form.api_key.trim(),
+  );
+
+  const loadConnections = useCallback(async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const response = await fetch("/api/router/connections");
+      if (!response.ok) throw new Error(await readError(response));
+      setConnections((await response.json()) as RouterConnection[]);
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : "无法读取模型服务连接。");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadConnections();
+  }, [loadConnections]);
+
+  const updateForm = useCallback(
+    (updates: Partial<ConnectionForm>) => {
+      setForm((current) => ({ ...current, ...updates }));
+      setTestResult(null);
+      setError("");
+    },
+    [],
+  );
+
+  const selectProvider = useCallback(
+    (kind: ConnectionKind) => {
+      const next = PROVIDERS[kind];
+      updateForm({
+        kind,
+        name: next.name,
+        base_url: next.baseUrl,
+      });
+    },
+    [updateForm],
+  );
+
+  const payload = useMemo(
+    () => ({
+      kind: form.kind,
+      name: form.name.trim(),
+      base_url: form.base_url.trim(),
+      api_key: form.api_key,
+      enabled: true,
+    }),
+    [form],
+  );
+
+  const testNewConnection = useCallback(async () => {
+    if (!canTest) return;
+    setTesting(true);
+    setError("");
+    setTestResult(null);
+    try {
+      const response = await fetch("/api/router/connections/test", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!response.ok) throw new Error(await readError(response));
+      setTestResult((await response.json()) as ConnectionTestResult);
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : "连接测试失败。");
+    } finally {
+      setTesting(false);
+    }
+  }, [canTest, payload]);
+
+  const saveConnection = useCallback(async () => {
+    if (!testResult?.ok) return;
+    setSaving(true);
+    setError("");
+    try {
+      const response = await fetch("/api/router/connections", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!response.ok) throw new Error(await readError(response));
+      const created = (await response.json()) as RouterConnection;
+      const tested = await fetch(
+        `/api/router/connections/${encodeURIComponent(created.id)}/test`,
+        { method: "POST" },
+      );
+      if (!tested.ok) throw new Error(await readError(tested));
+      setForm(INITIAL_FORM);
+      setTestResult(null);
+      await loadConnections();
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : "保存连接失败。");
+    } finally {
+      setSaving(false);
+    }
+  }, [loadConnections, payload, testResult]);
+
+  const testSavedConnection = useCallback(
+    async (connectionId: string) => {
+      setBusyId(connectionId);
+      setError("");
+      try {
+        const response = await fetch(
+          `/api/router/connections/${encodeURIComponent(connectionId)}/test`,
+          { method: "POST" },
+        );
+        if (!response.ok) throw new Error(await readError(response));
+        await loadConnections();
+      } catch (reason) {
+        setError(reason instanceof Error ? reason.message : "连接测试失败。");
+        await loadConnections();
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [loadConnections],
+  );
+
+  const toggleConnection = useCallback(
+    async (connection: RouterConnection) => {
+      setBusyId(connection.id);
+      setError("");
+      try {
+        const response = await fetch(
+          `/api/router/connections/${encodeURIComponent(connection.id)}`,
+          {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ enabled: !connection.enabled }),
+          },
+        );
+        if (!response.ok) throw new Error(await readError(response));
+        await loadConnections();
+      } catch (reason) {
+        setError(reason instanceof Error ? reason.message : "更新连接失败。");
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [loadConnections],
+  );
+
+  return (
+    <section className="mb-6 overflow-hidden rounded-lg border border-white/10 bg-ink-950/82 shadow-prism">
+      <div className="flex flex-col gap-3 border-b border-white/10 bg-white/[0.035] px-5 py-5 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <div className="flex items-center gap-2 text-hire-100">
+            <Server className="h-4 w-4" aria-hidden="true" />
+            <p className="text-sm font-semibold">模型服务连接</p>
+          </div>
+          <h2 className="mt-2 text-2xl font-semibold text-white">
+            连接可调用的模型服务
+          </h2>
+          <p className="mt-2 max-w-[70ch] text-sm leading-6 text-slate-300">
+            选择服务、填写地址和密钥，然后先测试再保存。密钥只会加密保存在本机后端。
+          </p>
+        </div>
+        <div className="text-sm text-slate-300">
+          已保存 <span className="font-semibold text-white">{connections.length}</span>{" "}
+          个连接
+        </div>
+      </div>
+
+      <ol className="grid border-b border-white/10 bg-slate-950/45 sm:grid-cols-3">
+        {[
+          ["1", "选择服务"],
+          ["2", "填写连接信息"],
+          ["3", "测试并保存"],
+        ].map(([number, label], index) => (
+          <li
+            className={`flex items-center gap-3 px-5 py-3 text-sm ${
+              index < 2 ? "border-b border-white/10 sm:border-b-0 sm:border-r" : ""
+            }`}
+            key={number}
+          >
+            <span className="flex h-6 w-6 items-center justify-center rounded-full bg-hire-300/15 text-xs font-semibold text-hire-100">
+              {number}
+            </span>
+            <span className="font-medium text-slate-200">{label}</span>
+          </li>
+        ))}
+      </ol>
+
+      <div className="grid gap-0 lg:grid-cols-[minmax(0,1.05fr)_minmax(340px,0.95fr)]">
+        <form
+          className="space-y-5 border-b border-white/10 p-5 lg:border-b-0 lg:border-r"
+          onSubmit={(event) => {
+            event.preventDefault();
+            void testNewConnection();
+          }}
+        >
+          <label className="block">
+            <span className="mb-2 block text-sm font-medium text-slate-200">
+              模型服务
+            </span>
+            <select
+              className="w-full rounded-lg border border-white/15 bg-slate-950 px-3 py-2.5 text-sm text-white outline-none transition focus:border-cyan-300/60"
+              onChange={(event) =>
+                selectProvider(event.target.value as ConnectionKind)
+              }
+              value={form.kind}
+            >
+              {Object.entries(PROVIDERS).map(([kind, item]) => (
+                <option key={kind} value={kind}>
+                  {item.label}
+                </option>
+              ))}
+            </select>
+            <span className="mt-2 block text-xs leading-5 text-slate-400">
+              {provider.hint}
+            </span>
+          </label>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <label className="block">
+              <span className="mb-2 block text-sm font-medium text-slate-200">
+                连接名称
+              </span>
+              <input
+                className="w-full rounded-lg border border-white/15 bg-slate-950 px-3 py-2.5 text-sm text-white outline-none transition placeholder:text-slate-500 focus:border-cyan-300/60"
+                maxLength={120}
+                onChange={(event) => updateForm({ name: event.target.value })}
+                placeholder="例如：团队 OpenRouter"
+                value={form.name}
+              />
+            </label>
+            <label className="block">
+              <span className="mb-2 block text-sm font-medium text-slate-200">
+                API 密钥
+              </span>
+              <input
+                autoComplete="new-password"
+                className="w-full rounded-lg border border-white/15 bg-slate-950 px-3 py-2.5 text-sm text-white outline-none transition placeholder:text-slate-500 focus:border-cyan-300/60"
+                onChange={(event) => updateForm({ api_key: event.target.value })}
+                placeholder="仅发送到本机后端"
+                type="password"
+                value={form.api_key}
+              />
+            </label>
+          </div>
+
+          <label className="block">
+            <span className="mb-2 block text-sm font-medium text-slate-200">
+              服务地址
+            </span>
+            <input
+              className="w-full rounded-lg border border-white/15 bg-slate-950 px-3 py-2.5 font-mono text-sm text-white outline-none transition placeholder:text-slate-500 focus:border-cyan-300/60"
+              maxLength={2048}
+              onChange={(event) => updateForm({ base_url: event.target.value })}
+              placeholder="https://example.com/v1"
+              spellCheck={false}
+              type="url"
+              value={form.base_url}
+            />
+          </label>
+
+          {error ? (
+            <div
+              className="flex gap-3 rounded-lg bg-rose-400/10 px-3 py-3 text-sm text-rose-100"
+              role="alert"
+            >
+              <CircleAlert className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+              <span>{error}</span>
+            </div>
+          ) : null}
+
+          {testResult ? (
+            <div
+              className={`rounded-lg px-4 py-3 ${
+                testResult.ok
+                  ? "bg-emerald-300/10 text-emerald-100"
+                  : "bg-amber-300/10 text-amber-100"
+              }`}
+              role="status"
+            >
+              <div className="flex items-start gap-2 text-sm font-medium">
+                {testResult.ok ? (
+                  <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0" />
+                ) : (
+                  <CircleAlert className="mt-0.5 h-4 w-4 shrink-0" />
+                )}
+                <span>{testResult.message}</span>
+              </div>
+              {testResult.models_preview.length > 0 ? (
+                <p className="mt-2 truncate font-mono text-xs opacity-80">
+                  {testResult.models_preview.join(" · ")}
+                </p>
+              ) : null}
+            </div>
+          ) : null}
+
+          <div className="flex flex-wrap gap-3">
+            <button
+              className="inline-flex items-center justify-center gap-2 rounded-full border border-cyan-300/30 bg-cyan-300/10 px-4 py-2 text-sm font-semibold text-cyan-100 transition hover:bg-cyan-300/18 disabled:cursor-not-allowed disabled:opacity-45"
+              disabled={!canTest || testing || saving}
+              type="submit"
+            >
+              {testing ? (
+                <LoaderCircle className="h-4 w-4 animate-spin" />
+              ) : (
+                <Plug className="h-4 w-4" />
+              )}
+              测试连接
+            </button>
+            <button
+              className="rounded-full bg-hire-300 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-hire-200 disabled:cursor-not-allowed disabled:opacity-45"
+              disabled={!testResult?.ok || saving || testing}
+              onClick={() => void saveConnection()}
+              type="button"
+            >
+              {saving ? "正在保存" : "保存连接"}
+            </button>
+          </div>
+        </form>
+
+        <div className="min-w-0 p-5">
+          <div className="mb-4 flex items-center justify-between gap-3">
+            <div>
+              <h3 className="text-base font-semibold text-white">已保存连接</h3>
+              <p className="mt-1 text-xs text-slate-400">
+                可随时测试、停用或恢复，不会删除配置。
+              </p>
+            </div>
+            <button
+              aria-label="刷新连接列表"
+              className="rounded-full p-2 text-slate-300 transition hover:bg-white/[0.07] hover:text-white"
+              onClick={() => void loadConnections()}
+              type="button"
+            >
+              <RefreshCw className={`h-4 w-4 ${loading ? "animate-spin" : ""}`} />
+            </button>
+          </div>
+
+          {loading && connections.length === 0 ? (
+            <div className="space-y-3" aria-label="正在读取连接">
+              <div className="h-20 animate-pulse rounded-lg bg-white/[0.045]" />
+              <div className="h-20 animate-pulse rounded-lg bg-white/[0.045]" />
+            </div>
+          ) : connections.length === 0 ? (
+            <div className="rounded-lg bg-white/[0.035] px-4 py-8 text-center">
+              <Server className="mx-auto h-6 w-6 text-slate-400" />
+              <p className="mt-3 text-sm font-medium text-slate-200">
+                还没有模型服务连接
+              </p>
+              <p className="mt-1 text-xs leading-5 text-slate-400">
+                完成左侧三步后，可用模型会进入智能调度候选池。
+              </p>
+            </div>
+          ) : (
+            <ul className="divide-y divide-white/10">
+              {connections.map((connection) => (
+                <li className="py-4 first:pt-0 last:pb-0" key={connection.id}>
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <p className="font-medium text-white">{connection.name}</p>
+                        <span
+                          className={`rounded-full border px-2 py-0.5 text-xs ${healthClass(
+                            connection.health,
+                          )}`}
+                        >
+                          {healthLabel(connection.health)}
+                        </span>
+                      </div>
+                      <p className="mt-1 truncate font-mono text-xs text-slate-400">
+                        {connection.base_url}
+                      </p>
+                      <p className="mt-2 text-xs text-slate-400">
+                        {connection.masked_key} · {connection.model_count} 个模型
+                      </p>
+                      {connection.last_error_hint ? (
+                        <p className="mt-2 text-xs leading-5 text-amber-200">
+                          {connection.last_error_hint}
+                        </p>
+                      ) : null}
+                    </div>
+                    <div className="flex shrink-0 gap-2">
+                      <button
+                        className="rounded-full border border-white/15 px-3 py-1.5 text-xs font-medium text-slate-200 transition hover:bg-white/[0.07] disabled:opacity-45"
+                        disabled={!connection.enabled || busyId === connection.id}
+                        onClick={() => void testSavedConnection(connection.id)}
+                        type="button"
+                      >
+                        测试
+                      </button>
+                      <button
+                        className="rounded-full border border-white/15 px-3 py-1.5 text-xs font-medium text-slate-200 transition hover:bg-white/[0.07] disabled:opacity-45"
+                        disabled={busyId === connection.id}
+                        onClick={() => void toggleConnection(connection)}
+                        type="button"
+                      >
+                        {connection.enabled ? "停用" : "恢复"}
+                      </button>
+                    </div>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/client/src/components/settings/SmartRoutingSettings.tsx
+++ b/client/src/components/settings/SmartRoutingSettings.tsx
@@ -1,0 +1,532 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Activity,
+  CheckCircle2,
+  Gauge,
+  LoaderCircle,
+  RefreshCw,
+  SlidersHorizontal,
+} from "lucide-react";
+
+type RouterEngine = "sidecar" | "shadow" | "native_canary" | "native";
+type RoutingMode =
+  | "auto"
+  | "fast"
+  | "quality"
+  | "cheap"
+  | "reliable"
+  | "offline";
+type CompressionMode = "auto" | "off" | "standard" | "strong";
+
+interface RouterPolicy {
+  tenant_id: string;
+  engine: RouterEngine;
+  default_mode: RoutingMode;
+  canary_percent: number;
+  compression_mode: CompressionMode;
+  updated_at?: string | null;
+}
+
+interface RouterStatus {
+  connection_count: number;
+  online_connection_count: number;
+  model_count: number;
+  ready: boolean;
+}
+
+interface MigrationGate {
+  request_count: number;
+  success_rate?: number | null;
+  empty_stream_rate?: number | null;
+  observed_days: number;
+  request_gate_met: boolean;
+  duration_gate_met: boolean;
+  automatic_native_default_allowed: boolean;
+}
+
+interface RecentDecision {
+  id: string;
+  engine: string;
+  strategy: string;
+  model_id?: string | null;
+  connection_name?: string | null;
+  outcome?: string | null;
+  created_at: string;
+}
+
+interface RouterDiagnostics {
+  redacted: boolean;
+  migration_gate: MigrationGate;
+  breaker_summary: Record<string, number>;
+  recent_decisions: RecentDecision[];
+}
+
+const MODE_OPTIONS: Array<{
+  value: RoutingMode;
+  label: string;
+  description: string;
+}> = [
+  { value: "auto", label: "均衡推荐", description: "兼顾质量、速度与费用" },
+  { value: "fast", label: "速度优先", description: "优先更快完成回答" },
+  { value: "quality", label: "质量优先", description: "优先能力更强的模型" },
+  { value: "cheap", label: "成本优先", description: "在满足任务时降低费用" },
+  { value: "reliable", label: "稳定优先", description: "优先近期成功的模型" },
+  { value: "offline", label: "本地优先", description: "优先本地与充足配额" },
+];
+
+const ENGINE_OPTIONS: Array<{
+  value: RouterEngine;
+  label: string;
+  description: string;
+}> = [
+  {
+    value: "sidecar",
+    label: "稳定模式",
+    description: "继续使用当前已验收的调度服务",
+  },
+  {
+    value: "shadow",
+    label: "对照观察",
+    description: "只比较本地决策，不发起额外模型请求",
+  },
+  {
+    value: "native_canary",
+    label: "本地试运行",
+    description: "按稳定会话比例逐步启用本地调度",
+  },
+  {
+    value: "native",
+    label: "本地默认",
+    description: "达到稳定性门槛并人工验收后开放",
+  },
+];
+
+const COMPRESSION_OPTIONS: Array<{
+  value: CompressionMode;
+  label: string;
+  description: string;
+}> = [
+  { value: "auto", label: "自动推荐", description: "仅在接近上下文上限时优化" },
+  { value: "off", label: "关闭", description: "始终保留原始上下文" },
+  { value: "standard", label: "标准", description: "去重并压缩冗余工具与资料内容" },
+  { value: "strong", label: "强力", description: "长对话时允许进一步摘要旧内容" },
+];
+
+async function readError(response: Response) {
+  try {
+    const payload = await response.json();
+    if (typeof payload?.detail === "string") return payload.detail;
+    if (typeof payload?.detail?.message === "string") {
+      return payload.detail.message;
+    }
+  } catch {
+    // Use a stable message without exposing an upstream response body.
+  }
+  return "操作未完成，请检查模型服务连接后重试。";
+}
+
+function percent(value?: number | null) {
+  return value == null ? "暂无样本" : `${Math.round(value * 1000) / 10}%`;
+}
+
+export default function SmartRoutingSettings() {
+  const [policy, setPolicy] = useState<RouterPolicy | null>(null);
+  const [status, setStatus] = useState<RouterStatus | null>(null);
+  const [diagnostics, setDiagnostics] = useState<RouterDiagnostics | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+  const [notice, setNotice] = useState("");
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const [policyResponse, statusResponse, diagnosticsResponse] =
+        await Promise.all([
+          fetch("/api/router/policy"),
+          fetch("/api/router/status"),
+          fetch("/api/router/diagnostics"),
+        ]);
+      for (const response of [
+        policyResponse,
+        statusResponse,
+        diagnosticsResponse,
+      ]) {
+        if (!response.ok) throw new Error(await readError(response));
+      }
+      setPolicy((await policyResponse.json()) as RouterPolicy);
+      setStatus((await statusResponse.json()) as RouterStatus);
+      setDiagnostics(
+        (await diagnosticsResponse.json()) as RouterDiagnostics,
+      );
+    } catch (reason) {
+      setError(
+        reason instanceof Error ? reason.message : "无法读取智能调度设置。",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const nativeReady =
+    diagnostics?.migration_gate.automatic_native_default_allowed ?? false;
+  const selectedEngine = useMemo(
+    () => ENGINE_OPTIONS.find((item) => item.value === policy?.engine),
+    [policy?.engine],
+  );
+
+  const save = useCallback(async () => {
+    if (!policy) return;
+    setSaving(true);
+    setError("");
+    setNotice("");
+    try {
+      const response = await fetch("/api/router/policy", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(policy),
+      });
+      if (!response.ok) throw new Error(await readError(response));
+      setPolicy((await response.json()) as RouterPolicy);
+      setNotice("设置已保存，新的智能调度会话将使用此配置。");
+      await load();
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : "保存设置失败。");
+    } finally {
+      setSaving(false);
+    }
+  }, [load, policy]);
+
+  return (
+    <section className="mb-6 overflow-hidden rounded-lg border border-white/10 bg-ink-950/82 shadow-prism">
+      <div className="flex flex-col gap-3 border-b border-white/10 bg-white/[0.035] px-5 py-5 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <div className="flex items-center gap-2 text-hire-100">
+            <SlidersHorizontal className="h-4 w-4" aria-hidden="true" />
+            <p className="text-sm font-semibold">智能调度与上下文优化</p>
+          </div>
+          <h2 className="mt-2 text-2xl font-semibold text-white">
+            按任务自动选择合适模型
+          </h2>
+          <p className="mt-2 max-w-[72ch] text-sm leading-6 text-slate-300">
+            普通使用推荐保持“均衡推荐”和“自动推荐”。本地试运行按会话稳定分流，
+            同一次对话不会来回切换。
+          </p>
+        </div>
+        <div
+          className={`inline-flex w-fit items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-semibold ${
+            status?.ready
+              ? "border-emerald-300/25 bg-emerald-300/10 text-emerald-200"
+              : "border-amber-300/25 bg-amber-300/10 text-amber-100"
+          }`}
+        >
+          <Activity className="h-3.5 w-3.5" aria-hidden="true" />
+          {status?.ready
+            ? `${status.online_connection_count} 个连接可用`
+            : "等待可用连接"}
+        </div>
+      </div>
+
+      {loading || !policy ? (
+        <div className="flex items-center gap-3 p-5 text-sm text-slate-300">
+          <LoaderCircle className="h-4 w-4 animate-spin" aria-hidden="true" />
+          正在读取设置…
+        </div>
+      ) : (
+        <div className="grid lg:grid-cols-3">
+          <fieldset className="border-b border-white/10 p-5 lg:border-b-0 lg:border-r">
+            <legend className="flex items-center gap-2 text-sm font-semibold text-white">
+              <Gauge className="h-4 w-4 text-brand-200" aria-hidden="true" />
+              智能调度
+            </legend>
+            <p className="mt-2 text-xs leading-5 text-slate-400">
+              选择你更看重的回答结果。
+            </p>
+            <div className="mt-4 space-y-2">
+              {MODE_OPTIONS.map((option) => (
+                <label
+                  className={`flex cursor-pointer gap-3 rounded-lg border p-3 transition ${
+                    policy.default_mode === option.value
+                      ? "border-brand-300/40 bg-brand-300/10"
+                      : "border-white/10 bg-white/[0.035] hover:border-white/20"
+                  }`}
+                  key={option.value}
+                >
+                  <input
+                    checked={policy.default_mode === option.value}
+                    className="mt-1 accent-cyan-300"
+                    name="routing-mode"
+                    onChange={() =>
+                      setPolicy((current) =>
+                        current
+                          ? { ...current, default_mode: option.value }
+                          : current,
+                      )
+                    }
+                    type="radio"
+                  />
+                  <span>
+                    <span className="block text-sm font-medium text-white">
+                      {option.label}
+                    </span>
+                    <span className="mt-0.5 block text-xs leading-5 text-slate-400">
+                      {option.description}
+                    </span>
+                  </span>
+                </label>
+              ))}
+            </div>
+          </fieldset>
+
+          <fieldset className="border-b border-white/10 p-5 lg:border-b-0 lg:border-r">
+            <legend className="text-sm font-semibold text-white">
+              上下文优化
+            </legend>
+            <p className="mt-2 text-xs leading-5 text-slate-400">
+              系统提示、最新问题、代码和结构化内容始终受保护。
+            </p>
+            <div className="mt-4 space-y-2">
+              {COMPRESSION_OPTIONS.map((option) => (
+                <label
+                  className={`flex cursor-pointer gap-3 rounded-lg border p-3 transition ${
+                    policy.compression_mode === option.value
+                      ? "border-hire-300/35 bg-hire-300/10"
+                      : "border-white/10 bg-white/[0.035] hover:border-white/20"
+                  }`}
+                  key={option.value}
+                >
+                  <input
+                    checked={policy.compression_mode === option.value}
+                    className="mt-1 accent-orange-300"
+                    name="compression-mode"
+                    onChange={() =>
+                      setPolicy((current) =>
+                        current
+                          ? { ...current, compression_mode: option.value }
+                          : current,
+                      )
+                    }
+                    type="radio"
+                  />
+                  <span>
+                    <span className="block text-sm font-medium text-white">
+                      {option.label}
+                    </span>
+                    <span className="mt-0.5 block text-xs leading-5 text-slate-400">
+                      {option.description}
+                    </span>
+                  </span>
+                </label>
+              ))}
+            </div>
+          </fieldset>
+
+          <div className="p-5">
+            <label className="block text-sm font-semibold text-white">
+              运行方式
+              <select
+                className="mt-3 w-full rounded-lg border border-white/15 bg-slate-950 px-3 py-2.5 text-sm text-white outline-none transition focus:border-cyan-300/60"
+                onChange={(event) =>
+                  setPolicy((current) =>
+                    current
+                      ? {
+                          ...current,
+                          engine: event.target.value as RouterEngine,
+                          canary_percent:
+                            event.target.value === "native_canary"
+                              ? Math.max(10, current.canary_percent)
+                              : current.canary_percent,
+                        }
+                      : current,
+                  )
+                }
+                value={policy.engine}
+              >
+                {ENGINE_OPTIONS.map((option) => (
+                  <option
+                    disabled={
+                      (option.value === "native_canary" && !status?.ready) ||
+                      (option.value === "native" &&
+                        (!status?.ready || !nativeReady))
+                    }
+                    key={option.value}
+                    value={option.value}
+                  >
+                    {option.label}
+                    {option.value === "native_canary" && !status?.ready
+                      ? "（需先连接模型服务）"
+                      : option.value === "native" && !nativeReady
+                      ? "（未达门槛）"
+                      : ""}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <p className="mt-2 text-xs leading-5 text-slate-400">
+              {selectedEngine?.description}
+            </p>
+
+            {policy.engine === "native_canary" ? (
+              <label className="mt-5 block text-sm font-semibold text-white">
+                本地试运行比例：{policy.canary_percent}%
+                <input
+                  aria-label="本地试运行比例"
+                  className="mt-3 w-full accent-cyan-300"
+                  max="100"
+                  min="0"
+                  onChange={(event) =>
+                    setPolicy((current) =>
+                      current
+                        ? {
+                            ...current,
+                            canary_percent: Number(event.target.value),
+                          }
+                        : current,
+                    )
+                  }
+                  step="10"
+                  type="range"
+                  value={policy.canary_percent}
+                />
+                <span className="mt-1 flex justify-between text-xs font-normal text-slate-500">
+                  <span>0%</span>
+                  <span>100%</span>
+                </span>
+              </label>
+            ) : null}
+
+            <div className="mt-5 rounded-lg border border-white/10 bg-white/[0.035] p-3 text-xs leading-5 text-slate-400">
+              已发现 {status?.model_count ?? 0} 个可调用模型；
+              {diagnostics?.migration_gate.request_count ?? 0}/500 次试运行，
+              {diagnostics?.migration_gate.observed_days ?? 0}/14 天观察。
+            </div>
+
+            <button
+              className="mt-5 inline-flex w-full items-center justify-center gap-2 rounded-full bg-brand-300 px-4 py-2.5 text-sm font-semibold text-ink-950 transition hover:bg-brand-200 disabled:cursor-not-allowed disabled:opacity-50"
+              disabled={
+                saving ||
+                (policy.engine === "native_canary" && !status?.ready) ||
+                (policy.engine === "native" &&
+                  (!status?.ready || !nativeReady))
+              }
+              onClick={() => void save()}
+              type="button"
+            >
+              {saving ? (
+                <LoaderCircle className="h-4 w-4 animate-spin" aria-hidden="true" />
+              ) : (
+                <CheckCircle2 className="h-4 w-4" aria-hidden="true" />
+              )}
+              保存调度设置
+            </button>
+          </div>
+        </div>
+      )}
+
+      {error || notice ? (
+        <div
+          aria-live="polite"
+          className={`border-t px-5 py-3 text-sm ${
+            error
+              ? "border-rose-300/20 bg-rose-300/10 text-rose-100"
+              : "border-emerald-300/20 bg-emerald-300/10 text-emerald-100"
+          }`}
+        >
+          {error || notice}
+        </div>
+      ) : null}
+
+      <details className="border-t border-white/10 bg-slate-950/35">
+        <summary className="flex cursor-pointer list-none items-center justify-between gap-4 px-5 py-4 text-sm font-semibold text-slate-200">
+          <span>运行诊断（高级）</span>
+          <Activity className="h-4 w-4 text-slate-400" aria-hidden="true" />
+        </summary>
+        <div className="grid gap-4 border-t border-white/10 p-5 text-sm md:grid-cols-3">
+          <div className="flex items-center justify-between gap-3 md:col-span-3">
+            <p className="text-xs leading-5 text-slate-400">
+              只展示脱敏后的健康与运行记录。
+            </p>
+            <button
+              className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/[0.04] px-3 py-1.5 text-xs font-semibold text-slate-200 transition hover:border-brand-300/30 hover:text-brand-100"
+              onClick={() => void load()}
+              type="button"
+            >
+              <RefreshCw className="h-3.5 w-3.5" aria-hidden="true" />
+              刷新
+            </button>
+          </div>
+          <div className="rounded-lg border border-white/10 bg-white/[0.035] p-4">
+            <p className="text-xs text-slate-400">成功率</p>
+            <p className="mt-2 text-xl font-semibold text-white">
+              {percent(diagnostics?.migration_gate.success_rate)}
+            </p>
+          </div>
+          <div className="rounded-lg border border-white/10 bg-white/[0.035] p-4">
+            <p className="text-xs text-slate-400">空响应率</p>
+            <p className="mt-2 text-xl font-semibold text-white">
+              {percent(diagnostics?.migration_gate.empty_stream_rate)}
+            </p>
+          </div>
+          <div className="rounded-lg border border-white/10 bg-white/[0.035] p-4">
+            <p className="text-xs text-slate-400">本地默认门槛</p>
+            <p className="mt-2 text-sm font-semibold text-white">
+              {nativeReady ? "自动门槛已达到，仍需人工验收" : "继续本地试运行"}
+            </p>
+          </div>
+          <div className="md:col-span-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-400">
+              最近调度
+            </p>
+            <div className="mt-2 overflow-x-auto rounded-lg border border-white/10">
+              <table className="w-full min-w-[620px] text-left text-xs">
+                <thead className="bg-white/[0.04] text-slate-400">
+                  <tr>
+                    <th className="px-3 py-2 font-medium">时间</th>
+                    <th className="px-3 py-2 font-medium">策略</th>
+                    <th className="px-3 py-2 font-medium">模型</th>
+                    <th className="px-3 py-2 font-medium">服务</th>
+                    <th className="px-3 py-2 font-medium">结果</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {(diagnostics?.recent_decisions ?? []).slice(0, 10).map((item) => (
+                    <tr className="border-t border-white/10" key={item.id}>
+                      <td className="px-3 py-2 text-slate-400">
+                        {new Date(item.created_at).toLocaleString("zh-CN")}
+                      </td>
+                      <td className="px-3 py-2 text-slate-300">{item.strategy}</td>
+                      <td className="max-w-56 truncate px-3 py-2 text-white">
+                        {item.model_id || "未选择"}
+                      </td>
+                      <td className="px-3 py-2 text-slate-300">
+                        {item.connection_name || "未选择"}
+                      </td>
+                      <td className="px-3 py-2 text-slate-300">
+                        {item.outcome || "待完成"}
+                      </td>
+                    </tr>
+                  ))}
+                  {!diagnostics?.recent_decisions.length ? (
+                    <tr>
+                      <td className="px-3 py-4 text-slate-400" colSpan={5}>
+                        尚无本地试运行记录。
+                      </td>
+                    </tr>
+                  ) : null}
+                </tbody>
+              </table>
+            </div>
+            <p className="mt-3 text-xs leading-5 text-slate-500">
+              诊断记录已脱敏，不包含 API 密钥、完整提示词或上游错误体。
+            </p>
+          </div>
+        </div>
+      </details>
+    </section>
+  );
+}

--- a/client/src/pages/ChatPage.tsx
+++ b/client/src/pages/ChatPage.tsx
@@ -73,6 +73,15 @@ interface ChatMessage {
 
 const STREAM_UI_UPDATE_INTERVAL_MS = 80;
 
+function defaultRoutingMode(
+  modelId: string,
+): "fast" | "balanced" | "quality" | "cheap" | "reliable" | "offline" {
+  if (modelId === "auto/fast") return "fast";
+  if (modelId === "auto/cheap") return "cheap";
+  if (modelId === "auto/smart" || modelId === "auto/coding") return "quality";
+  return "balanced";
+}
+
 function createStreamingUiScheduler(
   update: () => void,
   interval = STREAM_UI_UPDATE_INTERVAL_MS,
@@ -267,11 +276,14 @@ function createId() {
   return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
 }
 
-function defaultAdvancedParams(maxTokenLimit = 2048): ChatAdvancedParams {
+function defaultAdvancedParams(
+  maxTokenLimit = 2048,
+  defaultMaxTokens = 2048,
+): ChatAdvancedParams {
   return {
     temperature: 0.7,
     topP: 1,
-    maxTokens: Math.min(2048, maxTokenLimit),
+    maxTokens: Math.min(defaultMaxTokens, maxTokenLimit),
     seed: "",
     stopSequences: "",
   };
@@ -456,19 +468,69 @@ function markdownComponents(
   };
 }
 
+const routeReasonLabels: Record<string, string> = {
+  preference_pool_fallback: "放宽非必要偏好后找到可用模型",
+  soft_budget_cheapest_fallback: "预算不足时选择了最低成本候选",
+  last_known_good: "优先选择本会话近期成功的模型",
+  half_open_probe: "正在小流量验证已恢复的模型",
+  mode_auto: "综合质量、速度与费用",
+  mode_fast: "优先响应速度",
+  mode_quality: "优先回答质量",
+  mode_cheap: "优先降低费用",
+  mode_reliable: "优先近期稳定性",
+  mode_offline: "优先本地可用性与配额",
+  output_limit_reached: "回答达到最大输出长度，内容可能不完整",
+};
+
+const compressionStageLabels: Record<string, string> = {
+  tool_output_filtering: "工具输出整理",
+  redundancy_folding: "重复内容折叠",
+  caveman_redundancy: "冗余语句压缩",
+  rag_deduplication: "资料片段去重",
+  cross_message_deduplication: "跨消息重复内容去重",
+  history_summary: "旧对话摘要",
+};
+
+const budgetStatusLabels: Record<string, string> = {
+  not_set: "未设置单次预算",
+  settled: "已按实际用量结算",
+  covered_by_reservation: "用量缺失，费用仍在预留上限内",
+  released: "调用未完成，预算预留已释放",
+  unavailable: "当前模型无法可靠估价",
+  over_limit: "上游用量超过预留，请检查服务计费",
+};
+
 function RouteReceiptCard({ receipt }: { receipt: RouteReceipt }) {
   const costLabel =
     receipt.cost_kind === "unavailable" || receipt.response_cost_usd == null
-      ? "成本待网关结算"
+      ? "成本暂不可用"
       : `$${receipt.response_cost_usd.toFixed(6)} ${
           receipt.cost_kind === "estimated" ? "估算" : "实际"
         }`;
   const tokenTotal = receipt.tokens?.total;
+  const compression = receipt.compression;
+  const savedPercent =
+    compression?.applied && compression.saved_ratio != null
+      ? Math.round(compression.saved_ratio * 100)
+      : 0;
+  const engineLabel =
+    receipt.engine === "native"
+      ? "本地调度"
+      : receipt.engine === "shadow"
+        ? "对照观察"
+        : receipt.engine
+          ? "稳定调度"
+          : null;
 
   return (
     <div className="mt-4 border-t border-white/10 pt-3 text-xs">
       <div className="flex flex-wrap items-center gap-2">
         <span className="font-semibold text-hire-100">路由回执</span>
+        {engineLabel ? (
+          <span className="rounded-full border border-hire-300/20 bg-hire-300/10 px-2 py-1 text-hire-100">
+            {engineLabel}
+          </span>
+        ) : null}
         {receipt.provider ? (
           <span className="rounded-full border border-white/10 bg-white/[0.055] px-2 py-1 text-slate-300">
             {receipt.provider}
@@ -507,6 +569,54 @@ function RouteReceiptCard({ receipt }: { receipt: RouteReceipt }) {
           </dd>
         </div>
       </dl>
+      {receipt.reason_codes?.includes("output_limit_reached") ? (
+        <p className="mt-2 rounded-lg border border-amber-300/20 bg-amber-300/10 px-3 py-2 text-amber-100">
+          回答已达到最大输出长度。内容可能不完整，可在“高级参数”中调高最大输出 Token 后重试。
+        </p>
+      ) : null}
+      {savedPercent > 0 ? (
+        <p className="mt-2 text-emerald-200">
+          已节省约 {savedPercent}% 上下文，回答内容保持完整。
+        </p>
+      ) : compression?.fallback_reason ? (
+        <p className="mt-2 text-slate-300">
+          为保证内容完整，本次未压缩。
+        </p>
+      ) : null}
+      {receipt.reason_codes?.length ||
+      compression?.stages?.length ||
+      receipt.budget?.status ? (
+        <details className="mt-2 text-slate-400">
+          <summary className="cursor-pointer select-none text-slate-300">
+            查看运行详情
+          </summary>
+          <div className="mt-2 space-y-1 rounded-lg border border-white/10 bg-black/10 p-2">
+            {receipt.reason_codes?.length ? (
+              <p>
+                选择依据：
+                {receipt.reason_codes
+                  .map((code) => routeReasonLabels[code] ?? code)
+                  .join("；")}
+              </p>
+            ) : null}
+            {compression?.stages?.length ? (
+              <p>
+                优化阶段：
+                {compression.stages
+                  .map((stage) => compressionStageLabels[stage] ?? stage)
+                  .join("、")}
+              </p>
+            ) : null}
+            {receipt.budget?.status ? (
+              <p>
+                预算状态：
+                {budgetStatusLabels[receipt.budget.status] ??
+                  receipt.budget.status}
+              </p>
+            ) : null}
+          </div>
+        </details>
+      ) : null}
     </div>
   );
 }
@@ -634,7 +744,6 @@ export default function ChatPage() {
   const decodedModelId = useMemo(() => decodeModelId(modelId), [modelId]);
   const isFederationRoute = decodedModelId === federationRouteId;
   const isOmniAutoRoute =
-    searchParams.get("gateway") === "omniroute" &&
     (decodedModelId === "auto" || decodedModelId.startsWith("auto/"));
   const model = useMemo(
     () => {
@@ -674,6 +783,12 @@ export default function ChatPage() {
   const maxTokenLimit = model
     ? Math.min(128000, Math.max(1, model.context_length))
     : 2048;
+  const defaultMaxTokens = isOmniAutoRoute ? 8192 : 2048;
+  const advancedParamsKey = model
+    ? advancedParamsStorageKey(
+        isOmniAutoRoute ? `smart-router-v2:${decodedModelId}` : model.id,
+      )
+    : "";
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState("");
   const [uploadedImages, setUploadedImages] = useState<UploadedImage[]>([]);
@@ -710,11 +825,14 @@ export default function ChatPage() {
   const [agentDefaultModelNotice, setAgentDefaultModelNotice] = useState("");
   const [routingMode, setRoutingMode] = useState<
     "fast" | "balanced" | "quality" | "cheap" | "reliable" | "offline"
-  >("balanced");
+  >(() => defaultRoutingMode(decodedModelId));
   const [routingBudget, setRoutingBudget] = useState("");
   const [routingBudgetFallback, setRoutingBudgetFallback] = useState<
     "strict" | "cheapest"
   >("cheapest");
+  const [compressionMode, setCompressionMode] = useState<
+    "auto" | "off" | "standard" | "strong"
+  >("auto");
   const routingSessionId = useMemo(
     () => (isOmniAutoRoute ? getOrCreateRoutingSessionId(decodedModelId) : ""),
     [decodedModelId, isOmniAutoRoute],
@@ -758,7 +876,8 @@ export default function ChatPage() {
     if (!isOmniAutoRoute) return;
     setRuntimeToolsEnabled(false);
     setSelectedKnowledgeBaseId("");
-  }, [isOmniAutoRoute]);
+    setRoutingMode(defaultRoutingMode(decodedModelId));
+  }, [decodedModelId, isOmniAutoRoute]);
 
   useEffect(() => {
     if (window.matchMedia("(min-width: 1024px)").matches) {
@@ -836,8 +955,8 @@ export default function ChatPage() {
   useEffect(() => {
     if (!model) return;
 
-    const defaults = defaultAdvancedParams(maxTokenLimit);
-    const raw = window.localStorage.getItem(advancedParamsStorageKey(model.id));
+    const defaults = defaultAdvancedParams(maxTokenLimit, defaultMaxTokens);
+    const raw = window.localStorage.getItem(advancedParamsKey);
     if (!raw) {
       setAdvancedParams(defaults);
       return;
@@ -856,7 +975,7 @@ export default function ChatPage() {
     } catch {
       setAdvancedParams(defaults);
     }
-  }, [maxTokenLimit, model]);
+  }, [advancedParamsKey, defaultMaxTokens, maxTokenLimit, model]);
 
   async function addImageFiles(files: File[]) {
     const imageFiles = files.filter((file) => file.type.startsWith("image/"));
@@ -1084,6 +1203,7 @@ export default function ChatPage() {
     }
 
     let pendingAssistantDelta = "";
+    let receivedAssistantDelta = false;
     const flushAssistantDelta = () => {
       if (!pendingAssistantDelta) return;
       const delta = pendingAssistantDelta;
@@ -1147,7 +1267,7 @@ export default function ChatPage() {
       await fetchChatStream({
         modelId: isOmniAutoRoute ? decodedModelId : model.id,
         messages: apiMessages,
-        gateway: isOmniAutoRoute ? "omniroute" : "default",
+        gateway: isOmniAutoRoute ? "auto" : "default",
         routing: isOmniAutoRoute
           ? {
               session_id: routingSessionId,
@@ -1159,6 +1279,7 @@ export default function ChatPage() {
                   : routingBudgetFallback,
             }
           : undefined,
+        compression: isOmniAutoRoute ? { mode: compressionMode } : undefined,
         temperature: advancedParams.temperature,
         topP: advancedParams.topP,
         maxTokens: advancedParams.maxTokens,
@@ -1197,6 +1318,7 @@ export default function ChatPage() {
             }
           : undefined,
         onDelta: (delta) => {
+          receivedAssistantDelta = true;
           pendingAssistantDelta += delta;
           assistantUiUpdate.schedule();
         },
@@ -1233,8 +1355,12 @@ export default function ChatPage() {
           item.id === assistantId
             ? {
                 ...item,
-                content: "抱歉，模型暂时无法响应，请稍后重试。",
-                displayContent: "抱歉，模型暂时无法响应，请稍后重试。",
+                content: receivedAssistantDelta
+                  ? item.content
+                  : "抱歉，模型暂时无法响应，请稍后重试。",
+                displayContent: receivedAssistantDelta
+                  ? item.displayContent
+                  : "抱歉，模型暂时无法响应，请稍后重试。",
               }
             : item,
         ),
@@ -1299,19 +1425,19 @@ export default function ChatPage() {
     };
 
     setAdvancedParams(normalizedParams);
-    if (model) {
+    if (advancedParamsKey) {
       window.localStorage.setItem(
-        advancedParamsStorageKey(model.id),
+        advancedParamsKey,
         JSON.stringify(normalizedParams),
       );
     }
   }
 
   function resetAdvancedParams() {
-    const defaults = defaultAdvancedParams(maxTokenLimit);
+    const defaults = defaultAdvancedParams(maxTokenLimit, defaultMaxTokens);
     setAdvancedParams(defaults);
-    if (model) {
-      window.localStorage.removeItem(advancedParamsStorageKey(model.id));
+    if (advancedParamsKey) {
+      window.localStorage.removeItem(advancedParamsKey);
     }
   }
 
@@ -1342,7 +1468,7 @@ export default function ChatPage() {
   const supportsImageInput =
     omniRouteSupportsImage || model.input_modalities.includes("image");
   const providerName = isOmniAutoRoute
-    ? "OmniRoute"
+    ? "智能调度"
     : deriveProviderFromModel(model);
   const displayCandidateName = isOmniAutoRoute
     ? `${decodedModelId} 智能路由`
@@ -1350,7 +1476,7 @@ export default function ChatPage() {
     ? "模型联邦智能路由器"
     : agentInterview?.agentName ?? model.name;
   const displayCandidateDescription = isOmniAutoRoute
-    ? "OmniRoute 会按当前模式、预算和渠道健康状态选择实际回答模型，完成后展示路由回执。"
+    ? "模镜会按当前模式、预算和服务健康状态选择实际回答模型，完成后展示路由回执。"
     : isFederationRoute
     ? "智能路由功能正在紧锣密鼓开发中，当前将使用默认模型为您服务。"
     : agentInterview?.expertise ?? model.description;
@@ -1383,7 +1509,7 @@ export default function ChatPage() {
               ) : null}
               {isOmniAutoRoute ? (
                 <span className="rounded-full border border-brand-300/30 bg-brand-300/10 px-3 py-1.5 text-xs font-semibold text-brand-100">
-                  OmniRoute · {decodedModelId}
+                  智能调度 · {decodedModelId}
                 </span>
               ) : isFederationRoute ? (
                 <span className="rounded-full border border-hire-300/30 bg-hire-300/10 px-3 py-1.5 text-xs font-semibold text-hire-100">
@@ -1482,7 +1608,7 @@ export default function ChatPage() {
                 <div>
                   <p className="text-xs font-semibold text-brand-100">路由控制</p>
                   <p className="mt-1 text-xs leading-5 text-slate-400">
-                    设置只作用于本次 OmniRoute 会话。
+                    设置只作用于本次智能调度会话。
                   </p>
                 </div>
                 <label className="block text-xs font-semibold text-slate-300">
@@ -1540,6 +1666,28 @@ export default function ChatPage() {
                   >
                     <option value="cheapest">改用最低成本候选</option>
                     <option value="strict">严格拒绝并返回 402</option>
+                  </select>
+                </label>
+                <label className="block text-xs font-semibold text-slate-300">
+                  上下文优化
+                  <select
+                    className="mt-1 w-full rounded-lg border border-white/10 bg-ink-950/85 px-3 py-2 text-xs text-white outline-none transition focus:border-brand-300/50 focus:ring-4 focus:ring-brand-300/10"
+                    disabled={isSending}
+                    onChange={(event) =>
+                      setCompressionMode(
+                        event.target.value as
+                          | "auto"
+                          | "off"
+                          | "standard"
+                          | "strong",
+                      )
+                    }
+                    value={compressionMode}
+                  >
+                    <option value="auto">自动推荐</option>
+                    <option value="off">关闭</option>
+                    <option value="standard">标准</option>
+                    <option value="strong">强力</option>
                   </select>
                 </label>
               </div>
@@ -1629,7 +1777,7 @@ export default function ChatPage() {
                     </h2>
                     <p className="mt-2 max-w-md text-sm leading-6 text-slate-400">
                       {isOmniAutoRoute
-                        ? "描述任务后，OmniRoute 会选择实际模型，并在回答末尾给出供应方、Token、成本与请求编号。"
+                        ? "描述任务后，模镜会选择实际模型，并在回答末尾给出服务、Token、成本与请求编号。"
                         : isFederationRoute
                         ? "先由默认模型代班回答。后续路由上线后，会自动按任务挑选更合适的候选人。"
                         : agentInterview

--- a/client/src/pages/SystemSettingsPage.tsx
+++ b/client/src/pages/SystemSettingsPage.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import PageContainer from "../components/PageContainer";
+import ModelServiceConnections from "../components/settings/ModelServiceConnections";
+import SmartRoutingSettings from "../components/settings/SmartRoutingSettings";
 
 const DEFAULT_NEWAPI_WEB_URL = "http://localhost:3000";
 
@@ -35,13 +37,16 @@ export default function SystemSettingsPage() {
       <header className="mb-6 overflow-hidden rounded-lg border border-hire-300/20 bg-[linear-gradient(135deg,rgba(67,20,7,0.74),rgba(6,9,22,0.92)_52%,rgba(8,51,68,0.48))] p-6 shadow-prism">
         <p className="text-sm font-semibold text-hire-100">系统设置</p>
         <h1 className="mt-3 text-3xl font-semibold text-white sm:text-4xl">
-          外部网关与集成管理
+          模型服务与智能调度
         </h1>
         <p className="mt-3 max-w-3xl text-sm leading-6 text-slate-300">
-          工作流默认使用模镜自研经典画布。newAPI 控制台在这里以内嵌方式接入，
-          用于统一管理模型渠道、API Key 和调用策略，让对话与工作流可以共享同一层网关。
+          在这里完成模型服务连接、智能调度和上下文优化。日常使用无需理解底层网关；
+          newAPI 控制台仍作为高级渠道管理入口保留。
         </p>
       </header>
+
+      <ModelServiceConnections />
+      <SmartRoutingSettings />
 
       <section className="overflow-hidden rounded-lg border border-white/10 bg-ink-950/82 shadow-prism">
         <div className="flex flex-col gap-3 border-b border-white/10 bg-white/[0.035] px-4 py-4 sm:flex-row sm:items-center sm:justify-between">

--- a/client/src/utils/fetchChatStream.ts
+++ b/client/src/utils/fetchChatStream.ts
@@ -25,7 +25,7 @@ export interface ChatRuntimeMeta {
   toolMode: string;
 }
 
-export type ChatGateway = "default" | "omniroute";
+export type ChatGateway = "default" | "auto" | "omniroute";
 
 export interface ChatRoutingOptions {
   session_id?: string;
@@ -34,11 +34,17 @@ export interface ChatRoutingOptions {
   budget_fallback?: "strict" | "cheapest";
 }
 
+export interface ChatCompressionOptions {
+  mode?: "auto" | "off" | "standard" | "strong";
+}
+
 export interface RouteReceipt {
   requested_model: string;
   actual_model?: string | null;
   provider?: string | null;
   strategy?: string | null;
+  engine?: "sidecar" | "shadow" | "native_canary" | "native" | string | null;
+  reason_codes?: string[];
   latency_ms?: number | null;
   tokens?: {
     input?: number | null;
@@ -50,6 +56,22 @@ export interface RouteReceipt {
   fallback_attempts?: number;
   cache_hit?: boolean | null;
   request_id?: string | null;
+  budget?: {
+    limit_usd?: number | null;
+    mode?: "strict" | "cheapest" | null;
+    status?: string | null;
+  };
+  compression?: {
+    applied?: boolean;
+    profile?: "auto" | "off" | "standard" | "strong" | string;
+    original_tokens?: number | null;
+    final_tokens?: number | null;
+    saved_tokens?: number | null;
+    saved_ratio?: number | null;
+    fidelity_status?: string | null;
+    fallback_reason?: string | null;
+    stages?: string[];
+  };
   version?: string | null;
 }
 
@@ -58,6 +80,7 @@ interface FetchChatStreamOptions {
   messages: ChatApiMessage[];
   gateway?: ChatGateway;
   routing?: ChatRoutingOptions;
+  compression?: ChatCompressionOptions;
   temperature?: number;
   topP?: number;
   maxTokens?: number;
@@ -205,6 +228,26 @@ function readStreamError(payload: unknown) {
   return "";
 }
 
+function readFinishReason(payload: unknown) {
+  if (!payload || typeof payload !== "object" || !("choices" in payload)) {
+    return "";
+  }
+  const choices = payload.choices;
+  if (!Array.isArray(choices)) return "";
+  for (const choice of choices) {
+    if (
+      choice &&
+      typeof choice === "object" &&
+      "finish_reason" in choice &&
+      typeof choice.finish_reason === "string" &&
+      choice.finish_reason
+    ) {
+      return choice.finish_reason;
+    }
+  }
+  return "";
+}
+
 function handleSseEvent(
   eventText: string,
   onDelta: (text: string) => void,
@@ -256,6 +299,7 @@ function handleSseEvent(
 
     const delta = readDelta(payload);
     if (delta) onDelta(delta);
+    if (readFinishReason(payload)) onMessageEnd?.();
   }
 }
 
@@ -264,6 +308,7 @@ export async function fetchChatStream({
   messages,
   gateway = "default",
   routing,
+  compression,
   temperature = 0.7,
   topP,
   maxTokens = 2048,
@@ -287,6 +332,7 @@ export async function fetchChatStream({
       messages,
       gateway,
       routing,
+      compression,
       temperature,
       top_p: topP,
       max_tokens: maxTokens,
@@ -369,5 +415,9 @@ export async function fetchChatStream({
       throw error;
     }
   }
-  emitMessageEnd();
+  if (!messageEnded) {
+    throw new Error(
+      "流式响应在完成标记到达前中断。已保留收到的内容，请检查模型服务连接后重试。",
+    );
+  }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -151,6 +151,12 @@ services:
       OMNIROUTE_API_KEY: ${OMNIROUTE_API_KEY:-}
       MODEL_ROUTER_DEFAULT: ${MODEL_ROUTER_DEFAULT:-newapi}
       OMNIROUTE_BUDGET_HEADERS_ENABLED: ${OMNIROUTE_BUDGET_HEADERS_ENABLED:-false}
+      MODEL_ROUTER_ENGINE: ${MODEL_ROUTER_ENGINE:-}
+      MODEL_ROUTER_CANARY_PERCENT: ${MODEL_ROUTER_CANARY_PERCENT:-0}
+      MODEL_ROUTER_TENANT_ID: ${MODEL_ROUTER_TENANT_ID:-local}
+      MODEL_ROUTER_ALLOW_NATIVE_OVERRIDE: ${MODEL_ROUTER_ALLOW_NATIVE_OVERRIDE:-false}
+      MODEL_ROUTER_STORAGE_DIR: /app/model_router/storage
+      MODELMIRROR_DEFAULT_TENANT_ID: ${MODELMIRROR_DEFAULT_TENANT_ID:-local}
       RAG_STORAGE_DIR: /app/rag/storage
       RAG_UPLOAD_DIR: /app/rag/uploads
       CHROMA_DB_PATH: /app/rag/storage/chroma_db
@@ -177,6 +183,7 @@ services:
       - ${MODELMIRROR_DATA_ROOT:-.}/server/xpert_runtime/storage:/app/xpert_runtime/storage
       - ${MODELMIRROR_DATA_ROOT:-.}/server/datax/storage:/app/datax/storage
       - ${MODELMIRROR_DATA_ROOT:-.}/server/toolsets/storage:/app/toolsets/storage
+      - ${MODELMIRROR_DATA_ROOT:-.}/server/model_router/storage:/app/model_router/storage
       - sandbox_socket:/run/modelmirror-sandbox
       - sandbox_workspaces:/app/sandbox-workspaces:ro
       - browser_socket:/run/modelmirror-browser

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -34,6 +34,9 @@
 | Fusion | Model Fusion | 多模型并行回答后由裁判模型综合。 | 专家团。 |
 | AI Team | AI Team | 多智能体串行或协作处理任务。 | 专家团。 |
 | 自动路由 | Auto Routing | 根据用户需求匹配最合适的智能体。 | `/api/route-agent`。 |
+| 智能调度 | Model Routing | 在满足权限、能力、预算和健康约束后，为 `auto/*` 选择实际回答模型。 | `/chat/auto`、`server/model_router/`。 |
+| 上下文优化 | Context Optimization | 在保护系统提示、最新问题和结构化内容的前提下，减少重复的历史、RAG 与工具内容。 | `server/context_engine/`、聊天路由回执。 |
+| 本地试运行 | Native Canary | 按稳定会话哈希逐步启用原生调度，支持随时回到稳定模式。 | 设置页智能调度。 |
 | Prompt Engineering | Prompt Engineering | 设计高质量模型输入的方法。 | 提示词助手、超级提示词模式。 |
 | localStorage | localStorage | 浏览器本地键值存储。 | 偏好模型、高级参数、工作流草稿。 |
 | FastAPI | FastAPI | Python Web 框架。 | 后端 API 服务。 |

--- a/docs/MODEL_ROUTER_NATIVE.md
+++ b/docs/MODEL_ROUTER_NATIVE.md
@@ -1,0 +1,238 @@
+# 原生智能调度与上下文优化
+
+最后更新日期：2026-07-28
+
+## 当前状态
+
+ModelMirror 已完成从 OmniRoute 侧车向本地原生能力迁移的阶段 0–4：
+
+- 原生模型服务连接、目录归一、健康状态和加密凭据存储。
+- 六种用户策略、硬约束过滤、稳定会话灰度、有限重试、熔断与 LKGP。
+- Chat、RAG、工具输出和 Xpert Runtime 共享同一上下文优化内核。
+- 严格预算调用前预留、最终 usage 结算、脱敏决策和压缩审计。
+- 设置页提供普通用户可理解的连接向导、策略、上下文优化和折叠诊断区。
+
+阶段 5 尚未完成，也不得通过修改数据伪造完成。只有同时达到至少 500 次
+原生请求、连续观察 14 天、无 P0/P1、完成全部故障演练并通过人工验收，
+才能把本地原生调度设为默认。当前默认和紧急回退路径仍是侧车；普通模型
+聊天的 default/newAPI 路径始终独立。
+
+## 2026-07-28 冻结决定
+
+当前实现只获得初步本地验收，正式定级仍是“实验性原生候选”，不得表述为
+稳定原生路由。OmniRoute 行为对齐进度冻结在本文记录的阶段 0–4 基线：
+
+- 暂停新增原生路由、压缩、连接、预算或审计能力，不继续扩大对齐范围。
+- 允许修复已发现的正确性、安全性、兼容性和数据完整性问题，并必须补充
+  对应回归测试；缺陷修复不得借机改变评分权重或产品契约。
+- 保留并维护 OmniRoute 侧车、`sidecar` 紧急回退和独立 default/newAPI
+  路径，不删除镜像 profile、适配器、迁移记录或既有回退数据。
+- `native` 默认门禁保持锁定。达到 500 次请求和 14 天仅是必要条件，不会
+  自动获得稳定定级；仍需全面人工检验、故障修复和明确的恢复实施决定。
+- 冻结期间的新迭代必须与 OmniRoute/原生迁移模块解耦，不得依赖
+  `model_router` 的实验行为，也不得把实验入口替换为产品稳定入口。
+
+只有项目维护人明确解除冻结后，才允许继续原生增量、提高灰度或讨论切换
+本地默认。解除冻结应另建任务，重新检查基线、风险、回退和验收证据。
+
+## 架构边界
+
+```text
+Chat / RAG / Xpert Runtime
+        |
+        +-- context_engine（共享、确定性保护与可选旧对话摘要）
+        |
+        +-- gateway=default ------> newAPI / OpenRouter（稳定路径）
+        |
+        +-- gateway=auto ---------> model_router policy
+                                      | sidecar
+                                      | shadow（只计算，不二次调用）
+                                      | native_canary（稳定会话哈希）
+                                      ` native（达标后）
+```
+
+- `server/model_router/` 只依赖 ModelMirror 的 FastAPI/httpx/Pydantic/SQLite
+  边界，不引入 OmniRoute 控制台、数据库或私有 workspace 包。
+- `server/context_engine/` 是聊天、RAG、工具和 Xpert Runtime 的共享内核。
+- `server/main.py` 只保留请求编排和 SSE 兼容；评分、持久化、连接和压缩
+  逻辑不得继续堆入该文件。
+- 所有连接、策略、候选统计、决策和压缩记录都携带 `tenant_id`。首期固定
+  为 `local`，仓储接口不向调用方暴露 SQLite 细节。
+
+## 用户契约
+
+普通用户只看到：
+
+- **模型服务连接**：选择服务、填写地址和密钥、测试、保存、停用或恢复。
+- **智能调度**：均衡、速度、质量、成本、稳定、本地优先。
+- **上下文优化**：自动推荐、关闭、标准、强力。
+- **运行诊断**：脱敏后的成功率、空响应率、模型与连接、迁移进度。
+
+普通界面不显示 sidecar、candidate、breaker、LKGP 等内部术语。后端错误
+只给出“密钥无效”“地址不可达”“没有可调用模型”等行动建议，不返回上游
+完整错误体。连接密钥只在后端加密保存，列表、日志和诊断接口只返回摘要。
+
+`/chat/auto` 是统一入口。历史
+`/chat/auto?gateway=omniroute` 仍会进入同一 auto 契约，但普通页面不再生成
+该参数。`gateway=omniroute` 仅保留为诊断兼容入口。
+
+## 路由规则
+
+六种策略固定为：
+
+| 用户策略 | 后端 ID | 结果导向 |
+| --- | --- | --- |
+| 均衡推荐 | `auto` | 综合质量、速度与费用 |
+| 速度优先 | `fast` | 提高延迟与可用性权重 |
+| 质量优先 | `quality` | 提高任务匹配与模型档位权重 |
+| 成本优先 | `cheap` | 优先可可靠估价的低成本候选 |
+| 稳定优先 | `reliable` | 优先本会话近期成功候选（LKGP） |
+| 本地优先 | `offline` | 优先本地可用性与充足配额 |
+
+评分因子、默认权重和模式包来自固定 OmniRoute
+`release/v3.8.49` / commit `36f8fd10052f` 的行为审计；ModelMirror 使用
+Python 等价改写，没有复制上游控制台、存储或运行架构。固定向量位于
+`server/model_router/fixtures/omniroute-v3.8.49-routing.json`。
+
+硬过滤顺序覆盖租户、连接启用、凭据、熔断、输入输出模态、工具能力、
+上下文长度和严格预算。能力、权限和预算永不 fail-open；非必要类别偏好
+可以回到完整合格池。失败最多切换两个候选，且只允许在尚未向用户输出正文
+前切换。空流、零 Token 且无正文、只有 `[DONE]` 均按失败处理。
+
+熔断按租户、连接和模型隔离：
+
+- 连续三次失败进入 `open`。
+- 冷却后进入 `half_open`，只作为探测候选。
+- 成功关闭熔断；失败延长冷却时间，最长 30 分钟。
+
+Shadow 只保存原生决策，不发送第二次模型请求，不增加费用。
+`auto` 会用最新用户消息做本地、确定性的高置信任务标签判断；只有明确的
+代码、报错、证明或多步推理信号才增加对应类别偏好，不发送分类模型请求，
+也不保存原始消息。无明确标签时优先通用对话模型，避免代码、Embedding、
+Rerank 等专用模型因低价被误选；若没有通用候选则按软偏好规则回到完整
+合格池。`auto/coding` 等显式入口始终优先于该轻量判断。
+
+## 上下文优化
+
+自动模式在“预计输入 + 最大输出 + 5% 安全余量”达到模型上下文的 80%
+时启动，按以下顺序处理：
+
+1. 工具输出过滤与重复行折叠。
+2. 冗余语句和填充内容压缩。
+3. RAG 片段去重与跨消息重复内容折叠。
+4. 仍超阈值时，调用现有会话摘要能力压缩旧对话。
+
+系统提示、最新用户消息、工具 schema、代码块、JSON/XML、URL、引用标识
+和文件来源永不改写。每阶段都执行保真检查；结构损坏、关键标记缺失、
+节省不足 10% 或异常时回退原文。原文仍超出候选上限时返回 422，并建议
+减少附件、清理历史或选择更长上下文模型。
+
+路由回执 v2 只展示实际模型、连接、策略、成本种类、请求 ID、预算状态和
+压缩摘要。详细原因码与阶段数据默认折叠，不返回评分矩阵、密钥或完整
+Prompt。
+
+## 存储与预算
+
+SQLite 当前 schema 版本为 3，表固定为：
+
+- `router_connections`
+- `router_policies`
+- `router_candidate_stats`
+- `router_decisions`
+- `compression_runs`
+
+连接凭据使用本机 Fernet 主密钥加密。主密钥与数据库均位于
+`server/model_router/storage/` 的持久目录并被 Git 忽略。未来迁移
+PostgreSQL 时替换 repository 实现，不改变 service 或 API 契约。
+
+严格预算要求候选同时提供输入和输出价格。调用前按预计输入与
+`max_tokens` 上限预留，最终 usage 到达后按实际输入/输出 Token 结算；
+失败则释放预留。缺失最终 usage 时不把费用展示为 0，也不标记为实际成本。
+
+## 配置
+
+```dotenv
+MODEL_ROUTER_TENANT_ID=local
+MODEL_ROUTER_CANARY_PERCENT=0
+MODEL_ROUTER_ALLOW_NATIVE_OVERRIDE=false
+```
+
+运行方式通常由设置页持久化。`MODEL_ROUTER_ENGINE` 默认应为空：
+
+```dotenv
+MODEL_ROUTER_ENGINE=
+```
+
+只有紧急回退时显式设置：
+
+```dotenv
+MODEL_ROUTER_ENGINE=sidecar
+```
+
+显式 `sidecar` 会只读覆盖数据库中的运行方式；删除或留空并重建后端后恢复
+设置页策略。`MODEL_ROUTER_ALLOW_NATIVE_OVERRIDE=true` 只供灾备或独立审计
+使用，常规环境必须为 `false`。
+
+## 阶段门禁与回退
+
+设置页允许：
+
+- 稳定模式：全部 auto 请求走侧车。
+- 对照观察：用户请求仍走侧车，同时记录一次本地决策。
+- 本地试运行：按 `session_id` 稳定哈希执行 0–100% 灰度。
+- 本地默认：500 次与 14 天自动门槛达标后才可选择，仍需人工验收。
+
+阶段升级必须依次完成空流、超时、429、5xx、预算、连接停用和服务重启
+演练。数据库记录是观察证据，不是自动批准；无 P0/P1、完整回归和人工
+验收属于独立手工门禁。
+
+紧急回退：
+
+1. 设置 `MODEL_ROUTER_ENGINE=sidecar`。
+2. 重新创建 `server`。
+3. 确认 `/api/router/status` 的 `engine` 为 `sidecar`。
+
+```powershell
+docker compose -p modelmirror up -d --force-recreate server
+curl.exe http://localhost:8000/api/router/status
+```
+
+回退不删除 SQLite、连接、策略、用量、压缩或侧车数据。若侧车本身不可用，
+普通模型聊天仍可用 `gateway=default` 走 newAPI/OpenRouter；auto 不做
+跨网关静默回退。
+
+## Harness 验收
+
+```powershell
+cd client
+npm.cmd run build
+
+python -m py_compile server/main.py
+python -m pytest server/tests/ -q
+
+docker compose -p modelmirror up -d --build --force-recreate
+curl.exe http://localhost:8000/api/health
+curl.exe http://localhost:8000/api/router/status
+curl.exe http://localhost:8000/api/models/catalog
+```
+
+人工验收至少覆盖：
+
+1. 首次连接无需理解网关术语，错误有下一步建议。
+2. `/chat/auto` 六种策略的选择原因可理解。
+3. 空流在正文输出前切换候选，输出后不切换；流式响应只有收到
+   `[DONE]` 或明确 `finish_reason` 才算完成。
+4. 严格预算超限返回 402，不发生跨网关回退。
+5. 长上下文回执显示节省比例；保真失败显示未压缩。
+6. 切回稳定模式后 default 聊天、RAG、Workflow、Expert Team 和 Xpert
+   Runtime 均无回归。
+
+### 流式截断经验
+
+- 推理模型的思考 Token 与正文共用输出上限。`auto/*` 使用独立设置键，
+  新会话默认上限为 8192，避免继承普通模型旧的 2048 配置。
+- `finish_reason=length` 是达到用户输出上限，不计为普通成功；回执显示
+  “回答达到最大输出长度”，用户可在高级参数中调整。
+- HTTP 流自然关闭不等于模型完成。缺失 `[DONE]` 和 `finish_reason` 时按
+  `stream_interrupted` 记录，保留已收到正文并提示重试，且不得在正文
+  已输出后静默切换候选。

--- a/docs/OMNIROUTE_INTEGRATION.md
+++ b/docs/OMNIROUTE_INTEGRATION.md
@@ -1,12 +1,18 @@
 # OmniRoute 侧车集成
 
-OmniRoute 作为可选路由侧车接入“模型招聘会”。默认聊天仍走
-newAPI/OpenRouter；只有显式选择 OmniRoute 模型或 `auto/*` 路由时才进入
-侧车。
+OmniRoute 作为可选路由侧车和回退路径接入“模型招聘会”。默认聊天仍走
+newAPI/OpenRouter；`auto/*` 的实际引擎由本地策略决定，可处于
+`sidecar → shadow → native_canary → native`。当前原生阶段 0–4 的实现、
+用户契约和门禁见 [MODEL_ROUTER_NATIVE.md](./MODEL_ROUTER_NATIVE.md)。
 
-侧车现在被定位为兼容层、能力验证环境和故障隔离边界，不再作为长期产品
-形态。后续路线由“持续加深侧车集成”调整为“从侧车验证逐步收敛到稳定的
-ModelMirror 本地原生实现”。
+> **进度冻结（2026-07-28）**：本地路由仅完成初步验收，尚未定级为稳定
+> 原生实现。暂停一切原生增量和新的 OmniRoute 行为对齐；仅继续缺陷修复
+> 与回归验证。侧车必须保留为兼容层、能力验证环境和故障隔离边界，
+> `native` 不得设为默认。冻结期间转向与本模块解耦的其他产品优化，后续
+> 是否继续原生化必须由项目维护人完成全面检验后明确决定。
+
+长期方向仍是从侧车验证逐步收敛到稳定的 ModelMirror 本地原生实现，但这
+只是保留的架构方向，不代表当前排期、稳定性承诺或删除侧车的授权。
 
 ## 供应链固定
 
@@ -160,10 +166,18 @@ OmniRoute 内建立多个边界清晰的候选组合；ModelMirror 不在本地�
 OmniRoute 运行、能纳入 ModelMirror 的测试与权限边界、对未来多租户没有
 结构性阻碍。否则只参考行为和接口，不复制实现。
 
-## 回退
+## 侧车回退
 
-设置 `OMNIROUTE_ENABLED=false`、`MODEL_ROUTER_DEFAULT=newapi`，重新创建
-后端，然后停止侧车：
+原生调度紧急回退时先显式设置 `MODEL_ROUTER_ENGINE=sidecar` 并重新创建
+后端。该值会只读覆盖 SQLite 策略，不删除任何原生记录：
+
+```powershell
+docker compose -p modelmirror up -d --force-recreate server
+curl.exe http://localhost:8000/api/router/status
+```
+
+若需要完全关闭 auto 侧车能力，再设置 `OMNIROUTE_ENABLED=false`、
+`MODEL_ROUTER_DEFAULT=newapi`，重新创建后端并停止侧车：
 
 ```powershell
 docker compose -p modelmirror --profile omniroute stop omniroute

--- a/docs/RAG_INTEGRATION.md
+++ b/docs/RAG_INTEGRATION.md
@@ -37,7 +37,7 @@ data_source -> image_understanding -> structured_processor
             -> embedding -> dual_index -> retrieval
 ```
 
-- PDF 页面由 `pypdfium2`/PDFium 渲染，图片由 Pillow 解码；上传校验真实格式、声明 MIME、损坏文件、10MB 文件限制和 40MP 解压像素限制。
+- PDF 页面由 `pypdfium2`/PDFium 渲染，图片由 Pillow 解码；上传校验真实格式、声明 MIME、损坏文件、10MB 文件限制和 40MP 解压像素限制。PDFium 原生渲染在进程内串行执行，避免多页 worker 同时渲染时的原生崩溃；后续 VLM 请求仍按配置并发。
 - `pdf_page_strategy=auto` 选择文字少于 80 字符或图片覆盖率至少 12% 的页面；画布预览可临时使用全页策略。
 - VLM 沿用现有 LLM Gateway/OpenRouter，不新增供应商 SDK。严格 JSON 输出转换为 OCR、视觉描述、表格和图表块，并继续经过 General/QA/Summary Processor。
 - Job 新增 `vision` stage，候选版本固定 `vision_profile`。逐页缓存以 source/config hash 隔离，失败页可重试，重启后可恢复。

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,8 @@
 | [DEPLOYMENT.md](./DEPLOYMENT.md) | 开发、生产、Docker、日志和运维建议。 |
 | [MCP_INTEGRATION.md](./MCP_INTEGRATION.md) | MCP stdio 集成、REST API、前端交互和测试指南。 |
 | [RAG_INTEGRATION.md](./RAG_INTEGRATION.md) | 本地 RAG 资料库、文档上传、向量检索、聊天引用和测试指南。 |
+| [MODEL_ROUTER_NATIVE.md](./MODEL_ROUTER_NATIVE.md) | 原生智能调度、上下文优化、灰度门禁、预算审计与回退指南。 |
+| [OMNIROUTE_INTEGRATION.md](./OMNIROUTE_INTEGRATION.md) | OmniRoute 侧车兼容层、供应链固定与历史经验教训。 |
 | [XPERT_RUNTIME.md](./XPERT_RUNTIME.md) | Xpert 发布、Goal、Handoff、文件记忆、Knowledge Execute 与运行契约。 |
 | [XPERT_APP_API.md](./XPERT_APP_API.md) | Xpert App 部署、分享、兼容 API、凭据、配额和回滚。 |
 | [XPERT_FREEZE.md](./XPERT_FREEZE.md) | Xpert 冻结快照、维护边界、延期项、技术债和回归入口。 |

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -39,6 +39,8 @@ COPY client_extension ./client_extension
 COPY office_addin ./office_addin
 COPY meta_agent ./meta_agent
 COPY omniroute ./omniroute
+COPY model_router ./model_router
+COPY context_engine ./context_engine
 
 EXPOSE 8000
 

--- a/server/context_engine/__init__.py
+++ b/server/context_engine/__init__.py
@@ -1,0 +1,30 @@
+"""Shared context optimization primitives.
+
+The package is intentionally small in phase 0. Deterministic compression and
+the Xpert Runtime adapter are introduced only after routing parity gates pass.
+"""
+
+from .core import (
+    CompressionProfile,
+    CompressionReport,
+    ContextOptimization,
+    deterministic_compress,
+    estimate_messages_tokens,
+    estimate_text_tokens,
+    optimize_context,
+    protected_markers,
+)
+
+CONTEXT_ENGINE_VERSION = "modelmirror-context-v1"
+
+__all__ = [
+    "CONTEXT_ENGINE_VERSION",
+    "CompressionProfile",
+    "CompressionReport",
+    "ContextOptimization",
+    "deterministic_compress",
+    "estimate_messages_tokens",
+    "estimate_text_tokens",
+    "optimize_context",
+    "protected_markers",
+]

--- a/server/context_engine/core.py
+++ b/server/context_engine/core.py
@@ -1,0 +1,559 @@
+from __future__ import annotations
+
+import json
+import math
+import re
+import time
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Literal
+
+
+CompressionProfile = Literal["auto", "off", "standard", "strong"]
+ModelTextCallback = Callable[[str, list[dict[str, Any]], int], Awaitable[str]]
+PersistSummaryCallback = Callable[[str, str, str | None], Awaitable[None]]
+
+_CJK_PATTERN = re.compile(r"[\u3400-\u9fff\uf900-\ufaff]")
+_URL_PATTERN = re.compile(r"https?://\S+", re.IGNORECASE)
+_CODE_FENCE_PATTERN = re.compile(r"```[\s\S]*?```")
+_XML_PATTERN = re.compile(r"<[A-Za-z][^>]*>[\s\S]*?</[A-Za-z][^>]*>")
+_CITATION_PATTERN = re.compile(
+    r"(?:\[[0-9]{1,4}\]|\[source:[^\]]+\]|\bcitation[_ -]?id\b|\bsource[_ -]?id\b)",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class CompressionReport:
+    applied: bool
+    profile: CompressionProfile
+    original_tokens: int
+    final_tokens: int
+    saved_tokens: int
+    saved_ratio: float
+    fidelity_status: Literal["passed", "not_needed", "fallback"]
+    fallback_reason: str | None
+    stages: tuple[str, ...]
+    duration_ms: float
+    summarized_messages: int = 0
+    reused_summary: bool = False
+    fits_context: bool = True
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "applied": self.applied,
+            "profile": self.profile,
+            "original_tokens": self.original_tokens,
+            "final_tokens": self.final_tokens,
+            "saved_tokens": self.saved_tokens,
+            "saved_ratio": self.saved_ratio,
+            "fidelity_status": self.fidelity_status,
+            "fallback_reason": self.fallback_reason,
+            "stages": list(self.stages),
+            "duration_ms": self.duration_ms,
+            "summarized_messages": self.summarized_messages,
+            "reused_summary": self.reused_summary,
+            "fits_context": self.fits_context,
+        }
+
+
+@dataclass(frozen=True)
+class ContextOptimization:
+    messages: list[dict[str, Any]]
+    report: CompressionReport
+
+
+def estimate_text_tokens(text: str) -> int:
+    """Conservative tokenizer-free estimate for mixed CJK and Latin text."""
+
+    if not text:
+        return 0
+    cjk_count = len(_CJK_PATTERN.findall(text))
+    non_cjk_count = max(0, len(text) - cjk_count)
+    return cjk_count + math.ceil(non_cjk_count / 4)
+
+
+def message_content_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    try:
+        return json.dumps(content, ensure_ascii=False, separators=(",", ":"))
+    except (TypeError, ValueError):
+        return str(content or "")
+
+
+def estimate_messages_tokens(messages: list[dict[str, Any]]) -> int:
+    return sum(
+        4 + estimate_text_tokens(message_content_text(message.get("content")))
+        for message in messages
+    )
+
+
+def _looks_like_json(text: str) -> bool:
+    stripped = text.strip()
+    if not stripped or stripped[0] not in "[{" or stripped[-1] not in "]}":
+        return False
+    try:
+        json.loads(stripped)
+    except (json.JSONDecodeError, ValueError):
+        return False
+    return True
+
+
+def protected_markers(text: str) -> tuple[str, ...]:
+    markers: list[str] = []
+    markers.extend(_CODE_FENCE_PATTERN.findall(text))
+    markers.extend(_URL_PATTERN.findall(text))
+    markers.extend(_XML_PATTERN.findall(text))
+    markers.extend(_CITATION_PATTERN.findall(text))
+    if _looks_like_json(text):
+        markers.append(text)
+    return tuple(markers)
+
+
+def _is_structured_or_referenced(text: str) -> bool:
+    return bool(protected_markers(text))
+
+
+def _latest_user_index(messages: list[dict[str, Any]]) -> int | None:
+    return next(
+        (
+            index
+            for index in range(len(messages) - 1, -1, -1)
+            if messages[index].get("role") == "user"
+        ),
+        None,
+    )
+
+
+def _is_rag_message(message: dict[str, Any]) -> bool:
+    metadata = message.get("metadata")
+    metadata = metadata if isinstance(metadata, dict) else {}
+    return bool(
+        message.get("rag_context")
+        or str(message.get("name") or "").lower() == "rag_context"
+        or str(metadata.get("kind") or "").lower() in {"rag", "rag_context"}
+    )
+
+
+def _is_tool_output(message: dict[str, Any]) -> bool:
+    return bool(
+        message.get("role") == "tool"
+        or message.get("tool_call_id")
+        or message.get("tool_output")
+    )
+
+
+def _dedupe_plain_lines(text: str) -> str:
+    lines = text.splitlines()
+    if len(lines) < 3:
+        return text
+    seen: set[str] = set()
+    result: list[str] = []
+    for line in lines:
+        normalized = " ".join(line.split()).strip().lower()
+        if normalized and len(normalized) >= 24 and normalized in seen:
+            continue
+        if normalized:
+            seen.add(normalized)
+        result.append(line.rstrip())
+    return "\n".join(result)
+
+
+def _collapse_repeated_sentences(text: str) -> str:
+    parts = re.split(r"(?<=[。！？.!?])(\s+)", text)
+    if len(parts) < 3:
+        return text
+    result: list[str] = []
+    last_sentence = ""
+    for index, part in enumerate(parts):
+        if index % 2 == 1:
+            if result:
+                result.append(part)
+            continue
+        normalized = " ".join(part.split()).strip().lower()
+        if normalized and normalized == last_sentence and len(normalized) >= 16:
+            if result and result[-1].isspace():
+                result.pop()
+            continue
+        if normalized:
+            last_sentence = normalized
+        result.append(part)
+    return "".join(result)
+
+
+def _dedupe_rag_blocks(text: str) -> str:
+    blocks = re.split(r"\n\s*\n", text)
+    if len(blocks) < 2:
+        return text
+    seen: set[str] = set()
+    result: list[str] = []
+    for block in blocks:
+        normalized = " ".join(block.split()).strip().lower()
+        if normalized and normalized in seen:
+            continue
+        if normalized:
+            seen.add(normalized)
+        result.append(block.strip())
+    return "\n\n".join(result)
+
+
+def deterministic_compress(
+    messages: list[dict[str, Any]],
+    *,
+    max_tool_output_chars: int,
+    strength: Literal["standard", "strong"],
+) -> tuple[list[dict[str, Any]], tuple[str, ...]]:
+    latest_user = _latest_user_index(messages)
+    result: list[dict[str, Any]] = []
+    stages: list[str] = []
+    seen_message_content: set[str] = set()
+    for index, message in enumerate(messages):
+        copied = dict(message)
+        content = copied.get("content")
+        if not isinstance(content, str):
+            result.append(copied)
+            continue
+        protected = (
+            copied.get("role") == "system"
+            or index == latest_user
+            or _is_structured_or_referenced(content)
+        )
+        if protected:
+            result.append(copied)
+            continue
+
+        prepared = content
+        if (
+            _is_tool_output(copied)
+            and len(prepared) > max_tool_output_chars
+            and "[工具输出已折叠]" not in prepared
+        ):
+            tail_chars = max(120, max_tool_output_chars // 5)
+            head_chars = max_tool_output_chars - tail_chars
+            prepared = (
+                prepared[:head_chars].rstrip()
+                + "\n[工具输出已折叠]\n"
+                + prepared[-tail_chars:].lstrip()
+            )
+            stages.append("tool_output_filtering")
+
+        line_deduped = _dedupe_plain_lines(prepared)
+        if line_deduped != prepared:
+            prepared = line_deduped
+            stages.append("redundancy_folding")
+
+        if strength == "strong":
+            sentence_deduped = _collapse_repeated_sentences(prepared)
+            if sentence_deduped != prepared:
+                prepared = sentence_deduped
+                stages.append("caveman_redundancy")
+
+        if _is_rag_message(copied):
+            rag_deduped = _dedupe_rag_blocks(prepared)
+            if rag_deduped != prepared:
+                prepared = rag_deduped
+                stages.append("rag_deduplication")
+
+        normalized_message = " ".join(prepared.split()).strip().lower()
+        if (
+            strength == "strong"
+            and normalized_message
+            and len(normalized_message) >= 80
+            and normalized_message in seen_message_content
+            and copied.get("role") in {"assistant", "tool"}
+        ):
+            prepared = "[重复内容已折叠，保留首次出现内容]"
+            stages.append("cross_message_deduplication")
+        elif normalized_message:
+            seen_message_content.add(normalized_message)
+        copied["content"] = prepared
+        result.append(copied)
+    return result, tuple(dict.fromkeys(stages))
+
+
+def _fidelity_ok(
+    original: list[dict[str, Any]],
+    prepared: list[dict[str, Any]],
+) -> bool:
+    latest_user = _latest_user_index(original)
+    prepared_contents = [
+        message_content_text(message.get("content")) for message in prepared
+    ]
+    for index, message in enumerate(original):
+        original_text = message_content_text(message.get("content"))
+        if message.get("role") == "system" or index == latest_user:
+            if original_text not in prepared_contents:
+                return False
+        for marker in protected_markers(original_text):
+            if not any(marker in content for content in prepared_contents):
+                return False
+    return True
+
+
+async def optimize_context(
+    messages: list[dict[str, Any]],
+    *,
+    profile: CompressionProfile = "auto",
+    max_context_tokens: int = 128_000,
+    max_output_tokens: int = 2_048,
+    safety_margin_tokens: int | None = None,
+    trigger_ratio: float = 0.8,
+    keep_recent_messages: int = 8,
+    max_tool_output_chars: int = 4_000,
+    summary_model_id: str = "",
+    summary_max_tokens: int = 1_500,
+    summarizer: ModelTextCallback | None = None,
+    existing_summary: str = "",
+    summary_boundary: str = "",
+    persist_summary: PersistSummaryCallback | None = None,
+) -> ContextOptimization:
+    started_at = time.perf_counter()
+    original = [dict(message) for message in messages]
+    original_tokens = estimate_messages_tokens(original)
+    margin = (
+        max(256, int(max_context_tokens * 0.05))
+        if safety_margin_tokens is None
+        else max(0, int(safety_margin_tokens))
+    )
+    required_tokens = original_tokens + max_output_tokens + margin
+    trigger = int(max_context_tokens * max(0.5, min(trigger_ratio, 0.95)))
+    if profile == "off":
+        return _result(
+            original,
+            original_tokens,
+            profile,
+            started_at,
+            fidelity_status="not_needed",
+            fallback_reason="disabled",
+            fits_context=required_tokens <= max_context_tokens,
+        )
+    if profile == "auto" and required_tokens < trigger:
+        return _result(
+            original,
+            original_tokens,
+            profile,
+            started_at,
+            fidelity_status="not_needed",
+            fits_context=True,
+        )
+
+    strength: Literal["standard", "strong"] = (
+        "strong" if profile == "strong" else "standard"
+    )
+    deterministic, stages = deterministic_compress(
+        original,
+        max_tool_output_chars=max_tool_output_chars,
+        strength=strength,
+    )
+    deterministic_tokens = estimate_messages_tokens(deterministic)
+    deterministic_savings = (
+        (original_tokens - deterministic_tokens) / original_tokens
+        if original_tokens
+        else 0.0
+    )
+    if deterministic_savings < 0.10:
+        deterministic = original
+        deterministic_tokens = original_tokens
+        stages = ()
+
+    final_messages = deterministic
+    summarized_messages = 0
+    reused_summary = False
+    fallback_reason: str | None = None
+    current_required = deterministic_tokens + max_output_tokens + margin
+    if current_required > trigger:
+        latest_user = _latest_user_index(deterministic)
+        protected_indices = {
+            index
+            for index, message in enumerate(deterministic)
+            if message.get("role") == "system"
+            or index == latest_user
+            or _is_structured_or_referenced(
+                message_content_text(message.get("content"))
+            )
+        }
+        non_system_indices = [
+            index
+            for index, message in enumerate(deterministic)
+            if message.get("role") != "system"
+        ]
+        recent_indices = set(non_system_indices[-max(1, keep_recent_messages) :])
+        retain_indices = protected_indices | recent_indices
+        omitted_indices = [
+            index
+            for index in non_system_indices
+            if index not in retain_indices
+        ]
+        if existing_summary and summary_boundary:
+            boundary_index = next(
+                (
+                    index
+                    for index in omitted_indices
+                    if str(deterministic[index].get("message_id") or "")
+                    == summary_boundary
+                ),
+                None,
+            )
+            if boundary_index is not None:
+                omitted_indices = [
+                    index for index in omitted_indices if index > boundary_index
+                ]
+            elif any(
+                str(deterministic[index].get("message_id") or "")
+                == summary_boundary
+                for index in retain_indices
+            ):
+                omitted_indices = []
+
+        summary = existing_summary.strip()
+        if omitted_indices and summarizer is not None:
+            source_text = "\n\n".join(
+                f"{str(deterministic[index].get('role') or 'unknown')}: "
+                f"{message_content_text(deterministic[index].get('content'))}"
+                for index in omitted_indices
+            )
+            summary_prompt = (
+                "Summarize older conversation context. Preserve decisions, "
+                "constraints, identifiers, unfinished tasks and user preferences. "
+                "Do not invent facts and do not rewrite quoted code or references.\n\n"
+                + (f"Existing summary:\n{summary}\n\n" if summary else "")
+                + f"Older messages:\n{source_text}"
+            )
+            try:
+                summary = (
+                    await summarizer(
+                        summary_model_id,
+                        [{"role": "user", "content": summary_prompt}],
+                        summary_max_tokens,
+                    )
+                ).strip()
+            except Exception:
+                fallback_reason = "summary_failed"
+            if summary:
+                summarized_messages = len(omitted_indices)
+                stages = (*stages, "history_summary")
+                if persist_summary is not None:
+                    try:
+                        boundary = (
+                            str(
+                                deterministic[omitted_indices[-1]].get(
+                                    "message_id"
+                                )
+                                or ""
+                            )
+                            or None
+                        )
+                        await persist_summary(
+                            summary,
+                            summary_model_id,
+                            boundary,
+                        )
+                    except Exception:
+                        fallback_reason = "summary_persistence_failed"
+        elif summary:
+            reused_summary = True
+        elif omitted_indices:
+            fallback_reason = "summary_unavailable"
+
+        if summary:
+            summary_message = {
+                "role": "system",
+                "content": f"Conversation summary (derived):\n{summary}",
+                "metadata": {"context_engine_summary": True},
+            }
+            retained_system = [
+                message
+                for index, message in enumerate(deterministic)
+                if index in retain_indices and message.get("role") == "system"
+            ]
+            retained_non_system = [
+                message
+                for index, message in enumerate(deterministic)
+                if index in retain_indices and message.get("role") != "system"
+            ]
+            final_messages = [
+                *retained_system,
+                summary_message,
+                *retained_non_system,
+            ]
+
+    final_tokens = estimate_messages_tokens(final_messages)
+    saved_ratio = (
+        (original_tokens - final_tokens) / original_tokens
+        if original_tokens
+        else 0.0
+    )
+    if not _fidelity_ok(original, final_messages):
+        return _result(
+            original,
+            original_tokens,
+            profile,
+            started_at,
+            fidelity_status="fallback",
+            fallback_reason="fidelity_check_failed",
+            fits_context=required_tokens <= max_context_tokens,
+        )
+    if final_messages != original and saved_ratio < 0.10:
+        return _result(
+            original,
+            original_tokens,
+            profile,
+            started_at,
+            fidelity_status="fallback",
+            fallback_reason="insufficient_savings",
+            fits_context=required_tokens <= max_context_tokens,
+        )
+    fits_context = (
+        final_tokens + max_output_tokens + margin <= max_context_tokens
+    )
+    if not fits_context and fallback_reason is None:
+        fallback_reason = "context_limit_exceeded"
+    return _result(
+        final_messages,
+        original_tokens,
+        profile,
+        started_at,
+        fidelity_status="passed" if final_messages != original else "not_needed",
+        fallback_reason=fallback_reason,
+        stages=stages,
+        summarized_messages=summarized_messages,
+        reused_summary=reused_summary,
+        fits_context=fits_context,
+    )
+
+
+def _result(
+    messages: list[dict[str, Any]],
+    original_tokens: int,
+    profile: CompressionProfile,
+    started_at: float,
+    *,
+    fidelity_status: Literal["passed", "not_needed", "fallback"],
+    fallback_reason: str | None = None,
+    stages: tuple[str, ...] = (),
+    summarized_messages: int = 0,
+    reused_summary: bool = False,
+    fits_context: bool,
+) -> ContextOptimization:
+    final_tokens = estimate_messages_tokens(messages)
+    saved_tokens = max(0, original_tokens - final_tokens)
+    return ContextOptimization(
+        messages=messages,
+        report=CompressionReport(
+            applied=messages != [] and saved_tokens > 0,
+            profile=profile,
+            original_tokens=original_tokens,
+            final_tokens=final_tokens,
+            saved_tokens=saved_tokens,
+            saved_ratio=(
+                saved_tokens / original_tokens if original_tokens > 0 else 0.0
+            ),
+            fidelity_status=fidelity_status,
+            fallback_reason=fallback_reason,
+            stages=tuple(dict.fromkeys(stages)),
+            duration_ms=round((time.perf_counter() - started_at) * 1000, 2),
+            summarized_messages=summarized_messages,
+            reused_summary=reused_summary,
+            fits_context=fits_context,
+        ),
+    )

--- a/server/context_engine/fixtures/compression-baseline-v1.json
+++ b/server/context_engine/fixtures/compression-baseline-v1.json
@@ -1,0 +1,27 @@
+{
+  "version": "modelmirror-compression-baseline-v1",
+  "protected_content": [
+    "system_messages",
+    "latest_user_message",
+    "tool_schemas",
+    "code_blocks",
+    "json",
+    "xml",
+    "urls",
+    "citation_markers",
+    "file_sources"
+  ],
+  "stage_order": [
+    "tool_output_filtering",
+    "redundancy_folding",
+    "rag_deduplication",
+    "history_summary"
+  ],
+  "fallback_conditions": [
+    "structure_damage",
+    "missing_protected_marker",
+    "saved_ratio_below_0.10",
+    "unexpected_error"
+  ],
+  "auto_trigger_ratio": 0.8
+}

--- a/server/main.py
+++ b/server/main.py
@@ -527,6 +527,30 @@ except ModuleNotFoundError:
         update_stream_state,
     )
 
+try:
+    from server.model_router import (
+        NoEligibleCandidateError,
+        get_model_router_service,
+        get_native_router_engine,
+        infer_task_tags,
+        models_router as model_catalog_router,
+        router as model_router_router,
+    )
+except ModuleNotFoundError:
+    from model_router import (
+        NoEligibleCandidateError,
+        get_model_router_service,
+        get_native_router_engine,
+        infer_task_tags,
+        models_router as model_catalog_router,
+        router as model_router_router,
+    )
+
+try:
+    from server.context_engine import estimate_messages_tokens, optimize_context
+except ModuleNotFoundError:
+    from context_engine import estimate_messages_tokens, optimize_context
+
 load_dotenv()
 
 
@@ -668,7 +692,7 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=allowed_origins,
     allow_credentials=True,
-    allow_methods=["GET", "POST", "PATCH", "DELETE", "OPTIONS"],
+    allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
     allow_headers=["*"],
     expose_headers=[
         "X-ModelMirror-Actual-Model",
@@ -697,6 +721,8 @@ app.include_router(prompt_profiles_router)
 app.include_router(plugins_router)
 app.include_router(xpert_evaluations_router)
 app.include_router(xpert_evolutions_router)
+app.include_router(model_router_router)
+app.include_router(model_catalog_router)
 app.include_router(omniroute_router)
 
 request_windows: dict[str, deque[float]] = defaultdict(deque)
@@ -984,6 +1010,10 @@ class ChatRoutingOptions(BaseModel):
     budget_fallback: Literal["strict", "cheapest"] | None = None
 
 
+class ChatCompressionOptions(BaseModel):
+    mode: Literal["auto", "off", "standard", "strong"] = "auto"
+
+
 class ChatRequest(BaseModel):
     model_id: str = Field(min_length=1, max_length=256)
     messages: list[ChatMessage] = Field(min_length=1, max_length=80)
@@ -996,8 +1026,9 @@ class ChatRequest(BaseModel):
     tool_names: str = Field(default="", max_length=2_000)
     max_tool_iterations: int = Field(default=5, ge=1, le=20)
     prompt_suffix: str = Field(default="", max_length=4_000)
-    gateway: Literal["default", "omniroute"] = "default"
+    gateway: Literal["default", "auto", "omniroute"] = "default"
     routing: ChatRoutingOptions | None = None
+    compression: ChatCompressionOptions | None = None
 
 
 class AgentRecord(BaseModel):
@@ -1764,13 +1795,39 @@ async def collect_chat_completion_text(
     *,
     temperature: float = 0.7,
     max_tokens: int = 2048,
+    gateway_url: str | None = None,
+    gateway_key: str | None = None,
 ) -> str:
-    url, key = get_llm_gateway_config()
+    if gateway_url is not None:
+        url = gateway_url
+        key = gateway_key or ""
+    else:
+        url, key = get_llm_gateway_config()
     if not url:
         raise RuntimeError(LLM_GATEWAY_NOT_CONFIGURED_MESSAGE)
+    configured_profile = os.getenv(
+        "CHAT_TOOL_CONTEXT_COMPRESSION_MODE", "auto"
+    ).strip().lower()
+    optimization = await optimize_context(
+        chat_messages_json(messages),
+        profile=(
+            configured_profile
+            if configured_profile in {"auto", "off", "standard", "strong"}
+            else "auto"
+        ),
+        max_context_tokens=max(
+            2_048,
+            int(os.getenv("CHAT_TOOL_CONTEXT_MAX_TOKENS", "128000")),
+        ),
+        max_output_tokens=max_tokens,
+    )
+    prepared_messages = [
+        ChatMessage.model_validate(message)
+        for message in optimization.messages
+    ]
     request_payload = build_chat_payload_from_messages(
         model_id,
-        messages,
+        prepared_messages,
         stream=False,
         temperature=temperature,
         max_tokens=max_tokens,
@@ -1803,6 +1860,9 @@ async def stream_chat_toolset_text(
     runtime_context: MiddlewareContext,
     run_id: str | None = None,
     audit_store: InMemoryToolAuditStore | None = None,
+    model_id_override: str | None = None,
+    gateway_url: str | None = None,
+    gateway_key: str | None = None,
 ) -> AsyncIterator[str]:
     requested_tools = parse_chat_tool_names(payload.tool_names)
     all_tools = await workflow_mcp_provider.list_tools()
@@ -1846,10 +1906,12 @@ async def stream_chat_toolset_text(
     for iteration_index in range(payload.max_tool_iterations):
         raw_response = (
             await collect_chat_completion_text(
-                payload.model_id,
+                model_id_override or payload.model_id,
                 messages,
                 temperature=payload.temperature,
                 max_tokens=payload.max_tokens,
+                gateway_url=gateway_url,
+                gateway_key=gateway_key,
             )
         ).strip()
         decision = extract_json_decision(raw_response)
@@ -13361,11 +13423,33 @@ async def disconnect_mcp_server(session_id: str):
 @app.post("/api/chat")
 async def chat(payload: ChatRequest, request: Request):
     omniroute_settings = get_omniroute_settings()
+    native_router_engine = get_native_router_engine()
+    native_router_policy = get_model_router_service().get_policy()
+    auto_gateway_requested = payload.gateway == "auto"
+    canary_native = (
+        auto_gateway_requested
+        and native_router_policy.engine == "native_canary"
+        and native_router_engine.stable_canary_selected(
+            payload.routing.session_id if payload.routing else None,
+            native_router_policy.canary_percent,
+        )
+    )
+    use_native_router = auto_gateway_requested and (
+        native_router_policy.engine == "native" or canary_native
+    )
+    shadow_native_router = (
+        auto_gateway_requested and native_router_policy.engine == "shadow"
+    )
     use_omniroute = payload.gateway == "omniroute" or (
+        auto_gateway_requested and not use_native_router
+    ) or (
         payload.gateway == "default"
         and omniroute_settings.default_router == "omniroute"
     )
-    if use_omniroute:
+    if use_native_router:
+        url = ""
+        key = ""
+    elif use_omniroute:
         url = omniroute_settings.chat_completions_url
         key = omniroute_settings.api_key
     else:
@@ -13375,12 +13459,12 @@ async def chat(payload: ChatRequest, request: Request):
             status_code=503,
             content={
                 "error": (
-                    "OmniRoute 尚未启用或未配置后端专用 API Key，"
-                    "请返回模型招聘会选择默认网关候选人。"
+                    "当前稳定调度服务尚未配置。请在系统设置检查服务状态，"
+                    "或返回模型招聘会选择普通候选人。"
                 )
             },
         )
-    if not url:
+    if not url and not use_native_router:
         return JSONResponse(
             status_code=500,
             content={"error": LLM_GATEWAY_NOT_CONFIGURED_MESSAGE},
@@ -13389,11 +13473,12 @@ async def chat(payload: ChatRequest, request: Request):
     try:
         rate_limit_or_raise(client_ip(request))
         if payload.routing is not None and (
-            not use_omniroute or not is_omniroute_auto_model(payload.model_id)
+            not (use_omniroute or use_native_router)
+            or not is_omniroute_auto_model(payload.model_id)
         ):
             raise HTTPException(
                 status_code=400,
-                detail="路由模式和预算参数仅适用于 OmniRoute 的 auto/* 路由。",
+                detail="路由模式和预算参数仅适用于智能调度的 auto/* 路由。",
             )
         if (
             payload.routing is not None
@@ -13413,20 +13498,20 @@ async def chat(payload: ChatRequest, request: Request):
             raise HTTPException(
                 status_code=501,
                 detail=(
-                    "当前固定的 OmniRoute 3.8.48 镜像不会执行逐请求预算头，"
-                    "为避免隐式超支，本次请求已拒绝。请清空预算，或在完成"
-                    " 3.8.49+ 镜像审计后显式启用预算头。"
+                    "当前稳定模式不能可靠执行单次预算，为避免隐式超支，"
+                    "本次请求已拒绝。请清空预算，或在系统设置中完成连接"
+                    "测试后启用“本地试运行”。"
                 ),
             )
         if use_omniroute and payload.tool_mode != "none":
             raise HTTPException(
                 status_code=400,
-                detail="OmniRoute MVP 暂不与 Runtime MCP 工具模式组合使用。",
+                detail="智能调度暂不与 Runtime MCP 工具模式组合使用。",
             )
         validate_multimodal_content(
             payload.model_id,
             payload.messages,
-            trust_gateway_catalog=use_omniroute,
+            trust_gateway_catalog=use_omniroute or use_native_router,
         )
         validate_content(payload.messages)
     except HTTPException as exc:
@@ -13439,6 +13524,158 @@ async def chat(payload: ChatRequest, request: Request):
         return JSONResponse(
             status_code=500,
             content={"error": "后端校验请求时出错，请查看服务日志。"},
+        )
+
+    native_plan = None
+    native_target_index = 0
+    native_fallback_attempts = 0
+    native_attempt_started_at = 0.0
+    native_current_failure_recorded = False
+    if use_native_router or shadow_native_router:
+        requested_mode = payload.routing.mode if payload.routing else None
+        native_mode = native_router_engine.mode_for_request(
+            payload.model_id,
+            requested_mode,
+            native_router_policy.default_mode,
+        )
+        required_input_modalities = {"text"}
+        if any(
+            message_has_image(message.content) for message in payload.messages
+        ):
+            required_input_modalities.add("image")
+        preferred_tags: set[str] = set()
+        route_suffix = (
+            payload.model_id.lower().removeprefix("auto/").split(":", 1)[0]
+        )
+        if route_suffix in {"vision", "coding", "reasoning", "multimodal"}:
+            preferred_tags.add(route_suffix)
+        latest_user_text = next(
+            (
+                message_text(message.content)
+                for message in reversed(payload.messages)
+                if message.role == "user"
+            ),
+            "",
+        )
+        if not preferred_tags:
+            preferred_tags.update(infer_task_tags(latest_user_text))
+            if not preferred_tags:
+                preferred_tags.add("general")
+        try:
+            planning_messages = chat_messages_json(payload.messages)
+            if use_native_router:
+                planning_optimization = await optimize_context(
+                    planning_messages,
+                    profile=(
+                        payload.compression.mode
+                        if payload.compression is not None
+                        else native_router_policy.compression_mode
+                    ),
+                    max_context_tokens=128_000,
+                    max_output_tokens=payload.max_tokens,
+                )
+                planning_messages = planning_optimization.messages
+            native_plan = await native_router_engine.plan(
+                mode=native_mode,
+                session_id=payload.routing.session_id if payload.routing else None,
+                estimated_input_tokens=estimate_messages_tokens(
+                    planning_messages
+                ),
+                max_output_tokens=payload.max_tokens,
+                required_input_modalities=required_input_modalities,
+                required_capabilities=(
+                    {"tools"} if payload.tool_mode == "mcp_tools" else set()
+                ),
+                preferred_tags=preferred_tags,
+                budget_usd=payload.routing.budget_usd if payload.routing else None,
+                budget_fallback=(
+                    payload.routing.budget_fallback
+                    if payload.routing and payload.routing.budget_fallback
+                    else "cheapest"
+                ),
+                audit_engine="native" if use_native_router else "shadow",
+            )
+        except NoEligibleCandidateError as exc:
+            if use_native_router:
+                return JSONResponse(
+                    status_code=(
+                        402
+                        if exc.code == "strict_budget_exceeded"
+                        else 422
+                        if exc.code == "context_limit_exceeded"
+                        else 503
+                    ),
+                    content={"error": str(exc), "code": exc.code},
+                )
+            logger.info("Native shadow decision unavailable: %s", exc.code)
+        except Exception:
+            if use_native_router:
+                logger.exception("Native router planning failed")
+                return JSONResponse(
+                    status_code=503,
+                    content={
+                        "error": "智能调度暂时无法生成可用路线，请检查模型服务连接。",
+                        "code": "native_router_unavailable",
+                    },
+                )
+            logger.exception("Native shadow decision failed")
+
+    if use_native_router and native_plan is not None:
+        first_native_target = native_plan.targets[0]
+        url = first_native_target.chat_completions_url
+        key = first_native_target.api_key
+
+    upstream_chat_payload = payload
+    native_compression_report: dict[str, Any] | None = None
+    if use_native_router and native_plan is not None:
+        compression_mode = (
+            payload.compression.mode
+            if payload.compression is not None
+            else native_router_policy.compression_mode
+        )
+        optimization = await optimize_context(
+            chat_messages_json(payload.messages),
+            profile=compression_mode,
+            max_context_tokens=(
+                native_plan.targets[0].context_length or 128_000
+            ),
+            max_output_tokens=payload.max_tokens,
+        )
+        native_compression_report = optimization.report.as_dict()
+        record_compression = getattr(
+            get_model_router_service().repository,
+            "record_compression_run",
+            None,
+        )
+        if callable(record_compression):
+            record_compression(
+                get_model_router_service().tenant_id,
+                request_id=native_plan.decision_id or None,
+                profile=optimization.report.profile,
+                original_tokens=optimization.report.original_tokens,
+                final_tokens=optimization.report.final_tokens,
+                fidelity_status=optimization.report.fidelity_status,
+                fallback_reason=optimization.report.fallback_reason,
+            )
+        if not optimization.report.fits_context:
+            return JSONResponse(
+                status_code=422,
+                content={
+                    "error": (
+                        "当前对话仍超过候选模型的上下文限制。"
+                        "请减少附件、清理较早历史，或选择更长上下文模型。"
+                    ),
+                    "code": "context_limit_exceeded",
+                    "compression": native_compression_report,
+                },
+            )
+        upstream_chat_payload = payload.model_copy(
+            update={
+                "messages": [
+                    ChatMessage.model_validate(message)
+                    for message in optimization.messages
+                ]
+            }
         )
 
     runtime_pipeline = None
@@ -13469,9 +13706,13 @@ async def chat(payload: ChatRequest, request: Request):
 
     client = httpx.AsyncClient(**llm_client_kwargs())
     actual_model_id = (
-        omniroute_model_for_request(payload.model_id, payload.routing)
-        if use_omniroute
-        else payload.model_id
+        native_plan.targets[0].model_id
+        if use_native_router and native_plan is not None
+        else (
+            omniroute_model_for_request(payload.model_id, payload.routing)
+            if use_omniroute
+            else payload.model_id
+        )
     )
     fallback_notice = ""
 
@@ -13574,6 +13815,7 @@ async def chat(payload: ChatRequest, request: Request):
             accumulated_chunks: list[str] = []
             runtime_status = "completed"
             runtime_error: str | None = None
+            tool_stream_started_at = time.perf_counter()
             try:
                 async for delta in stream_chat_toolset_text(
                     payload,
@@ -13581,13 +13823,82 @@ async def chat(payload: ChatRequest, request: Request):
                     runtime_context=runtime_context,
                     run_id=chat_run.run_id,
                     audit_store=chat_audit_store,
+                    model_id_override=(
+                        actual_model_id if use_native_router else None
+                    ),
+                    gateway_url=url if use_native_router else None,
+                    gateway_key=key if use_native_router else None,
                 ):
                     accumulated_chunks.append(delta)
                     yield chat_sse_delta(delta)
                     await asyncio.sleep(0)
+                if use_native_router and native_plan is not None:
+                    selected_target = native_plan.targets[0]
+                    elapsed_ms = (
+                        time.perf_counter() - tool_stream_started_at
+                    ) * 1000
+                    native_router_engine.record_outcome(
+                        native_plan,
+                        selected_target,
+                        success=True,
+                        latency_ms=elapsed_ms,
+                        outcome="success",
+                    )
+                    tool_actual_cost, tool_budget_status = (
+                        native_router_engine.settle_budget(
+                            native_plan,
+                            selected_target,
+                            input_tokens=None,
+                            output_tokens=None,
+                        )
+                    )
+                    yield route_receipt_sse(
+                        {
+                            "requested_model": payload.model_id,
+                            "actual_model": selected_target.model_id,
+                            "provider": selected_target.connection_name,
+                            "strategy": native_plan.mode,
+                            "engine": "native",
+                            "reason_codes": list(native_plan.reason_codes),
+                            "latency_ms": round(elapsed_ms, 2),
+                            "tokens": {
+                                "input": None,
+                                "output": None,
+                                "total": None,
+                            },
+                            "response_cost_usd": tool_actual_cost,
+                            "cost_kind": (
+                                "actual"
+                                if tool_actual_cost is not None
+                                else "unavailable"
+                            ),
+                            "fallback_attempts": 0,
+                            "cache_hit": None,
+                            "request_id": native_plan.decision_id
+                            or runtime_task_id,
+                            "budget": {
+                                "limit_usd": native_plan.budget_usd,
+                                "mode": native_plan.budget_fallback,
+                                "status": tool_budget_status,
+                            },
+                            "compression": native_compression_report,
+                            "version": "2",
+                        }
+                    )
             except Exception as exc:
                 runtime_status = "error"
                 runtime_error = str(exc)
+                if use_native_router and native_plan is not None:
+                    native_router_engine.record_outcome(
+                        native_plan,
+                        native_plan.targets[0],
+                        success=False,
+                        latency_ms=(
+                            time.perf_counter() - tool_stream_started_at
+                        )
+                        * 1000,
+                        outcome="tool_runtime_error",
+                    )
                 logger.warning("Runtime chat toolset failed: %s", exc)
                 await record_chat_checkpoint(
                     chat_run.run_id,
@@ -13619,6 +13930,7 @@ async def chat(payload: ChatRequest, request: Request):
                         )
                     except Exception as update_exc:
                         logger.warning("Chat runtime run completion update failed: %s", update_exc)
+                yield b"data: [DONE]\n\n"
                 await client.aclose()
                 await finalize_runtime(
                     runtime_status,
@@ -13667,8 +13979,48 @@ async def chat(payload: ChatRequest, request: Request):
         gateway_url: str = url,
         gateway_key: str = key,
     ) -> httpx.Response:
-        request_payload = build_upstream_payload(payload, model_id)
+        request_payload = build_upstream_payload(upstream_chat_payload, model_id)
         if runtime_pipeline is None or runtime_context is None:
+            return await send_prepared_to_upstream(
+                model_id,
+                request_payload,
+                gateway_url=gateway_url,
+                gateway_key=gateway_key,
+            )
+
+        if use_native_router:
+            try:
+                prepared = await runtime_pipeline.before_model(
+                    ModelCallRequest(
+                        model_id=model_id,
+                        messages=chat_messages_json(upstream_chat_payload.messages),
+                        params={
+                            "temperature": upstream_chat_payload.temperature,
+                            "top_p": upstream_chat_payload.top_p,
+                            "max_tokens": upstream_chat_payload.max_tokens,
+                            "seed": upstream_chat_payload.seed,
+                            "stop": upstream_chat_payload.stop,
+                            "stream": True,
+                        },
+                    ),
+                    runtime_context,
+                )
+                runtime_payload = upstream_chat_payload.model_copy(
+                    update={
+                        "messages": [
+                            ChatMessage.model_validate(message)
+                            for message in prepared.messages
+                        ]
+                    }
+                )
+                request_payload = build_upstream_payload(
+                    runtime_payload, model_id
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Native runtime chat prepare failed; using original payload: %s",
+                    exc,
+                )
             return await send_prepared_to_upstream(
                 model_id,
                 request_payload,
@@ -13680,18 +14032,18 @@ async def chat(payload: ChatRequest, request: Request):
         try:
             runtime_request = ModelCallRequest(
                 model_id=model_id,
-                messages=chat_messages_json(payload.messages),
+                messages=chat_messages_json(upstream_chat_payload.messages),
                 params={
-                    "temperature": payload.temperature,
-                    "top_p": payload.top_p,
-                    "max_tokens": payload.max_tokens,
-                    "seed": payload.seed,
-                    "stop": payload.stop,
+                    "temperature": upstream_chat_payload.temperature,
+                    "top_p": upstream_chat_payload.top_p,
+                    "max_tokens": upstream_chat_payload.max_tokens,
+                    "seed": upstream_chat_payload.seed,
+                    "stop": upstream_chat_payload.stop,
                     "stream": True,
                 },
             )
             prepared = await runtime_pipeline.before_model(runtime_request, runtime_context)
-            runtime_payload = payload.model_copy(
+            runtime_payload = upstream_chat_payload.model_copy(
                 update={
                     "messages": [
                         ChatMessage.model_validate(message)
@@ -13738,8 +14090,73 @@ async def chat(payload: ChatRequest, request: Request):
             gateway_key=gateway_key,
         )
 
+    async def send_initial_response() -> httpx.Response:
+        nonlocal actual_model_id
+        nonlocal native_target_index
+        nonlocal native_fallback_attempts
+        nonlocal native_attempt_started_at
+        nonlocal native_current_failure_recorded
+        if not use_native_router or native_plan is None:
+            return await send_to_upstream(actual_model_id)
+
+        last_error: Exception | None = None
+        for index, target in enumerate(native_plan.targets):
+            native_target_index = index
+            native_fallback_attempts = index
+            actual_model_id = target.model_id
+            native_attempt_started_at = time.perf_counter()
+            native_current_failure_recorded = False
+            try:
+                candidate_response = await send_to_upstream(
+                    target.model_id,
+                    gateway_url=target.chat_completions_url,
+                    gateway_key=target.api_key,
+                )
+            except (httpx.TimeoutException, httpx.HTTPError) as exc:
+                last_error = exc
+                native_router_engine.record_outcome(
+                    native_plan,
+                    target,
+                    success=False,
+                    latency_ms=(time.perf_counter() - native_attempt_started_at)
+                    * 1000,
+                    outcome="transport_error",
+                )
+                native_current_failure_recorded = True
+                if index + 1 < len(native_plan.targets):
+                    continue
+                raise
+
+            retryable_status = candidate_response.status_code in {
+                401,
+                402,
+                403,
+                408,
+                409,
+                425,
+                429,
+            } or candidate_response.status_code >= 500
+            if retryable_status:
+                native_router_engine.record_outcome(
+                    native_plan,
+                    target,
+                    success=False,
+                    latency_ms=(time.perf_counter() - native_attempt_started_at)
+                    * 1000,
+                    outcome=f"http_{candidate_response.status_code}",
+                )
+                native_current_failure_recorded = True
+                if index + 1 < len(native_plan.targets):
+                    await candidate_response.aread()
+                    await candidate_response.aclose()
+                    continue
+            return candidate_response
+        if last_error is not None:
+            raise last_error
+        raise httpx.ConnectError("No native dispatch target was available.")
+
     try:
-        response = await send_to_upstream(actual_model_id)
+        response = await send_initial_response()
     except httpx.TimeoutException:
         logger.exception("OpenRouter request timed out model=%s", actual_model_id)
         await finalize_runtime("error", actual_model_id, error="timeout")
@@ -13768,11 +14185,15 @@ async def chat(payload: ChatRequest, request: Request):
             body[:500].decode("utf-8", errors="replace"),
         )
 
-        if not use_omniroute and should_fallback_gateway_to_openrouter(
+        if (
+            not use_omniroute
+            and not use_native_router
+            and should_fallback_gateway_to_openrouter(
             response.status_code,
             message,
             data,
             url,
+            )
         ):
             try:
                 response = await send_to_upstream(
@@ -13825,6 +14246,7 @@ async def chat(payload: ChatRequest, request: Request):
 
         if (
             not use_omniroute
+            and not use_native_router
             and response.status_code >= 400
             and should_fallback_model(
                 response.status_code,
@@ -13881,6 +14303,19 @@ async def chat(payload: ChatRequest, request: Request):
                     content={"error": f"{message}；兜底模型也暂不可用：{fallback_message}"},
                 )
         elif response.status_code >= 400:
+            if (
+                use_native_router
+                and native_plan is not None
+                and not native_current_failure_recorded
+            ):
+                native_router_engine.record_outcome(
+                    native_plan,
+                    native_plan.targets[native_target_index],
+                    success=False,
+                    latency_ms=(time.perf_counter() - native_attempt_started_at)
+                    * 1000,
+                    outcome=f"http_{response.status_code}",
+                )
             await finalize_runtime("error", actual_model_id, error=message)
             await client.aclose()
             return JSONResponse(
@@ -13894,6 +14329,335 @@ async def chat(payload: ChatRequest, request: Request):
     if use_omniroute and payload.routing is not None and payload.routing.mode:
         omniroute_header_state.setdefault("decision", payload.routing.mode)
     omniroute_stream_state: dict[str, Any] = {}
+
+    async def stream_native_response():
+        nonlocal actual_model_id
+        nonlocal native_target_index
+        nonlocal native_fallback_attempts
+        nonlocal native_attempt_started_at
+        current_response: httpx.Response | None = response
+        accumulated_chunks: list[str] = []
+        final_state: dict[str, Any] = {}
+        runtime_status = "error"
+        runtime_error: str | None = None
+        terminal_error_emitted = False
+        selected_target = native_plan.targets[native_target_index]
+
+        while native_target_index < len(native_plan.targets):
+            selected_target = native_plan.targets[native_target_index]
+            actual_model_id = selected_target.model_id
+            if current_response is None:
+                native_attempt_started_at = time.perf_counter()
+                try:
+                    current_response = await send_to_upstream(
+                        selected_target.model_id,
+                        gateway_url=selected_target.chat_completions_url,
+                        gateway_key=selected_target.api_key,
+                    )
+                except (httpx.TimeoutException, httpx.HTTPError) as exc:
+                    runtime_error = "transport_error"
+                    logger.warning(
+                        "Native fallback connection failed model=%s error=%s",
+                        selected_target.model_id,
+                        exc,
+                    )
+                    native_router_engine.record_outcome(
+                        native_plan,
+                        selected_target,
+                        success=False,
+                        latency_ms=(
+                            time.perf_counter() - native_attempt_started_at
+                        )
+                        * 1000,
+                        outcome="transport_error",
+                    )
+                    native_target_index += 1
+                    native_fallback_attempts = native_target_index
+                    continue
+                if current_response.status_code >= 400:
+                    status_code = current_response.status_code
+                    runtime_error = f"http_{status_code}"
+                    await current_response.aread()
+                    await current_response.aclose()
+                    current_response = None
+                    native_router_engine.record_outcome(
+                        native_plan,
+                        selected_target,
+                        success=False,
+                        latency_ms=(
+                            time.perf_counter() - native_attempt_started_at
+                        )
+                        * 1000,
+                        outcome=f"http_{status_code}",
+                    )
+                    native_target_index += 1
+                    native_fallback_attempts = native_target_index
+                    continue
+            state: dict[str, Any] = {}
+            pending: list[bytes] = []
+            candidate_chunks: list[str] = []
+            buffer = ""
+            content_started = False
+            stream_transport_finished = False
+            deferred_done = False
+            stream_exception: Exception | None = None
+            try:
+                async for chunk in current_response.aiter_text():
+                    if not chunk:
+                        continue
+                    buffer += chunk
+                    lines = buffer.splitlines(keepends=True)
+                    if buffer.endswith("\n") or buffer.endswith("\r"):
+                        complete_lines = lines
+                        buffer = ""
+                    else:
+                        complete_lines = lines[:-1]
+                        buffer = lines[-1] if lines else buffer
+
+                    for line in complete_lines:
+                        update_stream_state(line, state)
+                        if line.lstrip().startswith(":"):
+                            continue
+                        if line.strip() == "data: [DONE]":
+                            deferred_done = True
+                            continue
+                        if deferred_done and not line.strip():
+                            continue
+                        candidate_chunks.extend(sse_delta_text(line))
+                        encoded = line.encode("utf-8")
+                        if not content_started:
+                            pending.append(encoded)
+                            if state.get("content_observed"):
+                                content_started = True
+                                for pending_line in pending:
+                                    yield pending_line
+                                pending.clear()
+                        else:
+                            yield encoded
+                    await asyncio.sleep(0)
+                stream_transport_finished = True
+            except Exception as exc:
+                stream_exception = exc
+                logger.warning(
+                    "Native routed stream failed model=%s error=%s",
+                    selected_target.model_id,
+                    exc,
+                )
+            finally:
+                if buffer:
+                    update_stream_state(buffer, state)
+                    if buffer.strip() == "data: [DONE]":
+                        deferred_done = True
+                    elif not buffer.lstrip().startswith(":"):
+                        candidate_chunks.extend(sse_delta_text(buffer))
+                        encoded = buffer.encode("utf-8")
+                        if not content_started:
+                            pending.append(encoded)
+                            if state.get("content_observed"):
+                                content_started = True
+                                for pending_line in pending:
+                                    yield pending_line
+                                pending.clear()
+                        else:
+                            yield encoded
+                await current_response.aclose()
+                current_response = None
+
+            elapsed_ms = (
+                time.perf_counter() - native_attempt_started_at
+            ) * 1000
+            finish_reason = str(state.get("finish_reason") or "").strip()
+            stream_completed = stream_transport_finished and bool(
+                deferred_done
+                or state.get("_done_observed")
+                or finish_reason
+            )
+            if content_started:
+                accumulated_chunks.extend(candidate_chunks)
+                final_state = state
+                if stream_completed:
+                    runtime_status = (
+                        "output_limit"
+                        if finish_reason == "length"
+                        else "completed"
+                    )
+                    native_router_engine.record_outcome(
+                        native_plan,
+                        selected_target,
+                        success=True,
+                        latency_ms=elapsed_ms,
+                        outcome=(
+                            "output_limit"
+                            if runtime_status == "output_limit"
+                            else "success"
+                        ),
+                    )
+                else:
+                    runtime_error = "stream interrupted"
+                    native_router_engine.record_outcome(
+                        native_plan,
+                        selected_target,
+                        success=False,
+                        latency_ms=elapsed_ms,
+                        outcome="stream_interrupted",
+                    )
+                    error_payload = {
+                        "error": {
+                            "message": "模型服务连接中断，请稍后重试。"
+                        }
+                    }
+                    yield (
+                        f"data: {json.dumps(error_payload, ensure_ascii=False)}\n\n"
+                    ).encode("utf-8")
+                    terminal_error_emitted = True
+                break
+
+            outcome = "empty_stream" if stream_exception is None else "stream_error"
+            native_router_engine.record_outcome(
+                native_plan,
+                selected_target,
+                success=False,
+                latency_ms=elapsed_ms,
+                outcome=outcome,
+            )
+            native_target_index += 1
+            native_fallback_attempts = native_target_index
+            if native_target_index >= len(native_plan.targets):
+                runtime_error = outcome
+                final_state = state
+                error_payload = {
+                    "error": {
+                        "message": (
+                            "智能调度已尝试可用候选，但模型没有返回正文。"
+                            "请检查模型服务连接或稍后重试。"
+                        )
+                    }
+                }
+                yield (
+                    f"data: {json.dumps(error_payload, ensure_ascii=False)}\n\n"
+                ).encode("utf-8")
+                terminal_error_emitted = True
+                break
+
+            current_response = None
+
+        if (
+            runtime_status not in {"completed", "output_limit"}
+            and not terminal_error_emitted
+        ):
+            error_payload = {
+                "error": {
+                    "message": "智能调度候选暂时不可用，请检查模型服务连接后重试。"
+                }
+            }
+            yield (
+                f"data: {json.dumps(error_payload, ensure_ascii=False)}\n\n"
+            ).encode("utf-8")
+
+        tokens_in = final_state.get("tokens_in")
+        tokens_out = final_state.get("tokens_out")
+        tokens_total = final_state.get("tokens_total")
+        if tokens_total is None and isinstance(tokens_in, int) and isinstance(
+            tokens_out, int
+        ):
+            tokens_total = tokens_in + tokens_out
+        has_usage = any(
+            isinstance(value, int) and value > 0
+            for value in (tokens_in, tokens_out, tokens_total)
+        )
+        upstream_completed = runtime_status in {"completed", "output_limit"}
+        if upstream_completed:
+            actual_cost, budget_status = native_router_engine.settle_budget(
+                native_plan,
+                selected_target,
+                input_tokens=tokens_in if isinstance(tokens_in, int) else None,
+                output_tokens=tokens_out if isinstance(tokens_out, int) else None,
+            )
+        else:
+            actual_cost = None
+            budget_status = (
+                "released" if native_plan.budget_usd is not None else "not_set"
+            )
+        estimated_cost = (
+            selected_target.estimated_request_cost
+            if has_usage and upstream_completed
+            else None
+        )
+        response_cost = actual_cost if actual_cost is not None else estimated_cost
+        receipt_reason_codes = list(native_plan.reason_codes)
+        if runtime_status == "output_limit":
+            receipt_reason_codes.append("output_limit_reached")
+        receipt = {
+            "requested_model": payload.model_id,
+            "actual_model": selected_target.model_id,
+            "provider": selected_target.connection_name,
+            "strategy": native_plan.mode,
+            "engine": "native",
+            "reason_codes": receipt_reason_codes,
+            "latency_ms": round(
+                (time.perf_counter() - native_attempt_started_at) * 1000,
+                2,
+            ),
+            "tokens": {
+                "input": tokens_in,
+                "output": tokens_out,
+                "total": tokens_total,
+            },
+            "response_cost_usd": response_cost,
+            "cost_kind": (
+                "actual"
+                if actual_cost is not None
+                else "estimated"
+                if estimated_cost is not None
+                else "unavailable"
+            ),
+            "fallback_attempts": native_fallback_attempts,
+            "cache_hit": None,
+            "request_id": native_plan.decision_id or runtime_task_id,
+            "budget": {
+                "limit_usd": (
+                    payload.routing.budget_usd if payload.routing else None
+                ),
+                "mode": (
+                    payload.routing.budget_fallback
+                    if payload.routing and payload.routing.budget_fallback
+                    else None
+                ),
+                "status": budget_status,
+            },
+            "compression": native_compression_report
+            or {
+                "applied": False,
+                "profile": "off",
+                "original_tokens": None,
+                "final_tokens": None,
+                "saved_tokens": None,
+                "saved_ratio": None,
+                "fidelity_status": "not_needed",
+                "fallback_reason": None,
+            },
+            "version": "2",
+        }
+        yield route_receipt_sse(receipt)
+        yield b"data: [DONE]\n\n"
+        await client.aclose()
+        await finalize_runtime(
+            runtime_status,
+            selected_target.model_id,
+            "".join(accumulated_chunks),
+            runtime_error,
+        )
+
+    if use_native_router and native_plan is not None:
+        return StreamingResponse(
+            stream_native_response(),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "Connection": "keep-alive",
+                "X-ModelMirror-Actual-Model": actual_model_id,
+            },
+        )
 
     async def stream_response():
         buffer = ""
@@ -13977,8 +14741,8 @@ async def chat(payload: ChatRequest, request: Request):
                     empty_error = {
                         "error": {
                             "message": (
-                                "OmniRoute 返回了成功状态，但上游候选没有生成正文。"
-                                "请检查该候选的认证状态，或在 OmniRoute 中停用未认证供应商。"
+                                "模型服务返回了成功状态，但没有生成正文。"
+                                "请在系统设置中重新测试对应连接，并停用未完成认证的服务。"
                             )
                         }
                     }

--- a/server/model_router/__init__.py
+++ b/server/model_router/__init__.py
@@ -1,0 +1,68 @@
+from .api import (
+    configure_model_router,
+    get_model_router_service,
+    get_native_router_engine,
+    models_router,
+    router,
+)
+from .repository import (
+    DEFAULT_TENANT_ID,
+    RouterConnectionNotFound,
+    RouterCredentialUnavailable,
+    RouterRepository,
+    RouterRepositoryError,
+    SQLiteRouterRepository,
+)
+from .schemas import (
+    CompressionMode,
+    ConnectionHealth,
+    ConnectionKind,
+    ConnectionTestResult,
+    RouterConnection,
+    RouterConnectionCreate,
+    RouterConnectionUpdate,
+    RouterEngine,
+    RouterPolicy,
+    RouterStatus,
+    RoutingMode,
+)
+from .service import ModelRouterService, RouterServiceError
+from .engine import (
+    NativeDispatchTarget,
+    NativeRoutePlan,
+    NativeRouterEngine,
+    infer_task_tags,
+)
+from .routing import NoEligibleCandidateError
+
+__all__ = [
+    "CompressionMode",
+    "ConnectionHealth",
+    "ConnectionKind",
+    "ConnectionTestResult",
+    "DEFAULT_TENANT_ID",
+    "ModelRouterService",
+    "NativeDispatchTarget",
+    "NativeRoutePlan",
+    "NativeRouterEngine",
+    "NoEligibleCandidateError",
+    "RouterConnection",
+    "RouterConnectionCreate",
+    "RouterConnectionNotFound",
+    "RouterConnectionUpdate",
+    "RouterCredentialUnavailable",
+    "RouterEngine",
+    "RouterPolicy",
+    "RouterRepository",
+    "RouterRepositoryError",
+    "RouterServiceError",
+    "RouterStatus",
+    "RoutingMode",
+    "SQLiteRouterRepository",
+    "configure_model_router",
+    "get_model_router_service",
+    "get_native_router_engine",
+    "infer_task_tags",
+    "models_router",
+    "router",
+]

--- a/server/model_router/api.py
+++ b/server/model_router/api.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, status
+
+try:
+    from server.omniroute.catalog import OmniRouteCatalogService
+    from server.omniroute.config import get_omniroute_settings
+    from server.omniroute.schemas import ModelCatalogResponse, RouterStatusResponse
+except ModuleNotFoundError:
+    from omniroute.catalog import OmniRouteCatalogService
+    from omniroute.config import get_omniroute_settings
+    from omniroute.schemas import ModelCatalogResponse, RouterStatusResponse
+
+from .repository import RouterRepositoryError
+from .schemas import (
+    ConnectionTestResult,
+    RouterConnection,
+    RouterConnectionCreate,
+    RouterConnectionUpdate,
+    RouterPolicy,
+    RouterStatus,
+)
+from .service import (
+    ModelRouterService,
+    RouterServiceError,
+    translate_repository_error,
+)
+
+
+router = APIRouter(prefix="/api/router", tags=["model-router"])
+models_router = APIRouter(prefix="/api/models", tags=["model-catalog"])
+_service: ModelRouterService | None = None
+_catalog_coordinator: object | None = None
+_native_engine: object | None = None
+
+
+def configure_model_router(service: ModelRouterService) -> None:
+    global _service, _native_engine, _catalog_coordinator
+    _service = service
+    _native_engine = None
+    _catalog_coordinator = None
+
+
+def get_model_router_service() -> ModelRouterService:
+    global _service
+    if _service is None:
+        _service = ModelRouterService()
+    return _service
+
+
+def get_catalog_coordinator():
+    global _catalog_coordinator
+    if _catalog_coordinator is None:
+        from .catalog import CatalogCoordinator
+
+        _catalog_coordinator = CatalogCoordinator(
+            OmniRouteCatalogService(get_omniroute_settings)
+        )
+    return _catalog_coordinator
+
+
+def get_native_router_engine():
+    global _native_engine
+    if _native_engine is None:
+        from .engine import NativeRouterEngine
+
+        _native_engine = NativeRouterEngine(get_model_router_service())
+    return _native_engine
+
+
+def _raise_public_error(exc: Exception) -> None:
+    public = (
+        exc
+        if isinstance(exc, RouterServiceError)
+        else translate_repository_error(exc)
+    )
+    raise HTTPException(
+        status_code=public.status_code,
+        detail={"code": public.code, "message": public.hint},
+    ) from exc
+
+
+@router.get("/connections", response_model=list[RouterConnection])
+def list_connections() -> list[RouterConnection]:
+    try:
+        return get_model_router_service().list_connections()
+    except RouterRepositoryError as exc:
+        _raise_public_error(exc)
+
+
+@router.post(
+    "/connections",
+    response_model=RouterConnection,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_connection(payload: RouterConnectionCreate) -> RouterConnection:
+    try:
+        return get_model_router_service().create_connection(payload)
+    except (RouterServiceError, RouterRepositoryError) as exc:
+        _raise_public_error(exc)
+
+
+@router.patch("/connections/{connection_id}", response_model=RouterConnection)
+def update_connection(
+    connection_id: str, payload: RouterConnectionUpdate
+) -> RouterConnection:
+    try:
+        return get_model_router_service().update_connection(connection_id, payload)
+    except (RouterServiceError, RouterRepositoryError) as exc:
+        _raise_public_error(exc)
+
+
+@router.post(
+    "/connections/test",
+    response_model=ConnectionTestResult,
+)
+async def test_unsaved_connection(
+    payload: RouterConnectionCreate,
+) -> ConnectionTestResult:
+    try:
+        return await get_model_router_service().test_unsaved_connection(payload)
+    except (RouterServiceError, RouterRepositoryError) as exc:
+        _raise_public_error(exc)
+
+
+@router.post(
+    "/connections/{connection_id}/test",
+    response_model=ConnectionTestResult,
+)
+async def test_saved_connection(connection_id: str) -> ConnectionTestResult:
+    try:
+        return await get_model_router_service().test_saved_connection(connection_id)
+    except (RouterServiceError, RouterRepositoryError) as exc:
+        _raise_public_error(exc)
+
+
+@router.get("/policy", response_model=RouterPolicy)
+def get_policy() -> RouterPolicy:
+    try:
+        return get_model_router_service().get_policy()
+    except RouterRepositoryError as exc:
+        _raise_public_error(exc)
+
+
+@router.put("/policy", response_model=RouterPolicy)
+def save_policy(policy: RouterPolicy) -> RouterPolicy:
+    try:
+        return get_model_router_service().save_policy(policy)
+    except (RouterServiceError, RouterRepositoryError) as exc:
+        _raise_public_error(exc)
+
+
+@router.get("/status", response_model=RouterStatus)
+def get_status() -> RouterStatus:
+    try:
+        return get_model_router_service().status()
+    except RouterRepositoryError as exc:
+        _raise_public_error(exc)
+
+
+@router.get("/diagnostics")
+def get_diagnostics() -> dict[str, object]:
+    try:
+        return get_model_router_service().diagnostics()
+    except RouterRepositoryError as exc:
+        _raise_public_error(exc)
+
+
+@models_router.get("/catalog", response_model=ModelCatalogResponse)
+async def get_model_catalog() -> ModelCatalogResponse:
+    return await get_catalog_coordinator().get_catalog()
+
+
+@models_router.get("/router-status", response_model=RouterStatusResponse)
+async def get_public_router_status() -> RouterStatusResponse:
+    return await get_catalog_coordinator().get_status()

--- a/server/model_router/catalog.py
+++ b/server/model_router/catalog.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+try:
+    from server.omniroute.catalog import OmniRouteCatalogService
+    from server.omniroute.schemas import (
+        ModelCandidate,
+        ModelCatalogResponse,
+        RouteCandidate,
+        RouterStatusResponse,
+    )
+except ModuleNotFoundError:
+    from omniroute.catalog import OmniRouteCatalogService
+    from omniroute.schemas import (
+        ModelCandidate,
+        ModelCatalogResponse,
+        RouteCandidate,
+        RouterStatusResponse,
+    )
+
+from .api import get_model_router_service
+from .schemas import RouterConnection
+from .service import ModelRouterService
+
+
+CATALOG_TTL_SECONDS = 30.0
+STALE_IF_ERROR_SECONDS = 600.0
+NATIVE_CATALOG_VERSION = "modelmirror-native-catalog-v1"
+
+ROUTES = (
+    ("auto", "智能调度", "在质量、速度、成本和稳定性之间自动平衡"),
+    ("auto/fast", "速度优先", "优先选择响应更快的可用模型"),
+    ("auto/quality", "质量优先", "优先选择综合能力更强的可用模型"),
+    ("auto/cheap", "成本优先", "在满足能力要求时优先降低费用"),
+    ("auto/reliable", "稳定优先", "优先选择近期成功率更高的模型"),
+    ("auto/offline", "本地优先", "优先选择本地或不依赖外部额度的连接"),
+)
+
+
+@dataclass
+class _CacheEntry:
+    catalog: ModelCatalogResponse
+    stored_at: float
+
+
+class NativeCatalogService:
+    def __init__(self) -> None:
+        self._cache: _CacheEntry | None = None
+        self._lock = asyncio.Lock()
+
+    async def get_catalog(
+        self,
+        service: ModelRouterService,
+        fallback: OmniRouteCatalogService,
+    ) -> ModelCatalogResponse:
+        now = time.monotonic()
+        cached = self._cache
+        if cached and now - cached.stored_at <= CATALOG_TTL_SECONDS:
+            return cached.catalog.model_copy(deep=True)
+        async with self._lock:
+            now = time.monotonic()
+            cached = self._cache
+            if cached and now - cached.stored_at <= CATALOG_TTL_SECONDS:
+                return cached.catalog.model_copy(deep=True)
+            fresh = await self._fetch(service)
+            if fresh.models:
+                self._cache = _CacheEntry(catalog=fresh, stored_at=now)
+                return fresh.model_copy(deep=True)
+            if cached and now - cached.stored_at <= STALE_IF_ERROR_SECONDS:
+                stale = cached.catalog.model_copy(deep=True)
+                stale.stale = True
+                stale.router_status = "stale"
+                for model in stale.models:
+                    model.availability = "degraded"
+                return stale
+            bundled = await fallback.get_catalog()
+            bundled = bundled.model_copy(deep=True)
+            bundled.source = "bundled"
+            bundled.router_status = "offline"
+            bundled.stale = False
+            bundled.catalog_version = NATIVE_CATALOG_VERSION
+            for model in bundled.models:
+                model.invocable = False
+                model.availability = "offline"
+                model.source = "bundled"
+                model.connection_id = None
+            bundled.routes = self._routes(0, False)
+            return bundled
+
+    async def get_status(
+        self,
+        service: ModelRouterService,
+        fallback: OmniRouteCatalogService,
+    ) -> RouterStatusResponse:
+        catalog = await self.get_catalog(service, fallback)
+        status = service.status()
+        return RouterStatusResponse(
+            enabled=True,
+            configured=status.connection_count > 0,
+            status=catalog.router_status,
+            version=NATIVE_CATALOG_VERSION,
+            candidate_count=sum(1 for item in catalog.models if item.invocable),
+            route_count=sum(1 for item in catalog.routes if item.invocable),
+            synced_at=catalog.synced_at,
+            stale=catalog.stale,
+        )
+
+    async def _fetch(
+        self, service: ModelRouterService
+    ) -> ModelCatalogResponse:
+        connections = [
+            item for item in service.list_connections() if item.enabled
+        ]
+        results = await asyncio.gather(
+            *(self._fetch_connection(service, item) for item in connections),
+            return_exceptions=True,
+        )
+        models: list[ModelCandidate] = []
+        for result in results:
+            if isinstance(result, list):
+                models.extend(result)
+        models.sort(key=lambda item: (item.provider.lower(), item.name.lower()))
+        synced_at = (
+            datetime.now(UTC).isoformat() if models else None
+        )
+        return ModelCatalogResponse(
+            source="native",
+            router_status="online" if models else "offline",
+            stale=False,
+            synced_at=synced_at,
+            catalog_version=NATIVE_CATALOG_VERSION,
+            models=models,
+            routes=self._routes(len(models), bool(models)),
+        )
+
+    async def _fetch_connection(
+        self,
+        service: ModelRouterService,
+        connection: RouterConnection,
+    ) -> list[ModelCandidate]:
+        result, model_ids = await service.fetch_connection_models(connection.id)
+        if not result.ok:
+            return []
+        return [
+            ModelCandidate(
+                profile_id=f"native:{connection.id}:{model_id}",
+                invocation_id=model_id,
+                root=model_id,
+                name=model_id.rsplit("/", 1)[-1],
+                provider=connection.name,
+                type="chat",
+                source="native",
+                connection_id=connection.id,
+                invocable=True,
+                availability="live",
+            )
+            for model_id in model_ids
+        ]
+
+    @staticmethod
+    def _routes(
+        candidate_count: int, invocable: bool
+    ) -> list[RouteCandidate]:
+        return [
+            RouteCandidate(
+                id=route_id,
+                name=name,
+                description=description,
+                channel=route_id.removeprefix("auto/") or "auto",
+                candidate_count=candidate_count,
+                reachable_count=candidate_count,
+                invocable=invocable,
+                availability="live" if invocable else "offline",
+            )
+            for route_id, name, description in ROUTES
+        ]
+
+
+class CatalogCoordinator:
+    def __init__(
+        self,
+        sidecar: OmniRouteCatalogService,
+        native: NativeCatalogService | None = None,
+    ) -> None:
+        self.sidecar = sidecar
+        self.native = native or NativeCatalogService()
+
+    async def get_catalog(self) -> ModelCatalogResponse:
+        service = get_model_router_service()
+        policy = service.get_policy()
+        if policy.engine in {"native", "native_canary"}:
+            return await self.native.get_catalog(service, self.sidecar)
+        return await self.sidecar.get_catalog()
+
+    async def get_status(self) -> RouterStatusResponse:
+        service = get_model_router_service()
+        policy = service.get_policy()
+        if policy.engine in {"native", "native_canary"}:
+            return await self.native.get_status(service, self.sidecar)
+        return await self.sidecar.get_status()

--- a/server/model_router/engine.py
+++ b/server/model_router/engine.py
@@ -1,0 +1,673 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import time
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlparse
+
+from .repository import SQLiteRouterRepository
+from .routing import (
+    NoEligibleCandidateError,
+    RouterDecision,
+    RoutingCandidate,
+    RoutingRequest,
+    decide_route,
+)
+from .schemas import RouterConnection, RoutingMode
+from .service import ModelRouterService
+
+
+def infer_task_tags(text: str) -> set[str]:
+    """Infer only high-confidence task hints without another model request."""
+
+    normalized = str(text or "")[-12_000:].lower()
+    coding_hints = (
+        "```",
+        "traceback",
+        "stack trace",
+        "syntaxerror",
+        "exception",
+        "debug",
+        "refactor",
+        "代码",
+        "编程",
+        "函数",
+        "报错",
+        "单元测试",
+        "正则",
+        "sql ",
+        "python ",
+        "javascript ",
+        "typescript ",
+        "java ",
+        "golang ",
+        "rust ",
+    )
+    reasoning_hints = (
+        "逐步推理",
+        "严谨证明",
+        "数学证明",
+        "逻辑推导",
+        "多步分析",
+        "step-by-step reasoning",
+        "prove that",
+        "formal proof",
+    )
+    tags: set[str] = set()
+    if any(hint in normalized for hint in coding_hints):
+        tags.add("coding")
+    if any(hint in normalized for hint in reasoning_hints):
+        tags.add("reasoning")
+    return tags
+
+
+@dataclass(frozen=True)
+class NativeDispatchTarget:
+    connection_id: str
+    connection_name: str
+    model_id: str
+    chat_completions_url: str
+    api_key: str
+    context_length: int | None
+    input_price_per_token: float | None
+    output_price_per_token: float | None
+    estimated_request_cost: float | None
+    score: float
+
+
+@dataclass(frozen=True)
+class NativeRoutePlan:
+    decision_id: str
+    session_id_hash: str | None
+    mode: RoutingMode
+    reason_codes: tuple[str, ...]
+    targets: tuple[NativeDispatchTarget, ...]
+    candidates_considered: int
+    budget_usd: float | None
+    budget_fallback: str
+
+
+@dataclass
+class _ConnectionCatalogCache:
+    records: list[dict[str, object]]
+    stored_at: float
+
+
+class NativeRouterEngine:
+    def __init__(
+        self,
+        service: ModelRouterService,
+        *,
+        catalog_ttl_seconds: float = 30.0,
+    ) -> None:
+        self.service = service
+        self.repository = service.repository
+        self.catalog_ttl_seconds = catalog_ttl_seconds
+        self._catalog_cache: dict[str, _ConnectionCatalogCache] = {}
+        self._cache_lock = asyncio.Lock()
+
+    async def plan(
+        self,
+        *,
+        mode: RoutingMode,
+        session_id: str | None,
+        estimated_input_tokens: int,
+        max_output_tokens: int,
+        required_input_modalities: set[str] | None = None,
+        required_output_modalities: set[str] | None = None,
+        required_capabilities: set[str] | None = None,
+        preferred_tags: set[str] | None = None,
+        budget_usd: float | None = None,
+        budget_fallback: str = "cheapest",
+        excluded_paths: set[tuple[str, str]] | None = None,
+        audit_engine: str = "native",
+    ) -> NativeRoutePlan:
+        session_hash = self.hash_session_id(session_id)
+        candidates = await self.build_candidates(
+            mode=mode,
+            estimated_input_tokens=estimated_input_tokens,
+            max_output_tokens=max_output_tokens,
+            task_tags=preferred_tags or set(),
+        )
+        last_known_good = None
+        get_lkgp = getattr(self.repository, "get_last_known_good", None)
+        if callable(get_lkgp):
+            last_known_good = get_lkgp(self.service.tenant_id, session_hash)
+        request = RoutingRequest(
+            tenant_id=self.service.tenant_id,
+            mode=mode,
+            required_input_modalities=frozenset(
+                required_input_modalities or {"text"}
+            ),
+            required_output_modalities=frozenset(
+                required_output_modalities or {"text"}
+            ),
+            required_capabilities=frozenset(required_capabilities or set()),
+            estimated_input_tokens=estimated_input_tokens,
+            max_output_tokens=max_output_tokens,
+            budget_usd=budget_usd,
+            budget_fallback=(
+                "strict" if budget_fallback == "strict" else "cheapest"
+            ),
+            preferred_tags=frozenset(preferred_tags or set()),
+            last_known_good=last_known_good,
+            excluded_paths=frozenset(excluded_paths or set()),
+        )
+        decision = decide_route(candidates, request)
+        targets = self._dispatch_targets(decision)
+        record = getattr(self.repository, "record_routing_decision", None)
+        decision_id = ""
+        if callable(record):
+            decision_id = record(
+                self.service.tenant_id,
+                session_id_hash=session_hash,
+                engine=audit_engine,
+                strategy=mode,
+                connection_id=decision.selected.connection_id,
+                model_id=decision.selected.model_id,
+                reason_codes=list(decision.reason_codes),
+                budget_limit_usd=(
+                    budget_usd if audit_engine == "native" else None
+                ),
+                reserved_cost_usd=(
+                    decision.selected.estimated_request_cost
+                    if budget_usd is not None and audit_engine == "native"
+                    else None
+                ),
+            )
+        return NativeRoutePlan(
+            decision_id=decision_id,
+            session_id_hash=session_hash,
+            mode=mode,
+            reason_codes=decision.reason_codes,
+            targets=targets,
+            candidates_considered=len(decision.ranked),
+            budget_usd=budget_usd,
+            budget_fallback=budget_fallback,
+        )
+
+    async def build_candidates(
+        self,
+        *,
+        mode: RoutingMode,
+        estimated_input_tokens: int,
+        max_output_tokens: int,
+        task_tags: set[str] | None = None,
+    ) -> list[RoutingCandidate]:
+        connections = [
+            item for item in self.service.list_connections() if item.enabled
+        ]
+        records_by_connection = await asyncio.gather(
+            *(self._records_for_connection(item) for item in connections)
+        )
+        provider_counts: dict[str, int] = {}
+        for connection in connections:
+            provider_counts[connection.kind] = (
+                provider_counts.get(connection.kind, 0) + 1
+            )
+        candidates: list[RoutingCandidate] = []
+        for connection, records in zip(
+            connections, records_by_connection, strict=True
+        ):
+            for record in records:
+                model_id = str(record.get("id", "")).strip()
+                if not model_id:
+                    continue
+                candidates.append(
+                    self._candidate_from_record(
+                        connection,
+                        record,
+                        mode=mode,
+                        estimated_input_tokens=estimated_input_tokens,
+                        max_output_tokens=max_output_tokens,
+                        connection_pool_size=provider_counts[connection.kind],
+                        task_tags=task_tags or set(),
+                    )
+                )
+        return candidates
+
+    def record_outcome(
+        self,
+        plan: NativeRoutePlan,
+        target: NativeDispatchTarget,
+        *,
+        success: bool,
+        latency_ms: float | None,
+        outcome: str,
+    ) -> None:
+        record_stats = getattr(self.repository, "record_candidate_outcome", None)
+        if callable(record_stats):
+            record_stats(
+                self.service.tenant_id,
+                target.connection_id,
+                target.model_id,
+                success=success,
+                latency_ms=latency_ms,
+            )
+        update_decision = getattr(
+            self.repository, "update_routing_decision_outcome", None
+        )
+        if callable(update_decision) and plan.decision_id:
+            update_decision(
+                self.service.tenant_id, plan.decision_id, outcome
+            )
+        if not success and plan.budget_usd is not None and plan.decision_id:
+            settle_budget = getattr(
+                self.repository, "settle_routing_budget", None
+            )
+            if callable(settle_budget):
+                settle_budget(
+                    self.service.tenant_id,
+                    plan.decision_id,
+                    settled_cost_usd=None,
+                    status="released",
+                )
+
+    def settle_budget(
+        self,
+        plan: NativeRoutePlan,
+        target: NativeDispatchTarget,
+        *,
+        input_tokens: int | None,
+        output_tokens: int | None,
+    ) -> tuple[float | None, str]:
+        actual_cost = None
+        if (
+            isinstance(input_tokens, int)
+            and isinstance(output_tokens, int)
+            and target.input_price_per_token is not None
+            and target.output_price_per_token is not None
+        ):
+            actual_cost = (
+                max(0, input_tokens) * target.input_price_per_token
+                + max(0, output_tokens) * target.output_price_per_token
+            )
+        settled_cost = (
+            actual_cost
+            if actual_cost is not None
+            else target.estimated_request_cost
+        )
+        status = "not_set"
+        if plan.budget_usd is not None:
+            if settled_cost is None:
+                status = "unavailable"
+            elif settled_cost <= plan.budget_usd:
+                status = (
+                    "settled"
+                    if actual_cost is not None
+                    else "covered_by_reservation"
+                )
+            else:
+                status = "over_limit"
+            settle = getattr(self.repository, "settle_routing_budget", None)
+            if callable(settle) and plan.decision_id:
+                settle(
+                    self.service.tenant_id,
+                    plan.decision_id,
+                    settled_cost_usd=settled_cost,
+                    status=status,
+                )
+        return actual_cost, status
+
+    async def _records_for_connection(
+        self, connection: RouterConnection
+    ) -> list[dict[str, object]]:
+        cached = self._catalog_cache.get(connection.id)
+        now = time.monotonic()
+        if cached and now - cached.stored_at <= self.catalog_ttl_seconds:
+            return [dict(item) for item in cached.records]
+        async with self._cache_lock:
+            cached = self._catalog_cache.get(connection.id)
+            now = time.monotonic()
+            if cached and now - cached.stored_at <= self.catalog_ttl_seconds:
+                return [dict(item) for item in cached.records]
+            result, records = await self.service.fetch_connection_model_records(
+                connection.id
+            )
+            if not result.ok:
+                return []
+            self._catalog_cache[connection.id] = _ConnectionCatalogCache(
+                records=[dict(item) for item in records],
+                stored_at=now,
+            )
+            return records
+
+    def _candidate_from_record(
+        self,
+        connection: RouterConnection,
+        record: dict[str, object],
+        *,
+        mode: RoutingMode,
+        estimated_input_tokens: int,
+        max_output_tokens: int,
+        connection_pool_size: int,
+        task_tags: set[str],
+    ) -> RoutingCandidate:
+        model_id = str(record["id"]).strip()
+        input_price, output_price = self._prices(record)
+        blended_cost = (
+            input_price * 1_000_000 * 0.6
+            + output_price * 1_000_000 * 0.4
+            if input_price is not None and output_price is not None
+            else None
+        )
+        estimated_cost = (
+            input_price * estimated_input_tokens
+            + output_price * max_output_tokens
+            if input_price is not None and output_price is not None
+            else None
+        )
+        stats_reader = getattr(self.repository, "get_candidate_stats", None)
+        stats = (
+            stats_reader(self.service.tenant_id, connection.id, model_id)
+            if callable(stats_reader)
+            else {}
+        )
+        input_modalities, output_modalities = self._modalities(record)
+        capabilities = self._capabilities(record)
+        preference_tags = self._preference_tags(
+            connection, model_id, input_modalities, capabilities
+        )
+        return RoutingCandidate(
+            tenant_id=self.service.tenant_id,
+            connection_id=connection.id,
+            connection_name=connection.name,
+            model_id=model_id,
+            enabled=connection.enabled,
+            credential_available=bool(connection.masked_key),
+            input_modalities=frozenset(input_modalities),
+            output_modalities=frozenset(output_modalities),
+            capabilities=frozenset(capabilities),
+            context_length=self._integer(record.get("context_length")),
+            quota_remaining=100.0,
+            cost_per_million_tokens=blended_cost,
+            estimated_request_cost=estimated_cost,
+            p95_latency_ms=float(stats.get("latency_ema_ms", 1000)),
+            latency_stddev_ms=float(stats.get("latency_stddev_ms", 0)),
+            error_rate=float(stats.get("error_rate", 0)),
+            breaker_state=str(stats.get("breaker_state", "closed")),  # type: ignore[arg-type]
+            task_fit=self._task_fit(model_id, mode, task_tags),
+            tier_priority=self._tier_priority(connection, model_id),
+            context_affinity=self._context_affinity(
+                self._integer(record.get("context_length")),
+                estimated_input_tokens + max_output_tokens,
+            ),
+            connection_pool_size=connection_pool_size,
+            preference_tags=frozenset(preference_tags),
+        )
+
+    def _dispatch_targets(
+        self, decision: RouterDecision
+    ) -> tuple[NativeDispatchTarget, ...]:
+        connections = {
+            item.id: item for item in self.service.list_connections()
+        }
+        targets: list[NativeDispatchTarget] = []
+        for item in decision.ranked[:3]:
+            candidate = item.candidate
+            connection = connections.get(candidate.connection_id)
+            if connection is None:
+                continue
+            targets.append(
+                NativeDispatchTarget(
+                    connection_id=connection.id,
+                    connection_name=connection.name,
+                    model_id=candidate.model_id,
+                    chat_completions_url=self._chat_url(connection.base_url),
+                    api_key=self.repository.resolve_api_key(
+                        self.service.tenant_id, connection.id
+                    ),
+                    context_length=candidate.context_length,
+                    input_price_per_token=self._prices(
+                        self._catalog_record(connection.id, candidate.model_id)
+                    )[0],
+                    output_price_per_token=self._prices(
+                        self._catalog_record(connection.id, candidate.model_id)
+                    )[1],
+                    estimated_request_cost=candidate.estimated_request_cost,
+                    score=item.score,
+                )
+            )
+        if not targets:
+            raise NoEligibleCandidateError(
+                "no_dispatch_target",
+                "没有可调用的模型服务连接。",
+            )
+        return tuple(targets)
+
+    def _catalog_record(
+        self, connection_id: str, model_id: str
+    ) -> dict[str, object]:
+        cached = self._catalog_cache.get(connection_id)
+        if cached is None:
+            return {}
+        return next(
+            (
+                record
+                for record in cached.records
+                if str(record.get("id", "")).strip() == model_id
+            ),
+            {},
+        )
+
+    @staticmethod
+    def mode_for_request(
+        model_id: str,
+        requested_mode: str | None,
+        default_mode: RoutingMode = "auto",
+    ) -> RoutingMode:
+        mode = (requested_mode or "").strip().lower()
+        aliases = {"balanced": "auto"}
+        mode = aliases.get(mode, mode)
+        if mode in {"auto", "fast", "quality", "cheap", "reliable", "offline"}:
+            return mode  # type: ignore[return-value]
+        suffix = model_id.strip().lower().removeprefix("auto/").split(":", 1)[0]
+        if suffix in {"fast", "quality", "cheap", "reliable", "offline"}:
+            return suffix  # type: ignore[return-value]
+        return default_mode
+
+    @staticmethod
+    def stable_canary_selected(
+        session_id: str | None, canary_percent: int
+    ) -> bool:
+        if canary_percent <= 0:
+            return False
+        if canary_percent >= 100:
+            return True
+        stable = session_id or "anonymous"
+        bucket = int.from_bytes(
+            hashlib.sha256(stable.encode("utf-8")).digest()[:4], "big"
+        ) % 100
+        return bucket < canary_percent
+
+    def hash_session_id(self, session_id: str | None) -> str | None:
+        if not session_id:
+            return None
+        material = f"{self.service.tenant_id}:{session_id}".encode("utf-8")
+        return hashlib.sha256(material).hexdigest()
+
+    @staticmethod
+    def _prices(
+        record: dict[str, object]
+    ) -> tuple[float | None, float | None]:
+        pricing = record.get("pricing")
+        if not isinstance(pricing, dict):
+            return None, None
+
+        def parse(name: str) -> float | None:
+            try:
+                value = float(pricing.get(name))
+            except (TypeError, ValueError):
+                return None
+            return max(0.0, value)
+
+        return parse("prompt"), parse("completion")
+
+    @staticmethod
+    def _modalities(
+        record: dict[str, object]
+    ) -> tuple[set[str], set[str]]:
+        architecture = record.get("architecture")
+        raw_input: object = None
+        raw_output: object = None
+        if isinstance(architecture, dict):
+            raw_input = architecture.get("input_modalities")
+            raw_output = architecture.get("output_modalities")
+            modality = str(architecture.get("modality", "")).lower()
+        else:
+            modality = ""
+        inputs = (
+            {str(item).lower() for item in raw_input}
+            if isinstance(raw_input, list)
+            else {"text"}
+        )
+        outputs = (
+            {str(item).lower() for item in raw_output}
+            if isinstance(raw_output, list)
+            else {"text"}
+        )
+        if "image" in modality:
+            inputs.add("image")
+        return inputs or {"text"}, outputs or {"text"}
+
+    @staticmethod
+    def _capabilities(record: dict[str, object]) -> set[str]:
+        parameters = record.get("supported_parameters")
+        values = (
+            {str(item).lower() for item in parameters}
+            if isinstance(parameters, list)
+            else set()
+        )
+        capabilities: set[str] = set()
+        if {"tools", "tool_choice"}.intersection(values):
+            capabilities.add("tools")
+        if {"reasoning", "include_reasoning"}.intersection(values):
+            capabilities.add("reasoning")
+        return capabilities
+
+    @staticmethod
+    def _preference_tags(
+        connection: RouterConnection,
+        model_id: str,
+        input_modalities: set[str],
+        capabilities: set[str],
+    ) -> set[str]:
+        lowered = model_id.lower()
+        tags = {"chat"}
+        if "image" in input_modalities:
+            tags.update({"vision", "multimodal"})
+        if "reasoning" in capabilities or any(
+            hint in lowered for hint in ("reason", "thinking", "o3", "o4")
+        ):
+            tags.add("reasoning")
+        if any(
+            hint in lowered
+            for hint in ("code", "coder", "codex", "devstral", "sol")
+        ):
+            tags.add("coding")
+        specialized_only = any(
+            hint in lowered
+            for hint in (
+                "code",
+                "coder",
+                "codex",
+                "devstral",
+                "embedding",
+                "rerank",
+                "moderation",
+                "image-gen",
+                "text-to-speech",
+            )
+        )
+        if not specialized_only:
+            tags.add("general")
+        host = (urlparse(connection.base_url).hostname or "").lower()
+        if connection.kind == "newapi" or host in {
+            "localhost",
+            "127.0.0.1",
+            "new-api",
+        }:
+            tags.add("offline")
+        return tags
+
+    @staticmethod
+    def _task_fit(
+        model_id: str, mode: RoutingMode, task_tags: set[str]
+    ) -> float:
+        lowered = model_id.lower()
+        quality_hints = (
+            ("opus-5", 1.0),
+            ("gpt-5.6", 0.98),
+            ("fable-5", 0.96),
+            ("sonnet-4.6", 0.92),
+            ("gemini-3", 0.90),
+            ("kimi-k3", 0.88),
+            ("deepseek-v4", 0.86),
+        )
+        quality = next(
+            (score for hint, score in quality_hints if hint in lowered),
+            0.62,
+        )
+        if mode == "quality":
+            return quality
+        if "coding" in task_tags and any(
+            hint in lowered
+            for hint in ("code", "coder", "codex", "devstral", "sol")
+        ):
+            return max(quality, 0.92)
+        if "reasoning" in task_tags and (
+            "reasoning" in lowered
+            or any(hint in lowered for hint in ("o3", "o4", "thinking"))
+        ):
+            return max(quality, 0.92)
+        return max(0.5, quality * 0.8)
+
+    @staticmethod
+    def _tier_priority(
+        connection: RouterConnection, model_id: str
+    ) -> float:
+        lowered = model_id.lower()
+        if lowered.endswith(":free") or "/free" in lowered:
+            return 0.0
+        quality_hints = (
+            ("opus-5", 1.0),
+            ("gpt-5.6", 0.98),
+            ("fable-5", 0.96),
+            ("sonnet-4.6", 0.92),
+            ("gemini-3", 0.90),
+            ("kimi-k3", 0.88),
+            ("deepseek-v4", 0.86),
+        )
+        return next(
+            (score for hint, score in quality_hints if hint in lowered),
+            0.5,
+        )
+
+    @staticmethod
+    def _context_affinity(
+        context_length: int | None, required_tokens: int
+    ) -> float:
+        if context_length is None or context_length <= 0:
+            return 0.5
+        if required_tokens <= 0:
+            return 0.5
+        return max(0.0, min(1.0, context_length / (required_tokens * 2)))
+
+    @staticmethod
+    def _chat_url(base_url: str) -> str:
+        base = base_url.rstrip("/")
+        if base.lower().endswith("/models"):
+            return f"{base[:-7]}/chat/completions"
+        if base.lower().endswith("/v1"):
+            return f"{base}/chat/completions"
+        return f"{base}/v1/chat/completions"
+
+    @staticmethod
+    def _integer(value: Any) -> int | None:
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            return None
+        return parsed if parsed > 0 else None

--- a/server/model_router/fixtures/omniroute-v3.8.49-routing.json
+++ b/server/model_router/fixtures/omniroute-v3.8.49-routing.json
@@ -1,0 +1,38 @@
+{
+  "source": {
+    "project": "diegosouzapw/OmniRoute",
+    "release": "v3.8.49",
+    "commit": "36f8fd10052f",
+    "kind": "behavior-reference",
+    "source_code_copied": false
+  },
+  "score_factors": {
+    "health": 0.2,
+    "quota": 0.15,
+    "cost_inverse": 0.15,
+    "latency_inverse": 0.12,
+    "task_fit": 0.08,
+    "stability": 0.05,
+    "tier_priority": 0.05,
+    "tier_affinity": 0.05,
+    "specificity_match": 0.05,
+    "context_affinity": 0.05,
+    "connection_density": 0.05,
+    "reset_window_affinity": 0.0
+  },
+  "public_modes": [
+    "auto",
+    "fast",
+    "quality",
+    "cheap",
+    "reliable",
+    "offline"
+  ],
+  "invariants": [
+    "hard_constraints_never_fail_open",
+    "shadow_does_not_send_a_second_request",
+    "retry_only_before_visible_output",
+    "empty_stream_is_failure",
+    "lkgp_is_tenant_connection_model_scoped"
+  ]
+}

--- a/server/model_router/repository.py
+++ b/server/model_router/repository.py
@@ -1,0 +1,951 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import sqlite3
+import threading
+import time
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Protocol
+
+from cryptography.fernet import Fernet, InvalidToken
+
+from .schemas import (
+    RouterConnection,
+    RouterConnectionCreate,
+    RouterConnectionUpdate,
+    RouterPolicy,
+)
+
+
+SCHEMA_VERSION = 3
+DEFAULT_TENANT_ID = "local"
+
+
+class RouterRepositoryError(Exception):
+    """Base error for the native model-router repository."""
+
+
+class RouterConnectionNotFound(RouterRepositoryError):
+    """Raised when a tenant cannot see the requested connection."""
+
+
+class RouterCredentialUnavailable(RouterRepositoryError):
+    """Raised when encrypted connection material cannot be recovered."""
+
+
+class RouterRepository(Protocol):
+    def list_connections(self, tenant_id: str) -> list[RouterConnection]: ...
+
+    def create_connection(
+        self, tenant_id: str, payload: RouterConnectionCreate
+    ) -> RouterConnection: ...
+
+    def update_connection(
+        self, tenant_id: str, connection_id: str, payload: RouterConnectionUpdate
+    ) -> RouterConnection: ...
+
+    def get_connection(
+        self, tenant_id: str, connection_id: str
+    ) -> RouterConnection: ...
+
+    def resolve_api_key(self, tenant_id: str, connection_id: str) -> str: ...
+
+    def get_policy(self, tenant_id: str) -> RouterPolicy: ...
+
+    def save_policy(self, tenant_id: str, policy: RouterPolicy) -> RouterPolicy: ...
+
+
+def utc_now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+class SQLiteRouterRepository:
+    """Tenant-scoped SQLite persistence with encrypted provider credentials."""
+
+    def __init__(
+        self,
+        storage_dir: str | Path | None = None,
+        *,
+        master_key: str | bytes | None = None,
+    ) -> None:
+        package_dir = Path(__file__).resolve().parent
+        self.storage_dir = Path(
+            storage_dir
+            or os.getenv("MODEL_ROUTER_STORAGE_DIR", "").strip()
+            or package_dir / "storage"
+        )
+        self.database_path = self.storage_dir / "router.sqlite3"
+        self.master_key_path = self.storage_dir / "credential-master.key"
+        self._lock = threading.RLock()
+        self.storage_dir.mkdir(parents=True, exist_ok=True)
+        self._fernet = Fernet(self._resolve_master_key(master_key))
+        self._initialize()
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self.database_path, timeout=15)
+        connection.row_factory = sqlite3.Row
+        connection.execute("PRAGMA foreign_keys = ON")
+        connection.execute("PRAGMA journal_mode = WAL")
+        return connection
+
+    def _initialize(self) -> None:
+        schema = """
+        CREATE TABLE IF NOT EXISTS router_connections (
+            id TEXT NOT NULL,
+            tenant_id TEXT NOT NULL,
+            name TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            base_url TEXT NOT NULL,
+            masked_key TEXT NOT NULL,
+            api_key_ciphertext TEXT NOT NULL,
+            enabled INTEGER NOT NULL DEFAULT 1,
+            health TEXT NOT NULL DEFAULT 'untested',
+            model_count INTEGER NOT NULL DEFAULT 0,
+            last_checked_at TEXT,
+            last_error_code TEXT,
+            last_error_hint TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, id)
+        );
+        CREATE TABLE IF NOT EXISTS router_policies (
+            tenant_id TEXT PRIMARY KEY,
+            engine TEXT NOT NULL DEFAULT 'sidecar',
+            default_mode TEXT NOT NULL DEFAULT 'auto',
+            canary_percent INTEGER NOT NULL DEFAULT 0,
+            compression_mode TEXT NOT NULL DEFAULT 'auto',
+            updated_at TEXT NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS router_candidate_stats (
+            tenant_id TEXT NOT NULL,
+            connection_id TEXT NOT NULL,
+            model_id TEXT NOT NULL,
+            success_count INTEGER NOT NULL DEFAULT 0,
+            failure_count INTEGER NOT NULL DEFAULT 0,
+            latency_ema_ms REAL,
+            latency_stddev_ms REAL NOT NULL DEFAULT 0,
+            consecutive_failures INTEGER NOT NULL DEFAULT 0,
+            breaker_state TEXT NOT NULL DEFAULT 'closed',
+            breaker_open_until REAL,
+            last_success_at TEXT,
+            updated_at TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, connection_id, model_id)
+        );
+        CREATE TABLE IF NOT EXISTS router_decisions (
+            id TEXT NOT NULL,
+            tenant_id TEXT NOT NULL,
+            session_id_hash TEXT,
+            engine TEXT NOT NULL,
+            strategy TEXT NOT NULL,
+            selected_connection_id TEXT,
+            selected_model_id TEXT,
+            reason_codes_json TEXT NOT NULL DEFAULT '[]',
+            outcome TEXT,
+            budget_limit_usd REAL,
+            reserved_cost_usd REAL,
+            settled_cost_usd REAL,
+            budget_status TEXT,
+            created_at TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, id)
+        );
+        CREATE TABLE IF NOT EXISTS compression_runs (
+            id TEXT NOT NULL,
+            tenant_id TEXT NOT NULL,
+            request_id TEXT,
+            profile TEXT NOT NULL,
+            original_tokens INTEGER NOT NULL,
+            final_tokens INTEGER NOT NULL,
+            fidelity_status TEXT NOT NULL,
+            fallback_reason TEXT,
+            created_at TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, id)
+        );
+        CREATE INDEX IF NOT EXISTS idx_router_connections_tenant_enabled
+            ON router_connections (tenant_id, enabled);
+        CREATE INDEX IF NOT EXISTS idx_router_decisions_tenant_created
+            ON router_decisions (tenant_id, created_at);
+        CREATE INDEX IF NOT EXISTS idx_compression_runs_tenant_created
+            ON compression_runs (tenant_id, created_at);
+        """
+        with self._lock, self._connect() as connection:
+            connection.executescript(schema)
+            existing = {
+                row["name"]
+                for row in connection.execute(
+                    "PRAGMA table_info(router_candidate_stats)"
+                ).fetchall()
+            }
+            migrations = {
+                "latency_stddev_ms": (
+                    "ALTER TABLE router_candidate_stats "
+                    "ADD COLUMN latency_stddev_ms REAL NOT NULL DEFAULT 0"
+                ),
+                "consecutive_failures": (
+                    "ALTER TABLE router_candidate_stats "
+                    "ADD COLUMN consecutive_failures INTEGER NOT NULL DEFAULT 0"
+                ),
+                "breaker_open_until": (
+                    "ALTER TABLE router_candidate_stats "
+                    "ADD COLUMN breaker_open_until REAL"
+                ),
+                "last_success_at": (
+                    "ALTER TABLE router_candidate_stats "
+                    "ADD COLUMN last_success_at TEXT"
+                ),
+            }
+            for column, statement in migrations.items():
+                if column not in existing:
+                    connection.execute(statement)
+            decision_columns = {
+                row["name"]
+                for row in connection.execute(
+                    "PRAGMA table_info(router_decisions)"
+                ).fetchall()
+            }
+            decision_migrations = {
+                "budget_limit_usd": (
+                    "ALTER TABLE router_decisions "
+                    "ADD COLUMN budget_limit_usd REAL"
+                ),
+                "reserved_cost_usd": (
+                    "ALTER TABLE router_decisions "
+                    "ADD COLUMN reserved_cost_usd REAL"
+                ),
+                "settled_cost_usd": (
+                    "ALTER TABLE router_decisions "
+                    "ADD COLUMN settled_cost_usd REAL"
+                ),
+                "budget_status": (
+                    "ALTER TABLE router_decisions "
+                    "ADD COLUMN budget_status TEXT"
+                ),
+            }
+            for column, statement in decision_migrations.items():
+                if column not in decision_columns:
+                    connection.execute(statement)
+            connection.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
+
+    def create_connection(
+        self, tenant_id: str, payload: RouterConnectionCreate
+    ) -> RouterConnection:
+        clean_tenant = self._tenant_id(tenant_id)
+        api_key = payload.api_key.get_secret_value().strip()
+        now = utc_now()
+        connection_id = f"conn_{uuid.uuid4().hex}"
+        encrypted = self._fernet.encrypt(api_key.encode("utf-8")).decode("ascii")
+        with self._lock, self._connect() as connection:
+            connection.execute(
+                """
+                INSERT INTO router_connections (
+                    id, tenant_id, name, kind, base_url, masked_key,
+                    api_key_ciphertext, enabled, health, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    connection_id,
+                    clean_tenant,
+                    payload.name,
+                    payload.kind,
+                    payload.base_url,
+                    self._mask(api_key),
+                    encrypted,
+                    int(payload.enabled),
+                    "untested" if payload.enabled else "disabled",
+                    now,
+                    now,
+                ),
+            )
+        return self.get_connection(clean_tenant, connection_id)
+
+    def list_connections(self, tenant_id: str) -> list[RouterConnection]:
+        clean_tenant = self._tenant_id(tenant_id)
+        with self._lock, self._connect() as connection:
+            rows = connection.execute(
+                """
+                SELECT * FROM router_connections
+                WHERE tenant_id = ?
+                ORDER BY updated_at DESC, id ASC
+                """,
+                (clean_tenant,),
+            ).fetchall()
+        return [self._public_connection(row) for row in rows]
+
+    def get_connection(
+        self, tenant_id: str, connection_id: str
+    ) -> RouterConnection:
+        clean_tenant = self._tenant_id(tenant_id)
+        with self._lock, self._connect() as connection:
+            row = connection.execute(
+                """
+                SELECT * FROM router_connections
+                WHERE tenant_id = ? AND id = ?
+                """,
+                (clean_tenant, connection_id),
+            ).fetchone()
+        if row is None:
+            raise RouterConnectionNotFound("Model service connection was not found.")
+        return self._public_connection(row)
+
+    def update_connection(
+        self, tenant_id: str, connection_id: str, payload: RouterConnectionUpdate
+    ) -> RouterConnection:
+        current = self.get_connection(tenant_id, connection_id)
+        updates: list[str] = []
+        values: list[object] = []
+        for field_name in ("name", "base_url"):
+            value = getattr(payload, field_name)
+            if value is not None:
+                updates.append(f"{field_name} = ?")
+                values.append(value)
+        if payload.api_key is not None:
+            api_key = payload.api_key.get_secret_value().strip()
+            if not api_key:
+                raise RouterRepositoryError("api_key cannot be empty")
+            updates.extend(["api_key_ciphertext = ?", "masked_key = ?"])
+            values.extend(
+                [
+                    self._fernet.encrypt(api_key.encode("utf-8")).decode("ascii"),
+                    self._mask(api_key),
+                ]
+            )
+        if payload.enabled is not None:
+            updates.extend(["enabled = ?", "health = ?"])
+            values.extend(
+                [
+                    int(payload.enabled),
+                    "untested" if payload.enabled else "disabled",
+                ]
+            )
+        if not updates:
+            return current
+        updates.append("updated_at = ?")
+        values.append(utc_now())
+        values.extend([self._tenant_id(tenant_id), connection_id])
+        with self._lock, self._connect() as connection:
+            cursor = connection.execute(
+                f"""
+                UPDATE router_connections SET {", ".join(updates)}
+                WHERE tenant_id = ? AND id = ?
+                """,
+                tuple(values),
+            )
+            if cursor.rowcount != 1:
+                raise RouterConnectionNotFound(
+                    "Model service connection was not found."
+                )
+        return self.get_connection(tenant_id, connection_id)
+
+    def resolve_api_key(self, tenant_id: str, connection_id: str) -> str:
+        clean_tenant = self._tenant_id(tenant_id)
+        with self._lock, self._connect() as connection:
+            row = connection.execute(
+                """
+                SELECT api_key_ciphertext FROM router_connections
+                WHERE tenant_id = ? AND id = ?
+                """,
+                (clean_tenant, connection_id),
+            ).fetchone()
+        if row is None:
+            raise RouterConnectionNotFound("Model service connection was not found.")
+        try:
+            return self._fernet.decrypt(
+                str(row["api_key_ciphertext"]).encode("ascii")
+            ).decode("utf-8")
+        except (InvalidToken, ValueError, UnicodeDecodeError) as exc:
+            raise RouterCredentialUnavailable(
+                "The saved credential is unavailable. Please enter the key again."
+            ) from exc
+
+    def save_test_result(
+        self,
+        tenant_id: str,
+        connection_id: str,
+        *,
+        health: str,
+        model_count: int,
+        checked_at: str,
+        error_code: str | None = None,
+        error_hint: str | None = None,
+    ) -> RouterConnection:
+        self.get_connection(tenant_id, connection_id)
+        with self._lock, self._connect() as connection:
+            connection.execute(
+                """
+                UPDATE router_connections
+                SET health = ?, model_count = ?, last_checked_at = ?,
+                    last_error_code = ?, last_error_hint = ?, updated_at = ?
+                WHERE tenant_id = ? AND id = ?
+                """,
+                (
+                    health,
+                    model_count,
+                    checked_at,
+                    error_code,
+                    error_hint,
+                    checked_at,
+                    self._tenant_id(tenant_id),
+                    connection_id,
+                ),
+            )
+        return self.get_connection(tenant_id, connection_id)
+
+    def get_policy(self, tenant_id: str) -> RouterPolicy:
+        clean_tenant = self._tenant_id(tenant_id)
+        with self._lock, self._connect() as connection:
+            row = connection.execute(
+                "SELECT * FROM router_policies WHERE tenant_id = ?",
+                (clean_tenant,),
+            ).fetchone()
+        configured_engine = os.getenv("MODEL_ROUTER_ENGINE", "").strip().lower()
+        if configured_engine == "sidecar":
+            return RouterPolicy(
+                tenant_id=clean_tenant,
+                engine="sidecar",
+                default_mode=(row["default_mode"] if row is not None else "auto"),
+                canary_percent=(
+                    row["canary_percent"] if row is not None else 0
+                ),
+                compression_mode=(
+                    row["compression_mode"] if row is not None else "auto"
+                ),
+                updated_at=(row["updated_at"] if row is not None else None),
+            )
+        if row is None:
+            engine = configured_engine or "sidecar"
+            if engine not in {"sidecar", "shadow", "native_canary", "native"}:
+                engine = "sidecar"
+            try:
+                canary_percent = int(
+                    os.getenv("MODEL_ROUTER_CANARY_PERCENT", "0")
+                )
+            except ValueError:
+                canary_percent = 0
+            return RouterPolicy(
+                tenant_id=clean_tenant,
+                engine=engine,
+                canary_percent=max(0, min(100, canary_percent)),
+            )
+        return RouterPolicy(
+            tenant_id=clean_tenant,
+            engine=row["engine"],
+            default_mode=row["default_mode"],
+            canary_percent=row["canary_percent"],
+            compression_mode=row["compression_mode"],
+            updated_at=row["updated_at"],
+        )
+
+    def save_policy(self, tenant_id: str, policy: RouterPolicy) -> RouterPolicy:
+        clean_tenant = self._tenant_id(tenant_id)
+        now = utc_now()
+        normalized = policy.model_copy(
+            update={"tenant_id": clean_tenant, "updated_at": now}
+        )
+        with self._lock, self._connect() as connection:
+            connection.execute(
+                """
+                INSERT INTO router_policies (
+                    tenant_id, engine, default_mode, canary_percent,
+                    compression_mode, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                ON CONFLICT(tenant_id) DO UPDATE SET
+                    engine = excluded.engine,
+                    default_mode = excluded.default_mode,
+                    canary_percent = excluded.canary_percent,
+                    compression_mode = excluded.compression_mode,
+                    updated_at = excluded.updated_at
+                """,
+                (
+                    clean_tenant,
+                    normalized.engine,
+                    normalized.default_mode,
+                    normalized.canary_percent,
+                    normalized.compression_mode,
+                    now,
+                ),
+            )
+        return normalized
+
+    def count_schema_tenant_columns(self) -> dict[str, bool]:
+        tables = (
+            "router_connections",
+            "router_policies",
+            "router_candidate_stats",
+            "router_decisions",
+            "compression_runs",
+        )
+        with self._lock, self._connect() as connection:
+            return {
+                table: any(
+                    row["name"] == "tenant_id"
+                    for row in connection.execute(
+                        f"PRAGMA table_info({table})"
+                    ).fetchall()
+                )
+                for table in tables
+            }
+
+    def get_candidate_stats(
+        self,
+        tenant_id: str,
+        connection_id: str,
+        model_id: str,
+    ) -> dict[str, object]:
+        clean_tenant = self._tenant_id(tenant_id)
+        with self._lock, self._connect() as connection:
+            row = connection.execute(
+                """
+                SELECT * FROM router_candidate_stats
+                WHERE tenant_id = ? AND connection_id = ? AND model_id = ?
+                """,
+                (clean_tenant, connection_id, model_id),
+            ).fetchone()
+        if row is None:
+            return {
+                "success_count": 0,
+                "failure_count": 0,
+                "latency_ema_ms": 1000.0,
+                "latency_stddev_ms": 0.0,
+                "error_rate": 0.0,
+                "consecutive_failures": 0,
+                "breaker_state": "closed",
+                "breaker_open_until": None,
+                "last_success_at": None,
+            }
+        breaker_state = str(row["breaker_state"])
+        open_until = row["breaker_open_until"]
+        if (
+            breaker_state == "open"
+            and open_until is not None
+            and float(open_until) <= time.time()
+        ):
+            breaker_state = "half_open"
+        total = int(row["success_count"]) + int(row["failure_count"])
+        return {
+            "success_count": int(row["success_count"]),
+            "failure_count": int(row["failure_count"]),
+            "latency_ema_ms": float(row["latency_ema_ms"] or 1000),
+            "latency_stddev_ms": float(row["latency_stddev_ms"] or 0),
+            "error_rate": (
+                float(row["failure_count"]) / total if total > 0 else 0.0
+            ),
+            "consecutive_failures": int(row["consecutive_failures"]),
+            "breaker_state": breaker_state,
+            "breaker_open_until": open_until,
+            "last_success_at": row["last_success_at"],
+        }
+
+    def record_candidate_outcome(
+        self,
+        tenant_id: str,
+        connection_id: str,
+        model_id: str,
+        *,
+        success: bool,
+        latency_ms: float | None,
+    ) -> dict[str, object]:
+        clean_tenant = self._tenant_id(tenant_id)
+        current = self.get_candidate_stats(
+            clean_tenant, connection_id, model_id
+        )
+        success_count = int(current["success_count"]) + int(success)
+        failure_count = int(current["failure_count"]) + int(not success)
+        consecutive = 0 if success else int(current["consecutive_failures"]) + 1
+        old_latency = float(current["latency_ema_ms"])
+        sample = max(0.0, float(latency_ms or old_latency))
+        latency_ema = sample if success_count + failure_count == 1 else (
+            old_latency * 0.8 + sample * 0.2
+        )
+        latency_stddev = (
+            float(current["latency_stddev_ms"]) * 0.8
+            + abs(sample - old_latency) * 0.2
+        )
+        breaker_state = "closed"
+        breaker_open_until: float | None = None
+        if not success and consecutive >= 3:
+            breaker_state = "open"
+            breaker_open_until = time.time() + min(
+                1800.0, 300.0 * (2 ** (consecutive - 3))
+            )
+        last_success_at = utc_now() if success else current["last_success_at"]
+        now = utc_now()
+        with self._lock, self._connect() as connection:
+            connection.execute(
+                """
+                INSERT INTO router_candidate_stats (
+                    tenant_id, connection_id, model_id, success_count,
+                    failure_count, latency_ema_ms, latency_stddev_ms,
+                    consecutive_failures, breaker_state, breaker_open_until,
+                    last_success_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(tenant_id, connection_id, model_id) DO UPDATE SET
+                    success_count = excluded.success_count,
+                    failure_count = excluded.failure_count,
+                    latency_ema_ms = excluded.latency_ema_ms,
+                    latency_stddev_ms = excluded.latency_stddev_ms,
+                    consecutive_failures = excluded.consecutive_failures,
+                    breaker_state = excluded.breaker_state,
+                    breaker_open_until = excluded.breaker_open_until,
+                    last_success_at = excluded.last_success_at,
+                    updated_at = excluded.updated_at
+                """,
+                (
+                    clean_tenant,
+                    connection_id,
+                    model_id,
+                    success_count,
+                    failure_count,
+                    latency_ema,
+                    latency_stddev,
+                    consecutive,
+                    breaker_state,
+                    breaker_open_until,
+                    last_success_at,
+                    now,
+                ),
+            )
+        return self.get_candidate_stats(clean_tenant, connection_id, model_id)
+
+    def record_routing_decision(
+        self,
+        tenant_id: str,
+        *,
+        session_id_hash: str | None,
+        engine: str,
+        strategy: str,
+        connection_id: str | None,
+        model_id: str | None,
+        reason_codes: list[str],
+        outcome: str | None = None,
+        budget_limit_usd: float | None = None,
+        reserved_cost_usd: float | None = None,
+    ) -> str:
+        clean_tenant = self._tenant_id(tenant_id)
+        decision_id = f"decision_{uuid.uuid4().hex}"
+        with self._lock, self._connect() as connection:
+            connection.execute(
+                """
+                INSERT INTO router_decisions (
+                    id, tenant_id, session_id_hash, engine, strategy,
+                    selected_connection_id, selected_model_id,
+                    reason_codes_json, outcome, budget_limit_usd,
+                    reserved_cost_usd, budget_status, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    decision_id,
+                    clean_tenant,
+                    session_id_hash,
+                    engine,
+                    strategy,
+                    connection_id,
+                    model_id,
+                    json.dumps(reason_codes, ensure_ascii=False),
+                    outcome,
+                    budget_limit_usd,
+                    reserved_cost_usd,
+                    "reserved" if budget_limit_usd is not None else None,
+                    utc_now(),
+                ),
+            )
+        return decision_id
+
+    def update_routing_decision_outcome(
+        self, tenant_id: str, decision_id: str, outcome: str
+    ) -> None:
+        with self._lock, self._connect() as connection:
+            connection.execute(
+                """
+                UPDATE router_decisions SET outcome = ?
+                WHERE tenant_id = ? AND id = ?
+                """,
+                (outcome, self._tenant_id(tenant_id), decision_id),
+            )
+
+    def settle_routing_budget(
+        self,
+        tenant_id: str,
+        decision_id: str,
+        *,
+        settled_cost_usd: float | None,
+        status: str,
+    ) -> None:
+        with self._lock, self._connect() as connection:
+            connection.execute(
+                """
+                UPDATE router_decisions
+                SET settled_cost_usd = ?, budget_status = ?
+                WHERE tenant_id = ? AND id = ?
+                """,
+                (
+                    settled_cost_usd,
+                    status,
+                    self._tenant_id(tenant_id),
+                    decision_id,
+                ),
+            )
+
+    def get_last_known_good(
+        self, tenant_id: str, session_id_hash: str | None
+    ) -> tuple[str, str] | None:
+        if not session_id_hash:
+            return None
+        with self._lock, self._connect() as connection:
+            row = connection.execute(
+                """
+                SELECT selected_connection_id, selected_model_id
+                FROM router_decisions
+                WHERE tenant_id = ? AND session_id_hash = ?
+                    AND outcome = 'success'
+                    AND selected_connection_id IS NOT NULL
+                    AND selected_model_id IS NOT NULL
+                ORDER BY created_at DESC LIMIT 1
+                """,
+                (self._tenant_id(tenant_id), session_id_hash),
+            ).fetchone()
+        if row is None:
+            return None
+        return str(row["selected_connection_id"]), str(row["selected_model_id"])
+
+    def record_compression_run(
+        self,
+        tenant_id: str,
+        *,
+        request_id: str | None,
+        profile: str,
+        original_tokens: int,
+        final_tokens: int,
+        fidelity_status: str,
+        fallback_reason: str | None,
+    ) -> str:
+        run_id = f"compression_{uuid.uuid4().hex}"
+        with self._lock, self._connect() as connection:
+            connection.execute(
+                """
+                INSERT INTO compression_runs (
+                    id, tenant_id, request_id, profile, original_tokens,
+                    final_tokens, fidelity_status, fallback_reason, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    run_id,
+                    self._tenant_id(tenant_id),
+                    request_id,
+                    profile,
+                    max(0, int(original_tokens)),
+                    max(0, int(final_tokens)),
+                    fidelity_status,
+                    fallback_reason,
+                    utc_now(),
+                ),
+            )
+        return run_id
+
+    def get_diagnostics(
+        self, tenant_id: str, *, limit: int = 20
+    ) -> dict[str, object]:
+        clean_tenant = self._tenant_id(tenant_id)
+        safe_limit = max(1, min(int(limit), 100))
+        with self._lock, self._connect() as connection:
+            decision_rows = connection.execute(
+                """
+                SELECT d.id, d.engine, d.strategy, d.selected_model_id,
+                    d.reason_codes_json, d.outcome, d.budget_limit_usd,
+                    d.reserved_cost_usd, d.settled_cost_usd,
+                    d.budget_status, d.created_at,
+                    c.name AS connection_name
+                FROM router_decisions d
+                LEFT JOIN router_connections c
+                    ON c.tenant_id = d.tenant_id
+                    AND c.id = d.selected_connection_id
+                WHERE d.tenant_id = ?
+                ORDER BY d.created_at DESC
+                LIMIT ?
+                """,
+                (clean_tenant, safe_limit),
+            ).fetchall()
+            compression_rows = connection.execute(
+                """
+                SELECT id, request_id, profile, original_tokens, final_tokens,
+                    fidelity_status, fallback_reason, created_at
+                FROM compression_runs
+                WHERE tenant_id = ?
+                ORDER BY created_at DESC
+                LIMIT ?
+                """,
+                (clean_tenant, safe_limit),
+            ).fetchall()
+            stats_rows = connection.execute(
+                """
+                SELECT breaker_state, COUNT(*) AS count
+                FROM router_candidate_stats
+                WHERE tenant_id = ?
+                GROUP BY breaker_state
+                """,
+                (clean_tenant,),
+            ).fetchall()
+            aggregate = connection.execute(
+                """
+                SELECT
+                    COUNT(*) AS request_count,
+                    SUM(CASE WHEN outcome = 'success' THEN 1 ELSE 0 END)
+                        AS success_count,
+                    SUM(CASE WHEN outcome = 'empty_stream' THEN 1 ELSE 0 END)
+                        AS empty_stream_count,
+                    MIN(created_at) AS first_request_at,
+                    MAX(created_at) AS last_request_at
+                FROM router_decisions
+                WHERE tenant_id = ? AND engine = 'native'
+                """,
+                (clean_tenant,),
+            ).fetchone()
+        request_count = int(aggregate["request_count"] or 0)
+        success_count = int(aggregate["success_count"] or 0)
+        empty_count = int(aggregate["empty_stream_count"] or 0)
+        first_request = aggregate["first_request_at"]
+        observed_days = 0.0
+        if first_request:
+            try:
+                observed_days = max(
+                    0.0,
+                    (
+                        datetime.now(UTC)
+                        - datetime.fromisoformat(str(first_request))
+                    ).total_seconds()
+                    / 86_400,
+                )
+            except ValueError:
+                observed_days = 0.0
+        gate = {
+            "request_count": request_count,
+            "success_count": success_count,
+            "success_rate": (
+                success_count / request_count if request_count else None
+            ),
+            "empty_stream_count": empty_count,
+            "empty_stream_rate": (
+                empty_count / request_count if request_count else None
+            ),
+            "first_request_at": first_request,
+            "last_request_at": aggregate["last_request_at"],
+            "observed_days": round(observed_days, 2),
+            "request_gate_met": request_count >= 500,
+            "duration_gate_met": observed_days >= 14,
+            "automatic_native_default_allowed": (
+                request_count >= 500 and observed_days >= 14
+            ),
+            "manual_safety_gates_required": True,
+        }
+        return {
+            "tenant_id": clean_tenant,
+            "redacted": True,
+            "breaker_summary": {
+                str(row["breaker_state"]): int(row["count"])
+                for row in stats_rows
+            },
+            "migration_gate": gate,
+            "recent_decisions": [
+                {
+                    "id": row["id"],
+                    "engine": row["engine"],
+                    "strategy": row["strategy"],
+                    "model_id": row["selected_model_id"],
+                    "connection_name": row["connection_name"],
+                    "reason_codes": json.loads(
+                        str(row["reason_codes_json"] or "[]")
+                    ),
+                    "outcome": row["outcome"],
+                    "budget": {
+                        "limit_usd": row["budget_limit_usd"],
+                        "reserved_cost_usd": row["reserved_cost_usd"],
+                        "settled_cost_usd": row["settled_cost_usd"],
+                        "status": row["budget_status"],
+                    },
+                    "created_at": row["created_at"],
+                }
+                for row in decision_rows
+            ],
+            "recent_compressions": [
+                {
+                    "id": row["id"],
+                    "request_id": row["request_id"],
+                    "profile": row["profile"],
+                    "original_tokens": row["original_tokens"],
+                    "final_tokens": row["final_tokens"],
+                    "saved_tokens": max(
+                        0,
+                        int(row["original_tokens"])
+                        - int(row["final_tokens"]),
+                    ),
+                    "fidelity_status": row["fidelity_status"],
+                    "fallback_reason": row["fallback_reason"],
+                    "created_at": row["created_at"],
+                }
+                for row in compression_rows
+            ],
+        }
+
+    def _resolve_master_key(self, supplied: str | bytes | None) -> bytes:
+        if supplied:
+            return self._normalize_key(supplied)
+        environment_key = os.getenv(
+            "MODEL_ROUTER_CREDENTIAL_MASTER_KEY", ""
+        ).strip()
+        if environment_key:
+            return self._normalize_key(environment_key)
+        if self.master_key_path.exists():
+            return self._normalize_key(self.master_key_path.read_bytes().strip())
+        key = Fernet.generate_key()
+        temporary = self.master_key_path.with_suffix(".tmp")
+        temporary.write_bytes(key)
+        os.replace(temporary, self.master_key_path)
+        try:
+            os.chmod(self.master_key_path, 0o600)
+        except OSError:
+            pass
+        return key
+
+    @staticmethod
+    def _normalize_key(value: str | bytes) -> bytes:
+        raw = value.encode("utf-8") if isinstance(value, str) else bytes(value)
+        try:
+            Fernet(raw)
+            return raw
+        except ValueError:
+            return base64.urlsafe_b64encode(hashlib.sha256(raw).digest())
+
+    @staticmethod
+    def _public_connection(row: sqlite3.Row) -> RouterConnection:
+        return RouterConnection(
+            id=row["id"],
+            tenant_id=row["tenant_id"],
+            name=row["name"],
+            kind=row["kind"],
+            base_url=row["base_url"],
+            masked_key=row["masked_key"],
+            enabled=bool(row["enabled"]),
+            health=row["health"],
+            model_count=row["model_count"],
+            last_checked_at=row["last_checked_at"],
+            last_error_code=row["last_error_code"],
+            last_error_hint=row["last_error_hint"],
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
+        )
+
+    @staticmethod
+    def _mask(value: str) -> str:
+        if len(value) <= 4:
+            return "*" * len(value)
+        return f"{value[:2]}{'*' * min(12, len(value) - 4)}{value[-2:]}"
+
+    @staticmethod
+    def _tenant_id(value: str) -> str:
+        tenant_id = str(value or "").strip()
+        if not tenant_id or len(tenant_id) > 120:
+            raise RouterRepositoryError("tenant_id is invalid")
+        return tenant_id

--- a/server/model_router/routing.py
+++ b/server/model_router/routing.py
@@ -1,0 +1,414 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+from .schemas import RoutingMode
+
+
+BreakerState = Literal["closed", "open", "half_open"]
+
+FACTOR_NAMES = (
+    "quota",
+    "health",
+    "cost_inverse",
+    "latency_inverse",
+    "task_fit",
+    "stability",
+    "tier_priority",
+    "tier_affinity",
+    "specificity_match",
+    "context_affinity",
+    "cache_affinity",
+    "reset_window_affinity",
+    "connection_density",
+)
+
+DEFAULT_WEIGHTS = {
+    "quota": 0.15,
+    "health": 0.20,
+    "cost_inverse": 0.15,
+    "latency_inverse": 0.12,
+    "task_fit": 0.08,
+    "stability": 0.05,
+    "tier_priority": 0.05,
+    "tier_affinity": 0.05,
+    "specificity_match": 0.05,
+    "context_affinity": 0.05,
+    "cache_affinity": 0.00,
+    "reset_window_affinity": 0.00,
+    "connection_density": 0.05,
+}
+
+MODE_WEIGHTS: dict[RoutingMode, dict[str, float]] = {
+    "auto": DEFAULT_WEIGHTS,
+    "reliable": DEFAULT_WEIGHTS,
+    "fast": {
+        "quota": 0.14,
+        "health": 0.28,
+        "cost_inverse": 0.05,
+        "latency_inverse": 0.32,
+        "task_fit": 0.10,
+        "stability": 0.00,
+        "tier_priority": 0.05,
+        "tier_affinity": 0.00,
+        "specificity_match": 0.00,
+        "context_affinity": 0.00,
+        "cache_affinity": 0.00,
+        "reset_window_affinity": 0.00,
+        "connection_density": 0.06,
+    },
+    "cheap": {
+        "quota": 0.14,
+        "health": 0.19,
+        "cost_inverse": 0.37,
+        "latency_inverse": 0.05,
+        "task_fit": 0.10,
+        "stability": 0.05,
+        "tier_priority": 0.05,
+        "tier_affinity": 0.00,
+        "specificity_match": 0.00,
+        "context_affinity": 0.00,
+        "cache_affinity": 0.00,
+        "reset_window_affinity": 0.00,
+        "connection_density": 0.05,
+    },
+    "quality": {
+        "quota": 0.10,
+        "health": 0.18,
+        "cost_inverse": 0.05,
+        "latency_inverse": 0.05,
+        "task_fit": 0.37,
+        "stability": 0.15,
+        "tier_priority": 0.05,
+        "tier_affinity": 0.00,
+        "specificity_match": 0.00,
+        "context_affinity": 0.00,
+        "cache_affinity": 0.00,
+        "reset_window_affinity": 0.00,
+        "connection_density": 0.05,
+    },
+    "offline": {
+        "quota": 0.37,
+        "health": 0.28,
+        "cost_inverse": 0.10,
+        "latency_inverse": 0.05,
+        "task_fit": 0.00,
+        "stability": 0.10,
+        "tier_priority": 0.05,
+        "tier_affinity": 0.00,
+        "specificity_match": 0.00,
+        "context_affinity": 0.00,
+        "cache_affinity": 0.00,
+        "reset_window_affinity": 0.00,
+        "connection_density": 0.05,
+    },
+}
+
+
+def clamp01(value: float) -> float:
+    if value != value:
+        return 0.0
+    return max(0.0, min(1.0, float(value)))
+
+
+@dataclass(frozen=True)
+class RoutingCandidate:
+    tenant_id: str
+    connection_id: str
+    connection_name: str
+    model_id: str
+    enabled: bool = True
+    credential_available: bool = True
+    input_modalities: frozenset[str] = frozenset({"text"})
+    output_modalities: frozenset[str] = frozenset({"text"})
+    capabilities: frozenset[str] = frozenset()
+    context_length: int | None = None
+    quota_remaining: float = 100.0
+    cost_per_million_tokens: float | None = None
+    estimated_request_cost: float | None = None
+    p95_latency_ms: float = 1000.0
+    latency_stddev_ms: float = 0.0
+    error_rate: float = 0.0
+    breaker_state: BreakerState = "closed"
+    task_fit: float = 0.5
+    tier_priority: float = 0.33
+    tier_affinity: float = 0.5
+    specificity_match: float = 0.5
+    context_affinity: float = 0.5
+    cache_affinity: float = 0.0
+    reset_window_affinity: float = 0.5
+    connection_pool_size: int = 1
+    preference_tags: frozenset[str] = frozenset()
+
+
+@dataclass(frozen=True)
+class RoutingRequest:
+    tenant_id: str
+    mode: RoutingMode = "auto"
+    required_input_modalities: frozenset[str] = frozenset({"text"})
+    required_output_modalities: frozenset[str] = frozenset({"text"})
+    required_capabilities: frozenset[str] = frozenset()
+    estimated_input_tokens: int = 0
+    max_output_tokens: int = 2048
+    budget_usd: float | None = None
+    budget_fallback: Literal["strict", "cheapest"] = "cheapest"
+    preferred_tags: frozenset[str] = frozenset()
+    last_known_good: tuple[str, str] | None = None
+    excluded_paths: frozenset[tuple[str, str]] = frozenset()
+
+
+@dataclass(frozen=True)
+class RankedCandidate:
+    candidate: RoutingCandidate
+    score: float
+    factors: dict[str, float]
+
+
+@dataclass(frozen=True)
+class RouterDecision:
+    selected: RoutingCandidate
+    ranked: tuple[RankedCandidate, ...]
+    mode: RoutingMode
+    reason_codes: tuple[str, ...]
+    filtered_counts: dict[str, int] = field(default_factory=dict)
+
+
+class NoEligibleCandidateError(Exception):
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        *,
+        filtered_counts: dict[str, int] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.filtered_counts = filtered_counts or {}
+
+
+def validate_weights(weights: dict[str, float]) -> bool:
+    return set(weights) == set(FACTOR_NAMES) and abs(sum(weights.values()) - 1) < 0.01
+
+
+def _hard_filter(
+    candidates: list[RoutingCandidate],
+    request: RoutingRequest,
+) -> tuple[list[RoutingCandidate], dict[str, int]]:
+    counts: dict[str, int] = {}
+    eligible: list[RoutingCandidate] = []
+    for candidate in candidates:
+        reason: str | None = None
+        if candidate.tenant_id != request.tenant_id:
+            reason = "tenant"
+        elif not candidate.enabled:
+            reason = "connection_disabled"
+        elif not candidate.credential_available:
+            reason = "credential_unavailable"
+        elif candidate.breaker_state == "open":
+            reason = "breaker_open"
+        elif (candidate.connection_id, candidate.model_id) in request.excluded_paths:
+            reason = "request_excluded"
+        elif not request.required_input_modalities.issubset(
+            candidate.input_modalities
+        ):
+            reason = "input_modality"
+        elif not request.required_output_modalities.issubset(
+            candidate.output_modalities
+        ):
+            reason = "output_modality"
+        elif not request.required_capabilities.issubset(candidate.capabilities):
+            reason = "capability"
+        elif (
+            candidate.context_length is not None
+            and request.estimated_input_tokens + request.max_output_tokens
+            > candidate.context_length
+        ):
+            reason = "context_length"
+        elif (
+            request.budget_usd is not None
+            and request.budget_fallback == "strict"
+            and (
+                candidate.estimated_request_cost is None
+                or candidate.estimated_request_cost > request.budget_usd
+            )
+        ):
+            reason = "strict_budget"
+        if reason:
+            counts[reason] = counts.get(reason, 0) + 1
+        else:
+            eligible.append(candidate)
+    return eligible, counts
+
+
+def _apply_soft_preferences(
+    candidates: list[RoutingCandidate],
+    request: RoutingRequest,
+) -> tuple[list[RoutingCandidate], bool]:
+    if not request.preferred_tags:
+        return candidates, False
+    preferred = [
+        candidate
+        for candidate in candidates
+        if request.preferred_tags.intersection(candidate.preference_tags)
+    ]
+    return (preferred, False) if preferred else (candidates, True)
+
+
+def _apply_soft_budget(
+    candidates: list[RoutingCandidate],
+    request: RoutingRequest,
+) -> tuple[list[RoutingCandidate], bool]:
+    if request.budget_usd is None or request.budget_fallback == "strict":
+        return candidates, False
+    within_budget = [
+        candidate
+        for candidate in candidates
+        if candidate.estimated_request_cost is not None
+        and candidate.estimated_request_cost <= request.budget_usd
+    ]
+    if within_budget:
+        return within_budget, False
+    known = [
+        candidate
+        for candidate in candidates
+        if candidate.estimated_request_cost is not None
+    ]
+    if not known:
+        return candidates, True
+    cheapest = min(
+        candidate.estimated_request_cost
+        for candidate in known
+        if candidate.estimated_request_cost is not None
+    )
+    return (
+        [
+            candidate
+            for candidate in known
+            if candidate.estimated_request_cost == cheapest
+        ],
+        True,
+    )
+
+
+def calculate_factors(
+    candidate: RoutingCandidate,
+    pool: list[RoutingCandidate],
+) -> dict[str, float]:
+    known_costs = [
+        value
+        for value in (item.cost_per_million_tokens for item in pool)
+        if value is not None and value >= 0
+    ]
+    max_cost = max(known_costs, default=0.001)
+    max_latency = max((item.p95_latency_ms for item in pool), default=1.0)
+    max_stddev = max((item.latency_stddev_ms for item in pool), default=0.001)
+    cost = candidate.cost_per_million_tokens
+    cost_inverse = 0.0 if cost is None else 1 - cost / max(max_cost, 0.001)
+    health = (
+        1.0
+        if candidate.breaker_state == "closed"
+        else 0.5
+        if candidate.breaker_state == "half_open"
+        else 0.0
+    )
+    return {
+        "quota": clamp01(candidate.quota_remaining / 100),
+        "health": health,
+        "cost_inverse": clamp01(cost_inverse),
+        "latency_inverse": clamp01(
+            1 - candidate.p95_latency_ms / max(max_latency, 1)
+        ),
+        "task_fit": clamp01(candidate.task_fit),
+        "stability": clamp01(
+            (1 - candidate.latency_stddev_ms / max(max_stddev, 0.001))
+            * (1 - candidate.error_rate)
+        ),
+        "tier_priority": clamp01(candidate.tier_priority),
+        "tier_affinity": clamp01(candidate.tier_affinity),
+        "specificity_match": clamp01(candidate.specificity_match),
+        "context_affinity": clamp01(candidate.context_affinity),
+        "cache_affinity": clamp01(candidate.cache_affinity),
+        "reset_window_affinity": clamp01(candidate.reset_window_affinity),
+        "connection_density": clamp01(
+            (max(1, candidate.connection_pool_size) - 1) / 10
+        ),
+    }
+
+
+def rank_candidates(
+    candidates: list[RoutingCandidate],
+    mode: RoutingMode,
+) -> list[RankedCandidate]:
+    weights = MODE_WEIGHTS[mode]
+    ranked = []
+    for candidate in candidates:
+        factors = calculate_factors(candidate, candidates)
+        score = clamp01(
+            sum(weights[name] * factors[name] for name in FACTOR_NAMES)
+        )
+        ranked.append(
+            RankedCandidate(candidate=candidate, score=score, factors=factors)
+        )
+    return sorted(
+        ranked,
+        key=lambda item: (
+            -item.score,
+            item.candidate.connection_id,
+            item.candidate.model_id,
+        ),
+    )
+
+
+def decide_route(
+    candidates: list[RoutingCandidate],
+    request: RoutingRequest,
+) -> RouterDecision:
+    eligible, filtered_counts = _hard_filter(candidates, request)
+    if not eligible:
+        code = (
+            "strict_budget_exceeded"
+            if filtered_counts.get("strict_budget")
+            else "context_limit_exceeded"
+            if filtered_counts.get("context_length")
+            else "no_eligible_candidate"
+        )
+        message = (
+            "没有可在严格预算内调用的模型。"
+            if code == "strict_budget_exceeded"
+            else "当前内容超过所有可用候选的上下文限制。"
+            if code == "context_limit_exceeded"
+            else "没有满足当前能力、连接状态和上下文要求的模型。"
+        )
+        raise NoEligibleCandidateError(
+            code, message, filtered_counts=filtered_counts
+        )
+
+    eligible, preference_fallback = _apply_soft_preferences(eligible, request)
+    eligible, budget_fallback = _apply_soft_budget(eligible, request)
+    reason_codes: list[str] = []
+    if preference_fallback:
+        reason_codes.append("preference_pool_fallback")
+    if budget_fallback:
+        reason_codes.append("soft_budget_cheapest_fallback")
+
+    ranked = rank_candidates(eligible, request.mode)
+    if request.mode == "reliable" and request.last_known_good is not None:
+        for index, item in enumerate(ranked):
+            path = (item.candidate.connection_id, item.candidate.model_id)
+            if path == request.last_known_good:
+                ranked.insert(0, ranked.pop(index))
+                reason_codes.append("last_known_good")
+                break
+
+    selected = ranked[0].candidate
+    reason_codes.append(f"mode_{request.mode}")
+    if selected.breaker_state == "half_open":
+        reason_codes.append("half_open_probe")
+    return RouterDecision(
+        selected=selected,
+        ranked=tuple(ranked),
+        mode=request.mode,
+        reason_codes=tuple(reason_codes),
+        filtered_counts=filtered_counts,
+    )

--- a/server/model_router/schemas.py
+++ b/server/model_router/schemas.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field, SecretStr, field_validator
+
+
+TenantId = str
+RouterEngine = Literal["sidecar", "shadow", "native_canary", "native"]
+RoutingMode = Literal["auto", "fast", "quality", "cheap", "reliable", "offline"]
+CompressionMode = Literal["auto", "off", "standard", "strong"]
+ConnectionKind = Literal["openrouter", "newapi", "openai_compatible"]
+ConnectionHealth = Literal["untested", "online", "offline", "disabled"]
+
+
+def _required_text(value: str, *, field_name: str, limit: int) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError(f"{field_name} is required")
+    if len(text) > limit:
+        raise ValueError(f"{field_name} exceeds {limit} characters")
+    return text
+
+
+class RouterConnectionCreate(BaseModel):
+    name: str = Field(min_length=1, max_length=120)
+    kind: ConnectionKind
+    base_url: str = Field(min_length=1, max_length=2048)
+    api_key: SecretStr
+    enabled: bool = True
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, value: str) -> str:
+        return _required_text(value, field_name="name", limit=120)
+
+    @field_validator("base_url")
+    @classmethod
+    def validate_base_url(cls, value: str) -> str:
+        return _required_text(value, field_name="base_url", limit=2048)
+
+    @field_validator("api_key")
+    @classmethod
+    def validate_api_key(cls, value: SecretStr) -> SecretStr:
+        if not value.get_secret_value().strip():
+            raise ValueError("api_key is required")
+        if len(value.get_secret_value()) > 20_000:
+            raise ValueError("api_key exceeds 20000 characters")
+        return value
+
+
+class RouterConnectionUpdate(BaseModel):
+    name: str | None = Field(default=None, min_length=1, max_length=120)
+    base_url: str | None = Field(default=None, min_length=1, max_length=2048)
+    api_key: SecretStr | None = None
+    enabled: bool | None = None
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return _required_text(value, field_name="name", limit=120)
+
+    @field_validator("base_url")
+    @classmethod
+    def validate_base_url(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return _required_text(value, field_name="base_url", limit=2048)
+
+
+class RouterConnection(BaseModel):
+    id: str
+    tenant_id: TenantId
+    name: str
+    kind: ConnectionKind
+    base_url: str
+    masked_key: str
+    enabled: bool
+    health: ConnectionHealth
+    model_count: int = 0
+    last_checked_at: str | None = None
+    last_error_code: str | None = None
+    last_error_hint: str | None = None
+    created_at: str
+    updated_at: str
+
+
+class ConnectionTestResult(BaseModel):
+    ok: bool
+    health: ConnectionHealth
+    model_count: int = 0
+    models_preview: list[str] = Field(default_factory=list)
+    message: str
+    checked_at: str
+
+
+class RouterPolicy(BaseModel):
+    tenant_id: TenantId
+    engine: RouterEngine = "sidecar"
+    default_mode: RoutingMode = "auto"
+    canary_percent: int = Field(default=0, ge=0, le=100)
+    compression_mode: CompressionMode = "auto"
+    updated_at: str | None = None
+
+
+class RouterStatus(BaseModel):
+    tenant_id: TenantId
+    engine: RouterEngine
+    default_mode: RoutingMode
+    compression_mode: CompressionMode
+    canary_percent: int
+    connection_count: int
+    online_connection_count: int
+    model_count: int
+    ready: bool
+    redacted: bool = True

--- a/server/model_router/service.py
+++ b/server/model_router/service.py
@@ -1,0 +1,422 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from urllib.parse import urlparse
+
+import httpx
+
+from .repository import (
+    DEFAULT_TENANT_ID,
+    RouterConnectionNotFound,
+    RouterRepository,
+    SQLiteRouterRepository,
+    utc_now,
+)
+from .schemas import (
+    ConnectionTestResult,
+    RouterConnection,
+    RouterConnectionCreate,
+    RouterConnectionUpdate,
+    RouterPolicy,
+    RouterStatus,
+)
+
+
+class RouterServiceError(Exception):
+    def __init__(self, code: str, hint: str, *, status_code: int = 400) -> None:
+        super().__init__(hint)
+        self.code = code
+        self.hint = hint
+        self.status_code = status_code
+
+
+def normalize_base_url(value: str) -> str:
+    url = str(value or "").strip().rstrip("/")
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise RouterServiceError(
+            "invalid_address",
+            "请输入以 http:// 或 https:// 开头的模型服务地址。",
+        )
+    if parsed.username or parsed.password:
+        raise RouterServiceError(
+            "invalid_address",
+            "服务地址不能包含用户名或密码，请单独填写密钥。",
+        )
+    if parsed.query or parsed.fragment:
+        raise RouterServiceError(
+            "invalid_address",
+            "服务地址不能包含查询参数或片段。",
+        )
+    return url
+
+
+class ModelRouterService:
+    def __init__(
+        self,
+        repository: RouterRepository | None = None,
+        *,
+        tenant_id: str | None = None,
+        client_factory: Callable[[], httpx.AsyncClient] | None = None,
+    ) -> None:
+        self.repository = repository or SQLiteRouterRepository()
+        self.tenant_id = (
+            tenant_id
+            or os.getenv("MODELMIRROR_DEFAULT_TENANT_ID", "").strip()
+            or DEFAULT_TENANT_ID
+        )
+        self._client_factory = client_factory or (
+            lambda: httpx.AsyncClient(
+                timeout=httpx.Timeout(12.0, connect=5.0),
+                follow_redirects=False,
+            )
+        )
+
+    def list_connections(self) -> list[RouterConnection]:
+        return self.repository.list_connections(self.tenant_id)
+
+    def create_connection(
+        self, payload: RouterConnectionCreate
+    ) -> RouterConnection:
+        normalized = payload.model_copy(
+            update={"base_url": normalize_base_url(payload.base_url)}
+        )
+        return self.repository.create_connection(self.tenant_id, normalized)
+
+    def update_connection(
+        self, connection_id: str, payload: RouterConnectionUpdate
+    ) -> RouterConnection:
+        normalized = payload
+        if payload.base_url is not None:
+            normalized = payload.model_copy(
+                update={"base_url": normalize_base_url(payload.base_url)}
+            )
+        return self.repository.update_connection(
+            self.tenant_id, connection_id, normalized
+        )
+
+    async def test_unsaved_connection(
+        self, payload: RouterConnectionCreate
+    ) -> ConnectionTestResult:
+        return await self._probe(
+            normalize_base_url(payload.base_url),
+            payload.api_key.get_secret_value(),
+        )
+
+    async def test_saved_connection(
+        self, connection_id: str
+    ) -> ConnectionTestResult:
+        connection = self.repository.get_connection(self.tenant_id, connection_id)
+        if not connection.enabled:
+            raise RouterServiceError(
+                "connection_disabled",
+                "该模型服务已停用，请先启用后再测试。",
+                status_code=409,
+            )
+        api_key = self.repository.resolve_api_key(self.tenant_id, connection_id)
+        result = await self._probe(connection.base_url, api_key)
+        save_result = getattr(self.repository, "save_test_result", None)
+        if callable(save_result):
+            error_code = None if result.ok else self._result_error_code(result)
+            save_result(
+                self.tenant_id,
+                connection_id,
+                health=result.health,
+                model_count=result.model_count,
+                checked_at=result.checked_at,
+                error_code=error_code,
+                error_hint=None if result.ok else result.message,
+            )
+        return result
+
+    async def fetch_connection_models(
+        self, connection_id: str
+    ) -> tuple[ConnectionTestResult, list[str]]:
+        connection = self.repository.get_connection(self.tenant_id, connection_id)
+        if not connection.enabled:
+            raise RouterServiceError(
+                "connection_disabled",
+                "该模型服务已停用。",
+                status_code=409,
+            )
+        api_key = self.repository.resolve_api_key(self.tenant_id, connection_id)
+        result, model_ids, _ = await self._probe_with_models(
+            connection.base_url, api_key
+        )
+        save_result = getattr(self.repository, "save_test_result", None)
+        if callable(save_result):
+            save_result(
+                self.tenant_id,
+                connection_id,
+                health=result.health,
+                model_count=result.model_count,
+                checked_at=result.checked_at,
+                error_code=None if result.ok else self._result_error_code(result),
+                error_hint=None if result.ok else result.message,
+            )
+        return result, model_ids
+
+    async def fetch_connection_model_records(
+        self, connection_id: str
+    ) -> tuple[ConnectionTestResult, list[dict[str, object]]]:
+        connection = self.repository.get_connection(self.tenant_id, connection_id)
+        if not connection.enabled:
+            raise RouterServiceError(
+                "connection_disabled",
+                "该模型服务已停用。",
+                status_code=409,
+            )
+        api_key = self.repository.resolve_api_key(self.tenant_id, connection_id)
+        result, _, records = await self._probe_with_models(
+            connection.base_url, api_key
+        )
+        save_result = getattr(self.repository, "save_test_result", None)
+        if callable(save_result):
+            save_result(
+                self.tenant_id,
+                connection_id,
+                health=result.health,
+                model_count=result.model_count,
+                checked_at=result.checked_at,
+                error_code=None if result.ok else self._result_error_code(result),
+                error_hint=None if result.ok else result.message,
+            )
+        return result, records
+
+    def get_policy(self) -> RouterPolicy:
+        return self.repository.get_policy(self.tenant_id)
+
+    def save_policy(self, policy: RouterPolicy) -> RouterPolicy:
+        if (
+            policy.engine in {"native_canary", "native"}
+            and not self.status().ready
+        ):
+            raise RouterServiceError(
+                "native_connection_required",
+                "请先新增并测试至少一个可用的模型服务连接，再启用本地试运行。",
+                status_code=409,
+            )
+        if (
+            policy.engine == "native"
+            and os.getenv("MODEL_ROUTER_ALLOW_NATIVE_OVERRIDE", "false")
+            .strip()
+            .lower()
+            not in {"1", "true", "yes", "on"}
+        ):
+            gate = self.diagnostics().get("migration_gate", {})
+            if not bool(gate.get("automatic_native_default_allowed")):
+                request_count = int(gate.get("request_count") or 0)
+                observed_days = float(gate.get("observed_days") or 0)
+                raise RouterServiceError(
+                    "native_gate_not_met",
+                    (
+                        "本地默认尚未达到安全门槛："
+                        f"当前 {request_count}/500 次请求、"
+                        f"{observed_days:.1f}/14 天。"
+                        "请先使用“本地试运行”，完成故障演练和人工验收。"
+                    ),
+                    status_code=409,
+                )
+        return self.repository.save_policy(self.tenant_id, policy)
+
+    def status(self) -> RouterStatus:
+        connections = self.list_connections()
+        online = [item for item in connections if item.health == "online"]
+        policy = self.get_policy()
+        return RouterStatus(
+            tenant_id=self.tenant_id,
+            engine=policy.engine,
+            default_mode=policy.default_mode,
+            compression_mode=policy.compression_mode,
+            canary_percent=policy.canary_percent,
+            connection_count=len(connections),
+            online_connection_count=len(online),
+            model_count=sum(item.model_count for item in online),
+            ready=bool(online),
+        )
+
+    def diagnostics(self) -> dict[str, object]:
+        reader = getattr(self.repository, "get_diagnostics", None)
+        if not callable(reader):
+            return {
+                "tenant_id": self.tenant_id,
+                "redacted": True,
+                "migration_gate": {
+                    "automatic_native_default_allowed": False,
+                    "manual_safety_gates_required": True,
+                },
+                "recent_decisions": [],
+                "recent_compressions": [],
+            }
+        return reader(self.tenant_id)
+
+    async def _probe(self, base_url: str, api_key: str) -> ConnectionTestResult:
+        result, _, _ = await self._probe_with_models(base_url, api_key)
+        return result
+
+    async def _probe_with_models(
+        self, base_url: str, api_key: str
+    ) -> tuple[ConnectionTestResult, list[str], list[dict[str, object]]]:
+        checked_at = utc_now()
+        models_url = self._models_url(base_url)
+        headers = {"Authorization": f"Bearer {api_key.strip()}"}
+        try:
+            async with self._client_factory() as client:
+                response = await client.get(models_url, headers=headers)
+        except (httpx.ConnectError, httpx.ConnectTimeout, httpx.ReadTimeout):
+            return (
+                ConnectionTestResult(
+                    ok=False,
+                    health="offline",
+                    message="无法连接该地址。请检查地址、网络和服务是否已启动。",
+                    checked_at=checked_at,
+                ),
+                [],
+                [],
+            )
+        except httpx.HTTPError:
+            return (
+                ConnectionTestResult(
+                    ok=False,
+                    health="offline",
+                    message="模型服务连接失败，请稍后重试。",
+                    checked_at=checked_at,
+                ),
+                [],
+                [],
+            )
+
+        if response.status_code in {401, 403}:
+            return (
+                ConnectionTestResult(
+                    ok=False,
+                    health="offline",
+                    message="密钥无效或没有读取模型目录的权限。",
+                    checked_at=checked_at,
+                ),
+                [],
+                [],
+            )
+        if response.status_code == 404:
+            return (
+                ConnectionTestResult(
+                    ok=False,
+                    health="offline",
+                    message="未找到模型目录接口，请确认地址包含正确的 API 版本路径。",
+                    checked_at=checked_at,
+                ),
+                [],
+                [],
+            )
+        if response.status_code == 429:
+            return (
+                ConnectionTestResult(
+                    ok=False,
+                    health="offline",
+                    message="模型服务暂时限流，请稍后重试。",
+                    checked_at=checked_at,
+                ),
+                [],
+                [],
+            )
+        if response.status_code >= 500:
+            return (
+                ConnectionTestResult(
+                    ok=False,
+                    health="offline",
+                    message="模型服务暂时不可用，请检查服务状态后重试。",
+                    checked_at=checked_at,
+                ),
+                [],
+                [],
+            )
+        if response.status_code >= 400:
+            return (
+                ConnectionTestResult(
+                    ok=False,
+                    health="offline",
+                    message="模型目录请求被拒绝，请检查服务地址和访问权限。",
+                    checked_at=checked_at,
+                ),
+                [],
+                [],
+            )
+        try:
+            payload = response.json()
+        except ValueError:
+            payload = None
+        raw_models = payload.get("data") if isinstance(payload, dict) else None
+        if not isinstance(raw_models, list):
+            return (
+                ConnectionTestResult(
+                    ok=False,
+                    health="offline",
+                    message="服务已连接，但模型目录格式不兼容。",
+                    checked_at=checked_at,
+                ),
+                [],
+                [],
+            )
+        model_ids = sorted(
+            {
+                str(item.get("id", "")).strip()
+                for item in raw_models
+                if isinstance(item, dict) and str(item.get("id", "")).strip()
+            }
+        )
+        if not model_ids:
+            return (
+                ConnectionTestResult(
+                    ok=False,
+                    health="offline",
+                    message="服务已连接，但没有发现可调用模型。",
+                    checked_at=checked_at,
+                ),
+                [],
+                [],
+            )
+        return (
+            ConnectionTestResult(
+                ok=True,
+                health="online",
+                model_count=len(model_ids),
+                models_preview=model_ids[:8],
+                message=f"连接成功，发现 {len(model_ids)} 个可用模型。",
+                checked_at=checked_at,
+            ),
+            model_ids,
+            [dict(item) for item in raw_models if isinstance(item, dict)],
+        )
+
+    @staticmethod
+    def _models_url(base_url: str) -> str:
+        lowered = base_url.lower()
+        if lowered.endswith("/models"):
+            return base_url
+        if lowered.endswith("/v1"):
+            return f"{base_url}/models"
+        return f"{base_url}/v1/models"
+
+    @staticmethod
+    def _result_error_code(result: ConnectionTestResult) -> str:
+        message = result.message
+        if "密钥" in message:
+            return "invalid_key"
+        if "没有发现" in message:
+            return "no_models"
+        if "格式" in message:
+            return "incompatible_catalog"
+        if "限流" in message:
+            return "rate_limited"
+        return "unreachable"
+
+
+def translate_repository_error(exc: Exception) -> RouterServiceError:
+    if isinstance(exc, RouterConnectionNotFound):
+        return RouterServiceError("not_found", str(exc), status_code=404)
+    return RouterServiceError(
+        "storage_error",
+        "模型服务配置暂时无法读取，请检查本地存储后重试。",
+        status_code=500,
+    )

--- a/server/omniroute/api.py
+++ b/server/omniroute/api.py
@@ -6,7 +6,7 @@ from .catalog import OmniRouteCatalogService
 from .config import get_omniroute_settings
 from .schemas import ModelCatalogResponse, RouterStatusResponse
 
-router = APIRouter(prefix="/api/models", tags=["omniroute"])
+router = APIRouter(prefix="/api/omniroute", tags=["omniroute-diagnostics"])
 catalog_service = OmniRouteCatalogService(get_omniroute_settings)
 
 

--- a/server/omniroute/schemas.py
+++ b/server/omniroute/schemas.py
@@ -21,7 +21,8 @@ class ModelCandidate(BaseModel):
     input_modalities: list[str] = Field(default_factory=lambda: ["text"])
     output_modalities: list[str] = Field(default_factory=lambda: ["text"])
     capabilities: list[str] = Field(default_factory=list)
-    source: Literal["omniroute", "bundled"] = "omniroute"
+    source: Literal["native", "omniroute", "bundled"] = "omniroute"
+    connection_id: str | None = None
     invocable: bool = True
     availability: Availability = "live"
     free: bool | None = None
@@ -39,7 +40,7 @@ class RouteCandidate(BaseModel):
 
 
 class ModelCatalogResponse(BaseModel):
-    source: Literal["omniroute", "bundled"]
+    source: Literal["native", "omniroute", "bundled", "mixed"]
     router_status: RouterStatus
     stale: bool
     synced_at: str | None

--- a/server/omniroute/telemetry.py
+++ b/server/omniroute/telemetry.py
@@ -91,7 +91,10 @@ def update_stream_state(line: str, state: dict[str, Any]) -> None:
     if not stripped.startswith("data:"):
         return
     data = stripped[5:].strip()
-    if not data or data == "[DONE]":
+    if not data:
+        return
+    if data == "[DONE]":
+        state["_done_observed"] = True
         return
     try:
         payload = json.loads(data)
@@ -109,6 +112,9 @@ def update_stream_state(line: str, state: dict[str, Any]) -> None:
         for choice in choices:
             if not isinstance(choice, dict):
                 continue
+            finish_reason = choice.get("finish_reason")
+            if isinstance(finish_reason, str) and finish_reason.strip():
+                state["finish_reason"] = finish_reason.strip()
             candidate = choice.get("delta") or choice.get("message")
             if not isinstance(candidate, dict):
                 continue

--- a/server/rag/rag_service.py
+++ b/server/rag/rag_service.py
@@ -15,6 +15,11 @@ from typing import Any
 
 import httpx
 
+try:
+    from server.context_engine import optimize_context
+except ModuleNotFoundError:
+    from context_engine import optimize_context
+
 from .document_parser import DocumentParseError, parse_document, supported_extensions
 from .document_processor import ProcessedDocument, StructuredDocumentProcessor
 from .embedder import EmbeddingClient, EmbeddingError
@@ -38,6 +43,13 @@ from .vision_processor import (
     VisionProcessingError,
     VisionUnderstandingService,
 )
+
+
+def _safe_env_int(name: str, default: int, *, minimum: int = 1) -> int:
+    try:
+        return max(minimum, int(os.getenv(name, str(default))))
+    except ValueError:
+        return max(minimum, default)
 
 
 class RagError(RuntimeError):
@@ -2885,6 +2897,32 @@ class RagService:
 
         context = "\n\n".join(
             f"[来源：{result.document_name}]\n{result.context_text}" for result in results
+        )
+        configured_profile = (
+            os.getenv("RAG_CONTEXT_COMPRESSION_MODE", "auto").strip().lower()
+        )
+        context_optimization = await optimize_context(
+            [
+                {
+                    "role": "assistant",
+                    "content": context,
+                    "metadata": {"kind": "rag_context"},
+                }
+            ],
+            profile=(
+                configured_profile
+                if configured_profile in {"auto", "off", "standard", "strong"}
+                else "auto"
+            ),
+            max_context_tokens=_safe_env_int(
+                "RAG_CONTEXT_MAX_TOKENS", 32_000, minimum=2_048
+            ),
+            max_output_tokens=_safe_env_int(
+                "RAG_MAX_TOKENS", 1_200
+            ),
+        )
+        context = str(
+            context_optimization.messages[0].get("content") or context
         )
         prompt = (
             "请仅依据<context>中的资料回答用户问题。如果资料不足，请明确说明不知道。"

--- a/server/rag/vision_processor.py
+++ b/server/rag/vision_processor.py
@@ -7,6 +7,7 @@ import io
 import json
 import os
 import re
+import threading
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -23,6 +24,7 @@ MAX_IMAGE_PIXELS = 40_000_000
 DEFAULT_MAX_IMAGE_EDGE = 2048
 DEFAULT_RENDER_DPI = 144
 DEFAULT_MAX_PAGES = 100
+_PDFIUM_RENDER_LOCK = threading.Lock()
 
 
 class VisionProcessingError(RuntimeError):
@@ -357,22 +359,33 @@ class VisionUnderstandingService:
         else:
             import pypdfium2 as pdfium
 
-            document = pdfium.PdfDocument(str(path))
-            try:
-                if page_number < 1 or page_number > len(document):
-                    raise VisionProcessingError("PDF page number is out of range.")
-                page = document[page_number - 1]
+            # PDFium can segfault when separate documents render concurrently in
+            # worker threads. Keep the native renderer serialized; VLM requests
+            # remain concurrent under the service semaphore.
+            with _PDFIUM_RENDER_LOCK:
+                document = pdfium.PdfDocument(str(path))
                 try:
-                    scale = float(config.get("render_dpi", DEFAULT_RENDER_DPI)) / 72.0
-                    bitmap = page.render(scale=scale)
+                    if page_number < 1 or page_number > len(document):
+                        raise VisionProcessingError(
+                            "PDF page number is out of range."
+                        )
+                    page = document[page_number - 1]
                     try:
-                        image = bitmap.to_pil().copy()
+                        scale = (
+                            float(
+                                config.get("render_dpi", DEFAULT_RENDER_DPI)
+                            )
+                            / 72.0
+                        )
+                        bitmap = page.render(scale=scale)
+                        try:
+                            image = bitmap.to_pil().copy()
+                        finally:
+                            bitmap.close()
                     finally:
-                        bitmap.close()
+                        page.close()
                 finally:
-                    page.close()
-            finally:
-                document.close()
+                    document.close()
         image = image.convert("RGB")
         image.thumbnail((max_edge, max_edge))
         output = io.BytesIO()

--- a/server/tests/test_context_engine.py
+++ b/server/tests/test_context_engine.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+
+import pytest
+
+from server.context_engine import (
+    estimate_messages_tokens,
+    optimize_context,
+)
+
+
+@pytest.mark.asyncio
+async def test_deterministic_compression_preserves_protected_content() -> None:
+    protected_code = "```python\nprint('keep exactly')\n```"
+    protected_json = json.dumps(
+        {"items": [{"id": index, "value": "x" * 20} for index in range(80)]}
+    )
+    latest_user = (
+        "请检查 https://example.test/file 并保留引用 [12]\n" + protected_code
+    )
+    repeated_tool = "\n".join(["plain diagnostic output " * 12] * 100)
+    messages = [
+        {"role": "system", "content": "Never change this system instruction."},
+        {"role": "tool", "content": repeated_tool, "tool_call_id": "call-1"},
+        {"role": "tool", "content": protected_json, "tool_call_id": "call-2"},
+        {"role": "user", "content": latest_user},
+    ]
+
+    result = await optimize_context(
+        messages,
+        profile="strong",
+        max_context_tokens=16_000,
+        max_output_tokens=100,
+        max_tool_output_chars=1_000,
+    )
+
+    serialized = json.dumps(result.messages, ensure_ascii=False)
+    assert result.report.applied is True
+    assert result.report.saved_ratio >= 0.10
+    assert result.report.fidelity_status == "passed"
+    assert messages[0]["content"] in serialized
+    assert any(
+        message.get("content") == protected_json for message in result.messages
+    )
+    assert any(
+        message.get("content") == latest_user for message in result.messages
+    )
+    assert any(
+        protected_code in str(message.get("content") or "")
+        for message in result.messages
+    )
+
+
+@pytest.mark.asyncio
+async def test_context_engine_summarizes_old_plain_history_and_is_idempotent() -> None:
+    calls: list[list[dict[str, Any]]] = []
+
+    async def summarize(
+        _model_id: str,
+        messages: list[dict[str, Any]],
+        _max_tokens: int,
+    ) -> str:
+        calls.append(messages)
+        return "用户已决定采用 Aurora，并要求保留预算上限。"
+
+    old = "Earlier plain discussion about Aurora and the budget. " * 500
+    messages = [
+        {"role": "system", "content": "Stay precise."},
+        {"role": "user", "content": old, "message_id": "m1"},
+        {"role": "assistant", "content": old, "message_id": "m2"},
+        {"role": "user", "content": "What is next?", "message_id": "m3"},
+    ]
+    first = await optimize_context(
+        messages,
+        profile="auto",
+        max_context_tokens=3_000,
+        max_output_tokens=300,
+        keep_recent_messages=1,
+        summarizer=summarize,
+        summary_model_id="summary-model",
+    )
+    second = await optimize_context(
+        first.messages,
+        profile="standard",
+        max_context_tokens=3_000,
+        max_output_tokens=300,
+        keep_recent_messages=1,
+        summarizer=summarize,
+        summary_model_id="summary-model",
+    )
+
+    assert len(calls) == 1
+    assert first.report.summarized_messages == 2
+    assert first.report.saved_ratio >= 0.15
+    assert first.messages[-1]["content"] == "What is next?"
+    assert second.messages == first.messages
+
+
+@pytest.mark.asyncio
+async def test_small_savings_fall_back_to_original() -> None:
+    messages = [
+        {"role": "assistant", "content": "same sentence. same sentence."},
+        {"role": "user", "content": "latest"},
+    ]
+    result = await optimize_context(
+        messages,
+        profile="strong",
+        max_context_tokens=128_000,
+    )
+    assert result.messages == messages
+    assert result.report.applied is False
+    assert result.report.fidelity_status in {"not_needed", "fallback"}
+
+
+@pytest.mark.asyncio
+async def test_deterministic_rules_p95_budget_smoke() -> None:
+    messages = [
+        {
+            "role": "tool",
+            "tool_call_id": "call",
+            "content": ("diagnostic line without structure " * 1000),
+        },
+        {"role": "user", "content": "latest"},
+    ]
+    durations = []
+    for _ in range(30):
+        started = time.perf_counter()
+        result = await optimize_context(
+            messages,
+            profile="standard",
+            max_context_tokens=128_000,
+            max_tool_output_chars=1_000,
+        )
+        durations.append((time.perf_counter() - started) * 1000)
+        assert estimate_messages_tokens(result.messages) < estimate_messages_tokens(
+            messages
+        )
+    durations.sort()
+    assert durations[int(len(durations) * 0.95) - 1] < 20

--- a/server/tests/test_model_router_foundation.py
+++ b/server/tests/test_model_router_foundation.py
@@ -1,0 +1,407 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient, MockTransport, Request, Response
+
+from server.model_router.api import configure_model_router, router
+from server.model_router.catalog import NativeCatalogService
+from server.model_router.repository import (
+    RouterConnectionNotFound,
+    SQLiteRouterRepository,
+)
+from server.model_router.schemas import (
+    RouterConnectionCreate,
+    RouterConnectionUpdate,
+    RouterPolicy,
+)
+from server.model_router.service import ModelRouterService
+from server.model_router.service import RouterServiceError
+from server.omniroute.schemas import ModelCatalogResponse
+
+
+def connection_payload(**updates: object) -> RouterConnectionCreate:
+    data: dict[str, object] = {
+        "name": "OpenRouter",
+        "kind": "openrouter",
+        "base_url": "https://openrouter.ai/api/v1",
+        "api_key": "sk-test-secret-value",
+    }
+    data.update(updates)
+    return RouterConnectionCreate.model_validate(data)
+
+
+def test_schema_and_credentials_are_tenant_scoped_and_persistent(
+    tmp_path: Path,
+) -> None:
+    repository = SQLiteRouterRepository(tmp_path)
+    created = repository.create_connection("local", connection_payload())
+
+    assert all(repository.count_schema_tenant_columns().values())
+    assert created.tenant_id == "local"
+    assert created.masked_key != "sk-test-secret-value"
+    assert repository.resolve_api_key("local", created.id) == "sk-test-secret-value"
+    with pytest.raises(RouterConnectionNotFound):
+        repository.get_connection("another-tenant", created.id)
+
+    persisted = repository.database_path.read_bytes()
+    assert b"sk-test-secret-value" not in persisted
+
+    restarted = SQLiteRouterRepository(tmp_path)
+    restored = restarted.get_connection("local", created.id)
+    assert restored.id == created.id
+    assert restarted.resolve_api_key("local", created.id) == "sk-test-secret-value"
+
+    with sqlite3.connect(restarted.database_path) as connection:
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 3
+
+
+def test_disable_restore_and_policy_persist_without_delete(tmp_path: Path) -> None:
+    repository = SQLiteRouterRepository(tmp_path)
+    created = repository.create_connection("local", connection_payload())
+
+    disabled = repository.update_connection(
+        "local", created.id, RouterConnectionUpdate(enabled=False)
+    )
+    assert disabled.enabled is False
+    assert disabled.health == "disabled"
+
+    restored = repository.update_connection(
+        "local", created.id, RouterConnectionUpdate(enabled=True)
+    )
+    assert restored.enabled is True
+    assert restored.health == "untested"
+
+    saved = repository.save_policy(
+        "local",
+        RouterPolicy(
+            tenant_id="ignored-by-repository",
+            engine="shadow",
+            default_mode="reliable",
+            canary_percent=10,
+            compression_mode="auto",
+        ),
+    )
+    assert saved.tenant_id == "local"
+    assert SQLiteRouterRepository(tmp_path).get_policy("local") == saved
+
+
+def test_candidate_breaker_and_lkgp_are_tenant_model_scoped(
+    tmp_path: Path,
+) -> None:
+    repository = SQLiteRouterRepository(tmp_path)
+    for _ in range(3):
+        stats = repository.record_candidate_outcome(
+            "local",
+            "connection-a",
+            "model-a",
+            success=False,
+            latency_ms=800,
+        )
+    assert stats["breaker_state"] == "open"
+    assert (
+        repository.get_candidate_stats("local", "connection-a", "model-b")[
+            "breaker_state"
+        ]
+        == "closed"
+    )
+    assert (
+        repository.get_candidate_stats("another", "connection-a", "model-a")[
+            "breaker_state"
+        ]
+        == "closed"
+    )
+
+    decision_id = repository.record_routing_decision(
+        "local",
+        session_id_hash="session-hash",
+        engine="native",
+        strategy="reliable",
+        connection_id="connection-a",
+        model_id="model-a",
+        reason_codes=["mode_reliable"],
+        outcome="success",
+    )
+    assert decision_id.startswith("decision_")
+    assert repository.get_last_known_good("local", "session-hash") == (
+        "connection-a",
+        "model-a",
+    )
+    assert repository.get_last_known_good("another", "session-hash") is None
+
+
+def test_diagnostics_are_tenant_scoped_and_native_default_is_gated(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("MODEL_ROUTER_ALLOW_NATIVE_OVERRIDE", raising=False)
+    repository = SQLiteRouterRepository(tmp_path)
+    repository.record_routing_decision(
+        "local",
+        session_id_hash="local-session",
+        engine="native",
+        strategy="auto",
+        connection_id="connection-a",
+        model_id="model-a",
+        reason_codes=["mode_auto"],
+        outcome="success",
+        budget_limit_usd=0.1,
+        reserved_cost_usd=0.05,
+    )
+    repository.record_routing_decision(
+        "another",
+        session_id_hash="other-session",
+        engine="native",
+        strategy="cheap",
+        connection_id="connection-b",
+        model_id="private-model",
+        reason_codes=["mode_cheap"],
+        outcome="success",
+    )
+
+    diagnostics = repository.get_diagnostics("local")
+    assert diagnostics["migration_gate"]["request_count"] == 1
+    assert len(diagnostics["recent_decisions"]) == 1
+    assert "private-model" not in json.dumps(diagnostics)
+    assert diagnostics["recent_decisions"][0]["budget"]["status"] == "reserved"
+
+    empty_service = ModelRouterService(SQLiteRouterRepository(tmp_path / "empty"))
+    with pytest.raises(RouterServiceError) as no_connection:
+        empty_service.save_policy(
+            RouterPolicy(
+                tenant_id="local",
+                engine="native_canary",
+                default_mode="auto",
+                canary_percent=10,
+                compression_mode="auto",
+            )
+        )
+    assert no_connection.value.code == "native_connection_required"
+
+    service = ModelRouterService(repository)
+    connection = repository.create_connection("local", connection_payload())
+    repository.save_test_result(
+        "local",
+        connection.id,
+        health="online",
+        model_count=1,
+        checked_at="2026-07-27T00:00:00+00:00",
+        error_code=None,
+        error_hint=None,
+    )
+    service.save_policy(
+        RouterPolicy(
+            tenant_id="local",
+            engine="native_canary",
+            default_mode="auto",
+            canary_percent=100,
+            compression_mode="auto",
+        )
+    )
+    with pytest.raises(RouterServiceError) as exc:
+        service.save_policy(
+            RouterPolicy(
+                tenant_id="local",
+                engine="native",
+                default_mode="auto",
+                canary_percent=100,
+                compression_mode="auto",
+            )
+        )
+    assert exc.value.code == "native_gate_not_met"
+
+    monkeypatch.setenv("MODEL_ROUTER_ALLOW_NATIVE_OVERRIDE", "true")
+    saved = service.save_policy(
+        RouterPolicy(
+            tenant_id="local",
+            engine="native",
+            default_mode="auto",
+            canary_percent=100,
+            compression_mode="auto",
+        )
+    )
+    assert saved.engine == "native"
+    monkeypatch.setenv("MODEL_ROUTER_ENGINE", "sidecar")
+    assert service.get_policy().engine == "sidecar"
+
+
+@pytest.mark.asyncio
+async def test_connection_probe_returns_safe_actionable_results(
+    tmp_path: Path,
+) -> None:
+    requests: list[Request] = []
+
+    def success(request: Request) -> Response:
+        requests.append(request)
+        return Response(
+            200,
+            json={"data": [{"id": "openai/gpt-5.6"}, {"id": "anthropic/opus-5"}]},
+        )
+
+    service = ModelRouterService(
+        SQLiteRouterRepository(tmp_path),
+        client_factory=lambda: httpx.AsyncClient(transport=MockTransport(success)),
+    )
+    result = await service.test_unsaved_connection(connection_payload())
+    assert result.ok is True
+    assert result.model_count == 2
+    assert requests[0].url == "https://openrouter.ai/api/v1/models"
+    assert requests[0].headers["authorization"] == "Bearer sk-test-secret-value"
+
+    def unauthorized(_: Request) -> Response:
+        return Response(401, text="upstream secret diagnostics must not leak")
+
+    service = ModelRouterService(
+        SQLiteRouterRepository(tmp_path / "unauthorized"),
+        client_factory=lambda: httpx.AsyncClient(
+            transport=MockTransport(unauthorized)
+        ),
+    )
+    failed = await service.test_unsaved_connection(connection_payload())
+    assert failed.ok is False
+    assert "密钥无效" in failed.message
+    assert "upstream secret diagnostics" not in failed.message
+
+
+@pytest.mark.asyncio
+async def test_connection_api_is_redacted_and_records_health(tmp_path: Path) -> None:
+    def success(_: Request) -> Response:
+        return Response(200, json={"data": [{"id": "model-a"}]})
+
+    repository = SQLiteRouterRepository(tmp_path)
+    service = ModelRouterService(
+        repository,
+        client_factory=lambda: httpx.AsyncClient(transport=MockTransport(success)),
+    )
+    configure_model_router(service)
+    app = FastAPI()
+    app.include_router(router)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        created_response = await client.post(
+            "/api/router/connections",
+            json=connection_payload().model_dump(mode="json"),
+        )
+        assert created_response.status_code == 201
+        created = created_response.json()
+        serialized = json.dumps(created, ensure_ascii=False)
+        assert "sk-test-secret-value" not in serialized
+        assert "api_key_ciphertext" not in serialized
+
+        tested_response = await client.post(
+            f"/api/router/connections/{created['id']}/test"
+        )
+        assert tested_response.status_code == 200
+        assert tested_response.json()["model_count"] == 1
+
+        status_response = await client.get("/api/router/status")
+        status = status_response.json()
+        assert status["tenant_id"] == "local"
+        assert status["online_connection_count"] == 1
+        assert status["ready"] is True
+
+
+def test_behavior_baselines_are_pinned_and_non_vendored() -> None:
+    root = Path(__file__).resolve().parents[1]
+    routing = json.loads(
+        (root / "model_router/fixtures/omniroute-v3.8.49-routing.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    compression = json.loads(
+        (
+            root / "context_engine/fixtures/compression-baseline-v1.json"
+        ).read_text(encoding="utf-8")
+    )
+
+    assert routing["source"]["commit"] == "36f8fd10052f"
+    assert routing["source"]["source_code_copied"] is False
+    assert sum(routing["score_factors"].values()) == pytest.approx(1.0)
+    assert routing["public_modes"] == [
+        "auto",
+        "fast",
+        "quality",
+        "cheap",
+        "reliable",
+        "offline",
+    ]
+    assert compression["auto_trigger_ratio"] == 0.8
+    assert "latest_user_message" in compression["protected_content"]
+
+
+def test_model_router_imports_in_flat_docker_layout() -> None:
+    server_root = Path(__file__).resolve().parents[1]
+    completed = subprocess.run(
+        [sys.executable, "-c", "import model_router; import context_engine"],
+        cwd=server_root,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+
+
+@pytest.mark.asyncio
+async def test_native_catalog_uses_30_second_cache_and_stale_if_error(
+    tmp_path: Path,
+) -> None:
+    call_count = 0
+
+    def handler(_: Request) -> Response:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return Response(200, json={"data": [{"id": "provider/model-a"}]})
+        return Response(503, text="internal upstream details")
+
+    repository = SQLiteRouterRepository(tmp_path)
+    connection = repository.create_connection("local", connection_payload())
+    service = ModelRouterService(
+        repository,
+        client_factory=lambda: httpx.AsyncClient(transport=MockTransport(handler)),
+    )
+
+    class FallbackCatalog:
+        async def get_catalog(self) -> ModelCatalogResponse:
+            return ModelCatalogResponse(
+                source="bundled",
+                router_status="offline",
+                stale=False,
+                synced_at=None,
+                catalog_version="test",
+                models=[],
+                routes=[],
+            )
+
+    catalog_service = NativeCatalogService()
+    fresh = await catalog_service.get_catalog(
+        service, FallbackCatalog()  # type: ignore[arg-type]
+    )
+    assert fresh.source == "native"
+    assert fresh.models[0].connection_id == connection.id
+    assert fresh.models[0].invocation_id == "provider/model-a"
+
+    cached = await catalog_service.get_catalog(
+        service, FallbackCatalog()  # type: ignore[arg-type]
+    )
+    assert cached.router_status == "online"
+    assert call_count == 1
+
+    assert catalog_service._cache is not None
+    catalog_service._cache.stored_at -= 31
+    stale = await catalog_service.get_catalog(
+        service, FallbackCatalog()  # type: ignore[arg-type]
+    )
+    assert stale.stale is True
+    assert stale.router_status == "stale"
+    assert stale.models[0].availability == "degraded"

--- a/server/tests/test_model_router_routing.py
+++ b/server/tests/test_model_router_routing.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import pytest
+
+from server.model_router.engine import NativeRouterEngine, infer_task_tags
+from server.model_router.routing import (
+    DEFAULT_WEIGHTS,
+    MODE_WEIGHTS,
+    NoEligibleCandidateError,
+    RoutingCandidate,
+    RoutingRequest,
+    decide_route,
+    validate_weights,
+)
+
+
+def candidate(
+    name: str,
+    *,
+    cost: float,
+    latency: float,
+    task_fit: float,
+    quota: float = 100,
+    error_rate: float = 0,
+    breaker: str = "closed",
+    modalities: frozenset[str] = frozenset({"text"}),
+    capabilities: frozenset[str] = frozenset(),
+    context_length: int = 128_000,
+    request_cost: float | None = None,
+    latency_stddev: float | None = None,
+) -> RoutingCandidate:
+    return RoutingCandidate(
+        tenant_id="local",
+        connection_id=f"conn-{name}",
+        connection_name=name,
+        model_id=f"provider/{name}",
+        cost_per_million_tokens=cost,
+        estimated_request_cost=request_cost,
+        p95_latency_ms=latency,
+        latency_stddev_ms=(
+            latency * 0.1 if latency_stddev is None else latency_stddev
+        ),
+        error_rate=error_rate,
+        quota_remaining=quota,
+        task_fit=task_fit,
+        breaker_state=breaker,  # type: ignore[arg-type]
+        input_modalities=modalities,
+        capabilities=capabilities,
+        context_length=context_length,
+    )
+
+
+def test_pinned_weights_are_normalized() -> None:
+    assert DEFAULT_WEIGHTS["health"] == 0.20
+    assert DEFAULT_WEIGHTS["cost_inverse"] == 0.15
+    assert DEFAULT_WEIGHTS["latency_inverse"] == 0.12
+    assert all(validate_weights(weights) for weights in MODE_WEIGHTS.values())
+
+
+def test_task_hints_only_boost_matching_model_categories() -> None:
+    assert infer_task_tags("请修复这段 Python 代码的 traceback") == {"coding"}
+    assert infer_task_tags("请严谨证明这个结论并逐步推理") == {"reasoning"}
+    assert infer_task_tags("请概括这段普通说明") == set()
+
+    generic_code_fit = NativeRouterEngine._task_fit(
+        "openrouter/pareto-code", "auto", set()
+    )
+    coding_fit = NativeRouterEngine._task_fit(
+        "openrouter/pareto-code", "auto", {"coding"}
+    )
+    general_quality_fit = NativeRouterEngine._task_fit(
+        "openai/gpt-5.6-sol", "auto", set()
+    )
+    assert coding_fit > generic_code_fit
+    assert general_quality_fit > generic_code_fit
+
+
+def test_six_modes_produce_result_oriented_choices() -> None:
+    fast = candidate("fast", cost=8, latency=80, task_fit=0.6, quota=60)
+    quality = candidate(
+        "quality",
+        cost=25,
+        latency=900,
+        latency_stddev=10,
+        task_fit=1.0,
+        quota=80,
+    )
+    cheap = candidate("cheap", cost=0.2, latency=650, task_fit=0.55, quota=70)
+    offline = candidate("offline", cost=2, latency=700, task_fit=0.4, quota=100)
+    pool = [quality, cheap, offline, fast]
+
+    assert decide_route(pool, RoutingRequest("local", mode="fast")).selected == fast
+    assert (
+        decide_route(pool, RoutingRequest("local", mode="quality")).selected
+        == quality
+    )
+    assert decide_route(pool, RoutingRequest("local", mode="cheap")).selected == cheap
+    assert (
+        decide_route(pool, RoutingRequest("local", mode="offline")).selected
+        == offline
+    )
+    assert decide_route(pool, RoutingRequest("local", mode="auto")).ranked
+
+
+def test_reliable_mode_prefers_healthy_lkgp_and_exits_open_path() -> None:
+    sticky = candidate("sticky", cost=4, latency=500, task_fit=0.6)
+    top = candidate("top", cost=3, latency=100, task_fit=0.9)
+    request = RoutingRequest(
+        "local",
+        mode="reliable",
+        last_known_good=(sticky.connection_id, sticky.model_id),
+    )
+    decision = decide_route([top, sticky], request)
+    assert decision.selected == sticky
+    assert "last_known_good" in decision.reason_codes
+
+    opened = candidate(
+        "sticky", cost=4, latency=500, task_fit=0.6, breaker="open"
+    )
+    decision = decide_route([top, opened], request)
+    assert decision.selected == top
+    assert decision.filtered_counts["breaker_open"] == 1
+
+
+def test_hard_constraints_never_fail_open() -> None:
+    text_only = candidate(
+        "text",
+        cost=1,
+        latency=100,
+        task_fit=1,
+        capabilities=frozenset(),
+        context_length=4096,
+    )
+    request = RoutingRequest(
+        "local",
+        required_input_modalities=frozenset({"text", "image"}),
+        required_capabilities=frozenset({"tools"}),
+        estimated_input_tokens=5000,
+    )
+    with pytest.raises(NoEligibleCandidateError) as exc:
+        decide_route([text_only], request)
+    assert exc.value.code == "no_eligible_candidate"
+
+
+def test_preference_can_fail_open_but_strict_budget_cannot() -> None:
+    known = candidate(
+        "known",
+        cost=1,
+        latency=100,
+        task_fit=0.8,
+        request_cost=0.05,
+    )
+    preference = RoutingRequest(
+        "local",
+        preferred_tags=frozenset({"vision"}),
+    )
+    decision = decide_route([known], preference)
+    assert decision.selected == known
+    assert "preference_pool_fallback" in decision.reason_codes
+
+    strict = RoutingRequest(
+        "local",
+        budget_usd=0.01,
+        budget_fallback="strict",
+    )
+    with pytest.raises(NoEligibleCandidateError) as exc:
+        decide_route([known], strict)
+    assert exc.value.code == "strict_budget_exceeded"
+
+    unknown_price = candidate(
+        "unknown",
+        cost=1,
+        latency=100,
+        task_fit=0.8,
+        request_cost=None,
+    )
+    with pytest.raises(NoEligibleCandidateError):
+        decide_route([unknown_price], strict)

--- a/server/tests/test_native_router_chat.py
+++ b/server/tests/test_native_router_chat.py
@@ -1,0 +1,335 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from server import main as main_module
+from server.main import app
+from server.model_router import (
+    ModelRouterService,
+    RouterConnectionCreate,
+    RouterPolicy,
+    SQLiteRouterRepository,
+    configure_model_router,
+    get_model_router_service,
+)
+
+
+@pytest_asyncio.fixture
+async def client():
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://testserver",
+    ) as async_client:
+        yield async_client
+
+
+class CatalogClient:
+    def __init__(self, records: list[dict[str, Any]]) -> None:
+        self.records = records
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return None
+
+    async def get(self, _url: str, headers: dict[str, str]):
+        assert headers["Authorization"] == "Bearer native-secret"
+        return httpx.Response(200, json={"data": self.records})
+
+
+def native_service(tmp_path: Path) -> ModelRouterService:
+    records = [
+        {
+            "id": "provider/model-a",
+            "context_length": 128000,
+            "pricing": {"prompt": "0.000001", "completion": "0.000002"},
+            "architecture": {
+                "input_modalities": ["text"],
+                "output_modalities": ["text"],
+            },
+        },
+        {
+            "id": "provider/model-b",
+            "context_length": 128000,
+            "pricing": {"prompt": "0.000001", "completion": "0.000002"},
+            "architecture": {
+                "input_modalities": ["text"],
+                "output_modalities": ["text"],
+            },
+        },
+    ]
+    repository = SQLiteRouterRepository(tmp_path)
+    repository.create_connection(
+        "local",
+        RouterConnectionCreate(
+            name="Native test",
+            kind="openai_compatible",
+            base_url="https://native.example/v1",
+            api_key="native-secret",
+        ),
+    )
+    repository.save_policy(
+        "local",
+        RouterPolicy(tenant_id="local", engine="native"),
+    )
+    return ModelRouterService(
+        repository,
+        client_factory=lambda: CatalogClient(records),  # type: ignore[arg-type]
+    )
+
+
+@pytest.mark.asyncio
+async def test_native_auto_retries_empty_stream_before_visible_output(
+    client: httpx.AsyncClient,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_service = get_model_router_service()
+    service = native_service(tmp_path)
+    configure_model_router(service)
+    sent_models: list[str] = []
+
+    class FakeResponse:
+        status_code = 200
+        headers: dict[str, str] = {}
+        content = b""
+
+        def __init__(self, model_id: str) -> None:
+            self.model_id = model_id
+
+        async def aiter_text(self):
+            if self.model_id.endswith("model-a"):
+                yield "data: [DONE]\n\n"
+                return
+            yield (
+                'data: {"model":"provider/model-b","choices":'
+                '[{"delta":{"content":"native answer"}}]}\n\n'
+            )
+            yield (
+                'data: {"choices":[],"usage":{"prompt_tokens":4,'
+                '"completion_tokens":2,"total_tokens":6}}\n\n'
+            )
+            yield "data: [DONE]\n\n"
+
+        async def aread(self):
+            return self.content
+
+        async def aclose(self):
+            return None
+
+    class FakeChatClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def build_request(self, method, url, headers, json):
+            return {
+                "method": method,
+                "url": url,
+                "headers": headers,
+                "json": json,
+            }
+
+        async def send(self, request, stream):
+            assert stream is True
+            model_id = request["json"]["model"]
+            sent_models.append(model_id)
+            return FakeResponse(model_id)
+
+        async def aclose(self):
+            return None
+
+    try:
+        monkeypatch.setattr(main_module, "rate_limit_or_raise", lambda _ip: None)
+        monkeypatch.setattr(main_module.httpx, "AsyncClient", FakeChatClient)
+        response = await client.post(
+            "/api/chat",
+            json={
+                "model_id": "auto",
+                "gateway": "auto",
+                "messages": [{"role": "user", "content": "hi"}],
+                "routing": {
+                    "session_id": "stable-session",
+                    "mode": "balanced",
+                    "budget_usd": 0.01,
+                    "budget_fallback": "strict",
+                },
+            },
+        )
+    finally:
+        configure_model_router(original_service)
+
+    assert response.status_code == 200, response.text
+    assert sent_models == ["provider/model-a", "provider/model-b"]
+    assert "native answer" in response.text
+    assert response.text.count("event: route_receipt") == 1
+    receipt_event = next(
+        event
+        for event in response.text.split("\n\n")
+        if event.startswith("event: route_receipt")
+    )
+    receipt = json.loads(
+        next(
+            line.removeprefix("data:").strip()
+            for line in receipt_event.splitlines()
+            if line.startswith("data:")
+        )
+    )
+    assert receipt["engine"] == "native"
+    assert receipt["actual_model"] == "provider/model-b"
+    assert receipt["fallback_attempts"] == 1
+    assert receipt["tokens"]["total"] == 6
+    assert receipt["response_cost_usd"] == pytest.approx(0.000008)
+    assert receipt["cost_kind"] == "actual"
+    assert receipt["budget"]["status"] == "settled"
+    assert receipt["version"] == "2"
+    assert response.text.rstrip().endswith("data: [DONE]")
+    diagnostics = service.diagnostics()
+    assert diagnostics["recent_decisions"][0]["budget"]["status"] == "settled"
+    assert diagnostics["recent_decisions"][0]["budget"][
+        "settled_cost_usd"
+    ] == pytest.approx(0.000008)
+
+
+def test_native_canary_assignment_is_stable() -> None:
+    from server.model_router.engine import NativeRouterEngine
+
+    first = NativeRouterEngine.stable_canary_selected("session-a", 50)
+    assert all(
+        NativeRouterEngine.stable_canary_selected("session-a", 50) == first
+        for _ in range(20)
+    )
+    assert NativeRouterEngine.stable_canary_selected("session-a", 0) is False
+    assert NativeRouterEngine.stable_canary_selected("session-a", 100) is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("chunks", "expected_outcome", "expect_error", "expect_output_limit"),
+    [
+        (
+            [
+                (
+                    'data: {"model":"provider/model-a","choices":'
+                    '[{"delta":{"content":"partial answer"},'
+                    '"finish_reason":null}]}\n\n'
+                ),
+            ],
+            "stream_interrupted",
+            True,
+            False,
+        ),
+        (
+            [
+                (
+                    'data: {"model":"provider/model-a","choices":'
+                    '[{"delta":{"content":"limited answer"},'
+                    '"finish_reason":null}]}\n\n'
+                ),
+                (
+                    'data: {"choices":[{"delta":{"content":""},'
+                    '"finish_reason":"length"}],"usage":{"prompt_tokens":4,'
+                    '"completion_tokens":8,"total_tokens":12}}\n\n'
+                ),
+                "data: [DONE]\n\n",
+            ],
+            "output_limit",
+            False,
+            True,
+        ),
+    ],
+)
+async def test_native_stream_requires_a_terminal_marker_and_reports_output_limit(
+    client: httpx.AsyncClient,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    chunks: list[str],
+    expected_outcome: str,
+    expect_error: bool,
+    expect_output_limit: bool,
+) -> None:
+    original_service = get_model_router_service()
+    service = native_service(tmp_path)
+    configure_model_router(service)
+
+    class FakeResponse:
+        status_code = 200
+        headers: dict[str, str] = {}
+        content = b""
+
+        async def aiter_text(self):
+            for chunk in chunks:
+                yield chunk
+
+        async def aread(self):
+            return self.content
+
+        async def aclose(self):
+            return None
+
+    class FakeChatClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def build_request(self, method, url, headers, json):
+            return {
+                "method": method,
+                "url": url,
+                "headers": headers,
+                "json": json,
+            }
+
+        async def send(self, request, stream):
+            assert stream is True
+            return FakeResponse()
+
+        async def aclose(self):
+            return None
+
+    try:
+        monkeypatch.setattr(main_module, "rate_limit_or_raise", lambda _ip: None)
+        monkeypatch.setattr(main_module.httpx, "AsyncClient", FakeChatClient)
+        response = await client.post(
+            "/api/chat",
+            json={
+                "model_id": "auto",
+                "gateway": "auto",
+                "messages": [{"role": "user", "content": "hi"}],
+                "routing": {
+                    "session_id": "stream-completion-session",
+                    "mode": "fast",
+                },
+                "compression": {"mode": "off"},
+            },
+        )
+    finally:
+        configure_model_router(original_service)
+
+    assert response.status_code == 200, response.text
+    assert response.text.count("event: route_receipt") == 1
+    assert response.text.rstrip().endswith("data: [DONE]")
+    assert ('"error":' in response.text) is expect_error
+    receipt_event = next(
+        event
+        for event in response.text.split("\n\n")
+        if event.startswith("event: route_receipt")
+    )
+    receipt = json.loads(
+        next(
+            line.removeprefix("data:").strip()
+            for line in receipt_event.splitlines()
+            if line.startswith("data:")
+        )
+    )
+    assert (
+        "output_limit_reached" in receipt["reason_codes"]
+    ) is expect_output_limit
+    assert service.diagnostics()["recent_decisions"][0]["outcome"] == (
+        expected_outcome
+    )

--- a/server/tests/test_omniroute_integration.py
+++ b/server/tests/test_omniroute_integration.py
@@ -437,7 +437,7 @@ async def test_omniroute_empty_success_stream_becomes_explicit_error(
 
     assert response.status_code == 200
     assert response.text.count("event: route_receipt") == 1
-    assert "上游候选没有生成正文" in response.text
+    assert "模型服务返回了成功状态，但没有生成正文" in response.text
     assert response.text.rstrip().endswith("data: [DONE]")
 
 
@@ -462,4 +462,4 @@ async def test_routing_options_rejected_for_default_gateway(
     )
 
     assert response.status_code == 400
-    assert "仅适用于 OmniRoute" in response.json()["error"]
+    assert "仅适用于智能调度" in response.json()["error"]

--- a/server/xpert_runtime/core_middlewares.py
+++ b/server/xpert_runtime/core_middlewares.py
@@ -1,13 +1,24 @@
 from __future__ import annotations
 
 import json
-import math
 import re
-import time
 from dataclasses import dataclass, field
 from typing import Any, Awaitable, Callable
 
 from jsonschema import Draft202012Validator
+
+try:
+    from server.context_engine import (
+        estimate_messages_tokens,
+        estimate_text_tokens,
+        optimize_context,
+    )
+except ModuleNotFoundError:
+    from context_engine import (
+        estimate_messages_tokens,
+        estimate_text_tokens,
+        optimize_context,
+    )
 
 from .middleware import AgentMiddleware
 from .models import MiddlewareContext, ModelCallRequest
@@ -113,23 +124,6 @@ def middleware_spec(
     )
 
 
-def estimate_text_tokens(text: str) -> int:
-    """Conservative tokenizer-free estimate for mixed CJK and Latin text."""
-
-    if not text:
-        return 0
-    cjk_count = len(re.findall(r"[\u3400-\u9fff\uf900-\ufaff]", text))
-    non_cjk_count = max(0, len(text) - cjk_count)
-    return cjk_count + math.ceil(non_cjk_count / 4)
-
-
-def estimate_messages_tokens(messages: list[dict[str, Any]]) -> int:
-    return sum(
-        4 + estimate_text_tokens(str(message.get("content") or ""))
-        for message in messages
-    )
-
-
 def build_context_compression_middleware(
     spec: RuntimeMiddlewareSpec,
 ) -> AgentMiddleware:
@@ -137,125 +131,69 @@ def build_context_compression_middleware(
         request: ModelCallRequest,
         context: MiddlewareContext,
     ) -> dict[str, Any] | None:
-        started_at = time.perf_counter()
         config = spec.config
         max_context_tokens = _int(config.get("max_context_tokens"), 24_000, 2_048, 200_000)
         trigger_ratio = _float(config.get("trigger_ratio"), 0.8, 0.5, 0.95)
         keep_recent = _int(config.get("keep_recent_messages"), 8, 2, 40)
         summary_max_tokens = _int(config.get("summary_max_tokens"), 1_500, 256, 4_000)
         max_tool_output_chars = _int(config.get("max_tool_output_chars"), 4_000, 500, 20_000)
-        messages = _truncate_tool_messages(request.messages, max_tool_output_chars)
-        before_tokens = estimate_messages_tokens(messages)
-        if before_tokens < int(max_context_tokens * trigger_ratio):
-            if messages != request.messages:
-                return {"messages": messages}
-            return None
-
-        system_messages = [message for message in messages if message.get("role") == "system"][:1]
-        non_system = [message for message in messages if message.get("role") != "system"]
-        recent = non_system[-keep_recent:]
-        omitted = non_system[:-keep_recent]
         existing_summary = str(context.metadata.get("conversation_summary") or "").strip()
         summary_boundary = str(
             context.metadata.get("conversation_summary_through_message_id") or ""
         ).strip()
-        if existing_summary and summary_boundary:
-            boundary_index = next(
-                (
-                    index
-                    for index, message in enumerate(omitted)
-                    if str(message.get("message_id") or "") == summary_boundary
-                ),
-                None,
-            )
-            if boundary_index is not None:
-                omitted = omitted[boundary_index + 1 :]
-            elif any(
-                str(message.get("message_id") or "") == summary_boundary
-                for message in recent
-            ):
-                omitted = []
-
-        def compressed_messages(summary: str) -> list[dict[str, Any]]:
-            summary_message = (
-                [
-                    {
-                        "role": "system",
-                        "content": f"Conversation summary (derived):\n{summary}",
-                    }
-                ]
-                if summary
-                else []
-            )
-            return [*system_messages, *summary_message, *recent]
-
-        if not omitted:
-            if not existing_summary:
-                return {"messages": messages}
-            prepared = compressed_messages(existing_summary)
-            context.metadata["context_compression"] = {
-                "before_tokens": before_tokens,
-                "after_tokens": estimate_messages_tokens(prepared),
-                "summarized_messages": 0,
-                "reused_summary": True,
-                "duration_ms": round((time.perf_counter() - started_at) * 1000, 2),
-            }
-            return {"messages": prepared}
-
         summarizer = context.metadata.get("middleware_model_text")
-        if not callable(summarizer):
+        summary_model_id = str(config.get("summary_model_id") or request.model_id).strip()
+        persist_summary = context.metadata.get("persist_conversation_summary")
+        optimization = await optimize_context(
+            request.messages,
+            profile="standard",
+            max_context_tokens=max_context_tokens,
+            max_output_tokens=0,
+            safety_margin_tokens=0,
+            trigger_ratio=trigger_ratio,
+            keep_recent_messages=keep_recent,
+            max_tool_output_chars=max_tool_output_chars,
+            summary_model_id=summary_model_id,
+            summary_max_tokens=summary_max_tokens,
+            summarizer=summarizer if callable(summarizer) else None,
+            existing_summary=existing_summary,
+            summary_boundary=summary_boundary,
+            persist_summary=persist_summary if callable(persist_summary) else None,
+        )
+        report = optimization.report
+        context.metadata["context_compression"] = {
+            **report.as_dict(),
+            "before_tokens": report.original_tokens,
+            "after_tokens": report.final_tokens,
+            "summarized_messages": report.summarized_messages,
+            "reused_summary": report.reused_summary,
+        }
+        if report.fallback_reason in {"summary_failed", "summary_unavailable"}:
             context.metadata.setdefault("middleware_warnings", []).append(
                 "context_compression summarizer is unavailable"
+                if report.fallback_reason == "summary_unavailable"
+                else "context_compression failed: summary unavailable"
             )
-            return {"messages": compressed_messages(existing_summary)}
-
-        summary_model_id = str(config.get("summary_model_id") or request.model_id).strip()
-        source_text = "\n\n".join(
-            f"{str(message.get('role') or 'unknown')}: {str(message.get('content') or '')}"
-            for message in omitted
-        )
-        summary_prompt = (
-            "Summarize the older conversation context for another model. Preserve decisions, "
-            "constraints, identifiers, unfinished tasks, and user preferences. Do not invent facts.\n\n"
-            + (f"Existing summary:\n{existing_summary}\n\n" if existing_summary else "")
-            + f"Older messages:\n{source_text}"
-        )
-        try:
-            summary = (
-                await summarizer(
-                    summary_model_id,
-                    [{"role": "user", "content": summary_prompt}],
-                    summary_max_tokens,
-                )
-            ).strip()
-        except Exception as exc:
-            context.metadata.setdefault("middleware_warnings", []).append(
-                f"context_compression failed: {str(exc)[:160]}"
-            )
-            return {"messages": compressed_messages(existing_summary)}
-        if not summary:
-            return {"messages": compressed_messages(existing_summary)}
-
-        persist_summary = context.metadata.get("persist_conversation_summary")
-        if callable(persist_summary):
-            try:
-                await persist_summary(
-                    summary,
-                    summary_model_id,
-                    str(omitted[-1].get("message_id") or "") or None,
-                )
-            except Exception as exc:
-                context.metadata.setdefault("middleware_warnings", []).append(
-                    f"context_compression persistence failed: {str(exc)[:160]}"
-                )
-        context.metadata["context_compression"] = {
-            "before_tokens": before_tokens,
-            "after_tokens": estimate_messages_tokens(compressed_messages(summary)),
-            "summarized_messages": len(omitted),
-            "reused_summary": False,
-            "duration_ms": round((time.perf_counter() - started_at) * 1000, 2),
-        }
-        return {"messages": compressed_messages(summary)}
+            if report.original_tokens >= int(max_context_tokens * trigger_ratio):
+                system_messages = [
+                    message
+                    for message in request.messages
+                    if message.get("role") == "system"
+                ]
+                non_system = [
+                    message
+                    for message in request.messages
+                    if message.get("role") != "system"
+                ]
+                return {
+                    "messages": [
+                        *system_messages,
+                        *non_system[-keep_recent:],
+                    ]
+                }
+        if optimization.messages != request.messages:
+            return {"messages": optimization.messages}
+        return None
 
     return AgentMiddleware(name="context_compression", before_model=before_model)
 
@@ -396,21 +334,6 @@ def middleware_config_schema(config: dict[str, Any]) -> dict[str, Any]:
         raise ValueError("structured_output schema_json must be a JSON object.")
     Draft202012Validator.check_schema(schema)
     return schema
-
-
-def _truncate_tool_messages(
-    messages: list[dict[str, Any]],
-    max_chars: int,
-) -> list[dict[str, Any]]:
-    result: list[dict[str, Any]] = []
-    for message in messages:
-        copied = dict(message)
-        if copied.get("role") in {"tool", "assistant"}:
-            content = str(copied.get("content") or "")
-            if len(content) > max_chars:
-                copied["content"] = content[:max_chars] + "\n[tool output truncated]"
-        result.append(copied)
-    return result
 
 
 def _extract_json_text(text: str) -> str:


### PR DESCRIPTION
## 改动摘要

- 增加租户隔离的 SQLite 原生路由仓储、模型服务连接、目录归一和脱敏诊断。
- 实现六种用户策略、硬过滤、熔断、LKGP、Shadow 与稳定会话灰度。
- 增加共享上下文优化内核，并接入 Chat、RAG 和 Xpert Runtime。
- 增加严格预算预留/结算、路由回执 v2 和压缩审计。
- 设置页增加普通用户可理解的模型服务连接、智能调度和上下文优化配置。
- 修复原生流式输出达到 Token 上限或缺少终止标记时被误报为成功的问题。
- 保留 default/newAPI 和 OmniRoute 侧车作为独立稳定路径与即时回退。

## 稳定性与冻结声明

本 PR 只代表初步本地验收通过，不代表本地路由已定级为稳定原生实现。

- 阶段 5 的 500 次请求、14 天观察、故障演练和全面人工验收均未完成。
- 暂停新增任何原生集成功能和新的 OmniRoute 行为对齐。
- 不删除 OmniRoute profile、适配器或回退数据，不把 `native` 设为默认。
- 冻结期间只允许有回归测试的正确性、安全性、兼容性和数据完整性修复。
- 后续产品优化应与 OmniRoute/原生迁移模块解耦。

详细边界见 `docs/MODEL_ROUTER_NATIVE.md` 和
`docs/OMNIROUTE_INTEGRATION.md`。

## Harness 范围说明

本 PR 超过“原则上 5 个核心文件”的原因是路由契约、SQLite 仓储、SSE
生命周期、前端设置、Docker 复制路径和对应回归测试构成同一可运行闭环。
继续机械拆分会产生无法启动、接口存在但不可配置或主聊天链路缺少护栏的
中间状态。本 PR 合并后已在文档中冻结原生增量，后续迭代恢复小批次交付。

## 验证

- `npm.cmd run build`
- `python -m py_compile server/main.py server/omniroute/telemetry.py`
- `python -m pytest server/tests/ -q`：522 passed
- `docker compose ... build server client`
- 重建后 `/api/health` 正常、`/chat/auto` HTTP 200
- 真实受控输出上限请求正确返回 `output_limit_reached`、单个路由回执和 `[DONE]`
- `git diff --check`
- 变更文件敏感凭据扫描

## 回退

- 设置页切回稳定模式，或设置 `MODEL_ROUTER_ENGINE=sidecar` 后重新创建 server。
- 不需要删除或迁移 SQLite 数据。
- default/newAPI 聊天路径保持独立。
