### PR TITLE
feature: 适配第二批公网 MCP 工具

### DIFF
--- a/client/src/components/McpServerCard.tsx
+++ b/client/src/components/McpServerCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import {
@@ -137,6 +137,7 @@ export default function McpServerCard({
   const [isInstallOpen, setIsInstallOpen] = useState(false);
   const [installState, setInstallState] = useState<InstallState>("checking");
   const [installError, setInstallError] = useState("");
+  const ignoredRestoredSessionRef = useRef<string | null>(null);
 
   const availability = adapterStatus?.availability ?? project.availability;
   const connectionKind = adapterStatus?.connection_kind ?? project.connectionKind;
@@ -203,15 +204,23 @@ export default function McpServerCard({
   }, [canInstall, project.id]);
 
   useEffect(() => {
+    if (!adapterStatus?.connected) {
+      ignoredRestoredSessionRef.current = null;
+      return;
+    }
     if (
-      !adapterStatus?.connected ||
       !restoredSession ||
-      restoredSession.session_id === sessionId
+      restoredSession.session_id === sessionId ||
+      restoredSession.session_id === ignoredRestoredSessionRef.current
     ) return;
     setSessionId(restoredSession.session_id);
     setState("connected");
     setError("");
-    void fetchTools(restoredSession.session_id);
+    void fetchTools(restoredSession.session_id).catch((exc) => {
+      if (ignoredRestoredSessionRef.current === restoredSession.session_id) return;
+      setState("error");
+      setError(exc instanceof Error ? exc.message : "无法恢复 MCP 会话");
+    });
   }, [adapterStatus?.connected, restoredSession, sessionId]);
 
   async function readError(response: Response) {
@@ -225,6 +234,7 @@ export default function McpServerCard({
 
   async function connect() {
     if (!canConnect) return;
+    ignoredRestoredSessionRef.current = null;
     setState("connecting");
     setError("");
     setTools([]);
@@ -254,6 +264,8 @@ export default function McpServerCard({
   }
 
   async function disconnect() {
+    ignoredRestoredSessionRef.current =
+      sessionId ?? restoredSession?.session_id ?? null;
     await fetch(`/api/mcp/catalog/${project.id}/session`, {
       method: "DELETE",
     }).catch(() => undefined);
@@ -509,7 +521,9 @@ export default function McpServerCard({
         </div>
       ) : (
         <div className="relative mt-4 rounded-lg border border-emerald-300/20 bg-emerald-300/[0.07] p-3 text-xs leading-5 text-emerald-50">
-          不需要 OAuth、Token、额外运行时或桌面宿主，可由当前模镜后端以本地 stdio 启动。
+          {wave === 2
+            ? "不需要 OAuth、Token 或用户安装运行时；由独立公网 sidecar 通过固定出口策略提供隔离 stdio 会话。"
+            : "不需要 OAuth、Token、额外运行时或桌面宿主，可由当前模镜后端以本地 stdio 启动。"}
         </div>
       )}
 

--- a/client/src/data/mcpAdaptationPlan.ts
+++ b/client/src/data/mcpAdaptationPlan.ts
@@ -72,6 +72,9 @@ export const mcpCapabilityLabels: Record<string, string> = {
   "resource-limits": "CPU、内存、时限与输出限制",
   "public-remote-policy": "公共远程访问策略",
   "ssrf-protection": "SSRF 与 DNS 重绑定防护",
+  "dns-pinning": "DNS 解析校验与连接地址固定",
+  "redirect-response-limits": "重定向与响应大小限制",
+  "schema-drift-recovery": "上游工具契约漂移恢复",
   "scoped-filesystem": "受控目录授权",
   "artifact-cleanup": "产物清理",
   "encrypted-credential-binding": "加密凭据绑定",
@@ -96,6 +99,14 @@ export const mcpCapabilityLabels: Record<string, string> = {
 export const mcpIsolationLabels: Record<string, string> = {
   disabled: "完全断网",
   "read-only-empty-workspace": "空白只读工作区",
+  "validated-public-https:user-supplied-host": "用户指定公网 HTTPS；逐跳校验 DNS 与重定向",
+  "allowlist:quickchart.io": "仅允许 quickchart.io",
+  "allowlist:www.airbnb.com,photon.komoot.io,nominatim.openstreetmap.org":
+    "仅允许 Airbnb、Photon 与 Nominatim",
+  "allowlist:nominatim.openstreetmap.org,router.project-osrm.org":
+    "仅允许 Nominatim 与公共 OSRM",
+  "blocked:authentication-required": "已阻断：上游要求账号授权",
+  "blocked:upstream-schema-drift": "已阻断：上游公开数据契约漂移",
 };
 
 export function formatMcpCapability(capability: string) {
@@ -165,10 +176,18 @@ const waveMetadata: Record<
     ],
   },
   2: {
-    connectionKind: "remote-mcp",
+    connectionKind: "sandboxed-stdio",
     risk: "medium",
-    requiredCapabilities: ["公共远程策略", "SSRF 防护"],
-    limitations: ["等待公网目标、DNS、重定向和响应大小策略验证。"],
+    requiredCapabilities: [
+      "公共远程访问策略",
+      "SSRF 与 DNS 重绑定防护",
+      "DNS 连接地址固定",
+      "重定向与响应大小限制",
+    ],
+    limitations: [
+      "公网适配器在独立非 root、只读 sidecar 中运行；不接受浏览器提交命令、端点、Header 或环境变量。",
+      "每次请求与重定向都会重新校验公网 HTTPS 目标，固定超时、响应和工具输出上限。",
+    ],
   },
   3: {
     connectionKind: "sandboxed-stdio",
@@ -245,11 +264,35 @@ function buildAdaptationPlan() {
       if (records[projectId]) throw new Error(`重复的 MCP 适配计划：${projectId}`);
       records[projectId] = {
         wave,
-        availability: wave === 1 ? "ready" : "planned",
-        connectionKind: metadata.connectionKind,
+        availability:
+          projectId === "bibigpt-mcp" || projectId === "airbnb-mcp"
+            ? "blocked"
+            : wave <= 2
+              ? "ready"
+              : "planned",
+        connectionKind:
+          projectId === "bibigpt-mcp"
+            ? "remote-mcp"
+            : metadata.connectionKind,
         risk: metadata.risk,
-        requiredCapabilities: [...metadata.requiredCapabilities],
-        limitations: [...metadata.limitations],
+        requiredCapabilities:
+          projectId === "bibigpt-mcp"
+            ? ["OAuth PKCE", "授权撤销与解绑", "最小 Scope 审核"]
+            : projectId === "airbnb-mcp"
+              ? ["公共远程访问策略", "SSRF 防护", "上游工具契约漂移恢复"]
+            : [...metadata.requiredCapabilities],
+        limitations:
+          projectId === "bibigpt-mcp"
+            ? [
+                "上游远程 MCP 现在要求 OAuth 2.1 或 API Key 才能执行工具，不满足本批无凭据门槛。",
+                "已转入第 10 批 OAuth 适配；在服务端授权、撤销与解绑通过前不展示外站登录入口。",
+              ]
+            : projectId === "airbnb-mcp"
+              ? [
+                  "Airbnb 0.3.0 当前公开搜索页缺少上游适配器固定依赖的数据节点，代表调用触发 schema 漂移阻断。",
+                  "在上游恢复稳定公开契约并重新通过 robots.txt 与 smoke 前，不提供连接或绕过入口。",
+                ]
+            : [...metadata.limitations],
       };
     }
   }

--- a/client/src/data/mcpProjects.ts
+++ b/client/src/data/mcpProjects.ts
@@ -436,7 +436,7 @@ const originalMcpProjectSeeds: McpProjectSeed[] = [
     repoUrl: "https://github.com/JimmyLv/bibigpt-skill",
     category: "多媒体",
     description:
-      "通过远程 MCP 总结 YouTube、Bilibili、TikTok 等平台的视频、音频和播客。",
+      "通过远程 MCP 总结 YouTube、Bilibili、TikTok 等平台的视频、音频和播客；当前上游调用需要账号授权。",
     readmeSummary:
       "面向中文内容消费的远程 MCP 与 Skill 组合，适合长视频、播客和音频摘要。",
     stars: 0,
@@ -444,7 +444,7 @@ const originalMcpProjectSeeds: McpProjectSeed[] = [
     verifiedAt: "2026-08-02",
     installMode: "manual",
     installCommand: "远程端点：https://bibigpt.co/api/mcp",
-    installNote: "当前模镜只连接本地 stdio Server，远程端点需在支持 Streamable HTTP 的宿主中添加。",
+    installNote: "上游当前要求 OAuth 2.1 或 API Key；已转入第 10 批授权适配，本批不提供登录入口。",
     tags: ["视频总结", "Bilibili", "远程 MCP"],
   },
   {
@@ -1204,7 +1204,7 @@ const expandedMcpProjectSeeds: McpProjectSeed[] = [
     repoUrl: "https://github.com/GongRzhe/Quickchart-MCP-Server",
     category: "数据分析",
     description: "根据数据与图表配置生成可分享的图表图像。",
-    readmeSummary: "社区 MCP Server，使用 QuickChart 服务快速生成多种 Chart.js 图表。",
+    readmeSummary: "社区 MCP Server，使用 QuickChart 服务生成 Chart.js 图表；上游仓库已归档，模镜固定兼容 1.0.6 的受控子集。",
     language: "Python",
     tags: ["QuickChart", "Chart.js", "图表生成"],
     requirements: ["external-runtime", "remote-transport"],
@@ -1662,8 +1662,8 @@ const expandedMcpProjectSeeds: McpProjectSeed[] = [
   plannedMcp({
     id: "fetch-mcp",
     name: "Fetch MCP",
-    repoName: "modelcontextprotocol/servers-archived",
-    repoUrl: "https://github.com/modelcontextprotocol/servers-archived/tree/main/src/fetch",
+    repoName: "modelcontextprotocol/servers",
+    repoUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/fetch",
     category: "通用工具",
     description: "获取公开 URL 内容并转换为适合语言模型阅读的文本。",
     readmeSummary: "MCP 官方归档 Python 参考实现，提供受 robots.txt 约束的网页获取工具。",
@@ -1703,7 +1703,7 @@ const originalRequirements: Partial<Record<string, McpRequirement[]>> = {
   "grafana-mcp": ["token", "account-binding", "remote-transport"],
   "notion-mcp-server": ["token", "account-binding", "remote-transport"],
   "blender-mcp": ["desktop-host", "external-runtime", "system-permission"],
-  "bibigpt-mcp": ["remote-transport"],
+  "bibigpt-mcp": ["oauth", "token", "account-binding", "remote-transport"],
   "mcp-cn-commerce": ["token", "account-binding", "remote-transport"],
   chatcrystal: ["desktop-host", "system-permission"],
   "zotero-mcp": ["desktop-host", "token", "account-binding"],
@@ -1718,6 +1718,7 @@ function normalizeMcpProject(seed: McpProjectSeed): McpProject {
     isReady && adaptation.connectionKind === "local-stdio";
   const isBundledSandbox =
     isReady && adaptation.connectionKind === "sandboxed-stdio";
+  const isPublicSandbox = isBundledSandbox && adaptation.wave === 2;
   const requirements = isReady
     ? []
     : (seed.requirements ?? originalRequirements[seed.id] ?? ["external-runtime"]);
@@ -1730,11 +1731,15 @@ function normalizeMcpProject(seed: McpProjectSeed): McpProject {
     installMode: isLocalStdio ? "one-click" : "manual",
     installCommand: isLocalStdio
       ? seed.installCommand
-      : isBundledSandbox
-        ? "内置隔离适配器由服务端固定部署，无需安装命令。"
+      : isPublicSandbox
+        ? "内置公网适配器由服务端固定部署，不接受自定义命令、端点或 Header。"
+        : isBundledSandbox
+          ? "内置隔离适配器由服务端固定部署，无需安装命令。"
         : "当前版本仅收录资料，不提供本地 stdio 安装或外站认证入口。",
-    installNote: isBundledSandbox
-      ? "适配器随断网 Python 沙箱镜像固定部署；浏览器不会提交命令、目录或环境变量。"
+    installNote: isPublicSandbox
+      ? "适配器在独立非 root、只读公网 sidecar 中运行；出口域名、DNS、重定向、超时和响应大小均由服务端控制。"
+      : isBundledSandbox
+        ? "适配器随断网 Python 沙箱镜像固定部署；浏览器不会提交命令、目录或环境变量。"
       : seed.installNote,
     availability: adaptation.availability,
     connectionKind: adaptation.connectionKind,
@@ -1751,7 +1756,13 @@ function normalizeMcpProject(seed: McpProjectSeed): McpProject {
             "安装完成后点击“连接 Server”，后端会在 MCP 沙盒目录启动进程。",
             "连接成功后展开工具表单，确认参数范围再执行；随时可以断开连接。",
           ]
-        : isBundledSandbox
+        : isPublicSandbox
+          ? [
+              "无需安装 npm、Python 包或外部运行时；点击“连接 Server”启动服务端固定适配器。",
+              "Fetch 仅访问用户明确提供的公网 HTTPS；其他项目只访问卡片列出的固定公共域名，每次重定向都会重新校验。",
+              "调用受超时、robots.txt、速率、响应大小和只读工具策略限制；被策略拒绝时不会回退到不受控连接。",
+            ]
+          : isBundledSandbox
           ? [
               "无需安装 Python、uv、npm 或上游包；点击“连接 Server”即可启动受控适配器。",
               "每次连接都在断网、非 root、只读文件系统的临时沙箱内运行，结束后自动清理。",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,47 @@ services:
       retries: 5
       start_period: 10s
 
+  mcp-public:
+    build:
+      context: ./server/sandbox_sidecar
+    container_name: modelmirror-mcp-public
+    command: ["python", "-m", "sandbox_sidecar.public_server"]
+    networks:
+      - mcp_public_egress
+    environment:
+      MCP_PUBLIC_MAX_SESSIONS: "6"
+      MCP_PUBLIC_SOCKET_PATH: /run/modelmirror-public-mcp/public-mcp.sock
+      MCP_PUBLIC_WORKSPACE_ROOT: /workspaces
+      # Docker Desktop/VPN DNS may map public hosts into RFC 2544 Fake-IP space.
+      # Literal IP URLs and every other non-global range remain denied.
+      MCP_PUBLIC_ALLOW_SYNTHETIC_DNS: "true"
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    pids_limit: 128
+    mem_limit: 512m
+    cpus: 1.0
+    tmpfs:
+      - /tmp:rw,nosuid,noexec,size=64m,uid=65532,gid=65532,mode=0700
+      - /workspaces:rw,nosuid,noexec,size=128m,uid=65532,gid=65532,mode=0700
+    volumes:
+      - mcp_public_socket:/run/modelmirror-public-mcp
+    restart: unless-stopped
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import json,socket; s=socket.socket(socket.AF_UNIX); s.connect('/run/modelmirror-public-mcp/public-mcp.sock'); s.sendall(b'{\"action\":\"health\"}\\n'); assert json.loads(s.recv(4096))['ok']",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
   omniroute:
     image: diegosouzapw/omniroute:3.8.48@sha256:badb560971fdc23c2fb84b3e8695116239ff215b4cca4b07076201a8efae7f0d
     container_name: modelmirror-omniroute
@@ -144,6 +185,8 @@ services:
         condition: service_healthy
       sandbox:
         condition: service_healthy
+      mcp-public:
+        condition: service_healthy
       new-api:
         condition: service_healthy
     env_file:
@@ -179,6 +222,7 @@ services:
       GOAL_COORDINATOR_ENABLED: "true"
       SANDBOX_SOCKET_PATH: /run/modelmirror-sandbox/sandbox.sock
       SANDBOX_WORKSPACE_ROOT: /app/sandbox-workspaces
+      MCP_PUBLIC_SOCKET_PATH: /run/modelmirror-public-mcp/public-mcp.sock
       BROWSER_SOCKET_PATH: /run/modelmirror-browser/browser.sock
       BROWSER_DATA_ROOT: /app/browser-data
       CODING_AGENT_ENABLED: ${CODING_AGENT_ENABLED:-false}
@@ -198,6 +242,7 @@ services:
       - ${MODELMIRROR_DATA_ROOT:-.}/server/world/storage:/app/world/storage
       - sandbox_socket:/run/modelmirror-sandbox
       - sandbox_workspaces:/app/sandbox-workspaces:ro
+      - mcp_public_socket:/run/modelmirror-public-mcp
       - browser_socket:/run/modelmirror-browser
       - browser_data:/app/browser-data:ro
       - coding_socket:/run/modelmirror-coding
@@ -348,6 +393,7 @@ volumes:
   omniroute-data:
   sandbox_socket:
   sandbox_workspaces:
+  mcp_public_socket:
   browser_socket:
   browser_data:
   coding_socket:
@@ -358,3 +404,5 @@ networks:
   coding_internal:
     driver: bridge
     internal: true
+  mcp_public_egress:
+    driver: bridge

--- a/docs/MCP_CATALOG_ROADMAP.md
+++ b/docs/MCP_CATALOG_ROADMAP.md
@@ -15,16 +15,17 @@
 - [Awesome-MCP-ZH](https://github.com/yzfly/Awesome-MCP-ZH)
 - [awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers)
 
-截至 2026-08-05，目录仍冻结为 100 个 MCP 条目、18 个分类。批次 0 的 7 个 Node stdio Server 与批次 1 的 3 个隔离 Python 适配器已标记为 `ready`；其余 90 个条目继续保持 `planned`。
+截至 2026-08-05，目录仍冻结为 100 个 MCP 条目、18 个分类。批次 0 的 7 个 Node stdio Server、批次 1 的 3 个断网计算适配器，以及批次 2 的 Fetch、QuickChart、GeoWire 已标记为 `ready`；Airbnb 与 BibiGPT 标记为 `blocked`，其余 85 个条目保持 `planned`。当前状态合计为 13 ready / 85 planned / 2 blocked。
 
 ## 2. 当前边界与明确不实现
 
-批次 1 只增加三个固定、断网的内置计算适配器，不扩大授权、远程访问或任意执行能力：
+批次 1—2 只增加固定的内置兼容适配器：批次 1 使用完全断网计算 sidecar，批次 2 使用独立公网 sidecar。两批都不扩大账号授权、任意连接或任意执行能力：
 
 - 不接受用户指定的 Python 包、解释器、命令、工作目录或其他额外运行时。
 - 不实现 OAuth 回调、Token / API Key 输入、保存、刷新或注入。
 - 不打开外站认证登录页，也不提供认证按钮或深链。
-- 不连接 Streamable HTTP、SSE 等远程 MCP 端点。
+- 不把 Streamable HTTP、SSE 或任意 MCP URL 暴露为目录配置；批次 2 仅由固定 stdio 适配器访问受控公共 HTTPS 服务。
+- Fetch 的用户 URL 只是工具参数，只允许公网 HTTPS，并逐次执行 DNS、SSRF、重定向和响应大小校验；它不是自定义 MCP 连接入口。
 - 不接管 Blender、Zotero、Obsidian、JetBrains、Xcode、Ghidra 等桌面宿主。
 - 不提供用户自定义 MCP 连接。
 - 不提供 MCP Builder、可视化生成器或发布市场流程。
@@ -44,7 +45,7 @@
 数据层必须满足以下约束：
 
 1. 前端条目不得包含可执行 `command`、MCP URL、Header 或环境变量配置。
-2. `ready` 后端适配器必须有固定命令或端点、独立功能开关和显式工具策略；现有 7 项以兼容策略保持行为不变，批次 1 的 3 项使用完整的逐工具策略。
+2. `ready` 后端适配器必须有固定命令或端点、独立功能开关和显式工具策略；现有 7 项以兼容策略保持行为不变，批次 1—2 的 6 项使用完整的逐工具策略。
 3. `planned` 后端适配器不得包含可执行命令或端点，环境开关不能绕过状态门禁。
 4. 前端不得保存真实 Secret，也不得在仓库内出现真实凭证。
 5. 上游清单只用于发现项目；能否连接必须按模镜运行边界重新核验。
@@ -74,7 +75,7 @@
 | --- | --- | ---: | --- |
 | 0 | 现有 Node stdio 基线与适配 Harness | 7 | 100 项契约、服务端清单、功能开关、状态 API、现有行为回归 |
 | 1 | `calculator-mcp`、`time-mcp`、`vegalite-mcp` | 3 | **已实现**：非 root Python 沙箱、默认断网、只读文件、CPU/内存/时间/输出上限 |
-| 2 | `bibigpt-mcp`、`fetch-mcp`、`quickchart-mcp`、`airbnb-mcp`、`geowire-mcp` | 5 | 公网目标、DNS 重绑定、SSRF、重定向与响应大小验证 |
+| 2 | `bibigpt-mcp`、`fetch-mcp`、`quickchart-mcp`、`airbnb-mcp`、`geowire-mcp` | 5 | **已完成门槛判定**：Fetch、QuickChart、GeoWire 可用；BibiGPT 因 OAuth、Airbnb 因上游 schema 漂移受阻 |
 | 3 | `basic-memory-mcp`、`excel-mcp-server`、`git-mcp`、`manim-mcp`、`markitdown-mcp` | 5 | 目录授权、路径越界与符号链接防护、产物清理 |
 | 4 | AgentQL、Brave、Exa、Firecrawl、Perplexity、Tavily、Axiom、Figma Context、Google Maps、Grafana、Graphlit、Kagi、Pinecone、Shodan、Snyk、VirusTotal | 16 | 加密凭据槽、固定出口域、只读工具清单、Secret 泄漏测试 |
 | 5 | DBHub、PostgreSQL、MongoDB、ClickHouse、Cognee、Graphiti、Hindsight、Redis、SQLite、DuckDB、Supabase | 11 | 只读账号、TLS、查询超时、行数限制、写入审批 |
@@ -86,6 +87,14 @@
 | 11 | 小红书、Ableton、Binary Ninja、Blender、Ghidra、JetBrains、ChatCrystal、Obsidian、OpenTabs、Zotero、Docker、Mobile、XcodeBuild | 13 | 版本化本机桥接、宿主校验、逐应用与目录授权 |
 
 每批在前一批验收完成后单独建分支和 PR；批内可以逐项开启功能开关，但不能绕过整批共享的安全门槛。
+
+批次 2 的执行结论：
+
+- `fetch-mcp` 固定兼容上游 0.6.3，只允许公网 HTTPS，遵守 robots.txt；每次 DNS 与重定向都重新校验并固定连接地址。
+- `quickchart-mcp` 固定兼容上游 1.0.6，仅开放 `generate_chart`；拒绝远程引用和脚本回调，本批不开放本地文件下载。
+- `geowire-mcp` 固定兼容上游 0.6.2，只开放无需 Key 的 Nominatim / OSRM 子集；Nominatim 固定每秒最多 1 次，OSRM 仅开放受限驾车查询。
+- `bibigpt-mcp` 的上游远程 MCP 现在要求 OAuth 2.1 或 API Key，转入第 10 批授权适配；当前不展示登录入口。
+- `airbnb-mcp` 0.3.0 的公开搜索页数据节点发生漂移，代表调用失败；在上游恢复稳定契约并重新通过 smoke 前保持不可连接。
 
 ## 6. 验收、发布和回退
 
@@ -105,10 +114,11 @@
 
 主要风险是上游项目快速变化、条目说明过期，以及把“已收录”误解为“当前可安全运行”。前端必须持续使用明确的状态标签和禁用按钮表达边界。
 
-批次 0—1 不引入数据库迁移。批次 1 回退时关闭三个 `MCP_CATALOG_ENABLE_*` 开关、断开目录会话并停止 sandbox sidecar，再恢复以下适配器、展示与文档文件；旧版 `/api/mcp/*` 接口保持兼容：
+批次 0—2 不引入数据库迁移。批次 2 回退时关闭 `MCP_CATALOG_ENABLE_FETCH_MCP`、`MCP_CATALOG_ENABLE_QUICKCHART_MCP`、`MCP_CATALOG_ENABLE_GEOWIRE_MCP`，断开目录会话并停止 `mcp-public` sidecar；Airbnb 与 BibiGPT 本来就不可执行。旧版 `/api/mcp/*` 接口保持兼容：
 
 - `server/mcp/catalog.py`
 - `server/mcp/sandbox_proxy.py`
+- `server/mcp/public_proxy.py`
 - `server/sandbox_sidecar/`
 - `client/src/data/mcpProjects.ts`
 - `client/src/data/mcpAdaptationPlan.ts`

--- a/docs/MCP_INTEGRATION.md
+++ b/docs/MCP_INTEGRATION.md
@@ -82,7 +82,7 @@ Agent 画布使用 `toolset_resource -> workflow_agent` 的 `toolset` 绑定边�
 目录适配器安全默认值：
 
 - 前端不能提交 `server_command`、MCP URL、Header、环境变量名或工作目录。
-- 90 个待适配项目没有后端命令或端点；设置环境功能开关也不能使其可执行。
+- 当前目录状态为 13 ready / 85 planned / 2 blocked；planned 与 blocked 项没有可执行命令或端点，设置环境功能开关也不能绕过状态门槛。
 - 新适配器若没有显式工具读写与审批策略，工具调用会 fail-closed。
 - 日志只记录项目 ID、工具名、状态和耗时，不记录参数、返回正文或 Secret。
 
@@ -92,6 +92,16 @@ Agent 画布使用 `toolset_resource -> workflow_agent` 的 `toolset` 绑定边�
 - sidecar 固定为 `network_mode: none`、只读容器、UID/GID 65532、丢弃全部 capabilities 且启用 `no-new-privileges`。
 - 每个 MCP 子进程再使用 Landlock 只读规则与 RLIMIT CPU、内存、文件及句柄限制；sidecar 由 cgroup 限制为 128 PIDs 和最多 6 个并发会话，调用超时 10 秒，返回上限 128 KiB。
 - Vega-Lite 数据只保存在当前进程内存，拒绝远程 URL，连接结束后随临时进程和空白工作区一起清理。
+
+批次 2 的三个可用公网适配器通过固定 `public_proxy.py` 接入独立 `mcp-public` sidecar：
+
+- `fetch-mcp`、`quickchart-mcp`、`geowire-mcp` 只运行仓库内置 Python 兼容实现，不动态下载或执行上游代码。
+- sidecar 非 root、只读根文件系统、丢弃全部 capabilities、启用 `no-new-privileges`，并使用独立 bridge 网络和 Unix socket；不挂载宿主文件或 Docker socket。
+- 公网 HTTPS 请求先解析 DNS，拒绝 IP 字面量和私网、回环、链路本地及保留地址，再把连接固定到已验证地址并保留原域名 TLS 校验；每次重定向重复全部校验。
+- Docker Desktop/VPN 的 RFC 2544 Fake-IP 兼容默认关闭，仅由 Compose 为公网 sidecar 显式开启 `198.18.0.0/15`；其他非公网地址仍拒绝。
+- 单跳请求超时 12 秒、最多重定向 3 次、原始响应最多 2 MiB、工具输出最多 128 KiB；Nominatim 固定为每秒最多 1 次。
+- Fetch 只接受公网 HTTPS 工具参数并遵守 robots.txt；QuickChart 只生成受控 URL，不写文件；GeoWire 只开放无 Key 的 OSM/OSRM 子集。
+- BibiGPT 因 OAuth / API Key 要求保持 `blocked`；Airbnb 因上游公开页面 schema 漂移保持 `blocked`，两者都没有命令、端点或登录入口。
 
 兼容层仍保留以下默认值：
 
@@ -373,7 +383,11 @@ python server/mcp/test_manager.py
 | `server/mcp/manager.py` | MCPClientManager，负责 Stdio、Streamable HTTP 与旧 SSE session 生命周期。 |
 | `server/mcp/catalog.py` | 冻结目录、固定适配器、功能开关、配置门禁和目录 API。 |
 | `server/mcp/sandbox_proxy.py` | 把固定项目 ID 的 stdio 流代理到断网 sandbox sidecar。 |
+| `server/mcp/public_proxy.py` | 把批次 2 固定项目 ID 的 stdio 流代理到公网策略 sidecar。 |
 | `server/sandbox_sidecar/compute_mcp.py` | 批次 1 的三个内置 Python MCP 工具契约。 |
+| `server/sandbox_sidecar/public_mcp.py` | 批次 2 的内置公网 MCP 兼容契约。 |
+| `server/sandbox_sidecar/safe_http.py` | 公网 HTTPS、DNS 固定、SSRF、重定向与响应上限策略。 |
+| `server/sandbox_sidecar/public_server.py` | 公网 MCP 子进程的非 root、只读 Unix-socket sidecar。 |
 | `server/toolsets/` | Toolset/凭据 Store、版本发布、Schema 漂移与固定版本 Provider。 |
 | `client/src/pages/ToolsetsPage.tsx` | MCP Toolset 创建、连接、工具配置、测试和发布管理页。 |
 | `server/tests/test_toolset_*.py` | Toolset Store、API、连接、固定版本与安全回归。 |
@@ -384,6 +398,7 @@ python server/mcp/test_manager.py
 | `server/tests/test_mcp_multisession.py` | 多 session、TTL 与 ToolRegistry 集成测试。 |
 | `server/tests/test_mcp_catalog.py` | 100 项契约、前后端 ID、服务端配置来源与 fail-closed 测试。 |
 | `server/tests/test_mcp_compute_adapters.py` | 批次 1 工具契约、输入上限、URL 拒绝与沙箱配置测试。 |
+| `server/tests/test_mcp_public_adapters.py` | 批次 2 SSRF、DNS、robots、响应上限、工具契约与容器隔离测试。 |
 | `client/src/components/McpServerCard.tsx` | 前端连接、工具表单、执行结果组件。 |
 | `client/src/data/mcpProjects.ts` | MCP 中文展示资料；不能作为执行配置来源。 |
 | `client/src/data/mcpAdaptationPlan.ts` | 前端批次、状态、连接形态和风险展示。 |

--- a/server/mcp/catalog.py
+++ b/server/mcp/catalog.py
@@ -188,6 +188,10 @@ SANDBOX_PROXY = (
     sys.executable,
     str(Path(__file__).resolve().with_name("sandbox_proxy.py")),
 )
+PUBLIC_SANDBOX_PROXY = (
+    sys.executable,
+    str(Path(__file__).resolve().with_name("public_proxy.py")),
+)
 WAVE_ONE_ADAPTERS: dict[str, tuple[str, tuple[str, ...]]] = {
     "calculator-mcp": (
         "0.2.1-compatible-python-v1",
@@ -200,6 +204,31 @@ WAVE_ONE_ADAPTERS: dict[str, tuple[str, tuple[str, ...]]] = {
     "vegalite-mcp": (
         "0.0.1-compatible-python-v1",
         ("save_data", "visualize_data"),
+    ),
+}
+
+WAVE_TWO_ADAPTERS: dict[str, tuple[str, tuple[str, ...], str]] = {
+    "fetch-mcp": (
+        "0.6.3-secure-compatible-v1",
+        ("fetch",),
+        "validated-public-https:user-supplied-host",
+    ),
+    "quickchart-mcp": (
+        "1.0.6-secure-compatible-v1",
+        ("generate_chart",),
+        "allowlist:quickchart.io",
+    ),
+    "geowire-mcp": (
+        "0.6.2-secure-compatible-v1",
+        (
+            "search_places",
+            "geocode_address",
+            "reverse_geocode",
+            "get_directions",
+            "distance_matrix",
+            "list_geo_providers",
+        ),
+        "allowlist:nominatim.openstreetmap.org,router.project-osrm.org",
     ),
 }
 
@@ -442,6 +471,102 @@ def build_catalog_manifests() -> dict[str, CatalogAdapterManifest]:
             operation_timeout=10.0,
             max_output_bytes=128 * 1024,
         )
+
+    for project_id, (
+        adapter_version,
+        tool_names,
+        network_policy,
+    ) in WAVE_TWO_ADAPTERS.items():
+        project_limitations = {
+            "fetch-mcp": (
+                "仅允许用户明确提供的公网 HTTPS URL；每次请求和重定向都会重新执行 DNS 与 SSRF 校验。",
+                "固定遵守 robots.txt；最多重定向 3 次，原始响应不超过 1 MiB，工具返回不超过 128 KiB。",
+            ),
+            "quickchart-mcp": (
+                "仅生成 quickchart.io 的受控 Chart.js 图表 URL；拒绝远程引用、脚本回调和超大配置。",
+                "本批关闭上游 download_chart，本地文件写入将在文件处理批次单独适配。",
+            ),
+            "geowire-mcp": (
+                "仅开放无需 Key 的 Nominatim 与公共 OSRM 子集，并保留 OpenStreetMap 来源标注。",
+                "Nominatim 固定为每秒最多 1 次；公共 OSRM 仅开放驾车模式和受限坐标数量。",
+            ),
+        }[project_id]
+        manifests[project_id] = CatalogAdapterManifest(
+            project_id=project_id,
+            wave=2,
+            availability="ready",
+            connection_kind="sandboxed-stdio",
+            risk="medium",
+            required_capabilities=(
+                "public-remote-policy",
+                "ssrf-protection",
+                "dns-pinning",
+                "redirect-response-limits",
+            ),
+            limitations=project_limitations,
+            adapter_version=adapter_version,
+            runtime_image="modelmirror-sandbox:wave2-public-v1",
+            network_policy=network_policy,
+            filesystem_policy="read-only-empty-workspace",
+            resource_limits=(
+                ("cpu", "1 core / 60 CPU seconds per session"),
+                ("memory", "256 MiB per process / 512 MiB sidecar"),
+                ("processes", "maximum 6 sessions / 128 sidecar PIDs"),
+                ("request_timeout", "12 seconds per HTTPS hop"),
+                ("operation_timeout", "45 seconds"),
+                ("redirects", "maximum 3, revalidated each hop"),
+                ("raw_response", "maximum 2 MiB"),
+                ("tool_output", "128 KiB"),
+            ),
+            server_command=(*PUBLIC_SANDBOX_PROXY, project_id),
+            preparation_kind="bundled",
+            tool_policies={
+                name: CatalogToolPolicy(read_only=True)
+                for name in tool_names
+            },
+            enabled_by_default=True,
+            operation_timeout=45.0,
+            max_output_bytes=128 * 1024,
+        )
+
+    manifests["bibigpt-mcp"] = CatalogAdapterManifest(
+        project_id="bibigpt-mcp",
+        wave=2,
+        availability="blocked",
+        connection_kind="remote-mcp",
+        risk="medium",
+        required_capabilities=(
+            "oauth-pkce",
+            "oauth-revocation",
+            "scope-review",
+        ),
+        limitations=(
+            "上游远程 MCP 当前要求 OAuth 2.1 或 API Key 才能执行工具，不再满足本批无凭据门槛。",
+            "已转入第 10 批 OAuth 适配；完成服务端 PKCE、撤销、解绑与最小 scope 前不提供登录或连接入口。",
+        ),
+        network_policy="blocked:authentication-required",
+        filesystem_policy="not-applicable",
+    )
+
+    manifests["airbnb-mcp"] = CatalogAdapterManifest(
+        project_id="airbnb-mcp",
+        wave=2,
+        availability="blocked",
+        connection_kind="sandboxed-stdio",
+        risk="medium",
+        required_capabilities=(
+            "public-remote-policy",
+            "ssrf-protection",
+            "schema-drift-recovery",
+        ),
+        limitations=(
+            "Airbnb 0.3.0 当前公开搜索页未返回其固定依赖的数据节点，代表调用触发工具契约漂移阻断。",
+            "在上游恢复稳定公开契约并重新通过 robots.txt、代表调用和回归 smoke 前，不提供连接或绕过入口。",
+        ),
+        adapter_version="0.3.0-blocked-schema-drift",
+        network_policy="blocked:upstream-schema-drift",
+        filesystem_policy="read-only-empty-workspace",
+    )
 
     for wave, project_ids in WAVE_PROJECTS.items():
         connection_kind, risk, capabilities, limitations = WAVE_METADATA[wave]

--- a/server/mcp/public_proxy.py
+++ b/server/mcp/public_proxy.py
@@ -1,0 +1,99 @@
+"""Fixed stdio proxy for reviewed public-network catalog adapters."""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import sys
+import threading
+from pathlib import Path
+
+
+ALLOWED_ADAPTERS = {
+    "fetch-mcp",
+    "quickchart-mcp",
+    "geowire-mcp",
+}
+SOCKET_PATH = Path(
+    os.getenv(
+        "MCP_PUBLIC_SOCKET_PATH",
+        "/run/modelmirror-public-mcp/public-mcp.sock",
+    )
+)
+HANDSHAKE_LIMIT = 4096
+
+
+def _copy_stdin(sock: socket.socket) -> None:
+    try:
+        while True:
+            chunk = os.read(sys.stdin.fileno(), 64 * 1024)
+            if not chunk:
+                break
+            sock.sendall(chunk)
+    except (BrokenPipeError, ConnectionError, OSError):
+        pass
+    finally:
+        try:
+            sock.shutdown(socket.SHUT_WR)
+        except OSError:
+            pass
+
+
+def run(adapter_id: str) -> int:
+    if adapter_id not in ALLOWED_ADAPTERS:
+        print("MCP public adapter is not allowed.", file=sys.stderr)
+        return 64
+    if not SOCKET_PATH.is_absolute():
+        print("MCP public socket path must be absolute.", file=sys.stderr)
+        return 78
+
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        sock.settimeout(10)
+        sock.connect(str(SOCKET_PATH))
+        request = json.dumps(
+            {"action": "mcp_stdio", "adapter_id": adapter_id},
+            separators=(",", ":"),
+        ).encode("utf-8")
+        sock.sendall(request + b"\n")
+        handshake_file = sock.makefile("rb", buffering=0)
+        raw = handshake_file.readline(HANDSHAKE_LIMIT + 1)
+        if not raw or len(raw) > HANDSHAKE_LIMIT:
+            print("MCP public sidecar handshake failed.", file=sys.stderr)
+            return 69
+        response = json.loads(raw.decode("utf-8"))
+        if not isinstance(response, dict) or response.get("ok") is not True:
+            code = str(response.get("code") or "public_sidecar_unavailable")
+            print(f"MCP public sidecar rejected the session: {code}", file=sys.stderr)
+            return 69
+
+        sock.settimeout(None)
+        input_thread = threading.Thread(target=_copy_stdin, args=(sock,), daemon=True)
+        input_thread.start()
+        while True:
+            chunk = sock.recv(64 * 1024)
+            if not chunk:
+                break
+            sys.stdout.buffer.write(chunk)
+            sys.stdout.buffer.flush()
+        return 0
+    except (ConnectionError, OSError, ValueError, json.JSONDecodeError) as exc:
+        print(
+            f"MCP public proxy unavailable: {type(exc).__name__}",
+            file=sys.stderr,
+        )
+        return 69
+    finally:
+        sock.close()
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: public_proxy.py ADAPTER_ID", file=sys.stderr)
+        return 64
+    return run(sys.argv[1].strip())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/server/mcp/smoke_public_adapters.py
+++ b/server/mcp/smoke_public_adapters.py
@@ -1,0 +1,144 @@
+"""Docker smoke harness for wave-2 public-network catalog adapters."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from server.mcp.manager import MCPClientManager
+
+
+PROXY_PATH = Path(__file__).resolve().with_name("public_proxy.py")
+EXPECTED_TOOLS = {
+    "fetch-mcp": {"fetch"},
+    "quickchart-mcp": {"generate_chart"},
+    "geowire-mcp": {
+        "search_places",
+        "geocode_address",
+        "reverse_geocode",
+        "get_directions",
+        "distance_matrix",
+        "list_geo_providers",
+    },
+}
+
+
+def _command(project_id: str) -> list[str]:
+    return [sys.executable, str(PROXY_PATH), project_id]
+
+
+def _representative_call(project_id: str) -> tuple[str, dict[str, Any]]:
+    if project_id == "fetch-mcp":
+        return "fetch", {
+            "url": "https://example.com/",
+            "max_length": 1_000,
+        }
+    if project_id == "quickchart-mcp":
+        return "generate_chart", {
+            "type": "bar",
+            "labels": ["A", "B"],
+            "datasets": [{"label": "smoke", "data": [1, 2]}],
+        }
+    return "geocode_address", {
+        "address": "Eiffel Tower, Paris",
+        "limit": 1,
+    }
+
+
+async def _connect_and_exercise(
+    manager: MCPClientManager,
+    project_id: str,
+) -> tuple[dict[str, Any], str]:
+    session_id = await manager.connect_profile(
+        transport="stdio",
+        server_command=_command(project_id),
+        network_policy="catalog-public-policy",
+        reconnect_attempts=1,
+        operation_timeout=45,
+    )
+    try:
+        tools = await manager.list_tools(session_id)
+        tool_names = {tool.name for tool in tools}
+        if tool_names != EXPECTED_TOOLS[project_id]:
+            raise RuntimeError(
+                f"schema drift for {project_id}: {sorted(tool_names)}"
+            )
+        tool_name, arguments = _representative_call(project_id)
+        result = await manager.call_tool(
+            session_id,
+            tool_name,
+            arguments,
+        )
+        serialized = result.model_dump(mode="json", exclude_none=True)
+        if serialized.get("isError") or serialized.get("is_error"):
+            raise RuntimeError(
+                f"representative call failed for {project_id}: "
+                f"{json.dumps(serialized, ensure_ascii=False)[:800]}"
+            )
+        if len(json.dumps(serialized, ensure_ascii=False).encode("utf-8")) > 128 * 1024:
+            raise RuntimeError(f"output limit exceeded for {project_id}")
+        return (
+            {
+                "project_id": project_id,
+                "tools": sorted(tool_names),
+                "representative_call": "passed",
+            },
+            session_id,
+        )
+    except Exception:
+        await manager.disconnect(session_id)
+        raise
+
+
+async def main() -> None:
+    manager = MCPClientManager(operation_timeout=45, idle_timeout_seconds=120)
+    results: list[dict[str, Any]] = []
+    active_sessions: list[str] = []
+    try:
+        for project_id in EXPECTED_TOOLS:
+            result, session_id = await _connect_and_exercise(manager, project_id)
+            results.append(result)
+            active_sessions.append(session_id)
+        if len(await manager.get_sessions_summary()) != len(EXPECTED_TOOLS):
+            raise RuntimeError("concurrent public-sidecar residency smoke failed")
+        for session_id in reversed(active_sessions):
+            await manager.disconnect(session_id)
+        active_sessions.clear()
+
+        reconnect, reconnect_session = await _connect_and_exercise(
+            manager,
+            "fetch-mcp",
+        )
+        active_sessions.append(reconnect_session)
+        if reconnect["representative_call"] != "passed":
+            raise RuntimeError("reconnect smoke failed")
+        await manager.disconnect(reconnect_session)
+        active_sessions.clear()
+        if await manager.get_sessions_summary():
+            raise RuntimeError("public MCP sessions were not cleaned")
+    finally:
+        for session_id in reversed(active_sessions):
+            try:
+                await manager.disconnect(session_id)
+            except Exception:
+                pass
+        await manager.close_all()
+    print(
+        json.dumps(
+            {
+                "ok": True,
+                "adapters": results,
+                "concurrent_residency": "passed",
+                "reconnect": "passed",
+                "cleanup": "passed",
+            },
+            ensure_ascii=False,
+        )
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/server/sandbox_sidecar/Dockerfile
+++ b/server/sandbox_sidecar/Dockerfile
@@ -16,13 +16,13 @@ RUN ln -sf ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
     && rm -rf /var/lib/apt/lists/* \
     && groupadd --gid 65532 sandbox \
     && useradd --uid 65532 --gid 65532 --home-dir /workspaces --no-create-home sandbox \
-    && mkdir -p /opt/modelmirror /workspaces /run/modelmirror-sandbox \
-    && chown -R sandbox:sandbox /workspaces /run/modelmirror-sandbox
+    && mkdir -p /opt/modelmirror /workspaces /run/modelmirror-sandbox /run/modelmirror-public-mcp \
+    && chown -R sandbox:sandbox /workspaces /run/modelmirror-sandbox /run/modelmirror-public-mcp
 
 WORKDIR /opt/modelmirror
 COPY requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir --retries 5 --timeout 120 -r requirements.txt
-COPY __init__.py compute_mcp.py engine.py landlock_exec.py server.py smoke_child.py ./sandbox_sidecar/
+COPY __init__.py compute_mcp.py engine.py landlock_exec.py public_mcp.py public_server.py safe_http.py server.py smoke_child.py ./sandbox_sidecar/
 COPY THIRD_PARTY_NOTICES.md /usr/share/doc/modelmirror-sandbox/THIRD_PARTY_NOTICES.md
 
 USER 65532:65532

--- a/server/sandbox_sidecar/THIRD_PARTY_NOTICES.md
+++ b/server/sandbox_sidecar/THIRD_PARTY_NOTICES.md
@@ -18,3 +18,18 @@ Runtime components are distributed under their respective licenses:
 
 The Landlock integration calls the Linux kernel userspace ABI through Python
 `ctypes`; it does not bundle a third-party Landlock library.
+
+Wave-2 compatibility contracts were independently implemented after reviewing
+the following open-source MCP servers. Their source packages are not installed
+or dynamically downloaded by the sidecar:
+
+- MCP Fetch Server 0.6.3 (`modelcontextprotocol/servers`): MIT License.
+- QuickChart MCP Server 1.0.6 (`GongRzhe/Quickchart-MCP-Server`): MIT License.
+- GeoWire MCP 0.6.2 (`geowire/geowire`): Apache License 2.0.
+- OpenBnB Airbnb MCP 0.3.0 (`openbnb-org/mcp-server-airbnb`): MIT License.
+  The catalog adapter is currently blocked because its public page contract
+  failed the schema-drift smoke gate.
+
+Public geocoding and routing results may be subject to provider-specific terms
+and attribution requirements. The adapter preserves OpenStreetMap attribution
+and rate-limits public Nominatim access.

--- a/server/sandbox_sidecar/public_mcp.py
+++ b/server/sandbox_sidecar/public_mcp.py
@@ -1,0 +1,919 @@
+"""Bundled public-network MCP adapters for catalog wave 2.
+
+These adapters intentionally expose a reviewed subset of their upstream tool
+contracts.  They never accept commands, environment names, headers, endpoints,
+or working directories from the MCP client.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import math
+import re
+from html import unescape
+from html.parser import HTMLParser
+from typing import Any
+from urllib.parse import quote, urlencode
+
+from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
+
+from .safe_http import NetworkPolicyError, SafeHttpClient
+
+
+MAX_RESULT_BYTES = 128 * 1024
+MAX_FETCH_BYTES = 1024 * 1024
+MAX_AIRBNB_BYTES = 2 * 1024 * 1024
+MAX_FETCH_LENGTH = 100_000
+MAX_GEO_RESULTS = 10
+VALID_CHART_TYPES = {
+    "bar",
+    "line",
+    "pie",
+    "doughnut",
+    "radar",
+    "polarArea",
+    "scatter",
+    "bubble",
+    "radialGauge",
+    "speedometer",
+}
+DATE_VALUE = re.compile(r"\d{4}-\d{2}-\d{2}")
+LISTING_ID = re.compile(r"[0-9]{1,24}")
+
+FETCH_USER_AGENT = (
+    "ModelMirrorMCP/1.0 (Autonomous; "
+    "+https://github.com/PinkElf-Elysia/ModelMirror)"
+)
+AIRBNB_USER_AGENT = (
+    "ModelMirror-Airbnb-MCP/0.3.0-compatible "
+    "(+https://github.com/PinkElf-Elysia/ModelMirror)"
+)
+GEO_USER_AGENT = (
+    "ModelMirror-GeoWire-MCP/0.6.2-compatible "
+    "(+https://github.com/PinkElf-Elysia/ModelMirror)"
+)
+
+QUICKCHART_HOSTS = frozenset({"quickchart.io"})
+AIRBNB_HOSTS = frozenset(
+    {
+        "www.airbnb.com",
+        "airbnb.com",
+        "photon.komoot.io",
+        "nominatim.openstreetmap.org",
+    }
+)
+GEOWIRE_HOSTS = frozenset(
+    {
+        "nominatim.openstreetmap.org",
+        "router.project-osrm.org",
+    }
+)
+
+READ_ONLY_NETWORK = ToolAnnotations(
+    readOnlyHint=True,
+    destructiveHint=False,
+    idempotentHint=True,
+    openWorldHint=True,
+)
+
+
+def _json_size(value: Any) -> int:
+    return len(
+        json.dumps(value, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    )
+
+
+def _bounded_result(value: Any) -> Any:
+    if _json_size(value) > MAX_RESULT_BYTES:
+        raise ValueError("工具返回内容超过 128 KiB 上限。")
+    return value
+
+
+def _bounded_string(value: Any, name: str, *, maximum: int = 1_024) -> str:
+    clean = str(value or "").strip()
+    if not clean or len(clean) > maximum:
+        raise ValueError(f"{name}不能为空且不能超过 {maximum} 个字符。")
+    return clean
+
+
+def _finite(value: Any, name: str, minimum: float, maximum: float) -> float:
+    try:
+        number = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name}必须是数字。") from exc
+    if not math.isfinite(number) or not minimum <= number <= maximum:
+        raise ValueError(f"{name}必须位于 {minimum} 到 {maximum} 之间。")
+    return number
+
+
+def _coordinates(value: dict[str, Any], name: str) -> dict[str, float]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{name}必须是经纬度对象。")
+    return {
+        "latitude": _finite(value.get("latitude"), f"{name}.latitude", -90, 90),
+        "longitude": _finite(value.get("longitude"), f"{name}.longitude", -180, 180),
+    }
+
+
+def _require_success(status: int, provider: str) -> None:
+    if status < 200 or status >= 300:
+        raise ValueError(f"{provider} 公共服务返回 HTTP {status}。")
+
+
+class _ReadableHtml(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.parts: list[str] = []
+        self.skip_depth = 0
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag in {"script", "style", "svg", "noscript"}:
+            self.skip_depth += 1
+        elif not self.skip_depth and tag in {
+            "article", "br", "div", "h1", "h2", "h3", "h4", "li", "main", "p", "section"
+        }:
+            self.parts.append("\n")
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag in {"script", "style", "svg", "noscript"} and self.skip_depth:
+            self.skip_depth -= 1
+        elif not self.skip_depth and tag in {"article", "div", "li", "main", "p", "section"}:
+            self.parts.append("\n")
+
+    def handle_data(self, data: str) -> None:
+        if not self.skip_depth:
+            self.parts.append(data)
+
+    def text(self) -> str:
+        lines = []
+        for line in "".join(self.parts).splitlines():
+            clean = re.sub(r"\s+", " ", line).strip()
+            if clean:
+                lines.append(clean)
+        return "\n".join(lines)
+
+
+class _ScriptCapture(HTMLParser):
+    def __init__(self, element_id: str) -> None:
+        super().__init__(convert_charrefs=True)
+        self.element_id = element_id
+        self.active = False
+        self.parts: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag == "script" and dict(attrs).get("id") == self.element_id:
+            self.active = True
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "script" and self.active:
+            self.active = False
+
+    def handle_data(self, data: str) -> None:
+        if self.active:
+            self.parts.append(data)
+
+
+def _html_to_text(html: str) -> str:
+    parser = _ReadableHtml()
+    parser.feed(html)
+    return parser.text()
+
+
+def fetch_payload(
+    url: str,
+    max_length: int = 5_000,
+    start_index: int = 0,
+    raw: bool = False,
+) -> str:
+    if not 1 <= int(max_length) <= MAX_FETCH_LENGTH:
+        raise ValueError(f"max_length 必须位于 1 到 {MAX_FETCH_LENGTH} 之间。")
+    if not 0 <= int(start_index) <= 1_000_000:
+        raise ValueError("start_index 必须位于 0 到 1000000 之间。")
+    client = SafeHttpClient(
+        allowed_hosts=None,
+        max_response_bytes=MAX_FETCH_BYTES,
+    )
+    client.assert_robots_allowed(url, FETCH_USER_AGENT)
+    response = client.request(
+        url,
+        headers={"User-Agent": FETCH_USER_AGENT},
+        max_response_bytes=MAX_FETCH_BYTES,
+    )
+    _require_success(response.status, "目标站点")
+    content_type = response.headers.get("content-type", "").lower()
+    if not any(
+        token in content_type
+        for token in ("text/", "application/json", "application/xml", "application/xhtml+xml")
+    ):
+        raise ValueError("Fetch 仅允许文本、HTML、JSON 或 XML 响应。")
+    content = response.text()
+    if "text/html" in content_type and not raw:
+        content = _html_to_text(content)
+    start = int(start_index)
+    if start >= len(content):
+        return "<error>没有更多内容。</error>"
+    end = start + int(max_length)
+    selected = content[start:end]
+    if end < len(content):
+        selected += f"\n\n<error>内容已截断；下一次请使用 start_index={end}。</error>"
+    return f"Contents of {response.url}:\n{selected}"
+
+
+def build_fetch() -> FastMCP:
+    mcp = FastMCP("ModelMirror Fetch")
+
+    @mcp.tool(annotations=READ_ONLY_NETWORK)
+    def fetch(
+        url: str,
+        max_length: int = 5_000,
+        start_index: int = 0,
+        raw: bool = False,
+    ) -> str:
+        """安全获取公网 HTTPS 页面，遵守 robots.txt 并按字符分页。"""
+
+        return fetch_payload(url, max_length, start_index, raw)
+
+    return mcp
+
+
+def _reject_chart_executable_values(value: Any) -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if str(key).lower() in {"url", "href", "callback", "function"}:
+                raise ValueError("图表配置不得包含远程 URL 或可执行回调。")
+            _reject_chart_executable_values(child)
+    elif isinstance(value, list):
+        for child in value:
+            _reject_chart_executable_values(child)
+    elif isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered.startswith(("http://", "https://", "javascript:")) or "=>" in value:
+            raise ValueError("图表配置不得包含远程 URL 或可执行脚本。")
+    elif isinstance(value, float) and not math.isfinite(value):
+        raise ValueError("图表配置不能包含 NaN 或 Infinity。")
+
+
+def quickchart_url(
+    type: str,
+    datasets: list[dict[str, Any]],
+    labels: list[str] | None = None,
+    title: str | None = None,
+    options: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    chart_type = _bounded_string(type, "type", maximum=32)
+    if chart_type not in VALID_CHART_TYPES:
+        raise ValueError("图表类型不在固定允许清单中。")
+    if not isinstance(datasets, list) or not 1 <= len(datasets) <= 8:
+        raise ValueError("datasets 必须包含 1 到 8 个数据系列。")
+    clean_datasets: list[dict[str, Any]] = []
+    for dataset in datasets:
+        if not isinstance(dataset, dict) or not isinstance(dataset.get("data"), list):
+            raise ValueError("每个数据系列都必须包含 data 数组。")
+        if len(dataset["data"]) > 200:
+            raise ValueError("每个数据系列最多包含 200 个数据点。")
+        allowed = {
+            key: dataset[key]
+            for key in ("label", "data", "backgroundColor", "borderColor")
+            if key in dataset
+        }
+        _reject_chart_executable_values(allowed)
+        clean_datasets.append(allowed)
+    clean_labels = list(labels or [])
+    if len(clean_labels) > 200 or any(len(str(item)) > 256 for item in clean_labels):
+        raise ValueError("labels 最多包含 200 项，单项不超过 256 个字符。")
+    clean_options = dict(options or {})
+    _reject_chart_executable_values(clean_options)
+    config: dict[str, Any] = {
+        "type": chart_type,
+        "data": {"labels": clean_labels, "datasets": clean_datasets},
+        "options": clean_options,
+    }
+    if title:
+        config["options"] = {
+            **clean_options,
+            "plugins": {
+                **(clean_options.get("plugins", {}) if isinstance(clean_options.get("plugins"), dict) else {}),
+                "title": {"display": True, "text": _bounded_string(title, "title", maximum=256)},
+            },
+        }
+    encoded = quote(json.dumps(config, ensure_ascii=False, separators=(",", ":")), safe="")
+    url = f"https://quickchart.io/chart?c={encoded}"
+    if len(url) > 16_384:
+        raise ValueError("图表配置编码后超过 16384 个字符。")
+    return _bounded_result(
+        {
+            "url": url,
+            "chart_type": chart_type,
+            "datasets": len(clean_datasets),
+            "network_target": "quickchart.io",
+            "note": "仅生成受控图表 URL；本批不写入本地文件。",
+        }
+    )
+
+
+def build_quickchart() -> FastMCP:
+    mcp = FastMCP("ModelMirror QuickChart")
+
+    @mcp.tool(annotations=READ_ONLY_NETWORK)
+    def generate_chart(
+        type: str,
+        datasets: list[dict[str, Any]],
+        labels: list[str] | None = None,
+        title: str | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """生成固定 quickchart.io 域名的 Chart.js 图表 URL。"""
+
+        return quickchart_url(type, datasets, labels, title, options)
+
+    return mcp
+
+
+def _json_response(client: SafeHttpClient, url: str, *, provider: str) -> Any:
+    response = client.request(
+        url,
+        headers={"User-Agent": GEO_USER_AGENT, "Accept": "application/json"},
+    )
+    _require_success(response.status, provider)
+    try:
+        return json.loads(response.text())
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{provider} 返回了无效 JSON。") from exc
+
+
+def _airbnb_geocode(client: SafeHttpClient, location: str) -> tuple[float, float, float, float] | None:
+    photon_url = "https://photon.komoot.io/api/?" + urlencode(
+        {"q": location, "limit": "5"}
+    )
+    try:
+        data = _json_response(client, photon_url, provider="Photon")
+        features = data.get("features", []) if isinstance(data, dict) else []
+        priorities = {
+            "country": 1, "state": 2, "county": 3, "city": 4,
+            "district": 5, "locality": 6, "street": 7, "house": 8,
+        }
+        features = sorted(
+            (item for item in features if isinstance(item, dict)),
+            key=lambda item: priorities.get(item.get("properties", {}).get("type"), 9),
+        )
+        for feature in features:
+            extent = feature.get("properties", {}).get("extent")
+            if isinstance(extent, list) and len(extent) == 4:
+                west, north, east, south = (float(item) for item in extent)
+                return south, north, west, east
+    except (NetworkPolicyError, ValueError, TypeError):
+        pass
+    nominatim_url = "https://nominatim.openstreetmap.org/search?" + urlencode(
+        {"q": location, "format": "jsonv2", "limit": "1"}
+    )
+    try:
+        data = _json_response(client, nominatim_url, provider="Nominatim")
+        box = data[0].get("boundingbox") if isinstance(data, list) and data else None
+        if isinstance(box, list) and len(box) == 4:
+            south, north, west, east = (float(item) for item in box)
+            return south, north, west, east
+    except (NetworkPolicyError, ValueError, TypeError):
+        pass
+    return None
+
+
+def _airbnb_script_data(html: str) -> Any:
+    parser = _ScriptCapture("data-deferred-state-0")
+    parser.feed(html)
+    raw = unescape("".join(parser.parts)).strip()
+    if not raw:
+        raise ValueError("Airbnb 页面缺少固定数据节点，上游页面结构可能已经漂移。")
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError("Airbnb 固定数据节点无法解析，上游页面结构可能已经漂移。") from exc
+
+
+def _find_airbnb_branch(data: Any, branch: tuple[str, ...]) -> Any:
+    entries = data.get("niobeClientData", []) if isinstance(data, dict) else []
+    for entry in entries:
+        if not isinstance(entry, list) or len(entry) < 2:
+            continue
+        current = entry[1]
+        try:
+            for key in branch:
+                current = current[key]
+            return current
+        except (KeyError, TypeError):
+            continue
+    raise ValueError("Airbnb 页面数据契约已漂移，未找到预期结果节点。")
+
+
+def _decode_listing_id(value: Any) -> str | None:
+    raw = str(value or "").strip()
+    if not raw:
+        return None
+    try:
+        decoded = base64.b64decode(raw + "=" * (-len(raw) % 4)).decode("utf-8")
+        candidate = decoded.rsplit(":", 1)[-1]
+    except (ValueError, UnicodeDecodeError):
+        candidate = raw
+    return candidate if LISTING_ID.fullmatch(candidate) else None
+
+
+def _airbnb_date(value: str | None, name: str) -> str | None:
+    if value is None or value == "":
+        return None
+    clean = str(value).strip()
+    if not DATE_VALUE.fullmatch(clean):
+        raise ValueError(f"{name} 必须使用 YYYY-MM-DD 格式。")
+    return clean
+
+
+def airbnb_search_payload(
+    location: str,
+    checkin: str | None = None,
+    checkout: str | None = None,
+    adults: int = 1,
+    children: int = 0,
+    minPrice: float | None = None,
+    maxPrice: float | None = None,
+) -> dict[str, Any]:
+    clean_location = _bounded_string(location, "location", maximum=256)
+    adults_value = int(_finite(adults, "adults", 1, 16))
+    children_value = int(_finite(children, "children", 0, 16))
+    slug = quote(re.sub(r"\s+", "-", re.sub(r",\s*", "--", clean_location)), safe="-")
+    query: dict[str, str] = {
+        "adults": str(adults_value),
+        "children": str(children_value),
+    }
+    if value := _airbnb_date(checkin, "checkin"):
+        query["checkin"] = value
+    if value := _airbnb_date(checkout, "checkout"):
+        query["checkout"] = value
+    if minPrice is not None:
+        query["price_min"] = str(int(_finite(minPrice, "minPrice", 0, 1_000_000)))
+    if maxPrice is not None:
+        query["price_max"] = str(int(_finite(maxPrice, "maxPrice", 0, 1_000_000)))
+    client = SafeHttpClient(
+        allowed_hosts=AIRBNB_HOSTS,
+        max_response_bytes=MAX_AIRBNB_BYTES,
+        minimum_intervals={"nominatim.openstreetmap.org": 1.0},
+    )
+    if bounds := _airbnb_geocode(client, clean_location):
+        south, north, west, east = bounds
+        lat_pad = max((north - south) * 0.25, 0.1)
+        lon_pad = max((east - west) * 0.25, 0.1)
+        query.update(
+            {
+                "sw_lat": f"{max(south - lat_pad, -90):.7f}",
+                "ne_lat": f"{min(north + lat_pad, 90):.7f}",
+                "sw_lng": f"{max(west - lon_pad, -180):.7f}",
+                "ne_lng": f"{min(east + lon_pad, 180):.7f}",
+            }
+        )
+    url = f"https://www.airbnb.com/s/{slug}/homes?{urlencode(query)}"
+    client.assert_robots_allowed(url, AIRBNB_USER_AGENT)
+    response = client.request(
+        url,
+        headers={
+            "User-Agent": AIRBNB_USER_AGENT,
+            "Accept": "text/html,application/xhtml+xml",
+            "Accept-Language": "zh-CN,zh;q=0.9,en;q=0.7",
+        },
+        max_response_bytes=MAX_AIRBNB_BYTES,
+    )
+    _require_success(response.status, "Airbnb")
+    data = _airbnb_script_data(response.text())
+    results = _find_airbnb_branch(
+        data,
+        ("data", "presentation", "staysSearch", "results"),
+    )
+    rows = results.get("searchResults", []) if isinstance(results, dict) else []
+    output = []
+    for row in rows[:10]:
+        if not isinstance(row, dict):
+            continue
+        listing = row.get("demandStayListing") or {}
+        listing_id = _decode_listing_id(listing.get("id"))
+        if not listing_id:
+            continue
+        display = row.get("structuredContent") or {}
+        price = row.get("structuredDisplayPrice") or {}
+        output.append(
+            {
+                "id": listing_id,
+                "url": f"https://www.airbnb.com/rooms/{listing_id}",
+                "description": listing.get("description"),
+                "location": listing.get("location"),
+                "rating": row.get("avgRatingA11yLabel"),
+                "primary": (display.get("primaryLine") or {}).get("body"),
+                "secondary": (display.get("secondaryLine") or {}).get("body"),
+                "price": ((price.get("primaryLine") or {}).get("accessibilityLabel")),
+            }
+        )
+    return _bounded_result(
+        {
+            "search_url": response.url,
+            "results": output,
+            "result_count": len(output),
+            "robots_respected": True,
+            "note": "房源信息来自公开页面，价格和可订状态需在官方页面复核。",
+        }
+    )
+
+
+def airbnb_details_payload(
+    id: str,
+    checkin: str | None = None,
+    checkout: str | None = None,
+    adults: int = 1,
+) -> dict[str, Any]:
+    listing_id = _bounded_string(id, "id", maximum=24)
+    if not LISTING_ID.fullmatch(listing_id):
+        raise ValueError("Airbnb 房源 ID 只能包含数字。")
+    query = {"adults": str(int(_finite(adults, "adults", 1, 16)))}
+    if value := _airbnb_date(checkin, "checkin"):
+        query["check_in"] = value
+    if value := _airbnb_date(checkout, "checkout"):
+        query["check_out"] = value
+    url = f"https://www.airbnb.com/rooms/{listing_id}?{urlencode(query)}"
+    client = SafeHttpClient(
+        allowed_hosts=AIRBNB_HOSTS,
+        max_response_bytes=MAX_AIRBNB_BYTES,
+    )
+    client.assert_robots_allowed(url, AIRBNB_USER_AGENT)
+    response = client.request(
+        url,
+        headers={
+            "User-Agent": AIRBNB_USER_AGENT,
+            "Accept": "text/html,application/xhtml+xml",
+            "Accept-Language": "zh-CN,zh;q=0.9,en;q=0.7",
+        },
+        max_response_bytes=MAX_AIRBNB_BYTES,
+    )
+    _require_success(response.status, "Airbnb")
+    data = _airbnb_script_data(response.text())
+    sections = _find_airbnb_branch(
+        data,
+        ("data", "presentation", "stayProductDetailPage", "sections", "sections"),
+    )
+    allowed_sections = {
+        "LOCATION_DEFAULT",
+        "POLICIES_DEFAULT",
+        "HIGHLIGHTS_DEFAULT",
+        "DESCRIPTION_DEFAULT",
+        "AMENITIES_DEFAULT",
+    }
+    output = []
+    for item in sections if isinstance(sections, list) else []:
+        if not isinstance(item, dict) or item.get("sectionId") not in allowed_sections:
+            continue
+        section = item.get("section")
+        if isinstance(section, dict):
+            raw = json.dumps(section, ensure_ascii=False)
+            output.append(
+                {
+                    "section_id": item.get("sectionId"),
+                    "content": json.loads(raw[:24_000]) if len(raw) <= 24_000 else {"truncated": True},
+                }
+            )
+    return _bounded_result(
+        {
+            "listing_url": response.url,
+            "sections": output,
+            "robots_respected": True,
+        }
+    )
+
+
+def build_airbnb() -> FastMCP:
+    mcp = FastMCP("ModelMirror Airbnb")
+
+    @mcp.tool(annotations=READ_ONLY_NETWORK)
+    def airbnb_search(
+        location: str,
+        checkin: str | None = None,
+        checkout: str | None = None,
+        adults: int = 1,
+        children: int = 0,
+        minPrice: float | None = None,
+        maxPrice: float | None = None,
+    ) -> dict[str, Any]:
+        """搜索公开 Airbnb 房源；固定遵守 robots.txt，最多返回 10 项。"""
+
+        return airbnb_search_payload(
+            location, checkin, checkout, adults, children, minPrice, maxPrice
+        )
+
+    @mcp.tool(annotations=READ_ONLY_NETWORK)
+    def airbnb_listing_details(
+        id: str,
+        checkin: str | None = None,
+        checkout: str | None = None,
+        adults: int = 1,
+    ) -> dict[str, Any]:
+        """读取一个数字房源 ID 的公开详情；固定遵守 robots.txt。"""
+
+        return airbnb_details_payload(id, checkin, checkout, adults)
+
+    return mcp
+
+
+def _geo_client() -> SafeHttpClient:
+    return SafeHttpClient(
+        allowed_hosts=GEOWIRE_HOSTS,
+        max_response_bytes=MAX_FETCH_BYTES,
+        minimum_intervals={"nominatim.openstreetmap.org": 1.0},
+    )
+
+
+def _nominatim_places(data: Any) -> list[dict[str, Any]]:
+    rows = data if isinstance(data, list) else [data]
+    output = []
+    for row in rows[:MAX_GEO_RESULTS]:
+        if not isinstance(row, dict):
+            continue
+        output.append(
+            {
+                "name": row.get("display_name") or row.get("name"),
+                "latitude": float(row["lat"]) if row.get("lat") is not None else None,
+                "longitude": float(row["lon"]) if row.get("lon") is not None else None,
+                "type": row.get("type"),
+                "category": row.get("category"),
+                "address": row.get("address"),
+                "source": "OpenStreetMap / Nominatim",
+                "attribution": "© OpenStreetMap contributors",
+            }
+        )
+    return output
+
+
+def geowire_search_payload(
+    query: str,
+    near: dict[str, Any] | None = None,
+    radiusMeters: int | None = None,
+    country: str | None = None,
+    limit: int = 5,
+) -> dict[str, Any]:
+    clean_query = _bounded_string(query, "query", maximum=256)
+    limit_value = int(_finite(limit, "limit", 1, MAX_GEO_RESULTS))
+    params: dict[str, str] = {
+        "q": clean_query,
+        "format": "jsonv2",
+        "addressdetails": "1",
+        "limit": str(limit_value),
+    }
+    if country:
+        clean_country = _bounded_string(country, "country", maximum=2).lower()
+        if not re.fullmatch(r"[a-z]{2}", clean_country):
+            raise ValueError("country 必须是两位国家代码。")
+        params["countrycodes"] = clean_country
+    if near is not None:
+        point = _coordinates(near, "near")
+        radius = _finite(radiusMeters or 25_000, "radiusMeters", 100, 50_000)
+        lat_delta = radius / 111_320
+        lon_delta = radius / (111_320 * max(math.cos(math.radians(point["latitude"])), 0.01))
+        params["viewbox"] = ",".join(
+            str(value)
+            for value in (
+                max(point["longitude"] - lon_delta, -180),
+                min(point["latitude"] + lat_delta, 90),
+                min(point["longitude"] + lon_delta, 180),
+                max(point["latitude"] - lat_delta, -90),
+            )
+        )
+        if radiusMeters is not None:
+            params["bounded"] = "1"
+    data = _json_response(
+        _geo_client(),
+        "https://nominatim.openstreetmap.org/search?" + urlencode(params),
+        provider="Nominatim",
+    )
+    return _bounded_result({"results": _nominatim_places(data), "provider": "nominatim"})
+
+
+def geowire_geocode_payload(
+    address: str,
+    country: str | None = None,
+    limit: int = 5,
+) -> dict[str, Any]:
+    return geowire_search_payload(address, country=country, limit=limit)
+
+
+def geowire_reverse_payload(location: dict[str, Any]) -> dict[str, Any]:
+    point = _coordinates(location, "location")
+    params = urlencode(
+        {
+            "lat": point["latitude"],
+            "lon": point["longitude"],
+            "format": "jsonv2",
+            "addressdetails": "1",
+        }
+    )
+    data = _json_response(
+        _geo_client(),
+        "https://nominatim.openstreetmap.org/reverse?" + params,
+        provider="Nominatim",
+    )
+    return _bounded_result({"results": _nominatim_places(data), "provider": "nominatim"})
+
+
+def geowire_directions_payload(
+    waypoints: list[dict[str, Any]],
+    mode: str = "driving",
+    geometry: bool = False,
+    alternatives: bool = False,
+) -> dict[str, Any]:
+    if mode != "driving":
+        raise ValueError("公共 OSRM 适配器仅开放 driving 模式。")
+    if not isinstance(waypoints, list) or not 2 <= len(waypoints) <= 8:
+        raise ValueError("waypoints 必须包含 2 到 8 个坐标。")
+    points = [_coordinates(item, f"waypoints[{index}]") for index, item in enumerate(waypoints)]
+    coords = ";".join(f"{point['longitude']},{point['latitude']}" for point in points)
+    query = urlencode(
+        {
+            "overview": "full" if geometry else "false",
+            "geometries": "geojson",
+            "steps": "false",
+            "alternatives": "true" if alternatives else "false",
+        }
+    )
+    data = _json_response(
+        _geo_client(),
+        f"https://router.project-osrm.org/route/v1/driving/{coords}?{query}",
+        provider="OSRM",
+    )
+    if not isinstance(data, dict) or data.get("code") != "Ok":
+        raise ValueError("OSRM 没有返回可用路线。")
+    routes = []
+    for route in data.get("routes", [])[:3]:
+        if not isinstance(route, dict):
+            continue
+        item = {
+            "distanceMeters": route.get("distance"),
+            "durationSeconds": route.get("duration"),
+            "legs": [
+                {
+                    "distanceMeters": leg.get("distance"),
+                    "durationSeconds": leg.get("duration"),
+                }
+                for leg in route.get("legs", [])
+                if isinstance(leg, dict)
+            ],
+        }
+        if geometry:
+            item["geometry"] = route.get("geometry")
+        routes.append(item)
+    return _bounded_result({"routes": routes, "provider": "osrm"})
+
+
+def geowire_matrix_payload(
+    origins: list[dict[str, Any]],
+    destinations: list[dict[str, Any]],
+    mode: str = "driving",
+) -> dict[str, Any]:
+    if mode != "driving":
+        raise ValueError("公共 OSRM 适配器仅开放 driving 模式。")
+    if not isinstance(origins, list) or not 1 <= len(origins) <= 5:
+        raise ValueError("origins 必须包含 1 到 5 个坐标。")
+    if not isinstance(destinations, list) or not 1 <= len(destinations) <= 5:
+        raise ValueError("destinations 必须包含 1 到 5 个坐标。")
+    source_points = [_coordinates(item, f"origins[{index}]") for index, item in enumerate(origins)]
+    target_points = [_coordinates(item, f"destinations[{index}]") for index, item in enumerate(destinations)]
+    points = [*source_points, *target_points]
+    coords = ";".join(f"{point['longitude']},{point['latitude']}" for point in points)
+    query = urlencode(
+        {
+            "sources": ";".join(str(index) for index in range(len(source_points))),
+            "destinations": ";".join(
+                str(index) for index in range(len(source_points), len(points))
+            ),
+            "annotations": "duration,distance",
+        }
+    )
+    data = _json_response(
+        _geo_client(),
+        f"https://router.project-osrm.org/table/v1/driving/{coords}?{query}",
+        provider="OSRM",
+    )
+    if not isinstance(data, dict) or data.get("code") != "Ok":
+        raise ValueError("OSRM 没有返回可用距离矩阵。")
+    return _bounded_result(
+        {
+            "durations": data.get("durations", []),
+            "distances": data.get("distances", []),
+            "provider": "osrm",
+        }
+    )
+
+
+def geowire_providers_payload() -> dict[str, Any]:
+    return {
+        "providers": [
+            {
+                "id": "nominatim",
+                "capabilities": ["search_places", "geocode_address", "reverse_geocode"],
+                "rate_limit": "1 request/second",
+                "attribution": "© OpenStreetMap contributors",
+            },
+            {
+                "id": "osrm",
+                "capabilities": ["get_directions", "distance_matrix"],
+                "mode": "driving",
+                "attribution": "OpenStreetMap / OSRM",
+            },
+        ],
+        "credentials": "none",
+    }
+
+
+def build_geowire() -> FastMCP:
+    mcp = FastMCP("ModelMirror GeoWire")
+
+    @mcp.tool(annotations=READ_ONLY_NETWORK)
+    def search_places(
+        query: str,
+        near: dict[str, Any] | None = None,
+        radiusMeters: int | None = None,
+        country: str | None = None,
+        limit: int = 5,
+    ) -> dict[str, Any]:
+        """使用 Nominatim 搜索地点，最多返回 10 项。"""
+
+        return geowire_search_payload(query, near, radiusMeters, country, limit)
+
+    @mcp.tool(annotations=READ_ONLY_NETWORK)
+    def geocode_address(
+        address: str,
+        country: str | None = None,
+        limit: int = 5,
+    ) -> dict[str, Any]:
+        """把地址转换为坐标和规范化地址。"""
+
+        return geowire_geocode_payload(address, country, limit)
+
+    @mcp.tool(annotations=READ_ONLY_NETWORK)
+    def reverse_geocode(location: dict[str, Any]) -> dict[str, Any]:
+        """把经纬度转换为附近地址。"""
+
+        return geowire_reverse_payload(location)
+
+    @mcp.tool(annotations=READ_ONLY_NETWORK)
+    def get_directions(
+        waypoints: list[dict[str, Any]],
+        mode: str = "driving",
+        geometry: bool = False,
+        alternatives: bool = False,
+    ) -> dict[str, Any]:
+        """通过公共 OSRM 获取 2 到 8 个途经点之间的驾车路线。"""
+
+        return geowire_directions_payload(waypoints, mode, geometry, alternatives)
+
+    @mcp.tool(annotations=READ_ONLY_NETWORK)
+    def distance_matrix(
+        origins: list[dict[str, Any]],
+        destinations: list[dict[str, Any]],
+        mode: str = "driving",
+    ) -> dict[str, Any]:
+        """通过公共 OSRM 计算最多 5×5 的驾车距离和时间矩阵。"""
+
+        return geowire_matrix_payload(origins, destinations, mode)
+
+    @mcp.tool(annotations=READ_ONLY_NETWORK)
+    def list_geo_providers() -> dict[str, Any]:
+        """列出本批固定启用的零凭据地理数据提供方。"""
+
+        return geowire_providers_payload()
+
+    return mcp
+
+
+BUILDERS = {
+    "fetch-mcp": build_fetch,
+    "quickchart-mcp": build_quickchart,
+    "geowire-mcp": build_geowire,
+}
+
+ADAPTER_TOOL_NAMES = {
+    "fetch-mcp": ("fetch",),
+    "quickchart-mcp": ("generate_chart",),
+    "geowire-mcp": (
+        "search_places",
+        "geocode_address",
+        "reverse_geocode",
+        "get_directions",
+        "distance_matrix",
+        "list_geo_providers",
+    ),
+}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("adapter_id", choices=sorted(BUILDERS))
+    args = parser.parse_args()
+    BUILDERS[args.adapter_id]().run(transport="stdio")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/server/sandbox_sidecar/public_server.py
+++ b/server/sandbox_sidecar/public_server.py
@@ -1,0 +1,268 @@
+"""Unix-socket sidecar for fixed public-network MCP child processes."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import shutil
+import sys
+import uuid
+from pathlib import Path
+from typing import Any
+
+from .engine import MAX_REQUEST_BYTES, SandboxEngineError
+from .public_mcp import BUILDERS
+
+
+SOCKET_PATH = Path(
+    os.getenv(
+        "MCP_PUBLIC_SOCKET_PATH",
+        "/run/modelmirror-public-mcp/public-mcp.sock",
+    )
+)
+WORKSPACE_ROOT = Path(os.getenv("MCP_PUBLIC_WORKSPACE_ROOT", "/workspaces"))
+PUBLIC_ADAPTERS = frozenset(BUILDERS)
+MAX_MCP_MESSAGE_BYTES = 256 * 1024
+MAX_PUBLIC_SESSIONS = max(
+    1,
+    min(int(os.getenv("MCP_PUBLIC_MAX_SESSIONS", "6")), 16),
+)
+PUBLIC_SEMAPHORE = asyncio.Semaphore(MAX_PUBLIC_SESSIONS)
+
+
+async def _pump_lines(
+    source: asyncio.StreamReader,
+    destination: asyncio.StreamWriter,
+    *,
+    adapter_id: str,
+    direction: str,
+) -> None:
+    first_line = True
+    while True:
+        raw = await source.readline()
+        if not raw:
+            break
+        if len(raw) > MAX_MCP_MESSAGE_BYTES:
+            raise SandboxEngineError(
+                "MCP message exceeds the 256 KiB limit.",
+                code="mcp_message_too_large",
+            )
+        if first_line:
+            print(
+                f"MCP public stream active: adapter={adapter_id} direction={direction}",
+                file=sys.stderr,
+            )
+            first_line = False
+        destination.write(raw)
+        await destination.drain()
+
+
+async def _drain_stderr(stream: asyncio.StreamReader | None) -> None:
+    if stream is None:
+        return
+    while await stream.read(4096):
+        pass
+
+
+async def _handle_mcp_stdio(
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+    request: dict[str, Any],
+) -> None:
+    adapter_id = str(request.get("adapter_id") or "").strip()
+    if adapter_id not in PUBLIC_ADAPTERS:
+        raise SandboxEngineError(
+            "MCP public adapter is not allowed.",
+            code="mcp_adapter_denied",
+        )
+
+    async with PUBLIC_SEMAPHORE:
+        workspace = (WORKSPACE_ROOT / f"mcp-public-{uuid.uuid4().hex}").resolve()
+        if workspace.parent != WORKSPACE_ROOT.resolve():
+            raise SandboxEngineError(
+                "Unsafe public MCP workspace.",
+                code="unsafe_workspace",
+            )
+        (workspace / "work").mkdir(parents=True, exist_ok=False)
+        command = [
+            sys.executable,
+            str(Path(__file__).with_name("landlock_exec.py")),
+            str(workspace),
+            "--read-only",
+            "--compute-limits",
+            "--",
+            sys.executable,
+            "-m",
+            "sandbox_sidecar.public_mcp",
+            adapter_id,
+        ]
+        env = {
+            "PATH": "/usr/local/bin:/usr/bin:/bin",
+            "PYTHONPATH": "/opt/modelmirror",
+            "PYTHONDONTWRITEBYTECODE": "1",
+            "PYTHONNOUSERSITE": "1",
+            "PYTHONUNBUFFERED": "1",
+            "HOME": str(workspace / "work"),
+            "TMPDIR": str(workspace / "work"),
+            "LANG": "C.UTF-8",
+            "LC_ALL": "C.UTF-8",
+            "TZ": "UTC",
+            "MCP_PUBLIC_ALLOW_SYNTHETIC_DNS": os.getenv(
+                "MCP_PUBLIC_ALLOW_SYNTHETIC_DNS",
+                "false",
+            ),
+            "NO_PROXY": "*",
+            "no_proxy": "*",
+        }
+        process: asyncio.subprocess.Process | None = None
+        tasks: list[asyncio.Task[None]] = []
+        handshake_sent = False
+        try:
+            process = await asyncio.create_subprocess_exec(
+                *command,
+                cwd=str(workspace / "work"),
+                env=env,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                start_new_session=True,
+                limit=MAX_MCP_MESSAGE_BYTES + 1,
+            )
+            if process.stdin is None or process.stdout is None:
+                raise SandboxEngineError(
+                    "MCP public stdio is unavailable.",
+                    code="mcp_stdio_unavailable",
+                )
+            writer.write(
+                json.dumps(
+                    {
+                        "ok": True,
+                        "adapter_id": adapter_id,
+                        "protocol": "modelmirror-mcp-stdio-v1",
+                    },
+                    separators=(",", ":"),
+                ).encode("utf-8")
+                + b"\n"
+            )
+            await writer.drain()
+            handshake_sent = True
+            tasks = [
+                asyncio.create_task(
+                    _pump_lines(
+                        reader,
+                        process.stdin,
+                        adapter_id=adapter_id,
+                        direction="client_to_child",
+                    )
+                ),
+                asyncio.create_task(
+                    _pump_lines(
+                        process.stdout,
+                        writer,
+                        adapter_id=adapter_id,
+                        direction="child_to_client",
+                    )
+                ),
+                asyncio.create_task(_drain_stderr(process.stderr)),
+            ]
+            done, pending = await asyncio.wait(
+                tasks[:2],
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            for task in done:
+                task.result()
+            for task in pending:
+                task.cancel()
+        except Exception as exc:
+            if not handshake_sent:
+                raise
+            print(
+                f"MCP public session ended: adapter={adapter_id} error_type={type(exc).__name__}",
+                file=sys.stderr,
+            )
+        finally:
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            if tasks:
+                await asyncio.gather(*tasks, return_exceptions=True)
+            if process is not None and process.returncode is None:
+                process.terminate()
+                try:
+                    await asyncio.wait_for(process.wait(), timeout=2)
+                except asyncio.TimeoutError:
+                    process.kill()
+                    await process.wait()
+            if process is not None:
+                print(
+                    f"MCP public process stopped: adapter={adapter_id} exit_code={process.returncode}",
+                    file=sys.stderr,
+                )
+            shutil.rmtree(workspace, ignore_errors=True)
+            if handshake_sent:
+                writer.close()
+                await writer.wait_closed()
+
+
+async def handle_client(
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+) -> None:
+    try:
+        raw = await reader.readline()
+        if not raw or len(raw) > MAX_REQUEST_BYTES:
+            raise SandboxEngineError(
+                "Public sidecar request is empty or too large.",
+                code="invalid_request",
+            )
+        request = json.loads(raw.decode("utf-8"))
+        if not isinstance(request, dict):
+            raise SandboxEngineError(
+                "Public sidecar request must be an object.",
+                code="invalid_request",
+            )
+        action = str(request.get("action") or "").strip()
+        if action == "mcp_stdio":
+            await _handle_mcp_stdio(reader, writer, request)
+            return
+        if action != "health":
+            raise SandboxEngineError(
+                "Public sidecar action is not allowed.",
+                code="action_denied",
+            )
+        response = {
+            "ok": True,
+            "mcp_public_adapters": sorted(PUBLIC_ADAPTERS),
+            "mcp_public_max_sessions": MAX_PUBLIC_SESSIONS,
+            "mcp_message_limit_bytes": MAX_MCP_MESSAGE_BYTES,
+        }
+    except SandboxEngineError as exc:
+        response = {"ok": False, "error": str(exc), "code": exc.code}
+    except Exception as exc:
+        response = {
+            "ok": False,
+            "error": str(exc)[:1000],
+            "code": "public_sidecar_internal_error",
+        }
+    writer.write(json.dumps(response, ensure_ascii=False).encode("utf-8") + b"\n")
+    await writer.drain()
+    writer.close()
+    await writer.wait_closed()
+
+
+async def main() -> None:
+    SOCKET_PATH.parent.mkdir(parents=True, exist_ok=True)
+    SOCKET_PATH.unlink(missing_ok=True)
+    server = await asyncio.start_unix_server(
+        handle_client,
+        path=str(SOCKET_PATH),
+        limit=MAX_REQUEST_BYTES + 1,
+    )
+    os.chmod(SOCKET_PATH, 0o660)
+    async with server:
+        await server.serve_forever()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/server/sandbox_sidecar/safe_http.py
+++ b/server/sandbox_sidecar/safe_http.py
@@ -1,0 +1,344 @@
+"""HTTPS client with DNS pinning and fail-closed public-network policy.
+
+The public MCP adapters do not use requests/httpx directly.  Every outbound
+request resolves the target first, rejects non-global addresses, connects to
+one validated address, keeps the original hostname for TLS verification, and
+repeats the checks for every redirect.
+"""
+
+from __future__ import annotations
+
+import http.client
+import ipaddress
+import os
+import re
+import socket
+import ssl
+import threading
+import time
+from dataclasses import dataclass
+from urllib.parse import urljoin, urlsplit
+from urllib.robotparser import RobotFileParser
+
+
+MAX_REDIRECTS = 3
+DEFAULT_MAX_RESPONSE_BYTES = 2 * 1024 * 1024
+ALLOWED_REQUEST_HEADERS = {
+    "accept",
+    "accept-language",
+    "content-type",
+    "user-agent",
+}
+REDIRECT_STATUSES = {301, 302, 303, 307, 308}
+BLOCKED_HOST_SUFFIXES = (
+    ".internal",
+    ".local",
+    ".localhost",
+    ".home.arpa",
+)
+CHARSET = re.compile(r"charset=([A-Za-z0-9._-]+)", re.IGNORECASE)
+SYNTHETIC_DNS_NETWORK = ipaddress.ip_network("198.18.0.0/15")
+
+
+class NetworkPolicyError(RuntimeError):
+    """Raised when an outbound target violates the public-network policy."""
+
+
+class ResponseLimitError(RuntimeError):
+    """Raised when a response exceeds its adapter-owned byte limit."""
+
+
+@dataclass(frozen=True, slots=True)
+class SafeHttpResponse:
+    url: str
+    status: int
+    headers: dict[str, str]
+    body: bytes
+
+    def text(self) -> str:
+        content_type = self.headers.get("content-type", "")
+        match = CHARSET.search(content_type)
+        encoding = match.group(1) if match else "utf-8"
+        try:
+            return self.body.decode(encoding, errors="replace")
+        except LookupError:
+            return self.body.decode("utf-8", errors="replace")
+
+
+def _normalized_host(hostname: str | None) -> str:
+    raw = str(hostname or "").strip().rstrip(".").lower()
+    if not raw or len(raw) > 253:
+        raise NetworkPolicyError("目标 URL 必须包含有效公网主机名。")
+    try:
+        host = raw.encode("idna").decode("ascii")
+    except UnicodeError as exc:
+        raise NetworkPolicyError("目标主机名无法安全规范化。") from exc
+    if host == "localhost" or host.endswith(BLOCKED_HOST_SUFFIXES):
+        raise NetworkPolicyError("目标主机属于本地或内部命名空间。")
+    try:
+        ipaddress.ip_address(host)
+    except ValueError:
+        return host
+    raise NetworkPolicyError("不允许使用 IP 字面量作为公网 MCP 目标。")
+
+
+def validate_public_https_url(
+    url: str,
+    *,
+    allowed_hosts: frozenset[str] | None = None,
+) -> tuple[str, str, int, str]:
+    clean = str(url or "").strip()
+    if not clean or len(clean) > 16_384:
+        raise NetworkPolicyError("目标 URL 不能为空且不能超过 16384 个字符。")
+    parsed = urlsplit(clean)
+    if parsed.scheme.lower() != "https":
+        raise NetworkPolicyError("仅允许访问公网 HTTPS 地址。")
+    if parsed.username is not None or parsed.password is not None:
+        raise NetworkPolicyError("目标 URL 不得嵌入用户名或密码。")
+    host = _normalized_host(parsed.hostname)
+    try:
+        port = parsed.port or 443
+    except ValueError as exc:
+        raise NetworkPolicyError("目标 URL 端口无效。") from exc
+    if port != 443:
+        raise NetworkPolicyError("公网 MCP 适配器仅允许 HTTPS 443 端口。")
+    if allowed_hosts is not None and host not in allowed_hosts:
+        raise NetworkPolicyError("目标域名不在该适配器的固定出口清单中。")
+    path = parsed.path or "/"
+    if parsed.query:
+        path = f"{path}?{parsed.query}"
+    normalized = f"https://{host}{path}"
+    return normalized, host, port, path
+
+
+def resolve_public_addresses(host: str, port: int = 443) -> tuple[str, ...]:
+    try:
+        records = socket.getaddrinfo(
+            host,
+            port,
+            type=socket.SOCK_STREAM,
+            proto=socket.IPPROTO_TCP,
+        )
+    except socket.gaierror as exc:
+        raise NetworkPolicyError("公网目标 DNS 解析失败。") from exc
+    addresses = tuple(dict.fromkeys(record[4][0] for record in records))
+    if not addresses:
+        raise NetworkPolicyError("公网目标没有可用 DNS 地址。")
+    allow_synthetic_dns = os.getenv(
+        "MCP_PUBLIC_ALLOW_SYNTHETIC_DNS",
+        "",
+    ).strip().lower() in {"1", "true", "yes", "on"}
+    for value in addresses:
+        try:
+            address = ipaddress.ip_address(value)
+        except ValueError as exc:
+            raise NetworkPolicyError("DNS 返回了无效地址。") from exc
+        if not address.is_global and not (
+            allow_synthetic_dns and address in SYNTHETIC_DNS_NETWORK
+        ):
+            raise NetworkPolicyError("DNS 返回了私网、回环、链路本地或保留地址。")
+    return addresses
+
+
+class _PinnedHTTPSConnection(http.client.HTTPSConnection):
+    def __init__(
+        self,
+        host: str,
+        resolved_ip: str,
+        *,
+        port: int,
+        timeout: float,
+    ) -> None:
+        super().__init__(
+            host,
+            port=port,
+            timeout=timeout,
+            context=ssl.create_default_context(),
+        )
+        self._resolved_ip = resolved_ip
+
+    def connect(self) -> None:
+        self.sock = socket.create_connection(
+            (self._resolved_ip, self.port),
+            self.timeout,
+            self.source_address,
+        )
+        if self._tunnel_host:
+            self._tunnel()
+        self.sock = self._context.wrap_socket(
+            self.sock,
+            server_hostname=self.host,
+        )
+
+
+class SafeHttpClient:
+    def __init__(
+        self,
+        *,
+        allowed_hosts: frozenset[str] | None,
+        timeout: float = 12.0,
+        max_redirects: int = MAX_REDIRECTS,
+        max_response_bytes: int = DEFAULT_MAX_RESPONSE_BYTES,
+        minimum_intervals: dict[str, float] | None = None,
+    ) -> None:
+        self.allowed_hosts = allowed_hosts
+        self.timeout = min(max(float(timeout), 1.0), 30.0)
+        self.max_redirects = min(max(int(max_redirects), 0), MAX_REDIRECTS)
+        self.max_response_bytes = min(
+            max(int(max_response_bytes), 1),
+            DEFAULT_MAX_RESPONSE_BYTES,
+        )
+        self.minimum_intervals = dict(minimum_intervals or {})
+        self._next_request_at: dict[str, float] = {}
+        self._rate_lock = threading.Lock()
+        self._robots_cache: dict[tuple[str, str], RobotFileParser] = {}
+
+    def _throttle(self, host: str) -> None:
+        interval = max(float(self.minimum_intervals.get(host, 0.0)), 0.0)
+        if not interval:
+            return
+        with self._rate_lock:
+            now = time.monotonic()
+            wait = max(self._next_request_at.get(host, now) - now, 0.0)
+            self._next_request_at[host] = max(now, self._next_request_at.get(host, now)) + interval
+        if wait:
+            time.sleep(wait)
+
+    @staticmethod
+    def _headers(headers: dict[str, str] | None) -> dict[str, str]:
+        output: dict[str, str] = {}
+        for raw_name, raw_value in (headers or {}).items():
+            name = str(raw_name).strip()
+            value = str(raw_value).strip()
+            if name.lower() not in ALLOWED_REQUEST_HEADERS:
+                raise NetworkPolicyError("适配器尝试发送未授权的 HTTP Header。")
+            if not value or "\r" in value or "\n" in value or len(value) > 1_024:
+                raise NetworkPolicyError("HTTP Header 值无效。")
+            output[name] = value
+        output.setdefault(
+            "User-Agent",
+            "ModelMirror-MCP/1.0 (+https://github.com/PinkElf-Elysia/ModelMirror)",
+        )
+        output.setdefault("Accept", "application/json,text/plain,text/html;q=0.9")
+        output.setdefault("Connection", "close")
+        return output
+
+    def request(
+        self,
+        url: str,
+        *,
+        method: str = "GET",
+        headers: dict[str, str] | None = None,
+        body: bytes | None = None,
+        max_response_bytes: int | None = None,
+    ) -> SafeHttpResponse:
+        current_url = str(url)
+        current_method = str(method or "GET").upper()
+        if current_method not in {"GET", "HEAD", "POST"}:
+            raise NetworkPolicyError("公网适配器只允许 GET、HEAD 或固定 POST 请求。")
+        current_body = body
+        request_headers = self._headers(headers)
+        response_limit = min(
+            max(int(max_response_bytes or self.max_response_bytes), 1),
+            self.max_response_bytes,
+        )
+
+        for redirect_count in range(self.max_redirects + 1):
+            normalized, host, port, path = validate_public_https_url(
+                current_url,
+                allowed_hosts=self.allowed_hosts,
+            )
+            addresses = resolve_public_addresses(host, port)
+            self._throttle(host)
+            connection = _PinnedHTTPSConnection(
+                host,
+                addresses[0],
+                port=port,
+                timeout=self.timeout,
+            )
+            try:
+                connection.request(
+                    current_method,
+                    path,
+                    body=current_body,
+                    headers=request_headers,
+                )
+                response = connection.getresponse()
+                response_headers = {
+                    str(name).lower(): str(value)
+                    for name, value in response.getheaders()
+                }
+                if response.status in REDIRECT_STATUSES:
+                    location = response_headers.get("location")
+                    response.read(64 * 1024)
+                    if not location:
+                        raise NetworkPolicyError("远程服务返回了缺少 Location 的重定向。")
+                    if redirect_count >= self.max_redirects:
+                        raise NetworkPolicyError("远程服务重定向次数超过上限。")
+                    current_url = urljoin(normalized, location)
+                    if response.status == 303 or (
+                        response.status in {301, 302} and current_method == "POST"
+                    ):
+                        current_method = "GET"
+                        current_body = None
+                    continue
+                content_length = response_headers.get("content-length")
+                if content_length:
+                    try:
+                        if int(content_length) > response_limit:
+                            raise ResponseLimitError("远程响应声明的大小超过适配器上限。")
+                    except ValueError:
+                        pass
+                chunks: list[bytes] = []
+                total = 0
+                while True:
+                    chunk = response.read(min(64 * 1024, response_limit + 1 - total))
+                    if not chunk:
+                        break
+                    total += len(chunk)
+                    if total > response_limit:
+                        raise ResponseLimitError("远程响应超过适配器大小上限。")
+                    chunks.append(chunk)
+                return SafeHttpResponse(
+                    url=normalized,
+                    status=int(response.status),
+                    headers=response_headers,
+                    body=b"".join(chunks),
+                )
+            except (OSError, ssl.SSLError, http.client.HTTPException) as exc:
+                raise NetworkPolicyError("公网 HTTPS 请求失败。") from exc
+            finally:
+                connection.close()
+        raise NetworkPolicyError("远程服务重定向次数超过上限。")
+
+    def assert_robots_allowed(self, url: str, user_agent: str) -> None:
+        normalized, host, _, path = validate_public_https_url(
+            url,
+            allowed_hosts=self.allowed_hosts,
+        )
+        key = (host, user_agent)
+        parser = self._robots_cache.get(key)
+        if parser is None:
+            robots_url = f"https://{host}/robots.txt"
+            robots_client = SafeHttpClient(
+                allowed_hosts=frozenset({host}),
+                timeout=self.timeout,
+                max_redirects=self.max_redirects,
+                max_response_bytes=min(self.max_response_bytes, 256 * 1024),
+                minimum_intervals=self.minimum_intervals,
+            )
+            response = robots_client.request(
+                robots_url,
+                headers={"User-Agent": user_agent, "Accept": "text/plain"},
+            )
+            if response.status in {401, 403} or response.status >= 500:
+                raise NetworkPolicyError("无法确认 robots.txt 允许该页面，已按失败关闭处理。")
+            parser = RobotFileParser()
+            parser.set_url(robots_url)
+            if 400 <= response.status < 500:
+                parser.parse([])
+            else:
+                parser.parse(response.text().splitlines())
+            self._robots_cache[key] = parser
+        if not parser.can_fetch(user_agent, path):
+            raise NetworkPolicyError("目标站点 robots.txt 不允许自动获取该页面。")

--- a/server/tests/test_mcp_catalog.py
+++ b/server/tests/test_mcp_catalog.py
@@ -15,6 +15,7 @@ from server.mcp.catalog import (
     CATALOG_ADAPTERS,
     LOCAL_STDIO_ADAPTERS,
     WAVE_ONE_ADAPTERS,
+    WAVE_TWO_ADAPTERS,
     WAVE_PROJECTS,
     CatalogAdapterManifest,
     CatalogConfigurationRequest,
@@ -141,17 +142,26 @@ def test_catalog_freezes_100_projects_and_maps_all_waves_once() -> None:
     assert set(phased).isdisjoint(LOCAL_STDIO_ADAPTERS)
     assert set(CATALOG_ADAPTERS) == set(phased) | set(LOCAL_STDIO_ADAPTERS)
     assert set(WAVE_ONE_ADAPTERS) == set(WAVE_PROJECTS[1])
+    assert set(WAVE_TWO_ADAPTERS) == set(WAVE_PROJECTS[2]) - {
+        "bibigpt-mcp",
+        "airbnb-mcp",
+    }
     assert sum(
         manifest.availability == "ready"
         for manifest in CATALOG_ADAPTERS.values()
-    ) == 10
+    ) == 13
     assert sum(
         manifest.availability == "planned"
         for manifest in CATALOG_ADAPTERS.values()
-    ) == 90
+    ) == 85
+    assert sum(
+        manifest.availability == "blocked"
+        for manifest in CATALOG_ADAPTERS.values()
+    ) == 2
     assert {manifest.availability for manifest in CATALOG_ADAPTERS.values()} == {
         "ready",
         "planned",
+        "blocked",
     }
 
 
@@ -184,7 +194,7 @@ def test_frontend_catalog_ids_match_backend_registry_and_never_submit_commands()
 def test_planned_adapter_cannot_be_enabled_by_environment(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    manifest = CATALOG_ADAPTERS["fetch-mcp"]
+    manifest = CATALOG_ADAPTERS["basic-memory-mcp"]
     monkeypatch.setenv(manifest.feature_flag, "true")
 
     assert manifest.feature_enabled is True
@@ -209,15 +219,16 @@ async def test_catalog_api_hides_execution_details_and_rejects_planned_connect()
             assert response.status_code == 200
             payload = response.json()
             assert payload["total"] == 100
-            assert payload["ready"] == 10
-            assert payload["planned"] == 90
+            assert payload["ready"] == 13
+            assert payload["planned"] == 85
+            assert payload["blocked"] == 2
             serialized = response.text.lower()
             assert "server_command" not in serialized
             assert "install_command" not in serialized
             assert '"endpoint"' not in serialized
 
             blocked = await client.post(
-                "/api/mcp/catalog/fetch-mcp/connect"
+                "/api/mcp/catalog/bibigpt-mcp/connect"
             )
             assert blocked.status_code == 409
             assert "尚未通过生产级适配验收" in blocked.text
@@ -319,6 +330,61 @@ async def test_wave_one_adapter_uses_bundled_sandbox_profile() -> None:
     assert set(public["tool_policies"]) == set(
         WAVE_ONE_ADAPTERS["calculator-mcp"][1]
     )
+
+
+@pytest.mark.asyncio
+async def test_wave_two_adapter_uses_fixed_public_sidecar_profile() -> None:
+    service, manager, installer, _ = make_service()
+
+    prepared = await service.prepare("fetch-mcp")
+    assert prepared["prepared"] is True
+    assert prepared["metadata"]["adapter_version"] == "0.6.3-secure-compatible-v1"
+    assert prepared["metadata"]["runtime_image"] == "modelmirror-sandbox:wave2-public-v1"
+    assert installer.calls == []
+
+    connected = await service.connect("fetch-mcp")
+    assert connected["tools_count"] == 1
+    assert manager.profiles == [
+        {
+            "transport": "stdio",
+            "server_command": list(CATALOG_ADAPTERS["fetch-mcp"].server_command),
+            "network_policy": "validated-public-https:user-supplied-host",
+            "reconnect_attempts": 1,
+            "operation_timeout": 45.0,
+        }
+    ]
+    public = next(
+        item
+        for item in service.list_adapters()["adapters"]
+        if item["project_id"] == "fetch-mcp"
+    )
+    assert public["availability"] == "ready"
+    assert public["executable"] is True
+    assert public["connection_kind"] == "sandboxed-stdio"
+    assert set(public["tool_policies"]) == {"fetch"}
+
+
+def test_bibigpt_is_fail_closed_until_oauth_wave() -> None:
+    manifest = CATALOG_ADAPTERS["bibigpt-mcp"]
+
+    assert manifest.availability == "blocked"
+    assert manifest.wave == 2
+    assert manifest.connection_kind == "remote-mcp"
+    assert manifest.server_command == ()
+    assert manifest.endpoint == ""
+    assert manifest.executable is False
+    assert "oauth-pkce" in manifest.required_capabilities
+
+
+def test_airbnb_is_fail_closed_on_upstream_schema_drift() -> None:
+    manifest = CATALOG_ADAPTERS["airbnb-mcp"]
+
+    assert manifest.availability == "blocked"
+    assert manifest.wave == 2
+    assert manifest.server_command == ()
+    assert manifest.executable is False
+    assert manifest.network_policy == "blocked:upstream-schema-drift"
+    assert "schema-drift-recovery" in manifest.required_capabilities
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_mcp_public_adapters.py
+++ b/server/tests/test_mcp_public_adapters.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+import json
+import socket
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from server.mcp.public_proxy import ALLOWED_ADAPTERS as PROXY_ADAPTERS
+from server.sandbox_sidecar import safe_http
+from server.sandbox_sidecar.public_mcp import (
+    ADAPTER_TOOL_NAMES,
+    BUILDERS,
+    _airbnb_script_data,
+    _find_airbnb_branch,
+    airbnb_details_payload,
+    fetch_payload,
+    geowire_providers_payload,
+    quickchart_url,
+)
+from server.sandbox_sidecar.public_server import PUBLIC_ADAPTERS
+from server.sandbox_sidecar.safe_http import (
+    NetworkPolicyError,
+    ResponseLimitError,
+    SafeHttpClient,
+    SafeHttpResponse,
+    resolve_public_addresses,
+    validate_public_https_url,
+)
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_public_url_policy_rejects_ssrf_primitives() -> None:
+    for url in (
+        "http://example.com",
+        "https://localhost/health",
+        "https://127.0.0.1/health",
+        "https://[::1]/health",
+        "https://user:pass@example.com/",
+        "https://example.com:8443/",
+        "https://service.internal/",
+    ):
+        with pytest.raises(NetworkPolicyError):
+            validate_public_https_url(url)
+
+    normalized, host, port, path = validate_public_https_url(
+        "https://Example.COM/docs?q=1",
+        allowed_hosts=frozenset({"example.com"}),
+    )
+    assert normalized == "https://example.com/docs?q=1"
+    assert (host, port, path) == ("example.com", 443, "/docs?q=1")
+
+    with pytest.raises(NetworkPolicyError, match="固定出口清单"):
+        validate_public_https_url(
+            "https://other.example/",
+            allowed_hosts=frozenset({"example.com"}),
+        )
+
+
+def test_dns_policy_rejects_private_or_mixed_answers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda *args, **kwargs: [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443)),
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 443)),
+        ],
+    )
+    with pytest.raises(NetworkPolicyError, match="私网"):
+        resolve_public_addresses("example.com")
+
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda *args, **kwargs: [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443)),
+        ],
+    )
+    assert resolve_public_addresses("example.com") == ("93.184.216.34",)
+
+
+def test_dns_policy_allows_only_explicit_rfc2544_fake_ip_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda *args, **kwargs: [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("198.18.0.42", 443)),
+        ],
+    )
+    monkeypatch.delenv("MCP_PUBLIC_ALLOW_SYNTHETIC_DNS", raising=False)
+    with pytest.raises(NetworkPolicyError):
+        resolve_public_addresses("example.com")
+
+    monkeypatch.setenv("MCP_PUBLIC_ALLOW_SYNTHETIC_DNS", "true")
+    assert resolve_public_addresses("example.com") == ("198.18.0.42",)
+
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda *args, **kwargs: [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.0.0.42", 443)),
+        ],
+    )
+    with pytest.raises(NetworkPolicyError):
+        resolve_public_addresses("example.com")
+
+
+class _FakeResponse:
+    def __init__(self, status: int, headers: dict[str, str], body: bytes = b"") -> None:
+        self.status = status
+        self._headers = headers
+        self._body = body
+        self._offset = 0
+
+    def getheaders(self) -> list[tuple[str, str]]:
+        return list(self._headers.items())
+
+    def read(self, amount: int = -1) -> bytes:
+        if amount < 0:
+            amount = len(self._body) - self._offset
+        chunk = self._body[self._offset : self._offset + amount]
+        self._offset += len(chunk)
+        return chunk
+
+
+class _FakeConnection:
+    responses: list[_FakeResponse] = []
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.response = self.responses.pop(0)
+
+    def request(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    def getresponse(self) -> _FakeResponse:
+        return self.response
+
+    def close(self) -> None:
+        return None
+
+
+def test_redirect_target_is_revalidated_and_response_is_bounded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(safe_http, "_PinnedHTTPSConnection", _FakeConnection)
+    monkeypatch.setattr(
+        safe_http,
+        "resolve_public_addresses",
+        lambda host, port=443: ("93.184.216.34",),
+    )
+    _FakeConnection.responses = [
+        _FakeResponse(302, {"location": "https://127.0.0.1/admin"})
+    ]
+    with pytest.raises(NetworkPolicyError):
+        SafeHttpClient(allowed_hosts=None).request("https://example.com/")
+
+    _FakeConnection.responses = [
+        _FakeResponse(200, {"content-length": "33"}, b"x" * 33)
+    ]
+    with pytest.raises(ResponseLimitError):
+        SafeHttpClient(
+            allowed_hosts=frozenset({"example.com"}),
+            max_response_bytes=32,
+        ).request("https://example.com/")
+
+
+def test_robots_policy_is_fail_closed_and_cannot_be_bypassed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = SafeHttpClient(allowed_hosts=frozenset({"example.com"}))
+
+    def deny_robots(*args: Any, **kwargs: Any) -> SafeHttpResponse:
+        return SafeHttpResponse(
+            url="https://example.com/robots.txt",
+            status=200,
+            headers={"content-type": "text/plain"},
+            body=b"User-agent: *\nDisallow: /private\n",
+        )
+
+    monkeypatch.setattr(SafeHttpClient, "request", deny_robots)
+    with pytest.raises(NetworkPolicyError, match="robots.txt"):
+        client.assert_robots_allowed("https://example.com/private/data", "test-agent")
+
+    failed = SafeHttpClient(allowed_hosts=frozenset({"example.com"}))
+
+    def unavailable(*args: Any, **kwargs: Any) -> SafeHttpResponse:
+        return SafeHttpResponse(
+            url="https://example.com/robots.txt",
+            status=503,
+            headers={},
+            body=b"",
+        )
+
+    monkeypatch.setattr(SafeHttpClient, "request", unavailable)
+    with pytest.raises(NetworkPolicyError, match="失败关闭"):
+        failed.assert_robots_allowed("https://example.com/docs", "test-agent")
+
+
+def test_fetch_contract_uses_safe_client_and_paginates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+
+    class FakeSafeClient:
+        def __init__(self, **kwargs: Any) -> None:
+            assert kwargs["allowed_hosts"] is None
+
+        def assert_robots_allowed(self, url: str, user_agent: str) -> None:
+            events.append(f"robots:{url}")
+
+        def request(self, url: str, **kwargs: Any) -> SafeHttpResponse:
+            events.append(f"request:{url}")
+            return SafeHttpResponse(
+                url=url,
+                status=200,
+                headers={"content-type": "text/html; charset=utf-8"},
+                body=(b"<html><main><h1>Title</h1><p>Hello world</p></main></html>"),
+            )
+
+    monkeypatch.setattr(
+        "server.sandbox_sidecar.public_mcp.SafeHttpClient",
+        FakeSafeClient,
+    )
+    content = fetch_payload("https://example.com/docs", max_length=8)
+    assert "Title" in content
+    assert "内容已截断" in content
+    assert events == [
+        "robots:https://example.com/docs",
+        "request:https://example.com/docs",
+    ]
+
+
+def test_quickchart_contract_is_url_only_and_rejects_executable_config() -> None:
+    result = quickchart_url(
+        "bar",
+        [{"label": "销售额", "data": [1, 2]}],
+        ["一月", "二月"],
+        "月度销售",
+    )
+    assert result["url"].startswith("https://quickchart.io/chart?c=")
+    assert result["datasets"] == 1
+    assert "本批不写入本地文件" in result["note"]
+
+    with pytest.raises(ValueError, match="远程 URL"):
+        quickchart_url(
+            "bar",
+            [{"data": [1]}],
+            options={"image": {"url": "https://evil.invalid/a.png"}},
+        )
+    with pytest.raises(ValueError, match="固定允许清单"):
+        quickchart_url("unknown", [{"data": [1]}])
+
+
+def test_airbnb_schema_drift_probe_and_input_limits() -> None:
+    fixture = {
+        "niobeClientData": [
+            [
+                "key",
+                {
+                    "data": {
+                        "presentation": {
+                            "staysSearch": {"results": {"searchResults": []}}
+                        }
+                    }
+                },
+            ]
+        ]
+    }
+    html = (
+        '<script id="data-deferred-state-0">'
+        + json.dumps(fixture)
+        + "</script>"
+    )
+    data = _airbnb_script_data(html)
+    branch = _find_airbnb_branch(
+        data,
+        ("data", "presentation", "staysSearch", "results"),
+    )
+    assert branch == {"searchResults": []}
+
+    with pytest.raises(ValueError, match="房源 ID"):
+        airbnb_details_payload("../admin")
+
+
+def test_public_adapter_contract_and_container_isolation() -> None:
+    assert set(BUILDERS) == set(ADAPTER_TOOL_NAMES) == PROXY_ADAPTERS == PUBLIC_ADAPTERS
+    assert ADAPTER_TOOL_NAMES == {
+        "fetch-mcp": ("fetch",),
+        "quickchart-mcp": ("generate_chart",),
+        "geowire-mcp": (
+            "search_places",
+            "geocode_address",
+            "reverse_geocode",
+            "get_directions",
+            "distance_matrix",
+            "list_geo_providers",
+        ),
+    }
+    assert geowire_providers_payload()["credentials"] == "none"
+
+    compose = (PROJECT_ROOT / "docker-compose.yml").read_text(encoding="utf-8")
+    dockerfile = (
+        PROJECT_ROOT / "server" / "sandbox_sidecar" / "Dockerfile"
+    ).read_text(encoding="utf-8")
+    public_server = (
+        PROJECT_ROOT / "server" / "sandbox_sidecar" / "public_server.py"
+    ).read_text(encoding="utf-8")
+    safe_client = (
+        PROJECT_ROOT / "server" / "sandbox_sidecar" / "safe_http.py"
+    ).read_text(encoding="utf-8")
+
+    assert "mcp-public:" in compose
+    assert "mcp_public_egress" in compose
+    assert "read_only: true" in compose
+    assert "pids_limit: 128" in compose
+    assert "cap_drop:" in compose and "no-new-privileges:true" in compose
+    assert "USER 65532:65532" in dockerfile
+    assert "preexec_fn" not in public_server
+    assert '"--read-only"' in public_server
+    assert '"--compute-limits"' in public_server
+    assert "resolve_public_addresses(host, port)" in safe_client
+    assert "address.is_global" in safe_client
+    assert "server_hostname=self.host" in safe_client


### PR DESCRIPTION
## 变更摘要

在冻结的 100 项 MCP 目录基线上完成第 2 批“无凭据公共远程能力”适配，不扩充条目数量，也不引入自定义连接或 MCP Builder。

- 放行 `fetch-mcp`、`quickchart-mcp`、`geowire-mcp`
- `bibigpt-mcp` 因上游现要求 OAuth 2.1 或 API Key，标记为 `blocked` 并转入第 10 批
- `airbnb-mcp` 因上游工具契约漂移未通过代表调用，标记为 `blocked`
- 目录状态更新为 13 个 `ready`、85 个 `planned`、2 个 `blocked`
- 前端展示中文批次、连接方式、风险、限制、固定运行版本与未满足条件

## 架构与安全

- 新增独立非 root `mcp-public` sidecar，通过 Unix socket 向后端提供固定适配器
- 只允许 HTTPS 443，拒绝 IP literal、localhost、内网和非全局地址
- DNS 解析后固定连接地址，每次重定向重新校验，防止 DNS 重绑定和 SSRF
- 限制重定向次数、原始响应大小、工具输出大小、进程数、CPU、内存和执行时间
- 只允许服务端固定 Header、出口域和工具集合，不接受客户端命令、MCP URL、环境变量名或工作目录
- Fetch 遵守 robots.txt；QuickChart 禁用文件下载；GeoWire 仅开放 Nominatim/公共 OSRM 无 Key 子集
- 上游 schema 漂移视为阻断，不提供绕过路径

## 用户影响

- 用户可从 MCP 目录直接连接 Fetch、QuickChart 和 GeoWire，并查看中文工具说明与配置表单
- BibiGPT 和 Airbnb 保留目录条目及阻断原因，但按钮不可连接，也不出现外站认证入口
- 自定义连接和 MCP Builder 仍为未排期远期规划

## 验证

- `npm.cmd run build`：通过
- MCP/Toolset 后端测试：`77 passed`
- `docker compose -p modelmirror config --quiet`：通过
- 真实 Docker smoke：三项初始化、工具发现、代表性调用、并发驻留、重连、断开与清理通过
- 共享栈 `5173/8000`：目录状态 100 / 13 / 85 / 2；Fetch 前端连接、工具发现与断开通过
- 全新页面控制台无错误，最终 MCP 会话为空
- 390px 移动端无横向溢出

## 回退

每个项目使用独立服务端开关。回退时可关闭项目开关、断开会话并清理 sidecar 工作区，无需删除目录条目或凭据。
