### PR TITLE
feature: 完成音频能力闭环

### DIFF
--- a/client/scripts/verify-streaming-audio.mjs
+++ b/client/scripts/verify-streaming-audio.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { fetchChatStream } from "../src/utils/fetchChatStream.ts";
 import { IncrementalBase64Decoder } from "../src/utils/streamingAudio.ts";
 
 globalThis.window = {
@@ -36,5 +37,73 @@ assert.equal(merge(paddedDecoded).toString(), "ID3-tail");
 const incomplete = new IncrementalBase64Decoder();
 incomplete.push("S");
 assert.throws(() => incomplete.finish(), /结尾不完整/);
+
+const encoder = new TextEncoder();
+const streamEvents = [];
+const audioPieces = [
+  Buffer.from("ID3-first").toString("base64"),
+  Buffer.from("-last").toString("base64"),
+];
+globalThis.fetch = async () =>
+  new Response(
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode(
+            `data: ${JSON.stringify({
+              choices: [
+                {
+                  delta: {
+                    audio: {
+                      data: audioPieces[0],
+                      transcript: "第一段",
+                    },
+                  },
+                  finish_reason: "stop",
+                },
+              ],
+            })}\n\n`,
+          ),
+        );
+        controller.enqueue(
+          encoder.encode(
+            `data: ${JSON.stringify({
+              choices: [
+                {
+                  delta: {
+                    audio: {
+                      data: audioPieces[1],
+                      transcript: "第二段",
+                    },
+                  },
+                  finish_reason: null,
+                },
+              ],
+            })}\n\nevent: message_end\ndata: {}\n\ndata: [DONE]\n\n`,
+          ),
+        );
+        controller.close();
+      },
+    }),
+    {
+      status: 200,
+      headers: { "Content-Type": "text/event-stream" },
+    },
+  );
+
+await fetchChatStream({
+  modelId: "openai/gpt-audio",
+  messages: [{ role: "user", content: "请用语音回答" }],
+  responseAudio: { enabled: true, voice: "alloy", format: "mp3" },
+  onDelta: (delta) => streamEvents.push(`text:${delta}`),
+  onAudioDelta: (audio) =>
+    streamEvents.push(`audio:${audio.transcript ?? ""}`),
+  onMessageEnd: () => streamEvents.push("end"),
+});
+assert.deepEqual(streamEvents, [
+  "audio:第一段",
+  "audio:第二段",
+  "end",
+]);
 
 console.log("streaming audio base64 checks passed");

--- a/client/src/components/AudioCreationWorkspace.tsx
+++ b/client/src/components/AudioCreationWorkspace.tsx
@@ -1,0 +1,963 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+} from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { models, type Model } from "../data/models";
+import BrandLogo from "./BrandLogo";
+import ResourceNav from "./ResourceNav";
+
+const MAX_PROMPT_CHARS = 4_000;
+const MAX_IMAGE_BYTES = 10 * 1024 * 1024;
+const ACTIVE_STATUSES = new Set<AudioJobStatus>(["queued", "running"]);
+const POLL_DELAYS = [2_000, 5_000, 10_000] as const;
+const IMAGE_EXTENSIONS = new Set(["jpg", "jpeg", "png", "webp"]);
+
+type AudioJobStatus =
+  | "queued"
+  | "running"
+  | "succeeded"
+  | "failed"
+  | "expired";
+
+interface AudioModelProfile {
+  model_id: string;
+  display_name: string;
+  invocable: boolean;
+  interaction_status: "ready" | "planned" | "disabled";
+  status_reason: string | null;
+  operations: string[];
+  output_formats: string[];
+  supports_image_prompt: boolean;
+  price_per_generation_usd: number | null;
+  fixed_duration_seconds: number | null;
+}
+
+interface AudioCatalogResponse {
+  status: "online" | "stale" | "offline" | "disabled";
+  stale: boolean;
+  profiles: AudioModelProfile[];
+}
+
+interface AudioJob {
+  job_id: string;
+  status: AudioJobStatus;
+  requested_model: string;
+  actual_model: string | null;
+  provider: "openrouter";
+  generation_id: string | null;
+  parameters: {
+    has_image: boolean;
+  };
+  usage: {
+    cost_usd: number | null;
+    cost_kind: "actual" | "unavailable";
+  };
+  output_bytes: number;
+  created_at: string;
+  updated_at: string;
+  expires_at: string | null;
+  error: {
+    code: string;
+    message: string;
+  } | null;
+}
+
+interface AudioJobListResponse {
+  jobs: AudioJob[];
+}
+
+interface AudioCreationWorkspaceProps {
+  model: Model;
+}
+
+const statusPresentation: Record<
+  AudioJobStatus,
+  { label: string; className: string; description: string }
+> = {
+  queued: {
+    label: "已提交",
+    className: "border-amber-300/30 bg-amber-300/10 text-amber-100",
+    description: "任务已接收，正在等待音乐模型开始生成。",
+  },
+  running: {
+    label: "创作中",
+    className: "border-sky-300/30 bg-sky-300/10 text-sky-100",
+    description: "正在接收并校验完整音频，完成前不会交付损坏文件。",
+  },
+  succeeded: {
+    label: "已完成",
+    className: "border-emerald-300/30 bg-emerald-300/10 text-emerald-100",
+    description: "音乐已生成，可以试听或下载。",
+  },
+  failed: {
+    label: "未完成",
+    className: "border-rose-300/30 bg-rose-300/10 text-rose-100",
+    description: "任务没有生成可用音频，请按提示调整后重新提交。",
+  },
+  expired: {
+    label: "已过期",
+    className: "border-slate-300/25 bg-slate-300/10 text-slate-200",
+    description: "临时音频已超过 30 分钟保留时间，请重新生成。",
+  },
+};
+
+function responseErrorMessage(payload: unknown, fallback: string) {
+  if (payload && typeof payload === "object") {
+    const detail = (payload as { detail?: unknown }).detail;
+    if (detail && typeof detail === "object") {
+      const message = (detail as { message?: unknown }).message;
+      if (typeof message === "string" && message.trim()) return message;
+    }
+  }
+  return fallback;
+}
+
+async function readJson<T>(response: Response, fallback: string): Promise<T> {
+  let payload: unknown = null;
+  try {
+    payload = await response.json();
+  } catch {
+    payload = null;
+  }
+  if (!response.ok) {
+    throw new Error(responseErrorMessage(payload, fallback));
+  }
+  return payload as T;
+}
+
+function mergeJob(current: AudioJob[], job: AudioJob) {
+  return [job, ...current.filter((item) => item.job_id !== job.job_id)].sort(
+    (left, right) =>
+      new Date(right.created_at).getTime() -
+      new Date(left.created_at).getTime(),
+  );
+}
+
+function formatDate(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "时间待确认";
+  return date.toLocaleString("zh-CN", {
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+}
+
+function formatBytes(bytes: number) {
+  if (bytes <= 0) return "大小待确认";
+  if (bytes >= 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MiB`;
+  }
+  return `${Math.max(1, Math.round(bytes / 1024))} KiB`;
+}
+
+function formatCost(job: AudioJob) {
+  return job.usage.cost_usd === null
+    ? "费用以网关结算为准"
+    : `$${job.usage.cost_usd.toFixed(4)}`;
+}
+
+function creationType(
+  modelId: string,
+  fixedDurationSeconds: number | null | undefined,
+) {
+  const durationLabel = fixedDurationSeconds
+    ? `约 ${fixedDurationSeconds} 秒`
+    : "时长由模型决定";
+  return modelId.includes("clip")
+    ? {
+        label: "短音乐片段",
+        description: `适合快速验证旋律、配器和整体氛围，${durationLabel}。`,
+      }
+    : {
+        label: "完整音乐作品",
+        description: `适合需要更完整段落与编排的创作，${durationLabel}。`,
+      };
+}
+
+function newIdempotencyKey() {
+  if (typeof crypto.randomUUID === "function") {
+    return `audio-${crypto.randomUUID()}`;
+  }
+  return `audio-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function validateImage(file: File) {
+  const extension = file.name.split(".").pop()?.toLowerCase() ?? "";
+  if (!IMAGE_EXTENSIONS.has(extension)) {
+    return "图片提示只支持 JPEG、PNG 和 WebP。";
+  }
+  if (file.size > MAX_IMAGE_BYTES) {
+    return "图片提示超过 10 MiB，请压缩后重试。";
+  }
+  const allowedTypes = new Set([
+    "",
+    "image/jpeg",
+    "image/jpg",
+    "image/png",
+    "image/webp",
+  ]);
+  if (!allowedTypes.has(file.type.toLowerCase())) {
+    return "图片扩展名与文件类型不一致，请重新导出后重试。";
+  }
+  return "";
+}
+
+export default function AudioCreationWorkspace({
+  model,
+}: AudioCreationWorkspaceProps) {
+  const navigate = useNavigate();
+  const [catalog, setCatalog] = useState<AudioCatalogResponse | null>(null);
+  const [catalogLoading, setCatalogLoading] = useState(true);
+  const [jobs, setJobs] = useState<AudioJob[]>([]);
+  const [jobsLoading, setJobsLoading] = useState(true);
+  const [prompt, setPrompt] = useState("");
+  const [image, setImage] = useState<File | null>(null);
+  const [imageUrl, setImageUrl] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+  const [notice, setNotice] = useState("");
+  const [pollWarnings, setPollWarnings] = useState<Record<string, string>>({});
+  const [confirmDeleteId, setConfirmDeleteId] = useState("");
+  const imageInputRef = useRef<HTMLInputElement>(null);
+  const promptRef = useRef<HTMLTextAreaElement>(null);
+  const idempotencyKeyRef = useRef("");
+  const jobsRef = useRef<AudioJob[]>([]);
+
+  const profile = useMemo(
+    () =>
+      catalog?.profiles.find(
+        (item) =>
+          item.model_id === model.id &&
+          item.operations.includes("generate_audio"),
+      ) ?? null,
+    [catalog, model.id],
+  );
+  const readyProfiles = useMemo(
+    () =>
+      (catalog?.profiles ?? []).filter(
+        (item) =>
+          item.invocable &&
+          item.interaction_status === "ready" &&
+          item.operations.includes("generate_audio") &&
+          item.output_formats.includes("mp3"),
+      ),
+    [catalog],
+  );
+  const visibleJobs = useMemo(
+    () => jobs.filter((job) => job.requested_model === model.id),
+    [jobs, model.id],
+  );
+  const type = creationType(model.id, profile?.fixed_duration_seconds);
+  const canSubmit =
+    Boolean(profile) &&
+    profile?.invocable === true &&
+    profile?.interaction_status === "ready" &&
+    prompt.trim().length > 0 &&
+    prompt.length <= MAX_PROMPT_CHARS &&
+    !submitting;
+
+  useEffect(() => {
+    document.title = `生成音乐 · ${model.name} · 模镜`;
+  }, [model.name]);
+
+  useEffect(() => {
+    jobsRef.current = jobs;
+  }, [jobs]);
+
+  useEffect(() => {
+    if (!image) {
+      setImageUrl("");
+      return undefined;
+    }
+    const nextUrl = URL.createObjectURL(image);
+    setImageUrl(nextUrl);
+    return () => URL.revokeObjectURL(nextUrl);
+  }, [image]);
+
+  const loadCatalog = useCallback(async (signal?: AbortSignal) => {
+    const response = await fetch("/api/multimodal/audio/models", { signal });
+    const payload = await readJson<AudioCatalogResponse>(
+      response,
+      "暂时无法读取音乐模型能力。",
+    );
+    setCatalog(payload);
+  }, []);
+
+  const loadJobs = useCallback(async () => {
+    const response = await fetch("/api/multimodal/audio/jobs");
+    const payload = await readJson<AudioJobListResponse>(
+      response,
+      "暂时无法读取音乐任务，请稍后刷新。",
+    );
+    setJobs(payload.jobs);
+  }, []);
+
+  const refreshJob = useCallback(async (jobId: string) => {
+    try {
+      const response = await fetch(
+        `/api/multimodal/audio/jobs/${encodeURIComponent(jobId)}`,
+      );
+      const job = await readJson<AudioJob>(
+        response,
+        "暂时无法刷新音乐任务。",
+      );
+      setJobs((current) => mergeJob(current, job));
+      setPollWarnings((current) => {
+        if (!current[jobId]) return current;
+        const next = { ...current };
+        delete next[jobId];
+        return next;
+      });
+      return true;
+    } catch (refreshError) {
+      setPollWarnings((current) => ({
+        ...current,
+        [jobId]:
+          refreshError instanceof Error
+            ? refreshError.message
+            : "暂时无法刷新音乐任务。",
+      }));
+      return false;
+    }
+  }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setCatalogLoading(true);
+    setJobsLoading(true);
+    setError("");
+
+    void loadCatalog(controller.signal)
+      .catch((loadError) => {
+        if (!controller.signal.aborted) {
+          setCatalog(null);
+          setError(
+            loadError instanceof Error
+              ? loadError.message
+              : "暂时无法读取音乐模型能力。",
+          );
+        }
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setCatalogLoading(false);
+      });
+    void loadJobs()
+      .catch((loadError) => {
+        if (!controller.signal.aborted) {
+          setError(
+            loadError instanceof Error
+              ? loadError.message
+              : "暂时无法读取音乐任务。",
+          );
+        }
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setJobsLoading(false);
+      });
+
+    return () => controller.abort();
+  }, [loadCatalog, loadJobs]);
+
+  useEffect(() => {
+    let stopped = false;
+    let polling = false;
+    let timer: number | null = null;
+    let errorStreak = 0;
+
+    const clearTimer = () => {
+      if (timer !== null) window.clearTimeout(timer);
+      timer = null;
+    };
+    const schedule = () => {
+      clearTimer();
+      if (stopped || document.visibilityState === "hidden") return;
+      const delay =
+        POLL_DELAYS[Math.min(errorStreak, POLL_DELAYS.length - 1)];
+      timer = window.setTimeout(() => void tick(), delay);
+    };
+    const tick = async () => {
+      if (stopped || polling || document.visibilityState === "hidden") {
+        schedule();
+        return;
+      }
+      const activeJobs = jobsRef.current.filter(
+        (job) =>
+          job.requested_model === model.id &&
+          ACTIVE_STATUSES.has(job.status),
+      );
+      if (activeJobs.length === 0) {
+        errorStreak = 0;
+        schedule();
+        return;
+      }
+      polling = true;
+      const results = await Promise.all(
+        activeJobs.map((job) => refreshJob(job.job_id)),
+      );
+      polling = false;
+      errorStreak = results.every(Boolean)
+        ? 0
+        : Math.min(errorStreak + 1, POLL_DELAYS.length - 1);
+      schedule();
+    };
+    const handleVisibility = () => {
+      if (document.visibilityState === "hidden") clearTimer();
+      else void tick();
+    };
+
+    document.addEventListener("visibilitychange", handleVisibility);
+    schedule();
+    return () => {
+      stopped = true;
+      clearTimer();
+      document.removeEventListener("visibilitychange", handleVisibility);
+    };
+  }, [model.id, refreshJob]);
+
+  function markFormChanged() {
+    idempotencyKeyRef.current = "";
+    setError("");
+    setNotice("");
+  }
+
+  function chooseImage(file: File | undefined) {
+    if (!file || submitting) return;
+    const validationError = validateImage(file);
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+    setImage(file);
+    markFormChanged();
+  }
+
+  function handleImageInput(event: ChangeEvent<HTMLInputElement>) {
+    chooseImage(event.target.files?.[0]);
+    event.target.value = "";
+  }
+
+  async function submitJob() {
+    if (!canSubmit || !profile) return;
+    const cleanPrompt = prompt.trim();
+    if (!cleanPrompt) {
+      setError("请先描述希望生成的音乐。");
+      promptRef.current?.focus();
+      return;
+    }
+    const key =
+      idempotencyKeyRef.current ||
+      (idempotencyKeyRef.current = newIdempotencyKey());
+    const form = new FormData();
+    form.append("model_id", model.id);
+    form.append("prompt", cleanPrompt);
+    form.append("idempotency_key", key);
+    if (image) form.append("image", image, image.name);
+
+    setSubmitting(true);
+    setError("");
+    setNotice("");
+    try {
+      const response = await fetch("/api/multimodal/audio/jobs", {
+        method: "POST",
+        body: form,
+      });
+      const job = await readJson<AudioJob>(
+        response,
+        "音乐任务没有提交成功，请检查连接后重试。",
+      );
+      setJobs((current) => mergeJob(current, job));
+      setNotice(
+        job.status === "failed"
+          ? "这次提交未被接受，请查看任务提示后重试。"
+          : "任务已提交，完成后可在下方试听和下载。",
+      );
+      idempotencyKeyRef.current = "";
+    } catch (submitError) {
+      setError(
+        submitError instanceof Error
+          ? submitError.message
+          : "音乐任务没有提交成功，请稍后重试。",
+      );
+      try {
+        await loadJobs();
+      } catch {
+        // Keep the original actionable error.
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function removeJob(jobId: string) {
+    if (confirmDeleteId !== jobId) {
+      setConfirmDeleteId(jobId);
+      return;
+    }
+    try {
+      const response = await fetch(
+        `/api/multimodal/audio/jobs/${encodeURIComponent(jobId)}`,
+        { method: "DELETE" },
+      );
+      await readJson(
+        response,
+        "暂时无法移除任务记录，请稍后重试。",
+      );
+      setJobs((current) => current.filter((job) => job.job_id !== jobId));
+      setConfirmDeleteId("");
+      setNotice("本地任务记录已移除，不代表取消上游调用。");
+    } catch (removeError) {
+      setError(
+        removeError instanceof Error
+          ? removeError.message
+          : "暂时无法移除任务记录。",
+      );
+    }
+  }
+
+  return (
+    <main className="museum-grid min-h-screen overflow-x-hidden pb-28 pt-5 text-slate-100 lg:pb-12 lg:pt-24">
+      <ResourceNav activeResource="models" />
+      <div className="mx-auto w-full max-w-[1180px] px-4 py-5 sm:px-6 lg:px-8">
+        <header className="border-y border-hire-300/20 bg-ink-950/72 py-5 backdrop-blur-xl">
+          <BrandLogo className="mb-4 lg:hidden" />
+        <div className="flex flex-wrap items-start justify-between gap-5">
+          <div className="min-w-0">
+            <Link
+              className="text-sm font-semibold text-slate-300 transition hover:text-brand-100"
+              to="/models"
+            >
+              ← 返回模型招聘会
+            </Link>
+            <h1 className="mt-4 text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+              生成音乐
+            </h1>
+            <p className="mt-3 max-w-3xl text-sm leading-6 text-slate-300 sm:text-base">
+              描述旋律、节奏、乐器与氛围。任务完成后可试听并下载 MP3，生成内容在本地临时保留 30 分钟。
+            </p>
+          </div>
+          <span className="rounded-full border border-brand-300/30 bg-brand-300/10 px-3 py-1.5 text-xs font-semibold text-brand-100">
+            {catalog?.stale ? "使用缓存能力" : "音乐创作"}
+          </span>
+        </div>
+        </header>
+
+        <div className="mt-8 grid gap-6 lg:grid-cols-[minmax(0,1fr)_300px] lg:items-start">
+          <section className="surface-panel overflow-hidden rounded-lg">
+            <div className="border-b border-white/10 px-5 py-4 sm:px-6">
+              <h2 className="text-lg font-semibold text-white">创作设置</h2>
+              <p className="mt-1 text-sm text-slate-400">
+                选择创作类型，图片只作为风格和氛围参考。
+              </p>
+            </div>
+
+            {catalogLoading ? (
+              <div
+                aria-label="正在加载音乐模型能力"
+                className="space-y-4 p-5 sm:p-6"
+              >
+                <div className="h-12 animate-pulse rounded-lg bg-white/[0.05] motion-reduce:animate-none" />
+                <div className="h-44 animate-pulse rounded-lg bg-white/[0.04] motion-reduce:animate-none" />
+              </div>
+            ) : profile?.interaction_status === "ready" ? (
+              <div className="space-y-5 p-5 sm:p-6">
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <label className="block text-sm font-medium text-slate-200">
+                    音乐模型
+                    <select
+                      className="mt-2 w-full rounded-lg border border-white/15 bg-ink-950 px-3 py-2.5 text-sm text-white outline-none transition focus:border-brand-300/60 focus:ring-4 focus:ring-brand-300/10"
+                      disabled={submitting || readyProfiles.length === 0}
+                      onChange={(event) => {
+                        const nextId = event.target.value;
+                        if (nextId === model.id) return;
+                        navigate(
+                          `/chat/${encodeURIComponent(nextId)}?operation=generate_audio`,
+                        );
+                      }}
+                      value={model.id}
+                    >
+                      {readyProfiles.map((item) => {
+                        const catalogModel = models.find(
+                          (candidate) => candidate.id === item.model_id,
+                        );
+                        return (
+                          <option key={item.model_id} value={item.model_id}>
+                            {catalogModel?.name ?? item.display_name}
+                          </option>
+                        );
+                      })}
+                    </select>
+                  </label>
+                  <div>
+                    <p className="text-sm font-medium text-slate-200">
+                      创作类型
+                    </p>
+                    <div className="mt-2 min-h-11 rounded-lg bg-white/[0.05] px-3 py-2.5">
+                      <p className="text-sm font-semibold text-white">
+                        {type.label}
+                      </p>
+                      <p className="mt-1 text-xs leading-5 text-slate-400">
+                        {type.description}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+
+                <label className="block text-sm font-medium text-slate-200">
+                  音乐描述
+                  <textarea
+                    className="mt-2 min-h-40 w-full resize-y rounded-lg border border-white/15 bg-ink-950 px-4 py-3 text-sm leading-6 text-white outline-none transition placeholder:text-slate-400 focus:border-brand-300/60 focus:ring-4 focus:ring-brand-300/10"
+                    disabled={submitting}
+                    maxLength={MAX_PROMPT_CHARS}
+                    onChange={(event) => {
+                      setPrompt(event.target.value);
+                      markFormChanged();
+                    }}
+                    placeholder="例如：轻快的城市流行乐，女声哼唱感的主旋律，加入钢琴、清脆鼓点和温暖弦乐，适合作为清晨通勤配乐。"
+                    ref={promptRef}
+                    value={prompt}
+                  />
+                  <span
+                    className={`mt-1 block text-right text-xs ${
+                      prompt.length >= MAX_PROMPT_CHARS
+                        ? "text-amber-100"
+                        : "text-slate-400"
+                    }`}
+                  >
+                    {prompt.length} / {MAX_PROMPT_CHARS}
+                  </span>
+                </label>
+
+                {profile.supports_image_prompt ? (
+                  <div className="rounded-lg bg-white/[0.045] p-4">
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div>
+                        <p className="text-sm font-semibold text-white">
+                          图片提示（可选）
+                        </p>
+                        <p className="mt-1 text-xs leading-5 text-slate-400">
+                          用于传达色彩、场景和情绪，不保证复刻图片内容。支持 JPEG、PNG、WebP，最大 10 MiB。
+                        </p>
+                      </div>
+                      <input
+                        accept=".jpg,.jpeg,.png,.webp,image/jpeg,image/png,image/webp"
+                        className="hidden"
+                        disabled={submitting}
+                        onChange={handleImageInput}
+                        ref={imageInputRef}
+                        type="file"
+                      />
+                      <button
+                        className="rounded-full border border-white/15 px-3 py-1.5 text-xs font-semibold text-slate-200 transition hover:border-brand-300/40 hover:bg-brand-300/10 hover:text-brand-100 disabled:cursor-not-allowed disabled:opacity-50"
+                        disabled={submitting}
+                        onClick={() => imageInputRef.current?.click()}
+                        type="button"
+                      >
+                        {image ? "替换图片" : "选择图片"}
+                      </button>
+                    </div>
+                    {image ? (
+                      <div className="mt-4 flex min-w-0 items-center gap-3">
+                        {imageUrl ? (
+                          <img
+                            alt="音乐图片提示预览"
+                            className="h-24 w-32 shrink-0 rounded-md bg-black object-contain"
+                            src={imageUrl}
+                          />
+                        ) : null}
+                        <div className="min-w-0">
+                          <p className="truncate text-xs font-medium text-slate-200">
+                            {image.name}
+                          </p>
+                          <p className="mt-1 text-xs text-slate-400">
+                            {formatBytes(image.size)}
+                          </p>
+                          <button
+                            className="mt-2 text-xs font-semibold text-rose-200 transition hover:text-rose-100"
+                            disabled={submitting}
+                            onClick={() => {
+                              setImage(null);
+                              markFormChanged();
+                            }}
+                            type="button"
+                          >
+                            移除图片
+                          </button>
+                        </div>
+                      </div>
+                    ) : null}
+                  </div>
+                ) : null}
+
+                {error ? (
+                  <div
+                    className="rounded-lg border border-rose-300/25 bg-rose-300/10 px-4 py-3 text-sm leading-6 text-rose-100"
+                    role="alert"
+                  >
+                    {error}
+                  </div>
+                ) : null}
+                {notice ? (
+                  <div
+                    className="rounded-lg border border-emerald-300/20 bg-emerald-300/[0.08] px-4 py-3 text-sm leading-6 text-emerald-100"
+                    role="status"
+                  >
+                    {notice}
+                  </div>
+                ) : null}
+
+                <div className="flex flex-wrap items-center justify-between gap-4 border-t border-white/10 pt-5">
+                  <div>
+                    <p className="text-sm font-semibold text-white">
+                      {profile.price_per_generation_usd === null
+                        ? "费用以网关结算为准"
+                        : `目录估算 $${profile.price_per_generation_usd.toFixed(2)}`}
+                    </p>
+                    <p className="mt-1 text-xs leading-5 text-slate-400">
+                      提交会产生费用，未知费用不会显示为零。
+                    </p>
+                  </div>
+                  <button
+                    className="rounded-full bg-hire-300 px-5 py-2.5 text-sm font-semibold text-ink-950 transition hover:bg-hire-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hire-100 focus-visible:ring-offset-2 focus-visible:ring-offset-ink-950 disabled:cursor-not-allowed disabled:opacity-45"
+                    disabled={!canSubmit}
+                    onClick={() => void submitJob()}
+                    type="button"
+                  >
+                    {submitting
+                      ? "正在提交…"
+                      : profile.price_per_generation_usd === null
+                        ? "提交生成 · 费用以网关结算为准"
+                        : `提交生成 · 预计 $${profile.price_per_generation_usd.toFixed(2)}`}
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <div className="p-5 sm:p-6">
+                <div
+                  className="rounded-lg border border-amber-300/25 bg-amber-300/[0.08] px-4 py-4 text-sm leading-6 text-amber-100"
+                  role="status"
+                >
+                  {catalog?.status === "disabled" ||
+                  profile?.interaction_status === "disabled"
+                    ? "音乐生成当前未启用，请在服务配置中开启后再试。"
+                    : profile?.status_reason ??
+                      "实时目录尚未确认这个模型可生成音乐，请返回模型招聘会重新选择。"}
+                </div>
+              </div>
+            )}
+          </section>
+
+          <aside className="space-y-4 lg:sticky lg:top-24">
+            <div className="surface-card rounded-lg p-5">
+              <h2 className="text-sm font-semibold text-white">本次创作</h2>
+              <dl className="mt-4 space-y-3 text-sm">
+                <div>
+                  <dt className="text-slate-400">模型</dt>
+                  <dd className="mt-1 break-words font-medium text-slate-100">
+                    {model.name}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-slate-400">类型</dt>
+                  <dd className="mt-1 font-medium text-slate-100">
+                    {type.label}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-slate-400">图片提示</dt>
+                  <dd className="mt-1 font-medium text-slate-100">
+                    {image ? "已添加" : "未添加"}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-slate-400">输出</dt>
+                  <dd className="mt-1 font-medium text-slate-100">MP3</dd>
+                </div>
+              </dl>
+            </div>
+            <div className="rounded-lg border border-amber-300/20 bg-amber-300/[0.07] p-5">
+              <h2 className="text-sm font-semibold text-amber-100">
+                保存与隐私
+              </h2>
+              <p className="mt-3 text-sm leading-6 text-slate-300">
+                描述和图片会交给模型供应商处理。模镜不把描述、图片或音频写入数据库；生成音频只在本机临时保存 30 分钟，请及时下载。
+              </p>
+            </div>
+          </aside>
+        </div>
+
+        <section className="surface-panel mt-6 overflow-hidden rounded-lg">
+          <div className="flex flex-wrap items-center justify-between gap-3 border-b border-white/10 px-5 py-4 sm:px-6">
+            <div>
+              <h2 className="text-lg font-semibold text-white">生成任务</h2>
+              <p className="mt-1 text-sm text-slate-400">
+                创作中每 2 秒检查一次状态，页面隐藏时暂停。
+              </p>
+            </div>
+            <button
+              className="rounded-full border border-white/15 px-4 py-2 text-sm font-semibold text-slate-200 transition hover:border-brand-300/40 hover:bg-brand-300/10 hover:text-brand-100 disabled:cursor-not-allowed disabled:opacity-50"
+              disabled={jobsLoading}
+              onClick={() => {
+                setJobsLoading(true);
+                void loadJobs()
+                  .catch((loadError) =>
+                    setError(
+                      loadError instanceof Error
+                        ? loadError.message
+                        : "暂时无法读取音乐任务。",
+                    ),
+                  )
+                  .finally(() => setJobsLoading(false));
+              }}
+              type="button"
+            >
+              刷新任务
+            </button>
+          </div>
+
+          {jobsLoading ? (
+            <div
+              aria-label="正在加载音乐任务"
+              className="space-y-3 p-5 sm:p-6"
+            >
+              <div className="h-28 animate-pulse rounded-lg bg-white/[0.05] motion-reduce:animate-none" />
+              <div className="h-28 animate-pulse rounded-lg bg-white/[0.04] motion-reduce:animate-none" />
+            </div>
+          ) : visibleJobs.length === 0 ? (
+            <div className="px-5 py-12 text-center sm:px-6">
+              <p className="font-semibold text-white">还没有生成任务</p>
+              <p className="mx-auto mt-2 max-w-xl text-sm leading-6 text-slate-400">
+                填写音乐描述并提交后，创作进度和试听入口会显示在这里。
+              </p>
+            </div>
+          ) : (
+            <div aria-live="polite" className="divide-y divide-white/10">
+              {visibleJobs.map((job) => {
+                const presentation = statusPresentation[job.status];
+                const isActive = ACTIVE_STATUSES.has(job.status);
+                const contentUrl = `/api/multimodal/audio/jobs/${encodeURIComponent(job.job_id)}/content`;
+                return (
+                  <article className="px-5 py-5 sm:px-6" key={job.job_id}>
+                    <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                      <div className="min-w-0">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span
+                            className={`rounded-full border px-2.5 py-1 text-xs font-semibold ${presentation.className}`}
+                          >
+                            {presentation.label}
+                          </span>
+                          {job.parameters.has_image ? (
+                            <span className="rounded-full bg-white/[0.06] px-2.5 py-1 text-xs text-slate-300">
+                              使用图片提示
+                            </span>
+                          ) : null}
+                        </div>
+                        <p className="mt-3 text-sm leading-6 text-slate-300">
+                          {presentation.description}
+                        </p>
+                        <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-xs text-slate-400">
+                          <span>{formatDate(job.created_at)}</span>
+                          <span>{formatCost(job)}</span>
+                          {job.output_bytes > 0 ? (
+                            <span>{formatBytes(job.output_bytes)}</span>
+                          ) : null}
+                          {job.expires_at && job.status === "succeeded" ? (
+                            <span>
+                              临时保存至 {formatDate(job.expires_at)}
+                            </span>
+                          ) : null}
+                        </div>
+                        <p
+                          className="mt-2 truncate font-mono text-[11px] text-slate-500"
+                          title={job.job_id}
+                        >
+                          {job.job_id}
+                        </p>
+                      </div>
+
+                      <div className="flex shrink-0 flex-wrap gap-2">
+                        {isActive ? (
+                          <button
+                            className="rounded-full border border-white/15 px-3 py-1.5 text-xs font-semibold text-slate-200 transition hover:border-brand-300/40 hover:bg-brand-300/10"
+                            onClick={() => void refreshJob(job.job_id)}
+                            type="button"
+                          >
+                            刷新状态
+                          </button>
+                        ) : null}
+                        <button
+                          className={`rounded-full border px-3 py-1.5 text-xs font-semibold transition ${
+                            confirmDeleteId === job.job_id
+                              ? "border-rose-300/40 bg-rose-300/10 text-rose-100"
+                              : "border-white/15 text-slate-300 hover:border-rose-300/35 hover:text-rose-100"
+                          }`}
+                          onBlur={() => {
+                            if (confirmDeleteId === job.job_id) {
+                              setConfirmDeleteId("");
+                            }
+                          }}
+                          onClick={() => void removeJob(job.job_id)}
+                          type="button"
+                        >
+                          {confirmDeleteId === job.job_id
+                            ? "确认移除记录"
+                            : "移除记录"}
+                        </button>
+                      </div>
+                    </div>
+
+                    {pollWarnings[job.job_id] ? (
+                      <p
+                        className="mt-4 rounded-lg border border-amber-300/20 bg-amber-300/[0.07] px-4 py-3 text-sm leading-6 text-amber-100"
+                        role="status"
+                      >
+                        {pollWarnings[job.job_id]} 本地任务状态未改变。
+                      </p>
+                    ) : null}
+
+                    {job.error ? (
+                      <p
+                        className="mt-4 rounded-lg border border-rose-300/25 bg-rose-300/10 px-4 py-3 text-sm leading-6 text-rose-100"
+                        role="alert"
+                      >
+                        {job.error.message}
+                      </p>
+                    ) : null}
+
+                    {job.status === "succeeded" ? (
+                      <div className="mt-5 rounded-lg bg-white/[0.045] p-4">
+                        <audio
+                          aria-label="生成的音乐"
+                          className="w-full"
+                          controls
+                          preload="metadata"
+                          src={contentUrl}
+                        />
+                        <div className="mt-3 flex justify-end">
+                          <a
+                            className="rounded-full border border-brand-300/35 px-3 py-1.5 text-xs font-semibold text-brand-100 transition hover:bg-brand-300/10"
+                            download={`modelmirror-${job.job_id}.mp3`}
+                            href={contentUrl}
+                          >
+                            下载 MP3
+                          </a>
+                        </div>
+                      </div>
+                    ) : null}
+                  </article>
+                );
+              })}
+            </div>
+          )}
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/client/src/components/ModelCard.tsx
+++ b/client/src/components/ModelCard.tsx
@@ -18,8 +18,19 @@ import {
 
 interface ModelCardProps {
   model: Model;
+  confirmedAudioOperations?: ModelOperation[];
   confirmedVideoOperations?: ModelOperation[];
+  audioCapabilityStatus?: AudioCapabilityStatus;
+  audioCatalogStale?: boolean;
   videoCatalogStale?: boolean;
+}
+
+export interface AudioCapabilityStatus {
+  status: "ready" | "planned" | "disabled";
+  operations: ModelOperation[];
+  reason: string | null;
+  pricePerGenerationUsd: number | null;
+  fixedDurationSeconds: number | null;
 }
 
 const capabilityIcons: Record<Capability, { icon: string; label: string }> = {
@@ -39,6 +50,7 @@ const tagStyles: Record<string, string> = {
   多模态: "border-fuchsia-300/30 bg-fuchsia-300/10 text-fuchsia-100",
   开源: "border-amber-300/30 bg-amber-300/10 text-amber-100",
   免费: "border-lime-300/30 bg-lime-300/10 text-lime-100",
+  动态计费: "border-sky-300/30 bg-sky-300/10 text-sky-100",
 };
 
 function formatCnyPrice(priceCnyPerMillion: number) {
@@ -95,6 +107,7 @@ const operationLabels: Record<ModelOperation, string> = {
   synthesize_speech: "文字转语音",
   generate_audio: "音频生成",
   analyze_audio: "音频理解",
+  realtime_voice: "实时语音",
   analyze_video: "视频理解",
   generate_video: "视频生成",
   embed: "向量检索",
@@ -103,11 +116,20 @@ const operationLabels: Record<ModelOperation, string> = {
 
 const ModelCard = memo(function ModelCard({
   model,
+  confirmedAudioOperations = [],
   confirmedVideoOperations = [],
+  audioCapabilityStatus,
+  audioCatalogStale = false,
   videoCatalogStale = false,
 }: ModelCardProps) {
   const { preferredModelId, setPreferredModelId } = useModelPreference();
-  const isFree = model.price_cny.input === 0 && model.price_cny.output === 0;
+  const isFree = model.pricing_status === "free";
+  const isDynamicPricing = model.pricing_status === "dynamic";
+  const audioGenerationPriceUsd =
+    model.primary_operation === "generate_audio"
+      ? (audioCapabilityStatus?.pricePerGenerationUsd ?? null)
+      : null;
+  const hasAudioGenerationPrice = audioGenerationPriceUsd !== null;
   const talentStats = getTalentStats(model);
   const providerName = deriveProviderFromModel(model);
   const personaDescription = buildFriendlyTalentIntro(model);
@@ -127,6 +149,22 @@ const ModelCard = memo(function ModelCard({
     model.active &&
     model.interaction_status === "ready" &&
     model.ui_entrypoint === "rag";
+  const canAnalyzeAudio =
+    model.active && confirmedAudioOperations.includes("analyze_audio");
+  const canSynthesizeSpeech =
+    model.active &&
+    confirmedAudioOperations.includes("synthesize_speech");
+  const canGenerateAudio =
+    model.active &&
+    confirmedAudioOperations.includes("generate_audio");
+  const isRealtimeVoiceModel =
+    model.operations.includes("realtime_voice");
+  const canOpenRealtimeVoice =
+    model.active && isRealtimeVoiceModel;
+  const realtimeVoiceReady =
+    confirmedAudioOperations.includes("realtime_voice");
+  const canTranscribe =
+    model.active && confirmedAudioOperations.includes("transcribe");
   const operationLabel = operationLabels[model.primary_operation];
   const canAnalyzeVideo =
     model.active && confirmedVideoOperations.includes("analyze_video");
@@ -139,13 +177,76 @@ const ModelCard = memo(function ModelCard({
         operation === "generate_video",
     )
     .map((operation) => operationLabels[operation]);
-  const isInteractionReady =
-    model.interaction_status === "ready" ||
-    canAnalyzeVideo ||
-    canGenerateVideo;
+  const confirmedAudioLabels = confirmedAudioOperations
+    .filter(
+      (operation) =>
+        operation === "analyze_audio" ||
+        operation === "transcribe" ||
+        operation === "synthesize_speech" ||
+        operation === "generate_audio" ||
+        operation === "realtime_voice",
+    )
+    .map((operation) => operationLabels[operation]);
   const isTranscriptionModel =
     model.primary_operation === "transcribe" &&
     model.operations.includes("transcribe");
+  const staticAudioOperations = model.operations.filter(
+    (operation) =>
+      operation === "analyze_audio" ||
+      operation === "transcribe" ||
+      operation === "synthesize_speech" ||
+      operation === "generate_audio" ||
+      operation === "realtime_voice",
+  );
+  const unresolvedAudioOperations = (
+    audioCapabilityStatus?.operations ?? staticAudioOperations
+  ).filter(
+    (operation) =>
+      !confirmedAudioOperations.includes(operation),
+  );
+  const pendingAudioOperations =
+    audioCapabilityStatus?.status === "ready"
+      ? []
+      : unresolvedAudioOperations;
+  const pendingAudioLabels = pendingAudioOperations.map(
+    (operation) => operationLabels[operation],
+  );
+  const pendingAudioStateLabel =
+    isRealtimeVoiceModel && !realtimeVoiceReady
+      ? "需要配置"
+      : audioCapabilityStatus?.status === "disabled"
+      ? "当前未启用"
+      : "待适配";
+  const pendingAudioReason =
+    audioCapabilityStatus?.reason ??
+    (
+      pendingAudioLabels.length > 0
+        ? isRealtimeVoiceModel
+          ? "请在设置中添加“OpenAI 音频与实时语音”连接并完成测试。"
+          : "静态目录已收录，实时能力尚未确认。"
+        : null
+    );
+  const primaryAudioOperationBlocked =
+    (
+      isTranscriptionModel ||
+      model.primary_operation === "synthesize_speech" ||
+      model.primary_operation === "generate_audio" ||
+      model.primary_operation === "realtime_voice"
+    ) &&
+    Boolean(audioCapabilityStatus) &&
+    audioCapabilityStatus?.status !== "ready";
+  const isInteractionReady =
+    (
+      model.interaction_status === "ready" &&
+      !primaryAudioOperationBlocked
+    ) ||
+    confirmedAudioLabels.length > 0 ||
+    canAnalyzeVideo ||
+    canGenerateVideo;
+  const showGeneralChatAction =
+    canChat &&
+    model.primary_operation !== "synthesize_speech" &&
+    (!isTranscriptionModel || canTranscribe);
   const primaryChatPath = isTranscriptionModel
     ? `/chat/${encodeURIComponent(
         preferredModelId,
@@ -161,7 +262,9 @@ const ModelCard = memo(function ModelCard({
         <div className="flex items-center justify-between gap-3">
           <span className="rounded-full border border-hire-200/30 bg-hire-400/15 px-3 py-1 text-xs font-semibold text-hire-100">
             {!isInteractionReady
-              ? "交互待适配"
+              ? isRealtimeVoiceModel
+                ? "需要配置"
+                : "交互待适配"
               : talentStats.urgent
                 ? "急聘"
                 : "可预约面试"}
@@ -192,8 +295,46 @@ const ModelCard = memo(function ModelCard({
           </p>
         </div>
 
-        {canAnalyzeVideo || canGenerateVideo || canChat ? (
+        {canAnalyzeAudio ||
+        canSynthesizeSpeech ||
+        canGenerateAudio ||
+        canOpenRealtimeVoice ||
+        canAnalyzeVideo ||
+        canGenerateVideo ||
+        showGeneralChatAction ? (
           <div className="flex shrink-0 flex-col items-stretch gap-2">
+            {canAnalyzeAudio ? (
+              <Link
+                className="rounded-full bg-hire-300 px-3.5 py-2 text-center text-sm font-semibold text-ink-950 shadow-[0_0_0_1px_rgba(253,186,116,0.28),0_0_26px_rgba(251,146,60,0.18)] transition duration-200 hover:bg-hire-200 active:scale-[0.98]"
+                to={`/chat/${encodeURIComponent(model.id)}?media=audio`}
+              >
+                理解音频
+              </Link>
+            ) : null}
+            {canSynthesizeSpeech ? (
+              <Link
+                className="rounded-full bg-hire-300 px-3.5 py-2 text-center text-sm font-semibold text-ink-950 shadow-[0_0_0_1px_rgba(253,186,116,0.28),0_0_26px_rgba(251,146,60,0.18)] transition duration-200 hover:bg-hire-200 active:scale-[0.98]"
+                to={`/chat/${encodeURIComponent(model.id)}?operation=synthesize_speech`}
+              >
+                生成语音
+              </Link>
+            ) : null}
+            {canGenerateAudio ? (
+              <Link
+                className="rounded-full bg-hire-300 px-3.5 py-2 text-center text-sm font-semibold text-ink-950 shadow-[0_0_0_1px_rgba(253,186,116,0.28),0_0_26px_rgba(251,146,60,0.18)] transition duration-200 hover:bg-hire-200 active:scale-[0.98]"
+                to={`/chat/${encodeURIComponent(model.id)}?operation=generate_audio`}
+              >
+                生成音乐
+              </Link>
+            ) : null}
+            {canOpenRealtimeVoice ? (
+              <Link
+                className="rounded-full bg-hire-300 px-3.5 py-2 text-center text-sm font-semibold text-ink-950 shadow-[0_0_0_1px_rgba(253,186,116,0.28),0_0_26px_rgba(251,146,60,0.18)] transition duration-200 hover:bg-hire-200 active:scale-[0.98]"
+                to={`/chat/${encodeURIComponent(model.id)}?operation=realtime_voice`}
+              >
+                {realtimeVoiceReady ? "开始实时语音" : "配置实时语音"}
+              </Link>
+            ) : null}
             {canAnalyzeVideo ? (
               <Link
                 className="rounded-full bg-hire-300 px-3.5 py-2 text-center text-sm font-semibold text-ink-950 shadow-[0_0_0_1px_rgba(253,186,116,0.28),0_0_26px_rgba(251,146,60,0.18)] transition duration-200 hover:bg-hire-200 active:scale-[0.98]"
@@ -210,10 +351,15 @@ const ModelCard = memo(function ModelCard({
                 生成视频
               </Link>
             ) : null}
-            {canChat ? (
+            {showGeneralChatAction ? (
               <Link
                 className={`rounded-full px-3.5 py-2 text-center text-sm font-semibold transition duration-200 active:scale-[0.98] ${
-                  canAnalyzeVideo || canGenerateVideo
+                  canAnalyzeAudio ||
+                  canSynthesizeSpeech ||
+                  canGenerateAudio ||
+                  canOpenRealtimeVoice ||
+                  canAnalyzeVideo ||
+                  canGenerateVideo
                     ? "border border-hire-300/35 bg-ink-950/70 text-hire-100 hover:bg-hire-300/10"
                     : "bg-hire-300 text-ink-950 shadow-[0_0_0_1px_rgba(253,186,116,0.28),0_0_26px_rgba(251,146,60,0.18)] hover:bg-hire-200"
                 }`}
@@ -252,13 +398,17 @@ const ModelCard = memo(function ModelCard({
             className="shrink-0 cursor-not-allowed rounded-full border border-white/10 bg-white/[0.045] px-3.5 py-2 text-sm font-semibold text-slate-400"
             disabled
             title={
-              confirmedVideoLabels.length > 0
+              pendingAudioLabels.length > 0
+                ? pendingAudioReason ?? `${pendingAudioLabels.join("、")}尚未适配`
+                : confirmedVideoLabels.length > 0
                 ? `${confirmedVideoLabels.join("、")}能力已确认`
                 : `${operationLabel}入口尚未适配`
             }
             type="button"
           >
-            {confirmedVideoLabels.length > 0
+            {pendingAudioLabels.length > 0
+              ? `${pendingAudioLabels.join("、")}${pendingAudioStateLabel}`
+              : confirmedVideoLabels.length > 0
               ? `${confirmedVideoLabels.join("、")}已确认`
               : "交互待适配"}
           </button>
@@ -274,7 +424,11 @@ const ModelCard = memo(function ModelCard({
           }`}
         >
           {operationLabel}
-          {!isInteractionReady ? " · 待适配" : ""}
+          {!isInteractionReady
+            ? isRealtimeVoiceModel
+              ? " · 需要连接"
+              : " · 待适配"
+            : ""}
         </span>
         {confirmedVideoLabels.map((label) => (
           <span
@@ -285,7 +439,20 @@ const ModelCard = memo(function ModelCard({
             {videoCatalogStale ? " · 缓存目录" : ""}
           </span>
         ))}
-        {model.tags.map((tag) => (
+        {confirmedAudioLabels.map((label) => (
+          <span
+            className="rounded-full border border-cyan-300/30 bg-cyan-300/10 px-2.5 py-1 text-xs font-medium text-cyan-100"
+            key={`audio-${label}`}
+          >
+            {label}已适配
+            {audioCatalogStale ? " · 缓存目录" : ""}
+          </span>
+        ))}
+        {model.tags
+          .filter(
+            (tag) => !(hasAudioGenerationPrice && tag === "免费"),
+          )
+          .map((tag) => (
           <span
             className={`rounded-full border px-2.5 py-1 text-xs font-medium ${
               tagStyles[tag] ?? "border-white/10 bg-white/[0.06] text-slate-300"
@@ -305,45 +472,91 @@ const ModelCard = memo(function ModelCard({
           </span>
         ) : null}
       </div>
+      {pendingAudioLabels.length > 0 ? (
+        <p className="relative mt-2 line-clamp-2 px-5 text-xs leading-5 text-amber-100">
+          <span className="font-semibold">
+            {pendingAudioLabels.join("、")}{pendingAudioStateLabel}：
+          </span>
+          {pendingAudioReason}
+        </p>
+      ) : null}
 
       <div className="relative mx-5 mt-5 rounded-lg border border-white/10 bg-white/[0.045] p-3">
         <div className="flex items-center justify-between gap-3 border-b border-white/10 pb-3">
           <p className="text-[11px] text-slate-400">
-            期望薪资
+            {hasAudioGenerationPrice ? "单次生成费用" : "期望薪资"}
           </p>
-          <p className={`text-sm font-semibold ${isFree ? "text-lime-100" : "text-white"}`}>
-            {isFree
-              ? "免费试工"
-              : `${formatCnyPrice(model.price_cny.input)} / ${formatCnyPrice(model.price_cny.output)}`}
-            <span className="ml-1 text-xs font-normal text-slate-400">
-              输入/输出
-            </span>
+          <p
+            className={`text-right text-sm font-semibold ${
+              hasAudioGenerationPrice
+                ? "text-hire-100"
+                : isFree
+                ? "text-lime-100"
+                : isDynamicPricing
+                  ? "text-sky-100"
+                  : "text-white"
+            }`}
+          >
+            {hasAudioGenerationPrice
+              ? `约 $${audioGenerationPriceUsd.toFixed(2)} / 次`
+              : isFree
+              ? "当前免费"
+              : isDynamicPricing
+                ? "按实际调用计费"
+                : `${formatCnyPrice(model.price_cny.input)} / ${formatCnyPrice(model.price_cny.output)}`}
+            {!hasAudioGenerationPrice && !isFree && !isDynamicPricing ? (
+              <span className="ml-1 text-xs font-normal text-slate-400">
+                输入/输出
+              </span>
+            ) : null}
           </p>
         </div>
 
         <div className="mt-3 grid grid-cols-3 gap-3">
           <div>
             <p className="text-[11px] text-slate-400">
-              输入薪资
+              {hasAudioGenerationPrice ? "目录估算" : "输入薪资"}
             </p>
             <p className="mt-1 text-sm font-semibold text-slate-100">
-              {formatCnyPrice(model.price_cny.input)}
+              {hasAudioGenerationPrice
+                ? `$${audioGenerationPriceUsd.toFixed(2)}`
+                : isDynamicPricing
+                ? "动态"
+                : isFree
+                  ? "免费"
+                  : formatCnyPrice(model.price_cny.input)}
             </p>
           </div>
           <div>
             <p className="text-[11px] text-slate-400">
-              输出薪资
+              {hasAudioGenerationPrice ? "作品时长" : "输出薪资"}
             </p>
             <p className="mt-1 text-sm font-semibold text-slate-100">
-              {formatCnyPrice(model.price_cny.output)}
+              {hasAudioGenerationPrice
+                ? audioCapabilityStatus?.fixedDurationSeconds
+                  ? `约 ${audioCapabilityStatus.fixedDurationSeconds} 秒`
+                  : "模型决定"
+                : isDynamicPricing
+                ? "动态"
+                : isFree
+                  ? "免费"
+                  : formatCnyPrice(model.price_cny.output)}
             </p>
           </div>
           <div>
             <p className="text-[11px] text-slate-400">
-              工作经验
+              {hasAudioGenerationPrice
+                ? "输出格式"
+                : isRealtimeVoiceModel
+                  ? "会话上限"
+                  : "工作经验"}
             </p>
             <p className="mt-1 text-sm font-semibold text-slate-100">
-              {formatContextLength(model.context_length)}
+              {hasAudioGenerationPrice
+                ? "MP3"
+                : isRealtimeVoiceModel
+                  ? "10 分钟"
+                : formatContextLength(model.context_length)}
             </p>
           </div>
         </div>

--- a/client/src/components/RealtimeVoiceWorkspace.tsx
+++ b/client/src/components/RealtimeVoiceWorkspace.tsx
@@ -1,0 +1,921 @@
+import {
+  ArrowLeft,
+  Mic,
+  MicOff,
+  PhoneOff,
+  RefreshCw,
+  Radio,
+  Volume2,
+} from "lucide-react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { Link } from "react-router-dom";
+import BrandLogo from "./BrandLogo";
+import ResourceNav from "./ResourceNav";
+
+const DEFAULT_REALTIME_MODEL = "gpt-realtime-2.1-mini";
+const DEFAULT_REALTIME_VOICE = "marin";
+
+type RealtimeStatus =
+  | "idle"
+  | "requesting_permission"
+  | "connecting"
+  | "listening"
+  | "user_speaking"
+  | "thinking"
+  | "assistant_speaking"
+  | "interrupted"
+  | "reconnect_required"
+  | "ending"
+  | "ended"
+  | "error";
+
+interface RealtimeVoiceProfile {
+  model_id: string;
+  display_name: string;
+  provider: "openai" | "openrouter";
+  invocable: boolean;
+  interaction_status: "ready" | "planned" | "disabled";
+  status_reason: string | null;
+  operations: string[];
+  voices: string[];
+  supports_streaming_input: boolean;
+  supports_streaming_output: boolean;
+}
+
+interface AudioCatalogResponse {
+  status: "online" | "stale" | "offline" | "disabled";
+  stale: boolean;
+  profiles: RealtimeVoiceProfile[];
+}
+
+interface RealtimeCallResponse {
+  session_id: string;
+  sdp_answer: string;
+  expires_at: string;
+  model_id: string;
+  voice: string;
+}
+
+interface RealtimeVoiceWorkspaceProps {
+  initialModelId?: string;
+}
+
+const STATUS_CONTENT: Record<
+  RealtimeStatus,
+  { title: string; detail: string; tone: string }
+> = {
+  idle: {
+    title: "准备开始",
+    detail: "点击开始后才会申请麦克风权限。",
+    tone: "text-slate-200",
+  },
+  requesting_permission: {
+    title: "正在请求麦克风权限",
+    detail: "请在浏览器提示中允许模镜使用麦克风。",
+    tone: "text-cyan-100",
+  },
+  connecting: {
+    title: "正在建立安全连接",
+    detail: "模型服务密钥只在后端使用。",
+    tone: "text-cyan-100",
+  },
+  listening: {
+    title: "正在聆听",
+    detail: "可以直接说话，停顿后模型会自然回答。",
+    tone: "text-emerald-100",
+  },
+  user_speaking: {
+    title: "正在听你说",
+    detail: "继续说即可，语义停顿会自动结束本轮输入。",
+    tone: "text-emerald-100",
+  },
+  thinking: {
+    title: "正在组织回答",
+    detail: "保持连接，模型即将开始说话。",
+    tone: "text-amber-100",
+  },
+  assistant_speaking: {
+    title: "模型正在回答",
+    detail: "你可以随时开口，自然打断当前回答。",
+    tone: "text-violet-100",
+  },
+  interrupted: {
+    title: "已打断模型",
+    detail: "正在听你继续说。",
+    tone: "text-emerald-100",
+  },
+  reconnect_required: {
+    title: "连接已中断",
+    detail: "不会自动建立新的付费会话，请手动重新连接。",
+    tone: "text-amber-100",
+  },
+  ending: {
+    title: "正在结束会话",
+    detail: "正在关闭麦克风和模型连接。",
+    tone: "text-slate-300",
+  },
+  ended: {
+    title: "会话已结束",
+    detail: "本次音频没有保存在模镜中。",
+    tone: "text-slate-300",
+  },
+  error: {
+    title: "未能建立会话",
+    detail: "检查提示后可以重新尝试。",
+    tone: "text-rose-100",
+  },
+};
+
+function modelLabel(modelId: string) {
+  return modelId === "gpt-realtime-2.1"
+    ? "质量优先 · GPT Realtime 2.1"
+    : "均衡推荐 · GPT Realtime 2.1 Mini";
+}
+
+function formatRemaining(seconds: number | null) {
+  if (seconds === null) return "10:00";
+  const safe = Math.max(0, seconds);
+  const minutes = Math.floor(safe / 60);
+  return `${minutes}:${String(safe % 60).padStart(2, "0")}`;
+}
+
+async function apiError(response: Response, fallback: string) {
+  try {
+    const payload = (await response.json()) as {
+      detail?: { message?: string } | string;
+    };
+    if (
+      payload.detail &&
+      typeof payload.detail === "object" &&
+      typeof payload.detail.message === "string"
+    ) {
+      return payload.detail.message;
+    }
+    if (typeof payload.detail === "string") return payload.detail;
+  } catch {
+    // The UI intentionally does not expose upstream response bodies.
+  }
+  return fallback;
+}
+
+function microphoneError(error: unknown) {
+  if (error instanceof DOMException) {
+    if (
+      error.name === "NotAllowedError" ||
+      error.name === "PermissionDeniedError"
+    ) {
+      return "麦克风权限被拒绝。请在浏览器地址栏中允许麦克风，然后重试。";
+    }
+    if (
+      error.name === "NotFoundError" ||
+      error.name === "DevicesNotFoundError"
+    ) {
+      return "没有找到可用麦克风。请连接设备后重试。";
+    }
+    if (
+      error.name === "NotReadableError" ||
+      error.name === "TrackStartError"
+    ) {
+      return "麦克风正被其他应用占用。关闭占用程序后重试。";
+    }
+  }
+  return "无法使用麦克风。请检查浏览器权限和音频设备。";
+}
+
+export default function RealtimeVoiceWorkspace({
+  initialModelId = DEFAULT_REALTIME_MODEL,
+}: RealtimeVoiceWorkspaceProps) {
+  const [profiles, setProfiles] = useState<RealtimeVoiceProfile[]>([]);
+  const [catalogStatus, setCatalogStatus] =
+    useState<AudioCatalogResponse["status"]>("offline");
+  const [catalogLoading, setCatalogLoading] = useState(true);
+  const [catalogError, setCatalogError] = useState("");
+  const [selectedModelId, setSelectedModelId] = useState(initialModelId);
+  const [voice, setVoice] = useState(DEFAULT_REALTIME_VOICE);
+  const [language, setLanguage] = useState("zh-CN");
+  const [status, setStatus] = useState<RealtimeStatus>("idle");
+  const [error, setError] = useState("");
+  const [muted, setMuted] = useState(false);
+  const [remainingSeconds, setRemainingSeconds] = useState<number | null>(null);
+  const [playbackBlocked, setPlaybackBlocked] = useState(false);
+
+  const peerRef = useRef<RTCPeerConnection | null>(null);
+  const localStreamRef = useRef<MediaStream | null>(null);
+  const dataChannelRef = useRef<RTCDataChannel | null>(null);
+  const remoteAudioRef = useRef<HTMLAudioElement | null>(null);
+  const sessionIdRef = useRef("");
+  const expiresAtRef = useRef<number | null>(null);
+  const statusRef = useRef<RealtimeStatus>("idle");
+  const attemptRef = useRef(0);
+  const disposedRef = useRef(false);
+  const endingRef = useRef(false);
+
+  const realtimeProfiles = useMemo(
+    () =>
+      profiles.filter(
+        (profile) =>
+          profile.provider === "openai" &&
+          profile.operations.includes("realtime_voice") &&
+          profile.supports_streaming_input &&
+          profile.supports_streaming_output,
+      ),
+    [profiles],
+  );
+  const selectedProfile = useMemo(
+    () =>
+      realtimeProfiles.find(
+        (profile) => profile.model_id === selectedModelId,
+      ) ??
+      realtimeProfiles.find(
+        (profile) => profile.model_id === DEFAULT_REALTIME_MODEL,
+      ) ??
+      realtimeProfiles[0] ??
+      null,
+    [realtimeProfiles, selectedModelId],
+  );
+  const isActive = [
+    "listening",
+    "user_speaking",
+    "thinking",
+    "assistant_speaking",
+    "interrupted",
+  ].includes(status);
+  const isBusy = [
+    "requesting_permission",
+    "connecting",
+    "ending",
+  ].includes(status);
+  const canStart =
+    !catalogLoading &&
+    Boolean(selectedProfile?.invocable) &&
+    selectedProfile?.interaction_status === "ready" &&
+    !isActive &&
+    !isBusy;
+  const statusContent = STATUS_CONTENT[status];
+  const nearingLimit =
+    remainingSeconds !== null &&
+    remainingSeconds > 0 &&
+    remainingSeconds <= 60;
+  const browserSupported =
+    typeof window !== "undefined" &&
+    "RTCPeerConnection" in window &&
+    Boolean(navigator.mediaDevices?.getUserMedia);
+
+  const updateStatus = useCallback((next: RealtimeStatus) => {
+    statusRef.current = next;
+    if (!disposedRef.current) setStatus(next);
+  }, []);
+
+  const closeLocalMedia = useCallback(() => {
+    dataChannelRef.current?.close();
+    dataChannelRef.current = null;
+    const peer = peerRef.current;
+    peerRef.current = null;
+    if (peer) {
+      peer.ontrack = null;
+      peer.onconnectionstatechange = null;
+      peer.close();
+    }
+    for (const track of localStreamRef.current?.getTracks() ?? []) {
+      track.stop();
+    }
+    localStreamRef.current = null;
+    const remoteAudio = remoteAudioRef.current;
+    if (remoteAudio) {
+      remoteAudio.pause();
+      remoteAudio.srcObject = null;
+    }
+  }, []);
+
+  const endRemoteSession = useCallback(async (sessionId: string) => {
+    if (!sessionId) return;
+    try {
+      await fetch(
+        `/api/multimodal/realtime/calls/${encodeURIComponent(sessionId)}`,
+        { method: "DELETE", keepalive: true },
+      );
+    } catch {
+      // The server also enforces the hard expiry, so local cleanup can finish.
+    }
+  }, []);
+
+  const finishSession = useCallback(
+    async (
+      nextStatus: "ended" | "reconnect_required",
+      nextError = "",
+    ) => {
+      endingRef.current = true;
+      attemptRef.current += 1;
+      if (nextStatus === "ended") updateStatus("ending");
+      const sessionId = sessionIdRef.current;
+      sessionIdRef.current = "";
+      expiresAtRef.current = null;
+      setRemainingSeconds(null);
+      closeLocalMedia();
+      await endRemoteSession(sessionId);
+      if (disposedRef.current) return;
+      setMuted(false);
+      setError(nextError);
+      updateStatus(nextStatus);
+    },
+    [closeLocalMedia, endRemoteSession, updateStatus],
+  );
+
+  const handleServerEvent = useCallback(
+    (event: MessageEvent<string>) => {
+      let payload: { type?: string };
+      try {
+        payload = JSON.parse(event.data) as { type?: string };
+      } catch {
+        return;
+      }
+      const eventType = payload.type ?? "";
+      if (
+        eventType === "session.created" ||
+        eventType === "session.updated"
+      ) {
+        if (statusRef.current === "connecting") updateStatus("listening");
+        return;
+      }
+      if (eventType === "input_audio_buffer.speech_started") {
+        updateStatus(
+          statusRef.current === "assistant_speaking"
+            ? "interrupted"
+            : "user_speaking",
+        );
+        return;
+      }
+      if (eventType === "input_audio_buffer.speech_stopped") {
+        updateStatus("thinking");
+        return;
+      }
+      if (
+        eventType === "response.created" ||
+        eventType === "response.output_audio.delta" ||
+        eventType === "response.audio.delta" ||
+        eventType === "output_audio_buffer.started"
+      ) {
+        updateStatus("assistant_speaking");
+        return;
+      }
+      if (
+        eventType === "response.done" ||
+        eventType === "output_audio_buffer.stopped"
+      ) {
+        updateStatus("listening");
+        return;
+      }
+      if (eventType === "error") {
+        setError("实时语音服务返回错误。请结束会话后重新连接。");
+      }
+    },
+    [updateStatus],
+  );
+
+  const refreshCatalog = useCallback(async () => {
+    setCatalogLoading(true);
+    setCatalogError("");
+    try {
+      const response = await fetch(
+        "/api/multimodal/audio/models?refresh=true",
+      );
+      if (!response.ok) {
+        throw new Error(
+          await apiError(response, "暂时无法读取实时语音能力。"),
+        );
+      }
+      const payload = (await response.json()) as AudioCatalogResponse;
+      if (disposedRef.current) return;
+      setProfiles(payload.profiles);
+      setCatalogStatus(payload.status);
+    } catch (loadError) {
+      if (disposedRef.current) return;
+      setProfiles([]);
+      setCatalogStatus("offline");
+      setCatalogError(
+        loadError instanceof Error
+          ? loadError.message
+          : "暂时无法读取实时语音能力。",
+      );
+    } finally {
+      if (!disposedRef.current) setCatalogLoading(false);
+    }
+  }, []);
+
+  const startSession = useCallback(async () => {
+    if (!canStart || !selectedProfile || !browserSupported) {
+      if (!browserSupported) {
+        setError(
+          "当前浏览器不支持所需的麦克风或 WebRTC 能力，请使用最新版 Chrome、Edge 或 Safari。",
+        );
+        updateStatus("error");
+      }
+      return;
+    }
+
+    const attempt = attemptRef.current + 1;
+    attemptRef.current = attempt;
+    endingRef.current = false;
+    sessionIdRef.current = "";
+    expiresAtRef.current = null;
+    setRemainingSeconds(null);
+    setMuted(false);
+    setError("");
+    setPlaybackBlocked(false);
+    updateStatus("requesting_permission");
+
+    let localStream: MediaStream | null = null;
+    let peer: RTCPeerConnection | null = null;
+    let createdSessionId = "";
+    try {
+      localStream = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          echoCancellation: true,
+          noiseSuppression: true,
+          autoGainControl: true,
+        },
+      });
+      if (attempt !== attemptRef.current || disposedRef.current) {
+        localStream.getTracks().forEach((track) => track.stop());
+        return;
+      }
+
+      updateStatus("connecting");
+      peer = new RTCPeerConnection();
+      peerRef.current = peer;
+      localStreamRef.current = localStream;
+      for (const track of localStream.getAudioTracks()) {
+        peer.addTrack(track, localStream);
+      }
+
+      peer.ontrack = (trackEvent) => {
+        const remoteAudio = remoteAudioRef.current;
+        const remoteStream = trackEvent.streams[0];
+        if (!remoteAudio || !remoteStream) return;
+        remoteAudio.srcObject = remoteStream;
+        void remoteAudio.play().catch(() => setPlaybackBlocked(true));
+      };
+
+      const dataChannel = peer.createDataChannel("oai-events");
+      dataChannelRef.current = dataChannel;
+      dataChannel.addEventListener("message", handleServerEvent);
+      dataChannel.addEventListener("open", () => {
+        if (!endingRef.current) updateStatus("listening");
+      });
+
+      peer.onconnectionstatechange = () => {
+        if (endingRef.current || peerRef.current !== peer) return;
+        if (peer?.connectionState === "connected") {
+          if (statusRef.current === "connecting") updateStatus("listening");
+          return;
+        }
+        if (
+          peer?.connectionState === "failed" ||
+          peer?.connectionState === "disconnected" ||
+          peer?.connectionState === "closed"
+        ) {
+          void finishSession(
+            "reconnect_required",
+            "网络或音频连接已中断。模镜没有自动创建新会话。",
+          );
+        }
+      };
+
+      const offer = await peer.createOffer();
+      await peer.setLocalDescription(offer);
+      const sdp = peer.localDescription?.sdp;
+      if (!sdp) {
+        throw new Error("浏览器没有生成有效的语音连接信息。");
+      }
+
+      const response = await fetch("/api/multimodal/realtime/calls", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          sdp,
+          model_id: selectedProfile.model_id,
+          voice,
+          vad_mode: "semantic_vad",
+          language,
+        }),
+      });
+      if (!response.ok) {
+        throw new Error(
+          await apiError(response, "实时语音连接失败，请稍后重试。"),
+        );
+      }
+      const call = (await response.json()) as RealtimeCallResponse;
+      createdSessionId = call.session_id;
+      if (
+        attempt !== attemptRef.current ||
+        endingRef.current ||
+        disposedRef.current
+      ) {
+        await endRemoteSession(createdSessionId);
+        return;
+      }
+
+      sessionIdRef.current = call.session_id;
+      const expiresAt = Date.parse(call.expires_at);
+      expiresAtRef.current = Number.isFinite(expiresAt) ? expiresAt : null;
+      if (expiresAtRef.current !== null) {
+        setRemainingSeconds(
+          Math.max(
+            0,
+            Math.ceil((expiresAtRef.current - Date.now()) / 1000),
+          ),
+        );
+      }
+      await peer.setRemoteDescription({
+        type: "answer",
+        sdp: call.sdp_answer,
+      });
+    } catch (startError) {
+      if (createdSessionId) await endRemoteSession(createdSessionId);
+      if (sessionIdRef.current === createdSessionId) {
+        sessionIdRef.current = "";
+      }
+      expiresAtRef.current = null;
+      closeLocalMedia();
+      if (
+        attempt !== attemptRef.current ||
+        disposedRef.current ||
+        endingRef.current
+      ) {
+        return;
+      }
+      setRemainingSeconds(null);
+      setError(
+        statusRef.current === "requesting_permission"
+          ? microphoneError(startError)
+          : startError instanceof Error
+            ? startError.message
+            : "实时语音连接失败，请稍后重试。",
+      );
+      updateStatus("error");
+    }
+  }, [
+    browserSupported,
+    canStart,
+    closeLocalMedia,
+    endRemoteSession,
+    finishSession,
+    handleServerEvent,
+    language,
+    selectedProfile,
+    updateStatus,
+    voice,
+  ]);
+
+  useEffect(() => {
+    document.title = "实时语音 · 模镜";
+    void refreshCatalog();
+  }, [refreshCatalog]);
+
+  useEffect(() => {
+    if (!selectedProfile) return;
+    if (selectedProfile.model_id !== selectedModelId) {
+      setSelectedModelId(selectedProfile.model_id);
+    }
+    setVoice((current) =>
+      selectedProfile.voices.includes(current)
+        ? current
+        : selectedProfile.voices[0] ?? DEFAULT_REALTIME_VOICE,
+    );
+  }, [selectedModelId, selectedProfile]);
+
+  useEffect(() => {
+    if (!isActive || expiresAtRef.current === null) return undefined;
+    const timer = window.setInterval(() => {
+      const expiresAt = expiresAtRef.current;
+      if (expiresAt === null) return;
+      const next = Math.max(0, Math.ceil((expiresAt - Date.now()) / 1000));
+      setRemainingSeconds(next);
+      if (next === 0) {
+        void finishSession(
+          "ended",
+          "本次实时语音已达到 10 分钟上限。",
+        );
+      }
+    }, 1_000);
+    return () => window.clearInterval(timer);
+  }, [finishSession, isActive]);
+
+  useEffect(() => {
+    const handlePageHide = () => {
+      endingRef.current = true;
+      attemptRef.current += 1;
+      closeLocalMedia();
+      const sessionId = sessionIdRef.current;
+      sessionIdRef.current = "";
+      if (sessionId) {
+        void fetch(
+          `/api/multimodal/realtime/calls/${encodeURIComponent(sessionId)}`,
+          { method: "DELETE", keepalive: true },
+        );
+      }
+    };
+    window.addEventListener("pagehide", handlePageHide);
+    return () => {
+      window.removeEventListener("pagehide", handlePageHide);
+    };
+  }, [closeLocalMedia]);
+
+  useEffect(
+    () => {
+      disposedRef.current = false;
+      return () => {
+        disposedRef.current = true;
+        endingRef.current = true;
+        attemptRef.current += 1;
+        closeLocalMedia();
+        const sessionId = sessionIdRef.current;
+        sessionIdRef.current = "";
+        if (sessionId) void endRemoteSession(sessionId);
+      };
+    },
+    [closeLocalMedia, endRemoteSession],
+  );
+
+  function toggleMute() {
+    const nextMuted = !muted;
+    for (const track of localStreamRef.current?.getAudioTracks() ?? []) {
+      track.enabled = !nextMuted;
+    }
+    setMuted(nextMuted);
+  }
+
+  const availabilityReason =
+    selectedProfile?.interaction_status === "ready"
+      ? null
+      : selectedProfile?.status_reason ??
+        (
+          realtimeProfiles.length === 0
+            ? "尚未配置可用于实时语音的 OpenAI 连接。"
+            : "实时语音当前未启用。"
+        );
+
+  return (
+    <main className="museum-grid min-h-screen pb-20 pt-5 text-slate-100 lg:pb-12 lg:pt-24">
+      <ResourceNav activeResource="models" />
+      <div className="mx-auto w-full max-w-[1120px] px-4 py-5 sm:px-6 lg:px-8">
+        <header className="border-y border-cyan-300/20 bg-ink-950/72 py-5 backdrop-blur-xl">
+          <BrandLogo className="mb-4 lg:hidden" />
+          <Link
+            className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.05] px-3 py-1.5 text-sm font-medium text-slate-200 transition hover:border-cyan-300/35 hover:bg-cyan-300/10 hover:text-cyan-100"
+            to="/models"
+          >
+            <ArrowLeft aria-hidden="true" size={15} />
+            返回模型招聘会
+          </Link>
+          <div className="mt-4 flex flex-wrap items-center gap-2">
+            <span className="rounded-full border border-cyan-300/30 bg-cyan-300/10 px-3 py-1.5 text-xs font-semibold text-cyan-100">
+              实时双向语音
+            </span>
+            <span className="rounded-full border border-white/10 bg-white/[0.05] px-3 py-1.5 text-xs text-slate-300">
+              纯语音对话 · 单次最多 10 分钟
+            </span>
+          </div>
+          <h1 className="mt-4 text-2xl font-semibold text-white sm:text-4xl">
+            与模型实时交谈
+          </h1>
+          <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-300">
+            这是连续语音通话。单轮麦克风转写仍在普通聊天输入框中，两者不会混用。
+          </p>
+        </header>
+
+        <section className="surface-panel mt-6 overflow-hidden rounded-lg">
+          <div className="grid lg:grid-cols-[minmax(0,1fr)_320px]">
+            <div className="min-h-[460px] px-5 py-6 sm:px-8 sm:py-8">
+              <div
+                aria-live="polite"
+                className="flex min-h-[330px] flex-col items-center justify-center text-center"
+              >
+                <div
+                  className={`flex h-20 w-20 items-center justify-center rounded-full border ${
+                    isActive
+                      ? "border-cyan-300/45 bg-cyan-300/12 text-cyan-100"
+                      : "border-white/12 bg-white/[0.055] text-slate-300"
+                  }`}
+                >
+                  {muted ? (
+                    <MicOff aria-hidden="true" size={30} />
+                  ) : (
+                    <Radio aria-hidden="true" size={30} />
+                  )}
+                </div>
+                <p className={`mt-5 text-2xl font-semibold ${statusContent.tone}`}>
+                  {muted && isActive ? "麦克风已静音" : statusContent.title}
+                </p>
+                <p className="mt-2 max-w-md text-sm leading-6 text-slate-400">
+                  {muted && isActive
+                    ? "模型仍可完成当前回答，取消静音后才能继续说话。"
+                    : statusContent.detail}
+                </p>
+
+                {isActive || status === "ending" ? (
+                  <div className="mt-7 flex flex-wrap items-center justify-center gap-3">
+                    <button
+                      className="inline-flex min-w-28 items-center justify-center gap-2 rounded-full border border-white/12 bg-white/[0.06] px-4 py-2.5 text-sm font-semibold text-white transition hover:border-cyan-300/40 hover:bg-cyan-300/10 disabled:cursor-not-allowed disabled:opacity-50"
+                      disabled={status === "ending"}
+                      onClick={toggleMute}
+                      type="button"
+                    >
+                      {muted ? (
+                        <Mic aria-hidden="true" size={17} />
+                      ) : (
+                        <MicOff aria-hidden="true" size={17} />
+                      )}
+                      {muted ? "取消静音" : "静音"}
+                    </button>
+                    <button
+                      className="inline-flex min-w-28 items-center justify-center gap-2 rounded-full bg-rose-300 px-4 py-2.5 text-sm font-semibold text-rose-950 transition hover:bg-rose-200 disabled:cursor-not-allowed disabled:opacity-50"
+                      disabled={status === "ending"}
+                      onClick={() => void finishSession("ended")}
+                      type="button"
+                    >
+                      <PhoneOff aria-hidden="true" size={17} />
+                      结束通话
+                    </button>
+                  </div>
+                ) : (
+                  <div className="mt-7 flex flex-wrap items-center justify-center gap-3">
+                    <button
+                      className="inline-flex min-w-40 items-center justify-center gap-2 rounded-full bg-cyan-300 px-5 py-2.5 text-sm font-semibold text-ink-950 transition hover:bg-cyan-200 disabled:cursor-not-allowed disabled:bg-white/10 disabled:text-slate-500"
+                      disabled={!canStart || !browserSupported}
+                      onClick={() => void startSession()}
+                      type="button"
+                    >
+                      {status === "reconnect_required" ? (
+                        <RefreshCw aria-hidden="true" size={17} />
+                      ) : (
+                        <Mic aria-hidden="true" size={17} />
+                      )}
+                      {status === "reconnect_required"
+                        ? "重新连接新会话"
+                        : "开始实时语音"}
+                    </button>
+                  </div>
+                )}
+
+                {remainingSeconds !== null ? (
+                  <p
+                    className={`mt-5 text-sm font-medium ${
+                      nearingLimit ? "text-amber-100" : "text-slate-400"
+                    }`}
+                  >
+                    剩余 {formatRemaining(remainingSeconds)}
+                    {nearingLimit ? "，会话即将自动结束" : ""}
+                  </p>
+                ) : null}
+                {playbackBlocked ? (
+                  <button
+                    className="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-cyan-100 underline decoration-cyan-300/30 underline-offset-4"
+                    onClick={() => {
+                      void remoteAudioRef.current
+                        ?.play()
+                        .then(() => setPlaybackBlocked(false));
+                    }}
+                    type="button"
+                  >
+                    <Volume2 aria-hidden="true" size={16} />
+                    恢复模型声音
+                  </button>
+                ) : null}
+                {error ? (
+                  <p
+                    className="mt-5 max-w-lg rounded-md bg-rose-300/10 px-4 py-3 text-sm leading-6 text-rose-100"
+                    role="alert"
+                  >
+                    {error}
+                  </p>
+                ) : null}
+              </div>
+              <audio
+                autoPlay
+                className="hidden"
+                onCanPlay={() => setPlaybackBlocked(false)}
+                playsInline
+                ref={remoteAudioRef}
+              />
+            </div>
+
+            <aside className="border-t border-white/10 bg-ink-950/36 px-5 py-6 lg:border-l lg:border-t-0">
+              <h2 className="text-base font-semibold text-white">通话设置</h2>
+              <p className="mt-1 text-sm leading-6 text-slate-400">
+                建连后模型与声音会锁定。网络中断不会自动重连。
+              </p>
+
+              <div className="mt-5 space-y-4">
+                <label className="block">
+                  <span className="text-sm font-medium text-slate-200">模型</span>
+                  <select
+                    className="mt-2 h-11 w-full rounded-lg border border-white/10 bg-ink-950/80 px-3 text-sm text-white outline-none transition focus:border-cyan-300/50"
+                    disabled={isActive || isBusy || catalogLoading}
+                    onChange={(event) => setSelectedModelId(event.target.value)}
+                    value={selectedProfile?.model_id ?? selectedModelId}
+                  >
+                    {(realtimeProfiles.length > 0
+                      ? realtimeProfiles
+                      : [
+                          {
+                            model_id: DEFAULT_REALTIME_MODEL,
+                            display_name: modelLabel(DEFAULT_REALTIME_MODEL),
+                          },
+                          {
+                            model_id: "gpt-realtime-2.1",
+                            display_name: modelLabel("gpt-realtime-2.1"),
+                          },
+                        ]
+                    ).map((profile) => (
+                      <option key={profile.model_id} value={profile.model_id}>
+                        {modelLabel(profile.model_id)}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                <label className="block">
+                  <span className="text-sm font-medium text-slate-200">声音</span>
+                  <select
+                    className="mt-2 h-11 w-full rounded-lg border border-white/10 bg-ink-950/80 px-3 text-sm text-white outline-none transition focus:border-cyan-300/50"
+                    disabled={isActive || isBusy}
+                    onChange={(event) => setVoice(event.target.value)}
+                    value={voice}
+                  >
+                    {(selectedProfile?.voices.length
+                      ? selectedProfile.voices
+                      : ["marin", "cedar"]
+                    ).map((item) => (
+                      <option key={item} value={item}>
+                        {item === "marin" ? "Marin（推荐）" : "Cedar"}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                <label className="block">
+                  <span className="text-sm font-medium text-slate-200">主要语言</span>
+                  <select
+                    className="mt-2 h-11 w-full rounded-lg border border-white/10 bg-ink-950/80 px-3 text-sm text-white outline-none transition focus:border-cyan-300/50"
+                    disabled={isActive || isBusy}
+                    onChange={(event) => setLanguage(event.target.value)}
+                    value={language}
+                  >
+                    <option value="zh-CN">简体中文</option>
+                    <option value="en-US">English</option>
+                    <option value="ja-JP">日本語</option>
+                    <option value="ko-KR">한국어</option>
+                  </select>
+                </label>
+              </div>
+
+              {catalogLoading ? (
+                <p className="mt-5 text-sm text-slate-400">正在检查实时语音能力...</p>
+              ) : availabilityReason || catalogError ? (
+                <div className="mt-5 rounded-md bg-amber-300/[0.08] px-3 py-3 text-sm leading-6 text-amber-100">
+                  <p>{catalogError || availabilityReason}</p>
+                  <div className="mt-2 flex flex-wrap gap-3">
+                    <Link
+                      className="font-semibold underline decoration-amber-200/30 underline-offset-4"
+                      to="/settings"
+                    >
+                      检查模型服务连接
+                    </Link>
+                    <button
+                      className="font-semibold underline decoration-amber-200/30 underline-offset-4"
+                      onClick={() => void refreshCatalog()}
+                      type="button"
+                    >
+                      重新检查
+                    </button>
+                  </div>
+                </div>
+              ) : catalogStatus === "stale" ? (
+                <p className="mt-5 text-sm leading-6 text-amber-100">
+                  当前使用最近一次能力结果，建议在开始前重新检查。
+                </p>
+              ) : null}
+
+              <div className="mt-6 border-t border-white/10 pt-5 text-sm leading-6 text-slate-400">
+                <p>实时语音可能产生额外费用，费用以 OpenAI 结算为准。</p>
+                <p className="mt-2">
+                  本批次不组合资料库、Skill、工具、附件或智能调度。
+                </p>
+                <p className="mt-2">
+                  模镜不保存原始音频和实时字幕。
+                </p>
+              </div>
+            </aside>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/client/src/components/SpeechWorkspace.tsx
+++ b/client/src/components/SpeechWorkspace.tsx
@@ -4,6 +4,7 @@ import type { Model } from "../data/models";
 import {
   DEFAULT_SPEECH_VOICE,
   generateSpeechAudio,
+  type SpeechResponseFormat,
 } from "../utils/speechAudio";
 import BrandLogo from "./BrandLogo";
 import ResourceNav from "./ResourceNav";
@@ -29,6 +30,19 @@ interface SpeechWorkspaceProps {
   model: Model;
 }
 
+interface SpeechCatalogProfile {
+  model_id: string;
+  invocable: boolean;
+  interaction_status: "ready" | "planned" | "disabled";
+  chat_modes: string[];
+  output_formats: string[];
+  voices: string[];
+}
+
+interface SpeechCatalogResponse {
+  profiles: SpeechCatalogProfile[];
+}
+
 function formatBytes(bytes: number | null) {
   if (bytes === null) return "未提供";
   if (bytes >= 1024 * 1024) {
@@ -39,7 +53,12 @@ function formatBytes(bytes: number | null) {
 
 export default function SpeechWorkspace({ model }: SpeechWorkspaceProps) {
   const [text, setText] = useState("");
-  const [voice, setVoice] = useState(DEFAULT_SPEECH_VOICE);
+  const [voice, setVoice] = useState("");
+  const [availableVoices, setAvailableVoices] = useState<string[]>([]);
+  const [responseFormat, setResponseFormat] =
+    useState<SpeechResponseFormat>("mp3");
+  const [isLoadingProfile, setIsLoadingProfile] = useState(true);
+  const [profileError, setProfileError] = useState("");
   const [speed, setSpeed] = useState(1);
   const [status, setStatus] = useState<SpeechStatus>("idle");
   const [audioBlob, setAudioBlob] = useState<Blob | null>(null);
@@ -52,11 +71,82 @@ export default function SpeechWorkspace({ model }: SpeechWorkspaceProps) {
   const canGenerate =
     text.trim().length > 0 &&
     characterCount <= MAX_TEXT_CHARS &&
+    Boolean(voice) &&
+    !isLoadingProfile &&
     !isGenerating;
 
   useEffect(() => {
     document.title = `生成语音 · ${model.name} · 模镜`;
   }, [model.name]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setIsLoadingProfile(true);
+    setProfileError("");
+    fetch("/api/multimodal/audio/models", { signal: controller.signal })
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error("暂时无法读取语音模型能力。");
+        }
+        return (await response.json()) as SpeechCatalogResponse;
+      })
+      .then((catalog) => {
+        const profile = catalog.profiles.find(
+          (item) =>
+            item.model_id === model.id &&
+            item.invocable &&
+            item.interaction_status === "ready" &&
+            item.chat_modes.includes("synthesize_speech") &&
+            item.output_formats.some(
+              (format) => format === "mp3" || format === "wav",
+            ) &&
+            item.voices.length > 0,
+        );
+        if (!profile) {
+          setAvailableVoices([]);
+          setVoice("");
+          setResponseFormat("mp3");
+          setProfileError(
+            "该模型当前没有已验证的语音格式和声线，请返回模型招聘会选择可用语音模型。",
+          );
+          return;
+        }
+        setResponseFormat(
+          profile.output_formats.includes("mp3") ? "mp3" : "wav",
+        );
+        setAvailableVoices(profile.voices);
+        setVoice((current) => {
+          if (profile.voices.includes(current)) return current;
+          if (
+            model.id === "microsoft/mai-voice-2" &&
+            profile.voices.includes(DEFAULT_SPEECH_VOICE)
+          ) {
+            return DEFAULT_SPEECH_VOICE;
+          }
+          return profile.voices[0];
+        });
+      })
+      .catch((loadError) => {
+        if (
+          loadError instanceof DOMException &&
+          loadError.name === "AbortError"
+        ) {
+          return;
+        }
+        setAvailableVoices([]);
+        setVoice("");
+        setResponseFormat("mp3");
+        setProfileError(
+          loadError instanceof Error
+            ? loadError.message
+            : "暂时无法读取语音模型能力。",
+        );
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setIsLoadingProfile(false);
+      });
+    return () => controller.abort();
+  }, [model.id]);
 
   useEffect(() => {
     if (!audioBlob) {
@@ -89,6 +179,7 @@ export default function SpeechWorkspace({ model }: SpeechWorkspaceProps) {
         modelId: model.id,
         input: text.trim(),
         voice,
+        responseFormat,
         speed,
         signal: controller.signal,
       });
@@ -211,7 +302,11 @@ export default function SpeechWorkspace({ model }: SpeechWorkspaceProps) {
                   </label>
                   <select
                     className="w-full rounded-lg border border-white/15 bg-ink-950 px-3 py-3 text-sm text-white outline-none transition focus:border-brand-300/60 focus:ring-4 focus:ring-brand-300/10 disabled:cursor-not-allowed disabled:opacity-60"
-                    disabled={isGenerating}
+                    disabled={
+                      isGenerating ||
+                      isLoadingProfile ||
+                      availableVoices.length === 0
+                    }
                     id="speech-voice"
                     onChange={(event) => {
                       setVoice(event.target.value);
@@ -219,12 +314,20 @@ export default function SpeechWorkspace({ model }: SpeechWorkspaceProps) {
                     }}
                     value={voice}
                   >
-                    <option value={DEFAULT_SPEECH_VOICE}>
-                      Harper · MAI-Voice-2（已验证）
-                    </option>
+                    {isLoadingProfile ? (
+                      <option value="">正在读取声线…</option>
+                    ) : null}
+                    {!isLoadingProfile && availableVoices.length === 0 ? (
+                      <option value="">暂无可用声线</option>
+                    ) : null}
+                    {availableVoices.map((item) => (
+                      <option key={item} value={item}>
+                        {item}
+                      </option>
+                    ))}
                   </select>
                   <p className="mt-2 text-xs leading-5 text-slate-400">
-                    首期只开放已完成行为测试的声线。
+                    仅显示实时目录中仍存在且已完成行为验证的声线。
                   </p>
                 </div>
 
@@ -290,6 +393,15 @@ export default function SpeechWorkspace({ model }: SpeechWorkspaceProps) {
                 </div>
               ) : null}
 
+              {profileError ? (
+                <div
+                  className="rounded-lg border border-amber-300/25 bg-amber-300/10 px-4 py-3 text-sm leading-6 text-amber-100"
+                  role="status"
+                >
+                  {profileError}
+                </div>
+              ) : null}
+
               {status === "cancelled" ? (
                 <div
                   className="rounded-lg border border-amber-300/25 bg-amber-300/10 px-4 py-3 text-sm text-amber-100"
@@ -339,7 +451,9 @@ export default function SpeechWorkspace({ model }: SpeechWorkspaceProps) {
               </div>
               <div>
                 <dt className="text-slate-400">输出格式</dt>
-                <dd className="mt-1 text-slate-200">MP3</dd>
+                <dd className="mt-1 text-slate-200">
+                  {responseFormat.toUpperCase()}
+                </dd>
               </div>
               <div>
                 <dt className="text-slate-400">隐私</dt>
@@ -365,10 +479,10 @@ export default function SpeechWorkspace({ model }: SpeechWorkspaceProps) {
               </div>
               <a
                 className="self-start rounded-full border border-brand-300/35 bg-brand-300/10 px-4 py-2 text-sm font-semibold text-brand-100 transition hover:border-brand-300/60 hover:bg-brand-300/15 sm:self-auto"
-                download="modelmirror-speech.mp3"
+                download={`modelmirror-speech.${responseFormat}`}
                 href={audioUrl}
               >
-                下载 MP3
+                下载 {responseFormat.toUpperCase()}
               </a>
             </div>
             <div className="p-5 sm:p-6">

--- a/client/src/components/settings/ModelServiceConnections.tsx
+++ b/client/src/components/settings/ModelServiceConnections.tsx
@@ -8,7 +8,12 @@ import {
   Server,
 } from "lucide-react";
 
-type ConnectionKind = "openrouter" | "newapi" | "openai_compatible";
+type ConnectionKind =
+  | "openrouter"
+  | "newapi"
+  | "openai_compatible"
+  | "openai";
+type ConnectionScope = "chat" | "audio" | "realtime";
 type ConnectionHealth = "untested" | "online" | "offline" | "disabled";
 
 interface RouterConnection {
@@ -17,6 +22,7 @@ interface RouterConnection {
   kind: ConnectionKind;
   base_url: string;
   masked_key: string;
+  scopes?: ConnectionScope[];
   enabled: boolean;
   health: ConnectionHealth;
   model_count: number;
@@ -38,30 +44,53 @@ interface ConnectionForm {
   name: string;
   base_url: string;
   api_key: string;
+  scopes: ConnectionScope[];
 }
 
 const PROVIDERS: Record<
   ConnectionKind,
-  { label: string; name: string; baseUrl: string; hint: string }
+  {
+    label: string;
+    name: string;
+    baseUrl: string;
+    hint: string;
+    scopes: ConnectionScope[];
+  }
 > = {
   openrouter: {
     label: "OpenRouter",
     name: "OpenRouter",
     baseUrl: "https://openrouter.ai/api/v1",
     hint: "适合直接使用 OpenRouter 的统一模型目录。",
+    scopes: ["chat", "audio"],
   },
   newapi: {
     label: "newAPI",
     name: "本地 newAPI",
     baseUrl: "http://localhost:3000/v1",
     hint: "适合已经在模镜中配置好的本地模型渠道。",
+    scopes: ["chat"],
   },
   openai_compatible: {
     label: "其他 OpenAI 兼容服务",
     name: "自定义模型服务",
     baseUrl: "",
     hint: "适合带有 /v1/models 与 /v1/chat/completions 接口的服务。",
+    scopes: ["chat"],
   },
+  openai: {
+    label: "OpenAI 音频服务",
+    name: "OpenAI 音频与实时语音",
+    baseUrl: "https://api.openai.com/v1",
+    hint: "仅用于音频能力与实时语音，不会自动加入普通聊天或智能调度。",
+    scopes: ["audio", "realtime"],
+  },
+};
+
+const SCOPE_LABELS: Record<ConnectionScope, string> = {
+  chat: "普通模型调用",
+  audio: "音频能力",
+  realtime: "实时语音",
 };
 
 const INITIAL_FORM: ConnectionForm = {
@@ -69,6 +98,7 @@ const INITIAL_FORM: ConnectionForm = {
   name: PROVIDERS.openrouter.name,
   base_url: PROVIDERS.openrouter.baseUrl,
   api_key: "",
+  scopes: [...PROVIDERS.openrouter.scopes],
 };
 
 function healthLabel(health: ConnectionHealth) {
@@ -76,6 +106,12 @@ function healthLabel(health: ConnectionHealth) {
   if (health === "offline") return "需检查";
   if (health === "disabled") return "已停用";
   return "未测试";
+}
+
+function scopesForConnection(connection: RouterConnection) {
+  return connection.scopes?.length
+    ? connection.scopes
+    : PROVIDERS[connection.kind]?.scopes ?? ["chat"];
 }
 
 function healthClass(health: ConnectionHealth) {
@@ -149,6 +185,7 @@ export default function ModelServiceConnections() {
         kind,
         name: next.name,
         base_url: next.baseUrl,
+        scopes: [...next.scopes],
       });
     },
     [updateForm],
@@ -160,6 +197,7 @@ export default function ModelServiceConnections() {
       name: form.name.trim(),
       base_url: form.base_url.trim(),
       api_key: form.api_key,
+      scopes: form.scopes,
       enabled: true,
     }),
     [form],
@@ -326,6 +364,16 @@ export default function ModelServiceConnections() {
             <span className="mt-2 block text-xs leading-5 text-slate-400">
               {provider.hint}
             </span>
+            <span className="mt-2 flex flex-wrap gap-2">
+              {form.scopes.map((scope) => (
+                <span
+                  className="rounded-full bg-white/[0.055] px-2.5 py-1 text-xs text-slate-300"
+                  key={scope}
+                >
+                  {SCOPE_LABELS[scope]}
+                </span>
+              ))}
+            </span>
           </label>
 
           <div className="grid gap-4 sm:grid-cols-2">
@@ -460,7 +508,7 @@ export default function ModelServiceConnections() {
                 还没有模型服务连接
               </p>
               <p className="mt-1 text-xs leading-5 text-slate-400">
-                完成左侧三步后，可用模型会进入智能调度候选池。
+                完成左侧三步后，连接只会进入对应的模型与音频功能。
               </p>
             </div>
           ) : (
@@ -485,6 +533,16 @@ export default function ModelServiceConnections() {
                       <p className="mt-2 text-xs text-slate-400">
                         {connection.masked_key} · {connection.model_count} 个模型
                       </p>
+                      <div className="mt-2 flex flex-wrap gap-1.5">
+                        {scopesForConnection(connection).map((scope) => (
+                          <span
+                            className="rounded-full bg-white/[0.055] px-2 py-0.5 text-[11px] text-slate-300"
+                            key={scope}
+                          >
+                            {SCOPE_LABELS[scope]}
+                          </span>
+                        ))}
+                      </div>
                       {connection.last_error_hint ? (
                         <p className="mt-2 text-xs leading-5 text-amber-200">
                           {connection.last_error_hint}

--- a/client/src/data/models.ts
+++ b/client/src/data/models.ts
@@ -30,6 +30,7 @@ export type ModelOperation =
   | "synthesize_speech"
   | "generate_audio"
   | "analyze_audio"
+  | "realtime_voice"
   | "analyze_video"
   | "generate_video"
   | "embed"
@@ -38,7 +39,8 @@ export type InteractionStatus = "ready" | "planned" | "unsupported";
 export type ModelUiEntrypoint = "chat" | "rag" | "multimodal" | "planned";
 export type Category = string;
 export type SupportedParameter = string;
-export type PricingTier = "free" | "low" | "medium" | "high";
+export type PricingTier = "free" | "dynamic" | "low" | "medium" | "high";
+export type PricingStatus = "fixed" | "free" | "dynamic";
 
 export interface Model {
   id: string;
@@ -55,6 +57,7 @@ export interface Model {
     input: number;
     output: number;
   };
+  pricing_status: PricingStatus;
   pricing_tier: PricingTier;
   capabilities: Capability[];
   input_modalities: InputModality[];
@@ -17164,9 +17167,19 @@ function toCny(usdPerMillion: number) {
   return roundMoney(usdPerMillion * USD_TO_CNY);
 }
 
-function getPricingTier(inputUsdPerMillion: number): PricingTier {
+function getPricingStatus(raw: RawCatalogModel): PricingStatus {
+  if (raw.pricing.input < 0 || raw.pricing.output < 0) return "dynamic";
+  if (raw.pricing.input === 0 && raw.pricing.output === 0) return "free";
+  return "fixed";
+}
+
+function getPricingTier(
+  inputUsdPerMillion: number,
+  pricingStatus: PricingStatus,
+): PricingTier {
+  if (pricingStatus === "free") return "free";
+  if (pricingStatus === "dynamic") return "dynamic";
   const inputCny = inputUsdPerMillion * USD_TO_CNY;
-  if (inputUsdPerMillion === 0) return "free";
   if (inputCny <= 1) return "low";
   if (inputCny <= 5) return "medium";
   return "high";
@@ -17240,12 +17253,19 @@ function inferCategories(raw: RawCatalogModel, capabilities: Capability[]): Cate
   return Array.from(categories);
 }
 
-function inferTags(raw: RawCatalogModel, capabilities: Capability[], categories: Category[], active: boolean): string[] {
+function inferTags(
+  raw: RawCatalogModel,
+  capabilities: Capability[],
+  categories: Category[],
+  active: boolean,
+  pricingStatus: PricingStatus,
+): string[] {
   const tags = new Set<string>();
   const haystack = (raw.id + " " + raw.name).toLowerCase();
   const ageDays = raw.created > 0 ? (CURRENT_TIME_SECONDS - raw.created) / 86400 : Number.POSITIVE_INFINITY;
   if (ageDays <= 45) tags.add("新");
-  if (raw.pricing.input === 0 && raw.pricing.output === 0) tags.add("免费");
+  if (pricingStatus === "free") tags.add("免费");
+  if (pricingStatus === "dynamic") tags.add("动态计费");
   if (capabilities.includes("image") || capabilities.includes("audio") || capabilities.includes("video")) tags.add("多模态");
   if (capabilities.includes("audio")) tags.add("音频");
   if (capabilities.includes("video")) tags.add("视频");
@@ -17334,19 +17354,34 @@ function interactionForOperation(
   return { status: "planned", entrypoint: "planned" };
 }
 
-function buildChineseDescription(raw: RawCatalogModel, categories: Category[], active: boolean, priceCny: Model["price_cny"]) {
+function buildChineseDescription(
+  raw: RawCatalogModel,
+  categories: Category[],
+  active: boolean,
+  priceCny: Model["price_cny"],
+  pricingStatus: PricingStatus,
+) {
   const inputs = describeModalities(raw.input_modalities);
   const outputs = describeModalities(raw.output_modalities);
   const scenes = describeCategories(categories);
   const context = raw.context_length > 0 ? raw.context_length.toLocaleString("zh-CN") + " tokens" : "未公开";
-  const price = raw.pricing.input === 0 && raw.pricing.output === 0 ? "当前目录价格为免费。" : "输入约 ¥" + priceCny.input.toFixed(2) + "，输出约 ¥" + priceCny.output.toFixed(2) + " / 百万 token。";
+  const price =
+    pricingStatus === "free"
+      ? "当前目录价格为免费，后续以平台结算为准。"
+      : pricingStatus === "dynamic"
+        ? "费用由实际路由模型或组合调用决定。"
+        : "输入约 ¥" + priceCny.input.toFixed(2) + "，输出约 ¥" + priceCny.output.toFixed(2) + " / 百万 token。";
   const lifecycle = active ? "" : "\u8be5\u6761\u76ee\u5df2\u6309\u5e73\u53f0\u76ee\u5f55\u6807\u8bb0\u4e3a\u975e\u6d3b\u8dc3\u3002";
   return raw.name + " \u662f模镜\u76ee\u5f55\u6536\u5f55\u7684 " + raw.model_author + " 模型，支持" + inputs + "输入并输出" + outputs + "，适合" + scenes + "等场景。上下文长度为 " + context + "，" + price + lifecycle;
 }
 
 function enrichModel(raw: RawCatalogModel): Model {
   const active = raw.expiration_date === null || raw.expiration_date > CURRENT_TIME_SECONDS;
-  const price_cny = { input: toCny(raw.pricing.input), output: toCny(raw.pricing.output) };
+  const pricing_status = getPricingStatus(raw);
+  const price_cny =
+    pricing_status === "free"
+      ? { input: 0, output: 0 }
+      : { input: toCny(raw.pricing.input), output: toCny(raw.pricing.output) };
   const capabilities = inferCapabilities(raw);
   const categories = inferCategories(raw, capabilities);
   const operations = inferOperations(raw);
@@ -17357,11 +17392,18 @@ function enrichModel(raw: RawCatalogModel): Model {
     name: raw.name,
     provider: normalizeProvider(raw.model_author),
     model_author: raw.model_author,
-    description: buildChineseDescription(raw, categories, active, price_cny),
+    description: buildChineseDescription(
+      raw,
+      categories,
+      active,
+      price_cny,
+      pricing_status,
+    ),
     context_length: raw.context_length,
     pricing: raw.pricing,
     price_cny,
-    pricing_tier: getPricingTier(raw.pricing.input),
+    pricing_status,
+    pricing_tier: getPricingTier(raw.pricing.input, pricing_status),
     capabilities,
     input_modalities: raw.input_modalities,
     output_modalities: raw.output_modalities,
@@ -17376,7 +17418,13 @@ function enrichModel(raw: RawCatalogModel): Model {
     zero_data_retention: false,
     in_region_routing: false,
     active,
-    tags: inferTags(raw, capabilities, categories, active),
+    tags: inferTags(
+      raw,
+      capabilities,
+      categories,
+      active,
+      pricing_status,
+    ),
   };
 }
 
@@ -17416,6 +17464,68 @@ function catalogSort(left: RawCatalogModel, right: RawCatalogModel) {
   return right.created - left.created || left.id.localeCompare(right.id);
 }
 
-export const models: Model[] = [...rawCatalogModels]
-  .sort(catalogSort)
-  .map(enrichModel);
+const DIRECT_OPENAI_REALTIME_MODELS: Model[] = [
+  {
+    id: "gpt-realtime-2.1-mini",
+    name: "OpenAI: GPT Realtime 2.1 Mini",
+    provider: "OpenAI",
+    model_author: "OpenAI",
+    description:
+      "OpenAI 实时双向语音模型的均衡版本，适合低延迟连续语音对话、自然停顿和随时打断。该模型通过独立 OpenAI 音频连接调用，不进入普通聊天或智能调度候选池。",
+    context_length: 0,
+    pricing: { input: -1, output: -1 },
+    price_cny: { input: 0, output: 0 },
+    pricing_status: "dynamic",
+    pricing_tier: "dynamic",
+    capabilities: ["audio"],
+    input_modalities: ["audio"],
+    output_modalities: ["audio"],
+    operations: ["realtime_voice"],
+    primary_operation: "realtime_voice",
+    interaction_status: "planned",
+    ui_entrypoint: "multimodal",
+    series: "GPT Realtime 2.1",
+    categories: ["audio"],
+    supported_parameters: [],
+    distillable: false,
+    zero_data_retention: false,
+    in_region_routing: false,
+    active: true,
+    tags: ["新", "音频", "热门"],
+    note: "需要配置 OpenAI 音频与实时语音连接。",
+  },
+  {
+    id: "gpt-realtime-2.1",
+    name: "OpenAI: GPT Realtime 2.1",
+    provider: "OpenAI",
+    model_author: "OpenAI",
+    description:
+      "OpenAI 实时双向语音模型的质量版本，适合更重视回答质量的连续语音对话，支持自然停顿和随时打断。该模型通过独立 OpenAI 音频连接调用，不进入普通聊天或智能调度候选池。",
+    context_length: 0,
+    pricing: { input: -1, output: -1 },
+    price_cny: { input: 0, output: 0 },
+    pricing_status: "dynamic",
+    pricing_tier: "dynamic",
+    capabilities: ["audio"],
+    input_modalities: ["audio"],
+    output_modalities: ["audio"],
+    operations: ["realtime_voice"],
+    primary_operation: "realtime_voice",
+    interaction_status: "planned",
+    ui_entrypoint: "multimodal",
+    series: "GPT Realtime 2.1",
+    categories: ["audio"],
+    supported_parameters: [],
+    distillable: false,
+    zero_data_retention: false,
+    in_region_routing: false,
+    active: true,
+    tags: ["新", "音频", "热门"],
+    note: "需要配置 OpenAI 音频与实时语音连接。",
+  },
+];
+
+export const models: Model[] = [
+  ...DIRECT_OPENAI_REALTIME_MODELS,
+  ...[...rawCatalogModels].sort(catalogSort).map(enrichModel),
+];

--- a/client/src/pages/ChatPage.tsx
+++ b/client/src/pages/ChatPage.tsx
@@ -12,6 +12,7 @@ import remarkGfm from "remark-gfm";
 import AdvancedParamsPanel, {
   type ChatAdvancedParams,
 } from "../components/AdvancedParamsPanel";
+import AudioCreationWorkspace from "../components/AudioCreationWorkspace";
 import BrandLogo from "../components/BrandLogo";
 import ChatAudioComposer, {
   QuickTranscriptionControl,
@@ -28,6 +29,7 @@ import {
   federationRouteId,
 } from "../components/FederationRouterCard";
 import PromptSidebar from "../components/PromptSidebar";
+import RealtimeVoiceWorkspace from "../components/RealtimeVoiceWorkspace";
 import ResourceNav from "../components/ResourceNav";
 import SpeechWorkspace from "../components/SpeechWorkspace";
 import TranscriptionWorkspace from "../components/TranscriptionWorkspace";
@@ -65,9 +67,13 @@ import {
 } from "../utils/fetchChatStream";
 import {
   DEFAULT_SPEECH_MODEL_ID,
+  DEFAULT_SPEECH_VOICE,
   generateSpeechAudio,
 } from "../utils/speechAudio";
 import { StreamingMp3Session } from "../utils/streamingAudio";
+
+const TTS_MODEL_SESSION_KEY = "modelmirror-chat-tts-model";
+const TTS_VOICE_SESSION_KEY = "modelmirror-chat-tts-voice";
 
 interface UploadedImage {
   id: string;
@@ -102,8 +108,11 @@ interface ChatSendOptions {
 interface ChatAudioProfile {
   model_id: string;
   display_name: string;
+  provider: "openrouter" | "openai";
   invocable: boolean;
   interaction_status: "ready" | "planned" | "disabled";
+  status_reason: string | null;
+  operations: string[];
   chat_modes: Array<
     | "direct_audio_input"
     | "native_streaming_audio_output"
@@ -125,7 +134,7 @@ interface AssistantMessageAudio {
   status: "waiting" | "streaming" | "generating" | "ready" | "failed";
   playbackUrl?: string;
   downloadUrl?: string;
-  format: "mp3";
+  format: "mp3" | "wav";
   streamed?: boolean;
   autoPlay?: boolean;
   byteLength?: number;
@@ -948,6 +957,11 @@ export default function ChatPage() {
   const [searchParams] = useSearchParams();
   const decodedModelId = decodeModelId(modelId);
   const requestedOperation = searchParams.get("operation");
+
+  if (requestedOperation === "realtime_voice") {
+    return <RealtimeVoiceWorkspace initialModelId={decodedModelId} />;
+  }
+
   const videoAnalysisModel = models.find(
     (item) =>
       item.id === decodedModelId &&
@@ -974,6 +988,24 @@ export default function ChatPage() {
     return <VideoGenerationWorkspace model={videoGenerationModel} />;
   }
 
+  const audioGenerationModel = models.find(
+    (item) =>
+      item.id === decodedModelId &&
+      item.operations.includes("generate_audio"),
+  );
+
+  if (
+    requestedOperation === "generate_audio" &&
+    audioGenerationModel
+  ) {
+    return (
+      <AudioCreationWorkspace
+        key={audioGenerationModel.id}
+        model={audioGenerationModel}
+      />
+    );
+  }
+
   const transcriptionModel = models.find(
     (item) =>
       item.id === decodedModelId &&
@@ -988,10 +1020,18 @@ export default function ChatPage() {
   const speechModel = models.find(
     (item) =>
       item.id === decodedModelId &&
-      item.primary_operation === "synthesize_speech" &&
-      item.interaction_status === "ready",
+      item.operations.includes("synthesize_speech"),
   );
-  if (speechModel) {
+  if (
+    speechModel &&
+    (
+      requestedOperation === "synthesize_speech" ||
+      (
+        speechModel.primary_operation === "synthesize_speech" &&
+        speechModel.interaction_status === "ready"
+      )
+    )
+  ) {
     return <SpeechWorkspace model={speechModel} />;
   }
 
@@ -1072,6 +1112,16 @@ function ChatConversationPage() {
   const [chatVideoEnabled, setChatVideoEnabled] = useState(false);
   const [nativeAudioEnabled, setNativeAudioEnabled] = useState(false);
   const [nativeAudioVoice, setNativeAudioVoice] = useState("");
+  const [ttsModelId, setTtsModelId] = useState(
+    () =>
+      window.sessionStorage.getItem(TTS_MODEL_SESSION_KEY) ??
+      DEFAULT_SPEECH_MODEL_ID,
+  );
+  const [ttsVoice, setTtsVoice] = useState(
+    () =>
+      window.sessionStorage.getItem(TTS_VOICE_SESSION_KEY) ??
+      DEFAULT_SPEECH_VOICE,
+  );
   const [autoReadEnabled, setAutoReadEnabled] = useState(false);
   const [autoReadConfirmationOpen, setAutoReadConfirmationOpen] =
     useState(false);
@@ -1146,16 +1196,29 @@ function ChatConversationPage() {
     result: ChatVideoAnalysisResult;
   } | null>(null);
 
-  const ttsProfile = useMemo(
+  const ttsProfiles = useMemo(
     () =>
-      chatAudioFeatures?.profiles.find(
+      (chatAudioFeatures?.profiles ?? []).filter(
         (profile) =>
-          profile.model_id === DEFAULT_SPEECH_MODEL_ID &&
           profile.invocable &&
           profile.interaction_status === "ready" &&
-          profile.chat_modes.includes("synthesize_speech"),
-      ) ?? null,
+          profile.chat_modes.includes("synthesize_speech") &&
+          profile.output_formats.some(
+            (format) => format === "mp3" || format === "wav",
+          ) &&
+          profile.voices.length > 0,
+      ),
     [chatAudioFeatures],
+  );
+  const ttsProfile = useMemo(
+    () =>
+      ttsProfiles.find((profile) => profile.model_id === ttsModelId) ??
+      ttsProfiles.find(
+        (profile) => profile.model_id === DEFAULT_SPEECH_MODEL_ID,
+      ) ??
+      ttsProfiles[0] ??
+      null,
+    [ttsModelId, ttsProfiles],
   );
   const nativeAudioProfile = useMemo(
     () =>
@@ -1171,6 +1234,22 @@ function ChatConversationPage() {
   );
   const nativeAudioAvailable = Boolean(
     nativeAudioProfile && !isOmniAutoRoute,
+  );
+  const realtimeVoiceProfile = useMemo(
+    () =>
+      chatAudioFeatures?.profiles.find(
+        (profile) =>
+          profile.provider === "openai" &&
+          profile.model_id === "gpt-realtime-2.1-mini" &&
+          profile.operations.includes("realtime_voice"),
+      ) ??
+      chatAudioFeatures?.profiles.find(
+        (profile) =>
+          profile.provider === "openai" &&
+          profile.operations.includes("realtime_voice"),
+      ) ??
+      null,
+    [chatAudioFeatures],
   );
   const handleVideoSelectionChange = useCallback(
     (nextSelection: ChatVideoSelection | null) => {
@@ -1296,6 +1375,32 @@ function ChatConversationPage() {
         : nativeAudioProfile.voices[0] ?? "",
     );
   }, [nativeAudioProfile]);
+
+  useEffect(() => {
+    if (!ttsProfile) {
+      setTtsVoice("");
+      return;
+    }
+    if (ttsModelId !== ttsProfile.model_id) {
+      setTtsModelId(ttsProfile.model_id);
+      window.sessionStorage.setItem(
+        TTS_MODEL_SESSION_KEY,
+        ttsProfile.model_id,
+      );
+    }
+    setTtsVoice((current) => {
+      const preferred =
+        ttsProfile.model_id === DEFAULT_SPEECH_MODEL_ID &&
+        ttsProfile.voices.includes(DEFAULT_SPEECH_VOICE)
+          ? DEFAULT_SPEECH_VOICE
+          : ttsProfile.voices[0];
+      const nextVoice = ttsProfile.voices.includes(current)
+        ? current
+        : preferred;
+      window.sessionStorage.setItem(TTS_VOICE_SESSION_KEY, nextVoice);
+      return nextVoice;
+    });
+  }, [ttsModelId, ttsProfile]);
 
   useEffect(
     () => () => {
@@ -1615,6 +1720,9 @@ function ChatConversationPage() {
     }
 
     releaseMessageAudio(messageId);
+    const responseFormat = ttsProfile.output_formats.includes("mp3")
+      ? "mp3"
+      : "wav";
     const controller = new AbortController();
     speechAbortControllersRef.current.set(messageId, controller);
     setMessages((current) =>
@@ -1625,7 +1733,7 @@ function ChatConversationPage() {
               audio: {
                 source: "tts",
                 status: "generating",
-                format: "mp3",
+                format: responseFormat,
                 autoPlay,
               },
             }
@@ -1637,7 +1745,8 @@ function ChatConversationPage() {
       const result = await generateSpeechAudio({
         modelId: ttsProfile.model_id,
         input: readableText,
-        voice: ttsProfile.voices[0],
+        voice: ttsVoice,
+        responseFormat,
         signal: controller.signal,
       });
       const url = URL.createObjectURL(result.blob);
@@ -1652,7 +1761,7 @@ function ChatConversationPage() {
                   status: "ready",
                   playbackUrl: url,
                   downloadUrl: url,
-                  format: "mp3",
+                  format: result.responseFormat,
                   streamed: false,
                   autoPlay,
                   byteLength: result.outputBytes,
@@ -2811,12 +2920,16 @@ function ChatConversationPage() {
                 </label>
               </div>
             ) : null}
-            {isOmniAutoRoute ? (
+            {isOmniAutoRoute || model.pricing_status === "dynamic" ? (
               <div className="mt-4 rounded-lg border border-white/10 bg-white/[0.045] p-3 text-sm">
                 <p className="text-xs text-slate-400">结算方式</p>
-                <p className="mt-1 font-semibold text-white">按实际路由模型计费</p>
+                <p className="mt-1 font-semibold text-white">
+                  {isOmniAutoRoute
+                    ? "按实际路由模型计费"
+                    : "按实际路由或组合调用计费"}
+                </p>
                 <p className="mt-1 text-xs leading-5 text-slate-500">
-                  最终费用以回答下方的路由回执为准。
+                  最终费用以网关结算和回答下方的调用回执为准。
                 </p>
               </div>
             ) : (
@@ -3224,25 +3337,76 @@ function ChatConversationPage() {
                       </label>
                     ) : null}
                     {ttsProfile ? (
-                      <label className="inline-flex items-center gap-2 font-semibold text-slate-200">
-                        <input
-                          checked={autoReadEnabled}
-                          className="h-4 w-4 rounded border-white/20 bg-ink-950 text-cyan-300 focus:ring-cyan-300/30"
-                          disabled={isSending}
-                          onChange={(event) => {
-                            if (
-                              event.target.checked &&
-                              !autoReadConfirmedRef.current
-                            ) {
-                              setAutoReadConfirmationOpen(true);
-                              return;
-                            }
-                            setAutoReadEnabled(event.target.checked);
-                          }}
-                          type="checkbox"
-                        />
-                        自动朗读后续回答
-                      </label>
+                      <>
+                        <label className="inline-flex items-center gap-2 text-slate-300">
+                          朗读模型
+                          <select
+                            aria-label="朗读模型"
+                            className="max-w-52 rounded-full border border-white/10 bg-ink-950/80 px-2.5 py-1.5 text-xs font-semibold text-white outline-none focus:border-cyan-300/45"
+                            disabled={isSending}
+                            onChange={(event) => {
+                              const nextModelId = event.target.value;
+                              setTtsModelId(nextModelId);
+                              window.sessionStorage.setItem(
+                                TTS_MODEL_SESSION_KEY,
+                                nextModelId,
+                              );
+                            }}
+                            value={ttsProfile.model_id}
+                          >
+                            {ttsProfiles.map((profile) => (
+                              <option
+                                key={profile.model_id}
+                                value={profile.model_id}
+                              >
+                                {profile.display_name}
+                              </option>
+                            ))}
+                          </select>
+                        </label>
+                        <label className="inline-flex items-center gap-2 text-slate-300">
+                          声线
+                          <select
+                            aria-label="朗读声线"
+                            className="max-w-44 rounded-full border border-white/10 bg-ink-950/80 px-2.5 py-1.5 text-xs font-semibold text-white outline-none focus:border-cyan-300/45"
+                            disabled={isSending}
+                            onChange={(event) => {
+                              const nextVoice = event.target.value;
+                              setTtsVoice(nextVoice);
+                              window.sessionStorage.setItem(
+                                TTS_VOICE_SESSION_KEY,
+                                nextVoice,
+                              );
+                            }}
+                            value={ttsVoice}
+                          >
+                            {ttsProfile.voices.map((voice) => (
+                              <option key={voice} value={voice}>
+                                {voice}
+                              </option>
+                            ))}
+                          </select>
+                        </label>
+                        <label className="inline-flex items-center gap-2 font-semibold text-slate-200">
+                          <input
+                            checked={autoReadEnabled}
+                            className="h-4 w-4 rounded border-white/20 bg-ink-950 text-cyan-300 focus:ring-cyan-300/30"
+                            disabled={isSending}
+                            onChange={(event) => {
+                              if (
+                                event.target.checked &&
+                                !autoReadConfirmedRef.current
+                              ) {
+                                setAutoReadConfirmationOpen(true);
+                                return;
+                              }
+                              setAutoReadEnabled(event.target.checked);
+                            }}
+                            type="checkbox"
+                          />
+                          自动朗读后续回答
+                        </label>
+                      </>
                     ) : null}
                     <span className="text-slate-500">
                       默认关闭；原生语音开启时不会重复调用辅助朗读。
@@ -3428,6 +3592,24 @@ function ChatConversationPage() {
                           onSendDirectAudio={sendDirectAudio}
                           onTranscript={fillQuickTranscript}
                         />
+                      ) : null}
+                      {realtimeVoiceProfile ? (
+                        <Link
+                          className={`inline-flex items-center rounded-full border px-3 py-2 text-xs font-semibold transition ${
+                            realtimeVoiceProfile.interaction_status === "ready"
+                              ? "border-cyan-300/35 bg-cyan-300/10 text-cyan-100 hover:border-cyan-300/60 hover:bg-cyan-300/15"
+                              : "border-white/10 bg-white/[0.045] text-slate-400 hover:border-white/20 hover:text-slate-200"
+                          }`}
+                          title={
+                            realtimeVoiceProfile.status_reason ??
+                            "进入连续语音通话，区别于单轮麦克风转写"
+                          }
+                          to={`/chat/${encodeURIComponent(
+                            realtimeVoiceProfile.model_id,
+                          )}?operation=realtime_voice`}
+                        >
+                          实时语音
+                        </Link>
                       ) : null}
                       <p className="text-xs text-slate-400">
                         {isUploadingImage

--- a/client/src/pages/ModelListPage.tsx
+++ b/client/src/pages/ModelListPage.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useMemo, useState } from "react";
 import FederationRouterCard from "../components/FederationRouterCard";
-import ModelCard from "../components/ModelCard";
+import ModelCard, {
+  type AudioCapabilityStatus,
+} from "../components/ModelCard";
 import PageContainer from "../components/PageContainer";
 import FilterPanel from "../components/filters/FilterPanel";
 import {
@@ -9,6 +11,8 @@ import {
 } from "../data/filterState";
 import {
   models,
+  type InputModality,
+  type Model,
   type ModelOperation,
 } from "../data/models";
 import { recruitmentTheme } from "../theme/recruitmentTheme";
@@ -19,6 +23,33 @@ import {
 
 function includesEvery<T>(values: T[], selected: T[]) {
   return selected.every((value) => values.includes(value));
+}
+
+function matchesWorkSkills(
+  model: Model,
+  selectedSkills: InputModality[],
+) {
+  return selectedSkills.every((skill) => {
+    if (skill === "file") {
+      return model.input_modalities.includes("file");
+    }
+    if (skill === "text") {
+      return (
+        model.input_modalities.includes("text") ||
+        model.output_modalities.includes("text")
+      );
+    }
+    if (skill === "image") {
+      return model.capabilities.includes("image");
+    }
+    if (skill === "audio") {
+      return model.capabilities.includes("audio");
+    }
+    if (skill === "video") {
+      return model.capabilities.includes("video");
+    }
+    return false;
+  });
 }
 
 function matchesAny<T>(value: T, selected: T[]) {
@@ -74,12 +105,36 @@ interface VideoCatalogPayload {
   profiles: VideoModelProfile[];
 }
 
+interface AudioModelProfile {
+  model_id: string;
+  invocable: boolean;
+  interaction_status: "ready" | "planned" | "disabled";
+  status_reason: string | null;
+  operations: ModelOperation[];
+  price_per_generation_usd: number | null;
+  fixed_duration_seconds: number | null;
+  chat_modes: (
+    | "direct_audio_input"
+    | "native_streaming_audio_output"
+    | "transcribe"
+    | "synthesize_speech"
+  )[];
+}
+
+interface AudioCatalogPayload {
+  status: "online" | "stale" | "offline" | "disabled";
+  stale: boolean;
+  profiles: AudioModelProfile[];
+}
+
 export default function ModelListPage() {
   const [filters, setFilters] =
     useState<ModelFilterState>(createDefaultFilters);
   const [searchTerm, setSearchTerm] = useState("");
   const [videoCatalog, setVideoCatalog] =
     useState<VideoCatalogPayload | null>(null);
+  const [audioCatalog, setAudioCatalog] =
+    useState<AudioCatalogPayload | null>(null);
 
   useEffect(() => {
     document.title = "模镜 - AI 牛马招聘会";
@@ -108,6 +163,26 @@ export default function ModelListPage() {
         }
       });
 
+    void fetch("/api/multimodal/audio/models", {
+      signal: controller.signal,
+    })
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error("audio catalog unavailable");
+        }
+        return (await response.json()) as AudioCatalogPayload;
+      })
+      .then((payload) => {
+        if (!controller.signal.aborted) {
+          setAudioCatalog(payload);
+        }
+      })
+      .catch(() => {
+        if (!controller.signal.aborted) {
+          setAudioCatalog(null);
+        }
+      });
+
     return () => controller.abort();
   }, []);
 
@@ -122,6 +197,63 @@ export default function ModelListPage() {
     }
     return result;
   }, [videoCatalog]);
+
+  const confirmedAudioOperations = useMemo(() => {
+    const result = new Map<string, ModelOperation[]>();
+    for (const profile of audioCatalog?.profiles ?? []) {
+      if (
+        !profile.invocable ||
+        profile.interaction_status !== "ready"
+      ) {
+        continue;
+      }
+      const operations: ModelOperation[] = [];
+      if (profile.chat_modes.includes("direct_audio_input")) {
+        operations.push("analyze_audio");
+      }
+      if (profile.chat_modes.includes("transcribe")) {
+        operations.push("transcribe");
+      }
+      if (profile.chat_modes.includes("synthesize_speech")) {
+        operations.push("synthesize_speech");
+      }
+      if (profile.operations.includes("generate_audio")) {
+        operations.push("generate_audio");
+      }
+      if (profile.operations.includes("realtime_voice")) {
+        operations.push("realtime_voice");
+      }
+      if (operations.length > 0) {
+        result.set(profile.model_id, operations);
+      }
+    }
+    return result;
+  }, [audioCatalog]);
+
+  const audioCapabilityStatuses = useMemo(() => {
+    const result = new Map<string, AudioCapabilityStatus>();
+    for (const profile of audioCatalog?.profiles ?? []) {
+      const operations = profile.operations.filter(
+        (operation) =>
+          operation === "analyze_audio" ||
+          operation === "transcribe" ||
+          operation === "synthesize_speech" ||
+          operation === "generate_audio" ||
+          operation === "realtime_voice",
+      );
+      if (operations.length === 0) {
+        continue;
+      }
+      result.set(profile.model_id, {
+        status: profile.interaction_status,
+        operations,
+        reason: profile.status_reason,
+        pricePerGenerationUsd: profile.price_per_generation_usd,
+        fixedDurationSeconds: profile.fixed_duration_seconds,
+      });
+    }
+    return result;
+  }, [audioCatalog]);
 
   const seriesOptions = useMemo(
     () =>
@@ -169,7 +301,7 @@ export default function ModelListPage() {
       if (!providerFilterMatches(model, filters.provider)) {
         return false;
       }
-      if (!includesEvery(model.input_modalities, filters.inputModalities)) {
+      if (!matchesWorkSkills(model, filters.inputModalities)) {
         return false;
       }
       if (!matchesAny(model.series, filters.series)) return false;
@@ -199,14 +331,23 @@ export default function ModelListPage() {
         return false;
       }
 
-      const inputPriceCny = model.price_cny.input;
-      if (inputPriceCny < filters.promptPriceCnyRange.min) return false;
-      if (
-        filters.promptPriceCnyRange.max <
-          defaultFilterState.promptPriceCnyRange.max &&
-        inputPriceCny > filters.promptPriceCnyRange.max
-      ) {
-        return false;
+      const usesExplicitPriceFilter =
+        filters.promptPriceCnyRange.min !==
+          defaultFilterState.promptPriceCnyRange.min ||
+        filters.promptPriceCnyRange.max !==
+          defaultFilterState.promptPriceCnyRange.max;
+      if (model.pricing_status === "dynamic") {
+        if (usesExplicitPriceFilter) return false;
+      } else {
+        const inputPriceCny = model.price_cny.input;
+        if (inputPriceCny < filters.promptPriceCnyRange.min) return false;
+        if (
+          filters.promptPriceCnyRange.max <
+            defaultFilterState.promptPriceCnyRange.max &&
+          inputPriceCny > filters.promptPriceCnyRange.max
+        ) {
+          return false;
+        }
       }
 
       return true;
@@ -223,15 +364,34 @@ export default function ModelListPage() {
   const activeFilterCount =
     countActiveFilters(filters) + (hasSearchTerm ? 1 : 0);
   const readyFilteredCount = filteredModels.filter(
-    (model) =>
-      model.interaction_status === "ready" ||
-      confirmedVideoOperations
-        .get(model.id)
-        ?.some(
-          (operation) =>
-            operation === "analyze_video" ||
-            operation === "generate_video",
-        ),
+    (model) => {
+      const audioStatus = audioCapabilityStatuses.get(model.id);
+      const primaryAudioBlocked =
+        (
+          model.primary_operation === "transcribe" ||
+          model.primary_operation === "synthesize_speech" ||
+          model.primary_operation === "generate_audio" ||
+          model.primary_operation === "realtime_voice"
+        ) &&
+        Boolean(audioStatus) &&
+        audioStatus?.status !== "ready";
+      return (
+        (
+          model.interaction_status === "ready" &&
+          !primaryAudioBlocked
+        ) ||
+        Boolean(confirmedAudioOperations.get(model.id)?.length) ||
+        Boolean(
+          confirmedVideoOperations
+            .get(model.id)
+            ?.some(
+              (operation) =>
+                operation === "analyze_video" ||
+                operation === "generate_video",
+            ),
+        )
+      );
+    },
   ).length;
   const featuredModels = filteredModels.slice(0, 2);
   const galleryModels = filteredModels.slice(featuredModels.length);
@@ -366,6 +526,13 @@ export default function ModelListPage() {
                     key={`featured-${model.id}`}
                   >
                     <ModelCard
+                      audioCatalogStale={audioCatalog?.stale ?? false}
+                      audioCapabilityStatus={
+                        audioCapabilityStatuses.get(model.id)
+                      }
+                      confirmedAudioOperations={
+                        confirmedAudioOperations.get(model.id)
+                      }
                       confirmedVideoOperations={
                         confirmedVideoOperations.get(model.id)
                       }
@@ -381,6 +548,13 @@ export default function ModelListPage() {
             <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
               {galleryModels.map((model) => (
                 <ModelCard
+                  audioCatalogStale={audioCatalog?.stale ?? false}
+                  audioCapabilityStatus={
+                    audioCapabilityStatuses.get(model.id)
+                  }
+                  confirmedAudioOperations={
+                    confirmedAudioOperations.get(model.id)
+                  }
                   confirmedVideoOperations={
                     confirmedVideoOperations.get(model.id)
                   }

--- a/client/src/theme/recruitmentTheme.ts
+++ b/client/src/theme/recruitmentTheme.ts
@@ -7,6 +7,7 @@ interface TalentProfileSource {
     input: number;
     output: number;
   };
+  pricing_status?: "fixed" | "free" | "dynamic";
   capabilities: string[];
   categories: string[];
   tags: string[];
@@ -79,7 +80,9 @@ export function getTalentStats(model: TalentProfileSource) {
   const seed = hashText(model.id);
   const popularity = 72 + (seed % 28);
   const hiredCount = 120 + (seed % 880);
-  const isBudgetFriendly = model.price_cny.input === 0 || model.price_cny.input <= 1;
+  const isBudgetFriendly =
+    model.pricing_status !== "dynamic" &&
+    (model.pricing_status === "free" || model.price_cny.input <= 1);
   const urgent = isBudgetFriendly || model.tags.some((tag) => ["热门", "精选", "免费"].includes(tag));
 
   return {

--- a/client/src/utils/fetchChatStream.ts
+++ b/client/src/utils/fetchChatStream.ts
@@ -313,6 +313,7 @@ function handleSseEvent(
   onRouteReceipt?: (receipt: RouteReceipt) => void,
   onAudioDelta?: (audio: ChatAudioDelta) => void,
   onMessageEnd?: () => void,
+  endOnFinishReason = true,
 ) {
   const eventName = eventText
     .split(/\r?\n/)
@@ -361,7 +362,7 @@ function handleSseEvent(
     if (delta) onDelta(delta);
     const audio = readAudioDelta(payload);
     if (audio) onAudioDelta?.(audio);
-    if (readFinishReason(payload)) onMessageEnd?.();
+    if (endOnFinishReason && readFinishReason(payload)) onMessageEnd?.();
   }
 }
 
@@ -469,6 +470,7 @@ export async function fetchChatStream({
           onRouteReceipt,
           onAudioDelta,
           emitMessageEnd,
+          !responseAudio?.enabled,
         );
       } catch (error) {
         console.error("ModelMirror chat stream event failed", error);
@@ -486,6 +488,7 @@ export async function fetchChatStream({
         onRouteReceipt,
         onAudioDelta,
         emitMessageEnd,
+        !responseAudio?.enabled,
       );
     } catch (error) {
       console.error("ModelMirror chat stream tail failed", error);

--- a/client/src/utils/speechAudio.ts
+++ b/client/src/utils/speechAudio.ts
@@ -1,5 +1,6 @@
 export const DEFAULT_SPEECH_MODEL_ID = "microsoft/mai-voice-2";
 export const DEFAULT_SPEECH_VOICE = "en-US-Harper:MAI-Voice-2";
+export type SpeechResponseFormat = "mp3" | "wav";
 
 export interface SpeechAudioResult {
   blob: Blob;
@@ -8,12 +9,14 @@ export interface SpeechAudioResult {
   provider: string;
   costKind: "actual" | "estimated" | "unavailable";
   outputBytes: number;
+  responseFormat: SpeechResponseFormat;
 }
 
 interface GenerateSpeechAudioOptions {
   input: string;
   modelId?: string;
   voice?: string;
+  responseFormat?: SpeechResponseFormat;
   speed?: number;
   signal?: AbortSignal;
 }
@@ -59,6 +62,7 @@ export async function generateSpeechAudio({
   input,
   modelId = DEFAULT_SPEECH_MODEL_ID,
   voice = DEFAULT_SPEECH_VOICE,
+  responseFormat = "mp3",
   speed = 1,
   signal,
 }: GenerateSpeechAudioOptions): Promise<SpeechAudioResult> {
@@ -69,7 +73,7 @@ export async function generateSpeechAudio({
       model_id: modelId,
       input,
       voice,
-      response_format: "mp3",
+      response_format: responseFormat,
       speed,
     }),
     signal,
@@ -80,8 +84,12 @@ export async function generateSpeechAudio({
   const contentType = headerValue(response, "content-type")
     .split(";", 1)[0]
     .toLowerCase();
-  if (contentType !== "audio/mpeg") {
-    throw new Error("语音服务没有返回标准 MP3，请稍后重试。");
+  const expectedContentType =
+    responseFormat === "wav" ? "audio/wav" : "audio/mpeg";
+  if (contentType !== expectedContentType) {
+    throw new Error(
+      `语音服务没有返回标准 ${responseFormat.toUpperCase()}，请稍后重试。`,
+    );
   }
   const blob = await response.blob();
   if (blob.size <= 0) {
@@ -107,5 +115,6 @@ export async function generateSpeechAudio({
       Number.isFinite(outputBytesHeader) && outputBytesHeader > 0
         ? outputBytesHeader
         : blob.size,
+    responseFormat,
   };
 }

--- a/docs/BACKEND.md
+++ b/docs/BACKEND.md
@@ -1,6 +1,6 @@
 # 后端架构与 API 文档
 
-最后更新日期：2026-07-28
+最后更新日期：2026-07-30
 维护人：模镜团队
 
 ## 技术栈
@@ -18,7 +18,7 @@ server/
 ├── api/                 # 独立 FastAPI router
 ├── model_router/        # 连接、目录、策略、熔断、预算、决策与 SQLite repository
 ├── context_engine/      # 上下文估算、压缩、保真与回退
-├── multimodal/          # STT、TTS、视频理解、视频目录与异步任务
+├── multimodal/          # STT、TTS、音乐任务、实时语音、视频理解与异步任务
 ├── rag/                 # 本地知识库、流水线、索引与评测
 ├── workflow_native/     # classic/shared schema、validate 与实验线
 ├── xperts/              # Agent Studio 内部存储与发布契约
@@ -39,6 +39,9 @@ server/
    native canary 或 native。
 
 默认网关与 auto 调度是两条独立稳定路径。auto 失败不能静默改走普通网关。
+直接 OpenAI 连接只承担音频与实时语音：连接类型为 `openai`、官方地址为
+`https://api.openai.com/v1`、用途范围为 `audio + realtime`。它不会自动进入
+普通 Chat 或原生智能调度候选池。
 
 ## 关键环境变量
 
@@ -55,6 +58,9 @@ server/
 | `MULTIMODAL_CHAT_AUDIO_ENABLED` | Chat 音频附件与直接理解，默认关闭。 |
 | `MULTIMODAL_MICROPHONE_ENABLED` | 录音完成后提交，默认关闭。 |
 | `MULTIMODAL_STREAMING_AUDIO_ENABLED` | 已验证模型的原生流式语音输出，默认关闭。 |
+| `MULTIMODAL_AUDIO_GENERATION_ENABLED` | 独立音乐生成任务，默认关闭。 |
+| `MULTIMODAL_REALTIME_VOICE_ENABLED` | 直接 OpenAI WebRTC 实时语音，默认关闭。 |
+| `MULTIMODAL_VOICE_CLONING_ENABLED` | 声音克隆预留开关；本轮安全门禁始终阻止创建资源。 |
 | `MULTIMODAL_CHAT_VIDEO_ENABLED` | Chat 本地视频附件，默认关闭。 |
 | `RAG_STORAGE_DIR` / `RAG_UPLOAD_DIR` | RAG 持久化位置。 |
 | `CHROMA_DB_PATH` | Chroma 目录。 |
@@ -84,13 +90,17 @@ server/
 - `POST /api/multimodal/chat/attachments`
 - `DELETE /api/multimodal/chat/attachments/{attachment_id}`
 - `GET /api/multimodal/audio/models`
+- `/api/multimodal/audio/jobs*`：音乐生成提交、列表、内容代理和删除本地记录。
+- `POST /api/multimodal/realtime/calls`：用后端密钥交换浏览器 WebRTC SDP。
+- `DELETE /api/multimodal/realtime/calls/{session_id}`：结束并审计本地实时会话。
 - `GET /api/multimodal/video/models`，`refresh=true` 强制重新确认实时能力。
 - `POST /api/multimodal/video/analysis`
 - `/api/multimodal/video/jobs*`：提交、列表、刷新、内容代理和删除本地记录。
 
-STT/TTS 与视频完整契约见
+音频、实时语音与视频完整契约见
 [MULTIMODAL_FORMAT_AUDIT.md](./MULTIMODAL_FORMAT_AUDIT.md)。音视频附件可进入
-Chat，但视频生成仍使用独立异步任务，不复用 `/api/chat` SSE。
+Chat；音乐和视频生成使用独立异步任务，实时语音使用 WebRTC，三者均不复用
+普通 `/api/chat` SSE。媒体、Prompt 和实时字幕不写入数据库或日志。
 
 ### 工作流、RAG 与 Agent
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,6 +1,6 @@
 # 部署与运维指南
 
-最后更新日期：2026-07-29
+最后更新日期：2026-07-30
 维护人：模镜团队
 
 ## 支持边界
@@ -69,8 +69,25 @@ OPENROUTER_API_KEY=your-openrouter-key
 - `.env`、API Key、token 和 master key 不得提交。
 - 前端环境变量不得保存后端凭据。
 - 日志不得记录 Prompt、音视频正文、URL 查询签名或上游完整错误体。
+- 音乐生成和实时语音均可能额外计费；费用未知时不得显示为零。
 - 视频生成可能产生费用且不保证 ZDR，启用前必须完成人工验收。
 - OmniRoute secrets 必须独立生成，不与模型网关 Key 复用。
+
+音频闭环新增功能默认关闭：
+
+```bash
+MULTIMODAL_AUDIO_GENERATION_ENABLED=false
+MULTIMODAL_REALTIME_VOICE_ENABLED=false
+MULTIMODAL_VOICE_CLONING_ENABLED=false
+```
+
+实时语音不能只靠环境开关启用。还需在设置页“模型服务连接”中创建
+“OpenAI 音频与实时语音”连接，地址使用 `https://api.openai.com/v1`，用途选择
+“音频能力”和“实时语音”。永久密钥仅由后端加密保存，不写入前端或普通聊天
+环境变量；该连接不会自动加入 default/auto 模型池。
+
+声音克隆仍处于安全占位状态：即使把开关设为 `true`，在上游无法验证删除临时
+音色前也不会创建授权录音或自定义音色资源。
 
 ## 可选 profile
 
@@ -137,6 +154,7 @@ location /api/ {
 ```bash
 curl http://localhost:8000/api/health
 curl http://localhost:8000/api/models/router-status
+curl "http://localhost:8000/api/multimodal/audio/models?refresh=true"
 curl http://localhost:8000/api/multimodal/video/models
 curl http://localhost:5173/studio
 ```
@@ -146,6 +164,10 @@ curl http://localhost:5173/studio
 - HTTP 状态、耗时、脱敏错误码。
 - 模型路由 engine、actual model、request ID、空流和失败切换。
 - RAG active version、候选版本和流水线状态。
+- 音频目录中的 `ready / planned / disabled` 与状态原因；实时档案为零时优先检查
+  功能开关、直接 OpenAI 连接、`audio + realtime` 用途及连接测试结果。
+- 实时语音默认 10 分钟，不提供严格预算承诺；断网后只允许用户显式重连，
+  不得自动创建新的付费会话。
 - 视频任务状态与连续轮询错误；临时网络错误不直接写成任务失败。
 - Browser、Sandbox、newAPI 和 server health。
 - 启用后检查 Coding capabilities、Worker health、取消清理和源码 Git 状态。
@@ -167,6 +189,8 @@ curl http://localhost:5173/studio
 - Chat 音视频：分别关闭 `MULTIMODAL_CHAT_AUDIO_ENABLED`、
   `MULTIMODAL_MICROPHONE_ENABLED`、`MULTIMODAL_STREAMING_AUDIO_ENABLED`
   和 `MULTIMODAL_CHAT_VIDEO_ENABLED`；独立 STT、TTS、视频分析及旧视频任务不受影响。
+- 音乐生成与实时语音：分别关闭 `MULTIMODAL_AUDIO_GENERATION_ENABLED` 和
+  `MULTIMODAL_REALTIME_VOICE_ENABLED`；已有 STT/TTS、普通 Chat 和视频链路不受影响。
 - 智能调度：切回 `MODEL_ROUTER_ENGINE=sidecar` 或 default/newAPI，保留 SQLite。
 - OmniRoute：停止 profile，不删除 `omniroute-data`。
 - 代码助手：设置 `CODING_AGENT_ENABLED=false`，停止 `coding-runtime`；没有

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -1,6 +1,6 @@
 # 前端架构与开发指南
 
-最后更新日期：2026-07-28
+最后更新日期：2026-07-30
 维护人：模镜团队
 
 ## 技术栈
@@ -75,12 +75,23 @@ client/
 
 - `chat`：现有文本和图片聊天。
 - `transcribe`：音频文件转录。
-- `synthesize_speech`：文字生成 MP3。
+- `synthesize_speech`：按已验证模型与声线生成语音。
+- `generate_audio`：独立音乐生成任务、播放器与临时下载。
+- `realtime_voice`：纯语音 WebRTC 工作区，不进入普通消息 SSE。
 - `analyze_video`：本地视频或 HTTPS URL 一次性分析。
 - `generate_video`：独立异步视频任务，不进入 Chat SSE。
 
 模型被目录收录或 `invocable=true` 不代表当前 UI 已适配。CTA 必须同时检查
 operation 和 `interaction_status`。
+
+`/models` 保留原 493 个 OpenRouter 快照模型，并额外展示
+`gpt-realtime-2.1-mini` 和 `gpt-realtime-2.1` 两个直接 OpenAI 档案。即使当前
+没有可用连接，卡片仍提供“配置实时语音”入口；连接、功能开关和能力档案同时
+满足后才显示“开始实时语音”。
+
+Chat 的音频上传与麦克风共用转写设置，默认先转文字并允许用户编辑。单轮录音
+按钮与“实时语音”入口必须保持可辨识：前者录完再提交，后者创建最长 10 分钟的
+持续 WebRTC 会话。实时语音不会自动组合 RAG、Skill、MCP 或 `/chat/auto`。
 
 ## 聊天图片输出链路
 

--- a/docs/MULTIMODAL_FORMAT_AUDIT.md
+++ b/docs/MULTIMODAL_FORMAT_AUDIT.md
@@ -1,6 +1,6 @@
 # 模镜全模态与常用格式缺口审计
 
-> 审计基线：多模态批次 A–G，实时模型目录复核日期 2026-07-29；静态目录快照仍保留 493 个模型。
+> 审计基线：多模态与音频闭环批次 A–I，实时模型目录复核日期 2026-07-29；原 493 个 OpenRouter 快照模型保持不变，另增加 2 个直接 OpenAI Realtime 展示档案。
 > 本文描述的是当前真实能力和分阶段交付边界，不代表一次性承诺支持所有格式。
 
 ## 1. “全模态”的交付定义
@@ -13,7 +13,7 @@
 |---|---|---|
 | 文本 | TXT、Markdown、HTML、JSON、YAML、XML、代码、SQL、日志 | 审计现状与模块入口 |
 | 图片 | JPEG/JPG、PNG、WebP、GIF、SVG、TIFF、HEIC/HEIF、BMP | 审计；不新增 GIF 动画处理 |
-| 音频 | WAV、MP3、AAC、M4A、FLAC、OGG/Opus、WebM | 已交付 STT、TTS、Chat 音频附件、录音后转写和已验证模型的原生音频流 |
+| 音频 | WAV、MP3、AAC、M4A、FLAC、OGG/Opus、WebM、WebRTC 媒体流 | 已交付 STT、TTS、Chat 音频附件、录音后转写、原生音频流、音乐生成和纯语音实时对话 |
 | 视频 | MP4、MPEG、MOV、WebM、MKV、AVI | 已交付 MP4/MPEG/MOV/WebM 理解、Chat 单轮附件和异步生成闭环；MKV/AVI 仅审计 |
 | 文档 | PDF、DOCX、PPTX、XLSX、CSV/TSV、EPUB、RTF、ODF | 只审计；RAG XLSX 延后到专项路线审计 |
 | 结构化数据 | JSON、JSON Schema、表格、数据库查询结果、Parquet | 审计 Chat、RAG、Data X 分工 |
@@ -30,7 +30,7 @@
 - 文本、Markdown、代码块。
 - JSON 与 JSON Schema 约束输出。
 - 图片生成、编辑和局部重绘。
-- 语音合成、通用音频生成。
+- 语音合成、音乐/通用音频生成、实时语音流。
 - 视频生成。
 - PDF、DOCX、PPTX、XLSX 等文件与报告。
 - Embedding、分类标签、检测框、时间轴、字幕。
@@ -72,10 +72,12 @@
 | GIF 动画 | 已收录为图片 | 当前压缩会静态化 | 当前按静态图片处理 | 不适用 | 未验证 | 未验证 | 无 | 仅静态首帧，不算动画支持 |
 | PDF | 已收录为 file | 无附件契约 | 已支持，文本/视觉转换 | 不适用 | 文件能力按配置 | 文件节点按配置 | 无 | 部分支持 |
 | 音频转写 STT | 实时与本地档案确认 | Chat 媒体面板可上传或录音后转写并编辑 | 不适用 | 不适用 | Agent Runtime 可按配置调用 | 无 | 独立深链兼容保留 | 已支持，OpenRouter-first |
-| 文字转语音 TTS | 实时与本地档案确认 | 助手回答可朗读，自动朗读默认关闭 | 不适用 | 不适用 | Agent Runtime 可按配置调用 | 无 | 独立深链兼容保留 | 已支持，MAI-Voice-2 |
+| 文字转语音 TTS | 实时与版本化档案确认 | 助手回答可朗读，自动朗读默认关闭 | 不适用 | 不适用 | Agent Runtime 可按配置调用 | 无 | 独立深链兼容保留 | 已支持，按已验证模型/声线开放 |
 | 音频理解 | 实时与本地档案确认 | 已验证模型可直接理解；普通模型和 auto 显式先转写 | 不适用 | 不适用 | 按模型配置 | 无 | 无 | 部分支持，OpenRouter-first |
 | 原生语音输出 | 实时与本地档案确认 | 已验证的 GPT Audio 模型可返回流式语音；失败保留文字 | 不适用 | 不适用 | 按模型配置 | 无 | 无 | 部分支持 |
-| 通用音频生成 | 已收录 | 音乐等非语音生成不进入朗读模型池 | 不适用 | 不适用 | 未形成通用能力 | 无 | 无 | 计划中 |
+| 音乐生成 | 实时与版本化档案确认 | 不进入朗读模型池 | 不适用 | 不适用 | 未形成通用能力 | 无 | 独立异步音乐工作区 | 已支持，Lyria Clip/Pro |
+| 实时双向语音 | 2 个直接 OpenAI 档案 | 独立纯语音工作区，不进入普通消息流 | 不适用 | 不适用 | 不组合 Agent 工具 | 不适用 | `/chat/:modelId?operation=realtime_voice` | 已支持，需直接 OpenAI `audio+realtime` 连接 |
+| 声音克隆 | 能力可识别 | 不开放上传或创建 | 不适用 | 不适用 | 不开放 | 不适用 | 仅安全占位 | 计划中，上游无法验证删除临时音色 |
 | 视频理解 | 实时能力确认 | 本地附件可由当前模型直接理解或先生成辅助摘要 | 无拆帧流水线 | 不适用 | 未形成通用能力 | 无 | 文件或 HTTPS/YouTube URL | 已支持，OpenRouter-first |
 | 视频生成 | 实时能力确认 | 独立异步工作区，不复用 Chat SSE | 不适用 | 不适用 | 未形成通用能力 | 无 | 文生视频、首尾帧、最多三参考图、受控高级参数 | 已支持，OpenRouter-first |
 | XLSX | 归类为 file | 不支持 | 未支持，待专项审计 | 已支持，结构化解析 | 文件能力按配置 | 文件节点按配置 | 不适用 | 部分支持，仅 Data X 等特定模块 |
@@ -94,8 +96,8 @@
 - `datax`：CSV、XLSX、Parquet 的结构化分析，不承担知识库语义切片。
 - `agents`：配置化媒体工具、工具调用、审批和 Agent 事件。
 - `workflow`：节点编排和节点事件，不作为通用媒体播放器。
-- `multimodal`：保留 STT/TTS 兼容深链、视频 URL 分析和独立视频生成任务；普通音视频输入统一从 Chat 媒体面板进入。
-- `models`：只展示真实能力、适配状态和正确入口，不直接承担推理。
+- `multimodal`：保留 STT/TTS 兼容深链、音乐/视频异步任务、视频 URL 分析和实时语音工作区；普通音视频附件统一从 Chat 媒体面板进入。
+- `models`：保留 493 个快照模型，并单独展示 2 个直接 OpenAI Realtime 档案；卡片只负责状态和入口，不直接承担推理。
 
 ## 3. 当前格式清单
 
@@ -138,6 +140,7 @@
 | WAV、MP3、AAC、M4A、FLAC、OGG、WebM | Chat 可上传或录音后转写；支持模型可直接理解部分格式 | 不适用 | 原生或 STT 组合支持 | 不适用 |
 | MP3 | 可转写或直接理解 | MAI-Voice-2 朗读；已验证模型可原生流式输出 | Chat 内可播放，独立深链可下载 | 不适用 |
 | PCM | 不适用 | 上游可能支持，首期不开放 | 不适用 | 不适用 |
+| WebRTC 媒体流 | 不适用 | 模型原生双向流 | 仅实时语音工作区，不写入普通 Chat 历史 | 不适用 |
 | MP4、MPEG、MOV、WebM | 不适用 | 不适用 | 模型原生理解，文件最大 20 MiB | 异步生成结果可播放与下载 |
 | MKV、AVI | 不适用 | 不适用 | 未接受，需转码后支持 | 仅审计 |
 
@@ -202,8 +205,10 @@ UI：模型卡进入“分析视频”或“生成视频”专用工作区
 6. Chat 音频上传、录音后转写、原生音频流和显式辅助 TTS。
 7. Chat 本地视频附件的直接理解与辅助摘要。
 8. 视频生成异步任务、状态恢复、首尾帧、多参考图、受控高级参数、播放器与下载代理。
+9. Lyria Clip/Pro 音乐生成、幂等任务、临时播放器和下载。
+10. 直接 OpenAI WebRTC 实时语音、语义 VAD、自然打断、静音、显式重连和 10 分钟硬上限。
 
-批次 G 完成视频生成表单与运维收尾。实时双向语音、边录边传、音频 URL、Chat 视频 URL、RAG XLSX 和其他文件格式继续延期，必须重新建立独立验收路线。
+实时翻译、语音/视频电话、SIP、自定义持久音色库、实时工具调用、音频 URL、Chat 视频 URL、RAG XLSX 和其他文件格式继续延期，必须重新建立独立验收路线。
 
 ### 通用 STT 后端契约
 
@@ -266,12 +271,43 @@ Content-Type: application/json
 }
 ```
 
-- 首期只开放完成行为测试的 `microsoft/mai-voice-2` 与 Harper 声线；其他 TTS 模型继续标记为待适配。
-- 输入不能为空且最多 4,000 个字符；速度限定为 `0.5–2.0`，输出仅允许 MP3。
-- 后端完整接收上游响应，并同时校验 `audio/mpeg`、MP3 文件签名、非空内容和 20 MiB 安全上限，校验通过后才返回浏览器。
-- 成功响应为原始 MP3 字节；脱敏响应头提供 request ID、实际模型、供应商、费用状态和输出字节数。
+- TTS 下拉框来自实时目录与版本化行为档案的交集；未通过模型、声线和格式验证的条目保持待适配。
+- 输入不能为空且最多 4,000 个字符；速度限定为 `0.5–2.0`，输出格式按模型档案开放 MP3 或 WAV。
+- 后端完整接收上游响应，并按能力档案校验 MP3 MIME/文件签名或 PCM 完整性；WAV 由后端补齐标准容器头。所有格式同时执行非空内容和 20 MiB 安全上限检查，校验通过后才返回浏览器。
+- 成功响应为能力档案声明的 MP3 或 WAV 字节；脱敏响应头提供 request ID、实际模型、供应商、费用状态和输出字节数。
 - 文字和音频不写入数据库；审计仅记录租户、operation、模型、连接、输入/输出字节数、状态和可用费用信息。
 - 前端自适应语音生成工作区提供文字保留、已验证声线、语速、取消、重试、播放器和下载；替换结果或离开页面时释放 Blob URL。
+
+### 音乐生成与实时语音
+
+音乐生成使用独立任务，不进入普通 Chat SSE：
+
+```http
+POST   /api/multimodal/audio/jobs
+GET    /api/multimodal/audio/jobs
+GET    /api/multimodal/audio/jobs/{job_id}
+GET    /api/multimodal/audio/jobs/{job_id}/content
+DELETE /api/multimodal/audio/jobs/{job_id}
+```
+
+- 当前开放完成行为验证的 Lyria Clip/Pro；Pro 图片提示先按能力档案开放。
+- `idempotency_key` 防止重复付费请求；后端完整校验音频后才标记成功。
+- SQLite 不保存 Prompt、图片或音频正文；结果只在非持久化目录保留 30 分钟。
+- 容器重建后任务元数据可保留，但临时音频正文不保证恢复。
+
+实时语音使用独立 WebRTC 生命周期：
+
+```http
+POST   /api/multimodal/realtime/calls
+DELETE /api/multimodal/realtime/calls/{session_id}
+```
+
+- 浏览器只把 SDP 交给模镜后端，永久 OpenAI Key 不进入前端。
+- 音频在浏览器与 OpenAI 之间通过 WebRTC 传输，模镜不转发或保存 PCM。
+- 默认 `gpt-realtime-2.1-mini + marin + semantic_vad`，可切换质量版和 Cedar。
+- 单次最多 10 分钟，结束前 60 秒提示；网络中断只提供显式重新连接，不自动创建新付费会话。
+- 首期只做纯语音，不组合 RAG、Skill、MCP、Agent、附件或 `/chat/auto`。
+- 两张模型卡始终可进入工作区；未配置直接 OpenAI 连接时显示配置建议，不伪装为可调用。
 
 ### 视频理解与生成闭环
 
@@ -317,14 +353,22 @@ MULTIMODAL_CHAT_AUDIO_ENABLED=true
 MULTIMODAL_MICROPHONE_ENABLED=true
 MULTIMODAL_STREAMING_AUDIO_ENABLED=true
 MULTIMODAL_CHAT_VIDEO_ENABLED=true
+MULTIMODAL_AUDIO_GENERATION_ENABLED=true
+MULTIMODAL_REALTIME_VOICE_ENABLED=true
+MULTIMODAL_VOICE_CLONING_ENABLED=false
 ```
 
 任一开关设为 `false` 后，模型仍保留在目录，但对应入口显示“当前未启用”；文本、图片、STT、TTS、RAG、工作流和智能调度不受影响。
 
+直接 OpenAI Realtime 还要求在设置页创建 `openai` 类型连接，地址必须为
+`https://api.openai.com/v1`，用途范围为 `audio + realtime`。环境开关不能替代连接和密钥。
+声音克隆开关保持关闭；本轮没有上传授权录音、创建音色或绕过删除安全门禁的接口。
+
 ### 只审计
 
 - GIF 动画、SVG 主动内容、HEIC/TIFF 高级处理。
-- 视频音轨单独识别、视频多轮原始媒体上下文和实时双向语音。
+- 视频音轨单独识别、视频多轮原始媒体上下文。
+- 实时翻译、语音/视频电话、电话/SIP 接入、实时工具调用和自定义持久音色库。
 - RAG XLSX、CSV 等表格资料解析及其前端入口。
 - 3D、点云、传感器、科学数据和医学影像。
 - 压缩包、旧版 Office 和复杂办公版式保真。
@@ -349,3 +393,4 @@ MULTIMODAL_CHAT_VIDEO_ENABLED=true
 - OpenRouter PDFs: <https://openrouter.ai/docs/guides/overview/multimodal/pdfs>
 - OpenRouter Video Understanding: <https://openrouter.ai/docs/guides/overview/multimodal/videos>
 - OpenRouter Video Generation: <https://openrouter.ai/docs/guides/overview/multimodal/video-generation>
+- OpenAI Realtime WebRTC: <https://developers.openai.com/api/docs/guides/realtime-webrtc>

--- a/docs/REPOSITORY_FACTS.md
+++ b/docs/REPOSITORY_FACTS.md
@@ -2,10 +2,10 @@
 
 本文只记录可由当前仓库或可重复命令证明的事实。它不是产品需求文档，也不推断目标客户、用户故事或商业目标。
 
-基线日期：2026-07-28
-仓库 HEAD：`77df89447e5f9926a1ab06fc3be6d37d064a4b1d`
+基线日期：2026-07-30
+审计基线主线 HEAD：`de43ab2`
 
-本次事实审计同时覆盖当前未提交工作树中的视频闭环、F 批次体验修复和文档维护；
+本次事实审计同时覆盖当前未提交工作树中的音频闭环批次 A–I 和文档维护；
 这些变更在人工验收和 PR 合并前不能被描述为 `main` 已发布能力。
 
 ## 1. 已证实事实
@@ -24,7 +24,8 @@
 | 持久化 | 多数 Runtime/Xpert 元数据使用文件型 Store；RAG 使用 Chroma/FTS，Data X 使用 DuckDB | `server/xpert_runtime/`、`server/xperts/`、`server/rag/`、`server/datax/` |
 | 隔离服务 | Compose 包含 Browser 和 Sandbox sidecar；另有 new-api、server、client，可选 office-host | `docker-compose.yml` |
 | Dify | 只保留 `/api/dify/*` 兼容代理和旧 iframe 组件；主前端路由与 Compose 不依赖 Dify | `client/src/App.tsx`、`server/api/dify_proxy.py`、`docker-compose.yml` |
-| 多模态 | 已有 STT、TTS、视频理解和独立异步视频任务；视频入口受功能开关控制 | `server/multimodal/`、`client/src/components/Video*Workspace.tsx` |
+| 多模态 | 已有 STT/TTS、Chat 音频附件、原生音频流、独立音乐任务、直接 OpenAI WebRTC 实时语音、视频理解和独立视频任务；新增入口均受功能开关与能力档案控制 | `server/multimodal/`、`client/src/components/*Workspace.tsx` |
+| 模型快照 | 原 493 个 OpenRouter 快照模型保持不变；`/models` 额外展示 2 个直接 OpenAI Realtime 档案 | `client/src/data/models.ts`、`client/src/pages/ModelListPage.tsx` |
 | 前端验证 | 只有 `dev`、`build`、`preview` 脚本，没有独立 lint/test 脚本 | `client/package.json` |
 | 后端验证 | pytest 测试位于 `server/tests/` | `server/tests/`、`server/requirements.txt` |
 | CI | 仓库当前没有 `.github/workflows/` | 文件系统检查 |
@@ -52,9 +53,11 @@
 
 | 验证 | 状态 | 结果 |
 | --- | --- | --- |
-| 当前功能分支 `cd client && npm.cmd run build` | 通过 | 2026-07-28：TypeScript 与 Vite 生产构建成功 |
-| 当前功能分支 `python -m pytest server/tests/ -q` | 通过 | 2026-07-28：582 passed；现有 FastAPI lifespan deprecation warnings 4 条 |
-| 视频专项测试 | 通过 | 38 passed |
+| 当前功能分支 `cd client && npm.cmd run build` | 通过 | 2026-07-30：TypeScript 与 Vite 生产构建成功 |
+| 当前功能分支 `python -m pytest server/tests/ -q` | 通过 | 2026-07-30：691 passed；现有 FastAPI lifespan deprecation warnings 4 条 |
+| 音乐任务与实时语音专项测试 | 通过 | 28 passed |
+| 原生音频流分片检查 | 通过 | Base64 尾部、`message_end` 强制 flush 和纯音频响应检查通过 |
+| `/models` Realtime 卡片检查 | 通过 | 两个卡片与 `operation=realtime_voice` 入口可见；无连接时显示配置态 |
 | 文档维护检查 | 通过 | 57 个 Markdown 相对链接、legacy 状态、个人绝对路径、密钥模式和 `git diff --check` |
 
 验证结果只适用于执行时的当前功能分支。后续代码改动必须重新验证；纯文档改动

--- a/server/.env.example
+++ b/server/.env.example
@@ -21,6 +21,11 @@ MULTIMODAL_CHAT_AUDIO_ENABLED=false
 MULTIMODAL_MICROPHONE_ENABLED=false
 MULTIMODAL_STREAMING_AUDIO_ENABLED=false
 MULTIMODAL_CHAT_VIDEO_ENABLED=false
+# 音频闭环扩展开关；保持关闭时不会影响现有 STT、TTS 或普通聊天。
+MULTIMODAL_AUDIO_GENERATION_ENABLED=false
+MULTIMODAL_REALTIME_VOICE_ENABLED=false
+# 即使启用，声音克隆仍受上游可验证删除能力的安全门禁约束。
+MULTIMODAL_VOICE_CLONING_ENABLED=false
 
 # OmniRoute optional sidecar. Keep disabled until the profile is healthy and a
 # dedicated execution/catalog-only API key has been created in OmniRoute.

--- a/server/main.py
+++ b/server/main.py
@@ -15604,6 +15604,8 @@ async def chat(payload: ChatRequest, request: Request):
                     yield (
                         f"data: {json.dumps(empty_error, ensure_ascii=False)}\n\n"
                     ).encode("utf-8")
+            if native_audio_succeeded:
+                yield b"event: message_end\ndata: {}\n\n"
             if deferred_done or native_audio_succeeded:
                 yield b"data: [DONE]\n\n"
             await response.aclose()

--- a/server/model_router/repository.py
+++ b/server/model_router/repository.py
@@ -19,10 +19,12 @@ from .schemas import (
     RouterConnectionCreate,
     RouterConnectionUpdate,
     RouterPolicy,
+    default_connection_scopes,
+    normalize_connection_scopes,
 )
 
 
-SCHEMA_VERSION = 7
+SCHEMA_VERSION = 10
 DEFAULT_TENANT_ID = "local"
 
 
@@ -103,6 +105,7 @@ class SQLiteRouterRepository:
             base_url TEXT NOT NULL,
             masked_key TEXT NOT NULL,
             api_key_ciphertext TEXT NOT NULL,
+            scopes_json TEXT NOT NULL DEFAULT '["chat"]',
             enabled INTEGER NOT NULL DEFAULT 1,
             health TEXT NOT NULL DEFAULT 'untested',
             model_count INTEGER NOT NULL DEFAULT 0,
@@ -199,6 +202,53 @@ class SQLiteRouterRepository:
             PRIMARY KEY (tenant_id, id),
             UNIQUE (tenant_id, idempotency_key_hash)
         );
+        CREATE TABLE IF NOT EXISTS audio_jobs (
+            id TEXT NOT NULL,
+            tenant_id TEXT NOT NULL,
+            idempotency_key_hash TEXT NOT NULL,
+            decision_id TEXT,
+            connection_id TEXT,
+            requested_model TEXT NOT NULL,
+            actual_model TEXT,
+            provider TEXT NOT NULL DEFAULT 'openrouter',
+            generation_id TEXT,
+            status TEXT NOT NULL,
+            has_image INTEGER NOT NULL DEFAULT 0,
+            output_bytes INTEGER NOT NULL DEFAULT 0,
+            cost_usd REAL,
+            cost_kind TEXT NOT NULL DEFAULT 'unavailable',
+            error_code TEXT,
+            expires_at TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, id),
+            UNIQUE (tenant_id, idempotency_key_hash)
+        );
+        CREATE TABLE IF NOT EXISTS realtime_calls (
+            id TEXT NOT NULL,
+            tenant_id TEXT NOT NULL,
+            decision_id TEXT,
+            connection_id TEXT NOT NULL,
+            model_id TEXT NOT NULL,
+            provider TEXT NOT NULL DEFAULT 'openai',
+            upstream_call_id TEXT,
+            voice TEXT NOT NULL,
+            vad_mode TEXT NOT NULL,
+            language TEXT NOT NULL,
+            status TEXT NOT NULL,
+            started_at TEXT,
+            expires_at TEXT NOT NULL,
+            ended_at TEXT,
+            duration_seconds REAL,
+            input_tokens INTEGER,
+            output_tokens INTEGER,
+            cost_usd REAL,
+            cost_kind TEXT NOT NULL DEFAULT 'unavailable',
+            error_code TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, id)
+        );
         CREATE INDEX IF NOT EXISTS idx_router_connections_tenant_enabled
             ON router_connections (tenant_id, enabled);
         CREATE INDEX IF NOT EXISTS idx_router_decisions_tenant_created
@@ -209,9 +259,43 @@ class SQLiteRouterRepository:
             ON video_jobs (tenant_id, created_at DESC);
         CREATE INDEX IF NOT EXISTS idx_video_jobs_tenant_status
             ON video_jobs (tenant_id, status);
+        CREATE INDEX IF NOT EXISTS idx_audio_jobs_tenant_created
+            ON audio_jobs (tenant_id, created_at DESC);
+        CREATE INDEX IF NOT EXISTS idx_audio_jobs_tenant_status
+            ON audio_jobs (tenant_id, status);
+        CREATE INDEX IF NOT EXISTS idx_realtime_calls_tenant_created
+            ON realtime_calls (tenant_id, created_at DESC);
+        CREATE INDEX IF NOT EXISTS idx_realtime_calls_tenant_status
+            ON realtime_calls (tenant_id, status);
         """
         with self._lock, self._connect() as connection:
+            previous_schema_version = int(
+                connection.execute("PRAGMA user_version").fetchone()[0]
+            )
             connection.executescript(schema)
+            connection_columns = {
+                row["name"]
+                for row in connection.execute(
+                    "PRAGMA table_info(router_connections)"
+                ).fetchall()
+            }
+            if "scopes_json" not in connection_columns:
+                connection.execute(
+                    "ALTER TABLE router_connections "
+                    "ADD COLUMN scopes_json "
+                    """TEXT NOT NULL DEFAULT '["chat"]'"""
+                )
+            if previous_schema_version < 8:
+                connection.execute(
+                    "UPDATE router_connections "
+                    """SET scopes_json = '["chat","audio"]' """
+                    "WHERE kind = 'openrouter'"
+                )
+                connection.execute(
+                    "UPDATE router_connections "
+                    """SET scopes_json = '["chat"]' """
+                    "WHERE kind IN ('newapi', 'openai_compatible')"
+                )
             existing = {
                 row["name"]
                 for row in connection.execute(
@@ -322,8 +406,9 @@ class SQLiteRouterRepository:
                 """
                 INSERT INTO router_connections (
                     id, tenant_id, name, kind, base_url, masked_key,
-                    api_key_ciphertext, enabled, health, created_at, updated_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    api_key_ciphertext, scopes_json, enabled, health,
+                    created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     connection_id,
@@ -333,6 +418,7 @@ class SQLiteRouterRepository:
                     payload.base_url,
                     self._mask(api_key),
                     encrypted,
+                    json.dumps(payload.scopes, separators=(",", ":")),
                     int(payload.enabled),
                     "untested" if payload.enabled else "disabled",
                     now,
@@ -381,6 +467,11 @@ class SQLiteRouterRepository:
             if value is not None:
                 updates.append(f"{field_name} = ?")
                 values.append(value)
+        if payload.scopes is not None:
+            updates.append("scopes_json = ?")
+            values.append(
+                json.dumps(payload.scopes, separators=(",", ":"))
+            )
         if payload.api_key is not None:
             api_key = payload.api_key.get_secret_value().strip()
             if not api_key:
@@ -557,6 +648,8 @@ class SQLiteRouterRepository:
             "router_decisions",
             "compression_runs",
             "video_jobs",
+            "audio_jobs",
+            "realtime_calls",
         )
         with self._lock, self._connect() as connection:
             return {
@@ -736,6 +829,268 @@ class SQLiteRouterRepository:
                 (self._tenant_id(tenant_id), job_id),
             )
         return cursor.rowcount == 1
+
+    def create_audio_job_if_absent(
+        self,
+        tenant_id: str,
+        *,
+        job_id: str,
+        idempotency_key_hash: str,
+        connection_id: str | None,
+        requested_model: str,
+        provider: str,
+        has_image: bool,
+        cost_usd: float | None = None,
+        cost_kind: str = "unavailable",
+    ) -> tuple[dict[str, object], bool]:
+        """Atomically claim an idempotency key before a paid audio call."""
+
+        clean_tenant = self._tenant_id(tenant_id)
+        now = utc_now()
+        with self._lock, self._connect() as connection:
+            cursor = connection.execute(
+                """
+                INSERT OR IGNORE INTO audio_jobs (
+                    id, tenant_id, idempotency_key_hash, connection_id,
+                    requested_model, provider, status, has_image,
+                    cost_usd, cost_kind, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, 'queued', ?, ?, ?, ?, ?)
+                """,
+                (
+                    job_id,
+                    clean_tenant,
+                    idempotency_key_hash,
+                    connection_id,
+                    requested_model,
+                    provider,
+                    int(has_image),
+                    cost_usd,
+                    cost_kind,
+                    now,
+                    now,
+                ),
+            )
+            created = cursor.rowcount == 1
+            row = connection.execute(
+                """
+                SELECT * FROM audio_jobs
+                WHERE tenant_id = ? AND idempotency_key_hash = ?
+                """,
+                (clean_tenant, idempotency_key_hash),
+            ).fetchone()
+        if row is None:
+            raise RouterRepositoryError("audio job idempotency claim failed")
+        return dict(row), created
+
+    def get_audio_job(
+        self, tenant_id: str, job_id: str
+    ) -> dict[str, object] | None:
+        clean_tenant = self._tenant_id(tenant_id)
+        with self._lock, self._connect() as connection:
+            row = connection.execute(
+                """
+                SELECT * FROM audio_jobs
+                WHERE tenant_id = ? AND id = ?
+                """,
+                (clean_tenant, job_id),
+            ).fetchone()
+        return dict(row) if row is not None else None
+
+    def get_audio_job_by_idempotency_hash(
+        self, tenant_id: str, idempotency_key_hash: str
+    ) -> dict[str, object] | None:
+        clean_tenant = self._tenant_id(tenant_id)
+        with self._lock, self._connect() as connection:
+            row = connection.execute(
+                """
+                SELECT * FROM audio_jobs
+                WHERE tenant_id = ? AND idempotency_key_hash = ?
+                """,
+                (clean_tenant, idempotency_key_hash),
+            ).fetchone()
+        return dict(row) if row is not None else None
+
+    def list_audio_jobs(
+        self, tenant_id: str, *, limit: int = 50
+    ) -> list[dict[str, object]]:
+        clean_tenant = self._tenant_id(tenant_id)
+        safe_limit = max(1, min(int(limit), 100))
+        with self._lock, self._connect() as connection:
+            rows = connection.execute(
+                """
+                SELECT * FROM audio_jobs
+                WHERE tenant_id = ?
+                ORDER BY created_at DESC, id DESC
+                LIMIT ?
+                """,
+                (clean_tenant, safe_limit),
+            ).fetchall()
+        return [dict(row) for row in rows]
+
+    def update_audio_job(
+        self,
+        tenant_id: str,
+        job_id: str,
+        **changes: object,
+    ) -> dict[str, object] | None:
+        allowed = {
+            "decision_id",
+            "actual_model",
+            "generation_id",
+            "status",
+            "output_bytes",
+            "cost_usd",
+            "cost_kind",
+            "error_code",
+            "expires_at",
+        }
+        selected = {
+            key: value for key, value in changes.items() if key in allowed
+        }
+        if not selected:
+            return self.get_audio_job(tenant_id, job_id)
+        selected["updated_at"] = utc_now()
+        assignments = ", ".join(f"{key} = ?" for key in selected)
+        values = list(selected.values())
+        values.extend((self._tenant_id(tenant_id), job_id))
+        with self._lock, self._connect() as connection:
+            cursor = connection.execute(
+                f"""
+                UPDATE audio_jobs SET {assignments}
+                WHERE tenant_id = ? AND id = ?
+                """,
+                values,
+            )
+            if cursor.rowcount != 1:
+                return None
+        return self.get_audio_job(tenant_id, job_id)
+
+    def delete_audio_job(self, tenant_id: str, job_id: str) -> bool:
+        with self._lock, self._connect() as connection:
+            cursor = connection.execute(
+                """
+                DELETE FROM audio_jobs
+                WHERE tenant_id = ? AND id = ?
+                """,
+                (self._tenant_id(tenant_id), job_id),
+            )
+        return cursor.rowcount == 1
+
+    def create_realtime_call(
+        self,
+        tenant_id: str,
+        *,
+        session_id: str,
+        decision_id: str | None,
+        connection_id: str,
+        model_id: str,
+        provider: str,
+        voice: str,
+        vad_mode: str,
+        language: str,
+        expires_at: str,
+    ) -> dict[str, object]:
+        clean_tenant = self._tenant_id(tenant_id)
+        now = utc_now()
+        with self._lock, self._connect() as connection:
+            connection.execute(
+                """
+                INSERT INTO realtime_calls (
+                    id, tenant_id, decision_id, connection_id, model_id,
+                    provider, voice, vad_mode, language, status, expires_at,
+                    created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'connecting', ?, ?, ?)
+                """,
+                (
+                    session_id,
+                    clean_tenant,
+                    decision_id,
+                    connection_id,
+                    model_id,
+                    provider,
+                    voice,
+                    vad_mode,
+                    language,
+                    expires_at,
+                    now,
+                    now,
+                ),
+            )
+        row = self.get_realtime_call(clean_tenant, session_id)
+        if row is None:
+            raise RouterRepositoryError("realtime call creation failed")
+        return row
+
+    def get_realtime_call(
+        self,
+        tenant_id: str,
+        session_id: str,
+    ) -> dict[str, object] | None:
+        clean_tenant = self._tenant_id(tenant_id)
+        with self._lock, self._connect() as connection:
+            row = connection.execute(
+                """
+                SELECT * FROM realtime_calls
+                WHERE tenant_id = ? AND id = ?
+                """,
+                (clean_tenant, session_id),
+            ).fetchone()
+        return dict(row) if row is not None else None
+
+    def list_active_realtime_calls(
+        self,
+        tenant_id: str,
+    ) -> list[dict[str, object]]:
+        clean_tenant = self._tenant_id(tenant_id)
+        with self._lock, self._connect() as connection:
+            rows = connection.execute(
+                """
+                SELECT * FROM realtime_calls
+                WHERE tenant_id = ? AND status IN ('connecting', 'active')
+                ORDER BY created_at ASC, id ASC
+                """,
+                (clean_tenant,),
+            ).fetchall()
+        return [dict(row) for row in rows]
+
+    def update_realtime_call(
+        self,
+        tenant_id: str,
+        session_id: str,
+        **changes: object,
+    ) -> dict[str, object] | None:
+        allowed = {
+            "upstream_call_id",
+            "status",
+            "started_at",
+            "ended_at",
+            "duration_seconds",
+            "input_tokens",
+            "output_tokens",
+            "cost_usd",
+            "cost_kind",
+            "error_code",
+        }
+        selected = {
+            key: value for key, value in changes.items() if key in allowed
+        }
+        if not selected:
+            return self.get_realtime_call(tenant_id, session_id)
+        selected["updated_at"] = utc_now()
+        assignments = ", ".join(f"{key} = ?" for key in selected)
+        values = list(selected.values())
+        values.extend((self._tenant_id(tenant_id), session_id))
+        with self._lock, self._connect() as connection:
+            cursor = connection.execute(
+                f"""
+                UPDATE realtime_calls SET {assignments}
+                WHERE tenant_id = ? AND id = ?
+                """,
+                values,
+            )
+            if cursor.rowcount != 1:
+                return None
+        return self.get_realtime_call(tenant_id, session_id)
 
     def get_candidate_stats(
         self,
@@ -1221,13 +1576,29 @@ class SQLiteRouterRepository:
 
     @staticmethod
     def _public_connection(row: sqlite3.Row) -> RouterConnection:
+        kind = row["kind"]
+        try:
+            decoded_scopes = json.loads(row["scopes_json"])
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+            decoded_scopes = default_connection_scopes(kind)
+        if not isinstance(decoded_scopes, list):
+            decoded_scopes = default_connection_scopes(kind)
+        scopes = normalize_connection_scopes(
+            [
+                scope
+                for scope in decoded_scopes
+                if scope in {"chat", "audio", "realtime"}
+            ],
+            kind=kind,
+        )
         return RouterConnection(
             id=row["id"],
             tenant_id=row["tenant_id"],
             name=row["name"],
-            kind=row["kind"],
+            kind=kind,
             base_url=row["base_url"],
             masked_key=row["masked_key"],
+            scopes=scopes,
             enabled=bool(row["enabled"]),
             health=row["health"],
             model_count=row["model_count"],

--- a/server/model_router/schemas.py
+++ b/server/model_router/schemas.py
@@ -2,15 +2,50 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, Field, SecretStr, field_validator
+from pydantic import BaseModel, Field, SecretStr, field_validator, model_validator
 
 
 TenantId = str
 RouterEngine = Literal["sidecar", "shadow", "native_canary", "native"]
 RoutingMode = Literal["auto", "fast", "quality", "cheap", "reliable", "offline"]
 CompressionMode = Literal["auto", "off", "standard", "strong"]
-ConnectionKind = Literal["openrouter", "newapi", "openai_compatible"]
+ConnectionKind = Literal[
+    "openrouter",
+    "newapi",
+    "openai_compatible",
+    "openai",
+]
+ConnectionScope = Literal["chat", "audio", "realtime"]
 ConnectionHealth = Literal["untested", "online", "offline", "disabled"]
+CONNECTION_SCOPE_ORDER: tuple[ConnectionScope, ...] = (
+    "chat",
+    "audio",
+    "realtime",
+)
+
+
+def default_connection_scopes(kind: ConnectionKind) -> list[ConnectionScope]:
+    if kind == "openrouter":
+        return ["chat", "audio"]
+    if kind == "openai":
+        return ["audio", "realtime"]
+    return ["chat"]
+
+
+def normalize_connection_scopes(
+    values: list[ConnectionScope] | None,
+    *,
+    kind: ConnectionKind | None = None,
+) -> list[ConnectionScope]:
+    requested = values or (
+        default_connection_scopes(kind) if kind is not None else []
+    )
+    normalized = [
+        scope for scope in CONNECTION_SCOPE_ORDER if scope in requested
+    ]
+    if not normalized:
+        raise ValueError("at least one connection scope is required")
+    return normalized
 
 
 def _required_text(value: str, *, field_name: str, limit: int) -> str:
@@ -27,6 +62,7 @@ class RouterConnectionCreate(BaseModel):
     kind: ConnectionKind
     base_url: str = Field(min_length=1, max_length=2048)
     api_key: SecretStr
+    scopes: list[ConnectionScope] = Field(default_factory=list, max_length=3)
     enabled: bool = True
 
     @field_validator("name")
@@ -48,11 +84,23 @@ class RouterConnectionCreate(BaseModel):
             raise ValueError("api_key exceeds 20000 characters")
         return value
 
+    @model_validator(mode="after")
+    def validate_scopes(self) -> "RouterConnectionCreate":
+        self.scopes = normalize_connection_scopes(
+            self.scopes,
+            kind=self.kind,
+        )
+        return self
+
 
 class RouterConnectionUpdate(BaseModel):
     name: str | None = Field(default=None, min_length=1, max_length=120)
     base_url: str | None = Field(default=None, min_length=1, max_length=2048)
     api_key: SecretStr | None = None
+    scopes: list[ConnectionScope] | None = Field(
+        default=None,
+        max_length=3,
+    )
     enabled: bool | None = None
 
     @field_validator("name")
@@ -69,6 +117,16 @@ class RouterConnectionUpdate(BaseModel):
             return None
         return _required_text(value, field_name="base_url", limit=2048)
 
+    @field_validator("scopes")
+    @classmethod
+    def validate_scopes(
+        cls,
+        value: list[ConnectionScope] | None,
+    ) -> list[ConnectionScope] | None:
+        if value is None:
+            return None
+        return normalize_connection_scopes(value)
+
 
 class RouterConnection(BaseModel):
     id: str
@@ -77,6 +135,7 @@ class RouterConnection(BaseModel):
     kind: ConnectionKind
     base_url: str
     masked_key: str
+    scopes: list[ConnectionScope]
     enabled: bool
     health: ConnectionHealth
     model_count: int = 0

--- a/server/model_router/service.py
+++ b/server/model_router/service.py
@@ -14,6 +14,7 @@ from .repository import (
     utc_now,
 )
 from .schemas import (
+    ConnectionScope,
     ConnectionTestResult,
     RouterConnection,
     RouterConnectionCreate,
@@ -73,8 +74,19 @@ class ModelRouterService:
             )
         )
 
-    def list_connections(self) -> list[RouterConnection]:
-        return self.repository.list_connections(self.tenant_id)
+    def list_connections(
+        self,
+        *,
+        scope: ConnectionScope | None = None,
+    ) -> list[RouterConnection]:
+        connections = self.repository.list_connections(self.tenant_id)
+        if scope is None:
+            return connections
+        return [
+            connection
+            for connection in connections
+            if scope in connection.scopes
+        ]
 
     def create_connection(
         self, payload: RouterConnectionCreate
@@ -140,6 +152,8 @@ class ModelRouterService:
                 "该模型服务已停用。",
                 status_code=409,
             )
+        if "chat" not in connection.scopes:
+            return self._scope_mismatch_result(connection), []
         api_key = self.repository.resolve_api_key(self.tenant_id, connection_id)
         result, model_ids, _ = await self._probe_with_models(
             connection.base_url, api_key
@@ -167,6 +181,8 @@ class ModelRouterService:
                 "该模型服务已停用。",
                 status_code=409,
             )
+        if "chat" not in connection.scopes:
+            return self._scope_mismatch_result(connection), []
         api_key = self.repository.resolve_api_key(self.tenant_id, connection_id)
         result, _, records = await self._probe_with_models(
             connection.base_url, api_key
@@ -221,7 +237,7 @@ class ModelRouterService:
         return self.repository.save_policy(self.tenant_id, policy)
 
     def status(self) -> RouterStatus:
-        connections = self.list_connections()
+        connections = self.list_connections(scope="chat")
         online = [item for item in connections if item.health == "online"]
         policy = self.get_policy()
         return RouterStatus(
@@ -410,6 +426,19 @@ class ModelRouterService:
         if "限流" in message:
             return "rate_limited"
         return "unreachable"
+
+    @staticmethod
+    def _scope_mismatch_result(
+        connection: RouterConnection,
+    ) -> ConnectionTestResult:
+        return ConnectionTestResult(
+            ok=False,
+            health=connection.health,
+            model_count=0,
+            models_preview=[],
+            message="该连接未启用普通模型调用，不会进入智能调度。",
+            checked_at=utc_now(),
+        )
 
 
 def translate_repository_error(exc: Exception) -> RouterServiceError:

--- a/server/multimodal/api.py
+++ b/server/multimodal/api.py
@@ -7,7 +7,15 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Literal
 
-from fastapi import APIRouter, File, Form, HTTPException, Response, UploadFile
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    File,
+    Form,
+    HTTPException,
+    Response,
+    UploadFile,
+)
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
@@ -20,10 +28,23 @@ from .audio_catalog import (
     AudioCatalogService,
     AudioModelCatalogResponse,
 )
+from .audio_jobs import (
+    MAX_AUDIO_JOB_IMAGE_BYTES,
+    AudioJob,
+    AudioJobDeleteResult,
+    AudioJobList,
+    AudioJobService,
+)
 from .chat_attachments import (
     ChatAttachmentDeleteResponse,
     ChatAttachmentResponse,
     ChatAttachmentStore,
+)
+from .realtime import (
+    RealtimeCallEndResponse,
+    RealtimeCallRequest,
+    RealtimeCallResponse,
+    RealtimeVoiceService,
 )
 from .stt import (
     MAX_AUDIO_BYTES,
@@ -73,7 +94,7 @@ class SpeechRequest(BaseModel):
     model_id: str = Field(min_length=1, max_length=256)
     input: str = Field(min_length=1, max_length=4_000)
     voice: str = Field(min_length=1, max_length=128)
-    response_format: Literal["mp3"] = "mp3"
+    response_format: Literal["mp3", "wav"] = "mp3"
     speed: float = Field(default=1.0, ge=0.5, le=2.0)
 
 
@@ -97,7 +118,7 @@ class VideoAnalysisResponse(BaseModel):
 
 @asynccontextmanager
 async def _multimodal_lifespan(_: object) -> AsyncIterator[None]:
-    enabled = any(
+    attachments_enabled = any(
         os.getenv(name, "false").strip().lower()
         in {"1", "true", "yes", "on"}
         for name in (
@@ -105,12 +126,34 @@ async def _multimodal_lifespan(_: object) -> AsyncIterator[None]:
             "MULTIMODAL_CHAT_VIDEO_ENABLED",
         )
     )
-    store = get_chat_attachment_store() if enabled else None
+    audio_jobs_enabled = (
+        os.getenv("MULTIMODAL_AUDIO_GENERATION_ENABLED", "false")
+        .strip()
+        .lower()
+        in {"1", "true", "yes", "on"}
+    )
+    store = get_chat_attachment_store() if attachments_enabled else None
+    audio_jobs = get_audio_job_service() if audio_jobs_enabled else None
+    realtime_enabled = (
+        os.getenv("MULTIMODAL_REALTIME_VOICE_ENABLED", "false")
+        .strip()
+        .lower()
+        in {"1", "true", "yes", "on"}
+    )
+    realtime = get_realtime_voice_service() if realtime_enabled else None
     if store is not None:
         await asyncio.to_thread(store.cleanup_expired)
+    if audio_jobs is not None:
+        await asyncio.to_thread(audio_jobs.recover_interrupted)
+    if realtime is not None:
+        await realtime.recover_active()
     try:
         yield
     finally:
+        if realtime is not None:
+            await realtime.shutdown()
+            if _realtime_voice_service is realtime:
+                configure_realtime_voice_service(None)
         if store is not None and _chat_attachment_store is store:
             configure_chat_attachment_store(None)
 
@@ -123,6 +166,8 @@ router = APIRouter(
 _transcription_service: TranscriptionService | None = None
 _speech_service: SpeechService | None = None
 _audio_catalog_service: AudioCatalogService | None = None
+_audio_job_service: AudioJobService | None = None
+_realtime_voice_service: RealtimeVoiceService | None = None
 _chat_attachment_store: ChatAttachmentStore | None = None
 _video_catalog_service: VideoCatalogService | None = None
 _video_analysis_service: VideoAnalysisService | None = None
@@ -171,6 +216,37 @@ def get_audio_catalog_service() -> AudioCatalogService:
             get_model_router_service()
         )
     return _audio_catalog_service
+
+
+def configure_audio_job_service(service: AudioJobService | None) -> None:
+    global _audio_job_service
+    _audio_job_service = service
+
+
+def get_audio_job_service() -> AudioJobService:
+    global _audio_job_service
+    if _audio_job_service is None:
+        _audio_job_service = AudioJobService(
+            get_model_router_service(),
+            get_audio_catalog_service(),
+        )
+    return _audio_job_service
+
+
+def configure_realtime_voice_service(
+    service: RealtimeVoiceService | None,
+) -> None:
+    global _realtime_voice_service
+    _realtime_voice_service = service
+
+
+def get_realtime_voice_service() -> RealtimeVoiceService:
+    global _realtime_voice_service
+    if _realtime_voice_service is None:
+        _realtime_voice_service = RealtimeVoiceService(
+            get_model_router_service()
+        )
+    return _realtime_voice_service
 
 
 def configure_chat_attachment_store(
@@ -242,8 +318,128 @@ def get_video_job_service() -> VideoJobService:
 
 
 @router.get("/audio/models", response_model=AudioModelCatalogResponse)
-async def get_audio_models() -> AudioModelCatalogResponse:
-    return await get_audio_catalog_service().get_catalog()
+async def get_audio_models(
+    refresh: bool = False,
+) -> AudioModelCatalogResponse:
+    return await get_audio_catalog_service().get_catalog(force=refresh)
+
+
+@router.post(
+    "/realtime/calls",
+    response_model=RealtimeCallResponse,
+)
+async def create_realtime_call(
+    payload: RealtimeCallRequest,
+) -> RealtimeCallResponse:
+    try:
+        return await get_realtime_voice_service().create(payload)
+    except MultimodalServiceError as exc:
+        raise _http_error(exc) from exc
+
+
+@router.delete(
+    "/realtime/calls/{session_id}",
+    response_model=RealtimeCallEndResponse,
+)
+async def end_realtime_call(
+    session_id: str,
+) -> RealtimeCallEndResponse:
+    try:
+        return await get_realtime_voice_service().end(session_id)
+    except MultimodalServiceError as exc:
+        raise _http_error(exc) from exc
+
+
+@router.post("/audio/jobs", response_model=AudioJob)
+async def create_audio_job(
+    background_tasks: BackgroundTasks,
+    model_id: str = Form(...),
+    prompt: str = Form(...),
+    idempotency_key: str = Form(...),
+    image: UploadFile | None = File(default=None),
+) -> AudioJob:
+    try:
+        image_content = (
+            await image.read(MAX_AUDIO_JOB_IMAGE_BYTES + 1)
+            if image is not None
+            else None
+        )
+        launch = await get_audio_job_service().create(
+            model_id=model_id,
+            prompt=prompt,
+            idempotency_key=idempotency_key,
+            image_filename=image.filename if image is not None else None,
+            image_content_type=(
+                image.content_type if image is not None else None
+            ),
+            image_content=image_content,
+        )
+        if launch.task is not None:
+            background_tasks.add_task(
+                get_audio_job_service().run,
+                launch.task,
+            )
+        return launch.job
+    except MultimodalServiceError as exc:
+        raise _http_error(exc) from exc
+    finally:
+        if image is not None:
+            await image.close()
+
+
+@router.get("/audio/jobs", response_model=AudioJobList)
+async def list_audio_jobs(limit: int = 50) -> AudioJobList:
+    try:
+        return await asyncio.to_thread(
+            get_audio_job_service().list,
+            limit=limit,
+        )
+    except MultimodalServiceError as exc:
+        raise _http_error(exc) from exc
+
+
+@router.get("/audio/jobs/{job_id}", response_model=AudioJob)
+async def get_audio_job(job_id: str) -> AudioJob:
+    try:
+        return await asyncio.to_thread(
+            get_audio_job_service().get,
+            job_id,
+        )
+    except MultimodalServiceError as exc:
+        raise _http_error(exc) from exc
+
+
+@router.get("/audio/jobs/{job_id}/content")
+async def get_audio_job_content(job_id: str) -> StreamingResponse:
+    try:
+        content = await get_audio_job_service().content(job_id)
+    except MultimodalServiceError as exc:
+        raise _http_error(exc) from exc
+    return StreamingResponse(
+        content.chunks,
+        media_type=content.media_type,
+        headers={
+            "Content-Disposition": (
+                'attachment; filename="modelmirror-music.mp3"'
+            ),
+            "Content-Length": str(content.content_length),
+            "X-Content-Type-Options": "nosniff",
+        },
+    )
+
+
+@router.delete(
+    "/audio/jobs/{job_id}",
+    response_model=AudioJobDeleteResult,
+)
+async def delete_audio_job(job_id: str) -> AudioJobDeleteResult:
+    try:
+        return await asyncio.to_thread(
+            get_audio_job_service().delete,
+            job_id,
+        )
+    except MultimodalServiceError as exc:
+        raise _http_error(exc) from exc
 
 
 @router.post(
@@ -551,9 +747,11 @@ def _response(result: TranscriptionResult) -> TranscriptionResponse:
 
 
 def _speech_response(result: SpeechResult) -> Response:
+    response_format = result.response_format
+    media_type = "audio/wav" if response_format == "wav" else "audio/mpeg"
     headers = {
         "Content-Disposition": (
-            'attachment; filename="modelmirror-speech.mp3"'
+            f'attachment; filename="modelmirror-speech.{response_format}"'
         ),
         "X-ModelMirror-Request-Id": result.request_id,
         "X-ModelMirror-Actual-Model": result.actual_model,
@@ -565,7 +763,7 @@ def _speech_response(result: SpeechResult) -> Response:
         headers["X-ModelMirror-Generation-Id"] = result.generation_id
     return Response(
         content=result.content,
-        media_type="audio/mpeg",
+        media_type=media_type,
         headers=headers,
     )
 

--- a/server/multimodal/audio_catalog.py
+++ b/server/multimodal/audio_catalog.py
@@ -4,6 +4,7 @@ import asyncio
 import os
 import time
 from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, Literal
 
@@ -11,27 +12,31 @@ import httpx
 from pydantic import BaseModel, Field
 
 try:
+    from server.model_router.schemas import RouterConnection
     from server.model_router.service import ModelRouterService
 except ModuleNotFoundError:
+    from model_router.schemas import RouterConnection
     from model_router.service import ModelRouterService
 
-from .stt import ALLOWED_AUDIO_FORMATS, MultimodalServiceError, OpenRouterTarget
-from .tts import ALLOWED_SPEECH_PROFILES
+from .stt import (
+    ALLOWED_AUDIO_FORMATS,
+    VERIFIED_TRANSCRIPTION_PROFILES,
+    MultimodalServiceError,
+    OpenRouterTarget,
+)
+from .tts import ALLOWED_SPEECH_PROFILES, speech_output_format
 
 
 AUDIO_CATALOG_TTL_SECONDS = 300.0
 AUDIO_CATALOG_STALE_SECONDS = 1_800.0
+AUDIO_PROFILE_REGISTRY_VERSION = "modelmirror-audio-contracts-2026-07-29-b10"
 
-VERIFIED_NATIVE_AUDIO_MODELS = {
-    "openai/gpt-audio",
-    "openai/gpt-audio-mini",
-}
 NATIVE_AUDIO_VOICES = (
     "alloy",
     "echo",
     "fable",
-    "onyx",
     "nova",
+    "onyx",
     "shimmer",
 )
 DIRECT_AUDIO_INPUT_FORMATS = (
@@ -43,6 +48,16 @@ DIRECT_AUDIO_INPUT_FORMATS = (
     "ogg",
 )
 
+AudioProvider = Literal["openrouter", "openai"]
+AudioCatalogSource = Literal["openrouter", "openai", "mixed"]
+AudioModelOperation = Literal[
+    "transcribe",
+    "synthesize_speech",
+    "analyze_audio",
+    "generate_audio",
+    "realtime_voice",
+    "clone_voice",
+]
 AudioChatMode = Literal[
     "direct_audio_input",
     "native_streaming_audio_output",
@@ -51,22 +66,215 @@ AudioChatMode = Literal[
 ]
 
 
+@dataclass(frozen=True)
+class AudioContract:
+    operations: tuple[AudioModelOperation, ...]
+    chat_modes: tuple[AudioChatMode, ...] = ()
+    input_formats: tuple[str, ...] = ()
+    output_formats: tuple[str, ...] = ()
+    voices: tuple[str, ...] = ()
+    supports_streaming_input: bool = False
+    supports_streaming_output: bool = False
+    supports_image_prompt: bool = False
+    price_per_generation_usd: float | None = None
+    fixed_duration_seconds: int | None = None
+    behavior_verified: bool = False
+    planned_reason: str | None = None
+
+
+OPENROUTER_AUDIO_CONTRACTS: dict[str, AudioContract] = {
+    "openai/gpt-audio": AudioContract(
+        operations=("analyze_audio",),
+        chat_modes=(
+            "direct_audio_input",
+            "native_streaming_audio_output",
+        ),
+        input_formats=DIRECT_AUDIO_INPUT_FORMATS,
+        output_formats=("mp3",),
+        voices=NATIVE_AUDIO_VOICES,
+        supports_streaming_output=True,
+        behavior_verified=True,
+    ),
+    "openai/gpt-audio-mini": AudioContract(
+        operations=("analyze_audio",),
+        chat_modes=(
+            "direct_audio_input",
+            "native_streaming_audio_output",
+        ),
+        input_formats=DIRECT_AUDIO_INPUT_FORMATS,
+        output_formats=("mp3",),
+        voices=NATIVE_AUDIO_VOICES,
+        supports_streaming_output=True,
+        behavior_verified=True,
+    ),
+    "google/gemini-3.6-flash": AudioContract(
+        operations=("analyze_audio",),
+        chat_modes=("direct_audio_input",),
+        input_formats=DIRECT_AUDIO_INPUT_FORMATS,
+        behavior_verified=True,
+    ),
+    "google/gemini-3.5-flash": AudioContract(
+        operations=("analyze_audio",),
+        chat_modes=("direct_audio_input",),
+        input_formats=DIRECT_AUDIO_INPUT_FORMATS,
+        behavior_verified=True,
+    ),
+    "google/gemini-3.5-flash-lite": AudioContract(
+        operations=("analyze_audio",),
+        chat_modes=("direct_audio_input",),
+        input_formats=DIRECT_AUDIO_INPUT_FORMATS,
+        behavior_verified=True,
+    ),
+    "mistralai/voxtral-small-24b-2507": AudioContract(
+        operations=("analyze_audio",),
+        chat_modes=("direct_audio_input",),
+        input_formats=("wav", "mp3", "m4a", "flac", "ogg"),
+        behavior_verified=True,
+    ),
+    "meta/muse-spark-1.1": AudioContract(
+        operations=("analyze_audio",),
+        planned_reason="实时行为探针返回供应商不可用，暂不开放。",
+    ),
+    "openrouter/auto": AudioContract(
+        operations=("analyze_audio",),
+        planned_reason="智能调度的音频必须先转写，再进入模型选择。",
+    ),
+    "openrouter/auto-beta": AudioContract(
+        operations=("analyze_audio",),
+        planned_reason="智能调度的音频必须先转写，再进入模型选择。",
+    ),
+    "google/lyria-3-clip-preview": AudioContract(
+        operations=("generate_audio",),
+        output_formats=("mp3",),
+        supports_image_prompt=True,
+        price_per_generation_usd=0.04,
+        fixed_duration_seconds=30,
+        behavior_verified=True,
+    ),
+    "google/lyria-3-pro-preview": AudioContract(
+        operations=("generate_audio",),
+        output_formats=("mp3",),
+        supports_image_prompt=True,
+        price_per_generation_usd=0.08,
+        behavior_verified=True,
+    ),
+}
+for _model_id in (
+    "google/gemini-2.5-flash",
+    "google/gemini-2.5-flash-lite",
+    "google/gemini-2.5-pro",
+    "google/gemini-2.5-pro-preview",
+    "google/gemini-2.5-pro-preview-05-06",
+    "google/gemini-3.1-flash-lite",
+    "google/gemini-3.1-flash-lite-preview",
+    "google/gemini-3.1-pro-preview",
+    "google/gemini-3.1-pro-preview-customtools",
+    "google/gemini-3-flash-preview",
+    "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free",
+    "thinkingmachines/inkling",
+    "xiaomi/mimo-v2.5",
+):
+    OPENROUTER_AUDIO_CONTRACTS.setdefault(
+        _model_id,
+        AudioContract(
+            operations=("analyze_audio",),
+            chat_modes=("direct_audio_input",),
+            input_formats=("wav",),
+            behavior_verified=True,
+        ),
+    )
+for _model_id, _profile in VERIFIED_TRANSCRIPTION_PROFILES.items():
+    OPENROUTER_AUDIO_CONTRACTS.setdefault(
+        _model_id,
+        AudioContract(
+            operations=("transcribe",),
+            chat_modes=("transcribe",),
+            input_formats=_profile.input_formats,
+            behavior_verified=True,
+        ),
+    )
+for _model_id, _voices in ALLOWED_SPEECH_PROFILES.items():
+    OPENROUTER_AUDIO_CONTRACTS.setdefault(
+        _model_id,
+        AudioContract(
+            operations=("synthesize_speech",),
+            chat_modes=("synthesize_speech",),
+            output_formats=(speech_output_format(_model_id),),
+            voices=_voices,
+            behavior_verified=True,
+        ),
+    )
+
+OPENAI_AUDIO_CONTRACTS: dict[str, AudioContract] = {
+    "gpt-realtime-2.1-mini": AudioContract(
+        operations=("realtime_voice",),
+        input_formats=("webrtc",),
+        output_formats=("webrtc",),
+        voices=("marin", "cedar"),
+        supports_streaming_input=True,
+        supports_streaming_output=True,
+        behavior_verified=True,
+    ),
+    "gpt-realtime-2.1": AudioContract(
+        operations=("realtime_voice",),
+        input_formats=("webrtc",),
+        output_formats=("webrtc",),
+        voices=("marin", "cedar"),
+        supports_streaming_input=True,
+        supports_streaming_output=True,
+        behavior_verified=True,
+    ),
+    "gpt-4o-mini-tts": AudioContract(
+        operations=("synthesize_speech", "clone_voice"),
+        output_formats=("mp3",),
+        voices=(
+            "alloy",
+            "ash",
+            "ballad",
+            "coral",
+            "echo",
+            "fable",
+            "marin",
+            "nova",
+            "onyx",
+            "sage",
+            "shimmer",
+            "verse",
+        ),
+        planned_reason=(
+            "直接 OpenAI 语音合成尚未开放；"
+            "临时声音克隆因上游无法验证删除而保持关闭。"
+        ),
+    ),
+}
+
+
 class AudioChatProfile(BaseModel):
     model_id: str
     display_name: str
+    provider: AudioProvider
+    connection_id: str | None = None
     invocable: bool
     interaction_status: Literal["ready", "planned", "disabled"]
+    status_reason: str | None = None
+    operations: list[AudioModelOperation] = Field(default_factory=list)
     chat_modes: list[AudioChatMode] = Field(default_factory=list)
     input_formats: list[str] = Field(default_factory=list)
     output_formats: list[str] = Field(default_factory=list)
     voices: list[str] = Field(default_factory=list)
+    supports_streaming_input: bool = False
+    supports_streaming_output: bool = False
+    supports_image_prompt: bool = False
+    price_per_generation_usd: float | None = None
+    fixed_duration_seconds: int | None = None
 
 
 class AudioModelCatalogResponse(BaseModel):
-    source: Literal["openrouter"]
+    source: AudioCatalogSource
     status: Literal["online", "stale", "offline", "disabled"]
     stale: bool
     synced_at: str | None
+    catalog_version: str = AUDIO_PROFILE_REGISTRY_VERSION
     microphone_enabled: bool = False
     profiles: list[AudioChatProfile] = Field(default_factory=list)
 
@@ -75,10 +283,12 @@ class _CachedAudioCatalog:
     def __init__(
         self,
         profiles: list[AudioChatProfile],
+        source: AudioCatalogSource,
         synced_at: str,
         stored_at: float,
     ) -> None:
         self.profiles = profiles
+        self.source = source
         self.synced_at = synced_at
         self.stored_at = stored_at
 
@@ -104,7 +314,21 @@ class AudioCatalogService:
         streaming_enabled = self._enabled(
             "MULTIMODAL_STREAMING_AUDIO_ENABLED"
         )
-        if not chat_enabled and not streaming_enabled:
+        generation_enabled = self._enabled(
+            "MULTIMODAL_AUDIO_GENERATION_ENABLED"
+        )
+        realtime_enabled = self._enabled(
+            "MULTIMODAL_REALTIME_VOICE_ENABLED"
+        )
+        future_audio_enabled = any(
+            self._enabled(name)
+            for name in (
+                "MULTIMODAL_AUDIO_GENERATION_ENABLED",
+                "MULTIMODAL_REALTIME_VOICE_ENABLED",
+                "MULTIMODAL_VOICE_CLONING_ENABLED",
+            )
+        )
+        if not chat_enabled and not streaming_enabled and not future_audio_enabled:
             return AudioModelCatalogResponse(
                 source="openrouter",
                 status="disabled",
@@ -135,10 +359,11 @@ class AudioCatalogService:
             ):
                 return self._response(cached, stale=False)
             try:
-                profiles = await self._fetch(
-                    self.resolve_target(),
+                profiles, source, partial_failure = await self._fetch_all(
                     chat_enabled=chat_enabled,
                     streaming_enabled=streaming_enabled,
+                    generation_enabled=generation_enabled,
+                    realtime_enabled=realtime_enabled,
                 )
             except (MultimodalServiceError, httpx.HTTPError, ValueError):
                 if (
@@ -158,97 +383,314 @@ class AudioCatalogService:
                     profiles=[],
                 )
 
+            if (
+                partial_failure
+                and cached is not None
+                and now - cached.stored_at <= AUDIO_CATALOG_STALE_SECONDS
+            ):
+                return self._response(cached, stale=True)
             synced_at = datetime.now(UTC).isoformat()
-            self._cache = _CachedAudioCatalog(profiles, synced_at, now)
+            self._cache = _CachedAudioCatalog(
+                profiles,
+                source,
+                synced_at,
+                now,
+            )
             return self._response(self._cache, stale=False)
 
-    async def _fetch(
+    async def _fetch_all(
         self,
+        *,
+        chat_enabled: bool,
+        streaming_enabled: bool,
+        generation_enabled: bool,
+        realtime_enabled: bool,
+    ) -> tuple[list[AudioChatProfile], AudioCatalogSource, bool]:
+        targets = self._catalog_targets()
+        if not targets:
+            raise MultimodalServiceError(
+                "audio_connections_not_configured",
+                "尚未配置可用于音频能力的模型服务连接。",
+                status_code=503,
+            )
+        results = await asyncio.gather(
+            *(
+                self._fetch_provider(
+                    provider,
+                    target,
+                    chat_enabled=chat_enabled,
+                    streaming_enabled=streaming_enabled,
+                    generation_enabled=generation_enabled,
+                    realtime_enabled=realtime_enabled,
+                )
+                for provider, target in targets
+            ),
+            return_exceptions=True,
+        )
+        profiles: list[AudioChatProfile] = []
+        successful_sources: set[AudioProvider] = set()
+        partial_failure = False
+        for (provider, _), result in zip(targets, results, strict=True):
+            if isinstance(result, Exception):
+                partial_failure = True
+                continue
+            successful_sources.add(provider)
+            profiles.extend(result)
+        if not successful_sources:
+            raise MultimodalServiceError(
+                "audio_catalog_unavailable",
+                "暂时无法读取音频模型目录，请检查模型服务连接。",
+                status_code=502,
+            )
+
+        unique: dict[tuple[str, str | None, str], AudioChatProfile] = {}
+        for profile in profiles:
+            unique[
+                (profile.provider, profile.connection_id, profile.model_id)
+            ] = profile
+        ordered = sorted(
+            unique.values(),
+            key=lambda profile: (
+                0 if profile.interaction_status == "ready" else 1,
+                0 if profile.interaction_status == "planned" else 1,
+                profile.display_name.casefold(),
+                profile.model_id,
+            ),
+        )
+        source: AudioCatalogSource
+        if len(successful_sources) > 1:
+            source = "mixed"
+        elif "openai" in successful_sources:
+            source = "openai"
+        else:
+            source = "openrouter"
+        return ordered, source, partial_failure
+
+    async def _fetch_provider(
+        self,
+        provider: AudioProvider,
         target: OpenRouterTarget,
         *,
         chat_enabled: bool,
         streaming_enabled: bool,
+        generation_enabled: bool,
+        realtime_enabled: bool,
     ) -> list[AudioChatProfile]:
+        params = (
+            {"output_modalities": "all", "sort": "newest"}
+            if provider == "openrouter"
+            else None
+        )
         async with self.client_factory() as client:
             response = await client.get(
                 self._api_url(target.base_url, "models"),
-                headers=self._headers(target.api_key),
-                params={"output_modalities": "all", "sort": "newest"},
+                headers=self._provider_headers(provider, target.api_key),
+                params=params,
             )
         self._raise_for_status(response)
 
         profiles: list[AudioChatProfile] = []
         for item in self._items(response.json()):
-            model_id = str(item.get("id") or "").strip()
-            if not model_id:
-                continue
-            inputs = self._modalities(item, "input_modalities")
-            outputs = self._modalities(item, "output_modalities")
-            relevant = bool(
-                {"audio"} & inputs
-                or {"audio", "speech", "transcription"} & outputs
+            profile = self._profile_from_item(
+                provider,
+                target.connection_id,
+                item,
+                chat_enabled=chat_enabled,
+                streaming_enabled=streaming_enabled,
+                generation_enabled=generation_enabled,
+                realtime_enabled=realtime_enabled,
             )
-            if not relevant:
-                continue
+            if profile is not None:
+                profiles.append(profile)
+        return profiles
 
-            modes: list[AudioChatMode] = []
-            input_formats: set[str] = set()
-            output_formats: set[str] = set()
-            voices: set[str] = set()
+    def _profile_from_item(
+        self,
+        provider: AudioProvider,
+        connection_id: str | None,
+        item: dict[str, Any],
+        *,
+        chat_enabled: bool,
+        streaming_enabled: bool,
+        generation_enabled: bool,
+        realtime_enabled: bool,
+    ) -> AudioChatProfile | None:
+        model_id = str(item.get("id") or "").strip()
+        if not model_id:
+            return None
+        inputs = self._modalities(item, "input_modalities")
+        outputs = self._modalities(item, "output_modalities")
+        contract = (
+            OPENROUTER_AUDIO_CONTRACTS.get(model_id)
+            if provider == "openrouter"
+            else OPENAI_AUDIO_CONTRACTS.get(model_id)
+        )
+        if provider == "openai" and contract is None:
+            return None
+        if provider == "openrouter" and not (
+            "audio" in inputs
+            or bool({"audio", "speech", "transcription"} & outputs)
+        ):
+            return None
 
-            if chat_enabled:
-                if (
-                    model_id in VERIFIED_NATIVE_AUDIO_MODELS
-                    and "audio" in inputs
-                    and "text" in outputs
-                ):
-                    modes.append("direct_audio_input")
-                    input_formats.update(DIRECT_AUDIO_INPUT_FORMATS)
-                if "transcription" in outputs:
-                    modes.append("transcribe")
-                    input_formats.update(ALLOWED_AUDIO_FORMATS)
-                if (
-                    model_id in ALLOWED_SPEECH_PROFILES
-                    and "speech" in outputs
-                ):
-                    modes.append("synthesize_speech")
-                    output_formats.add("mp3")
-                    voices.update(ALLOWED_SPEECH_PROFILES[model_id])
+        operations = list(contract.operations) if contract else []
+        if "transcription" in outputs and "transcribe" not in operations:
+            operations.append("transcribe")
+        if "speech" in outputs and "synthesize_speech" not in operations:
+            operations.append("synthesize_speech")
+        if (
+            "audio" in inputs
+            and "text" in outputs
+            and "analyze_audio" not in operations
+        ):
+            operations.append("analyze_audio")
+        if (
+            "audio" in outputs
+            and "audio" not in inputs
+            and "generate_audio" not in operations
+        ):
+            operations.append("generate_audio")
+        if not operations:
+            return None
 
-            if (
-                streaming_enabled
-                and model_id in VERIFIED_NATIVE_AUDIO_MODELS
-                and "audio" in outputs
-            ):
-                modes.append("native_streaming_audio_output")
-                output_formats.add("mp3")
-                voices.update(NATIVE_AUDIO_VOICES)
+        chat_modes: list[AudioChatMode] = []
+        input_formats: set[str] = set(
+            contract.input_formats if contract else ()
+        )
+        output_formats: set[str] = set(
+            contract.output_formats if contract else ()
+        )
+        catalog_voices = set(
+            self._string_list(item.get("supported_voices"))
+        )
+        voices: set[str] = set(contract.voices if contract else ())
+        if contract and contract.behavior_verified and voices:
+            if catalog_voices:
+                voices.intersection_update(catalog_voices)
+        else:
+            voices.update(catalog_voices)
+        status_reason: str | None = None
+        operation_ready = False
 
-            profiles.append(
-                AudioChatProfile(
-                    model_id=model_id,
-                    display_name=str(item.get("name") or model_id).strip(),
-                    invocable=True,
-                    interaction_status="ready" if modes else "planned",
-                    chat_modes=modes,
-                    input_formats=sorted(input_formats),
-                    output_formats=sorted(output_formats),
-                    voices=sorted(voices),
-                )
+        if provider == "openrouter" and "transcription" in outputs:
+            input_formats.update(ALLOWED_AUDIO_FORMATS)
+            if contract and contract.behavior_verified and chat_enabled:
+                chat_modes.append("transcribe")
+            elif not contract or not contract.behavior_verified:
+                status_reason = "该转写模型尚未完成格式与语言行为验证。"
+            else:
+                status_reason = "聊天音频功能当前未启用。"
+
+        if contract and contract.behavior_verified:
+            for mode in contract.chat_modes:
+                if mode == "synthesize_speech" and not voices:
+                    status_reason = (
+                        "已验证声线不在实时目录中，请刷新后重新选择模型。"
+                    )
+                    continue
+                if mode == "native_streaming_audio_output":
+                    if streaming_enabled:
+                        chat_modes.append(mode)
+                    continue
+                if chat_enabled:
+                    chat_modes.append(mode)
+            if "generate_audio" in operations:
+                if generation_enabled:
+                    operation_ready = True
+                else:
+                    status_reason = "音乐生成功能当前未启用。"
+            if "realtime_voice" in operations:
+                if realtime_enabled:
+                    operation_ready = True
+                else:
+                    status_reason = "实时语音功能当前未启用。"
+            if not chat_modes:
+                if not operation_ready and status_reason is None:
+                    status_reason = "对应的聊天音频功能当前未启用。"
+        elif contract and contract.planned_reason:
+            status_reason = contract.planned_reason
+        elif "transcribe" in operations:
+            status_reason = "该转写模型尚未完成格式与语言行为验证。"
+        elif "synthesize_speech" in operations:
+            status_reason = "该语音合成模型尚未完成声音与输出格式验证。"
+        elif "analyze_audio" in operations:
+            status_reason = "该音频理解模型尚未完成本地调用验证。"
+        elif "generate_audio" in operations:
+            status_reason = "该音频生成模型尚未完成本地交互适配。"
+
+        if chat_modes or operation_ready:
+            interaction_status: Literal["ready", "planned", "disabled"] = (
+                "ready"
             )
-        return sorted(
-            profiles,
-            key=lambda profile: (
-                0 if profile.interaction_status == "ready" else 1,
-                profile.display_name.casefold(),
-                profile.model_id,
+            status_reason = None
+        elif status_reason and "未启用" in status_reason:
+            interaction_status = "disabled"
+        else:
+            interaction_status = "planned"
+
+        return AudioChatProfile(
+            model_id=model_id,
+            display_name=str(item.get("name") or model_id).strip(),
+            provider=provider,
+            connection_id=connection_id,
+            invocable=True,
+            interaction_status=interaction_status,
+            status_reason=status_reason,
+            operations=operations,
+            chat_modes=list(dict.fromkeys(chat_modes)),
+            input_formats=sorted(input_formats),
+            output_formats=sorted(output_formats),
+            voices=sorted(voices),
+            supports_streaming_input=bool(
+                contract and contract.supports_streaming_input
+            ),
+            supports_streaming_output=bool(
+                contract and contract.supports_streaming_output
+            ),
+            supports_image_prompt=bool(
+                contract and contract.supports_image_prompt
+            ),
+            price_per_generation_usd=(
+                contract.price_per_generation_usd if contract else None
+            ),
+            fixed_duration_seconds=(
+                contract.fixed_duration_seconds if contract else None
             ),
         )
+
+    def _catalog_targets(
+        self,
+    ) -> list[tuple[AudioProvider, OpenRouterTarget]]:
+        targets: list[tuple[AudioProvider, OpenRouterTarget]] = []
+        try:
+            targets.append(("openrouter", self.resolve_target()))
+        except MultimodalServiceError:
+            pass
+
+        openai_connections = [
+            item
+            for item in self.router_service.list_connections()
+            if item.kind == "openai"
+            and item.enabled
+            and item.health != "offline"
+            and bool({"audio", "realtime"} & set(item.scopes))
+        ]
+        openai_connections.sort(
+            key=lambda item: (0 if item.health == "online" else 1, item.id)
+        )
+        if openai_connections:
+            targets.append(
+                (
+                    "openai",
+                    self._target_from_connection(openai_connections[0]),
+                )
+            )
+        return targets
 
     def resolve_target(self) -> OpenRouterTarget:
         connections = [
             item
-            for item in self.router_service.list_connections()
+            for item in self.router_service.list_connections(scope="audio")
             if item.kind == "openrouter"
             and item.enabled
             and item.health != "offline"
@@ -257,24 +699,7 @@ class AudioCatalogService:
             key=lambda item: (0 if item.health == "online" else 1, item.id)
         )
         if connections:
-            connection = connections[0]
-            try:
-                api_key = self.router_service.repository.resolve_api_key(
-                    self.router_service.tenant_id,
-                    connection.id,
-                )
-            except Exception as exc:
-                raise MultimodalServiceError(
-                    "provider_credentials_unavailable",
-                    "无法读取 OpenRouter 连接密钥，请重新保存模型服务连接。",
-                    status_code=503,
-                ) from exc
-            return OpenRouterTarget(
-                base_url=connection.base_url,
-                api_key=api_key,
-                connection_id=connection.id,
-                cache_key=f"connection:{connection.id}",
-            )
+            return self._target_from_connection(connections[0])
 
         api_key = (
             os.getenv("MULTIMODAL_OPENROUTER_API_KEY", "").strip()
@@ -296,6 +721,28 @@ class AudioCatalogService:
             cache_key="environment:openrouter",
         )
 
+    def _target_from_connection(
+        self,
+        connection: RouterConnection,
+    ) -> OpenRouterTarget:
+        try:
+            api_key = self.router_service.repository.resolve_api_key(
+                self.router_service.tenant_id,
+                connection.id,
+            )
+        except Exception as exc:
+            raise MultimodalServiceError(
+                "provider_credentials_unavailable",
+                f"无法读取“{connection.name}”的连接密钥，请重新保存连接。",
+                status_code=503,
+            ) from exc
+        return OpenRouterTarget(
+            base_url=connection.base_url,
+            api_key=api_key,
+            connection_id=connection.id,
+            cache_key=f"connection:{connection.id}",
+        )
+
     @classmethod
     def chat_completions_url(cls, target: OpenRouterTarget) -> str:
         return cls._api_url(target.base_url, "chat/completions")
@@ -307,7 +754,7 @@ class AudioCatalogService:
         stale: bool,
     ) -> AudioModelCatalogResponse:
         return AudioModelCatalogResponse(
-            source="openrouter",
+            source=cached.source,
             status="stale" if stale else "online",
             stale=stale,
             synced_at=cached.synced_at,
@@ -343,17 +790,24 @@ class AudioCatalogService:
         return f"{root}/{path.lstrip('/')}"
 
     @staticmethod
-    def _headers(api_key: str) -> dict[str, str]:
-        title = os.getenv("OPENROUTER_APP_TITLE", "ModelMirror").strip()
-        referer = os.getenv(
-            "OPENROUTER_HTTP_REFERER", "http://localhost:5173"
-        ).strip()
-        return {
-            "Authorization": f"Bearer {api_key}",
-            "HTTP-Referer": referer,
-            "X-Title": title,
-            "X-OpenRouter-Title": title,
-        }
+    def _provider_headers(
+        provider: AudioProvider,
+        api_key: str,
+    ) -> dict[str, str]:
+        headers = {"Authorization": f"Bearer {api_key}"}
+        if provider == "openrouter":
+            title = os.getenv("OPENROUTER_APP_TITLE", "ModelMirror").strip()
+            referer = os.getenv(
+                "OPENROUTER_HTTP_REFERER", "http://localhost:5173"
+            ).strip()
+            headers.update(
+                {
+                    "HTTP-Referer": referer,
+                    "X-Title": title,
+                    "X-OpenRouter-Title": title,
+                }
+            )
+        return headers
 
     @staticmethod
     def _raise_for_status(response: httpx.Response) -> None:
@@ -387,6 +841,16 @@ class AudioCatalogService:
             for value in raw
             if isinstance(value, str) and value.strip()
         }
+
+    @staticmethod
+    def _string_list(value: Any) -> list[str]:
+        if not isinstance(value, list):
+            return []
+        return [
+            str(item).strip()
+            for item in value
+            if isinstance(item, str) and item.strip()
+        ]
 
     @staticmethod
     def _default_client() -> httpx.AsyncClient:

--- a/server/multimodal/audio_jobs.py
+++ b/server/multimodal/audio_jobs.py
@@ -1,0 +1,990 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import binascii
+import hashlib
+import json
+import logging
+import os
+import re
+import tempfile
+import uuid
+from collections.abc import AsyncIterator, Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Literal
+
+import httpx
+from pydantic import BaseModel, Field
+
+try:
+    from server.model_router.service import ModelRouterService
+except ModuleNotFoundError:
+    from model_router.service import ModelRouterService
+
+from .audio_catalog import AudioCatalogService, AudioChatProfile
+from .stt import MultimodalServiceError, OpenRouterTarget
+
+
+logger = logging.getLogger("modelmirror.multimodal")
+
+LYRIA_MODEL_IDS = {
+    "google/lyria-3-clip-preview",
+    "google/lyria-3-pro-preview",
+}
+MAX_AUDIO_GENERATION_PROMPT_CHARS = 4_000
+MAX_AUDIO_JOB_IMAGE_BYTES = 10 * 1024 * 1024
+MAX_GENERATED_AUDIO_BYTES = 25 * 1024 * 1024
+MAX_IDEMPOTENCY_KEY_CHARS = 128
+DEFAULT_AUDIO_JOB_TTL_SECONDS = 30 * 60
+IDEMPOTENCY_KEY_PATTERN = re.compile(r"^[A-Za-z0-9._:-]{8,128}$")
+TERMINAL_AUDIO_JOB_STATUSES = {"succeeded", "failed", "expired"}
+
+AUDIO_JOB_IMAGE_FORMATS: dict[
+    str, tuple[str, tuple[str, ...]]
+] = {
+    "jpg": (
+        "image/jpeg",
+        ("image/jpeg", "image/jpg", "application/octet-stream"),
+    ),
+    "jpeg": (
+        "image/jpeg",
+        ("image/jpeg", "image/jpg", "application/octet-stream"),
+    ),
+    "png": ("image/png", ("image/png", "application/octet-stream")),
+    "webp": ("image/webp", ("image/webp", "application/octet-stream")),
+}
+
+SAFE_AUDIO_JOB_ERRORS: dict[str, str] = {
+    "audio_output_incomplete": (
+        "音乐服务没有返回完整音频，请重新提交；本次不会交付损坏文件。"
+    ),
+    "audio_output_too_large": (
+        "生成音频超过本地安全上限，请缩短创作要求后重新提交。"
+    ),
+    "provider_payment_required": (
+        "当前模型服务余额不足，请充值或更换可用连接后重试。"
+    ),
+    "provider_rate_limited": (
+        "音乐生成请求较多，请稍后重试；不要连续重复提交。"
+    ),
+    "provider_timeout": "音乐生成等待超时，请稍后重新提交。",
+    "provider_unavailable": "音乐生成服务暂时不可用，请稍后重试。",
+    "provider_rejected_request": (
+        "音乐生成请求未被接受，请调整创作描述或图片后重试。"
+    ),
+    "worker_interrupted": (
+        "服务重启中断了本地接收，请重新提交音乐生成任务。"
+    ),
+    "audio_expired": "临时音频已过期，请重新生成后下载。",
+    "generation_failed": "音乐生成未完成，请检查输入后重新提交。",
+}
+
+
+class AudioJobParameters(BaseModel):
+    has_image: bool = False
+
+
+class AudioJobUsage(BaseModel):
+    cost_usd: float | None = None
+    cost_kind: Literal[
+        "actual", "estimated", "unavailable"
+    ] = "unavailable"
+
+
+class AudioJobError(BaseModel):
+    code: str
+    message: str
+
+
+class AudioJob(BaseModel):
+    job_id: str
+    status: Literal["queued", "running", "succeeded", "failed", "expired"]
+    requested_model: str
+    actual_model: str | None = None
+    provider: Literal["openrouter"] = "openrouter"
+    generation_id: str | None = None
+    parameters: AudioJobParameters
+    usage: AudioJobUsage
+    output_bytes: int = 0
+    created_at: str
+    updated_at: str
+    expires_at: str | None = None
+    error: AudioJobError | None = None
+
+
+class AudioJobList(BaseModel):
+    jobs: list[AudioJob] = Field(default_factory=list)
+
+
+class AudioJobDeleteResult(BaseModel):
+    removed: bool
+    upstream_cancelled: Literal[False] = False
+
+
+@dataclass(frozen=True)
+class AudioContent:
+    chunks: AsyncIterator[bytes]
+    media_type: str
+    content_length: int
+
+
+@dataclass(frozen=True)
+class AudioGenerationResult:
+    content: bytes
+    actual_model: str
+    generation_id: str | None
+    cost_usd: float | None
+
+
+@dataclass(frozen=True)
+class AudioJobTask:
+    job_id: str
+    target: OpenRouterTarget
+    model_id: str
+    prompt: str
+    image_data_url: str | None
+
+
+@dataclass(frozen=True)
+class AudioJobLaunch:
+    job: AudioJob
+    task: AudioJobTask | None
+
+
+class OpenRouterAudioJobAdapter:
+    def __init__(
+        self,
+        *,
+        client_factory: Callable[[], httpx.AsyncClient] | None = None,
+    ) -> None:
+        self._client_factory = client_factory or self._default_client
+
+    async def generate(
+        self,
+        target: OpenRouterTarget,
+        *,
+        model_id: str,
+        prompt: str,
+        image_data_url: str | None,
+    ) -> AudioGenerationResult:
+        content: str | list[dict[str, object]] = prompt
+        if image_data_url:
+            content = [
+                {"type": "text", "text": prompt},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": image_data_url},
+                },
+            ]
+        payload = {
+            "model": model_id,
+            "stream": True,
+            "messages": [{"role": "user", "content": content}],
+        }
+
+        encoded_parts: list[str] = []
+        encoded_length = 0
+        actual_model = model_id
+        generation_id: str | None = None
+        finish_reason: str | None = None
+        usage: object = None
+        saw_done = False
+
+        async with self._client_factory() as client:
+            try:
+                async with client.stream(
+                    "POST",
+                    self._api_url(target.base_url),
+                    headers=self._headers(target.api_key),
+                    json=payload,
+                ) as response:
+                    await self._raise_for_status(response)
+                    generation_id = (
+                        response.headers.get("x-generation-id") or None
+                    )
+                    async for line in response.aiter_lines():
+                        if not line or not line.startswith("data: "):
+                            continue
+                        raw = line[6:]
+                        if raw.strip() == "[DONE]":
+                            saw_done = True
+                            continue
+                        try:
+                            item = json.loads(raw)
+                        except ValueError as exc:
+                            raise self._incomplete_error() from exc
+                        if isinstance(item.get("error"), dict):
+                            raise MultimodalServiceError(
+                                "provider_unavailable",
+                                SAFE_AUDIO_JOB_ERRORS["provider_unavailable"],
+                                status_code=502,
+                            )
+                        if isinstance(item.get("model"), str):
+                            actual_model = item["model"]
+                        if isinstance(item.get("id"), str):
+                            generation_id = generation_id or item["id"]
+                        if isinstance(item.get("usage"), dict):
+                            usage = item["usage"]
+                        choices = item.get("choices")
+                        if not isinstance(choices, list) or not choices:
+                            continue
+                        choice = choices[0]
+                        if not isinstance(choice, dict):
+                            continue
+                        if isinstance(choice.get("finish_reason"), str):
+                            finish_reason = choice["finish_reason"]
+                        delta = choice.get("delta")
+                        if not isinstance(delta, dict):
+                            continue
+                        audio = delta.get("audio")
+                        if not isinstance(audio, dict):
+                            continue
+                        data = audio.get("data")
+                        if not isinstance(data, str) or not data:
+                            continue
+                        encoded_length += len(data)
+                        if encoded_length > (MAX_GENERATED_AUDIO_BYTES * 4 // 3 + 16):
+                            raise MultimodalServiceError(
+                                "audio_output_too_large",
+                                SAFE_AUDIO_JOB_ERRORS[
+                                    "audio_output_too_large"
+                                ],
+                                status_code=502,
+                            )
+                        encoded_parts.append(data)
+            except MultimodalServiceError:
+                raise
+            except (
+                httpx.ConnectTimeout,
+                httpx.ReadTimeout,
+                httpx.WriteTimeout,
+                httpx.PoolTimeout,
+            ) as exc:
+                raise MultimodalServiceError(
+                    "provider_timeout",
+                    SAFE_AUDIO_JOB_ERRORS["provider_timeout"],
+                    status_code=504,
+                ) from exc
+            except httpx.HTTPError as exc:
+                raise MultimodalServiceError(
+                    "provider_unavailable",
+                    SAFE_AUDIO_JOB_ERRORS["provider_unavailable"],
+                    status_code=502,
+                ) from exc
+
+        if not saw_done or finish_reason != "stop" or not encoded_parts:
+            raise self._incomplete_error()
+        try:
+            audio_bytes = base64.b64decode(
+                "".join(encoded_parts), validate=True
+            )
+        except (binascii.Error, ValueError) as exc:
+            raise self._incomplete_error() from exc
+        if (
+            len(audio_bytes) < 1_024
+            or len(audio_bytes) > MAX_GENERATED_AUDIO_BYTES
+            or not self._is_mp3(audio_bytes)
+        ):
+            raise self._incomplete_error()
+        return AudioGenerationResult(
+            content=audio_bytes,
+            actual_model=actual_model,
+            generation_id=generation_id,
+            cost_usd=self._cost(usage),
+        )
+
+    @staticmethod
+    def _default_client() -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            timeout=httpx.Timeout(180.0, connect=15.0),
+            follow_redirects=False,
+        )
+
+    @staticmethod
+    def _api_url(base_url: str) -> str:
+        return f"{base_url.rstrip('/')}/chat/completions"
+
+    @staticmethod
+    def _headers(api_key: str) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "Accept": "text/event-stream",
+            "HTTP-Referer": "http://localhost",
+            "X-Title": "ModelMirror audio generation",
+        }
+
+    @staticmethod
+    async def _raise_for_status(response: httpx.Response) -> None:
+        status = response.status_code
+        if status < 400:
+            return
+        await response.aread()
+        if status == 401:
+            raise MultimodalServiceError(
+                "provider_unauthorized",
+                "音乐模型服务密钥无效，请在设置中重新测试连接。",
+                status_code=401,
+            )
+        if status == 402:
+            raise MultimodalServiceError(
+                "provider_payment_required",
+                SAFE_AUDIO_JOB_ERRORS["provider_payment_required"],
+                status_code=402,
+            )
+        if status == 429:
+            raise MultimodalServiceError(
+                "provider_rate_limited",
+                SAFE_AUDIO_JOB_ERRORS["provider_rate_limited"],
+                status_code=429,
+            )
+        if status >= 500:
+            raise MultimodalServiceError(
+                "provider_unavailable",
+                SAFE_AUDIO_JOB_ERRORS["provider_unavailable"],
+                status_code=502,
+            )
+        raise MultimodalServiceError(
+            "provider_rejected_request",
+            SAFE_AUDIO_JOB_ERRORS["provider_rejected_request"],
+            status_code=422,
+        )
+
+    @staticmethod
+    def _cost(usage: object) -> float | None:
+        if not isinstance(usage, dict):
+            return None
+        value = usage.get("cost")
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return max(0.0, float(value))
+        return None
+
+    @staticmethod
+    def _is_mp3(content: bytes) -> bool:
+        return content.startswith(b"ID3") or (
+            len(content) >= 2
+            and content[0] == 0xFF
+            and content[1] & 0xE0 == 0xE0
+        )
+
+    @staticmethod
+    def _incomplete_error() -> MultimodalServiceError:
+        return MultimodalServiceError(
+            "audio_output_incomplete",
+            SAFE_AUDIO_JOB_ERRORS["audio_output_incomplete"],
+            status_code=502,
+        )
+
+
+class AudioJobService:
+    def __init__(
+        self,
+        router_service: ModelRouterService,
+        catalog_service: AudioCatalogService,
+        *,
+        adapter: OpenRouterAudioJobAdapter | None = None,
+        output_dir: str | Path | None = None,
+        ttl_seconds: int = DEFAULT_AUDIO_JOB_TTL_SECONDS,
+    ) -> None:
+        self.router_service = router_service
+        self.catalog_service = catalog_service
+        self.adapter = adapter or OpenRouterAudioJobAdapter()
+        self.output_dir = Path(
+            output_dir
+            or Path(tempfile.gettempdir()) / "modelmirror-audio-jobs"
+        )
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        self.ttl_seconds = max(60, min(int(ttl_seconds), 24 * 60 * 60))
+
+    async def create(
+        self,
+        *,
+        model_id: str,
+        prompt: str,
+        idempotency_key: str,
+        image_filename: str | None = None,
+        image_content_type: str | None = None,
+        image_content: bytes | None = None,
+    ) -> AudioJobLaunch:
+        self._ensure_enabled()
+        clean_model = self._model_id(model_id)
+        clean_prompt = self._prompt(prompt)
+        clean_key = self._idempotency_key(idempotency_key)
+        image_data_url = self._image(
+            image_filename,
+            image_content_type,
+            image_content,
+        )
+        profile = await self._profile(
+            clean_model, has_image=image_data_url is not None
+        )
+        target = self.catalog_service.resolve_target()
+        tenant_id = self.router_service.tenant_id
+        key_hash = hashlib.sha256(
+            f"{tenant_id}\0{clean_key}".encode("utf-8")
+        ).hexdigest()
+        existing = (
+            self.router_service.repository
+            .get_audio_job_by_idempotency_hash(tenant_id, key_hash)
+        )
+        if existing is not None:
+            return AudioJobLaunch(job=self._public(existing), task=None)
+
+        job_id = f"audio_{uuid.uuid4().hex}"
+        row, created = (
+            self.router_service.repository.create_audio_job_if_absent(
+                tenant_id,
+                job_id=job_id,
+                idempotency_key_hash=key_hash,
+                connection_id=target.connection_id,
+                requested_model=clean_model,
+                provider="openrouter",
+                has_image=image_data_url is not None,
+                cost_usd=profile.price_per_generation_usd,
+                cost_kind=(
+                    "estimated"
+                    if profile.price_per_generation_usd is not None
+                    else "unavailable"
+                ),
+            )
+        )
+        if not created:
+            return AudioJobLaunch(job=self._public(row), task=None)
+        try:
+            decision_id = self._record_start(
+                target,
+                model_id=clean_model,
+                input_bytes=(
+                    len(clean_prompt.encode("utf-8"))
+                    + len(image_content or b"")
+                ),
+            )
+        except MultimodalServiceError as exc:
+            self._update(
+                job_id,
+                status="failed",
+                error_code=exc.code,
+            )
+            raise
+        row = self._update(job_id, decision_id=decision_id)
+        return AudioJobLaunch(
+            job=self._public(row),
+            task=AudioJobTask(
+                job_id=job_id,
+                target=target,
+                model_id=clean_model,
+                prompt=clean_prompt,
+                image_data_url=image_data_url,
+            ),
+        )
+
+    async def run(self, task: AudioJobTask) -> None:
+        row = self._update(task.job_id, status="running", error_code=None)
+        if row is None:
+            return
+        decision_id = str(row.get("decision_id") or "")
+        try:
+            result = await self.adapter.generate(
+                task.target,
+                model_id=task.model_id,
+                prompt=task.prompt,
+                image_data_url=task.image_data_url,
+            )
+            await asyncio.to_thread(
+                self._write_output, task.job_id, result.content
+            )
+            expires_at = (
+                datetime.now(UTC) + timedelta(seconds=self.ttl_seconds)
+            ).isoformat()
+            changes: dict[str, object] = {
+                "status": "succeeded",
+                "actual_model": result.actual_model,
+                "generation_id": result.generation_id,
+                "output_bytes": len(result.content),
+                "error_code": None,
+                "expires_at": expires_at,
+            }
+            if result.cost_usd is not None:
+                changes["cost_usd"] = result.cost_usd
+                changes["cost_kind"] = "actual"
+            row = self._update(task.job_id, **changes)
+            if row is None:
+                await asyncio.to_thread(self._remove_output, task.job_id)
+                return
+            self._record_success(
+                decision_id,
+                output_bytes=len(result.content),
+                cost_usd=result.cost_usd,
+            )
+        except MultimodalServiceError as exc:
+            await asyncio.to_thread(self._remove_output, task.job_id)
+            self._update(
+                task.job_id,
+                status="failed",
+                error_code=exc.code,
+            )
+            self._record_failure(decision_id, exc.code)
+        except Exception:
+            logger.exception(
+                "Audio job failed without exposing request content: %s",
+                task.job_id,
+            )
+            await asyncio.to_thread(self._remove_output, task.job_id)
+            self._update(
+                task.job_id,
+                status="failed",
+                error_code="generation_failed",
+            )
+            self._record_failure(decision_id, "generation_failed")
+
+    def list(self, *, limit: int = 50) -> AudioJobList:
+        self.cleanup_expired()
+        rows = self.router_service.repository.list_audio_jobs(
+            self.router_service.tenant_id, limit=limit
+        )
+        return AudioJobList(jobs=[self._public(row) for row in rows])
+
+    def get(self, job_id: str) -> AudioJob:
+        return self._public(self._refresh_expiry(self._row(job_id)))
+
+    async def content(self, job_id: str) -> AudioContent:
+        self._ensure_enabled()
+        row = self._refresh_expiry(self._row(job_id))
+        if str(row["status"]) != "succeeded":
+            raise MultimodalServiceError(
+                "audio_not_ready",
+                "音乐尚未生成完成，请稍后刷新任务状态。",
+                status_code=409,
+            )
+        path = self._output_path(job_id)
+        if not path.is_file():
+            row = self._update(
+                job_id,
+                status="expired",
+                error_code="audio_expired",
+                output_bytes=0,
+            )
+            raise MultimodalServiceError(
+                "audio_expired",
+                SAFE_AUDIO_JOB_ERRORS["audio_expired"],
+                status_code=410,
+            )
+        size = int(path.stat().st_size)
+
+        async def chunks() -> AsyncIterator[bytes]:
+            with path.open("rb") as handle:
+                while True:
+                    chunk = await asyncio.to_thread(handle.read, 64 * 1024)
+                    if not chunk:
+                        break
+                    yield chunk
+
+        return AudioContent(
+            chunks=chunks(),
+            media_type="audio/mpeg",
+            content_length=size,
+        )
+
+    def delete(self, job_id: str) -> AudioJobDeleteResult:
+        self._row(job_id)
+        if not self.router_service.repository.delete_audio_job(
+            self.router_service.tenant_id, job_id
+        ):
+            raise self._not_found()
+        self._remove_output(job_id)
+        return AudioJobDeleteResult(removed=True)
+
+    def cleanup_expired(self) -> None:
+        rows = self.router_service.repository.list_audio_jobs(
+            self.router_service.tenant_id, limit=100
+        )
+        now = datetime.now(UTC)
+        for row in rows:
+            job_id = str(row["id"])
+            status = str(row.get("status") or "")
+            if status in {"queued", "running"}:
+                continue
+            if status != "succeeded":
+                self._remove_output(job_id)
+                continue
+            expires_at = self._datetime(row.get("expires_at"))
+            if (
+                expires_at is None
+                or expires_at <= now
+                or not self._output_path(job_id).is_file()
+            ):
+                self._update(
+                    job_id,
+                    status="expired",
+                    error_code="audio_expired",
+                    output_bytes=0,
+                )
+                self._remove_output(job_id)
+
+    def recover_interrupted(self) -> None:
+        rows = self.router_service.repository.list_audio_jobs(
+            self.router_service.tenant_id, limit=100
+        )
+        for row in rows:
+            if str(row.get("status") or "") not in {"queued", "running"}:
+                continue
+            job_id = str(row["id"])
+            self._update(
+                job_id,
+                status="failed",
+                error_code="worker_interrupted",
+            )
+            self._record_failure(
+                str(row.get("decision_id") or ""),
+                "worker_interrupted",
+            )
+            self._remove_output(job_id)
+        self.cleanup_expired()
+
+    async def _profile(
+        self, model_id: str, *, has_image: bool
+    ) -> AudioChatProfile:
+        catalog = await self.catalog_service.get_catalog(force=False)
+        if catalog.status == "disabled":
+            self._ensure_enabled()
+        if catalog.status == "offline":
+            raise MultimodalServiceError(
+                "audio_catalog_unavailable",
+                "暂时无法确认音乐模型能力，请检查 OpenRouter 连接后重试。",
+                status_code=503,
+            )
+        profile = next(
+            (
+                item
+                for item in catalog.profiles
+                if item.model_id == model_id
+                and "generate_audio" in item.operations
+            ),
+            None,
+        )
+        if profile is None or not profile.invocable:
+            raise MultimodalServiceError(
+                "operation_mismatch",
+                "所选模型未确认支持音乐生成，请刷新目录后重新选择。",
+                status_code=422,
+            )
+        if has_image and not profile.supports_image_prompt:
+            raise MultimodalServiceError(
+                "image_prompt_unsupported",
+                "所选音乐模型不支持图片提示，请移除图片后重试。",
+                status_code=422,
+            )
+        return profile
+
+    @staticmethod
+    def _model_id(value: str) -> str:
+        clean = str(value or "").strip()
+        if clean not in LYRIA_MODEL_IDS:
+            raise MultimodalServiceError(
+                "operation_mismatch",
+                "本批次只开放已验证的 Lyria Clip 和 Lyria Pro。",
+                status_code=422,
+            )
+        return clean
+
+    @staticmethod
+    def _prompt(value: str) -> str:
+        clean = str(value or "").strip()
+        if not clean:
+            raise MultimodalServiceError(
+                "empty_prompt",
+                "请填写音乐创作描述后再提交。",
+                status_code=422,
+            )
+        if len(clean) > MAX_AUDIO_GENERATION_PROMPT_CHARS:
+            raise MultimodalServiceError(
+                "prompt_too_long",
+                "音乐创作描述不能超过 4,000 个字符。",
+                status_code=422,
+            )
+        return clean
+
+    @staticmethod
+    def _idempotency_key(value: str) -> str:
+        clean = str(value or "").strip()
+        if (
+            len(clean) > MAX_IDEMPOTENCY_KEY_CHARS
+            or not IDEMPOTENCY_KEY_PATTERN.fullmatch(clean)
+        ):
+            raise MultimodalServiceError(
+                "invalid_idempotency_key",
+                "提交标识格式无效，请刷新页面后重试。",
+                status_code=422,
+            )
+        return clean
+
+    @staticmethod
+    def _image(
+        filename: str | None,
+        content_type: str | None,
+        content: bytes | None,
+    ) -> str | None:
+        supplied = (
+            filename is not None
+            or content_type is not None
+            or content is not None
+        )
+        if not supplied:
+            return None
+        if not filename or content is None or not content:
+            raise MultimodalServiceError(
+                "invalid_image_prompt",
+                "图片提示不完整，请重新选择 JPEG、PNG 或 WebP 图片。",
+                status_code=422,
+            )
+        if len(content) > MAX_AUDIO_JOB_IMAGE_BYTES:
+            raise MultimodalServiceError(
+                "image_prompt_too_large",
+                "图片提示超过 10 MiB，请压缩后重试。",
+                status_code=413,
+            )
+        suffix = Path(filename).suffix.lower().lstrip(".")
+        profile = AUDIO_JOB_IMAGE_FORMATS.get(suffix)
+        if profile is None:
+            raise MultimodalServiceError(
+                "unsupported_image_prompt_format",
+                "图片提示只支持 JPEG、PNG 和 WebP。",
+                status_code=422,
+            )
+        media_type, allowed_types = profile
+        clean_type = (content_type or "").split(";", 1)[0].strip().lower()
+        if clean_type and clean_type not in allowed_types:
+            raise MultimodalServiceError(
+                "image_prompt_type_mismatch",
+                "图片扩展名与文件类型不一致，请重新导出后重试。",
+                status_code=422,
+            )
+        if not AudioJobService._matches_image_signature(suffix, content):
+            raise MultimodalServiceError(
+                "invalid_image_prompt",
+                "图片内容无效或与扩展名不一致，请重新导出后重试。",
+                status_code=422,
+            )
+        encoded = base64.b64encode(content).decode("ascii")
+        return f"data:{media_type};base64,{encoded}"
+
+    @staticmethod
+    def _matches_image_signature(suffix: str, content: bytes) -> bool:
+        if suffix in {"jpg", "jpeg"}:
+            return content.startswith(b"\xff\xd8\xff")
+        if suffix == "png":
+            return content.startswith(b"\x89PNG\r\n\x1a\n")
+        if suffix == "webp":
+            return (
+                len(content) >= 12
+                and content.startswith(b"RIFF")
+                and content[8:12] == b"WEBP"
+            )
+        return False
+
+    def _record_start(
+        self,
+        target: OpenRouterTarget,
+        *,
+        model_id: str,
+        input_bytes: int,
+    ) -> str:
+        try:
+            return str(
+                self.router_service.repository.record_routing_decision(
+                    self.router_service.tenant_id,
+                    session_id_hash=None,
+                    engine="openrouter",
+                    strategy="explicit",
+                    operation="generate_audio",
+                    connection_id=target.connection_id,
+                    model_id=model_id,
+                    reason_codes=[
+                        "explicit_model",
+                        "operation_generate_audio",
+                    ],
+                    input_bytes=input_bytes,
+                )
+            )
+        except Exception as exc:
+            raise MultimodalServiceError(
+                "audit_unavailable",
+                "暂时无法建立音乐生成审计记录，请稍后重试。",
+                status_code=503,
+            ) from exc
+
+    def _record_success(
+        self,
+        decision_id: str,
+        *,
+        output_bytes: int,
+        cost_usd: float | None,
+    ) -> None:
+        if not decision_id:
+            return
+        try:
+            self.router_service.repository.update_routing_decision_usage(
+                self.router_service.tenant_id,
+                decision_id,
+                outcome="success",
+                media_seconds=None,
+                settled_cost_usd=cost_usd,
+                cost_status=(
+                    "actual" if cost_usd is not None else "unavailable"
+                ),
+                output_bytes=output_bytes,
+            )
+        except Exception:
+            logger.warning(
+                "Unable to update audio job audit outcome: %s", decision_id
+            )
+
+    def _record_failure(self, decision_id: str, outcome: str) -> None:
+        if not decision_id:
+            return
+        try:
+            self.router_service.repository.update_routing_decision_outcome(
+                self.router_service.tenant_id, decision_id, outcome
+            )
+        except Exception:
+            logger.warning(
+                "Unable to update audio job audit failure: %s", decision_id
+            )
+
+    def _row(self, job_id: str) -> dict[str, object]:
+        row = self.router_service.repository.get_audio_job(
+            self.router_service.tenant_id, str(job_id or "").strip()
+        )
+        if row is None:
+            raise self._not_found()
+        return row
+
+    def _update(
+        self, job_id: str, **changes: object
+    ) -> dict[str, object] | None:
+        return self.router_service.repository.update_audio_job(
+            self.router_service.tenant_id, job_id, **changes
+        )
+
+    def _refresh_expiry(
+        self, row: dict[str, object]
+    ) -> dict[str, object]:
+        if str(row.get("status") or "") != "succeeded":
+            return row
+        expires_at = self._datetime(row.get("expires_at"))
+        if (
+            expires_at is not None
+            and expires_at > datetime.now(UTC)
+            and self._output_path(str(row["id"])).is_file()
+        ):
+            return row
+        updated = self._update(
+            str(row["id"]),
+            status="expired",
+            error_code="audio_expired",
+            output_bytes=0,
+        )
+        self._remove_output(str(row["id"]))
+        return updated or row
+
+    def _write_output(self, job_id: str, content: bytes) -> None:
+        path = self._output_path(job_id)
+        temporary = path.with_suffix(f".tmp-{uuid.uuid4().hex}")
+        try:
+            temporary.write_bytes(content)
+            try:
+                temporary.chmod(0o600)
+            except OSError:
+                pass
+            temporary.replace(path)
+        finally:
+            temporary.unlink(missing_ok=True)
+
+    def _remove_output(self, job_id: str) -> None:
+        self._output_path(job_id).unlink(missing_ok=True)
+
+    def _output_path(self, job_id: str) -> Path:
+        digest = hashlib.sha256(
+            f"{self.router_service.tenant_id}\0{job_id}".encode("utf-8")
+        ).hexdigest()
+        return self.output_dir / f"{digest}.mp3"
+
+    @staticmethod
+    def _datetime(value: object) -> datetime | None:
+        try:
+            parsed = datetime.fromisoformat(str(value or ""))
+        except ValueError:
+            return None
+        return (
+            parsed.replace(tzinfo=UTC)
+            if parsed.tzinfo is None
+            else parsed.astimezone(UTC)
+        )
+
+    @staticmethod
+    def _public(row: dict[str, object]) -> AudioJob:
+        error_code = str(row.get("error_code") or "").strip()
+        return AudioJob(
+            job_id=str(row["id"]),
+            status=str(row["status"]),
+            requested_model=str(row["requested_model"]),
+            actual_model=(
+                str(row["actual_model"]) if row.get("actual_model") else None
+            ),
+            provider="openrouter",
+            generation_id=(
+                str(row["generation_id"])
+                if row.get("generation_id")
+                else None
+            ),
+            parameters=AudioJobParameters(
+                has_image=bool(row.get("has_image")),
+            ),
+            usage=AudioJobUsage(
+                cost_usd=(
+                    float(row["cost_usd"])
+                    if row.get("cost_usd") is not None
+                    else None
+                ),
+                cost_kind=str(row.get("cost_kind") or "unavailable"),
+            ),
+            output_bytes=max(0, int(row.get("output_bytes") or 0)),
+            created_at=str(row["created_at"]),
+            updated_at=str(row["updated_at"]),
+            expires_at=(
+                str(row["expires_at"]) if row.get("expires_at") else None
+            ),
+            error=(
+                AudioJobError(
+                    code=error_code,
+                    message=SAFE_AUDIO_JOB_ERRORS.get(
+                        error_code,
+                        SAFE_AUDIO_JOB_ERRORS["generation_failed"],
+                    ),
+                )
+                if error_code
+                else None
+            ),
+        )
+
+    @staticmethod
+    def _not_found() -> MultimodalServiceError:
+        return MultimodalServiceError(
+            "audio_job_not_found",
+            "未找到该音乐任务，它可能已被移除。",
+            status_code=404,
+        )
+
+    @staticmethod
+    def _ensure_enabled() -> None:
+        if os.getenv(
+            "MULTIMODAL_AUDIO_GENERATION_ENABLED", "false"
+        ).strip().lower() not in {"1", "true", "yes", "on"}:
+            raise MultimodalServiceError(
+                "audio_generation_disabled",
+                "音乐生成功能当前未启用。",
+                status_code=503,
+            )

--- a/server/multimodal/realtime.py
+++ b/server/multimodal/realtime.py
@@ -1,0 +1,766 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import re
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any, Literal
+from urllib.parse import urlparse
+
+import httpx
+from pydantic import BaseModel
+
+try:
+    from server.model_router.repository import (
+        RouterConnectionNotFound,
+        utc_now,
+    )
+    from server.model_router.service import ModelRouterService
+except ModuleNotFoundError:
+    from model_router.repository import RouterConnectionNotFound, utc_now
+    from model_router.service import ModelRouterService
+
+from .stt import MultimodalServiceError
+
+
+MAX_REALTIME_SDP_CHARS = 256_000
+MAX_REALTIME_ANSWER_CHARS = 512_000
+MAX_REALTIME_SESSION_SECONDS = 600
+REALTIME_MODELS = (
+    "gpt-realtime-2.1-mini",
+    "gpt-realtime-2.1",
+)
+REALTIME_VOICES = ("marin", "cedar")
+REALTIME_VAD_MODES = ("semantic_vad",)
+_CALL_ID_PATTERN = re.compile(r"^rtc_[A-Za-z0-9_-]{3,128}$")
+_LANGUAGE_PATTERN = re.compile(
+    r"^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$"
+)
+
+
+class RealtimeCallRequest(BaseModel):
+    """Untrusted request envelope; the service returns only sanitized errors."""
+
+    sdp: Any = None
+    model_id: Any = "gpt-realtime-2.1-mini"
+    voice: Any = "marin"
+    vad_mode: Any = "semantic_vad"
+    language: Any = "zh-CN"
+
+
+class RealtimeCallResponse(BaseModel):
+    session_id: str
+    sdp_answer: str
+    expires_at: str
+    model_id: str
+    voice: str
+
+
+class RealtimeCallEndResponse(BaseModel):
+    session_id: str
+    status: Literal["ended", "expired", "interrupted"]
+    ended_at: str
+
+
+@dataclass(frozen=True)
+class DirectOpenAITarget:
+    base_url: str
+    api_key: str
+    connection_id: str
+    safety_identifier: str
+
+
+@dataclass(frozen=True)
+class RealtimeUpstreamCall:
+    call_id: str
+    sdp_answer: str
+
+
+@dataclass(frozen=True)
+class ValidatedRealtimeRequest:
+    sdp: str
+    model_id: str
+    voice: str
+    vad_mode: str
+    language: str
+
+
+class OpenAIRealtimeAdapter:
+    def __init__(
+        self,
+        *,
+        client_factory: Callable[[], httpx.AsyncClient] | None = None,
+    ) -> None:
+        self.client_factory = client_factory or self._default_client
+
+    async def create_call(
+        self,
+        target: DirectOpenAITarget,
+        *,
+        sdp: str,
+        session: dict[str, object],
+    ) -> RealtimeUpstreamCall:
+        files = {
+            "sdp": ("offer.sdp", sdp, "application/sdp"),
+            "session": (
+                "session.json",
+                json.dumps(
+                    session,
+                    ensure_ascii=False,
+                    separators=(",", ":"),
+                ),
+                "application/json",
+            ),
+        }
+        try:
+            async with self.client_factory() as client:
+                response = await client.post(
+                    self._calls_url(target.base_url),
+                    headers=self._headers(target),
+                    files=files,
+                )
+        except httpx.TimeoutException as exc:
+            raise MultimodalServiceError(
+                "realtime_timeout",
+                "实时语音连接超时，请检查网络后重试。",
+                status_code=504,
+            ) from exc
+        except httpx.HTTPError as exc:
+            raise MultimodalServiceError(
+                "realtime_unreachable",
+                "无法连接实时语音服务，请检查模型服务连接。",
+                status_code=502,
+            ) from exc
+
+        if response.status_code != 201:
+            self._raise_for_status(response)
+        content_type = response.headers.get("content-type", "").lower()
+        if not content_type.startswith("application/sdp"):
+            raise MultimodalServiceError(
+                "invalid_realtime_answer",
+                "实时语音服务返回了无效的连接信息，请稍后重试。",
+                status_code=502,
+            )
+        answer = response.text.strip()
+        if (
+            not answer.startswith("v=0")
+            or len(answer) > MAX_REALTIME_ANSWER_CHARS
+        ):
+            raise MultimodalServiceError(
+                "invalid_realtime_answer",
+                "实时语音服务返回了无效的连接信息，请稍后重试。",
+                status_code=502,
+            )
+        call_id = self._call_id(response.headers.get("location", ""))
+        return RealtimeUpstreamCall(call_id=call_id, sdp_answer=answer)
+
+    async def hangup(
+        self,
+        target: DirectOpenAITarget,
+        call_id: str,
+    ) -> None:
+        if not _CALL_ID_PATTERN.fullmatch(call_id):
+            raise MultimodalServiceError(
+                "invalid_realtime_session",
+                "实时语音会话标识无效，请重新发起会话。",
+                status_code=409,
+            )
+        try:
+            async with self.client_factory() as client:
+                response = await client.post(
+                    (
+                        f"{self._calls_url(target.base_url)}/"
+                        f"{call_id}/hangup"
+                    ),
+                    headers=self._headers(target),
+                )
+        except httpx.TimeoutException as exc:
+            raise MultimodalServiceError(
+                "realtime_hangup_timeout",
+                "结束实时语音连接超时，请稍后重试。",
+                status_code=504,
+            ) from exc
+        except httpx.HTTPError as exc:
+            raise MultimodalServiceError(
+                "realtime_hangup_unreachable",
+                "暂时无法通知实时语音服务结束连接，请稍后重试。",
+                status_code=502,
+            ) from exc
+        if response.status_code in {200, 204, 404, 410}:
+            return
+        self._raise_for_status(response)
+
+    @staticmethod
+    def _headers(target: DirectOpenAITarget) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {target.api_key}",
+            "OpenAI-Safety-Identifier": target.safety_identifier,
+        }
+
+    @staticmethod
+    def _calls_url(base_url: str) -> str:
+        root = base_url.rstrip("/")
+        if not root.endswith("/v1"):
+            root = f"{root}/v1"
+        return f"{root}/realtime/calls"
+
+    @staticmethod
+    def _call_id(location: str) -> str:
+        parsed = urlparse(str(location or "").strip())
+        call_id = parsed.path.rstrip("/").rsplit("/", 1)[-1]
+        if not _CALL_ID_PATTERN.fullmatch(call_id):
+            raise MultimodalServiceError(
+                "invalid_realtime_answer",
+                "实时语音服务未返回有效会话标识，请稍后重试。",
+                status_code=502,
+            )
+        return call_id
+
+    @staticmethod
+    def _raise_for_status(response: httpx.Response) -> None:
+        mapping = {
+            400: (
+                "realtime_request_rejected",
+                "实时语音连接参数被拒绝，请刷新页面后重试。",
+                422,
+            ),
+            401: (
+                "realtime_credentials_invalid",
+                "OpenAI 密钥无效，请在模型服务连接中重新保存。",
+                401,
+            ),
+            403: (
+                "realtime_access_denied",
+                "当前 OpenAI 项目无权使用实时语音，请检查模型权限。",
+                403,
+            ),
+            402: (
+                "realtime_payment_required",
+                "实时语音额度不足，请补充额度后重试。",
+                402,
+            ),
+            429: (
+                "realtime_rate_limited",
+                "实时语音请求过于频繁，请稍后重试。",
+                429,
+            ),
+        }
+        code, message, status_code = mapping.get(
+            response.status_code,
+            (
+                "realtime_provider_error",
+                "实时语音服务暂时不可用，请稍后重试。",
+                502,
+            ),
+        )
+        raise MultimodalServiceError(
+            code,
+            message,
+            status_code=status_code,
+        )
+
+    @staticmethod
+    def _default_client() -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            timeout=httpx.Timeout(
+                connect=10.0,
+                read=30.0,
+                write=30.0,
+                pool=10.0,
+            ),
+            follow_redirects=False,
+        )
+
+
+class RealtimeVoiceService:
+    def __init__(
+        self,
+        router_service: ModelRouterService,
+        *,
+        adapter: OpenAIRealtimeAdapter | None = None,
+        session_seconds: int = MAX_REALTIME_SESSION_SECONDS,
+    ) -> None:
+        self.router_service = router_service
+        self.repository = router_service.repository
+        self.tenant_id = router_service.tenant_id
+        self.adapter = adapter or OpenAIRealtimeAdapter()
+        self.session_seconds = max(
+            1,
+            min(int(session_seconds), MAX_REALTIME_SESSION_SECONDS),
+        )
+        self._expiry_tasks: dict[str, asyncio.Task[None]] = {}
+        self._closing = False
+
+    async def create(
+        self,
+        payload: RealtimeCallRequest,
+    ) -> RealtimeCallResponse:
+        self._require_enabled()
+        request = self._validate_request(payload)
+        target = self._resolve_target()
+        session_id = f"local_rt_{uuid.uuid4().hex}"
+        now = datetime.now(UTC)
+        expires_at = (now + timedelta(seconds=self.session_seconds)).isoformat()
+        decision_id = self.repository.record_routing_decision(
+            self.tenant_id,
+            session_id_hash=self._session_hash(session_id),
+            engine="native",
+            strategy="realtime",
+            operation="realtime_voice",
+            connection_id=target.connection_id,
+            model_id=request.model_id,
+            reason_codes=[
+                "explicit_realtime_model",
+                "operation_realtime_voice",
+                request.vad_mode,
+            ],
+            outcome="connecting",
+        )
+        self.repository.create_realtime_call(
+            self.tenant_id,
+            session_id=session_id,
+            decision_id=decision_id,
+            connection_id=target.connection_id,
+            model_id=request.model_id,
+            provider="openai",
+            voice=request.voice,
+            vad_mode=request.vad_mode,
+            language=request.language,
+            expires_at=expires_at,
+        )
+        try:
+            upstream = await self.adapter.create_call(
+                target,
+                sdp=request.sdp,
+                session=self._session_config(request),
+            )
+        except MultimodalServiceError as exc:
+            self.repository.update_realtime_call(
+                self.tenant_id,
+                session_id,
+                status="failed",
+                ended_at=utc_now(),
+                error_code=exc.code,
+            )
+            self.repository.update_routing_decision_outcome(
+                self.tenant_id,
+                decision_id,
+                "failed",
+            )
+            raise
+
+        started_at = utc_now()
+        try:
+            self.repository.update_realtime_call(
+                self.tenant_id,
+                session_id,
+                upstream_call_id=upstream.call_id,
+                status="active",
+                started_at=started_at,
+                error_code=None,
+            )
+            self.repository.update_routing_decision_outcome(
+                self.tenant_id,
+                decision_id,
+                "active",
+            )
+        except Exception:
+            try:
+                await self.adapter.hangup(target, upstream.call_id)
+            finally:
+                raise
+        self._schedule_expiry(session_id)
+        return RealtimeCallResponse(
+            session_id=session_id,
+            sdp_answer=upstream.sdp_answer,
+            expires_at=expires_at,
+            model_id=request.model_id,
+            voice=request.voice,
+        )
+
+    async def end(
+        self,
+        session_id: str,
+        *,
+        reason: Literal["ended", "expired", "interrupted"] = "ended",
+    ) -> RealtimeCallEndResponse:
+        clean_session_id = self._session_id(session_id)
+        row = self.repository.get_realtime_call(
+            self.tenant_id,
+            clean_session_id,
+        )
+        if row is None:
+            raise MultimodalServiceError(
+                "realtime_session_not_found",
+                "未找到该实时语音会话，可能已结束或不属于当前用户。",
+                status_code=404,
+            )
+        current_status = str(row.get("status") or "")
+        if current_status in {"ended", "expired", "interrupted"}:
+            return self._end_response(row)
+        if current_status == "failed":
+            raise MultimodalServiceError(
+                "realtime_session_failed",
+                "该实时语音会话未能建立，请重新发起。",
+                status_code=409,
+            )
+        upstream_call_id = str(row.get("upstream_call_id") or "").strip()
+        if upstream_call_id:
+            target = self._resolve_existing_target(row)
+            await self.adapter.hangup(target, upstream_call_id)
+        return self._finish(row, status=reason)
+
+    async def recover_active(self) -> None:
+        for row in self.repository.list_active_realtime_calls(self.tenant_id):
+            if not row.get("upstream_call_id"):
+                self._finish(
+                    row,
+                    status="interrupted",
+                    error_code="realtime_restart_interrupted",
+                )
+                continue
+            try:
+                target = self._resolve_existing_target(row)
+                await self.adapter.hangup(
+                    target,
+                    str(row["upstream_call_id"]),
+                )
+                self._finish(
+                    row,
+                    status="interrupted",
+                    error_code="realtime_restart_interrupted",
+                )
+            except (MultimodalServiceError, RouterConnectionNotFound):
+                self._finish(
+                    row,
+                    status="interrupted",
+                    error_code="realtime_recovery_failed",
+                )
+
+    async def shutdown(self) -> None:
+        self._closing = True
+        rows = self.repository.list_active_realtime_calls(self.tenant_id)
+        for row in rows:
+            try:
+                if row.get("upstream_call_id"):
+                    target = self._resolve_existing_target(row)
+                    await self.adapter.hangup(
+                        target,
+                        str(row["upstream_call_id"]),
+                    )
+                self._finish(
+                    row,
+                    status="interrupted",
+                    error_code="realtime_server_shutdown",
+                )
+            except (MultimodalServiceError, RouterConnectionNotFound):
+                self._finish(
+                    row,
+                    status="interrupted",
+                    error_code="realtime_shutdown_hangup_failed",
+                )
+        tasks = list(self._expiry_tasks.values())
+        self._expiry_tasks.clear()
+        for task in tasks:
+            if task is not asyncio.current_task():
+                task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    def _finish(
+        self,
+        row: dict[str, object],
+        *,
+        status: Literal["ended", "expired", "interrupted"],
+        error_code: str | None = None,
+    ) -> RealtimeCallEndResponse:
+        ended_at = datetime.now(UTC)
+        started_at = self._parse_time(row.get("started_at")) or self._parse_time(
+            row.get("created_at")
+        )
+        duration = (
+            max(0.0, (ended_at - started_at).total_seconds())
+            if started_at is not None
+            else None
+        )
+        session_id = str(row["id"])
+        updated = self.repository.update_realtime_call(
+            self.tenant_id,
+            session_id,
+            status=status,
+            ended_at=ended_at.isoformat(),
+            duration_seconds=duration,
+            cost_kind="unavailable",
+            error_code=error_code,
+        )
+        decision_id = str(row.get("decision_id") or "").strip()
+        if decision_id:
+            self.repository.update_routing_decision_usage(
+                self.tenant_id,
+                decision_id,
+                outcome=status,
+                media_seconds=duration,
+                settled_cost_usd=None,
+                cost_status="unavailable",
+            )
+        self._cancel_expiry(session_id)
+        if updated is None:
+            raise MultimodalServiceError(
+                "realtime_session_not_found",
+                "未找到该实时语音会话。",
+                status_code=404,
+            )
+        return self._end_response(updated)
+
+    def _schedule_expiry(self, session_id: str) -> None:
+        if self._closing:
+            return
+
+        async def expire() -> None:
+            try:
+                await asyncio.sleep(self.session_seconds)
+                await self.end(session_id, reason="expired")
+            except asyncio.CancelledError:
+                raise
+            except MultimodalServiceError:
+                return
+
+        task = asyncio.create_task(
+            expire(),
+            name=f"modelmirror-realtime-expiry-{session_id[-8:]}",
+        )
+        self._expiry_tasks[session_id] = task
+
+    def _cancel_expiry(self, session_id: str) -> None:
+        task = self._expiry_tasks.pop(session_id, None)
+        if task is not None and task is not asyncio.current_task():
+            task.cancel()
+
+    def _resolve_target(self) -> DirectOpenAITarget:
+        connections = [
+            item
+            for item in self.router_service.list_connections(
+                scope="realtime"
+            )
+            if item.kind == "openai"
+            and item.enabled
+            and item.health != "offline"
+        ]
+        connections.sort(
+            key=lambda item: (0 if item.health == "online" else 1, item.id)
+        )
+        if not connections:
+            raise MultimodalServiceError(
+                "realtime_connection_required",
+                "请先在模型服务连接中添加并启用 OpenAI 实时语音连接。",
+                status_code=503,
+            )
+        return self._target_from_connection(connections[0])
+
+    def _resolve_existing_target(
+        self,
+        row: dict[str, object],
+    ) -> DirectOpenAITarget:
+        connection_id = str(row.get("connection_id") or "")
+        connection = self.repository.get_connection(
+            self.tenant_id,
+            connection_id,
+        )
+        if connection.kind != "openai" or "realtime" not in connection.scopes:
+            raise MultimodalServiceError(
+                "realtime_connection_unavailable",
+                "实时语音连接配置已变化，请重新发起会话。",
+                status_code=409,
+            )
+        return self._target_from_connection(connection)
+
+    def _target_from_connection(self, connection: Any) -> DirectOpenAITarget:
+        base_url = str(connection.base_url).strip().rstrip("/")
+        parsed = urlparse(base_url)
+        if (
+            parsed.scheme != "https"
+            or (parsed.hostname or "").casefold() != "api.openai.com"
+            or parsed.port not in {None, 443}
+            or parsed.username
+            or parsed.password
+            or parsed.query
+            or parsed.fragment
+            or parsed.path.rstrip("/") not in {"", "/v1"}
+        ):
+            raise MultimodalServiceError(
+                "invalid_realtime_connection",
+                "实时语音仅允许使用官方 OpenAI API 地址，请检查连接设置。",
+                status_code=422,
+            )
+        try:
+            api_key = self.repository.resolve_api_key(
+                self.tenant_id,
+                connection.id,
+            )
+        except Exception as exc:
+            raise MultimodalServiceError(
+                "realtime_credentials_unavailable",
+                "无法读取 OpenAI 密钥，请重新保存模型服务连接。",
+                status_code=503,
+            ) from exc
+        return DirectOpenAITarget(
+            base_url=base_url,
+            api_key=api_key,
+            connection_id=connection.id,
+            safety_identifier=self._safety_identifier(),
+        )
+
+    def _validate_request(
+        self,
+        payload: RealtimeCallRequest,
+    ) -> ValidatedRealtimeRequest:
+        sdp = payload.sdp if isinstance(payload.sdp, str) else ""
+        if (
+            not sdp
+            or len(sdp) > MAX_REALTIME_SDP_CHARS
+            or not sdp.lstrip().startswith("v=0")
+            or "\x00" in sdp
+        ):
+            raise MultimodalServiceError(
+                "invalid_realtime_sdp",
+                "浏览器连接信息无效，请刷新页面后重新发起实时语音。",
+                status_code=422,
+            )
+        model_id = self._choice(
+            payload.model_id,
+            choices=REALTIME_MODELS,
+            code="unsupported_realtime_model",
+            message="请选择已验证的实时语音模型。",
+        )
+        voice = self._choice(
+            payload.voice,
+            choices=REALTIME_VOICES,
+            code="unsupported_realtime_voice",
+            message="请选择当前实时语音模型支持的声音。",
+        )
+        vad_mode = self._choice(
+            payload.vad_mode,
+            choices=REALTIME_VAD_MODES,
+            code="unsupported_realtime_vad",
+            message="当前仅支持语义语音活动检测。",
+        )
+        language = (
+            payload.language.strip()
+            if isinstance(payload.language, str)
+            else ""
+        )
+        if not _LANGUAGE_PATTERN.fullmatch(language):
+            raise MultimodalServiceError(
+                "invalid_realtime_language",
+                "语言代码无效，请使用 zh-CN、en-US 等格式。",
+                status_code=422,
+            )
+        return ValidatedRealtimeRequest(
+            sdp=sdp,
+            model_id=model_id,
+            voice=voice,
+            vad_mode=vad_mode,
+            language=language,
+        )
+
+    @staticmethod
+    def _session_config(
+        request: ValidatedRealtimeRequest,
+    ) -> dict[str, object]:
+        return {
+            "type": "realtime",
+            "model": request.model_id,
+            "instructions": (
+                f"Use {request.language} for this voice conversation. "
+                "Do not claim to use tools, files, or external knowledge."
+            ),
+            "audio": {
+                "input": {
+                    "turn_detection": {
+                        "type": request.vad_mode,
+                        "eagerness": "auto",
+                        "create_response": True,
+                        "interrupt_response": True,
+                    }
+                },
+                "output": {"voice": request.voice},
+            },
+        }
+
+    @staticmethod
+    def _choice(
+        value: Any,
+        *,
+        choices: tuple[str, ...],
+        code: str,
+        message: str,
+    ) -> str:
+        clean = value.strip() if isinstance(value, str) else ""
+        if clean not in choices:
+            raise MultimodalServiceError(
+                code,
+                message,
+                status_code=422,
+            )
+        return clean
+
+    @staticmethod
+    def _session_id(value: str) -> str:
+        clean = str(value or "").strip()
+        if not re.fullmatch(r"local_rt_[a-f0-9]{32}", clean):
+            raise MultimodalServiceError(
+                "invalid_realtime_session",
+                "实时语音会话标识无效。",
+                status_code=404,
+            )
+        return clean
+
+    @staticmethod
+    def _parse_time(value: object) -> datetime | None:
+        try:
+            parsed = datetime.fromisoformat(str(value))
+        except (TypeError, ValueError):
+            return None
+        if parsed.tzinfo is None:
+            return parsed.replace(tzinfo=UTC)
+        return parsed.astimezone(UTC)
+
+    @staticmethod
+    def _end_response(row: dict[str, object]) -> RealtimeCallEndResponse:
+        status = str(row.get("status") or "ended")
+        if status not in {"ended", "expired", "interrupted"}:
+            status = "ended"
+        return RealtimeCallEndResponse(
+            session_id=str(row["id"]),
+            status=status,
+            ended_at=str(row.get("ended_at") or utc_now()),
+        )
+
+    def _safety_identifier(self) -> str:
+        digest = hashlib.sha256(
+            f"modelmirror:{self.tenant_id}".encode("utf-8")
+        ).hexdigest()
+        return f"mm_{digest[:32]}"
+
+    @staticmethod
+    def _session_hash(session_id: str) -> str:
+        return hashlib.sha256(session_id.encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def _require_enabled() -> None:
+        if (
+            os.getenv("MULTIMODAL_REALTIME_VOICE_ENABLED", "false")
+            .strip()
+            .lower()
+            not in {"1", "true", "yes", "on"}
+        ):
+            raise MultimodalServiceError(
+                "realtime_voice_disabled",
+                "实时语音当前未启用。",
+                status_code=404,
+            )

--- a/server/multimodal/stt.py
+++ b/server/multimodal/stt.py
@@ -36,6 +36,35 @@ ALLOWED_AUDIO_FORMATS: dict[str, tuple[str, ...]] = {
     "webm": ("audio/webm", "video/webm", "application/octet-stream"),
     "aac": ("audio/aac", "audio/x-aac", "application/octet-stream"),
 }
+TRANSCRIPTION_PROFILE_VERSION = "stt-contracts-2026-07-29-b2"
+
+
+@dataclass(frozen=True)
+class TranscriptionProfile:
+    input_formats: tuple[str, ...]
+    smoke_languages: tuple[str, ...] = ("zh", "en")
+
+
+_STANDARD_TRANSCRIPTION_PROFILE = TranscriptionProfile(
+    input_formats=tuple(ALLOWED_AUDIO_FORMATS),
+)
+VERIFIED_TRANSCRIPTION_PROFILES: dict[str, TranscriptionProfile] = {
+    model_id: _STANDARD_TRANSCRIPTION_PROFILE
+    for model_id in (
+        "deepgram/nova-3",
+        "google/chirp-3",
+        "microsoft/mai-transcribe-1.5",
+        "mistralai/voxtral-mini-transcribe",
+        "nvidia/parakeet-tdt-0.6b-v3",
+        "openai/gpt-4o-mini-transcribe",
+        "openai/gpt-4o-transcribe",
+        "openai/whisper-1",
+        "openai/whisper-large-v3",
+        "openai/whisper-large-v3-turbo",
+        "qwen/qwen3-asr-flash-2026-02-10",
+        "x-ai/grok-stt-1.0",
+    )
+}
 
 
 class MultimodalServiceError(Exception):
@@ -370,11 +399,18 @@ class TranscriptionService:
     ) -> TranscriptionResult:
         clean_model = self._model_id(model_id)
         clean_language = self._language(language)
+        profile = VERIFIED_TRANSCRIPTION_PROFILES[clean_model]
         clean_filename, audio_format = self._validate_audio(
             filename,
             content_type,
             content,
         )
+        if audio_format not in profile.input_formats:
+            raise MultimodalServiceError(
+                "unsupported_model_audio_format",
+                "所选转写模型尚未验证该音频格式，请更换模型或重新导出音频。",
+                status_code=415,
+            )
         target = self._target()
         decision_id = self._record_start(
             target,
@@ -410,6 +446,7 @@ class TranscriptionService:
             if item.kind == "openrouter"
             and item.enabled
             and item.health != "offline"
+            and "audio" in item.scopes
         ]
         connections.sort(
             key=lambda item: (
@@ -552,6 +589,12 @@ class TranscriptionService:
             raise MultimodalServiceError(
                 "invalid_model_id",
                 "请选择一个具体的音频转文字模型。",
+                status_code=422,
+            )
+        if model_id not in VERIFIED_TRANSCRIPTION_PROFILES:
+            raise MultimodalServiceError(
+                "unsupported_transcription_model",
+                "该转写模型尚未完成本地契约验证，请从转写设置的可用列表中选择。",
                 status_code=422,
             )
         return model_id

--- a/server/multimodal/tts.py
+++ b/server/multimodal/tts.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
+import struct
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -22,9 +23,104 @@ logger = logging.getLogger("modelmirror.multimodal")
 MAX_SPEECH_INPUT_CHARS = 4_000
 MAX_SPEECH_BYTES = 20 * 1024 * 1024
 CATALOG_CACHE_SECONDS = 300.0
-ALLOWED_SPEECH_PROFILES: dict[str, tuple[str, ...]] = {
-    "microsoft/mai-voice-2": ("en-US-Harper:MAI-Voice-2",),
+SPEECH_PROFILE_VERSION = "tts-contracts-2026-07-29-b5"
+GEMINI_PCM_TTS_MODEL_ID = "google/gemini-3.1-flash-tts-preview"
+MINIMAX_SYSTEM_SPEECH_VOICES = (
+    "Chinese (Mandarin)_News_Anchor",
+    "Chinese (Mandarin)_Reliable_Executive",
+    "Chinese (Mandarin)_Mature_Woman",
+    "Chinese (Mandarin)_Warm_Girl",
+    "English_expressive_narrator",
+    "English_CalmWoman",
+    "English_magnetic_voiced_man",
+    "English_Graceful_Lady",
+)
+SPEECH_OUTPUT_FORMATS: dict[str, str] = {
+    GEMINI_PCM_TTS_MODEL_ID: "wav",
 }
+ALLOWED_SPEECH_PROFILES: dict[str, tuple[str, ...]] = {
+    "minimax/speech-2.8-hd": MINIMAX_SYSTEM_SPEECH_VOICES,
+    "minimax/speech-2.8-turbo": MINIMAX_SYSTEM_SPEECH_VOICES,
+    "microsoft/mai-voice-2": (
+        "en-US-Harper:MAI-Voice-2",
+        "de-DE-Klaus:MAI-Voice-2",
+        "es-MX-Valeria:MAI-Voice-2",
+        "fr-FR-Soleil:MAI-Voice-2",
+    ),
+    "microsoft/mai-voice-2-flash": (
+        "en-US-Harper:MAI-Voice-2",
+        "de-DE-Klaus:MAI-Voice-2",
+        "es-MX-Valeria:MAI-Voice-2",
+        "fr-FR-Soleil:MAI-Voice-2",
+    ),
+    "mistralai/voxtral-mini-tts-2603": (
+        "en_paul_neutral",
+        "fr_marie_neutral",
+        "gb_jane_neutral",
+        "gb_oliver_neutral",
+    ),
+    "qwen/qwen-audio-3.0-tts-flash": (
+        "longanhuan_v3.6",
+        "loongjohn",
+    ),
+    "qwen/qwen-audio-3.0-tts-plus": (
+        "longanlingxin",
+        "longanlufeng",
+    ),
+    "x-ai/grok-voice-tts-1.0": (
+        "ara",
+        "eve",
+        "leo",
+        "rex",
+        "sal",
+    ),
+    "deepgram/aura-2": (
+        "aura-2-amalthea-en",
+        "aura-2-andromeda-en",
+        "aura-2-apollo-en",
+        "aura-2-asteria-en",
+    ),
+    "zyphra/zonos-v0.1-transformer": (
+        "american_female",
+        "american_male",
+        "british_female",
+        "british_male",
+    ),
+    "zyphra/zonos-v0.1-hybrid": (
+        "american_female",
+        "american_male",
+        "british_female",
+        "british_male",
+    ),
+    "canopylabs/orpheus-3b-0.1-ft": (
+        "dan",
+        "jess",
+        "leah",
+        "leo",
+    ),
+    "sesame/csm-1b": (
+        "conversational_a",
+        "conversational_b",
+        "read_speech_a",
+        "read_speech_b",
+    ),
+    "hexgrad/kokoro-82m": (
+        "af_alloy",
+        "af_aoede",
+        "af_bella",
+        "am_fenrir",
+    ),
+    GEMINI_PCM_TTS_MODEL_ID: (
+        "Aoede",
+        "Charon",
+        "Kore",
+        "Puck",
+    ),
+}
+
+
+def speech_output_format(model_id: str) -> str:
+    return SPEECH_OUTPUT_FORMATS.get(model_id, "mp3")
 
 
 @dataclass(frozen=True)
@@ -36,6 +132,7 @@ class SpeechResult:
     request_id: str
     generation_id: str | None
     output_bytes: int
+    response_format: str = "mp3"
     cost_usd: float | None = None
     cost_kind: str = "unavailable"
 
@@ -59,8 +156,10 @@ class OpenRouterTtsAdapter:
         text: str,
         voice: str,
         speed: float,
-    ) -> tuple[bytes, str | None]:
+    ) -> tuple[bytes, str | None, str]:
         await self._verify_speech_model(target, model_id)
+        output_format = speech_output_format(model_id)
+        upstream_format = "pcm" if output_format == "wav" else "mp3"
         async with self._client_factory() as client:
             try:
                 response = await client.post(
@@ -70,7 +169,7 @@ class OpenRouterTtsAdapter:
                         "model": model_id,
                         "input": text,
                         "voice": voice,
-                        "response_format": "mp3",
+                        "response_format": upstream_format,
                         "speed": speed,
                     },
                 )
@@ -91,11 +190,15 @@ class OpenRouterTtsAdapter:
                     status_code=502,
                 ) from exc
         self._raise_for_status(response, model_id=model_id)
-        self._validate_mp3(response)
+        if output_format == "wav":
+            content = self._pcm_response_to_wav(response)
+        else:
+            self._validate_mp3(response)
+            content = bytes(response.content)
         generation_id = str(
             response.headers.get("X-Generation-Id") or ""
         ).strip() or None
-        return bytes(response.content), generation_id
+        return content, generation_id, output_format
 
     async def _verify_speech_model(
         self,
@@ -301,6 +404,69 @@ class OpenRouterTtsAdapter:
                 status_code=502,
             )
 
+    @staticmethod
+    def _pcm_response_to_wav(response: httpx.Response) -> bytes:
+        content = bytes(response.content)
+        content_type = str(response.headers.get("content-type") or "")
+        parts = [part.strip() for part in content_type.split(";")]
+        mime = parts[0].lower() if parts else ""
+        parameters: dict[str, str] = {}
+        for part in parts[1:]:
+            key, separator, value = part.partition("=")
+            if separator:
+                parameters[key.strip().lower()] = value.strip()
+        try:
+            sample_rate = int(parameters.get("rate", ""))
+            channels = int(parameters.get("channels", ""))
+        except ValueError as exc:
+            raise MultimodalServiceError(
+                "invalid_audio_mime",
+                "语音服务返回的 PCM 参数无效，请稍后重试。",
+                status_code=502,
+            ) from exc
+        if mime != "audio/pcm" or sample_rate != 24_000 or channels != 1:
+            raise MultimodalServiceError(
+                "invalid_audio_mime",
+                "语音服务没有返回已验证的 24 kHz 单声道 PCM，请稍后重试。",
+                status_code=502,
+            )
+        if not content:
+            raise MultimodalServiceError(
+                "empty_speech",
+                "语音服务没有返回音频，请稍后重试。",
+                status_code=502,
+            )
+        if len(content) > MAX_SPEECH_BYTES or len(content) % 2:
+            raise MultimodalServiceError(
+                "invalid_speech_audio",
+                "语音服务返回的 PCM 不完整或超过安全大小限制，请重新生成。",
+                status_code=502,
+            )
+        bits_per_sample = 16
+        block_align = channels * bits_per_sample // 8
+        byte_rate = sample_rate * block_align
+        header = b"".join(
+            (
+                b"RIFF",
+                struct.pack("<I", 36 + len(content)),
+                b"WAVE",
+                b"fmt ",
+                struct.pack(
+                    "<IHHIIHH",
+                    16,
+                    1,
+                    channels,
+                    sample_rate,
+                    byte_rate,
+                    block_align,
+                    bits_per_sample,
+                ),
+                b"data",
+                struct.pack("<I", len(content)),
+            )
+        )
+        return header + content
+
 
 class SpeechService:
     def __init__(
@@ -324,7 +490,7 @@ class SpeechService:
         clean_model = self._model_id(model_id)
         clean_text = self._text(text)
         clean_voice = self._voice(clean_model, voice)
-        clean_format = self._response_format(response_format)
+        clean_format = self._response_format(clean_model, response_format)
         clean_speed = self._speed(speed)
         target = self._target()
         decision_id = self._record_start(
@@ -333,7 +499,7 @@ class SpeechService:
             input_bytes=len(clean_text.encode("utf-8")),
         )
         try:
-            content, generation_id = await self.adapter.synthesize(
+            content, generation_id, actual_format = await self.adapter.synthesize(
                 target,
                 model_id=clean_model,
                 text=clean_text,
@@ -343,6 +509,13 @@ class SpeechService:
         except MultimodalServiceError as exc:
             self._record_failure(decision_id, exc.code)
             raise
+        if actual_format != clean_format:
+            self._record_failure(decision_id, "speech_format_mismatch")
+            raise MultimodalServiceError(
+                "speech_format_mismatch",
+                "语音服务返回格式与请求不一致，请刷新模型能力后重试。",
+                status_code=502,
+            )
         self._record_success(decision_id, output_bytes=len(content))
         return SpeechResult(
             content=content,
@@ -352,6 +525,7 @@ class SpeechService:
             request_id=decision_id,
             generation_id=generation_id,
             output_bytes=len(content),
+            response_format=actual_format,
         )
 
     def _target(self) -> OpenRouterTarget:
@@ -361,6 +535,7 @@ class SpeechService:
             if item.kind == "openrouter"
             and item.enabled
             and item.health != "offline"
+            and "audio" in item.scopes
         ]
         connections.sort(
             key=lambda item: (
@@ -496,7 +671,7 @@ class SpeechService:
         if model_id not in ALLOWED_SPEECH_PROFILES:
             raise MultimodalServiceError(
                 "unsupported_speech_model",
-                "该语音模型尚未完成行为验证，请选择 Microsoft MAI-Voice-2。",
+                "该语音模型尚未完成行为验证，请从页面的可用模型中选择。",
                 status_code=422,
             )
         return model_id
@@ -530,12 +705,13 @@ class SpeechService:
         return voice
 
     @staticmethod
-    def _response_format(value: str) -> str:
+    def _response_format(model_id: str, value: str) -> str:
         response_format = str(value or "").strip().lower()
-        if response_format != "mp3":
+        expected_format = speech_output_format(model_id)
+        if response_format != expected_format:
             raise MultimodalServiceError(
                 "unsupported_speech_format",
-                "首期语音生成只支持 MP3。",
+                f"该模型当前只支持 {expected_format.upper()} 输出。",
                 status_code=422,
             )
         return response_format

--- a/server/tests/test_model_router_foundation.py
+++ b/server/tests/test_model_router_foundation.py
@@ -47,6 +47,7 @@ def test_schema_and_credentials_are_tenant_scoped_and_persistent(
 
     assert all(repository.count_schema_tenant_columns().values())
     assert created.tenant_id == "local"
+    assert created.scopes == ["chat", "audio"]
     assert created.masked_key != "sk-test-secret-value"
     assert repository.resolve_api_key("local", created.id) == "sk-test-secret-value"
     with pytest.raises(RouterConnectionNotFound):
@@ -65,6 +66,78 @@ def test_schema_and_credentials_are_tenant_scoped_and_persistent(
             connection.execute("PRAGMA user_version").fetchone()[0]
             == SCHEMA_VERSION
         )
+
+
+def test_connection_scopes_default_by_provider_and_migrate_v7(
+    tmp_path: Path,
+) -> None:
+    legacy_dir = tmp_path / "legacy"
+    legacy_dir.mkdir()
+    legacy_database = legacy_dir / "router.sqlite3"
+    with sqlite3.connect(legacy_database) as connection:
+        connection.executescript(
+            """
+            CREATE TABLE router_connections (
+                id TEXT NOT NULL,
+                tenant_id TEXT NOT NULL,
+                name TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                base_url TEXT NOT NULL,
+                masked_key TEXT NOT NULL,
+                api_key_ciphertext TEXT NOT NULL,
+                enabled INTEGER NOT NULL DEFAULT 1,
+                health TEXT NOT NULL DEFAULT 'untested',
+                model_count INTEGER NOT NULL DEFAULT 0,
+                last_checked_at TEXT,
+                last_error_code TEXT,
+                last_error_hint TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                PRIMARY KEY (tenant_id, id)
+            );
+            PRAGMA user_version = 7;
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO router_connections (
+                id, tenant_id, name, kind, base_url, masked_key,
+                api_key_ciphertext, enabled, health, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "legacy-openrouter",
+                "local",
+                "Legacy OpenRouter",
+                "openrouter",
+                "https://openrouter.ai/api/v1",
+                "sk******cy",
+                "not-used-by-this-test",
+                1,
+                "online",
+                "2026-07-29T00:00:00+00:00",
+                "2026-07-29T00:00:00+00:00",
+            ),
+        )
+
+    migrated = SQLiteRouterRepository(
+        legacy_dir,
+        master_key=b"migration-test-key",
+    )
+    assert migrated.get_connection(
+        "local", "legacy-openrouter"
+    ).scopes == ["chat", "audio"]
+
+    direct_openai = migrated.create_connection(
+        "local",
+        connection_payload(
+            kind="openai",
+            name="OpenAI Audio",
+            base_url="https://api.openai.com/v1",
+        ),
+    )
+    assert direct_openai.scopes == ["audio", "realtime"]
+    assert ModelRouterService(migrated).status().connection_count == 1
 
 
 def test_disable_restore_and_policy_persist_without_delete(tmp_path: Path) -> None:
@@ -301,6 +374,7 @@ async def test_connection_api_is_redacted_and_records_health(tmp_path: Path) -> 
         serialized = json.dumps(created, ensure_ascii=False)
         assert "sk-test-secret-value" not in serialized
         assert "api_key_ciphertext" not in serialized
+        assert created["scopes"] == ["chat", "audio"]
 
         tested_response = await client.post(
             f"/api/router/connections/{created['id']}/test"
@@ -370,6 +444,14 @@ async def test_native_catalog_uses_30_second_cache_and_stale_if_error(
 
     repository = SQLiteRouterRepository(tmp_path)
     connection = repository.create_connection("local", connection_payload())
+    direct_openai = repository.create_connection(
+        "local",
+        connection_payload(
+            kind="openai",
+            name="OpenAI Audio",
+            base_url="https://api.openai.com/v1",
+        ),
+    )
     service = ModelRouterService(
         repository,
         client_factory=lambda: httpx.AsyncClient(transport=MockTransport(handler)),
@@ -394,6 +476,9 @@ async def test_native_catalog_uses_30_second_cache_and_stale_if_error(
     assert fresh.source == "native"
     assert fresh.models[0].connection_id == connection.id
     assert fresh.models[0].invocation_id == "provider/model-a"
+    assert all(
+        item.connection_id != direct_openai.id for item in fresh.models
+    )
 
     cached = await catalog_service.get_catalog(
         service, FallbackCatalog()  # type: ignore[arg-type]

--- a/server/tests/test_multimodal_audio_jobs.py
+++ b/server/tests/test_multimodal_audio_jobs.py
@@ -1,0 +1,558 @@
+from __future__ import annotations
+
+import base64
+import json
+import sqlite3
+from pathlib import Path
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient, MockTransport, Request, Response
+
+from server.model_router.repository import SQLiteRouterRepository
+from server.model_router.schemas import RouterConnectionCreate
+from server.model_router.service import ModelRouterService
+from server.multimodal.api import configure_audio_job_service, router
+from server.multimodal.audio_catalog import (
+    AudioChatProfile,
+    AudioModelCatalogResponse,
+)
+from server.multimodal.audio_jobs import (
+    AudioGenerationResult,
+    AudioJobService,
+    OpenRouterAudioJobAdapter,
+)
+from server.multimodal.stt import MultimodalServiceError, OpenRouterTarget
+
+
+MP3 = b"ID3" + b"\x04\x00\x00" + b"generated-music" * 100
+PNG = b"\x89PNG\r\n\x1a\n" + b"safe-image"
+
+
+def router_service(
+    storage: Path, *, tenant_id: str = "local"
+) -> ModelRouterService:
+    repository = SQLiteRouterRepository(storage)
+    connection = repository.create_connection(
+        tenant_id,
+        RouterConnectionCreate(
+            name="OpenRouter",
+            kind="openrouter",
+            base_url="https://openrouter.ai/api/v1",
+            api_key="audio-job-secret",
+        ),
+    )
+    repository.save_test_result(
+        tenant_id,
+        connection.id,
+        health="online",
+        model_count=2,
+        checked_at="2026-07-29T00:00:00+00:00",
+    )
+    return ModelRouterService(repository, tenant_id=tenant_id)
+
+
+class StubAudioCatalog:
+    def __init__(self, router_instance: ModelRouterService) -> None:
+        self.router = router_instance
+        pricing = {
+            "google/lyria-3-clip-preview": (0.04, 30),
+            "google/lyria-3-pro-preview": (0.08, None),
+        }
+        self.profiles = [
+            AudioChatProfile(
+                model_id=model_id,
+                display_name=model_id,
+                provider="openrouter",
+                connection_id=None,
+                invocable=True,
+                interaction_status="planned",
+                status_reason="frontend pending",
+                operations=["generate_audio"],
+                output_formats=["mp3"],
+                supports_image_prompt=True,
+                price_per_generation_usd=pricing[model_id][0],
+                fixed_duration_seconds=pricing[model_id][1],
+            )
+            for model_id in (
+                "google/lyria-3-clip-preview",
+                "google/lyria-3-pro-preview",
+            )
+        ]
+
+    async def get_catalog(
+        self, *, force: bool = False
+    ) -> AudioModelCatalogResponse:
+        del force
+        return AudioModelCatalogResponse(
+            source="openrouter",
+            status="online",
+            stale=False,
+            synced_at="2026-07-29T00:00:00+00:00",
+            profiles=self.profiles,
+        )
+
+    def resolve_target(self) -> OpenRouterTarget:
+        connection = self.router.list_connections(scope="audio")[0]
+        return OpenRouterTarget(
+            base_url=connection.base_url,
+            api_key=self.router.repository.resolve_api_key(
+                self.router.tenant_id, connection.id
+            ),
+            connection_id=connection.id,
+            cache_key=connection.id,
+        )
+
+
+class FakeAudioAdapter:
+    def __init__(
+        self,
+        *,
+        result: AudioGenerationResult | None = None,
+        error: MultimodalServiceError | None = None,
+    ) -> None:
+        self.result = result or AudioGenerationResult(
+            content=MP3,
+            actual_model="google/lyria-3-clip-preview",
+            generation_id="gen-audio-test",
+            cost_usd=0.04,
+        )
+        self.error = error
+        self.calls: list[dict[str, object]] = []
+
+    async def generate(
+        self,
+        _: OpenRouterTarget,
+        *,
+        model_id: str,
+        prompt: str,
+        image_data_url: str | None,
+    ) -> AudioGenerationResult:
+        self.calls.append(
+            {
+                "model_id": model_id,
+                "prompt": prompt,
+                "image_data_url": image_data_url,
+            }
+        )
+        if self.error is not None:
+            raise self.error
+        return self.result
+
+
+def job_service(
+    storage: Path,
+    *,
+    tenant_id: str = "local",
+    adapter: FakeAudioAdapter | None = None,
+) -> tuple[AudioJobService, FakeAudioAdapter]:
+    router_instance = router_service(storage, tenant_id=tenant_id)
+    fake = adapter or FakeAudioAdapter()
+    return (
+        AudioJobService(
+            router_instance,
+            StubAudioCatalog(router_instance),  # type: ignore[arg-type]
+            adapter=fake,  # type: ignore[arg-type]
+            output_dir=storage / f"audio-output-{tenant_id}",
+        ),
+        fake,
+    )
+
+
+@pytest.mark.asyncio
+async def test_adapter_decodes_split_sse_audio_and_actual_cost() -> None:
+    encoded = base64.b64encode(MP3).decode("ascii")
+    parts = (encoded[:17], encoded[17:503], encoded[503:])
+
+    def handler(request: Request) -> Response:
+        payload = json.loads(request.content)
+        assert payload["model"] == "google/lyria-3-clip-preview"
+        assert payload["stream"] is True
+        assert "audio-job-secret" in request.headers["authorization"]
+        events = [
+            {
+                "id": "gen-stream",
+                "model": "google/lyria-3-clip-preview",
+                "choices": [{"delta": {"audio": {"data": parts[0]}}}],
+            },
+            {
+                "choices": [{"delta": {"audio": {"data": parts[1]}}}],
+            },
+            {
+                "choices": [
+                    {
+                        "delta": {"audio": {"data": parts[2]}},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"cost": 0.04, "total_tokens": 12},
+            },
+        ]
+        body = "".join(
+            f"data: {json.dumps(event)}\n\n" for event in events
+        )
+        body += "data: [DONE]\n\n"
+        return Response(
+            200,
+            headers={
+                "content-type": "text/event-stream",
+                "x-generation-id": "gen-header",
+            },
+            content=body.encode(),
+        )
+
+    adapter = OpenRouterAudioJobAdapter(
+        client_factory=lambda: httpx.AsyncClient(
+            transport=MockTransport(handler)
+        )
+    )
+    result = await adapter.generate(
+        OpenRouterTarget(
+            base_url="https://openrouter.ai/api/v1",
+            api_key="audio-job-secret",
+            connection_id=None,
+            cache_key="test",
+        ),
+        model_id="google/lyria-3-clip-preview",
+        prompt="A calm instrumental",
+        image_data_url=None,
+    )
+
+    assert result.content == MP3
+    assert result.cost_usd == 0.04
+    assert result.generation_id == "gen-header"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("status", "code"),
+    [(402, "provider_payment_required"), (429, "provider_rate_limited")],
+)
+async def test_adapter_translates_paid_generation_errors(
+    status: int, code: str
+) -> None:
+    adapter = OpenRouterAudioJobAdapter(
+        client_factory=lambda: httpx.AsyncClient(
+            transport=MockTransport(
+                lambda _: Response(
+                    status,
+                    json={"error": {"message": "private upstream detail"}},
+                )
+            )
+        )
+    )
+    with pytest.raises(MultimodalServiceError) as captured:
+        await adapter.generate(
+            OpenRouterTarget(
+                base_url="https://openrouter.ai/api/v1",
+                api_key="secret",
+                connection_id=None,
+                cache_key="test",
+            ),
+            model_id="google/lyria-3-clip-preview",
+            prompt="A calm instrumental",
+            image_data_url=None,
+        )
+    assert captured.value.code == code
+    assert "private upstream detail" not in captured.value.message
+
+
+@pytest.mark.asyncio
+async def test_idempotent_job_runs_once_and_delivers_complete_mp3(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MULTIMODAL_AUDIO_GENERATION_ENABLED", "true")
+    service, adapter = job_service(tmp_path)
+
+    launch = await service.create(
+        model_id="google/lyria-3-clip-preview",
+        prompt="A calm instrumental",
+        idempotency_key="audio-job-0001",
+    )
+    duplicate = await service.create(
+        model_id="google/lyria-3-clip-preview",
+        prompt="A different prompt must not trigger another charge",
+        idempotency_key="audio-job-0001",
+    )
+
+    assert launch.job.status == "queued"
+    assert launch.job.usage.cost_usd == 0.04
+    assert launch.job.usage.cost_kind == "estimated"
+    assert launch.task is not None
+    assert duplicate.job.job_id == launch.job.job_id
+    assert duplicate.task is None
+    await service.run(launch.task)
+
+    completed = service.get(launch.job.job_id)
+    assert completed.status == "succeeded"
+    assert completed.output_bytes == len(MP3)
+    assert completed.usage.cost_usd == 0.04
+    assert completed.usage.cost_kind == "actual"
+    assert len(adapter.calls) == 1
+
+    content = await service.content(completed.job_id)
+    delivered = b"".join([chunk async for chunk in content.chunks])
+    assert delivered == MP3
+    assert content.media_type == "audio/mpeg"
+
+    repository = service.router_service.repository
+    row = repository.get_audio_job("local", completed.job_id)
+    assert row is not None
+    assert "prompt" not in row
+    assert repository.count_schema_tenant_columns()["audio_jobs"] is True
+    with sqlite3.connect(repository.database_path) as connection:
+        operation = connection.execute(
+            "SELECT operation FROM router_decisions WHERE tenant_id = ?",
+            ("local",),
+        ).fetchone()
+    assert operation == ("generate_audio",)
+
+
+@pytest.mark.asyncio
+async def test_pro_image_prompt_is_enabled_and_not_persisted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MULTIMODAL_AUDIO_GENERATION_ENABLED", "true")
+    result = AudioGenerationResult(
+        content=MP3,
+        actual_model="google/lyria-3-pro-preview",
+        generation_id="gen-pro",
+        cost_usd=0.08,
+    )
+    service, adapter = job_service(
+        tmp_path,
+        adapter=FakeAudioAdapter(result=result),
+    )
+
+    launch = await service.create(
+        model_id="google/lyria-3-pro-preview",
+        prompt="Turn the image into a full instrumental song",
+        idempotency_key="audio-job-pro-image",
+        image_filename="mood.png",
+        image_content_type="image/png",
+        image_content=PNG,
+    )
+    assert launch.task is not None
+    await service.run(launch.task)
+
+    job = service.get(launch.job.job_id)
+    assert job.status == "succeeded"
+    assert job.parameters.has_image is True
+    assert job.usage.cost_usd == 0.08
+    assert str(adapter.calls[0]["image_data_url"]).startswith(
+        "data:image/png;base64,"
+    )
+    row = service.router_service.repository.get_audio_job(
+        "local", job.job_id
+    )
+    assert row is not None
+    assert set(row).isdisjoint({"prompt", "image", "audio", "filename"})
+
+
+@pytest.mark.asyncio
+async def test_missing_gateway_cost_preserves_catalog_estimate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MULTIMODAL_AUDIO_GENERATION_ENABLED", "true")
+    result = AudioGenerationResult(
+        content=MP3,
+        actual_model="google/lyria-3-clip-preview",
+        generation_id="gen-estimated-cost",
+        cost_usd=None,
+    )
+    service, _ = job_service(
+        tmp_path,
+        adapter=FakeAudioAdapter(result=result),
+    )
+
+    launch = await service.create(
+        model_id="google/lyria-3-clip-preview",
+        prompt="A calm instrumental",
+        idempotency_key="audio-job-estimated-cost",
+    )
+    assert launch.task is not None
+    await service.run(launch.task)
+
+    completed = service.get(launch.job.job_id)
+    assert completed.status == "succeeded"
+    assert completed.usage.cost_usd == 0.04
+    assert completed.usage.cost_kind == "estimated"
+
+
+@pytest.mark.asyncio
+async def test_listing_keeps_live_job_and_startup_recovery_marks_it_failed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MULTIMODAL_AUDIO_GENERATION_ENABLED", "true")
+    service, adapter = job_service(tmp_path)
+    launch = await service.create(
+        model_id="google/lyria-3-clip-preview",
+        prompt="A calm instrumental",
+        idempotency_key="audio-job-live-listing",
+    )
+    assert launch.task is not None
+
+    listing = service.list()
+    assert listing.jobs[0].status == "queued"
+    assert service.get(launch.job.job_id).status == "queued"
+    assert adapter.calls == []
+
+    service.recover_interrupted()
+    recovered = service.get(launch.job.job_id)
+    assert recovered.status == "failed"
+    assert recovered.error is not None
+    assert recovered.error.code == "worker_interrupted"
+    assert adapter.calls == []
+
+
+@pytest.mark.asyncio
+async def test_invalid_image_is_rejected_before_job_or_paid_call(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MULTIMODAL_AUDIO_GENERATION_ENABLED", "true")
+    service, adapter = job_service(tmp_path)
+    with pytest.raises(MultimodalServiceError) as captured:
+        await service.create(
+            model_id="google/lyria-3-pro-preview",
+            prompt="A song",
+            idempotency_key="audio-job-invalid-image",
+            image_filename="mood.png",
+            image_content_type="image/png",
+            image_content=b"not-a-png",
+        )
+    assert captured.value.code == "invalid_image_prompt"
+    assert service.list().jobs == []
+    assert adapter.calls == []
+
+
+@pytest.mark.asyncio
+async def test_failed_generation_never_exposes_partial_content(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MULTIMODAL_AUDIO_GENERATION_ENABLED", "true")
+    error = MultimodalServiceError(
+        "audio_output_incomplete",
+        "safe error",
+        status_code=502,
+    )
+    service, _ = job_service(
+        tmp_path,
+        adapter=FakeAudioAdapter(error=error),
+    )
+    launch = await service.create(
+        model_id="google/lyria-3-clip-preview",
+        prompt="A calm instrumental",
+        idempotency_key="audio-job-incomplete",
+    )
+    assert launch.task is not None
+    await service.run(launch.task)
+
+    job = service.get(launch.job.job_id)
+    assert job.status == "failed"
+    assert job.error is not None
+    assert job.error.code == "audio_output_incomplete"
+    with pytest.raises(MultimodalServiceError) as captured:
+        await service.content(job.job_id)
+    assert captured.value.code == "audio_not_ready"
+
+
+@pytest.mark.asyncio
+async def test_expiry_and_tenant_isolation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MULTIMODAL_AUDIO_GENERATION_ENABLED", "true")
+    local, _ = job_service(tmp_path / "shared", tenant_id="local")
+    launch = await local.create(
+        model_id="google/lyria-3-clip-preview",
+        prompt="A calm instrumental",
+        idempotency_key="audio-job-expiry",
+    )
+    assert launch.task is not None
+    await local.run(launch.task)
+    local.router_service.repository.update_audio_job(
+        "local",
+        launch.job.job_id,
+        expires_at="2020-01-01T00:00:00+00:00",
+    )
+    assert local.get(launch.job.job_id).status == "expired"
+
+    other, _ = job_service(tmp_path / "shared", tenant_id="other")
+    with pytest.raises(MultimodalServiceError) as captured:
+        other.get(launch.job.job_id)
+    assert captured.value.code == "audio_job_not_found"
+
+
+@pytest.mark.asyncio
+async def test_api_creates_lists_downloads_and_removes_job(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MULTIMODAL_AUDIO_GENERATION_ENABLED", "true")
+    service, adapter = job_service(tmp_path)
+    configure_audio_job_service(service)
+    app = FastAPI()
+    app.include_router(router)
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            created = await client.post(
+                "/api/multimodal/audio/jobs",
+                data={
+                    "model_id": "google/lyria-3-clip-preview",
+                    "prompt": "A calm instrumental",
+                    "idempotency_key": "audio-job-api-0001",
+                },
+            )
+            assert created.status_code == 200
+            job_id = created.json()["job_id"]
+            assert len(adapter.calls) == 1
+
+            detail = await client.get(
+                f"/api/multimodal/audio/jobs/{job_id}"
+            )
+            assert detail.json()["status"] == "succeeded"
+            content = await client.get(
+                f"/api/multimodal/audio/jobs/{job_id}/content"
+            )
+            assert content.status_code == 200
+            assert content.headers["content-type"].startswith("audio/mpeg")
+            assert content.content == MP3
+
+            listing = await client.get("/api/multimodal/audio/jobs")
+            assert listing.json()["jobs"][0]["job_id"] == job_id
+            removed = await client.delete(
+                f"/api/multimodal/audio/jobs/{job_id}"
+            )
+            assert removed.json() == {
+                "removed": True,
+                "upstream_cancelled": False,
+            }
+    finally:
+        configure_audio_job_service(None)
+
+
+@pytest.mark.asyncio
+async def test_feature_flag_blocks_job_before_audit_or_call(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MULTIMODAL_AUDIO_GENERATION_ENABLED", "false")
+    service, adapter = job_service(tmp_path)
+    with pytest.raises(MultimodalServiceError) as captured:
+        await service.create(
+            model_id="google/lyria-3-clip-preview",
+            prompt="A calm instrumental",
+            idempotency_key="audio-job-disabled",
+        )
+    assert captured.value.code == "audio_generation_disabled"
+    assert adapter.calls == []

--- a/server/tests/test_multimodal_chat_audio.py
+++ b/server/tests/test_multimodal_chat_audio.py
@@ -339,8 +339,9 @@ async def test_direct_audio_chat_uses_verified_openrouter_contract(
         assert attachment_id not in json.dumps(sent["json"])
         assert "音频内容摘要" in result.text
         assert result.text.count("event: route_receipt") == 1
+        assert result.text.count("event: message_end") == 1
         assert result.text.index("event: route_receipt") < result.text.index(
-            "data: [DONE]"
+            "event: message_end"
         )
         receipt_event = next(
             event
@@ -591,7 +592,14 @@ async def test_native_audio_output_uses_verified_streaming_contract(
         assert first_audio in result.text
         assert second_audio in result.text
         assert result.text.count("event: route_receipt") == 1
+        assert result.text.count("event: message_end") == 1
         assert result.text.count("data: [DONE]") == 1
+        assert result.text.index("event: route_receipt") < result.text.index(
+            "event: message_end"
+        )
+        assert result.text.index("event: message_end") < result.text.index(
+            "data: [DONE]"
+        )
         receipt_event = next(
             event
             for event in result.text.split("\n\n")
@@ -612,6 +620,67 @@ async def test_native_audio_output_uses_verified_streaming_contract(
             "format": "mp3",
             "raw_retained": False,
         }
+        decision = service.diagnostics()["recent_decisions"][0]
+        assert decision["operation"] == "chat_audio_output"
+        assert decision["outcome"] == "success"
+    finally:
+        configure_audio_catalog_service(None)
+        configure_chat_attachment_store(None)
+        configure_model_router(original_service)
+
+
+@pytest.mark.asyncio
+async def test_native_audio_output_accepts_pure_audio_response(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_service = get_model_router_service()
+    service, _ = configure_audio_test_services(tmp_path, monkeypatch)
+    monkeypatch.setenv("MULTIMODAL_STREAMING_AUDIO_ENABLED", "true")
+    sent_requests: list[dict[str, Any]] = []
+    audio_chunks = [
+        base64.b64encode(b"ID3-pure-").decode("ascii"),
+        base64.b64encode(b"audio-tail").decode("ascii"),
+    ]
+    response = FakeResponse(
+        chunks=[
+            (
+                'data: {"model":"openai/gpt-audio","choices":'
+                '[{"delta":{"audio":{"data":"'
+                + audio_chunks[0]
+                + '"}},"finish_reason":null}]}\n\n'
+            ),
+            (
+                'data: {"choices":[{"delta":{"audio":{"data":"'
+                + audio_chunks[1]
+                + '"}},"finish_reason":"stop"}],"usage":'
+                '{"prompt_tokens":4,"completion_tokens":6,'
+                '"total_tokens":10}}\n\n'
+            ),
+            "data: [DONE]\n\n",
+        ]
+    )
+    fake_chat_client(monkeypatch, response, sent_requests)
+
+    try:
+        async with RealAsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://testserver",
+        ) as client:
+            result = await client.post(
+                "/api/chat",
+                json=native_audio_output_payload(),
+            )
+
+        assert result.status_code == 200, result.text
+        assert all(chunk in result.text for chunk in audio_chunks)
+        assert '"error":' not in result.text
+        assert result.text.count("event: route_receipt") == 1
+        assert result.text.count("event: message_end") == 1
+        assert result.text.count("data: [DONE]") == 1
+        assert result.text.index("event: route_receipt") < result.text.index(
+            "event: message_end"
+        )
         decision = service.diagnostics()["recent_decisions"][0]
         assert decision["operation"] == "chat_audio_output"
         assert decision["outcome"] == "success"

--- a/server/tests/test_multimodal_chat_foundation.py
+++ b/server/tests/test_multimodal_chat_foundation.py
@@ -15,7 +15,10 @@ from server.multimodal.api import (
     configure_chat_attachment_store,
     router,
 )
-from server.multimodal.audio_catalog import AudioCatalogService
+from server.multimodal.audio_catalog import (
+    OPENROUTER_AUDIO_CONTRACTS,
+    AudioCatalogService,
+)
 from server.multimodal.chat_attachments import ChatAttachmentStore
 from server.multimodal.stt import MultimodalServiceError
 
@@ -55,6 +58,54 @@ def audio_catalog_payload() -> dict[str, object]:
                 },
             },
             {
+                "id": "google/gemini-3.6-flash",
+                "name": "Google: Gemini 3.6 Flash",
+                "architecture": {
+                    "input_modalities": ["text", "audio"],
+                    "output_modalities": ["text"],
+                },
+            },
+            {
+                "id": "google/gemini-3.5-flash",
+                "name": "Google: Gemini 3.5 Flash",
+                "architecture": {
+                    "input_modalities": ["text", "audio"],
+                    "output_modalities": ["text"],
+                },
+            },
+            {
+                "id": "google/gemini-3.5-flash-lite",
+                "name": "Google: Gemini 3.5 Flash Lite",
+                "architecture": {
+                    "input_modalities": ["text", "audio"],
+                    "output_modalities": ["text"],
+                },
+            },
+            {
+                "id": "google/gemini-2.5-flash",
+                "name": "Google: Gemini 2.5 Flash",
+                "architecture": {
+                    "input_modalities": ["text", "audio"],
+                    "output_modalities": ["text"],
+                },
+            },
+            {
+                "id": "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free",
+                "name": "NVIDIA: Nemotron 3 Nano Omni",
+                "architecture": {
+                    "input_modalities": ["text", "audio"],
+                    "output_modalities": ["text"],
+                },
+            },
+            {
+                "id": "mistralai/voxtral-small-24b-2507",
+                "name": "Mistral: Voxtral Small 24B",
+                "architecture": {
+                    "input_modalities": ["text", "audio"],
+                    "output_modalities": ["text"],
+                },
+            },
+            {
                 "id": "microsoft/mai-transcribe-1.5",
                 "name": "Microsoft: MAI Transcribe 1.5",
                 "input_modalities": ["audio"],
@@ -65,6 +116,7 @@ def audio_catalog_payload() -> dict[str, object]:
                 "name": "Microsoft: MAI Voice 2",
                 "input_modalities": ["text"],
                 "output_modalities": ["speech"],
+                "supported_voices": ["en-US-Harper:MAI-Voice-2"],
             },
             {
                 "id": "google/lyria-test",
@@ -79,12 +131,107 @@ def audio_catalog_payload() -> dict[str, object]:
                 "output_modalities": ["text"],
             },
             {
+                "id": "provider/unverified-stt",
+                "name": "Provider: Unverified STT",
+                "input_modalities": ["audio"],
+                "output_modalities": ["transcription"],
+            },
+            {
+                "id": "x-ai/grok-voice-tts-1.0",
+                "name": "xAI: Grok Voice TTS 1.0",
+                "input_modalities": ["text"],
+                "output_modalities": ["speech"],
+                "supported_voices": ["ara", "eve", "unverified"],
+            },
+            {
+                "id": "google/gemini-3.1-flash-tts-preview",
+                "name": "Google: Gemini 3.1 Flash TTS Preview",
+                "input_modalities": ["text"],
+                "output_modalities": ["speech"],
+                "supported_voices": ["Aoede", "Kore", "Puck"],
+            },
+            {
+                "id": "deepgram/aura-2",
+                "name": "Deepgram: Aura 2",
+                "input_modalities": ["text"],
+                "output_modalities": ["speech"],
+                "supported_voices": [
+                    "aura-2-amalthea-en",
+                    "aura-2-apollo-en",
+                ],
+            },
+            {
+                "id": "minimax/speech-2.8-hd",
+                "name": "MiniMax: Speech 2.8 HD",
+                "input_modalities": ["text"],
+                "output_modalities": ["speech"],
+            },
+            {
+                "id": "minimax/speech-2.8-turbo",
+                "name": "MiniMax: Speech 2.8 Turbo",
+                "input_modalities": ["text"],
+                "output_modalities": ["speech"],
+            },
+            {
+                "id": "google/lyria-3-clip-preview",
+                "name": "Google: Lyria 3 Clip Preview",
+                "input_modalities": ["text"],
+                "output_modalities": ["audio"],
+            },
+            {
                 "id": "provider/text-only",
                 "input_modalities": ["text"],
                 "output_modalities": ["text"],
             },
+            {
+                "id": "provider/audio-conditioned-video",
+                "input_modalities": ["text", "audio"],
+                "output_modalities": ["video"],
+            },
         ]
     }
+
+
+def test_audio_contract_registry_keeps_verified_and_planned_models_separate() -> None:
+    verified_direct_models = {
+        "google/gemini-2.5-flash",
+        "google/gemini-2.5-pro",
+        "google/gemini-2.5-pro-preview-05-06",
+        "google/gemini-3.1-flash-lite",
+        "google/gemini-3.1-pro-preview",
+        "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free",
+        "thinkingmachines/inkling",
+        "xiaomi/mimo-v2.5",
+    }
+    assert all(
+        OPENROUTER_AUDIO_CONTRACTS[model_id].behavior_verified
+        for model_id in verified_direct_models
+    )
+    assert all(
+        OPENROUTER_AUDIO_CONTRACTS[model_id].input_formats == ("wav",)
+        for model_id in verified_direct_models
+    )
+    for model_id in (
+        "google/lyria-3-clip-preview",
+        "google/lyria-3-pro-preview",
+    ):
+        assert OPENROUTER_AUDIO_CONTRACTS[model_id].behavior_verified
+        assert (
+            OPENROUTER_AUDIO_CONTRACTS[model_id].supports_image_prompt
+            is True
+        )
+        assert OPENROUTER_AUDIO_CONTRACTS[model_id].output_formats == (
+            "mp3",
+        )
+    for model_id in (
+        "minimax/speech-2.8-hd",
+        "minimax/speech-2.8-turbo",
+    ):
+        contract = OPENROUTER_AUDIO_CONTRACTS[model_id]
+        assert contract.behavior_verified
+        assert contract.chat_modes == ("synthesize_speech",)
+        assert contract.output_formats == ("mp3",)
+        assert "Chinese (Mandarin)_News_Anchor" in contract.voices
 
 
 @pytest.mark.asyncio
@@ -94,6 +241,9 @@ async def test_audio_catalog_disabled_without_chat_flags(
 ) -> None:
     monkeypatch.delenv("MULTIMODAL_CHAT_AUDIO_ENABLED", raising=False)
     monkeypatch.delenv("MULTIMODAL_STREAMING_AUDIO_ENABLED", raising=False)
+    monkeypatch.delenv("MULTIMODAL_AUDIO_GENERATION_ENABLED", raising=False)
+    monkeypatch.delenv("MULTIMODAL_REALTIME_VOICE_ENABLED", raising=False)
+    monkeypatch.delenv("MULTIMODAL_VOICE_CLONING_ENABLED", raising=False)
     service = AudioCatalogService(openrouter_service(tmp_path))
 
     result = await service.get_catalog()
@@ -109,6 +259,7 @@ async def test_audio_catalog_only_marks_verified_interactions_ready(
 ) -> None:
     monkeypatch.setenv("MULTIMODAL_CHAT_AUDIO_ENABLED", "true")
     monkeypatch.setenv("MULTIMODAL_STREAMING_AUDIO_ENABLED", "true")
+    monkeypatch.setenv("MULTIMODAL_AUDIO_GENERATION_ENABLED", "true")
     requests: list[Request] = []
 
     def handler(request: Request) -> Response:
@@ -126,6 +277,11 @@ async def test_audio_catalog_only_marks_verified_interactions_ready(
     by_id = {profile.model_id: profile for profile in result.profiles}
 
     assert result.status == "online"
+    assert result.catalog_version == (
+        "modelmirror-audio-contracts-2026-07-29-b10"
+    )
+    assert by_id["openai/gpt-audio"].provider == "openrouter"
+    assert by_id["openai/gpt-audio"].operations == ["analyze_audio"]
     assert by_id["openai/gpt-audio"].chat_modes == [
         "direct_audio_input",
         "native_streaming_audio_output",
@@ -138,6 +294,25 @@ async def test_audio_catalog_only_marks_verified_interactions_ready(
         "ogg",
         "wav",
     ]
+    for model_id in (
+        "google/gemini-2.5-flash",
+        "google/gemini-3.6-flash",
+        "google/gemini-3.5-flash",
+        "google/gemini-3.5-flash-lite",
+    ):
+        assert by_id[model_id].interaction_status == "ready"
+        assert by_id[model_id].operations == ["analyze_audio"]
+        assert by_id[model_id].chat_modes == ["direct_audio_input"]
+        assert by_id[model_id].supports_streaming_output is False
+    assert by_id[
+        "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free"
+    ].chat_modes == ["direct_audio_input"]
+    assert by_id[
+        "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free"
+    ].input_formats == ["wav"]
+    assert by_id[
+        "mistralai/voxtral-small-24b-2507"
+    ].input_formats == ["flac", "m4a", "mp3", "ogg", "wav"]
     assert by_id["microsoft/mai-transcribe-1.5"].chat_modes == [
         "transcribe"
     ]
@@ -150,16 +325,164 @@ async def test_audio_catalog_only_marks_verified_interactions_ready(
     assert by_id["microsoft/mai-voice-2"].voices == [
         "en-US-Harper:MAI-Voice-2"
     ]
+    assert by_id["x-ai/grok-voice-tts-1.0"].interaction_status == "ready"
+    assert by_id["x-ai/grok-voice-tts-1.0"].voices == ["ara", "eve"]
+    assert by_id[
+        "google/gemini-3.1-flash-tts-preview"
+    ].interaction_status == "ready"
+    assert by_id[
+        "google/gemini-3.1-flash-tts-preview"
+    ].output_formats == ["wav"]
+    assert by_id["deepgram/aura-2"].interaction_status == "ready"
+    assert by_id["deepgram/aura-2"].voices == [
+        "aura-2-amalthea-en",
+        "aura-2-apollo-en",
+    ]
+    for model_id in (
+        "minimax/speech-2.8-hd",
+        "minimax/speech-2.8-turbo",
+    ):
+        assert by_id[model_id].interaction_status == "ready"
+        assert by_id[model_id].chat_modes == ["synthesize_speech"]
+        assert by_id[model_id].output_formats == ["mp3"]
+        assert by_id[model_id].voices == [
+            "Chinese (Mandarin)_Mature_Woman",
+            "Chinese (Mandarin)_News_Anchor",
+            "Chinese (Mandarin)_Reliable_Executive",
+            "Chinese (Mandarin)_Warm_Girl",
+            "English_CalmWoman",
+            "English_Graceful_Lady",
+            "English_expressive_narrator",
+            "English_magnetic_voiced_man",
+        ]
+    assert by_id[
+        "google/lyria-3-clip-preview"
+    ].interaction_status == "ready"
+    assert by_id[
+        "google/lyria-3-clip-preview"
+    ].supports_image_prompt is True
+    assert by_id[
+        "google/lyria-3-clip-preview"
+    ].output_formats == ["mp3"]
+    assert by_id[
+        "google/lyria-3-clip-preview"
+    ].price_per_generation_usd == 0.04
+    assert by_id[
+        "google/lyria-3-clip-preview"
+    ].fixed_duration_seconds == 30
+    assert by_id["google/lyria-3-clip-preview"].chat_modes == []
+    assert by_id["provider/unverified-stt"].interaction_status == "planned"
+    assert by_id["provider/unverified-stt"].chat_modes == []
+    assert "格式与语言行为验证" in (
+        by_id["provider/unverified-stt"].status_reason or ""
+    )
     assert by_id["google/lyria-test"].interaction_status == "planned"
+    assert by_id["google/lyria-test"].operations == ["generate_audio"]
+    assert by_id["google/lyria-test"].status_reason
     assert by_id["google/lyria-test"].chat_modes == []
     assert (
         by_id["provider/unverified-audio"].interaction_status == "planned"
     )
     assert "provider/text-only" not in by_id
+    assert "provider/audio-conditioned-video" not in by_id
     assert requests[0].headers["authorization"] == (
         "Bearer audio-catalog-secret"
     )
     assert requests[0].url.params["output_modalities"] == "all"
+
+
+@pytest.mark.asyncio
+async def test_audio_catalog_marks_enabled_direct_openai_realtime_ready(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MULTIMODAL_CHAT_AUDIO_ENABLED", "true")
+    monkeypatch.setenv("MULTIMODAL_REALTIME_VOICE_ENABLED", "true")
+    repository = SQLiteRouterRepository(tmp_path)
+    openrouter = repository.create_connection(
+        "local",
+        RouterConnectionCreate(
+            name="OpenRouter",
+            kind="openrouter",
+            base_url="https://openrouter.ai/api/v1",
+            api_key="openrouter-secret",
+        ),
+    )
+    direct_openai = repository.create_connection(
+        "local",
+        RouterConnectionCreate(
+            name="OpenAI Audio",
+            kind="openai",
+            base_url="https://api.openai.com/v1",
+            api_key="openai-secret",
+        ),
+    )
+    for connection in (openrouter, direct_openai):
+        repository.save_test_result(
+            "local",
+            connection.id,
+            health="online",
+            model_count=2,
+            checked_at="2026-07-29T00:00:00+00:00",
+        )
+    requests: list[Request] = []
+    openai_available = [True]
+
+    def handler(request: Request) -> Response:
+        requests.append(request)
+        if request.url.host == "api.openai.com":
+            if not openai_available[0]:
+                return Response(503, text="private direct provider error")
+            return Response(
+                200,
+                json={
+                    "data": [
+                        {"id": "gpt-realtime-2.1-mini"},
+                        {"id": "gpt-4o-mini-tts"},
+                        {"id": "gpt-5.6"},
+                    ]
+                },
+            )
+        return Response(200, json=audio_catalog_payload())
+
+    service = AudioCatalogService(
+        ModelRouterService(repository),
+        client_factory=lambda: httpx.AsyncClient(
+            transport=MockTransport(handler)
+        ),
+    )
+    result = await service.get_catalog()
+    by_id = {
+        (profile.provider, profile.model_id): profile
+        for profile in result.profiles
+    }
+
+    assert result.source == "mixed"
+    realtime = by_id[("openai", "gpt-realtime-2.1-mini")]
+    assert realtime.connection_id == direct_openai.id
+    assert realtime.operations == ["realtime_voice"]
+    assert realtime.interaction_status == "ready"
+    assert realtime.status_reason is None
+    assert realtime.supports_streaming_input is True
+    assert realtime.supports_streaming_output is True
+    voice = by_id[("openai", "gpt-4o-mini-tts")]
+    assert voice.operations == ["synthesize_speech", "clone_voice"]
+    assert "无法验证删除" in (voice.status_reason or "")
+    assert ("openai", "gpt-5.6") not in by_id
+    assert {
+        request.headers["authorization"] for request in requests
+    } == {"Bearer openrouter-secret", "Bearer openai-secret"}
+
+    assert service._cache is not None
+    service._cache.stored_at -= 301
+    openai_available[0] = False
+    stale = await service.get_catalog()
+    assert stale.status == "stale"
+    assert stale.stale is True
+    assert any(
+        profile.provider == "openai" for profile in stale.profiles
+    )
+    assert "private direct provider error" not in stale.model_dump_json()
 
 
 @pytest.mark.asyncio
@@ -220,12 +543,17 @@ async def test_audio_catalog_endpoint_does_not_expose_credentials(
             transport=ASGITransport(app=app),
             base_url="http://test",
         ) as client:
-            response = await client.get("/api/multimodal/audio/models")
+            response = await client.get(
+                "/api/multimodal/audio/models?refresh=true"
+            )
     finally:
         configure_audio_catalog_service(None)
 
     assert response.status_code == 200
     assert response.json()["profiles"]
+    assert response.json()["catalog_version"] == (
+        "modelmirror-audio-contracts-2026-07-29-b10"
+    )
     assert response.json()["microphone_enabled"] is True
     assert "audio-catalog-secret" not in response.text
     assert "openrouter.ai" not in response.text

--- a/server/tests/test_multimodal_realtime.py
+++ b/server/tests/test_multimodal_realtime.py
@@ -1,0 +1,416 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from server.main import app
+from server.model_router.repository import SQLiteRouterRepository
+from server.model_router.schemas import RouterConnectionCreate
+from server.model_router.service import ModelRouterService
+from server.multimodal.api import configure_realtime_voice_service
+from server.multimodal.realtime import (
+    DirectOpenAITarget,
+    OpenAIRealtimeAdapter,
+    RealtimeCallRequest,
+    RealtimeVoiceService,
+)
+from server.multimodal.stt import MultimodalServiceError
+
+
+SDP_OFFER = (
+    "v=0\r\n"
+    "o=- 1 1 IN IP4 127.0.0.1\r\n"
+    "s=-\r\n"
+    "t=0 0\r\n"
+    "m=audio 9 UDP/TLS/RTP/SAVPF 111\r\n"
+)
+SDP_ANSWER = (
+    "v=0\r\n"
+    "o=- 2 2 IN IP4 127.0.0.1\r\n"
+    "s=-\r\n"
+    "t=0 0\r\n"
+    "m=audio 9 UDP/TLS/RTP/SAVPF 111\r\n"
+)
+
+
+def realtime_router_service(
+    tmp_path: Path,
+    *,
+    tenant_id: str = "local",
+    base_url: str = "https://api.openai.com/v1",
+) -> tuple[ModelRouterService, SQLiteRouterRepository, str]:
+    repository = SQLiteRouterRepository(tmp_path)
+    connection = repository.create_connection(
+        tenant_id,
+        RouterConnectionCreate(
+            name="OpenAI Realtime",
+            kind="openai",
+            base_url=base_url,
+            api_key="direct-openai-test-secret",
+        ),
+    )
+    repository.save_test_result(
+        tenant_id,
+        connection.id,
+        health="online",
+        model_count=2,
+        checked_at="2026-07-29T00:00:00+00:00",
+    )
+    return (
+        ModelRouterService(repository, tenant_id=tenant_id),
+        repository,
+        connection.id,
+    )
+
+
+def realtime_handler(
+    requests: list[httpx.Request],
+    *,
+    create_status: int = 201,
+    create_body: bytes | None = None,
+) -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.url.path.endswith("/hangup"):
+            return httpx.Response(200)
+        return httpx.Response(
+            create_status,
+            content=(
+                create_body
+                if create_body is not None
+                else SDP_ANSWER.encode("utf-8")
+            ),
+            headers={
+                "content-type": "application/sdp",
+                "location": "/v1/realtime/calls/rtc_test123",
+            },
+        )
+
+    return httpx.MockTransport(handler)
+
+
+@pytest.mark.asyncio
+async def test_realtime_call_uses_multipart_and_tenant_audit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MULTIMODAL_REALTIME_VOICE_ENABLED", "true")
+    router_service, repository, connection_id = realtime_router_service(
+        tmp_path
+    )
+    requests: list[httpx.Request] = []
+    adapter = OpenAIRealtimeAdapter(
+        client_factory=lambda: httpx.AsyncClient(
+            transport=realtime_handler(requests)
+        )
+    )
+    service = RealtimeVoiceService(router_service, adapter=adapter)
+
+    created = await service.create(
+        RealtimeCallRequest(
+            sdp=SDP_OFFER,
+            model_id="gpt-realtime-2.1-mini",
+            voice="marin",
+            vad_mode="semantic_vad",
+            language="zh-CN",
+        )
+    )
+
+    assert created.session_id.startswith("local_rt_")
+    assert created.sdp_answer == SDP_ANSWER.strip()
+    assert created.model_id == "gpt-realtime-2.1-mini"
+    assert requests[0].url == "https://api.openai.com/v1/realtime/calls"
+    assert requests[0].headers["authorization"] == (
+        "Bearer direct-openai-test-secret"
+    )
+    assert requests[0].headers["openai-safety-identifier"].startswith("mm_")
+    assert requests[0].headers["content-type"].startswith(
+        "multipart/form-data"
+    )
+    request_body = requests[0].content
+    assert SDP_OFFER.encode("utf-8") in request_body
+    assert b'"type":"semantic_vad"' in request_body
+    assert b'"interrupt_response":true' in request_body
+    assert b'"model":"gpt-realtime-2.1-mini"' in request_body
+    assert b"direct-openai-test-secret" not in request_body
+
+    row = repository.get_realtime_call("local", created.session_id)
+    assert row is not None
+    assert row["status"] == "active"
+    assert row["connection_id"] == connection_id
+    assert row["upstream_call_id"] == "rtc_test123"
+    serialized = json.dumps(row, ensure_ascii=False)
+    assert SDP_OFFER not in serialized
+    assert "direct-openai-test-secret" not in serialized
+
+    diagnostics = repository.get_diagnostics("local", limit=5)
+    assert diagnostics["recent_decisions"][0]["operation"] == "realtime_voice"
+    assert diagnostics["recent_decisions"][0]["outcome"] == "active"
+
+    ended = await service.end(created.session_id)
+    assert ended.status == "ended"
+    assert requests[-1].url.path.endswith(
+        "/v1/realtime/calls/rtc_test123/hangup"
+    )
+    ended_row = repository.get_realtime_call("local", created.session_id)
+    assert ended_row is not None
+    assert ended_row["status"] == "ended"
+    assert ended_row["duration_seconds"] is not None
+    assert ended_row["cost_kind"] == "unavailable"
+    await service.shutdown()
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_code"),
+    [
+        (
+            RealtimeCallRequest(sdp="not-an-sdp"),
+            "invalid_realtime_sdp",
+        ),
+        (
+            RealtimeCallRequest(
+                sdp=SDP_OFFER,
+                model_id="gpt-realtime-unverified",
+            ),
+            "unsupported_realtime_model",
+        ),
+        (
+            RealtimeCallRequest(sdp=SDP_OFFER, voice="custom-voice"),
+            "unsupported_realtime_voice",
+        ),
+        (
+            RealtimeCallRequest(sdp=SDP_OFFER, vad_mode="server_vad"),
+            "unsupported_realtime_vad",
+        ),
+        (
+            RealtimeCallRequest(sdp=SDP_OFFER, language="bad language"),
+            "invalid_realtime_language",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_realtime_rejects_unverified_contract_values_safely(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    payload: RealtimeCallRequest,
+    expected_code: str,
+) -> None:
+    monkeypatch.setenv("MULTIMODAL_REALTIME_VOICE_ENABLED", "true")
+    router_service = ModelRouterService(SQLiteRouterRepository(tmp_path))
+    service = RealtimeVoiceService(router_service)
+
+    with pytest.raises(MultimodalServiceError) as captured:
+        await service.create(payload)
+
+    assert captured.value.code == expected_code
+    assert SDP_OFFER not in captured.value.message
+
+
+@pytest.mark.asyncio
+async def test_realtime_requires_feature_and_official_openai_connection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    router_service, _, _ = realtime_router_service(
+        tmp_path,
+        base_url="https://example.invalid/v1",
+    )
+    service = RealtimeVoiceService(router_service)
+    payload = RealtimeCallRequest(sdp=SDP_OFFER)
+
+    monkeypatch.setenv("MULTIMODAL_REALTIME_VOICE_ENABLED", "false")
+    with pytest.raises(MultimodalServiceError) as disabled:
+        await service.create(payload)
+    assert disabled.value.code == "realtime_voice_disabled"
+
+    monkeypatch.setenv("MULTIMODAL_REALTIME_VOICE_ENABLED", "true")
+    with pytest.raises(MultimodalServiceError) as invalid_target:
+        await service.create(payload)
+    assert invalid_target.value.code == "invalid_realtime_connection"
+
+
+@pytest.mark.parametrize(
+    ("status", "expected_status", "expected_code"),
+    [
+        (400, 422, "realtime_request_rejected"),
+        (401, 401, "realtime_credentials_invalid"),
+        (402, 402, "realtime_payment_required"),
+        (403, 403, "realtime_access_denied"),
+        (429, 429, "realtime_rate_limited"),
+        (500, 502, "realtime_provider_error"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_realtime_translates_upstream_errors_without_body(
+    status: int,
+    expected_status: int,
+    expected_code: str,
+) -> None:
+    requests: list[httpx.Request] = []
+    adapter = OpenAIRealtimeAdapter(
+        client_factory=lambda: httpx.AsyncClient(
+            transport=realtime_handler(
+                requests,
+                create_status=status,
+                create_body=b"private provider error and secret",
+            )
+        )
+    )
+    target = DirectOpenAITarget(
+        base_url="https://api.openai.com/v1",
+        api_key="private-key",
+        connection_id="conn_test",
+        safety_identifier="mm_test",
+    )
+
+    with pytest.raises(MultimodalServiceError) as captured:
+        await adapter.create_call(
+            target,
+            sdp=SDP_OFFER,
+            session={"type": "realtime", "model": "gpt-realtime-2.1-mini"},
+        )
+
+    assert captured.value.status_code == expected_status
+    assert captured.value.code == expected_code
+    assert "private provider error" not in captured.value.message
+    assert "private-key" not in captured.value.message
+
+
+@pytest.mark.asyncio
+async def test_realtime_session_is_tenant_scoped_and_recovered_on_restart(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MULTIMODAL_REALTIME_VOICE_ENABLED", "true")
+    router_service, repository, _ = realtime_router_service(tmp_path)
+    first_requests: list[httpx.Request] = []
+    first_service = RealtimeVoiceService(
+        router_service,
+        adapter=OpenAIRealtimeAdapter(
+            client_factory=lambda: httpx.AsyncClient(
+                transport=realtime_handler(first_requests)
+            )
+        ),
+    )
+    created = await first_service.create(
+        RealtimeCallRequest(sdp=SDP_OFFER)
+    )
+
+    other_service = RealtimeVoiceService(
+        ModelRouterService(repository, tenant_id="other")
+    )
+    with pytest.raises(MultimodalServiceError) as hidden:
+        await other_service.end(created.session_id)
+    assert hidden.value.code == "realtime_session_not_found"
+
+    recovery_requests: list[httpx.Request] = []
+    recovery = RealtimeVoiceService(
+        router_service,
+        adapter=OpenAIRealtimeAdapter(
+            client_factory=lambda: httpx.AsyncClient(
+                transport=realtime_handler(recovery_requests)
+            )
+        ),
+    )
+    await recovery.recover_active()
+
+    row = repository.get_realtime_call("local", created.session_id)
+    assert row is not None
+    assert row["status"] == "interrupted"
+    assert row["error_code"] == "realtime_restart_interrupted"
+    assert recovery_requests[-1].url.path.endswith("/hangup")
+    await first_service.shutdown()
+    await recovery.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_realtime_session_hard_limit_hangs_up_and_marks_expired(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MULTIMODAL_REALTIME_VOICE_ENABLED", "true")
+    router_service, repository, _ = realtime_router_service(tmp_path)
+    requests: list[httpx.Request] = []
+    service = RealtimeVoiceService(
+        router_service,
+        adapter=OpenAIRealtimeAdapter(
+            client_factory=lambda: httpx.AsyncClient(
+                transport=realtime_handler(requests)
+            )
+        ),
+        session_seconds=1,
+    )
+    created = await service.create(
+        RealtimeCallRequest(sdp=SDP_OFFER)
+    )
+
+    for _ in range(30):
+        row = repository.get_realtime_call("local", created.session_id)
+        if row is not None and row["status"] == "expired":
+            break
+        await asyncio.sleep(0.05)
+
+    assert row is not None
+    assert row["status"] == "expired"
+    assert requests[-1].url.path.endswith("/hangup")
+    await service.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_realtime_api_returns_only_safe_session_fields(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MULTIMODAL_REALTIME_VOICE_ENABLED", "true")
+    router_service, _, _ = realtime_router_service(tmp_path)
+    requests: list[httpx.Request] = []
+    service = RealtimeVoiceService(
+        router_service,
+        adapter=OpenAIRealtimeAdapter(
+            client_factory=lambda: httpx.AsyncClient(
+                transport=realtime_handler(requests)
+            )
+        ),
+    )
+    configure_realtime_voice_service(service)
+    try:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://testserver",
+        ) as client:
+            created = await client.post(
+                "/api/multimodal/realtime/calls",
+                json={
+                    "sdp": SDP_OFFER,
+                    "model_id": "gpt-realtime-2.1",
+                    "voice": "cedar",
+                    "vad_mode": "semantic_vad",
+                    "language": "zh-CN",
+                },
+            )
+            assert created.status_code == 200
+            payload: dict[str, Any] = created.json()
+            assert set(payload) == {
+                "session_id",
+                "sdp_answer",
+                "expires_at",
+                "model_id",
+                "voice",
+            }
+            assert "private" not in created.text
+            ended = await client.delete(
+                (
+                    "/api/multimodal/realtime/calls/"
+                    f"{payload['session_id']}"
+                )
+            )
+            assert ended.status_code == 200
+            assert ended.json()["status"] == "ended"
+    finally:
+        await service.shutdown()
+        configure_realtime_voice_service(None)

--- a/server/tests/test_multimodal_stt.py
+++ b/server/tests/test_multimodal_stt.py
@@ -18,10 +18,54 @@ from server.multimodal.stt import (
     OpenRouterTarget,
     TranscriptionService,
     TranscriptionUsage,
+    VERIFIED_TRANSCRIPTION_PROFILES,
 )
 
 
 WAV_BYTES = b"RIFF" + (36).to_bytes(4, "little") + b"WAVEfmt " + b"\x00" * 32
+MP3_BYTES = b"ID3" + b"\x04\x00\x00" + b"\x00" * 16
+M4A_BYTES = b"\x00\x00\x00\x18ftypM4A " + b"\x00" * 16
+WEBM_BYTES = b"\x1a\x45\xdf\xa3" + b"\x00" * 16
+
+
+def test_verified_transcription_profiles_cover_common_formats_and_providers() -> None:
+    expected_models = {
+        "microsoft/mai-transcribe-1.5",
+        "mistralai/voxtral-mini-transcribe",
+        "openai/whisper-1",
+        "qwen/qwen3-asr-flash-2026-02-10",
+        "x-ai/grok-stt-1.0",
+    }
+    assert expected_models <= VERIFIED_TRANSCRIPTION_PROFILES.keys()
+    for profile in VERIFIED_TRANSCRIPTION_PROFILES.values():
+        assert {"mp3", "wav", "m4a", "webm"} <= set(
+            profile.input_formats
+        )
+        assert profile.smoke_languages == ("zh", "en")
+
+
+@pytest.mark.parametrize(
+    ("filename", "content_type", "content", "expected_format"),
+    [
+        ("sample.mp3", "audio/mpeg", MP3_BYTES, "mp3"),
+        ("sample.wav", "audio/wav", WAV_BYTES, "wav"),
+        ("sample.m4a", "audio/mp4", M4A_BYTES, "m4a"),
+        ("sample.webm", "audio/webm", WEBM_BYTES, "webm"),
+    ],
+)
+def test_transcription_accepts_common_verified_audio_formats(
+    filename: str,
+    content_type: str,
+    content: bytes,
+    expected_format: str,
+) -> None:
+    clean_name, audio_format = TranscriptionService._validate_audio(
+        filename,
+        content_type,
+        content,
+    )
+    assert clean_name == filename
+    assert audio_format == expected_format
 
 
 def openrouter_service(tmp_path: Path) -> ModelRouterService:

--- a/server/tests/test_multimodal_tts.py
+++ b/server/tests/test_multimodal_tts.py
@@ -14,15 +14,89 @@ from server.model_router.service import ModelRouterService
 from server.multimodal.api import configure_speech_service
 from server.multimodal.stt import MultimodalServiceError, OpenRouterTarget
 from server.multimodal.tts import (
+    ALLOWED_SPEECH_PROFILES,
+    GEMINI_PCM_TTS_MODEL_ID,
     MAX_SPEECH_INPUT_CHARS,
+    MINIMAX_SYSTEM_SPEECH_VOICES,
     OpenRouterTtsAdapter,
     SpeechService,
+    speech_output_format,
 )
 
 
 MP3_BYTES = b"ID3" + b"\x04\x00\x00" + b"\x00" * 64
+PCM_BYTES = b"\x00\x01" * 256
 MODEL_ID = "microsoft/mai-voice-2"
 VOICE = "en-US-Harper:MAI-Voice-2"
+
+
+def test_verified_speech_profiles_cover_multiple_providers() -> None:
+    assert {
+        "minimax/speech-2.8-hd",
+        "minimax/speech-2.8-turbo",
+        "microsoft/mai-voice-2",
+        "mistralai/voxtral-mini-tts-2603",
+        "qwen/qwen-audio-3.0-tts-flash",
+        "x-ai/grok-voice-tts-1.0",
+        "deepgram/aura-2",
+        "zyphra/zonos-v0.1-transformer",
+        "zyphra/zonos-v0.1-hybrid",
+        "canopylabs/orpheus-3b-0.1-ft",
+        "sesame/csm-1b",
+        "hexgrad/kokoro-82m",
+        GEMINI_PCM_TTS_MODEL_ID,
+    } <= ALLOWED_SPEECH_PROFILES.keys()
+    assert all(ALLOWED_SPEECH_PROFILES.values())
+    assert speech_output_format(MODEL_ID) == "mp3"
+    assert speech_output_format(GEMINI_PCM_TTS_MODEL_ID) == "wav"
+
+
+@pytest.mark.parametrize(
+    ("model_id", "voice"),
+    [
+        ("microsoft/mai-voice-2", "fr-FR-Soleil:MAI-Voice-2"),
+        (
+            "minimax/speech-2.8-hd",
+            "Chinese (Mandarin)_News_Anchor",
+        ),
+        (
+            "minimax/speech-2.8-turbo",
+            "English_expressive_narrator",
+        ),
+        ("mistralai/voxtral-mini-tts-2603", "en_paul_neutral"),
+        ("qwen/qwen-audio-3.0-tts-flash", "longanhuan_v3.6"),
+        ("x-ai/grok-voice-tts-1.0", "ara"),
+        ("deepgram/aura-2", "aura-2-amalthea-en"),
+        ("zyphra/zonos-v0.1-transformer", "american_female"),
+        ("zyphra/zonos-v0.1-hybrid", "american_female"),
+        ("canopylabs/orpheus-3b-0.1-ft", "dan"),
+        ("sesame/csm-1b", "conversational_a"),
+        ("hexgrad/kokoro-82m", "af_alloy"),
+    ],
+)
+def test_speech_service_accepts_only_registered_model_voice_pairs(
+    model_id: str,
+    voice: str,
+) -> None:
+    assert SpeechService._model_id(model_id) == model_id
+    assert SpeechService._voice(model_id, voice) == voice
+
+
+def test_minimax_profiles_only_allow_curated_system_voices() -> None:
+    assert len(MINIMAX_SYSTEM_SPEECH_VOICES) == 8
+    assert set(
+        ALLOWED_SPEECH_PROFILES["minimax/speech-2.8-hd"]
+    ) == set(MINIMAX_SYSTEM_SPEECH_VOICES)
+    assert (
+        ALLOWED_SPEECH_PROFILES["minimax/speech-2.8-turbo"]
+        == MINIMAX_SYSTEM_SPEECH_VOICES
+    )
+    with pytest.raises(MultimodalServiceError) as captured:
+        SpeechService._voice(
+            "minimax/speech-2.8-hd",
+            "user-created-or-cloned-voice",
+        )
+    assert captured.value.code == "unsupported_voice"
 
 
 def openrouter_service(tmp_path: Path) -> ModelRouterService:
@@ -60,7 +134,7 @@ async def test_speech_service_records_bytes_without_text_or_secret(
         async def synthesize(self, target, **kwargs):
             captured["target"] = target
             captured["kwargs"] = kwargs
-            return MP3_BYTES, "generation-test"
+            return MP3_BYTES, "generation-test", "mp3"
 
     service = SpeechService(
         router_service,
@@ -161,12 +235,87 @@ async def test_tts_adapter_posts_json_and_caches_speech_catalog() -> None:
         speed=1.25,
     )
 
-    assert first == (MP3_BYTES, "generation-123")
+    assert first == (MP3_BYTES, "generation-123", "mp3")
     assert second[0] == MP3_BYTES
     assert sum(request.url.path.endswith("/models") for request in requests) == 1
     assert sum(
         request.url.path.endswith("/audio/speech") for request in requests
     ) == 2
+
+
+@pytest.mark.asyncio
+async def test_gemini_tts_wraps_verified_pcm_as_wav() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/models"):
+            return httpx.Response(
+                200,
+                json={"data": [{"id": GEMINI_PCM_TTS_MODEL_ID}]},
+            )
+        payload = json.loads((await request.aread()).decode("utf-8"))
+        assert payload["model"] == GEMINI_PCM_TTS_MODEL_ID
+        assert payload["voice"] == "Kore"
+        assert payload["response_format"] == "pcm"
+        return httpx.Response(
+            200,
+            content=PCM_BYTES,
+            headers={
+                "content-type": "audio/pcm;rate=24000;channels=1",
+                "x-generation-id": "generation-gemini",
+            },
+        )
+
+    adapter = OpenRouterTtsAdapter(
+        client_factory=lambda: httpx.AsyncClient(
+            transport=httpx.MockTransport(handler)
+        ),
+    )
+    target = OpenRouterTarget(
+        base_url="https://openrouter.ai/api/v1",
+        api_key="test-key",
+        connection_id=None,
+        cache_key="gemini-pcm",
+    )
+
+    content, generation_id, response_format = await adapter.synthesize(
+        target,
+        model_id=GEMINI_PCM_TTS_MODEL_ID,
+        text="Hello",
+        voice="Kore",
+        speed=1.0,
+    )
+
+    assert response_format == "wav"
+    assert generation_id == "generation-gemini"
+    assert content[:4] == b"RIFF"
+    assert content[8:12] == b"WAVE"
+    assert content[44:] == PCM_BYTES
+    assert len(content) == len(PCM_BYTES) + 44
+
+
+@pytest.mark.parametrize(
+    ("content", "content_type", "expected_code"),
+    [
+        (b"", "audio/pcm;rate=24000;channels=1", "empty_speech"),
+        (b"\x00", "audio/pcm;rate=24000;channels=1", "invalid_speech_audio"),
+        (PCM_BYTES, "audio/pcm;rate=16000;channels=1", "invalid_audio_mime"),
+        (PCM_BYTES, "audio/mpeg", "invalid_audio_mime"),
+    ],
+)
+def test_gemini_tts_rejects_invalid_pcm(
+    content: bytes,
+    content_type: str,
+    expected_code: str,
+) -> None:
+    response = httpx.Response(
+        200,
+        content=content,
+        headers={"content-type": content_type},
+    )
+
+    with pytest.raises(MultimodalServiceError) as captured:
+        OpenRouterTtsAdapter._pcm_response_to_wav(response)
+
+    assert captured.value.code == expected_code
 
 
 @pytest.mark.parametrize(
@@ -272,7 +421,7 @@ async def test_speech_endpoint_validates_profile_and_returns_safe_headers(
 ) -> None:
     class FakeAdapter:
         async def synthesize(self, _target, **_kwargs):
-            return MP3_BYTES, "generation-safe"
+            return MP3_BYTES, "generation-safe", "mp3"
 
     service = SpeechService(
         openrouter_service(tmp_path),
@@ -331,6 +480,54 @@ async def test_speech_endpoint_validates_profile_and_returns_safe_headers(
     assert success.headers["x-modelmirror-provider"] == "openrouter"
     assert success.headers["x-modelmirror-cost-kind"] == "unavailable"
     assert success.content == MP3_BYTES
+
+
+@pytest.mark.asyncio
+async def test_speech_endpoint_returns_gemini_wav_with_safe_headers(
+    tmp_path: Path,
+) -> None:
+    wav_bytes = OpenRouterTtsAdapter._pcm_response_to_wav(
+        httpx.Response(
+            200,
+            content=PCM_BYTES,
+            headers={"content-type": "audio/pcm;rate=24000;channels=1"},
+        )
+    )
+
+    class FakeAdapter:
+        async def synthesize(self, _target, **_kwargs):
+            return wav_bytes, "generation-wav", "wav"
+
+    service = SpeechService(
+        openrouter_service(tmp_path),
+        adapter=FakeAdapter(),  # type: ignore[arg-type]
+    )
+    configure_speech_service(service)
+    transport = httpx.ASGITransport(app=app)
+    try:
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+        ) as client:
+            response = await client.post(
+                "/api/multimodal/speech",
+                json={
+                    "model_id": GEMINI_PCM_TTS_MODEL_ID,
+                    "input": "Hello",
+                    "voice": "Kore",
+                    "response_format": "wav",
+                    "speed": 1.0,
+                },
+            )
+    finally:
+        configure_speech_service(None)
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "audio/wav"
+    assert "modelmirror-speech.wav" in response.headers[
+        "content-disposition"
+    ]
+    assert response.content == wav_bytes
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_multimodal_video_jobs.py
+++ b/server/tests/test_multimodal_video_jobs.py
@@ -16,7 +16,7 @@ from httpx import (
     Response,
 )
 
-from server.model_router.repository import SQLiteRouterRepository
+from server.model_router.repository import SCHEMA_VERSION, SQLiteRouterRepository
 from server.model_router.schemas import RouterConnectionCreate
 from server.model_router.service import ModelRouterService
 from server.multimodal.api import configure_video_job_service, router
@@ -861,7 +861,10 @@ def test_repository_migrates_existing_video_jobs_without_data_loss(
     assert row["reference_image_count"] == 0
     assert row["provider_option_keys"] == "[]"
     with sqlite3.connect(database_path) as connection:
-        assert connection.execute("PRAGMA user_version").fetchone()[0] == 7
+        assert (
+            connection.execute("PRAGMA user_version").fetchone()[0]
+            == SCHEMA_VERSION
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 变更摘要

- 建立版本化音频能力档案与连接 scope 隔离，准确区分 ready / planned / disabled。
- 扩展 STT、TTS、直接音频理解与原生流式语音输出，并保持 `/chat/auto` 先转写边界。
- 新增 Lyria Clip/Pro 独立音乐生成任务、工作区、幂等提交、临时播放与下载。
- 新增直接 OpenAI WebRTC 实时语音：语义 VAD、自然打断、静音、显式重连及 10 分钟上限。
- 在 `/models` 直接展示 GPT Realtime 2.1 Mini / 2.1 卡片；未配置连接时进入明确配置态。
- 声音克隆仅保留安全识别与延期说明，不创建授权录音或自定义音色资源。
- 更新多模态审计、前后端、部署和仓库事实文档。

## 用户体验与安全

- 音频上传与麦克风共用转写设置，转写结果仍由用户确认后发送。
- 音乐和实时语音使用独立生命周期，不塞入普通 Chat SSE。
- API Key 仅在后端加密连接中使用；媒体、Prompt、转写正文及实时字幕不写入审计正文。
- 费用未知时不显示零成本，实时语音不会隐式重连产生新付费会话。

## 验证

- `cd client && npm.cmd run build`：通过。
- `npm.cmd run test:streaming-audio`：通过。
- `python -m pytest server/tests/ -q`：691 passed，4 个既有 FastAPI lifespan deprecation warnings。
- 音乐任务与实时语音专项：28 passed。
- `python -m py_compile server/main.py`：通过。
- `git diff --check` 与文档相对链接检查：通过。
- 本地核心栈：后端 health 正常，`/models` HTTP 200；Realtime 两张卡片入口已确认。

## 人工验收说明

STT、TTS、音频理解、原生音频、音乐生成和模型卡入口已分批验收。实际付费 WebRTC 通话未在提交前执行；需要在设置页添加 `openai` 类型、`audio + realtime` scope 的直接 OpenAI 连接后进行。

## 回退

分别关闭 `MULTIMODAL_AUDIO_GENERATION_ENABLED`、`MULTIMODAL_REALTIME_VOICE_ENABLED`、`MULTIMODAL_STREAMING_AUDIO_ENABLED` 等对应开关即可隐藏新增入口；普通 Chat、STT/TTS、RAG、视频和智能调度无需迁移或删除数据。