### PR TITLE
feature: 添加 Coding 自定义项目命令与验证闭环

### DIFF
--- a/client/src/components/CodingChangesPanel.tsx
+++ b/client/src/components/CodingChangesPanel.tsx
@@ -49,6 +49,7 @@ interface CodingChangesPanelProps {
   onDiscard: () => Promise<void>;
   onDownload: () => Promise<void>;
   onCancelVerification: () => Promise<void>;
+  onConfirmVerification: () => Promise<void>;
   onRequestFix: (prompt: string) => void;
   onRunVerification: () => Promise<void>;
   onMarkPublishReady: () => Promise<void>;
@@ -572,6 +573,7 @@ export default function CodingChangesPanel({
   onDiscard,
   onDownload,
   onCancelVerification,
+  onConfirmVerification,
   onRequestFix,
   onRunVerification,
   onMarkPublishReady,
@@ -659,7 +661,10 @@ export default function CodingChangesPanel({
   );
   const isActing = action !== "idle";
   const verificationRunning =
-    verification?.state === "running" && verification.stale === false;
+    verification?.stale === false &&
+    ["awaiting_confirmation", "running"].includes(
+      verification?.state ?? "",
+    );
   const verificationSupportsDownload =
     verification?.revision === changes?.revision &&
     verification?.stale === false &&
@@ -857,12 +862,24 @@ export default function CodingChangesPanel({
             </ul>
 
             {localDraftOnly ? (
-              <div className="mt-4 rounded-lg border border-cyan-300/20 bg-cyan-300/[0.07] p-3 text-sm text-cyan-100">
-                <p className="font-semibold">此项目只准备修改草稿</p>
-                <p className="mt-1 text-xs leading-5 text-slate-300">
-                  你可以逐项查看、检查并下载 Diff。页面不会运行项目验证，也不会把修改写入本地项目。
-                </p>
-              </div>
+              <>
+                <div className="mt-4 rounded-lg border border-cyan-300/20 bg-cyan-300/[0.07] p-3 text-sm text-cyan-100">
+                  <p className="font-semibold">本地项目保持不变</p>
+                  <p className="mt-1 text-xs leading-5 text-slate-300">
+                    你可以查看 Diff、运行确认过的检查并下载修改。所有检查都在临时副本中完成，不会写入本地项目。
+                  </p>
+                </div>
+                <CodingVerificationPanel
+                  available={verificationAvailable}
+                  disabled={disabled || readOnly || frozen || isActing}
+                  error={verificationError}
+                  onCancel={onCancelVerification}
+                  onConfirm={onConfirmVerification}
+                  onRequestFix={onRequestFix}
+                  onRun={onRunVerification}
+                  verification={verification}
+                />
+              </>
             ) : (
               <>
                 <CodingVerificationPanel
@@ -870,6 +887,7 @@ export default function CodingChangesPanel({
                   disabled={disabled || readOnly || frozen || isActing}
                   error={verificationError}
                   onCancel={onCancelVerification}
+                  onConfirm={onConfirmVerification}
                   onRequestFix={onRequestFix}
                   onRun={onRunVerification}
                   verification={verification}
@@ -1068,6 +1086,7 @@ export default function CodingChangesPanel({
               empty
               error={verificationError}
               onCancel={onCancelVerification}
+              onConfirm={onConfirmVerification}
               onRequestFix={onRequestFix}
               onRun={onRunVerification}
               verification={verification}

--- a/client/src/components/CodingVerificationPanel.tsx
+++ b/client/src/components/CodingVerificationPanel.tsx
@@ -20,12 +20,13 @@ interface CodingVerificationPanelProps {
   empty?: boolean;
   error: string;
   onCancel: () => Promise<void>;
+  onConfirm: () => Promise<void>;
   onRequestFix: (prompt: string) => void;
   onRun: () => Promise<void>;
   verification: CodingVerification | null;
 }
 
-type ActionState = "idle" | "starting" | "stopping";
+type ActionState = "idle" | "starting" | "stopping" | "confirming";
 
 const reasonText: Record<string, string> = {
   dependency_change_unsupported:
@@ -35,7 +36,14 @@ const reasonText: Record<string, string> = {
   verifier_unavailable: "项目验证服务未启动，仍可查看和下载修改。",
   snapshot_mismatch: "项目版本正在更新，暂时无法运行验证，请稍后重试。",
   verification_timeout: "检查等待时间过长，已自动停止。你可以稍后重新运行。",
+  runner_environment_not_ready:
+    "当前运行环境与项目依赖不一致，因此没有把环境问题误报为代码问题。你仍可查看和下载修改。",
+  no_project_checks: "此项目没有可运行的检查。你仍可查看和下载修改。",
 };
+
+function formatArgv(argv: string[]) {
+  return argv.map((argument) => JSON.stringify(argument)).join(" ");
+}
 
 function stepState(step: CodingVerificationStep) {
   if (step.state === "running") return "正在检查";
@@ -66,6 +74,14 @@ function statusCopy(verification: CodingVerification | null, empty: boolean) {
     return {
       title: "正在验证当前修改",
       description: "你可以继续查看文件；验证完成前不能开始新一轮修改。",
+      tone: "text-cyan-100",
+    };
+  }
+  if (verification.state === "awaiting_confirmation") {
+    return {
+      title: "等待你确认",
+      description:
+        "下方列出了准备运行的检查。确认后只会在临时项目副本中运行，不能联网，也不会改变你的本地项目。",
       tone: "text-cyan-100",
     };
   }
@@ -113,6 +129,7 @@ export default function CodingVerificationPanel({
   empty = false,
   error,
   onCancel,
+  onConfirm,
   onRequestFix,
   onRun,
   verification,
@@ -121,6 +138,9 @@ export default function CodingVerificationPanel({
   const copy = statusCopy(verification, empty);
   const isRunning =
     verification?.state === "running" && verification.stale === false;
+  const isAwaiting =
+    verification?.state === "awaiting_confirmation" &&
+    verification.stale === false;
   const failedSteps = empty
     ? []
     : verification?.steps.filter((step) => step.result === "failed") ?? [];
@@ -207,7 +227,35 @@ export default function CodingVerificationPanel({
           </div>
         </div>
 
-        {empty ? null : isRunning ? (
+        {empty ? null : isAwaiting ? (
+          <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row">
+            <button
+              className="inline-flex min-h-10 items-center justify-center rounded-lg border border-white/15 px-3 text-xs font-semibold text-slate-200 transition hover:bg-white/[0.05] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-300/60 disabled:cursor-not-allowed disabled:opacity-50"
+              disabled={action !== "idle"}
+              onClick={() => void runAction("stopping", onCancel)}
+              type="button"
+            >
+              暂不运行
+            </button>
+            <button
+              className="inline-flex min-h-10 items-center justify-center gap-2 rounded-lg bg-cyan-200 px-3 text-xs font-semibold text-slate-950 transition hover:bg-cyan-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-100 disabled:cursor-not-allowed disabled:opacity-50"
+              disabled={action !== "idle"}
+              onClick={() => void runAction("confirming", onConfirm)}
+              type="button"
+            >
+              {action === "confirming" ? (
+                <LoaderCircle
+                  aria-hidden="true"
+                  className="animate-spin motion-reduce:animate-none"
+                  size={14}
+                />
+              ) : (
+                <Play aria-hidden="true" size={14} />
+              )}
+              允许这些检查
+            </button>
+          </div>
+        ) : isRunning ? (
           <button
             className="inline-flex min-h-9 shrink-0 items-center justify-center gap-2 rounded-lg border border-amber-300/30 px-3 text-xs font-semibold text-amber-100 transition hover:bg-amber-300/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-200/70 disabled:cursor-not-allowed disabled:opacity-50"
             disabled={action !== "idle"}
@@ -283,6 +331,23 @@ export default function CodingVerificationPanel({
                 <p className="mt-1.5 break-words text-xs leading-5 text-slate-400">
                   {step.summary}
                 </p>
+              ) : null}
+              {step.command ? (
+                <details className="mt-2">
+                  <summary className="cursor-pointer text-xs font-medium text-slate-400 outline-none hover:text-slate-200 focus-visible:ring-2 focus-visible:ring-cyan-300/60">
+                    查看命令
+                  </summary>
+                  <div className="mt-2 min-w-0 rounded-lg bg-black/25 p-3">
+                    <code className="block overflow-x-auto whitespace-pre-wrap break-all font-mono text-xs leading-5 text-slate-300">
+                      {formatArgv(step.command.argv)}
+                    </code>
+                    {step.command.cwd !== "." ? (
+                      <p className="mt-1 text-[11px] text-slate-500">
+                        运行位置：{step.command.cwd}
+                      </p>
+                    ) : null}
+                  </div>
+                </details>
               ) : null}
               {step.details ? (
                 <details className="mt-2">

--- a/client/src/components/CodingVerificationPanel.tsx
+++ b/client/src/components/CodingVerificationPanel.tsx
@@ -38,7 +38,8 @@ const reasonText: Record<string, string> = {
   verification_timeout: "检查等待时间过长，已自动停止。你可以稍后重新运行。",
   runner_environment_not_ready:
     "当前运行环境与项目依赖不一致，因此没有把环境问题误报为代码问题。你仍可查看和下载修改。",
-  no_project_checks: "此项目没有可运行的检查。你仍可查看和下载修改。",
+  no_project_checks:
+    "此项目没有配置可运行的测试或检查，因此无法判断代码是否正确；这不代表验证通过。",
 };
 
 function formatArgv(argv: string[]) {
@@ -106,7 +107,10 @@ function statusCopy(verification: CodingVerification | null, empty: boolean) {
       tone: "text-amber-100",
     };
   }
-  if (verification.result === "not_applicable") {
+  if (
+    verification.result === "not_applicable" &&
+    verification.reason !== "no_project_checks"
+  ) {
     return {
       title: "本次修改无需项目验证",
       description:

--- a/client/src/pages/CodingPage.tsx
+++ b/client/src/pages/CodingPage.tsx
@@ -32,6 +32,7 @@ import PageContainer from "../components/PageContainer";
 import type {
   CodingApplyResult,
   CodingCapabilities,
+  CodingCommandRequest,
   CodingCommitResult,
   CodingCycleHistory,
   CodingDraftChanges,
@@ -46,18 +47,21 @@ import {
   applyCodingChanges,
   cancelCodingTurn,
   cancelCodingVerification,
+  confirmCodingVerification,
   closeCodingSession,
   commitCodingChanges,
   continueCodingSession,
   CodingApiError,
   connectCodingEvents,
   createCodingSession,
+  decideCodingCommand,
   discardCodingRecovery,
   discardCodingChanges,
   getCodingCapabilities,
   getCodingApplyStatus,
   getCodingChanges,
   getCodingCommitStatus,
+  getPendingCodingCommand,
   getCodingHistory,
   getCodingPatch,
   getCodingProjects,
@@ -102,6 +106,7 @@ const BUILTIN_PROJECT: CodingProjectSummary = {
     apply: true,
     chat: true,
     commit: true,
+    commands: false,
     diff: true,
     download: true,
     draft: true,
@@ -190,6 +195,12 @@ const errorMessage: Record<string, string> = {
   verifier_unavailable: "项目验证服务未启动，仍可查看和下载修改。",
   snapshot_mismatch: "项目版本已经变化，当前操作不能继续；已有修改仍可查看和下载。",
   verification_not_found: "本次项目验证记录已失效，请重新运行。",
+  verification_confirmation_stale:
+    "检查内容已经变化，请重新查看命令并再次确认。",
+  command_request_not_found: "这项检查已结束或过期，无需再次处理。",
+  command_decision_invalid: "没有识别到这次选择，请重新操作。",
+  command_turn_inactive: "本轮处理已经结束，这项检查不会运行。",
+  runner_unauthorized: "检查请求已失效，请让代码助手重新提出。",
   recovery_pending: "发现一份未完成的修改，请先选择继续、下载或放弃。",
   recovery_conflict: "外部内容后来发生变化，为避免覆盖人工内容，现在只允许查看或下载。",
   recovery_data_corrupt: "保存的修改无法安全读取，请下载可用内容或联系开发者处理。",
@@ -248,6 +259,10 @@ function toolKindLabel(kind: string) {
   return "查阅代码";
 }
 
+function formatArgv(argv: string[]) {
+  return argv.map((argument) => JSON.stringify(argument)).join(" ");
+}
+
 function CodingSidebar({
   isDraft,
   localDraftOnly,
@@ -278,14 +293,14 @@ function CodingSidebar({
           </li>
           <li>
             {localDraftOnly
-              ? "本轮不运行项目验证，也不创建本地提交或 GitHub PR。"
+              ? "项目检查和代码助手提出的命令都需要你确认，只会在临时副本中运行。"
               : isDraft
               ? "代码助手不会自行运行检查；项目验证只在你手动启动时执行固定步骤。"
               : "不会执行命令、运行测试或访问外部网站。"}
           </li>
           <li>
             {localDraftOnly
-              ? "代码助手不会执行命令、访问外部网站或启用项目内的扩展配置。"
+              ? "检查不能联网，运行产生的文件会被丢弃；不会创建本地提交或 GitHub PR。"
               : isDraft
               ? "只有你再次确认，才会保存为本地提交；不会自动上传或合并，发布到 GitHub 还需单独确认。当前项目目录始终不受影响。"
               : "不会修改文件、生成变更或提交代码。"}
@@ -298,6 +313,87 @@ function CodingSidebar({
         </ul>
       </div>
     </div>
+  );
+}
+
+function CodingCommandConfirmation({
+  action,
+  error,
+  onDecision,
+  request,
+}: {
+  action: "idle" | "allowing" | "rejecting";
+  error: string;
+  onDecision: (decision: "allow_once" | "reject") => Promise<void>;
+  request: CodingCommandRequest;
+}) {
+  return (
+    <section
+      aria-live="polite"
+      aria-labelledby="coding-command-title"
+      className="order-2 rounded-lg border border-cyan-300/25 bg-cyan-300/[0.07] p-4"
+    >
+      <div className="flex items-start gap-3">
+        <ShieldCheck
+          aria-hidden="true"
+          className="mt-0.5 shrink-0 text-cyan-200"
+          size={19}
+        />
+        <div className="min-w-0 flex-1">
+          <h2 className="text-sm font-semibold text-white" id="coding-command-title">
+            代码助手希望运行一项检查
+          </h2>
+          <p className="mt-1 text-sm font-medium text-cyan-100">
+            {request.command.name}
+          </p>
+          <p className="mt-1 max-w-2xl text-xs leading-5 text-slate-300">
+            只会在临时项目副本中运行，不能联网，也不会改变你的本地项目。
+          </p>
+          <details className="mt-3">
+            <summary className="cursor-pointer text-xs font-semibold text-slate-300 outline-none hover:text-white focus-visible:ring-2 focus-visible:ring-cyan-300/70">
+              查看命令
+            </summary>
+            <div className="mt-2 min-w-0 rounded-lg bg-black/25 p-3">
+              <code className="block overflow-x-auto whitespace-pre-wrap break-all font-mono text-xs leading-5 text-slate-300">
+                {formatArgv(request.command.argv)}
+              </code>
+              {request.command.cwd !== "." ? (
+                <p className="mt-1 text-[11px] text-slate-500">
+                  运行位置：{request.command.cwd}
+                </p>
+              ) : null}
+            </div>
+          </details>
+          <div className="mt-4 flex flex-col gap-2 sm:flex-row">
+            <button
+              className="inline-flex min-h-10 items-center justify-center rounded-lg border border-white/15 px-3 text-sm font-semibold text-slate-200 transition hover:bg-white/[0.05] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-300/60 disabled:cursor-not-allowed disabled:opacity-50"
+              disabled={action !== "idle"}
+              onClick={() => void onDecision("reject")}
+              type="button"
+            >
+              {action === "rejecting" ? "正在拒绝" : "暂不运行"}
+            </button>
+            <button
+              className="inline-flex min-h-10 items-center justify-center rounded-lg bg-cyan-200 px-3 text-sm font-semibold text-slate-950 transition hover:bg-cyan-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-100 disabled:cursor-not-allowed disabled:opacity-50"
+              disabled={action !== "idle"}
+              onClick={() => void onDecision("allow_once")}
+              type="button"
+            >
+              {action === "allowing" ? "正在开始" : "允许本次运行"}
+            </button>
+          </div>
+          <p aria-live="polite" className="mt-3 flex items-center gap-2 text-xs text-slate-400">
+            <Clock3 aria-hidden="true" size={13} />
+            等待你确认时，代码助手会暂停这项检查。
+          </p>
+          {error ? (
+            <p className="mt-2 text-xs leading-5 text-rose-100" role="alert">
+              {error}
+            </p>
+          ) : null}
+        </div>
+      </div>
+    </section>
   );
 }
 
@@ -333,6 +429,12 @@ export default function CodingPage() {
   const [verification, setVerification] =
     useState<CodingVerification | null>(null);
   const [verificationError, setVerificationError] = useState("");
+  const [pendingCommand, setPendingCommand] =
+    useState<CodingCommandRequest | null>(null);
+  const [commandAction, setCommandAction] = useState<
+    "idle" | "allowing" | "rejecting"
+  >("idle");
+  const [commandError, setCommandError] = useState("");
   const [applyResult, setApplyResult] = useState<CodingApplyResult | null>(
     null,
   );
@@ -368,11 +470,15 @@ export default function CodingPage() {
     (selectedProjectId === "modelmirror" ? BUILTIN_PROJECT : null);
   const isLocalProject = selectedProject?.kind === "local_clone";
   const supportsVerification = selectedProject?.features.verification !== false;
+  const supportsCommands = selectedProject?.features.commands === true;
   const supportsApply = selectedProject?.features.apply !== false;
   const supportsCommit = selectedProject?.features.commit !== false;
   const supportsPublish = selectedProject?.features.publish !== false;
   const verificationAvailable =
-    supportsVerification && capabilities?.verification.available === true;
+    supportsVerification &&
+    (isLocalProject
+      ? capabilities?.commands.available === true
+      : capabilities?.verification.available === true);
   const serviceAvailable = capabilities?.available === true;
   const selectedProjectAvailable = Boolean(
     selectedProject &&
@@ -384,6 +490,11 @@ export default function CodingPage() {
   const isBusy = ["starting", "running", "stopping"].includes(runState);
   const verificationRunning =
     verification?.state === "running" && verification.stale === false;
+  const verificationActive =
+    verification?.stale === false &&
+    ["awaiting_confirmation", "running"].includes(
+      verification?.state ?? "",
+    );
   const publishRunning =
     publishResult?.state === "publishing" ||
     publishResult?.state === "marking_ready";
@@ -491,6 +602,9 @@ export default function CodingPage() {
       setDraftNotice("");
       setVerification(null);
       setVerificationError("");
+      setPendingCommand(null);
+      setCommandAction("idle");
+      setCommandError("");
       setApplyResult(null);
       setApplyError("");
       setCommitResult(null);
@@ -552,6 +666,9 @@ export default function CodingPage() {
         setDraftNotice("");
         setVerification(null);
         setVerificationError("");
+        setPendingCommand(null);
+        setCommandAction("idle");
+        setCommandError("");
         setApplyResult(null);
         setApplyError("");
         setCommitResult(null);
@@ -707,6 +824,47 @@ export default function CodingPage() {
     sessionId,
     verification?.revision,
     verificationRunning,
+  ]);
+
+  useEffect(() => {
+    if (
+      !sessionId ||
+      !isLocalProject ||
+      !supportsCommands ||
+      capabilities?.commands.available !== true
+    ) {
+      setPendingCommand(null);
+      setCommandAction("idle");
+      setCommandError("");
+      return;
+    }
+    let active = true;
+    void getPendingCodingCommand(sessionId)
+      .then(({ pending }) => {
+        if (!active) return;
+        setPendingCommand(pending);
+        setCommandError("");
+      })
+      .catch((requestError) => {
+        if (!active) return;
+        if (
+          requestError instanceof CodingApiError &&
+          requestError.code === "session_not_found"
+        ) {
+          resetExpiredSession(sessionId);
+          return;
+        }
+        setCommandError(describeError(requestError));
+      });
+    return () => {
+      active = false;
+    };
+  }, [
+    capabilities?.commands.available,
+    isLocalProject,
+    resetExpiredSession,
+    sessionId,
+    supportsCommands,
   ]);
 
   const answer = useMemo(
@@ -1032,8 +1190,30 @@ export default function CodingPage() {
       }
       queueStreamEvent(event, eventProject?.id ?? selectedProjectId);
       setTransportWarning("");
-      if (event.type === "turn_completed") {
+      if (
+        event.type === "command_requested" &&
+        event.data.request_id &&
+        event.data.command
+      ) {
+        setPendingCommand({
+          command: event.data.command,
+          created_at: event.created_at,
+          expires_at: event.data.expires_at ?? null,
+          request_id: event.data.request_id,
+          result: null,
+          state: "awaiting_confirmation",
+        });
+        setCommandAction("idle");
+        setCommandError("");
+      } else if (event.type === "command_resolved") {
+        setPendingCommand((current) =>
+          current?.request_id === event.data.request_id ? null : current,
+        );
+        setCommandAction("idle");
+      } else if (event.type === "turn_completed") {
         initialDraftLoadSessionRef.current = event.session_id;
+        setPendingCommand(null);
+        setCommandAction("idle");
         setRunState("idle");
         if (isDraftMode) {
           setDraftNotice("本轮已完成，修改草稿和检查结果已更新。");
@@ -1044,6 +1224,8 @@ export default function CodingPage() {
         }
       } else if (event.type === "cancelled") {
         initialDraftLoadSessionRef.current = event.session_id;
+        setPendingCommand(null);
+        setCommandAction("idle");
         setRunState("idle");
         if (isDraftMode) {
           setDraftNotice("本轮修改已撤销，此前保留的草稿不受影响。");
@@ -1054,6 +1236,8 @@ export default function CodingPage() {
         }
       } else if (event.type === "failed") {
         initialDraftLoadSessionRef.current = event.session_id;
+        setPendingCommand(null);
+        setCommandAction("idle");
         closeStreamRef.current?.();
         setRunState("error");
         setError(
@@ -1088,7 +1272,7 @@ export default function CodingPage() {
       runState === "starting" ||
       runState === "running" ||
       runState === "stopping" ||
-      verificationRunning ||
+      verificationActive ||
       sessionFrozen ||
       hasPendingRecovery
     ) {
@@ -1101,6 +1285,9 @@ export default function CodingPage() {
     setTransportWarning("");
     setDraftError("");
     setDraftNotice("");
+    setPendingCommand(null);
+    setCommandAction("idle");
+    setCommandError("");
     try {
       let activeSessionId = sessionId;
       if (!activeSessionId) {
@@ -1216,6 +1403,41 @@ export default function CodingPage() {
       setVerification(result);
     } catch (requestError) {
       setVerificationError(describeError(requestError));
+    }
+  };
+
+  const confirmVerification = async () => {
+    if (!sessionId || !verification?.confirmation_id) return;
+    setVerificationError("");
+    try {
+      const result = await confirmCodingVerification(
+        sessionId,
+        verification.revision,
+        verification.confirmation_id,
+      );
+      setVerification(result);
+    } catch (requestError) {
+      setVerificationError(describeError(requestError));
+    }
+  };
+
+  const decidePendingCommand = async (
+    decision: "allow_once" | "reject",
+  ) => {
+    if (!sessionId || !pendingCommand || commandAction !== "idle") return;
+    setCommandAction(decision === "allow_once" ? "allowing" : "rejecting");
+    setCommandError("");
+    try {
+      await decideCodingCommand(
+        sessionId,
+        pendingCommand.request_id,
+        decision,
+      );
+      setPendingCommand(null);
+    } catch (requestError) {
+      setCommandError(describeError(requestError));
+    } finally {
+      setCommandAction("idle");
     }
   };
 
@@ -1690,7 +1912,7 @@ export default function CodingPage() {
                 ? projectReason[selectedProject.reason ?? ""] ??
                   "这个项目目前不能安全读取，请由开发者检查项目状态。"
                 : isLocalProject
-                  ? "可查看、准备修改并下载 Diff；不会写入本地项目，也不会运行项目验证、创建提交或发布 PR。"
+                  ? "可查看、准备修改、确认离线检查并下载 Diff；不会写入本地项目、创建提交或发布 PR。"
                   : "ModelMirror 提供修改审阅、项目验证、受控应用、本地提交和 GitHub 草稿 PR 的完整流程。"}
             </p>
             {projectSelectionLocked ? (
@@ -1742,7 +1964,7 @@ export default function CodingPage() {
               : workspaceAvailable
                 ? isDraftMode
                   ? isLocalProject
-                    ? "修改只保存在临时副本。回答结束后，页面会自动列出文件并检查常见问题。"
+                    ? "修改只保存在临时副本。你可以审阅文件，并确认是否运行离线项目检查。"
                     : "修改会先保存在临时副本。回答结束后，页面会自动列出文件并检查常见问题。"
                   : "一次只处理一个问题，最长可输入 20,000 字符，闲置 30 分钟后会自动清理。"
                 : serviceAvailable
@@ -1799,7 +2021,9 @@ export default function CodingPage() {
               <span className="rounded-full bg-white/[0.055] px-2.5 py-1 text-xs text-slate-300">
                 {answer && runState === "idle"
                   ? "回答完成"
-                  : statusLabel(runState)}
+                  : pendingCommand
+                    ? "等待你确认"
+                    : statusLabel(runState)}
               </span>
             </div>
             <div
@@ -1809,7 +2033,7 @@ export default function CodingPage() {
               {answer ? (
                 <div className="max-w-none break-words text-sm leading-7 text-slate-200 [&_a]:text-cyan-200 [&_a]:underline [&_blockquote]:my-4 [&_blockquote]:border-l [&_blockquote]:border-white/20 [&_blockquote]:pl-4 [&_code]:text-cyan-100 [&_h1]:mb-4 [&_h1]:text-xl [&_h1]:font-semibold [&_h1]:text-white [&_h2]:mb-3 [&_h2]:mt-6 [&_h2]:text-lg [&_h2]:font-semibold [&_h2]:text-white [&_h3]:mb-2 [&_h3]:mt-5 [&_h3]:font-semibold [&_h3]:text-white [&_li]:my-1 [&_ol]:my-3 [&_ol]:list-decimal [&_ol]:pl-5 [&_p]:mb-3 [&_pre]:my-4 [&_pre]:overflow-x-auto [&_pre]:rounded-lg [&_pre]:bg-black/35 [&_pre]:p-4 [&_table]:my-4 [&_table]:block [&_table]:max-w-full [&_table]:overflow-x-auto [&_td]:border [&_td]:border-white/10 [&_td]:px-3 [&_td]:py-2 [&_th]:border [&_th]:border-white/10 [&_th]:px-3 [&_th]:py-2 [&_ul]:my-3 [&_ul]:list-disc [&_ul]:pl-5">
                   <ReactMarkdown remarkPlugins={[remarkGfm]}>{answer}</ReactMarkdown>
-                  {runState === "running" ? (
+                  {runState === "running" && !pendingCommand ? (
                     <span
                       aria-label="回答生成中"
                       className="ml-1 inline-block h-4 w-1 bg-cyan-300/80 align-middle"
@@ -1869,7 +2093,7 @@ export default function CodingPage() {
               disabled={
                 !workspaceAvailable ||
                 isBusy ||
-                verificationRunning ||
+                verificationActive ||
                 sessionFrozen ||
                 hasPendingRecovery
               }
@@ -1915,7 +2139,7 @@ export default function CodingPage() {
                     disabled={
                       !workspaceAvailable ||
                       !prompt.trim() ||
-                      verificationRunning ||
+                      verificationActive ||
                       sessionFrozen ||
                       hasPendingRecovery
                     }
@@ -1941,6 +2165,15 @@ export default function CodingPage() {
             >
               {error || transportWarning}
             </div>
+          ) : null}
+
+          {pendingCommand ? (
+            <CodingCommandConfirmation
+              action={commandAction}
+              error={commandError}
+              onDecision={decidePendingCommand}
+              request={pendingCommand}
+            />
           ) : null}
 
           {draftNotice && isDraftMode ? (
@@ -1999,6 +2232,7 @@ export default function CodingPage() {
                 onDiscard={discardDraft}
                 onDownload={downloadDraft}
                 onCancelVerification={stopVerification}
+                onConfirmVerification={confirmVerification}
                 onMarkPublishReady={markPublishedDraftReady}
                 onPublish={publishCommittedDraft}
                 onRequestFix={prepareVerificationFix}

--- a/client/src/types/coding.ts
+++ b/client/src/types/coding.ts
@@ -4,6 +4,8 @@ export type CodingEventType =
   | "plan"
   | "answer_delta"
   | "tool_status"
+  | "command_requested"
+  | "command_resolved"
   | "turn_completed"
   | "failed"
   | "cancelled"
@@ -21,6 +23,7 @@ export interface CodingProjectFeatures {
   publish: boolean;
   recovery: boolean;
   verification: boolean;
+  commands?: boolean;
 }
 
 export interface CodingProjectSummary {
@@ -82,6 +85,17 @@ export interface CodingCapabilities {
     supports_undo: true;
     target: "isolated_local_repository";
   };
+  commands: {
+    available: boolean;
+    confirmation: "always";
+    enabled: boolean;
+    execution: "isolated_copy";
+    max_commands_per_turn: number;
+    max_duration_seconds: number;
+    network: false;
+    persists_output: false;
+    reason?: string;
+  };
   incremental?: {
     available: boolean;
     commit_strategy: "linear";
@@ -134,10 +148,15 @@ export interface CodingEventData {
   kind?: string;
   project?: CodingProjectSummary;
   status?: string;
+  state?: string;
   stop_reason?: string;
   text?: string;
   title?: string;
   tool_call_id?: string;
+  request_id?: string;
+  command?: CodingProjectCommand;
+  expires_at?: number | null;
+  result?: CodingCommandResult | null;
 }
 
 export interface CodingEvent {
@@ -233,6 +252,7 @@ export interface CodingPatchDownload {
 
 export type CodingVerificationState =
   | "not_started"
+  | "awaiting_confirmation"
   | "running"
   | "completed"
   | "cancelled";
@@ -244,13 +264,10 @@ export type CodingVerificationResult =
   | "not_applicable";
 
 export interface CodingVerificationStep {
+  command?: CodingProjectCommand | null;
   details: string;
   duration_ms: number | null;
-  id:
-    | "backend_tests"
-    | "backend_baseline_tests"
-    | "backend_draft_tests"
-    | "frontend_build";
+  id: string;
   label: string;
   result: CodingVerificationResult;
   state: CodingVerificationState;
@@ -259,6 +276,7 @@ export interface CodingVerificationStep {
 }
 
 export interface CodingVerification {
+  confirmation_id?: string | null;
   finished_at: number | null;
   reason: string | null;
   result: CodingVerificationResult;
@@ -267,11 +285,44 @@ export interface CodingVerification {
   started_at: number | null;
   state: CodingVerificationState;
   steps: CodingVerificationStep[];
+  plan_fingerprint?: string | null;
 }
 
 export interface CodingVerificationCancelResponse
   extends CodingVerification {
   accepted: boolean;
+}
+
+export interface CodingProjectCommand {
+  argv: string[];
+  cwd: string;
+  id: string;
+  kind: "test" | "build" | "lint" | "typecheck" | "custom";
+  name: string;
+  timeout_seconds: number;
+}
+
+export interface CodingCommandResult {
+  duration_seconds: number;
+  exit_code: number | null;
+  output: string;
+  status: string;
+}
+
+export interface CodingCommandRequest {
+  command: CodingProjectCommand;
+  created_at: number | null;
+  expires_at: number | null;
+  request_id: string;
+  result: CodingCommandResult | null;
+  state:
+    | "awaiting_confirmation"
+    | "running"
+    | "completed"
+    | "rejected"
+    | "timed_out"
+    | "cancelled"
+    | "failed";
 }
 
 export type CodingApplyState =

--- a/client/src/utils/codingApi.ts
+++ b/client/src/utils/codingApi.ts
@@ -1,5 +1,6 @@
 import type {
   CodingCancelResponse,
+  CodingCommandRequest,
   CodingApplyResult,
   CodingCapabilities,
   CodingCommitResult,
@@ -251,6 +252,43 @@ export function cancelCodingVerification(
     {
       method: "POST",
       body: JSON.stringify({ revision }),
+    },
+  );
+}
+
+export function confirmCodingVerification(
+  sessionId: string,
+  revision: number,
+  confirmationId: string,
+) {
+  return requestJson<CodingVerificationCancelResponse>(
+    `/api/coding/sessions/${encodeURIComponent(sessionId)}/verification/confirm`,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        revision,
+        confirmation_id: confirmationId,
+      }),
+    },
+  );
+}
+
+export function getPendingCodingCommand(sessionId: string) {
+  return requestJson<{ pending: CodingCommandRequest | null }>(
+    `/api/coding/sessions/${encodeURIComponent(sessionId)}/commands/pending`,
+  );
+}
+
+export function decideCodingCommand(
+  sessionId: string,
+  requestId: string,
+  decision: "allow_once" | "reject",
+) {
+  return requestJson<{ request: CodingCommandRequest }>(
+    `/api/coding/sessions/${encodeURIComponent(sessionId)}/commands/${encodeURIComponent(requestId)}/decision`,
+    {
+      method: "POST",
+      body: JSON.stringify({ decision }),
     },
   );
 }

--- a/docker-compose.coding-commands.yml
+++ b/docker-compose.coding-commands.yml
@@ -1,0 +1,19 @@
+services:
+  server:
+    environment:
+      CODING_PROJECT_COMMANDS_ENABLED: ${CODING_PROJECT_COMMANDS_ENABLED:-true}
+
+  coding-runtime:
+    environment:
+      CODING_PROJECT_COMMANDS_ENABLED: ${CODING_PROJECT_COMMANDS_ENABLED:-true}
+
+  coding-verifier:
+    environment:
+      CODING_RUNNER_PACKS_ROOT: /runner-packs
+    volumes:
+      - type: bind
+        source: ${CODING_RUNNER_PACKS_ROOT:-./server/coding_verifier}
+        target: /runner-packs
+        read_only: true
+        bind:
+          create_host_path: false

--- a/docker-compose.coding-projects.yml
+++ b/docker-compose.coding-projects.yml
@@ -12,6 +12,8 @@ services:
         source: coding_project_snapshot
         target: /project-snapshots
         read_only: true
+        volume:
+          nocopy: true
 
   coding-verifier:
     environment:
@@ -21,6 +23,8 @@ services:
         source: coding_project_snapshot
         target: /project-snapshots
         read_only: true
+        volume:
+          nocopy: true
 
   coding-project-source:
     profiles:
@@ -49,7 +53,11 @@ services:
       CODING_PROJECT_SNAPSHOT_ROOT: /snapshot-slot
     volumes:
       - coding_project_source_socket:/run/modelmirror-coding-projects
-      - coding_project_snapshot:/snapshot-slot
+      - type: volume
+        source: coding_project_snapshot
+        target: /snapshot-slot
+        volume:
+          nocopy: true
       - type: bind
         source: ${CODING_PROJECTS_ROOT:?Set CODING_PROJECTS_ROOT to an absolute controlled projects directory}
         target: /projects-root

--- a/docker-compose.coding-projects.yml
+++ b/docker-compose.coding-projects.yml
@@ -13,6 +13,15 @@ services:
         target: /project-snapshots
         read_only: true
 
+  coding-verifier:
+    environment:
+      CODING_PROJECT_SNAPSHOT_PATH: /project-snapshots/current
+    volumes:
+      - type: volume
+        source: coding_project_snapshot
+        target: /project-snapshots
+        read_only: true
+
   coding-project-source:
     profiles:
       - coding-projects

--- a/docs/CODING_AGENT_INTEGRATION.md
+++ b/docs/CODING_AGENT_INTEGRATION.md
@@ -17,11 +17,12 @@ Diff、轻量检查结果和停止按钮。Draft 用户还可以手动启动独�
 确认是否标记为 Ready。
 
 ModelMirror 使用镜像内固定快照并保留完整闭环；自定义项目使用无网络 Project Source
-从干净独立克隆的 Git HEAD 生成单槽只读快照，只开放问答、草稿、Diff、下载和恢复。
+从干净独立克隆的 Git HEAD 生成单槽只读快照，开放问答、草稿、Diff、下载、恢复和
+逐次确认的离线项目检查。
 Draft 默认不会写回任何宿主目录；受控应用也只允许写入预先创建的专用工作树，当前主工作树始终不挂载。
 系统只在用户确认后向固定独立克隆创建本地提交；远程发布也只允许固定 GitHub.com
 仓库、系统分支和 Draft PR，不提供合并、关闭或远端清理。系统不支持删除、重命名、
-二进制、Agent Shell/测试命令、仓库或分支选择、多 Agent、完整 ACP、
+二进制、直接 Shell、未经确认的命令、仓库或分支选择、多 Agent、完整 ACP、
 分布式 Worker、保存对话、多任务历史或生产级多租户。不要将该入口直接暴露到公网。
 
 ## 用户体验约束
@@ -39,6 +40,8 @@ Draft 默认不会写回任何宿主目录；受控应用也只允许写入预�
 - “放弃修改”必须二次确认；检查失败时保留草稿供修正，但禁用下载。
 - “项目验证”由用户手动运行，使用“检查服务代码”“检查页面构建”等日常语言。
   运行时可停止，失败详情默认折叠；“让代码助手修复”只填入摘要，不自动提交。
+- 自定义项目先完整列出检查名称，再由用户一次确认本批固定命令；代码助手临时提出的
+  每条命令都单独显示确认卡。精确参数默认折叠，拒绝不是错误，等待确认不持续旋转。
 - 未运行或失败的项目验证不阻止下载，但必须原位警告并让用户再次确认；验证服务
   未启动时，Diff、轻量检查和下载继续可用。
 - “应用到本地项目副本”仅在门禁满足时启用；确认区必须说明文件数量、不会提交或
@@ -74,6 +77,9 @@ flowchart LR
   OC --> WORK
   OC -->|"内部网络"| GW["newAPI"]
   WORKER -->|"revision + 内部 Patch"| VERIFY["coding-verifier"]
+  OC -->|"固定系统 MCP"| RUNNER["逐次确认命令桥"]
+  RUNNER -->|"用户允许一次"| VERIFY
+  PACKS["可选只读离线依赖包"] --> VERIFY
   SOURCE2["Verifier 只读基准快照"] --> VERIFY
   VERIFY --> CHECKS["固定后端测试 / 前端构建"]
   API -->|"独立私有 Unix socket"| APPLY["coding-applier"]
@@ -114,6 +120,9 @@ flowchart LR
 | `POST /api/coding/sessions/{id}/verification` | 为指定 revision 启动项目验证；返回 `202`。 |
 | `GET /api/coding/sessions/{id}/verification?revision=` | 查询运行状态、结论和固定步骤摘要。 |
 | `POST /api/coding/sessions/{id}/verification/cancel` | 停止指定 revision 的验证；重复调用安全。 |
+| `POST /api/coding/sessions/{id}/verification/confirm` | 确认自定义项目当前 revision 的固定检查计划。 |
+| `GET /api/coding/sessions/{id}/commands/pending` | SSE 重连后查询当前待确认命令，不返回内部令牌。 |
+| `POST /api/coding/sessions/{id}/commands/{request_id}/decision` | 对一条代码助手命令选择 `allow_once` 或 `reject`。 |
 | `POST /api/coding/sessions/{id}/apply` | 应用指定 revision；请求体只允许 `revision`。Windows 绑定目录扫描较慢时最多等待 90 秒。 |
 | `POST /api/coding/sessions/{id}/commit` | 保存本地提交；Windows 绑定目录扫描较慢时最多等待 90 秒。 |
 | `GET /api/coding/sessions/{id}/apply?revision=` | 查询应用、撤销状态和是否仍可撤销。 |
@@ -145,8 +154,8 @@ Draft、精确基础版本要求和 Ready 支持；不可用原因不影响本�
 `projects` 公开 enabled、configured、available、selection、默认项目和最多项目数；
 会话开始事件、会话状态和恢复状态只携带项目 ID、显示名、来源、短 HEAD 与功能矩阵。
 
-公共事件限定为：会话开始、分析开始、计划、回答增量、查阅状态、完成、失败、
-取消和心跳。服务端只保留有限内存事件，不持久化问题、完整回答或工具输出。
+公共事件限定为：会话开始、分析开始、计划、回答增量、查阅状态、命令待确认、命令已处理、
+完成、失败、取消和心跳。服务端只保留有限内存事件，不持久化问题、完整回答、命令审批或工具输出。
 计划事件是可选能力：OpenCode 1.18.9 的 ACP 会话不保证每轮产生结构化计划，
 没有计划事件时页面直接展示查阅记录和流式回答。
 
@@ -187,8 +196,8 @@ FastAPI 的完整环境。源码变化后必须重建 `coding-runtime` 才会刷
   MCP、插件、provider 和其他可执行配置均隐藏且不会生效。Runtime 还会复核项目 ID、
   HEAD、租约与快照指纹，避免跨项目串读。
 - 自定义项目沿用 20 个变化文件、单文件 512 KiB、Patch 1 MiB 限额，只允许新增或修改
-  UTF-8 文本。项目验证、应用、本地提交和发布接口固定返回
-  `project_operation_unavailable`，不会误用 ModelMirror 的执行面。
+  UTF-8 文本。项目验证与逐次确认命令仅在临时副本中运行；应用、本地提交和发布接口固定
+  返回 `project_operation_unavailable`，不会误用 ModelMirror 的执行面。
 - 加密恢复存储在独立上下文表保存项目 ID、来源、显示名和基准 HEAD，不保存宿主路径，
   也不改变 recovery schema v3 的 `user_version`。旧记录自动视为 ModelMirror；项目
   被删除、变脏或 HEAD 改变时禁止继续恢复，但仍可下载原始 Diff。
@@ -208,6 +217,29 @@ FastAPI 的完整环境。源码变化后必须重建 `coding-runtime` 才会刷
 
 这些轻量检查不是完整项目测试。项目验证是额外的用户手动步骤；无论结果如何，
 下载后的 Patch 仍需由开发者审阅。
+
+## 自定义项目命令与验证
+
+- 项目清单 version 2 可配置最多 8 条检查；version 1 继续有效。系统还会识别根目录
+  Python 测试配置，以及根 `package.json` 的 `test`、`typecheck`、`lint`、`build` 脚本。
+  每条检查只包含规范化 argv、项目内相对 cwd、日常语言名称和 1–300 秒超时。
+- OpenCode 仍禁止 `bash`、`task`、仓库 MCP、插件与联网工具。只有产品注入的固定
+  `modelmirror-runner` MCP 可提出结构化命令；浏览器确认后由 Runtime 授予一次执行权，
+  不接受 shell 字符串、环境变量、stdin、宿主路径或网络设置。
+- 每轮最多提出 20 条命令，同时只等待或运行 1 条，累计执行不超过 600 秒。确认 300 秒
+  后失效；拒绝或超时作为普通工具结果返回代码助手，不结束本轮。整体停止会拒绝待确认
+  请求、终止运行进程组并清理临时工作区。
+- Verifier 每次复核项目 ID、HEAD、租约、快照指纹、Patch、cwd、argv 和可选 Runner Pack，
+  再复制到独立 tmpfs 执行；它无网络且不继承模型、Git 或宿主凭据。命令生成的缓存、构建
+  产物和文件修改在返回结果前全部丢弃，草稿与宿主项目不会改变。
+- 可选 Runner Pack 只读挂载给 Verifier，声明 Linux、Python 3.12、Node 22、依赖输入哈希
+  和安全相对依赖路径。Pack ID 必须对应不可变内容；内容更新必须使用新 ID，才能使计划
+  指纹和旧验证结果可靠过期。缺失、失配或不安全的 Pack 只显示“运行环境未就绪”。
+- 修改测试时，测试类检查先运行不含草稿测试改动的基准版本，再运行完整草稿。修改依赖
+  清单时自动验证不联网安装依赖，而是返回“运行环境未就绪”；基础 Python/Node 命令仍可
+  单独逐次确认。
+- 待确认命令、决定和输出不持久化。只有完成且经过脱敏的项目验证结论可以随完整草稿加密
+  保存；恢复时重新计算 HEAD、Patch、命令计划和 Pack ID 指纹，不一致即标记过期并要求重跑。
 
 ## 隔离项目验证
 
@@ -331,6 +363,8 @@ CODING_GITHUB_PUBLISH_ENABLED=false
 CODING_GITHUB_BASE_BRANCH=main
 CODING_PROJECTS_ENABLED=false
 CODING_PROJECTS_ROOT=
+CODING_PROJECT_COMMANDS_ENABLED=false
+CODING_RUNNER_PACKS_ROOT=
 ```
 
 `CODING_AGENT_MODE` 默认为 `readonly`，只有显式设置为 `draft` 才开放临时编辑。
@@ -345,7 +379,10 @@ CODING_PROJECTS_ROOT=
 和安装令牌不得写入 `.env`、日志、Git 配置或恢复数据库。
 受控项目必须显式设置绝对 `CODING_PROJECTS_ROOT` 并加载
 `docker-compose.coding-projects.yml`；完整清单格式、限制与重建命令见
-[DEPLOYMENT.md](./DEPLOYMENT.md)。本轮未新增前端或后端第三方依赖；OpenCode 仍固定
+[DEPLOYMENT.md](./DEPLOYMENT.md)。自定义项目命令还需加载
+`docker-compose.coding-commands.yml`；`CODING_RUNNER_PACKS_ROOT` 可省略，此时仅使用镜像内
+Python 3.12、Node 22/npm 与已有锁定依赖。若设置该变量，必须使用部署者控制的绝对目录，
+每个 Pack 使用不可变版本 ID，且只读挂载给 Verifier。本轮未新增前端或后端第三方依赖；OpenCode 仍固定
 为 `1.18.9`（MIT），现有第三方声明无需新增条目。
 
 实现分支尚未合并时，基于实现 HEAD 创建的验收仓库不可能与 GitHub `main` 精确匹配。
@@ -399,6 +436,13 @@ docker compose -f docker-compose.yml -f docker-compose.coding-apply.yml -f docke
 - `docker ps` 的 healthy 仅是第一层检查。还必须从 Server 通过各自 Unix socket 调用五个 Coding 执行面的 health，确认 socket 路径存在且可连接。
 - 多轮恢复中，累计修改可以位于 `base_patch`，当前轮 `patch` 可以为空；`patch/paths` 与 `base_patch/base_paths` 分别成对校验。恢复页连续返回 `invalid_request` 时优先检查这一契约。
 - 完整重建前检查 pending 恢复记录。源码快照指纹变化后旧记录只能下载或标记过期，不得改写指纹强行恢复。
+- 命令确认不能依赖供应商的非标准 raw input；只接受产品定义的四个结构化字段。曾出现的
+  “页面看似等待、后端实际没有可恢复请求”来自把确认状态只放在 SSE 瞬时事件中；当前必须
+  同时维护可查询 pending 状态，并让重复决定幂等失败而不是重复执行。
+- 不要为降低等待感而轮询整页或缩短安全清理。高频刷新会造成页面闪烁，命令卡应由事件增量
+  更新，断线时只补查 pending；等待用户确认时停止动画，但保留整体取消。
+- Runner Pack 失配属于环境问题，不是代码失败；不得为了“通过”而联网安装、复用宿主
+  `node_modules` 或降低哈希检查。命令输出返回前必须先清理工作区，防止成功路径遗漏产物清理。
 
 1. 以 `CODING_AGENT_MODE=readonly` 提交一个可从当前源码验证的问题，确认流式
    回答、取消和只读行为仍正常。
@@ -457,8 +501,20 @@ docker compose -f docker-compose.yml -f docker-compose.coding-apply.yml -f docke
 28. 保存自定义项目草稿后分别重启 Server、Runtime 和 Project Source。HEAD 未变时恢复
     精确 Diff；删除项目、弄脏仓库或推进 HEAD 后只允许下载，不显示此前对话或宿主路径。
 29. 停止 Project Source，确认内置 ModelMirror 的验证、应用、提交、恢复和发布完整可用。
+30. 为随机 Python 项目加入 `calc_k7m4.py` 和先失败后通过的断言；项目验证先列出精确 argv，
+    确认后按顺序运行。修改测试文件时必须先运行基准测试，再运行草稿测试。
+31. 为随机 Node 项目加入脚本 `verify_q9t2`；整组确认 test/build 后检查顺序。拒绝一条 Agent
+    命令并让另一条等待超时，代码助手应继续回答，页面不闪烁且整体停止始终可用。
+32. 批准会写入 `generated_r8v3.txt` 的命令，确认命令可以成功，但草稿、受控源仓库和恢复记录
+    均没有该文件；Shell、`../`、绝对路径、环境注入和公网请求必须拒绝或无网络失败。
+33. 分别改变 Pack ID、输入哈希、平台和内部链接，确认只禁用对应环境。待确认和运行中重启
+    Server、Runtime 或 Verifier 后不得残留占用；继续时只恢复上一份完整草稿，不恢复命令或输出。
 
 ## 回退
+
+先设置 `CODING_PROJECT_COMMANDS_ENABLED=false` 并省略
+`docker-compose.coding-commands.yml`，即恢复第九轮本地项目草稿能力；停止 Verifier 不影响
+问答、草稿、Diff、下载或恢复，也不会删除已有 Runner Pack。
 
 先设置 `CODING_PROJECTS_ENABLED=false` 并省略 `docker-compose.coding-projects.yml`，
 即恢复第八轮固定 ModelMirror 行为；不会修改任何受控源仓库，附加的加密项目上下文

--- a/docs/tasks/CODING_PROJECT_COMMANDS_V10.md
+++ b/docs/tasks/CODING_PROJECT_COMMANDS_V10.md
@@ -1,0 +1,94 @@
+# 任务卡：CODING-PROJECT-COMMANDS-V10
+
+> 第十轮为 Coding 自定义项目增加隔离验证与逐次确认命令。风险等级为 L4；任何命令
+> 绕过用户确认、继承模型密钥、访问网络或其他项目、写入宿主目录、留下残留进程，
+> 都必须立即停止。
+
+## 1. 基线与单一目标
+
+- 基线：PR #82 合并提交 `0f4599e4fb56ecdfd32977b717928b478d6212a2`。
+- 分支：`codex/coding-project-commands-v10`。
+- 工作树：`C:\tmp\modelmirror-coding-v10`。
+- 单一目标：自定义项目可以运行经用户明确确认的真实 Python/Node 项目验证；代码助手
+  可以通过系统内置 MCP 提出结构化 argv，用户逐条允许一次后在无网络临时副本执行。
+- ModelMirror 现有验证、应用、提交、多轮恢复和 GitHub 发布不得降级。
+
+本轮不包含命令文件变化导入、运行时联网安装、直接 Shell、环境变量或 stdin、自定义
+项目应用/提交/发布、删除、重命名、多任务、对话保存、第二 ACP、多 Agent 或分布式 Worker。
+
+## 2. 数据、执行与权限边界
+
+- 项目清单兼容 version 1；version 2 可配置自动识别、最多 8 条固定检查和一个部署者
+  准备的离线 Runner Pack。浏览器和 Agent 都不能修改项目验证配置。
+- Agent 命令只接受 `argv`、项目内相对 `cwd`、日常语言用途和 1–300 秒超时；最多
+  64 个参数、8 KiB、每轮 20 条、累计执行不超过 600 秒。
+- Runtime 仅在 Draft 模式注入固定 `modelmirror-runner` stdio MCP。仓库 MCP、插件、
+  `bash`、`task`、web 和外部目录继续禁用；系统 MCP 内部实施一次性产品确认。
+- 允许决定 300 秒后失效。拒绝或超时作为结构化工具结果返回 Agent，不结束本轮；
+  整体取消必须同时拒绝待确认请求并终止运行进程组。
+- 复用 `coding-verifier` 执行已确认 argv。它保持无网络、非 root、只读根目录、无端口、
+  无 Docker socket、无模型或 Git 凭据，只能读取当前项目租约快照和可选只读依赖包。
+- 命令在当前草稿的一次性 tmpfs 副本中执行；运行产生的所有文件变化、缓存和构建产物
+  在结束后清除，不得回灌草稿或宿主项目。
+- 输出合计最多 64 KiB，移除控制字符并脱敏路径、密钥模式和环境信息；命令、输出、
+  决定和待确认状态不落盘。恢复只保留最后一个完整草稿及可验证的脱敏验证结论。
+
+## 3. 离线依赖包契约
+
+- 可选 `CODING_RUNNER_PACKS_ROOT` 只读挂载给 Verifier，Server、Runtime 与 Agent 不可见。
+- 每个 Pack 使用安全 ID 和固定 `pack.json`，声明 Linux 平台、Python 3.12/Node 22、
+  依赖输入 Git blob 哈希、Python 路径、Node `node_modules` 映射和附加 bin 路径。
+- Pack 路径必须规范化且位于自身根目录；内部符号链接只允许解析到同一 Pack。Pack
+  不得包含项目源码、密钥、环境文件或可写目录。
+- Pack 缺失、版本或依赖哈希不匹配只使自动项目验证显示“运行环境未就绪”；问答、
+  草稿、Diff、下载、恢复和基础 Python/Node 命令继续可用。
+- 运行时禁止下载、更新或写入 Pack；依赖环境指纹变化后旧验证结果必须标记过期。
+
+## 4. 公共接口与用户体验
+
+- capabilities 新增 `commands`；项目功能矩阵新增 `commands`，自定义项目在执行面可用时
+  开放 `verification`，但 `apply/commit/publish` 继续为 false。
+- 新增 pending 查询、一次性 decision、项目验证确认接口；浏览器只提交不透明请求 ID、
+  revision、confirmation ID 与 `allow_once | reject`，不回传 argv。
+- 事件新增 `command_requested` 与 `command_resolved`；自定义项目验证状态增加
+  `awaiting_confirmation`。SSE 重连必须恢复待确认卡片，不刷新整个页面。
+- 页面使用“代码助手希望运行一项检查”“允许本次运行”“暂不运行”等日常语言；精确
+  argv 默认折叠。等待确认不是错误或持续旋转状态，整体停止始终可用。
+- 多条项目验证命令先完整列出，再由一次操作分别授予本批每条命令一次执行权；revision、
+  HEAD、计划或依赖环境变化后确认失效。
+
+## 5. 七个批次
+
+1. 现场保护与本任务契约。
+2. 清单 v2、命令领域、自动识别、Pack 和计划指纹。
+3. 固定系统 MCP、确认桥、超时、拒绝与取消。
+4. Verifier 动态快照、Pack、批准 argv、输出限制和进程清理。
+5. Worker、FastAPI、恢复、能力与 Compose 编排。
+6. 前端命令确认、验证预览、结果与重连体验。
+7. 安全加固、完整回归、架构/部署/Coding/Harness 文档。
+
+每批最多修改 5 个文件；固定执行文件范围检查、目标测试、`git diff --check`、完整 Diff
+Review、敏感信息和禁止产物扫描，通过后形成一个独立本地提交。前一批失败不得进入下一批。
+
+## 6. 验证与人工验收
+
+- 自动验证覆盖清单 v1/v2、命令规范化、自动识别、Pack 失配、MCP 工具发现、批准/拒绝/
+  超时/重连、Shell 与越界拒绝、无网络、无密钥、跨项目隔离、输出脱敏和进程组清理。
+- 对命令前、运行中、结果返回前及 Server/Runtime/Verifier 重启注入故障，确认不会导入
+  文件变化、留下占用或破坏最后一份完整恢复记录。
+- 执行 Coding 专项测试、`python -m py_compile`、全量 `server/tests/`、前端生产构建以及
+  基础和全部 Coding Compose overlay 配置检查。
+- 人工验收使用随机 Python/Node 项目、文件名、断言和正文，覆盖失败后修复、整组验证、
+  拒绝、超时、写文件产物丢弃、Pack 失配、项目 A/B 串读、重启恢复和宿主 Git 状态不变。
+- 自动验证完成后停止；取得共享栈独占窗口并由用户明确验收通过前不推送、不创建 PR。
+
+## 7. 停止条件与回退
+
+以下任一条件出现时停止：OpenCode 1.18.9 无法只启用固定系统 MCP；命令可绕过确认；
+命令进程继承模型/宿主凭据；可联网、访问其他项目或写快照/Pack/宿主；危险 cwd/argv
+可越界；取消后进程残留；SSE 重连丢失待确认状态；旧能力回归；公共响应泄露路径、
+密钥、环境或未截断输出。
+
+回退时设置 `CODING_PROJECT_COMMANDS_ENABLED=false` 并省略 Runner Pack overlay，恢复
+第九轮自定义项目草稿能力。停止 Verifier 不得影响问答、草稿、Diff、下载或恢复；
+本轮不升级恢复数据库版本，也不修改任何宿主项目。

--- a/server/coding_project_source/Dockerfile
+++ b/server/coding_project_source/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update \
 WORKDIR /opt/modelmirror
 
 COPY server/coding_runtime/projects.py ./server/coding_runtime/projects.py
+COPY server/coding_runtime/commands.py ./server/coding_runtime/commands.py
 COPY server/coding_project_source/server.py ./server/coding_project_source/server.py
 
 RUN test "$(id -u projectsource)" = "65532" \

--- a/server/coding_project_source/server.py
+++ b/server/coding_project_source/server.py
@@ -178,6 +178,10 @@ class ProjectSnapshotBroker:
                 ):
                     raise ProjectSourceError("project_changed", "Project changed while snapshotting")
                 _write_json(staging / "lease.json", lease.to_dict())
+                _write_json(
+                    staging / "verification.json",
+                    _verification_sidecar(entry, lease),
+                )
                 staging.replace(self._snapshot_slot / "current")
                 self._active = lease
                 return lease
@@ -472,6 +476,33 @@ def _read_exact(stream: Any, size: int) -> bytes:
 def _write_json(path: Path, payload: dict[str, object]) -> None:
     encoded = json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
     path.write_bytes(encoded)
+
+
+def _verification_sidecar(
+    entry: ProjectManifestEntry,
+    lease: SnapshotLease,
+) -> dict[str, object]:
+    config = entry.verification
+    return {
+        "lease_id": lease.lease_id,
+        "project_id": lease.project_id,
+        "head": lease.head,
+        "fingerprint": lease.fingerprint,
+        "verification": {
+            "auto": config.auto,
+            "runner_pack": config.runner_pack,
+            "commands": [
+                {
+                    "name": command.name,
+                    "kind": command.kind.value,
+                    "argv": list(command.argv),
+                    "cwd": command.cwd,
+                    "timeout_seconds": command.timeout_seconds,
+                }
+                for command in config.commands
+            ],
+        },
+    }
 
 
 def _require_keys(request: dict[str, Any], expected: set[str]) -> None:

--- a/server/coding_runtime/acp_client.py
+++ b/server/coding_runtime/acp_client.py
@@ -138,6 +138,8 @@ class AcpClient:
             raise ValueError("Prompt must not be empty")
 
         turn_id = session.begin_turn()
+        yield session.append_event(CodingEventKind.TURN_STARTED, turn_id=turn_id)
+
         prompt_task = asyncio.create_task(
             self._request(
                 "session/prompt",
@@ -149,7 +151,6 @@ class AcpClient:
             )
         )
         await asyncio.sleep(0)
-        yield session.append_event(CodingEventKind.TURN_STARTED, turn_id=turn_id)
 
         try:
             while True:

--- a/server/coding_runtime/api.py
+++ b/server/coding_runtime/api.py
@@ -1182,7 +1182,6 @@ class CodingService:
         if project_context.kind is ProjectKind.LOCAL_CLONE and any(
             item is not None
             for item in (
-                recovery.payload.verification,
                 recovery.payload.apply,
                 recovery.payload.commit,
                 recovery.payload.operation,
@@ -2547,7 +2546,7 @@ class CodingService:
             payload = RecoveryPayload(
                 patch=cumulative_patch,
                 changes=cumulative_changes,
-                verification=(verification if self._is_builtin_project(record) else None),
+                verification=verification,
                 apply=(
                     _apply_storage_payload(record)
                     if self._is_builtin_project(record)

--- a/server/coding_runtime/api.py
+++ b/server/coding_runtime/api.py
@@ -989,6 +989,7 @@ class CodingService:
         return record.revision, _safe_diff(record.payload.patch)
 
     async def discard_recovery(self) -> dict[str, bool]:
+        await self._prune_missing_worker_sessions()
         conflict_record: CodingApiSession | None = None
         async with self._lock:
             active = list(self._sessions.values())
@@ -1132,6 +1133,7 @@ class CodingService:
         if self.mode != "draft":
             raise _http_error(status.HTTP_409_CONFLICT, "draft_unavailable")
         await self.cleanup_expired()
+        await self._prune_missing_worker_sessions()
         recovery = await self._require_recovery_record()
         project_context = await self._load_recovery_project_context(recovery)
         async with self._lock:
@@ -2691,6 +2693,28 @@ class CodingService:
         if released:
             record.project_source = None
         return released
+
+    async def _prune_missing_worker_sessions(self) -> int:
+        async with self._lock:
+            records = list(self._sessions.values())
+        removed = 0
+        for record in records:
+            try:
+                await self.worker.session_status(record.worker_session_id)
+            except CodingWorkerError as exc:
+                if exc.code != "session_not_found":
+                    continue
+                released = await self._release_project_source(record.project_source)
+                if not released:
+                    continue
+                async with self._lock:
+                    if self._sessions.get(record.session_id) is record:
+                        self._sessions.pop(record.session_id, None)
+                        record.project_source = None
+                        removed += 1
+            except Exception:
+                continue
+        return removed
 
     async def _close_worker_session_and_release(
         self,

--- a/server/coding_runtime/api.py
+++ b/server/coding_runtime/api.py
@@ -184,6 +184,22 @@ class WorkerClient(Protocol):
         revision: int,
     ) -> dict[str, Any]: ...
 
+    async def verification_confirm(
+        self,
+        session_id: str,
+        revision: int,
+        confirmation_id: str,
+    ) -> dict[str, Any]: ...
+
+    async def command_pending(self, session_id: str) -> dict[str, Any] | None: ...
+
+    async def command_decision(
+        self,
+        session_id: str,
+        request_id: str,
+        decision: str,
+    ) -> dict[str, Any]: ...
+
 
 class ApplierClient(Protocol):
     async def health(self) -> dict[str, Any]: ...
@@ -365,6 +381,20 @@ class VerificationRevisionRequest(BaseModel):
     revision: int = Field(ge=0)
 
 
+class VerificationConfirmRequest(VerificationRevisionRequest):
+    confirmation_id: str = Field(
+        min_length=20,
+        max_length=80,
+        pattern=r"^[A-Za-z0-9_-]+$",
+    )
+
+
+class CommandDecisionRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    decision: Literal["allow_once", "reject"]
+
+
 class ApplyRequest(VerificationRevisionRequest):
     confirm_quality_risks: bool = Field(default=False, strict=True)
 
@@ -426,16 +456,23 @@ class PublishReadyRequest(VerificationRevisionRequest):
     publish_id: str = Field(min_length=20, max_length=64, pattern=r"^[A-Za-z0-9_-]+$")
 
 
+class VerificationCommandPayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    command_id: str = Field(alias="id", min_length=1, max_length=64)
+    name: str = Field(min_length=1, max_length=240)
+    kind: Literal["test", "build", "lint", "typecheck", "custom"]
+    argv: list[str] = Field(min_length=1, max_length=64)
+    cwd: str = Field(min_length=1, max_length=500)
+    timeout_seconds: int = Field(ge=1, le=300)
+
+
 class VerificationStepPayload(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    step_id: Literal[
-        "backend_tests",
-        "backend_baseline_tests",
-        "backend_draft_tests",
-        "frontend_build",
-    ] = Field(alias="id")
-    label: str = Field(min_length=1, max_length=100)
+    step_id: str = Field(alias="id", min_length=1, max_length=128)
+    label: str = Field(min_length=1, max_length=240)
+    command: VerificationCommandPayload | None = None
     state: Literal["not_started", "running", "completed", "cancelled"]
     result: Literal["not_run", "passed", "failed", "not_applicable"]
     duration_ms: int | None = Field(default=None, ge=0, le=600_000)
@@ -448,13 +485,26 @@ class VerificationPayload(BaseModel):
     model_config = ConfigDict(extra="forbid", allow_inf_nan=False)
 
     revision: int = Field(ge=0)
-    state: Literal["not_started", "running", "completed", "cancelled"]
+    state: Literal[
+        "not_started",
+        "awaiting_confirmation",
+        "running",
+        "completed",
+        "cancelled",
+    ]
     result: Literal["not_run", "passed", "failed", "not_applicable"]
     stale: bool
     reason: str | None = Field(default=None, max_length=64)
     started_at: float | None = Field(default=None, ge=0)
     finished_at: float | None = Field(default=None, ge=0)
-    steps: list[VerificationStepPayload] = Field(max_length=4)
+    confirmation_id: str | None = Field(default=None, min_length=20, max_length=80)
+    plan_fingerprint: str | None = Field(
+        default=None,
+        min_length=64,
+        max_length=64,
+        pattern=r"^[a-f0-9]{64}$",
+    )
+    steps: list[VerificationStepPayload] = Field(max_length=16)
 
     @model_validator(mode="after")
     def state_and_result_must_be_consistent(self) -> VerificationPayload:
@@ -463,8 +513,10 @@ class VerificationPayload(BaseModel):
             raise ValueError("Running verification must have a start time")
         if terminal and self.finished_at is None:
             raise ValueError("Terminal verification must have a finish time")
-        if self.state == "not_started" and self.result != "not_run":
+        if self.state in {"not_started", "awaiting_confirmation"} and self.result != "not_run":
             raise ValueError("Unstarted verification result is inconsistent")
+        if self.state == "awaiting_confirmation" and self.confirmation_id is None:
+            raise ValueError("Verification confirmation is missing")
         if self.state == "cancelled" and self.result != "not_run":
             raise ValueError("Cancelled verification result is inconsistent")
         if self.result in {"passed", "failed", "not_applicable"} and (
@@ -541,6 +593,7 @@ class CodingService:
         recovery_reason: str | None = None,
         incremental_enabled: bool | None = None,
         publish_enabled: bool | None = None,
+        commands_enabled: bool | None = None,
         ttl_seconds: float = SESSION_TTL_SECONDS,
         mode: str | None = None,
     ) -> None:
@@ -572,6 +625,12 @@ class CodingService:
             if publish_enabled is None
             else publish_enabled
         )
+        self.commands_enabled = (
+            os.getenv("CODING_PROJECT_COMMANDS_ENABLED", "false").strip().lower()
+            in {"1", "true", "yes", "on"}
+            if commands_enabled is None
+            else commands_enabled
+        )
         self.ttl_seconds = ttl_seconds
         self.mode = _normalize_mode(
             mode if mode is not None else os.getenv("CODING_AGENT_MODE", "readonly")
@@ -601,6 +660,21 @@ class CodingService:
                 "strategy": "adaptive",
                 "required_for_patch": False,
                 "max_duration_seconds": 600,
+            },
+            "commands": {
+                "enabled": self.commands_enabled,
+                "available": False,
+                "confirmation": "always",
+                "execution": "isolated_copy",
+                "network": False,
+                "persists_output": False,
+                "max_commands_per_turn": 20,
+                "max_duration_seconds": 300,
+                "reason": (
+                    "commands_unavailable"
+                    if self.commands_enabled
+                    else "commands_disabled"
+                ),
             },
             "recovery": {
                 "enabled": recovery["enabled"],
@@ -699,6 +773,26 @@ class CodingService:
                 response["verification"]["reason"] = _safe_code(
                     worker_verification.get("reason")
                 )
+        worker_commands = health.get("commands")
+        if self.mode == "draft" and isinstance(worker_commands, dict):
+            if (
+                self.commands_enabled
+                and worker_commands.get("enabled") is True
+                and worker_commands.get("available") is True
+                and worker_commands.get("confirmation") == "always"
+                and worker_commands.get("execution") == "isolated_copy"
+                and worker_commands.get("network") is False
+                and worker_commands.get("persists_output") is False
+            ):
+                response["commands"] = {
+                    **response["commands"],
+                    "available": True,
+                }
+                response["commands"].pop("reason", None)
+            else:
+                response["commands"]["reason"] = _safe_code(
+                    worker_commands.get("reason") or "commands_unavailable"
+                )
         if self.mode == "draft":
             apply_capability, commit_capability, publish_capability = (
                 await asyncio.gather(
@@ -726,11 +820,29 @@ class CodingService:
 
     async def project_catalog(self) -> dict[str, Any]:
         builtin = ProjectSummary.builtin().to_public_dict()
+        builtin["features"]["commands"] = False
         capability = await self._projects_capability()
         projects = [builtin]
         if capability["available"] is True and self.project_source is not None:
             try:
-                projects.extend(await self.project_source.list_projects())
+                local_projects = await self.project_source.list_projects()
+                commands_available = False
+                if self.commands_enabled:
+                    with contextlib.suppress(Exception):
+                        health = await self.worker.health()
+                        command_health = health.get("commands")
+                        commands_available = bool(
+                            isinstance(command_health, dict)
+                            and command_health.get("available") is True
+                        )
+                for project in local_projects:
+                    if not isinstance(project, dict):
+                        continue
+                    features = project.get("features")
+                    if isinstance(features, dict):
+                        features["commands"] = commands_available
+                        features["verification"] = commands_available
+                    projects.append(project)
                 self.projects_reason = None
             except ProjectSourceClientError as exc:
                 capability = {
@@ -1429,7 +1541,7 @@ class CodingService:
         revision: int,
     ) -> dict[str, Any]:
         record = await self._review_record(session_id)
-        self._require_builtin_project(record)
+        self._require_project_verification_enabled(record)
         if record.apply_lock.locked():
             raise _http_error(status.HTTP_409_CONFLICT, "apply_in_progress")
         async with record.apply_lock:
@@ -1454,7 +1566,7 @@ class CodingService:
         if self.mode != "draft":
             raise _http_error(status.HTTP_409_CONFLICT, "draft_unavailable")
         record = self._get_session(session_id)
-        self._require_builtin_project(record)
+        self._require_project_verification_enabled(record)
         try:
             payload = await self.worker.verification_status(
                 record.worker_session_id,
@@ -1477,7 +1589,7 @@ class CodingService:
         if self.mode != "draft":
             raise _http_error(status.HTTP_409_CONFLICT, "draft_unavailable")
         record = self._get_session(session_id)
-        self._require_builtin_project(record)
+        self._require_project_verification_enabled(record)
         if record.apply_lock.locked():
             raise _http_error(status.HTTP_409_CONFLICT, "apply_in_progress")
         async with record.apply_lock:
@@ -1494,6 +1606,80 @@ class CodingService:
         result = _verification_from_worker(payload)
         result["accepted"] = payload.get("accepted") is True
         return result
+
+    async def verification_confirm(
+        self,
+        session_id: str,
+        revision: int,
+        confirmation_id: str,
+    ) -> dict[str, Any]:
+        record = await self._review_record(session_id)
+        if self._is_builtin_project(record):
+            raise _http_error(
+                status.HTTP_409_CONFLICT,
+                "project_operation_unavailable",
+            )
+        if record.apply_lock.locked():
+            raise _http_error(status.HTTP_409_CONFLICT, "apply_in_progress")
+        async with record.apply_lock:
+            self._require_mutable(record)
+            try:
+                payload = await self.worker.verification_confirm(
+                    record.worker_session_id,
+                    revision,
+                    confirmation_id,
+                )
+            except CodingWorkerError as exc:
+                raise _worker_http_error(exc) from exc
+            record.updated_at = time.time()
+        result = _verification_from_worker(payload)
+        result["accepted"] = payload.get("accepted") is True
+        return result
+
+    async def command_pending(
+        self,
+        session_id: str,
+    ) -> dict[str, Any]:
+        await self.cleanup_expired()
+        record = self._get_session(session_id)
+        if self._is_builtin_project(record):
+            raise _http_error(
+                status.HTTP_409_CONFLICT,
+                "project_operation_unavailable",
+            )
+        try:
+            pending = await self.worker.command_pending(record.worker_session_id)
+        except CodingWorkerError as exc:
+            raise _worker_http_error(exc) from exc
+        return {"pending": _public_command_request(pending)}
+
+    async def command_decision(
+        self,
+        session_id: str,
+        request_id: str,
+        decision: str,
+    ) -> dict[str, Any]:
+        await self.cleanup_expired()
+        record = self._get_session(session_id)
+        if self._is_builtin_project(record):
+            raise _http_error(
+                status.HTTP_409_CONFLICT,
+                "project_operation_unavailable",
+            )
+        if SAFE_IDENTIFIER.fullmatch(request_id) is None:
+            raise _http_error(
+                status.HTTP_422_UNPROCESSABLE_CONTENT,
+                "invalid_request",
+            )
+        try:
+            resolved = await self.worker.command_decision(
+                record.worker_session_id,
+                request_id,
+                decision,
+            )
+        except CodingWorkerError as exc:
+            raise _worker_http_error(exc) from exc
+        return {"request": _public_command_request(resolved)}
 
     async def apply(
         self,
@@ -3287,7 +3473,9 @@ class CodingService:
         self,
         record: CodingApiSession,
     ) -> None:
-        if self.mode != "draft" or not self._is_builtin_project(record):
+        if self.mode != "draft":
+            return
+        if not self._is_builtin_project(record) and not self.commands_enabled:
             return
         try:
             changes = _public_changes(
@@ -3301,7 +3489,7 @@ class CodingService:
             raise _worker_http_error(exc) from exc
         verification = _verification_from_worker(payload)
         if (
-            verification["state"] == "running"
+            verification["state"] in {"awaiting_confirmation", "running"}
             and verification["stale"] is False
         ):
             raise _http_error(
@@ -3314,6 +3502,16 @@ class CodingService:
         if record is None:
             raise _http_error(status.HTTP_404_NOT_FOUND, "session_not_found")
         return record
+
+    def _require_project_verification_enabled(
+        self,
+        record: CodingApiSession,
+    ) -> None:
+        if not self._is_builtin_project(record) and not self.commands_enabled:
+            raise _http_error(
+                status.HTTP_409_CONFLICT,
+                "project_operation_unavailable",
+            )
 
 
 _service: CodingService | None = None
@@ -3581,6 +3779,44 @@ async def cancel_coding_verification(
     return await get_coding_service().verification_cancel(
         session_id,
         payload.revision,
+    )
+
+
+@router.post("/sessions/{session_id}/verification/confirm")
+async def confirm_coding_verification(
+    session_id: str,
+    payload: VerificationConfirmRequest,
+    response: Response,
+) -> dict[str, Any]:
+    response.headers["Cache-Control"] = "no-store"
+    return await get_coding_service().verification_confirm(
+        session_id,
+        payload.revision,
+        payload.confirmation_id,
+    )
+
+
+@router.get("/sessions/{session_id}/commands/pending")
+async def pending_coding_command(
+    session_id: str,
+    response: Response,
+) -> dict[str, Any]:
+    response.headers["Cache-Control"] = "no-store"
+    return await get_coding_service().command_pending(session_id)
+
+
+@router.post("/sessions/{session_id}/commands/{request_id}/decision")
+async def decide_coding_command(
+    session_id: str,
+    request_id: str,
+    payload: CommandDecisionRequest,
+    response: Response,
+) -> dict[str, Any]:
+    response.headers["Cache-Control"] = "no-store"
+    return await get_coding_service().command_decision(
+        session_id,
+        request_id,
+        payload.decision,
     )
 
 
@@ -4358,6 +4594,36 @@ def _public_event(event: CodingEvent) -> dict[str, Any]:
         }
     elif event.kind is CodingEventKind.FAILED:
         public_data = {"code": _safe_code(data.get("code"))}
+    elif event.kind is CodingEventKind.COMMAND_REQUESTED:
+        public_data = {
+            "request_id": _safe_identifier(data.get("request_id")),
+            "command": _public_command(data.get("command")),
+            "expires_at": _safe_timestamp(data.get("expires_at")),
+        }
+    elif event.kind is CodingEventKind.COMMAND_RESOLVED:
+        result = data.get("result")
+        public_data = {
+            "request_id": _safe_identifier(data.get("request_id")),
+            "state": _safe_code(data.get("state")),
+            "result": (
+                None
+                if not isinstance(result, dict)
+                else {
+                    "status": _safe_code(result.get("status")),
+                    "exit_code": (
+                        result.get("exit_code")
+                        if type(result.get("exit_code")) is int
+                        else None
+                    ),
+                    "output": sanitize_verification_output(
+                        result.get("output", ""), limit=16_000
+                    ).text,
+                    "duration_seconds": _safe_duration(
+                        result.get("duration_seconds")
+                    ),
+                }
+            ),
+        }
     else:
         public_data = {}
     return {
@@ -4379,6 +4645,84 @@ def _sanitize_text(value: Any, limit: int) -> str:
     return text[:limit]
 
 
+def _safe_identifier(value: Any) -> str:
+    text = str(value or "")
+    return text if SAFE_IDENTIFIER.fullmatch(text) is not None else "invalid"
+
+
+def _safe_timestamp(value: Any) -> float | None:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(value)
+        or value < 0
+    ):
+        return None
+    return float(value)
+
+
+def _safe_duration(value: Any) -> float:
+    duration = _safe_timestamp(value)
+    return 0.0 if duration is None else min(duration, 600.0)
+
+
+def _public_command(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise _http_error(status.HTTP_503_SERVICE_UNAVAILABLE, "invalid_worker_response")
+    try:
+        validated = VerificationCommandPayload.model_validate(value)
+    except (TypeError, ValueError) as exc:
+        raise _http_error(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            "invalid_worker_response",
+        ) from exc
+    result = validated.model_dump(by_alias=True)
+    result["id"] = _safe_identifier(result["id"])
+    result["name"] = sanitize_verification_output(
+        result["name"], limit=240, keep_tail=False
+    ).text
+    result["argv"] = [
+        sanitize_verification_output(item, limit=1_000, keep_tail=False).text
+        for item in result["argv"]
+    ]
+    result["cwd"] = _sanitize_text(result["cwd"], 500)
+    return result
+
+
+def _public_command_request(value: Any) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise _http_error(status.HTTP_503_SERVICE_UNAVAILABLE, "invalid_worker_response")
+    request_id = _safe_identifier(value.get("request_id"))
+    if request_id == "invalid":
+        raise _http_error(status.HTTP_503_SERVICE_UNAVAILABLE, "invalid_worker_response")
+    result = value.get("result")
+    return {
+        "request_id": request_id,
+        "command": _public_command(value.get("command")),
+        "state": _safe_code(value.get("state")),
+        "created_at": _safe_timestamp(value.get("created_at")),
+        "expires_at": _safe_timestamp(value.get("expires_at")),
+        "result": (
+            None
+            if not isinstance(result, dict)
+            else {
+                "status": _safe_code(result.get("status")),
+                "exit_code": (
+                    result.get("exit_code")
+                    if type(result.get("exit_code")) is int
+                    else None
+                ),
+                "output": sanitize_verification_output(
+                    result.get("output", ""), limit=16_000
+                ).text,
+                "duration_seconds": _safe_duration(result.get("duration_seconds")),
+            }
+        ),
+    }
+
+
 def _public_changes(payload: dict[str, Any]) -> dict[str, Any]:
     try:
         validated = DraftChangesPayload.model_validate(payload)
@@ -4397,6 +4741,12 @@ def _public_changes(payload: dict[str, Any]) -> dict[str, Any]:
 
 def _verification_from_worker(payload: dict[str, Any]) -> dict[str, Any]:
     verification = payload.get("verification")
+    if isinstance(verification, dict):
+        verification = {
+            key: value
+            for key, value in verification.items()
+            if not str(key).startswith("_")
+        }
     try:
         validated = VerificationPayload.model_validate(verification)
     except (TypeError, ValueError) as exc:
@@ -4411,7 +4761,10 @@ def _verification_from_worker(payload: dict[str, Any]) -> dict[str, Any]:
         else None
     )
     for step in result["steps"]:
-        step["label"] = _sanitize_text(step["label"], 100)
+        step["id"] = _safe_identifier(step["id"])
+        step["label"] = _sanitize_text(step["label"], 240)
+        if step.get("command") is not None:
+            step["command"] = _public_command(step["command"])
         step["summary"] = sanitize_verification_output(
             step["summary"],
             limit=500,

--- a/server/coding_runtime/command_bridge.py
+++ b/server/coding_runtime/command_bridge.py
@@ -1,0 +1,346 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import secrets
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+from .commands import ProjectCommand
+
+
+MAX_COMMANDS_PER_TURN = 20
+MAX_COMMAND_EXECUTION_SECONDS = 600.0
+COMMAND_CONFIRMATION_TIMEOUT_SECONDS = 300.0
+
+
+class CommandBridgeError(RuntimeError):
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+class CommandRequestState(StrEnum):
+    AWAITING_CONFIRMATION = "awaiting_confirmation"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    REJECTED = "rejected"
+    TIMED_OUT = "timed_out"
+    CANCELLED = "cancelled"
+    FAILED = "failed"
+
+
+class CommandDecision(StrEnum):
+    ALLOW_ONCE = "allow_once"
+    REJECT = "reject"
+
+
+@dataclass(frozen=True, slots=True)
+class CommandExecutionResult:
+    status: str
+    exit_code: int | None
+    output: str
+    duration_seconds: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "exit_code": self.exit_code,
+            "output": self.output,
+            "duration_seconds": round(max(0.0, self.duration_seconds), 3),
+        }
+
+
+@dataclass(slots=True)
+class CommandRequest:
+    request_id: str
+    session_id: str
+    turn_id: str
+    command: ProjectCommand
+    created_at: float
+    expires_at: float
+    state: CommandRequestState = CommandRequestState.AWAITING_CONFIRMATION
+    resolved_at: float | None = None
+    result: CommandExecutionResult | None = None
+    _decision: asyncio.Future[CommandDecision] | None = None
+    _execution: asyncio.Task[CommandExecutionResult] | None = None
+
+    def to_public_dict(self) -> dict[str, Any]:
+        return {
+            "request_id": self.request_id,
+            "command": self.command.to_public_dict(),
+            "state": self.state.value,
+            "created_at": self.created_at,
+            "expires_at": self.expires_at,
+            "result": None if self.result is None else self.result.to_dict(),
+        }
+
+
+CommandExecutor = Callable[[ProjectCommand, float], Awaitable[CommandExecutionResult]]
+CommandObserver = Callable[[CommandRequest], Awaitable[None]]
+
+
+class CommandConfirmationBridge:
+    """Per-turn, in-memory confirmation gate for one structured command at a time."""
+
+    def __init__(
+        self,
+        *,
+        confirmation_timeout: float = COMMAND_CONFIRMATION_TIMEOUT_SECONDS,
+        max_commands: int = MAX_COMMANDS_PER_TURN,
+        max_execution_seconds: float = MAX_COMMAND_EXECUTION_SECONDS,
+        clock: Callable[[], float] = time.time,
+        monotonic: Callable[[], float] = time.monotonic,
+        observer: CommandObserver | None = None,
+    ) -> None:
+        if confirmation_timeout <= 0 or max_commands < 1 or max_execution_seconds <= 0:
+            raise ValueError("Command bridge limits must be positive")
+        self._confirmation_timeout = confirmation_timeout
+        self._max_commands = max_commands
+        self._max_execution_seconds = max_execution_seconds
+        self._clock = clock
+        self._monotonic = monotonic
+        self._observer = observer
+        self._active_turn_id: str | None = None
+        self._request_count = 0
+        self._execution_seconds = 0.0
+        self._current: CommandRequest | None = None
+        self._resolved: dict[str, CommandRequest] = {}
+        self._lock = asyncio.Lock()
+
+    async def begin_turn(self, turn_id: str) -> None:
+        if not isinstance(turn_id, str) or not turn_id:
+            raise CommandBridgeError("command_turn_invalid", "Command turn is invalid")
+        async with self._lock:
+            if self._active_turn_id is not None:
+                raise CommandBridgeError("command_turn_busy", "Another command turn is active")
+            self._active_turn_id = turn_id
+            self._request_count = 0
+            self._execution_seconds = 0.0
+            self._current = None
+            self._resolved.clear()
+
+    async def finish_turn(self, reason: str = "turn_finished") -> None:
+        await self.cancel_pending(reason=reason)
+        async with self._lock:
+            self._active_turn_id = None
+
+    async def request(
+        self,
+        *,
+        session_id: str,
+        turn_id: str,
+        command: ProjectCommand,
+        executor: CommandExecutor,
+    ) -> dict[str, Any]:
+        loop = asyncio.get_running_loop()
+        now = self._clock()
+        request = CommandRequest(
+            request_id="command-request-" + secrets.token_hex(16),
+            session_id=session_id,
+            turn_id=turn_id,
+            command=command,
+            created_at=now,
+            expires_at=now + self._confirmation_timeout,
+            _decision=loop.create_future(),
+        )
+        async with self._lock:
+            if self._active_turn_id != turn_id:
+                raise CommandBridgeError("command_turn_inactive", "Command turn is not active")
+            if self._current is not None:
+                raise CommandBridgeError("command_request_busy", "Another command is pending")
+            if self._request_count >= self._max_commands:
+                raise CommandBridgeError("command_limit_reached", "Command limit reached")
+            if self._execution_seconds >= self._max_execution_seconds:
+                raise CommandBridgeError("command_time_limit_reached", "Command time limit reached")
+            self._request_count += 1
+            self._current = request
+        await self._notify(request)
+
+        try:
+            try:
+                decision = await asyncio.wait_for(
+                    asyncio.shield(request._decision),
+                    timeout=self._confirmation_timeout,
+                )
+            except TimeoutError:
+                await self._resolve_without_execution(
+                    request,
+                    CommandRequestState.TIMED_OUT,
+                    status="confirmation_timed_out",
+                )
+                return self._tool_result(request)
+
+            if decision is CommandDecision.REJECT:
+                await self._resolve_without_execution(
+                    request,
+                    CommandRequestState.REJECTED,
+                    status="rejected",
+                )
+                return self._tool_result(request)
+
+            async with self._lock:
+                if self._current is not request:
+                    return self._tool_result(request)
+                request.state = CommandRequestState.RUNNING
+                remaining = max(
+                    0.0,
+                    self._max_execution_seconds - self._execution_seconds,
+                )
+            await self._notify(request)
+            if remaining <= 0:
+                await self._resolve_without_execution(
+                    request,
+                    CommandRequestState.REJECTED,
+                    status="command_time_limit_reached",
+                )
+                return self._tool_result(request)
+
+            started = self._monotonic()
+            request._execution = asyncio.create_task(executor(command, remaining))
+            try:
+                result = await request._execution
+            except asyncio.CancelledError:
+                await self._resolve_without_execution(
+                    request,
+                    CommandRequestState.CANCELLED,
+                    status="turn_cancelled",
+                )
+                if asyncio.current_task() is not None and asyncio.current_task().cancelling():
+                    raise
+                return self._tool_result(request)
+            except Exception:
+                result = CommandExecutionResult(
+                    status="execution_failed",
+                    exit_code=None,
+                    output="The approved check could not be completed.",
+                    duration_seconds=max(0.0, self._monotonic() - started),
+                )
+                terminal_state = CommandRequestState.FAILED
+            else:
+                terminal_state = CommandRequestState.COMPLETED
+            duration = max(result.duration_seconds, self._monotonic() - started, 0.0)
+            async with self._lock:
+                self._execution_seconds = min(
+                    self._max_execution_seconds,
+                    self._execution_seconds + duration,
+                )
+                request.result = result
+                request.state = terminal_state
+                request.resolved_at = self._clock()
+                self._archive_current(request)
+            await self._notify(request)
+            return self._tool_result(request)
+        finally:
+            async with self._lock:
+                if self._current is request and request.state not in {
+                    CommandRequestState.AWAITING_CONFIRMATION,
+                    CommandRequestState.RUNNING,
+                }:
+                    self._archive_current(request)
+
+    async def pending(self, *, session_id: str, turn_id: str | None = None) -> dict[str, Any] | None:
+        async with self._lock:
+            request = self._current
+            if (
+                request is None
+                or request.session_id != session_id
+                or (turn_id is not None and request.turn_id != turn_id)
+            ):
+                return None
+            return request.to_public_dict()
+
+    async def decide(
+        self,
+        *,
+        session_id: str,
+        request_id: str,
+        decision: str,
+    ) -> dict[str, Any]:
+        try:
+            selected = CommandDecision(decision)
+        except ValueError as exc:
+            raise CommandBridgeError("command_decision_invalid", "Command decision is invalid") from exc
+        async with self._lock:
+            request = self._current
+            if request is None or request.request_id != request_id or request.session_id != session_id:
+                resolved = self._resolved.get(request_id)
+                if resolved is not None and resolved.session_id == session_id:
+                    return resolved.to_public_dict()
+                raise CommandBridgeError("command_request_not_found", "Command request is unavailable")
+            if request.state is not CommandRequestState.AWAITING_CONFIRMATION:
+                return request.to_public_dict()
+            assert request._decision is not None
+            if not request._decision.done():
+                request._decision.set_result(selected)
+            return request.to_public_dict()
+
+    async def cancel_pending(self, *, reason: str = "turn_cancelled") -> bool:
+        async with self._lock:
+            request = self._current
+            if request is None:
+                return False
+            if request.state is CommandRequestState.AWAITING_CONFIRMATION:
+                assert request._decision is not None
+                if not request._decision.done():
+                    request._decision.set_result(CommandDecision.REJECT)
+                request.state = CommandRequestState.CANCELLED
+                request.result = CommandExecutionResult(reason, None, "", 0.0)
+                request.resolved_at = self._clock()
+                self._archive_current(request)
+            elif request.state is CommandRequestState.RUNNING:
+                request.state = CommandRequestState.CANCELLED
+                request.result = CommandExecutionResult(reason, None, "", 0.0)
+                request.resolved_at = self._clock()
+                if request._execution is not None and not request._execution.done():
+                    request._execution.cancel()
+            else:
+                return False
+        await self._notify(request)
+        return True
+
+    async def _resolve_without_execution(
+        self,
+        request: CommandRequest,
+        state: CommandRequestState,
+        *,
+        status: str,
+    ) -> None:
+        async with self._lock:
+            if request.state is CommandRequestState.CANCELLED:
+                return
+            request.state = state
+            request.result = CommandExecutionResult(status, None, "", 0.0)
+            request.resolved_at = self._clock()
+            self._archive_current(request)
+        await self._notify(request)
+
+    def _archive_current(self, request: CommandRequest) -> None:
+        self._resolved[request.request_id] = request
+        if self._current is request:
+            self._current = None
+
+    async def _notify(self, request: CommandRequest) -> None:
+        if self._observer is not None:
+            await self._observer(request)
+
+    @staticmethod
+    def _tool_result(request: CommandRequest) -> dict[str, Any]:
+        result = request.result or CommandExecutionResult(
+            status="turn_cancelled",
+            exit_code=None,
+            output="",
+            duration_seconds=0.0,
+        )
+        return {
+            "request_id": request.request_id,
+            "state": request.state.value,
+            "result": result.to_dict(),
+        }
+
+
+def encode_tool_result(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))

--- a/server/coding_runtime/commands.py
+++ b/server/coding_runtime/commands.py
@@ -1,0 +1,587 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import unicodedata
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path, PurePosixPath
+from typing import Any, Iterable
+
+
+MAX_PROJECT_CHECKS = 8
+MAX_COMMAND_ARGS = 64
+MAX_COMMAND_BYTES = 8 * 1024
+MAX_COMMAND_NAME_CHARS = 80
+MAX_COMMAND_PURPOSE_CHARS = 240
+MIN_COMMAND_TIMEOUT_SECONDS = 1
+MAX_COMMAND_TIMEOUT_SECONDS = 300
+MAX_PACK_MANIFEST_BYTES = 64 * 1024
+MAX_PACK_PATHS = 16
+PACK_ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}$")
+_HASH_PATTERN = re.compile(r"^sha256:[a-f0-9]{64}$")
+_WINDOWS_ABSOLUTE = re.compile(r"^[A-Za-z]:[\\/]")
+_DIRECT_SHELLS = frozenset(
+    {"bash", "sh", "dash", "zsh", "fish", "cmd", "powershell", "pwsh"}
+)
+_DEPENDENCY_INPUT_NAMES = frozenset(
+    {
+        "pyproject.toml",
+        "requirements.txt",
+        "requirements-dev.txt",
+        "package.json",
+        "package-lock.json",
+        "npm-shrinkwrap.json",
+        "pnpm-lock.yaml",
+        "yarn.lock",
+    }
+)
+_NODE_SCRIPT_ORDER = ("test", "typecheck", "lint", "build")
+_NODE_SCRIPT_LABELS = {
+    "test": "运行页面测试",
+    "typecheck": "检查页面类型",
+    "lint": "检查页面规范",
+    "build": "检查页面构建",
+}
+
+
+class CommandContractError(ValueError):
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+class ProjectCommandKind(StrEnum):
+    TEST = "test"
+    BUILD = "build"
+    LINT = "lint"
+    TYPECHECK = "typecheck"
+    CUSTOM = "custom"
+
+
+class ProjectCommandOrigin(StrEnum):
+    AUTO = "auto"
+    MANIFEST = "manifest"
+    AGENT = "agent"
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectCommand:
+    command_id: str
+    name: str
+    kind: ProjectCommandKind
+    argv: tuple[str, ...]
+    cwd: str
+    timeout_seconds: int
+    origin: ProjectCommandOrigin
+
+    def to_internal_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.command_id,
+            "name": self.name,
+            "kind": self.kind.value,
+            "argv": list(self.argv),
+            "cwd": self.cwd,
+            "timeout_seconds": self.timeout_seconds,
+            "origin": self.origin.value,
+        }
+
+    def to_public_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.command_id,
+            "name": self.name,
+            "kind": self.kind.value,
+            "argv": list(self.argv),
+            "cwd": self.cwd,
+            "timeout_seconds": self.timeout_seconds,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectVerificationConfig:
+    auto: bool = True
+    runner_pack: str | None = None
+    commands: tuple[ProjectCommand, ...] = ()
+
+    def to_internal_dict(self) -> dict[str, Any]:
+        return {
+            "auto": self.auto,
+            "runner_pack": self.runner_pack,
+            "commands": [item.to_internal_dict() for item in self.commands],
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class RunnerPackManifest:
+    pack_id: str
+    platform: str
+    python_version: str
+    node_version: str
+    inputs: tuple[tuple[str, str], ...]
+    python_paths: tuple[str, ...]
+    node_modules: tuple[tuple[str, str], ...]
+    bin_paths: tuple[str, ...]
+    fingerprint: str
+
+
+def parse_project_verification(value: Any) -> ProjectVerificationConfig:
+    if value is None:
+        return ProjectVerificationConfig()
+    if not isinstance(value, dict) or not set(value).issubset(
+        {"auto", "runner_pack", "commands"}
+    ):
+        raise CommandContractError(
+            "project_verification_invalid",
+            "Project verification config is invalid",
+        )
+    auto = value.get("auto", True)
+    if type(auto) is not bool:
+        raise CommandContractError(
+            "project_verification_invalid",
+            "Project verification auto flag is invalid",
+        )
+    raw_pack = value.get("runner_pack")
+    if raw_pack is not None and (
+        not isinstance(raw_pack, str) or PACK_ID_PATTERN.fullmatch(raw_pack) is None
+    ):
+        raise CommandContractError("runner_pack_invalid", "Runner pack id is invalid")
+    raw_commands = value.get("commands", [])
+    if not isinstance(raw_commands, list) or len(raw_commands) > MAX_PROJECT_CHECKS:
+        raise CommandContractError(
+            "project_commands_invalid",
+            "Project verification command count is invalid",
+        )
+    commands = tuple(
+        normalize_project_command(item, origin=ProjectCommandOrigin.MANIFEST)
+        for item in raw_commands
+    )
+    _require_unique_commands(commands)
+    return ProjectVerificationConfig(
+        auto=auto,
+        runner_pack=raw_pack,
+        commands=commands,
+    )
+
+
+def normalize_project_command(
+    value: Any,
+    *,
+    origin: ProjectCommandOrigin,
+) -> ProjectCommand:
+    if not isinstance(value, dict) or set(value) != {
+        "name",
+        "kind",
+        "argv",
+        "cwd",
+        "timeout_seconds",
+    }:
+        raise CommandContractError("project_command_invalid", "Project command is invalid")
+    name_limit = (
+        MAX_COMMAND_PURPOSE_CHARS
+        if origin is ProjectCommandOrigin.AGENT
+        else MAX_COMMAND_NAME_CHARS
+    )
+    name = _normalize_text(value["name"], name_limit, "project_command_invalid")
+    try:
+        kind = ProjectCommandKind(value["kind"])
+    except (TypeError, ValueError) as exc:
+        raise CommandContractError(
+            "project_command_invalid",
+            "Project command kind is invalid",
+        ) from exc
+    if origin is ProjectCommandOrigin.AGENT and kind is not ProjectCommandKind.CUSTOM:
+        raise CommandContractError("project_command_invalid", "Agent command kind is invalid")
+    argv = normalize_argv(value["argv"])
+    cwd = normalize_command_cwd(value["cwd"])
+    timeout_seconds = value["timeout_seconds"]
+    if (
+        type(timeout_seconds) is not int
+        or not MIN_COMMAND_TIMEOUT_SECONDS
+        <= timeout_seconds
+        <= MAX_COMMAND_TIMEOUT_SECONDS
+    ):
+        raise CommandContractError(
+            "project_command_timeout_invalid",
+            "Project command timeout is invalid",
+        )
+    canonical = {
+        "name": name,
+        "kind": kind.value,
+        "argv": list(argv),
+        "cwd": cwd,
+        "timeout_seconds": timeout_seconds,
+        "origin": origin.value,
+    }
+    command_id = "command-" + hashlib.sha256(
+        json.dumps(canonical, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode(
+            "utf-8"
+        )
+    ).hexdigest()[:24]
+    return ProjectCommand(
+        command_id=command_id,
+        name=name,
+        kind=kind,
+        argv=argv,
+        cwd=cwd,
+        timeout_seconds=timeout_seconds,
+        origin=origin,
+    )
+
+
+def normalize_agent_command(
+    *,
+    argv: Any,
+    cwd: Any,
+    purpose: Any,
+    timeout_seconds: Any,
+) -> ProjectCommand:
+    return normalize_project_command(
+        {
+            "name": purpose,
+            "kind": ProjectCommandKind.CUSTOM.value,
+            "argv": argv,
+            "cwd": cwd,
+            "timeout_seconds": timeout_seconds,
+        },
+        origin=ProjectCommandOrigin.AGENT,
+    )
+
+
+def normalize_argv(value: Any) -> tuple[str, ...]:
+    if (
+        not isinstance(value, list)
+        or not value
+        or len(value) > MAX_COMMAND_ARGS
+        or not all(isinstance(item, str) for item in value)
+    ):
+        raise CommandContractError("command_argv_invalid", "Command argv is invalid")
+    argv: list[str] = []
+    total_bytes = 0
+    for item in value:
+        if (
+            not item
+            or item != unicodedata.normalize("NFC", item)
+            or any(_is_control(character) for character in item)
+        ):
+            raise CommandContractError("command_argv_invalid", "Command argv is invalid")
+        try:
+            total_bytes += len(item.encode("utf-8", errors="strict"))
+        except UnicodeEncodeError as exc:
+            raise CommandContractError("command_argv_invalid", "Command argv is invalid") from exc
+        if _looks_like_absolute_path(item) or item == ".." or item.startswith("../"):
+            raise CommandContractError("command_path_invalid", "Command path is invalid")
+        argv.append(item)
+    if total_bytes > MAX_COMMAND_BYTES:
+        raise CommandContractError("command_argv_invalid", "Command argv is too large")
+    executable = PurePosixPath(argv[0]).name.casefold()
+    if executable.endswith(".exe"):
+        executable = executable[:-4]
+    if executable in _DIRECT_SHELLS:
+        raise CommandContractError("command_shell_denied", "Direct shell commands are denied")
+    _normalize_relative_path(argv[0], allow_dot=False, allow_plain_name=True)
+    return tuple(argv)
+
+
+def normalize_command_cwd(value: Any) -> str:
+    if value == ".":
+        return "."
+    if not isinstance(value, str):
+        raise CommandContractError("command_cwd_invalid", "Command cwd is invalid")
+    return _normalize_relative_path(value, allow_dot=False, allow_plain_name=True)
+
+
+def detect_project_commands(
+    snapshot_root: Path,
+    config: ProjectVerificationConfig,
+) -> tuple[ProjectCommand, ...]:
+    root = Path(snapshot_root)
+    commands: list[ProjectCommand] = list(config.commands)
+    seen = {(item.argv, item.cwd) for item in commands}
+    if config.auto:
+        auto_commands: list[ProjectCommand] = []
+        if _has_python_tests(root):
+            auto_commands.append(
+                _auto_command(
+                    name="运行 Python 测试",
+                    kind=ProjectCommandKind.TEST,
+                    argv=["python", "-m", "pytest", "-p", "no:cacheprovider", "-q"],
+                )
+            )
+        auto_commands.extend(_detect_node_commands(root))
+        for item in auto_commands:
+            key = (item.argv, item.cwd)
+            if key not in seen and len(commands) < MAX_PROJECT_CHECKS:
+                commands.append(item)
+                seen.add(key)
+    return tuple(commands)
+
+
+def dependency_input_hashes(
+    snapshot_root: Path,
+    paths: Iterable[str] | None = None,
+) -> tuple[tuple[str, str], ...]:
+    root = Path(snapshot_root)
+    items: list[tuple[str, str]] = []
+    names = (
+        sorted(_DEPENDENCY_INPUT_NAMES)
+        if paths is None
+        else sorted(
+            _normalize_relative_path(
+                item,
+                allow_dot=False,
+                allow_plain_name=True,
+            )
+            for item in paths
+        )
+    )
+    if len(names) > MAX_PACK_PATHS or len(names) != len(set(names)):
+        raise CommandContractError("runner_pack_invalid", "Runner pack inputs are invalid")
+    for name in names:
+        path = root / name
+        if path.is_file() and not path.is_symlink():
+            digest = hashlib.sha256(path.read_bytes()).hexdigest()
+            items.append((name, f"sha256:{digest}"))
+    return tuple(items)
+
+
+def load_runner_pack_manifest(pack_root: Path, pack_id: str) -> RunnerPackManifest:
+    if PACK_ID_PATTERN.fullmatch(pack_id) is None:
+        raise CommandContractError("runner_pack_invalid", "Runner pack id is invalid")
+    root = Path(pack_root)
+    pack_path = root / pack_id
+    manifest_path = pack_path / "pack.json"
+    if (
+        not root.is_absolute()
+        or root.is_symlink()
+        or pack_path.is_symlink()
+        or manifest_path.is_symlink()
+        or not manifest_path.is_file()
+    ):
+        raise CommandContractError("runner_pack_unavailable", "Runner pack is unavailable")
+    try:
+        raw = manifest_path.read_bytes()
+        if len(raw) > MAX_PACK_MANIFEST_BYTES:
+            raise CommandContractError("runner_pack_invalid", "Runner pack manifest is too large")
+        payload = json.loads(raw.decode("utf-8", errors="strict"))
+    except CommandContractError:
+        raise
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise CommandContractError("runner_pack_invalid", "Runner pack manifest is invalid") from exc
+    expected = {
+        "version",
+        "id",
+        "platform",
+        "python_version",
+        "node_version",
+        "inputs",
+        "python_paths",
+        "node_modules",
+        "bin_paths",
+    }
+    if not isinstance(payload, dict) or set(payload) != expected:
+        raise CommandContractError("runner_pack_invalid", "Runner pack manifest is invalid")
+    if payload["version"] != 1 or payload["id"] != pack_id:
+        raise CommandContractError("runner_pack_invalid", "Runner pack identity is invalid")
+    if payload["platform"] != "linux-x86_64":
+        raise CommandContractError("runner_pack_platform_mismatch", "Runner pack platform is invalid")
+    if payload["python_version"] != "3.12" or payload["node_version"] != "22":
+        raise CommandContractError("runner_pack_runtime_mismatch", "Runner pack runtime is invalid")
+    inputs = _normalize_hash_mapping(payload["inputs"], allow_dot_key=False)
+    python_paths = _normalize_path_list(payload["python_paths"])
+    bin_paths = _normalize_path_list(payload["bin_paths"])
+    node_modules = _normalize_path_mapping(payload["node_modules"])
+    canonical = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return RunnerPackManifest(
+        pack_id=pack_id,
+        platform=payload["platform"],
+        python_version=payload["python_version"],
+        node_version=payload["node_version"],
+        inputs=inputs,
+        python_paths=python_paths,
+        node_modules=node_modules,
+        bin_paths=bin_paths,
+        fingerprint=hashlib.sha256(canonical.encode("utf-8")).hexdigest(),
+    )
+
+
+def runner_pack_matches_project(
+    manifest: RunnerPackManifest,
+    snapshot_root: Path,
+) -> bool:
+    expected_paths = tuple(path for path, _digest in manifest.inputs)
+    return manifest.inputs == dependency_input_hashes(snapshot_root, expected_paths)
+
+
+def command_plan_fingerprint(
+    commands: Iterable[ProjectCommand],
+    *,
+    source_fingerprint: str,
+    pack_fingerprint: str = "",
+) -> str:
+    payload = {
+        "commands": [item.to_internal_dict() for item in commands],
+        "source_fingerprint": source_fingerprint,
+        "pack_fingerprint": pack_fingerprint,
+    }
+    encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _auto_command(
+    *,
+    name: str,
+    kind: ProjectCommandKind,
+    argv: list[str],
+) -> ProjectCommand:
+    return normalize_project_command(
+        {
+            "name": name,
+            "kind": kind.value,
+            "argv": argv,
+            "cwd": ".",
+            "timeout_seconds": MAX_COMMAND_TIMEOUT_SECONDS,
+        },
+        origin=ProjectCommandOrigin.AUTO,
+    )
+
+
+def _has_python_tests(root: Path) -> bool:
+    if (root / "tests").is_dir() or (root / "pytest.ini").is_file():
+        return True
+    markers = {
+        "pyproject.toml": "[tool.pytest.",
+        "setup.cfg": "[tool:pytest]",
+        "tox.ini": "pytest",
+    }
+    for name, marker in markers.items():
+        path = root / name
+        if path.is_symlink() or not path.is_file():
+            continue
+        try:
+            raw = path.read_bytes()
+            if len(raw) <= 1024 * 1024 and marker in raw.decode("utf-8", errors="strict"):
+                return True
+        except (OSError, UnicodeError):
+            continue
+    return False
+
+
+def _detect_node_commands(root: Path) -> tuple[ProjectCommand, ...]:
+    package_json = root / "package.json"
+    if package_json.is_symlink() or not package_json.is_file():
+        return ()
+    try:
+        raw = package_json.read_bytes()
+        if len(raw) > 1024 * 1024:
+            return ()
+        payload = json.loads(raw.decode("utf-8", errors="strict"))
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return ()
+    scripts = payload.get("scripts") if isinstance(payload, dict) else None
+    if not isinstance(scripts, dict):
+        return ()
+    commands: list[ProjectCommand] = []
+    for script in _NODE_SCRIPT_ORDER:
+        value = scripts.get(script)
+        if isinstance(value, str) and value.strip():
+            commands.append(
+                _auto_command(
+                    name=_NODE_SCRIPT_LABELS[script],
+                    kind=ProjectCommandKind(script),
+                    argv=["npm", "run", script],
+                )
+            )
+    return tuple(commands)
+
+
+def _normalize_text(value: Any, limit: int, code: str) -> str:
+    if (
+        not isinstance(value, str)
+        or not value
+        or value != value.strip()
+        or len(value) > limit
+        or value != unicodedata.normalize("NFC", value)
+        or any(_is_control(character) for character in value)
+    ):
+        raise CommandContractError(code, "Command text is invalid")
+    return value
+
+
+def _normalize_relative_path(
+    value: str,
+    *,
+    allow_dot: bool,
+    allow_plain_name: bool,
+) -> str:
+    if not isinstance(value, str) or not value or "\\" in value or _WINDOWS_ABSOLUTE.match(value):
+        raise CommandContractError("command_path_invalid", "Command path is invalid")
+    if value == "." and allow_dot:
+        return value
+    path = PurePosixPath(value)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise CommandContractError("command_path_invalid", "Command path is invalid")
+    normalized = path.as_posix()
+    if normalized != value or (not allow_plain_name and len(path.parts) == 1):
+        raise CommandContractError("command_path_invalid", "Command path is invalid")
+    return normalized
+
+
+def _looks_like_absolute_path(value: str) -> bool:
+    if _WINDOWS_ABSOLUTE.match(value) or value.startswith("/"):
+        return True
+    if "=" in value:
+        possible_path = value.split("=", maxsplit=1)[1]
+        return bool(_WINDOWS_ABSOLUTE.match(possible_path) or possible_path.startswith("/"))
+    return False
+
+
+def _normalize_hash_mapping(value: Any, *, allow_dot_key: bool) -> tuple[tuple[str, str], ...]:
+    if not isinstance(value, dict) or len(value) > MAX_PACK_PATHS:
+        raise CommandContractError("runner_pack_invalid", "Runner pack inputs are invalid")
+    items: list[tuple[str, str]] = []
+    for key, digest in value.items():
+        path = "." if key == "." and allow_dot_key else _normalize_relative_path(
+            key,
+            allow_dot=False,
+            allow_plain_name=True,
+        )
+        if not isinstance(digest, str) or _HASH_PATTERN.fullmatch(digest) is None:
+            raise CommandContractError("runner_pack_invalid", "Runner pack hash is invalid")
+        items.append((path, digest))
+    return tuple(sorted(items))
+
+
+def _normalize_path_list(value: Any) -> tuple[str, ...]:
+    if not isinstance(value, list) or len(value) > MAX_PACK_PATHS:
+        raise CommandContractError("runner_pack_invalid", "Runner pack paths are invalid")
+    paths = tuple(
+        _normalize_relative_path(item, allow_dot=False, allow_plain_name=True)
+        for item in value
+    )
+    if len(paths) != len(set(paths)):
+        raise CommandContractError("runner_pack_invalid", "Runner pack paths are duplicated")
+    return paths
+
+
+def _normalize_path_mapping(value: Any) -> tuple[tuple[str, str], ...]:
+    if not isinstance(value, dict) or len(value) > MAX_PACK_PATHS:
+        raise CommandContractError("runner_pack_invalid", "Runner pack paths are invalid")
+    items: list[tuple[str, str]] = []
+    for key, path in value.items():
+        cwd = normalize_command_cwd(key)
+        safe_path = _normalize_relative_path(path, allow_dot=False, allow_plain_name=True)
+        items.append((cwd, safe_path))
+    if len({item[0] for item in items}) != len(items):
+        raise CommandContractError("runner_pack_invalid", "Runner pack paths are duplicated")
+    return tuple(sorted(items))
+
+
+def _require_unique_commands(commands: Iterable[ProjectCommand]) -> None:
+    identities = [(item.argv, item.cwd) for item in commands]
+    if len(identities) != len(set(identities)):
+        raise CommandContractError("project_commands_duplicate", "Project commands are duplicated")
+
+
+def _is_control(value: str) -> bool:
+    return unicodedata.category(value).startswith("C")

--- a/server/coding_runtime/commands.py
+++ b/server/coding_runtime/commands.py
@@ -236,12 +236,18 @@ def normalize_agent_command(
     purpose: Any,
     timeout_seconds: Any,
 ) -> ProjectCommand:
+    normalized_cwd = cwd
+    if isinstance(cwd, str):
+        if cwd == "/workspace":
+            normalized_cwd = "."
+        elif cwd.startswith("/workspace/"):
+            normalized_cwd = cwd.removeprefix("/workspace/")
     return normalize_project_command(
         {
             "name": purpose,
             "kind": ProjectCommandKind.CUSTOM.value,
             "argv": argv,
-            "cwd": cwd,
+            "cwd": normalized_cwd,
             "timeout_seconds": timeout_seconds,
         },
         origin=ProjectCommandOrigin.AGENT,

--- a/server/coding_runtime/models.py
+++ b/server/coding_runtime/models.py
@@ -15,6 +15,8 @@ class CodingEventKind(StrEnum):
     PLAN = "plan"
     ANSWER_DELTA = "answer_delta"
     TOOL_STATUS = "tool_status"
+    COMMAND_REQUESTED = "command_requested"
+    COMMAND_RESOLVED = "command_resolved"
     TURN_COMPLETED = "turn_completed"
     FAILED = "failed"
     CANCELLED = "cancelled"

--- a/server/coding_runtime/projects.py
+++ b/server/coding_runtime/projects.py
@@ -5,14 +5,21 @@ import json
 import os
 import subprocess
 import unicodedata
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path, PurePosixPath
 from typing import Any, Callable, Sequence
 
+from .commands import (
+    CommandContractError,
+    ProjectVerificationConfig,
+    parse_project_verification,
+)
+
 
 PROJECT_MANIFEST_NAME = ".modelmirror-coding-projects.json"
-PROJECT_MANIFEST_VERSION = 1
+PROJECT_MANIFEST_VERSION = 2
+SUPPORTED_PROJECT_MANIFEST_VERSIONS = frozenset({1, 2})
 MAX_PROJECTS = 50
 MAX_PROJECT_NAME_CHARS = 80
 MAX_PROJECT_PATH_CHARS = 512
@@ -128,6 +135,9 @@ class ProjectManifestEntry:
     project_id: str
     name: str
     relative_path: str
+    verification: ProjectVerificationConfig = field(
+        default_factory=ProjectVerificationConfig
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -217,8 +227,12 @@ def load_project_manifest(root: Path) -> tuple[ProjectManifestEntry, ...]:
         raise ProjectCatalogError("project_manifest_invalid", "Project manifest is invalid") from exc
     if not isinstance(payload, dict) or set(payload) != {"version", "projects"}:
         raise ProjectCatalogError("project_manifest_invalid", "Project manifest shape is invalid")
-    if type(payload["version"]) is not int or payload["version"] != PROJECT_MANIFEST_VERSION:
+    if (
+        type(payload["version"]) is not int
+        or payload["version"] not in SUPPORTED_PROJECT_MANIFEST_VERSIONS
+    ):
         raise ProjectCatalogError("project_manifest_version_unsupported", "Project manifest version is unsupported")
+    manifest_version = payload["version"]
     projects = payload["projects"]
     if not isinstance(projects, list) or len(projects) > MAX_PROJECTS:
         raise ProjectCatalogError("project_manifest_invalid", "Project manifest project count is invalid")
@@ -227,10 +241,23 @@ def load_project_manifest(root: Path) -> tuple[ProjectManifestEntry, ...]:
     seen_paths: set[str] = set()
     seen_folded_paths: set[str] = set()
     for item in projects:
-        if not isinstance(item, dict) or set(item) != {"name", "path"}:
+        allowed_keys = (
+            {"name", "path"}
+            if manifest_version == 1
+            else {"name", "path", "verification"}
+        )
+        if (
+            not isinstance(item, dict)
+            or not {"name", "path"}.issubset(item)
+            or not set(item).issubset(allowed_keys)
+        ):
             raise ProjectCatalogError("project_manifest_invalid", "Project entry is invalid")
         name = _normalize_project_name(item["name"])
         relative_path = normalize_project_path(item["path"])
+        try:
+            verification = parse_project_verification(item.get("verification"))
+        except CommandContractError as exc:
+            raise ProjectCatalogError(exc.code, str(exc)) from exc
         folded_path = relative_path.casefold()
         if relative_path in seen_paths:
             raise ProjectCatalogError("manifest_path_duplicate", "Project path is duplicated")
@@ -243,6 +270,7 @@ def load_project_manifest(root: Path) -> tuple[ProjectManifestEntry, ...]:
                 project_id=build_project_id(relative_path),
                 name=name,
                 relative_path=relative_path,
+                verification=verification,
             )
         )
     return tuple(entries)

--- a/server/coding_runtime/runner_mcp.py
+++ b/server/coding_runtime/runner_mcp.py
@@ -22,7 +22,8 @@ def _tool_definition() -> dict[str, Any]:
         "name": TOOL_NAME,
         "description": (
             "Request one structured Python or Node project check. The user must approve "
-            "each request before it runs in an isolated offline copy."
+            "each request before it runs in an isolated offline copy. Set cwd to '.' or "
+            "a project-relative directory; '/workspace' is accepted as the project root."
         ),
         "inputSchema": {
             "type": "object",
@@ -33,7 +34,13 @@ def _tool_definition() -> dict[str, Any]:
                     "minItems": 1,
                     "maxItems": 64,
                 },
-                "cwd": {"type": "string"},
+                "cwd": {
+                    "type": "string",
+                    "description": (
+                        "Project-relative directory. Use '.' or '/workspace' for the "
+                        "project root; do not use any other absolute path."
+                    ),
+                },
                 "purpose": {"type": "string", "minLength": 1, "maxLength": 240},
                 "timeout_seconds": {"type": "integer", "minimum": 1, "maximum": 300},
             },

--- a/server/coding_runtime/runner_mcp.py
+++ b/server/coding_runtime/runner_mcp.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import os
+import sys
+from typing import Any, BinaryIO
+
+
+MAX_MCP_FRAME_BYTES = 64 * 1024
+MCP_PROTOCOL_VERSION = "2024-11-05"
+TOOL_NAME = "run_project_command"
+
+
+class RunnerMcpError(RuntimeError):
+    pass
+
+
+def _tool_definition() -> dict[str, Any]:
+    return {
+        "name": TOOL_NAME,
+        "description": (
+            "Request one structured Python or Node project check. The user must approve "
+            "each request before it runs in an isolated offline copy."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "argv": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "minItems": 1,
+                    "maxItems": 64,
+                },
+                "cwd": {"type": "string"},
+                "purpose": {"type": "string", "minLength": 1, "maxLength": 240},
+                "timeout_seconds": {"type": "integer", "minimum": 1, "maximum": 300},
+            },
+            "required": ["argv", "cwd", "purpose", "timeout_seconds"],
+            "additionalProperties": False,
+        },
+    }
+
+
+class RunnerMcpServer:
+    def __init__(self, *, socket_path: str, token: str) -> None:
+        if not socket_path or not token:
+            raise RunnerMcpError("Runner bridge is not configured")
+        self._socket_path = socket_path
+        self._token = token
+
+    async def dispatch(self, frame: dict[str, Any]) -> dict[str, Any] | None:
+        if frame.get("jsonrpc") != "2.0" or not isinstance(frame.get("method"), str):
+            raise RunnerMcpError("Invalid MCP frame")
+        request_id = frame.get("id")
+        method = frame["method"]
+        params = frame.get("params", {})
+        if method == "notifications/initialized" and "id" not in frame:
+            return None
+        if "id" not in frame:
+            return None
+        if method == "initialize":
+            return self._result(
+                request_id,
+                {
+                    "protocolVersion": MCP_PROTOCOL_VERSION,
+                    "capabilities": {"tools": {"listChanged": False}},
+                    "serverInfo": {"name": "modelmirror-runner", "version": "1.0.0"},
+                },
+            )
+        if method == "ping":
+            return self._result(request_id, {})
+        if method == "tools/list":
+            return self._result(request_id, {"tools": [_tool_definition()]})
+        if method == "tools/call":
+            if not isinstance(params, dict) or params.get("name") != TOOL_NAME:
+                return self._error(request_id, -32602, "Unknown tool")
+            arguments = params.get("arguments")
+            if not isinstance(arguments, dict):
+                return self._error(request_id, -32602, "Invalid tool arguments")
+            try:
+                payload = await self._forward(arguments)
+            except (OSError, TimeoutError, RunnerMcpError):
+                payload = {
+                    "state": "failed",
+                    "result": {
+                        "status": "runner_unavailable",
+                        "exit_code": None,
+                        "output": "The requested check could not be sent for confirmation.",
+                        "duration_seconds": 0.0,
+                    },
+                }
+            text = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+            return self._result(
+                request_id,
+                {"content": [{"type": "text", "text": text}], "isError": False},
+            )
+        return self._error(request_id, -32601, "Method not found")
+
+    async def _forward(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        reader, writer = await asyncio.open_unix_connection(
+            self._socket_path,
+            limit=MAX_MCP_FRAME_BYTES + 1,
+        )
+        try:
+            encoded = json.dumps(
+                {"token": self._token, "arguments": arguments},
+                ensure_ascii=False,
+                separators=(",", ":"),
+            ).encode("utf-8") + b"\n"
+            if len(encoded) > MAX_MCP_FRAME_BYTES:
+                raise RunnerMcpError("Runner request is too large")
+            writer.write(encoded)
+            await writer.drain()
+            raw = await reader.readline()
+            if not raw or len(raw) > MAX_MCP_FRAME_BYTES:
+                raise RunnerMcpError("Runner response is invalid")
+            payload = json.loads(raw.decode("utf-8", errors="strict"))
+            if not isinstance(payload, dict):
+                raise RunnerMcpError("Runner response is invalid")
+            return payload
+        except (UnicodeError, json.JSONDecodeError) as exc:
+            raise RunnerMcpError("Runner response is invalid") from exc
+        finally:
+            writer.close()
+            with contextlib.suppress(OSError):
+                await writer.wait_closed()
+
+    @staticmethod
+    def _result(request_id: Any, result: dict[str, Any]) -> dict[str, Any]:
+        return {"jsonrpc": "2.0", "id": request_id, "result": result}
+
+    @staticmethod
+    def _error(request_id: Any, code: int, message: str) -> dict[str, Any]:
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": {"code": code, "message": message},
+        }
+
+
+async def _run(stdin: BinaryIO, stdout: BinaryIO) -> None:
+    socket_path = os.environ.get("MODELMIRROR_RUNNER_SOCKET", "")
+    token = os.environ.get("MODELMIRROR_RUNNER_TOKEN", "")
+    server = RunnerMcpServer(socket_path=socket_path, token=token)
+    os.environ.clear()
+    os.environ.update({"PATH": "/usr/local/bin:/usr/bin:/bin", "LANG": "C.UTF-8"})
+    while True:
+        raw = await asyncio.to_thread(stdin.readline)
+        if not raw:
+            return
+        if len(raw) > MAX_MCP_FRAME_BYTES:
+            raise RunnerMcpError("MCP frame is too large")
+        try:
+            frame = json.loads(raw.decode("utf-8", errors="strict"))
+            if not isinstance(frame, dict):
+                raise RunnerMcpError("Invalid MCP frame")
+            response = await server.dispatch(frame)
+        except (UnicodeError, json.JSONDecodeError, RunnerMcpError):
+            response = {
+                "jsonrpc": "2.0",
+                "id": None,
+                "error": {"code": -32700, "message": "Invalid MCP request"},
+            }
+        if response is not None:
+            encoded = json.dumps(response, ensure_ascii=False, separators=(",", ":")).encode(
+                "utf-8"
+            ) + b"\n"
+            await asyncio.to_thread(stdout.write, encoded)
+            await asyncio.to_thread(stdout.flush)
+
+
+def main() -> None:
+    asyncio.run(_run(sys.stdin.buffer, sys.stdout.buffer))
+
+
+if __name__ == "__main__":
+    main()

--- a/server/coding_runtime/verifier_client.py
+++ b/server/coding_runtime/verifier_client.py
@@ -73,7 +73,61 @@ class CodingVerifierClient:
     async def close(self, *, session_id: str) -> None:
         await self._request({"action": "close", "session_id": session_id})
 
-    async def _request(self, payload: dict[str, Any]) -> dict[str, Any]:
+    async def execute_command(
+        self,
+        *,
+        session_id: str,
+        request_id: str,
+        source: dict[str, Any],
+        patch: str,
+        paths: Sequence[str],
+        command: dict[str, Any],
+        runner_pack_id: str | None,
+        max_duration_seconds: float,
+    ) -> dict[str, Any]:
+        response = await self._request(
+            {
+                "action": "execute_command",
+                "session_id": session_id,
+                "request_id": request_id,
+                "source": source,
+                "patch": patch,
+                "paths": list(paths),
+                "command": command,
+                "runner_pack_id": runner_pack_id,
+                "max_duration_seconds": max_duration_seconds,
+            },
+            timeout=max(5.0, min(float(max_duration_seconds) + 10.0, 610.0)),
+        )
+        result = response.get("command")
+        if not isinstance(result, dict):
+            raise VerifierClientError(
+                "Project command response is invalid.",
+                code="invalid_response",
+            )
+        return result
+
+    async def cancel_command(
+        self,
+        *,
+        session_id: str,
+        request_id: str,
+    ) -> bool:
+        response = await self._request(
+            {
+                "action": "cancel_command",
+                "session_id": session_id,
+                "request_id": request_id,
+            }
+        )
+        return response.get("accepted") is True
+
+    async def _request(
+        self,
+        payload: dict[str, Any],
+        *,
+        timeout: float | None = None,
+    ) -> dict[str, Any]:
         try:
             reader, writer = await asyncio.wait_for(
                 asyncio.open_unix_connection(
@@ -105,7 +159,7 @@ class CodingVerifierClient:
             await writer.drain()
             raw = await asyncio.wait_for(
                 reader.readline(),
-                timeout=self._timeout,
+                timeout=timeout or self._timeout,
             )
             if not raw or len(raw) > MAX_VERIFIER_FRAME_BYTES:
                 raise VerifierClientError(

--- a/server/coding_runtime/worker.py
+++ b/server/coding_runtime/worker.py
@@ -675,10 +675,14 @@ class CodingWorkerServer:
                 code="snapshot_mismatch",
             )
         verification_paths = sorted(set(base_paths) | set(paths))
-        restored_verification = _validate_recovered_verification(
-            verification,
-            revision=revision,
-            paths=verification_paths,
+        restored_verification = (
+            None
+            if source.kind is ProjectKind.LOCAL_CLONE
+            else _validate_recovered_verification(
+                verification,
+                revision=revision,
+                paths=verification_paths,
+            )
         )
         if not source.verification_available and restored_verification is not None:
             raise CodingWorkerError(
@@ -761,6 +765,16 @@ class CodingWorkerServer:
                 command_events=command_events,
                 runner_token=runner_token,
             )
+            try:
+                if source.kind is ProjectKind.LOCAL_CLONE:
+                    record.verification = self._validate_recovered_local_verification(
+                        record,
+                        verification,
+                        revision=revision,
+                    )
+            except Exception:
+                await self._cleanup_record(record)
+                raise
             self._sessions[session.session_id] = record
         try:
             event = _event_with_project(await adapter.open(session), source)
@@ -1406,6 +1420,26 @@ class CodingWorkerServer:
                 "accepted": response.get("accepted") is True,
                 "verification": verification,
             },
+        )
+
+    def _validate_recovered_local_verification(
+        self,
+        record: _WorkerSession,
+        value: Any,
+        *,
+        revision: int,
+    ) -> dict[str, Any] | None:
+        if value is None:
+            return None
+        expected = self._prepare_local_verification(
+            record,
+            revision,
+            replace=False,
+        )
+        return _validate_recovered_project_verification(
+            value,
+            revision=revision,
+            expected=expected,
         )
 
     async def _verification_confirm(
@@ -3216,6 +3250,209 @@ def _validate_recovered_verification(
             code="recovery_invalid",
         )
     return {**value, "steps": normalized_steps}
+
+
+def _validate_recovered_project_verification(
+    value: Any,
+    *,
+    revision: int,
+    expected: dict[str, Any],
+) -> dict[str, Any]:
+    base_keys = {
+        "revision",
+        "state",
+        "result",
+        "stale",
+        "reason",
+        "started_at",
+        "finished_at",
+        "steps",
+    }
+    planned_keys = base_keys | {"confirmation_id", "plan_fingerprint"}
+    if not isinstance(value, dict) or set(value) not in (base_keys, planned_keys):
+        raise CodingWorkerError(
+            "Recovered project verification has an invalid shape.",
+            code="recovery_invalid",
+        )
+    reason = value["reason"]
+    timestamps = (value["started_at"], value["finished_at"])
+    if (
+        value["revision"] != revision
+        or value["state"] != VerificationState.COMPLETED.value
+        or value["result"]
+        not in {
+            VerificationResult.PASSED.value,
+            VerificationResult.FAILED.value,
+            VerificationResult.NOT_APPLICABLE.value,
+        }
+        or value["stale"] is not False
+        or (
+            reason is not None
+            and (
+                not isinstance(reason, str)
+                or SAFE_RECOVERY_REASON.fullmatch(reason) is None
+            )
+        )
+        or value["finished_at"] is None
+        or any(
+            timestamp is not None
+            and (
+                isinstance(timestamp, bool)
+                or not isinstance(timestamp, (int, float))
+                or not math.isfinite(timestamp)
+                or timestamp < 0
+            )
+            for timestamp in timestamps
+        )
+        or not isinstance(value["steps"], list)
+    ):
+        raise CodingWorkerError(
+            "Recovered project verification is inconsistent.",
+            code="recovery_invalid",
+        )
+
+    expected_fingerprint = expected.get("plan_fingerprint")
+    if expected_fingerprint is None:
+        if (
+            set(value) == base_keys
+            and expected.get("result") == VerificationResult.NOT_APPLICABLE.value
+            and value["result"] == VerificationResult.NOT_APPLICABLE.value
+            and value["reason"] == expected.get("reason")
+            and value["steps"] == []
+        ):
+            return dict(value)
+        return _stale_project_verification(value, revision)
+
+    if (
+        set(value) != planned_keys
+        or value.get("confirmation_id") is not None
+        or not isinstance(value.get("plan_fingerprint"), str)
+        or not _safe_hex(value["plan_fingerprint"], lengths={64})
+        or value["result"]
+        not in {
+            VerificationResult.PASSED.value,
+            VerificationResult.FAILED.value,
+        }
+        or value["reason"] is not None
+        or value["started_at"] is None
+    ):
+        raise CodingWorkerError(
+            "Recovered project verification plan is invalid.",
+            code="recovery_invalid",
+        )
+    expected_steps = expected.get("steps")
+    if not isinstance(expected_steps, list):
+        raise CodingWorkerError(
+            "Current project verification plan is invalid.",
+            code="recovery_invalid",
+        )
+    expected_structure = [
+        (step.get("id"), step.get("label"), step.get("command"))
+        for step in expected_steps
+        if isinstance(step, dict)
+    ]
+    actual_structure = [
+        (step.get("id"), step.get("label"), step.get("command"))
+        for step in value["steps"]
+        if isinstance(step, dict)
+    ]
+    if (
+        value["plan_fingerprint"] != expected_fingerprint
+        or len(expected_structure) != len(expected_steps)
+        or len(actual_structure) != len(value["steps"])
+        or actual_structure != expected_structure
+    ):
+        return _stale_project_verification(value, revision)
+
+    step_keys = {
+        "id",
+        "label",
+        "command",
+        "state",
+        "result",
+        "duration_ms",
+        "summary",
+        "details",
+        "truncated",
+    }
+    step_results: list[str] = []
+    normalized_steps: list[dict[str, Any]] = []
+    for raw in value["steps"]:
+        if not isinstance(raw, dict) or set(raw) != step_keys:
+            raise CodingWorkerError(
+                "Recovered project verification step is invalid.",
+                code="recovery_invalid",
+            )
+        duration = raw["duration_ms"]
+        summary = raw["summary"]
+        details = raw["details"]
+        if (
+            raw["state"] != VerificationState.COMPLETED.value
+            or raw["result"]
+            not in {
+                VerificationResult.PASSED.value,
+                VerificationResult.FAILED.value,
+                VerificationResult.NOT_RUN.value,
+            }
+            or (
+                duration is not None
+                and (
+                    isinstance(duration, bool)
+                    or not isinstance(duration, int)
+                    or not 0 <= duration <= 600_000
+                )
+            )
+            or not isinstance(summary, str)
+            or len(summary) > MAX_VERIFICATION_SUMMARY_CHARS
+            or sanitize_verification_output(
+                summary,
+                limit=MAX_VERIFICATION_SUMMARY_CHARS,
+                keep_tail=False,
+            ).text
+            != summary
+            or not isinstance(details, str)
+            or len(details) > MAX_VERIFICATION_DETAIL_CHARS
+            or sanitize_verification_output(
+                details,
+                limit=MAX_VERIFICATION_DETAIL_CHARS,
+            ).text
+            != details
+            or not isinstance(raw["truncated"], bool)
+        ):
+            raise CodingWorkerError(
+                "Recovered project verification step is inconsistent.",
+                code="recovery_invalid",
+            )
+        step_results.append(raw["result"])
+        normalized_steps.append(dict(raw))
+    if (
+        value["result"] == VerificationResult.PASSED.value
+        and any(result != VerificationResult.PASSED.value for result in step_results)
+    ) or (
+        value["result"] == VerificationResult.FAILED.value
+        and VerificationResult.FAILED.value not in step_results
+    ):
+        raise CodingWorkerError(
+            "Recovered project verification result is inconsistent.",
+            code="recovery_invalid",
+        )
+    return {**value, "steps": normalized_steps}
+
+
+def _stale_project_verification(
+    previous: dict[str, Any],
+    revision: int,
+) -> dict[str, Any]:
+    return {
+        "revision": revision,
+        "state": VerificationState.COMPLETED.value,
+        "result": VerificationResult.NOT_RUN.value,
+        "stale": True,
+        "reason": "verification_plan_changed",
+        "started_at": previous.get("started_at"),
+        "finished_at": previous.get("finished_at"),
+        "steps": [],
+    }
 
 
 def _event_from_dict(payload: dict[str, Any]) -> CodingEvent:

--- a/server/coding_runtime/worker.py
+++ b/server/coding_runtime/worker.py
@@ -7,6 +7,7 @@ import json
 import math
 import os
 import re
+import secrets
 import time
 import unicodedata
 from collections.abc import AsyncIterator
@@ -15,6 +16,24 @@ from pathlib import Path
 from typing import Any
 
 from .acp_client import AcpClient, AcpProcessConfig, AcpRequestTimeout
+from .command_bridge import (
+    CommandBridgeError,
+    CommandConfirmationBridge,
+    CommandExecutionResult,
+    CommandRequest,
+    CommandRequestState,
+)
+from .commands import (
+    CommandContractError,
+    ProjectCommand,
+    ProjectCommandKind,
+    ProjectCommandOrigin,
+    ProjectVerificationConfig,
+    command_plan_fingerprint,
+    detect_project_commands,
+    normalize_agent_command,
+    parse_project_verification,
+)
 from .draft_workspace import (
     DraftPolicyError,
     DraftRevisionError,
@@ -81,6 +100,20 @@ MODEL_OUTPUT_TOKENS = 8_192
 REQUIRED_RUNTIME_EXECUTABLES = (Path(OPENCODE_PATH), Path(RIPGREP_PATH))
 RUNNER_MCP_SOCKET_PATH = "/tmp/modelmirror-runner.sock"
 RUNNER_MCP_NAME = "modelmirror-runner"
+MAX_RUNNER_MCP_FRAME_BYTES = 64 * 1024
+MAX_PROJECT_VERIFICATION_SIDECAR_BYTES = 64 * 1024
+VERIFICATION_AWAITING_CONFIRMATION = "awaiting_confirmation"
+RUNNER_ENVIRONMENT_ERROR_CODES = frozenset(
+    {
+        "runner_pack_unavailable",
+        "runner_pack_invalid",
+        "runner_pack_mismatch",
+        "runner_pack_unsafe",
+        "runner_pack_limit_exceeded",
+        "runner_pack_target_unsafe",
+        "command_executable_unavailable",
+    }
+)
 
 
 class CodingWorkerError(RuntimeError):
@@ -101,6 +134,15 @@ def coding_agent_mode() -> str:
             code="not_configured",
         )
     return mode
+
+
+def coding_project_commands_enabled() -> bool:
+    return os.getenv("CODING_PROJECT_COMMANDS_ENABLED", "false").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
 
 
 def validate_runtime_dependencies(
@@ -184,7 +226,7 @@ def build_opencode_config(
         )
     permission = _permission_for_mode(mode, commands_enabled=commands_enabled)
     agent_name = "draft" if mode == "draft" else "readonly"
-    return {
+    config: dict[str, Any] = {
         "$schema": "https://opencode.ai/config.json",
         "model": f"modelmirror/{model_id}",
         "default_agent": agent_name,
@@ -221,26 +263,25 @@ def build_opencode_config(
             }
         },
         "plugin": [],
-        "mcp": (
-            {
-                RUNNER_MCP_NAME: {
-                    "type": "local",
-                    "command": ["python", "-m", "coding_runtime.runner_mcp"],
-                    "environment": {
-                        "MODELMIRROR_RUNNER_SOCKET": RUNNER_MCP_SOCKET_PATH,
-                        "MODELMIRROR_RUNNER_TOKEN": runner_token,
-                    },
-                    "enabled": True,
-                    "timeout": 310_000,
-                }
-            }
-            if commands_enabled
-            else {}
-        ),
+        "mcp": {},
         "instructions": ["/workspace/AGENTS.md"] if project_instructions else [],
         "share": "disabled",
         "autoupdate": False,
     }
+    if commands_enabled:
+        config["mcp"] = {
+            RUNNER_MCP_NAME: {
+                "type": "local",
+                "command": ["python", "-m", "coding_runtime.runner_mcp"],
+                "environment": {
+                    "MODELMIRROR_RUNNER_SOCKET": RUNNER_MCP_SOCKET_PATH,
+                    "MODELMIRROR_RUNNER_TOKEN": runner_token,
+                },
+                "enabled": True,
+                "timeout": 310_000,
+            }
+        }
+    return config
 
 
 def create_acp_client(
@@ -312,6 +353,11 @@ class _WorkerSession:
     source: WorkspaceSource | None = None
     turn_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     verification: dict[str, Any] | None = None
+    verification_task: asyncio.Task[None] | None = None
+    command_bridge: CommandConfirmationBridge | None = None
+    command_events: asyncio.Queue[CodingEvent] = field(default_factory=asyncio.Queue)
+    runner_token: str = ""
+    active_command_request_id: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -324,10 +370,19 @@ class WorkspaceSource:
     branch: str | None = None
     head: str | None = None
     lease_id: str | None = None
+    lease_payload: dict[str, Any] | None = field(default=None, repr=False, compare=False)
+    verification: ProjectVerificationConfig = field(
+        default_factory=ProjectVerificationConfig,
+        repr=False,
+        compare=False,
+    )
 
     @property
     def verification_available(self) -> bool:
-        return self.kind is ProjectKind.BUILTIN
+        return self.kind is ProjectKind.BUILTIN or (
+            self.kind is ProjectKind.LOCAL_CLONE
+            and coding_project_commands_enabled()
+        )
 
     def to_public_dict(self) -> dict[str, object]:
         return {
@@ -404,6 +459,7 @@ class CodingWorkerServer:
                         "mode": mode,
                         "snapshot_fingerprint": self._source_fingerprint,
                         "verification": await self._verification_health(),
+                        "commands": await self._commands_health(),
                     },
                 )
             elif action == "create_session":
@@ -436,6 +492,12 @@ class CodingWorkerServer:
                 await self._verification_status(request, writer)
             elif action == "verification_cancel":
                 await self._verification_cancel(request, writer)
+            elif action == "verification_confirm":
+                await self._verification_confirm(request, writer)
+            elif action == "command_pending":
+                await self._command_pending(request, writer)
+            elif action == "command_decision":
+                await self._command_decision(request, writer)
             else:
                 raise CodingWorkerProtocolError(
                     "Unsupported coding worker action.",
@@ -499,13 +561,22 @@ class CodingWorkerServer:
                 self._checkpoint_path,
                 preserve_workspace_root=True,
             )
+            runner_token, command_bridge, command_events = self._build_command_bridge(
+                session,
+                mode,
+                source,
+            )
             try:
                 workspace.initialize()
                 if mode == "readonly":
                     self._set_workspace_read_only(workspace.workspace_root)
                 else:
                     self._set_workspace_writable(workspace.workspace_root)
-                adapter = self._create_source_adapter(mode, source)
+                adapter = self._create_source_adapter(
+                    mode,
+                    source,
+                    runner_token=runner_token,
+                )
             except Exception as exc:
                 with contextlib.suppress(Exception):
                     self._set_workspace_writable(workspace.workspace_root)
@@ -520,6 +591,9 @@ class CodingWorkerServer:
                 workspace=workspace,
                 mode=mode,
                 source=source,
+                command_bridge=command_bridge,
+                command_events=command_events,
+                runner_token=runner_token,
             )
             self._sessions[session.session_id] = record
         try:
@@ -640,6 +714,11 @@ class CodingWorkerServer:
                 self._checkpoint_path,
                 preserve_workspace_root=True,
             )
+            runner_token, command_bridge, command_events = self._build_command_bridge(
+                session,
+                mode,
+                source,
+            )
             try:
                 workspace.initialize()
                 report = workspace.restore_incremental(
@@ -650,7 +729,11 @@ class CodingWorkerServer:
                     expected_paths=tuple(paths),
                 )
                 self._set_workspace_writable(workspace.workspace_root)
-                adapter = self._create_source_adapter(mode, source)
+                adapter = self._create_source_adapter(
+                    mode,
+                    source,
+                    runner_token=runner_token,
+                )
             except (DraftWorkspaceError, OSError, UnicodeError) as exc:
                 with contextlib.suppress(Exception):
                     self._set_workspace_writable(workspace.workspace_root)
@@ -674,6 +757,9 @@ class CodingWorkerServer:
                 mode=mode,
                 source=source,
                 verification=restored_verification,
+                command_bridge=command_bridge,
+                command_events=command_events,
+                runner_token=runner_token,
             )
             self._sessions[session.session_id] = record
         try:
@@ -778,7 +864,10 @@ class CodingWorkerServer:
             terminal_event: CodingEvent | None = None
             active_turn_id: str | None = None
             try:
-                event_stream = record.adapter.prompt(record.session, prompt)
+                event_stream = self._merge_command_events(
+                    record,
+                    record.adapter.prompt(record.session, prompt),
+                )
                 while True:
                     try:
                         event = await anext(event_stream)
@@ -810,6 +899,12 @@ class CodingWorkerServer:
                         return
                     if event.turn_id is not None:
                         active_turn_id = event.turn_id
+                    if (
+                        event.kind is CodingEventKind.TURN_STARTED
+                        and record.command_bridge is not None
+                        and event.turn_id is not None
+                    ):
+                        await record.command_bridge.begin_turn(event.turn_id)
                     if event.kind in {
                         CodingEventKind.TURN_COMPLETED,
                         CodingEventKind.FAILED,
@@ -826,6 +921,8 @@ class CodingWorkerServer:
                         "Coding Agent turn omitted a terminal event.",
                         code="agent_turn_failed",
                     )
+                if record.command_bridge is not None:
+                    await record.command_bridge.finish_turn()
                 if record.mode == "draft":
                     terminal_event = self._finish_draft_turn(
                         record,
@@ -839,6 +936,11 @@ class CodingWorkerServer:
                 )
                 await self._send(writer, {"ok": True, "done": True})
             except Exception:
+                if record.command_bridge is not None:
+                    with contextlib.suppress(CommandBridgeError):
+                        await record.command_bridge.finish_turn(
+                            reason="agent_turn_failed"
+                        )
                 if record.mode == "draft":
                     with contextlib.suppress(DraftWorkspaceError):
                         record.workspace.rollback_turn()
@@ -851,6 +953,62 @@ class CodingWorkerServer:
                 )
 
     @staticmethod
+    async def _merge_command_events(
+        record: _WorkerSession,
+        event_stream: AsyncIterator[CodingEvent],
+    ) -> AsyncIterator[CodingEvent]:
+        if record.command_bridge is None:
+            async for event in event_stream:
+                yield event
+            return
+        agent_task: asyncio.Task[CodingEvent] | None = None
+        command_task: asyncio.Task[CodingEvent] | None = None
+        try:
+            while True:
+                if agent_task is None:
+                    agent_task = asyncio.create_task(anext(event_stream))
+                if command_task is None:
+                    command_task = asyncio.create_task(record.command_events.get())
+                done, _ = await asyncio.wait(
+                    {agent_task, command_task},
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                if agent_task in done and command_task in done:
+                    try:
+                        agent_event = agent_task.result()
+                    except StopAsyncIteration:
+                        yield command_task.result()
+                        return
+                    command_event = command_task.result()
+                    if agent_event.seq <= command_event.seq:
+                        yield agent_event
+                        agent_task = None
+                    else:
+                        yield command_event
+                        command_task = None
+                    continue
+                if command_task in done:
+                    yield command_task.result()
+                    command_task = None
+                    continue
+                command_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await command_task
+                command_task = None
+                try:
+                    yield agent_task.result()
+                except StopAsyncIteration:
+                    return
+                finally:
+                    agent_task = None
+        finally:
+            for task in (agent_task, command_task):
+                if task is not None and not task.done():
+                    task.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await task
+
+    @staticmethod
     async def _reset_agent_context(record: _WorkerSession) -> None:
         old_session = record.session
         old_adapter = record.adapter
@@ -860,10 +1018,27 @@ class CodingWorkerServer:
             created_at=old_session.created_at,
             _next_seq=next_sequence,
         )
-        next_adapter = CodingWorkerServer._create_source_adapter(
-            record.mode,
-            record.source,
-        )
+        source = record.source
+        if source is None:
+            runner_token = ""
+            command_bridge = None
+            command_events: asyncio.Queue[CodingEvent] = asyncio.Queue()
+            next_adapter = create_acp_client(record.mode)
+        else:
+            runner_token, command_bridge, command_events = (
+                CodingWorkerServer._build_command_bridge(
+                    next_session,
+                    record.mode,
+                    source,
+                )
+            )
+            next_adapter = CodingWorkerServer._create_source_adapter(
+                record.mode,
+                source,
+                runner_token=runner_token,
+            )
+        if record.command_bridge is not None:
+            await record.command_bridge.finish_turn(reason="agent_context_reset")
         await old_adapter.close(old_session)
         try:
             await next_adapter.open(next_session)
@@ -875,6 +1050,9 @@ class CodingWorkerServer:
         next_session._next_seq = next_sequence
         record.session = next_session
         record.adapter = next_adapter
+        record.command_bridge = command_bridge
+        record.command_events = command_events
+        record.runner_token = runner_token
 
     async def _cancel(
         self,
@@ -882,8 +1060,65 @@ class CodingWorkerServer:
         writer: asyncio.StreamWriter,
     ) -> None:
         record = self._require_session(request)
+        if record.command_bridge is not None:
+            await record.command_bridge.cancel_pending(reason="turn_cancelled")
         accepted = await record.adapter.cancel(record.session)
         await self._send(writer, {"ok": True, "accepted": accepted})
+
+    async def _command_pending(
+        self,
+        request: dict[str, Any],
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        if set(request) != {"action", "session_id"}:
+            raise CodingWorkerProtocolError(
+                "Command pending request is invalid.",
+                code="invalid_request",
+            )
+        record = self._require_session(request)
+        if record.command_bridge is None:
+            raise CodingWorkerError(
+                "Project commands are unavailable.",
+                code="project_operation_unavailable",
+            )
+        pending = await record.command_bridge.pending(
+            session_id=record.session.session_id,
+            turn_id=record.session.active_turn_id,
+        )
+        await self._send(writer, {"ok": True, "pending": pending})
+
+    async def _command_decision(
+        self,
+        request: dict[str, Any],
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        if set(request) != {"action", "session_id", "request_id", "decision"}:
+            raise CodingWorkerProtocolError(
+                "Command decision request is invalid.",
+                code="invalid_request",
+            )
+        record = self._require_session(request)
+        request_id = request.get("request_id")
+        decision = request.get("decision")
+        if not isinstance(request_id, str) or not isinstance(decision, str):
+            raise CodingWorkerProtocolError(
+                "Command decision is invalid.",
+                code="invalid_request",
+            )
+        if record.command_bridge is None:
+            raise CodingWorkerError(
+                "Project commands are unavailable.",
+                code="project_operation_unavailable",
+            )
+        try:
+            resolved = await record.command_bridge.decide(
+                session_id=record.session.session_id,
+                request_id=request_id,
+                decision=decision,
+            )
+        except CommandBridgeError as exc:
+            raise CodingWorkerError(str(exc), code=exc.code) from exc
+        await self._send(writer, {"ok": True, "request": resolved})
 
     async def _close_session(
         self,
@@ -1030,6 +1265,13 @@ class CodingWorkerServer:
                 code="verification_in_progress",
             )
         source = self._record_source(record)
+        if source.kind is ProjectKind.LOCAL_CLONE:
+            verification = self._prepare_local_verification(record, revision)
+            await self._send(
+                writer,
+                {"ok": True, "verification": verification},
+            )
+            return
         if not source.fingerprint:
             raise CodingWorkerError(
                 "Project verification source is unavailable.",
@@ -1113,6 +1355,41 @@ class CodingWorkerServer:
                 },
             )
             return
+        source = self._record_source(record)
+        if source.kind is ProjectKind.LOCAL_CLONE:
+            if record.verification_task is not None:
+                record.verification_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await record.verification_task
+            if record.active_command_request_id is not None:
+                with contextlib.suppress(Exception):
+                    await self._verifier.cancel_command(
+                        session_id=record.session.session_id,
+                        request_id=record.active_command_request_id,
+                    )
+            now = time.time()
+            stored = dict(record.verification)
+            stored.update(
+                {
+                    "state": VerificationState.CANCELLED.value,
+                    "result": VerificationResult.NOT_RUN.value,
+                    "reason": "cancelled",
+                    "finished_at": now,
+                }
+            )
+            for step in stored.get("steps", []):
+                if step.get("state") in {
+                    VerificationState.NOT_STARTED.value,
+                    VerificationState.RUNNING.value,
+                }:
+                    step["state"] = VerificationState.CANCELLED.value
+                    step["result"] = VerificationResult.NOT_RUN.value
+            record.verification = stored
+            await self._send(
+                writer,
+                {"ok": True, "accepted": True, "verification": stored},
+            )
+            return
         response = await self._verifier.cancel(
             session_id=record.session.session_id,
             revision=revision,
@@ -1130,6 +1407,507 @@ class CodingWorkerServer:
                 "verification": verification,
             },
         )
+
+    async def _verification_confirm(
+        self,
+        request: dict[str, Any],
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        if set(request) != {
+            "action",
+            "session_id",
+            "revision",
+            "confirmation_id",
+        }:
+            raise CodingWorkerProtocolError(
+                "Verification confirmation is invalid.", code="invalid_request"
+            )
+        record = self._require_draft_session(request)
+        self._require_verification_available(record)
+        revision = self._require_revision(request)
+        confirmation_id = request.get("confirmation_id")
+        source = self._record_source(record)
+        if source.kind is not ProjectKind.LOCAL_CLONE:
+            raise CodingWorkerError(
+                "Verification confirmation is not required.",
+                code="project_operation_unavailable",
+            )
+        if (
+            not isinstance(confirmation_id, str)
+            or record.verification is None
+            or record.verification.get("revision") != revision
+            or record.verification.get("state")
+            != VERIFICATION_AWAITING_CONFIRMATION
+            or not secrets.compare_digest(
+                str(record.verification.get("confirmation_id", "")),
+                confirmation_id,
+            )
+        ):
+            raise CodingWorkerError(
+                "Verification confirmation is stale.",
+                code="verification_confirmation_stale",
+            )
+        current = self._prepare_local_verification(
+            record,
+            revision,
+            replace=False,
+        )
+        if current.get("plan_fingerprint") != record.verification.get(
+            "plan_fingerprint"
+        ):
+            raise CodingWorkerError(
+                "Verification plan has changed.",
+                code="verification_confirmation_stale",
+            )
+        stored = record.verification
+        stored["state"] = VerificationState.RUNNING.value
+        stored["started_at"] = time.time()
+        stored["confirmation_id"] = None
+        record.verification_task = asyncio.create_task(
+            self._run_local_verification(record, stored)
+        )
+        await self._send(
+            writer,
+            {"ok": True, "accepted": True, "verification": stored},
+        )
+
+    def _prepare_local_verification(
+        self,
+        record: _WorkerSession,
+        revision: int,
+        *,
+        replace: bool = True,
+    ) -> dict[str, Any]:
+        source = self._record_source(record)
+        if source.kind is not ProjectKind.LOCAL_CLONE:
+            raise CodingWorkerError(
+                "Project verification is unavailable.",
+                code="project_operation_unavailable",
+            )
+        report = record.workspace.cumulative_changes()
+        if report.revision != revision:
+            raise DraftRevisionError("stale_revision")
+        candidates = record.workspace._scan_cumulative_candidates()
+        paths = [item.path for item in candidates]
+        dependency_names = {
+            "pyproject.toml",
+            "requirements.txt",
+            "requirements-dev.txt",
+            "package.json",
+            "package-lock.json",
+            "npm-shrinkwrap.json",
+            "pnpm-lock.yaml",
+            "yarn.lock",
+        }
+        if any(path.rsplit("/", 1)[-1] in dependency_names for path in paths):
+            result = {
+                "revision": revision,
+                "state": VerificationState.COMPLETED.value,
+                "result": VerificationResult.NOT_RUN.value,
+                "stale": False,
+                "reason": "runner_environment_not_ready",
+                "started_at": None,
+                "finished_at": time.time(),
+                "steps": [],
+            }
+            if replace:
+                record.verification = result
+            return result
+        try:
+            commands = detect_project_commands(
+                record.workspace.workspace_root,
+                source.verification,
+            )
+        except CommandContractError as exc:
+            raise CodingWorkerError(str(exc), code=exc.code) from exc
+        if not commands:
+            result = {
+                "revision": revision,
+                "state": VerificationState.COMPLETED.value,
+                "result": VerificationResult.NOT_APPLICABLE.value,
+                "stale": False,
+                "reason": "no_project_checks",
+                "started_at": None,
+                "finished_at": time.time(),
+                "steps": [],
+            }
+            if replace:
+                record.verification = result
+            return result
+        full_patch = "".join(item.diff for item in candidates)
+        test_paths = {
+            path
+            for path in paths
+            if _is_project_test_path(path)
+        }
+        baseline_candidates = tuple(
+            item for item in candidates if item.path not in test_paths
+        )
+        baseline_patch = "".join(item.diff for item in baseline_candidates)
+        baseline_paths = [item.path for item in baseline_candidates]
+        plan: list[dict[str, Any]] = []
+        public_steps: list[dict[str, Any]] = []
+        for command in commands:
+            variants = (
+                (("baseline", baseline_patch, baseline_paths), ("draft", full_patch, paths))
+                if test_paths and command.kind is ProjectCommandKind.TEST
+                else (("draft", full_patch, paths),)
+            )
+            for variant, patch, selected_paths in variants:
+                step_id = f"{command.command_id}-{variant}"
+                label = (
+                    f"使用原有测试：{command.name}"
+                    if variant == "baseline"
+                    else command.name
+                )
+                execution_command = normalize_agent_command(
+                    argv=list(command.argv),
+                    cwd=command.cwd,
+                    purpose=label,
+                    timeout_seconds=command.timeout_seconds,
+                )
+                plan.append(
+                    {
+                        "id": step_id,
+                        "label": label,
+                        "command": execution_command.to_internal_dict(),
+                        "patch": patch,
+                        "paths": selected_paths,
+                    }
+                )
+                public_steps.append(
+                    {
+                        "id": step_id,
+                        "label": label,
+                        "command": command.to_public_dict(),
+                        "state": VerificationState.NOT_STARTED.value,
+                        "result": VerificationResult.NOT_RUN.value,
+                        "duration_ms": None,
+                        "summary": "",
+                        "details": "",
+                        "truncated": False,
+                    }
+                )
+        fingerprint = command_plan_fingerprint(
+            commands,
+            source_fingerprint=source.fingerprint,
+            pack_fingerprint=source.verification.runner_pack or "",
+        )
+        fingerprint = hashlib.sha256(
+            (fingerprint + full_patch).encode("utf-8")
+        ).hexdigest()
+        result = {
+            "revision": revision,
+            "state": VERIFICATION_AWAITING_CONFIRMATION,
+            "result": VerificationResult.NOT_RUN.value,
+            "stale": False,
+            "reason": None,
+            "started_at": None,
+            "finished_at": None,
+            "confirmation_id": "verification-confirmation-" + secrets.token_hex(16),
+            "plan_fingerprint": fingerprint,
+            "steps": public_steps,
+            "_plan": plan,
+        }
+        if replace:
+            record.verification = result
+        return result
+
+    async def _run_local_verification(
+        self,
+        record: _WorkerSession,
+        verification: dict[str, Any],
+    ) -> None:
+        source = self._record_source(record)
+        environment_error = False
+        verification_timed_out = False
+        verification_started = time.monotonic()
+        try:
+            plan = verification.get("_plan", [])
+            for index, item in enumerate(plan):
+                step = verification["steps"][index]
+                remaining = 600.0 - (time.monotonic() - verification_started)
+                if remaining <= 0:
+                    verification_timed_out = True
+                    break
+                step["state"] = VerificationState.RUNNING.value
+                request_id = "verification-command-" + secrets.token_hex(16)
+                record.active_command_request_id = request_id
+                started = time.monotonic()
+                try:
+                    response = await self._verifier.execute_command(
+                        session_id=record.session.session_id,
+                        request_id=request_id,
+                        source=source.lease_payload or {},
+                        patch=item["patch"],
+                        paths=item["paths"],
+                        command=item["command"],
+                        runner_pack_id=source.verification.runner_pack,
+                        max_duration_seconds=min(
+                            remaining,
+                            float(item["command"]["timeout_seconds"]),
+                        ),
+                    )
+                except VerifierClientError as exc:
+                    if exc.code in RUNNER_ENVIRONMENT_ERROR_CODES:
+                        environment_error = True
+                        step.update(
+                            {
+                                "state": VerificationState.COMPLETED.value,
+                                "result": VerificationResult.NOT_RUN.value,
+                                "summary": "运行环境未就绪",
+                                "details": exc.code,
+                            }
+                        )
+                        break
+                    raise
+                finally:
+                    if record.active_command_request_id == request_id:
+                        record.active_command_request_id = None
+                passed = response.get("status") == "passed"
+                output = sanitize_verification_output(
+                    response.get("output", ""),
+                    limit=MAX_VERIFICATION_DETAIL_CHARS,
+                )
+                step.update(
+                    {
+                        "state": VerificationState.COMPLETED.value,
+                        "result": (
+                            VerificationResult.PASSED.value
+                            if passed
+                            else VerificationResult.FAILED.value
+                        ),
+                        "duration_ms": round(
+                            max(
+                                float(response.get("duration_seconds", 0)),
+                                time.monotonic() - started,
+                            )
+                            * 1000
+                        ),
+                        "summary": "检查通过" if passed else "发现问题",
+                        "details": output.text,
+                        "truncated": output.truncated,
+                    }
+                )
+                if not passed:
+                    break
+            for step in verification["steps"]:
+                if step["state"] == VerificationState.NOT_STARTED.value:
+                    step["state"] = VerificationState.COMPLETED.value
+                    step["result"] = VerificationResult.NOT_RUN.value
+            results = {item["result"] for item in verification["steps"]}
+            verification.update(
+                {
+                    "state": VerificationState.COMPLETED.value,
+                    "result": (
+                        VerificationResult.NOT_RUN.value
+                        if environment_error or verification_timed_out
+                        else (
+                            VerificationResult.FAILED.value
+                            if VerificationResult.FAILED.value in results
+                            else VerificationResult.PASSED.value
+                        )
+                    ),
+                    "reason": (
+                        "runner_environment_not_ready"
+                        if environment_error
+                        else (
+                            "verification_timeout"
+                            if verification_timed_out
+                            else None
+                        )
+                    ),
+                    "finished_at": time.time(),
+                }
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            verification.update(
+                {
+                    "state": VerificationState.COMPLETED.value,
+                    "result": VerificationResult.NOT_RUN.value,
+                    "reason": "verifier_unavailable",
+                    "finished_at": time.time(),
+                }
+            )
+        finally:
+            record.verification_task = None
+
+    async def _handle_runner(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        try:
+            raw = await reader.readline()
+            if not raw or len(raw) > MAX_RUNNER_MCP_FRAME_BYTES:
+                raise CodingWorkerProtocolError(
+                    "Runner request is invalid.", code="invalid_request"
+                )
+            payload = json.loads(raw.decode("utf-8", errors="strict"))
+            if not isinstance(payload, dict) or set(payload) != {
+                "token",
+                "arguments",
+            }:
+                raise CodingWorkerProtocolError(
+                    "Runner request is invalid.", code="invalid_request"
+                )
+            token = payload.get("token")
+            arguments = payload.get("arguments")
+            if not isinstance(token, str) or not isinstance(arguments, dict):
+                raise CodingWorkerProtocolError(
+                    "Runner request is invalid.", code="invalid_request"
+                )
+            async with self._sessions_lock:
+                matches = [
+                    item
+                    for item in self._sessions.values()
+                    if item.runner_token
+                    and secrets.compare_digest(item.runner_token, token)
+                ]
+            if len(matches) != 1:
+                raise CodingWorkerError(
+                    "Runner authorization failed.", code="runner_unauthorized"
+                )
+            record = matches[0]
+            if record.command_bridge is None or record.session.active_turn_id is None:
+                raise CodingWorkerError(
+                    "Runner command turn is inactive.", code="command_turn_inactive"
+                )
+            if set(arguments) != {"argv", "cwd", "purpose", "timeout_seconds"}:
+                raise CodingWorkerProtocolError(
+                    "Runner arguments are invalid.", code="invalid_request"
+                )
+            try:
+                command = normalize_agent_command(
+                    argv=arguments["argv"],
+                    cwd=arguments["cwd"],
+                    purpose=arguments["purpose"],
+                    timeout_seconds=arguments["timeout_seconds"],
+                )
+                result = await record.command_bridge.request(
+                    session_id=record.session.session_id,
+                    turn_id=record.session.active_turn_id,
+                    command=command,
+                    executor=lambda selected, remaining: self._execute_agent_command(
+                        record, selected, remaining
+                    ),
+                )
+            except CommandContractError as exc:
+                raise CodingWorkerError(str(exc), code=exc.code) from exc
+            except CommandBridgeError as exc:
+                raise CodingWorkerError(str(exc), code=exc.code) from exc
+            await self._send_runner(writer, result)
+        except (UnicodeError, json.JSONDecodeError):
+            await self._send_runner(writer, {"state": "failed", "code": "invalid_request"})
+        except CodingWorkerError as exc:
+            await self._send_runner(writer, {"state": "failed", "code": exc.code})
+        except Exception:
+            await self._send_runner(
+                writer, {"state": "failed", "code": "runner_internal_error"}
+            )
+        finally:
+            writer.close()
+            with contextlib.suppress(Exception):
+                await writer.wait_closed()
+
+    async def _execute_agent_command(
+        self,
+        record: _WorkerSession,
+        command: ProjectCommand,
+        remaining_seconds: float,
+    ) -> CommandExecutionResult:
+        source = self._record_source(record)
+        if source.kind is not ProjectKind.LOCAL_CLONE or source.lease_payload is None:
+            raise CodingWorkerError(
+                "Project commands are unavailable.",
+                code="project_operation_unavailable",
+            )
+        candidates = record.workspace._scan_cumulative_candidates()
+        patch = "".join(item.diff for item in candidates)
+        paths = [item.path for item in candidates]
+        request_id = "command-execution-" + secrets.token_hex(16)
+        record.active_command_request_id = request_id
+        try:
+            response = await self._verifier.execute_command(
+                session_id=record.session.session_id,
+                request_id=request_id,
+                source=source.lease_payload,
+                patch=patch,
+                paths=paths,
+                command=command.to_internal_dict(),
+                runner_pack_id=None,
+                max_duration_seconds=min(
+                    remaining_seconds, float(command.timeout_seconds)
+                ),
+            )
+        except asyncio.CancelledError:
+            with contextlib.suppress(Exception):
+                await self._verifier.cancel_command(
+                    session_id=record.session.session_id,
+                    request_id=request_id,
+                )
+            raise
+        finally:
+            if record.active_command_request_id == request_id:
+                record.active_command_request_id = None
+        status = response.get("status")
+        exit_code = response.get("exit_code")
+        output = response.get("output")
+        duration = response.get("duration_seconds")
+        if (
+            status not in {"passed", "failed"}
+            or (exit_code is not None and type(exit_code) is not int)
+            or not isinstance(output, str)
+            or isinstance(duration, bool)
+            or not isinstance(duration, (int, float))
+        ):
+            raise CodingWorkerError(
+                "Runner response is invalid.", code="invalid_verifier_response"
+            )
+        return CommandExecutionResult(
+            status=status,
+            exit_code=exit_code,
+            output=sanitize_verification_output(
+                output, limit=MAX_VERIFICATION_DETAIL_CHARS
+            ).text,
+            duration_seconds=max(0.0, float(duration)),
+        )
+
+    async def _commands_health(self) -> dict[str, Any]:
+        capability = {
+            "enabled": coding_project_commands_enabled(),
+            "available": False,
+            "confirmation": "always",
+            "execution": "isolated_copy",
+            "network": False,
+            "persists_output": False,
+            "max_commands_per_turn": 20,
+            "max_duration_seconds": 300,
+        }
+        if not capability["enabled"]:
+            return {**capability, "reason": "disabled"}
+        try:
+            health = await self._verifier.health()
+        except Exception:
+            return {**capability, "reason": "verifier_unavailable"}
+        if health.get("configured") is not True or health.get("commands") is not True:
+            return {**capability, "reason": "verifier_unavailable"}
+        return {**capability, "available": True}
+
+    @staticmethod
+    async def _send_runner(
+        writer: asyncio.StreamWriter,
+        payload: dict[str, Any],
+    ) -> None:
+        encoded = json.dumps(
+            payload, ensure_ascii=False, separators=(",", ":")
+        ).encode("utf-8") + b"\n"
+        if len(encoded) > MAX_RUNNER_MCP_FRAME_BYTES:
+            encoded = b'{"state":"failed","code":"response_too_large"}\n'
+        writer.write(encoded)
+        await writer.drain()
 
     async def _verification_health(self) -> dict[str, Any]:
         capability = {
@@ -1156,6 +1934,15 @@ class CodingWorkerServer:
         if record.source is not None and not record.source.verification_available:
             record.verification = None
             return
+        if (
+            record.source is not None
+            and record.source.kind is ProjectKind.LOCAL_CLONE
+        ):
+            if record.verification_task is not None and record.verification_task.done():
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await record.verification_task
+                record.verification_task = None
+            return
         if not self._verification_running(record):
             return
         assert record.verification is not None
@@ -1181,6 +1968,20 @@ class CodingWorkerServer:
         record: _WorkerSession,
     ) -> dict[str, Any]:
         report = record.workspace.changes()
+        if (
+            record.source is not None
+            and record.source.kind is ProjectKind.LOCAL_CLONE
+        ):
+            return {
+                "revision": report.revision,
+                "state": VerificationState.NOT_STARTED.value,
+                "result": VerificationResult.NOT_RUN.value,
+                "stale": False,
+                "reason": None,
+                "started_at": None,
+                "finished_at": None,
+                "steps": [],
+            }
         plan = select_verification_plan(item.path for item in report.files)
         return initial_verification_report(
             report.revision,
@@ -1193,6 +1994,7 @@ class CodingWorkerServer:
             record.verification is not None
             and record.verification.get("state")
             in {
+                VERIFICATION_AWAITING_CONFIRMATION,
                 VerificationState.NOT_STARTED.value,
                 VerificationState.RUNNING.value,
             }
@@ -1302,15 +2104,94 @@ class CodingWorkerServer:
         )
 
     @staticmethod
+    def _build_command_bridge(
+        session: CodingSession,
+        mode: str,
+        source: WorkspaceSource,
+    ) -> tuple[
+        str,
+        CommandConfirmationBridge | None,
+        asyncio.Queue[CodingEvent],
+    ]:
+        event_queue: asyncio.Queue[CodingEvent] = asyncio.Queue()
+        if not (
+            mode == "draft"
+            and source.kind is ProjectKind.LOCAL_CLONE
+            and coding_project_commands_enabled()
+        ):
+            return "", None, event_queue
+        token = secrets.token_urlsafe(32)
+
+        async def observer(request: CommandRequest) -> None:
+            if request.state is CommandRequestState.AWAITING_CONFIRMATION:
+                event = session.append_event(
+                    CodingEventKind.COMMAND_REQUESTED,
+                    turn_id=request.turn_id,
+                    data={
+                        "request_id": request.request_id,
+                        "command": request.command.to_public_dict(),
+                        "expires_at": request.expires_at,
+                    },
+                )
+            elif request.state in {
+                CommandRequestState.COMPLETED,
+                CommandRequestState.REJECTED,
+                CommandRequestState.TIMED_OUT,
+                CommandRequestState.CANCELLED,
+                CommandRequestState.FAILED,
+            }:
+                result = request.result
+                event = session.append_event(
+                    CodingEventKind.COMMAND_RESOLVED,
+                    turn_id=request.turn_id,
+                    data={
+                        "request_id": request.request_id,
+                        "state": request.state.value,
+                        "result": (
+                            None
+                            if result is None
+                            else {
+                                **result.to_dict(),
+                                "output": sanitize_verification_output(
+                                    result.output,
+                                    limit=MAX_VERIFICATION_DETAIL_CHARS,
+                                ).text,
+                            }
+                        ),
+                    },
+                )
+            else:
+                return
+            await event_queue.put(event)
+
+        bridge = CommandConfirmationBridge(observer=observer)
+        return token, bridge, event_queue
+
+    @staticmethod
     def _create_source_adapter(
         mode: str,
         source: WorkspaceSource | None,
+        *,
+        runner_token: str = "",
     ) -> AcpClient:
-        if (
+        commands_enabled = bool(
+            runner_token
+            and source is not None
+            and source.kind is ProjectKind.LOCAL_CLONE
+        )
+        project_instructions = bool(
             source is not None
             and source.kind is ProjectKind.LOCAL_CLONE
             and (source.snapshot_path / "AGENTS.md").is_file()
-        ):
+        )
+        if commands_enabled:
+            return create_acp_client(
+                mode,
+                project_instructions=project_instructions,
+                commands_enabled=commands_enabled,
+                runner_token=runner_token,
+            )
+        if project_instructions:
             return create_acp_client(mode, project_instructions=True)
         return create_acp_client(mode)
 
@@ -1379,6 +2260,60 @@ class CodingWorkerServer:
                 "Project snapshot fingerprint does not match.",
                 code="snapshot_mismatch",
             )
+        verification_path = self._project_snapshot_path / "verification.json"
+        if not verification_path.exists() and not coding_project_commands_enabled():
+            verification = ProjectVerificationConfig()
+            return WorkspaceSource(
+                kind=ProjectKind.LOCAL_CLONE,
+                project_id=lease["project_id"],
+                name=lease["name"],
+                snapshot_path=workspace_path,
+                fingerprint=fingerprint,
+                branch=lease["branch"],
+                head=lease["head"],
+                lease_id=lease["lease_id"],
+                lease_payload=dict(payload),
+                verification=verification,
+            )
+        try:
+            if (
+                verification_path.is_symlink()
+                or not verification_path.is_file()
+                or verification_path.stat().st_size
+                > MAX_PROJECT_VERIFICATION_SIDECAR_BYTES
+            ):
+                raise CodingWorkerError(
+                    "Project verification plan is unavailable.",
+                    code="snapshot_unavailable",
+                )
+            sidecar = json.loads(
+                verification_path.read_text(encoding="utf-8", errors="strict")
+            )
+            if not isinstance(sidecar, dict) or set(sidecar) != {
+                "lease_id",
+                "project_id",
+                "head",
+                "fingerprint",
+                "verification",
+            }:
+                raise CodingWorkerError(
+                    "Project verification plan is invalid.",
+                    code="snapshot_mismatch",
+                )
+            for key in ("lease_id", "project_id", "head", "fingerprint"):
+                if sidecar[key] != lease[key]:
+                    raise CodingWorkerError(
+                        "Project verification plan does not match the snapshot.",
+                        code="snapshot_mismatch",
+                    )
+            verification = parse_project_verification(sidecar["verification"])
+        except CodingWorkerError:
+            raise
+        except (OSError, UnicodeError, json.JSONDecodeError, CommandContractError) as exc:
+            raise CodingWorkerError(
+                "Project verification plan is invalid.",
+                code="snapshot_mismatch",
+            ) from exc
         return WorkspaceSource(
             kind=ProjectKind.LOCAL_CLONE,
             project_id=lease["project_id"],
@@ -1388,6 +2323,8 @@ class CodingWorkerServer:
             branch=lease["branch"],
             head=lease["head"],
             lease_id=lease["lease_id"],
+            lease_payload=dict(payload),
+            verification=verification,
         )
 
     @staticmethod
@@ -1450,6 +2387,19 @@ class CodingWorkerServer:
                 (current_path / name).chmod(0o600)
 
     async def _cleanup_record(self, record: _WorkerSession) -> None:
+        if record.verification_task is not None and not record.verification_task.done():
+            record.verification_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await record.verification_task
+        if record.command_bridge is not None:
+            with contextlib.suppress(Exception):
+                await record.command_bridge.finish_turn(reason="session_closed")
+        if record.active_command_request_id is not None:
+            with contextlib.suppress(Exception):
+                await self._verifier.cancel_command(
+                    session_id=record.session.session_id,
+                    request_id=record.active_command_request_id,
+                )
         with contextlib.suppress(Exception):
             await self._verifier.close(session_id=record.session.session_id)
         with contextlib.suppress(Exception):
@@ -1489,18 +2439,31 @@ class CodingWorkerServer:
     async def serve_forever(self) -> None:
         self._socket_path.parent.mkdir(parents=True, exist_ok=True)
         self._socket_path.unlink(missing_ok=True)
+        runner_socket = Path(RUNNER_MCP_SOCKET_PATH)
+        runner_socket.parent.mkdir(parents=True, exist_ok=True)
+        runner_socket.unlink(missing_ok=True)
         server = await asyncio.start_unix_server(
             self.handle,
             path=str(self._socket_path),
             limit=MAX_WORKER_FRAME_BYTES + 1,
         )
+        runner_server = await asyncio.start_unix_server(
+            self._handle_runner,
+            path=str(runner_socket),
+            limit=MAX_RUNNER_MCP_FRAME_BYTES + 1,
+        )
         os.chmod(self._socket_path, 0o660)
+        os.chmod(runner_socket, 0o600)
         try:
-            async with server:
-                await server.serve_forever()
+            async with server, runner_server:
+                await asyncio.gather(
+                    server.serve_forever(),
+                    runner_server.serve_forever(),
+                )
         finally:
             await self.close()
             self._socket_path.unlink(missing_ok=True)
+            runner_socket.unlink(missing_ok=True)
 
 
 class CodingWorkerClient:
@@ -1724,6 +2687,65 @@ class CodingWorkerClient:
             session_id,
             revision,
         )
+
+    async def verification_confirm(
+        self,
+        session_id: str,
+        revision: int,
+        confirmation_id: str,
+    ) -> dict[str, Any]:
+        response = await self._request(
+            {
+                "action": "verification_confirm",
+                "session_id": session_id,
+                "revision": revision,
+                "confirmation_id": confirmation_id,
+            }
+        )
+        verification = response.get("verification")
+        if not isinstance(verification, dict):
+            raise CodingWorkerProtocolError(
+                "Coding worker omitted project verification.",
+                code="invalid_response",
+            )
+        return {
+            "verification": verification,
+            "accepted": response.get("accepted") is True,
+        }
+
+    async def command_pending(self, session_id: str) -> dict[str, Any] | None:
+        response = await self._request(
+            {"action": "command_pending", "session_id": session_id}
+        )
+        pending = response.get("pending")
+        if pending is not None and not isinstance(pending, dict):
+            raise CodingWorkerProtocolError(
+                "Coding worker command state is invalid.",
+                code="invalid_response",
+            )
+        return pending
+
+    async def command_decision(
+        self,
+        session_id: str,
+        request_id: str,
+        decision: str,
+    ) -> dict[str, Any]:
+        response = await self._request(
+            {
+                "action": "command_decision",
+                "session_id": session_id,
+                "request_id": request_id,
+                "decision": decision,
+            }
+        )
+        resolved = response.get("request")
+        if not isinstance(resolved, dict):
+            raise CodingWorkerProtocolError(
+                "Coding worker command decision is invalid.",
+                code="invalid_response",
+            )
+        return resolved
 
     async def _verification_request(
         self,
@@ -2217,6 +3239,18 @@ def _event_from_dict(payload: dict[str, Any]) -> CodingEvent:
             "Coding worker event is invalid.",
             code="invalid_response",
         ) from exc
+
+
+def _is_project_test_path(path: str) -> bool:
+    lowered = path.casefold()
+    name = lowered.rsplit("/", 1)[-1]
+    return (
+        "/tests/" in f"/{lowered}"
+        or name.startswith("test_")
+        or name.endswith(
+            ("_test.py", ".test.js", ".test.ts", ".spec.js", ".spec.ts")
+        )
+    )
 
 
 async def main() -> None:

--- a/server/coding_runtime/worker.py
+++ b/server/coding_runtime/worker.py
@@ -312,6 +312,7 @@ def create_acp_client(
     )
     child_environment = {
         "PATH": "/usr/local/bin:/usr/bin:/bin",
+        "PYTHONPATH": "/opt/modelmirror",
         "HOME": "/home/coding",
         "OPENCODE_TEST_HOME": "/home/coding",
         "XDG_CONFIG_HOME": "/home/coding/.config",

--- a/server/coding_runtime/worker.py
+++ b/server/coding_runtime/worker.py
@@ -73,11 +73,14 @@ RIPGREP_PATH = "/usr/bin/rg"
 INTERNAL_GATEWAY_BASE_URL = "http://new-api:3000/v1"
 SAFE_MODEL_ID = re.compile(r"^[A-Za-z0-9._:/-]{1,200}$")
 SAFE_RECOVERY_REASON = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
+SAFE_RUNNER_TOKEN = re.compile(r"^[A-Za-z0-9_-]{32,128}$")
 CODING_AGENT_MODES = frozenset({"readonly", "draft"})
 MAX_AGENT_STEPS = 12
 MODEL_CONTEXT_TOKENS = 131_072
 MODEL_OUTPUT_TOKENS = 8_192
 REQUIRED_RUNTIME_EXECUTABLES = (Path(OPENCODE_PATH), Path(RIPGREP_PATH))
+RUNNER_MCP_SOCKET_PATH = "/tmp/modelmirror-runner.sock"
+RUNNER_MCP_NAME = "modelmirror-runner"
 
 
 class CodingWorkerError(RuntimeError):
@@ -115,13 +118,17 @@ def validate_runtime_dependencies(
         )
 
 
-def _permission_for_mode(mode: str) -> dict[str, Any]:
+def _permission_for_mode(
+    mode: str,
+    *,
+    commands_enabled: bool = False,
+) -> dict[str, Any]:
     if mode not in CODING_AGENT_MODES:
         raise CodingWorkerError(
             "Coding Agent mode is not configured safely.",
             code="not_configured",
         )
-    return {
+    permission: dict[str, Any] = {
         "*": "deny",
         "read": {
             "*": "allow",
@@ -150,6 +157,9 @@ def _permission_for_mode(mode: str) -> dict[str, Any]:
         "todowrite": "deny",
         "doom_loop": "deny",
     }
+    if commands_enabled:
+        permission[f"{RUNNER_MCP_NAME}_*"] = "allow"
+    return permission
 
 
 def build_opencode_config(
@@ -157,13 +167,22 @@ def build_opencode_config(
     mode: str = "readonly",
     *,
     project_instructions: bool = False,
+    commands_enabled: bool = False,
+    runner_token: str = "",
 ) -> dict[str, Any]:
     if not SAFE_MODEL_ID.fullmatch(model_id):
         raise CodingWorkerError(
             "Coding Agent model is not configured safely.",
             code="not_configured",
         )
-    permission = _permission_for_mode(mode)
+    if commands_enabled and (
+        mode != "draft" or SAFE_RUNNER_TOKEN.fullmatch(runner_token) is None
+    ):
+        raise CodingWorkerError(
+            "Coding project commands are not configured safely.",
+            code="not_configured",
+        )
+    permission = _permission_for_mode(mode, commands_enabled=commands_enabled)
     agent_name = "draft" if mode == "draft" else "readonly"
     return {
         "$schema": "https://opencode.ai/config.json",
@@ -202,7 +221,22 @@ def build_opencode_config(
             }
         },
         "plugin": [],
-        "mcp": {},
+        "mcp": (
+            {
+                RUNNER_MCP_NAME: {
+                    "type": "local",
+                    "command": ["python", "-m", "coding_runtime.runner_mcp"],
+                    "environment": {
+                        "MODELMIRROR_RUNNER_SOCKET": RUNNER_MCP_SOCKET_PATH,
+                        "MODELMIRROR_RUNNER_TOKEN": runner_token,
+                    },
+                    "enabled": True,
+                    "timeout": 310_000,
+                }
+            }
+            if commands_enabled
+            else {}
+        ),
         "instructions": ["/workspace/AGENTS.md"] if project_instructions else [],
         "share": "disabled",
         "autoupdate": False,
@@ -213,6 +247,8 @@ def create_acp_client(
     mode: str | None = None,
     *,
     project_instructions: bool = False,
+    commands_enabled: bool = False,
+    runner_token: str = "",
 ) -> AcpClient:
     active_mode = mode or coding_agent_mode()
     model_id = os.getenv("CODING_AGENT_MODEL", "").strip()
@@ -227,6 +263,8 @@ def create_acp_client(
             model_id,
             active_mode,
             project_instructions=project_instructions,
+            commands_enabled=commands_enabled,
+            runner_token=runner_token,
         ),
         ensure_ascii=False,
         separators=(",", ":"),

--- a/server/coding_runtime/worker.py
+++ b/server/coding_runtime/worker.py
@@ -1558,7 +1558,7 @@ class CodingWorkerServer:
             result = {
                 "revision": revision,
                 "state": VerificationState.COMPLETED.value,
-                "result": VerificationResult.NOT_APPLICABLE.value,
+                "result": VerificationResult.NOT_RUN.value,
                 "stale": False,
                 "reason": "no_project_checks",
                 "started_at": None,

--- a/server/coding_runtime/worker.py
+++ b/server/coding_runtime/worker.py
@@ -473,6 +473,8 @@ class CodingWorkerServer:
                 await self._prompt(request, writer)
             elif action == "cancel":
                 await self._cancel(request, writer)
+            elif action == "session_status":
+                await self._session_status(request, writer)
             elif action == "close":
                 await self._close_session(request, writer)
             elif action == "changes":
@@ -1079,6 +1081,22 @@ class CodingWorkerServer:
             await record.command_bridge.cancel_pending(reason="turn_cancelled")
         accepted = await record.adapter.cancel(record.session)
         await self._send(writer, {"ok": True, "accepted": accepted})
+
+    async def _session_status(
+        self,
+        request: dict[str, Any],
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        if set(request) != {"action", "session_id"}:
+            raise CodingWorkerProtocolError(
+                "Session status request is invalid.",
+                code="invalid_request",
+            )
+        record = self._require_session(request)
+        await self._send(
+            writer,
+            {"ok": True, "state": record.session.state.value},
+        )
 
     async def _command_pending(
         self,
@@ -2590,6 +2608,17 @@ class CodingWorkerClient:
             {"action": "cancel", "session_id": session_id}
         )
         return result.get("accepted") is True
+
+    async def session_status(self, session_id: str) -> dict[str, Any]:
+        result = await self._request(
+            {"action": "session_status", "session_id": session_id}
+        )
+        if not isinstance(result.get("state"), str):
+            raise CodingWorkerProtocolError(
+                "Coding worker omitted session state.",
+                code="invalid_response",
+            )
+        return result
 
     async def close(self, session_id: str) -> None:
         await self._request({"action": "close", "session_id": session_id})

--- a/server/coding_verifier/engine.py
+++ b/server/coding_verifier/engine.py
@@ -4,6 +4,7 @@ import asyncio
 import contextlib
 import inspect
 import os
+import re
 import shutil
 import signal
 import stat
@@ -13,11 +14,18 @@ import tempfile
 import time
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass, replace
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Protocol
 
 from server.coding_runtime.draft_workspace import (
     DraftLimits,
+)
+from server.coding_runtime.command_bridge import CommandExecutionResult
+from server.coding_runtime.commands import (
+    ProjectCommand,
+    RunnerPackManifest,
+    load_runner_pack_manifest,
+    runner_pack_matches_project,
 )
 from server.coding_runtime.patch_policy import (
     PatchPolicyError,
@@ -41,8 +49,11 @@ from server.coding_runtime.verification import (
 
 
 MAX_COMMAND_OUTPUT_BYTES = 64 * 1024
+MAX_RUNNER_PACK_ENTRIES = 200_000
 BACKEND_TIMEOUT_SECONDS = 300
 FRONTEND_TIMEOUT_SECONDS = 240
+
+
 class VerificationEngineError(RuntimeError):
     def __init__(self, message: str, *, code: str = "verification_failed") -> None:
         super().__init__(message)
@@ -52,7 +63,7 @@ class VerificationEngineError(RuntimeError):
 @dataclass(frozen=True, slots=True)
 class FixedCommand:
     argv: tuple[str, ...]
-    timeout_seconds: int
+    timeout_seconds: int | float
 
 
 @dataclass(frozen=True, slots=True)
@@ -197,6 +208,245 @@ class SubprocessVerificationRunner:
             )
         finally:
             _clear_temporary_root(temporary)
+
+    async def run_project_command(
+        self,
+        command: ProjectCommand,
+        workspace: Path,
+        *,
+        environment: dict[str, str] | None = None,
+        max_duration_seconds: float | None = None,
+    ) -> CommandResult:
+        command_cwd = (workspace / command.cwd).resolve()
+        if (
+            command_cwd != workspace.resolve()
+            and workspace.resolve() not in command_cwd.parents
+        ) or command_cwd.is_symlink() or not command_cwd.is_dir():
+            raise VerificationEngineError(
+                "Project command working directory is unavailable.",
+                code="command_cwd_unavailable",
+            )
+        executable = Path(command.argv[0]).name.casefold()
+        if command.argv[0] != PurePosixPath(command.argv[0]).name:
+            raise VerificationEngineError(
+                "Project command executable path is denied.",
+                code="command_executable_denied",
+            )
+        if executable.endswith(".exe"):
+            executable = executable[:-4]
+        allowed = {"python", "python3", "node", "npm"}
+        extra_environment = dict(environment or {})
+        allowed.update(
+            item
+            for item in extra_environment.pop("MODELMIRROR_ALLOWED_BINS", "").split(":")
+            if item
+        )
+        if executable not in allowed:
+            raise VerificationEngineError(
+                "Project command executable is not available.",
+                code="command_executable_denied",
+            )
+        runtime_root = workspace / ".modelmirror-verifier"
+        home = runtime_root / "home"
+        temporary = Path(tempfile.gettempdir()).resolve() / ".mmv-tmp"
+        data_root = runtime_root / "data"
+        _prepare_temporary_root(temporary)
+        for path in (home, data_root):
+            path.mkdir(parents=True, exist_ok=True)
+        clean_environment = {
+            "PATH": "/usr/local/bin:/usr/bin:/bin",
+            "HOME": str(home),
+            "TMPDIR": str(temporary),
+            "LANG": "C.UTF-8",
+            "LC_ALL": "C.UTF-8",
+            "NO_PROXY": "*",
+            "no_proxy": "*",
+            "PYTHONDONTWRITEBYTECODE": "1",
+        }
+        clean_environment.update(extra_environment)
+        timeout = min(
+            float(command.timeout_seconds),
+            max_duration_seconds
+            if max_duration_seconds is not None
+            else float(command.timeout_seconds),
+        )
+        try:
+            return await _run_bounded_command(
+                FixedCommand(argv=command.argv, timeout_seconds=max(0.001, timeout)),
+                cwd=command_cwd,
+                environment=clean_environment,
+            )
+        finally:
+            _clear_temporary_root(temporary)
+
+
+class IsolatedProjectCommandExecutor:
+    """Rebuilds one dynamic project in tmpfs and discards all command writes."""
+
+    def __init__(
+        self,
+        workspace_root: Path,
+        *,
+        runner_packs_root: Path | None = None,
+        runner: SubprocessVerificationRunner | None = None,
+        limits: DraftLimits | None = None,
+    ) -> None:
+        self.workspace_root = workspace_root.resolve()
+        self.runner_packs_root = (
+            runner_packs_root.resolve() if runner_packs_root is not None else None
+        )
+        self.runner = runner or SubprocessVerificationRunner()
+        self.limits = limits or DraftLimits()
+
+    async def execute(
+        self,
+        *,
+        source_root: Path,
+        expected_fingerprint: str,
+        patch: str,
+        paths: Sequence[str],
+        command: ProjectCommand,
+        runner_pack_id: str | None = None,
+        max_duration_seconds: float | None = None,
+    ) -> CommandExecutionResult:
+        if source_root.is_symlink():
+            raise VerificationEngineError(
+                "Project snapshot is unsafe.",
+                code="snapshot_unsafe",
+            )
+        source = source_root.resolve()
+        if (
+            source == self.workspace_root
+            or source in self.workspace_root.parents
+            or self.workspace_root in source.parents
+            or snapshot_fingerprint(source) != expected_fingerprint
+        ):
+            raise VerificationEngineError(
+                "Project snapshot does not match.",
+                code="snapshot_mismatch",
+            )
+        if patch:
+            validate_verification_patch(
+                patch,
+                expected_paths=paths,
+                limits=self.limits,
+            )
+        elif paths:
+            raise VerificationEngineError(
+                "Project Patch paths are invalid.",
+                code="invalid_patch",
+            )
+        self._clear_workspace()
+        try:
+            shutil.copytree(source, self.workspace_root, symlinks=False)
+            _make_workspace_writable(self.workspace_root)
+            if patch:
+                _apply_patch(self.workspace_root, patch)
+            pack: tuple[RunnerPackManifest, Path] | None = None
+            if runner_pack_id is not None:
+                pack = self._load_runner_pack(runner_pack_id, self.workspace_root)
+            environment = self._attach_runner_pack(pack, command)
+            result = await self.runner.run_project_command(
+                command,
+                self.workspace_root,
+                environment=environment,
+                max_duration_seconds=max_duration_seconds,
+            )
+            output = _sanitize_command_result(result)
+            return CommandExecutionResult(
+                status="passed" if result.exit_code == 0 else "failed",
+                exit_code=result.exit_code,
+                output=output,
+                duration_seconds=result.duration_ms / 1000,
+            )
+        finally:
+            self._clear_workspace()
+
+    def _load_runner_pack(
+        self,
+        pack_id: str,
+        source_root: Path,
+    ) -> tuple[RunnerPackManifest, Path]:
+        if self.runner_packs_root is None:
+            raise VerificationEngineError(
+                "Runner pack service is not configured.",
+                code="runner_pack_unavailable",
+            )
+        try:
+            manifest = load_runner_pack_manifest(self.runner_packs_root, pack_id)
+        except Exception as exc:
+            code = getattr(exc, "code", "runner_pack_invalid")
+            raise VerificationEngineError(str(exc), code=code) from exc
+        pack_root = (self.runner_packs_root / pack_id).resolve()
+        _validate_runner_pack_tree(pack_root)
+        if not runner_pack_matches_project(manifest, source_root):
+            raise VerificationEngineError(
+                "Runner pack does not match this project.",
+                code="runner_pack_mismatch",
+            )
+        return manifest, pack_root
+
+    def _attach_runner_pack(
+        self,
+        pack: tuple[RunnerPackManifest, Path] | None,
+        command: ProjectCommand,
+    ) -> dict[str, str]:
+        if pack is None:
+            return {}
+        manifest, pack_root = pack
+        environment: dict[str, str] = {}
+        if manifest.python_paths:
+            environment["PYTHONPATH"] = ":".join(
+                str(_resolve_pack_path(pack_root, path))
+                for path in manifest.python_paths
+            )
+        bin_paths = tuple(
+            _resolve_pack_path(pack_root, path) for path in manifest.bin_paths
+        )
+        if bin_paths:
+            environment["PATH"] = ":".join(
+                [*(str(path) for path in bin_paths), "/usr/local/bin", "/usr/bin", "/bin"]
+            )
+            allowed_bins: set[str] = set()
+            for bin_path in bin_paths:
+                allowed_bins.update(
+                    item.name.casefold()
+                    for item in bin_path.iterdir()
+                    if item.is_file()
+                )
+            environment["MODELMIRROR_ALLOWED_BINS"] = ":".join(sorted(allowed_bins))
+        modules = dict(manifest.node_modules).get(command.cwd)
+        if modules is not None:
+            target = self.workspace_root / command.cwd / "node_modules"
+            if target.exists() or target.is_symlink():
+                raise VerificationEngineError(
+                    "Project dependency target is unsafe.",
+                    code="runner_pack_target_unsafe",
+                )
+            modules_root = _resolve_pack_path(pack_root, modules)
+            target.mkdir()
+            for dependency in sorted(modules_root.iterdir()):
+                if dependency.name in {".cache", ".tmp"}:
+                    continue
+                (target / dependency.name).symlink_to(
+                    dependency,
+                    target_is_directory=dependency.is_dir(),
+                )
+            (target / ".cache").mkdir(mode=0o700)
+            (target / ".tmp").mkdir(mode=0o700)
+            environment["NODE_PATH"] = str(target)
+        return environment
+
+    def _clear_workspace(self) -> None:
+        if not self.workspace_root.exists():
+            return
+        if self.workspace_root.is_symlink() or not self.workspace_root.is_dir():
+            raise VerificationEngineError(
+                "Project command workspace is unsafe.",
+                code="unsafe_workspace_root",
+            )
+        _make_tree_removable(self.workspace_root)
+        shutil.rmtree(self.workspace_root)
 
 
 class CodingVerifierEngine:
@@ -463,6 +713,139 @@ def _make_workspace_writable(root: Path) -> None:
             "Verifier workspace could not be prepared.",
             code="workspace_unavailable",
         ) from exc
+
+
+async def _run_bounded_command(
+    command: FixedCommand,
+    *,
+    cwd: Path,
+    environment: dict[str, str],
+) -> CommandResult:
+    started = time.monotonic()
+    process = await asyncio.create_subprocess_exec(
+        *command.argv,
+        cwd=str(cwd),
+        env=environment,
+        stdin=asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        start_new_session=os.name == "posix",
+    )
+    assert process.stdout is not None and process.stderr is not None
+    stdout_task = asyncio.create_task(_read_bounded_stream(process.stdout))
+    stderr_task = asyncio.create_task(_read_bounded_stream(process.stderr))
+    try:
+        await asyncio.wait_for(process.wait(), timeout=command.timeout_seconds)
+    except TimeoutError as exc:
+        await _terminate_process(process)
+        await asyncio.gather(stdout_task, stderr_task, return_exceptions=True)
+        raise VerificationEngineError(
+            "Project command timed out.",
+            code="command_timeout",
+        ) from exc
+    except asyncio.CancelledError:
+        await _terminate_process(process)
+        await asyncio.gather(stdout_task, stderr_task, return_exceptions=True)
+        raise
+    stdout, stdout_truncated = await stdout_task
+    stderr, stderr_truncated = await stderr_task
+    return CommandResult(
+        exit_code=int(process.returncode or 0),
+        stdout=stdout,
+        stderr=stderr,
+        duration_ms=round((time.monotonic() - started) * 1000),
+        output_truncated=stdout_truncated or stderr_truncated,
+    )
+
+
+_ANSI_ESCAPE = re.compile(r"\x1b(?:\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1b\\))")
+_FORBIDDEN_PACK_NAMES = frozenset(
+    {".git", ".env", "credentials.json", "opencode.json", "opencode.jsonc"}
+)
+_FORBIDDEN_PACK_SUFFIXES = (".pem", ".key", ".p12", ".pfx")
+
+
+def _sanitize_command_result(result: CommandResult) -> str:
+    raw = "\n".join(
+        part for part in (result.stdout.strip(), result.stderr.strip()) if part
+    )
+    raw = _ANSI_ESCAPE.sub("", raw)
+    raw = raw.replace("/runner-packs", "[runner-pack]")
+    raw = raw.replace("/project-snapshots", "[source]")
+    sanitized = sanitize_verification_output(
+        raw,
+        limit=MAX_COMMAND_OUTPUT_BYTES,
+    ).text
+    encoded = sanitized.encode("utf-8", errors="replace")
+    if len(encoded) <= MAX_COMMAND_OUTPUT_BYTES:
+        return sanitized
+    marker = "\n…输出已截断…\n".encode("utf-8")
+    tail = encoded[-(MAX_COMMAND_OUTPUT_BYTES - len(marker)) :]
+    while tail and (tail[0] & 0xC0) == 0x80:
+        tail = tail[1:]
+    return (marker + tail).decode("utf-8", errors="replace")
+
+
+def _validate_runner_pack_tree(pack_root: Path) -> None:
+    if pack_root.is_symlink() or not pack_root.is_dir():
+        raise VerificationEngineError(
+            "Runner pack is unavailable.",
+            code="runner_pack_unavailable",
+        )
+    count = 0
+    try:
+        for path in pack_root.rglob("*"):
+            count += 1
+            if count > MAX_RUNNER_PACK_ENTRIES:
+                raise VerificationEngineError(
+                    "Runner pack contains too many entries.",
+                    code="runner_pack_limit_exceeded",
+                )
+            relative = path.relative_to(pack_root)
+            if any(
+                part.casefold() in _FORBIDDEN_PACK_NAMES
+                or part.casefold().startswith(".env.")
+                or part.casefold().endswith(_FORBIDDEN_PACK_SUFFIXES)
+                for part in relative.parts
+            ):
+                raise VerificationEngineError(
+                    "Runner pack contains a forbidden path.",
+                    code="runner_pack_unsafe",
+                )
+            resolved = path.resolve(strict=True)
+            if resolved != pack_root and pack_root not in resolved.parents:
+                raise VerificationEngineError(
+                    "Runner pack symbolic link leaves the pack.",
+                    code="runner_pack_unsafe",
+                )
+            if not (path.is_file() or path.is_dir() or path.is_symlink()):
+                raise VerificationEngineError(
+                    "Runner pack contains an unsupported entry.",
+                    code="runner_pack_unsafe",
+                )
+    except VerificationEngineError:
+        raise
+    except (OSError, RuntimeError) as exc:
+        raise VerificationEngineError(
+            "Runner pack could not be inspected.",
+            code="runner_pack_unsafe",
+        ) from exc
+
+
+def _resolve_pack_path(pack_root: Path, relative: str) -> Path:
+    try:
+        resolved = (pack_root / relative).resolve(strict=True)
+    except (OSError, RuntimeError) as exc:
+        raise VerificationEngineError(
+            "Runner pack path is unavailable.",
+            code="runner_pack_invalid",
+        ) from exc
+    if pack_root not in resolved.parents or not resolved.is_dir():
+        raise VerificationEngineError(
+            "Runner pack path is unsafe.",
+            code="runner_pack_unsafe",
+        )
+    return resolved
 
 
 def _prepare_temporary_root(root: Path) -> None:

--- a/server/coding_verifier/server.py
+++ b/server/coding_verifier/server.py
@@ -11,6 +11,11 @@ from pathlib import Path
 from typing import Any
 
 from server.coding_runtime.draft_workspace import DraftPolicyError
+from server.coding_runtime.commands import (
+    CommandContractError,
+    ProjectCommandOrigin,
+    normalize_agent_command,
+)
 from server.coding_runtime.verification import (
     VerificationReport,
     VerificationResult,
@@ -22,6 +27,7 @@ from server.coding_runtime.verification import (
 
 from .engine import (
     CodingVerifierEngine,
+    IsolatedProjectCommandExecutor,
     VerificationEngineError,
     validate_verification_patch,
 )
@@ -38,7 +44,13 @@ SOCKET_PATH = Path(
 SOURCE_ROOT = Path("/opt/modelmirror-source")
 WORKSPACE_ROOT = Path("/workspace/current")
 FRONTEND_DEPENDENCIES = Path("/opt/modelmirror-client/node_modules")
+PROJECT_SNAPSHOT_PATH = Path(
+    os.getenv("CODING_PROJECT_SNAPSHOT_PATH", "/project-snapshots/current")
+)
+RUNNER_PACKS_ROOT = os.getenv("CODING_RUNNER_PACKS_ROOT", "").strip()
 SAFE_IDENTIFIER = re.compile(r"^[A-Za-z0-9_-]{1,128}$")
+SAFE_FINGERPRINT = re.compile(r"^[a-f0-9]{64}$")
+SAFE_HEAD = re.compile(r"^[a-f0-9]{40,64}$")
 
 
 class VerifierProtocolError(RuntimeError):
@@ -55,6 +67,13 @@ class _VerificationJob:
     task: asyncio.Task[None] | None = None
 
 
+@dataclass(slots=True)
+class _CommandJob:
+    session_id: str
+    request_id: str
+    task: asyncio.Task[Any]
+
+
 class CodingVerifierServer:
     """One-job Unix socket host for the offline verifier engine."""
 
@@ -63,6 +82,8 @@ class CodingVerifierServer:
         socket_path: Path = SOCKET_PATH,
         *,
         engine: CodingVerifierEngine | None = None,
+        command_executor: IsolatedProjectCommandExecutor | None = None,
+        project_snapshot_path: Path = PROJECT_SNAPSHOT_PATH,
     ) -> None:
         self._socket_path = socket_path
         self._engine = engine or CodingVerifierEngine(
@@ -71,6 +92,12 @@ class CodingVerifierServer:
             frontend_dependencies=FRONTEND_DEPENDENCIES,
         )
         self._job: _VerificationJob | None = None
+        self._command_executor = command_executor or IsolatedProjectCommandExecutor(
+            WORKSPACE_ROOT,
+            runner_packs_root=(Path(RUNNER_PACKS_ROOT) if RUNNER_PACKS_ROOT else None),
+        )
+        self._project_snapshot_path = project_snapshot_path
+        self._command_job: _CommandJob | None = None
         self._job_lock = asyncio.Lock()
 
     async def handle(
@@ -113,6 +140,7 @@ class CodingVerifierServer:
                 "configured": True,
                 "snapshot_fingerprint": self._engine.source_fingerprint,
                 "max_duration_seconds": MAX_VERIFICATION_DURATION_SECONDS,
+                "commands": True,
             }
         if action == "start":
             return await self._start(request)
@@ -123,6 +151,10 @@ class CodingVerifierServer:
             return await self._cancel(request)
         if action == "close":
             return await self._close_job(request)
+        if action == "execute_command":
+            return await self._execute_command(request)
+        if action == "cancel_command":
+            return await self._cancel_command(request)
         raise VerifierProtocolError(
             "Verifier action is not supported.",
             code="unsupported_action",
@@ -177,6 +209,11 @@ class CodingVerifierServer:
                 started_at=started_at,
             )
         async with self._job_lock:
+            if self._command_job is not None and not self._command_job.task.done():
+                raise VerifierProtocolError(
+                    "A project command is already running.",
+                    code="verification_busy",
+                )
             if self._job is not None and self._job.task is not None:
                 if not self._job.task.done():
                     raise VerifierProtocolError(
@@ -199,6 +236,162 @@ class CodingVerifierServer:
                     )
                 )
         return {"verification": job.report.to_dict()}
+
+    async def _execute_command(self, request: dict[str, Any]) -> dict[str, Any]:
+        expected_keys = {
+            "action",
+            "session_id",
+            "request_id",
+            "source",
+            "patch",
+            "paths",
+            "command",
+            "runner_pack_id",
+            "max_duration_seconds",
+        }
+        if set(request) != expected_keys:
+            raise VerifierProtocolError("Project command request is invalid.")
+        session_id = _identifier(request.get("session_id"))
+        request_id = _identifier(request.get("request_id"))
+        patch = request.get("patch")
+        paths = request.get("paths")
+        max_duration = request.get("max_duration_seconds")
+        runner_pack_id = request.get("runner_pack_id")
+        if (
+            not isinstance(patch, str)
+            or not isinstance(paths, list)
+            or any(not isinstance(path, str) for path in paths)
+            or isinstance(max_duration, bool)
+            or not isinstance(max_duration, (int, float))
+            or not 0 < max_duration <= MAX_VERIFICATION_DURATION_SECONDS
+            or (runner_pack_id is not None and not isinstance(runner_pack_id, str))
+        ):
+            raise VerifierProtocolError("Project command request is invalid.")
+        command_payload = request.get("command")
+        if not isinstance(command_payload, dict) or set(command_payload) != {
+            "id",
+            "name",
+            "kind",
+            "argv",
+            "cwd",
+            "timeout_seconds",
+            "origin",
+        }:
+            raise VerifierProtocolError("Project command is invalid.")
+        try:
+            command = normalize_agent_command(
+                argv=command_payload["argv"],
+                cwd=command_payload["cwd"],
+                purpose=command_payload["name"],
+                timeout_seconds=command_payload["timeout_seconds"],
+            )
+        except CommandContractError as exc:
+            raise VerifierProtocolError(str(exc), code=exc.code) from exc
+        if (
+            command.command_id != command_payload["id"]
+            or command_payload["kind"] != "custom"
+            or command_payload["origin"] != ProjectCommandOrigin.AGENT.value
+        ):
+            raise VerifierProtocolError("Project command identity is invalid.")
+        source_root, fingerprint = self._resolve_project_source(request.get("source"))
+        async with self._job_lock:
+            if self._job is not None and self._job.task is not None and not self._job.task.done():
+                raise VerifierProtocolError(
+                    "Project verification is already running.",
+                    code="verification_busy",
+                )
+            if self._command_job is not None and not self._command_job.task.done():
+                raise VerifierProtocolError(
+                    "Another project command is already running.",
+                    code="command_busy",
+                )
+            task = asyncio.create_task(
+                self._command_executor.execute(
+                    source_root=source_root,
+                    expected_fingerprint=fingerprint,
+                    patch=patch,
+                    paths=paths,
+                    command=command,
+                    runner_pack_id=runner_pack_id,
+                    max_duration_seconds=float(max_duration),
+                )
+            )
+            job = _CommandJob(session_id, request_id, task)
+            self._command_job = job
+        try:
+            result = await task
+        except asyncio.CancelledError as exc:
+            raise VerificationEngineError(
+                "Project command was cancelled.",
+                code="command_cancelled",
+            ) from exc
+        finally:
+            async with self._job_lock:
+                if self._command_job is job:
+                    self._command_job = None
+        return {"command": result.to_dict()}
+
+    async def _cancel_command(self, request: dict[str, Any]) -> dict[str, Any]:
+        if set(request) != {"action", "session_id", "request_id"}:
+            raise VerifierProtocolError("Project command cancellation is invalid.")
+        session_id = _identifier(request.get("session_id"))
+        request_id = _identifier(request.get("request_id"))
+        async with self._job_lock:
+            job = self._command_job
+            if job is None or job.session_id != session_id or job.request_id != request_id:
+                return {"accepted": False}
+            task = job.task
+        if not task.done():
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, VerificationEngineError):
+                await task
+        return {"accepted": True}
+
+    def _resolve_project_source(self, value: Any) -> tuple[Path, str]:
+        expected = {
+            "kind",
+            "lease_id",
+            "project_id",
+            "name",
+            "branch",
+            "head",
+            "fingerprint",
+            "file_count",
+            "total_bytes",
+            "hidden_files",
+            "created_at",
+        }
+        if not isinstance(value, dict) or set(value) != expected or value.get("kind") != "local_clone":
+            raise VerifierProtocolError("Project source is invalid.")
+        if (
+            not SAFE_IDENTIFIER.fullmatch(str(value.get("lease_id", "")))
+            or not SAFE_IDENTIFIER.fullmatch(str(value.get("project_id", "")))
+            or not SAFE_HEAD.fullmatch(str(value.get("head", "")))
+            or not SAFE_FINGERPRINT.fullmatch(str(value.get("fingerprint", "")))
+        ):
+            raise VerifierProtocolError("Project source identity is invalid.")
+        lease_path = self._project_snapshot_path / "lease.json"
+        workspace = self._project_snapshot_path / "workspace"
+        try:
+            if lease_path.is_symlink() or not lease_path.is_file() or lease_path.stat().st_size > 16 * 1024:
+                raise VerificationEngineError(
+                    "Project snapshot is unavailable.",
+                    code="snapshot_unavailable",
+                )
+            lease = json.loads(lease_path.read_text(encoding="utf-8", errors="strict"))
+        except VerificationEngineError:
+            raise
+        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+            raise VerificationEngineError(
+                "Project snapshot is unavailable.",
+                code="snapshot_unavailable",
+            ) from exc
+        if lease != {key: item for key, item in value.items() if key != "kind"}:
+            raise VerificationEngineError(
+                "Project snapshot lease does not match.",
+                code="snapshot_mismatch",
+            )
+        return workspace, value["fingerprint"]
 
     async def _run_job(
         self,
@@ -291,17 +484,33 @@ class CodingVerifierServer:
             with contextlib.suppress(asyncio.CancelledError):
                 await job.task
         async with self._job_lock:
+            command_job = (
+                self._command_job
+                if self._command_job and self._command_job.session_id == session_id
+                else None
+            )
+        if command_job is not None and not command_job.task.done():
+            command_job.task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, VerificationEngineError):
+                await command_job.task
+        async with self._job_lock:
             if self._job is job:
                 self._job = None
+            if self._command_job is command_job:
+                self._command_job = None
         return {"closed": True}
 
     async def close(self) -> None:
         async with self._job_lock:
             job = self._job
-        if job is not None:
-            await self._close_job(
-                {"session_id": job.session_id}
-            )
+            command_job = self._command_job
+        session_id = (
+            job.session_id
+            if job is not None
+            else command_job.session_id if command_job is not None else None
+        )
+        if session_id is not None:
+            await self._close_job({"session_id": session_id})
 
     async def serve_forever(self) -> None:
         self._socket_path.parent.mkdir(parents=True, exist_ok=True)

--- a/server/tests/test_coding_command_bridge.py
+++ b/server/tests/test_coding_command_bridge.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from server.coding_runtime.command_bridge import (
+    CommandBridgeError,
+    CommandConfirmationBridge,
+    CommandExecutionResult,
+)
+from server.coding_runtime.commands import normalize_agent_command
+from server.coding_runtime.runner_mcp import RunnerMcpServer
+from server.coding_runtime.worker import CodingWorkerError, build_opencode_config
+
+
+def _command(marker: str = "q7m4", timeout_seconds: int = 120):
+    return normalize_agent_command(
+        argv=["python", "-m", "pytest", f"tests/test_{marker}.py", "-q"],
+        cwd=".",
+        purpose=f"检查随机用例 {marker}",
+        timeout_seconds=timeout_seconds,
+    )
+
+
+@pytest.mark.asyncio
+async def test_confirmation_allows_one_request_and_returns_execution_result() -> None:
+    requested = asyncio.Event()
+    observed: list[str] = []
+
+    async def observer(request) -> None:
+        observed.append(request.state.value)
+        requested.set()
+
+    async def executor(command, remaining: float) -> CommandExecutionResult:
+        assert command == _command()
+        assert remaining == 600
+        return CommandExecutionResult("passed", 0, "1 passed", 0.25)
+
+    bridge = CommandConfirmationBridge(observer=observer)
+    await bridge.begin_turn("turn-r4t8")
+    task = asyncio.create_task(
+        bridge.request(
+            session_id="session-n5c2",
+            turn_id="turn-r4t8",
+            command=_command(),
+            executor=executor,
+        )
+    )
+    await requested.wait()
+    pending = await bridge.pending(session_id="session-n5c2")
+    assert pending is not None
+
+    decided = await bridge.decide(
+        session_id="session-n5c2",
+        request_id=pending["request_id"],
+        decision="allow_once",
+    )
+    result = await task
+
+    assert decided["state"] == "awaiting_confirmation"
+    assert result["state"] == "completed"
+    assert result["result"]["output"] == "1 passed"
+    assert observed == ["awaiting_confirmation", "running", "completed"]
+    assert await bridge.pending(session_id="session-n5c2") is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("decision", "expected_state", "expected_status"),
+    [
+        ("reject", "rejected", "rejected"),
+        (None, "timed_out", "confirmation_timed_out"),
+    ],
+)
+async def test_reject_and_timeout_are_non_error_tool_results(
+    decision: str | None,
+    expected_state: str,
+    expected_status: str,
+) -> None:
+    bridge = CommandConfirmationBridge(confirmation_timeout=0.02)
+    await bridge.begin_turn("turn-b3p9")
+
+    async def never_execute(_command, _remaining):
+        raise AssertionError("rejected commands must not execute")
+
+    task = asyncio.create_task(
+        bridge.request(
+            session_id="session-z8f1",
+            turn_id="turn-b3p9",
+            command=_command("b3p9"),
+            executor=never_execute,
+        )
+    )
+    while (pending := await bridge.pending(session_id="session-z8f1")) is None:
+        await asyncio.sleep(0)
+    if decision is not None:
+        await bridge.decide(
+            session_id="session-z8f1",
+            request_id=pending["request_id"],
+            decision=decision,
+        )
+
+    result = await task
+
+    assert result["state"] == expected_state
+    assert result["result"]["status"] == expected_status
+
+
+@pytest.mark.asyncio
+async def test_bridge_rejects_concurrent_commands_and_cancel_is_idempotent() -> None:
+    bridge = CommandConfirmationBridge()
+    await bridge.begin_turn("turn-v6k2")
+
+    async def executor(_command, _remaining):
+        return CommandExecutionResult("passed", 0, "", 0.0)
+
+    first = asyncio.create_task(
+        bridge.request(
+            session_id="session-a4d7",
+            turn_id="turn-v6k2",
+            command=_command("v6k2"),
+            executor=executor,
+        )
+    )
+    while await bridge.pending(session_id="session-a4d7") is None:
+        await asyncio.sleep(0)
+    with pytest.raises(CommandBridgeError) as busy:
+        await bridge.request(
+            session_id="session-a4d7",
+            turn_id="turn-v6k2",
+            command=_command("w8n1"),
+            executor=executor,
+        )
+    assert busy.value.code == "command_request_busy"
+
+    assert await bridge.cancel_pending() is True
+    assert await bridge.cancel_pending() is False
+    result = await first
+    assert result["state"] == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_cancel_stops_a_running_executor_without_overwriting_cancelled_state() -> None:
+    started = asyncio.Event()
+    cleaned = asyncio.Event()
+    bridge = CommandConfirmationBridge()
+    await bridge.begin_turn("turn-c8r3")
+
+    async def executor(_command, _remaining):
+        started.set()
+        try:
+            await asyncio.Future()
+        finally:
+            cleaned.set()
+
+    task = asyncio.create_task(
+        bridge.request(
+            session_id="session-c8r3",
+            turn_id="turn-c8r3",
+            command=_command("c8r3"),
+            executor=executor,
+        )
+    )
+    while (pending := await bridge.pending(session_id="session-c8r3")) is None:
+        await asyncio.sleep(0)
+    await bridge.decide(
+        session_id="session-c8r3",
+        request_id=pending["request_id"],
+        decision="allow_once",
+    )
+    await started.wait()
+
+    assert await bridge.cancel_pending() is True
+    result = await task
+
+    assert cleaned.is_set()
+    assert result["state"] == "cancelled"
+    assert result["result"]["status"] == "turn_cancelled"
+
+
+@pytest.mark.asyncio
+async def test_decision_is_idempotent_and_bound_to_session() -> None:
+    bridge = CommandConfirmationBridge()
+    await bridge.begin_turn("turn-j2s5")
+
+    async def executor(_command, _remaining):
+        return CommandExecutionResult("passed", 0, "", 0.0)
+
+    task = asyncio.create_task(
+        bridge.request(
+            session_id="session-j2s5",
+            turn_id="turn-j2s5",
+            command=_command("j2s5"),
+            executor=executor,
+        )
+    )
+    while (pending := await bridge.pending(session_id="session-j2s5")) is None:
+        await asyncio.sleep(0)
+    with pytest.raises(CommandBridgeError) as wrong_session:
+        await bridge.decide(
+            session_id="session-other",
+            request_id=pending["request_id"],
+            decision="allow_once",
+        )
+    assert wrong_session.value.code == "command_request_not_found"
+
+    await bridge.decide(
+        session_id="session-j2s5",
+        request_id=pending["request_id"],
+        decision="reject",
+    )
+    result = await task
+    repeated = await bridge.decide(
+        session_id="session-j2s5",
+        request_id=pending["request_id"],
+        decision="reject",
+    )
+    assert repeated["state"] == result["state"] == "rejected"
+
+
+@pytest.mark.asyncio
+async def test_per_turn_command_limit_fails_closed_after_completed_request() -> None:
+    bridge = CommandConfirmationBridge(max_commands=1)
+    await bridge.begin_turn("turn-limit-r9n4")
+
+    async def executor(_command, _remaining):
+        return CommandExecutionResult("passed", 0, "", 0.0)
+
+    first = asyncio.create_task(
+        bridge.request(
+            session_id="session-limit-r9n4",
+            turn_id="turn-limit-r9n4",
+            command=_command("limit-r9n4"),
+            executor=executor,
+        )
+    )
+    while (pending := await bridge.pending(session_id="session-limit-r9n4")) is None:
+        await asyncio.sleep(0)
+    await bridge.decide(
+        session_id="session-limit-r9n4",
+        request_id=pending["request_id"],
+        decision="allow_once",
+    )
+    assert (await first)["state"] == "completed"
+
+    with pytest.raises(CommandBridgeError) as limited:
+        await bridge.request(
+            session_id="session-limit-r9n4",
+            turn_id="turn-limit-r9n4",
+            command=_command("limit-next"),
+            executor=executor,
+        )
+    assert limited.value.code == "command_limit_reached"
+
+
+@pytest.mark.asyncio
+async def test_runner_mcp_exposes_only_structured_command_tool(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+    server = RunnerMcpServer(socket_path="/tmp/runner.sock", token="t" * 32)
+
+    async def forward(arguments):
+        captured.update(arguments)
+        return {"state": "rejected", "result": {"status": "rejected"}}
+
+    monkeypatch.setattr(server, "_forward", forward)
+    listed = await server.dispatch({"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+    called = await server.dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "run_project_command",
+                "arguments": {
+                    "argv": ["python", "-m", "pytest", "-q"],
+                    "cwd": ".",
+                    "purpose": "运行检查",
+                    "timeout_seconds": 120,
+                },
+            },
+        }
+    )
+
+    tools = listed["result"]["tools"]
+    assert [tool["name"] for tool in tools] == ["run_project_command"]
+    assert tools[0]["inputSchema"]["additionalProperties"] is False
+    assert captured["argv"] == ["python", "-m", "pytest", "-q"]
+    assert called["result"]["isError"] is False
+    assert json.loads(called["result"]["content"][0]["text"])["state"] == "rejected"
+
+
+def test_opencode_config_enables_only_internal_mcp_in_draft_mode() -> None:
+    config = build_opencode_config(
+        "provider/model",
+        "draft",
+        commands_enabled=True,
+        runner_token="r" * 32,
+    )
+
+    assert config["mcp"] == {
+        "modelmirror-runner": {
+            "type": "local",
+            "command": ["python", "-m", "coding_runtime.runner_mcp"],
+            "environment": {
+                "MODELMIRROR_RUNNER_SOCKET": "/tmp/modelmirror-runner.sock",
+                "MODELMIRROR_RUNNER_TOKEN": "r" * 32,
+            },
+            "enabled": True,
+            "timeout": 310_000,
+        }
+    }
+    assert config["permission"]["modelmirror-runner_*"] == "allow"
+    assert config["permission"]["bash"] == "deny"
+
+    with pytest.raises(CodingWorkerError):
+        build_opencode_config(
+            "provider/model",
+            "readonly",
+            commands_enabled=True,
+            runner_token="r" * 32,
+        )
+    with pytest.raises(CodingWorkerError):
+        build_opencode_config(
+            "provider/model",
+            "draft",
+            commands_enabled=True,
+            runner_token="unsafe token with spaces" * 2,
+        )

--- a/server/tests/test_coding_command_bridge.py
+++ b/server/tests/test_coding_command_bridge.py
@@ -286,6 +286,7 @@ async def test_runner_mcp_exposes_only_structured_command_tool(monkeypatch) -> N
     tools = listed["result"]["tools"]
     assert [tool["name"] for tool in tools] == ["run_project_command"]
     assert tools[0]["inputSchema"]["additionalProperties"] is False
+    assert "/workspace" in tools[0]["inputSchema"]["properties"]["cwd"]["description"]
     assert captured["argv"] == ["python", "-m", "pytest", "-q"]
     assert called["result"]["isError"] is False
     assert json.loads(called["result"]["content"][0]["text"])["state"] == "rejected"

--- a/server/tests/test_coding_commands.py
+++ b/server/tests/test_coding_commands.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from server.coding_runtime.commands import (
+    CommandContractError,
+    ProjectCommandKind,
+    ProjectCommandOrigin,
+    ProjectVerificationConfig,
+    command_plan_fingerprint,
+    dependency_input_hashes,
+    detect_project_commands,
+    load_runner_pack_manifest,
+    normalize_agent_command,
+    normalize_project_command,
+    parse_project_verification,
+    runner_pack_matches_project,
+)
+from server.coding_runtime.projects import load_project_manifest
+
+
+def _manifest_command(**overrides: object) -> dict[str, object]:
+    value: dict[str, object] = {
+        "name": "运行随机检查",
+        "kind": "test",
+        "argv": ["python", "-m", "pytest", "-q"],
+        "cwd": ".",
+        "timeout_seconds": 240,
+    }
+    value.update(overrides)
+    return value
+
+
+def test_manifest_v1_remains_compatible_and_v2_carries_verification(tmp_path: Path) -> None:
+    root = tmp_path / "projects"
+    root.mkdir()
+    manifest = root / ".modelmirror-coding-projects.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "projects": [{"name": "旧项目", "path": "team/legacy"}],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    legacy = load_project_manifest(root)[0]
+
+    assert legacy.verification == ProjectVerificationConfig()
+
+    manifest.write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "projects": [
+                    {
+                        "name": "新项目",
+                        "path": "team/current",
+                        "verification": {
+                            "auto": False,
+                            "runner_pack": "team-current-202608",
+                            "commands": [_manifest_command()],
+                        },
+                    }
+                ],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    current = load_project_manifest(root)[0]
+
+    assert current.verification.auto is False
+    assert current.verification.runner_pack == "team-current-202608"
+    assert current.verification.commands[0].argv == ("python", "-m", "pytest", "-q")
+
+
+@pytest.mark.parametrize(
+    ("overrides", "code"),
+    [
+        ({"argv": ["bash", "-c", "pytest"]}, "command_shell_denied"),
+        ({"argv": ["python", "/etc/passwd"]}, "command_path_invalid"),
+        ({"cwd": "../outside"}, "command_path_invalid"),
+        ({"timeout_seconds": 301}, "project_command_timeout_invalid"),
+        ({"argv": ["python"] * 65}, "command_argv_invalid"),
+    ],
+)
+def test_project_command_rejects_unsafe_or_unbounded_values(
+    overrides: dict[str, object],
+    code: str,
+) -> None:
+    with pytest.raises(CommandContractError) as error:
+        normalize_project_command(
+            _manifest_command(**overrides),
+            origin=ProjectCommandOrigin.MANIFEST,
+        )
+
+    assert error.value.code == code
+
+
+def test_agent_command_is_structured_and_stable() -> None:
+    first = normalize_agent_command(
+        argv=["python", "-m", "pytest", "tests/test_q7m4.py", "-q"],
+        cwd=".",
+        purpose="检查随机测试 q7m4",
+        timeout_seconds=120,
+    )
+    second = normalize_agent_command(
+        argv=["python", "-m", "pytest", "tests/test_q7m4.py", "-q"],
+        cwd=".",
+        purpose="检查随机测试 q7m4",
+        timeout_seconds=120,
+    )
+
+    assert first == second
+    assert first.kind is ProjectCommandKind.CUSTOM
+    assert first.origin is ProjectCommandOrigin.AGENT
+    assert first.command_id.startswith("command-")
+
+
+def test_auto_detection_combines_python_and_node_checks_without_duplicates(tmp_path: Path) -> None:
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "package.json").write_text(
+        json.dumps(
+            {
+                "scripts": {
+                    "test": "node test.js",
+                    "typecheck": "tsc --noEmit",
+                    "lint": "eslint .",
+                    "build": "vite build",
+                    "deploy": "ignored",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    configured = normalize_project_command(
+        _manifest_command(name="部署者测试"),
+        origin=ProjectCommandOrigin.MANIFEST,
+    )
+
+    commands = detect_project_commands(
+        tmp_path,
+        ProjectVerificationConfig(commands=(configured,)),
+    )
+
+    assert commands[0] == configured
+    assert len(commands) == 6
+    assert [item.kind.value for item in commands] == [
+        "test",
+        "test",
+        "test",
+        "typecheck",
+        "lint",
+        "build",
+    ]
+    assert commands[1].argv[:3] == ("python", "-m", "pytest")
+    assert commands[2].argv == ("npm", "run", "test")
+    assert all(item.origin in {ProjectCommandOrigin.AUTO, ProjectCommandOrigin.MANIFEST} for item in commands)
+
+
+def test_auto_detection_does_not_treat_unrelated_pyproject_as_tests(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "random-library"\n',
+        encoding="utf-8",
+    )
+
+    assert detect_project_commands(tmp_path, ProjectVerificationConfig()) == ()
+
+
+def test_parse_project_verification_rejects_duplicate_commands() -> None:
+    command = _manifest_command()
+
+    with pytest.raises(CommandContractError) as error:
+        parse_project_verification(
+            {"commands": [command, dict(command)]}
+        )
+
+    assert error.value.code == "project_commands_duplicate"
+
+
+def test_runner_pack_binds_exact_dependency_inputs_and_plan(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    requirements = b"pytest==8.4.1\n"
+    package_lock = b'{"lockfileVersion":3}\n'
+    (project / "requirements.txt").write_bytes(requirements)
+    (project / "client").mkdir()
+    (project / "client" / "package-lock.json").write_bytes(package_lock)
+    inputs = {
+        "requirements.txt": f"sha256:{hashlib.sha256(requirements).hexdigest()}",
+        "client/package-lock.json": f"sha256:{hashlib.sha256(package_lock).hexdigest()}",
+    }
+    packs = tmp_path / "packs"
+    pack = packs / "random-pack-7m2"
+    pack.mkdir(parents=True)
+    (pack / "pack.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "id": "random-pack-7m2",
+                "platform": "linux-x86_64",
+                "python_version": "3.12",
+                "node_version": "22",
+                "inputs": inputs,
+                "python_paths": ["python/site-packages"],
+                "node_modules": {".": "node/root/node_modules"},
+                "bin_paths": ["bin"],
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+    manifest = load_runner_pack_manifest(packs, "random-pack-7m2")
+    command = normalize_project_command(
+        _manifest_command(),
+        origin=ProjectCommandOrigin.MANIFEST,
+    )
+    first_plan = command_plan_fingerprint(
+        [command],
+        source_fingerprint="a" * 64,
+        pack_fingerprint=manifest.fingerprint,
+    )
+    second_plan = command_plan_fingerprint(
+        [command],
+        source_fingerprint="a" * 64,
+        pack_fingerprint=manifest.fingerprint,
+    )
+
+    assert manifest.inputs == dependency_input_hashes(
+        project,
+        ["requirements.txt", "client/package-lock.json"],
+    )
+    assert runner_pack_matches_project(manifest, project) is True
+    assert first_plan == second_plan
+
+    (project / "requirements.txt").write_text("pytest==0\n", encoding="utf-8")
+    assert runner_pack_matches_project(manifest, project) is False
+
+
+def test_runner_pack_rejects_platform_and_path_escape(tmp_path: Path) -> None:
+    packs = tmp_path / "packs"
+    pack = packs / "unsafe-pack"
+    pack.mkdir(parents=True)
+    payload = {
+        "version": 1,
+        "id": "unsafe-pack",
+        "platform": "windows-x86_64",
+        "python_version": "3.12",
+        "node_version": "22",
+        "inputs": {},
+        "python_paths": ["../outside"],
+        "node_modules": {},
+        "bin_paths": [],
+    }
+    (pack / "pack.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(CommandContractError) as platform_error:
+        load_runner_pack_manifest(packs, "unsafe-pack")
+    assert platform_error.value.code == "runner_pack_platform_mismatch"
+
+    payload["platform"] = "linux-x86_64"
+    (pack / "pack.json").write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(CommandContractError) as path_error:
+        load_runner_pack_manifest(packs, "unsafe-pack")
+    assert path_error.value.code == "command_path_invalid"

--- a/server/tests/test_coding_commands.py
+++ b/server/tests/test_coding_commands.py
@@ -125,6 +125,34 @@ def test_agent_command_is_structured_and_stable() -> None:
     assert first.command_id.startswith("command-")
 
 
+@pytest.mark.parametrize(
+    ("cwd", "expected"),
+    [
+        ("/workspace", "."),
+        ("/workspace/server/tests", "server/tests"),
+    ],
+)
+def test_agent_command_maps_only_fixed_workspace_cwd(cwd: str, expected: str) -> None:
+    command = normalize_agent_command(
+        argv=["python", "--version"],
+        cwd=cwd,
+        purpose="检查 Python 版本",
+        timeout_seconds=30,
+    )
+
+    assert command.cwd == expected
+
+    for unsafe_cwd in ("/tmp/workspace", "/workspace/../outside"):
+        with pytest.raises(CommandContractError) as unsafe:
+            normalize_agent_command(
+                argv=["python", "--version"],
+                cwd=unsafe_cwd,
+                purpose="检查 Python 版本",
+                timeout_seconds=30,
+            )
+        assert unsafe.value.code == "command_path_invalid"
+
+
 def test_auto_detection_combines_python_and_node_checks_without_duplicates(tmp_path: Path) -> None:
     (tmp_path / "tests").mkdir()
     (tmp_path / "package.json").write_text(

--- a/server/tests/test_coding_project_commands_api.py
+++ b/server/tests/test_coding_project_commands_api.py
@@ -226,6 +226,28 @@ async def test_custom_project_verification_previews_then_runs_exact_plan(
     assert verifier.commands[1]["paths"] == ["tests/test_app.py"]
 
 
+def test_custom_project_without_checks_is_not_reported_as_unnecessary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    server, record, _ = _record(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        "server.coding_runtime.worker.detect_project_commands",
+        lambda *_args, **_kwargs: (),
+    )
+    (record.workspace.workspace_root / "app.py").write_text(
+        "VALUE = 999\n",
+        encoding="utf-8",
+    )
+    revision = record.workspace.cumulative_changes().revision
+
+    report = server._prepare_local_verification(record, revision)
+
+    assert report["state"] == "completed"
+    assert report["result"] == "not_run"
+    assert report["reason"] == "no_project_checks"
+
+
 def test_command_and_confirmation_payloads_cross_only_the_public_api_boundary() -> None:
     command = {
         "id": "command-1234567890abcdef12345678",

--- a/server/tests/test_coding_project_commands_api.py
+++ b/server/tests/test_coding_project_commands_api.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from server.coding_runtime.commands import ProjectVerificationConfig
+from server.coding_runtime.api import _public_event, _verification_from_worker, router
+from server.coding_runtime.draft_workspace import DraftWorkspace
+from server.coding_runtime.models import CodingEventKind, CodingSession, CodingSessionState
+from server.coding_runtime.projects import ProjectKind
+from server.coding_runtime.worker import (
+    CodingWorkerServer,
+    WorkspaceSource,
+    _WorkerSession,
+)
+
+
+class _Adapter:
+    async def close(self, session: CodingSession) -> None:
+        return None
+
+
+class _Verifier:
+    def __init__(self) -> None:
+        self.commands: list[dict[str, Any]] = []
+
+    async def health(self) -> dict[str, Any]:
+        return {"configured": True, "commands": True}
+
+    async def execute_command(self, **kwargs: Any) -> dict[str, Any]:
+        self.commands.append(kwargs)
+        return {
+            "status": "passed",
+            "exit_code": 0,
+            "output": "ok /workspace " + "sk-" + "1" * 24,
+            "duration_seconds": 0.01,
+        }
+
+    async def cancel_command(self, **kwargs: Any) -> bool:
+        return True
+
+    async def close(self, **kwargs: Any) -> None:
+        return None
+
+
+class _Writer:
+    def __init__(self) -> None:
+        self.frames: list[dict[str, Any]] = []
+
+    def write(self, value: bytes) -> None:
+        self.frames.append(json.loads(value))
+
+    async def drain(self) -> None:
+        return None
+
+    def close(self) -> None:
+        return None
+
+    async def wait_closed(self) -> None:
+        return None
+
+
+def _record(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[CodingWorkerServer, _WorkerSession, _Verifier]:
+    monkeypatch.setenv("CODING_PROJECT_COMMANDS_ENABLED", "true")
+    source_root = tmp_path / "source"
+    source_root.mkdir()
+    (source_root / "app.py").write_text("VALUE = 1\n", encoding="utf-8")
+    tests = source_root / "tests"
+    tests.mkdir()
+    (tests / "test_app.py").write_text("def test_value():\n    assert True\n", encoding="utf-8")
+    verifier = _Verifier()
+    server = CodingWorkerServer(
+        tmp_path / "worker.sock",
+        source_snapshot_path=source_root,
+        project_snapshot_path=tmp_path / "project-slot",
+        workspace_path=tmp_path / "workspace",
+        checkpoint_path=tmp_path / "checkpoint",
+        verifier=verifier,  # type: ignore[arg-type]
+    )
+    session = CodingSession(state=CodingSessionState.READY)
+    lease = {
+        "kind": "local_clone",
+        "lease_id": "lease-random-k7m4",
+        "project_id": "local-1234567890abcdef12345678",
+        "name": "Random project",
+        "branch": "main",
+        "head": "a" * 40,
+        "fingerprint": "b" * 64,
+        "file_count": 2,
+        "total_bytes": 50,
+        "hidden_files": 0,
+        "created_at": 1_785_600_000.0,
+    }
+    source = WorkspaceSource(
+        kind=ProjectKind.LOCAL_CLONE,
+        project_id=lease["project_id"],
+        name=lease["name"],
+        snapshot_path=source_root,
+        fingerprint=lease["fingerprint"],
+        branch="main",
+        head=lease["head"],
+        lease_id=lease["lease_id"],
+        lease_payload=lease,
+        verification=ProjectVerificationConfig(),
+    )
+    workspace = DraftWorkspace(
+        source_root,
+        tmp_path / "workspace",
+        tmp_path / "checkpoint",
+        preserve_workspace_root=True,
+    )
+    workspace.initialize()
+    token, bridge, events = server._build_command_bridge(session, "draft", source)
+    assert bridge is not None
+    record = _WorkerSession(
+        session=session,
+        adapter=_Adapter(),  # type: ignore[arg-type]
+        workspace=workspace,
+        mode="draft",
+        source=source,
+        command_bridge=bridge,
+        command_events=events,
+        runner_token=token,
+    )
+    server._sessions[session.session_id] = record
+    return server, record, verifier
+
+
+@pytest.mark.asyncio
+async def test_agent_command_waits_for_allow_once_and_emits_sanitized_events(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    server, record, verifier = _record(tmp_path, monkeypatch)
+    turn_id = record.session.begin_turn()
+    assert record.command_bridge is not None
+    await record.command_bridge.begin_turn(turn_id)
+    reader = asyncio.StreamReader()
+    reader.feed_data(
+        json.dumps(
+            {
+                "token": record.runner_token,
+                "arguments": {
+                    "argv": ["python", "-m", "pytest", "-q"],
+                    "cwd": ".",
+                    "purpose": "Run random k7m4 check",
+                    "timeout_seconds": 30,
+                },
+            }
+        ).encode()
+        + b"\n"
+    )
+    reader.feed_eof()
+    writer = _Writer()
+    task = asyncio.create_task(server._handle_runner(reader, writer))
+    for _ in range(20):
+        pending = await record.command_bridge.pending(
+            session_id=record.session.session_id,
+            turn_id=turn_id,
+        )
+        if pending is not None:
+            break
+        await asyncio.sleep(0)
+    assert pending is not None
+    assert verifier.commands == []
+    await record.command_bridge.decide(
+        session_id=record.session.session_id,
+        request_id=pending["request_id"],
+        decision="allow_once",
+    )
+    await task
+
+    assert writer.frames[0]["state"] == "completed"
+    assert len(verifier.commands) == 1
+    requested = await record.command_events.get()
+    resolved = await record.command_events.get()
+    assert requested.kind is CodingEventKind.COMMAND_REQUESTED
+    assert resolved.kind is CodingEventKind.COMMAND_RESOLVED
+    assert "sk-" not in resolved.data["result"]["output"]
+    assert "[workspace]" in resolved.data["result"]["output"]
+
+
+@pytest.mark.asyncio
+async def test_custom_project_verification_previews_then_runs_exact_plan(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    server, record, verifier = _record(tmp_path, monkeypatch)
+    (record.workspace.workspace_root / "tests" / "test_app.py").write_text(
+        "def test_value():\n    assert 1 + 1 == 2\n",
+        encoding="utf-8",
+    )
+    revision = record.workspace.cumulative_changes().revision
+    preview = server._prepare_local_verification(record, revision)
+
+    assert preview["state"] == "awaiting_confirmation"
+    assert len(preview["steps"]) == 2
+    writer = _Writer()
+    await server._verification_confirm(
+        {
+            "action": "verification_confirm",
+            "session_id": record.session.session_id,
+            "revision": revision,
+            "confirmation_id": preview["confirmation_id"],
+        },
+        writer,
+    )
+    assert record.verification_task is not None
+    await record.verification_task
+
+    assert record.verification is not None
+    assert record.verification["result"] == "passed"
+    assert len(verifier.commands) == 2
+    assert verifier.commands[0]["paths"] == []
+    assert verifier.commands[1]["paths"] == ["tests/test_app.py"]
+
+
+def test_command_and_confirmation_payloads_cross_only_the_public_api_boundary() -> None:
+    command = {
+        "id": "command-1234567890abcdef12345678",
+        "name": "Run q9t2 check",
+        "kind": "test",
+        "argv": ["python", "-m", "pytest", "-q"],
+        "cwd": ".",
+        "timeout_seconds": 30,
+    }
+    verification = _verification_from_worker(
+        {
+            "verification": {
+                "revision": 7,
+                "state": "awaiting_confirmation",
+                "result": "not_run",
+                "stale": False,
+                "reason": None,
+                "started_at": None,
+                "finished_at": None,
+                "confirmation_id": "verification-confirmation-q9t2random",
+                "plan_fingerprint": "c" * 64,
+                "steps": [
+                    {
+                        "id": "command-1234567890abcdef12345678-draft",
+                        "label": "Run q9t2 check",
+                        "command": command,
+                        "state": "not_started",
+                        "result": "not_run",
+                        "duration_ms": None,
+                        "summary": "",
+                        "details": "",
+                        "truncated": False,
+                    }
+                ],
+                "_plan": [{"must": "not cross the API"}],
+            }
+        }
+    )
+    event = _public_event(
+        record := CodingSession().append_event(
+            CodingEventKind.COMMAND_REQUESTED,
+            turn_id="turn-q9t2",
+            data={
+                "request_id": "command-request-q9t2",
+                "command": command,
+                "expires_at": 1_785_600_300.0,
+                "raw": "must not cross the API",
+            },
+        )
+    )
+
+    assert verification["state"] == "awaiting_confirmation"
+    assert "_plan" not in verification
+    assert event["data"]["command"]["argv"] == command["argv"]
+    assert "raw" not in event["data"]
+    assert record.kind is CodingEventKind.COMMAND_REQUESTED
+    paths = {route.path for route in router.routes}
+    assert "/api/coding/sessions/{session_id}/verification/confirm" in paths
+    assert "/api/coding/sessions/{session_id}/commands/pending" in paths
+    assert "/api/coding/sessions/{session_id}/commands/{request_id}/decision" in paths

--- a/server/tests/test_coding_project_commands_api.py
+++ b/server/tests/test_coding_project_commands_api.py
@@ -12,10 +12,17 @@ from server.coding_runtime.api import _public_event, _verification_from_worker, 
 from server.coding_runtime.draft_workspace import DraftWorkspace
 from server.coding_runtime.models import CodingEventKind, CodingSession, CodingSessionState
 from server.coding_runtime.projects import ProjectKind
+from server.coding_runtime.recovery import CodingRecoveryStore
 from server.coding_runtime.worker import (
     CodingWorkerServer,
     WorkspaceSource,
     _WorkerSession,
+)
+from server.tests.test_coding_project_api import (
+    FakeProjectSource,
+    LocalProjectWorker,
+    PROJECT_ID,
+    _service,
 )
 
 
@@ -279,3 +286,106 @@ def test_command_and_confirmation_payloads_cross_only_the_public_api_boundary() 
     assert "/api/coding/sessions/{session_id}/verification/confirm" in paths
     assert "/api/coding/sessions/{session_id}/commands/pending" in paths
     assert "/api/coding/sessions/{session_id}/commands/{request_id}/decision" in paths
+
+
+@pytest.mark.asyncio
+async def test_local_verification_recovery_keeps_only_completed_matching_result(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    server, record, _ = _record(tmp_path, monkeypatch)
+    record.workspace.begin_turn()
+    (record.workspace.workspace_root / "app.py").write_text(
+        "VALUE = 73\n",
+        encoding="utf-8",
+    )
+    revision = record.workspace.commit_turn().revision
+    preview = server._prepare_local_verification(record, revision)
+    stored = {
+        key: value
+        for key, value in json.loads(json.dumps(preview)).items()
+        if not key.startswith("_")
+    }
+    stored.update(
+        {
+            "state": "completed",
+            "result": "passed",
+            "started_at": 1_785_600_001.0,
+            "finished_at": 1_785_600_002.0,
+            "confirmation_id": None,
+        }
+    )
+    for step in stored["steps"]:
+        step.update(
+            {
+                "state": "completed",
+                "result": "passed",
+                "duration_ms": 17,
+                "summary": "检查通过",
+                "details": "random-k7m4-ok",
+            }
+        )
+
+    restored = server._validate_recovered_local_verification(
+        record,
+        stored,
+        revision=revision,
+    )
+    assert restored is not None
+    assert restored["result"] == "passed"
+    assert restored["stale"] is False
+
+    changed_plan = json.loads(json.dumps(stored))
+    changed_plan["plan_fingerprint"] = "d" * 64
+    stale = server._validate_recovered_local_verification(
+        record,
+        changed_plan,
+        revision=revision,
+    )
+    assert stale is not None
+    assert stale["result"] == "not_run"
+    assert stale["stale"] is True
+    assert stale["reason"] == "verification_plan_changed"
+    assert stale["steps"] == []
+
+    record.verification = preview
+    awaiting_writer = _Writer()
+    await server._recovery_snapshot(
+        {"action": "recovery_snapshot", "session_id": record.session.session_id},
+        awaiting_writer,
+    )
+    assert awaiting_writer.frames[0]["verification"] is None
+
+    record.verification = stored
+    completed_writer = _Writer()
+    await server._recovery_snapshot(
+        {"action": "recovery_snapshot", "session_id": record.session.session_id},
+        completed_writer,
+    )
+    assert completed_writer.frames[0]["verification"]["result"] == "passed"
+
+
+@pytest.mark.asyncio
+async def test_api_persists_and_resumes_completed_local_verification(
+    tmp_path: Path,
+) -> None:
+    store = CodingRecoveryStore(tmp_path / "local-verification-recovery")
+    first_worker = LocalProjectWorker()
+    first_worker.verification_state = "completed"
+    first_worker.verification_result = "passed"
+    first = _service(first_worker, FakeProjectSource(), store=store)
+    record = await first.create_session(PROJECT_ID)
+    assert await first._persist_recovery(record, required=True) is True
+    saved = store.load()
+    assert saved is not None
+    assert saved.payload.verification is not None
+    assert saved.payload.verification["result"] == "passed"
+    await first.shutdown()
+
+    second_worker = LocalProjectWorker()
+    second = _service(second_worker, FakeProjectSource(), store=store)
+    resumed = await second.resume_recovery()
+
+    assert resumed.project["id"] == PROJECT_ID
+    assert second_worker.restore_calls[0]["verification"]["result"] == "passed"
+    await second.shutdown()

--- a/server/tests/test_coding_project_source.py
+++ b/server/tests/test_coding_project_source.py
@@ -261,5 +261,6 @@ def test_project_source_compose_isolates_root_socket_and_snapshot() -> None:
         "o": "size=256m,uid=65532,gid=65532,mode=0700",
     }
     assert "apt-get install --yes --no-install-recommends git" in dockerfile
+    assert "COPY server/coding_runtime/commands.py" in dockerfile
     assert "USER 65532:65532" in dockerfile
     assert 'CMD ["python", "-m", "server.coding_project_source.server"]' in dockerfile

--- a/server/tests/test_coding_project_source.py
+++ b/server/tests/test_coding_project_source.py
@@ -253,6 +253,14 @@ def test_project_source_compose_isolates_root_socket_and_snapshot() -> None:
     assert "/projects-root" not in repr(runtime)
     assert runtime["volumes"][0]["target"] == "/project-snapshots"
     assert runtime["volumes"][0]["read_only"] is True
+    assert runtime["volumes"][0]["volume"] == {"nocopy": True}
+    snapshot_mount = broker["volumes"][1]
+    assert snapshot_mount == {
+        "type": "volume",
+        "source": "coding_project_snapshot",
+        "target": "/snapshot-slot",
+        "volume": {"nocopy": True},
+    }
     snapshot_volume = compose["volumes"]["coding_project_snapshot"]
     assert snapshot_volume["driver"] == "local"
     assert snapshot_volume["driver_opts"] == {

--- a/server/tests/test_coding_runtime_acp.py
+++ b/server/tests/test_coding_runtime_acp.py
@@ -100,8 +100,10 @@ def test_worker_config_is_read_only_and_child_env_is_allowlisted(
     assert client._config.environment["OPENCODE_PURE"] == "1"
     assert client._config.environment["OPENCODE_DISABLE_AUTOUPDATE"] == "1"
     assert client._config.environment["OPENCODE_DISABLE_MODELS_FETCH"] == "1"
+    assert client._config.environment["PYTHONPATH"] == "/opt/modelmirror"
     assert set(client._config.environment) == {
         "PATH",
+        "PYTHONPATH",
         "HOME",
         "OPENCODE_TEST_HOME",
         "XDG_CONFIG_HOME",

--- a/server/tests/test_coding_runtime_acp.py
+++ b/server/tests/test_coding_runtime_acp.py
@@ -152,6 +152,34 @@ async def test_acp_initializes_and_maps_streaming_updates() -> None:
 
 
 @pytest.mark.asyncio
+async def test_turn_started_is_observable_before_prompt_request_can_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = make_client()
+    session = CodingSession(state=CodingSessionState.READY)
+    client._session = session
+    client._acp_session_id = "acp-session"
+    prompt_requested = False
+
+    async def request(method: str, _params: dict[str, Any], **_kwargs: Any):
+        nonlocal prompt_requested
+        assert method == "session/prompt"
+        prompt_requested = True
+        return {"stopReason": "end_turn"}
+
+    monkeypatch.setattr(client, "_request", request)
+    stream = client.prompt(session, "Request a confirmed project command")
+
+    started = await anext(stream)
+
+    assert started.kind is CodingEventKind.TURN_STARTED
+    assert prompt_requested is False
+    remaining = [event async for event in stream]
+    assert prompt_requested is True
+    assert remaining[-1].kind is CodingEventKind.TURN_COMPLETED
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("mode", "expected"),
     [

--- a/server/tests/test_coding_runtime_api.py
+++ b/server/tests/test_coding_runtime_api.py
@@ -87,6 +87,7 @@ class FakeWorker:
         self.verification_reason: str | None = None
         self.restore_calls: list[dict[str, Any]] = []
         self.current_empty = False
+        self.session_exists = True
 
     async def health(self) -> dict[str, Any]:
         if self.fail_health:
@@ -110,6 +111,7 @@ class FakeWorker:
         }
 
     async def create_session(self) -> dict[str, Any]:
+        self.session_exists = True
         return {
             "ok": True,
             "session_id": self.session_id,
@@ -118,6 +120,7 @@ class FakeWorker:
         }
 
     async def restore_session(self, **kwargs: Any) -> dict[str, Any]:
+        self.session_exists = True
         self.restore_calls.append(kwargs)
         self.revision = kwargs["revision"]
         self.current_empty = not bool(kwargs.get("paths"))
@@ -199,7 +202,13 @@ class FakeWorker:
         self.release.set()
         return True
 
+    async def session_status(self, session_id: str) -> dict[str, Any]:
+        if not self.session_exists:
+            raise CodingWorkerError("missing", code="session_not_found")
+        return {"state": "ready"}
+
     async def close(self, session_id: str) -> None:
+        self.session_exists = False
         self.closed.append(session_id)
 
     async def changes(self, session_id: str) -> dict[str, Any]:
@@ -2266,6 +2275,55 @@ async def test_recovery_persists_draft_without_conversation_and_resumes_explicit
     assert status_response.json() == {"state": "ready"}
     assert discard_while_active.json()["detail"]["code"] == "session_active"
     assert len(resumed_worker.restore_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_recovery_discard_prunes_session_lost_after_worker_restart(
+    make_client,
+    tmp_path: Path,
+) -> None:
+    worker = FakeWorker(mode="draft")
+    store = CodingRecoveryStore(tmp_path / "recovery-discard-after-restart")
+    client, _, _ = await make_client(
+        worker=worker,
+        recovery_store=store,
+        recovery_enabled=True,
+    )
+    async with client:
+        session_id = await _create_and_start(client, "RANDOM_DISCARD_4D91")
+        await client.get(f"/api/coding/sessions/{session_id}/events")
+        worker.session_exists = False
+
+        discarded = await client.post("/api/coding/recovery/discard")
+        old_session = await client.get(f"/api/coding/sessions/{session_id}")
+
+    assert discarded.json() == {"discarded": True}
+    assert old_session.status_code == 404
+    assert store.load() is None
+
+
+@pytest.mark.asyncio
+async def test_recovery_resume_prunes_session_lost_after_worker_restart(
+    make_client,
+    tmp_path: Path,
+) -> None:
+    worker = FakeWorker(mode="draft")
+    store = CodingRecoveryStore(tmp_path / "recovery-resume-after-restart")
+    client, _, _ = await make_client(
+        worker=worker,
+        recovery_store=store,
+        recovery_enabled=True,
+    )
+    async with client:
+        session_id = await _create_and_start(client, "RANDOM_RESUME_B72C")
+        await client.get(f"/api/coding/sessions/{session_id}/events")
+        worker.session_exists = False
+
+        resumed = await client.post("/api/coding/recovery/resume")
+
+    assert resumed.status_code == 200
+    assert resumed.json()["conversation_restored"] is False
+    assert len(worker.restore_calls) == 1
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_coding_verifier_security.py
+++ b/server/tests/test_coding_verifier_security.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import difflib
+import hashlib
+import json
 from pathlib import Path
 
 import pytest
@@ -10,6 +12,7 @@ import yaml
 
 import server.coding_verifier.server as verifier_server
 from server.coding_runtime.verification import VerificationStepId
+from server.coding_runtime.commands import normalize_agent_command
 from server.coding_runtime.verifier_client import (
     CodingVerifierClient,
     VerifierClientError,
@@ -18,6 +21,8 @@ from server.coding_runtime.verifier_client import (
 from server.coding_verifier.engine import (
     CodingVerifierEngine,
     CommandResult,
+    IsolatedProjectCommandExecutor,
+    VerificationEngineError,
     snapshot_fingerprint,
 )
 from server.coding_verifier.server import CodingVerifierServer
@@ -70,6 +75,9 @@ async def _running_server(
     tmp_path: Path,
     source_root: Path,
     runner: _Runner,
+    *,
+    project_snapshot_path: Path | None = None,
+    command_executor: IsolatedProjectCommandExecutor | None = None,
 ):
     socket_path = tmp_path / "verifier.sock"
     engine = CodingVerifierEngine(
@@ -77,7 +85,12 @@ async def _running_server(
         tmp_path / "workspace",
         runner=runner,
     )
-    server = CodingVerifierServer(socket_path, engine=engine)
+    server = CodingVerifierServer(
+        socket_path,
+        engine=engine,
+        project_snapshot_path=project_snapshot_path or tmp_path / "unused-project",
+        command_executor=command_executor,
+    )
     task = asyncio.create_task(server.serve_forever())
     for _ in range(100):
         if socket_path.exists():
@@ -257,6 +270,19 @@ def test_compose_verifier_is_offline_and_unprivileged() -> None:
         for name in service["environment"]
     )
 
+    projects_overlay = yaml.safe_load(
+        (root / "docker-compose.coding-projects.yml").read_text(encoding="utf-8")
+    )
+    project_mounts = projects_overlay["services"]["coding-verifier"]["volumes"]
+    assert project_mounts == [
+        {
+            "type": "volume",
+            "source": "coding_project_snapshot",
+            "target": "/project-snapshots",
+            "read_only": True,
+        }
+    ]
+
 
 def test_verifier_image_uses_preinstalled_locked_dependencies() -> None:
     root = Path(__file__).resolve().parents[2]
@@ -275,3 +301,260 @@ def test_verifier_image_uses_preinstalled_locked_dependencies() -> None:
     assert 'CMD ["python", "-m", "server.coding_verifier.server"]' in dockerfile
     assert "curl " not in dockerfile
     assert "wget " not in dockerfile
+
+
+def _agent_command(*, script: str, timeout_seconds: int = 30):
+    return normalize_agent_command(
+        argv=["python", "-c", script],
+        cwd=".",
+        purpose="运行随机隔离检查",
+        timeout_seconds=timeout_seconds,
+    )
+
+
+@pytest.mark.asyncio
+async def test_dynamic_command_discards_writes_and_uses_secret_free_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "selected-source"
+    source.mkdir()
+    (source / "marker.txt").write_text("SOURCE-k7m4\n", encoding="utf-8")
+    fingerprint = snapshot_fingerprint(source)
+    workspace = tmp_path / "command-workspace"
+    executor = IsolatedProjectCommandExecutor(workspace)
+    monkeypatch.setenv("CODING_AGENT_GATEWAY_KEY", "sk-" + "z" * 30)
+    script = (
+        "import os,pathlib;"
+        "pathlib.Path('generated-r8v3.txt').write_text('temporary');"
+        "print('\\x1b[31m'+os.getenv('CODING_AGENT_GATEWAY_KEY','missing'));"
+        "print(pathlib.Path.cwd())"
+    )
+
+    result = await executor.execute(
+        source_root=source,
+        expected_fingerprint=fingerprint,
+        patch="",
+        paths=[],
+        command=_agent_command(script=script),
+    )
+
+    assert result.status == "passed"
+    assert "missing" in result.output
+    assert "CODING_AGENT_GATEWAY_KEY" not in result.output
+    assert "sk-" not in result.output
+    assert "\x1b" not in result.output
+    assert "/workspace" not in result.output
+    assert not (source / "generated-r8v3.txt").exists()
+    assert not workspace.exists()
+
+
+@pytest.mark.asyncio
+async def test_dynamic_command_timeout_kills_execution_and_cleans_workspace(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "timeout-source"
+    source.mkdir()
+    (source / "marker.txt").write_text("TIMEOUT-v5n2\n", encoding="utf-8")
+    workspace = tmp_path / "timeout-workspace"
+    executor = IsolatedProjectCommandExecutor(workspace)
+
+    with pytest.raises(VerificationEngineError) as timeout:
+        await executor.execute(
+            source_root=source,
+            expected_fingerprint=snapshot_fingerprint(source),
+            patch="",
+            paths=[],
+            command=_agent_command(script="import time;time.sleep(30)"),
+            max_duration_seconds=0.02,
+        )
+
+    assert timeout.value.code == "command_timeout"
+    assert not workspace.exists()
+
+
+@pytest.mark.asyncio
+async def test_dynamic_command_cannot_execute_a_project_relative_binary(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "binary-source"
+    (source / "tools").mkdir(parents=True)
+    (source / "tools" / "python").write_text("not executable\n", encoding="utf-8")
+    executor = IsolatedProjectCommandExecutor(tmp_path / "binary-workspace")
+    command = normalize_agent_command(
+        argv=["tools/python", "-V"],
+        cwd=".",
+        purpose="尝试项目内程序",
+        timeout_seconds=10,
+    )
+
+    with pytest.raises(VerificationEngineError) as denied:
+        await executor.execute(
+            source_root=source,
+            expected_fingerprint=snapshot_fingerprint(source),
+            patch="",
+            paths=[],
+            command=command,
+        )
+
+    assert denied.value.code == "command_executable_denied"
+    assert not (tmp_path / "binary-workspace").exists()
+
+
+def _write_runner_pack(
+    packs: Path,
+    source: Path,
+    *,
+    pack_id: str = "random-pack-k4m7",
+) -> Path:
+    pack = packs / pack_id
+    (pack / "python" / "site-packages").mkdir(parents=True)
+    (pack / "node" / "node_modules").mkdir(parents=True)
+    (pack / "bin").mkdir()
+    requirements = (source / "requirements.txt").read_bytes()
+    (pack / "pack.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "id": pack_id,
+                "platform": "linux-x86_64",
+                "python_version": "3.12",
+                "node_version": "22",
+                "inputs": {
+                    "requirements.txt": "sha256:"
+                    + hashlib.sha256(requirements).hexdigest()
+                },
+                "python_paths": ["python/site-packages"],
+                "node_modules": {".": "node/node_modules"},
+                "bin_paths": ["bin"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return pack
+
+
+def test_runner_pack_is_bound_to_dependencies_and_rejects_escaping_links(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "pack-source"
+    source.mkdir()
+    (source / "requirements.txt").write_text("pytest==8.4.1\n", encoding="utf-8")
+    packs = tmp_path / "packs"
+    pack = _write_runner_pack(packs, source)
+    executor = IsolatedProjectCommandExecutor(
+        tmp_path / "pack-workspace",
+        runner_packs_root=packs,
+    )
+
+    manifest, resolved = executor._load_runner_pack("random-pack-k4m7", source)
+    assert manifest.pack_id == "random-pack-k4m7"
+    assert resolved == pack.resolve()
+
+    (source / "requirements.txt").write_text("pytest==0\n", encoding="utf-8")
+    with pytest.raises(VerificationEngineError) as mismatch:
+        executor._load_runner_pack("random-pack-k4m7", source)
+    assert mismatch.value.code == "runner_pack_mismatch"
+
+    (source / "requirements.txt").write_text("pytest==8.4.1\n", encoding="utf-8")
+    outside = tmp_path / "outside-secret"
+    outside.write_text("must-not-read", encoding="utf-8")
+    (pack / "python" / "site-packages" / "escape").symlink_to(outside)
+    with pytest.raises(VerificationEngineError) as unsafe:
+        executor._load_runner_pack("random-pack-k4m7", source)
+    assert unsafe.value.code == "runner_pack_unsafe"
+
+
+@pytest.mark.asyncio
+async def test_runner_pack_rechecks_dependency_hash_after_applying_draft(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "changed-pack-source"
+    source.mkdir()
+    old = "pytest==8.4.1\n"
+    new = "pytest==0\n"
+    (source / "requirements.txt").write_text(old, encoding="utf-8")
+    packs = tmp_path / "changed-packs"
+    _write_runner_pack(packs, source, pack_id="changed-pack-n2w5")
+    executor = IsolatedProjectCommandExecutor(
+        tmp_path / "changed-pack-workspace",
+        runner_packs_root=packs,
+    )
+
+    with pytest.raises(VerificationEngineError) as mismatch:
+        await executor.execute(
+            source_root=source,
+            expected_fingerprint=snapshot_fingerprint(source),
+            patch=_patch("requirements.txt", old, new),
+            paths=["requirements.txt"],
+            command=_agent_command(script="print('must not run')"),
+            runner_pack_id="changed-pack-n2w5",
+        )
+
+    assert mismatch.value.code == "runner_pack_mismatch"
+    assert not (tmp_path / "changed-pack-workspace").exists()
+
+
+@pytest.mark.asyncio
+async def test_command_socket_rechecks_exact_project_lease_and_patch(
+    tmp_path: Path,
+    source_root: Path,
+) -> None:
+    slot = tmp_path / "project-slot" / "current"
+    project = slot / "workspace"
+    project.mkdir(parents=True)
+    (project / "marker.txt").write_text("LEASE-q9t2\n", encoding="utf-8")
+    fingerprint = snapshot_fingerprint(project)
+    source = {
+        "kind": "local_clone",
+        "lease_id": "lease-q9t2-123456789012",
+        "project_id": "local-q9t2-123456789012",
+        "name": "随机 q9t2 项目",
+        "branch": "main",
+        "head": "a" * 40,
+        "fingerprint": fingerprint,
+        "file_count": 1,
+        "total_bytes": len("LEASE-q9t2\n".encode()),
+        "hidden_files": 0,
+        "created_at": 1_785_600_000.0,
+    }
+    (slot / "lease.json").write_text(
+        json.dumps({key: value for key, value in source.items() if key != "kind"}),
+        encoding="utf-8",
+    )
+    command_executor = IsolatedProjectCommandExecutor(tmp_path / "socket-command-workspace")
+    async with _running_server(
+        tmp_path,
+        source_root,
+        _Runner(),
+        project_snapshot_path=slot,
+        command_executor=command_executor,
+    ) as (client, _, _):
+        command = _agent_command(script="print(open('marker.txt').read().strip())")
+        result = await client.execute_command(
+            session_id="session-q9t2",
+            request_id="request-q9t2",
+            source=source,
+            patch="",
+            paths=[],
+            command=command.to_internal_dict(),
+            runner_pack_id=None,
+            max_duration_seconds=30,
+        )
+        assert result["status"] == "passed"
+        assert result["output"] == "LEASE-q9t2"
+
+        wrong = dict(source)
+        wrong["project_id"] = "local-other-123456789012"
+        with pytest.raises(VerifierClientError) as rejected:
+            await client.execute_command(
+                session_id="session-q9t2",
+                request_id="request-other-q9t2",
+                source=wrong,
+                patch="",
+                paths=[],
+                command=command.to_internal_dict(),
+                runner_pack_id=None,
+                max_duration_seconds=30,
+            )
+        assert rejected.value.code == "snapshot_mismatch"

--- a/server/tests/test_coding_verifier_security.py
+++ b/server/tests/test_coding_verifier_security.py
@@ -280,6 +280,7 @@ def test_compose_verifier_is_offline_and_unprivileged() -> None:
             "source": "coding_project_snapshot",
             "target": "/project-snapshots",
             "read_only": True,
+            "volume": {"nocopy": True},
         }
     ]
 


### PR DESCRIPTION
## 改动概述

- 为受控自定义项目增加真实项目验证、验证计划预览与整组确认。
- 增加内置结构化命令工具，用户逐次批准后在无网络临时副本中执行 Python/Node 命令。
- 扩展 Verifier 的动态项目快照、离线依赖包、固定 argv、超时/取消及输出脱敏能力。
- 增加前端内联确认卡、等待/拒绝/运行结果和断线恢复体验。
- 保持 ModelMirror 既有验证、应用、提交、恢复与 GitHub 发布闭环兼容。

## 收尾修复

- 修复自定义项目验证被误判为“无需验证”。
- 修复 OpenCode 无法发现内置命令工具及轮次启动竞态。
- 清理 Runtime 重启后的僵尸会话。
- 修复项目快照 tmpfs 卷因 copy-up 变为 root 属主的问题。
- 将 OpenCode 虚拟目录 `/workspace` 安全映射为项目相对目录，其他绝对路径与路径穿越仍拒绝。

## 用户影响

用户可以在自定义项目中看到将要运行的精确检查，逐次选择“允许本次运行”或拒绝；命令只在隔离、无网络副本中执行，不会修改宿主项目，也不会把执行产物导入草稿。

## 基线与范围

- 基于最新 `origin/main`：`d898084`（PR #85）。
- PR 增量仅包含 Coding、对应测试和文档；不包含并行 Skill/MCP 变更。
- 13 个小步提交，每个提交最多修改 5 个文件。

## 验证

- 后端全量：`1041 passed`。
- Coding 命令/ACP/API/项目快照/Verifier 回归：`79 passed`。
- 前端：`npm.cmd run build` 通过。
- 基础及全部 Coding Compose overlay：`docker compose ... config --quiet` 通过。
- 真实端到端：批准 `python --version` 后返回 `Python 3.12.13`、退出码 0。
- 人工验收通过。
