### PR TITLE
feature: 扩充 Skill 与 SkillSet 市场目录

### DIFF
--- a/client/src/data/anbeimeSkillCatalog.generated.json
+++ b/client/src/data/anbeimeSkillCatalog.generated.json
@@ -1,0 +1,983 @@
+{
+  "source": {
+    "repoName": "anbeime/skill",
+    "repoUrl": "https://github.com/anbeime/skill",
+    "commit": "011d53f4f238cf7cc8e2cdae8452fffaec7eb1ae",
+    "updatedAt": "2026-08-02",
+    "stars": 4605,
+    "discoveredSkillFiles": 69,
+    "catalogProjects": 64
+  },
+  "projects": [
+    {
+      "id": "anbeime-product-manager-toolkit",
+      "name": "product-manager-toolkit",
+      "kind": "skill",
+      "category": "产品与职业",
+      "description": "Comprehensive toolkit for product managers including RICE prioritization, customer interview analysis, PRD templates, discovery frameworks, and go-to-market strategies. Use for feature prioritization, user research sy...",
+      "subPath": "skills/product-manager-toolkit/product-manager-toolkit",
+      "language": "Markdown / Python",
+      "tags": [
+        "社区来源",
+        "含脚本",
+        "含参考资料"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-tailored-resume-generator",
+      "name": "tailored-resume-generator",
+      "kind": "skill",
+      "category": "产品与职业",
+      "description": "Analyzes job descriptions and generates tailored resumes that highlight relevant experience, skills, and achievements to maximize interview chances",
+      "subPath": "skills/tailored-resume-generator/tailored-resume-generator",
+      "language": "Markdown",
+      "tags": [
+        "社区来源",
+        "说明型",
+        "独立技能"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-agentkit-multimedia-shopping",
+      "name": "agentkit-multimedia-shopping",
+      "kind": "skill",
+      "category": "电商与营销",
+      "description": "基于ByteDance agentkit-samples多媒体用例的小省导购员数字人带货视频生成技能，整合多模态内容生成能力（图像、视频、音频），支持AI绘画、语音合成、视频生成，与小省导购员人设融合，9:16竖屏适配，直接对接带货视频生成流程",
+      "subPath": "skills/agentkit-multimedia-shopping/agentkit-multimedia-shopping",
+      "language": "Markdown / Python",
+      "tags": [
+        "社区来源",
+        "含脚本",
+        "含参考资料"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-digital-avatar-shopping-video",
+      "name": "digital-avatar-shopping-video",
+      "kind": "skill",
+      "category": "电商与营销",
+      "description": "小省导购员多智能体数字人口播带货视频生成系统，以\"小省导购员\"为核心人设，打造专业购物助手+数字人口播带货视频一体化服务。涵盖五大智能体（小省导购员、带货脚本师、数字人口播生成师、带货画面设计师、音画合成师），产出\"数字人口播+带货画面+字幕音效\"的成品视频，适配抖音、快手等短视频平台，支持淘宝、京东、拼多多、唯品会等全平台商品信息，具备知识库自动存取能力。",
+      "subPath": "skills/digital-avatar-shopping-video/digital-avatar-shopping-video",
+      "language": "Markdown",
+      "tags": [
+        "社区来源",
+        "说明型",
+        "含参考资料"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-dream-video-prompt-generator",
+      "name": "dream-video-prompt-generator",
+      "kind": "skill",
+      "category": "电商与营销",
+      "description": "小省导购员数字人带货版即梦视频提示词生成系统，基于四大智能体协同（提示词生成师、质量管控师、知识库运维师、跨环节适配师），按照\"主体+运动+场景+（镜头语言+光影+氛围）\"公式输出中英文双版提示词，适配5s短视频。确保人物一致性、视觉连贯性、情绪连贯性，支持知识库智能复用和跨工具适配（Suno音乐、AI绘画），为数字人带货视频提供高质量提示词生成服务。",
+      "subPath": "skills/dream-video-prompt-generator/dream-video-prompt-generator",
+      "language": "Markdown",
+      "tags": [
+        "社区来源",
+        "说明型",
+        "含参考资料"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-ecommerce-copywriter",
+      "name": "ecommerce-copywriter",
+      "kind": "skill",
+      "category": "电商与营销",
+      "description": "电商图片文案创作技能，支持多品类产品的吸引性文案生成，适用于电商平台的商品营销推广",
+      "subPath": "skills/ecommerce-copywriter/ecommerce-copywriter",
+      "language": "Markdown",
+      "tags": [
+        "社区来源",
+        "说明型",
+        "含参考资料"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-ecommerce-full-pipeline",
+      "name": "ecommerce-full-pipeline",
+      "kind": "skill",
+      "category": "电商与营销",
+      "description": "跨境电商全链路自动化工具。集成1688采集、智能清洗、多平台上架（微信小店/Shopify/TikTok）、推广方案（关键词/竞品分析/广告文案）、短视频创作（MoviePy竖屏视频）、一键代发、爆品挖掘（趋势聚合+6维评分）、闲鱼二手选品捡漏（品牌识别/虚标过滤/捡漏评分/价格监控）、全自动流水线（挖掘→采集→清洗→上架→推广→视频）。",
+      "subPath": "skills/ecommerce-full-pipeline/ecommerce-full-pipeline",
+      "language": "Markdown",
+      "tags": [
+        "社区来源",
+        "说明型",
+        "独立技能"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-ecommerce-video-marketing",
+      "name": "ecommerce-video-marketing",
+      "kind": "skill",
+      "category": "电商与营销",
+      "description": "电商视频营销创作技能，支持多品类商品的营销视频脚本生成，包含6阶段创作流程、智能体提示词框架、8种商品类型模板，适用于电商平台、社交媒体、品牌推广",
+      "subPath": "skills/ecommerce-video-marketing/ecommerce-video-marketing",
+      "language": "Markdown",
+      "tags": [
+        "社区来源",
+        "说明型",
+        "含参考资料"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-infinitetalk-shopping-avatar",
+      "name": "infinitetalk-shopping-avatar",
+      "kind": "skill",
+      "category": "电商与营销",
+      "description": "专为InfiniteTalk项目设计的小省导购员数字人带货提示词生成技能，基于四大智能体协同（提示词生成师、质量管控师、知识库运维师、跨环节适配师），生成适配Image-to-Video模式的结构化提示词（角色固定特征+动作时序+场景环境+音频匹配+光影氛围+技术约束），支持9:16竖屏、5s/幕、音频同步（Suno+chinese-wav2vec2-base）、一致性管控（角色/视觉/情绪），直接对接模型推理流程",
+      "subPath": "skills/infinitetalk-shopping-avatar/infinitetalk-shopping-avatar",
+      "language": "Markdown",
+      "tags": [
+        "社区来源",
+        "说明型",
+        "含参考资料"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-pet-commerce-creator",
+      "name": "pet-commerce-creator",
+      "kind": "skill",
+      "category": "电商与营销",
+      "description": "萌宠带货短视频全流程创作技能，基于COZE视频大模型API，支持萌宠剧情/好物测评/品种科普/宠品带货等全类型创作，覆盖爆款解析反推、知识库联动、互动优化、素材批量下载、全素材整合，实现从创意到带货引流型成品视频的自动化生成，适配15-30秒竖屏9:16主流平台规格。",
+      "subPath": "skills/pet-commerce-creator/pet-commerce-creator",
+      "language": "Markdown / Python",
+      "tags": [
+        "社区来源",
+        "含脚本",
+        "含参考资料"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-product-marketing-copywriter",
+      "name": "product-marketing-copywriter",
+      "kind": "skill",
+      "category": "电商与营销",
+      "description": "产品营销文案创作技能，支持多品类产品的吸引性营销文案生成，适用于产品推广、品牌营销、销售转化",
+      "subPath": "skills/product-marketing-copywriter/product-marketing-copywriter",
+      "language": "Markdown",
+      "tags": [
+        "社区来源",
+        "说明型",
+        "含参考资料"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-product-video-creator",
+      "name": "product-video-creator",
+      "kind": "skill",
+      "category": "电商与营销",
+      "description": "多智能体协同的商品视频创作流水线，支持从商品信息到成视频的全流程创作：文案生成、故事策划、脚本创作、分镜设计、图片生成、字幕创作、音效推荐及视频合成；适用于电商商品宣传、品牌推广、社交媒体营销等场景",
+      "subPath": "skills/product-video-creator/product-video-creator",
+      "language": "Markdown / Python",
+      "tags": [
+        "社区来源",
+        "含脚本",
+        "含参考资料"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-wechat-hotspot-publisher",
+      "name": "wechat-hotspot-publisher",
+      "kind": "skill",
+      "category": "电商与营销",
+      "description": "智能采集热点话题，10分制筛选优质选题，AI生成爆款内容（标题/封面/标签/图片/HTML排版），支持素材上传和草稿箱发布，一键发布到微信公众号、小红书、B站等多平台",
+      "subPath": "skills/wechat-hotspot-publisher/wechat-hotspot-publisher",
+      "language": "Markdown / Python",
+      "tags": [
+        "社区来源",
+        "含脚本",
+        "含参考资料"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-xiaohongshu-makeup",
+      "name": "xiaohongshu-makeup",
+      "kind": "skill",
+      "category": "电商与营销",
+      "description": "小红书美妆内容创作技能，支持笔记生成、笔记优化、文生图描述创作；适用于美妆护肤产品的内容创作、测评和营销推广",
+      "subPath": "skills/xiaohongshu-makeup/xiaohongshu-makeup",
+      "language": "Markdown",
+      "tags": [
+        "社区来源",
+        "说明型",
+        "含参考资料"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-frontend-design",
+      "name": "frontend-design",
+      "kind": "skill",
+      "category": "界面与设计",
+      "description": "Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, or applications. Generates creative, polished code that avoids gener...",
+      "subPath": "skills/frontend-design/frontend-design",
+      "language": "Markdown",
+      "tags": [
+        "社区来源",
+        "说明型",
+        "独立技能"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-pop-up-book-illustration",
+      "name": "pop-up-book-illustration",
+      "kind": "skill",
+      "category": "界面与设计",
+      "description": "生成3D纸艺弹出书风格插画，具备立体层次感、明亮温暖色调，适用于科技、教育、品牌展示等场景",
+      "subPath": "skills/pop-up-book-illustration/pop-up-book-illustration",
+      "language": "Markdown",
+      "tags": [
+        "社区来源",
+        "说明型",
+        "独立技能"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-web-design-analyzer",
+      "name": "web-design-analyzer",
+      "kind": "skill",
+      "category": "界面与设计",
+      "description": "分析网页截图，提取设计系统（Design System）并生成结构化数据和可用的 AI Coding Prompt。适用于 UI/UX 设计师和前端工程师需要从现有网页设计中提取设计规范、配色方案、排版系统和组件风格的场景。",
+      "subPath": "skills/web-design-analyzer/web-design-analyzer",
+      "language": "Markdown / Python",
+      "tags": [
+        "社区来源",
+        "含脚本",
+        "含参考资料"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-web-to-app",
+      "name": "web-to-app",
+      "kind": "skill",
+      "category": "界面与设计",
+      "description": "将任意网页转换为桌面应用，支持 macOS/Windows/Linux 三大平台。使用 Rust + Tauri 技术栈，生成的应用体积小（约 5MB）、性能高。支持自定义图标、窗口大小、快捷键等丰富配置。",
+      "subPath": "skills/web-to-app/web-to-app",
+      "language": "Markdown / Python",
+      "tags": [
+        "社区来源",
+        "含脚本",
+        "含参考资料"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-stock-analysis",
+      "name": "stock-analysis",
+      "kind": "skill",
+      "category": "金融分析",
+      "description": "股票个股分析，实时获取价格涨跌幅，计算技术指标和支撑位，识别缺口并判断支撑压力，智能预测未来3天走势并给出操作建议",
+      "subPath": "skills/stock-analysis/stock-analysis",
+      "language": "Markdown / Python",
+      "tags": [
+        "社区来源",
+        "含脚本",
+        "含参考资料"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-chrome-automation",
+      "name": "chrome-automation",
+      "kind": "skill",
+      "category": "浏览器与自动化",
+      "description": "Connect to and control Google Chrome browser using agent-browser with CDP (Chrome DevTools Protocol). Use when the user wants to automate their existing Chrome browser, see browser actions in real-time, or needs to co...",
+      "subPath": "skills/chrome-automation/chrome-automation",
+      "language": "Markdown / Shell / PowerShell",
+      "tags": [
+        "社区来源",
+        "含脚本",
+        "含参考资料"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-article-illustrator",
+      "name": "article-illustrator",
+      "kind": "skill",
+      "category": "内容创作与发布",
+      "description": "分析文章内容，在需要视觉辅助理解的位置生成插画。配图可以是信息补充、概念具象化，或引导读者想象。当用户要求\"给文章配图\"、\"为文章生成插图\"、\"添加配图\"时使用此技能。",
+      "subPath": "skills/article-illustrator/article-illustrator",
+      "language": "Markdown",
+      "tags": [
+        "社区来源",
+        "说明型",
+        "含参考资料"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-baoyu-format-markdown",
+      "name": "baoyu-format-markdown",
+      "kind": "skill",
+      "category": "内容创作与发布",
+      "description": "Formats plain text or markdown files with frontmatter, titles, summaries, headings, bold, lists, and code blocks. Use when user asks to \"format markdown\", \"beautify article\", \"add formatting\", or improve article layou...",
+      "subPath": "skills/content-creation-publisher/baoyu-format-markdown",
+      "language": "TypeScript / Markdown",
+      "tags": [
+        "社区来源",
+        "含脚本",
+        "独立技能"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-baoyu-post-to-wechat",
+      "name": "baoyu-post-to-wechat",
+      "kind": "skill",
+      "category": "内容创作与发布",
+      "description": "Posts content to WeChat Official Account (微信公众号) via API or Chrome CDP. Supports article posting (文章) with HTML, markdown, or plain text input, and image-text posting (图文) with multiple images. Use when user mentions ...",
+      "subPath": "skills/content-creation-publisher/baoyu-post-to-wechat",
+      "language": "Markdown / TypeScript / CSS",
+      "tags": [
+        "社区来源",
+        "含脚本",
+        "含参考资料"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-baoyu-post-to-x",
+      "name": "baoyu-post-to-x",
+      "kind": "skill",
+      "category": "内容创作与发布",
+      "description": "Posts content and articles to X (Twitter). Supports regular posts with images/videos and X Articles (long-form Markdown). Uses real Chrome with CDP to bypass anti-automation. Use when user asks to \"post to X\", \"tweet\"...",
+      "subPath": "skills/content-creation-publisher/baoyu-post-to-x",
+      "language": "Markdown / TypeScript",
+      "tags": [
+        "社区来源",
+        "含脚本",
+        "含参考资料"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-baoyu-url-to-markdown",
+      "name": "baoyu-url-to-markdown",
+      "kind": "skill",
+      "category": "内容创作与发布",
+      "description": "Fetch any URL and convert to markdown using Chrome CDP. Supports two modes - auto-capture on page load, or wait for user signal (for pages requiring login). Use when user wants to save a webpage as markdown.",
+      "subPath": "skills/content-creation-publisher/baoyu-url-to-markdown",
+      "language": "TypeScript / Markdown",
+      "tags": [
+        "社区来源",
+        "含脚本",
+        "独立技能"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-bedtime-story",
+      "name": "bedtime-story",
+      "kind": "skill",
+      "category": "内容创作与发布",
+      "description": "为3-12岁儿童提供温馨亲切的睡前寓言故事和成语典故讲解。支持用户唤醒后提供故事列表选择，或直接讲解指定故事/成语。讲解时保持亲切温馨的语气、0.6倍正常语速、通俗易懂的表达，为小朋友营造舒适的睡前氛围。",
+      "subPath": "skills/bedtime-story/bedtime-story",
+      "language": "Markdown",
+      "tags": [
+        "社区来源",
+        "说明型",
+        "含参考资料"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-content-creation-publisher",
+      "name": "content-creation-publisher",
+      "kind": "skillset",
+      "category": "内容创作与发布",
+      "description": "内容创作与发布全流程技能，整合网页采集、Markdown格式化、智能配图、多平台发布（微信公众号、X/Twitter）功能，实现从内容获取到发布的一站式解决方案",
+      "subPath": "skills/content-creation-publisher",
+      "language": "Markdown / TypeScript / CSS",
+      "tags": [
+        "社区来源",
+        "技能包",
+        "5 个子技能"
+      ],
+      "includedSkills": [
+        "article-illustrator",
+        "baoyu-format-markdown",
+        "baoyu-post-to-wechat",
+        "baoyu-post-to-x",
+        "baoyu-url-to-markdown"
+      ]
+    },
+    {
+      "id": "anbeime-content-research-writer",
+      "name": "content-research-writer",
+      "kind": "skill",
+      "category": "内容创作与发布",
+      "description": "Assists in writing high-quality content by conducting research, adding citations, improving hooks, iterating on outlines, and providing real-time feedback on each section. Transforms your writing process from solo eff...",
+      "subPath": "skills/content-research-writer",
+      "language": "Markdown",
+      "tags": [
+        "社区来源",
+        "说明型",
+        "独立技能"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-data-storytelling",
+      "name": "data-storytelling",
+      "kind": "skill",
+      "category": "内容创作与发布",
+      "description": "Transform data into compelling narratives using visualization, context, and persuasive structure. Use when presenting analytics to stakeholders, creating data reports, or building executive presentations.",
+      "subPath": "skills/data-storytelling/data-storytelling",
+      "language": "Markdown",
+      "tags": [
+        "社区来源",
+        "说明型",
+        "独立技能"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-intelligent-content-system",
+      "name": "intelligent-content-system",
+      "kind": "skill",
+      "category": "内容创作与发布",
+      "description": "智能内容创作与发布全流程系统。根据用户需求自动识别场景， 编排调用网页采集、智能配图、小红书图文生成、热点内容创作、多平台发布等技能， 实现从内容获取到发布的一站式自动化。 支持场景： - 网页内容采集与再创作（采集→配图→发布） - 热点内容创作（热点采集→AI生成→多平台发布） - 原创内容优化（配图→小红书图文→发布） - 单一功能调用（采集/配图/图文/发布） 支持平台：微信公众号、小红书、X/Twitter、B站",
+      "subPath": "skills/intelligent-content-system",
+      "language": "Markdown",
+      "tags": [
+        "社区来源",
+        "说明型",
+        "含参考资料"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-wechatsync-publisher",
+      "name": "wechatsync-publisher",
+      "kind": "skill",
+      "category": "内容创作与发布",
+      "description": "多平台内容发布助手，支持智能选题筛选、AI生成优质内容、一键发布到微信公众号等平台；支持内容格式自动适配（HTML/Markdown/纯文本）",
+      "subPath": "skills/wechatsync-publisher/wechatsync-publisher",
+      "language": "Markdown / Python",
+      "tags": [
+        "社区来源",
+        "含脚本",
+        "含参考资料"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-qiaomu-x-article-publisher",
+      "name": "x-article-publisher",
+      "kind": "skill",
+      "category": "内容创作与发布",
+      "description": "Publish Markdown articles to X (Twitter) Articles editor with proper formatting. Use when user wants to publish a Markdown file/URL to X Articles, or mentions \"publish to X\", \"post article to Twitter\", \"X article\", or...",
+      "subPath": "skills/qiaomu-x-article-publisher",
+      "language": "Markdown / Python",
+      "tags": [
+        "社区来源",
+        "含脚本",
+        "独立技能"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-moltbook",
+      "name": "moltbook",
+      "kind": "skill",
+      "category": "社区与社交",
+      "description": "AI Agent的社交网络. 发布帖子、评论、点赞和创建社区。当用户明确要求时才会使用，否则不会使用。",
+      "subPath": "skills/moltbook",
+      "language": "Markdown",
+      "tags": [
+        "社区来源",
+        "说明型",
+        "独立技能"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-historical-interview-scripts",
+      "name": "historical-interview-scripts",
+      "kind": "skill",
+      "category": "视频创作",
+      "description": "生成历史名人现代访谈短视频文案，通过古今反差与网络热梗的爆笑结合，创作具有传播力的虚构趣味内容",
+      "subPath": "skills/historical-interview-scripts/historical-interview-scripts",
+      "language": "Markdown / Python",
+      "tags": [
+        "社区来源",
+        "含脚本",
+        "含参考资料"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-historical-science-video-prod",
+      "name": "historical-science-video-prod",
+      "kind": "skill",
+      "category": "视频创作",
+      "description": "自动化生成历史科学类3分钟科普短视频的全流程素材包，包含口播文案、分镜脚本、Veo2提示词、人物形象规范等，适配即梦平台视频生成。",
+      "subPath": "skills/historical-science-video-prod/historical-science-video-prod",
+      "language": "Markdown / Python",
+      "tags": [
+        "社区来源",
+        "含脚本",
+        "含参考资料"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-media-processor",
+      "name": "media-processor",
+      "kind": "skill",
+      "category": "视频创作",
+      "description": "提供基于 FFmpeg 和 ImageMagick 的多媒体处理能力，支持视频和图像的格式转换、分辨率调整、压缩等操作",
+      "subPath": "skills/media-processor/media-processor",
+      "language": "Markdown / Python",
+      "tags": [
+        "社区来源",
+        "含脚本",
+        "含参考资料"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-remotion-video-enhancer",
+      "name": "remotion-video-enhancer",
+      "kind": "skill",
+      "category": "视频创作",
+      "description": "视频转场与动画增强工具，提取 Remotion 的动画理念，提供高级视频转场效果和 Framer Motion 交互式动画。可与 ppt-generator、nanobanana-ppt-visualizer、ppt-roadshow-generator Skill 协同工作。",
+      "subPath": "skills/remotion-video-enhancer/remotion-video-enhancer",
+      "language": "Markdown / Python",
+      "tags": [
+        "社区来源",
+        "含脚本",
+        "含参考资料"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-three-body-video-creator",
+      "name": "three-body-video-creator",
+      "kind": "skill",
+      "category": "视频创作",
+      "description": "《三体》赛道AI视频创作工具,提供结构化的多智能体协作流程、素材生成与视频合成,涵盖选题深化、视觉设计、音频生成、视频制作全流程",
+      "subPath": "skills/three-body-video-creator/three-body-video-creator",
+      "language": "Markdown / Python",
+      "tags": [
+        "社区来源",
+        "含脚本",
+        "含参考资料"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-video-creation-collaborator",
+      "name": "video-creation-collaborator",
+      "kind": "skill",
+      "category": "视频创作",
+      "description": "影品智创多智能体协同视频创作管理工具,提供11个智能体结构化分工、5阶段协同流程、质量管控标准与数据反馈机制,解决生图失真、视频合成瑕疵等问题,确保输出统一可控",
+      "subPath": "skills/video-creation-collaborator/video-creation-collaborator",
+      "language": "Markdown / Python",
+      "tags": [
+        "社区来源",
+        "含脚本",
+        "含参考资料"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-video-creation-pro",
+      "name": "video-creation-pro",
+      "kind": "skill",
+      "category": "视频创作",
+      "description": "10大智能体协同的商品视频创作系统，全流程质量闭环（创作→质检→反馈迭代），强制使用COZE视频大模型API进行视频合成，彻底移除本地依赖包逻辑，适用于智能硬件、美妆护肤、家居家电等多品类商品视频创作",
+      "subPath": "skills/video-creation-pro/video-creation-pro",
+      "language": "Markdown / Python",
+      "tags": [
+        "社区来源",
+        "含脚本",
+        "含参考资料"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-video-creation-suite",
+      "name": "video-creation-suite",
+      "kind": "skill",
+      "category": "视频创作",
+      "description": "完整的视频创作套件，支持原创创作、视频二创、视频分析三种模式，集成Coze Bot API、Edge-TTS、Suno API，涵盖多智能体协同、素材生成、视频合成全流程",
+      "subPath": "skills/video-creation-suite/video-creation-suite",
+      "language": "Markdown / Python",
+      "tags": [
+        "社区来源",
+        "含脚本",
+        "含参考资料"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-video-frame-extractor",
+      "name": "video-frame-extractor",
+      "kind": "skill",
+      "category": "视频创作",
+      "description": "视频反推工具,支持视频抽帧、视觉模型分析、提示词生成,适用于视频创作参考、内容提取、场景分析",
+      "subPath": "skills/video-frame-extractor/video-frame-extractor",
+      "language": "Markdown / Python",
+      "tags": [
+        "社区来源",
+        "含脚本",
+        "含参考资料"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-video-recreation",
+      "name": "video-recreation",
+      "kind": "skill",
+      "category": "视频创作",
+      "description": "完整的视频二创工具，支持视频反推、素材生成(图片/音效/背景音乐/配音/字幕)、视频合成、文件下载的全流程，集成Coze Bot API进行视觉分析，使用Edge-TTS进行语音合成",
+      "subPath": "skills/video-recreation/video-recreation",
+      "language": "Markdown / Python",
+      "tags": [
+        "社区来源",
+        "含脚本",
+        "含参考资料"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-video-transcript-downloader",
+      "name": "video-transcript-downloader",
+      "kind": "skill",
+      "category": "视频创作",
+      "description": "Download videos, audio, subtitles, and clean paragraph-style transcripts from YouTube and any other yt-dlp supported site. Use when asked to “download this video”, “save this clip”, “rip audio”, “get subtitles”, “get ...",
+      "subPath": "skills/video-transcript-downloader/video-transcript-downloader",
+      "language": "JavaScript / Markdown",
+      "tags": [
+        "社区来源",
+        "含脚本",
+        "独立技能"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-viral-video-copywriting",
+      "name": "viral-video-copywriting",
+      "kind": "skill",
+      "category": "视频创作",
+      "description": "专业的爆款短视频文案创作工具。通过对标抖音爆款视频，智能提取视频内容，深度拆解爆款因素，并结合用户需求创作出符合爆款规律的新文案。适用于短视频创作者、运营人员提升内容质量。",
+      "subPath": "skills/viral-video-copywriting/viral-video-copywriting",
+      "language": "Markdown / Python",
+      "tags": [
+        "社区来源",
+        "含脚本",
+        "含参考资料"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-contract-review",
+      "name": "contract-review",
+      "kind": "skill",
+      "category": "文档与研究",
+      "description": "Contract review skill that adds comment-based issue annotations without changing original text. Enforces a three-layer review (basic, business, legal), writes structured comments (issue type, risk reason, revision sug...",
+      "subPath": "skills/legal-assistant-skills-main/contract-review",
+      "language": "Markdown / Python",
+      "tags": [
+        "社区来源",
+        "含脚本",
+        "含参考资料"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-law-to-markdown",
+      "name": "law-to-markdown",
+      "kind": "skill",
+      "category": "文档与研究",
+      "description": "将法条/规范文件（.txt/.docx/.pdf）转为 Markdown。适用于用户要求“法条转 markdown”“pdf/docx 转 markdown”。处理 .pdf/.docx 时先检查是否已安装 mineru-ocr skill；未安装先引导安装，安装后优先用 mineru-ocr；仅在用户明确同意时再用本地回退方案。",
+      "subPath": "skills/legal-assistant-skills-main/law-to-markdown",
+      "language": "Python / Markdown",
+      "tags": [
+        "社区来源",
+        "含脚本",
+        "独立技能"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-paper-analysis-assistant",
+      "name": "paper-analysis-assistant",
+      "kind": "skill",
+      "category": "文档与研究",
+      "description": "根据arXiv论文网址自动下载PDF并进行多维度分析，包括文本提取、词频分析、语音播报、播客对话生成、交互式网页、PPT、总结图和引用分析",
+      "subPath": "skills/paper-analysis-assistant/paper-analysis-assistant",
+      "language": "Python / Markdown",
+      "tags": [
+        "社区来源",
+        "含脚本",
+        "含参考资料"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-pdf-processing-pro",
+      "name": "PDF Processing Pro",
+      "kind": "skill",
+      "category": "文档与研究",
+      "description": "Production-ready PDF processing with forms, tables, OCR, validation, and batch operations. Use when working with complex PDF workflows in production environments, processing large volumes of PDFs, or requiring robust ...",
+      "subPath": "skills/pdf-processing-pro/pdf-processing-pro",
+      "language": "Markdown / Python",
+      "tags": [
+        "社区来源",
+        "含脚本",
+        "独立技能"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-poetry-music-visual",
+      "name": "poetry-music-visual",
+      "kind": "skill",
+      "category": "文化创作",
+      "description": "为古诗词提供配图与配乐的全流程创作指导；支持深度解析诗词意境、生成画面描述、提供配乐创作蓝图（Suno格式）；适用于诗词可视化、MV创作、文化传播等场景",
+      "subPath": "skills/poetry-music-visual/poetry-music-visual",
+      "language": "Markdown",
+      "tags": [
+        "社区来源",
+        "说明型",
+        "含参考资料"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-infinitetalk",
+      "name": "infinitetalk",
+      "kind": "skill",
+      "category": "语音与数字人",
+      "description": "音频驱动的稀疏帧视频配音工具，支持音频驱动的 Video-to-Video 和 Image-to-Video 生成，实现精准的唇形、头部、身体姿态同步，支持无限时长视频生成",
+      "subPath": "skills/infinitetalk",
+      "language": "Markdown / Python",
+      "tags": [
+        "社区来源",
+        "含脚本",
+        "含参考资料"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-qwen3-asr-assistant",
+      "name": "qwen3-asr-assistant",
+      "kind": "skill",
+      "category": "语音与数字人",
+      "description": "智能语音转文字助手，基于 Qwen3-ASR 模型，支持实时语音识别和智能文本改写。可以将录音转换为文字，并一键改写成邮件、笔记、社交媒体文案，支持复制、分享和录音拼接。适用于会议纪要、语音备忘、内容创作等多种场景。",
+      "subPath": "skills/qwen3-asr-assistant/qwen3-asr-assistant",
+      "language": "Markdown / Python",
+      "tags": [
+        "社区来源",
+        "含脚本",
+        "含参考资料"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-qwen3-tts-local",
+      "name": "qwen3-tts-local",
+      "kind": "skill",
+      "category": "语音与数字人",
+      "description": "真正的本地语音合成服务，使用 Edge-TTS 引擎，零依赖、零配置、完全离线可用，支持多语言和多种音色",
+      "subPath": "skills/qwen3-tts-local/qwen3-tts-local",
+      "language": "Markdown / Python",
+      "tags": [
+        "社区来源",
+        "含脚本",
+        "含参考资料"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-tts-voice-synthesis",
+      "name": "tts-voice-synthesis",
+      "kind": "skill",
+      "category": "语音与数字人",
+      "description": "智能语音合成服务，支持音色克隆、拟人化语义适配配音、流式实时生成、多语言与方言支持，提供 1.7B/0.6B 双模型选择",
+      "subPath": "skills/tts-voice-synthesis",
+      "language": "Markdown / Python",
+      "tags": [
+        "社区来源",
+        "含脚本",
+        "含参考资料"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-json-canvas",
+      "name": "json-canvas",
+      "kind": "skill",
+      "category": "知识管理",
+      "description": "Create and edit JSON Canvas files (.canvas) with nodes, edges, groups, and connections. Use when working with .canvas files, creating visual canvases, mind maps, flowcharts, or when the user mentions Canvas files in O...",
+      "subPath": "skills/obsidian-skills-integrated/json-canvas",
+      "language": "Markdown",
+      "tags": [
+        "社区来源",
+        "说明型",
+        "独立技能"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-obsidian-skills-integrated",
+      "name": "Obsidian Skills - 官方知识管理技能集",
+      "kind": "skillset",
+      "category": "知识管理",
+      "description": "由 Obsidian CEO Steph Ango (kepano) 亲自开源的官方技能集，为 AI Agent 提供专业的 Obsidian 操作能力。",
+      "subPath": "skills/obsidian-skills-integrated",
+      "language": "Markdown",
+      "tags": [
+        "社区来源",
+        "技能包",
+        "3 个子技能"
+      ],
+      "includedSkills": [
+        "json-canvas",
+        "obsidian-bases",
+        "obsidian-markdown"
+      ]
+    },
+    {
+      "id": "anbeime-obsidian-bases",
+      "name": "obsidian-bases",
+      "kind": "skill",
+      "category": "知识管理",
+      "description": "Create and edit Obsidian Bases (.base files) with views, filters, formulas, and summaries. Use when working with .base files, creating database-like views of notes, or when the user mentions Bases, table views, card v...",
+      "subPath": "skills/obsidian-skills-integrated/obsidian-bases",
+      "language": "Markdown",
+      "tags": [
+        "社区来源",
+        "说明型",
+        "独立技能"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-obsidian-markdown",
+      "name": "obsidian-markdown",
+      "kind": "skill",
+      "category": "知识管理",
+      "description": "Create and edit Obsidian Flavored Markdown with wikilinks, embeds, callouts, properties, and other Obsidian-specific syntax. Use when working with .md files in Obsidian, or when the user mentions wikilinks, callouts, ...",
+      "subPath": "skills/obsidian-skills-integrated/obsidian-markdown",
+      "language": "Markdown",
+      "tags": [
+        "社区来源",
+        "说明型",
+        "独立技能"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-agent-team",
+      "name": "agent-team",
+      "kind": "skill",
+      "category": "智能体协作",
+      "description": "统一管理多智能体角色的团队协作框架，支持智能体动态组合、灵活协作和扩展新角色。智能体本质上是\"角色定义\"，可以根据任务需求灵活组建团队，实现从会议决策到系统构建的完整能力。智能体角色明确分工：有干活的、有指挥的、有挑毛病的，能实时看到沟通过程，共享数据库记忆，确保上下文一致。",
+      "subPath": "skills/agent-team/agent-team",
+      "language": "Markdown",
+      "tags": [
+        "社区来源",
+        "说明型",
+        "含参考资料"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-multi-agent-meeting",
+      "name": "multi-agent-meeting",
+      "kind": "skill",
+      "category": "智能体协作",
+      "description": "模拟多个AI智能体协作开会并进行决策讨论的场景。适用于需要从多个专业角度分析问题、进行辩论和达成共识的场景，如项目决策、技术方案评审、商业策略制定等。",
+      "subPath": "skills/multi-agent-meeting/multi-agent-meeting",
+      "language": "Markdown",
+      "tags": [
+        "社区来源",
+        "说明型",
+        "含参考资料"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-nanobanana-ppt-visualizer",
+      "name": "nanobanana-ppt-visualizer",
+      "kind": "skill",
+      "category": "PPT 与演示",
+      "description": "PPT 视觉增强工具，支持多种风格渲染、交互式播放器生成和视频合成。可与 ppt-generator Skill 协同工作，实现从内容规划到视觉呈现的完整流程。",
+      "subPath": "skills/nanobanana-ppt-visualizer/nanobanana-ppt-visualizer",
+      "language": "Markdown / Python",
+      "tags": [
+        "社区来源",
+        "含脚本",
+        "含参考资料"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-ppt-generator",
+      "name": "ppt-generator",
+      "kind": "skill",
+      "category": "PPT 与演示",
+      "description": "基于七角色协作的智能 PPT 生成与优化工具。支持主题生成、模板推荐、内容填充、AI 智能配图、文本润色和 PPTX 文件生成。适用于学术汇报、商业演示、培训课件、产品发布等多种场景。",
+      "subPath": "skills/ppt-generator/ppt-generator",
+      "language": "Markdown / Python",
+      "tags": [
+        "社区来源",
+        "含脚本",
+        "含参考资料"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-ppt-roadshow-generator",
+      "name": "ppt-roadshow-generator",
+      "kind": "skill",
+      "category": "PPT 与演示",
+      "description": "PPT 路演视频全流程生成器，支持品牌风格学习、智能配音、音效音乐、字幕和一键视频合成。可一次性生成 15-100 页风格统一的完整路演视频。",
+      "subPath": "skills/ppt-roadshow-generator/ppt-roadshow-generator",
+      "language": "Markdown / Python",
+      "tags": [
+        "社区来源",
+        "含脚本",
+        "含参考资料"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "anbeime-pptx-generator",
+      "name": "pptx-generator",
+      "kind": "skill",
+      "category": "PPT 与演示",
+      "description": "将 JSON 格式的 PPT 内容转换为标准的 .pptx 文件。使用 python-pptx 库，支持多种布局、图表、表格和样式。与 ppt-generator Skill 完全协同，可作为独立使用或与其他 PPT Skill 配合。",
+      "subPath": "skills/pptx-generator/pptx-generator",
+      "language": "Markdown / Python",
+      "tags": [
+        "社区来源",
+        "含脚本",
+        "含参考资料"
+      ],
+      "includedSkills": []
+    }
+  ]
+}

--- a/client/src/data/skillProjects.ts
+++ b/client/src/data/skillProjects.ts
@@ -1,7 +1,12 @@
+import anbeimeCatalogJson from "./anbeimeSkillCatalog.generated.json";
+import voltagentCatalogJson from "./voltagentSkillCatalog.generated.json";
+
 export interface SkillInstallSource {
   repoUrl: string;
   subPath: string;
 }
+
+export type SkillProjectKind = "skill" | "skillset";
 
 export interface SkillProject {
   id: string;
@@ -9,6 +14,7 @@ export interface SkillProject {
   repoName: string;
   repoUrl: string;
   category: string;
+  kind: SkillProjectKind;
   description: string;
   readmeSummary: string;
   stars: number;
@@ -18,15 +24,66 @@ export interface SkillProject {
   installNote: string;
   installSource?: SkillInstallSource;
   tags: string[];
+  includedSkills?: string[];
+  sourceCommit?: string;
+  catalogName?: string;
+  catalogUrl?: string;
+  publisher?: string;
+  sourceGroup?: string;
 }
 
-export const skillProjects: SkillProject[] = [
+interface GeneratedSkillIndex {
+  source: {
+    repoName: string;
+    repoUrl: string;
+    commit: string;
+    updatedAt: string;
+    stars: number;
+  };
+  projects: Array<{
+    id: string;
+    name: string;
+    kind: SkillProjectKind;
+    category: string;
+    publisher: string;
+    sourceGroup: string;
+    description: string;
+    sourceUrl: string;
+    installSource: SkillInstallSource | null;
+    tags: string[];
+    includedSkills: string[];
+  }>;
+}
+
+interface GeneratedSkillCatalog {
+  source: {
+    repoName: string;
+    repoUrl: string;
+    commit: string;
+    updatedAt: string;
+    stars: number;
+  };
+  projects: Array<{
+    id: string;
+    name: string;
+    kind: SkillProjectKind;
+    category: string;
+    description: string;
+    subPath: string;
+    language: string;
+    tags: string[];
+    includedSkills: string[];
+  }>;
+}
+
+const curatedSkillProjects: SkillProject[] = [
   {
     id: "anthropic-pdf-skill",
     name: "PDF 文档处理技能",
     repoName: "anthropics/skills",
     repoUrl: "https://github.com/anthropics/skills",
     category: "文档处理",
+    kind: "skill",
     description:
       "让模型按标准流程处理 PDF：抽取内容、整理结构、摘要重点，适合合同、论文、报告和说明书。",
     readmeSummary:
@@ -49,6 +106,7 @@ export const skillProjects: SkillProject[] = [
     repoName: "anthropics/skills",
     repoUrl: "https://github.com/anthropics/skills",
     category: "数据办公",
+    kind: "skill",
     description:
       "让模型理解电子表格任务：读取工作簿、解释数据、辅助分析和生成表格处理建议。",
     readmeSummary:
@@ -71,6 +129,7 @@ export const skillProjects: SkillProject[] = [
     repoName: "mattpocock/skills",
     repoUrl: "https://github.com/mattpocock/skills",
     category: "工程开发",
+    kind: "skill",
     description:
       "把 AI 训练成更稳的 TypeScript 工程搭档，强调测试先行、逐步实现和代码质量反馈。",
     readmeSummary:
@@ -94,6 +153,7 @@ export const skillProjects: SkillProject[] = [
     repoName: "agentskills/agentskills",
     repoUrl: "https://github.com/agentskills/agentskills",
     category: "开放标准",
+    kind: "skill",
     description:
       "定义 Skill 文件夹结构、SKILL.md 元数据和渐进加载方式，适合团队统一扩展包格式。",
     readmeSummary:
@@ -107,5 +167,90 @@ export const skillProjects: SkillProject[] = [
       "这是规范与模板仓库，不是单个可安装 Skill；适合团队参考并创建自己的技能包。",
     tags: ["开放标准", "模板", "规范"],
   },
+];
+
+const anbeimeCatalog = anbeimeCatalogJson as GeneratedSkillCatalog;
+
+const anbeimeSkillProjects: SkillProject[] = anbeimeCatalog.projects.map((project) => ({
+  id: project.id,
+  name: project.name,
+  repoName: anbeimeCatalog.source.repoName,
+  repoUrl: anbeimeCatalog.source.repoUrl,
+  category: project.category,
+  kind: project.kind,
+  description: project.description,
+  readmeSummary:
+    project.kind === "skillset"
+      ? `该 SkillSet 包含 ${project.includedSkills.length} 个子技能，安装父目录时会一并保留相关 SKILL.md、脚本和参考资料。`
+      : "目录数据由本地 skill-main 与远端 main 提交核对后生成。安装前请检查第三方说明和运行依赖。",
+  stars: anbeimeCatalog.source.stars,
+  language: project.language,
+  updatedAt: anbeimeCatalog.source.updatedAt,
+  installCommand: `git clone --depth 1 --filter=blob:none --sparse ${anbeimeCatalog.source.repoUrl}\ncd skill\ngit sparse-checkout set ${project.subPath}`,
+  installNote:
+    "模镜只复制该目录，不会在安装时执行其中脚本。使用社区 Skill 前请先检查依赖、外部服务与凭据要求。",
+  installSource: {
+    repoUrl: anbeimeCatalog.source.repoUrl,
+    subPath: project.subPath,
+  },
+  tags: project.tags,
+  includedSkills: project.includedSkills,
+  sourceCommit: anbeimeCatalog.source.commit,
+  catalogName: anbeimeCatalog.source.repoName,
+  catalogUrl: anbeimeCatalog.source.repoUrl,
+}));
+
+const primarySkillProjects: SkillProject[] = [
+  ...curatedSkillProjects,
+  ...anbeimeSkillProjects,
+];
+
+const installedSourceKeys = new Set(
+  primarySkillProjects.flatMap((project) =>
+    project.installSource
+      ? [`${project.installSource.repoUrl.toLowerCase()}#${project.installSource.subPath}`]
+      : [],
+  ),
+);
+const voltagentCatalog = voltagentCatalogJson as GeneratedSkillIndex;
+const voltagentSkillProjects: SkillProject[] = voltagentCatalog.projects
+  .filter((project) => {
+    if (!project.installSource) return true;
+    const key = `${project.installSource.repoUrl.toLowerCase()}#${project.installSource.subPath}`;
+    if (installedSourceKeys.has(key)) return false;
+    installedSourceKeys.add(key);
+    return true;
+  })
+  .map((project) => ({
+    id: project.id,
+    name: project.name,
+    repoName: project.name,
+    repoUrl: project.sourceUrl,
+    category: project.category,
+    kind: project.kind,
+    description: project.description,
+    readmeSummary: `收录分组：${project.sourceGroup}。该条目来自 VoltAgent 维护的外部 Skill 索引。`,
+    stars: voltagentCatalog.source.stars,
+    language: "Markdown",
+    updatedAt: voltagentCatalog.source.updatedAt,
+    installCommand: project.installSource
+      ? `git clone --depth 1 --filter=blob:none --sparse ${project.installSource.repoUrl}\ncd skill\ngit sparse-checkout set ${project.installSource.subPath}`
+      : "",
+    installNote: project.installSource
+      ? "README 提供了明确的 GitHub Skill 子目录，模镜可执行 sparse checkout 安装。"
+      : "VoltAgent 条目仅提供外部索引链接，未发现可由当前后端验证的 GitHub 子目录，因此仅作参考。",
+    installSource: project.installSource ?? undefined,
+    tags: project.tags,
+    includedSkills: project.includedSkills,
+    sourceCommit: voltagentCatalog.source.commit,
+    catalogName: voltagentCatalog.source.repoName,
+    catalogUrl: voltagentCatalog.source.repoUrl,
+    publisher: project.publisher,
+    sourceGroup: project.sourceGroup,
+  }));
+
+export const skillProjects: SkillProject[] = [
+  ...primarySkillProjects,
+  ...voltagentSkillProjects,
 ];
 

--- a/client/src/data/voltagentSkillCatalog.generated.json
+++ b/client/src/data/voltagentSkillCatalog.generated.json
@@ -1,0 +1,21466 @@
+{
+  "source": {
+    "repoName": "VoltAgent/awesome-agent-skills",
+    "repoUrl": "https://github.com/VoltAgent/awesome-agent-skills",
+    "commit": "6c82fb77e5bf84de77d1074b2d98d65d75ea730e",
+    "updatedAt": "2026-07-31",
+    "stars": 29447,
+    "indexedEntries": 1178,
+    "installableProjects": 475,
+    "referenceProjects": 703,
+    "sourceGroups": 70
+  },
+  "projects": [
+    {
+      "id": "voltagent-anthropics-docx",
+      "name": "anthropics/docx",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "anthropics",
+      "sourceGroup": "Official Claude Skills",
+      "description": "Create, edit, and analyze Word documents",
+      "sourceUrl": "https://officialskills.sh/anthropics/skills/docx",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "anthropics"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-anthropics-doc-coauthoring",
+      "name": "anthropics/doc-coauthoring",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "anthropics",
+      "sourceGroup": "Official Claude Skills",
+      "description": "Collaborative document editing and co-authoring",
+      "sourceUrl": "https://officialskills.sh/anthropics/skills/doc-coauthoring",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "anthropics"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-anthropics-pptx",
+      "name": "anthropics/pptx",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "anthropics",
+      "sourceGroup": "Official Claude Skills",
+      "description": "Create, edit, and analyze PowerPoint presentations",
+      "sourceUrl": "https://officialskills.sh/anthropics/skills/pptx",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "anthropics"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-anthropics-xlsx",
+      "name": "anthropics/xlsx",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "anthropics",
+      "sourceGroup": "Official Claude Skills",
+      "description": "Create, edit, and analyze Excel spreadsheets",
+      "sourceUrl": "https://officialskills.sh/anthropics/skills/xlsx",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "anthropics"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-anthropics-pdf",
+      "name": "anthropics/pdf",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "anthropics",
+      "sourceGroup": "Official Claude Skills",
+      "description": "Extract text, create PDFs, and handle forms",
+      "sourceUrl": "https://officialskills.sh/anthropics/skills/pdf",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "anthropics"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-anthropics-algorithmic-art",
+      "name": "anthropics/algorithmic-art",
+      "kind": "skill",
+      "category": "多媒体创作",
+      "publisher": "anthropics",
+      "sourceGroup": "Official Claude Skills",
+      "description": "Create generative art using p5.js with seeded randomness",
+      "sourceUrl": "https://officialskills.sh/anthropics/skills/algorithmic-art",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "anthropics"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-anthropics-canvas-design",
+      "name": "anthropics/canvas-design",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "anthropics",
+      "sourceGroup": "Official Claude Skills",
+      "description": "Design visual art in PNG and PDF formats",
+      "sourceUrl": "https://officialskills.sh/anthropics/skills/canvas-design",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "anthropics"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-anthropics-frontend-design",
+      "name": "anthropics/frontend-design",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "anthropics",
+      "sourceGroup": "Official Claude Skills",
+      "description": "Frontend design and UI/UX development tools",
+      "sourceUrl": "https://officialskills.sh/anthropics/skills/frontend-design",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "anthropics"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-anthropics-slack-gif-creator",
+      "name": "anthropics/slack-gif-creator",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "anthropics",
+      "sourceGroup": "Official Claude Skills",
+      "description": "Create animated GIFs optimized for Slack size constraints",
+      "sourceUrl": "https://officialskills.sh/anthropics/skills/slack-gif-creator",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "anthropics"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-anthropics-theme-factory",
+      "name": "anthropics/theme-factory",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "anthropics",
+      "sourceGroup": "Official Claude Skills",
+      "description": "Style artifacts with professional themes or generate custom themes",
+      "sourceUrl": "https://officialskills.sh/anthropics/skills/theme-factory",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "anthropics"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-anthropics-web-artifacts-builder",
+      "name": "anthropics/web-artifacts-builder",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "anthropics",
+      "sourceGroup": "Official Claude Skills",
+      "description": "Build complex claude.ai HTML artifacts with React and Tailwind",
+      "sourceUrl": "https://officialskills.sh/anthropics/skills/web-artifacts-builder",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "anthropics"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-anthropics-mcp-builder",
+      "name": "anthropics/mcp-builder",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "anthropics",
+      "sourceGroup": "Official Claude Skills",
+      "description": "Create MCP servers to integrate external APIs and services",
+      "sourceUrl": "https://officialskills.sh/anthropics/skills/mcp-builder",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "anthropics"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-anthropics-webapp-testing",
+      "name": "anthropics/webapp-testing",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "anthropics",
+      "sourceGroup": "Official Claude Skills",
+      "description": "Test local web applications using Playwright",
+      "sourceUrl": "https://officialskills.sh/anthropics/skills/webapp-testing",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "anthropics"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-anthropics-brand-guidelines",
+      "name": "anthropics/brand-guidelines",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "anthropics",
+      "sourceGroup": "Official Claude Skills",
+      "description": "Apply Anthropic's brand colors and typography to artifacts",
+      "sourceUrl": "https://officialskills.sh/anthropics/skills/brand-guidelines",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "anthropics"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-anthropics-internal-comms",
+      "name": "anthropics/internal-comms",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "anthropics",
+      "sourceGroup": "Official Claude Skills",
+      "description": "Write status reports, newsletters, and FAQs",
+      "sourceUrl": "https://officialskills.sh/anthropics/skills/internal-comms",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "anthropics"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-anthropics-skill-creator",
+      "name": "anthropics/skill-creator",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "anthropics",
+      "sourceGroup": "Official Claude Skills",
+      "description": "Guide for creating skills that extend Claude's capabilities",
+      "sourceUrl": "https://officialskills.sh/anthropics/skills/skill-creator",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "anthropics"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-anthropics-template",
+      "name": "anthropics/template",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "anthropics",
+      "sourceGroup": "Official Claude Skills",
+      "description": "Basic template for creating new skills",
+      "sourceUrl": "https://officialskills.sh/anthropics/skills/template",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "anthropics"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-voltagent-create-voltagent",
+      "name": "voltagent/create-voltagent",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "voltagent",
+      "sourceGroup": "Skills by VoltAgent",
+      "description": "Project setup guide with CLI and manual steps",
+      "sourceUrl": "https://officialskills.sh/voltagent/skills/create-voltagent",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "voltagent"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-voltagent-voltagent-best-practices",
+      "name": "voltagent/voltagent-best-practices",
+      "kind": "skill",
+      "category": "工程开发",
+      "publisher": "voltagent",
+      "sourceGroup": "Skills by VoltAgent",
+      "description": "Architecture and usage patterns for agents, workflows, memory, and servers",
+      "sourceUrl": "https://officialskills.sh/voltagent/skills/voltagent-best-practices",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "voltagent"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-voltagent-voltagent-core-reference",
+      "name": "voltagent/voltagent-core-reference",
+      "kind": "skill",
+      "category": "其他工具",
+      "publisher": "voltagent",
+      "sourceGroup": "Skills by VoltAgent",
+      "description": "Reference for the VoltAgent class options and lifecycle methods",
+      "sourceUrl": "https://officialskills.sh/voltagent/skills/voltagent-core-reference",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "voltagent"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-voltagent-voltagent-docs-bundle",
+      "name": "voltagent/voltagent-docs-bundle",
+      "kind": "skillset",
+      "category": "文档与办公",
+      "publisher": "voltagent",
+      "sourceGroup": "Skills by VoltAgent",
+      "description": "Lookup embedded docs from @voltagent/core for version-matched documentation",
+      "sourceUrl": "https://officialskills.sh/voltagent/skills/voltagent-docs-bundle",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "技能包"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-api-skill",
+      "name": "testmu-ai/api-skill",
+      "kind": "skillset",
+      "category": "后端与数据库",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Suite of API skills for designing, mocking, documenting, securing, and generating tests for REST/GraphQL/gRPC APIs",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/api-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "api-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "技能包"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-appium-skill",
+      "name": "testmu-ai/appium-skill",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Generate Appium mobile automation for Android and iOS in Java, Python, or JS",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/appium-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "appium-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "testmu-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-behat-skill",
+      "name": "testmu-ai/behat-skill",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Generate Behat BDD tests for PHP with Gherkin and Mink",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/behat-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "behat-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "testmu-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-behave-skill",
+      "name": "testmu-ai/behave-skill",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Generate Behave BDD tests for Python with Gherkin and step implementations",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/behave-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "behave-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "testmu-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-capybara-skill",
+      "name": "testmu-ai/capybara-skill",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Generate Capybara E2E tests in Ruby with RSpec integration",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/capybara-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "capybara-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "testmu-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-cicd-pipeline-skill",
+      "name": "testmu-ai/cicd-pipeline-skill",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Generate CI/CD pipelines for tests on GitHub Actions, Jenkins, GitLab CI, and Azure DevOps",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/cicd-pipeline-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "cicd-pipeline-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "testmu-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-codeception-skill",
+      "name": "testmu-ai/codeception-skill",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Generate Codeception acceptance, functional, and unit tests in PHP",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/codeception-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "codeception-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "testmu-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-cucumber-skill",
+      "name": "testmu-ai/cucumber-skill",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Generate Cucumber BDD tests with Gherkin and step definitions in Java, JS, or Ruby",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/cucumber-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "cucumber-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "testmu-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-cypress-skill",
+      "name": "testmu-ai/cypress-skill",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Generate Cypress E2E and component tests in JavaScript or TypeScript",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/cypress-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "cypress-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "testmu-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-detox-skill",
+      "name": "testmu-ai/detox-skill",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Generate Detox gray-box E2E tests for React Native apps in JavaScript",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/detox-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "detox-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "testmu-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-espresso-skill",
+      "name": "testmu-ai/espresso-skill",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Generate Espresso UI tests for Android apps in Kotlin or Java",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/espresso-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "espresso-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "testmu-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-flutter-testing-skill",
+      "name": "testmu-ai/flutter-testing-skill",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Generate Flutter widget, integration, and golden tests in Dart",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/flutter-testing-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "flutter-testing-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "testmu-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-gauge-skill",
+      "name": "testmu-ai/gauge-skill",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Generate Gauge specs in Markdown with steps in Java, Python, JS, or Ruby",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/gauge-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "gauge-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "testmu-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-geb-skill",
+      "name": "testmu-ai/geb-skill",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Generate Geb browser automation in Groovy with Spock and page objects",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/geb-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "geb-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "testmu-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-hyperexecute-skill",
+      "name": "testmu-ai/hyperexecute-skill",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Operate TestMu AI HyperExecute end-to-end: YAML, CLI runs, debugging, and CI wiring",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/hyperexecute-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "hyperexecute-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "testmu-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-jasmine-skill",
+      "name": "testmu-ai/jasmine-skill",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Generate Jasmine BDD tests in JavaScript with spies and async support",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/jasmine-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "jasmine-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "testmu-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-jest-skill",
+      "name": "testmu-ai/jest-skill",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Generate Jest unit and integration tests in JS/TS with mocking and snapshots",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/jest-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "jest-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "testmu-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-junit-5-skill",
+      "name": "testmu-ai/junit-5-skill",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Generate JUnit 5 unit and integration tests in Java with Mockito",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/junit-5-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "junit-5-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "testmu-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-karma-skill",
+      "name": "testmu-ai/karma-skill",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Generate Karma test-runner configs for browser-based JS testing",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/karma-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "karma-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "testmu-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-laravel-dusk-skill",
+      "name": "testmu-ai/laravel-dusk-skill",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Generate Laravel Dusk Chrome-based browser tests in PHP",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/laravel-dusk-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "laravel-dusk-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "testmu-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-lettuce-skill",
+      "name": "testmu-ai/lettuce-skill",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Generate Lettuce BDD tests for Python (legacy; prefer Behave)",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/lettuce-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "lettuce-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "testmu-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-mocha-skill",
+      "name": "testmu-ai/mocha-skill",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Generate Mocha tests in JavaScript with Chai and Sinon",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/mocha-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "mocha-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "testmu-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-mstest-skill",
+      "name": "testmu-ai/mstest-skill",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Generate MSTest tests in C# for .NET",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/mstest-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "mstest-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "testmu-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-nemojs-skill",
+      "name": "testmu-ai/nemojs-skill",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Generate Nemo.js Selenium-based tests for Node.js",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/nemojs-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "nemojs-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "testmu-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-nightwatchjs-skill",
+      "name": "testmu-ai/nightwatchjs-skill",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Generate NightwatchJS E2E tests in JavaScript with Selenium WebDriver",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/nightwatchjs-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "nightwatchjs-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "testmu-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-nunit-skill",
+      "name": "testmu-ai/nunit-skill",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Generate NUnit 3 tests in C# with the constraint model and Moq",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/nunit-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "nunit-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "testmu-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-phpunit-skill",
+      "name": "testmu-ai/phpunit-skill",
+      "kind": "skill",
+      "category": "数据与分析",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Generate PHPUnit tests in PHP with data providers and mocking",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/phpunit-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "phpunit-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "testmu-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-playwright-skill",
+      "name": "testmu-ai/playwright-skill",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Generate Playwright E2E tests in TS, JS, Python, Java, or C#",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/playwright-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "playwright-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "testmu-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-protractor-skill",
+      "name": "testmu-ai/protractor-skill",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Generate Protractor E2E tests for Angular in JS/TS (deprecated; prefer Playwright/Cypress)",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/protractor-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "protractor-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "testmu-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-puppeteer-skill",
+      "name": "testmu-ai/puppeteer-skill",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Generate Puppeteer scripts for browser automation, scraping, and PDF generation",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/puppeteer-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "puppeteer-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "testmu-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-pytest-skill",
+      "name": "testmu-ai/pytest-skill",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Generate pytest tests in Python with fixtures, parametrize, and mocking",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/pytest-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "pytest-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "testmu-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-reqnroll-skill",
+      "name": "testmu-ai/reqnroll-skill",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Generate Reqnroll BDD tests for web and mobile in C#",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/reqnroll-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "reqnroll-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "testmu-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-robot-framework-skill",
+      "name": "testmu-ai/robot-framework-skill",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Generate Robot Framework keyword-driven tests in Python",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/robot-framework-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "robot-framework-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "testmu-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-rspec-skill",
+      "name": "testmu-ai/rspec-skill",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Generate RSpec tests in Ruby with matchers, hooks, and mocking",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/rspec-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "rspec-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "testmu-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-selenide-skill",
+      "name": "testmu-ai/selenide-skill",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Generate Selenide UI tests in Java with auto-waits and a fluent API",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/selenide-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "selenide-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "testmu-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-selenium-skill",
+      "name": "testmu-ai/selenium-skill",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Generate Selenium WebDriver tests in Java, Python, JS, C#, Ruby, or PHP",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/selenium-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "selenium-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "testmu-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-serenity-bdd-skill",
+      "name": "testmu-ai/serenity-bdd-skill",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Generate Serenity BDD tests in Java with the Screenplay pattern and reporting",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/serenity-bdd-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "serenity-bdd-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "testmu-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-smartui-skill",
+      "name": "testmu-ai/smartui-skill",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Generate SmartUI visual regression configs for screenshot comparison",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/smartui-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "smartui-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "testmu-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-specflow-skill",
+      "name": "testmu-ai/specflow-skill",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Generate SpecFlow BDD tests for C#/.NET with Gherkin and step bindings",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/specflow-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "specflow-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "testmu-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-test-framework-migration-skill",
+      "name": "testmu-ai/test-framework-migration-skill",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Migrate tests between Selenium, Playwright, Puppeteer, and Cypress",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/test-framework-migration-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "test-framework-migration-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "testmu-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-testcafe-skill",
+      "name": "testmu-ai/testcafe-skill",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Generate TestCafe automation tests in JavaScript or TypeScript",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/testcafe-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "testcafe-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "testmu-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-testng-skill",
+      "name": "testmu-ai/testng-skill",
+      "kind": "skill",
+      "category": "数据与分析",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Generate TestNG tests in Java with data providers and parallel execution",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/testng-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "testng-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "testmu-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-testunit-skill",
+      "name": "testmu-ai/testunit-skill",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Generate Test::Unit xUnit-style tests in Ruby",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/testunit-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "testunit-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "testmu-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-unittest-skill",
+      "name": "testmu-ai/unittest-skill",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Generate Python unittest tests with TestCase and setUp/tearDown",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/unittest-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "unittest-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "testmu-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-vitest-skill",
+      "name": "testmu-ai/vitest-skill",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Generate Vitest tests in JS/TS with a Jest-compatible API and ESM",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/vitest-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "vitest-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "testmu-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-webdriverio-skill",
+      "name": "testmu-ai/webdriverio-skill",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Generate WebdriverIO (WDIO) automation tests in JavaScript or TypeScript",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/webdriverio-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "webdriverio-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "testmu-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-xcuitest-skill",
+      "name": "testmu-ai/xcuitest-skill",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Generate XCUITest UI tests for iOS/iPadOS apps in Swift",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/xcuitest-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "xcuitest-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "testmu-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testmu-ai-xunit-skill",
+      "name": "testmu-ai/xunit-skill",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "testmu-ai",
+      "sourceGroup": "Skills by TestMu AI",
+      "description": "Generate xUnit.net tests in C# with Fact/Theory and FluentAssertions",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills/tree/main/xunit-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/LambdaTest/agent-skills",
+        "subPath": "xunit-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "testmu-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-zero-zero",
+      "name": "zero/zero",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "zero",
+      "sourceGroup": "Skills by Zero",
+      "description": "Discover and call external paid tools for Claude Code agents instead of stopping to ask the user to sign up or fetch an API key",
+      "sourceUrl": "https://github.com/officialzeroxyz/zero-plugins/blob/main/plugins/zero/skills/zero/SKILL.md",
+      "installSource": {
+        "repoUrl": "https://github.com/officialzeroxyz/zero-plugins",
+        "subPath": "plugins/zero/skills/zero"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "zero"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-zero-zero-gemini",
+      "name": "zero/zero-gemini",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "zero",
+      "sourceGroup": "Skills by Zero",
+      "description": "Same Zero tool-discovery and payment layer packaged as a Gemini CLI extension",
+      "sourceUrl": "https://github.com/officialzeroxyz/zero-plugins/tree/main/plugins/zero-gemini",
+      "installSource": {
+        "repoUrl": "https://github.com/officialzeroxyz/zero-plugins",
+        "subPath": "plugins/zero-gemini"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "zero"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-angular-angular-developer",
+      "name": "angular/angular-developer",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "angular",
+      "sourceGroup": "Skills by Angular",
+      "description": "Generate Angular code and architectural guidance for components, services, reactivity",
+      "sourceUrl": "https://github.com/angular/skills",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "angular"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-angular-angular-new-app",
+      "name": "angular/angular-new-app",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "angular",
+      "sourceGroup": "Skills by Angular",
+      "description": "Create new Angular apps using CLI with modern best practices",
+      "sourceUrl": "https://github.com/angular/skills",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "angular"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-composiohq-composio",
+      "name": "composiohq/composio",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "composiohq",
+      "sourceGroup": "Skills by Composio Team",
+      "description": "Connect AI agents to 1000+ external apps with managed authentication",
+      "sourceUrl": "https://officialskills.sh/composiohq/skills/composio",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "composiohq"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-supabase-postgres-best-practices",
+      "name": "supabase/postgres-best-practices",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "supabase",
+      "sourceGroup": "Skills by Supabase Team",
+      "description": "PostgreSQL best practices for Supabase",
+      "sourceUrl": "https://officialskills.sh/supabase/skills/postgres-best-practices",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "supabase"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-google-gemini-gemini-api-dev",
+      "name": "google-gemini/gemini-api-dev",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "google-gemini",
+      "sourceGroup": "Skills by Google Gemini",
+      "description": "Best practices for developing Gemini-powered apps using the Gemini API",
+      "sourceUrl": "https://officialskills.sh/google-gemini/skills/gemini-api-dev",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "google-gemini"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-google-gemini-vertex-ai-api-dev",
+      "name": "google-gemini/vertex-ai-api-dev",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "google-gemini",
+      "sourceGroup": "Skills by Google Gemini",
+      "description": "Developing Gemini-powered apps on Google Cloud Vertex AI using the Gen AI SDK",
+      "sourceUrl": "https://officialskills.sh/google-gemini/skills/vertex-ai-api-dev",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "google-gemini"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-google-gemini-gemini-live-api-dev",
+      "name": "google-gemini/gemini-live-api-dev",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "google-gemini",
+      "sourceGroup": "Skills by Google Gemini",
+      "description": "Building real-time bidirectional streaming apps with the Gemini Live API",
+      "sourceUrl": "https://officialskills.sh/google-gemini/skills/gemini-live-api-dev",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "google-gemini"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-google-gemini-gemini-interactions-api",
+      "name": "google-gemini/gemini-interactions-api",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "google-gemini",
+      "sourceGroup": "Skills by Google Gemini",
+      "description": "Building apps with the Gemini Interactions API for text, chat, streaming, and image generation",
+      "sourceUrl": "https://officialskills.sh/google-gemini/skills/gemini-interactions-api",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "google-gemini"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-stripe-stripe-best-practices",
+      "name": "stripe/stripe-best-practices",
+      "kind": "skill",
+      "category": "其他工具",
+      "publisher": "stripe",
+      "sourceGroup": "Skills by Stripe Team",
+      "description": "Best practices for building Stripe integrations",
+      "sourceUrl": "https://officialskills.sh/stripe/skills/stripe-best-practices",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "stripe"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-stripe-upgrade-stripe",
+      "name": "stripe/upgrade-stripe",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "stripe",
+      "sourceGroup": "Skills by Stripe Team",
+      "description": "Upgrade Stripe SDK and API versions",
+      "sourceUrl": "https://officialskills.sh/stripe/skills/upgrade-stripe",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "stripe"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-trycourier-courier-skills",
+      "name": "trycourier/courier-skills",
+      "kind": "skillset",
+      "category": "文档与办公",
+      "publisher": "trycourier",
+      "sourceGroup": "Skills by Courier",
+      "description": "Multi-channel notifications via email, SMS, push, and chat",
+      "sourceUrl": "https://github.com/trycourier/courier-skills",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "技能包"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-callstackincubator-react-native-best-practices",
+      "name": "callstackincubator/react-native-best-practices",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "callstackincubator",
+      "sourceGroup": "Skills by CallStack",
+      "description": "Performance optimization for React Native apps from Callstack",
+      "sourceUrl": "https://officialskills.sh/callstackincubator/skills/react-native-best-practices",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "callstackincubator"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-callstackincubator-github",
+      "name": "callstackincubator/github",
+      "kind": "skill",
+      "category": "工程开发",
+      "publisher": "callstackincubator",
+      "sourceGroup": "Skills by CallStack",
+      "description": "GitHub workflow patterns for PRs, code review, branching",
+      "sourceUrl": "https://officialskills.sh/callstackincubator/skills/github",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "callstackincubator"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-callstackincubator-upgrading-react-native",
+      "name": "callstackincubator/upgrading-react-native",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "callstackincubator",
+      "sourceGroup": "Skills by CallStack",
+      "description": "React Native upgrade workflow: templates, dependencies, and common pitfalls",
+      "sourceUrl": "https://officialskills.sh/callstackincubator/skills/upgrading-react-native",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "callstackincubator"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-better-auth-best-practices",
+      "name": "better-auth/best-practices",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "better-auth",
+      "sourceGroup": "Skills by Better Auth Team",
+      "description": "Best practices for Better Auth integration",
+      "sourceUrl": "https://officialskills.sh/better-auth/skills/best-practices",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "better-auth"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-better-auth-explain-error",
+      "name": "better-auth/explain-error",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "better-auth",
+      "sourceGroup": "Skills by Better Auth Team",
+      "description": "Explain Better Auth error messages",
+      "sourceUrl": "https://officialskills.sh/better-auth/skills/explain-error",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "better-auth"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-better-auth-providers",
+      "name": "better-auth/providers",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "better-auth",
+      "sourceGroup": "Skills by Better Auth Team",
+      "description": "Better Auth authentication providers",
+      "sourceUrl": "https://officialskills.sh/better-auth/skills/providers",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "better-auth"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-better-auth-create-auth",
+      "name": "better-auth/create-auth",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "better-auth",
+      "sourceGroup": "Skills by Better Auth Team",
+      "description": "Create authentication setup with Better Auth",
+      "sourceUrl": "https://officialskills.sh/better-auth/skills/create-auth",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "better-auth"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-better-auth-emailandpassword",
+      "name": "better-auth/emailAndPassword",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "better-auth",
+      "sourceGroup": "Skills by Better Auth Team",
+      "description": "Email and password authentication with Better Auth",
+      "sourceUrl": "https://officialskills.sh/better-auth/skills/emailAndPassword",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "better-auth"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-better-auth-organization",
+      "name": "better-auth/organization",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "better-auth",
+      "sourceGroup": "Skills by Better Auth Team",
+      "description": "Organization management with Better Auth",
+      "sourceUrl": "https://officialskills.sh/better-auth/skills/organization",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "better-auth"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-better-auth-twofactor",
+      "name": "better-auth/twoFactor",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "better-auth",
+      "sourceGroup": "Skills by Better Auth Team",
+      "description": "Two-factor authentication with Better Auth",
+      "sourceUrl": "https://officialskills.sh/better-auth/skills/twoFactor",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "better-auth"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-tinybirdco-tinybird-best-practices",
+      "name": "tinybirdco/tinybird-best-practices",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "tinybirdco",
+      "sourceGroup": "Skills by Tinybird Team",
+      "description": "Tinybird project guidelines for datasources, pipes, endpoints, and SQL",
+      "sourceUrl": "https://officialskills.sh/tinybirdco/skills/tinybird-best-practices",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "tinybirdco"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-tinybirdco-tinybird-cli-guidelines",
+      "name": "tinybirdco/tinybird-cli-guidelines",
+      "kind": "skill",
+      "category": "工程开发",
+      "publisher": "tinybirdco",
+      "sourceGroup": "Skills by Tinybird Team",
+      "description": "Tinybird CLI usage guidelines and commands",
+      "sourceUrl": "https://officialskills.sh/tinybirdco/skills/tinybird-cli-guidelines",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "tinybirdco"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-tinybirdco-tinybird-python-sdk-guidelines",
+      "name": "tinybirdco/tinybird-python-sdk-guidelines",
+      "kind": "skill",
+      "category": "工程开发",
+      "publisher": "tinybirdco",
+      "sourceGroup": "Skills by Tinybird Team",
+      "description": "Tinybird Python SDK usage guidelines",
+      "sourceUrl": "https://officialskills.sh/tinybirdco/skills/tinybird-python-sdk-guidelines",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "tinybirdco"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-tinybirdco-tinybird-typescript-sdk-guidelines",
+      "name": "tinybirdco/tinybird-typescript-sdk-guidelines",
+      "kind": "skill",
+      "category": "工程开发",
+      "publisher": "tinybirdco",
+      "sourceGroup": "Skills by Tinybird Team",
+      "description": "Tinybird TypeScript SDK usage guidelines",
+      "sourceUrl": "https://officialskills.sh/tinybirdco/skills/tinybird-typescript-sdk-guidelines",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "tinybirdco"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-hashicorp-azure-verified-modules",
+      "name": "hashicorp/azure-verified-modules",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "hashicorp",
+      "sourceGroup": "Skills by HashiCorp Team for Terraform",
+      "description": "Azure Verified Modules (AVM) certification standards for Terraform modules",
+      "sourceUrl": "https://officialskills.sh/hashicorp/skills/azure-verified-modules",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "hashicorp"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-hashicorp-new-terraform-provider",
+      "name": "hashicorp/new-terraform-provider",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "hashicorp",
+      "sourceGroup": "Skills by HashiCorp Team for Terraform",
+      "description": "Scaffold a new Terraform provider project using the Plugin Framework",
+      "sourceUrl": "https://officialskills.sh/hashicorp/skills/new-terraform-provider",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "hashicorp"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-hashicorp-provider-resources",
+      "name": "hashicorp/provider-resources",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "hashicorp",
+      "sourceGroup": "Skills by HashiCorp Team for Terraform",
+      "description": "Implement Terraform Provider resources and data sources using the Plugin Framework",
+      "sourceUrl": "https://officialskills.sh/hashicorp/skills/provider-resources",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "hashicorp"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-hashicorp-provider-test-patterns",
+      "name": "hashicorp/provider-test-patterns",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "hashicorp",
+      "sourceGroup": "Skills by HashiCorp Team for Terraform",
+      "description": "Acceptance test patterns for Terraform providers using terraform-plugin-testing",
+      "sourceUrl": "https://officialskills.sh/hashicorp/skills/provider-test-patterns",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "hashicorp"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-hashicorp-provider-actions",
+      "name": "hashicorp/provider-actions",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "hashicorp",
+      "sourceGroup": "Skills by HashiCorp Team for Terraform",
+      "description": "Implement Terraform Provider Actions using the Plugin Framework",
+      "sourceUrl": "https://officialskills.sh/hashicorp/skills/provider-actions",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "hashicorp"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-hashicorp-run-acceptance-tests",
+      "name": "hashicorp/run-acceptance-tests",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "hashicorp",
+      "sourceGroup": "Skills by HashiCorp Team for Terraform",
+      "description": "Run acceptance tests for Terraform providers using Go's test runner",
+      "sourceUrl": "https://officialskills.sh/hashicorp/skills/run-acceptance-tests",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "hashicorp"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-hashicorp-refactor-module",
+      "name": "hashicorp/refactor-module",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "hashicorp",
+      "sourceGroup": "Skills by HashiCorp Team for Terraform",
+      "description": "Transform monolithic Terraform configurations into reusable modules",
+      "sourceUrl": "https://officialskills.sh/hashicorp/skills/refactor-module",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "hashicorp"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-hashicorp-terraform-search-import",
+      "name": "hashicorp/terraform-search-import",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "hashicorp",
+      "sourceGroup": "Skills by HashiCorp Team for Terraform",
+      "description": "Discover existing cloud resources and bulk import them into Terraform state",
+      "sourceUrl": "https://officialskills.sh/hashicorp/skills/terraform-search-import",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "hashicorp"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-hashicorp-terraform-style-guide",
+      "name": "hashicorp/terraform-style-guide",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "hashicorp",
+      "sourceGroup": "Skills by HashiCorp Team for Terraform",
+      "description": "Generate Terraform HCL code following HashiCorp's official style conventions",
+      "sourceUrl": "https://officialskills.sh/hashicorp/skills/terraform-style-guide",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "hashicorp"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-hashicorp-terraform-stacks",
+      "name": "hashicorp/terraform-stacks",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "hashicorp",
+      "sourceGroup": "Skills by HashiCorp Team for Terraform",
+      "description": "Manage infrastructure across multiple environments, regions, and cloud accounts",
+      "sourceUrl": "https://officialskills.sh/hashicorp/skills/terraform-stacks",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "hashicorp"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-hashicorp-terraform-test",
+      "name": "hashicorp/terraform-test",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "hashicorp",
+      "sourceGroup": "Skills by HashiCorp Team for Terraform",
+      "description": "Built-in testing framework for Terraform configurations with .tftest.hcl files",
+      "sourceUrl": "https://officialskills.sh/hashicorp/skills/terraform-test",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "hashicorp"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-sanity-io-sanity-best-practices",
+      "name": "sanity-io/sanity-best-practices",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "sanity-io",
+      "sourceGroup": "Skills by Sanity Team",
+      "description": "Best practices for Sanity Studio, GROQ queries, and content workflows",
+      "sourceUrl": "https://officialskills.sh/sanity-io/skills/sanity-best-practices",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "sanity-io"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-sanity-io-content-modeling-best-practices",
+      "name": "sanity-io/content-modeling-best-practices",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "sanity-io",
+      "sourceGroup": "Skills by Sanity Team",
+      "description": "Guidelines for designing scalable content models in Sanity",
+      "sourceUrl": "https://officialskills.sh/sanity-io/skills/content-modeling-best-practices",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "sanity-io"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-sanity-io-seo-aeo-best-practices",
+      "name": "sanity-io/seo-aeo-best-practices",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "sanity-io",
+      "sourceGroup": "Skills by Sanity Team",
+      "description": "SEO and answer engine optimization patterns for content sites",
+      "sourceUrl": "https://officialskills.sh/sanity-io/skills/seo-aeo-best-practices",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "sanity-io"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-sanity-io-content-experimentation-best-practices",
+      "name": "sanity-io/content-experimentation-best-practices",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "sanity-io",
+      "sourceGroup": "Skills by Sanity Team",
+      "description": "Content A/B testing and experimentation workflows",
+      "sourceUrl": "https://officialskills.sh/sanity-io/skills/content-experimentation-best-practices",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "sanity-io"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-firecrawl-firecrawl-build",
+      "name": "firecrawl/firecrawl-build",
+      "kind": "skill",
+      "category": "工程开发",
+      "publisher": "firecrawl",
+      "sourceGroup": "Skills by Firecrawl Team",
+      "description": "Integrate Firecrawl into application code for web search, scraping, extraction, and browser interaction",
+      "sourceUrl": "https://officialskills.sh/firecrawl/skills/firecrawl-build",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "firecrawl"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-firecrawl-firecrawl-build-interact",
+      "name": "firecrawl/firecrawl-build-interact",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "firecrawl",
+      "sourceGroup": "Skills by Firecrawl Team",
+      "description": "Multi-step Firecrawl browser flows: clicks, form fills, pagination, and auth-aware navigation",
+      "sourceUrl": "https://officialskills.sh/firecrawl/skills/firecrawl-build-interact",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "firecrawl"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-firecrawl-firecrawl-build-onboarding",
+      "name": "firecrawl/firecrawl-build-onboarding",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "firecrawl",
+      "sourceGroup": "Skills by Firecrawl Team",
+      "description": "Set up Firecrawl credentials and SDK in a project for the first integration",
+      "sourceUrl": "https://officialskills.sh/firecrawl/skills/firecrawl-build-onboarding",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "firecrawl"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-firecrawl-firecrawl-build-scrape",
+      "name": "firecrawl/firecrawl-build-scrape",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "firecrawl",
+      "sourceGroup": "Skills by Firecrawl Team",
+      "description": "Integrate Firecrawl /scrape for single-page extraction from product code",
+      "sourceUrl": "https://officialskills.sh/firecrawl/skills/firecrawl-build-scrape",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "firecrawl"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-firecrawl-firecrawl-build-search",
+      "name": "firecrawl/firecrawl-build-search",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "firecrawl",
+      "sourceGroup": "Skills by Firecrawl Team",
+      "description": "Integrate Firecrawl /search for query-first discovery with optional content hydration",
+      "sourceUrl": "https://officialskills.sh/firecrawl/skills/firecrawl-build-search",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "firecrawl"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-neondatabase-neon-postgres",
+      "name": "neondatabase/neon-postgres",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "neondatabase",
+      "sourceGroup": "Skills by Neon",
+      "description": "Best practices for Neon Serverless Postgres",
+      "sourceUrl": "https://officialskills.sh/neondatabase/skills/neon-postgres",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "neondatabase"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-neondatabase-claimable-postgres",
+      "name": "neondatabase/claimable-postgres",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "neondatabase",
+      "sourceGroup": "Skills by Neon",
+      "description": "Claimable Postgres database provisioning with Neon",
+      "sourceUrl": "https://officialskills.sh/neondatabase/skills/claimable-postgres",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "neondatabase"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-neondatabase-neon-postgres-egress-optimizer",
+      "name": "neondatabase/neon-postgres-egress-optimizer",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "neondatabase",
+      "sourceGroup": "Skills by Neon",
+      "description": "Optimize Neon Postgres egress and data transfer",
+      "sourceUrl": "https://officialskills.sh/neondatabase/skills/neon-postgres-egress-optimizer",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "neondatabase"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-clickhouse-clickhouse-best-practices",
+      "name": "clickhouse/clickhouse-best-practices",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "clickhouse",
+      "sourceGroup": "Skills by ClickHouse",
+      "description": "Best practices for working with ClickHouse",
+      "sourceUrl": "https://officialskills.sh/clickhouse/skills/clickhouse-best-practices",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "clickhouse"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-clickhouse-chdb-datastore",
+      "name": "clickhouse/chdb-datastore",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "clickhouse",
+      "sourceGroup": "Skills by ClickHouse",
+      "description": "Drop-in pandas replacement with ClickHouse performance across 16+ data sources",
+      "sourceUrl": "https://officialskills.sh/clickhouse/skills/chdb-datastore",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "clickhouse"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-clickhouse-chdb-sql",
+      "name": "clickhouse/chdb-sql",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "clickhouse",
+      "sourceGroup": "Skills by ClickHouse",
+      "description": "In-process ClickHouse SQL engine for Python — query files, databases, and cloud storage without a server",
+      "sourceUrl": "https://officialskills.sh/clickhouse/skills/chdb-sql",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "clickhouse"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-clickhouse-clickhouse-architecture-advisor",
+      "name": "clickhouse/clickhouse-architecture-advisor",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "clickhouse",
+      "sourceGroup": "Skills by ClickHouse",
+      "description": "Design ClickHouse architectures and translate best practices into workload-specific decisions",
+      "sourceUrl": "https://officialskills.sh/clickhouse/skills/clickhouse-architecture-advisor",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "clickhouse"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-clickhouse-clickhousectl-cloud-deploy",
+      "name": "clickhouse/clickhousectl-cloud-deploy",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "clickhouse",
+      "sourceGroup": "Skills by ClickHouse",
+      "description": "Deploy to ClickHouse Cloud and migrate from local setups with clickhousectl",
+      "sourceUrl": "https://officialskills.sh/clickhouse/skills/clickhousectl-cloud-deploy",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "clickhouse"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-clickhouse-clickhousectl-local-dev",
+      "name": "clickhouse/clickhousectl-local-dev",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "clickhouse",
+      "sourceGroup": "Skills by ClickHouse",
+      "description": "Spin up a local ClickHouse development environment from zero with clickhousectl",
+      "sourceUrl": "https://officialskills.sh/clickhouse/skills/clickhousectl-local-dev",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "clickhouse"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-remotion-dev-remotion",
+      "name": "remotion-dev/remotion",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "remotion-dev",
+      "sourceGroup": "Skills by Remotion",
+      "description": "Programmatic video creation with React",
+      "sourceUrl": "https://officialskills.sh/remotion-dev/skills/remotion",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "remotion-dev"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-replicate-replicate",
+      "name": "replicate/replicate",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "replicate",
+      "sourceGroup": "Skills by Replicate",
+      "description": "Discover, compare, and run AI models using Replicate's API",
+      "sourceUrl": "https://officialskills.sh/replicate/skills/replicate",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "replicate"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-typefully-typefully",
+      "name": "typefully/typefully",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "typefully",
+      "sourceGroup": "Skills by Typefully",
+      "description": "Create, schedule, and publish social media content across X, LinkedIn, Threads, Bluesky, and Mastodon",
+      "sourceUrl": "https://officialskills.sh/typefully/skills/typefully",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "typefully"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-veniceai-venice-api-overview",
+      "name": "veniceai/venice-api-overview",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "veniceai",
+      "sourceGroup": "Skills by Venice.ai",
+      "description": "API basics, auth modes, pricing, and versioning",
+      "sourceUrl": "https://github.com/veniceai/skills/tree/main/skills/venice-api-overview",
+      "installSource": {
+        "repoUrl": "https://github.com/veniceai/skills",
+        "subPath": "skills/venice-api-overview"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "veniceai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-veniceai-venice-auth",
+      "name": "veniceai/venice-auth",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "veniceai",
+      "sourceGroup": "Skills by Venice.ai",
+      "description": "API keys and wallet-based Venice authentication",
+      "sourceUrl": "https://github.com/veniceai/skills/tree/main/skills/venice-auth",
+      "installSource": {
+        "repoUrl": "https://github.com/veniceai/skills",
+        "subPath": "skills/venice-auth"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "veniceai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-veniceai-venice-chat",
+      "name": "veniceai/venice-chat",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "veniceai",
+      "sourceGroup": "Skills by Venice.ai",
+      "description": "Chat completions, multimodal inputs, tools, and streaming",
+      "sourceUrl": "https://github.com/veniceai/skills/tree/main/skills/venice-chat",
+      "installSource": {
+        "repoUrl": "https://github.com/veniceai/skills",
+        "subPath": "skills/venice-chat"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "veniceai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-veniceai-venice-responses",
+      "name": "veniceai/venice-responses",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "veniceai",
+      "sourceGroup": "Skills by Venice.ai",
+      "description": "OpenAI-compatible Responses API for Venice",
+      "sourceUrl": "https://github.com/veniceai/skills/tree/main/skills/venice-responses",
+      "installSource": {
+        "repoUrl": "https://github.com/veniceai/skills",
+        "subPath": "skills/venice-responses"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "veniceai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-veniceai-venice-embeddings",
+      "name": "veniceai/venice-embeddings",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "veniceai",
+      "sourceGroup": "Skills by Venice.ai",
+      "description": "Embeddings models, dimensions, and encoding formats",
+      "sourceUrl": "https://github.com/veniceai/skills/tree/main/skills/venice-embeddings",
+      "installSource": {
+        "repoUrl": "https://github.com/veniceai/skills",
+        "subPath": "skills/venice-embeddings"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "veniceai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-veniceai-venice-image-generate",
+      "name": "veniceai/venice-image-generate",
+      "kind": "skill",
+      "category": "多媒体创作",
+      "publisher": "veniceai",
+      "sourceGroup": "Skills by Venice.ai",
+      "description": "Image generation endpoints and available styles",
+      "sourceUrl": "https://github.com/veniceai/skills/tree/main/skills/venice-image-generate",
+      "installSource": {
+        "repoUrl": "https://github.com/veniceai/skills",
+        "subPath": "skills/venice-image-generate"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "veniceai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-veniceai-venice-image-edit",
+      "name": "veniceai/venice-image-edit",
+      "kind": "skill",
+      "category": "多媒体创作",
+      "publisher": "veniceai",
+      "sourceGroup": "Skills by Venice.ai",
+      "description": "Image edits, upscaling, and background removal",
+      "sourceUrl": "https://github.com/veniceai/skills/tree/main/skills/venice-image-edit",
+      "installSource": {
+        "repoUrl": "https://github.com/veniceai/skills",
+        "subPath": "skills/venice-image-edit"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "veniceai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-veniceai-venice-audio-speech",
+      "name": "veniceai/venice-audio-speech",
+      "kind": "skill",
+      "category": "多媒体创作",
+      "publisher": "veniceai",
+      "sourceGroup": "Skills by Venice.ai",
+      "description": "Text-to-speech models, voices, formats, and streaming",
+      "sourceUrl": "https://github.com/veniceai/skills/tree/main/skills/venice-audio-speech",
+      "installSource": {
+        "repoUrl": "https://github.com/veniceai/skills",
+        "subPath": "skills/venice-audio-speech"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "veniceai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-veniceai-venice-audio-music",
+      "name": "veniceai/venice-audio-music",
+      "kind": "skill",
+      "category": "多媒体创作",
+      "publisher": "veniceai",
+      "sourceGroup": "Skills by Venice.ai",
+      "description": "Music generation queueing, retrieval, and completion endpoints",
+      "sourceUrl": "https://github.com/veniceai/skills/tree/main/skills/venice-audio-music",
+      "installSource": {
+        "repoUrl": "https://github.com/veniceai/skills",
+        "subPath": "skills/venice-audio-music"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "veniceai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-veniceai-venice-audio-transcription",
+      "name": "veniceai/venice-audio-transcription",
+      "kind": "skill",
+      "category": "多媒体创作",
+      "publisher": "veniceai",
+      "sourceGroup": "Skills by Venice.ai",
+      "description": "Audio transcription models and speech-to-text options",
+      "sourceUrl": "https://github.com/veniceai/skills/tree/main/skills/venice-audio-transcription",
+      "installSource": {
+        "repoUrl": "https://github.com/veniceai/skills",
+        "subPath": "skills/venice-audio-transcription"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "veniceai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-veniceai-venice-video",
+      "name": "veniceai/venice-video",
+      "kind": "skill",
+      "category": "多媒体创作",
+      "publisher": "veniceai",
+      "sourceGroup": "Skills by Venice.ai",
+      "description": "Video generation and transcription workflows",
+      "sourceUrl": "https://github.com/veniceai/skills/tree/main/skills/venice-video",
+      "installSource": {
+        "repoUrl": "https://github.com/veniceai/skills",
+        "subPath": "skills/venice-video"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "veniceai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-veniceai-venice-models",
+      "name": "veniceai/venice-models",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "veniceai",
+      "sourceGroup": "Skills by Venice.ai",
+      "description": "Model catalog, traits, and compatibility mappings",
+      "sourceUrl": "https://github.com/veniceai/skills/tree/main/skills/venice-models",
+      "installSource": {
+        "repoUrl": "https://github.com/veniceai/skills",
+        "subPath": "skills/venice-models"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "veniceai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-veniceai-venice-characters",
+      "name": "veniceai/venice-characters",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "veniceai",
+      "sourceGroup": "Skills by Venice.ai",
+      "description": "Character endpoints and characterslug usage",
+      "sourceUrl": "https://github.com/veniceai/skills/tree/main/skills/venice-characters",
+      "installSource": {
+        "repoUrl": "https://github.com/veniceai/skills",
+        "subPath": "skills/venice-characters"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "veniceai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-veniceai-venice-api-keys",
+      "name": "veniceai/venice-api-keys",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "veniceai",
+      "sourceGroup": "Skills by Venice.ai",
+      "description": "API key CRUD, rate limits, and Web3 keys",
+      "sourceUrl": "https://github.com/veniceai/skills/tree/main/skills/venice-api-keys",
+      "installSource": {
+        "repoUrl": "https://github.com/veniceai/skills",
+        "subPath": "skills/venice-api-keys"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "veniceai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-veniceai-venice-billing",
+      "name": "veniceai/venice-billing",
+      "kind": "skill",
+      "category": "数据与分析",
+      "publisher": "veniceai",
+      "sourceGroup": "Skills by Venice.ai",
+      "description": "Balance, usage, and billing analytics endpoints",
+      "sourceUrl": "https://github.com/veniceai/skills/tree/main/skills/venice-billing",
+      "installSource": {
+        "repoUrl": "https://github.com/veniceai/skills",
+        "subPath": "skills/venice-billing"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "veniceai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-veniceai-venice-x402",
+      "name": "veniceai/venice-x402",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "veniceai",
+      "sourceGroup": "Skills by Venice.ai",
+      "description": "Wallet credits and x402 payments on Base",
+      "sourceUrl": "https://github.com/veniceai/skills/tree/main/skills/venice-x402",
+      "installSource": {
+        "repoUrl": "https://github.com/veniceai/skills",
+        "subPath": "skills/venice-x402"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "veniceai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-veniceai-venice-crypto-rpc",
+      "name": "veniceai/venice-crypto-rpc",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "veniceai",
+      "sourceGroup": "Skills by Venice.ai",
+      "description": "JSON-RPC proxying for supported crypto networks",
+      "sourceUrl": "https://github.com/veniceai/skills/tree/main/skills/venice-crypto-rpc",
+      "installSource": {
+        "repoUrl": "https://github.com/veniceai/skills",
+        "subPath": "skills/venice-crypto-rpc"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "veniceai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-veniceai-venice-augment",
+      "name": "veniceai/venice-augment",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "veniceai",
+      "sourceGroup": "Skills by Venice.ai",
+      "description": "Search, scraping, and text parsing endpoints",
+      "sourceUrl": "https://github.com/veniceai/skills/tree/main/skills/venice-augment",
+      "installSource": {
+        "repoUrl": "https://github.com/veniceai/skills",
+        "subPath": "skills/venice-augment"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "veniceai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-veniceai-venice-errors",
+      "name": "veniceai/venice-errors",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "veniceai",
+      "sourceGroup": "Skills by Venice.ai",
+      "description": "Error handling, retries, and API status codes",
+      "sourceUrl": "https://github.com/veniceai/skills/tree/main/skills/venice-errors",
+      "installSource": {
+        "repoUrl": "https://github.com/veniceai/skills",
+        "subPath": "skills/venice-errors"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "veniceai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-vercel-labs-next-best-practices",
+      "name": "vercel-labs/next-best-practices",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "vercel-labs",
+      "sourceGroup": "Skills by Vercel Engineering Team",
+      "description": "Next.js best practices and recommended patterns",
+      "sourceUrl": "https://officialskills.sh/vercel-labs/skills/next-best-practices",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "vercel-labs"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-vercel-labs-next-cache-components",
+      "name": "vercel-labs/next-cache-components",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "vercel-labs",
+      "sourceGroup": "Skills by Vercel Engineering Team",
+      "description": "Caching strategies and cache-aware components in Next.js",
+      "sourceUrl": "https://officialskills.sh/vercel-labs/skills/next-cache-components",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "vercel-labs"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-vercel-labs-next-upgrade",
+      "name": "vercel-labs/next-upgrade",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "vercel-labs",
+      "sourceGroup": "Skills by Vercel Engineering Team",
+      "description": "Upgrade Next.js projects to newer versions",
+      "sourceUrl": "https://officialskills.sh/vercel-labs/skills/next-upgrade",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "vercel-labs"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-cloudflare-agents-sdk",
+      "name": "cloudflare/agents-sdk",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "cloudflare",
+      "sourceGroup": "Skills by Cloudflare Team",
+      "description": "Build stateful AI agents with scheduling, RPC, and MCP servers",
+      "sourceUrl": "https://officialskills.sh/cloudflare/skills/agents-sdk",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "cloudflare"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-cloudflare-cloudflare",
+      "name": "cloudflare/cloudflare",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "cloudflare",
+      "sourceGroup": "Skills by Cloudflare Team",
+      "description": "Comprehensive Cloudflare platform skill covering Workers, Pages, storage, AI, networking, security, and IaC",
+      "sourceUrl": "https://officialskills.sh/cloudflare/skills/cloudflare",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "cloudflare"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-cloudflare-cloudflare-email-service",
+      "name": "cloudflare/cloudflare-email-service",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "cloudflare",
+      "sourceGroup": "Skills by Cloudflare Team",
+      "description": "Send transactional email and route inbound mail with Cloudflare Email Sending and Email Routing",
+      "sourceUrl": "https://officialskills.sh/cloudflare/skills/cloudflare-email-service",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "cloudflare"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-cloudflare-durable-objects",
+      "name": "cloudflare/durable-objects",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "cloudflare",
+      "sourceGroup": "Skills by Cloudflare Team",
+      "description": "Stateful coordination with RPC, SQLite, and WebSockets",
+      "sourceUrl": "https://officialskills.sh/cloudflare/skills/durable-objects",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "cloudflare"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-cloudflare-sandbox-sdk",
+      "name": "cloudflare/sandbox-sdk",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "cloudflare",
+      "sourceGroup": "Skills by Cloudflare Team",
+      "description": "Build sandboxed applications for secure, isolated code execution on Workers",
+      "sourceUrl": "https://officialskills.sh/cloudflare/skills/sandbox-sdk",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "cloudflare"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-cloudflare-web-perf",
+      "name": "cloudflare/web-perf",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "cloudflare",
+      "sourceGroup": "Skills by Cloudflare Team",
+      "description": "Audit Core Web Vitals and render-blocking resources",
+      "sourceUrl": "https://officialskills.sh/cloudflare/skills/web-perf",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "cloudflare"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-cloudflare-workers-best-practices",
+      "name": "cloudflare/workers-best-practices",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "cloudflare",
+      "sourceGroup": "Skills by Cloudflare Team",
+      "description": "Review and author Workers code against production best practices and wrangler.jsonc conventions",
+      "sourceUrl": "https://officialskills.sh/cloudflare/skills/workers-best-practices",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "cloudflare"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-cloudflare-wrangler",
+      "name": "cloudflare/wrangler",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "cloudflare",
+      "sourceGroup": "Skills by Cloudflare Team",
+      "description": "Deploy and manage Workers, KV, R2, D1, Vectorize, Queues, Workflows",
+      "sourceUrl": "https://officialskills.sh/cloudflare/skills/wrangler",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "cloudflare"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-netlify-netlify-functions",
+      "name": "netlify/netlify-functions",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "netlify",
+      "sourceGroup": "Skills by Netlify Team",
+      "description": "Build serverless API endpoints and background tasks",
+      "sourceUrl": "https://officialskills.sh/netlify/skills/netlify-functions",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "netlify"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-netlify-netlify-edge-functions",
+      "name": "netlify/netlify-edge-functions",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "netlify",
+      "sourceGroup": "Skills by Netlify Team",
+      "description": "Low-latency edge middleware and geolocation logic",
+      "sourceUrl": "https://officialskills.sh/netlify/skills/netlify-edge-functions",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "netlify"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-netlify-netlify-blobs",
+      "name": "netlify/netlify-blobs",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "netlify",
+      "sourceGroup": "Skills by Netlify Team",
+      "description": "Key-value object storage for files and data",
+      "sourceUrl": "https://officialskills.sh/netlify/skills/netlify-blobs",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "netlify"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-netlify-netlify-db",
+      "name": "netlify/netlify-db",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "netlify",
+      "sourceGroup": "Skills by Netlify Team",
+      "description": "Managed Postgres with deploy preview branching",
+      "sourceUrl": "https://officialskills.sh/netlify/skills/netlify-db",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "netlify"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-netlify-netlify-image-cdn",
+      "name": "netlify/netlify-image-cdn",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "netlify",
+      "sourceGroup": "Skills by Netlify Team",
+      "description": "Optimize and transform images via CDN",
+      "sourceUrl": "https://officialskills.sh/netlify/skills/netlify-image-cdn",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "netlify"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-netlify-netlify-forms",
+      "name": "netlify/netlify-forms",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "netlify",
+      "sourceGroup": "Skills by Netlify Team",
+      "description": "HTML form handling with spam filtering",
+      "sourceUrl": "https://officialskills.sh/netlify/skills/netlify-forms",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "netlify"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-netlify-netlify-frameworks",
+      "name": "netlify/netlify-frameworks",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "netlify",
+      "sourceGroup": "Skills by Netlify Team",
+      "description": "Deploy web frameworks with SSR support",
+      "sourceUrl": "https://officialskills.sh/netlify/skills/netlify-frameworks",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "netlify"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-netlify-netlify-caching",
+      "name": "netlify/netlify-caching",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "netlify",
+      "sourceGroup": "Skills by Netlify Team",
+      "description": "Configure CDN caching and cache purging",
+      "sourceUrl": "https://officialskills.sh/netlify/skills/netlify-caching",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "netlify"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-netlify-netlify-config",
+      "name": "netlify/netlify-config",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "netlify",
+      "sourceGroup": "Skills by Netlify Team",
+      "description": "Reference for netlify.toml site configuration",
+      "sourceUrl": "https://officialskills.sh/netlify/skills/netlify-config",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "netlify"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-netlify-netlify-cli-and-deploy",
+      "name": "netlify/netlify-cli-and-deploy",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "netlify",
+      "sourceGroup": "Skills by Netlify Team",
+      "description": "CLI setup, local dev, and deployment workflows",
+      "sourceUrl": "https://officialskills.sh/netlify/skills/netlify-cli-and-deploy",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "netlify"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-netlify-netlify-deploy",
+      "name": "netlify/netlify-deploy",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "netlify",
+      "sourceGroup": "Skills by Netlify Team",
+      "description": "Automated deployment workflow for Netlify sites",
+      "sourceUrl": "https://officialskills.sh/netlify/skills/netlify-deploy",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "netlify"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-netlify-netlify-ai-gateway",
+      "name": "netlify/netlify-ai-gateway",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "netlify",
+      "sourceGroup": "Skills by Netlify Team",
+      "description": "Access AI models via unified gateway endpoint",
+      "sourceUrl": "https://officialskills.sh/netlify/skills/netlify-ai-gateway",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "netlify"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-google-labs-code-design-md",
+      "name": "google-labs-code/design-md",
+      "kind": "skill",
+      "category": "多媒体创作",
+      "publisher": "google-labs-code",
+      "sourceGroup": "Skills by Google Labs (Stitch)",
+      "description": "Create and manage DESIGN.md files",
+      "sourceUrl": "https://officialskills.sh/google-labs-code/skills/design-md",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "google-labs-code"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-google-labs-code-enhance-prompt",
+      "name": "google-labs-code/enhance-prompt",
+      "kind": "skill",
+      "category": "多媒体创作",
+      "publisher": "google-labs-code",
+      "sourceGroup": "Skills by Google Labs (Stitch)",
+      "description": "Improve prompts with design specs and UI/UX vocabulary",
+      "sourceUrl": "https://officialskills.sh/google-labs-code/skills/enhance-prompt",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "google-labs-code"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-google-labs-code-react-components",
+      "name": "google-labs-code/react-components",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "google-labs-code",
+      "sourceGroup": "Skills by Google Labs (Stitch)",
+      "description": "Stitch to React components conversion",
+      "sourceUrl": "https://officialskills.sh/google-labs-code/skills/react-components",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "google-labs-code"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-google-labs-code-remotion",
+      "name": "google-labs-code/remotion",
+      "kind": "skill",
+      "category": "多媒体创作",
+      "publisher": "google-labs-code",
+      "sourceGroup": "Skills by Google Labs (Stitch)",
+      "description": "Generate walkthrough videos from Stitch app designs",
+      "sourceUrl": "https://officialskills.sh/google-labs-code/skills/remotion",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "google-labs-code"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-google-labs-code-shadcn-ui",
+      "name": "google-labs-code/shadcn-ui",
+      "kind": "skill",
+      "category": "工程开发",
+      "publisher": "google-labs-code",
+      "sourceGroup": "Skills by Google Labs (Stitch)",
+      "description": "Build UI components with shadcn/ui",
+      "sourceUrl": "https://officialskills.sh/google-labs-code/skills/shadcn-ui",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "google-labs-code"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-google-labs-code-stitch-loop",
+      "name": "google-labs-code/stitch-loop",
+      "kind": "skill",
+      "category": "多媒体创作",
+      "publisher": "google-labs-code",
+      "sourceGroup": "Skills by Google Labs (Stitch)",
+      "description": "Iterative design-to-code feedback loop",
+      "sourceUrl": "https://officialskills.sh/google-labs-code/skills/stitch-loop",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "google-labs-code"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-googleworkspace-gws-shared",
+      "name": "googleworkspace/gws-shared",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "googleworkspace",
+      "sourceGroup": "Skills by Google Workspace CLI",
+      "description": "Shared authentication, global flags, and output formatting",
+      "sourceUrl": "https://officialskills.sh/googleworkspace/skills/gws-shared",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "googleworkspace"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-googleworkspace-gws-drive",
+      "name": "googleworkspace/gws-drive",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "googleworkspace",
+      "sourceGroup": "Skills by Google Workspace CLI",
+      "description": "Manage Google Drive files, folders, and shared drives",
+      "sourceUrl": "https://officialskills.sh/googleworkspace/skills/gws-drive",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "googleworkspace"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-googleworkspace-gws-sheets",
+      "name": "googleworkspace/gws-sheets",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "googleworkspace",
+      "sourceGroup": "Skills by Google Workspace CLI",
+      "description": "Read and write Google Sheets spreadsheets",
+      "sourceUrl": "https://officialskills.sh/googleworkspace/skills/gws-sheets",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "googleworkspace"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-googleworkspace-gws-gmail",
+      "name": "googleworkspace/gws-gmail",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "googleworkspace",
+      "sourceGroup": "Skills by Google Workspace CLI",
+      "description": "Send, read, and manage Gmail email",
+      "sourceUrl": "https://officialskills.sh/googleworkspace/skills/gws-gmail",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "googleworkspace"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-googleworkspace-gws-calendar",
+      "name": "googleworkspace/gws-calendar",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "googleworkspace",
+      "sourceGroup": "Skills by Google Workspace CLI",
+      "description": "Manage Google Calendar calendars and events",
+      "sourceUrl": "https://officialskills.sh/googleworkspace/skills/gws-calendar",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "googleworkspace"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-googleworkspace-gws-admin-reports",
+      "name": "googleworkspace/gws-admin-reports",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "googleworkspace",
+      "sourceGroup": "Skills by Google Workspace CLI",
+      "description": "Audit logs and usage reports for Workspace",
+      "sourceUrl": "https://officialskills.sh/googleworkspace/skills/gws-admin-reports",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "googleworkspace"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-googleworkspace-gws-docs",
+      "name": "googleworkspace/gws-docs",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "googleworkspace",
+      "sourceGroup": "Skills by Google Workspace CLI",
+      "description": "Read and write Google Docs documents",
+      "sourceUrl": "https://officialskills.sh/googleworkspace/skills/gws-docs",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "googleworkspace"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-googleworkspace-gws-slides",
+      "name": "googleworkspace/gws-slides",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "googleworkspace",
+      "sourceGroup": "Skills by Google Workspace CLI",
+      "description": "Read and write Google Slides presentations",
+      "sourceUrl": "https://officialskills.sh/googleworkspace/skills/gws-slides",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "googleworkspace"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-googleworkspace-gws-tasks",
+      "name": "googleworkspace/gws-tasks",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "googleworkspace",
+      "sourceGroup": "Skills by Google Workspace CLI",
+      "description": "Manage Google Tasks task lists and tasks",
+      "sourceUrl": "https://officialskills.sh/googleworkspace/skills/gws-tasks",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "googleworkspace"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-googleworkspace-gws-people",
+      "name": "googleworkspace/gws-people",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "googleworkspace",
+      "sourceGroup": "Skills by Google Workspace CLI",
+      "description": "Manage Google People contacts and profiles",
+      "sourceUrl": "https://officialskills.sh/googleworkspace/skills/gws-people",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "googleworkspace"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-googleworkspace-gws-chat",
+      "name": "googleworkspace/gws-chat",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "googleworkspace",
+      "sourceGroup": "Skills by Google Workspace CLI",
+      "description": "Manage Google Chat spaces and messages",
+      "sourceUrl": "https://officialskills.sh/googleworkspace/skills/gws-chat",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "googleworkspace"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-googleworkspace-gws-classroom",
+      "name": "googleworkspace/gws-classroom",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "googleworkspace",
+      "sourceGroup": "Skills by Google Workspace CLI",
+      "description": "Manage Google Classroom classes, rosters, and coursework",
+      "sourceUrl": "https://officialskills.sh/googleworkspace/skills/gws-classroom",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "googleworkspace"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-googleworkspace-gws-forms",
+      "name": "googleworkspace/gws-forms",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "googleworkspace",
+      "sourceGroup": "Skills by Google Workspace CLI",
+      "description": "Read and write Google Forms",
+      "sourceUrl": "https://officialskills.sh/googleworkspace/skills/gws-forms",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "googleworkspace"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-googleworkspace-gws-keep",
+      "name": "googleworkspace/gws-keep",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "googleworkspace",
+      "sourceGroup": "Skills by Google Workspace CLI",
+      "description": "Manage Google Keep notes",
+      "sourceUrl": "https://officialskills.sh/googleworkspace/skills/gws-keep",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "googleworkspace"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-googleworkspace-gws-events",
+      "name": "googleworkspace/gws-events",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "googleworkspace",
+      "sourceGroup": "Skills by Google Workspace CLI",
+      "description": "Subscribe to Google Workspace events",
+      "sourceUrl": "https://officialskills.sh/googleworkspace/skills/gws-events",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "googleworkspace"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-googleworkspace-gws-modelarmor",
+      "name": "googleworkspace/gws-modelarmor",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "googleworkspace",
+      "sourceGroup": "Skills by Google Workspace CLI",
+      "description": "Filter user-generated content for safety",
+      "sourceUrl": "https://officialskills.sh/googleworkspace/skills/gws-modelarmor",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "googleworkspace"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-googleworkspace-gws-workflow",
+      "name": "googleworkspace/gws-workflow",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "googleworkspace",
+      "sourceGroup": "Skills by Google Workspace CLI",
+      "description": "Cross-service Google Workspace productivity workflows",
+      "sourceUrl": "https://officialskills.sh/googleworkspace/skills/gws-workflow",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "googleworkspace"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-expo-building-native-ui",
+      "name": "expo/building-native-ui",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "expo",
+      "sourceGroup": "Skills by Expo Team",
+      "description": "Build apps with Expo Router, styling, components, navigation, and animations",
+      "sourceUrl": "https://officialskills.sh/expo/skills/building-native-ui",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "expo"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-expo-expo-api-routes",
+      "name": "expo/expo-api-routes",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "expo",
+      "sourceGroup": "Skills by Expo Team",
+      "description": "Create API routes in Expo Router with EAS Hosting",
+      "sourceUrl": "https://officialskills.sh/expo/skills/expo-api-routes",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "expo"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-expo-expo-cicd-workflows",
+      "name": "expo/expo-cicd-workflows",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "expo",
+      "sourceGroup": "Skills by Expo Team",
+      "description": "CI/CD workflows for Expo projects",
+      "sourceUrl": "https://officialskills.sh/expo/skills/expo-cicd-workflows",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "expo"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-expo-expo-deployment",
+      "name": "expo/expo-deployment",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "expo",
+      "sourceGroup": "Skills by Expo Team",
+      "description": "Deploy Expo apps to production",
+      "sourceUrl": "https://officialskills.sh/expo/skills/expo-deployment",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "expo"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-expo-expo-dev-client",
+      "name": "expo/expo-dev-client",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "expo",
+      "sourceGroup": "Skills by Expo Team",
+      "description": "Build and distribute Expo dev clients locally or via TestFlight",
+      "sourceUrl": "https://officialskills.sh/expo/skills/expo-dev-client",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "expo"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-expo-expo-tailwind-setup",
+      "name": "expo/expo-tailwind-setup",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "expo",
+      "sourceGroup": "Skills by Expo Team",
+      "description": "Set up Tailwind CSS v4 in Expo with NativeWind v5",
+      "sourceUrl": "https://officialskills.sh/expo/skills/expo-tailwind-setup",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "expo"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-expo-expo-ui-jetpack-compose",
+      "name": "expo/expo-ui-jetpack-compose",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "expo",
+      "sourceGroup": "Skills by Expo Team",
+      "description": "Jetpack Compose UI components for Expo",
+      "sourceUrl": "https://officialskills.sh/expo/skills/expo-ui-jetpack-compose",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "expo"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-expo-expo-ui-swift-ui",
+      "name": "expo/expo-ui-swift-ui",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "expo",
+      "sourceGroup": "Skills by Expo Team",
+      "description": "SwiftUI components for Expo",
+      "sourceUrl": "https://officialskills.sh/expo/skills/expo-ui-swift-ui",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "expo"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-expo-native-data-fetching",
+      "name": "expo/native-data-fetching",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "expo",
+      "sourceGroup": "Skills by Expo Team",
+      "description": "Network requests, API calls, caching, and offline support",
+      "sourceUrl": "https://officialskills.sh/expo/skills/native-data-fetching",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "expo"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-expo-upgrading-expo",
+      "name": "expo/upgrading-expo",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "expo",
+      "sourceGroup": "Skills by Expo Team",
+      "description": "Upgrade Expo SDK versions",
+      "sourceUrl": "https://officialskills.sh/expo/skills/upgrading-expo",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "expo"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-expo-use-dom",
+      "name": "expo/use-dom",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "expo",
+      "sourceGroup": "Skills by Expo Team",
+      "description": "Run web code in a webview on native using DOM components",
+      "sourceUrl": "https://officialskills.sh/expo/skills/use-dom",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "expo"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-huggingface-hf-cli",
+      "name": "huggingface/hf-cli",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "huggingface",
+      "sourceGroup": "Skills by Hugging Face Team",
+      "description": "HF CLI tool for Hub operations",
+      "sourceUrl": "https://officialskills.sh/huggingface/skills/hf-cli",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "huggingface"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-huggingface-hugging-face-dataset-viewer",
+      "name": "huggingface/hugging-face-dataset-viewer",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "huggingface",
+      "sourceGroup": "Skills by Hugging Face Team",
+      "description": "Browse and query HF datasets with the Dataset Viewer API",
+      "sourceUrl": "https://officialskills.sh/huggingface/skills/hugging-face-dataset-viewer",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "huggingface"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-huggingface-hugging-face-datasets",
+      "name": "huggingface/hugging-face-datasets",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "huggingface",
+      "sourceGroup": "Skills by Hugging Face Team",
+      "description": "Create and manage datasets with configs and SQL querying",
+      "sourceUrl": "https://officialskills.sh/huggingface/skills/hugging-face-datasets",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "huggingface"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-huggingface-hugging-face-evaluation",
+      "name": "huggingface/hugging-face-evaluation",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "huggingface",
+      "sourceGroup": "Skills by Hugging Face Team",
+      "description": "Model evaluation with vLLM/lighteval and eval tables",
+      "sourceUrl": "https://officialskills.sh/huggingface/skills/hugging-face-evaluation",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "huggingface"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-huggingface-hugging-face-jobs",
+      "name": "huggingface/hugging-face-jobs",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "huggingface",
+      "sourceGroup": "Skills by Hugging Face Team",
+      "description": "Run compute jobs and Python scripts on HF infrastructure",
+      "sourceUrl": "https://officialskills.sh/huggingface/skills/hugging-face-jobs",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "huggingface"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-huggingface-hugging-face-model-trainer",
+      "name": "huggingface/hugging-face-model-trainer",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "huggingface",
+      "sourceGroup": "Skills by Hugging Face Team",
+      "description": "Train models with TRL: SFT, DPO, GRPO, GGUF conversion",
+      "sourceUrl": "https://officialskills.sh/huggingface/skills/hugging-face-model-trainer",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "huggingface"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-huggingface-hugging-face-paper-pages",
+      "name": "huggingface/hugging-face-paper-pages",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "huggingface",
+      "sourceGroup": "Skills by Hugging Face Team",
+      "description": "Create and manage paper pages on HF Hub",
+      "sourceUrl": "https://officialskills.sh/huggingface/skills/hugging-face-paper-pages",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "huggingface"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-huggingface-hugging-face-paper-publisher",
+      "name": "huggingface/hugging-face-paper-publisher",
+      "kind": "skill",
+      "category": "数据与分析",
+      "publisher": "huggingface",
+      "sourceGroup": "Skills by Hugging Face Team",
+      "description": "Publish papers on HF Hub with model/dataset links",
+      "sourceUrl": "https://officialskills.sh/huggingface/skills/hugging-face-paper-publisher",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "huggingface"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-huggingface-hugging-face-tool-builder",
+      "name": "huggingface/hugging-face-tool-builder",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "huggingface",
+      "sourceGroup": "Skills by Hugging Face Team",
+      "description": "Build reusable scripts for HF API operations",
+      "sourceUrl": "https://officialskills.sh/huggingface/skills/hugging-face-tool-builder",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "huggingface"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-huggingface-hugging-face-trackio",
+      "name": "huggingface/hugging-face-trackio",
+      "kind": "skill",
+      "category": "数据与分析",
+      "publisher": "huggingface",
+      "sourceGroup": "Skills by Hugging Face Team",
+      "description": "Track ML experiments with real-time dashboards",
+      "sourceUrl": "https://officialskills.sh/huggingface/skills/hugging-face-trackio",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "huggingface"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-huggingface-hugging-face-vision-trainer",
+      "name": "huggingface/hugging-face-vision-trainer",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "huggingface",
+      "sourceGroup": "Skills by Hugging Face Team",
+      "description": "Train vision models on HF infrastructure",
+      "sourceUrl": "https://officialskills.sh/huggingface/skills/hugging-face-vision-trainer",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "huggingface"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-huggingface-huggingface-gradio",
+      "name": "huggingface/huggingface-gradio",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "huggingface",
+      "sourceGroup": "Skills by Hugging Face Team",
+      "description": "Build Gradio apps and deploy to HF Spaces",
+      "sourceUrl": "https://officialskills.sh/huggingface/skills/huggingface-gradio",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "huggingface"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-huggingface-transformers-js",
+      "name": "huggingface/transformers.js",
+      "kind": "skill",
+      "category": "数据与分析",
+      "publisher": "huggingface",
+      "sourceGroup": "Skills by Hugging Face Team",
+      "description": "Run ML models in the browser with Transformers.js",
+      "sourceUrl": "https://officialskills.sh/huggingface/skills/transformers.js",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "huggingface"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-trailofbits-ask-questions-if-underspecified",
+      "name": "trailofbits/ask-questions-if-underspecified",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "trailofbits",
+      "sourceGroup": "Security Skills by Trail of Bits Team",
+      "description": "Prompt for clarification on ambiguous requirements",
+      "sourceUrl": "https://officialskills.sh/trailofbits/skills/ask-questions-if-underspecified",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "trailofbits"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-trailofbits-audit-context-building",
+      "name": "trailofbits/audit-context-building",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "trailofbits",
+      "sourceGroup": "Security Skills by Trail of Bits Team",
+      "description": "Deep architectural context via ultra-granular code analysis",
+      "sourceUrl": "https://officialskills.sh/trailofbits/skills/audit-context-building",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "trailofbits"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-trailofbits-building-secure-contracts",
+      "name": "trailofbits/building-secure-contracts",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "trailofbits",
+      "sourceGroup": "Security Skills by Trail of Bits Team",
+      "description": "Smart contract security toolkit with vulnerability scanners for 6 blockchains",
+      "sourceUrl": "https://officialskills.sh/trailofbits/skills/building-secure-contracts",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "trailofbits"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-trailofbits-burpsuite-project-parser",
+      "name": "trailofbits/burpsuite-project-parser",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "trailofbits",
+      "sourceGroup": "Security Skills by Trail of Bits Team",
+      "description": "Search and extract data from Burp Suite project files",
+      "sourceUrl": "https://officialskills.sh/trailofbits/skills/burpsuite-project-parser",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "trailofbits"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-trailofbits-claude-in-chrome-troubleshooting",
+      "name": "trailofbits/claude-in-chrome-troubleshooting",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "trailofbits",
+      "sourceGroup": "Security Skills by Trail of Bits Team",
+      "description": "Diagnose and fix Claude in Chrome MCP extension connectivity issues",
+      "sourceUrl": "https://officialskills.sh/trailofbits/skills/claude-in-chrome-troubleshooting",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "trailofbits"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-trailofbits-constant-time-analysis",
+      "name": "trailofbits/constant-time-analysis",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "trailofbits",
+      "sourceGroup": "Security Skills by Trail of Bits Team",
+      "description": "Detect compiler-induced timing side-channels in crypto code",
+      "sourceUrl": "https://officialskills.sh/trailofbits/skills/constant-time-analysis",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "trailofbits"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-trailofbits-culture-index",
+      "name": "trailofbits/culture-index",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "trailofbits",
+      "sourceGroup": "Security Skills by Trail of Bits Team",
+      "description": "Index and search culture documentation",
+      "sourceUrl": "https://officialskills.sh/trailofbits/skills/culture-index",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "trailofbits"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-trailofbits-differential-review",
+      "name": "trailofbits/differential-review",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "trailofbits",
+      "sourceGroup": "Security Skills by Trail of Bits Team",
+      "description": "Security-focused diff review with git history analysis",
+      "sourceUrl": "https://officialskills.sh/trailofbits/skills/differential-review",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "trailofbits"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-trailofbits-dwarf-expert",
+      "name": "trailofbits/dwarf-expert",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "trailofbits",
+      "sourceGroup": "Security Skills by Trail of Bits Team",
+      "description": "DWARF debugging format expertise",
+      "sourceUrl": "https://officialskills.sh/trailofbits/skills/dwarf-expert",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "trailofbits"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-trailofbits-entry-point-analyzer",
+      "name": "trailofbits/entry-point-analyzer",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "trailofbits",
+      "sourceGroup": "Security Skills by Trail of Bits Team",
+      "description": "Identify state-changing entry points in smart contracts",
+      "sourceUrl": "https://officialskills.sh/trailofbits/skills/entry-point-analyzer",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "trailofbits"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-trailofbits-firebase-apk-scanner",
+      "name": "trailofbits/firebase-apk-scanner",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "trailofbits",
+      "sourceGroup": "Security Skills by Trail of Bits Team",
+      "description": "Scan Android APKs for Firebase misconfigurations and security vulnerabilities",
+      "sourceUrl": "https://officialskills.sh/trailofbits/skills/firebase-apk-scanner",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "trailofbits"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-trailofbits-insecure-defaults",
+      "name": "trailofbits/insecure-defaults",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "trailofbits",
+      "sourceGroup": "Security Skills by Trail of Bits Team",
+      "description": "Detect insecure default configurations like hardcoded secrets, default credentials, and weak crypto",
+      "sourceUrl": "https://officialskills.sh/trailofbits/skills/insecure-defaults",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "trailofbits"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-trailofbits-modern-python",
+      "name": "trailofbits/modern-python",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "trailofbits",
+      "sourceGroup": "Security Skills by Trail of Bits Team",
+      "description": "Modern Python tooling with uv, ruff, ty, and pytest best practices",
+      "sourceUrl": "https://officialskills.sh/trailofbits/skills/modern-python",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "trailofbits"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-trailofbits-property-based-testing",
+      "name": "trailofbits/property-based-testing",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "trailofbits",
+      "sourceGroup": "Security Skills by Trail of Bits Team",
+      "description": "Property-based testing for multiple languages and smart contracts",
+      "sourceUrl": "https://officialskills.sh/trailofbits/skills/property-based-testing",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "trailofbits"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-trailofbits-semgrep-rule-creator",
+      "name": "trailofbits/semgrep-rule-creator",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "trailofbits",
+      "sourceGroup": "Security Skills by Trail of Bits Team",
+      "description": "Create and refine Semgrep rules for vulnerability detection",
+      "sourceUrl": "https://officialskills.sh/trailofbits/skills/semgrep-rule-creator",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "trailofbits"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-trailofbits-semgrep-rule-variant-creator",
+      "name": "trailofbits/semgrep-rule-variant-creator",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "trailofbits",
+      "sourceGroup": "Security Skills by Trail of Bits Team",
+      "description": "Port existing Semgrep rules to new target languages with test-driven validation",
+      "sourceUrl": "https://officialskills.sh/trailofbits/skills/semgrep-rule-variant-creator",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "trailofbits"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-trailofbits-sharp-edges",
+      "name": "trailofbits/sharp-edges",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "trailofbits",
+      "sourceGroup": "Security Skills by Trail of Bits Team",
+      "description": "Identify error-prone APIs and dangerous configurations",
+      "sourceUrl": "https://officialskills.sh/trailofbits/skills/sharp-edges",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "trailofbits"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-trailofbits-spec-to-code-compliance",
+      "name": "trailofbits/spec-to-code-compliance",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "trailofbits",
+      "sourceGroup": "Security Skills by Trail of Bits Team",
+      "description": "Specification-to-code compliance checker for blockchain audits",
+      "sourceUrl": "https://officialskills.sh/trailofbits/skills/spec-to-code-compliance",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "trailofbits"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-trailofbits-static-analysis",
+      "name": "trailofbits/static-analysis",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "trailofbits",
+      "sourceGroup": "Security Skills by Trail of Bits Team",
+      "description": "Static analysis toolkit with CodeQL, Semgrep, and SARIF",
+      "sourceUrl": "https://officialskills.sh/trailofbits/skills/static-analysis",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "trailofbits"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-trailofbits-testing-handbook-skills",
+      "name": "trailofbits/testing-handbook-skills",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "trailofbits",
+      "sourceGroup": "Security Skills by Trail of Bits Team",
+      "description": "Testing Handbook skills: fuzzers, static analysis, sanitizers",
+      "sourceUrl": "https://officialskills.sh/trailofbits/skills/testing-handbook-skills",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "trailofbits"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-trailofbits-variant-analysis",
+      "name": "trailofbits/variant-analysis",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "trailofbits",
+      "sourceGroup": "Security Skills by Trail of Bits Team",
+      "description": "Find similar vulnerabilities via pattern-based analysis",
+      "sourceUrl": "https://officialskills.sh/trailofbits/skills/variant-analysis",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "trailofbits"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-getsentry-sentry-sdk-setup",
+      "name": "getsentry/sentry-sdk-setup",
+      "kind": "skill",
+      "category": "工程开发",
+      "publisher": "getsentry",
+      "sourceGroup": "Skills by Sentry team for their dev team",
+      "description": "Set up Sentry in any language or framework — detects platform and routes to the right SDK",
+      "sourceUrl": "https://officialskills.sh/getsentry/skills/sentry-sdk-setup",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "getsentry"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-getsentry-sentry-workflow",
+      "name": "getsentry/sentry-workflow",
+      "kind": "skill",
+      "category": "工程开发",
+      "publisher": "getsentry",
+      "sourceGroup": "Skills by Sentry team for their dev team",
+      "description": "End-to-end Sentry workflow: fix production issues and review code with Sentry context",
+      "sourceUrl": "https://officialskills.sh/getsentry/skills/sentry-workflow",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "getsentry"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-getsentry-sentry-fix-issues",
+      "name": "getsentry/sentry-fix-issues",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "getsentry",
+      "sourceGroup": "Skills by Sentry team for their dev team",
+      "description": "Find and fix Sentry issues with stack trace, breadcrumb, and trace context via MCP",
+      "sourceUrl": "https://officialskills.sh/getsentry/skills/sentry-fix-issues",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "getsentry"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-getsentry-sentry-code-review",
+      "name": "getsentry/sentry-code-review",
+      "kind": "skill",
+      "category": "工程开发",
+      "publisher": "getsentry",
+      "sourceGroup": "Skills by Sentry team for their dev team",
+      "description": "Review code changes using Sentry issue and trace context",
+      "sourceUrl": "https://officialskills.sh/getsentry/skills/sentry-code-review",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "getsentry"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-getsentry-sentry-pr-code-review",
+      "name": "getsentry/sentry-pr-code-review",
+      "kind": "skill",
+      "category": "工程开发",
+      "publisher": "getsentry",
+      "sourceGroup": "Skills by Sentry team for their dev team",
+      "description": "Review PR comments from Seer Bug Prediction and Sentry feedback",
+      "sourceUrl": "https://officialskills.sh/getsentry/skills/sentry-pr-code-review",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "getsentry"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-getsentry-sentry-create-alert",
+      "name": "getsentry/sentry-create-alert",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "getsentry",
+      "sourceGroup": "Skills by Sentry team for their dev team",
+      "description": "Create Sentry alerts with email, Slack, PagerDuty, Discord, and more",
+      "sourceUrl": "https://officialskills.sh/getsentry/skills/sentry-create-alert",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "getsentry"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-getsentry-sentry-feature-setup",
+      "name": "getsentry/sentry-feature-setup",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "getsentry",
+      "sourceGroup": "Skills by Sentry team for their dev team",
+      "description": "Configure advanced Sentry features: AI monitoring, OTel pipelines, and alerts",
+      "sourceUrl": "https://officialskills.sh/getsentry/skills/sentry-feature-setup",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "getsentry"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-getsentry-sentry-otel-exporter-setup",
+      "name": "getsentry/sentry-otel-exporter-setup",
+      "kind": "skill",
+      "category": "其他工具",
+      "publisher": "getsentry",
+      "sourceGroup": "Skills by Sentry team for their dev team",
+      "description": "Configure the OpenTelemetry Collector with Sentry Exporter",
+      "sourceUrl": "https://officialskills.sh/getsentry/skills/sentry-otel-exporter-setup",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "getsentry"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-getsentry-sentry-setup-ai-monitoring",
+      "name": "getsentry/sentry-setup-ai-monitoring",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "getsentry",
+      "sourceGroup": "Skills by Sentry team for their dev team",
+      "description": "Instrument OpenAI, Anthropic, Vercel AI, LangChain, Google GenAI, and Pydantic AI",
+      "sourceUrl": "https://officialskills.sh/getsentry/skills/sentry-setup-ai-monitoring",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "getsentry"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-getsentry-sentry-sdk-upgrade",
+      "name": "getsentry/sentry-sdk-upgrade",
+      "kind": "skill",
+      "category": "工程开发",
+      "publisher": "getsentry",
+      "sourceGroup": "Skills by Sentry team for their dev team",
+      "description": "Upgrade the Sentry JavaScript SDK across major versions",
+      "sourceUrl": "https://officialskills.sh/getsentry/skills/sentry-sdk-upgrade",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "getsentry"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-getsentry-sentry-sdk-skill-creator",
+      "name": "getsentry/sentry-sdk-skill-creator",
+      "kind": "skill",
+      "category": "工程开发",
+      "publisher": "getsentry",
+      "sourceGroup": "Skills by Sentry team for their dev team",
+      "description": "Create a new Sentry SDK skill bundle for a platform",
+      "sourceUrl": "https://officialskills.sh/getsentry/skills/sentry-sdk-skill-creator",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "getsentry"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-getsentry-sentry-android-sdk",
+      "name": "getsentry/sentry-android-sdk",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "getsentry",
+      "sourceGroup": "Skills by Sentry team for their dev team",
+      "description": "Full Sentry SDK setup for Android (Kotlin and Java)",
+      "sourceUrl": "https://officialskills.sh/getsentry/skills/sentry-android-sdk",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "getsentry"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-getsentry-sentry-browser-sdk",
+      "name": "getsentry/sentry-browser-sdk",
+      "kind": "skill",
+      "category": "工程开发",
+      "publisher": "getsentry",
+      "sourceGroup": "Skills by Sentry team for their dev team",
+      "description": "Full Sentry SDK setup for browser JavaScript",
+      "sourceUrl": "https://officialskills.sh/getsentry/skills/sentry-browser-sdk",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "getsentry"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-getsentry-sentry-cloudflare-sdk",
+      "name": "getsentry/sentry-cloudflare-sdk",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "getsentry",
+      "sourceGroup": "Skills by Sentry team for their dev team",
+      "description": "Full Sentry SDK setup for Cloudflare Workers, Pages, Durable Objects, Queues, and Workflows",
+      "sourceUrl": "https://officialskills.sh/getsentry/skills/sentry-cloudflare-sdk",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "getsentry"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-getsentry-sentry-cocoa-sdk",
+      "name": "getsentry/sentry-cocoa-sdk",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "getsentry",
+      "sourceGroup": "Skills by Sentry team for their dev team",
+      "description": "Full Sentry SDK setup for Apple platforms (iOS, macOS, tvOS, watchOS, visionOS)",
+      "sourceUrl": "https://officialskills.sh/getsentry/skills/sentry-cocoa-sdk",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "getsentry"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-getsentry-sentry-dotnet-sdk",
+      "name": "getsentry/sentry-dotnet-sdk",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "getsentry",
+      "sourceGroup": "Skills by Sentry team for their dev team",
+      "description": "Full Sentry SDK setup for .NET (ASP.NET Core, MAUI, WPF, WinForms, Blazor, Azure Functions)",
+      "sourceUrl": "https://officialskills.sh/getsentry/skills/sentry-dotnet-sdk",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "getsentry"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-getsentry-sentry-elixir-sdk",
+      "name": "getsentry/sentry-elixir-sdk",
+      "kind": "skill",
+      "category": "工程开发",
+      "publisher": "getsentry",
+      "sourceGroup": "Skills by Sentry team for their dev team",
+      "description": "Full Sentry SDK setup for Elixir, Phoenix, Plug, LiveView, Oban, and Quantum",
+      "sourceUrl": "https://officialskills.sh/getsentry/skills/sentry-elixir-sdk",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "getsentry"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-getsentry-sentry-flutter-sdk",
+      "name": "getsentry/sentry-flutter-sdk",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "getsentry",
+      "sourceGroup": "Skills by Sentry team for their dev team",
+      "description": "Full Sentry SDK setup for Flutter and Dart across all platforms",
+      "sourceUrl": "https://officialskills.sh/getsentry/skills/sentry-flutter-sdk",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "getsentry"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-getsentry-sentry-go-sdk",
+      "name": "getsentry/sentry-go-sdk",
+      "kind": "skill",
+      "category": "工程开发",
+      "publisher": "getsentry",
+      "sourceGroup": "Skills by Sentry team for their dev team",
+      "description": "Full Sentry SDK setup for Go (net/http, Gin, Echo, Fiber, FastHTTP, Iris, Negroni)",
+      "sourceUrl": "https://officialskills.sh/getsentry/skills/sentry-go-sdk",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "getsentry"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-getsentry-sentry-nestjs-sdk",
+      "name": "getsentry/sentry-nestjs-sdk",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "getsentry",
+      "sourceGroup": "Skills by Sentry team for their dev team",
+      "description": "Full Sentry SDK setup for NestJS with Express or Fastify, GraphQL, microservices",
+      "sourceUrl": "https://officialskills.sh/getsentry/skills/sentry-nestjs-sdk",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "getsentry"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-getsentry-sentry-nextjs-sdk",
+      "name": "getsentry/sentry-nextjs-sdk",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "getsentry",
+      "sourceGroup": "Skills by Sentry team for their dev team",
+      "description": "Full Sentry SDK setup for Next.js 13+ (App Router and Pages Router)",
+      "sourceUrl": "https://officialskills.sh/getsentry/skills/sentry-nextjs-sdk",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "getsentry"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-getsentry-sentry-node-sdk",
+      "name": "getsentry/sentry-node-sdk",
+      "kind": "skill",
+      "category": "工程开发",
+      "publisher": "getsentry",
+      "sourceGroup": "Skills by Sentry team for their dev team",
+      "description": "Full Sentry SDK setup for Node.js, Bun, and Deno",
+      "sourceUrl": "https://officialskills.sh/getsentry/skills/sentry-node-sdk",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "getsentry"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-getsentry-sentry-php-sdk",
+      "name": "getsentry/sentry-php-sdk",
+      "kind": "skill",
+      "category": "工程开发",
+      "publisher": "getsentry",
+      "sourceGroup": "Skills by Sentry team for their dev team",
+      "description": "Full Sentry SDK setup for PHP, Laravel, and Symfony",
+      "sourceUrl": "https://officialskills.sh/getsentry/skills/sentry-php-sdk",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "getsentry"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-getsentry-sentry-python-sdk",
+      "name": "getsentry/sentry-python-sdk",
+      "kind": "skill",
+      "category": "工程开发",
+      "publisher": "getsentry",
+      "sourceGroup": "Skills by Sentry team for their dev team",
+      "description": "Full Sentry SDK setup for Python (Django, Flask, FastAPI, Celery, Starlette, AIOHTTP, Tornado)",
+      "sourceUrl": "https://officialskills.sh/getsentry/skills/sentry-python-sdk",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "getsentry"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-getsentry-sentry-react-native-sdk",
+      "name": "getsentry/sentry-react-native-sdk",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "getsentry",
+      "sourceGroup": "Skills by Sentry team for their dev team",
+      "description": "Full Sentry SDK setup for React Native and Expo",
+      "sourceUrl": "https://officialskills.sh/getsentry/skills/sentry-react-native-sdk",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "getsentry"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-getsentry-sentry-react-sdk",
+      "name": "getsentry/sentry-react-sdk",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "getsentry",
+      "sourceGroup": "Skills by Sentry team for their dev team",
+      "description": "Full Sentry SDK setup for React (React Router v5-v7, TanStack Router, Redux, Vite, webpack)",
+      "sourceUrl": "https://officialskills.sh/getsentry/skills/sentry-react-sdk",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "getsentry"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-getsentry-sentry-ruby-sdk",
+      "name": "getsentry/sentry-ruby-sdk",
+      "kind": "skill",
+      "category": "工程开发",
+      "publisher": "getsentry",
+      "sourceGroup": "Skills by Sentry team for their dev team",
+      "description": "Full Sentry SDK setup for Ruby (Rails, Sinatra, Rack, Sidekiq, Resque)",
+      "sourceUrl": "https://officialskills.sh/getsentry/skills/sentry-ruby-sdk",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "getsentry"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-getsentry-sentry-svelte-sdk",
+      "name": "getsentry/sentry-svelte-sdk",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "getsentry",
+      "sourceGroup": "Skills by Sentry team for their dev team",
+      "description": "Full Sentry SDK setup for Svelte and SvelteKit",
+      "sourceUrl": "https://officialskills.sh/getsentry/skills/sentry-svelte-sdk",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "getsentry"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-cloud-solution-architect",
+      "name": "microsoft/cloud-solution-architect",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Design well-architected Azure cloud systems",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/cloud-solution-architect",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-continual-learning",
+      "name": "microsoft/continual-learning",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Continual learning patterns for Azure AI",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/continual-learning",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-copilot-sdk",
+      "name": "microsoft/copilot-sdk",
+      "kind": "skill",
+      "category": "工程开发",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Build applications powered by GitHub Copilot SDK",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/copilot-sdk",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-entra-agent-id",
+      "name": "microsoft/entra-agent-id",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Microsoft Entra Agent ID OAuth2 identities via Graph API",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/entra-agent-id",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-frontend-design-review",
+      "name": "microsoft/frontend-design-review",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Review and create distinctive frontend interfaces",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/frontend-design-review",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-github-issue-creator",
+      "name": "microsoft/github-issue-creator",
+      "kind": "skill",
+      "category": "工程开发",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Structured GitHub issue reports from notes",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/github-issue-creator",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-mcp-builder",
+      "name": "microsoft/mcp-builder",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "MCP server creation guide for LLM tool integration",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/mcp-builder",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-podcast-generation",
+      "name": "microsoft/podcast-generation",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "AI podcast audio with Azure OpenAI Realtime API",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/podcast-generation",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-skill-creator",
+      "name": "microsoft/skill-creator",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Guide for creating effective skills for AI coding agents",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/skill-creator",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-ai-document-intelligence-dotnet",
+      "name": "microsoft/azure-ai-document-intelligence-dotnet",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Document text, table, and data extraction",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-ai-document-intelligence-dotnet",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-ai-openai-dotnet",
+      "name": "microsoft/azure-ai-openai-dotnet",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "GPT-4, embeddings, DALL-E, and Whisper client",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-ai-openai-dotnet",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-ai-projects-dotnet",
+      "name": "microsoft/azure-ai-projects-dotnet",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "AI Foundry project management SDK",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-ai-projects-dotnet",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-ai-voicelive-dotnet",
+      "name": "microsoft/azure-ai-voicelive-dotnet",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Real-time bidirectional voice AI",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-ai-voicelive-dotnet",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-eventgrid-dotnet",
+      "name": "microsoft/azure-eventgrid-dotnet",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Event Grid topic and domain publishing",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-eventgrid-dotnet",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-eventhub-dotnet",
+      "name": "microsoft/azure-eventhub-dotnet",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "High-throughput event streaming",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-eventhub-dotnet",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-identity-dotnet",
+      "name": "microsoft/azure-identity-dotnet",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Microsoft Entra ID authentication",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-identity-dotnet",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-maps-search-dotnet",
+      "name": "microsoft/azure-maps-search-dotnet",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Geocoding, routing, and weather services",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-maps-search-dotnet",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-mgmt-apicenter-dotnet",
+      "name": "microsoft/azure-mgmt-apicenter-dotnet",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "API inventory and governance",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-mgmt-apicenter-dotnet",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-mgmt-apimanagement-dotnet",
+      "name": "microsoft/azure-mgmt-apimanagement-dotnet",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "API Management provisioning via ARM",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-mgmt-apimanagement-dotnet",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-mgmt-applicationinsights-dotnet",
+      "name": "microsoft/azure-mgmt-applicationinsights-dotnet",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Application Insights resource management",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-mgmt-applicationinsights-dotnet",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-mgmt-arizeaiobservabilityeval-dotnet",
+      "name": "microsoft/azure-mgmt-arizeaiobservabilityeval-dotnet",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Arize AI observability management",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-mgmt-arizeaiobservabilityeval-dotnet",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-mgmt-botservice-dotnet",
+      "name": "microsoft/azure-mgmt-botservice-dotnet",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Bot Service provisioning via ARM",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-mgmt-botservice-dotnet",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-mgmt-fabric-dotnet",
+      "name": "microsoft/azure-mgmt-fabric-dotnet",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Microsoft Fabric capacity management",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-mgmt-fabric-dotnet",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-mgmt-mongodbatlas-dotnet",
+      "name": "microsoft/azure-mgmt-mongodbatlas-dotnet",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "MongoDB Atlas as ARM resources",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-mgmt-mongodbatlas-dotnet",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-mgmt-weightsandbiases-dotnet",
+      "name": "microsoft/azure-mgmt-weightsandbiases-dotnet",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Weights & Biases deployment management",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-mgmt-weightsandbiases-dotnet",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-resource-manager-cosmosdb-dotnet",
+      "name": "microsoft/azure-resource-manager-cosmosdb-dotnet",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Cosmos DB resource provisioning",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-resource-manager-cosmosdb-dotnet",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-resource-manager-durabletask-dotnet",
+      "name": "microsoft/azure-resource-manager-durabletask-dotnet",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Durable Task Scheduler management",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-resource-manager-durabletask-dotnet",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-resource-manager-mysql-dotnet",
+      "name": "microsoft/azure-resource-manager-mysql-dotnet",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "MySQL Flexible Server management",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-resource-manager-mysql-dotnet",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-resource-manager-playwright-dotnet",
+      "name": "microsoft/azure-resource-manager-playwright-dotnet",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Playwright Testing workspace management",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-resource-manager-playwright-dotnet",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-resource-manager-postgresql-dotnet",
+      "name": "microsoft/azure-resource-manager-postgresql-dotnet",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "PostgreSQL Flexible Server management",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-resource-manager-postgresql-dotnet",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-resource-manager-redis-dotnet",
+      "name": "microsoft/azure-resource-manager-redis-dotnet",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Azure Cache for Redis provisioning",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-resource-manager-redis-dotnet",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-resource-manager-sql-dotnet",
+      "name": "microsoft/azure-resource-manager-sql-dotnet",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Azure SQL resource management",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-resource-manager-sql-dotnet",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-search-documents-dotnet",
+      "name": "microsoft/azure-search-documents-dotnet",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Full-text, vector, and hybrid search",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-search-documents-dotnet",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-security-keyvault-keys-dotnet",
+      "name": "microsoft/azure-security-keyvault-keys-dotnet",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Cryptographic key management",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-security-keyvault-keys-dotnet",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-servicebus-dotnet",
+      "name": "microsoft/azure-servicebus-dotnet",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Enterprise messaging with queues and topics",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-servicebus-dotnet",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-m365-agents-dotnet",
+      "name": "microsoft/m365-agents-dotnet",
+      "kind": "skill",
+      "category": "其他工具",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "M365, Teams, and Copilot Studio agents",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/m365-agents-dotnet",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-microsoft-azure-webjobs-extensions-authentication-events-dotnet",
+      "name": "microsoft/microsoft-azure-webjobs-extensions-authentication-events-dotnet",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Entra ID custom auth events handler",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/microsoft-azure-webjobs-extensions-authentication-events-dotnet",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-ai-anomalydetector-java",
+      "name": "microsoft/azure-ai-anomalydetector-java",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Anomaly detection applications",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-ai-anomalydetector-java",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-ai-contentsafety-java",
+      "name": "microsoft/azure-ai-contentsafety-java",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Content moderation and safety",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-ai-contentsafety-java",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-ai-formrecognizer-java",
+      "name": "microsoft/azure-ai-formrecognizer-java",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Document analysis and form extraction",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-ai-formrecognizer-java",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-ai-projects-java",
+      "name": "microsoft/azure-ai-projects-java",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "AI Foundry project management",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-ai-projects-java",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-ai-vision-imageanalysis-java",
+      "name": "microsoft/azure-ai-vision-imageanalysis-java",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Image captioning, OCR, and object detection",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-ai-vision-imageanalysis-java",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-ai-voicelive-java",
+      "name": "microsoft/azure-ai-voicelive-java",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Real-time bidirectional voice AI",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-ai-voicelive-java",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-appconfiguration-java",
+      "name": "microsoft/azure-appconfiguration-java",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Centralized app configuration management",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-appconfiguration-java",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-communication-callautomation-java",
+      "name": "microsoft/azure-communication-callautomation-java",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Call automation with IVR and AI",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-communication-callautomation-java",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-communication-callingserver-java",
+      "name": "microsoft/azure-communication-callingserver-java",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "CallingServer legacy SDK",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-communication-callingserver-java",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-communication-chat-java",
+      "name": "microsoft/azure-communication-chat-java",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Real-time chat with threads and receipts",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-communication-chat-java",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-communication-common-java",
+      "name": "microsoft/azure-communication-common-java",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Communication Services common utilities",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-communication-common-java",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-communication-sms-java",
+      "name": "microsoft/azure-communication-sms-java",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "SMS sending and delivery reports",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-communication-sms-java",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-compute-batch-java",
+      "name": "microsoft/azure-compute-batch-java",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Large-scale parallel and HPC batch jobs",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-compute-batch-java",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-cosmos-java",
+      "name": "microsoft/azure-cosmos-java",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Cosmos DB NoSQL with global distribution",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-cosmos-java",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-data-tables-java",
+      "name": "microsoft/azure-data-tables-java",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "NoSQL key-value table storage",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-data-tables-java",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-eventgrid-java",
+      "name": "microsoft/azure-eventgrid-java",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Event-driven pub/sub messaging",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-eventgrid-java",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-eventhub-java",
+      "name": "microsoft/azure-eventhub-java",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Real-time high-throughput streaming",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-eventhub-java",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-identity-java",
+      "name": "microsoft/azure-identity-java",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Microsoft Entra ID authentication",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-identity-java",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-messaging-webpubsub-java",
+      "name": "microsoft/azure-messaging-webpubsub-java",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Real-time WebSocket messaging",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-messaging-webpubsub-java",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-monitor-ingestion-java",
+      "name": "microsoft/azure-monitor-ingestion-java",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Custom log ingestion to Azure Monitor",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-monitor-ingestion-java",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-monitor-opentelemetry-exporter-java",
+      "name": "microsoft/azure-monitor-opentelemetry-exporter-java",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "OpenTelemetry export to Azure Monitor",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-monitor-opentelemetry-exporter-java",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-monitor-query-java",
+      "name": "microsoft/azure-monitor-query-java",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Query Azure Monitor logs and metrics",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-monitor-query-java",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-security-keyvault-keys-java",
+      "name": "microsoft/azure-security-keyvault-keys-java",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Cryptographic key management",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-security-keyvault-keys-java",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-security-keyvault-secrets-java",
+      "name": "microsoft/azure-security-keyvault-secrets-java",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Secret management for passwords and keys",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-security-keyvault-secrets-java",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-storage-blob-java",
+      "name": "microsoft/azure-storage-blob-java",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Blob storage for file management",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-storage-blob-java",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-agent-framework-azure-ai-py",
+      "name": "microsoft/agent-framework-azure-ai-py",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Agent Framework for Azure AI Foundry",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/agent-framework-azure-ai-py",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-agents-v2-py",
+      "name": "microsoft/agents-v2-py",
+      "kind": "skill",
+      "category": "工程开发",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Foundry Agents SDK — container-based agents with custom images",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/agents-v2-py",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-ai-contentsafety-py",
+      "name": "microsoft/azure-ai-contentsafety-py",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Harmful content detection",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-ai-contentsafety-py",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-ai-contentunderstanding-py",
+      "name": "microsoft/azure-ai-contentunderstanding-py",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Multimodal content extraction",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-ai-contentunderstanding-py",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-ai-ml-py",
+      "name": "microsoft/azure-ai-ml-py",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Azure ML workspace and job management",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-ai-ml-py",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-ai-projects-py",
+      "name": "microsoft/azure-ai-projects-py",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "AI Foundry project client and agents",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-ai-projects-py",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-ai-textanalytics-py",
+      "name": "microsoft/azure-ai-textanalytics-py",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "NLP: sentiment, entities, key phrases",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-ai-textanalytics-py",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-ai-transcription-py",
+      "name": "microsoft/azure-ai-transcription-py",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Speech-to-text transcription",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-ai-transcription-py",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-ai-translation-document-py",
+      "name": "microsoft/azure-ai-translation-document-py",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Batch document translation",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-ai-translation-document-py",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-ai-translation-text-py",
+      "name": "microsoft/azure-ai-translation-text-py",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Real-time text translation",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-ai-translation-text-py",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-ai-vision-imageanalysis-py",
+      "name": "microsoft/azure-ai-vision-imageanalysis-py",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Image captions, tags, OCR, objects",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-ai-vision-imageanalysis-py",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-ai-voicelive-py",
+      "name": "microsoft/azure-ai-voicelive-py",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Real-time bidirectional voice AI",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-ai-voicelive-py",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-appconfiguration-py",
+      "name": "microsoft/azure-appconfiguration-py",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Feature flags and dynamic settings",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-appconfiguration-py",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-containerregistry-py",
+      "name": "microsoft/azure-containerregistry-py",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Container image and registry management",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-containerregistry-py",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-cosmos-db-py",
+      "name": "microsoft/azure-cosmos-db-py",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Cosmos DB with Python/FastAPI patterns",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-cosmos-db-py",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-cosmos-py",
+      "name": "microsoft/azure-cosmos-py",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Cosmos DB NoSQL client library",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-cosmos-py",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-data-tables-py",
+      "name": "microsoft/azure-data-tables-py",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "NoSQL key-value table storage",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-data-tables-py",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-eventgrid-py",
+      "name": "microsoft/azure-eventgrid-py",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Event-driven pub/sub routing",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-eventgrid-py",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-eventhub-py",
+      "name": "microsoft/azure-eventhub-py",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "High-throughput event streaming",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-eventhub-py",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-identity-py",
+      "name": "microsoft/azure-identity-py",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Microsoft Entra ID authentication",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-identity-py",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-keyvault-py",
+      "name": "microsoft/azure-keyvault-py",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Secrets, keys, and certificate management",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-keyvault-py",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-messaging-webpubsubservice-py",
+      "name": "microsoft/azure-messaging-webpubsubservice-py",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Real-time WebSocket messaging",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-messaging-webpubsubservice-py",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-mgmt-apicenter-py",
+      "name": "microsoft/azure-mgmt-apicenter-py",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "API inventory and governance",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-mgmt-apicenter-py",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-mgmt-apimanagement-py",
+      "name": "microsoft/azure-mgmt-apimanagement-py",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "API Management service administration",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-mgmt-apimanagement-py",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-mgmt-botservice-py",
+      "name": "microsoft/azure-mgmt-botservice-py",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Bot Service resource management",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-mgmt-botservice-py",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-mgmt-fabric-py",
+      "name": "microsoft/azure-mgmt-fabric-py",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Microsoft Fabric capacity management",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-mgmt-fabric-py",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-monitor-ingestion-py",
+      "name": "microsoft/azure-monitor-ingestion-py",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Custom log ingestion to Azure Monitor",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-monitor-ingestion-py",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-monitor-opentelemetry-exporter-py",
+      "name": "microsoft/azure-monitor-opentelemetry-exporter-py",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "OpenTelemetry export to Application Insights",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-monitor-opentelemetry-exporter-py",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-monitor-opentelemetry-py",
+      "name": "microsoft/azure-monitor-opentelemetry-py",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "One-line Application Insights setup",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-monitor-opentelemetry-py",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-monitor-query-py",
+      "name": "microsoft/azure-monitor-query-py",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Query Azure Monitor logs and metrics",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-monitor-query-py",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-search-documents-py",
+      "name": "microsoft/azure-search-documents-py",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Full-text, vector, and hybrid search",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-search-documents-py",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-servicebus-py",
+      "name": "microsoft/azure-servicebus-py",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Enterprise messaging with queues and topics",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-servicebus-py",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-speech-to-text-rest-py",
+      "name": "microsoft/azure-speech-to-text-rest-py",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "REST speech-to-text for short audio",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-speech-to-text-rest-py",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-storage-blob-py",
+      "name": "microsoft/azure-storage-blob-py",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Blob object storage client",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-storage-blob-py",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-storage-file-datalake-py",
+      "name": "microsoft/azure-storage-file-datalake-py",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Hierarchical data lake storage",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-storage-file-datalake-py",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-storage-file-share-py",
+      "name": "microsoft/azure-storage-file-share-py",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "SMB file share management",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-storage-file-share-py",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-storage-queue-py",
+      "name": "microsoft/azure-storage-queue-py",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Simple message queuing",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-storage-queue-py",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-fastapi-router-py",
+      "name": "microsoft/fastapi-router-py",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "FastAPI routers with CRUD and auth",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/fastapi-router-py",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-m365-agents-py",
+      "name": "microsoft/m365-agents-py",
+      "kind": "skill",
+      "category": "其他工具",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "M365, Teams, and Copilot Studio agents",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/m365-agents-py",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-pydantic-models-py",
+      "name": "microsoft/pydantic-models-py",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Pydantic models for API schemas",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/pydantic-models-py",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-cosmos-rust",
+      "name": "microsoft/azure-cosmos-rust",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Cosmos DB NoSQL client",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-cosmos-rust",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-eventhub-rust",
+      "name": "microsoft/azure-eventhub-rust",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Event Hubs streaming client",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-eventhub-rust",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-identity-rust",
+      "name": "microsoft/azure-identity-rust",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Microsoft Entra ID authentication",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-identity-rust",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-keyvault-certificates-rust",
+      "name": "microsoft/azure-keyvault-certificates-rust",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Key Vault certificate management",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-keyvault-certificates-rust",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-keyvault-keys-rust",
+      "name": "microsoft/azure-keyvault-keys-rust",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Key Vault cryptographic key management",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-keyvault-keys-rust",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-keyvault-secrets-rust",
+      "name": "microsoft/azure-keyvault-secrets-rust",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Key Vault secret storage",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-keyvault-secrets-rust",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-storage-blob-rust",
+      "name": "microsoft/azure-storage-blob-rust",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Blob object storage client",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-storage-blob-rust",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-ai-contentsafety-ts",
+      "name": "microsoft/azure-ai-contentsafety-ts",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Content safety for text and images",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-ai-contentsafety-ts",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-ai-document-intelligence-ts",
+      "name": "microsoft/azure-ai-document-intelligence-ts",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Document text and table extraction",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-ai-document-intelligence-ts",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-ai-projects-ts",
+      "name": "microsoft/azure-ai-projects-ts",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "AI Foundry project client and agents",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-ai-projects-ts",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-ai-translation-ts",
+      "name": "microsoft/azure-ai-translation-ts",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Text and document translation",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-ai-translation-ts",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-ai-voicelive-ts",
+      "name": "microsoft/azure-ai-voicelive-ts",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Real-time bidirectional voice AI",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-ai-voicelive-ts",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-appconfiguration-ts",
+      "name": "microsoft/azure-appconfiguration-ts",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "App config, feature flags, dynamic refresh",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-appconfiguration-ts",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-cosmos-ts",
+      "name": "microsoft/azure-cosmos-ts",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Cosmos DB NoSQL CRUD and queries",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-cosmos-ts",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-eventhub-ts",
+      "name": "microsoft/azure-eventhub-ts",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "High-throughput event streaming",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-eventhub-ts",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-identity-ts",
+      "name": "microsoft/azure-identity-ts",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Microsoft Entra ID authentication",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-identity-ts",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-keyvault-keys-ts",
+      "name": "microsoft/azure-keyvault-keys-ts",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Cryptographic key management",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-keyvault-keys-ts",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-keyvault-secrets-ts",
+      "name": "microsoft/azure-keyvault-secrets-ts",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Secret storage and retrieval",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-keyvault-secrets-ts",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-microsoft-playwright-testing-ts",
+      "name": "microsoft/azure-microsoft-playwright-testing-ts",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Playwright tests at scale on Azure",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-microsoft-playwright-testing-ts",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-monitor-opentelemetry-ts",
+      "name": "microsoft/azure-monitor-opentelemetry-ts",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Application Insights tracing and metrics",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-monitor-opentelemetry-ts",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-postgres-ts",
+      "name": "microsoft/azure-postgres-ts",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "PostgreSQL Flexible Server connection",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-postgres-ts",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-search-documents-ts",
+      "name": "microsoft/azure-search-documents-ts",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Vector/hybrid search with semantic ranking",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-search-documents-ts",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-servicebus-ts",
+      "name": "microsoft/azure-servicebus-ts",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Messaging with queues and topics",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-servicebus-ts",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-storage-blob-ts",
+      "name": "microsoft/azure-storage-blob-ts",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Blob upload, download, and management",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-storage-blob-ts",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-storage-file-share-ts",
+      "name": "microsoft/azure-storage-file-share-ts",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "SMB file share operations",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-storage-file-share-ts",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-storage-queue-ts",
+      "name": "microsoft/azure-storage-queue-ts",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Queue message operations",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-storage-queue-ts",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-azure-web-pubsub-ts",
+      "name": "microsoft/azure-web-pubsub-ts",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Real-time WebSocket pub/sub messaging",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/azure-web-pubsub-ts",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-frontend-ui-dark-ts",
+      "name": "microsoft/frontend-ui-dark-ts",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Dark-themed React with Tailwind and animations",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/frontend-ui-dark-ts",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-m365-agents-ts",
+      "name": "microsoft/m365-agents-ts",
+      "kind": "skill",
+      "category": "其他工具",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "M365, Teams, and Copilot Studio agents",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/m365-agents-ts",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-react-flow-node-ts",
+      "name": "microsoft/react-flow-node-ts",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "React Flow node components with Zustand",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/react-flow-node-ts",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-microsoft-zustand-store-ts",
+      "name": "microsoft/zustand-store-ts",
+      "kind": "skill",
+      "category": "其他工具",
+      "publisher": "microsoft",
+      "sourceGroup": "Skills by Microsoft",
+      "description": "Zustand stores with middleware patterns",
+      "sourceUrl": "https://officialskills.sh/microsoft/skills/zustand-store-ts",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "microsoft"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-fal-ai-community-fal-3d",
+      "name": "fal-ai-community/fal-3d",
+      "kind": "skill",
+      "category": "多媒体创作",
+      "publisher": "fal-ai-community",
+      "sourceGroup": "Skills by fal.ai Team",
+      "description": "Generate 3D models from text or images",
+      "sourceUrl": "https://officialskills.sh/fal-ai-community/skills/fal-3d",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "fal-ai-community"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-fal-ai-community-fal-audio",
+      "name": "fal-ai-community/fal-audio",
+      "kind": "skill",
+      "category": "多媒体创作",
+      "publisher": "fal-ai-community",
+      "sourceGroup": "Skills by fal.ai Team",
+      "description": "Text-to-speech and speech-to-text using fal.ai audio models",
+      "sourceUrl": "https://officialskills.sh/fal-ai-community/skills/fal-audio",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "fal-ai-community"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-fal-ai-community-fal-generate",
+      "name": "fal-ai-community/fal-generate",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "fal-ai-community",
+      "sourceGroup": "Skills by fal.ai Team",
+      "description": "Generate images and videos using fal.ai AI models",
+      "sourceUrl": "https://officialskills.sh/fal-ai-community/skills/fal-generate",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "fal-ai-community"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-fal-ai-community-fal-image-edit",
+      "name": "fal-ai-community/fal-image-edit",
+      "kind": "skill",
+      "category": "多媒体创作",
+      "publisher": "fal-ai-community",
+      "sourceGroup": "Skills by fal.ai Team",
+      "description": "AI-powered image editing with style transfer and object removal",
+      "sourceUrl": "https://officialskills.sh/fal-ai-community/skills/fal-image-edit",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "fal-ai-community"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-fal-ai-community-fal-kling-o3",
+      "name": "fal-ai-community/fal-kling-o3",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "fal-ai-community",
+      "sourceGroup": "Skills by fal.ai Team",
+      "description": "Generate images and videos with Kling O3 — Kling's most powerful model family",
+      "sourceUrl": "https://officialskills.sh/fal-ai-community/skills/fal-kling-o3",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "fal-ai-community"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-fal-ai-community-fal-lip-sync",
+      "name": "fal-ai-community/fal-lip-sync",
+      "kind": "skill",
+      "category": "多媒体创作",
+      "publisher": "fal-ai-community",
+      "sourceGroup": "Skills by fal.ai Team",
+      "description": "Create talking head videos and lip sync audio to video",
+      "sourceUrl": "https://officialskills.sh/fal-ai-community/skills/fal-lip-sync",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "fal-ai-community"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-fal-ai-community-fal-platform",
+      "name": "fal-ai-community/fal-platform",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "fal-ai-community",
+      "sourceGroup": "Skills by fal.ai Team",
+      "description": "Platform APIs for model management, pricing, and usage tracking",
+      "sourceUrl": "https://officialskills.sh/fal-ai-community/skills/fal-platform",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "fal-ai-community"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-fal-ai-community-fal-realtime",
+      "name": "fal-ai-community/fal-realtime",
+      "kind": "skill",
+      "category": "多媒体创作",
+      "publisher": "fal-ai-community",
+      "sourceGroup": "Skills by fal.ai Team",
+      "description": "Real-time and streaming AI image generation",
+      "sourceUrl": "https://officialskills.sh/fal-ai-community/skills/fal-realtime",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "fal-ai-community"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-fal-ai-community-fal-restore",
+      "name": "fal-ai-community/fal-restore",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "fal-ai-community",
+      "sourceGroup": "Skills by fal.ai Team",
+      "description": "Restore and fix image quality — deblur, denoise, fix faces, restore documents",
+      "sourceUrl": "https://officialskills.sh/fal-ai-community/skills/fal-restore",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "fal-ai-community"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-fal-ai-community-fal-train",
+      "name": "fal-ai-community/fal-train",
+      "kind": "skill",
+      "category": "多媒体创作",
+      "publisher": "fal-ai-community",
+      "sourceGroup": "Skills by fal.ai Team",
+      "description": "Train custom AI models (LoRA) on fal.ai for personalized image generation",
+      "sourceUrl": "https://officialskills.sh/fal-ai-community/skills/fal-train",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "fal-ai-community"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-fal-ai-community-fal-tryon",
+      "name": "fal-ai-community/fal-tryon",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "fal-ai-community",
+      "sourceGroup": "Skills by fal.ai Team",
+      "description": "Virtual try-on — see how clothes look on a person",
+      "sourceUrl": "https://officialskills.sh/fal-ai-community/skills/fal-tryon",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "fal-ai-community"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-fal-ai-community-fal-upscale",
+      "name": "fal-ai-community/fal-upscale",
+      "kind": "skill",
+      "category": "多媒体创作",
+      "publisher": "fal-ai-community",
+      "sourceGroup": "Skills by fal.ai Team",
+      "description": "Upscale and enhance image and video resolution using AI",
+      "sourceUrl": "https://officialskills.sh/fal-ai-community/skills/fal-upscale",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "fal-ai-community"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-fal-ai-community-fal-video-edit",
+      "name": "fal-ai-community/fal-video-edit",
+      "kind": "skill",
+      "category": "多媒体创作",
+      "publisher": "fal-ai-community",
+      "sourceGroup": "Skills by fal.ai Team",
+      "description": "Edit existing videos using AI — remix style, upscale, remove background, add audio",
+      "sourceUrl": "https://officialskills.sh/fal-ai-community/skills/fal-video-edit",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "fal-ai-community"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-fal-ai-community-fal-vision",
+      "name": "fal-ai-community/fal-vision",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "fal-ai-community",
+      "sourceGroup": "Skills by fal.ai Team",
+      "description": "Analyze images — segment objects, detect, OCR, describe, visual Q&A",
+      "sourceUrl": "https://officialskills.sh/fal-ai-community/skills/fal-vision",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "fal-ai-community"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-fal-ai-community-fal-workflow",
+      "name": "fal-ai-community/fal-workflow",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "fal-ai-community",
+      "sourceGroup": "Skills by fal.ai Team",
+      "description": "Generate workflow JSON files for chaining AI models",
+      "sourceUrl": "https://officialskills.sh/fal-ai-community/skills/fal-workflow",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "fal-ai-community"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-wordpress-wordpress-router",
+      "name": "WordPress/wordpress-router",
+      "kind": "skill",
+      "category": "工程开发",
+      "publisher": "WordPress",
+      "sourceGroup": "Skills by WordPress Development Team",
+      "description": "Classifies WordPress repos and routes to the right workflow",
+      "sourceUrl": "https://officialskills.sh/WordPress/skills/wordpress-router",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "WordPress"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-wordpress-wp-project-triage",
+      "name": "WordPress/wp-project-triage",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "WordPress",
+      "sourceGroup": "Skills by WordPress Development Team",
+      "description": "Detects project type, tooling, and versions automatically",
+      "sourceUrl": "https://officialskills.sh/WordPress/skills/wp-project-triage",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "WordPress"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-wordpress-wp-block-development",
+      "name": "WordPress/wp-block-development",
+      "kind": "skill",
+      "category": "工程开发",
+      "publisher": "WordPress",
+      "sourceGroup": "Skills by WordPress Development Team",
+      "description": "Gutenberg blocks: block.json, attributes, rendering, deprecations",
+      "sourceUrl": "https://officialskills.sh/WordPress/skills/wp-block-development",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "WordPress"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-wordpress-wp-block-themes",
+      "name": "WordPress/wp-block-themes",
+      "kind": "skill",
+      "category": "工程开发",
+      "publisher": "WordPress",
+      "sourceGroup": "Skills by WordPress Development Team",
+      "description": "Block themes: theme.json, templates, patterns, style variations",
+      "sourceUrl": "https://officialskills.sh/WordPress/skills/wp-block-themes",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "WordPress"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-wordpress-wp-plugin-development",
+      "name": "WordPress/wp-plugin-development",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "WordPress",
+      "sourceGroup": "Skills by WordPress Development Team",
+      "description": "Plugin architecture, hooks, settings API, security",
+      "sourceUrl": "https://officialskills.sh/WordPress/skills/wp-plugin-development",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "WordPress"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-wordpress-wp-rest-api",
+      "name": "WordPress/wp-rest-api",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "WordPress",
+      "sourceGroup": "Skills by WordPress Development Team",
+      "description": "REST API routes/endpoints, schema, auth, and response shaping",
+      "sourceUrl": "https://officialskills.sh/WordPress/skills/wp-rest-api",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "WordPress"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-wordpress-wp-interactivity-api",
+      "name": "WordPress/wp-interactivity-api",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "WordPress",
+      "sourceGroup": "Skills by WordPress Development Team",
+      "description": "Frontend interactivity with data-wp- directives and stores",
+      "sourceUrl": "https://officialskills.sh/WordPress/skills/wp-interactivity-api",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "WordPress"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-wordpress-wp-abilities-api",
+      "name": "WordPress/wp-abilities-api",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "WordPress",
+      "sourceGroup": "Skills by WordPress Development Team",
+      "description": "Capability-based permissions and REST API authentication",
+      "sourceUrl": "https://officialskills.sh/WordPress/skills/wp-abilities-api",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "WordPress"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-wordpress-wp-wpcli-and-ops",
+      "name": "WordPress/wp-wpcli-and-ops",
+      "kind": "skill",
+      "category": "工程开发",
+      "publisher": "WordPress",
+      "sourceGroup": "Skills by WordPress Development Team",
+      "description": "WP-CLI commands, automation, multisite, search-replace",
+      "sourceUrl": "https://officialskills.sh/WordPress/skills/wp-wpcli-and-ops",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "WordPress"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-wordpress-wp-performance",
+      "name": "WordPress/wp-performance",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "WordPress",
+      "sourceGroup": "Skills by WordPress Development Team",
+      "description": "Profiling, caching, database optimization, Server-Timing",
+      "sourceUrl": "https://officialskills.sh/WordPress/skills/wp-performance",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "WordPress"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-wordpress-wp-phpstan",
+      "name": "WordPress/wp-phpstan",
+      "kind": "skill",
+      "category": "数据与分析",
+      "publisher": "WordPress",
+      "sourceGroup": "Skills by WordPress Development Team",
+      "description": "PHPStan static analysis for WordPress projects",
+      "sourceUrl": "https://officialskills.sh/WordPress/skills/wp-phpstan",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "WordPress"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-wordpress-wp-playground",
+      "name": "WordPress/wp-playground",
+      "kind": "skill",
+      "category": "工程开发",
+      "publisher": "WordPress",
+      "sourceGroup": "Skills by WordPress Development Team",
+      "description": "WordPress Playground for instant local environments",
+      "sourceUrl": "https://officialskills.sh/WordPress/skills/wp-playground",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "WordPress"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-wordpress-wpds",
+      "name": "WordPress/wpds",
+      "kind": "skill",
+      "category": "多媒体创作",
+      "publisher": "WordPress",
+      "sourceGroup": "Skills by WordPress Development Team",
+      "description": "WordPress Design System",
+      "sourceUrl": "https://officialskills.sh/WordPress/skills/wpds",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "WordPress"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-openai-cloudflare-deploy",
+      "name": "openai/cloudflare-deploy",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "openai",
+      "sourceGroup": "Skills by OpenAI",
+      "description": "Deploy apps to Cloudflare using Workers, Pages, and platform services",
+      "sourceUrl": "https://officialskills.sh/openai/skills/cloudflare-deploy",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "openai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-openai-develop-web-game",
+      "name": "openai/develop-web-game",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "openai",
+      "sourceGroup": "Skills by OpenAI",
+      "description": "Build and test web games iteratively using Playwright with time-stepping",
+      "sourceUrl": "https://officialskills.sh/openai/skills/develop-web-game",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "openai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-openai-doc",
+      "name": "openai/doc",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "openai",
+      "sourceGroup": "Skills by OpenAI",
+      "description": "Read, create, and edit .docx documents with formatting and layout fidelity",
+      "sourceUrl": "https://officialskills.sh/openai/skills/doc",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "openai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-openai-gh-address-comments",
+      "name": "openai/gh-address-comments",
+      "kind": "skill",
+      "category": "工程开发",
+      "publisher": "openai",
+      "sourceGroup": "Skills by OpenAI",
+      "description": "Address review and issue comments on open GitHub PRs via CLI",
+      "sourceUrl": "https://officialskills.sh/openai/skills/gh-address-comments",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "openai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-openai-gh-fix-ci",
+      "name": "openai/gh-fix-ci",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "openai",
+      "sourceGroup": "Skills by OpenAI",
+      "description": "Debug and fix failing GitHub Actions PR checks using log inspection",
+      "sourceUrl": "https://officialskills.sh/openai/skills/gh-fix-ci",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "openai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-openai-imagegen",
+      "name": "openai/imagegen",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "openai",
+      "sourceGroup": "Skills by OpenAI",
+      "description": "Generate and edit images using OpenAI's Image API for projects",
+      "sourceUrl": "https://officialskills.sh/openai/skills/imagegen",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "openai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-openai-jupyter-notebook",
+      "name": "openai/jupyter-notebook",
+      "kind": "skill",
+      "category": "数据与分析",
+      "publisher": "openai",
+      "sourceGroup": "Skills by OpenAI",
+      "description": "Create clean, reproducible Jupyter notebooks for experiments and tutorials",
+      "sourceUrl": "https://officialskills.sh/openai/skills/jupyter-notebook",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "openai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-openai-linear",
+      "name": "openai/linear",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "openai",
+      "sourceGroup": "Skills by OpenAI",
+      "description": "Manage issues, projects, and team workflows in Linear",
+      "sourceUrl": "https://officialskills.sh/openai/skills/linear",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "openai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-openai-netlify-deploy",
+      "name": "openai/netlify-deploy",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "openai",
+      "sourceGroup": "Skills by OpenAI",
+      "description": "Automate Netlify deployments with CLI auth, linking, and environment support",
+      "sourceUrl": "https://officialskills.sh/openai/skills/netlify-deploy",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "openai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-openai-notion-knowledge-capture",
+      "name": "openai/notion-knowledge-capture",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "openai",
+      "sourceGroup": "Skills by OpenAI",
+      "description": "Convert conversations into structured, searchable Notion wiki entries",
+      "sourceUrl": "https://officialskills.sh/openai/skills/notion-knowledge-capture",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "openai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-openai-notion-meeting-intelligence",
+      "name": "openai/notion-meeting-intelligence",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "openai",
+      "sourceGroup": "Skills by OpenAI",
+      "description": "Prep meetings by pulling Notion context and tailoring agendas",
+      "sourceUrl": "https://officialskills.sh/openai/skills/notion-meeting-intelligence",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "openai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-openai-notion-research-documentation",
+      "name": "openai/notion-research-documentation",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "openai",
+      "sourceGroup": "Skills by OpenAI",
+      "description": "Research Notion content and synthesize findings into structured briefs",
+      "sourceUrl": "https://officialskills.sh/openai/skills/notion-research-documentation",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "openai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-openai-notion-spec-to-implementation",
+      "name": "openai/notion-spec-to-implementation",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "openai",
+      "sourceGroup": "Skills by OpenAI",
+      "description": "Convert Notion specs into linked implementation plans and tasks",
+      "sourceUrl": "https://officialskills.sh/openai/skills/notion-spec-to-implementation",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "openai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-openai-openai-docs",
+      "name": "openai/openai-docs",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "openai",
+      "sourceGroup": "Skills by OpenAI",
+      "description": "Provide authoritative guidance from OpenAI developer documentation",
+      "sourceUrl": "https://officialskills.sh/openai/skills/openai-docs",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "openai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-openai-pdf",
+      "name": "openai/pdf",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "openai",
+      "sourceGroup": "Skills by OpenAI",
+      "description": "Read, create, and review PDFs with layout and visual formatting integrity",
+      "sourceUrl": "https://officialskills.sh/openai/skills/pdf",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "openai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-openai-playwright",
+      "name": "openai/playwright",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "openai",
+      "sourceGroup": "Skills by OpenAI",
+      "description": "Automate real browser interactions for navigation, forms, and scraping",
+      "sourceUrl": "https://officialskills.sh/openai/skills/playwright",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "openai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-openai-render-deploy",
+      "name": "openai/render-deploy",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "openai",
+      "sourceGroup": "Skills by OpenAI",
+      "description": "Deploy applications to Render's cloud platform using Git-backed services",
+      "sourceUrl": "https://officialskills.sh/openai/skills/render-deploy",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "openai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-openai-screenshot",
+      "name": "openai/screenshot",
+      "kind": "skill",
+      "category": "其他工具",
+      "publisher": "openai",
+      "sourceGroup": "Skills by OpenAI",
+      "description": "Capture desktop, app windows, or pixel regions across OS platforms",
+      "sourceUrl": "https://officialskills.sh/openai/skills/screenshot",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "openai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-openai-security-best-practices",
+      "name": "openai/security-best-practices",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "openai",
+      "sourceGroup": "Skills by OpenAI",
+      "description": "Review code for language-specific security vulnerabilities",
+      "sourceUrl": "https://officialskills.sh/openai/skills/security-best-practices",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "openai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-openai-security-ownership-map",
+      "name": "openai/security-ownership-map",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "openai",
+      "sourceGroup": "Skills by OpenAI",
+      "description": "Map people-to-file ownership, compute bus factor, and identify risks",
+      "sourceUrl": "https://officialskills.sh/openai/skills/security-ownership-map",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "openai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-openai-security-threat-model",
+      "name": "openai/security-threat-model",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "openai",
+      "sourceGroup": "Skills by OpenAI",
+      "description": "Generate repo-specific threat models identifying trust boundaries",
+      "sourceUrl": "https://officialskills.sh/openai/skills/security-threat-model",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "openai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-openai-sentry",
+      "name": "openai/sentry",
+      "kind": "skill",
+      "category": "数据与分析",
+      "publisher": "openai",
+      "sourceGroup": "Skills by OpenAI",
+      "description": "Inspect Sentry issues, summarize production errors, and pull health data",
+      "sourceUrl": "https://officialskills.sh/openai/skills/sentry",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "openai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-openai-sora",
+      "name": "openai/sora",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "openai",
+      "sourceGroup": "Skills by OpenAI",
+      "description": "Generate, remix, and manage short video clips via OpenAI's Sora API",
+      "sourceUrl": "https://officialskills.sh/openai/skills/sora",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "openai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-openai-speech",
+      "name": "openai/speech",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "openai",
+      "sourceGroup": "Skills by OpenAI",
+      "description": "Generate spoken audio from text using OpenAI's API with built-in voices",
+      "sourceUrl": "https://officialskills.sh/openai/skills/speech",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "openai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-openai-spreadsheet",
+      "name": "openai/spreadsheet",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "openai",
+      "sourceGroup": "Skills by OpenAI",
+      "description": "Create, edit, analyze, and visualize spreadsheets with formulas",
+      "sourceUrl": "https://officialskills.sh/openai/skills/spreadsheet",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "openai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-openai-transcribe",
+      "name": "openai/transcribe",
+      "kind": "skill",
+      "category": "多媒体创作",
+      "publisher": "openai",
+      "sourceGroup": "Skills by OpenAI",
+      "description": "Transcribe audio files to text with optional speaker diarization",
+      "sourceUrl": "https://officialskills.sh/openai/skills/transcribe",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "openai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-openai-vercel-deploy",
+      "name": "openai/vercel-deploy",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "openai",
+      "sourceGroup": "Skills by OpenAI",
+      "description": "Deploy applications and websites to Vercel with preview or production options",
+      "sourceUrl": "https://officialskills.sh/openai/skills/vercel-deploy",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "openai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-openai-yeet",
+      "name": "openai/yeet",
+      "kind": "skill",
+      "category": "工程开发",
+      "publisher": "openai",
+      "sourceGroup": "Skills by OpenAI",
+      "description": "Stage, commit, push code, and open a GitHub pull request via CLI",
+      "sourceUrl": "https://officialskills.sh/openai/skills/yeet",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "openai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-openai-aspnet-core",
+      "name": "openai/aspnet-core",
+      "kind": "skill",
+      "category": "工程开发",
+      "publisher": "openai",
+      "sourceGroup": "Skills by OpenAI",
+      "description": "Build, review, and architect ASP.NET Core apps (Blazor, MVC, Minimal APIs, etc.)",
+      "sourceUrl": "https://officialskills.sh/openai/skills/aspnet-core",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "openai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-openai-chatgpt-apps",
+      "name": "openai/chatgpt-apps",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "openai",
+      "sourceGroup": "Skills by OpenAI",
+      "description": "Build, scaffold, and troubleshoot ChatGPT Apps SDK apps with MCP server and widget UI",
+      "sourceUrl": "https://officialskills.sh/openai/skills/chatgpt-apps",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "openai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-openai-figma",
+      "name": "openai/figma",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "openai",
+      "sourceGroup": "Skills by OpenAI",
+      "description": "Use the Figma MCP server to fetch design context and translate nodes into production code",
+      "sourceUrl": "https://officialskills.sh/openai/skills/figma",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "openai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-openai-figma-code-connect-components",
+      "name": "openai/figma-code-connect-components",
+      "kind": "skill",
+      "category": "多媒体创作",
+      "publisher": "openai",
+      "sourceGroup": "Skills by OpenAI",
+      "description": "Connect Figma design components to code components using Code Connect",
+      "sourceUrl": "https://officialskills.sh/openai/skills/figma-code-connect-components",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "openai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-openai-figma-create-design-system-rules",
+      "name": "openai/figma-create-design-system-rules",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "openai",
+      "sourceGroup": "Skills by OpenAI",
+      "description": "Rules for implementing Figma designs using the Figma MCP server",
+      "sourceUrl": "https://officialskills.sh/openai/skills/figma-create-design-system-rules",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "openai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-openai-figma-create-new-file",
+      "name": "openai/figma-create-new-file",
+      "kind": "skill",
+      "category": "多媒体创作",
+      "publisher": "openai",
+      "sourceGroup": "Skills by OpenAI",
+      "description": "Create a new blank Figma file or FigJam file",
+      "sourceUrl": "https://officialskills.sh/openai/skills/figma-create-new-file",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "openai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-openai-figma-generate-design",
+      "name": "openai/figma-generate-design",
+      "kind": "skill",
+      "category": "多媒体创作",
+      "publisher": "openai",
+      "sourceGroup": "Skills by OpenAI",
+      "description": "Translate app pages and layouts into Figma using design system tokens",
+      "sourceUrl": "https://officialskills.sh/openai/skills/figma-generate-design",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "openai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-openai-figma-generate-library",
+      "name": "openai/figma-generate-library",
+      "kind": "skill",
+      "category": "多媒体创作",
+      "publisher": "openai",
+      "sourceGroup": "Skills by OpenAI",
+      "description": "Build or update a professional-grade design system in Figma from a codebase",
+      "sourceUrl": "https://officialskills.sh/openai/skills/figma-generate-library",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "openai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-openai-figma-implement-design",
+      "name": "openai/figma-implement-design",
+      "kind": "skill",
+      "category": "多媒体创作",
+      "publisher": "openai",
+      "sourceGroup": "Skills by OpenAI",
+      "description": "Translate Figma designs into production-ready code with 1:1 visual fidelity",
+      "sourceUrl": "https://officialskills.sh/openai/skills/figma-implement-design",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "openai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-openai-figma-use",
+      "name": "openai/figma-use",
+      "kind": "skill",
+      "category": "多媒体创作",
+      "publisher": "openai",
+      "sourceGroup": "Skills by OpenAI",
+      "description": "Prerequisite skill for every usefigma tool call — write/read actions in Figma context",
+      "sourceUrl": "https://officialskills.sh/openai/skills/figma-use",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "openai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-openai-frontend-skill",
+      "name": "openai/frontend-skill",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "openai",
+      "sourceGroup": "Skills by OpenAI",
+      "description": "Create visually strong landing pages, websites, and app UIs with restrained composition",
+      "sourceUrl": "https://officialskills.sh/openai/skills/frontend-skill",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "openai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-openai-playwright-interactive",
+      "name": "openai/playwright-interactive",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "openai",
+      "sourceGroup": "Skills by OpenAI",
+      "description": "Persistent browser and Electron interaction via jsrepl for iterative UI debugging",
+      "sourceUrl": "https://officialskills.sh/openai/skills/playwright-interactive",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "openai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-openai-slides",
+      "name": "openai/slides",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "openai",
+      "sourceGroup": "Skills by OpenAI",
+      "description": "Create and edit .pptx presentation decks with PptxGenJS",
+      "sourceUrl": "https://officialskills.sh/openai/skills/slides",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "openai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-openai-winui-app",
+      "name": "openai/winui-app",
+      "kind": "skill",
+      "category": "工程开发",
+      "publisher": "openai",
+      "sourceGroup": "Skills by OpenAI",
+      "description": "Bootstrap and develop modern WinUI 3 desktop apps with C# and Windows App SDK",
+      "sourceUrl": "https://officialskills.sh/openai/skills/winui-app",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "openai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-figma-figma-code-connect-components",
+      "name": "figma/figma-code-connect-components",
+      "kind": "skill",
+      "category": "多媒体创作",
+      "publisher": "figma",
+      "sourceGroup": "Skills by Figma",
+      "description": "Connect Figma design components to code components using Code Connect",
+      "sourceUrl": "https://officialskills.sh/figma/skills/figma-code-connect-components",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "figma"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-figma-figma-create-design-system-rules",
+      "name": "figma/figma-create-design-system-rules",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "figma",
+      "sourceGroup": "Skills by Figma",
+      "description": "Generate project-specific design system rules for Figma-to-code workflows",
+      "sourceUrl": "https://officialskills.sh/figma/skills/figma-create-design-system-rules",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "figma"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-figma-figma-create-new-file",
+      "name": "figma/figma-create-new-file",
+      "kind": "skill",
+      "category": "多媒体创作",
+      "publisher": "figma",
+      "sourceGroup": "Skills by Figma",
+      "description": "Create a new blank Figma Design or FigJam file",
+      "sourceUrl": "https://officialskills.sh/figma/skills/figma-create-new-file",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "figma"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-figma-figma-generate-design",
+      "name": "figma/figma-generate-design",
+      "kind": "skill",
+      "category": "多媒体创作",
+      "publisher": "figma",
+      "sourceGroup": "Skills by Figma",
+      "description": "Build or update screens in Figma from code or description using design system components",
+      "sourceUrl": "https://officialskills.sh/figma/skills/figma-generate-design",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "figma"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-figma-figma-generate-library",
+      "name": "figma/figma-generate-library",
+      "kind": "skill",
+      "category": "多媒体创作",
+      "publisher": "figma",
+      "sourceGroup": "Skills by Figma",
+      "description": "Build or update a design system library in Figma from a codebase",
+      "sourceUrl": "https://officialskills.sh/figma/skills/figma-generate-library",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "figma"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-figma-figma-implement-design",
+      "name": "figma/figma-implement-design",
+      "kind": "skill",
+      "category": "多媒体创作",
+      "publisher": "figma",
+      "sourceGroup": "Skills by Figma",
+      "description": "Translate Figma designs into production-ready application code with 1:1 fidelity",
+      "sourceUrl": "https://officialskills.sh/figma/skills/figma-implement-design",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "figma"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-figma-figma-use",
+      "name": "figma/figma-use",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "figma",
+      "sourceGroup": "Skills by Figma",
+      "description": "Run Figma Plugin API scripts for canvas writes, inspections, variables, and design-system work",
+      "sourceUrl": "https://officialskills.sh/figma/skills/figma-use",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "figma"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-coreyhaines31-ab-test-setup",
+      "name": "coreyhaines31/ab-test-setup",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "coreyhaines31",
+      "sourceGroup": "Marketing Skills by Corey Haines",
+      "description": "Plan and implement A/B tests or experiments for any digital experience",
+      "sourceUrl": "https://github.com/coreyhaines31/marketingskills/tree/main/skills/ab-test-setup",
+      "installSource": {
+        "repoUrl": "https://github.com/coreyhaines31/marketingskills",
+        "subPath": "skills/ab-test-setup"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "coreyhaines31"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-coreyhaines31-ad-creative",
+      "name": "coreyhaines31/ad-creative",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "coreyhaines31",
+      "sourceGroup": "Marketing Skills by Corey Haines",
+      "description": "Generate and iterate ad creative including headlines, descriptions, and primary text",
+      "sourceUrl": "https://github.com/coreyhaines31/marketingskills/tree/main/skills/ad-creative",
+      "installSource": {
+        "repoUrl": "https://github.com/coreyhaines31/marketingskills",
+        "subPath": "skills/ad-creative"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "coreyhaines31"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-coreyhaines31-ai-seo",
+      "name": "coreyhaines31/ai-seo",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "coreyhaines31",
+      "sourceGroup": "Marketing Skills by Corey Haines",
+      "description": "Optimize content to appear in AI-generated answers and LLM search results",
+      "sourceUrl": "https://github.com/coreyhaines31/marketingskills/tree/main/skills/ai-seo",
+      "installSource": {
+        "repoUrl": "https://github.com/coreyhaines31/marketingskills",
+        "subPath": "skills/ai-seo"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "coreyhaines31"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-coreyhaines31-analytics-tracking",
+      "name": "coreyhaines31/analytics-tracking",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "coreyhaines31",
+      "sourceGroup": "Marketing Skills by Corey Haines",
+      "description": "Set up and audit analytics tracking and measurement pipelines",
+      "sourceUrl": "https://github.com/coreyhaines31/marketingskills/tree/main/skills/analytics-tracking",
+      "installSource": {
+        "repoUrl": "https://github.com/coreyhaines31/marketingskills",
+        "subPath": "skills/analytics-tracking"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "coreyhaines31"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-coreyhaines31-churn-prevention",
+      "name": "coreyhaines31/churn-prevention",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "coreyhaines31",
+      "sourceGroup": "Marketing Skills by Corey Haines",
+      "description": "Build cancellation flows, save offers, and recover failed payments",
+      "sourceUrl": "https://github.com/coreyhaines31/marketingskills/tree/main/skills/churn-prevention",
+      "installSource": {
+        "repoUrl": "https://github.com/coreyhaines31/marketingskills",
+        "subPath": "skills/churn-prevention"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "coreyhaines31"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-coreyhaines31-cold-email",
+      "name": "coreyhaines31/cold-email",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "coreyhaines31",
+      "sourceGroup": "Marketing Skills by Corey Haines",
+      "description": "Write B2B cold emails and follow-up sequences that convert",
+      "sourceUrl": "https://github.com/coreyhaines31/marketingskills/tree/main/skills/cold-email",
+      "installSource": {
+        "repoUrl": "https://github.com/coreyhaines31/marketingskills",
+        "subPath": "skills/cold-email"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "coreyhaines31"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-coreyhaines31-competitor-alternatives",
+      "name": "coreyhaines31/competitor-alternatives",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "coreyhaines31",
+      "sourceGroup": "Marketing Skills by Corey Haines",
+      "description": "Build competitor comparison and alternative landing pages for SEO",
+      "sourceUrl": "https://github.com/coreyhaines31/marketingskills/tree/main/skills/competitor-alternatives",
+      "installSource": {
+        "repoUrl": "https://github.com/coreyhaines31/marketingskills",
+        "subPath": "skills/competitor-alternatives"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "coreyhaines31"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-coreyhaines31-content-strategy",
+      "name": "coreyhaines31/content-strategy",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "coreyhaines31",
+      "sourceGroup": "Marketing Skills by Corey Haines",
+      "description": "Plan content strategy and decide what topics and formats to prioritize",
+      "sourceUrl": "https://github.com/coreyhaines31/marketingskills/tree/main/skills/content-strategy",
+      "installSource": {
+        "repoUrl": "https://github.com/coreyhaines31/marketingskills",
+        "subPath": "skills/content-strategy"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "coreyhaines31"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-coreyhaines31-copy-editing",
+      "name": "coreyhaines31/copy-editing",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "coreyhaines31",
+      "sourceGroup": "Marketing Skills by Corey Haines",
+      "description": "Edit and improve existing marketing copy for clarity and impact",
+      "sourceUrl": "https://github.com/coreyhaines31/marketingskills/tree/main/skills/copy-editing",
+      "installSource": {
+        "repoUrl": "https://github.com/coreyhaines31/marketingskills",
+        "subPath": "skills/copy-editing"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "coreyhaines31"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-coreyhaines31-copywriting",
+      "name": "coreyhaines31/copywriting",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "coreyhaines31",
+      "sourceGroup": "Marketing Skills by Corey Haines",
+      "description": "Write and rewrite marketing copy for landing pages, homepages, and ads",
+      "sourceUrl": "https://github.com/coreyhaines31/marketingskills/tree/main/skills/copywriting",
+      "installSource": {
+        "repoUrl": "https://github.com/coreyhaines31/marketingskills",
+        "subPath": "skills/copywriting"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "coreyhaines31"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-coreyhaines31-email-sequence",
+      "name": "coreyhaines31/email-sequence",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "coreyhaines31",
+      "sourceGroup": "Marketing Skills by Corey Haines",
+      "description": "Build email sequences, drip campaigns, and lifecycle email flows",
+      "sourceUrl": "https://github.com/coreyhaines31/marketingskills/tree/main/skills/email-sequence",
+      "installSource": {
+        "repoUrl": "https://github.com/coreyhaines31/marketingskills",
+        "subPath": "skills/email-sequence"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "coreyhaines31"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-coreyhaines31-form-cro",
+      "name": "coreyhaines31/form-cro",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "coreyhaines31",
+      "sourceGroup": "Marketing Skills by Corey Haines",
+      "description": "Optimize lead capture and contact forms to improve conversion",
+      "sourceUrl": "https://github.com/coreyhaines31/marketingskills/tree/main/skills/form-cro",
+      "installSource": {
+        "repoUrl": "https://github.com/coreyhaines31/marketingskills",
+        "subPath": "skills/form-cro"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "coreyhaines31"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-coreyhaines31-free-tool-strategy",
+      "name": "coreyhaines31/free-tool-strategy",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "coreyhaines31",
+      "sourceGroup": "Marketing Skills by Corey Haines",
+      "description": "Plan and build free tools for lead generation and SEO value",
+      "sourceUrl": "https://github.com/coreyhaines31/marketingskills/tree/main/skills/free-tool-strategy",
+      "installSource": {
+        "repoUrl": "https://github.com/coreyhaines31/marketingskills",
+        "subPath": "skills/free-tool-strategy"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "coreyhaines31"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-coreyhaines31-launch-strategy",
+      "name": "coreyhaines31/launch-strategy",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "coreyhaines31",
+      "sourceGroup": "Marketing Skills by Corey Haines",
+      "description": "Plan product launches, feature announcements, and go-to-market strategies",
+      "sourceUrl": "https://github.com/coreyhaines31/marketingskills/tree/main/skills/launch-strategy",
+      "installSource": {
+        "repoUrl": "https://github.com/coreyhaines31/marketingskills",
+        "subPath": "skills/launch-strategy"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "coreyhaines31"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-coreyhaines31-marketing-ideas",
+      "name": "coreyhaines31/marketing-ideas",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "coreyhaines31",
+      "sourceGroup": "Marketing Skills by Corey Haines",
+      "description": "Generate marketing strategies and campaign ideas for SaaS products",
+      "sourceUrl": "https://github.com/coreyhaines31/marketingskills/tree/main/skills/marketing-ideas",
+      "installSource": {
+        "repoUrl": "https://github.com/coreyhaines31/marketingskills",
+        "subPath": "skills/marketing-ideas"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "coreyhaines31"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-coreyhaines31-marketing-psychology",
+      "name": "coreyhaines31/marketing-psychology",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "coreyhaines31",
+      "sourceGroup": "Marketing Skills by Corey Haines",
+      "description": "Apply psychological principles and behavioral science to copy and design",
+      "sourceUrl": "https://github.com/coreyhaines31/marketingskills/tree/main/skills/marketing-psychology",
+      "installSource": {
+        "repoUrl": "https://github.com/coreyhaines31/marketingskills",
+        "subPath": "skills/marketing-psychology"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "coreyhaines31"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-coreyhaines31-onboarding-cro",
+      "name": "coreyhaines31/onboarding-cro",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "coreyhaines31",
+      "sourceGroup": "Marketing Skills by Corey Haines",
+      "description": "Optimize post-signup onboarding and user activation to improve time-to-value",
+      "sourceUrl": "https://github.com/coreyhaines31/marketingskills/tree/main/skills/onboarding-cro",
+      "installSource": {
+        "repoUrl": "https://github.com/coreyhaines31/marketingskills",
+        "subPath": "skills/onboarding-cro"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "coreyhaines31"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-coreyhaines31-page-cro",
+      "name": "coreyhaines31/page-cro",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "coreyhaines31",
+      "sourceGroup": "Marketing Skills by Corey Haines",
+      "description": "Improve conversion rates on any marketing page including homepages and landing pages",
+      "sourceUrl": "https://github.com/coreyhaines31/marketingskills/tree/main/skills/page-cro",
+      "installSource": {
+        "repoUrl": "https://github.com/coreyhaines31/marketingskills",
+        "subPath": "skills/page-cro"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "coreyhaines31"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-coreyhaines31-paid-ads",
+      "name": "coreyhaines31/paid-ads",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "coreyhaines31",
+      "sourceGroup": "Marketing Skills by Corey Haines",
+      "description": "Create and optimize paid campaigns on Google, Meta, LinkedIn, and more",
+      "sourceUrl": "https://github.com/coreyhaines31/marketingskills/tree/main/skills/paid-ads",
+      "installSource": {
+        "repoUrl": "https://github.com/coreyhaines31/marketingskills",
+        "subPath": "skills/paid-ads"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "coreyhaines31"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-coreyhaines31-paywall-upgrade-cro",
+      "name": "coreyhaines31/paywall-upgrade-cro",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "coreyhaines31",
+      "sourceGroup": "Marketing Skills by Corey Haines",
+      "description": "Design and optimize upgrade screens, paywalls, and upsell modals",
+      "sourceUrl": "https://github.com/coreyhaines31/marketingskills/tree/main/skills/paywall-upgrade-cro",
+      "installSource": {
+        "repoUrl": "https://github.com/coreyhaines31/marketingskills",
+        "subPath": "skills/paywall-upgrade-cro"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "coreyhaines31"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-coreyhaines31-popup-cro",
+      "name": "coreyhaines31/popup-cro",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "coreyhaines31",
+      "sourceGroup": "Marketing Skills by Corey Haines",
+      "description": "Create and optimize popups, modals, and slide-ins for conversions",
+      "sourceUrl": "https://github.com/coreyhaines31/marketingskills/tree/main/skills/popup-cro",
+      "installSource": {
+        "repoUrl": "https://github.com/coreyhaines31/marketingskills",
+        "subPath": "skills/popup-cro"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "coreyhaines31"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-coreyhaines31-pricing-strategy",
+      "name": "coreyhaines31/pricing-strategy",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "coreyhaines31",
+      "sourceGroup": "Marketing Skills by Corey Haines",
+      "description": "Define pricing, packaging, and monetization strategy for SaaS products",
+      "sourceUrl": "https://github.com/coreyhaines31/marketingskills/tree/main/skills/pricing-strategy",
+      "installSource": {
+        "repoUrl": "https://github.com/coreyhaines31/marketingskills",
+        "subPath": "skills/pricing-strategy"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "coreyhaines31"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-coreyhaines31-product-marketing-context",
+      "name": "coreyhaines31/product-marketing-context",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "coreyhaines31",
+      "sourceGroup": "Marketing Skills by Corey Haines",
+      "description": "Create and maintain a product marketing context document for consistent messaging",
+      "sourceUrl": "https://github.com/coreyhaines31/marketingskills/tree/main/skills/product-marketing-context",
+      "installSource": {
+        "repoUrl": "https://github.com/coreyhaines31/marketingskills",
+        "subPath": "skills/product-marketing-context"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "coreyhaines31"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-coreyhaines31-programmatic-seo",
+      "name": "coreyhaines31/programmatic-seo",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "coreyhaines31",
+      "sourceGroup": "Marketing Skills by Corey Haines",
+      "description": "Build SEO-driven page templates for large-scale content generation",
+      "sourceUrl": "https://github.com/coreyhaines31/marketingskills/tree/main/skills/programmatic-seo",
+      "installSource": {
+        "repoUrl": "https://github.com/coreyhaines31/marketingskills",
+        "subPath": "skills/programmatic-seo"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "coreyhaines31"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-coreyhaines31-referral-program",
+      "name": "coreyhaines31/referral-program",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "coreyhaines31",
+      "sourceGroup": "Marketing Skills by Corey Haines",
+      "description": "Design and optimize referral, affiliate, and word-of-mouth programs",
+      "sourceUrl": "https://github.com/coreyhaines31/marketingskills/tree/main/skills/referral-program",
+      "installSource": {
+        "repoUrl": "https://github.com/coreyhaines31/marketingskills",
+        "subPath": "skills/referral-program"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "coreyhaines31"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-coreyhaines31-revops",
+      "name": "coreyhaines31/revops",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "coreyhaines31",
+      "sourceGroup": "Marketing Skills by Corey Haines",
+      "description": "Streamline revenue operations, lead lifecycle, and marketing-to-sales handoff",
+      "sourceUrl": "https://github.com/coreyhaines31/marketingskills/tree/main/skills/revops",
+      "installSource": {
+        "repoUrl": "https://github.com/coreyhaines31/marketingskills",
+        "subPath": "skills/revops"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "coreyhaines31"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-coreyhaines31-sales-enablement",
+      "name": "coreyhaines31/sales-enablement",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "coreyhaines31",
+      "sourceGroup": "Marketing Skills by Corey Haines",
+      "description": "Create pitch decks, one-pagers, objection handling docs, and demo scripts",
+      "sourceUrl": "https://github.com/coreyhaines31/marketingskills/tree/main/skills/sales-enablement",
+      "installSource": {
+        "repoUrl": "https://github.com/coreyhaines31/marketingskills",
+        "subPath": "skills/sales-enablement"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "coreyhaines31"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-coreyhaines31-schema-markup",
+      "name": "coreyhaines31/schema-markup",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "coreyhaines31",
+      "sourceGroup": "Marketing Skills by Corey Haines",
+      "description": "Add and optimize schema markup and structured data for better SEO",
+      "sourceUrl": "https://github.com/coreyhaines31/marketingskills/tree/main/skills/schema-markup",
+      "installSource": {
+        "repoUrl": "https://github.com/coreyhaines31/marketingskills",
+        "subPath": "skills/schema-markup"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "coreyhaines31"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-coreyhaines31-seo-audit",
+      "name": "coreyhaines31/seo-audit",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "coreyhaines31",
+      "sourceGroup": "Marketing Skills by Corey Haines",
+      "description": "Audit and diagnose technical and on-page SEO issues on a site",
+      "sourceUrl": "https://github.com/coreyhaines31/marketingskills/tree/main/skills/seo-audit",
+      "installSource": {
+        "repoUrl": "https://github.com/coreyhaines31/marketingskills",
+        "subPath": "skills/seo-audit"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "coreyhaines31"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-coreyhaines31-signup-flow-cro",
+      "name": "coreyhaines31/signup-flow-cro",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "coreyhaines31",
+      "sourceGroup": "Marketing Skills by Corey Haines",
+      "description": "Optimize signup, registration, and trial activation flows for higher conversion",
+      "sourceUrl": "https://github.com/coreyhaines31/marketingskills/tree/main/skills/signup-flow-cro",
+      "installSource": {
+        "repoUrl": "https://github.com/coreyhaines31/marketingskills",
+        "subPath": "skills/signup-flow-cro"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "coreyhaines31"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-coreyhaines31-site-architecture",
+      "name": "coreyhaines31/site-architecture",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "coreyhaines31",
+      "sourceGroup": "Marketing Skills by Corey Haines",
+      "description": "Plan and restructure page hierarchy, navigation, and URL structure",
+      "sourceUrl": "https://github.com/coreyhaines31/marketingskills/tree/main/skills/site-architecture",
+      "installSource": {
+        "repoUrl": "https://github.com/coreyhaines31/marketingskills",
+        "subPath": "skills/site-architecture"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "coreyhaines31"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-coreyhaines31-social-content",
+      "name": "coreyhaines31/social-content",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "coreyhaines31",
+      "sourceGroup": "Marketing Skills by Corey Haines",
+      "description": "Create and schedule social media content for LinkedIn, Twitter/X, and Instagram",
+      "sourceUrl": "https://github.com/coreyhaines31/marketingskills/tree/main/skills/social-content",
+      "installSource": {
+        "repoUrl": "https://github.com/coreyhaines31/marketingskills",
+        "subPath": "skills/social-content"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "coreyhaines31"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-realkimbarrett-avatar-extraction",
+      "name": "realkimbarrett/avatar-extraction",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "realkimbarrett",
+      "sourceGroup": "Advertising Skills by Kim Barrett",
+      "description": "Define exactly who the buyer is, what they want, what they've tried, and what's driving their decisions",
+      "sourceUrl": "https://github.com/realkimbarrett/advertising-skills/tree/main/skills/foundations/avatar-extraction",
+      "installSource": {
+        "repoUrl": "https://github.com/realkimbarrett/advertising-skills",
+        "subPath": "skills/foundations/avatar-extraction"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "realkimbarrett"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-realkimbarrett-offer-extraction",
+      "name": "realkimbarrett/offer-extraction",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "realkimbarrett",
+      "sourceGroup": "Advertising Skills by Kim Barrett",
+      "description": "Turn a product or service into a compelling, high-converting offer",
+      "sourceUrl": "https://github.com/realkimbarrett/advertising-skills/tree/main/skills/foundations/offer-extraction",
+      "installSource": {
+        "repoUrl": "https://github.com/realkimbarrett/advertising-skills",
+        "subPath": "skills/foundations/offer-extraction"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "realkimbarrett"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-realkimbarrett-schwartz-awareness-mapper",
+      "name": "realkimbarrett/schwartz-awareness-mapper",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "realkimbarrett",
+      "sourceGroup": "Advertising Skills by Kim Barrett",
+      "description": "Determine audience awareness level and the correct messaging approach",
+      "sourceUrl": "https://github.com/realkimbarrett/advertising-skills/tree/main/skills/copy-chief/schwartz-awareness-mapper",
+      "installSource": {
+        "repoUrl": "https://github.com/realkimbarrett/advertising-skills",
+        "subPath": "skills/copy-chief/schwartz-awareness-mapper"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "realkimbarrett"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-realkimbarrett-mechanism-builder",
+      "name": "realkimbarrett/mechanism-builder",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "realkimbarrett",
+      "sourceGroup": "Advertising Skills by Kim Barrett",
+      "description": "Explain why your solution works and others failed with a unique mechanism",
+      "sourceUrl": "https://github.com/realkimbarrett/advertising-skills/tree/main/skills/copy-chief/mechanism-builder",
+      "installSource": {
+        "repoUrl": "https://github.com/realkimbarrett/advertising-skills",
+        "subPath": "skills/copy-chief/mechanism-builder"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "realkimbarrett"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-realkimbarrett-headline-matrix",
+      "name": "realkimbarrett/headline-matrix",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "realkimbarrett",
+      "sourceGroup": "Advertising Skills by Kim Barrett",
+      "description": "Generate high-performing headline variations across different angles",
+      "sourceUrl": "https://github.com/realkimbarrett/advertising-skills/tree/main/skills/copy-chief/headline-matrix",
+      "installSource": {
+        "repoUrl": "https://github.com/realkimbarrett/advertising-skills",
+        "subPath": "skills/copy-chief/headline-matrix"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "realkimbarrett"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-realkimbarrett-objection-crusher",
+      "name": "realkimbarrett/objection-crusher",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "realkimbarrett",
+      "sourceGroup": "Advertising Skills by Kim Barrett",
+      "description": "Identify and neutralize buyer objections and hesitation",
+      "sourceUrl": "https://github.com/realkimbarrett/advertising-skills/tree/main/skills/copy-chief/objection-crusher",
+      "installSource": {
+        "repoUrl": "https://github.com/realkimbarrett/advertising-skills",
+        "subPath": "skills/copy-chief/objection-crusher"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "realkimbarrett"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-realkimbarrett-ad-angle-multiplier",
+      "name": "realkimbarrett/ad-angle-multiplier",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "realkimbarrett",
+      "sourceGroup": "Advertising Skills by Kim Barrett",
+      "description": "Expand a core idea into multiple distinct ad angles for creative testing",
+      "sourceUrl": "https://github.com/realkimbarrett/advertising-skills/tree/main/skills/operator-os/ad-angle-multiplier",
+      "installSource": {
+        "repoUrl": "https://github.com/realkimbarrett/advertising-skills",
+        "subPath": "skills/operator-os/ad-angle-multiplier"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "realkimbarrett"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-realkimbarrett-scroll-stopping-creative",
+      "name": "realkimbarrett/scroll-stopping-creative",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "realkimbarrett",
+      "sourceGroup": "Advertising Skills by Kim Barrett",
+      "description": "Create ad concepts that stop attention in the first 3 seconds",
+      "sourceUrl": "https://github.com/realkimbarrett/advertising-skills/tree/main/skills/operator-os/scroll-stopping-creative",
+      "installSource": {
+        "repoUrl": "https://github.com/realkimbarrett/advertising-skills",
+        "subPath": "skills/operator-os/scroll-stopping-creative"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "realkimbarrett"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-realkimbarrett-conversion-path-builder",
+      "name": "realkimbarrett/conversion-path-builder",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "realkimbarrett",
+      "sourceGroup": "Advertising Skills by Kim Barrett",
+      "description": "Design the optimal funnel from click to conversion and booked calls",
+      "sourceUrl": "https://github.com/realkimbarrett/advertising-skills/tree/main/skills/operator-os/conversion-path-builder",
+      "installSource": {
+        "repoUrl": "https://github.com/realkimbarrett/advertising-skills",
+        "subPath": "skills/operator-os/conversion-path-builder"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "realkimbarrett"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-realkimbarrett-performance-diagnosis",
+      "name": "realkimbarrett/performance-diagnosis",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "realkimbarrett",
+      "sourceGroup": "Advertising Skills by Kim Barrett",
+      "description": "Diagnose why campaigns are underperforming — low conversion, high CPL, bad ads",
+      "sourceUrl": "https://github.com/realkimbarrett/advertising-skills/tree/main/skills/operator-os/performance-diagnosis",
+      "installSource": {
+        "repoUrl": "https://github.com/realkimbarrett/advertising-skills",
+        "subPath": "skills/operator-os/performance-diagnosis"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "realkimbarrett"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-realkimbarrett-full-funnel-campaign-orchestrator",
+      "name": "realkimbarrett/full-funnel-campaign-orchestrator",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "realkimbarrett",
+      "sourceGroup": "Advertising Skills by Kim Barrett",
+      "description": "Coordinate all skills to build a complete ads + funnel campaign end-to-end",
+      "sourceUrl": "https://github.com/realkimbarrett/advertising-skills/tree/main/skills/orchestrators/full-funnel-campaign-orchestrator",
+      "installSource": {
+        "repoUrl": "https://github.com/realkimbarrett/advertising-skills",
+        "subPath": "skills/orchestrators/full-funnel-campaign-orchestrator"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "realkimbarrett"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-realkimbarrett-generic-language-killer",
+      "name": "realkimbarrett/generic-language-killer",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "realkimbarrett",
+      "sourceGroup": "Advertising Skills by Kim Barrett",
+      "description": "Remove vague, corporate, or AI-sounding language and replace it with clear, specific, human wording",
+      "sourceUrl": "https://github.com/realkimbarrett/advertising-skills/tree/main/skills/qa/generic-language-killer",
+      "installSource": {
+        "repoUrl": "https://github.com/realkimbarrett/advertising-skills",
+        "subPath": "skills/qa/generic-language-killer"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "realkimbarrett"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-binance-crypto-market-rank",
+      "name": "binance/crypto-market-rank",
+      "kind": "skill",
+      "category": "其他工具",
+      "publisher": "binance",
+      "sourceGroup": "Skills by Binance",
+      "description": "Query crypto market rankings including trending tokens, smart money inflows, meme rankings, and top trader PnL leaderboards",
+      "sourceUrl": "https://officialskills.sh/binance/skills/crypto-market-rank",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "binance"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-binance-meme-rush",
+      "name": "binance/meme-rush",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "binance",
+      "sourceGroup": "Skills by Binance",
+      "description": "Track real-time meme token lists from launchpads (Pump.fun, Four.meme) and AI-powered hot market topics ranked by net inflow",
+      "sourceUrl": "https://officialskills.sh/binance/skills/meme-rush",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "binance"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-binance-query-address-info",
+      "name": "binance/query-address-info",
+      "kind": "skill",
+      "category": "其他工具",
+      "publisher": "binance",
+      "sourceGroup": "Skills by Binance",
+      "description": "Retrieve all token holdings and portfolio positions for any wallet address on BSC, Base, or Solana",
+      "sourceUrl": "https://officialskills.sh/binance/skills/query-address-info",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "binance"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-binance-query-token-audit",
+      "name": "binance/query-token-audit",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "binance",
+      "sourceGroup": "Skills by Binance",
+      "description": "Audit token security to detect scams, honeypots, and malicious contracts across BSC, Base, Solana, and Ethereum",
+      "sourceUrl": "https://officialskills.sh/binance/skills/query-token-audit",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "binance"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-binance-query-token-info",
+      "name": "binance/query-token-info",
+      "kind": "skill",
+      "category": "数据与分析",
+      "publisher": "binance",
+      "sourceGroup": "Skills by Binance",
+      "description": "Search tokens and fetch metadata, real-time market data, and K-Line candlestick charts by keyword or contract address",
+      "sourceUrl": "https://officialskills.sh/binance/skills/query-token-info",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "binance"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-binance-trading-signal",
+      "name": "binance/trading-signal",
+      "kind": "skill",
+      "category": "数据与分析",
+      "publisher": "binance",
+      "sourceGroup": "Skills by Binance",
+      "description": "Monitor on-chain Smart Money buy/sell signals with price, max gain, and exit rate data on Solana and BSC",
+      "sourceUrl": "https://officialskills.sh/binance/skills/trading-signal",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "binance"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-binance-spot",
+      "name": "binance/spot",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "binance",
+      "sourceGroup": "Skills by Binance",
+      "description": "Place and manage spot trading orders on Binance via API key authentication, supporting mainnet and testnet",
+      "sourceUrl": "https://officialskills.sh/binance/skills/spot",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "binance"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-apollographql-apollo-client",
+      "name": "apollographql/apollo-client",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "apollographql",
+      "sourceGroup": "Skills by Apollo GraphQL",
+      "description": "Build React applications with Apollo Client 4",
+      "sourceUrl": "https://officialskills.sh/apollographql/skills/apollo-client",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "apollographql"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-apollographql-apollo-connectors",
+      "name": "apollographql/apollo-connectors",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "apollographql",
+      "sourceGroup": "Skills by Apollo GraphQL",
+      "description": "Integrate REST APIs into GraphQL supergraphs using Apollo Connectors",
+      "sourceUrl": "https://officialskills.sh/apollographql/skills/apollo-connectors",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "apollographql"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-apollographql-apollo-federation",
+      "name": "apollographql/apollo-federation",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "apollographql",
+      "sourceGroup": "Skills by Apollo GraphQL",
+      "description": "Write Apollo Federation 2 subgraph schemas and compose them into a supergraph",
+      "sourceUrl": "https://officialskills.sh/apollographql/skills/apollo-federation",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "apollographql"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-apollographql-apollo-kotlin",
+      "name": "apollographql/apollo-kotlin",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "apollographql",
+      "sourceGroup": "Skills by Apollo GraphQL",
+      "description": "A GraphQL client for Android, JVM, and Kotlin Multiplatform projects",
+      "sourceUrl": "https://officialskills.sh/apollographql/skills/apollo-kotlin",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "apollographql"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-apollographql-apollo-mcp-server",
+      "name": "apollographql/apollo-mcp-server",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "apollographql",
+      "sourceGroup": "Skills by Apollo GraphQL",
+      "description": "Connect AI agents to GraphQL APIs through the Model Context Protocol",
+      "sourceUrl": "https://officialskills.sh/apollographql/skills/apollo-mcp-server",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "apollographql"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-apollographql-apollo-router",
+      "name": "apollographql/apollo-router",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "apollographql",
+      "sourceGroup": "Skills by Apollo GraphQL",
+      "description": "Version-aware configuration generator for the Rust-based Apollo Router",
+      "sourceUrl": "https://officialskills.sh/apollographql/skills/apollo-router",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "apollographql"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-apollographql-apollo-router-plugin-creator",
+      "name": "apollographql/apollo-router-plugin-creator",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "apollographql",
+      "sourceGroup": "Skills by Apollo GraphQL",
+      "description": "Write native Rust plugins for Apollo Router",
+      "sourceUrl": "https://officialskills.sh/apollographql/skills/apollo-router-plugin-creator",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "apollographql"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-apollographql-apollo-server",
+      "name": "apollographql/apollo-server",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "apollographql",
+      "sourceGroup": "Skills by Apollo GraphQL",
+      "description": "Build GraphQL servers using Apollo Server 5",
+      "sourceUrl": "https://officialskills.sh/apollographql/skills/apollo-server",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "apollographql"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-apollographql-graphql-operations",
+      "name": "apollographql/graphql-operations",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "apollographql",
+      "sourceGroup": "Skills by Apollo GraphQL",
+      "description": "Write GraphQL queries, mutations, and subscriptions following best practices",
+      "sourceUrl": "https://officialskills.sh/apollographql/skills/graphql-operations",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "apollographql"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-apollographql-graphql-schema",
+      "name": "apollographql/graphql-schema",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "apollographql",
+      "sourceGroup": "Skills by Apollo GraphQL",
+      "description": "Reference guide for designing clean, evolvable GraphQL schemas",
+      "sourceUrl": "https://officialskills.sh/apollographql/skills/graphql-schema",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "apollographql"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-apollographql-rover",
+      "name": "apollographql/rover",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "apollographql",
+      "sourceGroup": "Skills by Apollo GraphQL",
+      "description": "CLI tool for managing GraphQL schemas in Apollo GraphOS",
+      "sourceUrl": "https://officialskills.sh/apollographql/skills/rover",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "apollographql"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-apollographql-rust-best-practices",
+      "name": "apollographql/rust-best-practices",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "apollographql",
+      "sourceGroup": "Skills by Apollo GraphQL",
+      "description": "Rust coding guidelines drawn from Apollo GraphQL's internal handbook",
+      "sourceUrl": "https://officialskills.sh/apollographql/skills/rust-best-practices",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "apollographql"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-apollographql-skill-creator",
+      "name": "apollographql/skill-creator",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "apollographql",
+      "sourceGroup": "Skills by Apollo GraphQL",
+      "description": "Create and structure Agent Skills focused on Apollo GraphQL",
+      "sourceUrl": "https://officialskills.sh/apollographql/skills/skill-creator",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "apollographql"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-auth0-auth0-android",
+      "name": "auth0/auth0-android",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "auth0",
+      "sourceGroup": "Skills by Auth0",
+      "description": "Add authentication to native Android apps using the Auth0 SDK",
+      "sourceUrl": "https://officialskills.sh/auth0/skills/auth0-android",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "auth0"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-auth0-auth0-angular",
+      "name": "auth0/auth0-angular",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "auth0",
+      "sourceGroup": "Skills by Auth0",
+      "description": "Add authentication to Angular apps using @auth0/auth0-angular",
+      "sourceUrl": "https://officialskills.sh/auth0/skills/auth0-angular",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "auth0"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-auth0-auth0-aspnetcore-api",
+      "name": "auth0/auth0-aspnetcore-api",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "auth0",
+      "sourceGroup": "Skills by Auth0",
+      "description": "Add JWT access token validation to ASP.NET Core APIs",
+      "sourceUrl": "https://officialskills.sh/auth0/skills/auth0-aspnetcore-api",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "auth0"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-auth0-auth0-express",
+      "name": "auth0/auth0-express",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "auth0",
+      "sourceGroup": "Skills by Auth0",
+      "description": "Add session-based authentication to Express.js apps",
+      "sourceUrl": "https://officialskills.sh/auth0/skills/auth0-express",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "auth0"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-auth0-auth0-fastify",
+      "name": "auth0/auth0-fastify",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "auth0",
+      "sourceGroup": "Skills by Auth0",
+      "description": "Add session-based authentication to Fastify web apps",
+      "sourceUrl": "https://officialskills.sh/auth0/skills/auth0-fastify",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "auth0"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-auth0-auth0-fastify-api",
+      "name": "auth0/auth0-fastify-api",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "auth0",
+      "sourceGroup": "Skills by Auth0",
+      "description": "Secure Fastify API endpoints with JWT Bearer token validation",
+      "sourceUrl": "https://officialskills.sh/auth0/skills/auth0-fastify-api",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "auth0"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-auth0-auth0-mfa",
+      "name": "auth0/auth0-mfa",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "auth0",
+      "sourceGroup": "Skills by Auth0",
+      "description": "Add Multi-Factor Authentication to Auth0-powered apps",
+      "sourceUrl": "https://officialskills.sh/auth0/skills/auth0-mfa",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "auth0"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-auth0-auth0-migration",
+      "name": "auth0/auth0-migration",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "auth0",
+      "sourceGroup": "Skills by Auth0",
+      "description": "Migrate users and auth flows from other providers to Auth0",
+      "sourceUrl": "https://officialskills.sh/auth0/skills/auth0-migration",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "auth0"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-auth0-auth0-nextjs",
+      "name": "auth0/auth0-nextjs",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "auth0",
+      "sourceGroup": "Skills by Auth0",
+      "description": "Add authentication to Next.js apps",
+      "sourceUrl": "https://officialskills.sh/auth0/skills/auth0-nextjs",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "auth0"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-auth0-auth0-nuxt",
+      "name": "auth0/auth0-nuxt",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "auth0",
+      "sourceGroup": "Skills by Auth0",
+      "description": "Add Auth0 authentication to Nuxt 3/4 apps with encrypted cookie sessions",
+      "sourceUrl": "https://officialskills.sh/auth0/skills/auth0-nuxt",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "auth0"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-auth0-auth0-quickstart",
+      "name": "auth0/auth0-quickstart",
+      "kind": "skill",
+      "category": "工程开发",
+      "publisher": "auth0",
+      "sourceGroup": "Skills by Auth0",
+      "description": "Detect your framework and scaffold Auth0 integration automatically",
+      "sourceUrl": "https://officialskills.sh/auth0/skills/auth0-quickstart",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "auth0"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-auth0-auth0-react",
+      "name": "auth0/auth0-react",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "auth0",
+      "sourceGroup": "Skills by Auth0",
+      "description": "Add authentication to React SPAs using @auth0/auth0-react",
+      "sourceUrl": "https://officialskills.sh/auth0/skills/auth0-react",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "auth0"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-auth0-auth0-react-native",
+      "name": "auth0/auth0-react-native",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "auth0",
+      "sourceGroup": "Skills by Auth0",
+      "description": "Add authentication to React Native and Expo mobile apps",
+      "sourceUrl": "https://officialskills.sh/auth0/skills/auth0-react-native",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "auth0"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-auth0-auth0-vue",
+      "name": "auth0/auth0-vue",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "auth0",
+      "sourceGroup": "Skills by Auth0",
+      "description": "Add authentication to Vue.js apps",
+      "sourceUrl": "https://officialskills.sh/auth0/skills/auth0-vue",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "auth0"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-brave-answers",
+      "name": "brave/answers",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "brave",
+      "sourceGroup": "Skills by Brave",
+      "description": "AI-generated answers grounded in live web search results",
+      "sourceUrl": "https://officialskills.sh/brave/skills/answers",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "brave"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-brave-bx",
+      "name": "brave/bx",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "brave",
+      "sourceGroup": "Skills by Brave",
+      "description": "CLI tool for web search built for AI agents",
+      "sourceUrl": "https://officialskills.sh/brave/skills/bx",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "brave"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-brave-images-search",
+      "name": "brave/images-search",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "brave",
+      "sourceGroup": "Skills by Brave",
+      "description": "Search for images using the Brave Search API",
+      "sourceUrl": "https://officialskills.sh/brave/skills/images-search",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "brave"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-brave-llm-context",
+      "name": "brave/llm-context",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "brave",
+      "sourceGroup": "Skills by Brave",
+      "description": "Return pre-extracted web content (text, tables, code) from Brave Search",
+      "sourceUrl": "https://officialskills.sh/brave/skills/llm-context",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "brave"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-brave-local-descriptions",
+      "name": "brave/local-descriptions",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "brave",
+      "sourceGroup": "Skills by Brave",
+      "description": "Fetch AI-generated text descriptions for points of interest",
+      "sourceUrl": "https://officialskills.sh/brave/skills/local-descriptions",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "brave"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-brave-local-pois",
+      "name": "brave/local-pois",
+      "kind": "skill",
+      "category": "其他工具",
+      "publisher": "brave",
+      "sourceGroup": "Skills by Brave",
+      "description": "Retrieve detailed local business and POI information",
+      "sourceUrl": "https://officialskills.sh/brave/skills/local-pois",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "brave"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-brave-news-search",
+      "name": "brave/news-search",
+      "kind": "skill",
+      "category": "其他工具",
+      "publisher": "brave",
+      "sourceGroup": "Skills by Brave",
+      "description": "Search Brave's news index with article metadata",
+      "sourceUrl": "https://officialskills.sh/brave/skills/news-search",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "brave"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-brave-spellcheck",
+      "name": "brave/spellcheck",
+      "kind": "skill",
+      "category": "其他工具",
+      "publisher": "brave",
+      "sourceGroup": "Skills by Brave",
+      "description": "Check search queries for spelling errors and get corrections",
+      "sourceUrl": "https://officialskills.sh/brave/skills/spellcheck",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "brave"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-brave-suggest",
+      "name": "brave/suggest",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "brave",
+      "sourceGroup": "Skills by Brave",
+      "description": "Query autocomplete suggestions via the Brave Search API",
+      "sourceUrl": "https://officialskills.sh/brave/skills/suggest",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "brave"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-brave-videos-search",
+      "name": "brave/videos-search",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "brave",
+      "sourceGroup": "Skills by Brave",
+      "description": "Search for videos across the web via the Brave Search API",
+      "sourceUrl": "https://officialskills.sh/brave/skills/videos-search",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "brave"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-brave-web-search",
+      "name": "brave/web-search",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "brave",
+      "sourceGroup": "Skills by Brave",
+      "description": "Search the web via Brave's Search API with ranked results",
+      "sourceUrl": "https://officialskills.sh/brave/skills/web-search",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "brave"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-browserbase-browser",
+      "name": "browserbase/browser",
+      "kind": "skill",
+      "category": "工程开发",
+      "publisher": "browserbase",
+      "sourceGroup": "Skills by Browserbase",
+      "description": "Automate web browser interactions through natural language CLI commands",
+      "sourceUrl": "https://officialskills.sh/browserbase/skills/browser",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "browserbase"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-browserbase-browserbase-cli",
+      "name": "browserbase/browserbase-cli",
+      "kind": "skill",
+      "category": "工程开发",
+      "publisher": "browserbase",
+      "sourceGroup": "Skills by Browserbase",
+      "description": "CLI wrapper around the Browserbase platform",
+      "sourceUrl": "https://officialskills.sh/browserbase/skills/browserbase-cli",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "browserbase"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-browserbase-cookie-sync",
+      "name": "browserbase/cookie-sync",
+      "kind": "skill",
+      "category": "其他工具",
+      "publisher": "browserbase",
+      "sourceGroup": "Skills by Browserbase",
+      "description": "Export cookies from local Chrome into a Browserbase persistent context",
+      "sourceUrl": "https://officialskills.sh/browserbase/skills/cookie-sync",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "browserbase"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-browserbase-fetch",
+      "name": "browserbase/fetch",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "browserbase",
+      "sourceGroup": "Skills by Browserbase",
+      "description": "Fetch HTML, JSON, headers, and status codes through the Browserbase API",
+      "sourceUrl": "https://officialskills.sh/browserbase/skills/fetch",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "browserbase"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-browserbase-functions",
+      "name": "browserbase/functions",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "browserbase",
+      "sourceGroup": "Skills by Browserbase",
+      "description": "Deploy browser automation scripts as serverless cloud functions",
+      "sourceUrl": "https://officialskills.sh/browserbase/skills/functions",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "browserbase"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-browserbase-search",
+      "name": "browserbase/search",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "browserbase",
+      "sourceGroup": "Skills by Browserbase",
+      "description": "Search the web via the Browserbase API with structured results",
+      "sourceUrl": "https://officialskills.sh/browserbase/skills/search",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "browserbase"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-browserbase-ui-test",
+      "name": "browserbase/ui-test",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "browserbase",
+      "sourceGroup": "Skills by Browserbase",
+      "description": "Run adversarial UI tests by analyzing git diffs in a real browser",
+      "sourceUrl": "https://officialskills.sh/browserbase/skills/ui-test",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "browserbase"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-coderabbitai-autofix",
+      "name": "coderabbitai/autofix",
+      "kind": "skill",
+      "category": "工程开发",
+      "publisher": "coderabbitai",
+      "sourceGroup": "Skills by CodeRabbit",
+      "description": "Fetch unresolved CodeRabbit review comments from GitHub PRs and apply fixes",
+      "sourceUrl": "https://officialskills.sh/coderabbitai/skills/autofix",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "coderabbitai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-coderabbitai-code-review",
+      "name": "coderabbitai/code-review",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "coderabbitai",
+      "sourceGroup": "Skills by CodeRabbit",
+      "description": "Run AI-powered code reviews through the CodeRabbit CLI",
+      "sourceUrl": "https://officialskills.sh/coderabbitai/skills/code-review",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "coderabbitai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-coinbase-authenticate-wallet",
+      "name": "coinbase/authenticate-wallet",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "coinbase",
+      "sourceGroup": "Skills by Coinbase",
+      "description": "Handle sign-in for the Coinbase payments wallet via email OTP",
+      "sourceUrl": "https://officialskills.sh/coinbase/skills/authenticate-wallet",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "coinbase"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-coinbase-fund",
+      "name": "coinbase/fund",
+      "kind": "skill",
+      "category": "其他工具",
+      "publisher": "coinbase",
+      "sourceGroup": "Skills by Coinbase",
+      "description": "Add USDC to a Coinbase-powered wallet through Coinbase Onramp",
+      "sourceUrl": "https://officialskills.sh/coinbase/skills/fund",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "coinbase"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-coinbase-monetize-service",
+      "name": "coinbase/monetize-service",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "coinbase",
+      "sourceGroup": "Skills by Coinbase",
+      "description": "Scaffold an Express server that charges USDC per request using x402",
+      "sourceUrl": "https://officialskills.sh/coinbase/skills/monetize-service",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "coinbase"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-coinbase-pay-for-service",
+      "name": "coinbase/pay-for-service",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "coinbase",
+      "sourceGroup": "Skills by Coinbase",
+      "description": "Call paid API endpoints that use the x402 protocol with automatic USDC",
+      "sourceUrl": "https://officialskills.sh/coinbase/skills/pay-for-service",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "coinbase"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-coinbase-query-onchain-data",
+      "name": "coinbase/query-onchain-data",
+      "kind": "skill",
+      "category": "数据与分析",
+      "publisher": "coinbase",
+      "sourceGroup": "Skills by Coinbase",
+      "description": "Query decoded onchain data (events, tx, blocks) on Base",
+      "sourceUrl": "https://officialskills.sh/coinbase/skills/query-onchain-data",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "coinbase"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-coinbase-search-for-service",
+      "name": "coinbase/search-for-service",
+      "kind": "skill",
+      "category": "其他工具",
+      "publisher": "coinbase",
+      "sourceGroup": "Skills by Coinbase",
+      "description": "Search and browse the x402 bazaar marketplace",
+      "sourceUrl": "https://officialskills.sh/coinbase/skills/search-for-service",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "coinbase"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-coinbase-send-usdc",
+      "name": "coinbase/send-usdc",
+      "kind": "skill",
+      "category": "其他工具",
+      "publisher": "coinbase",
+      "sourceGroup": "Skills by Coinbase",
+      "description": "Send USDC to any Ethereum address or ENS name on Base",
+      "sourceUrl": "https://officialskills.sh/coinbase/skills/send-usdc",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "coinbase"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-coinbase-trade",
+      "name": "coinbase/trade",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "coinbase",
+      "sourceGroup": "Skills by Coinbase",
+      "description": "Swap and trade tokens on Base using the CDP Swap API",
+      "sourceUrl": "https://officialskills.sh/coinbase/skills/trade",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "coinbase"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-coinbase-x402",
+      "name": "coinbase/x402",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "coinbase",
+      "sourceGroup": "Skills by Coinbase",
+      "description": "Discover and call paid API endpoints using the x402 payment protocol",
+      "sourceUrl": "https://officialskills.sh/coinbase/skills/x402",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "coinbase"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-datadog-labs-dd-apm",
+      "name": "datadog-labs/dd-apm",
+      "kind": "skill",
+      "category": "数据与分析",
+      "publisher": "datadog-labs",
+      "sourceGroup": "Skills by Datadog Labs",
+      "description": "Query Datadog APM data directly from your editor",
+      "sourceUrl": "https://officialskills.sh/datadog-labs/skills/dd-apm",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "datadog-labs"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-datadog-labs-dd-docs",
+      "name": "datadog-labs/dd-docs",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "datadog-labs",
+      "sourceGroup": "Skills by Datadog Labs",
+      "description": "Look up Datadog documentation via the LLM-optimized docs index",
+      "sourceUrl": "https://officialskills.sh/datadog-labs/skills/dd-docs",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "datadog-labs"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-datadog-labs-dd-llmo-eval-bootstrap",
+      "name": "datadog-labs/dd-llmo-eval-bootstrap",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "datadog-labs",
+      "sourceGroup": "Skills by Datadog Labs",
+      "description": "Analyze production LLM traces and generate evaluators",
+      "sourceUrl": "https://officialskills.sh/datadog-labs/skills/dd-llmo-eval-bootstrap",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "datadog-labs"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-datadog-labs-dd-llmo-eval-trace-rca",
+      "name": "datadog-labs/dd-llmo-eval-trace-rca",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "datadog-labs",
+      "sourceGroup": "Skills by Datadog Labs",
+      "description": "Root-cause LLM app failures using eval traces",
+      "sourceUrl": "https://officialskills.sh/datadog-labs/skills/dd-llmo-eval-trace-rca",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "datadog-labs"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-datadog-labs-dd-llmo-experiment-analyzer",
+      "name": "datadog-labs/dd-llmo-experiment-analyzer",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "datadog-labs",
+      "sourceGroup": "Skills by Datadog Labs",
+      "description": "Analyze single or comparative LLM experiment results",
+      "sourceUrl": "https://officialskills.sh/datadog-labs/skills/dd-llmo-experiment-analyzer",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "datadog-labs"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-datadog-labs-dd-logs",
+      "name": "datadog-labs/dd-logs",
+      "kind": "skill",
+      "category": "工程开发",
+      "publisher": "datadog-labs",
+      "sourceGroup": "Skills by Datadog Labs",
+      "description": "Search, filter, and archive Datadog logs through pup CLI",
+      "sourceUrl": "https://officialskills.sh/datadog-labs/skills/dd-logs",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "datadog-labs"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-datadog-labs-dd-monitors",
+      "name": "datadog-labs/dd-monitors",
+      "kind": "skill",
+      "category": "工程开发",
+      "publisher": "datadog-labs",
+      "sourceGroup": "Skills by Datadog Labs",
+      "description": "Manage Datadog monitors through the pup CLI",
+      "sourceUrl": "https://officialskills.sh/datadog-labs/skills/dd-monitors",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "datadog-labs"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-datadog-labs-dd-pup",
+      "name": "datadog-labs/dd-pup",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "datadog-labs",
+      "sourceGroup": "Skills by Datadog Labs",
+      "description": "Rust-based CLI (pup) for talking to the Datadog API",
+      "sourceUrl": "https://officialskills.sh/datadog-labs/skills/dd-pup",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "datadog-labs"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-firebase-developing-genkit-dart",
+      "name": "firebase/developing-genkit-dart",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "firebase",
+      "sourceGroup": "Skills by Firebase",
+      "description": "Build AI apps with the Genkit Dart SDK",
+      "sourceUrl": "https://officialskills.sh/firebase/skills/developing-genkit-dart",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "firebase"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-firebase-developing-genkit-go",
+      "name": "firebase/developing-genkit-go",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "firebase",
+      "sourceGroup": "Skills by Firebase",
+      "description": "Build AI apps with the Genkit Go SDK",
+      "sourceUrl": "https://officialskills.sh/firebase/skills/developing-genkit-go",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "firebase"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-firebase-developing-genkit-js",
+      "name": "firebase/developing-genkit-js",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "firebase",
+      "sourceGroup": "Skills by Firebase",
+      "description": "Build AI-powered apps with Firebase Genkit in Node.js",
+      "sourceUrl": "https://officialskills.sh/firebase/skills/developing-genkit-js",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "firebase"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-firebase-firebase-ai-logic-basics",
+      "name": "firebase/firebase-ai-logic-basics",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "firebase",
+      "sourceGroup": "Skills by Firebase",
+      "description": "Call Gemini models from web and mobile apps via Firebase AI Logic",
+      "sourceUrl": "https://officialskills.sh/firebase/skills/firebase-ai-logic-basics",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "firebase"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-firebase-firebase-app-hosting-basics",
+      "name": "firebase/firebase-app-hosting-basics",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "firebase",
+      "sourceGroup": "Skills by Firebase",
+      "description": "Deploy and manage full-stack web apps (Next.js, Angular, etc.)",
+      "sourceUrl": "https://officialskills.sh/firebase/skills/firebase-app-hosting-basics",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "firebase"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-firebase-firebase-auth-basics",
+      "name": "firebase/firebase-auth-basics",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "firebase",
+      "sourceGroup": "Skills by Firebase",
+      "description": "Set up Firebase Authentication with sign-in providers",
+      "sourceUrl": "https://officialskills.sh/firebase/skills/firebase-auth-basics",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "firebase"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-firebase-firebase-basics",
+      "name": "firebase/firebase-basics",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "firebase",
+      "sourceGroup": "Skills by Firebase",
+      "description": "Handle Firebase CLI install, auth, and day-to-day workflow",
+      "sourceUrl": "https://officialskills.sh/firebase/skills/firebase-basics",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "firebase"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-firebase-firebase-data-connect-basics",
+      "name": "firebase/firebase-data-connect-basics",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "firebase",
+      "sourceGroup": "Skills by Firebase",
+      "description": "Build Firebase Data Connect backends backed by Cloud SQL",
+      "sourceUrl": "https://officialskills.sh/firebase/skills/firebase-data-connect-basics",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "firebase"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-firebase-firebase-firestore-enterprise-native-mode",
+      "name": "firebase/firebase-firestore-enterprise-native-mode",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "firebase",
+      "sourceGroup": "Skills by Firebase",
+      "description": "Set up and use Firestore Enterprise Native Mode",
+      "sourceUrl": "https://officialskills.sh/firebase/skills/firebase-firestore-enterprise-native-mode",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "firebase"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-firebase-firebase-firestore-standard",
+      "name": "firebase/firebase-firestore-standard",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "firebase",
+      "sourceGroup": "Skills by Firebase",
+      "description": "Complete guide for Cloud Firestore Standard Edition",
+      "sourceUrl": "https://officialskills.sh/firebase/skills/firebase-firestore-standard",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "firebase"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-firebase-firebase-hosting-basics",
+      "name": "firebase/firebase-hosting-basics",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "firebase",
+      "sourceGroup": "Skills by Firebase",
+      "description": "Deploy static sites, SPAs, and microservices to Firebase Hosting",
+      "sourceUrl": "https://officialskills.sh/firebase/skills/firebase-hosting-basics",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "firebase"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-firebase-firebase-security-rules-auditor",
+      "name": "firebase/firebase-security-rules-auditor",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "firebase",
+      "sourceGroup": "Skills by Firebase",
+      "description": "Audit Firestore security rules and flag risky patterns",
+      "sourceUrl": "https://officialskills.sh/firebase/skills/firebase-security-rules-auditor",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "firebase"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-flutter-flutter-adding-home-screen-widgets",
+      "name": "flutter/flutter-adding-home-screen-widgets",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "flutter",
+      "sourceGroup": "Skills by Flutter",
+      "description": "Add home screen widgets to Flutter apps on Android and iOS",
+      "sourceUrl": "https://officialskills.sh/flutter/skills/flutter-adding-home-screen-widgets",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "flutter"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-flutter-flutter-animating-apps",
+      "name": "flutter/flutter-animating-apps",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "flutter",
+      "sourceGroup": "Skills by Flutter",
+      "description": "Implement animated effects, transitions, and motion",
+      "sourceUrl": "https://officialskills.sh/flutter/skills/flutter-animating-apps",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "flutter"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-flutter-flutter-architecting-apps",
+      "name": "flutter/flutter-architecting-apps",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "flutter",
+      "sourceGroup": "Skills by Flutter",
+      "description": "Structure a Flutter app using layered architecture",
+      "sourceUrl": "https://officialskills.sh/flutter/skills/flutter-architecting-apps",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "flutter"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-flutter-flutter-building-forms",
+      "name": "flutter/flutter-building-forms",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "flutter",
+      "sourceGroup": "Skills by Flutter",
+      "description": "Build Flutter forms with validation and user input",
+      "sourceUrl": "https://officialskills.sh/flutter/skills/flutter-building-forms",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "flutter"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-flutter-flutter-building-layouts",
+      "name": "flutter/flutter-building-layouts",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "flutter",
+      "sourceGroup": "Skills by Flutter",
+      "description": "Build and fix layouts using the constraint system (Row, Column, Stack)",
+      "sourceUrl": "https://officialskills.sh/flutter/skills/flutter-building-layouts",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "flutter"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-flutter-flutter-building-plugins",
+      "name": "flutter/flutter-building-plugins",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "flutter",
+      "sourceGroup": "Skills by Flutter",
+      "description": "Create Flutter plugins that bridge Dart with platform code",
+      "sourceUrl": "https://officialskills.sh/flutter/skills/flutter-building-plugins",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "flutter"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-flutter-flutter-caching-data",
+      "name": "flutter/flutter-caching-data",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "flutter",
+      "sourceGroup": "Skills by Flutter",
+      "description": "Implement offline-first caching strategies",
+      "sourceUrl": "https://officialskills.sh/flutter/skills/flutter-caching-data",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "flutter"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-flutter-flutter-embedding-native-views",
+      "name": "flutter/flutter-embedding-native-views",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "flutter",
+      "sourceGroup": "Skills by Flutter",
+      "description": "Embed native Android, iOS, and macOS views in Flutter widgets",
+      "sourceUrl": "https://officialskills.sh/flutter/skills/flutter-embedding-native-views",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "flutter"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-flutter-flutter-handling-concurrency",
+      "name": "flutter/flutter-handling-concurrency",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "flutter",
+      "sourceGroup": "Skills by Flutter",
+      "description": "Run heavy work in background Dart isolates",
+      "sourceUrl": "https://officialskills.sh/flutter/skills/flutter-handling-concurrency",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "flutter"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-flutter-flutter-handling-http-and-json",
+      "name": "flutter/flutter-handling-http-and-json",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "flutter",
+      "sourceGroup": "Skills by Flutter",
+      "description": "Handle HTTP requests and JSON serialization",
+      "sourceUrl": "https://officialskills.sh/flutter/skills/flutter-handling-http-and-json",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "flutter"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-flutter-flutter-implementing-navigation-and-routing",
+      "name": "flutter/flutter-implementing-navigation-and-routing",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "flutter",
+      "sourceGroup": "Skills by Flutter",
+      "description": "Handle routing, navigation, and deep linking",
+      "sourceUrl": "https://officialskills.sh/flutter/skills/flutter-implementing-navigation-and-routing",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "flutter"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-flutter-flutter-improving-accessibility",
+      "name": "flutter/flutter-improving-accessibility",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "flutter",
+      "sourceGroup": "Skills by Flutter",
+      "description": "Configure Flutter for screen readers and assistive tech",
+      "sourceUrl": "https://officialskills.sh/flutter/skills/flutter-improving-accessibility",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "flutter"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-flutter-flutter-interoperating-with-native-apis",
+      "name": "flutter/flutter-interoperating-with-native-apis",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "flutter",
+      "sourceGroup": "Skills by Flutter",
+      "description": "Bridge Flutter with native platform APIs",
+      "sourceUrl": "https://officialskills.sh/flutter/skills/flutter-interoperating-with-native-apis",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "flutter"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-flutter-flutter-localizing-apps",
+      "name": "flutter/flutter-localizing-apps",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "flutter",
+      "sourceGroup": "Skills by Flutter",
+      "description": "Configure Flutter for multiple languages and regions",
+      "sourceUrl": "https://officialskills.sh/flutter/skills/flutter-localizing-apps",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "flutter"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-flutter-flutter-managing-state",
+      "name": "flutter/flutter-managing-state",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "flutter",
+      "sourceGroup": "Skills by Flutter",
+      "description": "Manage local widget state and shared application state",
+      "sourceUrl": "https://officialskills.sh/flutter/skills/flutter-managing-state",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "flutter"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-flutter-flutter-reducing-app-size",
+      "name": "flutter/flutter-reducing-app-size",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "flutter",
+      "sourceGroup": "Skills by Flutter",
+      "description": "Measure and optimize Flutter app bundle sizes",
+      "sourceUrl": "https://officialskills.sh/flutter/skills/flutter-reducing-app-size",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "flutter"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-flutter-flutter-setting-up-on-linux",
+      "name": "flutter/flutter-setting-up-on-linux",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "flutter",
+      "sourceGroup": "Skills by Flutter",
+      "description": "Set up a Linux machine for Flutter desktop development",
+      "sourceUrl": "https://officialskills.sh/flutter/skills/flutter-setting-up-on-linux",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "flutter"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-flutter-flutter-setting-up-on-macos",
+      "name": "flutter/flutter-setting-up-on-macos",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "flutter",
+      "sourceGroup": "Skills by Flutter",
+      "description": "Set up a macOS machine for Flutter development",
+      "sourceUrl": "https://officialskills.sh/flutter/skills/flutter-setting-up-on-macos",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "flutter"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-flutter-flutter-setting-up-on-windows",
+      "name": "flutter/flutter-setting-up-on-windows",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "flutter",
+      "sourceGroup": "Skills by Flutter",
+      "description": "Set up a Windows machine for Flutter development",
+      "sourceUrl": "https://officialskills.sh/flutter/skills/flutter-setting-up-on-windows",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "flutter"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-flutter-flutter-testing-apps",
+      "name": "flutter/flutter-testing-apps",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "flutter",
+      "sourceGroup": "Skills by Flutter",
+      "description": "Implement unit, widget, and integration tests",
+      "sourceUrl": "https://officialskills.sh/flutter/skills/flutter-testing-apps",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "flutter"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-flutter-flutter-theming-apps",
+      "name": "flutter/flutter-theming-apps",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "flutter",
+      "sourceGroup": "Skills by Flutter",
+      "description": "Customize Flutter app appearance through the theming system",
+      "sourceUrl": "https://officialskills.sh/flutter/skills/flutter-theming-apps",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "flutter"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-flutter-flutter-working-with-databases",
+      "name": "flutter/flutter-working-with-databases",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "flutter",
+      "sourceGroup": "Skills by Flutter",
+      "description": "Build a structured data layer using SQLite",
+      "sourceUrl": "https://officialskills.sh/flutter/skills/flutter-working-with-databases",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "flutter"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-deanpeters-acquisition-channel-advisor",
+      "name": "deanpeters/acquisition-channel-advisor",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "deanpeters",
+      "sourceGroup": "Product Manager Skills by Dean Peters",
+      "description": "Evaluate channels using unit economics and recommend scale/test/kill decisions",
+      "sourceUrl": "https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/acquisition-channel-advisor",
+      "installSource": {
+        "repoUrl": "https://github.com/deanpeters/Product-Manager-Skills",
+        "subPath": "skills/acquisition-channel-advisor"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "deanpeters"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-deanpeters-ai-shaped-readiness-advisor",
+      "name": "deanpeters/ai-shaped-readiness-advisor",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "deanpeters",
+      "sourceGroup": "Product Manager Skills by Dean Peters",
+      "description": "Assess automation vs. redesign opportunities across five competencies",
+      "sourceUrl": "https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/ai-shaped-readiness-advisor",
+      "installSource": {
+        "repoUrl": "https://github.com/deanpeters/Product-Manager-Skills",
+        "subPath": "skills/ai-shaped-readiness-advisor"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "deanpeters"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-deanpeters-altitude-horizon-framework",
+      "name": "deanpeters/altitude-horizon-framework",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "deanpeters",
+      "sourceGroup": "Product Manager Skills by Dean Peters",
+      "description": "Navigate the PM→Director mindset shift covering scope, time horizons, and failure modes",
+      "sourceUrl": "https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/altitude-horizon-framework",
+      "installSource": {
+        "repoUrl": "https://github.com/deanpeters/Product-Manager-Skills",
+        "subPath": "skills/altitude-horizon-framework"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "deanpeters"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-deanpeters-business-health-diagnostic",
+      "name": "deanpeters/business-health-diagnostic",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "deanpeters",
+      "sourceGroup": "Product Manager Skills by Dean Peters",
+      "description": "Diagnose SaaS health, identify red flags, and prioritize recovery actions",
+      "sourceUrl": "https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/business-health-diagnostic",
+      "installSource": {
+        "repoUrl": "https://github.com/deanpeters/Product-Manager-Skills",
+        "subPath": "skills/business-health-diagnostic"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "deanpeters"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-deanpeters-company-research",
+      "name": "deanpeters/company-research",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "deanpeters",
+      "sourceGroup": "Product Manager Skills by Dean Peters",
+      "description": "Deep-dive competitor or company analysis",
+      "sourceUrl": "https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/company-research",
+      "installSource": {
+        "repoUrl": "https://github.com/deanpeters/Product-Manager-Skills",
+        "subPath": "skills/company-research"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "deanpeters"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-deanpeters-customer-journey-map",
+      "name": "deanpeters/customer-journey-map",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "deanpeters",
+      "sourceGroup": "Product Manager Skills by Dean Peters",
+      "description": "Map customer experience across touchpoints using the NNGroup framework",
+      "sourceUrl": "https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/customer-journey-map",
+      "installSource": {
+        "repoUrl": "https://github.com/deanpeters/Product-Manager-Skills",
+        "subPath": "skills/customer-journey-map"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "deanpeters"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-deanpeters-eol-message",
+      "name": "deanpeters/eol-message",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "deanpeters",
+      "sourceGroup": "Product Manager Skills by Dean Peters",
+      "description": "Communicate product or feature deprecation gracefully",
+      "sourceUrl": "https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/eol-message",
+      "installSource": {
+        "repoUrl": "https://github.com/deanpeters/Product-Manager-Skills",
+        "subPath": "skills/eol-message"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "deanpeters"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-deanpeters-epic-hypothesis",
+      "name": "deanpeters/epic-hypothesis",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "deanpeters",
+      "sourceGroup": "Product Manager Skills by Dean Peters",
+      "description": "Turn initiatives into testable hypotheses with measurable success metrics",
+      "sourceUrl": "https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/epic-hypothesis",
+      "installSource": {
+        "repoUrl": "https://github.com/deanpeters/Product-Manager-Skills",
+        "subPath": "skills/epic-hypothesis"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "deanpeters"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-deanpeters-finance-metrics-quickref",
+      "name": "deanpeters/finance-metrics-quickref",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "deanpeters",
+      "sourceGroup": "Product Manager Skills by Dean Peters",
+      "description": "Reference guide for 32+ SaaS finance metrics with formulas and benchmarks",
+      "sourceUrl": "https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/finance-metrics-quickref",
+      "installSource": {
+        "repoUrl": "https://github.com/deanpeters/Product-Manager-Skills",
+        "subPath": "skills/finance-metrics-quickref"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "deanpeters"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-deanpeters-jobs-to-be-done",
+      "name": "deanpeters/jobs-to-be-done",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "deanpeters",
+      "sourceGroup": "Product Manager Skills by Dean Peters",
+      "description": "Understand customer objectives using the JTBD framework",
+      "sourceUrl": "https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/jobs-to-be-done",
+      "installSource": {
+        "repoUrl": "https://github.com/deanpeters/Product-Manager-Skills",
+        "subPath": "skills/jobs-to-be-done"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "deanpeters"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-deanpeters-pestel-analysis",
+      "name": "deanpeters/pestel-analysis",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "deanpeters",
+      "sourceGroup": "Product Manager Skills by Dean Peters",
+      "description": "Analyze external factors across Political, Economic, Social, Tech, Environmental, and Legal dimensions",
+      "sourceUrl": "https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/pestel-analysis",
+      "installSource": {
+        "repoUrl": "https://github.com/deanpeters/Product-Manager-Skills",
+        "subPath": "skills/pestel-analysis"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "deanpeters"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-deanpeters-pol-probe",
+      "name": "deanpeters/pol-probe",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "deanpeters",
+      "sourceGroup": "Product Manager Skills by Dean Peters",
+      "description": "Define lightweight validation experiments to test hypotheses",
+      "sourceUrl": "https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/pol-probe",
+      "installSource": {
+        "repoUrl": "https://github.com/deanpeters/Product-Manager-Skills",
+        "subPath": "skills/pol-probe"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "deanpeters"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-deanpeters-positioning-statement",
+      "name": "deanpeters/positioning-statement",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "deanpeters",
+      "sourceGroup": "Product Manager Skills by Dean Peters",
+      "description": "Define target audience, problem solved, and differentiation using Geoffrey Moore's framework",
+      "sourceUrl": "https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/positioning-statement",
+      "installSource": {
+        "repoUrl": "https://github.com/deanpeters/Product-Manager-Skills",
+        "subPath": "skills/positioning-statement"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "deanpeters"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-deanpeters-press-release",
+      "name": "deanpeters/press-release",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "deanpeters",
+      "sourceGroup": "Product Manager Skills by Dean Peters",
+      "description": "Clarify product vision with a future press release using Amazon's Working Backwards method",
+      "sourceUrl": "https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/press-release",
+      "installSource": {
+        "repoUrl": "https://github.com/deanpeters/Product-Manager-Skills",
+        "subPath": "skills/press-release"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "deanpeters"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-deanpeters-problem-statement",
+      "name": "deanpeters/problem-statement",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "deanpeters",
+      "sourceGroup": "Product Manager Skills by Dean Peters",
+      "description": "Frame customer problems with evidence before jumping to solutions",
+      "sourceUrl": "https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/problem-statement",
+      "installSource": {
+        "repoUrl": "https://github.com/deanpeters/Product-Manager-Skills",
+        "subPath": "skills/problem-statement"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "deanpeters"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-deanpeters-proto-persona",
+      "name": "deanpeters/proto-persona",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "deanpeters",
+      "sourceGroup": "Product Manager Skills by Dean Peters",
+      "description": "Create hypothesis-driven personas before conducting full research",
+      "sourceUrl": "https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/proto-persona",
+      "installSource": {
+        "repoUrl": "https://github.com/deanpeters/Product-Manager-Skills",
+        "subPath": "skills/proto-persona"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "deanpeters"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-deanpeters-recommendation-canvas",
+      "name": "deanpeters/recommendation-canvas",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "deanpeters",
+      "sourceGroup": "Product Manager Skills by Dean Peters",
+      "description": "Document AI-powered product recommendations",
+      "sourceUrl": "https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/recommendation-canvas",
+      "installSource": {
+        "repoUrl": "https://github.com/deanpeters/Product-Manager-Skills",
+        "subPath": "skills/recommendation-canvas"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "deanpeters"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-deanpeters-saas-economics-efficiency-metrics",
+      "name": "deanpeters/saas-economics-efficiency-metrics",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "deanpeters",
+      "sourceGroup": "Product Manager Skills by Dean Peters",
+      "description": "Calculate unit economics and capital efficiency including CAC, LTV, payback, and Rule of 40",
+      "sourceUrl": "https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/saas-economics-efficiency-metrics",
+      "installSource": {
+        "repoUrl": "https://github.com/deanpeters/Product-Manager-Skills",
+        "subPath": "skills/saas-economics-efficiency-metrics"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "deanpeters"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-deanpeters-saas-revenue-growth-metrics",
+      "name": "deanpeters/saas-revenue-growth-metrics",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "deanpeters",
+      "sourceGroup": "Product Manager Skills by Dean Peters",
+      "description": "Track revenue, retention, and growth metrics including MRR/ARR, churn, NRR, and expansion",
+      "sourceUrl": "https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/saas-revenue-growth-metrics",
+      "installSource": {
+        "repoUrl": "https://github.com/deanpeters/Product-Manager-Skills",
+        "subPath": "skills/saas-revenue-growth-metrics"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "deanpeters"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-deanpeters-storyboard",
+      "name": "deanpeters/storyboard",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "deanpeters",
+      "sourceGroup": "Product Manager Skills by Dean Peters",
+      "description": "Visualize user journeys with 6-frame narrative storyboards",
+      "sourceUrl": "https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/storyboard",
+      "installSource": {
+        "repoUrl": "https://github.com/deanpeters/Product-Manager-Skills",
+        "subPath": "skills/storyboard"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "deanpeters"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-deanpeters-user-story",
+      "name": "deanpeters/user-story",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "deanpeters",
+      "sourceGroup": "Product Manager Skills by Dean Peters",
+      "description": "Write user stories with acceptance criteria using Mike Cohn and Gherkin formats",
+      "sourceUrl": "https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/user-story",
+      "installSource": {
+        "repoUrl": "https://github.com/deanpeters/Product-Manager-Skills",
+        "subPath": "skills/user-story"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "deanpeters"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-deanpeters-user-story-mapping",
+      "name": "deanpeters/user-story-mapping",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "deanpeters",
+      "sourceGroup": "Product Manager Skills by Dean Peters",
+      "description": "Organize stories by user workflow using Jeff Patton's story mapping approach",
+      "sourceUrl": "https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/user-story-mapping",
+      "installSource": {
+        "repoUrl": "https://github.com/deanpeters/Product-Manager-Skills",
+        "subPath": "skills/user-story-mapping"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "deanpeters"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-deanpeters-user-story-splitting",
+      "name": "deanpeters/user-story-splitting",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "deanpeters",
+      "sourceGroup": "Product Manager Skills by Dean Peters",
+      "description": "Break down large stories using 8 proven splitting patterns",
+      "sourceUrl": "https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/user-story-splitting",
+      "installSource": {
+        "repoUrl": "https://github.com/deanpeters/Product-Manager-Skills",
+        "subPath": "skills/user-story-splitting"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "deanpeters"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-deanpeters-context-engineering-advisor",
+      "name": "deanpeters/context-engineering-advisor",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "deanpeters",
+      "sourceGroup": "Product Manager Skills by Dean Peters",
+      "description": "Diagnose context stuffing vs. engineering and guide memory and retrieval design",
+      "sourceUrl": "https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/context-engineering-advisor",
+      "installSource": {
+        "repoUrl": "https://github.com/deanpeters/Product-Manager-Skills",
+        "subPath": "skills/context-engineering-advisor"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "deanpeters"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-deanpeters-customer-journey-mapping-workshop",
+      "name": "deanpeters/customer-journey-mapping-workshop",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "deanpeters",
+      "sourceGroup": "Product Manager Skills by Dean Peters",
+      "description": "Guide journey mapping sessions with pain point identification",
+      "sourceUrl": "https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/customer-journey-mapping-workshop",
+      "installSource": {
+        "repoUrl": "https://github.com/deanpeters/Product-Manager-Skills",
+        "subPath": "skills/customer-journey-mapping-workshop"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "deanpeters"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-deanpeters-director-readiness-advisor",
+      "name": "deanpeters/director-readiness-advisor",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "deanpeters",
+      "sourceGroup": "Product Manager Skills by Dean Peters",
+      "description": "Coach the PM→Director transition across four key situations",
+      "sourceUrl": "https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/director-readiness-advisor",
+      "installSource": {
+        "repoUrl": "https://github.com/deanpeters/Product-Manager-Skills",
+        "subPath": "skills/director-readiness-advisor"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "deanpeters"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-deanpeters-discovery-interview-prep",
+      "name": "deanpeters/discovery-interview-prep",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "deanpeters",
+      "sourceGroup": "Product Manager Skills by Dean Peters",
+      "description": "Plan customer interviews using Mom Test style based on research goals",
+      "sourceUrl": "https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/discovery-interview-prep",
+      "installSource": {
+        "repoUrl": "https://github.com/deanpeters/Product-Manager-Skills",
+        "subPath": "skills/discovery-interview-prep"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "deanpeters"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-deanpeters-epic-breakdown-advisor",
+      "name": "deanpeters/epic-breakdown-advisor",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "deanpeters",
+      "sourceGroup": "Product Manager Skills by Dean Peters",
+      "description": "Split epics into stories using Richard Lawrence's 9 splitting patterns",
+      "sourceUrl": "https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/epic-breakdown-advisor",
+      "installSource": {
+        "repoUrl": "https://github.com/deanpeters/Product-Manager-Skills",
+        "subPath": "skills/epic-breakdown-advisor"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "deanpeters"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-deanpeters-feature-investment-advisor",
+      "name": "deanpeters/feature-investment-advisor",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "deanpeters",
+      "sourceGroup": "Product Manager Skills by Dean Peters",
+      "description": "Evaluate features using ROI and strategic value scoring",
+      "sourceUrl": "https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/feature-investment-advisor",
+      "installSource": {
+        "repoUrl": "https://github.com/deanpeters/Product-Manager-Skills",
+        "subPath": "skills/feature-investment-advisor"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "deanpeters"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-deanpeters-finance-based-pricing-advisor",
+      "name": "deanpeters/finance-based-pricing-advisor",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "deanpeters",
+      "sourceGroup": "Product Manager Skills by Dean Peters",
+      "description": "Evaluate pricing changes using financial impact analysis",
+      "sourceUrl": "https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/finance-based-pricing-advisor",
+      "installSource": {
+        "repoUrl": "https://github.com/deanpeters/Product-Manager-Skills",
+        "subPath": "skills/finance-based-pricing-advisor"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "deanpeters"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-deanpeters-lean-ux-canvas",
+      "name": "deanpeters/lean-ux-canvas",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "deanpeters",
+      "sourceGroup": "Product Manager Skills by Dean Peters",
+      "description": "Set up hypothesis-driven planning using Jeff Gothelf's Lean UX Canvas v2",
+      "sourceUrl": "https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/lean-ux-canvas",
+      "installSource": {
+        "repoUrl": "https://github.com/deanpeters/Product-Manager-Skills",
+        "subPath": "skills/lean-ux-canvas"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "deanpeters"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-deanpeters-opportunity-solution-tree",
+      "name": "deanpeters/opportunity-solution-tree",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "deanpeters",
+      "sourceGroup": "Product Manager Skills by Dean Peters",
+      "description": "Generate opportunities and solutions and recommend proof-of-concept tests",
+      "sourceUrl": "https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/opportunity-solution-tree",
+      "installSource": {
+        "repoUrl": "https://github.com/deanpeters/Product-Manager-Skills",
+        "subPath": "skills/opportunity-solution-tree"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "deanpeters"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-deanpeters-pol-probe-advisor",
+      "name": "deanpeters/pol-probe-advisor",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "deanpeters",
+      "sourceGroup": "Product Manager Skills by Dean Peters",
+      "description": "Recommend prototype type: Feasibility, Task-Focused, Narrative, Synthetic, or Vibe",
+      "sourceUrl": "https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/pol-probe-advisor",
+      "installSource": {
+        "repoUrl": "https://github.com/deanpeters/Product-Manager-Skills",
+        "subPath": "skills/pol-probe-advisor"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "deanpeters"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-deanpeters-positioning-workshop",
+      "name": "deanpeters/positioning-workshop",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "deanpeters",
+      "sourceGroup": "Product Manager Skills by Dean Peters",
+      "description": "Guide positioning definition with adaptive discovery questions",
+      "sourceUrl": "https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/positioning-workshop",
+      "installSource": {
+        "repoUrl": "https://github.com/deanpeters/Product-Manager-Skills",
+        "subPath": "skills/positioning-workshop"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "deanpeters"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-deanpeters-prioritization-advisor",
+      "name": "deanpeters/prioritization-advisor",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "deanpeters",
+      "sourceGroup": "Product Manager Skills by Dean Peters",
+      "description": "Recommend the right prioritization framework (RICE, ICE, Kano, etc.) for your situation",
+      "sourceUrl": "https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/prioritization-advisor",
+      "installSource": {
+        "repoUrl": "https://github.com/deanpeters/Product-Manager-Skills",
+        "subPath": "skills/prioritization-advisor"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "deanpeters"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-deanpeters-problem-framing-canvas",
+      "name": "deanpeters/problem-framing-canvas",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "deanpeters",
+      "sourceGroup": "Product Manager Skills by Dean Peters",
+      "description": "Lead through MITRE Problem Framing: Look Inward, Outward, and Reframe",
+      "sourceUrl": "https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/problem-framing-canvas",
+      "installSource": {
+        "repoUrl": "https://github.com/deanpeters/Product-Manager-Skills",
+        "subPath": "skills/problem-framing-canvas"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "deanpeters"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-deanpeters-tam-sam-som-calculator",
+      "name": "deanpeters/tam-sam-som-calculator",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "deanpeters",
+      "sourceGroup": "Product Manager Skills by Dean Peters",
+      "description": "Project market size with real-world data and citations",
+      "sourceUrl": "https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/tam-sam-som-calculator",
+      "installSource": {
+        "repoUrl": "https://github.com/deanpeters/Product-Manager-Skills",
+        "subPath": "skills/tam-sam-som-calculator"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "deanpeters"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-deanpeters-user-story-mapping-workshop",
+      "name": "deanpeters/user-story-mapping-workshop",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "deanpeters",
+      "sourceGroup": "Product Manager Skills by Dean Peters",
+      "description": "Walk through creating story maps with backbone and release slices",
+      "sourceUrl": "https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/user-story-mapping-workshop",
+      "installSource": {
+        "repoUrl": "https://github.com/deanpeters/Product-Manager-Skills",
+        "subPath": "skills/user-story-mapping-workshop"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "deanpeters"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-deanpeters-vp-cpo-readiness-advisor",
+      "name": "deanpeters/vp-cpo-readiness-advisor",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "deanpeters",
+      "sourceGroup": "Product Manager Skills by Dean Peters",
+      "description": "Coach the Director→VP/CPO transition including a CEO interview framework",
+      "sourceUrl": "https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/vp-cpo-readiness-advisor",
+      "installSource": {
+        "repoUrl": "https://github.com/deanpeters/Product-Manager-Skills",
+        "subPath": "skills/vp-cpo-readiness-advisor"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "deanpeters"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-deanpeters-workshop-facilitation",
+      "name": "deanpeters/workshop-facilitation",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "deanpeters",
+      "sourceGroup": "Product Manager Skills by Dean Peters",
+      "description": "Add step-by-step facilitation with numbered recommendations to any workshop",
+      "sourceUrl": "https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/workshop-facilitation",
+      "installSource": {
+        "repoUrl": "https://github.com/deanpeters/Product-Manager-Skills",
+        "subPath": "skills/workshop-facilitation"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "deanpeters"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-deanpeters-discovery-process",
+      "name": "deanpeters/discovery-process",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "deanpeters",
+      "sourceGroup": "Product Manager Skills by Dean Peters",
+      "description": "Full discovery cycle: frame problem → research → synthesize → validate (3-4 weeks)",
+      "sourceUrl": "https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/discovery-process",
+      "installSource": {
+        "repoUrl": "https://github.com/deanpeters/Product-Manager-Skills",
+        "subPath": "skills/discovery-process"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "deanpeters"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-deanpeters-executive-onboarding-playbook",
+      "name": "deanpeters/executive-onboarding-playbook",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "deanpeters",
+      "sourceGroup": "Product Manager Skills by Dean Peters",
+      "description": "30-60-90 day diagnostic playbook for VP/CPO onboarding transitions",
+      "sourceUrl": "https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/executive-onboarding-playbook",
+      "installSource": {
+        "repoUrl": "https://github.com/deanpeters/Product-Manager-Skills",
+        "subPath": "skills/executive-onboarding-playbook"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "deanpeters"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-deanpeters-prd-development",
+      "name": "deanpeters/prd-development",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "deanpeters",
+      "sourceGroup": "Product Manager Skills by Dean Peters",
+      "description": "Structured PRD process: problem → personas → solution → metrics → stories (2-4 days)",
+      "sourceUrl": "https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/prd-development",
+      "installSource": {
+        "repoUrl": "https://github.com/deanpeters/Product-Manager-Skills",
+        "subPath": "skills/prd-development"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "deanpeters"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-deanpeters-product-strategy-session",
+      "name": "deanpeters/product-strategy-session",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "deanpeters",
+      "sourceGroup": "Product Manager Skills by Dean Peters",
+      "description": "Full strategy session: positioning → framing → exploration → roadmap (2-4 weeks)",
+      "sourceUrl": "https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/product-strategy-session",
+      "installSource": {
+        "repoUrl": "https://github.com/deanpeters/Product-Manager-Skills",
+        "subPath": "skills/product-strategy-session"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "deanpeters"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-deanpeters-roadmap-planning",
+      "name": "deanpeters/roadmap-planning",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "deanpeters",
+      "sourceGroup": "Product Manager Skills by Dean Peters",
+      "description": "Strategic roadmap process: inputs → epics → prioritize → sequence → communicate (1-2 weeks)",
+      "sourceUrl": "https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/roadmap-planning",
+      "installSource": {
+        "repoUrl": "https://github.com/deanpeters/Product-Manager-Skills",
+        "subPath": "skills/roadmap-planning"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "deanpeters"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-deanpeters-skill-authoring-workflow",
+      "name": "deanpeters/skill-authoring-workflow",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "deanpeters",
+      "sourceGroup": "Product Manager Skills by Dean Peters",
+      "description": "Meta workflow for authoring skills: choose path → validate → update docs → package",
+      "sourceUrl": "https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/skill-authoring-workflow",
+      "installSource": {
+        "repoUrl": "https://github.com/deanpeters/Product-Manager-Skills",
+        "subPath": "skills/skill-authoring-workflow"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "deanpeters"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-ab-test-analysis",
+      "name": "phuryn/ab-test-analysis",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Analyze A/B test results with statistical significance and recommendations",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-data-analytics/skills/ab-test-analysis",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-data-analytics/skills/ab-test-analysis"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-cohort-analysis",
+      "name": "phuryn/cohort-analysis",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Cohort retention curves, feature adoption, and segment insights",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-data-analytics/skills/cohort-analysis",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-data-analytics/skills/cohort-analysis"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-sql-queries",
+      "name": "phuryn/sql-queries",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Generate SQL queries from natural language across major dialects",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-data-analytics/skills/sql-queries",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-data-analytics/skills/sql-queries"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-brainstorm-okrs",
+      "name": "phuryn/brainstorm-okrs",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Brainstorm team OKRs aligned with company objectives",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-execution/skills/brainstorm-okrs",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-execution/skills/brainstorm-okrs"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-create-prd",
+      "name": "phuryn/create-prd",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Create a PRD with 8-section template covering problem to release",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-execution/skills/create-prd",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-execution/skills/create-prd"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-dummy-dataset",
+      "name": "phuryn/dummy-dataset",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Generate realistic dummy datasets in CSV, JSON, or SQL",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-execution/skills/dummy-dataset",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-execution/skills/dummy-dataset"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-job-stories",
+      "name": "phuryn/job-stories",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Create job stories with acceptance criteria in JTBD format",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-execution/skills/job-stories",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-execution/skills/job-stories"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-outcome-roadmap",
+      "name": "phuryn/outcome-roadmap",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Transform output roadmaps into outcome-focused strategic plans",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-execution/skills/outcome-roadmap",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-execution/skills/outcome-roadmap"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-pre-mortem",
+      "name": "phuryn/pre-mortem",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Run pre-mortem risk analysis on PRDs and launch plans",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-execution/skills/pre-mortem",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-execution/skills/pre-mortem"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-prioritization-frameworks",
+      "name": "phuryn/prioritization-frameworks",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Reference guide to 9 prioritization frameworks with templates",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-execution/skills/prioritization-frameworks",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-execution/skills/prioritization-frameworks"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-release-notes",
+      "name": "phuryn/release-notes",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Generate user-facing release notes from tickets or changelogs",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-execution/skills/release-notes",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-execution/skills/release-notes"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-retro",
+      "name": "phuryn/retro",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Facilitate structured sprint retrospectives with action items",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-execution/skills/retro",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-execution/skills/retro"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-sprint-plan",
+      "name": "phuryn/sprint-plan",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Plan sprints with capacity, story selection, and risk mapping",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-execution/skills/sprint-plan",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-execution/skills/sprint-plan"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-stakeholder-map",
+      "name": "phuryn/stakeholder-map",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Build stakeholder maps with power/interest grid and comms plan",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-execution/skills/stakeholder-map",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-execution/skills/stakeholder-map"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-summarize-meeting",
+      "name": "phuryn/summarize-meeting",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Summarize meeting transcripts into structured notes and actions",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-execution/skills/summarize-meeting",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-execution/skills/summarize-meeting"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-test-scenarios",
+      "name": "phuryn/test-scenarios",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Create comprehensive test scenarios from user stories",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-execution/skills/test-scenarios",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-execution/skills/test-scenarios"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-user-stories",
+      "name": "phuryn/user-stories",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Create INVEST-compliant user stories with 3 C's structure",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-execution/skills/user-stories",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-execution/skills/user-stories"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-wwas",
+      "name": "phuryn/wwas",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Create backlog items in Why-What-Acceptance format",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-execution/skills/wwas",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-execution/skills/wwas"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-beachhead-segment",
+      "name": "phuryn/beachhead-segment",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Identify the first beachhead market segment for product launch",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-go-to-market/skills/beachhead-segment",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-go-to-market/skills/beachhead-segment"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-competitive-battlecard",
+      "name": "phuryn/competitive-battlecard",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Create sales-ready battlecards against specific competitors",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-go-to-market/skills/competitive-battlecard",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-go-to-market/skills/competitive-battlecard"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-growth-loops",
+      "name": "phuryn/growth-loops",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Identify growth loops across 5 flywheel types for traction",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-go-to-market/skills/growth-loops",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-go-to-market/skills/growth-loops"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-gtm-motions",
+      "name": "phuryn/gtm-motions",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Identify best GTM motions across 7 types including PLG and ABM",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-go-to-market/skills/gtm-motions",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-go-to-market/skills/gtm-motions"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-gtm-strategy",
+      "name": "phuryn/gtm-strategy",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Create GTM strategy with channels, messaging, and launch timeline",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-go-to-market/skills/gtm-strategy",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-go-to-market/skills/gtm-strategy"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-ideal-customer-profile",
+      "name": "phuryn/ideal-customer-profile",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Identify ICP with demographics, behaviors, and JTBD",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-go-to-market/skills/ideal-customer-profile",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-go-to-market/skills/ideal-customer-profile"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-competitor-analysis",
+      "name": "phuryn/competitor-analysis",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Analyze competitors with strengths, weaknesses, and differentiation",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-market-research/skills/competitor-analysis",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-market-research/skills/competitor-analysis"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-customer-journey-map",
+      "name": "phuryn/customer-journey-map",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Map customer journeys with touchpoints, emotions, and opportunities",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-market-research/skills/customer-journey-map",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-market-research/skills/customer-journey-map"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-market-segments",
+      "name": "phuryn/market-segments",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Identify 3-5 customer segments with JTBD and product fit",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-market-research/skills/market-segments",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-market-research/skills/market-segments"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-market-sizing",
+      "name": "phuryn/market-sizing",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Estimate TAM, SAM, SOM with top-down and bottom-up approaches",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-market-research/skills/market-sizing",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-market-research/skills/market-sizing"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-sentiment-analysis",
+      "name": "phuryn/sentiment-analysis",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Analyze user feedback with sentiment scores and JTBD insights",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-market-research/skills/sentiment-analysis",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-market-research/skills/sentiment-analysis"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-user-personas",
+      "name": "phuryn/user-personas",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Create 3 user personas with JTBD, pains, and gains",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-market-research/skills/user-personas",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-market-research/skills/user-personas"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-user-segmentation",
+      "name": "phuryn/user-segmentation",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Segment users by behavior, JTBD, and needs from feedback data",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-market-research/skills/user-segmentation",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-market-research/skills/user-segmentation"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-marketing-ideas",
+      "name": "phuryn/marketing-ideas",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Generate 5 creative, cost-effective marketing ideas with rationale",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-marketing-growth/skills/marketing-ideas",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-marketing-growth/skills/marketing-ideas"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-north-star-metric",
+      "name": "phuryn/north-star-metric",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Define North Star Metric and input metrics constellation",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-marketing-growth/skills/north-star-metric",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-marketing-growth/skills/north-star-metric"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-positioning-ideas",
+      "name": "phuryn/positioning-ideas",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Brainstorm positioning ideas differentiated from competitors",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-marketing-growth/skills/positioning-ideas",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-marketing-growth/skills/positioning-ideas"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-product-name",
+      "name": "phuryn/product-name",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Brainstorm 5 memorable product names aligned to brand values",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-marketing-growth/skills/product-name",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-marketing-growth/skills/product-name"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-value-prop-statements",
+      "name": "phuryn/value-prop-statements",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Generate value prop statements for marketing, sales, and onboarding",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-marketing-growth/skills/value-prop-statements",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-marketing-growth/skills/value-prop-statements"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-analyze-feature-requests",
+      "name": "phuryn/analyze-feature-requests",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Prioritize feature requests by theme, impact, effort, and risk",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-product-discovery/skills/analyze-feature-requests",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-product-discovery/skills/analyze-feature-requests"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-brainstorm-experiments-existing",
+      "name": "phuryn/brainstorm-experiments-existing",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Design experiments to test assumptions for existing products",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-product-discovery/skills/brainstorm-experiments-existing",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-product-discovery/skills/brainstorm-experiments-existing"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-brainstorm-experiments-new",
+      "name": "phuryn/brainstorm-experiments-new",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Design lean pretotypes for new product validation",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-product-discovery/skills/brainstorm-experiments-new",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-product-discovery/skills/brainstorm-experiments-new"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-brainstorm-ideas-existing",
+      "name": "phuryn/brainstorm-ideas-existing",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Brainstorm product ideas from PM, Designer, Engineer perspectives",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-product-discovery/skills/brainstorm-ideas-existing",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-product-discovery/skills/brainstorm-ideas-existing"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-brainstorm-ideas-new",
+      "name": "phuryn/brainstorm-ideas-new",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Brainstorm feature ideas for new products in early discovery",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-product-discovery/skills/brainstorm-ideas-new",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-product-discovery/skills/brainstorm-ideas-new"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-identify-assumptions-existing",
+      "name": "phuryn/identify-assumptions-existing",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Identify risky assumptions across Value, Usability, Viability, Feasibility",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-product-discovery/skills/identify-assumptions-existing",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-product-discovery/skills/identify-assumptions-existing"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-identify-assumptions-new",
+      "name": "phuryn/identify-assumptions-new",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Identify risky assumptions for new products across 8 risk categories",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-product-discovery/skills/identify-assumptions-new",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-product-discovery/skills/identify-assumptions-new"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-interview-script",
+      "name": "phuryn/interview-script",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Create structured customer interview scripts with JTBD probing",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-product-discovery/skills/interview-script",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-product-discovery/skills/interview-script"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-metrics-dashboard",
+      "name": "phuryn/metrics-dashboard",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Define product metrics dashboard with sources and alert thresholds",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-product-discovery/skills/metrics-dashboard",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-product-discovery/skills/metrics-dashboard"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-opportunity-solution-tree",
+      "name": "phuryn/opportunity-solution-tree",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Build Opportunity Solution Trees based on Teresa Torres' method",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-product-discovery/skills/opportunity-solution-tree",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-product-discovery/skills/opportunity-solution-tree"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-prioritize-assumptions",
+      "name": "phuryn/prioritize-assumptions",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Prioritize assumptions with Impact × Risk matrix and experiments",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-product-discovery/skills/prioritize-assumptions",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-product-discovery/skills/prioritize-assumptions"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-prioritize-features",
+      "name": "phuryn/prioritize-features",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Prioritize backlog by impact, effort, risk, and strategic alignment",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-product-discovery/skills/prioritize-features",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-product-discovery/skills/prioritize-features"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-summarize-interview",
+      "name": "phuryn/summarize-interview",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Summarize interview transcripts with JTBD and action items",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-product-discovery/skills/summarize-interview",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-product-discovery/skills/summarize-interview"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-ansoff-matrix",
+      "name": "phuryn/ansoff-matrix",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Ansoff Matrix analysis across 4 growth strategy quadrants",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-product-strategy/skills/ansoff-matrix",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-product-strategy/skills/ansoff-matrix"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-business-model",
+      "name": "phuryn/business-model",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Generate Business Model Canvas with all 9 building blocks",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-product-strategy/skills/business-model",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-product-strategy/skills/business-model"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-lean-canvas",
+      "name": "phuryn/lean-canvas",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Generate Lean Canvas with problem, solution, UVP, and metrics",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-product-strategy/skills/lean-canvas",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-product-strategy/skills/lean-canvas"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-monetization-strategy",
+      "name": "phuryn/monetization-strategy",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Brainstorm 3-5 monetization strategies with validation experiments",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-product-strategy/skills/monetization-strategy",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-product-strategy/skills/monetization-strategy"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-pestle-analysis",
+      "name": "phuryn/pestle-analysis",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "PESTLE analysis across Political, Economic, Social, Tech, Legal, Environmental",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-product-strategy/skills/pestle-analysis",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-product-strategy/skills/pestle-analysis"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-porters-five-forces",
+      "name": "phuryn/porters-five-forces",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Porter's Five Forces competitive analysis with strategic insights",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-product-strategy/skills/porters-five-forces",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-product-strategy/skills/porters-five-forces"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-pricing-strategy",
+      "name": "phuryn/pricing-strategy",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Design pricing strategies with competitive analysis and WTP estimation",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-product-strategy/skills/pricing-strategy",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-product-strategy/skills/pricing-strategy"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-product-strategy",
+      "name": "phuryn/product-strategy",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Create product strategy using 9-section Product Strategy Canvas",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-product-strategy/skills/product-strategy",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-product-strategy/skills/product-strategy"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-product-vision",
+      "name": "phuryn/product-vision",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Brainstorm inspiring, achievable product vision statements",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-product-strategy/skills/product-vision",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-product-strategy/skills/product-vision"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-startup-canvas",
+      "name": "phuryn/startup-canvas",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Generate Startup Canvas combining Product Strategy and Business Model",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-product-strategy/skills/startup-canvas",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-product-strategy/skills/startup-canvas"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-swot-analysis",
+      "name": "phuryn/swot-analysis",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "SWOT analysis with actionable recommendations per quadrant",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-product-strategy/skills/swot-analysis",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-product-strategy/skills/swot-analysis"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-value-proposition",
+      "name": "phuryn/value-proposition",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Design value propositions using 6-part JTBD template",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-product-strategy/skills/value-proposition",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-product-strategy/skills/value-proposition"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-draft-nda",
+      "name": "phuryn/draft-nda",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Draft NDAs covering information types, jurisdiction, and clauses",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-toolkit/skills/draft-nda",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-toolkit/skills/draft-nda"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-grammar-check",
+      "name": "phuryn/grammar-check",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Identify grammar and flow errors with targeted fix suggestions",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-toolkit/skills/grammar-check",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-toolkit/skills/grammar-check"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-privacy-policy",
+      "name": "phuryn/privacy-policy",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "Draft privacy policies with GDPR compliance considerations",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-toolkit/skills/privacy-policy",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-toolkit/skills/privacy-policy"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-phuryn-review-resume",
+      "name": "phuryn/review-resume",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "phuryn",
+      "sourceGroup": "Product Management Skills by Pawel Huryn",
+      "description": "PM resume review against 10 best practices including XYZ+S formula",
+      "sourceUrl": "https://github.com/phuryn/pm-skills/tree/main/pm-toolkit/skills/review-resume",
+      "installSource": {
+        "repoUrl": "https://github.com/phuryn/pm-skills",
+        "subPath": "pm-toolkit/skills/review-resume"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "phuryn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-minimax-ai-cli",
+      "name": "MiniMax-AI/cli",
+      "kind": "skill",
+      "category": "多媒体创作",
+      "publisher": "MiniMax-AI",
+      "sourceGroup": "Skills by MiniMax Team",
+      "description": "Generate text, image, video, speech, and music via MiniMax AI",
+      "sourceUrl": "https://officialskills.sh/MiniMax-AI/skills/cli",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "MiniMax-AI"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-minimax-ai-frontend-dev",
+      "name": "MiniMax-AI/frontend-dev",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "MiniMax-AI",
+      "sourceGroup": "Skills by MiniMax Team",
+      "description": "Full-stack frontend with cinematic animations, AI-generated media via MiniMax API, and generative art",
+      "sourceUrl": "https://officialskills.sh/MiniMax-AI/skills/frontend-dev",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "MiniMax-AI"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-minimax-ai-fullstack-dev",
+      "name": "MiniMax-AI/fullstack-dev",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "MiniMax-AI",
+      "sourceGroup": "Skills by MiniMax Team",
+      "description": "Backend architecture with REST API design, auth flows, real-time features, and database integration",
+      "sourceUrl": "https://officialskills.sh/MiniMax-AI/skills/fullstack-dev",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "MiniMax-AI"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-minimax-ai-android-native-dev",
+      "name": "MiniMax-AI/android-native-dev",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "MiniMax-AI",
+      "sourceGroup": "Skills by MiniMax Team",
+      "description": "Android native development with Kotlin/Jetpack Compose, Material Design 3, and accessibility",
+      "sourceUrl": "https://officialskills.sh/MiniMax-AI/skills/android-native-dev",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "MiniMax-AI"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-minimax-ai-ios-application-dev",
+      "name": "MiniMax-AI/ios-application-dev",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "MiniMax-AI",
+      "sourceGroup": "Skills by MiniMax Team",
+      "description": "iOS development with UIKit, SnapKit, and SwiftUI covering navigation, Dark Mode, and HIG compliance",
+      "sourceUrl": "https://officialskills.sh/MiniMax-AI/skills/ios-application-dev",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "MiniMax-AI"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-minimax-ai-shader-dev",
+      "name": "MiniMax-AI/shader-dev",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "MiniMax-AI",
+      "sourceGroup": "Skills by MiniMax Team",
+      "description": "GLSL shader techniques for ray marching, fluid simulation, particle systems, and procedural generation",
+      "sourceUrl": "https://officialskills.sh/MiniMax-AI/skills/shader-dev",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "MiniMax-AI"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-minimax-ai-gif-sticker-maker",
+      "name": "MiniMax-AI/gif-sticker-maker",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "MiniMax-AI",
+      "sourceGroup": "Skills by MiniMax Team",
+      "description": "Convert photos into animated GIF stickers in Funko Pop / Pop Mart style via MiniMax API",
+      "sourceUrl": "https://officialskills.sh/MiniMax-AI/skills/gif-sticker-maker",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "MiniMax-AI"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-minimax-ai-minimax-pdf",
+      "name": "MiniMax-AI/minimax-pdf",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "MiniMax-AI",
+      "sourceGroup": "Skills by MiniMax Team",
+      "description": "Generate, fill, and reformat PDFs with a token-based design system and 15 cover styles",
+      "sourceUrl": "https://officialskills.sh/MiniMax-AI/skills/minimax-pdf",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "MiniMax-AI"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-minimax-ai-pptx-generator",
+      "name": "MiniMax-AI/pptx-generator",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "MiniMax-AI",
+      "sourceGroup": "Skills by MiniMax Team",
+      "description": "Create and edit PowerPoint presentations from scratch with PptxGenJS",
+      "sourceUrl": "https://officialskills.sh/MiniMax-AI/skills/pptx-generator",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "MiniMax-AI"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-minimax-ai-minimax-xlsx",
+      "name": "MiniMax-AI/minimax-xlsx",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "MiniMax-AI",
+      "sourceGroup": "Skills by MiniMax Team",
+      "description": "Create, read, analyze, and validate Excel/spreadsheet files with zero format loss",
+      "sourceUrl": "https://officialskills.sh/MiniMax-AI/skills/minimax-xlsx",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "MiniMax-AI"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-minimax-ai-minimax-docx",
+      "name": "MiniMax-AI/minimax-docx",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "MiniMax-AI",
+      "sourceGroup": "Skills by MiniMax Team",
+      "description": "Professional DOCX document creation and editing using OpenXML SDK",
+      "sourceUrl": "https://officialskills.sh/MiniMax-AI/skills/minimax-docx",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "MiniMax-AI"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-duckdb-attach-db",
+      "name": "duckdb/attach-db",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "duckdb",
+      "sourceGroup": "Skills by DuckDB",
+      "description": "Attach a DuckDB database file for interactive querying with automatic schema exploration",
+      "sourceUrl": "https://officialskills.sh/duckdb/skills/attach-db",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "duckdb"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-duckdb-query",
+      "name": "duckdb/query",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "duckdb",
+      "sourceGroup": "Skills by DuckDB",
+      "description": "Run SQL queries against attached databases or ad-hoc against files using Friendly SQL dialect",
+      "sourceUrl": "https://officialskills.sh/duckdb/skills/query",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "duckdb"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-duckdb-read-file",
+      "name": "duckdb/read-file",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "duckdb",
+      "sourceGroup": "Skills by DuckDB",
+      "description": "Read any data file (CSV, JSON, Parquet, Avro, Excel, spatial) locally or from remote storage",
+      "sourceUrl": "https://officialskills.sh/duckdb/skills/read-file",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "duckdb"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-duckdb-duckdb-docs",
+      "name": "duckdb/duckdb-docs",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "duckdb",
+      "sourceGroup": "Skills by DuckDB",
+      "description": "Search DuckDB and DuckLake documentation using full-text search over HTTPS",
+      "sourceUrl": "https://officialskills.sh/duckdb/skills/duckdb-docs",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "duckdb"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-duckdb-read-memories",
+      "name": "duckdb/read-memories",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "duckdb",
+      "sourceGroup": "Skills by DuckDB",
+      "description": "Search past Claude Code session logs to recover context from previous conversations",
+      "sourceUrl": "https://officialskills.sh/duckdb/skills/read-memories",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "duckdb"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-duckdb-install-duckdb",
+      "name": "duckdb/install-duckdb",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "duckdb",
+      "sourceGroup": "Skills by DuckDB",
+      "description": "Install or update DuckDB CLI and extensions with version management",
+      "sourceUrl": "https://officialskills.sh/duckdb/skills/install-duckdb",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "duckdb"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-greensock-gsap-core",
+      "name": "greensock/gsap-core",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "greensock",
+      "sourceGroup": "Skills by GSAP (GreenSock)",
+      "description": "Core API with gsap.to(), from(), fromTo(), easing, duration, stagger, and defaults",
+      "sourceUrl": "https://officialskills.sh/greensock/skills/gsap-core",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "greensock"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-greensock-gsap-timeline",
+      "name": "greensock/gsap-timeline",
+      "kind": "skill",
+      "category": "其他工具",
+      "publisher": "greensock",
+      "sourceGroup": "Skills by GSAP (GreenSock)",
+      "description": "Timelines with sequencing, position parameter, labels, nesting, and playback control",
+      "sourceUrl": "https://officialskills.sh/greensock/skills/gsap-timeline",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "greensock"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-greensock-gsap-scrolltrigger",
+      "name": "greensock/gsap-scrolltrigger",
+      "kind": "skill",
+      "category": "其他工具",
+      "publisher": "greensock",
+      "sourceGroup": "Skills by GSAP (GreenSock)",
+      "description": "ScrollTrigger for scroll-linked animations, pinning, scrub, and refresh handling",
+      "sourceUrl": "https://officialskills.sh/greensock/skills/gsap-scrolltrigger",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "greensock"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-greensock-gsap-plugins",
+      "name": "greensock/gsap-plugins",
+      "kind": "skill",
+      "category": "其他工具",
+      "publisher": "greensock",
+      "sourceGroup": "Skills by GSAP (GreenSock)",
+      "description": "Plugins including ScrollToPlugin, Flip, Draggable, SplitText, SVG, and physics",
+      "sourceUrl": "https://officialskills.sh/greensock/skills/gsap-plugins",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "greensock"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-greensock-gsap-utils",
+      "name": "greensock/gsap-utils",
+      "kind": "skill",
+      "category": "其他工具",
+      "publisher": "greensock",
+      "sourceGroup": "Skills by GSAP (GreenSock)",
+      "description": "Utility functions like clamp, mapRange, interpolate, snap, selector, and wrap",
+      "sourceUrl": "https://officialskills.sh/greensock/skills/gsap-utils",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "greensock"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-greensock-gsap-react",
+      "name": "greensock/gsap-react",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "greensock",
+      "sourceGroup": "Skills by GSAP (GreenSock)",
+      "description": "React integration with useGSAP hook, refs, gsap.context(), cleanup, and SSR",
+      "sourceUrl": "https://officialskills.sh/greensock/skills/gsap-react",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "greensock"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-greensock-gsap-performance",
+      "name": "greensock/gsap-performance",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "greensock",
+      "sourceGroup": "Skills by GSAP (GreenSock)",
+      "description": "Performance tips for transforms, will-change, batching, and ScrollTrigger optimization",
+      "sourceUrl": "https://officialskills.sh/greensock/skills/gsap-performance",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "greensock"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-greensock-gsap-frameworks",
+      "name": "greensock/gsap-frameworks",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "greensock",
+      "sourceGroup": "Skills by GSAP (GreenSock)",
+      "description": "Vue, Svelte, and other frameworks with lifecycle, scoping, and cleanup patterns",
+      "sourceUrl": "https://officialskills.sh/greensock/skills/gsap-frameworks",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "greensock"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-garrytan-office-hours",
+      "name": "garrytan/office-hours",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "garrytan",
+      "sourceGroup": "Skills by Garry Tan (gstack)",
+      "description": "YC Office Hours: six forcing questions that reframe your product before you write code",
+      "sourceUrl": "https://officialskills.sh/garrytan/skills/office-hours",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "garrytan"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-garrytan-plan-ceo-review",
+      "name": "garrytan/plan-ceo-review",
+      "kind": "skill",
+      "category": "其他工具",
+      "publisher": "garrytan",
+      "sourceGroup": "Skills by Garry Tan (gstack)",
+      "description": "CEO/Founder plan review with four modes: Expansion, Selective Expansion, Hold Scope, Reduction",
+      "sourceUrl": "https://officialskills.sh/garrytan/skills/plan-ceo-review",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "garrytan"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-garrytan-plan-eng-review",
+      "name": "garrytan/plan-eng-review",
+      "kind": "skill",
+      "category": "数据与分析",
+      "publisher": "garrytan",
+      "sourceGroup": "Skills by Garry Tan (gstack)",
+      "description": "Eng Manager review: lock in architecture, data flow, diagrams, edge cases, and tests",
+      "sourceUrl": "https://officialskills.sh/garrytan/skills/plan-eng-review",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "garrytan"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-garrytan-plan-design-review",
+      "name": "garrytan/plan-design-review",
+      "kind": "skill",
+      "category": "多媒体创作",
+      "publisher": "garrytan",
+      "sourceGroup": "Skills by Garry Tan (gstack)",
+      "description": "Senior Designer review: rates each design dimension 0-10, explains what a 10 looks like, AI Slop detection",
+      "sourceUrl": "https://officialskills.sh/garrytan/skills/plan-design-review",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "garrytan"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-garrytan-design-consultation",
+      "name": "garrytan/design-consultation",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "garrytan",
+      "sourceGroup": "Skills by Garry Tan (gstack)",
+      "description": "Build a complete design system from scratch with creative risks and realistic product mockups",
+      "sourceUrl": "https://officialskills.sh/garrytan/skills/design-consultation",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "garrytan"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-garrytan-design-review",
+      "name": "garrytan/design-review",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "garrytan",
+      "sourceGroup": "Skills by Garry Tan (gstack)",
+      "description": "Designer Who Codes: visual audit then fixes with atomic commits and before/after screenshots",
+      "sourceUrl": "https://officialskills.sh/garrytan/skills/design-review",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "garrytan"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-garrytan-review",
+      "name": "garrytan/review",
+      "kind": "skill",
+      "category": "工程开发",
+      "publisher": "garrytan",
+      "sourceGroup": "Skills by Garry Tan (gstack)",
+      "description": "Staff Engineer code review: finds bugs that pass CI but blow up in production",
+      "sourceUrl": "https://officialskills.sh/garrytan/skills/review",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "garrytan"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-garrytan-investigate",
+      "name": "garrytan/investigate",
+      "kind": "skill",
+      "category": "数据与分析",
+      "publisher": "garrytan",
+      "sourceGroup": "Skills by Garry Tan (gstack)",
+      "description": "Systematic root-cause debugging: no fixes without investigation, traces data flow, tests hypotheses",
+      "sourceUrl": "https://officialskills.sh/garrytan/skills/investigate",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "garrytan"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-garrytan-qa",
+      "name": "garrytan/qa",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "garrytan",
+      "sourceGroup": "Skills by Garry Tan (gstack)",
+      "description": "QA Lead: test your app, find bugs, fix them with atomic commits, auto-generate regression tests",
+      "sourceUrl": "https://officialskills.sh/garrytan/skills/qa",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "garrytan"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-garrytan-qa-only",
+      "name": "garrytan/qa-only",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "garrytan",
+      "sourceGroup": "Skills by Garry Tan (gstack)",
+      "description": "QA Reporter: same methodology as /qa but report only, no code changes",
+      "sourceUrl": "https://officialskills.sh/garrytan/skills/qa-only",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "garrytan"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-garrytan-cso",
+      "name": "garrytan/cso",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "garrytan",
+      "sourceGroup": "Skills by Garry Tan (gstack)",
+      "description": "Chief Security Officer: OWASP Top 10 + STRIDE threat model with zero false-positive exclusions",
+      "sourceUrl": "https://officialskills.sh/garrytan/skills/cso",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "garrytan"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-garrytan-ship",
+      "name": "garrytan/ship",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "garrytan",
+      "sourceGroup": "Skills by Garry Tan (gstack)",
+      "description": "Release Engineer: sync main, run tests, audit coverage, push, open PR",
+      "sourceUrl": "https://officialskills.sh/garrytan/skills/ship",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "garrytan"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-garrytan-land-and-deploy",
+      "name": "garrytan/land-and-deploy",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "garrytan",
+      "sourceGroup": "Skills by Garry Tan (gstack)",
+      "description": "Merge the PR, wait for CI and deploy, verify production health",
+      "sourceUrl": "https://officialskills.sh/garrytan/skills/land-and-deploy",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "garrytan"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-garrytan-canary",
+      "name": "garrytan/canary",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "garrytan",
+      "sourceGroup": "Skills by Garry Tan (gstack)",
+      "description": "SRE post-deploy monitoring: watches for console errors, performance regressions, and page failures",
+      "sourceUrl": "https://officialskills.sh/garrytan/skills/canary",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "garrytan"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-garrytan-benchmark",
+      "name": "garrytan/benchmark",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "garrytan",
+      "sourceGroup": "Skills by Garry Tan (gstack)",
+      "description": "Performance Engineer: baseline page load times, Core Web Vitals, and resource sizes",
+      "sourceUrl": "https://officialskills.sh/garrytan/skills/benchmark",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "garrytan"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-garrytan-document-release",
+      "name": "garrytan/document-release",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "garrytan",
+      "sourceGroup": "Skills by Garry Tan (gstack)",
+      "description": "Technical Writer: update all project docs to match what you just shipped",
+      "sourceUrl": "https://officialskills.sh/garrytan/skills/document-release",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "garrytan"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-garrytan-retro",
+      "name": "garrytan/retro",
+      "kind": "skill",
+      "category": "其他工具",
+      "publisher": "garrytan",
+      "sourceGroup": "Skills by Garry Tan (gstack)",
+      "description": "Eng Manager weekly retro with per-person breakdowns and shipping streaks",
+      "sourceUrl": "https://officialskills.sh/garrytan/skills/retro",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "garrytan"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-garrytan-browse",
+      "name": "garrytan/browse",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "garrytan",
+      "sourceGroup": "Skills by Garry Tan (gstack)",
+      "description": "Real Chromium browser for QA: real clicks, real screenshots, ~100ms per command",
+      "sourceUrl": "https://officialskills.sh/garrytan/skills/browse",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "garrytan"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-garrytan-setup-browser-cookies",
+      "name": "garrytan/setup-browser-cookies",
+      "kind": "skill",
+      "category": "其他工具",
+      "publisher": "garrytan",
+      "sourceGroup": "Skills by Garry Tan (gstack)",
+      "description": "Import cookies from your real browser into the headless session",
+      "sourceUrl": "https://officialskills.sh/garrytan/skills/setup-browser-cookies",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "garrytan"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-garrytan-autoplan",
+      "name": "garrytan/autoplan",
+      "kind": "skill",
+      "category": "多媒体创作",
+      "publisher": "garrytan",
+      "sourceGroup": "Skills by Garry Tan (gstack)",
+      "description": "One command, fully reviewed plan: runs CEO → design → eng review automatically",
+      "sourceUrl": "https://officialskills.sh/garrytan/skills/autoplan",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "garrytan"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-garrytan-codex",
+      "name": "garrytan/codex",
+      "kind": "skill",
+      "category": "工程开发",
+      "publisher": "garrytan",
+      "sourceGroup": "Skills by Garry Tan (gstack)",
+      "description": "Second Opinion via OpenAI Codex CLI: review, adversarial challenge, and open consultation",
+      "sourceUrl": "https://officialskills.sh/garrytan/skills/codex",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "garrytan"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-garrytan-careful",
+      "name": "garrytan/careful",
+      "kind": "skill",
+      "category": "其他工具",
+      "publisher": "garrytan",
+      "sourceGroup": "Skills by Garry Tan (gstack)",
+      "description": "Safety Guardrails: warns before destructive commands (rm -rf, DROP TABLE, force-push)",
+      "sourceUrl": "https://officialskills.sh/garrytan/skills/careful",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "garrytan"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-garrytan-freeze",
+      "name": "garrytan/freeze",
+      "kind": "skill",
+      "category": "其他工具",
+      "publisher": "garrytan",
+      "sourceGroup": "Skills by Garry Tan (gstack)",
+      "description": "Edit Lock: restrict file edits to one directory while debugging",
+      "sourceUrl": "https://officialskills.sh/garrytan/skills/freeze",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "garrytan"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-garrytan-guard",
+      "name": "garrytan/guard",
+      "kind": "skill",
+      "category": "其他工具",
+      "publisher": "garrytan",
+      "sourceGroup": "Skills by Garry Tan (gstack)",
+      "description": "Full Safety: /careful + /freeze in one command for maximum safety",
+      "sourceUrl": "https://officialskills.sh/garrytan/skills/guard",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "garrytan"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-garrytan-unfreeze",
+      "name": "garrytan/unfreeze",
+      "kind": "skill",
+      "category": "其他工具",
+      "publisher": "garrytan",
+      "sourceGroup": "Skills by Garry Tan (gstack)",
+      "description": "Unlock: remove the /freeze boundary",
+      "sourceUrl": "https://officialskills.sh/garrytan/skills/unfreeze",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "garrytan"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-garrytan-setup-deploy",
+      "name": "garrytan/setup-deploy",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "garrytan",
+      "sourceGroup": "Skills by Garry Tan (gstack)",
+      "description": "Deploy Configurator: one-time setup for /land-and-deploy",
+      "sourceUrl": "https://officialskills.sh/garrytan/skills/setup-deploy",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "garrytan"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-garrytan-gstack-upgrade",
+      "name": "garrytan/gstack-upgrade",
+      "kind": "skill",
+      "category": "其他工具",
+      "publisher": "garrytan",
+      "sourceGroup": "Skills by Garry Tan (gstack)",
+      "description": "Self-Updater: upgrade gstack to latest version",
+      "sourceUrl": "https://officialskills.sh/garrytan/skills/gstack-upgrade",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "garrytan"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-makenotion-knowledge-capture",
+      "name": "makenotion/knowledge-capture",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "makenotion",
+      "sourceGroup": "Skills by Notion",
+      "description": "Transform conversations into structured Notion documentation pages with proper organization and linking",
+      "sourceUrl": "https://officialskills.sh/makenotion/skills/knowledge-capture",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "makenotion"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-makenotion-meeting-intelligence",
+      "name": "makenotion/meeting-intelligence",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "makenotion",
+      "sourceGroup": "Skills by Notion",
+      "description": "Prepare meeting materials by gathering Notion context and creating pre-reads and agendas",
+      "sourceUrl": "https://officialskills.sh/makenotion/skills/meeting-intelligence",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "makenotion"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-makenotion-research-documentation",
+      "name": "makenotion/research-documentation",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "makenotion",
+      "sourceGroup": "Skills by Notion",
+      "description": "Search Notion workspace, synthesize findings, and create comprehensive research reports",
+      "sourceUrl": "https://officialskills.sh/makenotion/skills/research-documentation",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "makenotion"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-makenotion-spec-to-implementation",
+      "name": "makenotion/spec-to-implementation",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "makenotion",
+      "sourceGroup": "Skills by Notion",
+      "description": "Turn product/tech specs into concrete Notion tasks with acceptance criteria and progress tracking",
+      "sourceUrl": "https://officialskills.sh/makenotion/skills/spec-to-implementation",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "makenotion"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-resend-resend",
+      "name": "resend/resend",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "resend",
+      "sourceGroup": "Skills by Resend",
+      "description": "Send and manage emails via the Resend API",
+      "sourceUrl": "https://github.com/resend/resend-skills/tree/main/skills/resend",
+      "installSource": {
+        "repoUrl": "https://github.com/resend/resend-skills",
+        "subPath": "skills/resend"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "resend"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-resend-react-email",
+      "name": "resend/react-email",
+      "kind": "skill",
+      "category": "前端与移动",
+      "publisher": "resend",
+      "sourceGroup": "Skills by Resend",
+      "description": "Build emails with React Email components",
+      "sourceUrl": "https://github.com/resend/resend-skills/tree/main/skills/react-email",
+      "installSource": {
+        "repoUrl": "https://github.com/resend/resend-skills",
+        "subPath": "skills/react-email"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "resend"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-resend-email-best-practices",
+      "name": "resend/email-best-practices",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "resend",
+      "sourceGroup": "Skills by Resend",
+      "description": "Email deliverability and design best practices",
+      "sourceUrl": "https://github.com/resend/resend-skills/tree/main/skills/email-best-practices",
+      "installSource": {
+        "repoUrl": "https://github.com/resend/resend-skills",
+        "subPath": "skills/email-best-practices"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "resend"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-resend-agent-email-inbox",
+      "name": "resend/agent-email-inbox",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "resend",
+      "sourceGroup": "Skills by Resend",
+      "description": "AI agent email inbox management",
+      "sourceUrl": "https://github.com/resend/resend-skills/tree/main/skills/agent-email-inbox",
+      "installSource": {
+        "repoUrl": "https://github.com/resend/resend-skills",
+        "subPath": "skills/agent-email-inbox"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "resend"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-resend-resend-cli",
+      "name": "resend/resend-cli",
+      "kind": "skill",
+      "category": "工程开发",
+      "publisher": "resend",
+      "sourceGroup": "Skills by Resend",
+      "description": "Resend CLI commands and workflows",
+      "sourceUrl": "https://github.com/resend/resend-skills/tree/main/skills/resend-cli",
+      "installSource": {
+        "repoUrl": "https://github.com/resend/resend-skills",
+        "subPath": "skills/resend-cli"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "resend"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-addyosmani-web-quality-audit",
+      "name": "addyosmani/web-quality-audit",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "addyosmani",
+      "sourceGroup": "Skills by - Google Chrome team - Addy Osmani (Web Quality)",
+      "description": "Comprehensive quality review across performance, accessibility, SEO, and best practices categories",
+      "sourceUrl": "https://officialskills.sh/addyosmani/skills/web-quality-audit",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "addyosmani"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-addyosmani-performance",
+      "name": "addyosmani/performance",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "addyosmani",
+      "sourceGroup": "Skills by - Google Chrome team - Addy Osmani (Web Quality)",
+      "description": "Loading speed, runtime efficiency, and resource optimization",
+      "sourceUrl": "https://officialskills.sh/addyosmani/skills/performance",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "addyosmani"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-addyosmani-core-web-vitals",
+      "name": "addyosmani/core-web-vitals",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "addyosmani",
+      "sourceGroup": "Skills by - Google Chrome team - Addy Osmani (Web Quality)",
+      "description": "LCP, INP, and CLS-specific optimizations",
+      "sourceUrl": "https://officialskills.sh/addyosmani/skills/core-web-vitals",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "addyosmani"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-addyosmani-accessibility",
+      "name": "addyosmani/accessibility",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "addyosmani",
+      "sourceGroup": "Skills by - Google Chrome team - Addy Osmani (Web Quality)",
+      "description": "WCAG compliance, screen reader support, and keyboard navigation",
+      "sourceUrl": "https://officialskills.sh/addyosmani/skills/accessibility",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "addyosmani"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-addyosmani-seo",
+      "name": "addyosmani/seo",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "addyosmani",
+      "sourceGroup": "Skills by - Google Chrome team - Addy Osmani (Web Quality)",
+      "description": "Search engine optimization, crawlability, and structured data",
+      "sourceUrl": "https://officialskills.sh/addyosmani/skills/seo",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "addyosmani"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-addyosmani-best-practices",
+      "name": "addyosmani/best-practices",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "addyosmani",
+      "sourceGroup": "Skills by - Google Chrome team - Addy Osmani (Web Quality)",
+      "description": "Security, modern web APIs, and code quality patterns",
+      "sourceUrl": "https://officialskills.sh/addyosmani/skills/best-practices",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "addyosmani"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-mongodb-mongodb-mcp-setup",
+      "name": "mongodb/mongodb-mcp-setup",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "mongodb",
+      "sourceGroup": "Skills by MongoDB",
+      "description": "Set up the MongoDB MCP server with authentication and connection configuration",
+      "sourceUrl": "https://officialskills.sh/mongodb/skills/mongodb-mcp-setup",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "mongodb"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-mongodb-mongodb-connection",
+      "name": "mongodb/mongodb-connection",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "mongodb",
+      "sourceGroup": "Skills by MongoDB",
+      "description": "Optimize MongoDB client connection pools, timeouts, and serverless patterns",
+      "sourceUrl": "https://officialskills.sh/mongodb/skills/mongodb-connection",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "mongodb"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-mongodb-mongodb-schema-design",
+      "name": "mongodb/mongodb-schema-design",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "mongodb",
+      "sourceGroup": "Skills by MongoDB",
+      "description": "Design efficient document schemas with validation and indexing patterns",
+      "sourceUrl": "https://officialskills.sh/mongodb/skills/mongodb-schema-design",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "mongodb"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-mongodb-atlas-stream-processing",
+      "name": "mongodb/atlas-stream-processing",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "mongodb",
+      "sourceGroup": "Skills by MongoDB",
+      "description": "Build, operate, and debug Atlas Stream Processing pipelines with Kafka, S3, and Lambda integrations",
+      "sourceUrl": "https://officialskills.sh/mongodb/skills/atlas-stream-processing",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "mongodb"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-mongodb-mongodb-natural-language-querying",
+      "name": "mongodb/mongodb-natural-language-querying",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "mongodb",
+      "sourceGroup": "Skills by MongoDB",
+      "description": "Translate natural language into MongoDB queries and aggregation pipelines",
+      "sourceUrl": "https://officialskills.sh/mongodb/skills/mongodb-natural-language-querying",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "mongodb"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-mongodb-mongodb-query-optimizer",
+      "name": "mongodb/mongodb-query-optimizer",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "mongodb",
+      "sourceGroup": "Skills by MongoDB",
+      "description": "Analyze and optimize query performance using Atlas Performance Advisor",
+      "sourceUrl": "https://officialskills.sh/mongodb/skills/mongodb-query-optimizer",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "mongodb"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-mongodb-mongodb-search-and-ai",
+      "name": "mongodb/mongodb-search-and-ai",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "mongodb",
+      "sourceGroup": "Skills by MongoDB",
+      "description": "Implement Atlas Search and AI-powered recommendations with vector search",
+      "sourceUrl": "https://officialskills.sh/mongodb/skills/mongodb-search-and-ai",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "mongodb"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-redis-redis-development",
+      "name": "redis/redis-development",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "redis",
+      "sourceGroup": "Skills by Redis",
+      "description": "Redis development best practices — data structures, query engine, vector search, caching, and performance optimization.",
+      "sourceUrl": "https://github.com/redis/agent-skills/tree/main/skills/redis-development",
+      "installSource": {
+        "repoUrl": "https://github.com/redis/agent-skills",
+        "subPath": "skills/redis-development"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "redis"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-cuda-q-cudaq-guide",
+      "name": "NVIDIA/CUDA-Q/cudaq-guide",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "CUDA-Q onboarding guide for installation, test programs, GPU simulation, QPU hardware, and quantum applications.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/CUDA-Q/cudaq-guide",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/CUDA-Q/cudaq-guide"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-dali-dali-dynamic-mode",
+      "name": "NVIDIA/DALI/dali-dynamic-mode",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Use when writing DALI data loading or preprocessing code with nvidia.dali.experimental.dynamic (ndd), or when converting DALI pipeline-mode code to dynamic mode, or when the user...",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/DALI/dali-dynamic-mode",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/DALI/dali-dynamic-mode"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-megatron-bridge-adding-model-support",
+      "name": "NVIDIA/Megatron-Bridge/adding-model-support",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Guide for adding support for new LLM or VLM models in Megatron-Bridge.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/adding-model-support",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Megatron-Bridge/adding-model-support"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-megatron-bridge-build-and-dependency",
+      "name": "NVIDIA/Megatron-Bridge/build-and-dependency",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Dev environment setup for Megatron Bridge — container-based development, uv package management, lockfile regeneration, adding dependencies, Slurm container usage, and common build...",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/build-and-dependency",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Megatron-Bridge/build-and-dependency"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-megatron-bridge-bump-dependency",
+      "name": "NVIDIA/Megatron-Bridge/bump-dependency",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Bump a pinned dependency (TransformerEngine, Megatron-LM, NRX, etc.), regenerate the lockfile, open a PR, and drive it to green by attaching a watchdog to the \"CICD NeMo\" workflow...",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/bump-dependency",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Megatron-Bridge/bump-dependency"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-megatron-bridge-cicd",
+      "name": "NVIDIA/Megatron-Bridge/cicd",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "CI/CD reference for Megatron Bridge — pipeline structure, commit and PR workflow, CI failure investigation, and common failure patterns.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/cicd",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Megatron-Bridge/cicd"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-megatron-bridge-linting-and-formatting",
+      "name": "NVIDIA/Megatron-Bridge/linting-and-formatting",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Code style and quality rules for Megatron Bridge — ruff configuration, naming conventions, type hints, mypy rules, docstrings, copyright headers, logging, and the code review check...",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/linting-and-formatting",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Megatron-Bridge/linting-and-formatting"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-megatron-bridge-mlm-bridge-training",
+      "name": "NVIDIA/Megatron-Bridge/mlm-bridge-training",
+      "kind": "skill",
+      "category": "数据与分析",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Run Megatron-LM (MLM) and Megatron Bridge training with mock or real data.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/mlm-bridge-training",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Megatron-Bridge/mlm-bridge-training"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-megatron-bridge-multi-node-slurm",
+      "name": "NVIDIA/Megatron-Bridge/multi-node-slurm",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Convert single-node scripts to multi-node Slurm sbatch jobs and debug common multi-node failures.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/multi-node-slurm",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Megatron-Bridge/multi-node-slurm"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-megatron-bridge-nemo-rl-e2e-testing",
+      "name": "NVIDIA/Megatron-Bridge/nemo-rl-e2e-testing",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "External NeMo-RL end-to-end validation workflow for Megatron-Bridge model/provider changes, including downstream compatibility checks, external RL lifecycle behavior, Megatron poli...",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/nemo-rl-e2e-testing",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Megatron-Bridge/nemo-rl-e2e-testing"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-megatron-bridge-parity-testing",
+      "name": "NVIDIA/Megatron-Bridge/parity-testing",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Structured framework for verifying numerical parity of HFMCore weight conversions.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/parity-testing",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Megatron-Bridge/parity-testing"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-megatron-bridge-perf-activation-recompute",
+      "name": "NVIDIA/Megatron-Bridge/perf-activation-recompute",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Validate and use selective and full activation recompute in Megatron Bridge to reduce GPU memory usage at the cost of extra compute.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/perf-activation-recompute",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Megatron-Bridge/perf-activation-recompute"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-megatron-bridge-perf-cpu-offloading",
+      "name": "NVIDIA/Megatron-Bridge/perf-cpu-offloading",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Validate and use CPU offloading in Megatron Bridge, including layer-level activation offloading and fractional optimizer state offloading with HybridDeviceOptimizer.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/perf-cpu-offloading",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Megatron-Bridge/perf-cpu-offloading"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-megatron-bridge-perf-cuda-graphs",
+      "name": "NVIDIA/Megatron-Bridge/perf-cuda-graphs",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Validate and use CUDA graph capture in Megatron Bridge, including local full-iteration graphs and Transformer Engine scoped graphs for attention, MLP, and MoE modules.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/perf-cuda-graphs",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Megatron-Bridge/perf-cuda-graphs"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-megatron-bridge-perf-expert-parallel-overlap",
+      "name": "NVIDIA/Megatron-Bridge/perf-expert-parallel-overlap",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Validate and use MoE expert-parallel communication overlap in Megatron-Bridge, including overlapmoeexpertparallelcomm, delaywgradcompute, and flex dispatcher backends such as...",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/perf-expert-parallel-overlap",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Megatron-Bridge/perf-expert-parallel-overlap"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-megatron-bridge-perf-hierarchical-context-parallel",
+      "name": "NVIDIA/Megatron-Bridge/perf-hierarchical-context-parallel",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Operational guide for enabling hierarchical context parallelism in Megatron-Bridge, including config knobs, code anchors, pitfalls, and verification.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/perf-hierarchical-context-parallel",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Megatron-Bridge/perf-hierarchical-context-parallel"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-megatron-bridge-perf-megatron-fsdp",
+      "name": "NVIDIA/Megatron-Bridge/perf-megatron-fsdp",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Operational guide for enabling Megatron FSDP in Megatron-Bridge, including config knobs, code anchors, pitfalls, and verification.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/perf-megatron-fsdp",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Megatron-Bridge/perf-megatron-fsdp"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-megatron-bridge-perf-memory-tuning",
+      "name": "NVIDIA/Megatron-Bridge/perf-memory-tuning",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Techniques for reducing peak GPU memory in Megatron Bridge — expandable segments, parallelism resizing, activation recompute, CPU offloading constraints, and common OOM fixes.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/perf-memory-tuning",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Megatron-Bridge/perf-memory-tuning"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-megatron-bridge-perf-moe-comm-overlap",
+      "name": "NVIDIA/Megatron-Bridge/perf-moe-comm-overlap",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "MoE expert-parallel communication overlap in Megatron Bridge.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/perf-moe-comm-overlap",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Megatron-Bridge/perf-moe-comm-overlap"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-megatron-bridge-perf-moe-dispatcher-selection",
+      "name": "NVIDIA/Megatron-Bridge/perf-moe-dispatcher-selection",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Choose the right MoE token dispatcher (alltoall, DeepEP, or HybridEP) for the hardware, EP degree, and optimization stage.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/perf-moe-dispatcher-selection",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Megatron-Bridge/perf-moe-dispatcher-selection"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-megatron-bridge-perf-moe-hardware-configs",
+      "name": "NVIDIA/Megatron-Bridge/perf-moe-hardware-configs",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Representative MoE training playbooks by hardware platform and model family.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/perf-moe-hardware-configs",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Megatron-Bridge/perf-moe-hardware-configs"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-megatron-bridge-perf-moe-long-context",
+      "name": "NVIDIA/Megatron-Bridge/perf-moe-long-context",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Long-context MoE training guidance for Megatron Bridge.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/perf-moe-long-context",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Megatron-Bridge/perf-moe-long-context"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-megatron-bridge-perf-moe-optimization-workflow",
+      "name": "NVIDIA/Megatron-Bridge/perf-moe-optimization-workflow",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Systematic workflow for MoE training optimization in Megatron Bridge, based on the Megatron-Core MoE paper.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/perf-moe-optimization-workflow",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Megatron-Bridge/perf-moe-optimization-workflow"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-megatron-bridge-perf-moe-vlm-training",
+      "name": "NVIDIA/Megatron-Bridge/perf-moe-vlm-training",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Practical guidance for training MoE VLMs in Megatron Bridge.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/perf-moe-vlm-training",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Megatron-Bridge/perf-moe-vlm-training"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-megatron-bridge-perf-parallelism-strategies",
+      "name": "NVIDIA/Megatron-Bridge/perf-parallelism-strategies",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Operational guide for choosing and combining parallelism strategies in Megatron Bridge, including sizing rules, hardware topology mapping, and combined parallelism configuration.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/perf-parallelism-strategies",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Megatron-Bridge/perf-parallelism-strategies"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-megatron-bridge-perf-sequence-packing",
+      "name": "NVIDIA/Megatron-Bridge/perf-sequence-packing",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Validate and use packed sequences and long-context training in Megatron-Bridge, distinguishing offline packed SFT for LLMs from in-batch packing for VLMs, and applying the right CP...",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/perf-sequence-packing",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Megatron-Bridge/perf-sequence-packing"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-megatron-bridge-perf-tp-dp-comm-overlap",
+      "name": "NVIDIA/Megatron-Bridge/perf-tp-dp-comm-overlap",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Operational guide for enabling TP, DP, and PP communication overlap in Megatron-Bridge, including config knobs, code anchors, pitfalls, and verification.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/perf-tp-dp-comm-overlap",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Megatron-Bridge/perf-tp-dp-comm-overlap"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-megatron-bridge-recipe-recommender",
+      "name": "NVIDIA/Megatron-Bridge/recipe-recommender",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Recommend and customize Megatron Bridge recipes for a user's model, GPU count, and training goal.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/recipe-recommender",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Megatron-Bridge/recipe-recommender"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-megatron-bridge-resiliency",
+      "name": "NVIDIA/Megatron-Bridge/resiliency",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Resiliency features in Megatron Bridge including fault tolerance, straggler detection, in-process restart, preemption, and re-run state machine.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/resiliency",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Megatron-Bridge/resiliency"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-megatron-bridge-testing",
+      "name": "NVIDIA/Megatron-Bridge/testing",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Testing reference for Megatron Bridge — unit and functional test layout, tier semantics (L0/L1/L2/flaky), script conventions, running tests locally, adding/moving/disabling tests,...",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/testing",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Megatron-Bridge/testing"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-megatron-bridge-verl-e2e-testing",
+      "name": "NVIDIA/Megatron-Bridge/verl-e2e-testing",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "External verl end-to-end validation workflow for Megatron-Bridge model/provider changes.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/verl-e2e-testing",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Megatron-Bridge/verl-e2e-testing"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-megatron-core-build-and-dependency",
+      "name": "NVIDIA/Megatron-Core/build-and-dependency",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Container-based dev environment setup and dependency management for Megatron-LM.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Core/build-and-dependency",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Megatron-Core/build-and-dependency"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-megatron-core-bump-base-image",
+      "name": "NVIDIA/Megatron-Core/bump-base-image",
+      "kind": "skill",
+      "category": "多媒体创作",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Bump the NVIDIA PyTorch base image (nvcr.io/nvidia/pytorch:-py3) used by Megatron-LM CI.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Core/bump-base-image",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Megatron-Core/bump-base-image"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-megatron-core-cicd",
+      "name": "NVIDIA/Megatron-Core/cicd",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "CI/CD reference for Megatron-LM.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Core/cicd",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Megatron-Core/cicd"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-megatron-core-create-issue",
+      "name": "NVIDIA/Megatron-Core/create-issue",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Investigate a failing GitHub Actions run or job and create a GitHub issue for the failure.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Core/create-issue",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Megatron-Core/create-issue"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-megatron-core-linting-and-formatting",
+      "name": "NVIDIA/Megatron-Core/linting-and-formatting",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Linting and formatting for Megatron-LM.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Core/linting-and-formatting",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Megatron-Core/linting-and-formatting"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-megatron-core-nightly-sync",
+      "name": "NVIDIA/Megatron-Core/nightly-sync",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Domain knowledge for the nightly main-to-dev sync workflow.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Core/nightly-sync",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Megatron-Core/nightly-sync"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-megatron-core-onboard-gb200-1node-tests",
+      "name": "NVIDIA/Megatron-Core/onboard-gb200-1node-tests",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Onboard 1-node GitHub MR functional tests for GB200 from existing mr-scoped 2-node tests.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Core/onboard-gb200-1node-tests",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Megatron-Core/onboard-gb200-1node-tests"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-megatron-core-respond-to-issue",
+      "name": "NVIDIA/Megatron-Core/respond-to-issue",
+      "kind": "skill",
+      "category": "数据与分析",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Research and draft a response to a GitHub issue or question from an external contributor.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Core/respond-to-issue",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Megatron-Core/respond-to-issue"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-megatron-core-run-on-slurm",
+      "name": "NVIDIA/Megatron-Core/run-on-slurm",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "How to launch distributed Megatron-LM training jobs on a SLURM cluster.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Core/run-on-slurm",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Megatron-Core/run-on-slurm"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-megatron-core-split-pr",
+      "name": "NVIDIA/Megatron-Core/split-pr",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Split a PR into multiple PRs to reduce the number of required CODEOWNERS reviewer groups.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Core/split-pr",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Megatron-Core/split-pr"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-megatron-core-testing",
+      "name": "NVIDIA/Megatron-Core/testing",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Test system for Megatron-LM.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Core/testing",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Megatron-Core/testing"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-megatron-core-update-golden-values",
+      "name": "NVIDIA/Megatron-Core/update-golden-values",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Refresh golden values from a GitHub Actions workflow run (failing-only or all jobs), score the change with average normalized relative differences, and produce a PR-ready summary.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Core/update-golden-values",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Megatron-Core/update-golden-values"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-model-optimizer-accessing-mlflow",
+      "name": "NVIDIA/Model-Optimizer/accessing-mlflow",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Query and browse evaluation results stored in MLflow.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Model-Optimizer/accessing-mlflow",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Model-Optimizer/accessing-mlflow"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-model-optimizer-debug",
+      "name": "NVIDIA/Model-Optimizer/debug",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Run commands inside a remote Docker container via the file-based command relay (tools/debugger).",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Model-Optimizer/debug",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Model-Optimizer/debug"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-model-optimizer-deployment",
+      "name": "NVIDIA/Model-Optimizer/deployment",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Serve a quantized or unquantized LLM checkpoint as an OpenAI-compatible API endpoint using vLLM, SGLang, or TRT-LLM.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Model-Optimizer/deployment",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Model-Optimizer/deployment"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-model-optimizer-evaluation",
+      "name": "NVIDIA/Model-Optimizer/evaluation",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Evaluates accuracy of quantized or unquantized LLMs using NeMo Evaluator Launcher (NEL).",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Model-Optimizer/evaluation",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Model-Optimizer/evaluation"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-model-optimizer-launching-evals",
+      "name": "NVIDIA/Model-Optimizer/launching-evals",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Run, monitor, analyze, and debug LLM evaluations via nemo-evaluator-launcher.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Model-Optimizer/launching-evals",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Model-Optimizer/launching-evals"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-model-optimizer-monitor",
+      "name": "NVIDIA/Model-Optimizer/monitor",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Monitor submitted jobs (PTQ, evaluation, deployment) on SLURM clusters.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Model-Optimizer/monitor",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Model-Optimizer/monitor"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-model-optimizer-ptq",
+      "name": "NVIDIA/Model-Optimizer/ptq",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "This skill should be used when the user asks to \"quantize a model\", \"run PTQ\", \"post-training quantization\", \"NVFP4 quantization\", \"FP8 quantization\", \"INT8 quantization\", \"INT4 AW...",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Model-Optimizer/ptq",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Model-Optimizer/ptq"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-model-optimizer-release-cherry-pick",
+      "name": "NVIDIA/Model-Optimizer/release-cherry-pick",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Cherry-pick merged PRs labeled for a release branch into that branch, then open a PR and apply the cherry-pick-done label.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/Model-Optimizer/release-cherry-pick",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/Model-Optimizer/release-cherry-pick"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-nemo-evaluator-byob",
+      "name": "NVIDIA/NeMo-Evaluator/byob",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Create custom LLM evaluation benchmarks using the BYOB decorator framework.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/NeMo-Evaluator/byob",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/NeMo-Evaluator/byob"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-nemo-evaluator-launcher-accessing-mlflow",
+      "name": "NVIDIA/NeMo-Evaluator-Launcher/accessing-mlflow",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Query and browse evaluation results stored in MLflow.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/NeMo-Evaluator-Launcher/accessing-mlflow",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/NeMo-Evaluator-Launcher/accessing-mlflow"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-nemo-evaluator-launcher-launching-evals",
+      "name": "NVIDIA/NeMo-Evaluator-Launcher/launching-evals",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Run, monitor, analyze, and debug LLM evaluations via nemo-evaluator-launcher.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/NeMo-Evaluator-Launcher/launching-evals",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/NeMo-Evaluator-Launcher/launching-evals"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-nemo-evaluator-launcher-nel-assistant",
+      "name": "NVIDIA/NeMo-Evaluator-Launcher/nel-assistant",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Interactive config wizard for NeMo Evaluator Launcher (NEL).",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/NeMo-Evaluator-Launcher/nel-assistant",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/NeMo-Evaluator-Launcher/nel-assistant"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-nemo-gym-add-benchmark",
+      "name": "NVIDIA/NeMo-Gym/add-benchmark",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "> Guide for adding a new benchmark or training environment to NeMo-Gym.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/NeMo-Gym/add-benchmark",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/NeMo-Gym/add-benchmark"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-nemo-gym-nemo-gym-debugging",
+      "name": "NVIDIA/NeMo-Gym/nemo-gym-debugging",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": ">- Use when debugging a Nemo Gym run or reward profiling job.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/NeMo-Gym/nemo-gym-debugging",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/NeMo-Gym/nemo-gym-debugging"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-nemo-gym-nemo-gym-docs",
+      "name": "NVIDIA/NeMo-Gym/nemo-gym-docs",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "> Maintain the NeMo Gym Fern docs site — add, update, move, or remove pages under fern/.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/NeMo-Gym/nemo-gym-docs",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/NeMo-Gym/nemo-gym-docs"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-nemo-gym-nemo-gym-pivot-datasets",
+      "name": "NVIDIA/NeMo-Gym/nemo-gym-pivot-datasets",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": ">- Use when creating, validating, or documenting Nemo Gym pivot datasets from rollout, trajectory, chat-completion, Responses API, or tool-call artifacts.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/NeMo-Gym/nemo-gym-pivot-datasets",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/NeMo-Gym/nemo-gym-pivot-datasets"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-nemo-gym-nemo-gym-reward-profiling",
+      "name": "NVIDIA/NeMo-Gym/nemo-gym-reward-profiling",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": ">- Use to help users get started with Nemo Gym reward profiling.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/NeMo-Gym/nemo-gym-reward-profiling",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/NeMo-Gym/nemo-gym-reward-profiling"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-nemo-rl-auto-research",
+      "name": "NVIDIA/NeMo-RL/auto-research",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Autonomous NeMo-RL research agent workflow for directed hypothesis testing and open-ended discovery.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/NeMo-RL/auto-research",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/NeMo-RL/auto-research"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-nemo-rl-brev-etiquette",
+      "name": "NVIDIA/NeMo-RL/brev-etiquette",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Brev instance operating guidance for NeMo-RL agents working in /home/ubuntu/RL with limited workspace disk, a larger /ephemeral volume, and optional /home/ubuntu/RL/.env secrets.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/NeMo-RL/brev-etiquette",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/NeMo-RL/brev-etiquette"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-nemo-rl-build-and-dependency",
+      "name": "NVIDIA/NeMo-RL/build-and-dependency",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Build and dependency management for NeMo-RL.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/NeMo-RL/build-and-dependency",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/NeMo-RL/build-and-dependency"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-nemo-rl-cicd",
+      "name": "NVIDIA/NeMo-RL/cicd",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "CI/CD reference for NeMo-RL.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/NeMo-RL/cicd",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/NeMo-RL/cicd"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-nemo-rl-config-conventions",
+      "name": "NVIDIA/NeMo-RL/config-conventions",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Configuration conventions for NeMo-RL.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/NeMo-RL/config-conventions",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/NeMo-RL/config-conventions"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-nemo-rl-contributing",
+      "name": "NVIDIA/NeMo-RL/contributing",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Contribution conventions for NeMo-RL.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/NeMo-RL/contributing",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/NeMo-RL/contributing"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-nemo-rl-copyright",
+      "name": "NVIDIA/NeMo-RL/copyright",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "NVIDIA copyright header requirements for NeMo-RL.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/NeMo-RL/copyright",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/NeMo-RL/copyright"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-nemo-rl-docs",
+      "name": "NVIDIA/NeMo-RL/docs",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Documentation conventions for NeMo-RL.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/NeMo-RL/docs",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/NeMo-RL/docs"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-nemo-rl-error-handling",
+      "name": "NVIDIA/NeMo-RL/error-handling",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Error handling guidelines for NeMo-RL.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/NeMo-RL/error-handling",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/NeMo-RL/error-handling"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-nemo-rl-launch-nemo-rl",
+      "name": "NVIDIA/NeMo-RL/launch-nemo-rl",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Playbook for launching, monitoring, stopping, and debugging NeMo-RL recipes on a Kubernetes cluster via the nrl-k8s CLI.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/NeMo-RL/launch-nemo-rl",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/NeMo-RL/launch-nemo-rl"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-nemo-rl-linting-and-formatting",
+      "name": "NVIDIA/NeMo-RL/linting-and-formatting",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Code style guidelines for NeMo-RL (Python and shell).",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/NeMo-RL/linting-and-formatting",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/NeMo-RL/linting-and-formatting"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-nemo-rl-review-pr",
+      "name": "NVIDIA/NeMo-RL/review-pr",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Interactive code review for NVIDIA-NeMo/RL pull requests.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/NeMo-RL/review-pr",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/NeMo-RL/review-pr"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-nemo-rl-session-memory",
+      "name": "NVIDIA/NeMo-RL/session-memory",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Manage durable working-session memory for coding agents.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/NeMo-RL/session-memory",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/NeMo-RL/session-memory"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-nemo-rl-testing",
+      "name": "NVIDIA/NeMo-RL/testing",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Testing conventions for NeMo-RL.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/NeMo-RL/testing",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/NeMo-RL/testing"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-nemoclaw-nemoclaw-contributor-create-pr",
+      "name": "NVIDIA/NemoClaw/nemoclaw-contributor-create-pr",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Create GitHub pull requests that follow the NemoClaw PR template.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/NemoClaw/nemoclaw-contributor-create-pr",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/NemoClaw/nemoclaw-contributor-create-pr"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-nemoclaw-nemoclaw-contributor-update-docs",
+      "name": "NVIDIA/NemoClaw/nemoclaw-contributor-update-docs",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Scan recent git commits for changes that affect user-facing behavior, then draft or update the corresponding documentation pages and refresh generated user skills for release prep.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/NemoClaw/nemoclaw-contributor-update-docs",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/NemoClaw/nemoclaw-contributor-update-docs"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-nemoclaw-nemoclaw-maintainer-cross-issue-sweep",
+      "name": "NVIDIA/NemoClaw/nemoclaw-maintainer-cross-issue-sweep",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Scans other open issues to find ones a given PR may also fix or accidentally break.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/NemoClaw/nemoclaw-maintainer-cross-issue-sweep",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/NemoClaw/nemoclaw-maintainer-cross-issue-sweep"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-nemoclaw-nemoclaw-maintainer-cut-release-tag",
+      "name": "NVIDIA/NemoClaw/nemoclaw-maintainer-cut-release-tag",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Cut a new semver release — bump all version strings via bump-version.ts, open a release PR, and after merge tag main and push.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/NemoClaw/nemoclaw-maintainer-cut-release-tag",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/NemoClaw/nemoclaw-maintainer-cut-release-tag"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-nemoclaw-nemoclaw-maintainer-day",
+      "name": "NVIDIA/NemoClaw/nemoclaw-maintainer-day",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Runs the daytime maintainer loop for NemoClaw, prioritizing items labeled with the current version target.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/NemoClaw/nemoclaw-maintainer-day",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/NemoClaw/nemoclaw-maintainer-day"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-nemoclaw-nemoclaw-maintainer-evening",
+      "name": "NVIDIA/NemoClaw/nemoclaw-maintainer-evening",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Runs the end-of-day maintainer handoff for NemoClaw.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/NemoClaw/nemoclaw-maintainer-evening",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/NemoClaw/nemoclaw-maintainer-evening"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-nemoclaw-nemoclaw-maintainer-find-review-pr",
+      "name": "NVIDIA/NemoClaw/nemoclaw-maintainer-find-review-pr",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Finds open GitHub PRs with security and priority-high labels, links each to its issue, detects duplicates (multiple PRs fixing the same issue), and presents a table of review candi...",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/NemoClaw/nemoclaw-maintainer-find-review-pr",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/NemoClaw/nemoclaw-maintainer-find-review-pr"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-nemoclaw-nemoclaw-maintainer-morning",
+      "name": "NVIDIA/NemoClaw/nemoclaw-maintainer-morning",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Runs the morning maintainer standup for NemoClaw.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/NemoClaw/nemoclaw-maintainer-morning",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/NemoClaw/nemoclaw-maintainer-morning"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-nemoclaw-nemoclaw-maintainer-normalize-title-tags",
+      "name": "NVIDIA/NemoClaw/nemoclaw-maintainer-normalize-title-tags",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Normalizes GitHub issue and PR titles by removing any bracketed [NemoClaw] tag case-insensitively, even when the tag appears later in the title.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/NemoClaw/nemoclaw-maintainer-normalize-title-tags",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/NemoClaw/nemoclaw-maintainer-normalize-title-tags"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-nemoclaw-nemoclaw-maintainer-pr-comparator",
+      "name": "NVIDIA/NemoClaw/nemoclaw-maintainer-pr-comparator",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Compares competing PRs that target the same issue and recommends which one to merge.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/NemoClaw/nemoclaw-maintainer-pr-comparator",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/NemoClaw/nemoclaw-maintainer-pr-comparator"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-nemoclaw-nemoclaw-maintainer-security-code-review",
+      "name": "NVIDIA/NemoClaw/nemoclaw-maintainer-security-code-review",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Performs a comprehensive security review of code changes in a GitHub PR or issue.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/NemoClaw/nemoclaw-maintainer-security-code-review",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/NemoClaw/nemoclaw-maintainer-security-code-review"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-nemoclaw-nemoclaw-maintainer-triage",
+      "name": "NVIDIA/NemoClaw/nemoclaw-maintainer-triage",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "AI-assisted label triage for NVIDIA/NemoClaw issues and PRs.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/NemoClaw/nemoclaw-maintainer-triage",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/NemoClaw/nemoclaw-maintainer-triage"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-nemoclaw-nemoclaw-skills-guide",
+      "name": "NVIDIA/NemoClaw/nemoclaw-skills-guide",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Start here.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/NemoClaw/nemoclaw-skills-guide",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/NemoClaw/nemoclaw-skills-guide"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-nemoclaw-nemoclaw-user-agent-skills",
+      "name": "NVIDIA/NemoClaw/nemoclaw-user-agent-skills",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Describes the agent skills shipped with NemoClaw and how to access them by cloning the repository.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/NemoClaw/nemoclaw-user-agent-skills",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/NemoClaw/nemoclaw-user-agent-skills"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-nemoclaw-nemoclaw-user-configure-inference",
+      "name": "NVIDIA/NemoClaw/nemoclaw-user-configure-inference",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Connects NemoClaw to a local inference server.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/NemoClaw/nemoclaw-user-configure-inference",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/NemoClaw/nemoclaw-user-configure-inference"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-nemoclaw-nemoclaw-user-configure-security",
+      "name": "NVIDIA/NemoClaw/nemoclaw-user-configure-security",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Presents a risk framework for every configurable security control in NemoClaw.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/NemoClaw/nemoclaw-user-configure-security",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/NemoClaw/nemoclaw-user-configure-security"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-nemoclaw-nemoclaw-user-deploy-remote",
+      "name": "NVIDIA/NemoClaw/nemoclaw-user-deploy-remote",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Explains how to run NemoClaw on a remote GPU instance, including the deprecated Brev compatibility path and the preferred installer plus onboard flow.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/NemoClaw/nemoclaw-user-deploy-remote",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/NemoClaw/nemoclaw-user-deploy-remote"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-nemoclaw-nemoclaw-user-get-started",
+      "name": "NVIDIA/NemoClaw/nemoclaw-user-get-started",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Installs NemoClaw, launches a sandbox, and runs the first agent prompt.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/NemoClaw/nemoclaw-user-get-started",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/NemoClaw/nemoclaw-user-get-started"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-nemoclaw-nemoclaw-user-manage-policy",
+      "name": "NVIDIA/NemoClaw/nemoclaw-user-manage-policy",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Adds, removes, or modifies allowed endpoints in the sandbox policy.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/NemoClaw/nemoclaw-user-manage-policy",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/NemoClaw/nemoclaw-user-manage-policy"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-nemoclaw-nemoclaw-user-manage-sandboxes",
+      "name": "NVIDIA/NemoClaw/nemoclaw-user-manage-sandboxes",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Explains operational tasks after the quickstart: listing sandboxes, status and health checks, logs, diagnostics, port forwards, multiple sandboxes, credential reset, rebuilds, netw...",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/NemoClaw/nemoclaw-user-manage-sandboxes",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/NemoClaw/nemoclaw-user-manage-sandboxes"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-nemoclaw-nemoclaw-user-monitor-sandbox",
+      "name": "NVIDIA/NemoClaw/nemoclaw-user-monitor-sandbox",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Inspects sandbox health, traces agent behavior, and diagnoses problems.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/NemoClaw/nemoclaw-user-monitor-sandbox",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/NemoClaw/nemoclaw-user-monitor-sandbox"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-nemoclaw-nemoclaw-user-overview",
+      "name": "NVIDIA/NemoClaw/nemoclaw-user-overview",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Explains how OpenClaw, OpenShell, and NemoClaw form the ecosystem, NemoClaw's position in the stack, what NemoClaw adds beyond the community sandbox, and when to prefer NemoClaw ve...",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/NemoClaw/nemoclaw-user-overview",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/NemoClaw/nemoclaw-user-overview"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-nemoclaw-nemoclaw-user-reference",
+      "name": "NVIDIA/NemoClaw/nemoclaw-user-reference",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Describes the NemoClaw plugin and blueprint architecture and how they orchestrate the OpenClaw sandbox.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/NemoClaw/nemoclaw-user-reference",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/NemoClaw/nemoclaw-user-reference"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-tensorrt-llm-ad-accuracy-debug",
+      "name": "NVIDIA/TensorRT-LLM/ad-accuracy-debug",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "> Debug AutoDeploy accuracy regressions vs a reference score (PyTorch backend or published baseline).",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/ad-accuracy-debug",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/TensorRT-LLM/ad-accuracy-debug"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-tensorrt-llm-ad-add-fusion-transformation",
+      "name": "NVIDIA/TensorRT-LLM/ad-add-fusion-transformation",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "> Claude Code skill (trtllm-agent-toolkit): implement or extend TensorRT-LLM AutoDeploy fusion transforms under transform/library/ in a TensorRT-LLM checkout.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/ad-add-fusion-transformation",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/TensorRT-LLM/ad-add-fusion-transformation"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-tensorrt-llm-ad-conf-check",
+      "name": "NVIDIA/TensorRT-LLM/ad-conf-check",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "> Check whether AutoDeploy YAML configs were actually applied by analyzing server logs and optionally graph dumps (ADDUMPGRAPHSDIR).",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/ad-conf-check",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/TensorRT-LLM/ad-conf-check"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-tensorrt-llm-ad-graph-dump",
+      "name": "NVIDIA/TensorRT-LLM/ad-graph-dump",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "> Enable and interpret TensorRT-LLM AutoDeploy FX graph text dumps via ADDUMPGRAPHSDIR.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/ad-graph-dump",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/TensorRT-LLM/ad-graph-dump"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-tensorrt-llm-ad-layer-visualizer",
+      "name": "NVIDIA/TensorRT-LLM/ad-layer-visualizer",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "> Visualize a specific transformer decoder layer from an AutoDeploy FX graph text dump as a hierarchical DOT/PNG diagram.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/ad-layer-visualizer",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/TensorRT-LLM/ad-layer-visualizer"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-tensorrt-llm-ad-model-onboard",
+      "name": "NVIDIA/TensorRT-LLM/ad-model-onboard",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "> Translates a HuggingFace model into a prefill-only AutoDeploy custom model using reference custom ops, validates with hierarchical equivalence tests.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/ad-model-onboard",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/TensorRT-LLM/ad-model-onboard"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-tensorrt-llm-exec-local-compile",
+      "name": "NVIDIA/TensorRT-LLM/exec-local-compile",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Compile TensorRT-LLM on a compute node inside a Docker container.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/exec-local-compile",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/TensorRT-LLM/exec-local-compile"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-tensorrt-llm-exec-slurm-compile",
+      "name": "NVIDIA/TensorRT-LLM/exec-slurm-compile",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Compile TensorRT-LLM on a SLURM cluster.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/exec-slurm-compile",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/TensorRT-LLM/exec-slurm-compile"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-tensorrt-llm-kernel-cute-writing",
+      "name": "NVIDIA/TensorRT-LLM/kernel-cute-writing",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "> Write and implement GPU kernels using NVIDIA CuTe DSL (CUTLASS 4.x Python API) — NOT for Triton, CUDA C++, or conceptual explanations.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/kernel-cute-writing",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/TensorRT-LLM/kernel-cute-writing"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-tensorrt-llm-kernel-tileir-optimization",
+      "name": "NVIDIA/TensorRT-LLM/kernel-tileir-optimization",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "> Optimize existing Triton kernels for NVIDIA TileIR backend on Blackwell GPUs (sm100+).",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/kernel-tileir-optimization",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/TensorRT-LLM/kernel-tileir-optimization"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-tensorrt-llm-kernel-triton-writing",
+      "name": "NVIDIA/TensorRT-LLM/kernel-triton-writing",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "> ONLY for OpenAI Triton (@triton.jit) kernel development.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/kernel-triton-writing",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/TensorRT-LLM/kernel-triton-writing"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-tensorrt-llm-perf-analysis",
+      "name": "NVIDIA/TensorRT-LLM/perf-analysis",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "> Performance analysis coordination workflow.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/perf-analysis",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/TensorRT-LLM/perf-analysis"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-tensorrt-llm-perf-host-analysis",
+      "name": "NVIDIA/TensorRT-LLM/perf-host-analysis",
+      "kind": "skill",
+      "category": "数据与分析",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "> Analyze host/CPU overhead in TensorRT-LLM inference from nsys traces.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/perf-host-analysis",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/TensorRT-LLM/perf-host-analysis"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-tensorrt-llm-perf-host-optimization",
+      "name": "NVIDIA/TensorRT-LLM/perf-host-optimization",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Profiles and optimizes TensorRT-LLM host/CPU overhead using lineprofiler (with nsys support planned).",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/perf-host-optimization",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/TensorRT-LLM/perf-host-optimization"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-tensorrt-llm-perf-nsight-compute-analysis",
+      "name": "NVIDIA/TensorRT-LLM/perf-nsight-compute-analysis",
+      "kind": "skill",
+      "category": "数据与分析",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "> Analyze ncu (NVIDIA Nsight Compute) profiling output: SOL% bottleneck classification, roofline analysis, occupancy diagnosis, memory hierarchy analysis, warp stall analysis, metr...",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/perf-nsight-compute-analysis",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/TensorRT-LLM/perf-nsight-compute-analysis"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-tensorrt-llm-perf-nsight-systems",
+      "name": "NVIDIA/TensorRT-LLM/perf-nsight-systems",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": ">- Nsight Systems (nsys) CLI for system-level timeline profiling.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/perf-nsight-systems",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/TensorRT-LLM/perf-nsight-systems"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-tensorrt-llm-perf-optimization",
+      "name": "NVIDIA/TensorRT-LLM/perf-optimization",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "> Performance optimization coordination playbook.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/perf-optimization",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/TensorRT-LLM/perf-optimization"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-tensorrt-llm-perf-torch-cuda-graphs",
+      "name": "NVIDIA/TensorRT-LLM/perf-torch-cuda-graphs",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": ">- Apply CUDA Graphs to PyTorch workloads — API selection (torch.compile, PyTorch makegraphedcallables, TE makegraphedcallables, MCore CudaGraphManager, FullCudaGraphWrapper, m...",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/perf-torch-cuda-graphs",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/TensorRT-LLM/perf-torch-cuda-graphs"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-tensorrt-llm-perf-torch-sync-free",
+      "name": "NVIDIA/TensorRT-LLM/perf-torch-sync-free",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": ">- Identify and eliminate host-device synchronizations in PyTorch code.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/perf-torch-sync-free",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/TensorRT-LLM/perf-torch-sync-free"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-tensorrt-llm-perf-workload-profiling",
+      "name": "NVIDIA/TensorRT-LLM/perf-workload-profiling",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "> Code instrumentation for timing workloads.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/perf-workload-profiling",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/TensorRT-LLM/perf-workload-profiling"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-tensorrt-llm-trtllm-code-contribution",
+      "name": "NVIDIA/TensorRT-LLM/trtllm-code-contribution",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "> Best practices for contributing code to TensorRT-LLM.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/trtllm-code-contribution",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/TensorRT-LLM/trtllm-code-contribution"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-tensorrt-llm-trtllm-codebase-exploration",
+      "name": "NVIDIA/TensorRT-LLM/trtllm-codebase-exploration",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "> Systematic approach to exploring the TensorRT-LLM codebase before implementing new features or optimizations.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/trtllm-codebase-exploration",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/TensorRT-LLM/trtllm-codebase-exploration"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-tensorrt-llm-trtllm-flashinfer-upgrade",
+      "name": "NVIDIA/TensorRT-LLM/trtllm-flashinfer-upgrade",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": ">- Upgrade flashinfer-python version in TensorRT-LLM.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/trtllm-flashinfer-upgrade",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/TensorRT-LLM/trtllm-flashinfer-upgrade"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-tensorrt-llm-trtllm-moe-develop",
+      "name": "NVIDIA/TensorRT-LLM/trtllm-moe-develop",
+      "kind": "skill",
+      "category": "多媒体创作",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": ">- Review, design, and refactor TensorRT-LLM PyTorch MoE code for architecture fit, clean code, maintainability, and testability.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/trtllm-moe-develop",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/TensorRT-LLM/trtllm-moe-develop"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-tensorrt-llm-trtllm-serve-config-guide",
+      "name": "NVIDIA/TensorRT-LLM/trtllm-serve-config-guide",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Generate a source-backed starting trtllm-serve --config YAML for basic aggregate single-node PyTorch serving, aligned with checked-in TensorRT-LLM configs and deployment docs.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/trtllm-serve-config-guide",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/TensorRT-LLM/trtllm-serve-config-guide"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-tilegym-adding-cutile-kernel",
+      "name": "NVIDIA/TileGym/adding-cutile-kernel",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Add a new cuTile GPU kernel operator to TileGym.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/TileGym/adding-cutile-kernel",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/TileGym/adding-cutile-kernel"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-tilegym-converting-cutile-to-julia",
+      "name": "NVIDIA/TileGym/converting-cutile-to-julia",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Converts cuTile Python GPU kernels (@ct.kernel) to cuTile.jl Julia equivalents.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/TileGym/converting-cutile-to-julia",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/TileGym/converting-cutile-to-julia"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-tilegym-converting-cutile-to-triton",
+      "name": "NVIDIA/TileGym/converting-cutile-to-triton",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Converts cuTile GPU kernels (@ct.kernel) to Triton (@triton.jit).",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/TileGym/converting-cutile-to-triton",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/TileGym/converting-cutile-to-triton"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-tilegym-cutile-autotuning",
+      "name": "NVIDIA/TileGym/cutile-autotuning",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Use when adding, modifying, optimizing, or debugging CuTile autotuning code.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/TileGym/cutile-autotuning",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/TileGym/cutile-autotuning"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-tilegym-cutile-python",
+      "name": "NVIDIA/TileGym/cutile-python",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Expert cuTile programming assistant.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/TileGym/cutile-python",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/TileGym/cutile-python"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-tilegym-improve-cutile-kernel-perf",
+      "name": "NVIDIA/TileGym/improve-cutile-kernel-perf",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Iteratively optimize cuTile kernel performance through systematic profiling, bottleneck analysis, IR comparison, and targeted tuning.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/TileGym/improve-cutile-kernel-perf",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/TileGym/improve-cutile-kernel-perf"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-tilegym-monkey-patch-kernels-to-transformers",
+      "name": "NVIDIA/TileGym/monkey-patch-kernels-to-transformers",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Integrate TileGym kernels into Hugging Face transformers models by replacing the library's submodule(s) and certain class(es)' implementations, and patching certain class(es)' in...",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/TileGym/monkey-patch-kernels-to-transformers",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/TileGym/monkey-patch-kernels-to-transformers"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-cuopt-cuopt-developer",
+      "name": "NVIDIA/cuopt/cuopt-developer",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Modify, build, test, debug, and contribute to NVIDIA cuOpt (C++/CUDA, Python, server, CI).",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/cuopt/cuopt-developer",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/cuopt/cuopt-developer"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-cuopt-cuopt-install",
+      "name": "NVIDIA/cuopt/cuopt-install",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Install cuOpt for Python, C, or as a server (pip, conda, Docker) — system requirements, install commands, and verification.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/cuopt/cuopt-install",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/cuopt/cuopt-install"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-cuopt-cuopt-numerical-optimization-api-c",
+      "name": "NVIDIA/cuopt/cuopt-numerical-optimization-api-c",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "LP, MILP, and QP (beta) with cuOpt — C API only.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/cuopt/cuopt-numerical-optimization-api-c",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/cuopt/cuopt-numerical-optimization-api-c"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-cuopt-cuopt-numerical-optimization-api-cli",
+      "name": "NVIDIA/cuopt/cuopt-numerical-optimization-api-cli",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "LP, MILP, and QP (beta) with cuOpt — CLI only (MPS files, cuoptcli).",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/cuopt/cuopt-numerical-optimization-api-cli",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/cuopt/cuopt-numerical-optimization-api-cli"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-cuopt-cuopt-numerical-optimization-api-python",
+      "name": "NVIDIA/cuopt/cuopt-numerical-optimization-api-python",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Solve Linear Programming (LP), Mixed-Integer Linear Programming (MILP), and Quadratic Programming (QP, beta) with the Python API.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/cuopt/cuopt-numerical-optimization-api-python",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/cuopt/cuopt-numerical-optimization-api-python"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-cuopt-cuopt-routing-api-python",
+      "name": "NVIDIA/cuopt/cuopt-routing-api-python",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Vehicle routing (VRP, TSP, PDP) with cuOpt — Python API only.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/cuopt/cuopt-routing-api-python",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/cuopt/cuopt-routing-api-python"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-cuopt-cuopt-server-api-python",
+      "name": "NVIDIA/cuopt/cuopt-server-api-python",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "cuOpt REST server — start server, endpoints, Python/curl client examples.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/cuopt/cuopt-server-api-python",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/cuopt/cuopt-server-api-python"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-cuopt-cuopt-server-common",
+      "name": "NVIDIA/cuopt/cuopt-server-common",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "cuOpt REST server — what it does and how requests flow.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/cuopt/cuopt-server-common",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/cuopt/cuopt-server-common"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-cuopt-cuopt-user-rules",
+      "name": "NVIDIA/cuopt/cuopt-user-rules",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Base rules for end users calling NVIDIA cuOpt (routing/LP/MILP/QP/install/server).",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/cuopt/cuopt-user-rules",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/cuopt/cuopt-user-rules"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-cuopt-numerical-optimization-formulation",
+      "name": "NVIDIA/cuopt/numerical-optimization-formulation",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Numerical optimization (LP, MILP, QP) — concepts, problem-text parsing, and formulation patterns.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/cuopt/numerical-optimization-formulation",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/cuopt/numerical-optimization-formulation"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-cuopt-routing-formulation",
+      "name": "NVIDIA/cuopt/routing-formulation",
+      "kind": "skill",
+      "category": "数据与分析",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Vehicle routing (VRP, TSP, PDP) — problem types and data requirements.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/cuopt/routing-formulation",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/cuopt/routing-formulation"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-cuopt-skill-evolution",
+      "name": "NVIDIA/cuopt/skill-evolution",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "After solving a non-trivial problem, detect generalizable learnings and propose skill updates so future interactions benefit automatically.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/cuopt/skill-evolution",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/cuopt/skill-evolution"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-deepstream-deepstream-dev",
+      "name": "NVIDIA/deepstream/deepstream-dev",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "NVIDIA DeepStream SDK 9.0 development with Python pyservicemaker API.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/deepstream/deepstream-dev",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/deepstream/deepstream-dev"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-deepstream-deepstream-import-vision-model",
+      "name": "NVIDIA/deepstream/deepstream-import-vision-model",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "> Use this skill to bring any vision model from HuggingFace or NVIDIA NGC into an NVIDIA DeepStream pipeline with end-to-end automation: ONNX download, SafeTensors export, TRT engi...",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/deepstream/deepstream-import-vision-model",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/deepstream/deepstream-import-vision-model"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-nemotron-voice-agent-nemotron-voice-agent-deploy",
+      "name": "NVIDIA/nemotron-voice-agent/nemotron-voice-agent-deploy",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Deploy Nemotron Voice Agent on Workstation (x86), Jetson Thor, or Cloud NIMs.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/nemotron-voice-agent/nemotron-voice-agent-deploy",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/nemotron-voice-agent/nemotron-voice-agent-deploy"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-rag-rag-blueprint",
+      "name": "NVIDIA/rag/rag-blueprint",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "\"NVIDIA RAG Blueprint — deploy, configure, troubleshoot, and manage.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/rag/rag-blueprint",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/rag/rag-blueprint"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-video-search-and-summarization-alerts",
+      "name": "NVIDIA/video-search-and-summarization/alerts",
+      "kind": "skill",
+      "category": "多媒体创作",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Manage and monitor VSS alerts after the alerts profile is deployed.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/video-search-and-summarization/alerts",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/video-search-and-summarization/alerts"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-video-search-and-summarization-deploy",
+      "name": "NVIDIA/video-search-and-summarization/deploy",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Deploy, debug, or tear down any VSS profile using a compose-centric workflow — config (dry-run) with env overrides, review resolved compose, then compose up.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/video-search-and-summarization/deploy",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/video-search-and-summarization/deploy"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-video-search-and-summarization-report",
+      "name": "NVIDIA/video-search-and-summarization/report",
+      "kind": "skill",
+      "category": "数据与分析",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Produce video analysis reports by discovering the deployed VSS agent, querying POST /generate for a timestamped captioned summary of the clip, then formatting the agent reply as th...",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/video-search-and-summarization/report",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/video-search-and-summarization/report"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-video-search-and-summarization-rt-vlm",
+      "name": "NVIDIA/video-search-and-summarization/rt-vlm",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "> Use this skill when working with the RTVI VLM or RT-VLM microservice API on VSS 3.1.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/video-search-and-summarization/rt-vlm",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/video-search-and-summarization/rt-vlm"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-video-search-and-summarization-video-analytics",
+      "name": "NVIDIA/video-search-and-summarization/video-analytics",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Query video analytics data and metrics from Elastic search via the VA-MCP server (port 9901).",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/video-search-and-summarization/video-analytics",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/video-search-and-summarization/video-analytics"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-video-search-and-summarization-video-search",
+      "name": "NVIDIA/video-search-and-summarization/video-search",
+      "kind": "skill",
+      "category": "多媒体创作",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Search video archives using natural language — find events, objects, actions, and people across recorded video using fusion search (Cosmos Embed1 semantic search + CV attribute sea...",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/video-search-and-summarization/video-search",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/video-search-and-summarization/video-search"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-video-search-and-summarization-video-summarization",
+      "name": "NVIDIA/video-search-and-summarization/video-summarization",
+      "kind": "skill",
+      "category": "多媒体创作",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Summarize a video by calling the VLM NIM or the Long Video Summarization (LVS) microservice directly.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/video-search-and-summarization/video-summarization",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/video-search-and-summarization/video-summarization"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-video-search-and-summarization-video-understanding",
+      "name": "NVIDIA/video-search-and-summarization/video-understanding",
+      "kind": "skill",
+      "category": "多媒体创作",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Call the vss agent to run video understanding on video to answer a text question.",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/video-search-and-summarization/video-understanding",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/video-search-and-summarization/video-understanding"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-video-search-and-summarization-vios",
+      "name": "NVIDIA/video-search-and-summarization/vios",
+      "kind": "skill",
+      "category": "多媒体创作",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Query VIOS REST APIs: sensor list, recording timelines, video clip extraction, snapshot capture, add/delete sensors and streams",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/video-search-and-summarization/vios",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/video-search-and-summarization/vios"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nvidia-video-search-and-summarization-vss-frag",
+      "name": "NVIDIA/video-search-and-summarization/vss-frag",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "NVIDIA",
+      "sourceGroup": "Skills by NVIDIA",
+      "description": "Generate video summary reports using the VSS videosearchfrag extension with Long Video Summarization (LVS), Enterprise RAG knowledge retrieval, and human-in-the-loop parameter co...",
+      "sourceUrl": "https://github.com/NVIDIA/skills/tree/main/skills/video-search-and-summarization/vss-frag",
+      "installSource": {
+        "repoUrl": "https://github.com/NVIDIA/skills",
+        "subPath": "skills/video-search-and-summarization/vss-frag"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NVIDIA"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-google-cloud-agent-platform-skill-registry",
+      "name": "google/cloud/agent-platform-skill-registry",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "google",
+      "sourceGroup": "Skills by Google Cloud",
+      "description": "Interact with the Gemini Enterprise Agent Platform Skill Registry to create and search for available skills.",
+      "sourceUrl": "https://github.com/google/skills/tree/main/skills/cloud/agent-platform-skill-registry",
+      "installSource": {
+        "repoUrl": "https://github.com/google/skills",
+        "subPath": "skills/cloud/agent-platform-skill-registry"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "google"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-google-cloud-alloydb-basics",
+      "name": "google/cloud/alloydb-basics",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "google",
+      "sourceGroup": "Skills by Google Cloud",
+      "description": "Manages clusters, instances, and backups for AlloyDB for PostgreSQL, and integrates with AlloyDB model context protocol (MCP) tools for automated database operations.",
+      "sourceUrl": "https://github.com/google/skills/tree/main/skills/cloud/alloydb-basics",
+      "installSource": {
+        "repoUrl": "https://github.com/google/skills",
+        "subPath": "skills/cloud/alloydb-basics"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "google"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-google-cloud-bigquery-basics",
+      "name": "google/cloud/bigquery-basics",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "google",
+      "sourceGroup": "Skills by Google Cloud",
+      "description": "Manages datasets, tables, and jobs in BigQuery, and integrates with BigQuery ML and Gemini for advanced data analytics and AI-driven insights.",
+      "sourceUrl": "https://github.com/google/skills/tree/main/skills/cloud/bigquery-basics",
+      "installSource": {
+        "repoUrl": "https://github.com/google/skills",
+        "subPath": "skills/cloud/bigquery-basics"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "google"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-google-cloud-cloud-run-basics",
+      "name": "google/cloud/cloud-run-basics",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "google",
+      "sourceGroup": "Skills by Google Cloud",
+      "description": "Manages Cloud Run services, jobs, and worker pools.",
+      "sourceUrl": "https://github.com/google/skills/tree/main/skills/cloud/cloud-run-basics",
+      "installSource": {
+        "repoUrl": "https://github.com/google/skills",
+        "subPath": "skills/cloud/cloud-run-basics"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "google"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-google-cloud-cloud-sql-basics",
+      "name": "google/cloud/cloud-sql-basics",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "google",
+      "sourceGroup": "Skills by Google Cloud",
+      "description": "This file generates or explains Cloud SQL resources.",
+      "sourceUrl": "https://github.com/google/skills/tree/main/skills/cloud/cloud-sql-basics",
+      "installSource": {
+        "repoUrl": "https://github.com/google/skills",
+        "subPath": "skills/cloud/cloud-sql-basics"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "google"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-google-cloud-firebase-basics",
+      "name": "google/cloud/firebase-basics",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "google",
+      "sourceGroup": "Skills by Google Cloud",
+      "description": "Use this skill whenever you are working on a project that uses Firebase products or services, especially for mobile or web apps.",
+      "sourceUrl": "https://github.com/google/skills/tree/main/skills/cloud/firebase-basics",
+      "installSource": {
+        "repoUrl": "https://github.com/google/skills",
+        "subPath": "skills/cloud/firebase-basics"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "google"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-google-cloud-gemini-agents-api",
+      "name": "google/cloud/gemini-agents-api",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "google",
+      "sourceGroup": "Skills by Google Cloud",
+      "description": "Manages custom Agent resources on Gemini Enterprise Agent Platform.",
+      "sourceUrl": "https://github.com/google/skills/tree/main/skills/cloud/gemini-agents-api",
+      "installSource": {
+        "repoUrl": "https://github.com/google/skills",
+        "subPath": "skills/cloud/gemini-agents-api"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "google"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-google-cloud-gemini-api",
+      "name": "google/cloud/gemini-api",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "google",
+      "sourceGroup": "Skills by Google Cloud",
+      "description": "Guides the usage of the Gemini API on Agent Platform with the Google Gen AI SDK.",
+      "sourceUrl": "https://github.com/google/skills/tree/main/skills/cloud/gemini-api",
+      "installSource": {
+        "repoUrl": "https://github.com/google/skills",
+        "subPath": "skills/cloud/gemini-api"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "google"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-google-cloud-gemini-interactions-api",
+      "name": "google/cloud/gemini-interactions-api",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "google",
+      "sourceGroup": "Skills by Google Cloud",
+      "description": "Guides the usage of Gemini Interactions API on Gemini Enterprise Agent Platform.",
+      "sourceUrl": "https://github.com/google/skills/tree/main/skills/cloud/gemini-interactions-api",
+      "installSource": {
+        "repoUrl": "https://github.com/google/skills",
+        "subPath": "skills/cloud/gemini-interactions-api"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "google"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-google-cloud-gke-basics",
+      "name": "google/cloud/gke-basics",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "google",
+      "sourceGroup": "Skills by Google Cloud",
+      "description": "Plan, create, and configure production-ready Google Kubernetes Engine (GKE) clusters using the golden path Autopilot configuration.",
+      "sourceUrl": "https://github.com/google/skills/tree/main/skills/cloud/gke-basics",
+      "installSource": {
+        "repoUrl": "https://github.com/google/skills",
+        "subPath": "skills/cloud/gke-basics"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "google"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-google-cloud-google-cloud-networking-observability",
+      "name": "google/cloud/google-cloud-networking-observability",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "google",
+      "sourceGroup": "Skills by Google Cloud",
+      "description": "Investigates Google Cloud networking issues by analyzing logs, metrics, and diagnostics.",
+      "sourceUrl": "https://github.com/google/skills/tree/main/skills/cloud/google-cloud-networking-observability",
+      "installSource": {
+        "repoUrl": "https://github.com/google/skills",
+        "subPath": "skills/cloud/google-cloud-networking-observability"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "google"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-google-cloud-google-cloud-recipe-auth",
+      "name": "google/cloud/google-cloud-recipe-auth",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "google",
+      "sourceGroup": "Skills by Google Cloud",
+      "description": "Provides expert guidance on authenticating and authorizing to Google Cloud services and APIs, covering human users, service identities, Application Default Credentials (ADC), and b...",
+      "sourceUrl": "https://github.com/google/skills/tree/main/skills/cloud/google-cloud-recipe-auth",
+      "installSource": {
+        "repoUrl": "https://github.com/google/skills",
+        "subPath": "skills/cloud/google-cloud-recipe-auth"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "google"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-google-cloud-google-cloud-recipe-onboarding",
+      "name": "google/cloud/google-cloud-recipe-onboarding",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "google",
+      "sourceGroup": "Skills by Google Cloud",
+      "description": "Guidance for a developer's first steps on Google Cloud, covering account creation, billing setup, project management, and deploying a first resource.",
+      "sourceUrl": "https://github.com/google/skills/tree/main/skills/cloud/google-cloud-recipe-onboarding",
+      "installSource": {
+        "repoUrl": "https://github.com/google/skills",
+        "subPath": "skills/cloud/google-cloud-recipe-onboarding"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "google"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-google-cloud-google-cloud-waf-cost-optimization",
+      "name": "google/cloud/google-cloud-waf-cost-optimization",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "google",
+      "sourceGroup": "Skills by Google Cloud",
+      "description": "Generates cost optimization guidance for Google Cloud workloads based on the Google Cloud Well-Architected Framework (WAF).",
+      "sourceUrl": "https://github.com/google/skills/tree/main/skills/cloud/google-cloud-waf-cost-optimization",
+      "installSource": {
+        "repoUrl": "https://github.com/google/skills",
+        "subPath": "skills/cloud/google-cloud-waf-cost-optimization"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "google"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-google-cloud-google-cloud-waf-operational-excellence",
+      "name": "google/cloud/google-cloud-waf-operational-excellence",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "google",
+      "sourceGroup": "Skills by Google Cloud",
+      "description": "Generates operations-focused guidance for Google Cloud workloads based on the design principles and recommendations in the Operational Excellence pillar of the Google Cloud Well-Ar...",
+      "sourceUrl": "https://github.com/google/skills/tree/main/skills/cloud/google-cloud-waf-operational-excellence",
+      "installSource": {
+        "repoUrl": "https://github.com/google/skills",
+        "subPath": "skills/cloud/google-cloud-waf-operational-excellence"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "google"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-google-cloud-google-cloud-waf-performance-optimization",
+      "name": "google/cloud/google-cloud-waf-performance-optimization",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "google",
+      "sourceGroup": "Skills by Google Cloud",
+      "description": "Generates performance-focused guidance for Google Cloud workloads based on the design principles and recommendations in the Performance Optimization pillar of the Google Cloud Well...",
+      "sourceUrl": "https://github.com/google/skills/tree/main/skills/cloud/google-cloud-waf-performance-optimization",
+      "installSource": {
+        "repoUrl": "https://github.com/google/skills",
+        "subPath": "skills/cloud/google-cloud-waf-performance-optimization"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "google"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-google-cloud-google-cloud-waf-reliability",
+      "name": "google/cloud/google-cloud-waf-reliability",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "google",
+      "sourceGroup": "Skills by Google Cloud",
+      "description": "Generates reliability-focused guidance for Google Cloud workloads based on the design principles and recommendations in the Google Cloud Well-Architected Framework.",
+      "sourceUrl": "https://github.com/google/skills/tree/main/skills/cloud/google-cloud-waf-reliability",
+      "installSource": {
+        "repoUrl": "https://github.com/google/skills",
+        "subPath": "skills/cloud/google-cloud-waf-reliability"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "google"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-google-cloud-google-cloud-waf-security",
+      "name": "google/cloud/google-cloud-waf-security",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "google",
+      "sourceGroup": "Skills by Google Cloud",
+      "description": "Generates security-focused guidance for Google Cloud workloads based on the design principles and recommendations in the Google Cloud Well-Architected Framework (WAF).",
+      "sourceUrl": "https://github.com/google/skills/tree/main/skills/cloud/google-cloud-waf-security",
+      "installSource": {
+        "repoUrl": "https://github.com/google/skills",
+        "subPath": "skills/cloud/google-cloud-waf-security"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "google"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-google-cloud-google-cloud-waf-sustainability",
+      "name": "google/cloud/google-cloud-waf-sustainability",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "google",
+      "sourceGroup": "Skills by Google Cloud",
+      "description": "Generates sustainability-focused guidance for Google Cloud workloads based on the design principles and recommendations in the Google Cloud Well-Architected Framework (WAF).",
+      "sourceUrl": "https://github.com/google/skills/tree/main/skills/cloud/google-cloud-waf-sustainability",
+      "installSource": {
+        "repoUrl": "https://github.com/google/skills",
+        "subPath": "skills/cloud/google-cloud-waf-sustainability"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "google"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-redhat-cve-skillpack",
+      "name": "redhat/cve-skillpack",
+      "kind": "skillset",
+      "category": "产品与项目",
+      "publisher": "redhat",
+      "sourceGroup": "Skills by RedHat",
+      "description": "Understand CVEs, check product lifecycle status, gather diagnostics, and file support cases at the right severity — essential Red Hat skills for everyday operations.",
+      "sourceUrl": "https://catalog.redhat.com/en/ai/skills/detail/agentic-skill-pack-for-red-hat-customers#agent-and-skills",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "技能包"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-redhat-sre-skillpack",
+      "name": "redhat/sre-skillpack",
+      "kind": "skillset",
+      "category": "云与运维",
+      "publisher": "redhat",
+      "sourceGroup": "Skills by RedHat",
+      "description": "Discover, remediate, and verify CVEs across your RHEL fleet — orchestrating Red Hat Lightspeed and Ansible Automation Platform through a single workflow.",
+      "sourceUrl": "https://catalog.redhat.com/en/ai/skills/detail/agentic-skill-pack-for-site-reliability-engineers",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "技能包"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-redhat-openshift-skillpack",
+      "name": "redhat/openshift-skillpack",
+      "kind": "skillset",
+      "category": "其他工具",
+      "publisher": "redhat",
+      "sourceGroup": "Skills by RedHat",
+      "description": "Provision, inventory, and report on OpenShift clusters — spanning Assisted Installer, OCM, ROSA, ARO, and kubeconfig fleets — through a single conversational workflow.",
+      "sourceUrl": "https://catalog.redhat.com/en/ai/skills/detail/agentic-skill-pack-for-red-hat-openshift",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "技能包"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-redhat-openshift-virtualization",
+      "name": "redhat/openshift-virtualization",
+      "kind": "skill",
+      "category": "其他工具",
+      "publisher": "redhat",
+      "sourceGroup": "Skills by RedHat",
+      "description": "Manage the full VM lifecycle on OpenShift Virtualization — create, clone, snapshot, restore, rebalance, and report — through a single conversational workflow.",
+      "sourceUrl": "https://catalog.redhat.com/en/ai/skills/detail/agentic-skill-pack-for-red-hat-openshift-virtualization",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "redhat"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-cypress-io-cypress-author",
+      "name": "cypress-io/cypress-author",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "cypress-io",
+      "sourceGroup": "Skills by Cypress",
+      "description": "Creates, updates, and fixes Cypress E2E and component tests.",
+      "sourceUrl": "https://github.com/cypress-io/ai-toolkit/tree/main/skills/cypress-author",
+      "installSource": {
+        "repoUrl": "https://github.com/cypress-io/ai-toolkit",
+        "subPath": "skills/cypress-author"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "cypress-io"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-cypress-io-cypress-explain",
+      "name": "cypress-io/cypress-explain",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "cypress-io",
+      "sourceGroup": "Skills by Cypress",
+      "description": "Explains Cypress E2E and component tests, and answers questions about Cypress use and behavior.",
+      "sourceUrl": "https://github.com/cypress-io/ai-toolkit/tree/main/skills/cypress-explain",
+      "installSource": {
+        "repoUrl": "https://github.com/cypress-io/ai-toolkit",
+        "subPath": "skills/cypress-explain"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "cypress-io"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-cypress-io-cypress-docs",
+      "name": "cypress-io/cypress-docs",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "cypress-io",
+      "sourceGroup": "Skills by Cypress",
+      "description": "Search and extract Cypress information from official documentation.",
+      "sourceUrl": "https://github.com/cypress-io/ai-toolkit/tree/main/skills/cypress-docs",
+      "installSource": {
+        "repoUrl": "https://github.com/cypress-io/ai-toolkit",
+        "subPath": "skills/cypress-docs"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "cypress-io"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-qdrant-skills",
+      "name": "qdrant/skills",
+      "kind": "skillset",
+      "category": "测试与质量",
+      "publisher": "qdrant",
+      "sourceGroup": "Vector Databases",
+      "description": "Agent skills for Qdrant vector search, covering scaling, performance optimization, search quality, monitoring, deployment, model migration, version upgrades, and SDK usage across Python, TypeScript, Rust, Go, .NET, and Java",
+      "sourceUrl": "https://github.com/qdrant/skills",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "技能包"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-brianrwagner-ai-marketing-skills",
+      "name": "BrianRWagner/ai-marketing-skills",
+      "kind": "skillset",
+      "category": "安全与合规",
+      "publisher": "BrianRWagner",
+      "sourceGroup": "Marketing",
+      "description": "17 marketing frameworks for cold outreach, homepage audit, social cards, and more",
+      "sourceUrl": "https://github.com/BrianRWagner/ai-marketing-skills",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "技能包"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-agricidaniel-claude-seo",
+      "name": "AgriciDaniel/claude-seo",
+      "kind": "skill",
+      "category": "数据与分析",
+      "publisher": "AgriciDaniel",
+      "sourceGroup": "Marketing",
+      "description": "Universal SEO skill for comprehensive website analysis and optimization",
+      "sourceUrl": "https://github.com/AgriciDaniel/claude-seo",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "AgriciDaniel"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-wshuyi-x-article-publisher-skill",
+      "name": "wshuyi/x-article-publisher-skill",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "wshuyi",
+      "sourceGroup": "Marketing",
+      "description": "Publish articles to X/Twitter",
+      "sourceUrl": "https://github.com/wshuyi/x-article-publisher-skill",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "wshuyi"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-cosmoblk-email-marketing-bible",
+      "name": "CosmoBlk/email-marketing-bible",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "CosmoBlk",
+      "sourceGroup": "Marketing",
+      "description": "55K-word email marketing guide as an AI skill",
+      "sourceUrl": "https://github.com/CosmoBlk/email-marketing-bible",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "CosmoBlk"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-smixs-creative-director-skill",
+      "name": "smixs/creative-director-skill",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "smixs",
+      "sourceGroup": "Marketing",
+      "description": "AI creative director with recursive self-assessment: 20+ methodologies (SIT, TRIZ, Bisociation, SCAMPER, Synectics), 3-axis evaluation calibrated against Cannes/D&AD/HumanKind, 5-phase process from brief to presentation",
+      "sourceUrl": "https://github.com/smixs/creative-director-skill",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "smixs"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-xquik-dev-x-twitter-scraper",
+      "name": "Xquik-dev/x-twitter-scraper",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "Xquik-dev",
+      "sourceGroup": "Marketing",
+      "description": "Tweet search, profile tweets, follower export, media, posting, replies, MCP",
+      "sourceUrl": "https://github.com/Xquik-dev/x-twitter-scraper",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "Xquik-dev"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-xquik-dev-tweetclaw",
+      "name": "Xquik-dev/tweetclaw",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "Xquik-dev",
+      "sourceGroup": "Marketing",
+      "description": "Post tweets, replies, DMs; search, monitor, run giveaways",
+      "sourceUrl": "https://github.com/Xquik-dev/tweetclaw",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "Xquik-dev"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-shadowpr0-beautifulprose",
+      "name": "SHADOWPR0/beautifulprose",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "SHADOWPR0",
+      "sourceGroup": "Marketing",
+      "description": "Hard-edged writing style contract for timeless, forceful English prose without AI tics",
+      "sourceUrl": "https://github.com/SHADOWPR0/beautiful_prose",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "SHADOWPR0"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-blader-humanizer",
+      "name": "blader/humanizer",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "blader",
+      "sourceGroup": "Marketing",
+      "description": "Remove signs of AI-generated writing from text, making it sound more natural and human",
+      "sourceUrl": "https://github.com/blader/humanizer",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "blader"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-mohamedabdallah-14-unslop",
+      "name": "MohamedAbdallah-14/unslop",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "MohamedAbdallah-14",
+      "sourceGroup": "Marketing",
+      "description": "Removes named AI writing tells (tricolons, em-dash pileups, hedging stacks, sycophancy openers, stock vocab like \"delve\"/\"crucial\"). Split lint/rewrite modes for auditing your own text without auto-rewriting. Five intensity levels, MIT",
+      "sourceUrl": "https://github.com/MohamedAbdallah-14/unslop",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "MohamedAbdallah-14"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-eronred-aso-skills",
+      "name": "Eronred/aso-skills",
+      "kind": "skillset",
+      "category": "后端与数据库",
+      "publisher": "Eronred",
+      "sourceGroup": "Marketing",
+      "description": "30+ App Store Optimization skills for keyword research, metadata optimization, competitor analysis, creative optimization, and mobile growth strategies via Appeeky API",
+      "sourceUrl": "https://github.com/Eronred/aso-skills",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "技能包"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-degausai-wonda",
+      "name": "degausai/wonda",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "degausai",
+      "sourceGroup": "Marketing",
+      "description": "AI content creation: images, video, music, audio, editing, publishing",
+      "sourceUrl": "https://github.com/degausai/wonda",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "degausai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-gitroomhq-postiz-agent",
+      "name": "gitroomhq/postiz-agent",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "gitroomhq",
+      "sourceGroup": "Marketing",
+      "description": "Schedule social media posts across 28+ platforms programmatically",
+      "sourceUrl": "https://github.com/gitroomhq/postiz-agent",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "gitroomhq"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-taisly-agent",
+      "name": "taisly/agent",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "taisly",
+      "sourceGroup": "Marketing",
+      "description": "Codex plugin, Agent Skill, CLI, and MCP server for publishing approved short-form videos to TikTok, Instagram Reels, YouTube Shorts, X, and Facebook through Taisly",
+      "sourceUrl": "https://github.com/taisly/agent",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "taisly"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-indranilbanerjee-digital-marketing-pro",
+      "name": "indranilbanerjee/digital-marketing-pro",
+      "kind": "skill",
+      "category": "内容与营销",
+      "publisher": "indranilbanerjee",
+      "sourceGroup": "Marketing",
+      "description": "150-skill engagement methodology — 12-Part Strategy Flow, 25 specialist agents, EU AI Act Article 50 ready (C2PA signing), 6-platform AEO/GEO incl. Google AI Mode",
+      "sourceUrl": "https://github.com/indranilbanerjee/digital-marketing-pro",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "indranilbanerjee"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nowork-studio-notfair",
+      "name": "nowork-studio/NotFair",
+      "kind": "skill",
+      "category": "数据与分析",
+      "publisher": "nowork-studio",
+      "sourceGroup": "Marketing",
+      "description": "SEO, GEO, Google Ads, and Meta Ads skills with live data",
+      "sourceUrl": "https://github.com/nowork-studio/NotFair",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "nowork-studio"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-aaron-he-zhu-aaron-marketing-skills",
+      "name": "aaron-he-zhu/aaron-marketing-skills",
+      "kind": "skillset",
+      "category": "测试与质量",
+      "publisher": "aaron-he-zhu",
+      "sourceGroup": "Marketing",
+      "description": "69 marketing skills across SEO/GEO, influencer, paid ads, and email on one shared contract, with 5 benchmark-driven auditor gates (CORE-EEAT, CITE, C³, ROAS, SEND) and keyless data connectors",
+      "sourceUrl": "https://github.com/aaron-he-zhu/aaron-marketing-skills",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "技能包"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-pspdfkit-labs-nutrient-agent-skill",
+      "name": "PSPDFKit-labs/nutrient-agent-skill",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "PSPDFKit-labs",
+      "sourceGroup": "Productivity and Collaboration",
+      "description": "Document processing with Nutrient DWS API: convert (PDF/DOCX/XLSX/PPTX/HTML/images), extract text/tables, OCR (20+ languages), redact PII (pattern + AI), watermark, digital signatures, form filling. MCP server also available.",
+      "sourceUrl": "https://github.com/PSPDFKit-labs/nutrient-agent-skill",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "PSPDFKit-labs"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-notiondevs-notion-skills-for-claude",
+      "name": "notiondevs/Notion Skills for Claude",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "notiondevs",
+      "sourceGroup": "Productivity and Collaboration",
+      "description": "Skills for working with Notion",
+      "sourceUrl": "https://www.notion.so/notiondevs/Notion-Skills-for-Claude-28da4445d27180c7af1df7d8615723d0",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "notiondevs"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-op7418-nanobanana-ppt-skills",
+      "name": "op7418/NanoBanana-PPT-Skills",
+      "kind": "skillset",
+      "category": "文档与办公",
+      "publisher": "op7418",
+      "sourceGroup": "Productivity and Collaboration",
+      "description": "AI-powered PPT generation with document analysis and styled images",
+      "sourceUrl": "https://github.com/op7418/NanoBanana-PPT-Skills",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "技能包"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-zarazhangrui-frontend-slides",
+      "name": "zarazhangrui/frontend-slides",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "zarazhangrui",
+      "sourceGroup": "Productivity and Collaboration",
+      "description": "Generate animation-rich HTML presentations with visual style previews",
+      "sourceUrl": "https://github.com/zarazhangrui/frontend-slides",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "zarazhangrui"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-gokapso-integrate-whatsapp",
+      "name": "gokapso/integrate-whatsapp",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "gokapso",
+      "sourceGroup": "Productivity and Collaboration",
+      "description": "Connect WhatsApp, set up webhooks, and send messages",
+      "sourceUrl": "https://github.com/gokapso/agent-skills/tree/master/skills/integrate-whatsapp",
+      "installSource": {
+        "repoUrl": "https://github.com/gokapso/agent-skills",
+        "subPath": "skills/integrate-whatsapp"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "gokapso"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-gokapso-automate-whatsapp",
+      "name": "gokapso/automate-whatsapp",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "gokapso",
+      "sourceGroup": "Productivity and Collaboration",
+      "description": "Build WhatsApp automations with workflows and agents",
+      "sourceUrl": "https://github.com/gokapso/agent-skills/tree/master/skills/automate-whatsapp",
+      "installSource": {
+        "repoUrl": "https://github.com/gokapso/agent-skills",
+        "subPath": "skills/automate-whatsapp"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "gokapso"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-gokapso-observe-whatsapp",
+      "name": "gokapso/observe-whatsapp",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "gokapso",
+      "sourceGroup": "Productivity and Collaboration",
+      "description": "Debug WhatsApp delivery issues and run health checks",
+      "sourceUrl": "https://github.com/gokapso/agent-skills/tree/master/skills/observe-whatsapp",
+      "installSource": {
+        "repoUrl": "https://github.com/gokapso/agent-skills",
+        "subPath": "skills/observe-whatsapp"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "gokapso"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-pleaseprompto-notebooklm-skill",
+      "name": "PleasePrompto/notebooklm-skill",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "PleasePrompto",
+      "sourceGroup": "Productivity and Collaboration",
+      "description": "Interact with NotebookLM for document-based conversations",
+      "sourceUrl": "https://github.com/PleasePrompto/notebooklm-skill",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "PleasePrompto"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-obra-superpowers-lab",
+      "name": "obra/superpowers-lab",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "obra",
+      "sourceGroup": "Productivity and Collaboration",
+      "description": "Lab environment for Claude superpowers",
+      "sourceUrl": "https://github.com/obra/superpowers-lab",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "obra"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-obra-brainstorming",
+      "name": "obra/brainstorming",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "obra",
+      "sourceGroup": "Productivity and Collaboration",
+      "description": "Generate and explore ideas",
+      "sourceUrl": "https://github.com/obra/superpowers/blob/main/skills/brainstorming/SKILL.md",
+      "installSource": {
+        "repoUrl": "https://github.com/obra/superpowers",
+        "subPath": "skills/brainstorming"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "obra"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-obra-writing-plans",
+      "name": "obra/writing-plans",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "obra",
+      "sourceGroup": "Productivity and Collaboration",
+      "description": "Create strategic documentation",
+      "sourceUrl": "https://github.com/obra/superpowers/blob/main/skills/writing-plans/SKILL.md",
+      "installSource": {
+        "repoUrl": "https://github.com/obra/superpowers",
+        "subPath": "skills/writing-plans"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "obra"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-obra-executing-plans",
+      "name": "obra/executing-plans",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "obra",
+      "sourceGroup": "Productivity and Collaboration",
+      "description": "Implement and run strategic plans",
+      "sourceUrl": "https://github.com/obra/superpowers/blob/main/skills/executing-plans/SKILL.md",
+      "installSource": {
+        "repoUrl": "https://github.com/obra/superpowers",
+        "subPath": "skills/executing-plans"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "obra"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-obra-dispatching-parallel-agents",
+      "name": "obra/dispatching-parallel-agents",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "obra",
+      "sourceGroup": "Productivity and Collaboration",
+      "description": "Coordinate multiple simultaneous agents",
+      "sourceUrl": "https://github.com/obra/superpowers/blob/main/skills/dispatching-parallel-agents/SKILL.md",
+      "installSource": {
+        "repoUrl": "https://github.com/obra/superpowers",
+        "subPath": "skills/dispatching-parallel-agents"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "obra"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-obra-sharing-skills",
+      "name": "obra/sharing-skills",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "obra",
+      "sourceGroup": "Productivity and Collaboration",
+      "description": "Distribute and communicate capabilities",
+      "sourceUrl": "https://github.com/obra/superpowers/blob/main/skills/sharing-skills/SKILL.md",
+      "installSource": {
+        "repoUrl": "https://github.com/obra/superpowers",
+        "subPath": "skills/sharing-skills"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "obra"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-obra-using-superpowers",
+      "name": "obra/using-superpowers",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "obra",
+      "sourceGroup": "Productivity and Collaboration",
+      "description": "Leverage core platform capabilities",
+      "sourceUrl": "https://github.com/obra/superpowers/blob/main/skills/using-superpowers/SKILL.md",
+      "installSource": {
+        "repoUrl": "https://github.com/obra/superpowers",
+        "subPath": "skills/using-superpowers"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "obra"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-op7418-youtube-clipper-skill",
+      "name": "op7418/Youtube-clipper-skill",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "op7418",
+      "sourceGroup": "Productivity and Collaboration",
+      "description": "YouTube clip generation and editing with automated workflows",
+      "sourceUrl": "https://github.com/op7418/Youtube-clipper-skill",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "op7418"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-ognjengt-founder-skills",
+      "name": "ognjengt/founder-skills",
+      "kind": "skillset",
+      "category": "文档与办公",
+      "publisher": "ognjengt",
+      "sourceGroup": "Productivity and Collaboration",
+      "description": "Claude skills for founders with packaged startup workflows",
+      "sourceUrl": "https://github.com/ognjengt/founder-skills",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "技能包"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-everyinc-charlie-cfo-skill",
+      "name": "EveryInc/charlie-cfo-skill",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "EveryInc",
+      "sourceGroup": "Productivity and Collaboration",
+      "description": "Bootstrapped CFO financial management inspired by Charlie Munger",
+      "sourceUrl": "https://github.com/EveryInc/charlie-cfo-skill",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "EveryInc"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-openaccountants-openaccountants",
+      "name": "openaccountants/openaccountants",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "openaccountants",
+      "sourceGroup": "Productivity and Collaboration",
+      "description": "371 tax classification skills across 134 countries",
+      "sourceUrl": "https://github.com/openaccountants/openaccountants",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "openaccountants"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-wrsmith108-linear-claude-skill",
+      "name": "wrsmith108/linear-claude-skill",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "wrsmith108",
+      "sourceGroup": "Productivity and Collaboration",
+      "description": "Manage Linear issues, projects, and teams",
+      "sourceUrl": "https://github.com/wrsmith108/linear-claude-skill",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "wrsmith108"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-shpigford-readme",
+      "name": "Shpigford/readme",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "Shpigford",
+      "sourceGroup": "Productivity and Collaboration",
+      "description": "Generate comprehensive project documentation",
+      "sourceUrl": "https://github.com/Shpigford/skills/tree/main/readme",
+      "installSource": {
+        "repoUrl": "https://github.com/Shpigford/skills",
+        "subPath": "readme"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "Shpigford"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-hanfang-claude-memory-skill",
+      "name": "hanfang/claude-memory-skill",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "hanfang",
+      "sourceGroup": "Productivity and Collaboration",
+      "description": "Minimal, low-friction hierarchical memory system with background agents and filesystem-based persistence",
+      "sourceUrl": "https://github.com/hanfang/claude-memory-skill",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "hanfang"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-kreuzberg-dev-kreuzberg",
+      "name": "kreuzberg-dev/kreuzberg",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "kreuzberg-dev",
+      "sourceGroup": "Productivity and Collaboration",
+      "description": "Extract text, tables, and metadata from 62+ document formats",
+      "sourceUrl": "https://github.com/kreuzberg-dev/kreuzberg/tree/main/skills/kreuzberg",
+      "installSource": {
+        "repoUrl": "https://github.com/kreuzberg-dev/kreuzberg",
+        "subPath": "skills/kreuzberg"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "kreuzberg-dev"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-paramchoudhary-resumeskills",
+      "name": "Paramchoudhary/ResumeSkills",
+      "kind": "skillset",
+      "category": "文档与办公",
+      "publisher": "Paramchoudhary",
+      "sourceGroup": "Productivity and Collaboration",
+      "description": "20 specialized skills for resume optimization, ATS analysis, interview prep, and career transitions",
+      "sourceUrl": "https://github.com/Paramchoudhary/ResumeSkills",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "技能包"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-roundtable02-tutor-skills",
+      "name": "RoundTable02/tutor-skills",
+      "kind": "skillset",
+      "category": "文档与办公",
+      "publisher": "RoundTable02",
+      "sourceGroup": "Productivity and Collaboration",
+      "description": "Transform docs or codebases into Obsidian StudyVaults with interactive quizzes",
+      "sourceUrl": "https://github.com/RoundTable02/tutor-skills",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "技能包"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-neolabhq-write-concisely",
+      "name": "NeoLabHQ/write-concisely",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "NeoLabHQ",
+      "sourceGroup": "Productivity and Collaboration",
+      "description": "Applies the famous The Elements of Style book principles to make documentation and writing clearer and more professional by eliminating wordiness and improving structure.",
+      "sourceUrl": "https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/docs/skills/write-concisely",
+      "installSource": {
+        "repoUrl": "https://github.com/NeoLabHQ/context-engineering-kit",
+        "subPath": "plugins/docs/skills/write-concisely"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NeoLabHQ"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-resciencelab-opc-skills",
+      "name": "ReScienceLab/opc-skills",
+      "kind": "skillset",
+      "category": "文档与办公",
+      "publisher": "ReScienceLab",
+      "sourceGroup": "Productivity and Collaboration",
+      "description": "Agent skills for solopreneurs with SEO, geo, and LLM tools",
+      "sourceUrl": "https://github.com/ReScienceLab/opc-skills",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "技能包"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-seanzor-claude-speed-reader",
+      "name": "SeanZoR/claude-speed-reader",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "SeanZoR",
+      "sourceGroup": "Productivity and Collaboration",
+      "description": "Speed read Claude's responses at 600+ WPM using RSVP with Spritz-style ORP highlighting",
+      "sourceUrl": "https://github.com/SeanZoR/claude-speed-reader",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "SeanZoR"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-charlie85270-dorothy",
+      "name": "Charlie85270/Dorothy",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "Charlie85270",
+      "sourceGroup": "Productivity and Collaboration",
+      "description": "Orchestrate multiple AI CLI agents with automations and MCP servers",
+      "sourceUrl": "https://github.com/Charlie85270/Dorothy",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "Charlie85270"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-digidai-product-manager-skills",
+      "name": "Digidai/product-manager-skills",
+      "kind": "skillset",
+      "category": "文档与办公",
+      "publisher": "Digidai",
+      "sourceGroup": "Productivity and Collaboration",
+      "description": "Senior PM agent with 30+ frameworks and SaaS metrics",
+      "sourceUrl": "https://github.com/Digidai/product-manager-skills",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "技能包"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-deusyu-translate-book",
+      "name": "deusyu/translate-book",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "deusyu",
+      "sourceGroup": "Productivity and Collaboration",
+      "description": "Translate books (PDF/DOCX/EPUB) via parallel sub-agents with resume",
+      "sourceUrl": "https://github.com/deusyu/translate-book",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "deusyu"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-mvanhorn-last30days-skill",
+      "name": "mvanhorn/last30days-skill",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "mvanhorn",
+      "sourceGroup": "Productivity and Collaboration",
+      "description": "Research any topic across Reddit, X, YouTube, HN, Polymarket, and the web, ranked by upvotes, likes, and real money instead of editors",
+      "sourceUrl": "https://github.com/mvanhorn/last30days-skill",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "mvanhorn"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-santifer-career-ops",
+      "name": "santifer/career-ops",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "santifer",
+      "sourceGroup": "Productivity and Collaboration",
+      "description": "14-skill collection for AI-powered job search: JD evaluation with A-F scoring, ATS-optimized PDF generation, portal scanners (Greenhouse/Ashby/Lever), interview prep with STAR+R, batch processing, and a Go dashboard TUI",
+      "sourceUrl": "https://github.com/santifer/career-ops",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "santifer"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-linked-api-linkedin",
+      "name": "Linked-API/linkedin",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "Linked-API",
+      "sourceGroup": "Productivity and Collaboration",
+      "description": "Fetch LinkedIn profiles, search people and companies, send messages, manage connections, create posts, react, comment, and run custom LinkedIn workflows from Claude Code, Codex, Cursor, and Windsurf.",
+      "sourceUrl": "https://github.com/Linked-API/linkedin-skills/tree/main/linkedin",
+      "installSource": {
+        "repoUrl": "https://github.com/Linked-API/linkedin-skills",
+        "subPath": "linkedin"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "Linked-API"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-pattern-ai-labs-agentcall",
+      "name": "pattern-ai-labs/agentcall",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "pattern-ai-labs",
+      "sourceGroup": "Productivity and Collaboration",
+      "description": "Let your AI agents join Google Meet, Zoom, Teams calls and collaborate like a real team-mate.",
+      "sourceUrl": "https://github.com/pattern-ai-labs/agentcall",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "pattern-ai-labs"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-sendmux-skills",
+      "name": "Sendmux/skills",
+      "kind": "skillset",
+      "category": "文档与办公",
+      "publisher": "Sendmux",
+      "sourceGroup": "Productivity and Collaboration",
+      "description": "Sendmux email and mailbox workflows for agents",
+      "sourceUrl": "https://github.com/Sendmux/skills",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "技能包"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-robzolkos-skill-rails-upgrade",
+      "name": "robzolkos/skill-rails-upgrade",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "robzolkos",
+      "sourceGroup": "Development and Testing",
+      "description": "Analyze Rails apps and provide upgrade assessments",
+      "sourceUrl": "https://github.com/robzolkos/skill-rails-upgrade",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "robzolkos"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-shpigford-screenshots",
+      "name": "Shpigford/screenshots",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "Shpigford",
+      "sourceGroup": "Development and Testing",
+      "description": "Generate marketing screenshots with Playwright",
+      "sourceUrl": "https://github.com/Shpigford/skills/tree/main/screenshots",
+      "installSource": {
+        "repoUrl": "https://github.com/Shpigford/skills",
+        "subPath": "screenshots"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "Shpigford"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-antonbabenko-terraform-skill",
+      "name": "antonbabenko/terraform-skill",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "antonbabenko",
+      "sourceGroup": "Development and Testing",
+      "description": "Terraform and OpenTofu patterns: testing, modules, state, CI/CD.",
+      "sourceUrl": "https://github.com/antonbabenko/terraform-skill",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "antonbabenko"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-zxkane-aws-skills",
+      "name": "zxkane/aws-skills",
+      "kind": "skillset",
+      "category": "测试与质量",
+      "publisher": "zxkane",
+      "sourceGroup": "Development and Testing",
+      "description": "AWS development with infrastructure automation and cloud architecture patterns",
+      "sourceUrl": "https://github.com/zxkane/aws-skills",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "技能包"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-rootly-ai-labs-rootly-incident-responder",
+      "name": "Rootly-AI-Labs/rootly-incident-responder",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "Rootly-AI-Labs",
+      "sourceGroup": "Development and Testing",
+      "description": "AI-powered incident response with ML similarity matching, solution suggestions, and on-call coordination. Requires Rootly MCP Server",
+      "sourceUrl": "https://github.com/Rootly-AI-Labs/Rootly-MCP-server/blob/main/examples/skills/rootly-incident-responder.md",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "Rootly-AI-Labs"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-conorluddy-ios-simulator-skill",
+      "name": "conorluddy/ios-simulator-skill",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "conorluddy",
+      "sourceGroup": "Development and Testing",
+      "description": "Control iOS Simulator",
+      "sourceUrl": "https://github.com/conorluddy/ios-simulator-skill",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "conorluddy"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-ramzesenok-ios-accessibility-audit-skill",
+      "name": "ramzesenok/iOS-Accessibility-Audit-Skill",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "ramzesenok",
+      "sourceGroup": "Development and Testing",
+      "description": "Audit iOS App against Accessibility norms",
+      "sourceUrl": "https://github.com/ramzesenok/iOS-Accessibility-Audit-Skill",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "ramzesenok"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-truongduy2611-app-store-preflight-skills",
+      "name": "truongduy2611/app-store-preflight-skills",
+      "kind": "skillset",
+      "category": "测试与质量",
+      "publisher": "truongduy2611",
+      "sourceGroup": "Development and Testing",
+      "description": "Scan iOS/macOS projects to catch common mistakes that lead to App Store rejection before submission",
+      "sourceUrl": "https://github.com/truongduy2611/app-store-preflight-skills",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "技能包"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-coderabbitai-skills",
+      "name": "coderabbitai/skills",
+      "kind": "skillset",
+      "category": "测试与质量",
+      "publisher": "coderabbitai",
+      "sourceGroup": "Development and Testing",
+      "description": "Code review and PR autofix workflows for coding agents",
+      "sourceUrl": "https://github.com/coderabbitai/skills",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "技能包"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-sanjay3290-postgres",
+      "name": "sanjay3290/postgres",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "sanjay3290",
+      "sourceGroup": "Development and Testing",
+      "description": "Execute safe read-only SQL queries against PostgreSQL databases",
+      "sourceUrl": "https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres",
+      "installSource": {
+        "repoUrl": "https://github.com/sanjay3290/ai-skills",
+        "subPath": "skills/postgres"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "sanjay3290"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-sanjay3290-deep-research",
+      "name": "sanjay3290/deep-research",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "sanjay3290",
+      "sourceGroup": "Development and Testing",
+      "description": "Autonomous multi-step research using Gemini Deep Research Agent",
+      "sourceUrl": "https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research",
+      "installSource": {
+        "repoUrl": "https://github.com/sanjay3290/ai-skills",
+        "subPath": "skills/deep-research"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "sanjay3290"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-jthack-ffuf-claude-skill",
+      "name": "jthack/ffuf-claude-skill",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "jthack",
+      "sourceGroup": "Development and Testing",
+      "description": "Web fuzzing with ffuf",
+      "sourceUrl": "https://github.com/jthack/ffuf_claude_skill",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "jthack"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-lackeyjb-playwright-skill",
+      "name": "lackeyjb/playwright-skill",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "lackeyjb",
+      "sourceGroup": "Development and Testing",
+      "description": "Browser automation with Playwright",
+      "sourceUrl": "https://github.com/lackeyjb/playwright-skill",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "lackeyjb"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-ibelick-ui-skills",
+      "name": "ibelick/ui-skills",
+      "kind": "skillset",
+      "category": "测试与质量",
+      "publisher": "ibelick",
+      "sourceGroup": "Development and Testing",
+      "description": "Opinionated, evolving constraints to guide agents when building interfaces",
+      "sourceUrl": "https://github.com/ibelick/ui-skills",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "技能包"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-muthuishere-hand-drawn-diagrams",
+      "name": "muthuishere/hand-drawn-diagrams",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "muthuishere",
+      "sourceGroup": "Development and Testing",
+      "description": "Generate hand-drawn Excalidraw diagrams from a prompt — animated SVG, hosted edit link, and PNG export. Works with Claude Code, Codex, Gemini CLI, and any agent supporting standard skill paths",
+      "sourceUrl": "https://github.com/muthuishere/hand-drawn-diagrams",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "muthuishere"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-nextlevelbuilder-ui-ux-pro-max-skill",
+      "name": "nextlevelbuilder/ui-ux-pro-max-skill",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "nextlevelbuilder",
+      "sourceGroup": "Development and Testing",
+      "description": "UI/UX design patterns and best practices",
+      "sourceUrl": "https://github.com/nextlevelbuilder/ui-ux-pro-max-skill",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "nextlevelbuilder"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-ehmo-platform-design-skills",
+      "name": "ehmo/platform-design-skills",
+      "kind": "skillset",
+      "category": "测试与质量",
+      "publisher": "ehmo",
+      "sourceGroup": "Development and Testing",
+      "description": "300+ design rules from Apple HIG, Material Design 3, and WCAG 2.2 for cross-platform apps",
+      "sourceUrl": "https://github.com/ehmo/platform-design-skills",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "技能包"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-scarletkc-vexor",
+      "name": "scarletkc/vexor",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "scarletkc",
+      "sourceGroup": "Development and Testing",
+      "description": "Vector-powered CLI for semantic file search with a Claude/Codex skill",
+      "sourceUrl": "https://github.com/scarletkc/vexor",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "scarletkc"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-obra-test-driven-development",
+      "name": "obra/test-driven-development",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "obra",
+      "sourceGroup": "Development and Testing",
+      "description": "Write tests before implementing code",
+      "sourceUrl": "https://github.com/obra/superpowers/blob/main/skills/test-driven-development/SKILL.md",
+      "installSource": {
+        "repoUrl": "https://github.com/obra/superpowers",
+        "subPath": "skills/test-driven-development"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "obra"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-obra-subagent-driven-development",
+      "name": "obra/subagent-driven-development",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "obra",
+      "sourceGroup": "Development and Testing",
+      "description": "Development using multiple sub-agents",
+      "sourceUrl": "https://github.com/obra/superpowers/blob/main/skills/subagent-driven-development/SKILL.md",
+      "installSource": {
+        "repoUrl": "https://github.com/obra/superpowers",
+        "subPath": "skills/subagent-driven-development"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "obra"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-obra-systematic-debugging",
+      "name": "obra/systematic-debugging",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "obra",
+      "sourceGroup": "Development and Testing",
+      "description": "Methodical problem-solving in code",
+      "sourceUrl": "https://github.com/obra/superpowers/blob/main/skills/systematic-debugging/SKILL.md",
+      "installSource": {
+        "repoUrl": "https://github.com/obra/superpowers",
+        "subPath": "skills/systematic-debugging"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "obra"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-obra-root-cause-tracing",
+      "name": "obra/root-cause-tracing",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "obra",
+      "sourceGroup": "Development and Testing",
+      "description": "Investigate and identify fundamental problems",
+      "sourceUrl": "https://github.com/obra/superpowers/blob/main/skills/root-cause-tracing/SKILL.md",
+      "installSource": {
+        "repoUrl": "https://github.com/obra/superpowers",
+        "subPath": "skills/root-cause-tracing"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "obra"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-obra-testing-skills-with-subagents",
+      "name": "obra/testing-skills-with-subagents",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "obra",
+      "sourceGroup": "Development and Testing",
+      "description": "Collaborative testing approaches",
+      "sourceUrl": "https://github.com/obra/superpowers/blob/main/skills/testing-skills-with-subagents/SKILL.md",
+      "installSource": {
+        "repoUrl": "https://github.com/obra/superpowers",
+        "subPath": "skills/testing-skills-with-subagents"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "obra"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-obra-testing-anti-patterns",
+      "name": "obra/testing-anti-patterns",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "obra",
+      "sourceGroup": "Development and Testing",
+      "description": "Identify ineffective testing practices",
+      "sourceUrl": "https://github.com/obra/superpowers/blob/main/skills/testing-anti-patterns/SKILL.md",
+      "installSource": {
+        "repoUrl": "https://github.com/obra/superpowers",
+        "subPath": "skills/testing-anti-patterns"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "obra"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-obra-finishing-a-development-branch",
+      "name": "obra/finishing-a-development-branch",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "obra",
+      "sourceGroup": "Development and Testing",
+      "description": "Complete Git code branches",
+      "sourceUrl": "https://github.com/obra/superpowers/blob/main/skills/finishing-a-development-branch/SKILL.md",
+      "installSource": {
+        "repoUrl": "https://github.com/obra/superpowers",
+        "subPath": "skills/finishing-a-development-branch"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "obra"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-obra-requesting-code-review",
+      "name": "obra/requesting-code-review",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "obra",
+      "sourceGroup": "Development and Testing",
+      "description": "Initiate code review processes",
+      "sourceUrl": "https://github.com/obra/superpowers/blob/main/skills/requesting-code-review/SKILL.md",
+      "installSource": {
+        "repoUrl": "https://github.com/obra/superpowers",
+        "subPath": "skills/requesting-code-review"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "obra"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-obra-receiving-code-review",
+      "name": "obra/receiving-code-review",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "obra",
+      "sourceGroup": "Development and Testing",
+      "description": "Process and incorporate code feedback",
+      "sourceUrl": "https://github.com/obra/superpowers/blob/main/skills/receiving-code-review/SKILL.md",
+      "installSource": {
+        "repoUrl": "https://github.com/obra/superpowers",
+        "subPath": "skills/receiving-code-review"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "obra"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-obra-using-git-worktrees",
+      "name": "obra/using-git-worktrees",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "obra",
+      "sourceGroup": "Development and Testing",
+      "description": "Manage multiple Git working trees",
+      "sourceUrl": "https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/SKILL.md",
+      "installSource": {
+        "repoUrl": "https://github.com/obra/superpowers",
+        "subPath": "skills/using-git-worktrees"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "obra"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-obra-verification-before-completion",
+      "name": "obra/verification-before-completion",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "obra",
+      "sourceGroup": "Development and Testing",
+      "description": "Validate work before finalizing",
+      "sourceUrl": "https://github.com/obra/superpowers/blob/main/skills/verification-before-completion/SKILL.md",
+      "installSource": {
+        "repoUrl": "https://github.com/obra/superpowers",
+        "subPath": "skills/verification-before-completion"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "obra"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-obra-condition-based-waiting",
+      "name": "obra/condition-based-waiting",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "obra",
+      "sourceGroup": "Development and Testing",
+      "description": "Manage conditional pauses or delays",
+      "sourceUrl": "https://github.com/obra/superpowers/blob/main/skills/condition-based-waiting/SKILL.md",
+      "installSource": {
+        "repoUrl": "https://github.com/obra/superpowers",
+        "subPath": "skills/condition-based-waiting"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "obra"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-obra-commands",
+      "name": "obra/commands",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "obra",
+      "sourceGroup": "Development and Testing",
+      "description": "Create and manage command structures",
+      "sourceUrl": "https://github.com/obra/superpowers/tree/main/skills/commands",
+      "installSource": {
+        "repoUrl": "https://github.com/obra/superpowers",
+        "subPath": "skills/commands"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "obra"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-obra-writing-skills",
+      "name": "obra/writing-skills",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "obra",
+      "sourceGroup": "Development and Testing",
+      "description": "Develop and document capabilities",
+      "sourceUrl": "https://github.com/obra/superpowers/blob/main/skills/writing-skills/SKILL.md",
+      "installSource": {
+        "repoUrl": "https://github.com/obra/superpowers",
+        "subPath": "skills/writing-skills"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "obra"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-fvadicamo-dev-agent-skills",
+      "name": "fvadicamo/dev-agent-skills",
+      "kind": "skillset",
+      "category": "测试与质量",
+      "publisher": "fvadicamo",
+      "sourceGroup": "Development and Testing",
+      "description": "Git and GitHub workflow skills for commits, PRs, and code reviews",
+      "sourceUrl": "https://github.com/fvadicamo/dev-agent-skills",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "技能包"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-omkamal-pypict-skill",
+      "name": "omkamal/pypict-skill",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "omkamal",
+      "sourceGroup": "Development and Testing",
+      "description": "Pairwise test generation",
+      "sourceUrl": "https://github.com/omkamal/pypict-claude-skill/blob/main/SKILL.md",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "omkamal"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-alinaqi-claude-bootstrap",
+      "name": "alinaqi/claude-bootstrap",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "alinaqi",
+      "sourceGroup": "Development and Testing",
+      "description": "Opinionated project initialization with security-first guardrails, spec-driven atomic todos, LLM testing patterns, and CLI tool orchestration (gh, vercel, supabase)",
+      "sourceUrl": "https://github.com/alinaqi/claude-bootstrap",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "alinaqi"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-zhanghandong-makepad-skills",
+      "name": "ZhangHanDong/makepad-skills",
+      "kind": "skillset",
+      "category": "测试与质量",
+      "publisher": "ZhangHanDong",
+      "sourceGroup": "Development and Testing",
+      "description": "Makepad UI development skills for Rust apps: setup, patterns, shaders, packaging, and troubleshooting.",
+      "sourceUrl": "https://github.com/ZhangHanDong/makepad-skills",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "技能包"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-massimodeluisa-recursive-decomposition-skill",
+      "name": "massimodeluisa/recursive-decomposition-skill",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "massimodeluisa",
+      "sourceGroup": "Development and Testing",
+      "description": "Handle long-context tasks (100+ files, 50k+ tokens) through recursive decomposition strategies based on RLM research",
+      "sourceUrl": "https://github.com/massimodeluisa/recursive-decomposition-skill",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "massimodeluisa"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-avdlee-swiftui-expert-skill",
+      "name": "AvdLee/swiftui-expert-skill",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "AvdLee",
+      "sourceGroup": "Development and Testing",
+      "description": "Modern SwiftUI best practices and iOS 26+ Liquid Glass adoption",
+      "sourceUrl": "https://github.com/AvdLee/SwiftUI-Agent-Skill/tree/main/swiftui-expert-skill",
+      "installSource": {
+        "repoUrl": "https://github.com/AvdLee/SwiftUI-Agent-Skill",
+        "subPath": "swiftui-expert-skill"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "AvdLee"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-efremidze-swift-patterns-skill",
+      "name": "efremidze/swift-patterns-skill",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "efremidze",
+      "sourceGroup": "Development and Testing",
+      "description": "Modern Swift/SwiftUI best practices",
+      "sourceUrl": "https://github.com/efremidze/swift-patterns-skill/tree/main/swift-patterns",
+      "installSource": {
+        "repoUrl": "https://github.com/efremidze/swift-patterns-skill",
+        "subPath": "swift-patterns"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "efremidze"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-joannis-claude-skills",
+      "name": "Joannis/claude-skills",
+      "kind": "skillset",
+      "category": "测试与质量",
+      "publisher": "Joannis",
+      "sourceGroup": "Development and Testing",
+      "description": "Swift Server development guidance with linting tool for best practices",
+      "sourceUrl": "https://github.com/Joannis/claude-skills",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "技能包"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-rudrankriyam-app-store-connect-cli-skills",
+      "name": "rudrankriyam/app-store-connect-cli-skills",
+      "kind": "skillset",
+      "category": "测试与质量",
+      "publisher": "rudrankriyam",
+      "sourceGroup": "Development and Testing",
+      "description": "Automate App Store deployments and management using ASC CLI",
+      "sourceUrl": "https://github.com/rudrankriyam/app-store-connect-cli-skills",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "技能包"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-rameerez-claude-code-startup-skills",
+      "name": "rameerez/claude-code-startup-skills",
+      "kind": "skillset",
+      "category": "测试与质量",
+      "publisher": "rameerez",
+      "sourceGroup": "Development and Testing",
+      "description": "Skills for building and running software startups, apps, and SaaS",
+      "sourceUrl": "https://github.com/rameerez/claude-code-startup-skills",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "技能包"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-zscole-model-hierarchy-skill",
+      "name": "zscole/model-hierarchy-skill",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "zscole",
+      "sourceGroup": "Development and Testing",
+      "description": "Cost-optimized model routing based on task complexity",
+      "sourceUrl": "https://github.com/zscole/model-hierarchy-skill",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "zscole"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-cloudai-x-threejs-skills",
+      "name": "CloudAI-X/threejs-skills",
+      "kind": "skillset",
+      "category": "测试与质量",
+      "publisher": "CloudAI-X",
+      "sourceGroup": "Development and Testing",
+      "description": "Three.js skills for creating 3D elements and interactive experiences",
+      "sourceUrl": "https://github.com/CloudAI-X/threejs-skills",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "技能包"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-leonxlnx-taste-skill",
+      "name": "Leonxlnx/taste-skill",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "Leonxlnx",
+      "sourceGroup": "Development and Testing",
+      "description": "High-agency frontend skill that gives AI good taste with tunable design variance, motion intensity, and visual density to stop generic UI slop",
+      "sourceUrl": "https://github.com/Leonxlnx/taste-skill",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "Leonxlnx"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-testdino-hq-playwright-skill",
+      "name": "testdino-hq/playwright-skill",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "testdino-hq",
+      "sourceGroup": "Development and Testing",
+      "description": "70+ production-tested Playwright automation testing patterns: E2E, POM, CI/CD, migrations, CLI",
+      "sourceUrl": "https://github.com/testdino-hq/playwright-skill",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "testdino-hq"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-neolabhq-code-review",
+      "name": "NeoLabHQ/code-review",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "NeoLabHQ",
+      "sourceGroup": "Development and Testing",
+      "description": "Comprehensive PR code review using specialized agents: bug-hunter, security-auditor, code-quality-reviewer, contracts-reviewer, historical-context-reviewer, test-coverage-reviewer",
+      "sourceUrl": "https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/code-review",
+      "installSource": {
+        "repoUrl": "https://github.com/NeoLabHQ/context-engineering-kit",
+        "subPath": "plugins/code-review"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NeoLabHQ"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-neolabhq-reflexion",
+      "name": "NeoLabHQ/reflexion",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "NeoLabHQ",
+      "sourceGroup": "Development and Testing",
+      "description": "Self-refinement loop that forces the LLM to reflect on previous output and correct itself.",
+      "sourceUrl": "https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/reflexion",
+      "installSource": {
+        "repoUrl": "https://github.com/NeoLabHQ/context-engineering-kit",
+        "subPath": "plugins/reflexion"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NeoLabHQ"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-neolabhq-sdd",
+      "name": "NeoLabHQ/sdd",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "NeoLabHQ",
+      "sourceGroup": "Development and Testing",
+      "description": "Spec-driven development workflow that transforms prompts into production-ready implementations through structured planning, architecture design, and LLM-as-a-Judge based quality gates.",
+      "sourceUrl": "https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/sdd",
+      "installSource": {
+        "repoUrl": "https://github.com/NeoLabHQ/context-engineering-kit",
+        "subPath": "plugins/sdd"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NeoLabHQ"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-neolabhq-ddd",
+      "name": "NeoLabHQ/ddd",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "NeoLabHQ",
+      "sourceGroup": "Development and Testing",
+      "description": "Domain-driven development skills that also include Clean Architecture, SOLID principles, and design patterns.",
+      "sourceUrl": "https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/ddd",
+      "installSource": {
+        "repoUrl": "https://github.com/NeoLabHQ/context-engineering-kit",
+        "subPath": "plugins/ddd"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NeoLabHQ"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-neolabhq-sadd",
+      "name": "NeoLabHQ/sadd",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "NeoLabHQ",
+      "sourceGroup": "Development and Testing",
+      "description": "Dispatches independent subagents for individual tasks with code review checkpoints between iterations for rapid, controlled development.",
+      "sourceUrl": "https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/sadd",
+      "installSource": {
+        "repoUrl": "https://github.com/NeoLabHQ/context-engineering-kit",
+        "subPath": "plugins/sadd"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NeoLabHQ"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-neolabhq-kaizen",
+      "name": "NeoLabHQ/kaizen",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "NeoLabHQ",
+      "sourceGroup": "Development and Testing",
+      "description": "Applies continuous improvement methodology with multiple analytical approaches, based on Japanese Kaizen philosophy and Lean methodology.",
+      "sourceUrl": "https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/kaizen",
+      "installSource": {
+        "repoUrl": "https://github.com/NeoLabHQ/context-engineering-kit",
+        "subPath": "plugins/kaizen"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NeoLabHQ"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-hamelsmu-eval-audit",
+      "name": "hamelsmu/eval-audit",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "hamelsmu",
+      "sourceGroup": "Development and Testing",
+      "description": "Audit LLM eval pipelines and surface problems",
+      "sourceUrl": "https://github.com/hamelsmu/prompts/tree/main/evals-skills/skills/eval-audit",
+      "installSource": {
+        "repoUrl": "https://github.com/hamelsmu/prompts",
+        "subPath": "evals-skills/skills/eval-audit"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "hamelsmu"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-hamelsmu-error-analysis",
+      "name": "hamelsmu/error-analysis",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "hamelsmu",
+      "sourceGroup": "Development and Testing",
+      "description": "Systematically identify failure modes in LLM pipelines",
+      "sourceUrl": "https://github.com/hamelsmu/prompts/tree/main/evals-skills/skills/error-analysis",
+      "installSource": {
+        "repoUrl": "https://github.com/hamelsmu/prompts",
+        "subPath": "evals-skills/skills/error-analysis"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "hamelsmu"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-hamelsmu-generate-synthetic-data",
+      "name": "hamelsmu/generate-synthetic-data",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "hamelsmu",
+      "sourceGroup": "Development and Testing",
+      "description": "Create diverse synthetic test inputs for LLM evals",
+      "sourceUrl": "https://github.com/hamelsmu/prompts/tree/main/evals-skills/skills/generate-synthetic-data",
+      "installSource": {
+        "repoUrl": "https://github.com/hamelsmu/prompts",
+        "subPath": "evals-skills/skills/generate-synthetic-data"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "hamelsmu"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-hamelsmu-write-judge-prompt",
+      "name": "hamelsmu/write-judge-prompt",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "hamelsmu",
+      "sourceGroup": "Development and Testing",
+      "description": "Design LLM-as-Judge evaluators for subjective criteria",
+      "sourceUrl": "https://github.com/hamelsmu/prompts/tree/main/evals-skills/skills/write-judge-prompt",
+      "installSource": {
+        "repoUrl": "https://github.com/hamelsmu/prompts",
+        "subPath": "evals-skills/skills/write-judge-prompt"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "hamelsmu"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-hamelsmu-validate-evaluator",
+      "name": "hamelsmu/validate-evaluator",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "hamelsmu",
+      "sourceGroup": "Development and Testing",
+      "description": "Calibrate LLM judges against human labels",
+      "sourceUrl": "https://github.com/hamelsmu/prompts/tree/main/evals-skills/skills/validate-evaluator",
+      "installSource": {
+        "repoUrl": "https://github.com/hamelsmu/prompts",
+        "subPath": "evals-skills/skills/validate-evaluator"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "hamelsmu"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-hamelsmu-evaluate-rag",
+      "name": "hamelsmu/evaluate-rag",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "hamelsmu",
+      "sourceGroup": "Development and Testing",
+      "description": "Evaluate RAG retrieval and generation quality",
+      "sourceUrl": "https://github.com/hamelsmu/prompts/tree/main/evals-skills/skills/evaluate-rag",
+      "installSource": {
+        "repoUrl": "https://github.com/hamelsmu/prompts",
+        "subPath": "evals-skills/skills/evaluate-rag"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "hamelsmu"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-uucz-moyu",
+      "name": "uucz/moyu",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "uucz",
+      "sourceGroup": "Development and Testing",
+      "description": "Anti-over-engineering skill with 5 variants and 10 platforms",
+      "sourceUrl": "https://github.com/uucz/moyu",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "uucz"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-hamelsmu-build-review-interface",
+      "name": "hamelsmu/build-review-interface",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "hamelsmu",
+      "sourceGroup": "Development and Testing",
+      "description": "Build annotation interfaces for reviewing LLM traces",
+      "sourceUrl": "https://github.com/hamelsmu/prompts/tree/main/evals-skills/skills/build-review-interface",
+      "installSource": {
+        "repoUrl": "https://github.com/hamelsmu/prompts",
+        "subPath": "evals-skills/skills/build-review-interface"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "hamelsmu"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-mattpocock-skills",
+      "name": "mattpocock/skills",
+      "kind": "skillset",
+      "category": "测试与质量",
+      "publisher": "mattpocock",
+      "sourceGroup": "Development and Testing",
+      "description": "17 dev workflow skills: PRD writing, TDD, codebase architecture, git guardrails, issue triage, refactoring plans, and more",
+      "sourceUrl": "https://github.com/mattpocock/skills",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "技能包"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-mukul975-anthropic-cybersecurity-skills",
+      "name": "mukul975/Anthropic-Cybersecurity-Skills",
+      "kind": "skillset",
+      "category": "测试与质量",
+      "publisher": "mukul975",
+      "sourceGroup": "Development and Testing",
+      "description": "753 cybersecurity skills across 38 domains: cloud security, pentesting, red teaming, DFIR, malware analysis, threat intel, and more (MITRE ATT&CK mapped)",
+      "sourceUrl": "https://github.com/mukul975/Anthropic-Cybersecurity-Skills",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "技能包"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-wrsmith108-varlock-claude-skill",
+      "name": "wrsmith108/varlock-claude-skill",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "wrsmith108",
+      "sourceGroup": "Development and Testing",
+      "description": "Secure environment variable management ensuring secrets are never exposed in Claude sessions, terminals, logs, or git commits",
+      "sourceUrl": "https://github.com/wrsmith108/varlock-claude-skill",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "wrsmith108"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-skillseekers",
+      "name": "SkillSeekers",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "Development and Testing",
+      "sourceGroup": "Development and Testing",
+      "description": "Automatically convert documentation websites, GitHub repositories, and PDFs into Claude AI skills in minutes",
+      "sourceUrl": "https://github.com/yusufkaraaslan/Skill_Seekers",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "Development and Testing"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-noizai-skills",
+      "name": "NoizAI/skills",
+      "kind": "skillset",
+      "category": "测试与质量",
+      "publisher": "NoizAI",
+      "sourceGroup": "Development and Testing",
+      "description": "Human-like TTS workflows with local/cloud APIs and app delivery",
+      "sourceUrl": "https://github.com/NoizAI/skills",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "技能包"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-kevin7qi-codex-collab",
+      "name": "Kevin7Qi/codex-collab",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "Kevin7Qi",
+      "sourceGroup": "Development and Testing",
+      "description": "Collaborate with Codex from Claude Code",
+      "sourceUrl": "https://github.com/Kevin7Qi/codex-collab",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "Kevin7Qi"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-ethos-link-rails-conventions",
+      "name": "ethos-link/rails-conventions",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "ethos-link",
+      "sourceGroup": "Development and Testing",
+      "description": "Rails 8 conventions for consistent production code changes",
+      "sourceUrl": "https://github.com/ethos-link/rails-conventions",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "ethos-link"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-shunsukehayashi-agent-skill-bus",
+      "name": "ShunsukeHayashi/agent-skill-bus",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "ShunsukeHayashi",
+      "sourceGroup": "Development and Testing",
+      "description": "Self-improving task orchestration for AI agent systems",
+      "sourceUrl": "https://github.com/ShunsukeHayashi/agent-skill-bus",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "ShunsukeHayashi"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-mcollina-skills",
+      "name": "mcollina/skills",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "mcollina",
+      "sourceGroup": "Development and Testing",
+      "description": "11 skills by Matteo Collina: Node.js, Fastify, TypeScript, OAuth, Git/GitHub, ESLint neostandard, documentation (Diataxis), Node.js core internals, skill optimizer, and more",
+      "sourceUrl": "https://github.com/mcollina/skills/tree/main/skills",
+      "installSource": {
+        "repoUrl": "https://github.com/mcollina/skills",
+        "subPath": "skills"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "mcollina"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-lum1104-understand-anything",
+      "name": "Lum1104/understand-anything",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "Lum1104",
+      "sourceGroup": "Development and Testing",
+      "description": "Interactive codebase knowledge graphs via multi-agent LLM analysis",
+      "sourceUrl": "https://github.com/Lum1104/Understand-Anything",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "Lum1104"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-hqhq1025-skill-optimizer",
+      "name": "hqhq1025/skill-optimizer",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "hqhq1025",
+      "sourceGroup": "Development and Testing",
+      "description": "Diagnose and optimize Agent Skills (SKILL.md) with real session data and research-backed static analysis. Works with Claude Code, Codex, and any Agent Skills-compatible agent",
+      "sourceUrl": "https://github.com/hqhq1025/skill-optimizer",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "hqhq1025"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-lambdatest-agent-skills",
+      "name": "LambdaTest/agent-skills",
+      "kind": "skillset",
+      "category": "测试与质量",
+      "publisher": "LambdaTest",
+      "sourceGroup": "Development and Testing",
+      "description": "TestMu AI (Formerly LambdaTest) Skills is a curated collection of Agent Skills that teach AI coding assistants how to write production-grade test automation.",
+      "sourceUrl": "https://github.com/LambdaTest/agent-skills",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "技能包"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-foryourhealth111-pixel-vibe-skills",
+      "name": "foryourhealth111-pixel/Vibe-Skills",
+      "kind": "skillset",
+      "category": "测试与质量",
+      "publisher": "foryourhealth111-pixel",
+      "sourceGroup": "Development and Testing",
+      "description": "A skills governed plug-and-play harness for staged, test-driven skill orchestration",
+      "sourceUrl": "https://github.com/foryourhealth111-pixel/Vibe-Skills",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "技能包"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-metalbear-co-skills",
+      "name": "metalbear-co/skills",
+      "kind": "skillset",
+      "category": "测试与质量",
+      "publisher": "metalbear-co",
+      "sourceGroup": "Development and Testing",
+      "description": "Skills that let agents code and test against your Kubernetes cluster using mirrord",
+      "sourceUrl": "https://github.com/metalbear-co/skills",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "技能包"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-dembrandt-dembrandt-skills",
+      "name": "dembrandt/dembrandt-skills",
+      "kind": "skillset",
+      "category": "测试与质量",
+      "publisher": "dembrandt",
+      "sourceGroup": "Development and Testing",
+      "description": "UX and design system skills: hierarchy, typography, accessibility, interactions",
+      "sourceUrl": "https://github.com/dembrandt/dembrandt-skills",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "技能包"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-ganyuanran-aegis",
+      "name": "GanyuanRan/Aegis",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "GanyuanRan",
+      "sourceGroup": "Development and Testing",
+      "description": "Evidence-driven method pack for AI coding agents",
+      "sourceUrl": "https://github.com/GanyuanRan/Aegis",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "GanyuanRan"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-baskduf-codex-fable5",
+      "name": "baskduf/codex-fable5",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "baskduf",
+      "sourceGroup": "Development and Testing",
+      "description": "Evidence-based workflow gates for Codex",
+      "sourceUrl": "https://github.com/baskduf/FableCodex/tree/main/plugins/codex-fable5/skills/codex-fable5",
+      "installSource": {
+        "repoUrl": "https://github.com/baskduf/FableCodex",
+        "subPath": "plugins/codex-fable5/skills/codex-fable5"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "baskduf"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-csthink-dashmotion",
+      "name": "csthink/dashmotion",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "csthink",
+      "sourceGroup": "Development and Testing",
+      "description": "Animated technical diagrams from plain English or Mermaid, self-contained HTML/SVG",
+      "sourceUrl": "https://github.com/csthink/dashmotion/tree/main/skills/dashmotion",
+      "installSource": {
+        "repoUrl": "https://github.com/csthink/dashmotion",
+        "subPath": "skills/dashmotion"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "csthink"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-muratcankoylan-context-fundamentals",
+      "name": "muratcankoylan/context-fundamentals",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "muratcankoylan",
+      "sourceGroup": "Context Engineering",
+      "description": "Understand what context is, why it matters, and the anatomy of context in agent systems",
+      "sourceUrl": "https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/context-fundamentals",
+      "installSource": {
+        "repoUrl": "https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering",
+        "subPath": "skills/context-fundamentals"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "muratcankoylan"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-muratcankoylan-context-degradation",
+      "name": "muratcankoylan/context-degradation",
+      "kind": "skill",
+      "category": "其他工具",
+      "publisher": "muratcankoylan",
+      "sourceGroup": "Context Engineering",
+      "description": "Recognize patterns of context failure: lost-in-middle, poisoning, distraction, and clash",
+      "sourceUrl": "https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/context-degradation",
+      "installSource": {
+        "repoUrl": "https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering",
+        "subPath": "skills/context-degradation"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "muratcankoylan"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-muratcankoylan-context-compression",
+      "name": "muratcankoylan/context-compression",
+      "kind": "skill",
+      "category": "多媒体创作",
+      "publisher": "muratcankoylan",
+      "sourceGroup": "Context Engineering",
+      "description": "Design and evaluate compression strategies for long-running sessions",
+      "sourceUrl": "https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/context-compression",
+      "installSource": {
+        "repoUrl": "https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering",
+        "subPath": "skills/context-compression"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "muratcankoylan"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-muratcankoylan-context-optimization",
+      "name": "muratcankoylan/context-optimization",
+      "kind": "skill",
+      "category": "其他工具",
+      "publisher": "muratcankoylan",
+      "sourceGroup": "Context Engineering",
+      "description": "Apply compaction, masking, and caching strategies",
+      "sourceUrl": "https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/context-optimization",
+      "installSource": {
+        "repoUrl": "https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering",
+        "subPath": "skills/context-optimization"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "muratcankoylan"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-muratcankoylan-multi-agent-patterns",
+      "name": "muratcankoylan/multi-agent-patterns",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "muratcankoylan",
+      "sourceGroup": "Context Engineering",
+      "description": "Master orchestrator, peer-to-peer, and hierarchical multi-agent architectures",
+      "sourceUrl": "https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/multi-agent-patterns",
+      "installSource": {
+        "repoUrl": "https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering",
+        "subPath": "skills/multi-agent-patterns"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "muratcankoylan"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-muratcankoylan-memory-systems",
+      "name": "muratcankoylan/memory-systems",
+      "kind": "skill",
+      "category": "多媒体创作",
+      "publisher": "muratcankoylan",
+      "sourceGroup": "Context Engineering",
+      "description": "Design short-term, long-term, and graph-based memory architectures",
+      "sourceUrl": "https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/memory-systems",
+      "installSource": {
+        "repoUrl": "https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering",
+        "subPath": "skills/memory-systems"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "muratcankoylan"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-muratcankoylan-tool-design",
+      "name": "muratcankoylan/tool-design",
+      "kind": "skill",
+      "category": "多媒体创作",
+      "publisher": "muratcankoylan",
+      "sourceGroup": "Context Engineering",
+      "description": "Build tools that agents can use effectively, including architectural reduction patterns",
+      "sourceUrl": "https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/tool-design",
+      "installSource": {
+        "repoUrl": "https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering",
+        "subPath": "skills/tool-design"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "muratcankoylan"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-muratcankoylan-evaluation",
+      "name": "muratcankoylan/evaluation",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "muratcankoylan",
+      "sourceGroup": "Context Engineering",
+      "description": "Build evaluation frameworks for agent systems",
+      "sourceUrl": "https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/evaluation",
+      "installSource": {
+        "repoUrl": "https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering",
+        "subPath": "skills/evaluation"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "muratcankoylan"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-k-kolomeitsev-data-structure-protocol",
+      "name": "k-kolomeitsev/data-structure-protocol",
+      "kind": "skill",
+      "category": "数据与分析",
+      "publisher": "k-kolomeitsev",
+      "sourceGroup": "Context Engineering",
+      "description": "Graph-based long-term memory skill for AI (LLM) coding agents — faster context, fewer tokens, safer refactors",
+      "sourceUrl": "https://github.com/k-kolomeitsev/data-structure-protocol",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "k-kolomeitsev"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-awrshift-claude-memory-kit",
+      "name": "awrshift/claude-memory-kit",
+      "kind": "skill",
+      "category": "产品与项目",
+      "publisher": "awrshift",
+      "sourceGroup": "Context Engineering",
+      "description": "Persistent memory with hooks, wiki, and daily synthesis for multi-project workflows",
+      "sourceUrl": "https://github.com/awrshift/claude-memory-kit",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "awrshift"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-neolabhq-prompt-engineering",
+      "name": "NeoLabHQ/prompt-engineering",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NeoLabHQ",
+      "sourceGroup": "Context Engineering",
+      "description": "Widely used prompt engineering techniques and patterns, including Anthropic best practices and agent persuasion principles.",
+      "sourceUrl": "https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/customaize-agent/skills/prompt-engineering",
+      "installSource": {
+        "repoUrl": "https://github.com/NeoLabHQ/context-engineering-kit",
+        "subPath": "plugins/customaize-agent/skills/prompt-engineering"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "NeoLabHQ"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-sametbrr-llm-wiki-manager",
+      "name": "sametbrr/llm-wiki-manager",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "sametbrr",
+      "sourceGroup": "Context Engineering",
+      "description": "Persistent LLM-managed personal wiki — the model writes, cross-references, and maintains the knowledge base while you curate sources. Implements Karpathy's LLM Wiki pattern with 8 operating modes.",
+      "sourceUrl": "https://github.com/sametbrr/llm-wiki-manager",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "sametbrr"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-panniantong-agent-reach",
+      "name": "Panniantong/Agent-Reach",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "Panniantong",
+      "sourceGroup": "Context Engineering",
+      "description": "Multi-platform search CLI for 17 sites including Chinese platforms",
+      "sourceUrl": "https://github.com/Panniantong/Agent-Reach",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "Panniantong"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-tubo2333-obsidian-knowledge-brain",
+      "name": "Tubo2333/obsidian-knowledge-brain",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "Tubo2333",
+      "sourceGroup": "Context Engineering",
+      "description": "Cross-session knowledge memory and rule evolution for AI coding agents",
+      "sourceUrl": "https://github.com/Tubo2333/obsidian-knowledge-brain",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "Tubo2333"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-shouldnotappearcalm-a-share-skill",
+      "name": "shouldnotappearcalm/a-share-skill",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "shouldnotappearcalm",
+      "sourceGroup": "Specialized Domains",
+      "description": "China A-share (Shanghai/Shenzhen) skills: real-time quotes, K-line history, technical indicators, events, capital flows, sector heatmaps, and paper trading. Works with Claude Code, Cursor, Codex, and Qoder",
+      "sourceUrl": "https://github.com/shouldnotappearcalm/a-share-skill",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "shouldnotappearcalm"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-transloadit-skills",
+      "name": "transloadit/skills",
+      "kind": "skill",
+      "category": "其他工具",
+      "publisher": "transloadit",
+      "sourceGroup": "Specialized Domains",
+      "description": "Transloadit skill collection (6)",
+      "sourceUrl": "https://github.com/transloadit/skills/tree/main/skills",
+      "installSource": {
+        "repoUrl": "https://github.com/transloadit/skills",
+        "subPath": "skills"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "transloadit"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-honeydew-ai-honeydew-ai-coding-agents-plugins",
+      "name": "honeydew-ai/honeydew-ai-coding-agents-plugins",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "honeydew-ai",
+      "sourceGroup": "Specialized Domains",
+      "description": "11 skills for the Honeydew semantic layer over Snowflake, Databricks, and BigQuery: model exploration, entity/relation/attribute/metric/context/domain creation, validation, query, filtering, and workspace branching",
+      "sourceUrl": "https://github.com/honeydew-ai/honeydew-ai-coding-agents-plugins",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "honeydew-ai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-raintree-technology-apple-hig-skills",
+      "name": "raintree-technology/apple-hig-skills",
+      "kind": "skillset",
+      "category": "前端与移动",
+      "publisher": "raintree-technology",
+      "sourceGroup": "Specialized Domains",
+      "description": "Apple Human Interface Guidelines as 14 agent skills covering platforms, foundations, components, patterns, inputs, and technologies for iOS, macOS, visionOS, watchOS, and tvOS",
+      "sourceUrl": "https://github.com/raintree-technology/apple-hig-skills",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "技能包"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-k-dense-ai-claude-scientific-skills",
+      "name": "K-Dense-AI/claude-scientific-skills",
+      "kind": "skillset",
+      "category": "数据与分析",
+      "publisher": "K-Dense-AI",
+      "sourceGroup": "Specialized Domains",
+      "description": "Scientific research and analysis skills",
+      "sourceUrl": "https://github.com/K-Dense-AI/claude-scientific-skills",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "技能包"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-notmyself-claude-win11-speckit-update-skill",
+      "name": "NotMyself/claude-win11-speckit-update-skill",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "NotMyself",
+      "sourceGroup": "Specialized Domains",
+      "description": "Windows 11 system management",
+      "sourceUrl": "https://github.com/NotMyself/claude-win11-speckit-update-skill",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "NotMyself"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-sanjay3290-imagen",
+      "name": "sanjay3290/imagen",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "sanjay3290",
+      "sourceGroup": "Specialized Domains",
+      "description": "Generate images using Google Gemini's API",
+      "sourceUrl": "https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen",
+      "installSource": {
+        "repoUrl": "https://github.com/sanjay3290/ai-skills",
+        "subPath": "skills/imagen"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "sanjay3290"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-jeffersonwarrior-claudisms",
+      "name": "jeffersonwarrior/claudisms",
+      "kind": "skill",
+      "category": "其他工具",
+      "publisher": "jeffersonwarrior",
+      "sourceGroup": "Specialized Domains",
+      "description": "SMS messaging integration",
+      "sourceUrl": "https://github.com/jeffersonwarrior/claudisms",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "jeffersonwarrior"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-shadowpr0-security-bluebook-builder",
+      "name": "SHADOWPR0/security-bluebook-builder",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "SHADOWPR0",
+      "sourceGroup": "Specialized Domains",
+      "description": "Build security Blue Books for sensitive apps",
+      "sourceUrl": "https://github.com/SHADOWPR0/security-bluebook-builder",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "SHADOWPR0"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-obra-defense-in-depth",
+      "name": "obra/defense-in-depth",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "obra",
+      "sourceGroup": "Specialized Domains",
+      "description": "Multi-layered security approaches",
+      "sourceUrl": "https://github.com/obra/superpowers/blob/main/skills/defense-in-depth/SKILL.md",
+      "installSource": {
+        "repoUrl": "https://github.com/obra/superpowers",
+        "subPath": "skills/defense-in-depth"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "obra"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-huifer-claude-ally-health",
+      "name": "huifer/Claude-Ally-Health",
+      "kind": "skill",
+      "category": "数据与分析",
+      "publisher": "huifer",
+      "sourceGroup": "Specialized Domains",
+      "description": "A health assistant skill for medical information analysis, symptom tracking, and wellness guidance.",
+      "sourceUrl": "https://github.com/huifer/Claude-Ally-Health",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "huifer"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-frmoretto-clarity-gate",
+      "name": "frmoretto/clarity-gate",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "frmoretto",
+      "sourceGroup": "Specialized Domains",
+      "description": "Epistemic quality verification for RAG systems",
+      "sourceUrl": "https://github.com/frmoretto/clarity-gate",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "frmoretto"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-wanshuiyin-auto-claude-code-research-in-sleep",
+      "name": "wanshuiyin/Auto-claude-code-research-in-sleep",
+      "kind": "skill",
+      "category": "云与运维",
+      "publisher": "wanshuiyin",
+      "sourceGroup": "Specialized Domains",
+      "description": "Autonomous ML research with cross-model review loops and GPU deployment",
+      "sourceUrl": "https://github.com/wanshuiyin/Auto-claude-code-research-in-sleep",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "wanshuiyin"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-zechenzhangagi-ai-research-skills",
+      "name": "zechenzhangAGI/AI-research-SKILLs",
+      "kind": "skillset",
+      "category": "数据与分析",
+      "publisher": "zechenzhangAGI",
+      "sourceGroup": "Specialized Domains",
+      "description": "77 AI research skills for model training, inference, and MLOps",
+      "sourceUrl": "https://github.com/zechenzhangAGI/AI-research-SKILLs",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "技能包"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-orchestra-research-ai-research-skills",
+      "name": "Orchestra-Research/AI-research-SKILLs",
+      "kind": "skillset",
+      "category": "数据与分析",
+      "publisher": "Orchestra-Research",
+      "sourceGroup": "Specialized Domains",
+      "description": "20-module AI research skill library for model architecture, training, and ML paper writing",
+      "sourceUrl": "https://github.com/Orchestra-Research/AI-research-SKILLs",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "技能包"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-komal-skynet-claude-skill-homeassistant",
+      "name": "komal-SkyNET/claude-skill-homeassistant",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "komal-SkyNET",
+      "sourceGroup": "Specialized Domains",
+      "description": "Supercharge and manage Home Assistant workflows",
+      "sourceUrl": "https://github.com/komal-SkyNET/claude-skill-homeassistant",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "komal-SkyNET"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-more-io-apple-bridges",
+      "name": "more-io/apple-bridges",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "more-io",
+      "sourceGroup": "Specialized Domains",
+      "description": "Native macOS app access — manage Apple Reminders, Calendar, Contacts, Notes, Mail, and tmux sessions via Swift CLI bridges",
+      "sourceUrl": "https://github.com/more-io/claude-apple-bridges",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "more-io"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-hanhuark-mechanical-engineering-research-skill",
+      "name": "hanhuark/mechanical-engineering-research-skill",
+      "kind": "skill",
+      "category": "文档与办公",
+      "publisher": "hanhuark",
+      "sourceGroup": "Specialized Domains",
+      "description": "Thermal-fluid research writing, proposals, DOE, and presentation feedback",
+      "sourceUrl": "https://github.com/hanhuark/mechanical-engineering-research-skill",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "hanhuark"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-prompt-security-clawsec",
+      "name": "prompt-security/clawsec",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "prompt-security",
+      "sourceGroup": "Specialized Domains",
+      "description": "Security skill suite with drift detection, automated audits, and skill integrity verification",
+      "sourceUrl": "https://github.com/prompt-security/clawsec",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "prompt-security"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-behisecc-vibesec",
+      "name": "BehiSecc/vibesec",
+      "kind": "skill",
+      "category": "安全与合规",
+      "publisher": "BehiSecc",
+      "sourceGroup": "Specialized Domains",
+      "description": "Helps write secure code by preventing common vulnerabilities including IDOR, XSS, SQL injection, SSRF, and weak authentication, approaching code from a bug hunter's perspective",
+      "sourceUrl": "https://github.com/BehiSecc/VibeSec-Skill",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "BehiSecc"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-lawvable-awesome-legal-skills",
+      "name": "lawvable/awesome-legal-skills",
+      "kind": "skillset",
+      "category": "AI 与智能体",
+      "publisher": "lawvable",
+      "sourceGroup": "Specialized Domains",
+      "description": "Curated agent skills for automating legal workflows",
+      "sourceUrl": "https://github.com/lawvable/awesome-legal-skills",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "技能包"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-peas-genealogy-research",
+      "name": "peas/genealogy-research",
+      "kind": "skill",
+      "category": "数据与分析",
+      "publisher": "peas",
+      "sourceGroup": "Specialized Domains",
+      "description": "Genealogy research agent with OCR, FamilySearch, YAML data, and human-in-the-loop",
+      "sourceUrl": "https://paulo.com.br/skills/genealogy-research/SKILL.md",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "peas"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-zw008-vmware-aiops",
+      "name": "zw008/VMware-AIops",
+      "kind": "skill",
+      "category": "数据与分析",
+      "publisher": "zw008",
+      "sourceGroup": "Specialized Domains",
+      "description": "AI-powered VMware vCenter/ESXi monitoring and operations: inventory queries, health/alarms, VM lifecycle (create, delete, snapshot, clone, migrate), vSAN management, Aria Operations analytics, and scheduled log scanning. Supports Claude Code, Gemini CLI, Codex, Aider, Trae, Kimi, and MCP.",
+      "sourceUrl": "https://github.com/zw008/VMware-AIops",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "zw008"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-video-db-skills",
+      "name": "video-db/skills",
+      "kind": "skillset",
+      "category": "多媒体创作",
+      "publisher": "video-db",
+      "sourceGroup": "Specialized Domains",
+      "description": "Realtime and batch video workflows: capture screen/audio, ingest URLs/YouTube/RTSP, transcribe, index, search, generate subtitles, edit timelines, and stream HLS output",
+      "sourceUrl": "https://github.com/video-db/skills",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "技能包"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-materials-simulation-skills",
+      "name": "materials-simulation-skills",
+      "kind": "skillset",
+      "category": "产品与项目",
+      "publisher": "Specialized Domains",
+      "sourceGroup": "Specialized Domains",
+      "description": "Agent skills for computational materials science: numerical stability, time-stepping, linear solvers, mesh generation, simulation validation, parameter optimization, and post-processing",
+      "sourceUrl": "https://github.com/HeshamFS/materials-simulation-skills",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "技能包"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-ericyoung-183-alpha-insights",
+      "name": "Ericyoung-183/alpha-insights",
+      "kind": "skill",
+      "category": "数据与分析",
+      "publisher": "Ericyoung-183",
+      "sourceGroup": "Specialized Domains",
+      "description": "Harness-enforced business research for Claude Code and Codex",
+      "sourceUrl": "https://github.com/Ericyoung-183/alpha-insights",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "Ericyoung-183"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-takechanman1228-claude-ecom",
+      "name": "takechanman1228/claude-ecom",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "takechanman1228",
+      "sourceGroup": "Specialized Domains",
+      "description": "Ecommerce CSV to business review with KPI decomposition",
+      "sourceUrl": "https://github.com/takechanman1228/claude-ecom",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "takechanman1228"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-talkstream-ru-text",
+      "name": "talkstream/ru-text",
+      "kind": "skill",
+      "category": "测试与质量",
+      "publisher": "talkstream",
+      "sourceGroup": "Specialized Domains",
+      "description": "Russian text quality: ~1,040 rules for typography, info-style, editorial, UX writing, business correspondence. Cross-platform: Claude Code, Codex CLI, Gemini CLI, Cursor.",
+      "sourceUrl": "https://github.com/talkstream/ru-text",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "talkstream"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-helius-labs-helius-skills",
+      "name": "helius-labs/helius-skills",
+      "kind": "skill",
+      "category": "数据与分析",
+      "publisher": "helius-labs",
+      "sourceGroup": "Specialized Domains",
+      "description": "Ship Solana apps end-to-end; transaction sending, asset queries, real-time streaming, token swaps, prediction markets, browser wallets, and deep research into protocol internals all powered by Helius APIs, DFlow trading, and Phantom wallet integrations",
+      "sourceUrl": "https://github.com/helius-labs/core-ai/tree/main/helius-skills",
+      "installSource": {
+        "repoUrl": "https://github.com/helius-labs/core-ai",
+        "subPath": "helius-skills"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "helius-labs"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-meodai-skill-color-expert",
+      "name": "meodai/skill.color-expert",
+      "kind": "skill",
+      "category": "其他工具",
+      "publisher": "meodai",
+      "sourceGroup": "Specialized Domains",
+      "description": "Color science expert skill with 286K words of reference material covering OKLCH/OKLAB, palette generation, accessibility/contrast, color naming, pigment mixing, and historical color theory",
+      "sourceUrl": "https://github.com/meodai/skill.color-expert",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "meodai"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-aklofas-kicad-happy",
+      "name": "aklofas/kicad-happy",
+      "kind": "skill",
+      "category": "数据与分析",
+      "publisher": "aklofas",
+      "sourceGroup": "Specialized Domains",
+      "description": "AI-powered KiCad electronics design review and analysis",
+      "sourceUrl": "https://github.com/aklofas/kicad-happy",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "aklofas"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-bitwize-music-studio-claude-ai-music-skills",
+      "name": "bitwize-music-studio/claude-ai-music-skills",
+      "kind": "skillset",
+      "category": "多媒体创作",
+      "publisher": "bitwize-music-studio",
+      "sourceGroup": "Specialized Domains",
+      "description": "Full-lifecycle AI music album production",
+      "sourceUrl": "https://github.com/bitwize-music-studio/claude-ai-music-skills",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "技能包"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-alisa0808-vibe-creating-skill",
+      "name": "Alisa0808/vibe-creating-skill",
+      "kind": "skill",
+      "category": "多媒体创作",
+      "publisher": "Alisa0808",
+      "sourceGroup": "Specialized Domains",
+      "description": "Rewrites a rough idea or shot script into text-to-video prompts",
+      "sourceUrl": "https://github.com/Alisa0808/vibe-creating-skill",
+      "installSource": null,
+      "tags": [
+        "VoltAgent 索引",
+        "外部索引",
+        "Alisa0808"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-czlonkowski-n8n-code-javascript",
+      "name": "czlonkowski/n8n-code-javascript",
+      "kind": "skill",
+      "category": "数据与分析",
+      "publisher": "czlonkowski",
+      "sourceGroup": "n8n Automation",
+      "description": "JavaScript in n8n Code nodes with data access patterns",
+      "sourceUrl": "https://github.com/czlonkowski/n8n-skills/tree/main/skills/n8n-code-javascript",
+      "installSource": {
+        "repoUrl": "https://github.com/czlonkowski/n8n-skills",
+        "subPath": "skills/n8n-code-javascript"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "czlonkowski"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-czlonkowski-n8n-code-python",
+      "name": "czlonkowski/n8n-code-python",
+      "kind": "skill",
+      "category": "工程开发",
+      "publisher": "czlonkowski",
+      "sourceGroup": "n8n Automation",
+      "description": "Python coding in n8n Code nodes with limitations",
+      "sourceUrl": "https://github.com/czlonkowski/n8n-skills/tree/main/skills/n8n-code-python",
+      "installSource": {
+        "repoUrl": "https://github.com/czlonkowski/n8n-skills",
+        "subPath": "skills/n8n-code-python"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "czlonkowski"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-czlonkowski-n8n-expression-syntax",
+      "name": "czlonkowski/n8n-expression-syntax",
+      "kind": "skill",
+      "category": "其他工具",
+      "publisher": "czlonkowski",
+      "sourceGroup": "n8n Automation",
+      "description": "n8n expression syntax with {{}} and $json/$node variables",
+      "sourceUrl": "https://github.com/czlonkowski/n8n-skills/tree/main/skills/n8n-expression-syntax",
+      "installSource": {
+        "repoUrl": "https://github.com/czlonkowski/n8n-skills",
+        "subPath": "skills/n8n-expression-syntax"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "czlonkowski"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-czlonkowski-n8n-mcp-tools-expert",
+      "name": "czlonkowski/n8n-mcp-tools-expert",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "czlonkowski",
+      "sourceGroup": "n8n Automation",
+      "description": "MCP tools guide with tool selection and node formats",
+      "sourceUrl": "https://github.com/czlonkowski/n8n-skills/tree/main/skills/n8n-mcp-tools-expert",
+      "installSource": {
+        "repoUrl": "https://github.com/czlonkowski/n8n-skills",
+        "subPath": "skills/n8n-mcp-tools-expert"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "czlonkowski"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-czlonkowski-n8n-node-configuration",
+      "name": "czlonkowski/n8n-node-configuration",
+      "kind": "skill",
+      "category": "AI 与智能体",
+      "publisher": "czlonkowski",
+      "sourceGroup": "n8n Automation",
+      "description": "Node configuration with dependency rules and AI connections",
+      "sourceUrl": "https://github.com/czlonkowski/n8n-skills/tree/main/skills/n8n-node-configuration",
+      "installSource": {
+        "repoUrl": "https://github.com/czlonkowski/n8n-skills",
+        "subPath": "skills/n8n-node-configuration"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "czlonkowski"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-czlonkowski-n8n-validation-expert",
+      "name": "czlonkowski/n8n-validation-expert",
+      "kind": "skill",
+      "category": "其他工具",
+      "publisher": "czlonkowski",
+      "sourceGroup": "n8n Automation",
+      "description": "Fix n8n validation errors with error catalog",
+      "sourceUrl": "https://github.com/czlonkowski/n8n-skills/tree/main/skills/n8n-validation-expert",
+      "installSource": {
+        "repoUrl": "https://github.com/czlonkowski/n8n-skills",
+        "subPath": "skills/n8n-validation-expert"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "czlonkowski"
+      ],
+      "includedSkills": []
+    },
+    {
+      "id": "voltagent-czlonkowski-n8n-workflow-patterns",
+      "name": "czlonkowski/n8n-workflow-patterns",
+      "kind": "skill",
+      "category": "后端与数据库",
+      "publisher": "czlonkowski",
+      "sourceGroup": "n8n Automation",
+      "description": "Workflow patterns for webhook, HTTP, database, and AI tasks",
+      "sourceUrl": "https://github.com/czlonkowski/n8n-skills/tree/main/skills/n8n-workflow-patterns",
+      "installSource": {
+        "repoUrl": "https://github.com/czlonkowski/n8n-skills",
+        "subPath": "skills/n8n-workflow-patterns"
+      },
+      "tags": [
+        "VoltAgent 索引",
+        "可一键安装",
+        "czlonkowski"
+      ],
+      "includedSkills": []
+    }
+  ]
+}

--- a/client/src/pages/SkillBrowserPage.tsx
+++ b/client/src/pages/SkillBrowserPage.tsx
@@ -2,7 +2,11 @@ import { useEffect, useMemo, useState } from "react";
 import PageContainer from "../components/PageContainer";
 import AuthoringProposalPanel from "../components/authoring/AuthoringProposalPanel";
 import SkillDraftPanel from "../components/authoring/SkillDraftPanel";
-import { type SkillProject, skillProjects } from "../data/skillProjects";
+import {
+  type SkillProject,
+  type SkillProjectKind,
+  skillProjects,
+} from "../data/skillProjects";
 
 interface InstalledSkill {
   skill_id: string;
@@ -18,9 +22,20 @@ interface InstalledSkillsResponse {
 }
 
 type SkillTab = "market" | "installed" | "drafts" | "proposals";
+type SkillKindFilter = "all" | SkillProjectKind;
+type SkillAvailabilityFilter = "all" | "installable" | "reference";
+const MARKET_PAGE_SIZE = 48;
 
 function formatStars(stars: number) {
-  return `${(stars / 1000).toFixed(1)}k`;
+  return stars >= 1000 ? `${(stars / 1000).toFixed(1)}k` : `${stars}`;
+}
+
+function formatProjectKind(project: SkillProject) {
+  if (project.kind === "skillset") {
+    const includedCount = project.includedSkills?.length ?? 0;
+    return includedCount > 0 ? `SkillSet · ${includedCount} 项` : "SkillSet";
+  }
+  return "Skill";
 }
 
 function formatInstallTime(value: number) {
@@ -63,18 +78,33 @@ function MarketSkillCard({
 }) {
   const canInstall = Boolean(project.installSource);
   const isInstalling = installingId === project.id;
+  const installLabel = project.kind === "skillset" ? "安装技能包" : "安装技能";
+  const hasIncludedSkills =
+    project.kind === "skillset" && (project.includedSkills?.length ?? 0) > 0;
 
   return (
-    <article className="group relative overflow-hidden rounded-lg border border-white/10 bg-ink-950/70 p-5 shadow-prism transition duration-200 hover:-translate-y-1 hover:border-hire-300/35 hover:bg-white/[0.065]">
+    <article className="group relative overflow-hidden rounded-lg border border-white/10 bg-ink-950/70 p-5 transition duration-200 hover:border-hire-300/35 hover:bg-white/[0.065]">
       <div className="absolute inset-x-5 top-0 h-px bg-gradient-to-r from-transparent via-hire-300/80 to-transparent opacity-0 transition group-hover:opacity-100" />
       <div className="flex items-start justify-between gap-4">
         <div>
           <p className="text-xs font-semibold text-hire-200">{project.category}</p>
           <h3 className="mt-2 text-xl font-semibold text-white">{project.name}</h3>
-          <p className="mt-1 text-xs text-slate-500">{project.repoName}</p>
+          <p className="mt-1 text-xs text-slate-400">
+            {project.repoName}
+            {project.catalogName && project.catalogName !== project.repoName
+              ? ` · ${project.catalogName}`
+              : ""}
+            {` · ★ ${formatStars(project.stars)}`}
+          </p>
         </div>
-        <span className="rounded-full border border-brand-300/25 bg-brand-300/10 px-3 py-1 text-xs font-semibold text-brand-100">
-          {formatStars(project.stars)}
+        <span
+          className={`shrink-0 rounded-full border px-3 py-1 text-xs font-semibold ${
+            project.kind === "skillset"
+              ? "border-accent-300/30 bg-accent-300/10 text-accent-100"
+              : "border-brand-300/25 bg-brand-300/10 text-brand-100"
+          }`}
+        >
+          {formatProjectKind(project)}
         </span>
       </div>
 
@@ -94,7 +124,18 @@ function MarketSkillCard({
       </div>
 
       <div className="mt-5 rounded-lg border border-white/10 bg-white/[0.045] p-3">
-        <p className="text-xs font-semibold text-slate-400">安装来源</p>
+        <p className="text-xs font-semibold text-slate-300">
+          {hasIncludedSkills
+            ? "技能包内容"
+            : project.kind === "skillset"
+              ? "技能包来源"
+              : "安装来源"}
+        </p>
+        {hasIncludedSkills ? (
+          <p className="mt-2 text-xs leading-5 text-slate-400">
+            {project.includedSkills?.join("、")}
+          </p>
+        ) : null}
         <code className="mt-2 block break-all rounded-md bg-ink-950/80 p-2 text-xs leading-5 text-hire-100">
           {project.installSource
             ? `${project.installSource.repoUrl} / ${project.installSource.subPath}`
@@ -103,21 +144,39 @@ function MarketSkillCard({
       </div>
 
       <div className="mt-5 flex items-center justify-between gap-3">
-        <a
-          className="text-xs font-semibold text-slate-400 underline decoration-white/20 underline-offset-4 transition hover:text-white"
-          href={project.repoUrl}
-          rel="noreferrer"
-          target="_blank"
-        >
-          查看仓库
-        </a>
+        <div className="flex flex-wrap items-center gap-3">
+          <a
+            className="text-xs font-semibold text-slate-400 underline decoration-white/20 underline-offset-4 transition hover:text-white"
+            href={project.repoUrl}
+            rel="noreferrer"
+            target="_blank"
+          >
+            查看来源
+          </a>
+          {project.catalogUrl && project.catalogUrl !== project.repoUrl ? (
+            <a
+              className="text-xs font-semibold text-slate-500 underline decoration-white/15 underline-offset-4 transition hover:text-white"
+              href={project.catalogUrl}
+              rel="noreferrer"
+              target="_blank"
+            >
+              查看索引
+            </a>
+          ) : null}
+        </div>
         <button
           className="rounded-full bg-hire-300 px-4 py-2 text-sm font-semibold text-ink-950 shadow-[0_0_22px_rgba(251,146,60,0.22)] transition hover:bg-hire-200 active:scale-[0.98] disabled:cursor-not-allowed disabled:bg-white/10 disabled:text-slate-500 disabled:shadow-none"
           disabled={!canInstall || installed || isInstalling}
           onClick={() => onInstall(project)}
           type="button"
         >
-          {isInstalling ? "安装中..." : installed ? "已安装" : canInstall ? "⚡ 安装" : "仅作参考"}
+          {isInstalling
+            ? "安装中..."
+            : installed
+              ? "已安装"
+              : canInstall
+                ? installLabel
+                : "仅作参考"}
         </button>
       </div>
     </article>
@@ -171,22 +230,87 @@ export default function SkillBrowserPage() {
       ? requestedTab
       : "market",
   );
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedCategory, setSelectedCategory] = useState("all");
+  const [selectedKind, setSelectedKind] = useState<SkillKindFilter>("all");
+  const [selectedAvailability, setSelectedAvailability] =
+    useState<SkillAvailabilityFilter>("all");
+  const [visibleProjectCount, setVisibleProjectCount] = useState(MARKET_PAGE_SIZE);
   const [installedSkills, setInstalledSkills] = useState<InstalledSkill[]>([]);
   const [isLoadingInstalled, setIsLoadingInstalled] = useState(false);
   const [installingId, setInstallingId] = useState("");
   const [uninstallingId, setUninstallingId] = useState("");
   const [notice, setNotice] = useState("");
   const [error, setError] = useState("");
-  const totalStars = useMemo(
-    () => skillProjects.reduce((sum, project) => sum + project.stars, 0),
+  const categories = useMemo(
+    () =>
+      [...new Set(skillProjects.map((project) => project.category))].sort((left, right) =>
+        left.localeCompare(right, "zh-CN"),
+      ),
     [],
   );
-  const installableProjects = skillProjects.filter((project) => project.installSource);
+  const totalStars = useMemo(() => {
+    const countedRepositories = new Set<string>();
+    return skillProjects.reduce((sum, project) => {
+      const metricsSource = project.catalogUrl ?? project.repoUrl;
+      if (countedRepositories.has(metricsSource)) return sum;
+      countedRepositories.add(metricsSource);
+      return sum + project.stars;
+    }, 0);
+  }, []);
+  const catalogCount = useMemo(
+    () =>
+      new Set(skillProjects.map((project) => project.catalogUrl ?? project.repoUrl)).size,
+    [],
+  );
+  const skillsetCount = useMemo(
+    () => skillProjects.filter((project) => project.kind === "skillset").length,
+    [],
+  );
+  const installableProjects = useMemo(
+    () => skillProjects.filter((project) => project.installSource),
+    [],
+  );
+  const filteredProjects = useMemo(() => {
+    const normalizedQuery = searchQuery.trim().toLocaleLowerCase("zh-CN");
+    return skillProjects.filter((project) => {
+      if (selectedCategory !== "all" && project.category !== selectedCategory) return false;
+      if (selectedKind !== "all" && project.kind !== selectedKind) return false;
+      if (selectedAvailability === "installable" && !project.installSource) return false;
+      if (selectedAvailability === "reference" && project.installSource) return false;
+      if (!normalizedQuery) return true;
+
+      const searchableText = [
+        project.name,
+        project.description,
+        project.category,
+        project.repoName,
+        project.catalogName ?? "",
+        project.publisher ?? "",
+        project.sourceGroup ?? "",
+        ...project.tags,
+        ...(project.includedSkills ?? []),
+      ]
+        .join(" ")
+        .toLocaleLowerCase("zh-CN");
+      return searchableText.includes(normalizedQuery);
+    });
+  }, [searchQuery, selectedAvailability, selectedCategory, selectedKind]);
+  const visibleProjects = filteredProjects.slice(0, visibleProjectCount);
+  const hasActiveFilters =
+    searchQuery.trim().length > 0 ||
+    selectedCategory !== "all" ||
+    selectedKind !== "all" ||
+    selectedAvailability !== "all";
 
   useEffect(() => {
     document.title = "模镜 - Skill 技能货架";
     void loadInstalledSkills();
   }, []);
+
+  useEffect(() => {
+    setVisibleProjectCount(MARKET_PAGE_SIZE);
+  }, [searchQuery, selectedAvailability, selectedCategory, selectedKind]);
 
   async function loadInstalledSkills() {
     setIsLoadingInstalled(true);
@@ -226,7 +350,9 @@ export default function SkillBrowserPage() {
         installed,
         ...current.filter((skill) => skill.skill_id !== installed.skill_id),
       ]);
-      setNotice(`${project.name} 已安装，可在面试间选择使用。`);
+      setNotice(
+        `${project.name} ${project.kind === "skillset" ? "技能包" : "技能"}已安装，可在面试间选择使用。`,
+      );
     } catch (installError) {
       setError(
         installError instanceof Error ? installError.message : "技能安装失败",
@@ -234,6 +360,14 @@ export default function SkillBrowserPage() {
     } finally {
       setInstallingId("");
     }
+  }
+
+  function resetMarketFilters() {
+    setSearchQuery("");
+    setSelectedCategory("all");
+    setSelectedKind("all");
+    setSelectedAvailability("all");
+    setVisibleProjectCount(MARKET_PAGE_SIZE);
   }
 
   async function uninstallSkill(skill: InstalledSkill) {
@@ -268,10 +402,10 @@ export default function SkillBrowserPage() {
         <div>
           <p className="text-sm font-semibold text-white">技能培训服务台</p>
           <p className="mt-2 text-sm leading-6 text-slate-400">
-            Skill 是 AI 打工人的岗位手册。安装后可在面试间激活，让模型按技能说明完成任务。
+            Skill 是单项岗位手册，SkillSet 是带多个子技能的组合包。安装后可在面试间激活。
           </p>
           <div className="mt-4 rounded-lg border border-white/10 bg-white/[0.045] p-3">
-            <p className="text-xs text-slate-400">可安装技能</p>
+            <p className="text-xs text-slate-400">可安装资源</p>
             <p className="mt-1 text-sm font-semibold text-hire-100">
               {installableProjects.length} 个
             </p>
@@ -283,11 +417,14 @@ export default function SkillBrowserPage() {
             </p>
           </div>
           <div className="mt-3 rounded-lg border border-white/10 bg-white/[0.045] p-3">
-            <p className="text-xs text-slate-400">GitHub 热度</p>
+            <p className="text-xs text-slate-400">目录来源</p>
             <p className="mt-1 text-sm font-semibold text-brand-100">
-              {formatStars(totalStars)} stars
+              {catalogCount} 个 · ★ {formatStars(totalStars)}
             </p>
           </div>
+          <p className="mt-4 text-xs leading-5 text-slate-500">
+            社区 Skill 安装时只复制目录，不自动执行脚本。激活前请检查依赖、外部服务和凭据要求。
+          </p>
         </div>
       }
     >
@@ -303,7 +440,7 @@ export default function SkillBrowserPage() {
               Skill 技能货架
             </h1>
             <p className="mt-5 max-w-2xl text-base leading-7 text-slate-300">
-              从技能市场领取岗位手册，安装到本地后即可在面试间激活。模型会把 Skill 当成系统级工作规范来执行。
+              按任务、分类和资源类型查找岗位手册。目录同时收录独立 Skill 与可一次安装的 SkillSet。
             </p>
           </div>
 
@@ -323,15 +460,15 @@ export default function SkillBrowserPage() {
               </div>
               <div className="rounded-lg bg-white/[0.055] px-2 py-3">
                 <p className="text-lg font-semibold text-emerald-100">
-                  {installedSkills.length}
+                  {skillsetCount}
                 </p>
-                <p className="mt-1 truncate text-slate-400">已入职</p>
+                <p className="mt-1 truncate text-slate-400">SkillSet</p>
               </div>
               <div className="rounded-lg bg-white/[0.055] px-2 py-3">
                 <p className="text-lg font-semibold text-brand-100">
-                  {formatStars(totalStars)}
+                  {categories.length}
                 </p>
-                <p className="mt-1 truncate text-slate-400">热度</p>
+                <p className="mt-1 truncate text-slate-400">分类</p>
               </div>
             </div>
           </div>
@@ -371,6 +508,94 @@ export default function SkillBrowserPage() {
           </button>
         </div>
 
+        {activeTab === "market" ? (
+          <div className="mb-5 rounded-lg border border-white/10 bg-white/[0.04] p-4">
+            <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_190px_170px_auto] lg:items-end">
+              <label className="block">
+                <span className="text-xs font-semibold text-slate-300">搜索技能</span>
+                <input
+                  className="mt-2 w-full rounded-lg border border-white/10 bg-ink-950/80 px-3 py-2.5 text-sm text-white placeholder:text-slate-500 transition focus:border-brand-300/50 focus:outline-none"
+                  onChange={(event) => setSearchQuery(event.target.value)}
+                  placeholder="名称、能力、标签或仓库"
+                  type="search"
+                  value={searchQuery}
+                />
+              </label>
+
+              <label className="block">
+                <span className="text-xs font-semibold text-slate-300">分类</span>
+                <select
+                  className="mt-2 w-full rounded-lg border border-white/10 bg-ink-950/80 px-3 py-2.5 text-sm text-white transition focus:border-brand-300/50 focus:outline-none"
+                  onChange={(event) => setSelectedCategory(event.target.value)}
+                  value={selectedCategory}
+                >
+                  <option value="all">全部分类</option>
+                  {categories.map((category) => (
+                    <option key={category} value={category}>
+                      {category}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <label className="block">
+                <span className="text-xs font-semibold text-slate-300">安装状态</span>
+                <select
+                  className="mt-2 w-full rounded-lg border border-white/10 bg-ink-950/80 px-3 py-2.5 text-sm text-white transition focus:border-brand-300/50 focus:outline-none"
+                  onChange={(event) =>
+                    setSelectedAvailability(event.target.value as SkillAvailabilityFilter)
+                  }
+                  value={selectedAvailability}
+                >
+                  <option value="all">全部资源</option>
+                  <option value="installable">可一键安装</option>
+                  <option value="reference">仅外部索引</option>
+                </select>
+              </label>
+
+              <fieldset>
+                <legend className="text-xs font-semibold text-slate-300">资源类型</legend>
+                <div className="mt-2 inline-flex rounded-lg border border-white/10 bg-ink-950/80 p-1">
+                  {[
+                    { id: "all", label: "全部" },
+                    { id: "skill", label: "Skill" },
+                    { id: "skillset", label: "SkillSet" },
+                  ].map((kind) => (
+                    <button
+                      aria-pressed={selectedKind === kind.id}
+                      className={`rounded-md px-3 py-1.5 text-sm font-semibold transition ${
+                        selectedKind === kind.id
+                          ? "bg-brand-300/20 text-brand-100"
+                          : "text-slate-400 hover:bg-white/[0.06] hover:text-white"
+                      }`}
+                      key={kind.id}
+                      onClick={() => setSelectedKind(kind.id as SkillKindFilter)}
+                      type="button"
+                    >
+                      {kind.label}
+                    </button>
+                  ))}
+                </div>
+              </fieldset>
+            </div>
+
+            <div className="mt-4 flex flex-wrap items-center justify-between gap-3 border-t border-white/10 pt-3">
+              <p aria-live="polite" className="text-sm text-slate-400">
+                显示 <span className="font-semibold text-white">{filteredProjects.length}</span> / {skillProjects.length} 项
+              </p>
+              {hasActiveFilters ? (
+                <button
+                  className="text-sm font-semibold text-brand-100 underline decoration-brand-300/30 underline-offset-4 transition hover:text-white"
+                  onClick={resetMarketFilters}
+                  type="button"
+                >
+                  清除筛选
+                </button>
+              ) : null}
+            </div>
+          </div>
+        ) : null}
+
         {notice ? (
           <div className="mb-4 rounded-lg border border-emerald-300/25 bg-emerald-300/10 px-4 py-3 text-sm text-emerald-50">
             {notice}
@@ -382,17 +607,46 @@ export default function SkillBrowserPage() {
           </div>
         ) : null}
 
-        {activeTab === "market" ? (
-          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-            {skillProjects.map((project) => (
-              <MarketSkillCard
-                installed={isProjectInstalled(project, installedSkills)}
-                installingId={installingId}
-                key={project.id}
-                onInstall={(item) => void installSkill(item)}
-                project={project}
-              />
-            ))}
+        {activeTab === "market" && filteredProjects.length > 0 ? (
+          <div>
+            <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
+              {visibleProjects.map((project) => (
+                <MarketSkillCard
+                  installed={isProjectInstalled(project, installedSkills)}
+                  installingId={installingId}
+                  key={project.id}
+                  onInstall={(item) => void installSkill(item)}
+                  project={project}
+                />
+              ))}
+            </div>
+            {visibleProjects.length < filteredProjects.length ? (
+              <div className="mt-6 flex justify-center">
+                <button
+                  className="rounded-full border border-white/15 px-5 py-2.5 text-sm font-semibold text-slate-200 transition hover:border-brand-300/35 hover:bg-brand-300/10 hover:text-white"
+                  onClick={() =>
+                    setVisibleProjectCount((current) => current + MARKET_PAGE_SIZE)
+                  }
+                  type="button"
+                >
+                  加载更多（剩余 {filteredProjects.length - visibleProjects.length} 项）
+                </button>
+              </div>
+            ) : null}
+          </div>
+        ) : activeTab === "market" ? (
+          <div className="rounded-lg border border-dashed border-white/15 bg-white/[0.04] px-6 py-12 text-center">
+            <p className="text-lg font-semibold text-white">没有匹配的技能资源。</p>
+            <p className="mt-2 text-sm text-slate-400">
+              换一个关键词、分类或资源类型，或者清除当前筛选。
+            </p>
+            <button
+              className="mt-5 rounded-full border border-brand-300/30 px-5 py-2 text-sm font-semibold text-brand-100 transition hover:bg-brand-300/10"
+              onClick={resetMarketFilters}
+              type="button"
+            >
+              清除筛选
+            </button>
           </div>
         ) : activeTab === "installed" && installedSkills.length > 0 ? (
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -95,7 +95,7 @@ flowchart LR
 
 | 分组 | 路由 | 当前用途 |
 | --- | --- | --- |
-| 资源 | `/models`、`/agents`、`/mcps`、`/skills`、`/prompts`、`/plugins` | 浏览和管理 AI 资源。 |
+| 资源 | `/models`、`/agents`、`/mcps`、`/skills`、`/prompts`、`/plugins` | 浏览和管理 AI 资源；`/skills` 支持多来源 Skill/SkillSet、搜索、安装能力筛选与分批渲染。 |
 | 工作空间 | `/studio`、`/runtime`、`/settings` | 聚合入口、运行诊断与模型服务设置。 |
 | 聊天 | `/chat/:modelId` | 文本、图片、STT、TTS、视频分析或视频生成自适应工作区。 |
 | Agent | `/agents/studio`、`/agents/xpert/:xpertId/chat`、`/agents/goals`、`/agents/automations` | Agent Studio、运行、Goal 与自动化。 |

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -11,6 +11,7 @@
 | 领域 | 存储 | 说明 |
 | --- | --- | --- |
 | 模型静态快照 | `client/src/data/models.ts` | 展示、能力与离线目录；实时可调用性来自后端目录。 |
+| Skill 静态目录 | `client/src/data/skillProjects.ts`、`client/src/data/*SkillCatalog.generated.json` | 手工精选与固定上游提交生成的外部目录快照。 |
 | 模型路由与视频任务 | `server/model_router/storage/router.sqlite3` | 连接、策略、候选统计、决策、压缩与视频任务元数据。 |
 | 路由凭据 | SQLite 加密字段 + `credential-master.key` | 只在后端解密，API 返回脱敏摘要。 |
 | RAG 元数据与流水线 | `server/rag/storage/` | metadata、候选/激活版本、处理和视觉产物。 |
@@ -24,6 +25,12 @@
 | 媒体正文 | 不持久化 | STT/TTS/视频请求媒体及视频生成 Prompt、首帧不进入任务数据库。 |
 
 Dify 数据库不属于当前主路径或备份范围。legacy Dify 代理只在显式配置后可用。
+
+## Skill 目录快照
+
+Skill 市场由手工精选条目与生成目录组合。组合目录使用 `kind: "skillset"`；
+`scripts/sync-*-skill-*.mjs` 根据固定上游 commit 生成 JSON 快照，禁止直接手改。
+只有明确指向 GitHub Skill 子目录的条目才生成一键安装源；其余条目仅作为外部参考。
 
 ## 租户边界
 

--- a/docs/SKILL_INTEGRATION.md
+++ b/docs/SKILL_INTEGRATION.md
@@ -2,7 +2,7 @@
 
 Skill 是模镜为 AI 打工人准备的“岗位手册”。每个 Skill 是一个包含 `SKILL.md` 的目录，可选携带脚本、模板、参考资料等资源。模镜后端负责安装、卸载和读取 Skill，前端负责在技能市场展示、管理已安装 Skill，并在面试间把选中的 `SKILL.md` 注入为系统提示词。
 
-最后更新日期：2026-06-16  
+最后更新日期：2026-08-02
 维护人：模镜团队
 
 ## 1. 概述
@@ -41,12 +41,34 @@ some-skill/
 
 当前 MVP 支持从 GitHub 仓库的指定子目录安装 Skill。生产默认只允许 `https://github.com/{owner}/{repo}` 来源，避免 SSRF 和任意路径读取。测试环境可以显式打开本地仓库来源。
 
+市场资源分为两种类型：
+
+- `skill`：一个可独立使用的 `SKILL.md` 目录。
+- `skillset`：包含多个子技能的组合包。若父目录自身有 `SKILL.md`，后端仍按单目录 sparse checkout 安装，并保留其子技能、脚本和参考资料。
+
+目录来源分为三层：
+
+| 来源 | 快照 | 导入结果 |
+| --- | --- | --- |
+| 手工精选 | `client/src/data/skillProjects.ts` | 4 个基线条目 |
+| [anbeime/skill](https://github.com/anbeime/skill) | `011d53f4f238cf7cc8e2cdae8452fffaec7eb1ae` | 从本地 `skill-main` 与远端核对后生成 64 个项目，其中 2 个 SkillSet |
+| [VoltAgent/awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills) | `6c82fb77e5bf84de77d1074b2d98d65d75ea730e` | README 索引去重后生成 1,178 个项目，其中 475 个具有可验证 GitHub 子目录，703 个仅作外部索引 |
+
+VoltAgent 仓库自身不包含 `SKILL.md`，不能把仓库根目录当成 Skill 安装。只有 README 明确给出 GitHub `tree/.../<目录>` 或 `blob/.../SKILL.md` 的条目才生成 `installSource`；`officialskills.sh`、仓库根链接及其他外部链接保留为可搜索参考。
+
 ## 2. 如何添加新的 Skill 到市场
 
-市场数据位于：
+手工精选市场数据位于：
 
 ```text
 client/src/data/skillProjects.ts
+```
+
+自动生成目录位于：
+
+```text
+client/src/data/anbeimeSkillCatalog.generated.json
+client/src/data/voltagentSkillCatalog.generated.json
 ```
 
 新增条目时，优先填写 `installSource`：
@@ -58,6 +80,7 @@ client/src/data/skillProjects.ts
   repoName: "owner/repo",
   repoUrl: "https://github.com/owner/repo",
   category: "文档处理",
+  kind: "skill",
   description: "一句话说明这个 Skill 能帮用户完成什么。",
   readmeSummary: "README 摘要。",
   stars: 1200,
@@ -78,6 +101,36 @@ client/src/data/skillProjects.ts
 - `installSource.repoUrl` 必须是 GitHub 仓库地址。
 - `installSource.subPath` 必须指向包含 `SKILL.md` 的目录。
 - 没有 `installSource` 的条目会显示为“仅作参考”，不能一键安装。
+- `kind: "skillset"` 只用于真实组合包；如果可识别子技能，应同时填写 `includedSkills`。
+- 批量来源不要手改 `*.generated.json`，应重新运行同步脚本。
+
+### 2.1 同步 anbeime 本地目录
+
+先确认本地副本与远端提交一致，再运行：
+
+```bash
+node scripts/sync-anbeime-skill-catalog.mjs <anbeime-checkout> \
+  --commit <verified-main-sha> \
+  --stars <repo-stars> \
+  --updated-at <YYYY-MM-DD>
+```
+
+生成器会扫描实际 `SKILL.md`、按标准化内容去重、排除 `_template` 与占位文件、识别嵌套 SkillSet，并从 `scripts/`、`references/`、`assets/` 生成标签。
+
+同步过程保留第三方 `SKILL.md` 原文，不会替上游重写 frontmatter。当前 64 个 anbeime 项目中，33 个通过 Codex `quick_validate.py` 的严格格式检查；另外 31 个主要使用了上游自定义的 `dependency` 字段。模镜安装器只读取 `name`、`description` 并支持标题回退，因此这些条目可进入市场，但“可安装”不等于“已通过 Codex 严格格式认证”。使用前仍需审查第三方依赖、脚本和密钥要求。
+
+### 2.2 同步 VoltAgent 索引
+
+```bash
+node scripts/sync-voltagent-skill-index.mjs <awesome-agent-skills-checkout> \
+  --commit <verified-main-sha> \
+  --stars <repo-stars> \
+  --updated-at <YYYY-MM-DD>
+```
+
+同步器只读取 README，不抓取或执行外部 Skill。它保留原始来源链接，并仅对后端当前可验证的 GitHub 子目录开放一键安装。
+
+两个脚本都支持 `--check`。传入与生成时相同的来源和快照参数，可验证已提交 JSON 是否过期。
 
 ## 3. 后端 API 文档
 
@@ -159,8 +212,10 @@ curl -X DELETE http://localhost:8000/api/skills/anthropics-skills-skills-pdf
 
 `/skills` 页面分为两个标签：
 
-- `技能市场`：展示 `skillProjects.ts` 中的 Skill 卡片，提供安装按钮。
+- `技能市场`：合并手工精选与两个生成目录，支持关键词、功能分类、Skill/SkillSet、可安装状态筛选；默认分批渲染 48 项，避免一次挂载全部索引卡片。
 - `已安装`：调用 `/api/skills/installed`，展示本地已安装 Skill，提供卸载按钮。
+
+社区资源卡片同时显示原始来源与收录索引。安装第三方条目只会复制目录，不会在安装阶段自动执行脚本；用户仍需在激活前检查依赖、外部服务和凭据要求。
 
 面试间 `/chat/:modelId` 增加 Skill 选择器：
 
@@ -185,6 +240,14 @@ curl -X DELETE http://localhost:8000/api/skills/anthropics-skills-skills-pdf
 python -m pytest server/tests/test_skill_integration.py -q
 ```
 
+目录快照检查：
+
+```bash
+node scripts/sync-anbeime-skill-catalog.mjs <anbeime-checkout> <其余快照参数> --check
+node scripts/sync-voltagent-skill-index.mjs <voltagent-checkout> <其余快照参数> --check
+cd client && npm.cmd run build
+```
+
 覆盖范围：
 
 - 安装本地 mock Skill。
@@ -192,6 +255,8 @@ python -m pytest server/tests/test_skill_integration.py -q
 - 读取 `SKILL.md` 原文。
 - 卸载 Skill 并清理目录。
 - 默认生产配置拒绝非 GitHub 来源。
+- anbeime 目录无未分类项目、无重复 id，Skill 与 SkillSet 类型合法。
+- VoltAgent 索引只为 GitHub 明确子路径生成 `installSource`，外部索引保持不可安装。
 
 手动验收：
 

--- a/scripts/sync-anbeime-skill-catalog.mjs
+++ b/scripts/sync-anbeime-skill-catalog.mjs
@@ -1,0 +1,412 @@
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import {
+  existsSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, dirname, extname, join, relative, resolve, sep } from "node:path";
+
+const REPO_NAME = "anbeime/skill";
+const REPO_URL = "https://github.com/anbeime/skill";
+const DEFAULT_OUTPUT = "client/src/data/anbeimeSkillCatalog.generated.json";
+
+const CATEGORY_GROUPS = {
+  "内容创作与发布": [
+    "article-illustrator",
+    "bedtime-story",
+    "content-creation-publisher",
+    "content-research-writer",
+    "data-storytelling",
+    "intelligent-content-system",
+    "baoyu-format-markdown",
+    "baoyu-post-to-wechat",
+    "baoyu-post-to-x",
+    "baoyu-url-to-markdown",
+    "qiaomu-x-article-publisher",
+    "wechatsync-publisher",
+  ],
+  "浏览器与自动化": ["chrome-automation"],
+  "电商与营销": [
+    "agentkit-multimedia-shopping",
+    "digital-avatar-shopping-video",
+    "dream-video-prompt-generator",
+    "ecommerce-copywriter",
+    "ecommerce-full-pipeline",
+    "ecommerce-video-marketing",
+    "infinitetalk-shopping-avatar",
+    "pet-commerce-creator",
+    "product-marketing-copywriter",
+    "product-video-creator",
+    "wechat-hotspot-publisher",
+    "xiaohongshu-makeup",
+  ],
+  "界面与设计": [
+    "frontend-design",
+    "icon-generator",
+    "pop-up-book-illustration",
+    "web-design-analyzer",
+    "web-to-app",
+  ],
+  "视频创作": [
+    "historical-interview-scripts",
+    "historical-science-video-prod",
+    "media-processor",
+    "remotion-video-enhancer",
+    "three-body-video-creator",
+    "video-creation-collaborator",
+    "video-creation-pro",
+    "video-creation-suite",
+    "video-frame-extractor",
+    "video-recreation",
+    "video-transcript-downloader",
+    "viral-video-copywriting",
+  ],
+  "语音与数字人": [
+    "infinitetalk",
+    "qwen3-asr-assistant",
+    "qwen3-tts-local",
+    "tts-voice-synthesis",
+  ],
+  "文档与研究": [
+    "contract-review",
+    "law-to-markdown",
+    "paper-analysis-assistant",
+    "pdf-processing-pro",
+  ],
+  "PPT 与演示": [
+    "nanobanana-ppt-visualizer",
+    "ppt-generator",
+    "ppt-roadshow-generator",
+    "pptx-generator",
+  ],
+  "智能体协作": ["agent-team", "multi-agent-meeting"],
+  "知识管理": [
+    "json-canvas",
+    "obsidian-bases",
+    "obsidian-markdown",
+    "obsidian-skills-integrated",
+  ],
+  "产品与职业": ["product-manager-toolkit", "tailored-resume-generator"],
+  "金融分析": ["stock-analysis"],
+  "文化创作": ["poetry-music-visual"],
+  "社区与社交": ["moltbook"],
+};
+
+const EXCLUDED_RELATIVE_PATHS = new Set([
+  "skills/qiaomu-x-article-publisher/qiaomu-x-article-publisher-github/SKILL.md",
+]);
+
+const CATEGORY_BY_DIRECTORY = new Map(
+  Object.entries(CATEGORY_GROUPS).flatMap(([category, directories]) =>
+    directories.map((directory) => [directory, category]),
+  ),
+);
+
+const LANGUAGE_BY_EXTENSION = new Map([
+  [".md", "Markdown"],
+  [".py", "Python"],
+  [".ts", "TypeScript"],
+  [".tsx", "TypeScript"],
+  [".js", "JavaScript"],
+  [".mjs", "JavaScript"],
+  [".sh", "Shell"],
+  [".ps1", "PowerShell"],
+  [".css", "CSS"],
+]);
+
+function parseArguments(argv) {
+  const options = {
+    sourceRoot: "",
+    outputPath: DEFAULT_OUTPUT,
+    commit: "",
+    stars: 0,
+    updatedAt: "",
+    check: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index];
+    if (value === "--output") options.outputPath = argv[++index] ?? "";
+    else if (value === "--commit") options.commit = argv[++index] ?? "";
+    else if (value === "--stars") options.stars = Number(argv[++index] ?? 0);
+    else if (value === "--updated-at") options.updatedAt = argv[++index] ?? "";
+    else if (value === "--check") options.check = true;
+    else if (!value.startsWith("--") && !options.sourceRoot) options.sourceRoot = value;
+    else throw new Error(`Unknown argument: ${value}`);
+  }
+
+  if (!options.sourceRoot) {
+    throw new Error(
+      "Usage: node scripts/sync-anbeime-skill-catalog.mjs <source-root> [--commit <sha>] [--stars <count>] [--updated-at <YYYY-MM-DD>] [--output <path>] [--check]",
+    );
+  }
+  return options;
+}
+
+function toPosixPath(value) {
+  return value.split(sep).join("/");
+}
+
+function walkFiles(root) {
+  const files = [];
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    if (entry.name === ".git" || entry.name === "node_modules") continue;
+    const fullPath = join(root, entry.name);
+    if (entry.isDirectory()) files.push(...walkFiles(fullPath));
+    else if (entry.isFile()) files.push(fullPath);
+  }
+  return files;
+}
+
+function stripYamlQuotes(value) {
+  const trimmed = value.trim();
+  if (
+    trimmed.length >= 2 &&
+    ((trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+      (trimmed.startsWith("'") && trimmed.endsWith("'")))
+  ) {
+    return trimmed.slice(1, -1).replace(/\\"/g, '"').replace(/''/g, "'");
+  }
+  return trimmed;
+}
+
+function parseFrontmatter(content) {
+  const normalized = content.replace(/^\uFEFF/, "").replace(/\r\n/g, "\n");
+  const match = normalized.match(/^---\s*\n([\s\S]*?)\n---(?:\s*\n|$)/);
+  if (!match) return { body: normalized, values: {} };
+
+  const lines = match[1].split("\n");
+  const values = {};
+  for (let index = 0; index < lines.length; index += 1) {
+    const keyMatch = lines[index].match(/^([A-Za-z][A-Za-z0-9_-]*):\s*(.*)$/);
+    if (!keyMatch) continue;
+    const [, key, rawValue] = keyMatch;
+    if (key !== "name" && key !== "description") continue;
+
+    if (/^[>|][+-]?$/.test(rawValue.trim())) {
+      const blockLines = [];
+      while (index + 1 < lines.length && /^\s+/.test(lines[index + 1])) {
+        blockLines.push(lines[++index].trim());
+      }
+      values[key] = blockLines.filter(Boolean).join(" ");
+    } else {
+      values[key] = stripYamlQuotes(rawValue);
+    }
+  }
+
+  return { body: normalized.slice(match[0].length), values };
+}
+
+function firstHeading(body) {
+  return body
+    .split("\n")
+    .map((line) => line.trim())
+    .find((line) => /^#{1,6}\s+/.test(line))
+    ?.replace(/^#{1,6}\s+/, "")
+    .trim();
+}
+
+function firstParagraph(body) {
+  return body
+    .split("\n")
+    .map((line) => line.trim())
+    .find(
+      (line) =>
+        line &&
+        !line.startsWith("#") &&
+        !line.startsWith("```") &&
+        !line.startsWith("<!--"),
+    );
+}
+
+function normalizeSkillName(value, fallback) {
+  return (value || fallback)
+    .replace(/\s+/g, " ")
+    .replace(/^['"]|['"]$/g, "")
+    .trim();
+}
+
+function normalizeDescription(value, fallback) {
+  const result = (value || fallback || "社区 Skill，安装前请检查其说明与依赖。")
+    .replace(/\s+/g, " ")
+    .trim();
+  return result.length > 220 ? `${result.slice(0, 217)}...` : result;
+}
+
+function normalizeNameForMatch(value) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+function normalizedContentHash(content) {
+  return createHash("sha256")
+    .update(content.replace(/^\uFEFF/, "").replace(/\r\n/g, "\n"))
+    .digest("hex");
+}
+
+function canonicalScore(record) {
+  const directoryName = basename(dirname(record.fullPath)).toLowerCase();
+  const nameMatchesDirectory = normalizeNameForMatch(record.name) === directoryName;
+  const depth = record.relativePath.split("/").length;
+  return (nameMatchesDirectory ? 10_000 : 0) - depth * 100 - record.relativePath.length;
+}
+
+function resolveGitCommit(sourceRoot, explicitCommit) {
+  if (explicitCommit) return explicitCommit;
+  try {
+    return execFileSync("git", ["-C", sourceRoot, "rev-parse", "HEAD"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    throw new Error("Source is not a Git checkout. Pass --commit with the verified remote SHA.");
+  }
+}
+
+function buildCatalog(options) {
+  const sourceRoot = resolve(options.sourceRoot);
+  const skillsRoot = join(sourceRoot, "skills");
+  if (!existsSync(skillsRoot) || !statSync(skillsRoot).isDirectory()) {
+    throw new Error(`Skills directory not found: ${skillsRoot}`);
+  }
+
+  const sourceFiles = walkFiles(skillsRoot);
+  const skillFiles = sourceFiles.filter((file) => basename(file) === "SKILL.md");
+  const parsedRecords = skillFiles
+    .map((fullPath) => {
+      const content = readFileSync(fullPath, "utf8");
+      const { body, values } = parseFrontmatter(content);
+      const directoryName = basename(dirname(fullPath));
+      return {
+        body,
+        content,
+        description: normalizeDescription(values.description, firstParagraph(body)),
+        fullPath,
+        hash: normalizedContentHash(content),
+        name: normalizeSkillName(values.name, firstHeading(body) || directoryName),
+        relativePath: toPosixPath(relative(sourceRoot, fullPath)),
+      };
+    })
+    .filter(
+      (record) =>
+        !record.relativePath.includes("/skills/_template/") &&
+        !record.relativePath.startsWith("skills/_template/") &&
+        !EXCLUDED_RELATIVE_PATHS.has(record.relativePath) &&
+        !/(?:此文件为占位文件|<占位符>)/.test(record.content),
+    );
+
+  const recordsByHash = new Map();
+  for (const record of parsedRecords) {
+    const group = recordsByHash.get(record.hash) ?? [];
+    group.push(record);
+    recordsByHash.set(record.hash, group);
+  }
+
+  const canonicalRecords = [...recordsByHash.values()].map((duplicates) =>
+    [...duplicates].sort((left, right) => canonicalScore(right) - canonicalScore(left))[0],
+  );
+
+  const projects = canonicalRecords.map((record) => {
+    const packageDirectory = dirname(record.fullPath);
+    const directoryKey = basename(packageDirectory).toLowerCase();
+    const packageFiles = sourceFiles.filter(
+      (file) => file === packageDirectory || file.startsWith(`${packageDirectory}${sep}`),
+    );
+    const nestedSkillNames = parsedRecords
+      .filter(
+        (candidate) =>
+          candidate.fullPath !== record.fullPath &&
+          candidate.fullPath.startsWith(`${packageDirectory}${sep}`),
+      )
+      .map((candidate) => candidate.name)
+      .filter((name, index, names) => name !== record.name && names.indexOf(name) === index);
+    const languages = [
+      ...new Set(
+        packageFiles
+          .map((file) => LANGUAGE_BY_EXTENSION.get(extname(file).toLowerCase()))
+          .filter(Boolean),
+      ),
+    ].slice(0, 4);
+    const hasDirectory = (directory) =>
+      packageFiles.some((file) =>
+        toPosixPath(relative(packageDirectory, file)).startsWith(`${directory}/`),
+      );
+    const kind = nestedSkillNames.length > 0 ? "skillset" : "skill";
+    const tags =
+      kind === "skillset"
+        ? ["社区来源", "技能包", `${nestedSkillNames.length} 个子技能`]
+        : [
+            "社区来源",
+            hasDirectory("scripts") ? "含脚本" : "说明型",
+            hasDirectory("references")
+              ? "含参考资料"
+              : hasDirectory("assets")
+                ? "含资源"
+                : "独立技能",
+          ];
+    const category = CATEGORY_BY_DIRECTORY.get(directoryKey) ?? "其他工具";
+
+    return {
+      id: `anbeime-${directoryKey}`,
+      name: record.name,
+      kind,
+      category,
+      description: record.description,
+      subPath: toPosixPath(relative(sourceRoot, packageDirectory)),
+      language: languages.join(" / ") || "Markdown",
+      tags,
+      includedSkills: nestedSkillNames,
+    };
+  });
+
+  projects.sort((left, right) =>
+    left.category.localeCompare(right.category, "zh-CN") ||
+    left.name.localeCompare(right.name, "zh-CN"),
+  );
+
+  const duplicateIds = projects.filter(
+    (project, index) => projects.findIndex((candidate) => candidate.id === project.id) !== index,
+  );
+  if (duplicateIds.length > 0) {
+    throw new Error(`Duplicate catalog ids: ${duplicateIds.map((item) => item.id).join(", ")}`);
+  }
+
+  return {
+    source: {
+      repoName: REPO_NAME,
+      repoUrl: REPO_URL,
+      commit: resolveGitCommit(sourceRoot, options.commit),
+      updatedAt: options.updatedAt || new Date().toISOString().slice(0, 10),
+      stars: options.stars,
+      discoveredSkillFiles: skillFiles.length,
+      catalogProjects: projects.length,
+    },
+    projects,
+  };
+}
+
+function main() {
+  const options = parseArguments(process.argv.slice(2));
+  const outputPath = resolve(options.outputPath);
+  const serialized = `${JSON.stringify(buildCatalog(options), null, 2)}\n`;
+
+  if (options.check) {
+    if (!existsSync(outputPath)) throw new Error(`Catalog does not exist: ${outputPath}`);
+    const currentCatalog = readFileSync(outputPath, "utf8").replace(/\r\n?/g, "\n");
+    if (currentCatalog !== serialized) {
+      throw new Error(`Catalog is stale: ${outputPath}`);
+    }
+    console.log(`Catalog is current: ${outputPath}`);
+    return;
+  }
+
+  writeFileSync(outputPath, serialized, "utf8");
+  console.log(`Wrote ${JSON.parse(serialized).projects.length} projects to ${outputPath}`);
+}
+
+main();

--- a/scripts/sync-voltagent-skill-index.mjs
+++ b/scripts/sync-voltagent-skill-index.mjs
@@ -1,0 +1,270 @@
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const REPO_NAME = "VoltAgent/awesome-agent-skills";
+const REPO_URL = "https://github.com/VoltAgent/awesome-agent-skills";
+const DEFAULT_OUTPUT = "client/src/data/voltagentSkillCatalog.generated.json";
+
+const SECTION_CATEGORIES = new Map([
+  ["Development and Testing", "测试与质量"],
+  ["Data and Analysis", "数据与分析"],
+  ["Business and Marketing", "内容与营销"],
+  ["Content and Communication", "内容与营销"],
+  ["Creative and Media", "多媒体创作"],
+  ["Productivity and Collaboration", "文档与办公"],
+  ["Security Skills by Trail of Bits Team", "安全与合规"],
+  ["Product Manager Skills by Dean Peters", "产品与项目"],
+  ["Product Management Skills by Pawel Huryn", "产品与项目"],
+  ["Marketing Skills by Corey Haines", "内容与营销"],
+  ["Advertising Skills by Kim Barrett", "内容与营销"],
+]);
+
+const CATEGORY_RULES = [
+  ["安全与合规", /\b(security|secure|vulnerab|threat|pentest|malware|compliance|incident|auth(?:entication)?|permission|privacy|forensic|audit)\b/i],
+  ["测试与质量", /\b(test|testing|qa|quality|playwright|cypress|selenium|jest|vitest|pytest|junit|rspec|debug|profil|performance|benchmark)\b/i],
+  ["云与运维", /\b(cloud|devops|deploy|deployment|docker|kubernetes|terraform|infrastructure|ci\/cd|pipeline|observability|sre|serverless|cloudflare|netlify|vercel|azure|aws|gcp)\b/i],
+  ["后端与数据库", /\b(database|postgres|postgresql|mysql|sqlite|sql\b|redis|mongodb|firebase|supabase|clickhouse|duckdb|graphql|backend|api\b|webhook|server\b|cache|queue)\b/i],
+  ["前端与移动", /\b(frontend|react(?: native)?|next\.js|angular|vue|svelte|flutter|expo|ios\b|android\b|mobile|css\b|tailwind|web component)\b/i],
+  ["文档与办公", /\b(document|docs?\b|docx|pdf\b|xlsx|spreadsheet|excel|pptx|slides?|presentation|notion|workspace|meeting|calendar|email|knowledge|markdown)\b/i],
+  ["数据与分析", /\b(data|analytics|analysis|visuali[sz]ation|metric|statistics|forecast|research|dataset|machine learning|ml\b|jupyter)\b/i],
+  ["内容与营销", /\b(marketing|seo\b|content|copywriting|social|advertis|campaign|brand|newsletter|growth|sales|customer|commerce|shopify)\b/i],
+  ["产品与项目", /\b(product|roadmap|project|agile|scrum|jira|linear|requirements|prd\b|user stor|prioriti[sz]|stakeholder)\b/i],
+  ["多媒体创作", /\b(image|video|audio|music|voice|animation|3d\b|blender|remotion|design|figma|creative|art\b|media|game)\b/i],
+  ["AI 与智能体", /\b(agent|llm\b|ai\b|prompt|rag\b|mcp\b|model|embedding|inference|hugging face|nvidia|gemini|claude)\b/i],
+  ["工程开发", /\b(code|coding|developer|development|git\b|github|refactor|architecture|framework|sdk\b|cli\b|typescript|javascript|python|java\b|rust\b|golang|go\b|ruby|php\b|\.net)\b/i],
+];
+
+function parseArguments(argv) {
+  const options = {
+    sourceRoot: "",
+    outputPath: DEFAULT_OUTPUT,
+    commit: "",
+    stars: 0,
+    updatedAt: "",
+    check: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index];
+    if (value === "--output") options.outputPath = argv[++index] ?? "";
+    else if (value === "--commit") options.commit = argv[++index] ?? "";
+    else if (value === "--stars") options.stars = Number(argv[++index] ?? 0);
+    else if (value === "--updated-at") options.updatedAt = argv[++index] ?? "";
+    else if (value === "--check") options.check = true;
+    else if (!value.startsWith("--") && !options.sourceRoot) options.sourceRoot = value;
+    else throw new Error(`Unknown argument: ${value}`);
+  }
+
+  if (!options.sourceRoot) {
+    throw new Error(
+      "Usage: node scripts/sync-voltagent-skill-index.mjs <source-root> [--commit <sha>] [--stars <count>] [--updated-at <YYYY-MM-DD>] [--output <path>] [--check]",
+    );
+  }
+  return options;
+}
+
+function resolveGitCommit(sourceRoot, explicitCommit) {
+  if (explicitCommit) return explicitCommit;
+  return execFileSync("git", ["-C", sourceRoot, "rev-parse", "HEAD"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  }).trim();
+}
+
+function decodeEntities(value) {
+  return value
+    .replace(/&amp;/g, "&")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;|&apos;/g, "'")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">");
+}
+
+function stripMarkup(value) {
+  return decodeEntities(value)
+    .replace(/<[^>]+>/g, "")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/[*_`]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function slugify(value) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 100);
+}
+
+function shortHash(value) {
+  return createHash("sha256").update(value).digest("hex").slice(0, 8);
+}
+
+function inferCategory(section, name, description) {
+  const sectionCategory = SECTION_CATEGORIES.get(section);
+  if (sectionCategory) return sectionCategory;
+  const searchable = `${section} ${name} ${description}`;
+  return CATEGORY_RULES.find(([, pattern]) => pattern.test(searchable))?.[0] ?? "其他工具";
+}
+
+function inferKind(name, description, sourceUrl) {
+  let pointsToRepositoryRoot = false;
+  try {
+    const url = new URL(sourceUrl);
+    pointsToRepositoryRoot =
+      url.hostname.toLowerCase() === "github.com" &&
+      url.pathname.split("/").filter(Boolean).length === 2;
+  } catch {
+    pointsToRepositoryRoot = false;
+  }
+  const nameSignalsPackage =
+    /(?:^|[\/-])(skillset|[^/]*skillpack|[^/]*skill-pack|[^/]*bundle)$/i.test(name) ||
+    (pointsToRepositoryRoot && /(?:^|[\/-])[^/]*skills$/i.test(name));
+  const descriptionSignalsPackage = /\b(?:suite|collection|repository|bundle|pack) of [^.]{0,80}\bskills\b|\bskills (?:suite|collection|library|bundle|pack)\b/i.test(
+    description,
+  );
+  return nameSignalsPackage || descriptionSignalsPackage
+    ? "skillset"
+    : "skill";
+}
+
+function githubInstallSource(rawUrl) {
+  let url;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== "https:" || url.hostname.toLowerCase() !== "github.com") return null;
+
+  const parts = url.pathname.split("/").filter(Boolean);
+  if (parts.length < 5 || !["tree", "blob"].includes(parts[2])) return null;
+  if (!/^(main|master)$/.test(parts[3])) return null;
+
+  const owner = parts[0];
+  const repository = parts[1].replace(/\.git$/, "");
+  const subPathParts = parts.slice(4);
+  if (parts[2] === "blob") {
+    if (subPathParts.at(-1)?.toLowerCase() !== "skill.md") return null;
+    subPathParts.pop();
+  }
+  if (
+    !/^[A-Za-z0-9_.-]+$/.test(owner) ||
+    !/^[A-Za-z0-9_.-]+$/.test(repository) ||
+    subPathParts.length === 0 ||
+    subPathParts.some((part) => !/^[A-Za-z0-9_.-]+$/.test(part))
+  ) {
+    return null;
+  }
+
+  return {
+    repoUrl: `https://github.com/${owner}/${repository}`,
+    subPath: subPathParts.join("/"),
+  };
+}
+
+function parseReadme(readme) {
+  const entries = [];
+  let section = "未分类";
+
+  for (const line of readme.split(/\r?\n/)) {
+    const summaryMatch = line.match(/<summary><h3[^>]*>(.*?)<\/h3><\/summary>/i);
+    if (summaryMatch) section = stripMarkup(summaryMatch[1]).replace(/\.$/, "");
+
+    const skillMatch = line.match(
+      /^- \*\*\[([^\]]+)\]\(([^)]+)\)\*\*\s+-\s+(.+)$/,
+    );
+    if (!skillMatch) continue;
+
+    const name = stripMarkup(skillMatch[1]);
+    const url = decodeEntities(skillMatch[2].trim());
+    const description = stripMarkup(skillMatch[3]);
+    entries.push({ name, url, description, section });
+  }
+
+  const seen = new Set();
+  return entries.filter((entry) => {
+    const key = `${entry.name}\n${entry.url}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function buildCatalog(options) {
+  const sourceRoot = resolve(options.sourceRoot);
+  const readmePath = resolve(sourceRoot, "README.md");
+  if (!existsSync(readmePath)) throw new Error(`README.md not found: ${readmePath}`);
+
+  const entries = parseReadme(readFileSync(readmePath, "utf8"));
+  const usedIds = new Set();
+  const projects = entries.map((entry) => {
+    const baseId = `voltagent-${slugify(entry.name) || "skill"}`;
+    const id = usedIds.has(baseId) ? `${baseId}-${shortHash(`${entry.name}\n${entry.url}`)}` : baseId;
+    usedIds.add(id);
+    const installSource = githubInstallSource(entry.url);
+    const publisher = entry.name.includes("/") ? entry.name.split("/", 1)[0] : entry.section;
+    const kind = inferKind(entry.name, entry.description, entry.url);
+
+    return {
+      id,
+      name: entry.name,
+      kind,
+      category: inferCategory(entry.section, entry.name, entry.description),
+      publisher,
+      sourceGroup: entry.section,
+      description: entry.description,
+      sourceUrl: entry.url,
+      installSource,
+      tags: [
+        "VoltAgent 索引",
+        installSource ? "可一键安装" : "外部索引",
+        kind === "skillset" ? "技能包" : publisher,
+      ],
+      includedSkills: [],
+    };
+  });
+
+  const installableProjects = projects.filter((project) => project.installSource).length;
+  return {
+    source: {
+      repoName: REPO_NAME,
+      repoUrl: REPO_URL,
+      commit: resolveGitCommit(sourceRoot, options.commit),
+      updatedAt: options.updatedAt || new Date().toISOString().slice(0, 10),
+      stars: options.stars,
+      indexedEntries: projects.length,
+      installableProjects,
+      referenceProjects: projects.length - installableProjects,
+      sourceGroups: new Set(projects.map((project) => project.sourceGroup)).size,
+    },
+    projects,
+  };
+}
+
+function main() {
+  const options = parseArguments(process.argv.slice(2));
+  const outputPath = resolve(options.outputPath);
+  const serialized = `${JSON.stringify(buildCatalog(options), null, 2)}\n`;
+
+  if (options.check) {
+    if (!existsSync(outputPath)) throw new Error(`Catalog does not exist: ${outputPath}`);
+    const currentCatalog = readFileSync(outputPath, "utf8").replace(/\r\n?/g, "\n");
+    if (currentCatalog !== serialized) {
+      throw new Error(`Catalog is stale: ${outputPath}`);
+    }
+    console.log(`Catalog is current: ${outputPath}`);
+    return;
+  }
+
+  writeFileSync(outputPath, serialized, "utf8");
+  const catalog = JSON.parse(serialized);
+  console.log(
+    `Wrote ${catalog.projects.length} projects (${catalog.source.installableProjects} installable) to ${outputPath}`,
+  );
+}
+
+main();


### PR DESCRIPTION
## 改动内容

- 新增 `skill` / `skillset` 类型及组合包元数据。
- 接入固定提交的 `anbeime/skill` 快照：64 项，其中 2 个 SkillSet。
- 接入 `VoltAgent/awesome-agent-skills` 索引：1,178 项，其中 475 项具有可验证 GitHub 子目录，703 项保留为外部参考。
- Skill 市场合计 1,246 项、542 项可直接安装、45 个 SkillSet；增加搜索、分类、类型、安装能力筛选及每批 48 项的渐进渲染。
- 新增两个可复现目录同步器，并兼容 Windows CRLF 工作树的 `--check`。
- 更新 Skill 集成、架构和数据快照文档。

## 原因与影响

扩充现有 Skill 市场，同时区分可直接安装的 GitHub Skill 子目录与仅供检索的外部索引，避免把聚合仓库根目录误当成可安装 Skill。第三方内容保持原文，不会在同步或浏览阶段执行外部脚本。

## 范围护栏

- PR 只包含 9 个 Skill 数据、页面、同步器和文档文件。
- 不包含 MCP 实现文件、`/coding` 页面或 Coding Runtime 改动。
- 共享栈重建时没有使用 `--remove-orphans`；现存 `modelmirror-coding-*` 容器未被重建或删除。

## 验证

- `node scripts/sync-anbeime-skill-catalog.mjs ... --check`：通过
- `node scripts/sync-voltagent-skill-index.mjs ... --check`：通过
- `npm.cmd ci && npm.cmd run build`：通过
- `docker compose -p modelmirror up -d --build --force-recreate`：通过
- `GET /api/health`：`{"status":"ok"}`
- `/models`、`/skills`、`/studio`：HTTP 200
- 重建镜像运行 `server/tests/test_skill_integration.py -q`：3 passed

## 已知事项

- Vite 仍提示主 chunk 超过 4.5 MB，功能构建成功。
- `npm ci` 对现有锁文件报告 4 个依赖漏洞；本 PR 未修改依赖清单。
- 64 个 anbeime 项目中 33 个通过 Codex 严格格式校验，31 个主要使用上游自定义 `dependency` frontmatter；兼容边界已写入文档。
