### PR TITLE
 接入 World Labs Marble API，支持图片/视频生成 3D 世界。

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ server/skills/tmp/
 .tmp-*/
 .tmp-*
 artifacts/
+
+# World generation runtime storage
+server/world/storage/

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,10 @@ artifacts/
 
 # World generation runtime storage
 server/world/storage/
+
+# World model temp verification scripts & assets
+test_marble_api.py
+verify_marble.py
+测试图片*.jpg
+rag_fts5.db
+*.docx

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -5,6 +5,8 @@
   "packages": {
     "": {
       "dependencies": {
+        "@mkkellogg/gaussian-splats-3d": "^0.4.7",
+        "@types/three": "^0.185.1",
         "@vitejs/plugin-react": "^5.0.0",
         "@xyflow/react": "^12.11.0",
         "autoprefixer": "^10.4.21",
@@ -15,6 +17,7 @@
         "react-router-dom": "^6.30.1",
         "remark-gfm": "^4.0.1",
         "tailwindcss": "^3.4.17",
+        "three": "^0.185.1",
         "typescript": "~5.8.3",
         "vite": "^7.0.0"
       },
@@ -297,6 +300,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "license": "Apache-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.7",
@@ -759,6 +768,15 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mkkellogg/gaussian-splats-3d": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@mkkellogg/gaussian-splats-3d/-/gaussian-splats-3d-0.4.7.tgz",
+      "integrity": "sha512-0vy9/i9sJLFH/v3WJZ4axCsqjkToe8UsV3xY7bvK5EUC0akiRsWZODoCiSzpxhTLNyzSKTsyQKozIFeNA5RWRA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.160.0"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1134,6 +1152,12 @@
         "win32"
       ]
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1291,10 +1315,36 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.185.1",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.185.1.tgz",
+      "integrity": "sha512-db1xTb+EgYF2didW+eudSvVPtn75zo+fGsY8ShQrJY/B5ZBmC2Fiaykv3aImHAlCNEGuMPkPGXBJGLwzu5mC7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": ">=0.5.17",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~1.1.1"
+      }
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
       "license": "MIT"
     },
     "node_modules/@ungap/structured-clone": {
@@ -1968,6 +2018,12 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -2582,6 +2638,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
+      "integrity": "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==",
+      "license": "MIT"
     },
     "node_modules/micromark": {
       "version": "4.0.2",
@@ -3914,6 +3976,12 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/three": {
+      "version": "0.185.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.185.1.tgz",
+      "integrity": "sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg==",
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",

--- a/client/package.json
+++ b/client/package.json
@@ -6,6 +6,8 @@
     "preview": "vite preview --host 0.0.0.0"
   },
   "dependencies": {
+    "@mkkellogg/gaussian-splats-3d": "^0.4.7",
+    "@types/three": "^0.185.1",
     "@vitejs/plugin-react": "^5.0.0",
     "@xyflow/react": "^12.11.0",
     "autoprefixer": "^10.4.21",
@@ -16,6 +18,7 @@
     "react-router-dom": "^6.30.1",
     "remark-gfm": "^4.0.1",
     "tailwindcss": "^3.4.17",
+    "three": "^0.185.1",
     "typescript": "~5.8.3",
     "vite": "^7.0.0"
   },

--- a/client/src/components/world/FourViewer.tsx
+++ b/client/src/components/world/FourViewer.tsx
@@ -1,0 +1,82 @@
+import { memo, useEffect, useMemo, useState } from "react";
+import { MeshViewer } from "./MeshViewer";
+import { PanoramaViewer } from "./PanoramaViewer";
+import { PointCloudViewer } from "./PointCloudViewer";
+import { SplatViewer } from "./SplatViewer";
+
+export type AssetFormat = "spz" | "ply" | "glb" | "gltf" | "png" | "unknown";
+export type AssetKind =
+  | "gaussian_splat"
+  | "textured_mesh"
+  | "panorama"
+  | "preview"
+  | "other";
+
+export interface FourViewerProps {
+  source: string;
+  format: AssetFormat;
+  kind?: AssetKind;
+}
+
+/**
+ * Unified 3D viewer entry — dispatches to a format-specific viewer.
+ * PNG panorama / GLB / SPZ / PLY all go through here.
+ */
+export const FourViewer = memo(function FourViewer({
+  source,
+  format,
+  kind = "other",
+}: FourViewerProps) {
+  const [webgl2, setWebgl2] = useState<boolean | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const canvas = document.createElement("canvas");
+    const gl2 = canvas.getContext("webgl2");
+    setWebgl2(gl2 !== null);
+  }, []);
+
+  // Gaussian splat PLY vs plain point cloud PLY must be distinguished
+  // by kind, not by the .ply extension.
+  const isSplatPly = format === "ply" && kind === "gaussian_splat";
+  const isSplat = format === "spz" || isSplatPly;
+
+  const view = useMemo(() => {
+    if (webgl2 === false && isSplat) {
+      return (
+        <div className="flex h-full items-center justify-center rounded-lg border border-amber-300/25 bg-amber-300/10 px-4 py-8 text-sm text-amber-100">
+          当前浏览器不支持 WebGL2，无法渲染高斯溅射（SPZ/PLY）场景。请使用支持 WebGL2 的浏览器（Chrome / Edge / Firefox 新版）。
+        </div>
+      );
+    }
+
+    if (format === "glb" || format === "gltf") {
+      return <MeshViewer source={source} format={format} onError={setError} />;
+    }
+    if (format === "png") {
+      return <PanoramaViewer source={source} onError={setError} />;
+    }
+    if (isSplat) {
+      return <SplatViewer source={source} onError={setError} />;
+    }
+    if (format === "ply") {
+      return <PointCloudViewer source={source} onError={setError} />;
+    }
+    return (
+      <div className="flex h-full items-center justify-center rounded-lg border border-white/10 bg-white/[0.04] px-4 py-8 text-sm text-slate-400">
+        暂不支持该文件格式：{format}
+      </div>
+    );
+  }, [format, isSplat, source, webgl2]);
+
+  return (
+    <div className="relative h-full w-full overflow-hidden rounded-lg border border-white/10 bg-ink-950">
+      {view}
+      {error ? (
+        <div className="absolute inset-x-0 bottom-0 border-t border-red-300/20 bg-red-950/80 px-3 py-2 text-xs text-red-100">
+          {error}
+        </div>
+      ) : null}
+    </div>
+  );
+});

--- a/client/src/components/world/MeshViewer.tsx
+++ b/client/src/components/world/MeshViewer.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useRef } from "react";
+import * as THREE from "three";
+import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js";
+import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
+
+interface MeshViewerProps {
+  source: string;
+  format: "glb" | "gltf";
+  onError?: (message: string) => void;
+}
+
+/** Loads a GLB/glTF mesh with Three.js and lets the user orbit/zoom. */
+export function MeshViewer({ source, format, onError }: MeshViewerProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color(0x0e1524);
+    let disposed = false;
+
+    const camera = new THREE.PerspectiveCamera(
+      50,
+      container.clientWidth / container.clientHeight,
+      0.1,
+      5000,
+    );
+    camera.position.set(1.5, 1.2, 2);
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    renderer.setSize(container.clientWidth, container.clientHeight);
+    container.appendChild(renderer.domElement);
+
+    const controls = new OrbitControls(camera, renderer.domElement);
+    controls.enableDamping = true;
+    controls.target.set(0, 0, 0);
+    controls.update();
+
+    // Lighting
+    scene.add(new THREE.AmbientLight(0xffffff, 0.6));
+    const dir = new THREE.DirectionalLight(0xffffff, 1.2);
+    dir.position.set(3, 5, 4);
+    scene.add(dir);
+
+    // Grid helper for spatial reference
+    scene.add(new THREE.GridHelper(10, 20, 0x334155, 0x1e293b));
+
+    let raf = 0;
+    const render = () => {
+      controls.update();
+      renderer.render(scene, camera);
+      raf = requestAnimationFrame(render);
+    };
+    raf = requestAnimationFrame(render);
+
+    const loader = new GLTFLoader();
+
+    loader.load(
+      source,
+      (gltf) => {
+        if (disposed) return;
+        const box = new THREE.Box3().setFromObject(gltf.scene);
+        const size = box.getSize(new THREE.Vector3());
+        const center = box.getCenter(new THREE.Vector3());
+        const maxDim = Math.max(size.x, size.y, size.z) || 1;
+        const scale = 4 / maxDim;
+        gltf.scene.scale.setScalar(scale);
+        gltf.scene.position.sub(center.multiplyScalar(scale));
+        scene.add(gltf.scene);
+        camera.near = 0.01;
+        camera.far = maxDim * 10 + 100;
+        camera.updateProjectionMatrix();
+      },
+      undefined,
+      (err) => {
+        if (!disposed) onError?.(`加载 3D 文件失败：${format.toUpperCase()} 解析错误`);
+      },
+    );
+
+    return () => {
+      disposed = true;
+      cancelAnimationFrame(raf);
+      controls.dispose();
+      renderer.dispose();
+      scene.traverse((obj) => {
+        if (obj instanceof THREE.Mesh) {
+          obj.geometry.dispose();
+          const mat = obj.material;
+          if (Array.isArray(mat)) mat.forEach((m) => m.dispose());
+          else if (mat) mat.dispose();
+        }
+      });
+      if (renderer.domElement.parentElement === container) {
+        container.removeChild(renderer.domElement);
+      }
+    };
+  }, [source, format, onError]);
+
+  return <div ref={containerRef} className="h-full w-full" />;
+}

--- a/client/src/components/world/PanoramaViewer.tsx
+++ b/client/src/components/world/PanoramaViewer.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useRef } from "react";
+import * as THREE from "three";
+import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
+
+interface PanoramaViewerProps {
+  source: string;
+  onError?: (message: string) => void;
+}
+
+/** Renders an equirectangular panorama PNG on the inside of a sphere. */
+export function PanoramaViewer({ source, onError }: PanoramaViewerProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color(0x0e1524);
+
+    const camera = new THREE.PerspectiveCamera(
+      75,
+      container.clientWidth / container.clientHeight,
+      0.1,
+      1000,
+    );
+    camera.position.set(0, 0, 0.1);
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    renderer.setSize(container.clientWidth, container.clientHeight);
+    container.appendChild(renderer.domElement);
+
+    const controls = new OrbitControls(camera, renderer.domElement);
+    controls.enableZoom = true;
+    controls.enablePan = false;
+    controls.minDistance = 0.1;
+    controls.maxDistance = 0.4;
+    controls.rotateSpeed = 0.6;
+
+    let disposed = false;
+    let raf = 0;
+    const render = () => {
+      controls.update();
+      renderer.render(scene, camera);
+      raf = requestAnimationFrame(render);
+    };
+    raf = requestAnimationFrame(render);
+
+    const textureLoader = new THREE.TextureLoader();
+    textureLoader.load(
+      source,
+      (texture) => {
+        if (disposed) return;
+        texture.colorSpace = THREE.SRGBColorSpace;
+        const geometry = new THREE.SphereGeometry(100, 64, 32);
+        // Flip so the panorama maps correctly to the sphere interior.
+        const material = new THREE.MeshBasicMaterial({
+          map: texture,
+          side: THREE.BackSide,
+        });
+        const mesh = new THREE.Mesh(geometry, material);
+        mesh.scale.set(-1, 1, 1);
+        scene.add(mesh);
+      },
+      undefined,
+      (err) => {
+        if (!disposed) {
+          const message = err instanceof Error ? err.message : "未知错误";
+          onError?.(`加载全景图失败：${message}`);
+        }
+      },
+    );
+
+    return () => {
+      disposed = true;
+      cancelAnimationFrame(raf);
+      controls.dispose();
+      renderer.dispose();
+      scene.traverse((obj) => {
+        if (obj instanceof THREE.Mesh) {
+          obj.geometry.dispose();
+          const mat = obj.material;
+          if (Array.isArray(mat)) mat.forEach((m) => m.dispose());
+          else if (mat instanceof THREE.Material) {
+            mat.dispose();
+            const withMap = mat as THREE.Material & { map?: THREE.Texture };
+            if (withMap.map) withMap.map.dispose();
+          }
+        }
+      });
+      if (renderer.domElement.parentElement === container) {
+        container.removeChild(renderer.domElement);
+      }
+    };
+  }, [source, onError]);
+
+  return <div ref={containerRef} className="h-full w-full" />;
+}

--- a/client/src/components/world/PointCloudViewer.tsx
+++ b/client/src/components/world/PointCloudViewer.tsx
@@ -1,0 +1,101 @@
+import { useEffect, useRef } from "react";
+import * as THREE from "three";
+import { PLYLoader } from "three/examples/jsm/loaders/PLYLoader.js";
+import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
+
+interface PointCloudViewerProps {
+  source: string;
+  onError?: (message: string) => void;
+}
+
+/** Renders a plain point-cloud PLY file with Three.js. */
+export function PointCloudViewer({ source, onError }: PointCloudViewerProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color(0x0e1524);
+
+    const camera = new THREE.PerspectiveCamera(
+      50,
+      container.clientWidth / container.clientHeight,
+      0.1,
+      5000,
+    );
+    camera.position.set(1.5, 1.2, 2);
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    renderer.setSize(container.clientWidth, container.clientHeight);
+    container.appendChild(renderer.domElement);
+
+    const controls = new OrbitControls(camera, renderer.domElement);
+    controls.enableDamping = true;
+    controls.update();
+
+    scene.add(new THREE.AmbientLight(0xffffff, 0.8));
+
+    let disposed = false;
+    let points: THREE.Points | null = null;
+
+    let raf = 0;
+    const render = () => {
+      controls.update();
+      renderer.render(scene, camera);
+      raf = requestAnimationFrame(render);
+    };
+    raf = requestAnimationFrame(render);
+
+    const loader = new PLYLoader();
+    loader.load(
+      source,
+      (geometry) => {
+        if (disposed) return;
+        const material = new THREE.PointsMaterial({
+          size: 0.01,
+          vertexColors: Boolean(geometry.getAttribute("color")),
+          color: geometry.getAttribute("color") ? undefined : 0x8fd3ff,
+        });
+        points = new THREE.Points(geometry, material);
+        const box = new THREE.Box3().setFromObject(points);
+        const size = box.getSize(new THREE.Vector3());
+        const maxDim = Math.max(size.x, size.y, size.z) || 1;
+        points.scale.setScalar(4 / maxDim);
+        const center = box.getCenter(new THREE.Vector3());
+        points.position.sub(center.multiplyScalar(4 / maxDim));
+        scene.add(points);
+      },
+      undefined,
+      (err) => {
+        if (!disposed) {
+          const message = err instanceof Error ? err.message : "未知错误";
+          onError?.(`加载点云失败：${message}`);
+        }
+      },
+    );
+
+    return () => {
+      disposed = true;
+      cancelAnimationFrame(raf);
+      controls.dispose();
+      renderer.dispose();
+      if (points) {
+        points.geometry.dispose();
+        (points.material as THREE.Material).dispose();
+      }
+      scene.traverse((obj) => {
+        if (obj instanceof THREE.Mesh) {
+          obj.geometry.dispose();
+        }
+      });
+      if (renderer.domElement.parentElement === container) {
+        container.removeChild(renderer.domElement);
+      }
+    };
+  }, [source, onError]);
+
+  return <div ref={containerRef} className="h-full w-full" />;
+}

--- a/client/src/components/world/SplatViewer.tsx
+++ b/client/src/components/world/SplatViewer.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useRef, useState } from "react";
+import * as THREE from "three";
+import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
 import { DropInViewer } from "@mkkellogg/gaussian-splats-3d";
 
 interface SplatViewerProps {
@@ -8,11 +10,11 @@ interface SplatViewerProps {
 
 /**
  * Downloads the SPZ/PLY file with a real progress bar (fetch + stream),
- * then hands the local blob to the gaussian-splats-3d viewer.
+ * then renders it with gaussian-splats-3d.
  *
- * Without this, loading a large real SPZ (up to ~29MB full_res) shows a
- * blank screen for many seconds with no feedback — the progress bar makes
- * the wait visible.
+ * DropInViewer extends THREE.Group (an Object3D, NOT a DOM node), so it
+ * must be added to our own Three.js scene and rendered by our own
+ * WebGLRenderer — never appendChild'd directly.
  */
 export function SplatViewer({ source, onError }: SplatViewerProps) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -25,7 +27,34 @@ export function SplatViewer({ source, onError }: SplatViewerProps) {
 
     let disposed = false;
     let objectUrl: string | null = null;
-    const target = container;
+    let viewer: DropInViewer | null = null;
+    let renderer: THREE.WebGLRenderer | null = null;
+
+    // Render loop (recursive requestAnimationFrame so the scene keeps painting).
+    let raf = 0;
+    const render = () => {
+      if (disposed) return;
+      controls.update();
+      if (renderer) renderer.render(scene, camera);
+      raf = requestAnimationFrame(render);
+    };
+
+    // Scene setup
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color(0x0e1524);
+    const camera = new THREE.PerspectiveCamera(
+      60,
+      container.clientWidth / container.clientHeight,
+      0.1,
+      1000,
+    );
+    camera.position.set(1, 1, 2);
+    const controls = new OrbitControls(camera, container);
+
+    renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    renderer.setSize(container.clientWidth, container.clientHeight);
+    container.appendChild(renderer.domElement);
 
     async function load() {
       try {
@@ -52,29 +81,36 @@ export function SplatViewer({ source, onError }: SplatViewerProps) {
             }
           }
         }
-        const blob = new Blob(chunks, {
-          type: source.endsWith(".ply") ? "application/octet-stream" : "application/octet-stream",
-        });
+        const blob = new Blob(chunks, { type: "application/octet-stream" });
         objectUrl = URL.createObjectURL(blob);
 
-        // 2) Parse + render.
+        // 2) Parse + add DropInViewer to OUR scene.
         setStage("parse");
         setProgress(null);
-        const viewer = new DropInViewer({
+        viewer = new DropInViewer({
           gpuAcceleratedSort: true,
           sharedMemoryForWorkers: false,
         });
-        target.appendChild(viewer.container);
         await viewer.addSplatScene(objectUrl, {
           showLoadingUI: true,
           progressiveLoad: true,
         });
+        scene.add(viewer);
         if (!disposed) {
-          viewer.start();
+          // Center the splat on the scene.
+          viewer.position.set(0, 0, 0);
+          viewer.updateMatrixWorld(true);
+          const box = new THREE.Box3().setFromObject(viewer);
+          const size = box.getSize(new THREE.Vector3());
+          const maxDim = Math.max(size.x, size.y, size.z) || 1;
+          camera.near = maxDim * 0.001;
+          camera.far = maxDim * 20;
+          camera.position.set(maxDim * 0.8, maxDim * 0.6, maxDim * 0.8);
+          camera.updateProjectionMatrix();
+          controls.target.set(0, 0, 0);
+          controls.update();
           setStage("ready");
           setProgress(null);
-        } else {
-          viewer.dispose();
         }
       } catch (err) {
         if (!disposed) {
@@ -86,10 +122,35 @@ export function SplatViewer({ source, onError }: SplatViewerProps) {
       }
     }
 
+    raf = requestAnimationFrame(render);
     void load();
 
     return () => {
       disposed = true;
+      cancelAnimationFrame(raf);
+      controls.dispose();
+      if (viewer) {
+        try {
+          scene.remove(viewer);
+          viewer.dispose();
+        } catch {
+          /* ignore dispose errors */
+        }
+      }
+      if (renderer) {
+        renderer.dispose();
+        if (renderer.domElement.parentElement === container) {
+          container.removeChild(renderer.domElement);
+        }
+      }
+      scene.traverse((obj) => {
+        if (obj instanceof THREE.Mesh) {
+          obj.geometry.dispose();
+          const mat = obj.material;
+          if (Array.isArray(mat)) mat.forEach((m) => m.dispose());
+          else if (mat) mat.dispose();
+        }
+      });
       if (objectUrl) URL.revokeObjectURL(objectUrl);
     };
   }, [source, onError]);

--- a/client/src/components/world/SplatViewer.tsx
+++ b/client/src/components/world/SplatViewer.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useRef, useState } from "react";
+import { DropInViewer } from "@mkkellogg/gaussian-splats-3d";
+
+interface SplatViewerProps {
+  source: string;
+  onError?: (message: string) => void;
+}
+
+/**
+ * Downloads the SPZ/PLY file with a real progress bar (fetch + stream),
+ * then hands the local blob to the gaussian-splats-3d viewer.
+ *
+ * Without this, loading a large real SPZ (up to ~29MB full_res) shows a
+ * blank screen for many seconds with no feedback — the progress bar makes
+ * the wait visible.
+ */
+export function SplatViewer({ source, onError }: SplatViewerProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [progress, setProgress] = useState<number | null>(null);
+  const [stage, setStage] = useState<"download" | "parse" | "ready" | "error">("download");
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    let disposed = false;
+    let objectUrl: string | null = null;
+    const target = container;
+
+    async function load() {
+      try {
+        // 1) Download with real progress.
+        setStage("download");
+        setProgress(0);
+        const response = await fetch(source);
+        if (!response.ok || !response.body) {
+          throw new Error(`下载失败 HTTP ${response.status}`);
+        }
+        const total = Number(response.headers.get("Content-Length") || 0);
+        const reader = response.body.getReader();
+        const chunks: Uint8Array[] = [];
+        let received = 0;
+        // eslint-disable-next-line no-constant-condition
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          if (value) {
+            chunks.push(value);
+            received += value.length;
+            if (total > 0) {
+              setProgress(Math.min(100, Math.round((received / total) * 100)));
+            }
+          }
+        }
+        const blob = new Blob(chunks, {
+          type: source.endsWith(".ply") ? "application/octet-stream" : "application/octet-stream",
+        });
+        objectUrl = URL.createObjectURL(blob);
+
+        // 2) Parse + render.
+        setStage("parse");
+        setProgress(null);
+        const viewer = new DropInViewer({
+          gpuAcceleratedSort: true,
+          sharedMemoryForWorkers: false,
+        });
+        target.appendChild(viewer.container);
+        await viewer.addSplatScene(objectUrl, {
+          showLoadingUI: true,
+          progressiveLoad: true,
+        });
+        if (!disposed) {
+          viewer.start();
+          setStage("ready");
+          setProgress(null);
+        } else {
+          viewer.dispose();
+        }
+      } catch (err) {
+        if (!disposed) {
+          setStage("error");
+          setProgress(null);
+          const message = err instanceof Error ? err.message : String(err);
+          onError?.(`加载高斯溅射场景失败：${message}`);
+        }
+      }
+    }
+
+    void load();
+
+    return () => {
+      disposed = true;
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [source, onError]);
+
+  const showOverlay = progress !== null || stage === "download" || stage === "parse";
+
+  return (
+    <div className="relative h-full w-full">
+      <div ref={containerRef} className="h-full w-full" />
+      {showOverlay ? (
+        <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-3 bg-ink-950/70">
+          <span className="text-sm font-medium text-slate-200">
+            {stage === "download"
+              ? "正在下载 3D 场景..."
+              : stage === "parse"
+                ? "正在解析并渲染 3D 场景（大文件可能需要十几秒）..."
+                : "加载失败"}
+          </span>
+          {progress !== null ? (
+            <div className="h-1.5 w-48 overflow-hidden rounded-full bg-white/10">
+              <div
+                className="h-full rounded-full bg-brand-300 transition-all"
+                style={{ width: `${progress}%` }}
+              />
+            </div>
+          ) : null}
+          {progress !== null ? (
+            <span className="text-xs text-slate-400">{progress}%</span>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/client/src/components/world/WorldGenerationPanel.tsx
+++ b/client/src/components/world/WorldGenerationPanel.tsx
@@ -1,0 +1,436 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { FourViewer, type AssetFormat, type AssetKind } from "./FourViewer";
+
+interface JobRecord {
+  job_id: string;
+  status: string;
+  assets: AssetItem[];
+  world_id?: string;
+  caption?: string;
+  error?: string;
+}
+
+interface AssetItem {
+  id: string;
+  kind: AssetKind;
+  format: AssetFormat;
+  url: string;
+  size_bytes?: number | null;
+}
+
+type InputMode = "image" | "multi_image" | "video";
+
+const MAX_FILES = 8;
+const MAX_FILE_BYTES = 50 * 1024 * 1024;
+const SUPPORTED_IMAGE = ["image/jpeg", "image/png", "image/webp"];
+const SUPPORTED_VIDEO = ["video/mp4", "video/quicktime", "video/webm", "video/x-matroska", "video/avi"];
+
+function friendlyError(message: string): string {
+  if (message.includes("WORLD_LABS_API_KEY")) {
+    return "后端尚未配置世界模型 API Key，请联系管理员配置后重试。";
+  }
+  if (message.includes("402")) return "世界模型额度不足，请先充值 Credits。";
+  if (message.includes("429")) return "请求过于频繁，请稍后再试。";
+  if (message.includes("401")) return "世界模型认证失败，请检查 API Key。";
+  return message;
+}
+
+function formatBytes(bytes?: number | null): string {
+  if (!bytes) return "";
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+const statusLabels: Record<string, string> = {
+  created: "已创建",
+  uploading: "上传中",
+  submitted: "已提交",
+  processing: "生成中",
+  succeeded: "已完成",
+  failed: "生成失败",
+  cancelled: "已取消",
+  expired: "已过期",
+};
+
+/**
+ * World-generation panel shown inside ChatPage when the selected model
+ * is a world model. Handles upload → create job → poll → show 3D assets,
+ * plus a local-file 3D preview that never calls the API.
+ */
+export function WorldGenerationPanel() {
+  const [mode, setMode] = useState<InputMode>("image");
+  const [files, setFiles] = useState<File[]>([]);
+  const [prompt, setPrompt] = useState("");
+  const [isCreating, setIsCreating] = useState(false);
+  const [job, setJob] = useState<JobRecord | null>(null);
+  const [error, setError] = useState("");
+  const [viewerAsset, setViewerAsset] = useState<AssetItem | null>(null);
+  const [localFile, setLocalFile] = useState<File | null>(null);
+  const [localViewer, setLocalViewer] = useState<{
+    url: string;
+    format: AssetFormat;
+    kind: AssetKind;
+  } | null>(null);
+
+  const pollTimerRef = useRef<number | null>(null);
+
+  const isImageMode = mode === "image" || mode === "multi_image";
+  const maxFiles = mode === "multi_image" ? MAX_FILES : 1;
+
+  useEffect(() => {
+    return () => {
+      if (pollTimerRef.current !== null) window.clearTimeout(pollTimerRef.current);
+      if (localViewer?.url.startsWith("blob:")) URL.revokeObjectURL(localViewer.url);
+    };
+  }, [localViewer]);
+
+  // ------------------------------------------------------------------
+  // File selection / validation
+  // ------------------------------------------------------------------
+  const validateFile = useCallback((file: File): string | null => {
+    const allowed = isImageMode ? SUPPORTED_IMAGE : SUPPORTED_VIDEO;
+    if (!allowed.includes(file.type)) {
+      return `不支持的文件类型：${file.name}`;
+    }
+    if (file.size > MAX_FILE_BYTES) {
+      return `文件过大：${file.name}（上限 50MB）`;
+    }
+    return null;
+  }, [isImageMode]);
+
+  const onFilesSelected = useCallback(
+    (selected: FileList | File[]) => {
+      const list = Array.from(selected);
+      const next = [...files];
+      for (const file of list) {
+        if (next.length >= maxFiles) break;
+        const problem = validateFile(file);
+        if (problem) {
+          setError(problem);
+          continue;
+        }
+        next.push(file);
+      }
+      setFiles(next);
+    },
+    [files, maxFiles, validateFile],
+  );
+
+  const removeFile = useCallback(
+    (index: number) => {
+      setFiles((prev) => prev.filter((_, i) => i !== index));
+    },
+    [],
+  );
+
+  // ------------------------------------------------------------------
+  // Create job
+  // ------------------------------------------------------------------
+  const createJob = useCallback(async () => {
+    if (files.length === 0) {
+      setError("请先选择素材文件。");
+      return;
+    }
+    setError("");
+    setIsCreating(true);
+    setJob(null);
+    setViewerAsset(null);
+
+    try {
+      const form = new FormData();
+      for (const file of files) form.append("files", file);
+      const params = new URLSearchParams({ input_type: mode });
+      if (prompt.trim()) params.set("prompt", prompt.trim());
+      const response = await fetch(`/api/world-generations?${params.toString()}`, {
+        method: "POST",
+        body: form,
+      });
+      const body = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        throw new Error(body.detail || "创建生成任务失败。");
+      }
+      setJob({
+        job_id: body.job_id,
+        status: body.status,
+        assets: [],
+      });
+      setFiles([]);
+    } catch (err) {
+      setError(friendlyError(err instanceof Error ? err.message : String(err)));
+    } finally {
+      setIsCreating(false);
+    }
+  }, [files, mode, prompt]);
+
+  // ------------------------------------------------------------------
+  // Poll job status
+  // ------------------------------------------------------------------
+  const pollJob = useCallback(async () => {
+    if (!job) return;
+    try {
+      const response = await fetch(`/api/world-generations/${job.job_id}`);
+      const body = await response.json().catch(() => ({}));
+      if (response.ok) {
+        setJob((prev) => ({
+          job_id: body.job_id ?? prev?.job_id ?? "",
+          status: body.status ?? prev?.status ?? "processing",
+          assets: body.assets ?? prev?.assets ?? [],
+          world_id: body.world_id,
+          caption: body.caption,
+          error: body.error,
+        }));
+      }
+    } catch {
+      // transient network error — keep polling
+    }
+  }, [job]);
+
+  useEffect(() => {
+    if (!job) return;
+    const status = job.status;
+    if (status === "succeeded" || status === "failed" || status === "expired" || status === "cancelled") {
+      return; // done — stop polling
+    }
+    pollTimerRef.current = window.setTimeout(pollJob, 4000);
+    return () => {
+      if (pollTimerRef.current !== null) window.clearTimeout(pollTimerRef.current);
+    };
+  }, [job, pollJob]);
+
+  // ------------------------------------------------------------------
+  // Local 3D file preview (no API)
+  // ------------------------------------------------------------------
+  const onLocalFileSelected = useCallback((selected: FileList | null) => {
+    const file = selected?.[0];
+    if (!file) return;
+    setError("");
+    setLocalViewer(null);
+    const ext = file.name.split(".").pop()?.toLowerCase() ?? "";
+    let format: AssetFormat = "unknown";
+    let kind: AssetKind = "other";
+    if (ext === "glb" || ext === "gltf") {
+      format = ext === "glb" ? "glb" : "gltf";
+      kind = "textured_mesh";
+    } else if (ext === "spz") {
+      format = "spz";
+      kind = "gaussian_splat";
+    } else if (ext === "ply") {
+      // PLY ambiguous — treat as splat by default, allow user note.
+      format = "ply";
+      kind = "gaussian_splat";
+    } else if (ext === "png") {
+      format = "png";
+      kind = "panorama";
+    } else {
+      setError(`不支持本地预览的格式：.${ext}（支持 glb/gltf/spz/ply/png）。`);
+      setLocalFile(null);
+      return;
+    }
+    const url = URL.createObjectURL(file);
+    if (localViewer?.url.startsWith("blob:")) URL.revokeObjectURL(localViewer.url);
+    setLocalFile(file);
+    setLocalViewer({ url, format, kind });
+  }, [localViewer]);
+
+  // ------------------------------------------------------------------
+  // Render helpers
+  // ------------------------------------------------------------------
+  const previewCard = useMemo(() => {
+    if (!job || job.status === "succeeded") return null;
+    const status = job.status;
+    return (
+      <div className="rounded-lg border border-white/10 bg-white/[0.04] px-4 py-3 text-sm">
+        <div className="flex items-center justify-between">
+          <span className="font-semibold text-white">
+            {statusLabels[status] ?? status}
+          </span>
+          {status === "processing" || status === "submitted" || status === "created" || status === "uploading" ? (
+            <span className="h-2 w-2 animate-pulse rounded-full bg-amber-300" />
+          ) : null}
+        </div>
+        <p className="mt-1 text-xs text-slate-400">任务 ID：{job.job_id}</p>
+        {job.error ? <p className="mt-1 text-xs text-rose-300">{job.error}</p> : null}
+      </div>
+    );
+  }, [job]);
+
+  return (
+    <div className="flex h-full min-h-[560px] flex-col gap-4 overflow-y-auto p-5">
+      <div>
+        <h2 className="text-lg font-semibold text-white">3D 世界生成</h2>
+        <p className="mt-1 text-sm leading-6 text-slate-400">
+          上传现实场景的图片或视频，World Labs 世界模型将生成可探索的 3D 世界。生成约需数分钟，完成后可在下方预览。
+        </p>
+      </div>
+
+      {/* 素材输入 */}
+      <div className="rounded-lg border border-white/10 bg-white/[0.04] p-4">
+        <div className="flex flex-wrap items-center gap-2">
+          {(["image", "multi_image", "video"] as InputMode[]).map((m) => (
+            <button
+              className={`rounded-full px-3 py-1.5 text-xs font-semibold transition ${
+                mode === m
+                  ? "border border-brand-300/40 bg-brand-300/10 text-brand-100"
+                  : "border border-white/10 bg-white/[0.05] text-slate-300 hover:border-white/20"
+              }`}
+              key={m}
+              onClick={() => {
+                setMode(m);
+                setFiles([]);
+                setError("");
+              }}
+              type="button"
+            >
+              {m === "image" ? "单张图片" : m === "multi_image" ? "多张图片" : "视频"}
+            </button>
+          ))}
+        </div>
+
+        <label className="mt-4 flex cursor-pointer flex-col items-center justify-center rounded-lg border border-dashed border-white/15 py-8 text-center transition hover:border-brand-300/40 hover:bg-brand-300/5">
+          <span className="text-2xl">📷</span>
+          <span className="mt-2 text-sm font-semibold text-slate-300">
+            点击选择或拖拽 {isImageMode ? "图片" : "视频"}
+          </span>
+          <span className="mt-1 text-xs text-slate-500">
+            {isImageMode ? "支持 JPG/PNG/WebP" : "支持 MP4/MOV/WebM/MKV/AVI"}，上限 50MB
+            {mode === "multi_image" ? `，最多 ${MAX_FILES} 张` : ""}
+          </span>
+          <input
+            accept={isImageMode ? SUPPORTED_IMAGE.join(",") : SUPPORTED_VIDEO.join(",")}
+            className="hidden"
+            multiple={mode === "multi_image"}
+            onChange={(e) => onFilesSelected(e.target.files ?? [])}
+            type="file"
+          />
+        </label>
+
+        {files.length > 0 ? (
+          <ul className="mt-3 space-y-2">
+            {files.map((file, index) => (
+              <li
+                className="flex items-center justify-between gap-3 rounded-lg border border-white/10 bg-white/[0.04] px-3 py-2 text-xs"
+                key={`${file.name}-${index}`}
+              >
+                <span className="truncate text-slate-200">{file.name}</span>
+                <span className="shrink-0 text-slate-400">{formatBytes(file.size)}</span>
+                <button
+                  className="shrink-0 text-slate-400 transition hover:text-rose-300"
+                  onClick={() => removeFile(index)}
+                  type="button"
+                >
+                  删除
+                </button>
+              </li>
+            ))}
+          </ul>
+        ) : null}
+
+        <input
+          className="mt-3 w-full rounded-lg border border-white/10 bg-ink-950/70 px-3 py-2 text-sm text-white outline-none placeholder:text-slate-500 focus:border-brand-300/40"
+          onChange={(e) => setPrompt(e.target.value)}
+          placeholder="可选：用文字描述你希望生成的世界（如“阳光充足的客厅”）"
+          value={prompt}
+        />
+
+        <button
+          className="mt-3 w-full rounded-full bg-hire-300 px-4 py-2.5 text-sm font-semibold text-ink-950 transition hover:bg-hire-200 active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-50"
+          disabled={isCreating || files.length === 0}
+          onClick={createJob}
+          type="button"
+        >
+          {isCreating ? "创建中..." : files.length === 0 ? "请先选择素材" : "开始生成 3D 世界"}
+        </button>
+      </div>
+
+      {error ? (
+        <div className="rounded-lg border border-rose-300/25 bg-rose-400/10 px-4 py-3 text-sm text-rose-100">
+          {error}
+        </div>
+      ) : null}
+
+      {/* 任务状态 */}
+      {previewCard}
+
+      {/* 生成结果 + 3D 查看 */}
+      {job && job.status === "succeeded" ? (
+        <div className="rounded-lg border border-white/10 bg-white/[0.04] p-4">
+          <div className="flex items-center justify-between">
+            <h3 className="text-sm font-semibold text-white">生成结果</h3>
+            {job.caption ? <span className="text-xs text-slate-500">已完成</span> : null}
+          </div>
+          {job.caption ? (
+            <p className="mt-2 line-clamp-3 text-xs leading-5 text-slate-400">{job.caption}</p>
+          ) : null}
+          <div className="mt-3 grid gap-2 sm:grid-cols-2">
+            {job.assets.map((asset) => (
+              <button
+                className="flex items-center justify-between rounded-lg border border-white/10 bg-white/[0.05] px-3 py-2 text-left text-xs transition hover:border-brand-300/40 hover:bg-brand-300/10"
+                key={asset.id}
+                onClick={() => setViewerAsset(asset)}
+                type="button"
+              >
+                <span className="font-medium text-slate-200">{asset.kind}</span>
+                <span className="text-slate-400">
+                  {asset.format.toUpperCase()} {formatBytes(asset.size_bytes)}
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      {/* 3D 查看器 */}
+      {viewerAsset ? (
+        <div className="h-[420px]">
+          <div className="mb-2 flex items-center justify-between">
+            <span className="text-xs font-semibold text-slate-300">
+              预览：{viewerAsset.format.toUpperCase()} · {viewerAsset.kind}
+            </span>
+            <button
+              className="text-xs text-slate-400 transition hover:text-slate-200"
+              onClick={() => setViewerAsset(null)}
+              type="button"
+            >
+              关闭
+            </button>
+          </div>
+          <FourViewer
+            format={viewerAsset.format}
+            kind={viewerAsset.kind}
+            source={viewerAsset.url}
+          />
+        </div>
+      ) : null}
+
+      {/* 本地 3D 文件测试（不调用 API） */}
+      <div className="rounded-lg border border-white/10 bg-white/[0.04] p-4">
+        <h3 className="text-sm font-semibold text-white">本地 3D 文件预览</h3>
+        <p className="mt-1 text-xs text-slate-500">
+          不调用世界模型，直接上传 3D 文件验证前端渲染：支持 glb / gltf / spz / ply / png 全景。
+        </p>
+        <label className="mt-3 flex cursor-pointer items-center justify-center rounded-lg border border-dashed border-white/15 py-6 text-sm text-slate-400 transition hover:border-brand-300/40 hover:bg-brand-300/5">
+          点击选择本地 3D 文件
+          <input
+            accept=".glb,.gltf,.spz,.ply,.png"
+            className="hidden"
+            onChange={(e) => onLocalFileSelected(e.target.files)}
+            type="file"
+          />
+        </label>
+        {localFile ? (
+          <p className="mt-2 text-xs text-slate-500">已选择：{localFile.name}</p>
+        ) : null}
+        {localViewer ? (
+          <div className="mt-3 h-[360px]">
+            <FourViewer
+              format={localViewer.format}
+              kind={localViewer.kind}
+              source={localViewer.url}
+            />
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/client/src/data/models.ts
+++ b/client/src/data/models.ts
@@ -46,6 +46,8 @@ export interface Model {
   active: boolean;
   tags: string[];
   note?: string;
+  /** True when this entry is a world-generation model (3D), not a chat model. */
+  worldModel?: boolean;
 }
 
 interface RawCatalogModel {
@@ -14824,4 +14826,28 @@ function enrichModel(raw: RawCatalogModel): Model {
   };
 }
 
-export const models: Model[] = rawCatalogModels.map(enrichModel);
+const worldModelEntry: Model = {
+  id: "worldlabs/marble",
+  name: "World Labs Marble",
+  provider: "World Labs",
+  model_author: "World Labs",
+  description:
+    "上传现实场景的图片或视频，异步生成可探索的 3D 世界，支持全景图、GLB、SPZ、PLY 资产直接预览。",
+  context_length: 0,
+  pricing: { input: 0, output: 0 },
+  price_cny: { input: 0, output: 0 },
+  pricing_tier: "free",
+  capabilities: ["image", "video"],
+  input_modalities: ["image", "video"],
+  series: "世界模型",
+  categories: ["3D", "空间智能"],
+  supported_parameters: [],
+  distillable: false,
+  zero_data_retention: false,
+  in_region_routing: false,
+  active: true,
+  tags: ["3D", "空间智能", "新"],
+  worldModel: true,
+};
+
+export const models: Model[] = [...rawCatalogModels.map(enrichModel), worldModelEntry];

--- a/client/src/pages/ChatPage.tsx
+++ b/client/src/pages/ChatPage.tsx
@@ -12,6 +12,7 @@ import {
 } from "../components/FederationRouterCard";
 import PromptSidebar from "../components/PromptSidebar";
 import ResourceNav from "../components/ResourceNav";
+import { WorldGenerationPanel } from "../components/world/WorldGenerationPanel";
 import { useModelPreference } from "../context/ModelPreferenceContext";
 import { models } from "../data/models";
 import { recruitmentTheme } from "../theme/recruitmentTheme";
@@ -978,6 +979,39 @@ export default function ChatPage() {
   const displayCandidateDescription = isFederationRoute
     ? "智能路由功能正在紧锣密鼓开发中，当前将使用默认模型为您服务。"
     : agentInterview?.expertise ?? model.description;
+
+  if (model?.worldModel) {
+    return (
+      <main className="museum-grid min-h-screen pb-24 pt-5 text-slate-100 lg:pt-24">
+        <ResourceNav activeResource="models" />
+        <div className="mx-auto flex min-h-screen w-full max-w-[1200px] flex-col px-4 py-5 sm:px-6 lg:px-8">
+          <header className="border-y border-hire-300/20 bg-ink-950/72 px-4 py-4 backdrop-blur-2xl">
+            <Link
+              className="inline-flex items-center rounded-full border border-white/10 bg-white/[0.05] px-3 py-1.5 text-sm font-medium text-slate-300 transition hover:border-brand-300/30 hover:bg-brand-300/10 hover:text-brand-100"
+              to="/models"
+            >
+              返回招聘会现场
+            </Link>
+            <div className="mt-3 flex flex-wrap items-center gap-3">
+              <span className="inline-flex items-center gap-2 rounded-full border border-emerald-300/30 bg-emerald-300/10 px-3 py-1.5 text-xs font-semibold text-emerald-100">
+                <span className="h-2 w-2 animate-pulse rounded-full bg-emerald-300" />
+                3D 世界生成
+              </span>
+            </div>
+            <h1 className="mt-3 text-2xl font-semibold tracking-normal text-white sm:text-4xl">
+              世界模型：{model.name}
+            </h1>
+            <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-300">
+              {model.description}
+            </p>
+          </header>
+          <div className="surface-panel mt-5 min-h-[560px] flex-1 overflow-hidden rounded-lg border border-white/10 shadow-prism">
+            <WorldGenerationPanel />
+          </div>
+        </div>
+      </main>
+    );
+  }
 
   return (
     <main className="museum-grid min-h-screen pb-24 pt-5 text-slate-100 lg:pt-24">

--- a/client/src/types/gaussian-splats-3d.d.ts
+++ b/client/src/types/gaussian-splats-3d.d.ts
@@ -3,12 +3,13 @@
  * The library ships no types; this covers only what the project uses.
  */
 declare module "@mkkellogg/gaussian-splats-3d" {
-  export class DropInViewer {
+  import type { Object3D } from "three";
+
+  export class DropInViewer extends Object3D {
     constructor(options?: {
       gpuAcceleratedSort?: boolean;
       sharedMemoryForWorkers?: boolean;
     });
-    container: HTMLDivElement;
     addSplatScene(
       path: string,
       options?: {

--- a/client/src/types/gaussian-splats-3d.d.ts
+++ b/client/src/types/gaussian-splats-3d.d.ts
@@ -1,0 +1,23 @@
+/**
+ * Minimal type declarations for @mkkellogg/gaussian-splats-3d.
+ * The library ships no types; this covers only what the project uses.
+ */
+declare module "@mkkellogg/gaussian-splats-3d" {
+  export class DropInViewer {
+    constructor(options?: {
+      gpuAcceleratedSort?: boolean;
+      sharedMemoryForWorkers?: boolean;
+    });
+    container: HTMLDivElement;
+    addSplatScene(
+      path: string,
+      options?: {
+        showLoadingUI?: boolean;
+        progressiveLoad?: boolean;
+        splatAlphaRemovalThreshold?: number;
+      },
+    ): Promise<void>;
+    start(): void;
+    dispose(): void;
+  }
+}

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -16,6 +16,7 @@ COPY registry ./registry
 COPY rag ./rag
 COPY skills ./skills
 COPY workflow_native ./workflow_native
+COPY world ./world
 
 EXPOSE 8000
 

--- a/server/main.py
+++ b/server/main.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import re
+import sys
 import time
 import uuid
 from collections.abc import AsyncIterator
@@ -10,6 +11,12 @@ from collections import defaultdict, deque
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Literal
+
+# Make subpackages (rag/api/mcp/world/...) importable as top-level modules
+# in both environments: locally (repo/server) and inside Docker (/app).
+_SERVER_ROOT = str(Path(__file__).resolve().parent)
+if _SERVER_ROOT not in sys.path:
+    sys.path.insert(0, _SERVER_ROOT)
 
 import httpx
 from dotenv import load_dotenv
@@ -37,6 +44,11 @@ try:
     from server.api.workflow_native import router as workflow_native_router
 except ModuleNotFoundError:
     from api.workflow_native import router as workflow_native_router
+
+try:
+    from server.world.api import router as world_router
+except ModuleNotFoundError:
+    from world.api import router as world_router
 
 try:
     from server.rag.document_parser import parse_document
@@ -158,6 +170,7 @@ app.include_router(dify_router)
 app.include_router(rag_router)
 app.include_router(skills_router)
 app.include_router(workflow_native_router)
+app.include_router(world_router)
 
 request_windows: dict[str, deque[float]] = defaultdict(deque)
 mcp_connect_windows: dict[str, deque[float]] = defaultdict(deque)

--- a/server/tests/test_world_generation.py
+++ b/server/tests/test_world_generation.py
@@ -1,0 +1,186 @@
+"""Tests for the world-generation feature (mock provider end-to-end).
+
+Covers: input-type validation, file validation, provider response mapping,
+status mapping, error mapping, and the full mock API lifecycle.
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from server.main import app
+from server.world.api import set_provider_for_tests, set_world_store_for_tests
+from server.world.models import GeneratedAsset, GeneratedWorld, WorldInput
+from server.world.providers.mock import MockWorldProvider
+from server.world.store import WorldStore
+
+# Shorten the mock so tests don't wait ~6 seconds.
+_MOCK_FAST_STEPS = 2
+_MOCK_FAST_STEP = 0.05
+
+
+@pytest_asyncio.fixture
+async def client(tmp_path: Path):
+    store = WorldStore(tmp_path / "world_records.json")
+    set_world_store_for_tests(store)
+
+    # Inject a fast mock so the lifecycle finishes quickly.
+    fast_mock = MockWorldProvider(steps=_MOCK_FAST_STEPS, step_seconds=_MOCK_FAST_STEP)
+    set_provider_for_tests(fast_mock)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://testserver",
+    ) as async_client:
+        yield async_client
+
+    set_world_store_for_tests(WorldStore(Path("__test_reset__") / "x.json"))
+
+
+def _png_file(name: str = "test.png", size: int = 10) -> tuple[str, bytes, str]:
+    return name, b"\x89PNG\r\n\x1a\n" + b"x" * size, "image/png"
+
+
+async def create_job(client: httpx.AsyncClient, input_type: str = "image") -> str:
+    response = await client.post(
+        "/api/world-generations",
+        params={"input_type": input_type},
+        files={"files": _png_file()},
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["job_id"]
+
+
+# ----------------------------------------------------------------------
+# Validation
+# ----------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_upload_rejects_unsupported_type(client: httpx.AsyncClient) -> None:
+    response = await client.post(
+        "/api/world-generations",
+        params={"input_type": "image"},
+        files={"files": ("bad.exe", b"MZ fake", "application/octet-stream")},
+    )
+    assert response.status_code == 400
+    assert "不支持的文件类型" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_upload_rejects_no_files(client: httpx.AsyncClient) -> None:
+    response = await client.post(
+        "/api/world-generations",
+        params={"input_type": "image"},
+        files={},
+    )
+    assert response.status_code in {400, 422}
+
+
+@pytest.mark.asyncio
+async def test_upload_rejects_too_many_multi_images(
+    client: httpx.AsyncClient,
+) -> None:
+    files = [("files", _png_file(f"{i}.png")) for i in range(9)]
+    response = await client.post(
+        "/api/world-generations",
+        params={"input_type": "multi_image"},
+        files=files,
+    )
+    assert response.status_code == 400
+    assert "最多上传 8 张" in response.json()["detail"]
+
+
+# ----------------------------------------------------------------------
+# Full lifecycle
+# ----------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_mock_lifecycle_processing_to_succeeded(
+    client: httpx.AsyncClient,
+) -> None:
+    response = await client.post(
+        "/api/world-generations",
+        params={"input_type": "image"},
+        files={"files": _png_file()},
+    )
+    assert response.status_code == 200
+    job_id = response.json()["job_id"]
+    assert response.json()["status"] == "processing"
+
+    # After mock finishes, status should flip to succeeded with assets.
+    await asyncio_sleep(0.5)
+    detail = await client.get(f"/api/world-generations/{job_id}")
+    assert detail.status_code == 200
+    body = detail.json()
+    assert body["status"] == "succeeded"
+    assert len(body["assets"]) >= 1
+
+    assets_resp = await client.get(f"/api/world-generations/{job_id}/assets")
+    assert assets_resp.status_code == 200
+    assert len(assets_resp.json()["assets"]) >= 1
+
+
+@pytest.mark.asyncio
+async def test_mock_video_lifecycle(client: httpx.AsyncClient) -> None:
+    response = await client.post(
+        "/api/world-generations",
+        params={"input_type": "video"},
+        files={"files": ("clip.mp4", b"\x00\x00\x00\x18ftypmp42", "video/mp4")},
+    )
+    assert response.status_code == 200
+    job_id = response.json()["job_id"]
+
+    await asyncio_sleep(0.5)
+    detail = await client.get(f"/api/world-generations/{job_id}")
+    assert detail.json()["status"] == "succeeded"
+
+
+@pytest.mark.asyncio
+async def test_unknown_job_returns_404(client: httpx.AsyncClient) -> None:
+    response = await client.get("/api/world-generations/does-not-exist")
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_provider_endpoint_reports_mock(client: httpx.AsyncClient) -> None:
+    response = await client.get("/api/world-generations/provider")
+    assert response.status_code == 200
+    assert response.json()["provider"] == "mock"
+
+
+# ----------------------------------------------------------------------
+# Provider-level unit tests (mapping)
+# ----------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_mock_provider_get_world_asset_kinds() -> None:
+    provider = MockWorldProvider()
+    world = await provider.get_world("w-test")
+    assert isinstance(world, GeneratedWorld)
+    assert world.status == "succeeded"
+    kinds = [a.kind for a in world.assets]
+    assert "panorama" in kinds
+    assert "textured_mesh" in kinds
+    assert all(isinstance(a, GeneratedAsset) for a in world.assets)
+
+
+@pytest.mark.asyncio
+async def test_mock_provider_job_status_flow() -> None:
+    provider = MockWorldProvider(steps=3, step_seconds=0.01)
+    job = await provider.create_world(
+        WorldInput(type="image", source_file_ids=["a"]), files=[]
+    )
+    # Immediately -> processing
+    assert await provider.get_job_status(job.provider_job_id) in {"processing", "submitted"}
+    await asyncio_sleep(0.1)
+    assert await provider.get_job_status(job.provider_job_id) == "succeeded"
+    # Unknown job -> failed
+    assert await provider.get_job_status("unknown-op") == "failed"
+
+
+async def asyncio_sleep(seconds: float) -> None:
+    import asyncio
+
+    await asyncio.sleep(seconds)

--- a/server/world/__init__.py
+++ b/server/world/__init__.py
@@ -1,0 +1,40 @@
+"""World-generation package for ModelMirror.
+
+Exposes the pluggable :class:`WorldProvider` abstraction, the registry,
+and the shared data models. Built-in providers auto-register on import.
+"""
+
+from __future__ import annotations
+
+from .models import (
+    AssetFormat,
+    AssetKind,
+    GeneratedAsset,
+    GeneratedWorld,
+    ProviderName,
+    WorldInput,
+    WorldJob,
+    WorldInputType,
+    WorldStatus,
+)
+from .provider import WorldProvider
+from .registry import WorldRegistry, register_provider
+
+__all__ = [
+    "WorldProvider",
+    "WorldRegistry",
+    "register_provider",
+    "WorldInput",
+    "WorldJob",
+    "GeneratedWorld",
+    "GeneratedAsset",
+    "WorldStatus",
+    "WorldInputType",
+    "AssetKind",
+    "AssetFormat",
+    "ProviderName",
+]
+
+# -- Auto-register built-in providers --
+from .providers.mock import MockWorldProvider  # noqa: F401, E402
+from .providers.marble import MarbleWorldProvider  # noqa: F401, E402

--- a/server/world/api.py
+++ b/server/world/api.py
@@ -1,0 +1,203 @@
+"""REST API for world generation.
+
+Endpoints:
+  POST /api/world-generations           create a generation task
+  GET  /api/world-generations/:id       query task status
+  GET  /api/world-generations/:id/assets  get the generated assets
+  GET  /api/world-generations/provider   which provider is active (mock/marble)
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, File, HTTPException, UploadFile
+from pydantic import BaseModel
+
+from .models import GeneratedWorld, WorldInput, WorldJob
+from .providers.marble import MarbleProviderError
+from .registry import WorldRegistry
+from .store import WorldStore
+
+router = APIRouter(prefix="/api/world-generations", tags=["world-generations"])
+
+MAX_UPLOAD_BYTES = 50 * 1024 * 1024  # 50MB
+SUPPORTED_IMAGE_EXTS = {"jpg", "jpeg", "png", "webp"}
+SUPPORTED_VIDEO_EXTS = {"mp4", "mov", "webm", "mkv", "avi"}
+SUPPORTED_EXTS = SUPPORTED_IMAGE_EXTS | SUPPORTED_VIDEO_EXTS
+
+_store = WorldStore()
+_provider_cache: dict[str, Any] = {}
+
+
+class WorldCreateRequest(BaseModel):
+    input_type: str = "image"  # image | multi_image | video
+    prompt: str | None = None
+
+
+class JobResponse(BaseModel):
+    job_id: str
+    status: str
+    provider: str
+
+
+class AssetsResponse(BaseModel):
+    assets: list[dict[str, Any]]
+
+
+def active_provider_name() -> str:
+    """Resolve the active provider name from env (default mock)."""
+
+    return os.getenv("WORLD_PROVIDER", "mock").strip().lower()
+
+
+def get_provider():
+    """Return a cached provider instance so state (mock timing, client pool)
+    survives across requests. Rebuilds if the env name changes."""
+
+    name = active_provider_name()
+    cached = _provider_cache.get("name")
+    if cached == name:
+        return _provider_cache["instance"]
+    provider_cls = WorldRegistry.get_provider(name)
+    instance = provider_cls()
+    _provider_cache["name"] = name
+    _provider_cache["instance"] = instance
+    return instance
+
+
+def set_provider_for_tests(provider: Any) -> None:
+    """Force a provider instance (or name) for tests, bypassing env."""
+
+    if isinstance(provider, str):
+        instance = WorldRegistry.get_provider(provider)()
+    else:
+        instance = provider
+    _provider_cache["name"] = instance.provider_name
+    _provider_cache["instance"] = instance
+    os.environ["WORLD_PROVIDER"] = instance.provider_name
+
+
+def set_world_store_for_tests(store: WorldStore) -> None:
+    """Replace the global store (test helper)."""
+
+    global _store
+    _store = store
+
+
+def _validate_uploads(files: list[UploadFile], input_type: str) -> list[str]:
+    """Validate file types/sizes and return their saved temp paths."""
+
+    if not files:
+        raise HTTPException(status_code=400, detail="请至少选择一个文件。")
+    if input_type in {"image", "multi_image"} and len(files) > 8:
+        raise HTTPException(status_code=400, detail="多图模式最多上传 8 张图片。")
+
+    saved: list[str] = []
+    for upload in files:
+        filename = upload.filename or "upload"
+        ext = Path(filename).suffix.lstrip(".").lower()
+        if ext not in SUPPORTED_EXTS:
+            raise HTTPException(
+                status_code=400,
+                detail=f"不支持的文件类型：.{ext}（支持 jpg/jpeg/png/webp/mp4/mov/webm/mkv/avi）。",
+            )
+        content = upload.file.read(MAX_UPLOAD_BYTES + 1)
+        if len(content) > MAX_UPLOAD_BYTES:
+            raise HTTPException(status_code=413, detail="文件过大，请上传 50MB 以内的素材。")
+        # Persist to a temp file for the provider.
+        tmp_dir = Path(tempfile.gettempdir()) / "modelmirror-world"
+        tmp_dir.mkdir(parents=True, exist_ok=True)
+        tmp_path = tmp_dir / f"{time.time_ns()}-{filename}"
+        tmp_path.write_bytes(content)
+        saved.append(str(tmp_path))
+    return saved
+
+
+def _cleanup_temp(paths: list[str]) -> None:
+    for path in paths:
+        try:
+            p = Path(path)
+            if p.exists() and p.parent.name == "modelmirror-world":
+                p.unlink()
+        except OSError:
+            pass
+
+
+@router.post("", response_model=JobResponse)
+async def create_world_generation(
+    input_type: str = "image",
+    prompt: str | None = None,
+    files: list[UploadFile] = File(...),
+) -> JobResponse:
+    saved_paths = _validate_uploads(files, input_type)
+
+    try:
+        provider = get_provider()
+        world_input = WorldInput(
+            type=input_type,  # type: ignore[arg-type]
+            source_file_ids=[Path(p).name for p in saved_paths],
+            prompt=prompt,
+        )
+        job = await provider.create_world(world_input, [Path(p) for p in saved_paths])
+        _store.save_job(job)
+        return JobResponse(
+            job_id=job.job_id, status=job.status, provider=active_provider_name()
+        )
+    except MarbleProviderError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"创建生成任务失败：{exc}") from exc
+    finally:
+        _cleanup_temp(saved_paths)
+
+
+@router.get("/provider")
+async def world_provider_info() -> dict[str, str]:
+    return {"provider": active_provider_name()}
+
+
+@router.get("/{job_id}")
+async def get_world_generation(job_id: str) -> dict[str, Any]:
+    record = _store.get(job_id)
+    if record is None:
+        raise HTTPException(status_code=404, detail="生成任务不存在。")
+
+    # If the job finished with a world but assets were never attached, refresh.
+    if (
+        record.get("status") in {"succeeded", "processing", "submitted"}
+        and not record.get("assets")
+        and record.get("provider_job_id")
+    ):
+        try:
+            provider = get_provider()
+            status = await provider.get_job_status(record["provider_job_id"])
+            record["status"] = status
+            _store.update_status(job_id, status)
+            if status == "succeeded":
+                # Resolve the provider's world id (differs from the job id for
+                # Marble), then fetch assets and attach them to the record.
+                world_id = await provider.get_world_id(record["provider_job_id"])
+                if world_id:
+                    world = await provider.get_world(world_id)
+                    _store.attach_world(job_id, world)
+                    record = _store.get(job_id) or record
+        except Exception:
+            # Polling may fail transiently; return the stored record as-is.
+            pass
+
+    return record
+
+
+@router.get("/{job_id}/assets", response_model=AssetsResponse)
+async def get_world_assets(job_id: str) -> AssetsResponse:
+    record = _store.get(job_id)
+    if record is None:
+        raise HTTPException(status_code=404, detail="生成任务不存在。")
+    assets = record.get("assets", [])
+    return AssetsResponse(assets=assets)

--- a/server/world/models.py
+++ b/server/world/models.py
@@ -1,0 +1,91 @@
+"""Data models for the world-generation feature.
+
+These are the project-internal unified formats. Every provider
+(Mock / Marble / future vendors) must convert its raw API response
+into these types so the business layer never depends on a vendor.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+WorldStatus = Literal[
+    "created",
+    "uploading",
+    "submitted",
+    "processing",
+    "succeeded",
+    "failed",
+    "cancelled",
+    "expired",
+]
+
+WorldInputType = Literal["image", "multi_image", "video"]
+
+AssetKind = Literal[
+    "gaussian_splat",
+    "textured_mesh",
+    "panorama",
+    "preview",
+    "other",
+]
+
+AssetFormat = Literal["spz", "ply", "glb", "gltf", "png", "unknown"]
+
+ProviderName = Literal["mock", "marble"]
+
+
+class WorldInput(BaseModel):
+    """What the user submitted for a world generation."""
+
+    type: WorldInputType
+    source_file_ids: list[str] = Field(default_factory=list)
+    prompt: str | None = Field(default=None, max_length=2000)
+
+
+class WorldJob(BaseModel):
+    """A generation task handle, returned when a task is created."""
+
+    job_id: str
+    provider_job_id: str
+    status: WorldStatus = "created"
+    created_at: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+
+class GeneratedAsset(BaseModel):
+    """One downloadable/rendereable asset produced by a world model."""
+
+    id: str
+    kind: AssetKind
+    format: AssetFormat
+    url: str
+    size_bytes: int | None = None
+
+
+class GeneratedWorld(BaseModel):
+    """A completed (or in-flight) world and its assets."""
+
+    id: str
+    provider: ProviderName
+    provider_world_id: str | None = None
+    model: str = "marble-1.1"
+    status: WorldStatus = "processing"
+
+    input: WorldInput = Field(
+        default_factory=lambda: WorldInput(type="image", source_file_ids=[])
+    )
+
+    preview_url: str | None = None
+    caption: str | None = None
+
+    assets: list[GeneratedAsset] = Field(default_factory=list)
+
+    credits: float | None = None
+    estimated_cost_usd: float | None = None
+
+    created_at: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    completed_at: str | None = None

--- a/server/world/provider.py
+++ b/server/world/provider.py
@@ -1,0 +1,61 @@
+"""Abstract WorldProvider interface.
+
+The business layer only depends on this interface, never on a specific
+vendor. Adding a new world model vendor means implementing this interface
+and registering it via ``@register_provider`` — nothing else changes.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+
+from .models import GeneratedAsset, GeneratedWorld, WorldInput, WorldJob, WorldStatus
+
+
+class WorldProvider(ABC):
+    """Base class for every world-generation backend.
+
+    Providers receive already-uploaded local files (uploaded to the
+    project server by the client) and are responsible for getting them
+    into the vendor's system, kicking off generation, polling status,
+    and returning the vendor's assets mapped into project formats.
+    """
+
+    provider_name: str = ""
+    provider_priority: int = 0
+
+    @abstractmethod
+    async def create_world(
+        self,
+        input_: WorldInput,
+        files: list[Path],
+    ) -> WorldJob:
+        """Upload files and submit a world-generation task.
+
+        Returns a ``WorldJob`` carrying the vendor's operation id so the
+        caller can poll later. Must not block until generation finishes.
+        """
+
+    @abstractmethod
+    async def get_job_status(self, provider_job_id: str) -> WorldStatus:
+        """Return the current status of a submitted job."""
+
+    @abstractmethod
+    async def get_world(self, provider_world_id: str) -> GeneratedWorld:
+        """Return the full world object (assets, preview, caption)."""
+
+    async def get_world_id(self, provider_job_id: str) -> str | None:
+        """Resolve the provider world id from a finished job (optional).
+
+        The world id differs from the job (operation) id for Marble.
+        Default implementation treats the job id as the world id.
+        """
+        return provider_job_id
+
+    @abstractmethod
+    async def list_assets(self, provider_world_id: str) -> list[GeneratedAsset]:
+        """Return the asset list for a world, mapped to project formats."""
+
+    def __str__(self) -> str:
+        return self.provider_name or self.__class__.__name__

--- a/server/world/providers/__init__.py
+++ b/server/world/providers/__init__.py
@@ -1,0 +1,1 @@
+"""Built-in world-model providers (mock + marble)."""

--- a/server/world/providers/marble.py
+++ b/server/world/providers/marble.py
@@ -1,0 +1,353 @@
+"""World Labs Marble world provider.
+
+Implements the verified Marble API flow:
+  [1] media-assets:prepare_upload  -> media_asset_id + upload_url + headers
+  [2] PUT binary file              -> asset ready
+  [3] worlds:generate              -> operation_id
+  [4] operations/{id} poll         -> done / world_id
+  [5] worlds/{id}                  -> pano / spz / glb / thumbnail / caption
+  [6] worlds/{id}:export (PLY)     -> download url (optional)
+
+Authentication: header ``WLT-Api-Key``. Key comes from the environment
+variable ``WORLD_LABS_API_KEY`` (never from client/frontend).
+"""
+
+from __future__ import annotations
+
+import logging
+import mimetypes
+import os
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from ..models import (
+    AssetFormat,
+    AssetKind,
+    GeneratedAsset,
+    GeneratedWorld,
+    WorldInput,
+    WorldJob,
+    WorldStatus,
+)
+from ..provider import WorldProvider
+from ..registry import register_provider
+
+API_BASE = "https://api.worldlabs.ai"
+MAX_POLL_SECONDS = 1800  # 30 minutes safety cap
+POLL_START_INTERVAL = 10
+
+logger = logging.getLogger("modelmirror.world.marble")
+
+
+class MarbleProviderError(RuntimeError):
+    """Raised when the Marble API rejects a request."""
+
+
+def _mime_for(filename: str) -> str:
+    return mimetypes.guess_type(filename)[0] or "application/octet-stream"
+
+
+def _map_status(raw: str) -> WorldStatus:
+    """Map Marble's raw status/progress text to our unified WorldStatus."""
+
+    lowered = (raw or "").lower()
+    if "fail" in lowered or "error" in lowered or "cancel" in lowered:
+        return "failed"
+    if "success" in lowered or "succeed" in lowered or "done" in lowered:
+        return "succeeded"
+    if "progress" in lowered or "process" in lowered or "pending" in lowered:
+        return "processing"
+    if "submit" in lowered:
+        return "submitted"
+    return "processing"
+
+
+@register_provider(name="marble", priority=10)
+class MarbleWorldProvider(WorldProvider):
+    """Real World Labs Marble adapter (requires WORLD_LABS_API_KEY)."""
+
+    def __init__(
+        self,
+        api_base: str = API_BASE,
+        api_key: str | None = None,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self.api_base = api_base.rstrip("/")
+        self.api_key = api_key or os.getenv("WORLD_LABS_API_KEY", "").strip()
+        self._client = client or httpx.AsyncClient(timeout=120)
+        # Inject the auth header up front so every request (create_world,
+        # get_job_status, get_world_id, get_world, export_ply) is authenticated.
+        self._client.headers.update({"WLT-Api-Key": self.api_key})
+        # world_id -> ply_url ("" = tried and failed) to avoid duplicate paid exports.
+        self._ply_cache: dict[str, str] = {}
+
+    # ------------------------------------------------------------------
+    # [1] Upload local file -> media_asset_id
+    # ------------------------------------------------------------------
+    async def _upload_file(self, path: Path, kind: str, extension: str) -> str:
+        prep = await self._client.post(
+            f"{self.api_base}/marble/v1/media-assets:prepare_upload",
+            json={"file_name": path.name, "kind": kind, "extension": extension},
+        )
+        self._raise_for_status(prep, "media asset prepare_upload")
+        body = prep.json()
+        media_asset_id = body["media_asset"]["media_asset_id"]
+        upload_url = body["upload_info"]["upload_url"]
+        required_headers = body["upload_info"].get("required_headers", {})
+
+        put_headers = {"Content-Type": _mime_for(path.name), **required_headers}
+        upload_resp = await self._client.put(
+            upload_url, content=path.read_bytes(), headers=put_headers
+        )
+        self._raise_for_status(upload_resp, "media asset upload")
+        return media_asset_id
+
+    # ------------------------------------------------------------------
+    # [2] create_world
+    # ------------------------------------------------------------------
+    async def create_world(self, input_: WorldInput, files: list[Path]) -> WorldJob:
+        if not self.api_key:
+            raise MarbleProviderError(
+                "WORLD_LABS_API_KEY 未配置。请在 server/.env 中设置后重试。"
+            )
+
+        # Upload each file and map to the Marble prompt shape.
+        file_ids: list[str] = []
+        for path in files:
+            ext = path.suffix.lstrip(".").lower()
+            kind = "image" if ext in {"jpg", "jpeg", "png", "webp"} else "video"
+            file_ids.append(await self._upload_file(path, kind, ext))
+
+        if input_.type == "image":
+            image_prompt: dict[str, Any] = {
+                "source": "media_asset",
+                "media_asset_id": file_ids[0],
+            }
+            world_prompt: dict[str, Any] = {
+                "type": "image",
+                "image_prompt": image_prompt,
+            }
+        elif input_.type == "multi_image":
+            world_prompt = {
+                "type": "multi-image",
+                "multi_image_prompt": [
+                    {"azimuth": 0, "content": {"source": "media_asset", "media_asset_id": fid}}
+                    for fid in file_ids
+                ],
+            }
+        else:  # video
+            world_prompt = {
+                "type": "video",
+                "video_prompt": {"source": "media_asset", "media_asset_id": file_ids[0]},
+            }
+        if input_.prompt:
+            world_prompt["text_prompt"] = input_.prompt
+
+        payload = {
+            "display_name": "modelmirror-world",
+            "model": "marble-1.1",
+            "world_prompt": world_prompt,
+        }
+        resp = await self._client.post(
+            f"{self.api_base}/marble/v1/worlds:generate",
+            json=payload,
+        )
+        self._raise_for_status(resp, "worlds:generate")
+        data = resp.json()
+        return WorldJob(
+            job_id=f"marble-{uuid.uuid4().hex[:12]}",
+            provider_job_id=data["operation_id"],
+            status="submitted",
+        )
+
+    # ------------------------------------------------------------------
+    # [3] get_job_status
+    # ------------------------------------------------------------------
+    async def get_job_status(self, provider_job_id: str) -> WorldStatus:
+        resp = await self._client.get(
+            f"{self.api_base}/marble/v1/operations/{provider_job_id}"
+        )
+        self._raise_for_status(resp, "operations/{id}")
+        data = resp.json()
+        if data.get("error"):
+            return "failed"
+        if data.get("done"):
+            return "succeeded"
+        progress = data.get("metadata", {}).get("progress", {})
+        return _map_status(progress.get("status", "IN_PROGRESS"))
+
+    # ------------------------------------------------------------------
+    # [3b] resolve world id from a finished operation
+    # ------------------------------------------------------------------
+    async def get_world_id(self, provider_job_id: str) -> str | None:
+        resp = await self._client.get(
+            f"{self.api_base}/marble/v1/operations/{provider_job_id}"
+        )
+        self._raise_for_status(resp, "operations/{id}")
+        data = resp.json()
+        if not data.get("done"):
+            return None
+        response = data.get("response")
+        if isinstance(response, dict):
+            return response.get("world_id")
+        return None
+
+    # ------------------------------------------------------------------
+    # [4] get_world + assets
+    # ------------------------------------------------------------------
+    async def get_world(
+        self,
+        provider_world_id: str,
+        *,
+        include_ply: bool = True,
+    ) -> GeneratedWorld:
+        resp = await self._client.get(
+            f"{self.api_base}/marble/v1/worlds/{provider_world_id}"
+        )
+        self._raise_for_status(resp, "worlds/{id}")
+        data = resp.json()
+        assets = data.get("assets", {})
+
+        asset_list: list[GeneratedAsset] = []
+        # Panorama
+        pano_url = assets.get("imagery", {}).get("pano_url")
+        if pano_url:
+            asset_list.append(
+                GeneratedAsset(id=f"{provider_world_id}-pano", kind="panorama", format="png", url=pano_url)
+            )
+        # SPZ (multiple resolutions)
+        spz_urls = assets.get("splats", {}).get("spz_urls", {})
+        if isinstance(spz_urls, dict):
+            for resolution, url in spz_urls.items():
+                if isinstance(url, str) and url:
+                    asset_list.append(
+                        GeneratedAsset(
+                            id=f"{provider_world_id}-spz-{resolution}",
+                            kind="gaussian_splat",
+                            format="spz",
+                            url=url,
+                        )
+                    )
+        # GLB collider mesh
+        glb_url = assets.get("mesh", {}).get("collider_mesh_url")
+        if glb_url:
+            asset_list.append(
+                GeneratedAsset(id=f"{provider_world_id}-glb", kind="textured_mesh", format="glb", url=glb_url)
+            )
+        # PLY (requires an extra :export call — cached so it only runs once)
+        if include_ply:
+            ply_url = await self._cached_ply_url(provider_world_id)
+            if ply_url:
+                asset_list.append(
+                    GeneratedAsset(
+                        id=f"{provider_world_id}-ply",
+                        kind="gaussian_splat",
+                        format="ply",
+                        url=ply_url,
+                    )
+                )
+
+        cost = data.get("cost") or {}
+        credits = cost.get("total_credits") if isinstance(cost, dict) else None
+
+        return GeneratedWorld(
+            id=provider_world_id,
+            provider="marble",
+            provider_world_id=provider_world_id,
+            model="marble-1.1",
+            status="succeeded",
+            preview_url=assets.get("thumbnail_url"),
+            caption=assets.get("caption"),
+            assets=asset_list,
+            credits=float(credits) if credits is not None else None,
+        )
+
+    # ------------------------------------------------------------------
+    # PLY export with per-world cache (avoid duplicate paid exports)
+    # ------------------------------------------------------------------
+    async def _cached_ply_url(self, provider_world_id: str) -> str | None:
+        cached = self._ply_cache.get(provider_world_id)
+        if cached is not None:
+            return cached or None  # "" means "already tried and failed"
+        try:
+            url = await self.export_ply(provider_world_id)
+            self._ply_cache[provider_world_id] = url
+            return url
+        except Exception as exc:
+            # PLY is an optional extra — do not break the whole world.
+            self._ply_cache[provider_world_id] = ""
+            logger.warning(
+                "PLY export skipped for %s: %s", provider_world_id, exc
+            )
+            return None
+
+    async def list_assets(self, provider_world_id: str) -> list[GeneratedAsset]:
+        world = await self.get_world(provider_world_id)
+        return world.assets
+
+    # ------------------------------------------------------------------
+    # [5] Export PLY (optional, costs credits)
+    # ------------------------------------------------------------------
+    async def export_ply(self, provider_world_id: str) -> str:
+        resp = await self._client.post(
+            f"{self.api_base}/marble/v1/worlds/{provider_world_id}:export",
+            json={"asset_type": "splats", "format": "ply", "resolution": "full_res"},
+        )
+        self._raise_for_status(resp, "worlds:export")
+        data = resp.json()
+        if data.get("done"):
+            url = data.get("response", {}).get("url")
+            if not url:
+                raise MarbleProviderError("PLY 导出未返回下载地址。")
+            return url
+        # Not done -> poll the returned operation.
+        operation_id = data["operation_id"]
+        url = await self._poll_for_export_url(operation_id)
+        return url
+
+    async def _poll_for_export_url(self, operation_id: str) -> str:
+        start = time.monotonic()
+        wait = POLL_START_INTERVAL
+        while True:
+            await asyncio_sleep(wait)
+            resp = await self._client.get(
+                f"{self.api_base}/marble/v1/operations/{operation_id}"
+            )
+            self._raise_for_status(resp, "operations/{id}")
+            data = resp.json()
+            if data.get("done"):
+                url = data.get("response", {}).get("url")
+                if not url:
+                    raise MarbleProviderError("PLY 导出完成后未返回下载地址。")
+                return url
+            if time.monotonic() - start > MAX_POLL_SECONDS:
+                raise MarbleProviderError("PLY 导出超时。")
+            wait = min(wait * 2, 60)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _raise_for_status(resp: httpx.Response, what: str) -> None:
+        if resp.status_code < 400:
+            return
+        detail = ""
+        try:
+            body = resp.json()
+        except ValueError:
+            body = None
+        if isinstance(body, dict):
+            detail = str(body.get("message") or body.get("error") or body.get("detail") or "")
+        raise MarbleProviderError(
+            f"Marble API {what} 失败: HTTP {resp.status_code} {detail}".strip()
+        )
+
+
+async def asyncio_sleep(seconds: float) -> None:
+    import asyncio
+
+    await asyncio.sleep(seconds)

--- a/server/world/providers/mock.py
+++ b/server/world/providers/mock.py
@@ -1,0 +1,110 @@
+"""Mock world provider — no API key, no network, for dev/test/demo.
+
+Simulates the full lifecycle: a job is created, polled a few times as
+``processing``, then flips to ``succeeded`` with a fixed set of example
+assets (a panorama PNG and a GLB). Use for development, tests, and the
+demo flow; switch to the real provider via ``WORLD_PROVIDER=marble``.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from ..models import (
+    GeneratedAsset,
+    GeneratedWorld,
+    WorldInput,
+    WorldJob,
+    WorldStatus,
+)
+from ..provider import WorldProvider
+from ..registry import register_provider
+
+if TYPE_CHECKING:
+    from ..models import GeneratedAsset as _GA
+
+# Number of polls before the mock job reports success.
+_MOCK_STEPS = 4
+# Time (seconds) between polls before flipping to succeeded.
+_MOCK_STEP_SECONDS = 1.5
+# Example asset URLs returned by the mock. These must be REAL, publicly
+# accessible, CORS-enabled assets so the frontend viewer can actually load
+# them (a fake URL like cdn.marble.../mock-world/... returns 404 and the
+# viewer reports a load failure).
+#   pano: three.js official equirectangular panorama (CORS: *)
+#   glb:  Khronos glTF sample model Duck (CORS: *)
+_MOCK_PANO_URL = (
+    "https://threejs.org/examples/textures/2294472375_24a3b8ef46_o.jpg"
+)
+_MOCK_GLB_URL = (
+    "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/main/2.0/Duck/glTF-Binary/Duck.glb"
+)
+
+
+@register_provider(name="mock", priority=-100)
+class MockWorldProvider(WorldProvider):
+    """Deterministic in-process provider that never touches the network."""
+
+    def __init__(
+        self,
+        steps: int | None = None,
+        step_seconds: float | None = None,
+    ) -> None:
+        self._started_at: dict[str, float] = {}
+        self._steps = steps if steps is not None else _MOCK_STEPS
+        self._step_seconds = step_seconds if step_seconds is not None else _MOCK_STEP_SECONDS
+
+    async def create_world(self, input_: WorldInput, files: list[Path]) -> WorldJob:
+        job_id = f"mock-{uuid.uuid4().hex[:12]}"
+        provider_job_id = f"op-{uuid.uuid4().hex[:12]}"
+        self._started_at[provider_job_id] = time.monotonic()
+        return WorldJob(
+            job_id=job_id,
+            provider_job_id=provider_job_id,
+            status="processing",
+        )
+
+    async def get_job_status(self, provider_job_id: str) -> WorldStatus:
+        started = self._started_at.get(provider_job_id)
+        if started is None:
+            return "failed"
+        elapsed = time.monotonic() - started
+        step = int(elapsed // self._step_seconds)
+        if step >= self._steps:
+            return "succeeded"
+        return "processing"
+
+    async def get_world(self, provider_world_id: str) -> GeneratedWorld:
+        world_id = provider_world_id or f"world-mock-{uuid.uuid4().hex[:8]}"
+        return GeneratedWorld(
+            id=world_id,
+            provider="mock",
+            provider_world_id=world_id,
+            model="marble-1.1",
+            status="succeeded",
+            preview_url=_MOCK_PANO_URL,
+            caption="Mock world generated for development/testing.",
+            assets=[
+                GeneratedAsset(
+                    id=f"asset-{uuid.uuid4().hex[:8]}",
+                    kind="panorama",
+                    format="png",
+                    url=_MOCK_PANO_URL,
+                ),
+                GeneratedAsset(
+                    id=f"asset-{uuid.uuid4().hex[:8]}",
+                    kind="textured_mesh",
+                    format="glb",
+                    url=_MOCK_GLB_URL,
+                ),
+            ],
+            credits=0.0,
+            estimated_cost_usd=0.0,
+        )
+
+    async def list_assets(self, provider_world_id: str) -> list["_GA"]:
+        world = await self.get_world(provider_world_id)
+        return world.assets

--- a/server/world/registry.py
+++ b/server/world/registry.py
@@ -1,0 +1,76 @@
+"""Registry for pluggable world-model providers.
+
+Mirrors the RAG embedder/retriever registry pattern so the whole project
+keeps one consistent pluggable-style API.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .provider import WorldProvider
+
+logger = logging.getLogger("modelmirror.world.registry")
+
+
+class WorldRegistry:
+    """Registry of available :class:`WorldProvider` implementations."""
+
+    _by_name: dict[str, type[WorldProvider]] = {}
+    _default_name: str = "mock"
+
+    @classmethod
+    def register(cls, provider_cls: type[WorldProvider]) -> None:
+        name: str = getattr(provider_cls, "provider_name", "") or provider_cls.__name__
+        priority: int = getattr(provider_cls, "provider_priority", 0)
+
+        existing = cls._by_name.get(name)
+        if existing is not None and existing is not provider_cls:
+            existing_prio = getattr(existing, "provider_priority", 0)
+            if priority >= existing_prio:
+                cls._by_name[name] = provider_cls
+                logger.debug("Overrode provider %r with %r", name, provider_cls.__name__)
+            return
+
+        cls._by_name[name] = provider_cls
+        logger.debug("Registered provider %r", name)
+
+    @classmethod
+    def get_provider(cls, name: str | None = None) -> type[WorldProvider]:
+        """Return a provider class by name, or the default."""
+
+        key = name or cls._default_name
+        cls_cls = cls._by_name.get(key)
+        if cls_cls is not None:
+            return cls_cls
+        fallback = cls._by_name.get(cls._default_name)
+        if fallback is not None:
+            return fallback
+        raise RuntimeError(
+            f"No world provider registered as {key!r} "
+            f"(registered: {list(cls._by_name)})"
+        )
+
+    @classmethod
+    def list_providers(cls) -> list[str]:
+        return list(cls._by_name)
+
+    @classmethod
+    def set_default(cls, name: str) -> None:
+        if name not in cls._by_name:
+            raise ValueError(f"Unknown provider: {name}")
+        cls._default_name = name
+
+
+def register_provider(name: str | None = None, priority: int = 0):
+    """Class decorator that registers a :class:`WorldProvider` subclass."""
+
+    def wrapper(cls):
+        cls.provider_name = name or cls.__name__
+        cls.provider_priority = priority
+        WorldRegistry.register(cls)
+        return cls
+
+    return wrapper

--- a/server/world/store.py
+++ b/server/world/store.py
@@ -1,0 +1,122 @@
+"""JSON-file-backed store for world-generation records.
+
+Mirrors the RAG metadata.json pattern: a single JSON file holding all
+records. Not suitable for heavy concurrency, but fine for the MVP.
+Asset URLs may expire — always persist ``world_id`` / ``provider_world_id``
+so assets can be re-fetched later.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import uuid
+from pathlib import Path
+from typing import Any
+
+from .models import GeneratedWorld, WorldJob, WorldStatus
+
+
+class WorldStore:
+    """Persist and query world-generation records."""
+
+    def __init__(self, storage_path: Path | None = None) -> None:
+        root = Path(__file__).resolve().parent
+        self.storage_path = storage_path or Path(
+            os.getenv("WORLD_STORAGE_DIR", str(root / "storage" / "world_records.json"))
+        )
+        self.storage_path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.RLock()
+
+    # ------------------------------------------------------------------
+    # Internal read/write
+    # ------------------------------------------------------------------
+    def _read_all(self) -> dict[str, dict[str, Any]]:
+        if not self.storage_path.exists():
+            return {}
+        try:
+            data = json.loads(self.storage_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def _write_all(self, data: dict[str, dict[str, Any]]) -> None:
+        self.storage_path.write_text(
+            json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def save_job(self, job: WorldJob) -> None:
+        """Create (or update) a record for a job."""
+
+        with self._lock:
+            records = self._read_all()
+            existing = records.get(job.job_id, {})
+            existing.update(
+                {
+                    "job_id": job.job_id,
+                    "provider_job_id": job.provider_job_id,
+                    "status": job.status,
+                    "created_at": job.created_at,
+                }
+            )
+            records[job.job_id] = existing
+            self._write_all(records)
+
+    def update_status(self, job_id: str, status: WorldStatus) -> None:
+        with self._lock:
+            records = self._read_all()
+            if job_id in records:
+                records[job_id]["status"] = status
+                self._write_all(records)
+
+    def attach_world(self, job_id: str, world: GeneratedWorld) -> None:
+        """Attach the completed world (assets, caption, etc.) to a job."""
+
+        with self._lock:
+            records = self._read_all()
+            if job_id not in records:
+                return
+            records[job_id].update(
+                {
+                    "status": world.status,
+                    "world_id": world.provider_world_id or world.id,
+                    "assets": [
+                        {
+                            "id": a.id,
+                            "kind": a.kind,
+                            "format": a.format,
+                            "url": a.url,
+                            "size_bytes": a.size_bytes,
+                        }
+                        for a in world.assets
+                    ],
+                    "preview_url": world.preview_url,
+                    "caption": world.caption,
+                    "credits": world.credits,
+                    "estimated_cost_usd": world.estimated_cost_usd,
+                    "completed_at": world.completed_at,
+                }
+            )
+            self._write_all(records)
+
+    def get(self, job_id: str) -> dict[str, Any] | None:
+        with self._lock:
+            records = self._read_all()
+            record = records.get(job_id)
+            return dict(record) if record else None
+
+    def list(self) -> list[dict[str, Any]]:
+        with self._lock:
+            records = self._read_all()
+            return [
+                dict(record) for record in sorted(
+                    records.values(), key=lambda r: r.get("created_at", ""), reverse=True
+                )
+            ]
+
+    def _new_job_id(self) -> str:
+        return f"job-{uuid.uuid4().hex[:12]}"


### PR DESCRIPTION
# 变更摘要

## 目标与事实依据

- 单一目标：
- 事实证据（代码/配置/测试/已确认需求）：
- 待确认项：

> 不得把“合理推断”或“建议方案”写成已存在能力。目标客户、用户故事、SLA 和权限规则无明确输入时保留“待确认”。

## 变更内容

-

## 范围声明

- 允许修改：
- 明确不改：
- 公共 API/SSE 变化：
- 持久化/迁移影响：
- 新增或升级依赖：

影响类型：

- [ ] 前端页面或交互
- [ ] 后端 API
- [ ] Chat / Workflow / Xpert 执行
- [ ] MCP / Toolset / 子进程
- [ ] RAG / Knowledge / Data X
- [ ] 持久化数据或迁移
- [ ] Docker / Sidecar / 网络
- [ ] 公开 App/API 或凭据
- [ ] 纯文档

## 验收标准

### 正常路径

- Given：
- When：
- Then：

### 失败路径

- Given：
- When：
- Then：

## 验证证据

状态只允许：`通过 / 失败 / 未运行 / 不适用`。

| 检查 | 状态 | 实际命令或人工步骤 | 结果摘要 |
| --- | --- | --- | --- |
| 前端生产构建 | 未运行 | `cd client && npm.cmd run build` |  |
| 后端语法 | 未运行 |  |  |
| 目标测试 | 未运行 |  |  |
| 全量测试 | 未运行 | `python -m pytest server/tests/ -q` |  |
| Docker/健康检查 | 未运行 |  |  |
| 人工验收 | 未运行 |  |  |
| 敏感信息扫描 | 未运行 |  |  |

## Harness 与安全检查

- [ ] 已阅读 `AGENTS.md`、任务相关文档和测试。
- [ ] 已检查工作树，未覆盖或回滚用户改动。
- [ ] 实际变更没有超出声明范围；超过 5 个文件时已说明原因。
- [ ] 未提交 `.env`、密钥、token、日志、运行存储、上传、索引、构建产物或 APK。
- [ ] 新依赖已说明用途、固定版本、许可证与安全影响，或本次未新增依赖。
- [ ] 正常、错误、空态、超时、取消、重试和重启恢复已按适用范围验证。
- [ ] 已执行 `git diff --check` 并审查完整 Diff。
- [ ] 相关文档已更新，过期文档已登记而非静默忽略。

## 风险、未完成项与回退

- 剩余风险：
- 未运行/未完成：
- 停止条件或后续人工决定：

回退步骤：

1.
2.
3.

## 截图 / 录屏

涉及 UI 时附上截图/录屏，或说明不适用原因。

