### PR TITLE
feature: 建立 MCP 分批适配 Harness 与冻结基线

### DIFF
--- a/client/src/components/McpServerCard.tsx
+++ b/client/src/components/McpServerCard.tsx
@@ -6,6 +6,12 @@ import {
   mcpRequirementLabels,
   type McpProject,
 } from "../data/mcpProjects";
+import {
+  mcpAvailabilityLabels,
+  mcpConnectionKindLabels,
+  mcpRiskLabels,
+  type McpCatalogAdapterStatus,
+} from "../data/mcpAdaptationPlan";
 
 type ConnectionState = "idle" | "connecting" | "connected" | "error";
 type InstallState = "idle" | "checking" | "installing" | "installed" | "error";
@@ -45,6 +51,7 @@ interface InstalledMcpRecord {
 
 interface McpServerCardProps {
   project: McpProject;
+  adapterStatus?: McpCatalogAdapterStatus;
   restoredSession?: McpSessionSummary;
   onConnectionChange?: () => void;
 }
@@ -112,6 +119,7 @@ function contentToMarkdown(result: ToolCallResult | null) {
 
 export default function McpServerCard({
   project,
+  adapterStatus,
   restoredSession,
   onConnectionChange,
 }: McpServerCardProps) {
@@ -128,16 +136,21 @@ export default function McpServerCard({
   const [installState, setInstallState] = useState<InstallState>("checking");
   const [installError, setInstallError] = useState("");
 
-  const canConnect =
-    project.compatibility === "local-stdio" && Boolean(project.command?.length);
+  const availability = adapterStatus?.availability ?? project.availability;
+  const connectionKind = adapterStatus?.connection_kind ?? project.connectionKind;
+  const risk = adapterStatus?.risk ?? project.risk;
+  const wave = adapterStatus?.wave ?? project.adaptationWave;
+  const requiredCapabilities =
+    adapterStatus?.required_capabilities ?? project.requiredCapabilities;
+  const limitations = adapterStatus?.limitations ?? project.adaptationLimitations;
+  const canConnect = adapterStatus?.executable === true && availability === "ready";
   const canInstall = canConnect && project.installMode === "one-click";
   const commandPreview = useMemo(
     () =>
-      project.command?.join(" ") ??
-      `等待适配：${project.requirements
-        .map((requirement) => mcpRequirementLabels[requirement])
-        .join("、")}`,
-    [project.command, project.requirements],
+      canConnect
+        ? `${mcpConnectionKindLabels[connectionKind]} · 执行配置由服务端受控适配器管理`
+        : `第 ${wave} 批 · ${mcpConnectionKindLabels[connectionKind]} · ${limitations[0] ?? "等待生产级验收"}`,
+    [canConnect, connectionKind, limitations, wave],
   );
   const sourceNames = useMemo(
     () =>
@@ -188,12 +201,16 @@ export default function McpServerCard({
   }, [canInstall, project.id]);
 
   useEffect(() => {
-    if (!restoredSession || restoredSession.session_id === sessionId) return;
+    if (
+      !adapterStatus?.connected ||
+      !restoredSession ||
+      restoredSession.session_id === sessionId
+    ) return;
     setSessionId(restoredSession.session_id);
     setState("connected");
     setError("");
     void fetchTools(restoredSession.session_id);
-  }, [restoredSession, sessionId]);
+  }, [adapterStatus?.connected, restoredSession, sessionId]);
 
   async function readError(response: Response) {
     try {
@@ -205,16 +222,14 @@ export default function McpServerCard({
   }
 
   async function connect() {
-    if (!project.command) return;
+    if (!canConnect) return;
     setState("connecting");
     setError("");
     setTools([]);
     setToolResults({});
     try {
-      const response = await fetch("/api/mcp/connect", {
+      const response = await fetch(`/api/mcp/catalog/${project.id}/connect`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ server_command: project.command }),
       });
       if (!response.ok) throw new Error(await readError(response));
       const data = (await response.json()) as { session_id: string };
@@ -237,9 +252,9 @@ export default function McpServerCard({
   }
 
   async function disconnect() {
-    if (sessionId) {
-      await fetch(`/api/mcp/${sessionId}`, { method: "DELETE" }).catch(() => undefined);
-    }
+    await fetch(`/api/mcp/catalog/${project.id}/session`, {
+      method: "DELETE",
+    }).catch(() => undefined);
     setSessionId(null);
     setTools([]);
     setToolResults({});
@@ -256,14 +271,8 @@ export default function McpServerCard({
     setInstallState("installing");
     setInstallError("");
     try {
-      const response = await fetch("/api/mcp/install", {
+      const response = await fetch(`/api/mcp/catalog/${project.id}/prepare`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          project_id: project.id,
-          install_command: project.installCommand,
-          server_command: project.command ?? null,
-        }),
       });
       if (!response.ok) throw new Error(await readError(response));
       setInstallState("installed");
@@ -300,14 +309,16 @@ export default function McpServerCard({
     setRunningTool(tool.name);
     setError("");
     try {
-      const response = await fetch(`/api/mcp/${sessionId}/call`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          tool_name: tool.name,
-          arguments: buildArguments(tool),
-        }),
-      });
+      const response = await fetch(
+        `/api/mcp/catalog/${project.id}/tools/${encodeURIComponent(tool.name)}/call`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            arguments: buildArguments(tool),
+          }),
+        },
+      );
       if (!response.ok) throw new Error(await readError(response));
       const data = (await response.json()) as ToolCallResult;
       setToolResults((current) => ({ ...current, [tool.name]: data }));
@@ -391,12 +402,16 @@ export default function McpServerCard({
               </span>
               <span
                 className={`rounded-full border px-2.5 py-1 text-xs font-semibold ${
-                  canConnect
+                  availability === "ready"
                     ? "border-emerald-300/25 bg-emerald-300/10 text-emerald-100"
+                    : availability === "adapting"
+                      ? "border-cyan-300/25 bg-cyan-300/10 text-cyan-100"
+                      : availability === "blocked"
+                        ? "border-rose-300/25 bg-rose-300/10 text-rose-100"
                     : "border-amber-300/25 bg-amber-300/10 text-amber-100"
                 }`}
               >
-                {canConnect ? "本地 stdio 可连" : "已收录 · 待适配"}
+                {mcpAvailabilityLabels[availability]}
               </span>
             </div>
             <h2 className="mt-3 line-clamp-2 text-xl font-semibold leading-7 text-white">
@@ -448,6 +463,23 @@ export default function McpServerCard({
         </div>
       </div>
 
+      <div className="relative mt-3 grid grid-cols-1 gap-2 text-xs sm:grid-cols-3">
+        <div className="rounded-lg border border-white/10 bg-white/[0.035] p-2.5">
+          <p className="text-slate-500">适配批次</p>
+          <p className="mt-1 font-semibold text-white">{wave === 0 ? "基线" : `第 ${wave} 批`}</p>
+        </div>
+        <div className="rounded-lg border border-white/10 bg-white/[0.035] p-2.5">
+          <p className="text-slate-500">连接方式</p>
+          <p className="mt-1 font-semibold text-brand-100">
+            {mcpConnectionKindLabels[connectionKind]}
+          </p>
+        </div>
+        <div className="rounded-lg border border-white/10 bg-white/[0.035] p-2.5">
+          <p className="text-slate-500">风险等级</p>
+          <p className="mt-1 font-semibold text-hire-100">{mcpRiskLabels[risk]}</p>
+        </div>
+      </div>
+
       <div className="relative mt-4 flex flex-wrap gap-2">
         {project.tags.map((tag) => (
           <span
@@ -479,6 +511,25 @@ export default function McpServerCard({
         </div>
       )}
 
+      <div className="relative mt-3 rounded-lg border border-cyan-300/15 bg-cyan-300/[0.05] p-3">
+        <p className="text-xs font-semibold text-cyan-100">本批生产验收门槛</p>
+        <div className="mt-2 flex flex-wrap gap-2">
+          {requiredCapabilities.map((capability) => (
+            <span
+              className="rounded-full border border-cyan-300/20 bg-cyan-300/10 px-2.5 py-1 text-xs text-cyan-50"
+              key={capability}
+            >
+              {capability}
+            </span>
+          ))}
+        </div>
+        {limitations.map((limitation) => (
+          <p className="mt-2 text-xs leading-5 text-slate-400" key={limitation}>
+            {limitation}
+          </p>
+        ))}
+      </div>
+
       <div className="relative mt-auto flex flex-wrap items-center gap-2 pt-5">
         {canConnect ? (
           <button
@@ -499,7 +550,13 @@ export default function McpServerCard({
             disabled
             type="button"
           >
-            等待安全适配
+            {!adapterStatus && availability === "ready"
+              ? "同步服务端状态..."
+              : availability === "adapting"
+                ? "正在适配"
+                : availability === "blocked"
+                  ? "适配受阻"
+                  : "等待安全适配"}
           </button>
         )}
         {state === "connected" ? (
@@ -548,7 +605,7 @@ export default function McpServerCard({
         <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
           <div>
             <p className="text-xs font-semibold text-slate-300">
-              {canConnect ? "stdio 命令" : "接入要求"}
+              {canConnect ? "受控连接" : "适配计划"}
             </p>
             <code
               className={`mt-2 block break-all text-xs ${
@@ -681,7 +738,9 @@ export default function McpServerCard({
                   canConnect ? "text-emerald-100" : "text-amber-100"
                 }`}
               >
-                {canConnect ? "当前可本地 stdio 连接" : "当前仅收录，等待后续适配"}
+                {canConnect
+                  ? `已通过生产验收 · ${mcpConnectionKindLabels[connectionKind]}`
+                  : `${mcpAvailabilityLabels[availability]} · 第 ${wave} 批`}
               </p>
               <p className="mt-2 text-sm leading-6 text-slate-300">
                 {project.installNote}
@@ -741,13 +800,13 @@ export default function McpServerCard({
             </section>
 
             {canConnect ? (
-              <section className="mt-5">
-                <h3 className="text-sm font-semibold text-white">
-                  已核验的本地 stdio 命令
+              <section className="mt-5 rounded-lg border border-emerald-300/20 bg-emerald-300/[0.07] p-4">
+                <h3 className="text-sm font-semibold text-emerald-100">
+                  服务端受控适配器
                 </h3>
-                <pre className="mt-3 max-h-72 overflow-auto rounded-lg border border-white/10 bg-slate-950/78 p-4 text-xs leading-5 text-brand-100">
-                  <code>{project.installCommand}</code>
-                </pre>
+                <p className="mt-2 text-sm leading-6 text-slate-300">
+                  安装命令、启动参数和工作目录由后端按项目 ID 固定管理；浏览器不会提交命令、URL、Header 或环境变量。
+                </p>
               </section>
             ) : null}
           </div>

--- a/client/src/data/mcpAdaptationPlan.ts
+++ b/client/src/data/mcpAdaptationPlan.ts
@@ -1,0 +1,211 @@
+export type McpAvailability = "planned" | "adapting" | "ready" | "blocked";
+export type McpConnectionKind =
+  | "local-stdio"
+  | "sandboxed-stdio"
+  | "remote-mcp"
+  | "desktop-bridge";
+export type McpRiskLevel = "low" | "medium" | "high" | "critical";
+
+export interface McpAdaptationRecord {
+  wave: number;
+  availability: McpAvailability;
+  connectionKind: McpConnectionKind;
+  risk: McpRiskLevel;
+  requiredCapabilities: string[];
+  limitations: string[];
+}
+
+export interface McpCatalogAdapterStatus {
+  project_id: string;
+  wave: number;
+  availability: McpAvailability;
+  connection_kind: McpConnectionKind;
+  risk: McpRiskLevel;
+  required_capabilities: string[];
+  limitations: string[];
+  feature_enabled: boolean;
+  executable: boolean;
+  connected: boolean;
+  session_id: string | null;
+  allowed_settings: string[];
+  credential_slots: string[];
+}
+
+export const mcpAvailabilityLabels: Record<McpAvailability, string> = {
+  planned: "已排期、待适配",
+  adapting: "适配中",
+  ready: "生产级可用",
+  blocked: "适配受阻",
+};
+
+export const mcpConnectionKindLabels: Record<McpConnectionKind, string> = {
+  "local-stdio": "本地 stdio",
+  "sandboxed-stdio": "隔离 stdio",
+  "remote-mcp": "远程 MCP",
+  "desktop-bridge": "桌面桥接",
+};
+
+export const mcpRiskLabels: Record<McpRiskLevel, string> = {
+  low: "低风险",
+  medium: "中风险",
+  high: "高风险",
+  critical: "关键风险",
+};
+
+const localStdioIds = [
+  "context7",
+  "filesystem-mcp",
+  "youtube-transcript-mcp",
+  "memory-mcp",
+  "12306-mcp",
+  "sequential-thinking-mcp",
+  "everything-mcp",
+] as const;
+
+export const mcpAdaptationWaves: Record<number, readonly string[]> = {
+  1: ["calculator-mcp", "time-mcp", "vegalite-mcp"],
+  2: ["bibigpt-mcp", "fetch-mcp", "quickchart-mcp", "airbnb-mcp", "geowire-mcp"],
+  3: ["basic-memory-mcp", "excel-mcp-server", "git-mcp", "manim-mcp", "markitdown-mcp"],
+  4: [
+    "agentql-mcp", "brave-search-mcp", "exa-mcp", "firecrawl-mcp",
+    "perplexity-mcp", "tavily-mcp", "axiom-mcp", "figma-context-mcp",
+    "google-maps-mcp", "grafana-mcp", "graphlit-mcp", "kagi-mcp",
+    "pinecone-assistant-mcp", "shodan-mcp", "snyk-mcp", "virustotal-mcp",
+  ],
+  5: [
+    "dbhub", "postgres-mcp", "mongodb-mcp", "clickhouse-mcp", "cognee-mcp",
+    "graphiti-mcp", "hindsight-mcp", "redis-mcp", "sqlite-mcp", "duckdb-mcp",
+    "supabase-mcp",
+  ],
+  6: ["airtable-mcp", "asana-mcp", "gitlab-mcp", "mcp-cn-commerce", "notion-mcp-server", "mem0-mcp"],
+  7: ["chrome-devtools-mcp", "playwright-mcp", "puppeteer-mcp", "selenium-mcp"],
+  8: ["mcp-run-python", "python-interpreter"],
+  9: [
+    "apify-mcp", "bright-data-mcp", "browserbase-mcp", "e2b-mcp", "stripe-mcp",
+    "terraform-mcp", "aiven-mcp", "alpaca-mcp", "aws-kb-mcp", "elevenlabs-mcp",
+    "minimax-mcp", "s3-mcp", "kubernetes-mcp", "semgrep-mcp",
+  ],
+  10: [
+    "gmail-mcp", "atlassian-mcp", "google-calendar-mcp", "google-drive-mcp",
+    "microsoft-365-mcp", "onedrive-mcp", "sentry-mcp", "azure-mcp", "box-mcp",
+    "cloudflare-mcp", "github-mcp-server", "linear-mcp", "neon-mcp", "slack-mcp",
+  ],
+  11: [
+    "xiaohongshu-mcp", "ableton-mcp", "binary-ninja-mcp", "blender-mcp",
+    "ghidra-mcp", "jetbrains-mcp", "chatcrystal", "obsidian-mcp", "opentabs",
+    "zotero-mcp", "docker-mcp", "mobile-mcp", "xcodebuild-mcp",
+  ],
+};
+
+const waveMetadata: Record<
+  number,
+  Omit<McpAdaptationRecord, "wave" | "availability">
+> = {
+  1: {
+    connectionKind: "sandboxed-stdio",
+    risk: "low",
+    requiredCapabilities: ["独立 Python 运行时", "资源上限"],
+    limitations: ["等待独立 Python 沙箱、断网策略和资源上限验证。"],
+  },
+  2: {
+    connectionKind: "remote-mcp",
+    risk: "medium",
+    requiredCapabilities: ["公共远程策略", "SSRF 防护"],
+    limitations: ["等待公网目标、DNS、重定向和响应大小策略验证。"],
+  },
+  3: {
+    connectionKind: "sandboxed-stdio",
+    risk: "medium",
+    requiredCapabilities: ["目录范围授权", "产物清理"],
+    limitations: ["等待目录授权、路径越界防护和产物清理验证。"],
+  },
+  4: {
+    connectionKind: "remote-mcp",
+    risk: "medium",
+    requiredCapabilities: ["加密凭据绑定", "只读工具策略"],
+    limitations: ["等待固定凭据槽、出口域名和只读工具清单验证。"],
+  },
+  5: {
+    connectionKind: "sandboxed-stdio",
+    risk: "high",
+    requiredCapabilities: ["数据库只读策略", "查询限制"],
+    limitations: ["等待只读账号、TLS、查询超时和结果行数限制验证。"],
+  },
+  6: {
+    connectionKind: "remote-mcp",
+    risk: "high",
+    requiredCapabilities: ["修改操作审批", "账号解绑"],
+    limitations: ["等待修改操作预览、审批、幂等和账号解绑验证。"],
+  },
+  7: {
+    connectionKind: "sandboxed-stdio",
+    risk: "high",
+    requiredCapabilities: ["临时浏览器", "浏览域策略"],
+    limitations: ["等待临时浏览器、目标域及上传下载边界验证。"],
+  },
+  8: {
+    connectionKind: "sandboxed-stdio",
+    risk: "critical",
+    requiredCapabilities: ["一次性代码沙箱", "进程资源上限"],
+    limitations: ["等待断网、无宿主挂载的一次性代码执行沙箱验证。"],
+  },
+  9: {
+    connectionKind: "sandboxed-stdio",
+    risk: "critical",
+    requiredCapabilities: ["费用与资源护栏", "终止性操作审批"],
+    limitations: ["等待费用上限、资源预览和终止性操作强制审批验证。"],
+  },
+  10: {
+    connectionKind: "remote-mcp",
+    risk: "high",
+    requiredCapabilities: ["OAuth PKCE", "撤销与解绑", "Scope 审核"],
+    limitations: ["等待 PKCE、state、最小 scope、刷新、撤销和解绑验证。"],
+  },
+  11: {
+    connectionKind: "desktop-bridge",
+    risk: "critical",
+    requiredCapabilities: ["版本化桌面桥接", "逐应用同意"],
+    limitations: ["等待本机桥接协议、宿主版本和逐应用授权验证。"],
+  },
+};
+
+function buildAdaptationPlan() {
+  const records: Record<string, McpAdaptationRecord> = {};
+  for (const projectId of localStdioIds) {
+    records[projectId] = {
+      wave: 0,
+      availability: "ready",
+      connectionKind: "local-stdio",
+      risk: projectId === "filesystem-mcp" || projectId === "memory-mcp" ? "medium" : "low",
+      requiredCapabilities: ["现有 Node stdio 运行时"],
+      limitations: ["沿用现有本地 stdio 行为；批次 0 不扩大权限范围。"],
+    };
+  }
+  for (const [rawWave, projectIds] of Object.entries(mcpAdaptationWaves)) {
+    const wave = Number(rawWave);
+    const metadata = waveMetadata[wave];
+    for (const projectId of projectIds) {
+      if (records[projectId]) throw new Error(`重复的 MCP 适配计划：${projectId}`);
+      records[projectId] = {
+        wave,
+        availability: "planned",
+        connectionKind: metadata.connectionKind,
+        risk: metadata.risk,
+        requiredCapabilities: [...metadata.requiredCapabilities],
+        limitations: [...metadata.limitations],
+      };
+    }
+  }
+  if (Object.keys(records).length !== 100) {
+    throw new Error(`MCP 适配计划必须包含 100 个条目，当前为 ${Object.keys(records).length}`);
+  }
+  return records;
+}
+
+export const mcpAdaptationPlan = buildAdaptationPlan();
+
+export function getMcpAdaptation(projectId: string): McpAdaptationRecord {
+  const record = mcpAdaptationPlan[projectId];
+  if (!record) throw new Error(`MCP 条目缺少适配计划：${projectId}`);
+  return record;
+}

--- a/client/src/data/mcpProjects.ts
+++ b/client/src/data/mcpProjects.ts
@@ -1,3 +1,10 @@
+import {
+  getMcpAdaptation,
+  type McpAvailability,
+  type McpConnectionKind,
+  type McpRiskLevel,
+} from "./mcpAdaptationPlan";
+
 export const mcpCategories = [
   "浏览器与网页",
   "开发与代码",
@@ -21,7 +28,6 @@ export const mcpCategories = [
 
 export type McpCategory = (typeof mcpCategories)[number];
 export type McpInstallMode = "one-click" | "manual";
-export type McpCompatibility = "local-stdio" | "planned";
 export type McpCatalogSourceId = "awesome-mcp-zh" | "awesome-mcp-servers";
 export type McpRequirement =
   | "oauth"
@@ -58,9 +64,13 @@ export interface McpProject {
   installMode: McpInstallMode;
   installCommand: string;
   installNote: string;
-  command?: string[];
   tags: string[];
-  compatibility: McpCompatibility;
+  availability: McpAvailability;
+  connectionKind: McpConnectionKind;
+  adaptationWave: number;
+  risk: McpRiskLevel;
+  requiredCapabilities: string[];
+  adaptationLimitations: string[];
   requirements: McpRequirement[];
   configGuide: string[];
   usageExamples: string[];
@@ -69,13 +79,17 @@ export interface McpProject {
 
 interface McpProjectSeed extends Omit<
   McpProject,
-  | "compatibility"
+  | "availability"
+  | "connectionKind"
+  | "adaptationWave"
+  | "risk"
+  | "requiredCapabilities"
+  | "adaptationLimitations"
   | "requirements"
   | "configGuide"
   | "usageExamples"
   | "sources"
 > {
-  compatibility?: McpCompatibility;
   requirements?: McpRequirement[];
   configGuide?: string[];
   usageExamples?: string[];
@@ -123,7 +137,6 @@ const originalMcpProjectSeeds: McpProjectSeed[] = [
     installCommand:
       '{\n  "mcpServers": {\n    "playwright": {\n      "command": "npx",\n      "args": ["@playwright/mcp@latest"]\n    }\n  }\n}',
     installNote: "官方 README 提供的标准 MCP 客户端配置，适合支持 stdio MCP 的宿主。",
-    command: ["npx", "-y", "@playwright/mcp@latest"],
     tags: ["微软官方", "浏览器自动化", "网页测试"],
   },
   {
@@ -144,7 +157,6 @@ const originalMcpProjectSeeds: McpProjectSeed[] = [
       '{\n  "mcpServers": {\n    "chrome-devtools": {\n      "command": "npx",\n      "args": ["-y", "chrome-devtools-mcp@latest", "--headless"]\n    }\n  }\n}',
     installNote:
       "模镜使用 headless 模式启动。后端运行环境仍需提供兼容版本的 Chrome 或 Chrome for Testing。",
-    command: ["npx", "-y", "chrome-devtools-mcp@latest", "--headless"],
     tags: ["Google 官方", "Chrome 调试", "性能分析"],
   },
   {
@@ -183,7 +195,6 @@ const originalMcpProjectSeeds: McpProjectSeed[] = [
     installCommand: "npx ctx7 setup",
     installNote:
       "官方推荐用 ctx7 CLI 配置；模镜原生连接使用其 npm stdio Server。",
-    command: ["npx", "-y", "@upstash/context7-mcp"],
     tags: ["Upstash 官方", "最新文档", "代码生成"],
   },
   {
@@ -302,7 +313,6 @@ const originalMcpProjectSeeds: McpProjectSeed[] = [
       "npx -y @modelcontextprotocol/server-filesystem <allowed-directory>",
     installNote:
       "本地 stdio 模式需要允许访问的目录；模镜统一从 MCP 沙盒目录启动。",
-    command: ["npx", "-y", "@modelcontextprotocol/server-filesystem", "."],
     tags: ["官方参考", "文件系统", "沙盒工具"],
   },
   {
@@ -417,7 +427,6 @@ const originalMcpProjectSeeds: McpProjectSeed[] = [
     installCommand:
       "npx -y @kimtaeyoon83/mcp-server-youtube-transcript",
     installNote: "官方 README 提供的标准 npm stdio 配置，不需要额外 API Key。",
-    command: ["npx", "-y", "@kimtaeyoon83/mcp-server-youtube-transcript"],
     tags: ["YouTube", "字幕提取", "无需密钥"],
   },
   {
@@ -474,7 +483,6 @@ const originalMcpProjectSeeds: McpProjectSeed[] = [
     installCommand: "npx -y @modelcontextprotocol/server-memory",
     installNote:
       "模镜会在 MCP 沙盒工作目录启动该 Server，使默认 memory.jsonl 保留在受控目录内。",
-    command: ["npx", "-y", "@modelcontextprotocol/server-memory"],
     tags: ["官方参考", "知识图谱", "本地记忆"],
   },
   {
@@ -493,7 +501,6 @@ const originalMcpProjectSeeds: McpProjectSeed[] = [
     installMode: "one-click",
     installCommand: "npx -y chatcrystal mcp",
     installNote: "npm 包要求 Node.js 20 或更高版本，模镜后端运行时满足该要求。",
-    command: ["npx", "-y", "chatcrystal", "mcp"],
     tags: ["编码对话", "本地知识库", "Windows"],
   },
   {
@@ -550,7 +557,6 @@ const originalMcpProjectSeeds: McpProjectSeed[] = [
     installMode: "one-click",
     installCommand: "npx -y 12306-mcp",
     installNote: "项目 README 提供的标准 npm stdio 启动方式，不需要额外 API Key。",
-    command: ["npx", "-y", "12306-mcp"],
     tags: ["中国铁路", "余票查询", "无需密钥"],
   },
   {
@@ -570,7 +576,6 @@ const originalMcpProjectSeeds: McpProjectSeed[] = [
     installMode: "one-click",
     installCommand: "npx -y @modelcontextprotocol/server-sequential-thinking",
     installNote: "官方 npm stdio Server，无需 API Key 或额外服务。",
-    command: ["npx", "-y", "@modelcontextprotocol/server-sequential-thinking"],
     tags: ["官方参考", "问题拆解", "无需密钥"],
   },
   {
@@ -589,7 +594,6 @@ const originalMcpProjectSeeds: McpProjectSeed[] = [
     installMode: "one-click",
     installCommand: "npx -y @modelcontextprotocol/server-everything",
     installNote: "用于协议演示和测试，不建议作为生产业务 Server 使用。",
-    command: ["npx", "-y", "@modelcontextprotocol/server-everything"],
     tags: ["官方参考", "协议测试", "无需密钥"],
   },
   {
@@ -638,7 +642,6 @@ function plannedMcp(input: ExpandedProjectInput): McpProjectSeed {
     installMode: "manual",
     installCommand: "当前版本仅收录资料，不提供本地 stdio 安装或外站认证入口。",
     installNote: `${requirementText}。本轮不配置这些依赖，条目等待后续安全适配。`,
-    compatibility: "planned",
     configGuide: [
       `先确认接入条件：${requirementText}。`,
       "当前模镜不会收集凭证、打开外站认证，也不会启动额外运行时或桌面宿主。",
@@ -1686,16 +1689,6 @@ const expandedMcpProjectSeeds: McpProjectSeed[] = [
   }),
 ];
 
-const localStdioIds = new Set([
-  "context7",
-  "filesystem-mcp",
-  "youtube-transcript-mcp",
-  "memory-mcp",
-  "12306-mcp",
-  "sequential-thinking-mcp",
-  "everything-mcp",
-]);
-
 const originalRequirements: Partial<Record<string, McpRequirement[]>> = {
   "playwright-mcp": ["external-runtime", "system-permission"],
   "chrome-devtools-mcp": ["external-runtime", "system-permission"],
@@ -1719,7 +1712,10 @@ const originalRequirements: Partial<Record<string, McpRequirement[]>> = {
 };
 
 function normalizeMcpProject(seed: McpProjectSeed): McpProject {
-  const isLocalStdio = localStdioIds.has(seed.id);
+  const adaptation = getMcpAdaptation(seed.id);
+  const isLocalStdio =
+    adaptation.availability === "ready" &&
+    adaptation.connectionKind === "local-stdio";
   const requirements = isLocalStdio
     ? []
     : (seed.requirements ?? originalRequirements[seed.id] ?? ["external-runtime"]);
@@ -1733,8 +1729,12 @@ function normalizeMcpProject(seed: McpProjectSeed): McpProject {
     installCommand: isLocalStdio
       ? seed.installCommand
       : "当前版本仅收录资料，不提供本地 stdio 安装或外站认证入口。",
-    command: isLocalStdio ? seed.command : undefined,
-    compatibility: isLocalStdio ? "local-stdio" : "planned",
+    availability: adaptation.availability,
+    connectionKind: adaptation.connectionKind,
+    adaptationWave: adaptation.wave,
+    risk: adaptation.risk,
+    requiredCapabilities: adaptation.requiredCapabilities,
+    adaptationLimitations: adaptation.limitations,
     requirements,
     configGuide:
       seed.configGuide ??

--- a/client/src/pages/McpBrowserPage.tsx
+++ b/client/src/pages/McpBrowserPage.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Link } from "react-router-dom";
 import McpServerCard, {
   type McpSessionSummary,
 } from "../components/McpServerCard";
@@ -9,8 +8,12 @@ import {
   mcpCategories,
   mcpProjects,
   type McpCategory,
-  type McpCompatibility,
 } from "../data/mcpProjects";
+import {
+  mcpAvailabilityLabels,
+  type McpAvailability,
+  type McpCatalogAdapterStatus,
+} from "../data/mcpAdaptationPlan";
 
 interface RegistryTool {
   name: string;
@@ -22,13 +25,9 @@ interface RegistryTool {
 }
 
 type CatalogCategory = "全部" | McpCategory;
-type CompatibilityFilter = "all" | McpCompatibility;
+type AvailabilityFilter = "all" | McpAvailability;
 
 const INITIAL_VISIBLE_COUNT = 18;
-
-function commandKey(command?: string[]) {
-  return command?.join("\u0000") ?? "";
-}
 
 export default function McpBrowserPage() {
   const [sessions, setSessions] = useState<McpSessionSummary[]>([]);
@@ -37,8 +36,11 @@ export default function McpBrowserPage() {
   const [query, setQuery] = useState("");
   const [selectedCategory, setSelectedCategory] =
     useState<CatalogCategory>("全部");
-  const [compatibilityFilter, setCompatibilityFilter] =
-    useState<CompatibilityFilter>("all");
+  const [availabilityFilter, setAvailabilityFilter] =
+    useState<AvailabilityFilter>("all");
+  const [adapterStatuses, setAdapterStatuses] = useState<
+    McpCatalogAdapterStatus[]
+  >([]);
   const [visibleCount, setVisibleCount] = useState(INITIAL_VISIBLE_COUNT);
   const [isLoadingRuntime, setIsLoadingRuntime] = useState(false);
   const [runtimeError, setRuntimeError] = useState("");
@@ -51,20 +53,26 @@ export default function McpBrowserPage() {
     setIsLoadingRuntime(true);
     setRuntimeError("");
     try {
-      const [sessionsResponse, registryResponse] = await Promise.all([
+      const [sessionsResponse, registryResponse, adaptersResponse] = await Promise.all([
         fetch("/api/mcp/sessions"),
         fetch("/api/registry/tools"),
+        fetch("/api/mcp/catalog/adapters"),
       ]);
       if (!sessionsResponse.ok) throw new Error("无法获取 MCP 会话列表");
       if (!registryResponse.ok) throw new Error("无法获取全局工具注册表");
+      if (!adaptersResponse.ok) throw new Error("无法获取 MCP 适配状态");
       const sessionsData = (await sessionsResponse.json()) as {
         sessions: McpSessionSummary[];
       };
       const registryData = (await registryResponse.json()) as {
         tools: RegistryTool[];
       };
+      const adaptersData = (await adaptersResponse.json()) as {
+        adapters: McpCatalogAdapterStatus[];
+      };
       setSessions(sessionsData.sessions);
       setRegistryTools(registryData.tools);
+      setAdapterStatuses(adaptersData.adapters);
     } catch (exc) {
       setRuntimeError(
         exc instanceof Error ? exc.message : "MCP 运行态信息加载失败",
@@ -78,10 +86,29 @@ export default function McpBrowserPage() {
     void refreshRuntime();
   }, [refreshRuntime]);
 
-  const connectableCount = mcpProjects.filter(
-    (project) => project.compatibility === "local-stdio",
+  const adapterByProject = useMemo(
+    () => new Map(adapterStatuses.map((adapter) => [adapter.project_id, adapter])),
+    [adapterStatuses],
+  );
+  const effectiveAvailability = useCallback(
+    (projectId: string) =>
+      adapterByProject.get(projectId)?.availability ??
+      mcpProjects.find((project) => project.id === projectId)?.availability ??
+      "blocked",
+    [adapterByProject],
+  );
+  const readyCount = mcpProjects.filter(
+    (project) => effectiveAvailability(project.id) === "ready",
   ).length;
-  const plannedCount = mcpProjects.length - connectableCount;
+  const plannedCount = mcpProjects.filter(
+    (project) => effectiveAvailability(project.id) === "planned",
+  ).length;
+  const adaptingCount = mcpProjects.filter(
+    (project) => effectiveAvailability(project.id) === "adapting",
+  ).length;
+  const blockedCount = mcpProjects.filter(
+    (project) => effectiveAvailability(project.id) === "blocked",
+  ).length;
   const categoryCounts = useMemo(() => {
     const counts = new Map<McpCategory, number>();
     for (const category of mcpCategories) counts.set(category, 0);
@@ -97,8 +124,8 @@ export default function McpBrowserPage() {
         return false;
       }
       if (
-        compatibilityFilter !== "all" &&
-        project.compatibility !== compatibilityFilter
+        availabilityFilter !== "all" &&
+        effectiveAvailability(project.id) !== availabilityFilter
       ) {
         return false;
       }
@@ -111,12 +138,14 @@ export default function McpBrowserPage() {
         project.readmeSummary,
         ...project.tags,
         ...project.requirements,
+        ...project.requiredCapabilities,
+        ...project.adaptationLimitations,
       ]
         .join(" ")
         .toLocaleLowerCase("zh-CN");
       return searchableText.includes(normalizedQuery);
     });
-  }, [compatibilityFilter, query, selectedCategory]);
+  }, [availabilityFilter, effectiveAvailability, query, selectedCategory]);
   const visibleProjects = useMemo(
     () => filteredProjects.slice(0, visibleCount),
     [filteredProjects, visibleCount],
@@ -124,16 +153,7 @@ export default function McpBrowserPage() {
 
   useEffect(() => {
     setVisibleCount(INITIAL_VISIBLE_COUNT);
-  }, [compatibilityFilter, query, selectedCategory]);
-  const sessionsByCommand = useMemo(() => {
-    const map = new Map<string, McpSessionSummary>();
-    for (const session of sessions) {
-      const key = commandKey(session.server_command);
-      if (!map.has(key)) map.set(key, session);
-    }
-    return map;
-  }, [sessions]);
-
+  }, [availabilityFilter, query, selectedCategory]);
   return (
     <PageContainer
       activeResource="mcps"
@@ -141,7 +161,7 @@ export default function McpBrowserPage() {
         <div>
           <p className="text-sm font-semibold text-white">工具采购清单</p>
           <p className="mt-2 text-sm leading-6 text-slate-400">
-            汇集两个社区清单，并按当前安全边界区分“本地可连”和“已收录、待适配”。
+            汇集两个社区清单，并按生产验收状态、适配批次和风险等级展示。
           </p>
           <div className="mt-4 rounded-lg border border-white/10 bg-white/[0.045] p-3">
             <p className="text-xs text-slate-400">已上架工具</p>
@@ -156,9 +176,9 @@ export default function McpBrowserPage() {
             </p>
           </div>
           <div className="mt-3 rounded-lg border border-white/10 bg-white/[0.045] p-3">
-            <p className="text-xs text-slate-400">本地 stdio 可连</p>
+            <p className="text-xs text-slate-400">生产级可用</p>
             <p className="mt-1 text-sm font-semibold text-emerald-100">
-              {connectableCount} 个
+              {readyCount} 个
             </p>
           </div>
           <button
@@ -168,12 +188,6 @@ export default function McpBrowserPage() {
           >
             刷新连接状态
           </button>
-          <Link
-            className="mt-2 block w-full rounded-full border border-cyan-300/25 bg-cyan-300/10 px-4 py-2 text-center text-sm font-semibold text-cyan-100 transition hover:bg-cyan-300/15"
-            to="/toolsets?tab=mcp"
-          >
-            管理 Toolset
-          </Link>
         </div>
       }
     >
@@ -189,7 +203,7 @@ export default function McpBrowserPage() {
               MCP 工具采购
             </h1>
             <p className="mt-5 max-w-2xl text-base leading-7 text-slate-300">
-              从 {mcpProjects.length} 个中文化条目中按场景与适配状态筛选。当前只开放无需 OAuth、Token、额外运行时或桌面宿主的本地 stdio Server。
+              从 {mcpProjects.length} 个中文化条目中按场景、批次与生产验收状态筛选。当前冻结 7 个可用项，其余 93 个必须逐批通过安全门槛后才会开放。
             </p>
           </div>
 
@@ -215,7 +229,7 @@ export default function McpBrowserPage() {
               </div>
               <div className="rounded-lg bg-white/[0.055] px-2 py-3">
                 <p className="text-lg font-semibold text-emerald-100">
-                  {connectableCount}
+                  {readyCount}
                 </p>
                 <p className="mt-1 truncate text-slate-400">可连接</p>
               </div>
@@ -298,15 +312,15 @@ export default function McpBrowserPage() {
                     </a>
                   </span>
                 ))}
-                ，并按模镜当前 stdio 边界重新分类、翻译和核验。
+                ，并按模镜的受控适配器边界重新分类、翻译和核验。
               </p>
               <p className="mt-2 text-xs leading-5 text-slate-400">
-                核验日期 2026-08-02 · MIT 清单来源 · 不提供 OAuth、Token、外部运行时、桌面宿主或外站认证入口
+                核验日期 2026-08-02 · 目录数量冻结 · 当前不提供自定义连接、MCP Builder 或外站认证入口
               </p>
             </div>
 
             <div className="rounded-lg border border-amber-300/25 bg-amber-300/[0.08] p-4 text-sm leading-6 text-amber-50">
-              “待适配”不代表项目不可用，而是当前模镜不会代管其凭证、账号授权、远程连接或桌面运行环境。此类条目仅展示中文用途与接入条件，按钮保持不可连接状态。
+              “待适配”不代表上游项目不可用，而是尚未通过模镜的安装、权限、Smoke 与回退验收。每个条目已归入固定批次；服务端未放行前，按钮始终不可连接。
             </div>
 
             <div className="rounded-lg border border-white/10 bg-white/[0.035] p-4">
@@ -322,13 +336,13 @@ export default function McpBrowserPage() {
                   type="search"
                   value={query}
                 />
-                {query || selectedCategory !== "全部" || compatibilityFilter !== "all" ? (
+                {query || selectedCategory !== "全部" || availabilityFilter !== "all" ? (
                   <button
                     className="rounded-lg border border-white/10 bg-white/[0.055] px-4 py-2.5 text-sm font-semibold text-slate-200 transition hover:border-brand-300/35 hover:text-brand-100"
                     onClick={() => {
                       setQuery("");
                       setSelectedCategory("全部");
-                      setCompatibilityFilter("all");
+                      setAvailabilityFilter("all");
                     }}
                     type="button"
                   >
@@ -345,22 +359,24 @@ export default function McpBrowserPage() {
                 >
                   {([
                     ["all", "全部状态", mcpProjects.length],
-                    ["local-stdio", "本地 stdio 可连", connectableCount],
-                    ["planned", "已收录、待适配", plannedCount],
+                    ["ready", mcpAvailabilityLabels.ready, readyCount],
+                    ["planned", mcpAvailabilityLabels.planned, plannedCount],
+                    ["adapting", mcpAvailabilityLabels.adapting, adaptingCount],
+                    ["blocked", mcpAvailabilityLabels.blocked, blockedCount],
                   ] as const).map(([value, label, count]) => {
-                    const isSelected = compatibilityFilter === value;
+                    const isSelected = availabilityFilter === value;
                     return (
                       <button
                         aria-pressed={isSelected}
                         className={`rounded-full border px-3 py-1.5 text-xs font-semibold transition ${
                           isSelected
-                            ? value === "planned"
+                            ? value === "planned" || value === "blocked"
                               ? "border-amber-300/60 bg-amber-300 text-ink-950"
                               : "border-emerald-300/60 bg-emerald-300 text-ink-950"
                             : "border-white/10 bg-white/[0.045] text-slate-300 hover:border-brand-300/35 hover:text-brand-100"
                         }`}
                         key={value}
-                        onClick={() => setCompatibilityFilter(value)}
+                        onClick={() => setAvailabilityFilter(value)}
                         type="button"
                       >
                         {label} · {count}
@@ -423,14 +439,20 @@ export default function McpBrowserPage() {
           filteredProjects.length > 0 ? (
             <>
               <div className="grid grid-cols-1 gap-4 lg:grid-cols-2 2xl:grid-cols-3">
-                {visibleProjects.map((project) => (
-                  <McpServerCard
-                    key={project.id}
-                    onConnectionChange={() => void refreshRuntime()}
-                    project={project}
-                    restoredSession={sessionsByCommand.get(commandKey(project.command))}
-                  />
-                ))}
+                {visibleProjects.map((project) => {
+                  const adapterStatus = adapterByProject.get(project.id);
+                  return (
+                    <McpServerCard
+                      adapterStatus={adapterStatus}
+                      key={project.id}
+                      onConnectionChange={() => void refreshRuntime()}
+                      project={project}
+                      restoredSession={sessions.find(
+                        (session) => session.session_id === adapterStatus?.session_id,
+                      )}
+                    />
+                  );
+                })}
               </div>
               {visibleProjects.length < filteredProjects.length ? (
                 <div className="mt-6 flex justify-center">
@@ -457,7 +479,7 @@ export default function McpBrowserPage() {
                 onClick={() => {
                   setQuery("");
                   setSelectedCategory("全部");
-                  setCompatibilityFilter("all");
+                  setAvailabilityFilter("all");
                 }}
                 type="button"
               >

--- a/docs/MCP_CATALOG_ROADMAP.md
+++ b/docs/MCP_CATALOG_ROADMAP.md
@@ -43,72 +43,72 @@
 
 数据层必须满足以下约束：
 
-1. `local-stdio` 条目必须有非空 `command`，并且 `requirements` 为空。
-2. `planned` 条目不得向前端暴露可执行 `command`。
-3. 前端不得保存真实 Secret，也不得在仓库内出现真实凭证。
-4. 上游清单只用于发现项目；能否连接必须按模镜运行边界重新核验。
+1. 前端条目不得包含可执行 `command`、MCP URL、Header 或环境变量配置。
+2. `ready` 后端适配器必须有固定命令或端点、独立功能开关和显式工具策略；现有 7 项以兼容策略保持行为不变。
+3. `planned` 后端适配器不得包含可执行命令或端点，环境开关不能绕过状态门禁。
+4. 前端不得保存真实 Secret，也不得在仓库内出现真实凭证。
+5. 上游清单只用于发现项目；能否连接必须按模镜运行边界重新核验。
 
-## 4. 分阶段路线
+## 4. 适配架构与状态契约
 
-### 阶段 A：目录维护与来源同步
+批次 0 引入目录专用的受控适配器层：
 
-- 建立定期来源核验，记录项目链接失效、归档和重命名。
-- 补充来源版本或提交哈希，避免“核验日期”与真实内容漂移。
-- 为条目增加维护状态、许可证和最后活跃时间。
-- 增加数据契约测试，检查重复 ID、未知分类、缺失中文字段和错误适配状态。
+- 前端目录只保存中文展示资料、批次和风险说明，不再把命令或 URL 作为执行依据。
+- 后端 `server/mcp/catalog.py` 是项目 ID、连接方式、固定命令、配置字段、凭据槽和功能开关的唯一执行来源。
+- 前端只能按项目 ID 调用目录专用的准备、配置、连接、断开和工具调用 API，不允许提交命令、URL、Header、环境变量名或工作目录。
+- `planned` 条目即使被错误设置环境开关，也不能获得可执行命令；没有显式工具策略的新适配器不能调用工具。
+- 后端已有 Streamable HTTP / SSE、SSRF 校验、加密凭据引用和工具审批元数据，但“底座存在”不代表目录项目已经完成生产适配。
 
-验收门槛：目录更新不改变任何现有 stdio 命令，前端构建通过，条目状态校验无错误。
+目录状态统一为：
 
-### 阶段 B：安全运行时与远程传输适配
+- `planned`：已归入批次，尚未进入实现。
+- `adapting`：正在实现和核验，前端仍不可连接。
+- `ready`：安装、连接、权限、Smoke 和回退全部通过。
+- `blocked`：上游、运行环境或安全门槛存在明确阻塞。
 
-- 为 Python、Go、Rust、Java 和 Docker 设计隔离运行时镜像与资源配额。
-- 增加 Streamable HTTP / SSE 客户端，并限制目标域名、重定向和响应大小。
-- 对文件、网络、数据库和系统权限建立显式授权范围。
-- 为每种适配器补超时、重试、断开、审计和清理测试。
+## 5. 固定批次
 
-验收门槛：每种运行时都有独立沙盒、最小权限、资源上限和可回退开关；远程连接有 SSRF 防护与域名策略。
+目录数量在适配期间冻结为 100；以下 93 项必须且只能属于一个批次。
 
-### 阶段 C：OAuth 与 Secret 代理
+| 批次 | 能力与条目 | 数量 | 主要退出门槛 |
+| --- | --- | ---: | --- |
+| 0 | 现有 Node stdio 基线与适配 Harness | 7 | 100 项契约、服务端清单、功能开关、状态 API、现有行为回归 |
+| 1 | `calculator-mcp`、`time-mcp`、`vegalite-mcp` | 3 | 非 root Python 沙箱、默认断网、CPU/内存/时间/输出上限 |
+| 2 | `bibigpt-mcp`、`fetch-mcp`、`quickchart-mcp`、`airbnb-mcp`、`geowire-mcp` | 5 | 公网目标、DNS 重绑定、SSRF、重定向与响应大小验证 |
+| 3 | `basic-memory-mcp`、`excel-mcp-server`、`git-mcp`、`manim-mcp`、`markitdown-mcp` | 5 | 目录授权、路径越界与符号链接防护、产物清理 |
+| 4 | AgentQL、Brave、Exa、Firecrawl、Perplexity、Tavily、Axiom、Figma Context、Google Maps、Grafana、Graphlit、Kagi、Pinecone、Shodan、Snyk、VirusTotal | 16 | 加密凭据槽、固定出口域、只读工具清单、Secret 泄漏测试 |
+| 5 | DBHub、PostgreSQL、MongoDB、ClickHouse、Cognee、Graphiti、Hindsight、Redis、SQLite、DuckDB、Supabase | 11 | 只读账号、TLS、查询超时、行数限制、写入审批 |
+| 6 | Airtable、Asana、GitLab、中国电商经营、Notion、Mem0 | 6 | 修改预览与审批、幂等、限流、账号解绑 |
+| 7 | Chrome DevTools、Playwright、Puppeteer、Selenium | 4 | 临时浏览器、目标域、上传下载与会话清理边界 |
+| 8 | MCP Run Python、MCP Python Interpreter | 2 | 一次性断网容器、无宿主挂载、无 Docker socket、进程资源限制 |
+| 9 | Apify、Bright Data、Browserbase、E2B、Stripe、Terraform、Aiven、Alpaca、AWS KB、ElevenLabs、MiniMax、S3、Kubernetes、Semgrep | 14 | 费用/资源上限、目标预览、终止性操作强制审批 |
+| 10 | Gmail、Atlassian、Google Calendar、Google Drive、Microsoft 365、OneDrive、Sentry、Azure、Box、Cloudflare、GitHub、Linear、Neon、Slack | 14 | PKCE、state、最小 scope、刷新、撤销与解绑 |
+| 11 | 小红书、Ableton、Binary Ninja、Blender、Ghidra、JetBrains、ChatCrystal、Obsidian、OpenTabs、Zotero、Docker、Mobile、XcodeBuild | 13 | 版本化本机桥接、宿主校验、逐应用与目录授权 |
 
-- OAuth 使用服务端回调、PKCE、state 校验和最小 scope。
-- Secret 只存放在服务端加密存储，不通过前端目录数据或日志传递。
-- 支持 Token 到期、刷新、撤销和账号解绑。
-- 高风险工具在执行前展示目标资源与权限，并要求用户确认。
+每批在前一批验收完成后单独建分支和 PR；批内可以逐项开启功能开关，但不能绕过整批共享的安全门槛。
 
-验收门槛：完成威胁建模、Secret 泄漏测试、权限撤销测试和审计日志验证后，才能把相关条目改为可连接。
+## 6. 验收、发布和回退
 
-### 阶段 D：桌面宿主适配
+- 每个项目必须通过初始化、工具发现、代表性调用、超时、重连、断开与清理测试；Schema 漂移视为阻断。
+- 安全测试按批次覆盖 Secret 泄漏、SSRF、重定向、路径越界、沙箱逃逸、权限撤销、审批绕过和高风险操作默认关闭。
+- 前端必须显示中文批次、状态、连接方式、风险、限制和门槛；后端未返回 `executable=true` 时按钮不可连接。
+- 每个项目有独立服务端开关。回退只关闭开关、断开会话并清理沙箱，不删除目录条目或凭据。
+- 运行日志只记录项目 ID、状态、耗时、错误类别和策略事件，不记录 Secret、完整参数或工具返回正文。
 
-- 为 Blender、Zotero、Obsidian、IDE、Xcode 和逆向工具分别设计本机代理协议。
-- 明确桌面应用版本、插件版本、端口、文件目录和进程生命周期。
-- 禁止后端容器直接假设存在桌面 GUI 或用户登录态。
+## 7. 明确不进入本路线的远期能力
 
-验收门槛：宿主可发现、版本可校验、连接可撤销，并且不越过用户选定的文件与应用范围。
+- 用户自定义 MCP 连接不进入批次 0—11；目录配置只允许固定适配器声明的字段。
+- MCP Builder、可视化生成器和公开发布市场不进入批次 0—11。
+- 若未来立项，必须另行威胁建模、设计评审和建立独立路线，不复用目录适配功能开关直接放行。
 
-### 阶段 E：用户自定义连接（远期）
-
-用户自定义连接只有在前述适配器稳定后才进入设计：
-
-- 提供 schema 化表单，不接受任意 shell 字符串。
-- 命令、环境变量、目录、网络目标和 Secret 分开校验。
-- 默认在临时沙盒中进行只读探测，列出工具后再请求启用。
-- 提供连接健康检查、权限预览、导入导出和安全删除。
-
-### 阶段 F：MCP Builder（远期）
-
-MCP Builder 作为最后阶段规划：
-
-- 从受控模板创建 Server，不直接生成任意进程命令。
-- 内置工具 schema 编辑、Mock 数据、契约测试和 stdio 调试器。
-- 发布前执行权限声明、Secret 扫描、输入校验和沙盒 smoke test。
-- Builder 产物先进入私有草稿，经过人工审核后才能加入公共目录。
-
-## 5. 风险与回退
+## 8. 风险与回退
 
 主要风险是上游项目快速变化、条目说明过期，以及把“已收录”误解为“当前可安全运行”。前端必须持续使用明确的状态标签和禁用按钮表达边界。
 
-本轮回退只需恢复以下目录与展示文件，不涉及后端数据迁移或运行态变更：
+批次 0 不引入数据库迁移。回退时先断开目录会话，再恢复以下适配器、展示与文档文件；旧版 `/api/mcp/*` 接口保持兼容，可继续承载已有会话：
 
+- `server/mcp/catalog.py`
 - `client/src/data/mcpProjects.ts`
+- `client/src/data/mcpAdaptationPlan.ts`
 - `client/src/pages/McpBrowserPage.tsx`
 - `client/src/components/McpServerCard.tsx`

--- a/docs/MCP_INTEGRATION.md
+++ b/docs/MCP_INTEGRATION.md
@@ -1,17 +1,17 @@
 # MCP 原生集成说明
 
-最后更新日期：2026-07-23
+最后更新日期：2026-08-02
 维护人：模镜团队
 
 ## 0. 产品入口与预算层级
 
-- `/mcps` 明确提供进入 `/toolsets` 的入口：前者负责 MCP 项目发现与即时连接，后者负责 MCP/API/内置 Provider 的草稿、凭据、工具语义、测试和不可变发布。
+- `/mcps` 负责冻结目录中的项目发现和预置适配器连接，不提供自定义命令、URL 或 MCP Builder。`/toolsets` 的通用草稿能力仍供其他产品路径使用，但不是目录条目的配置入口。
 - Tavily 与 Todos 作为稳定的内置默认 Toolset 存在。Todos 无需凭据即可直接绑定；Tavily 配置凭据时更新同一 Provider 实例，不重复生成不可发现的资源。
 - `XpertAgentConfig.max_concurrency` 与 `recursion_limit` 是整个 Xpert 执行树的全局预算；Toolset 的并行安全、`maxToolConcurrency`、`maxToolCalls`、`maxToolDepth` 和 `maxIterations` 是局部工具调用护栏。局部配置不能突破全局预算。
 
 ## 1. 概述
 
-MCP（Model Context Protocol）是一套让 AI 应用通过标准协议连接外部工具、资源和上下文的机制。模镜保留原 `/mcps` 即时连接入口，并新增 `/toolsets` 的版本化 MCP Runtime。后者支持 **Stdio、Streamable HTTP 与旧 SSE 兼容**：连接后发现工具 Schema，用户显式启停和配置工具，再发布不可变版本供 Workflow、Xpert、Goal 与 Handoff 绑定。
+MCP（Model Context Protocol）是一套让 AI 应用通过标准协议连接外部工具、资源和上下文的机制。`/mcps` 使用服务端受控适配器：前端只提交项目 ID，固定命令、传输、配置字段和工具策略由 `server/mcp/catalog.py` 管理。通用 `/toolsets` Runtime 支持 **Stdio、Streamable HTTP 与旧 SSE 兼容**，但目录条目不会把任意连接能力暴露给用户。
 
 `/toolsets` 现也承载同一版本模型下的 API Toolset。OpenAPI 3.0/3.1 与 OData v4 文档被编译为受控工具 Schema，并通过独立安全 HTTP 执行器调用；这不是 MCP transport，也不会改变 `/mcps` 的连接与安装职责。
 
@@ -57,10 +57,10 @@ Agent 画布使用 `toolset_resource -> workflow_agent` 的 `toolset` 绑定边�
                │ HTTP REST
                ▼
 ┌─────────────────────────────┐
-│ FastAPI /api/mcp/*          │
-│ - 输入校验                  │
-│ - 每 IP 连接限流            │
-│ - session 生命周期管理      │
+│ FastAPI /api/mcp/catalog/*  │
+│ - 按项目 ID 解析固定适配器  │
+│ - 功能开关与生产状态门禁    │
+│ - 配置字段与工具策略校验    │
 └──────────────┬──────────────┘
                │ 官方 mcp Python SDK
                ▼
@@ -79,7 +79,14 @@ Agent 画布使用 `toolset_resource -> workflow_agent` 的 `toolset` 绑定边�
 └─────────────────────────────┘
 ```
 
-安全默认值：
+目录适配器安全默认值：
+
+- 前端不能提交 `server_command`、MCP URL、Header、环境变量名或工作目录。
+- 93 个待适配项目没有后端命令或端点；设置环境功能开关也不能使其可执行。
+- 新适配器若没有显式工具读写与审批策略，工具调用会 fail-closed。
+- 日志只记录项目 ID、工具名、状态和耗时，不记录参数、返回正文或 Secret。
+
+兼容层仍保留以下默认值：
 
 - 后端只接受 `list[str]` 形式的命令，不使用 shell。
 - 拒绝 `;`、`&&`、`|`、重定向等 shell 特殊字符。
@@ -89,59 +96,48 @@ Agent 画布使用 `toolset_resource -> workflow_agent` 的 `toolset` 绑定边�
 - 每个 session TTL 为 30 分钟，后台任务每 5 分钟清理一次；查询 sessions 或 registry 时也会触发一次轻量清理。
 - 全局 ToolRegistry 会聚合所有活跃 session 的工具，重名工具按首次出现保留。
 
-## 2. 如何添加新的 MCP Server
+## 2. 如何适配冻结目录中的 MCP Server
 
-前端 MCP 项目数据位于：
+适配期间目录冻结为 100 项，不新增条目。中文展示数据与后端执行清单分别位于：
 
 ```text
 client/src/data/mcpProjects.ts
-```
-
-新增条目时保留现有字段，并在支持本地 stdio 启动时添加可选字段：
-
-```ts
-command: ["npx", "-y", "@example/mcp-server"]
-```
-
-示例：
-
-```ts
-{
-  id: "filesystem-mcp",
-  name: "Filesystem MCP",
-  repoName: "modelcontextprotocol/servers",
-  repoUrl: "https://github.com/modelcontextprotocol/servers",
-  description: "把受控目录内的文件读写能力交给 AI。",
-  readmeSummary: "官方 npm 包描述为 MCP server for filesystem access。",
-  stars: 0,
-  language: "TypeScript",
-  updatedAt: "2026-06-16",
-  installCommand: "npx -y @modelcontextprotocol/server-filesystem <allowed-directory>",
-  installNote: "模镜后端会把工作目录限制在 server/mcp/sandboxes。",
-  command: ["npx", "-y", "@modelcontextprotocol/server-filesystem", "."],
-  tags: ["官方示例", "文件系统", "沙盒工具"],
-}
+client/src/data/mcpAdaptationPlan.ts
+server/mcp/catalog.py
 ```
 
 接入检查清单：
 
-1. 确认包名真实存在，例如：
+1. 在前后端批次映射中确认项目 ID 唯一且批次一致。
+2. 核验上游版本、包名或远程端点，并在后端固定版本；不要把执行配置写进前端数据。
+3. 为适配器声明连接形态、允许的非敏感配置字段、凭据槽、网络/文件权限和独立功能开关。
+4. 发现全部工具并逐个标记只读、敏感、终止性和审批要求；未知工具默认不可调用。
+5. 通过初始化、代表性调用、超时、重连、清理、安全和回退 Smoke 后，才能把状态从 `adapting` 改为 `ready`。
+
+核验 npm 包示例：
 
 ```bash
 npm view @example/mcp-server version
 ```
 
-2. 确认 MCP Server 支持 stdio。
-3. 确认是否需要 API Key。需要密钥的 Server 不应把密钥写入 `command`，应改由后端环境变量白名单注入。
-4. 确认工具列表能正常返回：
-
-```bash
-python server/mcp/test_manager.py
-```
-
-如果 MCP Server 只能通过远程 HTTP/SSE 使用，可以继续展示安装信息，但不要添加 `command` 字段，避免前端显示“连接”能力。
+远程、凭据、OAuth、代码沙箱和桌面桥接的退出门槛见 [MCP_CATALOG_ROADMAP.md](./MCP_CATALOG_ROADMAP.md)。
 
 ## 3. 后端 API 文档
+
+### 目录专用 API
+
+| 方法 | 路径 | 说明 |
+| --- | --- | --- |
+| GET | `/api/mcp/catalog/adapters` | 返回 100 项安全状态，不返回命令、端点或 Secret |
+| POST | `/api/mcp/catalog/{project_id}/prepare` | 使用后端固定安装配置准备已验收适配器 |
+| PUT | `/api/mcp/catalog/{project_id}/configuration` | 只接受清单允许的设置和 `credential_id` 绑定 |
+| POST | `/api/mcp/catalog/{project_id}/connect` | 按项目 ID 建立受控会话 |
+| DELETE | `/api/mcp/catalog/{project_id}/session` | 断开该目录项目的会话 |
+| POST | `/api/mcp/catalog/{project_id}/tools/{tool_name}/call` | 经项目工具策略调用已连接工具 |
+
+`planned` 项目的准备、连接和调用返回 `409`。配置包含命令、URL、Header、环境变量或工作目录时返回 `400`。
+
+以下 `/api/mcp/*` session API 为现有调用方保留兼容；目录前端不再向它们提交命令或直接调用工具。
 
 ### POST `/api/mcp/connect`
 
@@ -310,22 +306,24 @@ client/src/pages/McpBrowserPage.tsx
 
 状态流：
 
-1. 初始状态为 `idle`。
-2. 点击“连接”后进入 `connecting`，调用 `POST /api/mcp/connect`。
-3. 连接成功后进入 `connected`，读取工具列表。
-4. 对每个工具，根据 `inputSchema.properties` 动态生成表单：
+1. 页面先读取 `/api/mcp/catalog/adapters`；服务端未返回 `executable=true` 时连接按钮禁用。
+2. 点击“安装”调用 `POST /api/mcp/catalog/{project_id}/prepare`，浏览器不提交安装命令。
+3. 点击“连接”后进入 `connecting`，调用 `POST /api/mcp/catalog/{project_id}/connect`。
+4. 连接成功后进入 `connected`，读取工具列表。
+5. 对每个工具，根据 `inputSchema.properties` 动态生成表单：
    - `string` → 文本输入框。
    - `number` / `integer` → 数字输入框。
    - `boolean` → true/false 下拉。
    - `enum` → 下拉选择。
    - `object` / `array` → JSON 文本框。
-5. 点击“执行”后调用 `/api/mcp/{session_id}/call`，结果使用 Markdown 区域展示。
-6. 点击“断开连接”后调用 DELETE 并清理本地状态。
+6. 点击“执行”后调用目录项目的策略化工具端点，结果使用 Markdown 区域展示。
+7. 点击“断开连接”后按项目 ID 调用 DELETE 并清理本地状态。
 
 UI 状态要求：
 
 - 连接中按钮禁用。
-- 无 `command` 的项目显示“展示项目”，不可连接。
+- `planned`、`adapting`、`blocked` 或 `executable=false` 的项目不可连接。
+- 每张卡片显示固定批次、连接方式、风险、限制和生产验收门槛。
 - API 失败时在卡片内展示错误。
 - 未知 JSON Schema 字段不应导致页面崩溃。
 
@@ -341,6 +339,7 @@ python -m pip install -r server/requirements.txt
 
 ```bash
 python -m pytest server/tests/test_mcp_integration.py -q
+python -m pytest server/tests/test_mcp_catalog.py server/tests/test_mcp_multisession.py -q
 ```
 
 测试覆盖：
@@ -365,6 +364,7 @@ python server/mcp/test_manager.py
 | 文件 | 说明 |
 | --- | --- |
 | `server/mcp/manager.py` | MCPClientManager，负责 Stdio、Streamable HTTP 与旧 SSE session 生命周期。 |
+| `server/mcp/catalog.py` | 冻结目录、固定适配器、功能开关、配置门禁和目录 API。 |
 | `server/toolsets/` | Toolset/凭据 Store、版本发布、Schema 漂移与固定版本 Provider。 |
 | `client/src/pages/ToolsetsPage.tsx` | MCP Toolset 创建、连接、工具配置、测试和发布管理页。 |
 | `server/tests/test_toolset_*.py` | Toolset Store、API、连接、固定版本与安全回归。 |
@@ -373,11 +373,13 @@ python server/mcp/test_manager.py
 | `server/tests/mock_mcp_server.py` | 本地 mock MCP Server。 |
 | `server/tests/test_mcp_integration.py` | FastAPI MCP 端点集成测试。 |
 | `server/tests/test_mcp_multisession.py` | 多 session、TTL 与 ToolRegistry 集成测试。 |
+| `server/tests/test_mcp_catalog.py` | 100 项契约、前后端 ID、服务端配置来源与 fail-closed 测试。 |
 | `client/src/components/McpServerCard.tsx` | 前端连接、工具表单、执行结果组件。 |
-| `client/src/data/mcpProjects.ts` | MCP 项目与可选 stdio 命令数据。 |
+| `client/src/data/mcpProjects.ts` | MCP 中文展示资料；不能作为执行配置来源。 |
+| `client/src/data/mcpAdaptationPlan.ts` | 前端批次、状态、连接形态和风险展示。 |
 
 ## 7. 中文目录与后续适配
 
-`/mcps` 同时展示可本地 stdio 连接的 Server 和已收录但尚未适配的生态项目。带 OAuth、Token、额外运行时、桌面宿主、远程传输或外站认证要求的条目不得暴露 `command`，只能展示中文用途、接入条件和等待适配状态。
+`/mcps` 同时展示已通过生产验收的 Server 和按批次排队的生态项目。待适配条目只能展示中文用途、接入条件、批次和安全门槛；只有后端返回 `ready + executable` 才能连接。
 
 来源同步、安全运行时、OAuth / Secret 代理、用户自定义连接和 MCP Builder 的阶段计划见 [MCP_CATALOG_ROADMAP.md](./MCP_CATALOG_ROADMAP.md)。

--- a/server/main.py
+++ b/server/main.py
@@ -240,6 +240,11 @@ except ModuleNotFoundError:
     )
 
 try:
+    from server.mcp.catalog import (
+        MCPCatalogService,
+        configure_mcp_catalog,
+        router as mcp_catalog_router,
+    )
     from server.mcp.manager import (
         MCPClientError,
         MCPClientManager,
@@ -250,6 +255,11 @@ try:
     )
     from server.registry.tool_registry import ToolRegistry
 except ModuleNotFoundError:
+    from mcp.catalog import (
+        MCPCatalogService,
+        configure_mcp_catalog,
+        router as mcp_catalog_router,
+    )
     from mcp.manager import (
         MCPClientError,
         MCPClientManager,
@@ -763,6 +773,7 @@ app.include_router(model_catalog_router)
 app.include_router(omniroute_router)
 app.include_router(multimodal_router)
 app.include_router(coding_router)
+app.include_router(mcp_catalog_router)
 
 request_windows: dict[str, deque[float]] = defaultdict(deque)
 mcp_connect_windows: dict[str, deque[float]] = defaultdict(deque)
@@ -772,6 +783,13 @@ tool_registry = ToolRegistry()
 workflow_mcp_provider = MCPToolsetProvider(tool_registry, mcp_manager)
 toolset_store = ToolsetStore()
 toolset_credential_store = CredentialStore(toolset_store.storage_dir)
+mcp_catalog_service = MCPCatalogService(
+    mcp_manager,
+    mcp_installer,
+    tool_registry,
+    credential_validator=toolset_credential_store.get_public,
+)
+configure_mcp_catalog(mcp_catalog_service)
 toolset_service = ToolsetService(
     toolset_store,
     toolset_credential_store,
@@ -1363,8 +1381,14 @@ def mcp_server_id_from_command(server_command: list[str]) -> str:
 async def cleanup_mcp_idle_sessions_and_registry() -> list[str]:
     cleaned_ids = await mcp_manager.cleanup_idle_sessions()
     if cleaned_ids:
+        await mcp_catalog_service.forget_sessions(cleaned_ids)
         await tool_registry.unregister_sessions(cleaned_ids)
     return cleaned_ids
+
+
+async def cleanup_mcp_session_state(session_ids: list[str]) -> None:
+    await mcp_catalog_service.forget_sessions(session_ids)
+    await tool_registry.unregister_sessions(session_ids)
 
 
 def validate_content(messages: list[ChatMessage]) -> None:
@@ -12686,7 +12710,7 @@ configure_xpert_evolutions(
 @app.on_event("startup")
 async def start_mcp_ttl_cleanup() -> None:
     await asyncio.to_thread(datax_service.recover_import_jobs)
-    mcp_manager.start_ttl_cleanup(on_cleanup=tool_registry.unregister_sessions)
+    mcp_manager.start_ttl_cleanup(on_cleanup=cleanup_mcp_session_state)
     builtin_warnings = await toolset_service.ensure_builtin_toolsets()
     for warning in builtin_warnings:
         logger.warning("Builtin Provider Toolset initialization failed: %s", warning)
@@ -12720,6 +12744,7 @@ async def shutdown_mcp_sessions() -> None:
         await client_tool_coordinator.stop()
     if automation_coordinator is not None:
         await automation_coordinator.stop()
+    await mcp_catalog_service.clear_sessions()
     await toolset_service.close()
     await mcp_manager.stop_ttl_cleanup()
     await mcp_manager.close_all()

--- a/server/mcp/catalog.py
+++ b/server/mcp/catalog.py
@@ -1,0 +1,779 @@
+"""Curated MCP catalog adapter registry and catalog-scoped runtime API.
+
+The frontend catalog is descriptive.  Executable commands, transports and
+permission policy live here so clients cannot turn a planned catalog entry into
+an arbitrary MCP connection.  Batch zero intentionally exposes only the seven
+previously supported local stdio adapters; every other project remains a
+non-executable roadmap entry.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Literal, Protocol
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from mcp.types import CallToolResult, Tool
+
+try:
+    from server.mcp.manager import (
+        MCPClientManager,
+        MCPInstaller,
+        MCPSessionNotFoundError,
+    )
+    from server.registry.tool_registry import ToolRegistry
+except ModuleNotFoundError:
+    from mcp.manager import MCPClientManager, MCPInstaller, MCPSessionNotFoundError
+    from registry.tool_registry import ToolRegistry
+
+
+AdapterAvailability = Literal["planned", "adapting", "ready", "blocked"]
+AdapterConnectionKind = Literal[
+    "local-stdio",
+    "sandboxed-stdio",
+    "remote-mcp",
+    "desktop-bridge",
+]
+AdapterRisk = Literal["low", "medium", "high", "critical"]
+
+logger = logging.getLogger("modelmirror.mcp.catalog")
+
+
+class CatalogAdapterError(RuntimeError):
+    """Base catalog adapter failure."""
+
+
+class CatalogAdapterNotFoundError(CatalogAdapterError):
+    """Raised when a project is not part of the frozen catalog."""
+
+
+class CatalogAdapterUnavailableError(CatalogAdapterError):
+    """Raised when a project has not crossed its production readiness gate."""
+
+
+class CatalogAdapterPolicyError(CatalogAdapterError):
+    """Raised when configuration or execution violates an adapter policy."""
+
+
+@dataclass(frozen=True, slots=True)
+class CatalogToolPolicy:
+    read_only: bool = True
+    requires_approval: bool = False
+    sensitive: bool = False
+    terminal: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class CatalogAdapterManifest:
+    project_id: str
+    wave: int
+    availability: AdapterAvailability
+    connection_kind: AdapterConnectionKind
+    risk: AdapterRisk
+    required_capabilities: tuple[str, ...]
+    limitations: tuple[str, ...]
+    server_command: tuple[str, ...] = ()
+    install_command: str = ""
+    transport: str = "stdio"
+    endpoint: str = ""
+    allowed_settings: tuple[str, ...] = ()
+    credential_slots: tuple[str, ...] = ()
+    tool_policies: dict[str, CatalogToolPolicy] = field(default_factory=dict)
+    legacy_unrestricted_calls: bool = False
+    enabled_by_default: bool = False
+
+    @property
+    def feature_flag(self) -> str:
+        normalized = re.sub(r"[^A-Za-z0-9]", "_", self.project_id).upper()
+        return f"MCP_CATALOG_ENABLE_{normalized}"
+
+    @property
+    def feature_enabled(self) -> bool:
+        raw = os.getenv(self.feature_flag, "").strip().lower()
+        if raw:
+            return raw in {"1", "true", "yes", "on"}
+        return self.enabled_by_default
+
+    @property
+    def executable(self) -> bool:
+        return (
+            self.availability == "ready"
+            and self.feature_enabled
+            and bool(self.server_command or self.endpoint)
+        )
+
+    def to_public(
+        self,
+        *,
+        connected: bool = False,
+        session_id: str | None = None,
+    ) -> dict[str, Any]:
+        return {
+            "project_id": self.project_id,
+            "wave": self.wave,
+            "availability": self.availability,
+            "connection_kind": self.connection_kind,
+            "risk": self.risk,
+            "required_capabilities": list(self.required_capabilities),
+            "limitations": list(self.limitations),
+            "feature_enabled": self.feature_enabled,
+            "executable": self.executable,
+            "connected": connected,
+            "session_id": session_id if connected else None,
+            "allowed_settings": list(self.allowed_settings),
+            "credential_slots": list(self.credential_slots),
+        }
+
+
+LOCAL_STDIO_ADAPTERS: dict[str, tuple[str, tuple[str, ...]]] = {
+    "context7": ("npx ctx7 setup", ("npx", "-y", "@upstash/context7-mcp")),
+    "filesystem-mcp": (
+        "npx -y @modelcontextprotocol/server-filesystem <allowed-directory>",
+        ("npx", "-y", "@modelcontextprotocol/server-filesystem", "."),
+    ),
+    "youtube-transcript-mcp": (
+        "npx -y @kimtaeyoon83/mcp-server-youtube-transcript",
+        ("npx", "-y", "@kimtaeyoon83/mcp-server-youtube-transcript"),
+    ),
+    "memory-mcp": (
+        "npx -y @modelcontextprotocol/server-memory",
+        ("npx", "-y", "@modelcontextprotocol/server-memory"),
+    ),
+    "12306-mcp": ("npx -y 12306-mcp", ("npx", "-y", "12306-mcp")),
+    "sequential-thinking-mcp": (
+        "npx -y @modelcontextprotocol/server-sequential-thinking",
+        ("npx", "-y", "@modelcontextprotocol/server-sequential-thinking"),
+    ),
+    "everything-mcp": (
+        "npx -y @modelcontextprotocol/server-everything",
+        ("npx", "-y", "@modelcontextprotocol/server-everything"),
+    ),
+}
+
+
+WAVE_PROJECTS: dict[int, tuple[str, ...]] = {
+    1: ("calculator-mcp", "time-mcp", "vegalite-mcp"),
+    2: (
+        "bibigpt-mcp",
+        "fetch-mcp",
+        "quickchart-mcp",
+        "airbnb-mcp",
+        "geowire-mcp",
+    ),
+    3: (
+        "basic-memory-mcp",
+        "excel-mcp-server",
+        "git-mcp",
+        "manim-mcp",
+        "markitdown-mcp",
+    ),
+    4: (
+        "agentql-mcp",
+        "brave-search-mcp",
+        "exa-mcp",
+        "firecrawl-mcp",
+        "perplexity-mcp",
+        "tavily-mcp",
+        "axiom-mcp",
+        "figma-context-mcp",
+        "google-maps-mcp",
+        "grafana-mcp",
+        "graphlit-mcp",
+        "kagi-mcp",
+        "pinecone-assistant-mcp",
+        "shodan-mcp",
+        "snyk-mcp",
+        "virustotal-mcp",
+    ),
+    5: (
+        "dbhub",
+        "postgres-mcp",
+        "mongodb-mcp",
+        "clickhouse-mcp",
+        "cognee-mcp",
+        "graphiti-mcp",
+        "hindsight-mcp",
+        "redis-mcp",
+        "sqlite-mcp",
+        "duckdb-mcp",
+        "supabase-mcp",
+    ),
+    6: (
+        "airtable-mcp",
+        "asana-mcp",
+        "gitlab-mcp",
+        "mcp-cn-commerce",
+        "notion-mcp-server",
+        "mem0-mcp",
+    ),
+    7: (
+        "chrome-devtools-mcp",
+        "playwright-mcp",
+        "puppeteer-mcp",
+        "selenium-mcp",
+    ),
+    8: ("mcp-run-python", "python-interpreter"),
+    9: (
+        "apify-mcp",
+        "bright-data-mcp",
+        "browserbase-mcp",
+        "e2b-mcp",
+        "stripe-mcp",
+        "terraform-mcp",
+        "aiven-mcp",
+        "alpaca-mcp",
+        "aws-kb-mcp",
+        "elevenlabs-mcp",
+        "minimax-mcp",
+        "s3-mcp",
+        "kubernetes-mcp",
+        "semgrep-mcp",
+    ),
+    10: (
+        "gmail-mcp",
+        "atlassian-mcp",
+        "google-calendar-mcp",
+        "google-drive-mcp",
+        "microsoft-365-mcp",
+        "onedrive-mcp",
+        "sentry-mcp",
+        "azure-mcp",
+        "box-mcp",
+        "cloudflare-mcp",
+        "github-mcp-server",
+        "linear-mcp",
+        "neon-mcp",
+        "slack-mcp",
+    ),
+    11: (
+        "xiaohongshu-mcp",
+        "ableton-mcp",
+        "binary-ninja-mcp",
+        "blender-mcp",
+        "ghidra-mcp",
+        "jetbrains-mcp",
+        "chatcrystal",
+        "obsidian-mcp",
+        "opentabs",
+        "zotero-mcp",
+        "docker-mcp",
+        "mobile-mcp",
+        "xcodebuild-mcp",
+    ),
+}
+
+
+WAVE_METADATA: dict[
+    int,
+    tuple[AdapterConnectionKind, AdapterRisk, tuple[str, ...], tuple[str, ...]],
+] = {
+    1: (
+        "sandboxed-stdio",
+        "low",
+        ("isolated-python-runtime", "resource-limits"),
+        ("等待独立 Python 沙箱、断网策略和资源上限验证。",),
+    ),
+    2: (
+        "remote-mcp",
+        "medium",
+        ("public-remote-policy", "ssrf-protection"),
+        ("等待公网目标、DNS、重定向和响应大小策略验证。",),
+    ),
+    3: (
+        "sandboxed-stdio",
+        "medium",
+        ("scoped-filesystem", "artifact-cleanup"),
+        ("等待目录授权、路径越界防护和产物清理验证。",),
+    ),
+    4: (
+        "remote-mcp",
+        "medium",
+        ("encrypted-credential-binding", "read-only-tool-policy"),
+        ("等待固定凭据槽、出口域名和只读工具清单验证。",),
+    ),
+    5: (
+        "sandboxed-stdio",
+        "high",
+        ("database-read-only-policy", "query-limits"),
+        ("等待只读账号、TLS、查询超时和结果行数限制验证。",),
+    ),
+    6: (
+        "remote-mcp",
+        "high",
+        ("mutating-tool-approval", "account-unbinding"),
+        ("等待修改操作预览、审批、幂等和账号解绑验证。",),
+    ),
+    7: (
+        "sandboxed-stdio",
+        "high",
+        ("ephemeral-browser", "browser-domain-policy"),
+        ("等待临时浏览器、目标域及上传下载边界验证。",),
+    ),
+    8: (
+        "sandboxed-stdio",
+        "critical",
+        ("ephemeral-code-sandbox", "process-resource-limits"),
+        ("等待断网、无宿主挂载的一次性代码执行沙箱验证。",),
+    ),
+    9: (
+        "sandboxed-stdio",
+        "critical",
+        ("cost-guardrails", "terminal-action-approval"),
+        ("等待费用上限、资源预览和终止性操作强制审批验证。",),
+    ),
+    10: (
+        "remote-mcp",
+        "high",
+        ("oauth-pkce", "oauth-revocation", "scope-review"),
+        ("等待 PKCE、state、最小 scope、刷新、撤销和解绑验证。",),
+    ),
+    11: (
+        "desktop-bridge",
+        "critical",
+        ("versioned-desktop-bridge", "per-app-consent"),
+        ("等待本机桥接协议、宿主版本和逐应用授权验证。",),
+    ),
+}
+
+
+def build_catalog_manifests() -> dict[str, CatalogAdapterManifest]:
+    manifests: dict[str, CatalogAdapterManifest] = {}
+    for project_id, (install_command, server_command) in LOCAL_STDIO_ADAPTERS.items():
+        manifests[project_id] = CatalogAdapterManifest(
+            project_id=project_id,
+            wave=0,
+            availability="ready",
+            connection_kind="local-stdio",
+            risk="medium" if project_id in {"filesystem-mcp", "memory-mcp"} else "low",
+            required_capabilities=("existing-node-stdio-runtime",),
+            limitations=("沿用现有本地 stdio 行为；批次 0 不扩大权限范围。",),
+            server_command=server_command,
+            install_command=install_command,
+            legacy_unrestricted_calls=True,
+            enabled_by_default=True,
+        )
+
+    for wave, project_ids in WAVE_PROJECTS.items():
+        connection_kind, risk, capabilities, limitations = WAVE_METADATA[wave]
+        for project_id in project_ids:
+            if project_id in manifests:
+                raise RuntimeError(f"Duplicate MCP catalog project: {project_id}")
+            manifests[project_id] = CatalogAdapterManifest(
+                project_id=project_id,
+                wave=wave,
+                availability="planned",
+                connection_kind=connection_kind,
+                risk=risk,
+                required_capabilities=capabilities,
+                limitations=limitations,
+            )
+
+    if len(manifests) != 100:
+        raise RuntimeError(f"MCP catalog must contain 100 adapters, got {len(manifests)}")
+    return manifests
+
+
+CATALOG_ADAPTERS = build_catalog_manifests()
+
+
+class InstallerProtocol(Protocol):
+    def install(
+        self,
+        *,
+        project_id: str,
+        install_command: str,
+        server_command: list[str] | None = None,
+    ) -> dict[str, Any]: ...
+
+    def get_installed(self, project_id: str) -> dict[str, Any] | None: ...
+
+
+class CatalogConfigurationRequest(BaseModel):
+    settings: dict[str, str | int | float | bool] = Field(default_factory=dict)
+    credential_bindings: dict[str, str] = Field(default_factory=dict)
+
+
+class CatalogToolCallRequest(BaseModel):
+    arguments: dict[str, Any] = Field(default_factory=dict)
+
+
+class MCPCatalogService:
+    """Operate only server-owned adapters from the frozen catalog."""
+
+    _RESERVED_CONFIGURATION_KEYS = {
+        "command",
+        "server_command",
+        "url",
+        "endpoint",
+        "headers",
+        "environment",
+        "cwd",
+        "working_directory",
+    }
+
+    def __init__(
+        self,
+        manager: MCPClientManager,
+        installer: InstallerProtocol,
+        registry: ToolRegistry,
+        *,
+        manifests: dict[str, CatalogAdapterManifest] | None = None,
+        credential_validator: Callable[[str], Any] | None = None,
+    ) -> None:
+        self.manager = manager
+        self.installer = installer
+        self.registry = registry
+        self.manifests = dict(manifests or CATALOG_ADAPTERS)
+        self.credential_validator = credential_validator
+        self._sessions: dict[str, str] = {}
+        self._configurations: dict[str, CatalogConfigurationRequest] = {}
+        self._lock = asyncio.Lock()
+
+    def get_manifest(self, project_id: str) -> CatalogAdapterManifest:
+        manifest = self.manifests.get(str(project_id or "").strip())
+        if manifest is None:
+            raise CatalogAdapterNotFoundError(
+                f"MCP 目录中不存在项目：{project_id}"
+            )
+        return manifest
+
+    def list_adapters(self) -> dict[str, Any]:
+        adapters = [
+            manifest.to_public(
+                connected=project_id in self._sessions,
+                session_id=self._sessions.get(project_id),
+            )
+            for project_id, manifest in sorted(self.manifests.items())
+        ]
+        return {
+            "total": len(adapters),
+            "ready": sum(item["availability"] == "ready" for item in adapters),
+            "planned": sum(item["availability"] == "planned" for item in adapters),
+            "adapting": sum(item["availability"] == "adapting" for item in adapters),
+            "blocked": sum(item["availability"] == "blocked" for item in adapters),
+            "adapters": adapters,
+        }
+
+    async def prepare(self, project_id: str) -> dict[str, Any]:
+        manifest = self._require_executable(project_id)
+        started_at = time.monotonic()
+        existing = self.installer.get_installed(manifest.project_id)
+        if existing is not None:
+            return {
+                "project_id": manifest.project_id,
+                "prepared": True,
+                "message": "MCP 适配器已经准备完成。",
+                "metadata": self._public_install_metadata(existing),
+            }
+        result = await asyncio.to_thread(
+            self.installer.install,
+            project_id=manifest.project_id,
+            install_command=manifest.install_command,
+            server_command=list(manifest.server_command),
+        )
+        payload = {
+            "project_id": manifest.project_id,
+            "prepared": bool(result.get("installed")),
+            "message": str(result.get("message") or "MCP 适配器已准备。"),
+            "metadata": self._public_install_metadata(result.get("metadata")),
+        }
+        logger.info(
+            "MCP catalog prepare project=%s prepared=%s duration_ms=%d",
+            manifest.project_id,
+            payload["prepared"],
+            int((time.monotonic() - started_at) * 1000),
+        )
+        return payload
+
+    def configure(
+        self,
+        project_id: str,
+        request: CatalogConfigurationRequest,
+    ) -> dict[str, Any]:
+        manifest = self.get_manifest(project_id)
+        if manifest.availability not in {"adapting", "ready"}:
+            raise CatalogAdapterUnavailableError(
+                "该 MCP 仍处于待适配状态，当前不能提交配置。"
+            )
+
+        supplied_setting_keys = set(request.settings)
+        supplied_credential_slots = set(request.credential_bindings)
+        if supplied_setting_keys & self._RESERVED_CONFIGURATION_KEYS:
+            raise CatalogAdapterPolicyError(
+                "目录配置不能包含命令、URL、Header、环境变量或工作目录。"
+            )
+        unknown_settings = supplied_setting_keys - set(manifest.allowed_settings)
+        unknown_slots = supplied_credential_slots - set(manifest.credential_slots)
+        if unknown_settings or unknown_slots:
+            unknown = sorted(unknown_settings | unknown_slots)
+            raise CatalogAdapterPolicyError(
+                "配置包含适配器未声明的字段：" + "、".join(unknown)
+            )
+        for credential_id in request.credential_bindings.values():
+            if not re.fullmatch(r"cred_[A-Za-z0-9]+", credential_id):
+                raise CatalogAdapterPolicyError("凭据绑定必须使用有效 credential_id。")
+            if self.credential_validator is None:
+                raise CatalogAdapterPolicyError("目录凭据存储当前不可用。")
+            try:
+                credential = self.credential_validator(credential_id)
+            except Exception as exc:
+                raise CatalogAdapterPolicyError(
+                    f"凭据绑定不存在或不可用：{credential_id}"
+                ) from exc
+            if getattr(credential, "status", "") != "active":
+                raise CatalogAdapterPolicyError(
+                    f"凭据绑定不是可用状态：{credential_id}"
+                )
+
+        self._configurations[manifest.project_id] = request.model_copy(deep=True)
+        return {
+            "project_id": manifest.project_id,
+            "configured": True,
+            "configured_settings": sorted(request.settings),
+            "configured_credential_slots": sorted(request.credential_bindings),
+        }
+
+    async def connect(self, project_id: str) -> dict[str, Any]:
+        manifest = self._require_executable(project_id)
+        started_at = time.monotonic()
+        async with self._lock:
+            existing = self._sessions.get(manifest.project_id)
+            if existing:
+                try:
+                    tools = await self.manager.list_tools(existing)
+                    return self._connection_payload(manifest, existing, tools)
+                except MCPSessionNotFoundError:
+                    self._sessions.pop(manifest.project_id, None)
+
+            if manifest.transport != "stdio" or not manifest.server_command:
+                raise CatalogAdapterUnavailableError(
+                    "该适配器尚未配置受控的可执行传输。"
+                )
+            session_id = await self.manager.connect(list(manifest.server_command))
+            try:
+                tools = await self.manager.list_tools(session_id)
+                await self.registry.register_session_tools(
+                    session_id=session_id,
+                    server_id=f"catalog:{manifest.project_id}",
+                    tools=tools,
+                )
+            except Exception:
+                await self.manager.disconnect(session_id)
+                raise
+            self._sessions[manifest.project_id] = session_id
+            payload = self._connection_payload(manifest, session_id, tools)
+            logger.info(
+                "MCP catalog connect project=%s tools=%d duration_ms=%d",
+                manifest.project_id,
+                len(tools),
+                int((time.monotonic() - started_at) * 1000),
+            )
+            return payload
+
+    async def disconnect(self, project_id: str) -> dict[str, Any]:
+        manifest = self.get_manifest(project_id)
+        async with self._lock:
+            session_id = self._sessions.pop(manifest.project_id, None)
+        if session_id is None:
+            raise MCPSessionNotFoundError(
+                f"MCP catalog session not found: {manifest.project_id}"
+            )
+        try:
+            await self.manager.disconnect(session_id)
+        finally:
+            await self.registry.unregister_session(session_id)
+        logger.info("MCP catalog disconnect project=%s", manifest.project_id)
+        return {"ok": True, "project_id": manifest.project_id}
+
+    async def call_tool(
+        self,
+        project_id: str,
+        tool_name: str,
+        arguments: dict[str, Any],
+    ) -> dict[str, Any]:
+        manifest = self._require_executable(project_id)
+        session_id = self._sessions.get(manifest.project_id)
+        if session_id is None:
+            raise CatalogAdapterUnavailableError("请先连接该 MCP 适配器。")
+
+        if not manifest.legacy_unrestricted_calls:
+            policy = manifest.tool_policies.get(tool_name)
+            if policy is None:
+                raise CatalogAdapterPolicyError(
+                    "该工具尚未完成显式读写与审批策略分类。"
+                )
+            if policy.requires_approval or not policy.read_only:
+                raise CatalogAdapterPolicyError(
+                    "该工具需要通过运行时审批流程后执行。"
+                )
+
+        started_at = time.monotonic()
+        result = await self.manager.call_tool(session_id, tool_name, arguments)
+        logger.info(
+            "MCP catalog call project=%s tool=%s duration_ms=%d",
+            manifest.project_id,
+            tool_name,
+            int((time.monotonic() - started_at) * 1000),
+        )
+        return self._serialize_call_result(result)
+
+    async def clear_sessions(self) -> None:
+        async with self._lock:
+            sessions = list(self._sessions.values())
+            self._sessions.clear()
+        for session_id in sessions:
+            try:
+                await self.manager.disconnect(session_id)
+            except Exception:
+                pass
+            await self.registry.unregister_session(session_id)
+
+    async def forget_sessions(self, session_ids: list[str]) -> None:
+        """Forget sessions already removed by the manager TTL cleanup."""
+
+        cleaned = set(session_ids)
+        if not cleaned:
+            return
+        async with self._lock:
+            for project_id, session_id in list(self._sessions.items()):
+                if session_id in cleaned:
+                    self._sessions.pop(project_id, None)
+
+    def _require_executable(self, project_id: str) -> CatalogAdapterManifest:
+        manifest = self.get_manifest(project_id)
+        if not manifest.executable:
+            raise CatalogAdapterUnavailableError(
+                "该 MCP 尚未通过生产级适配验收，当前不可准备、连接或执行。"
+            )
+        return manifest
+
+    @staticmethod
+    def _connection_payload(
+        manifest: CatalogAdapterManifest,
+        session_id: str,
+        tools: list[Tool],
+    ) -> dict[str, Any]:
+        return {
+            "project_id": manifest.project_id,
+            "session_id": session_id,
+            "tools_count": len(tools),
+        }
+
+    @staticmethod
+    def _public_install_metadata(value: Any) -> dict[str, Any]:
+        if not isinstance(value, dict):
+            return {}
+        allowed = {"project_id", "install_type", "npm_package", "installed_at"}
+        return {key: value[key] for key in allowed if key in value}
+
+    @staticmethod
+    def _serialize_call_result(result: CallToolResult) -> dict[str, Any]:
+        payload = result.model_dump(mode="json", exclude_none=True)
+        content = payload.get("content")
+        return {
+            "content": content if isinstance(content, list) else [],
+            "is_error": bool(payload.get("isError") or payload.get("is_error")),
+            "raw": payload,
+        }
+
+
+router = APIRouter(tags=["mcp-catalog"])
+_catalog_service: MCPCatalogService | None = None
+
+
+def configure_mcp_catalog(service: MCPCatalogService) -> None:
+    global _catalog_service
+    _catalog_service = service
+
+
+def get_mcp_catalog_service() -> MCPCatalogService:
+    if _catalog_service is None:
+        raise RuntimeError("MCP catalog service is not configured.")
+    return _catalog_service
+
+
+def _raise_http_error(exc: Exception) -> None:
+    if isinstance(exc, CatalogAdapterNotFoundError):
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    if isinstance(exc, CatalogAdapterUnavailableError):
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    if isinstance(exc, CatalogAdapterPolicyError):
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if isinstance(exc, MCPSessionNotFoundError):
+        raise HTTPException(status_code=404, detail="MCP 目录会话不存在或已断开。") from exc
+    logger.warning(
+        "MCP catalog operation failed error_type=%s",
+        type(exc).__name__,
+    )
+    raise HTTPException(
+        status_code=500,
+        detail="MCP 目录操作失败，请检查适配器运行状态。",
+    ) from exc
+
+
+@router.get("/api/mcp/catalog/adapters")
+async def list_catalog_adapters() -> dict[str, Any]:
+    return get_mcp_catalog_service().list_adapters()
+
+
+@router.post("/api/mcp/catalog/{project_id}/prepare")
+async def prepare_catalog_adapter(project_id: str) -> dict[str, Any]:
+    try:
+        return await get_mcp_catalog_service().prepare(project_id)
+    except Exception as exc:
+        _raise_http_error(exc)
+        raise
+
+
+@router.put("/api/mcp/catalog/{project_id}/configuration")
+async def configure_catalog_adapter(
+    project_id: str,
+    request: CatalogConfigurationRequest,
+) -> dict[str, Any]:
+    try:
+        return get_mcp_catalog_service().configure(project_id, request)
+    except Exception as exc:
+        _raise_http_error(exc)
+        raise
+
+
+@router.post("/api/mcp/catalog/{project_id}/connect")
+async def connect_catalog_adapter(project_id: str) -> dict[str, Any]:
+    try:
+        return await get_mcp_catalog_service().connect(project_id)
+    except Exception as exc:
+        _raise_http_error(exc)
+        raise
+
+
+@router.delete("/api/mcp/catalog/{project_id}/session")
+async def disconnect_catalog_adapter(project_id: str) -> dict[str, Any]:
+    try:
+        return await get_mcp_catalog_service().disconnect(project_id)
+    except Exception as exc:
+        _raise_http_error(exc)
+        raise
+
+
+@router.post("/api/mcp/catalog/{project_id}/tools/{tool_name}/call")
+async def call_catalog_tool(
+    project_id: str,
+    tool_name: str,
+    request: CatalogToolCallRequest,
+) -> dict[str, Any]:
+    try:
+        return await get_mcp_catalog_service().call_tool(
+            project_id,
+            tool_name,
+            request.arguments,
+        )
+    except Exception as exc:
+        _raise_http_error(exc)
+        raise

--- a/server/tests/test_mcp_catalog.py
+++ b/server/tests/test_mcp_catalog.py
@@ -1,0 +1,344 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from mcp.types import CallToolResult, TextContent, Tool
+
+from server.mcp import catalog
+from server.mcp.catalog import (
+    CATALOG_ADAPTERS,
+    LOCAL_STDIO_ADAPTERS,
+    WAVE_PROJECTS,
+    CatalogAdapterManifest,
+    CatalogConfigurationRequest,
+    MCPCatalogService,
+)
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+class FakeManager:
+    def __init__(self) -> None:
+        self.commands: list[list[str]] = []
+        self.calls: list[tuple[str, str, dict[str, Any]]] = []
+        self.disconnected: list[str] = []
+        self.sessions: set[str] = set()
+
+    async def connect(self, command: list[str]) -> str:
+        self.commands.append(list(command))
+        session_id = f"session-{len(self.commands)}"
+        self.sessions.add(session_id)
+        return session_id
+
+    async def list_tools(self, session_id: str) -> list[Tool]:
+        if session_id not in self.sessions:
+            raise catalog.MCPSessionNotFoundError(session_id)
+        return [Tool(name="echo", description="Echo", inputSchema={})]
+
+    async def call_tool(
+        self,
+        session_id: str,
+        tool_name: str,
+        arguments: dict[str, Any],
+    ) -> CallToolResult:
+        self.calls.append((session_id, tool_name, dict(arguments)))
+        return CallToolResult(
+            content=[TextContent(type="text", text=str(arguments.get("value", "ok")))]
+        )
+
+    async def disconnect(self, session_id: str) -> None:
+        if session_id not in self.sessions:
+            raise catalog.MCPSessionNotFoundError(session_id)
+        self.sessions.remove(session_id)
+        self.disconnected.append(session_id)
+
+
+class FakeInstaller:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.installed: dict[str, dict[str, Any]] = {}
+
+    def install(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(dict(kwargs))
+        result = {
+            "project_id": kwargs["project_id"],
+            "installed": True,
+            "message": "prepared",
+            "metadata": {
+                "project_id": kwargs["project_id"],
+                "install_type": "npm_global",
+                "npm_package": kwargs["server_command"][2],
+                "installed_at": 1.0,
+                "config_path": "C:/private/catalog/config.json",
+                "install_command": "must-not-leak",
+            },
+        }
+        self.installed[kwargs["project_id"]] = result["metadata"]
+        return result
+
+    def get_installed(self, project_id: str) -> dict[str, Any] | None:
+        return self.installed.get(project_id)
+
+
+class FakeRegistry:
+    def __init__(self) -> None:
+        self.registered: list[tuple[str, str]] = []
+        self.unregistered: list[str] = []
+
+    async def register_session_tools(
+        self,
+        *,
+        session_id: str,
+        server_id: str,
+        tools: list[Tool],
+    ) -> None:
+        assert tools
+        self.registered.append((session_id, server_id))
+
+    async def unregister_session(self, session_id: str) -> None:
+        self.unregistered.append(session_id)
+
+
+def make_service(
+    manifests: dict[str, CatalogAdapterManifest] | None = None,
+) -> tuple[MCPCatalogService, FakeManager, FakeInstaller, FakeRegistry]:
+    manager = FakeManager()
+    installer = FakeInstaller()
+    registry = FakeRegistry()
+    service = MCPCatalogService(  # type: ignore[arg-type]
+        manager,
+        installer,
+        registry,
+        manifests=manifests,
+        credential_validator=lambda credential_id: SimpleNamespace(
+            credential_id=credential_id,
+            status="active",
+        ),
+    )
+    return service, manager, installer, registry
+
+
+def test_catalog_freezes_100_projects_and_maps_93_planned_once() -> None:
+    planned = [project for projects in WAVE_PROJECTS.values() for project in projects]
+
+    assert len(CATALOG_ADAPTERS) == 100
+    assert len(LOCAL_STDIO_ADAPTERS) == 7
+    assert len(planned) == 93
+    assert len(set(planned)) == 93
+    assert set(planned).isdisjoint(LOCAL_STDIO_ADAPTERS)
+    assert set(CATALOG_ADAPTERS) == set(planned) | set(LOCAL_STDIO_ADAPTERS)
+    assert {manifest.availability for manifest in CATALOG_ADAPTERS.values()} == {
+        "ready",
+        "planned",
+    }
+
+
+def test_frontend_catalog_ids_match_backend_registry_and_never_submit_commands() -> None:
+    projects_source = (
+        PROJECT_ROOT / "client" / "src" / "data" / "mcpProjects.ts"
+    ).read_text(encoding="utf-8")
+    seed_source = projects_source[
+        projects_source.index("const originalMcpProjectSeeds") :
+        projects_source.index("const originalRequirements")
+    ]
+    frontend_ids = set(
+        re.findall(r'^\s{4}id: "([a-z0-9.-]+)"', seed_source, flags=re.MULTILINE)
+    )
+    card_source = (
+        PROJECT_ROOT / "client" / "src" / "components" / "McpServerCard.tsx"
+    ).read_text(encoding="utf-8")
+
+    assert frontend_ids == set(CATALOG_ADAPTERS)
+    assert not re.search(r"^\s+command:", seed_source, flags=re.MULTILINE)
+    assert 'fetch("/api/mcp/connect"' not in card_source
+    assert 'fetch("/api/mcp/install"' not in card_source
+    assert not re.search(
+        r"body:\s*JSON\.stringify\([^)]*server_command",
+        card_source,
+        flags=re.DOTALL,
+    )
+
+
+def test_planned_adapter_cannot_be_enabled_by_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = CATALOG_ADAPTERS["calculator-mcp"]
+    monkeypatch.setenv(manifest.feature_flag, "true")
+
+    assert manifest.feature_enabled is True
+    assert manifest.executable is False
+    assert not manifest.server_command
+    assert not manifest.endpoint
+
+
+@pytest.mark.asyncio
+async def test_catalog_api_hides_execution_details_and_rejects_planned_connect() -> None:
+    service, _, _, _ = make_service()
+    previous = catalog._catalog_service
+    catalog.configure_mcp_catalog(service)
+    app = FastAPI()
+    app.include_router(catalog.router)
+    try:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://testserver",
+        ) as client:
+            response = await client.get("/api/mcp/catalog/adapters")
+            assert response.status_code == 200
+            payload = response.json()
+            assert payload["total"] == 100
+            assert payload["ready"] == 7
+            assert payload["planned"] == 93
+            serialized = response.text.lower()
+            assert "server_command" not in serialized
+            assert "install_command" not in serialized
+            assert '"endpoint"' not in serialized
+
+            blocked = await client.post(
+                "/api/mcp/catalog/calculator-mcp/connect"
+            )
+            assert blocked.status_code == 409
+            assert "尚未通过生产级适配验收" in blocked.text
+    finally:
+        catalog._catalog_service = previous
+
+
+@pytest.mark.asyncio
+async def test_main_app_registers_catalog_status_endpoint() -> None:
+    from server.main import app
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://testserver",
+    ) as client:
+        response = await client.get("/api/mcp/catalog/adapters")
+
+    assert response.status_code == 200
+    assert response.json()["total"] == 100
+
+
+@pytest.mark.asyncio
+async def test_ready_adapter_uses_server_owned_prepare_connect_call_and_disconnect(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    service, manager, installer, registry = make_service()
+    caplog.set_level("INFO", logger="modelmirror.mcp.catalog")
+
+    prepared = await service.prepare("context7")
+    assert prepared["prepared"] is True
+    assert installer.calls == [
+        {
+            "project_id": "context7",
+            "install_command": "npx ctx7 setup",
+            "server_command": ["npx", "-y", "@upstash/context7-mcp"],
+        }
+    ]
+    assert "config_path" not in prepared["metadata"]
+    assert "install_command" not in prepared["metadata"]
+
+    prepared_again = await service.prepare("context7")
+    assert prepared_again["prepared"] is True
+    assert len(installer.calls) == 1
+
+    connected = await service.connect("context7")
+    assert connected["tools_count"] == 1
+    assert manager.commands == [["npx", "-y", "@upstash/context7-mcp"]]
+    assert registry.registered == [(connected["session_id"], "catalog:context7")]
+    status = next(
+        item
+        for item in service.list_adapters()["adapters"]
+        if item["project_id"] == "context7"
+    )
+    assert status["connected"] is True
+
+    called = await service.call_tool("context7", "echo", {"value": "hello"})
+    assert called["content"][0]["text"] == "hello"
+    assert manager.calls == [(connected["session_id"], "echo", {"value": "hello"})]
+    assert "hello" not in caplog.text
+
+    disconnected = await service.disconnect("context7")
+    assert disconnected == {"ok": True, "project_id": "context7"}
+    assert manager.disconnected == [connected["session_id"]]
+    assert registry.unregistered == [connected["session_id"]]
+
+
+@pytest.mark.asyncio
+async def test_ttl_cleanup_can_forget_catalog_session_mapping() -> None:
+    service, _, _, _ = make_service()
+    connected = await service.connect("context7")
+
+    await service.forget_sessions([connected["session_id"]])
+
+    status = next(
+        item
+        for item in service.list_adapters()["adapters"]
+        if item["project_id"] == "context7"
+    )
+    assert status["connected"] is False
+
+
+def test_configuration_rejects_execution_fields_and_unknown_credential_slots() -> None:
+    manifest = CatalogAdapterManifest(
+        project_id="adapting-example",
+        wave=4,
+        availability="adapting",
+        connection_kind="remote-mcp",
+        risk="medium",
+        required_capabilities=("credential-binding",),
+        limitations=("test",),
+        allowed_settings=("region",),
+        credential_slots=("api_token",),
+    )
+    service, _, _, _ = make_service({manifest.project_id: manifest})
+
+    with pytest.raises(catalog.CatalogAdapterPolicyError, match="不能包含命令"):
+        service.configure(
+            manifest.project_id,
+            CatalogConfigurationRequest(settings={"url": "https://evil.invalid"}),
+        )
+
+    with pytest.raises(catalog.CatalogAdapterPolicyError, match="未声明的字段"):
+        service.configure(
+            manifest.project_id,
+            CatalogConfigurationRequest(
+                settings={"region": "cn"},
+                credential_bindings={"admin_secret": "cred_example"},
+            ),
+        )
+
+    configured = service.configure(
+        manifest.project_id,
+        CatalogConfigurationRequest(
+            settings={"region": "cn"},
+            credential_bindings={"api_token": "cred_example"},
+        ),
+    )
+    assert configured["configured_settings"] == ["region"]
+    assert configured["configured_credential_slots"] == ["api_token"]
+
+
+@pytest.mark.asyncio
+async def test_future_ready_adapter_requires_explicit_tool_policy() -> None:
+    manifest = CatalogAdapterManifest(
+        project_id="future-ready",
+        wave=1,
+        availability="ready",
+        connection_kind="sandboxed-stdio",
+        risk="low",
+        required_capabilities=("sandbox",),
+        limitations=(),
+        server_command=("python", "-m", "example"),
+        enabled_by_default=True,
+    )
+    service, _, _, _ = make_service({manifest.project_id: manifest})
+    await service.connect(manifest.project_id)
+
+    with pytest.raises(catalog.CatalogAdapterPolicyError, match="显式读写"):
+        await service.call_tool(manifest.project_id, "echo", {})


### PR DESCRIPTION
## 范围

- 以已合并的 #87 为 100 项冻结基线：7 项保持可连接，93 项固定映射到第 1–11 批。
- 新增服务端可信适配器清单与目录专用 API，前端不再提交命令、URL、Header、环境变量或工作目录。
- 前端显示 planned / adapting / ready / blocked、连接方式、批次、风险、限制和生产验收门槛。
- 新适配器缺少显式工具策略时 fail-closed；现有 7 项保持原命令与调用体验。
- 不新增条目、自定义连接、OAuth 登录入口或 MCP Builder。

## 验证

- npm.cmd run build：通过。
- Python 最终静态语法解析：通过。
- MCP / Toolset 相关回归：22 passed（最终小幅 Harness 增量由本 PR CI 继续复核）。
- git diff --cached --check：通过。

## 回退

按项目关闭服务端功能开关、断开目录会话并清理沙箱；目录条目和凭据不删除，旧 /api/mcp/* 兼容接口保留。