### PR TITLE
fix: 完成 Runway 视频模型适配

### DIFF
--- a/client/src/data/models.ts
+++ b/client/src/data/models.ts
@@ -17523,6 +17523,11 @@ const VERIFIED_SPEECH_MODEL_IDS = new Set([
   "microsoft/mai-voice-2",
 ]);
 
+const VERIFIED_VIDEO_MODEL_IDS = new Set([
+  "runway/aleph-2",
+  "runway/gen-4.5",
+]);
+
 function inferOperations(raw: RawCatalogModel): ModelOperation[] {
   const operations = new Set<ModelOperation>();
   const inputs = new Set(raw.input_modalities);
@@ -17580,6 +17585,12 @@ function interactionForOperation(
   }
   if (operation === "embed" || operation === "rerank") {
     return { status: "ready", entrypoint: "rag" };
+  }
+  if (
+    operation === "generate_video" &&
+    VERIFIED_VIDEO_MODEL_IDS.has(modelId)
+  ) {
+    return { status: "ready", entrypoint: "multimodal" };
   }
   return { status: "planned", entrypoint: "planned" };
 }

--- a/server/multimodal/video_catalog.py
+++ b/server/multimodal/video_catalog.py
@@ -21,6 +21,13 @@ from .stt import MultimodalServiceError, OpenRouterTarget
 VIDEO_CATALOG_TTL_SECONDS = 300.0
 VIDEO_CATALOG_STALE_SECONDS = 1_800.0
 
+VERIFIED_VIDEO_GENERATION_MODELS = frozenset(
+    {
+        "runway/aleph-2",
+        "runway/gen-4.5",
+    }
+)
+
 
 class VideoProviderOption(BaseModel):
     key: str
@@ -269,7 +276,11 @@ class VideoCatalogService:
                             model_id, item
                         ),
                         pricing_skus=self._pricing(item.get("pricing_skus")),
-                        interaction_status="planned",
+                        interaction_status=(
+                            "ready"
+                            if model_id in VERIFIED_VIDEO_GENERATION_MODELS
+                            else "planned"
+                        ),
                     )
                 )
         return [

--- a/server/tests/test_multimodal_video_catalog.py
+++ b/server/tests/test_multimodal_video_catalog.py
@@ -96,7 +96,41 @@ async def test_video_catalog_normalizes_analysis_and_generation_models(
                             "supported_resolutions": ["720p"],
                             "supported_aspect_ratios": ["16:9"],
                             "supported_durations": [5],
-                        }
+                        },
+                        {
+                            "id": "runway/aleph-2",
+                            "supported_resolutions": None,
+                            "supported_aspect_ratios": [
+                                "16:9",
+                                "4:3",
+                                "3:2",
+                                "1:1",
+                                "2:3",
+                                "3:4",
+                                "9:16",
+                                "21:9",
+                            ],
+                            "supported_durations": None,
+                            "supported_frame_images": None,
+                            "generate_audio": False,
+                            "seed": True,
+                            "allowed_passthrough_parameters": [
+                                "contentModeration",
+                                "keyframes",
+                            ],
+                        },
+                        {
+                            "id": "runway/gen-4.5",
+                            "supported_resolutions": ["720p"],
+                            "supported_aspect_ratios": ["16:9", "9:16"],
+                            "supported_durations": list(range(2, 11)),
+                            "supported_frame_images": ["first_frame"],
+                            "generate_audio": False,
+                            "seed": True,
+                            "allowed_passthrough_parameters": [
+                                "contentModeration"
+                            ],
+                        },
                     ]
                 },
             )
@@ -132,7 +166,7 @@ async def test_video_catalog_normalizes_analysis_and_generation_models(
 
     assert result.status == "online"
     assert result.stale is False
-    assert len(result.profiles) == 3
+    assert len(result.profiles) == 5
     analysis = next(
         item for item in result.profiles if item.operation == "analyze_video"
     )
@@ -145,6 +179,12 @@ async def test_video_catalog_normalizes_analysis_and_generation_models(
         item
         for item in result.profiles
         if item.model_id == "bytedance/seedance-2.0-fast"
+    )
+    runway_aleph = next(
+        item for item in result.profiles if item.model_id == "runway/aleph-2"
+    )
+    runway_gen = next(
+        item for item in result.profiles if item.model_id == "runway/gen-4.5"
     )
     assert analysis.model_id == "google/gemini-video-test"
     assert analysis.supported_input_sources == ["file", "url"]
@@ -167,6 +207,28 @@ async def test_video_catalog_normalizes_analysis_and_generation_models(
     assert generation.interaction_status == "planned"
     assert reference_model.supports_reference_images is True
     assert reference_model.max_reference_images == 3
+    assert runway_aleph.interaction_status == "ready"
+    assert runway_aleph.supported_resolutions == []
+    assert runway_aleph.supported_durations == []
+    assert runway_aleph.supported_aspect_ratios == [
+        "16:9",
+        "4:3",
+        "3:2",
+        "1:1",
+        "2:3",
+        "3:4",
+        "9:16",
+        "21:9",
+    ]
+    assert runway_aleph.supports_generated_audio is False
+    assert runway_aleph.supports_seed is True
+    assert runway_gen.interaction_status == "ready"
+    assert runway_gen.supported_resolutions == ["720p"]
+    assert runway_gen.supported_durations == list(range(2, 11))
+    assert runway_gen.supported_frame_types == ["first_frame"]
+    assert runway_gen.supports_first_frame is True
+    assert runway_gen.supports_generated_audio is False
+    assert runway_gen.supports_seed is True
     assert all(
         request.headers["authorization"]
         == "Bearer video-catalog-secret"


### PR DESCRIPTION
## 概要

- 将 `runway/aleph-2` 与 `runway/gen-4.5` 纳入已验证的视频生成模型。
- 首页离线/缓存状态下仍能正确识别两个模型，适配统计由 `499/501` 闭合为 `501/501`。
- 保留 OpenRouter 动态目录提供的分辨率、时长、比例、首帧、音频和 seed 能力边界；不开放未经审计的私有参数。

## 验证

- 视频目录专项测试：4 passed。
- 前端生产构建：通过。
- Python `py_compile`：通过。
- 两个模型的前端状态与多模态入口断言：通过。
- Diff、敏感信息与禁止产物检查：通过。

## 说明

PR #73 已在本提交推送前合并，因此以最小 follow-up PR 交付这一独立收尾提交。
