### PR TITLE
feature: 复刻 Dify Agent Strategy 双策略运行时

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,9 @@ OPENROUTER_API_KEY=your-openrouter-key
 OPENROUTER_HTTP_REFERER=http://localhost:5173
 OPENROUTER_APP_TITLE=ModelMirror
 
+# Agent Strategy V2。设为 false 并重启可立即恢复旧 ReAct-Lite 运行路径。
+WORKFLOW_AGENT_STRATEGY_V2_ENABLED=true
+
 # CORS（可选）
 ALLOWED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,5 +1,21 @@
 # Third-party notices
 
+## Dify Agent Strategy 0.0.42
+
+- Project: `langgenius/dify-official-plugins`
+- Package: `langgenius-agent_0.0.42.difypkg`
+- Package SHA-256: `7C5FEEE39FC5B534B8822472E3DFD771C9E3C2960A96A164A02B0873D922343B`
+- License: Apache License 2.0
+- Upstream: <https://github.com/langgenius/dify-official-plugins>
+- Integration boundary: behavioral reference for Function Calling and ReAct
+  strategy semantics. ModelMirror does not vendor `dify_plugin`, execute the
+  package, or copy the upstream SDK implementation line by line.
+
+The ModelMirror implementation under `server/xpert_runtime/agent_strategy/`
+is an independent adapter over the existing Runtime Toolset, policy,
+middleware, and audit chain. Copyright and license ownership of Dify remains
+with LangGenius, Inc. and the upstream contributors under Apache-2.0.
+
 ## PenguinHarness built-in Skills
 
 - Project: `Prism-Shadow/penguin-harness`

--- a/client/src/components/workflow/WorkflowEditor.tsx
+++ b/client/src/components/workflow/WorkflowEditor.tsx
@@ -291,6 +291,7 @@ function createNodeData(
       title: "Agent",
       description: "模型驱动的任务执行节点。",
       agentMode: "tool_first",
+      agentStrategy: "auto",
       instruction: "{{user_input}}",
       modelId: "",
       toolNames: "",
@@ -327,6 +328,7 @@ function createNodeData(
       rolePrompt: "你是负责执行当前工作流步骤的智能体，请直接输出结果。",
       taskInput: "{{user_input}}",
       toolMode: "none",
+      agentStrategy: "auto",
       toolNames: "",
       maxIterations: "5",
       promptSuffix: "",
@@ -729,15 +731,19 @@ function ConfigSwitch({
   label,
   description,
   checked,
+  disabled = false,
   onChange,
 }: {
   label: string;
   description?: string;
   checked: boolean;
+  disabled?: boolean;
   onChange: (checked: boolean) => void;
 }) {
   return (
-    <label className="flex items-start justify-between gap-3 rounded-lg border border-white/10 bg-white/[0.045] px-3 py-2">
+    <label
+      className={`flex items-start justify-between gap-3 rounded-lg border border-white/10 bg-white/[0.045] px-3 py-2 ${disabled ? "opacity-55" : ""}`}
+    >
       <span>
         <span className="block text-sm font-medium text-slate-100">{label}</span>
         {description ? (
@@ -749,6 +755,7 @@ function ConfigSwitch({
       <input
         checked={checked}
         className="mt-1 h-4 w-4 shrink-0 rounded border-white/20 bg-slate-950 text-brand-300"
+        disabled={disabled}
         onChange={(event) => onChange(event.target.checked)}
         type="checkbox"
       />
@@ -900,6 +907,10 @@ function AgentStudioPanel({
   onSelectNode: (nodeId: string) => void;
 }) {
   const isWorkflowAgent = data.kind === "workflow_agent";
+  const toolsEnabled = isWorkflowAgent
+    ? data.toolMode === "mcp_tools"
+    : data.agentMode !== "direct";
+  const selectedStrategy = data.agentStrategy ?? "auto";
   const [knowledgeBases, setKnowledgeBases] = useState<
     Array<{ id: string; name: string }>
   >([]);
@@ -968,7 +979,7 @@ function AgentStudioPanel({
   return (
     <div className="space-y-3">
       <div className="rounded-lg border border-brand-300/25 bg-brand-300/10 px-3 py-2 text-xs leading-5 text-brand-50">
-        智能体配置侧栏：当前保存配置草稿，实际执行继续沿用当前节点语义。
+        Agent Strategy V2：工具模式支持原生 Function Calling 与 ReAct，所有调用继续经过权限、中间件和审计链路。
       </div>
 
       <ConfigSection
@@ -1003,7 +1014,7 @@ function AgentStudioPanel({
         <div className="grid gap-2">
           <ConfigSwitch
             checked={workflowBooleanValue(data.disableOutput)}
-            description="仅保存配置，当前 runner 不改变输出行为。"
+            description="节点仍会执行；开启后不把最终结果写入输出变量。"
             label="禁用输出"
             onChange={(checked) => setStringBoolean("disableOutput", checked)}
           />
@@ -1017,7 +1028,14 @@ function AgentStudioPanel({
           />
           <ConfigSwitch
             checked={workflowBooleanValue(data.parallelToolCalls)}
-            description="仅并行执行只读、可并行且无需审批的工具。"
+            description={
+              !toolsEnabled
+                ? "当前为直接回答模式，不会调度工具。"
+                : selectedStrategy === "react"
+                  ? "ReAct 每轮只允许一个 Action；切换到 auto 或 function_calling 后可启用。"
+                  : "允许原生 Function Calling 在同一轮并发执行多个工具；默认关闭以保护有副作用的工具。"
+            }
+            disabled={!toolsEnabled || selectedStrategy === "react"}
             label="并行工具调用"
             onChange={(checked) =>
               setStringBoolean("parallelToolCalls", checked)
@@ -1229,8 +1247,36 @@ function AgentStudioPanel({
           </Field>
         ) : null}
 
-        {!isWorkflowAgent || data.toolMode === "mcp_tools" ? (
+        {toolsEnabled ? (
           <>
+            <Field label="Agent 策略">
+              <select
+                className={textInputClass()}
+                onChange={(event) => {
+                  const nextStrategy = event.target.value as
+                    | "auto"
+                    | "function_calling"
+                    | "react";
+                  update({
+                    agentStrategy: nextStrategy,
+                    ...(nextStrategy === "react"
+                      ? { parallelToolCalls: "false" }
+                      : {}),
+                  });
+                }}
+                value={selectedStrategy}
+              >
+                <option className="bg-slate-950" value="auto">
+                  auto：优先 Function Calling，安全回退 ReAct
+                </option>
+                <option className="bg-slate-950" value="function_calling">
+                  function_calling：原生工具调用
+                </option>
+                <option className="bg-slate-950" value="react">
+                  react：文本 Action / Observation 循环
+                </option>
+              </select>
+            </Field>
             <Field label="允许工具名（逗号分隔，留空代表全部已注册工具）">
               <input
                 className={textInputClass()}

--- a/client/src/types/workflow.ts
+++ b/client/src/types/workflow.ts
@@ -81,6 +81,7 @@ export interface WorkflowNodeData extends Record<string, unknown> {
   llmFallbackPrompt?: string;
   agentName?: string;
   agentMode?: string;
+  agentStrategy?: "auto" | "function_calling" | "react";
   toolMode?: string;
   rolePrompt?: string;
   taskTitle?: string;
@@ -201,4 +202,9 @@ export interface WorkflowRunEvent {
   variables?: Record<string, string>;
   message?: string;
   at?: number;
+  strategy?: "function_calling" | "react";
+  iteration?: number;
+  status?: string;
+  tool_call_id?: string;
+  duration_ms?: number;
 }

--- a/docs/workflow-native-design.md
+++ b/docs/workflow-native-design.md
@@ -4,6 +4,13 @@
 > `/workflow-native` 是静态校验与设计实验线，`/rag` 是独立的本地知识系统。
 > 本文前半部分保留增量时间线；涉及 Dify 主路径的早期表述已由当前状态取代。
 
+> 2026-08-06 Agent Strategy V2：`agent.tool_first` 与
+> `workflow_agent.mcp_tools` 共享 `server/xpert_runtime/agent_strategy/`
+> 运行时。新增 `agentStrategy=auto|function_calling|react`；旧工作流缺失字段
+> 时按 `auto`。`auto` 只在尚未执行工具且网关以 400/422 明确拒绝
+> `tools/tool_choice/parallel_tool_calls` 时回退 ReAct。关闭
+> `WORKFLOW_AGENT_STRATEGY_V2_ENABLED` 并重启即可恢复 ReAct-Lite，无需迁移数据。
+
 > 2026-07-23 Prompt/Plugin：新增 `plugin_resource`，通过 `plugin-binding -> plugin` 绑定一个 `workflow_agent`，不参与控制流、变量可达性或节点调度。Xpert 发布固定 Plugin 与直接 Prompt Profile 版本；运行时把 Plugin 编译为固定 Toolset、命名空间化 Skill、已注册中间件预设和私有命令。别名、工具或中间件冲突 fail-closed。Slash Command 仍执行当前 Xpert，SSE 事件类型不变。
 
 > 2026-07-23 Agent Features：Xpert 草稿和不可变版本已固定开场白、建议问题、会话标题/摘要、记忆回复、文件策略和 TTS/STT。会话摘要编译为输出 `workflow_agent` 的隐式 `context_compression`，文件关闭时附件不会进入运行或 Goal。`XpertAgentConfig` 的最大并发与递归限制约束整棵执行树；节点级工具预算仍是更窄的局部限制。Classic Workflow SSE 不新增事件类型。
@@ -641,19 +648,24 @@ Agent Task Runtime 包含三层：
 
 classic workflow 已新增 `agent_task` 节点，作为 Xpert Agent/Handoff 对齐的第一步闭环。前端可从节点调色板拖入“智能体任务”，配置 `taskTitle`、`taskInput`、`assignedAgent` 与 `outputVariable`；运行时会渲染 `{{变量}}` 模板，调用 `AgentTaskStore.create_task(...)` 创建一条 AgentTask，并将新任务的 `task_id` 写入 `outputVariable`。该节点当前只负责创建任务和输出 ID，不做真实队列分派、专家协作或任务执行；完整任务详情继续通过现有 Agent Task API 查询。
 
-classic workflow 已新增 `workflow_agent` 节点，作为 Xpert Workflow Agent 的最小执行闭环。前端可从节点调色板拖入“工作流智能体”，配置 `agentName`、`modelId`、`rolePrompt`、`taskInput`、`toolMode`、`toolNames`、`maxIterations`、`promptSuffix` 与 `outputVariable`；运行时会先渲染 `{{变量}}`，再以 `rolePrompt` 作为该节点 system prompt、`taskInput` 作为用户输入执行。
+classic workflow 已新增 `workflow_agent` 节点，作为 Xpert Workflow Agent 的最小执行闭环。前端可从节点调色板拖入“工作流智能体”，配置 `agentName`、`modelId`、`rolePrompt`、`taskInput`、`toolMode`、`agentStrategy`、`toolNames`、`maxIterations`、`parallelToolCalls`、`promptSuffix` 与 `outputVariable`；运行时会先渲染 `{{变量}}`，再以 `rolePrompt` 作为该节点 system prompt、`taskInput` 作为用户输入执行。
 
-`toolMode=none` 时，节点直接调用现有工作流 LLM 流式函数，最终把模型输出写入 `outputVariable`。`toolMode=mcp_tools` 时，节点进入 ReAct-Lite 工具循环：模型每轮必须返回 `{"tool":"工具名","arguments":{...}}` 或 `{"answer":"最终答案"}`；工具调用统一经过 `run_tool_with_runtime`、`MCPToolsetProvider` 和 `MiddlewarePipeline.wrap_tool_call`，因此 workflow 中的 `tool_policy` 与 `tool_audit` 会对 `workflow_agent` 生效。该节点会登记 `workflow_agent` 子 run，便于运行观测查看；当前不使用 OpenAI function calling、不做 Handoff 自动调度、不实现真实多 Agent 协作。
+`toolMode=none` 时，节点保持直接回答。`toolMode=mcp_tools` 时，V2 默认先发送 OpenAI 兼容的 `tools`、`tool_choice` 与 `parallel_tool_calls`；强制 `react` 时使用 `Thought → Action JSON → Observation → FinalAnswer`，隐藏 Thought，只输出动作级 `node_delta`。所有真实工具调用继续经过 `run_tool_with_runtime`、Toolset、Middleware、权限策略和审计；checkpoint 只保存脱敏参数摘要、结果预览、耗时、调用 ID、策略和 token usage。关闭 V2 开关后恢复既有 ReAct-Lite JSON 决策协议。
 
-Knowledge Agent 复用同一条 ReAct-Lite 运行路径，不新增第二套 Agent runner。`knowledgeReadEnabled` / `knowledgeWriteEnabled` 仅对 `workflow_agent` 生效，且要求 `toolMode=mcp_tools` 与 1 至 5 个 `knowledgeBaseIds`。`toolNames` 继续只过滤 MCP 工具；Memory/Knowledge capability 分别由节点开关控制。Knowledge 工具仍经过 runtime middleware、policy、audit 和 checkpoint。模型只能提出写入，正式审批和候选构建统一由 `/rag/:kbId/inbox` 完成。
+首版 V2 只接管已注册 MCP 工具。绑定 Knowledge/Toolset/Browser/Client/Office/Sandbox、Todo、Automation、Authoring 或交互式 HITL 的 `workflow_agent` 继续走可恢复的 ReAct-Lite 路径，避免破坏现有暂停/恢复和幂等语义；这些能力完成 V2 transcript checkpoint 后再迁移。
+
+Knowledge Agent 与其他 Runtime 工具复用同一共享策略运行时，不新增第二套 Agent runner。`knowledgeReadEnabled` / `knowledgeWriteEnabled` 仅对 `workflow_agent` 生效，且要求 `toolMode=mcp_tools` 与 1 至 5 个 `knowledgeBaseIds`。`toolNames` 继续只过滤 MCP 工具；Memory/Knowledge capability 分别由节点开关控制。Knowledge 工具仍经过 runtime middleware、policy、audit 和 checkpoint。模型只能提出写入，正式审批和候选构建统一由 `/rag/:kbId/inbox` 完成。
+
+V2 当前只处理文本消息与文本 observation。既有文本历史可由 middleware 传入，但不扩展公开 `ChatMessage`；不会把独立 RAG context、图片、文件或二进制工具结果直接透传给策略模型。非文本工具结果只记录类型和安全摘要，完整多模态透传留待后续。
 
 ## 2026-06-17 增量：Agent 节点
 
-`agent` 已进入 workflow-native / classic 共享实验线。它不是完整 Dify Agent 复刻，而是 ReAct-Lite MVP：模型要么直接返回答案，要么返回一个 JSON 工具调用决策，运行器再通过全局 MCP 工具注册表调用对应工具。
+`agent` 已进入 workflow-native / classic 共享实验线。工具模式复用 Agent Strategy V2；这是基于 Dify Agent 0.0.42 行为协议的独立适配实现，不引入 `dify_plugin`，也不逐行复制 SDK 代码。
 
 ### 字段
 
 - `agentMode`：`tool_first` 或 `direct`。默认 `tool_first`。
+- `agentStrategy`：`auto`、`function_calling` 或 `react`；缺失时按 `auto`。
 - `instruction`：任务指令，支持 `{{variable}}` 模板。
 - `modelId`：调用模型 ID。
 - `toolNames`：可选，逗号分隔的工具白名单；留空代表全部已注册工具。
@@ -661,13 +673,15 @@ Knowledge Agent 复用同一条 ReAct-Lite 运行路径，不新增第二套 Age
 - `maxIterations`：工具循环上限，默认 5，运行器最多允许 20。
 - `temperature`：模型温度，范围 0-2。
 - `promptSuffix`：可选补充提示词，支持 `{{variable}}` 模板。
+- `parallelToolCalls`：仅 Function Calling 使用；ReAct 模式在 UI 中禁用。
 
 ### 安全边界
 
-- `agent` 可通过 `WORKFLOW_AGENT_ENABLED=False` 降级为 no-op。
+- `agent` 可通过 `WORKFLOW_AGENT_ENABLED=False` 降级为 no-op；V2 可通过 `WORKFLOW_AGENT_STRATEGY_V2_ENABLED=false` 回退 ReAct-Lite。
 - `tool_first` 模式依赖 `/mcps` 已连接的 MCP Server；没有可用工具时会切换到直接回答。
 - 未配置 API Key、模型调用失败或工具调用失败时，运行器发出 `error` 事件并写入空字符串，不中断后续节点。
-- 当前只支持单 Agent 节点内的轻量工具循环，不实现复杂多 Agent 协作、记忆、长期任务或持久化运行态。
+- 一旦尝试真实工具调用，自动策略回退、整轮重试和备用模型切换均被禁止，避免重复外部副作用。
+- 当前不扩展 `/api/chat`、Dify 代理或 `agent_task`，也不实现图片/文件二进制工具结果透传。
 
 ## 回退方案
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -8,6 +8,8 @@ OPENROUTER_API_KEY=sk-or-v1-your-key-here
 ALLOWED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
 OPENROUTER_HTTP_REFERER=http://localhost:5173
 OPENROUTER_APP_TITLE=ModelMirror
+# Agent Strategy V2。设为 false 并重启可立即恢复旧 ReAct-Lite 运行路径。
+WORKFLOW_AGENT_STRATEGY_V2_ENABLED=true
 # 可选运维覆盖；实时目录和前端默认选择不依赖这两个旧回退值。
 OPENROUTER_TEXT_FALLBACK_MODEL=deepseek/deepseek-chat
 OPENROUTER_VISION_FALLBACK_MODEL=qwen/qwen2.5-vl-72b-instruct

--- a/server/main.py
+++ b/server/main.py
@@ -357,6 +357,7 @@ try:
         WorkflowExecution,
         WorkflowExecutionStore,
         RuntimeToolCall,
+        RuntimeToolError,
         RuntimeToolResult,
         TodoToolsetProvider,
         ToolPermissionPolicy,
@@ -471,6 +472,7 @@ except ModuleNotFoundError:
         WorkflowExecution,
         WorkflowExecutionStore,
         RuntimeToolCall,
+        RuntimeToolError,
         RuntimeToolResult,
         TodoToolsetProvider,
         ToolPermissionPolicy,
@@ -523,6 +525,25 @@ except ModuleNotFoundError:
         create_final_output_approval,
         human_in_the_loop_final_confirmation,
         workflow_node_registry,
+    )
+
+try:
+    from server.xpert_runtime.agent_strategy import (
+        AgentModelTurn,
+        AgentStrategyError,
+        AgentStrategyEvent,
+        AgentStrategyResult,
+        AgentStrategyRunner,
+        OpenAICompatibleAgentModelClient,
+    )
+except ModuleNotFoundError:
+    from xpert_runtime.agent_strategy import (
+        AgentModelTurn,
+        AgentStrategyError,
+        AgentStrategyEvent,
+        AgentStrategyResult,
+        AgentStrategyRunner,
+        OpenAICompatibleAgentModelClient,
     )
 
 try:
@@ -653,6 +674,10 @@ WORKFLOW_TIME_TOOL_ENABLED = True
 WORKFLOW_PYTHON_TIMEOUT_SECONDS = 3
 WORKFLOW_PYTHON_SANDBOX_ROOT = Path(__file__).resolve().parent / "workflow_sandboxes"
 WORKFLOW_AGENT_ENABLED = True
+WORKFLOW_AGENT_STRATEGY_V2_ENABLED = (
+    os.getenv("WORKFLOW_AGENT_STRATEGY_V2_ENABLED", "true").strip().lower()
+    in {"1", "true", "yes", "on"}
+)
 WORKFLOW_AGENT_MAX_ITERATIONS_DEFAULT = 5
 WORKFLOW_AGENT_MAX_TOKENS = 1024
 AGENT_TASK_STORAGE_DIR = os.getenv("AGENT_TASK_STORAGE_DIR", "").strip()
@@ -5187,10 +5212,18 @@ async def _run_workflow_response(
             )
             requested_tool_names = {
                 item.strip()
-                for item in str(tool_names_raw or "").split(",")
+                for item in re.split(r"[,\n]+", str(tool_names_raw or ""))
                 if item.strip()
             }
-            if requested_tool_names:
+            if requested_tool_names and include_mcp:
+                registered_names = {tool.name for tool in tools}
+                missing_names = sorted(requested_tool_names - registered_names)
+                if missing_names:
+                    raise AgentStrategyError(
+                        "Agent 工具白名单包含未注册或未连接的工具："
+                        + ", ".join(missing_names),
+                        code="capability_not_found",
+                    )
                 tools = [tool for tool in tools if tool.name in requested_tool_names]
             memory_tools = (
                 await workflow_memory_provider.list_tools()
@@ -5353,6 +5386,457 @@ async def _run_workflow_response(
                         allowed_tools.append(tool)
                 tools = allowed_tools
             return tools
+
+        async def record_agent_strategy_events(
+            events: list[AgentStrategyEvent],
+            *,
+            run_id: str | None,
+            checkpoint_prefix: str,
+            node: WorkflowNodePayload,
+            model_id: str,
+        ) -> None:
+            if not run_id:
+                return
+            checkpoint_names = {
+                "strategy_selected": f"{checkpoint_prefix}.strategy_selected",
+                "strategy_fallback": f"{checkpoint_prefix}.strategy_fallback",
+                "model_round": f"{checkpoint_prefix}.model_decision",
+                "tool_call": f"{checkpoint_prefix}.tool_call",
+                "final_answer": f"{checkpoint_prefix}.model_answer",
+                "iteration_limit": f"{checkpoint_prefix}.iteration_limit",
+            }
+            for event in events:
+                metadata = {
+                    "node_id": node.id,
+                    "model_id": model_id,
+                    "strategy": event.strategy,
+                    "iteration": event.iteration,
+                    "status": event.status,
+                    "tool_name": event.tool_name,
+                    "tool_call_id": event.tool_call_id,
+                    "arguments_summary": event.arguments_summary,
+                    "output_preview": event.output_preview,
+                    "duration_ms": event.duration_ms,
+                    **dict(event.metadata or {}),
+                }
+                await run_registry.record_checkpoint(
+                    run_id,
+                    event_type=checkpoint_names.get(
+                        event.event_type,
+                        f"{checkpoint_prefix}.{event.event_type}",
+                    ),
+                    title=event.event_type.replace("_", " ").title(),
+                    summary=event.message[:500],
+                    severity=(
+                        "error"
+                        if event.status in {"failed", "error"}
+                        else "warning"
+                        if event.status in {"warning", "rejected"}
+                        else "info"
+                    ),
+                    metadata={
+                        key: value
+                        for key, value in metadata.items()
+                        if value is not None
+                    },
+                )
+
+        def agent_strategy_node_events(
+            events: list[AgentStrategyEvent],
+            *,
+            node: WorkflowNodePayload,
+            title: str,
+            kind: str,
+            output_variable: str,
+            run_id: str | None,
+            max_iterations: int,
+        ) -> list[dict[str, Any]]:
+            node_events: list[dict[str, Any]] = []
+            for event in events:
+                if event.event_type == "final_answer":
+                    continue
+                if event.event_type == "tool_call":
+                    output = (
+                        f"[{event.iteration}/{max_iterations}] 调用工具 "
+                        f"{event.tool_name or 'unknown'}，状态：{event.status}"
+                    )
+                    if event.arguments_summary:
+                        output += f"，参数：{event.arguments_summary}"
+                    if event.output_preview:
+                        output += f"，结果预览：{event.output_preview}"
+                else:
+                    output = event.message
+                payload_event: dict[str, Any] = {
+                    "event": "node_delta",
+                    "node_id": node.id,
+                    "node_title": title,
+                    "node_type": kind,
+                    "output": output,
+                    "variable": output_variable,
+                    "strategy": event.strategy,
+                    "iteration": event.iteration,
+                    "status": event.status,
+                    "tool_name": event.tool_name,
+                    "tool_call_id": event.tool_call_id,
+                    "duration_ms": event.duration_ms,
+                }
+                if run_id:
+                    payload_event["run_id"] = run_id
+                node_events.append(payload_event)
+            return node_events
+
+        async def run_agent_strategy_v2(
+            *,
+            node: WorkflowNodePayload,
+            title: str,
+            kind: str,
+            model_id: str,
+            system_prompt: str,
+            user_prompt: str,
+            tool_names_raw: Any,
+            strategy: str,
+            max_iterations: int,
+            temperature: float,
+            parallel_tool_calls: bool,
+            output_variable: str,
+            max_tool_calls: int = 12,
+            max_tool_depth: int = 4,
+            run_id: str | None = None,
+            checkpoint_prefix: str = "workflow_agent",
+            include_mcp: bool = True,
+            include_memory_read: bool = False,
+            include_memory_write: bool = False,
+            include_knowledge_read: bool = False,
+            include_knowledge_write: bool = False,
+            knowledge_base_ids: list[str] | None = None,
+            external_xpert_tools: list[dict[str, Any]] | None = None,
+            toolset_resources: list[dict[str, Any]] | None = None,
+            include_datax: bool = False,
+            include_datax_proposals: bool = False,
+            include_todo: bool = False,
+            include_sandbox: bool = False,
+            include_skills: bool = False,
+            include_browser: bool = False,
+            include_client: bool = False,
+            include_office: bool = False,
+            include_automation: bool = False,
+            include_xpert_authoring: bool = False,
+            include_skill_creator: bool = False,
+            client_tools_config: dict[str, Any] | None = None,
+            office_automation_config: dict[str, Any] | None = None,
+            pipeline: MiddlewarePipeline | None = None,
+            middleware_context: MiddlewareContext | None = None,
+            middleware_specs: list[RuntimeMiddlewareSpec] | None = None,
+            selector_spec: RuntimeMiddlewareSpec | None = None,
+            history_messages: list[dict[str, Any]] | None = None,
+        ) -> AgentStrategyResult:
+            runtime_metadata = dict(task_state.get("runtime_metadata") or {})
+            current_depth = int(runtime_metadata.get("external_xpert_depth") or 0)
+            if current_depth > max_tool_depth:
+                raise RuntimeMiddlewareFatalError(
+                    f"Agent tool nesting depth exceeded maxToolDepth={max_tool_depth}."
+                )
+            available_tools = await workflow_available_tools(
+                tool_names_raw,
+                include_mcp=include_mcp,
+                include_memory_read=include_memory_read,
+                include_memory_write=include_memory_write,
+                include_knowledge_read=include_knowledge_read,
+                include_knowledge_write=include_knowledge_write,
+                external_xpert_tools=external_xpert_tools,
+                toolset_resources=toolset_resources,
+                include_datax=include_datax,
+                include_datax_proposals=include_datax_proposals,
+                include_todo=include_todo,
+                include_sandbox=include_sandbox,
+                include_skills=include_skills,
+                include_browser=include_browser,
+                include_client=include_client,
+                include_office=include_office,
+                include_automation=include_automation,
+                include_xpert_authoring=include_xpert_authoring,
+                include_skill_creator=include_skill_creator,
+                client_tools_config=client_tools_config,
+                office_automation_config=office_automation_config,
+                middleware_specs=middleware_specs,
+                apply_policy_filter=selector_spec is not None,
+            )
+            if selector_spec is not None and available_tools:
+                required_tools = set()
+                if include_todo:
+                    required_tools.update({"todo_list", "todo_create", "todo_update"})
+                if include_skills:
+                    required_tools.update({"skill_list", "skill_read", "skill_stage"})
+                if include_browser:
+                    required_tools.update(
+                        {"browser_navigate", "browser_snapshot", "browser_read"}
+                    )
+                if include_client:
+                    required_tools.update({"host_page_snapshot", "host_page_read"})
+                if include_office:
+                    required_tools.update(
+                        {
+                            "office_word_snapshot",
+                            "office_excel_snapshot",
+                            "office_powerpoint_snapshot",
+                        }
+                    )
+                if include_automation:
+                    required_tools.update({"automation_list", "automation_get"})
+                if include_datax:
+                    required_tools.update({"datax_scope", "datax_indicator_list"})
+                if include_xpert_authoring:
+                    required_tools.add("xpert_authoring_catalog")
+                if include_skill_creator:
+                    required_tools.add("skill_authoring_catalog")
+                required_tools.update(
+                    item.strip()
+                    for item in re.split(
+                        r"[,\n]",
+                        str(selector_spec.config.get("always_include_tools") or ""),
+                    )
+                    if item.strip()
+                )
+                selector_model_id = str(
+                    selector_spec.config.get("selector_model_id") or model_id
+                ).strip() or model_id
+                available_tools, selector_metadata = await select_runtime_tools(
+                    available_tools,
+                    user_prompt=user_prompt,
+                    model_id=selector_model_id,
+                    max_selected_tools=middleware_config_int(
+                        selector_spec.config,
+                        "max_selected_tools",
+                        8,
+                        1,
+                        20,
+                    ),
+                    required_tools=required_tools,
+                    model_text=middleware_model_text,
+                )
+                if middleware_context is not None:
+                    middleware_context.metadata["tool_selection"] = selector_metadata
+
+            gateway_url, gateway_key = get_llm_gateway_config()
+            if not gateway_url:
+                raise ValueError(LLM_GATEWAY_NOT_CONFIGURED_MESSAGE)
+            base_model_client = OpenAICompatibleAgentModelClient(
+                endpoint=gateway_url,
+                headers=llm_gateway_headers(gateway_key),
+                client_kwargs=llm_client_kwargs(),
+            )
+
+            class MiddlewareAgentModelClient:
+                async def complete(self, **kwargs: Any) -> AgentModelTurn:
+                    if pipeline is None or middleware_context is None:
+                        return await base_model_client.complete(**kwargs)
+                    captured_turn: AgentModelTurn | None = None
+
+                    async def handler(request: ModelCallRequest) -> ModelCallResponse:
+                        nonlocal captured_turn
+                        params = dict(request.params or {})
+                        captured_turn = await base_model_client.complete(
+                            model_id=request.model_id,
+                            messages=list(request.messages),
+                            temperature=float(
+                                params.get("temperature", kwargs["temperature"])
+                            ),
+                            max_tokens=int(params.get("max_tokens", kwargs["max_tokens"])),
+                            tools=params.get("tools", kwargs.get("tools")),
+                            tool_choice=params.get(
+                                "tool_choice", kwargs.get("tool_choice")
+                            ),
+                            parallel_tool_calls=params.get(
+                                "parallel_tool_calls",
+                                kwargs.get("parallel_tool_calls"),
+                            ),
+                        )
+                        return ModelCallResponse(
+                            text=captured_turn.content,
+                            raw=captured_turn,
+                            metadata={
+                                "model_id": request.model_id,
+                                "finish_reason": captured_turn.finish_reason,
+                                "usage": captured_turn.usage.to_dict(),
+                            },
+                        )
+
+                    response = await pipeline.run_model_call(
+                        ModelCallRequest(
+                            model_id=kwargs["model_id"],
+                            messages=list(kwargs["messages"]),
+                            params={
+                                "temperature": kwargs["temperature"],
+                                "max_tokens": kwargs["max_tokens"],
+                                "tools": kwargs.get("tools"),
+                                "tool_choice": kwargs.get("tool_choice"),
+                                "parallel_tool_calls": kwargs.get(
+                                    "parallel_tool_calls"
+                                ),
+                            },
+                        ),
+                        handler,
+                        middleware_context,
+                    )
+                    turn = (
+                        response.raw
+                        if isinstance(response.raw, AgentModelTurn)
+                        else captured_turn
+                    )
+                    if turn is None:
+                        raise RuntimeError("Agent model middleware returned no model turn.")
+                    turn.content = response.text
+                    return turn
+
+            model_client = MiddlewareAgentModelClient()
+            if not available_tools:
+                direct_turn = await model_client.complete(
+                    model_id=model_id,
+                    messages=[
+                        {"role": "system", "content": system_prompt},
+                        *list(history_messages or []),
+                        {"role": "user", "content": user_prompt},
+                    ],
+                    temperature=temperature,
+                    max_tokens=WORKFLOW_AGENT_MAX_TOKENS,
+                )
+                answer = direct_turn.content.strip()
+                if not answer:
+                    raise AgentStrategyError(
+                        "模型没有返回直接回答。", code="empty_model_response"
+                    )
+                active_strategy = "react" if strategy == "react" else "function_calling"
+                result = AgentStrategyResult(
+                    answer=answer,
+                    strategy=active_strategy,
+                    events=[
+                        AgentStrategyEvent(
+                            event_type="strategy_fallback",
+                            strategy=active_strategy,
+                            status="warning",
+                            message="Agent 切换为直接回答：没有可用 Runtime 工具。",
+                            metadata={"reason": "no_available_tools"},
+                        ),
+                        AgentStrategyEvent(
+                            event_type="final_answer",
+                            strategy=active_strategy,
+                            status="completed",
+                            message=f"Agent 已生成最终答案（{len(answer)} 字符）。",
+                            metadata={
+                                "answer_length": len(answer),
+                                "direct_fallback": True,
+                                "usage": direct_turn.usage.to_dict(),
+                            },
+                        ),
+                    ],
+                    usage=direct_turn.usage,
+                )
+                await record_agent_strategy_events(
+                    result.events,
+                    run_id=run_id,
+                    checkpoint_prefix=checkpoint_prefix,
+                    node=node,
+                    model_id=model_id,
+                )
+                return result
+
+            tool_calls_used = 0
+
+            async def execute_tool(
+                tool_name: str,
+                arguments: dict[str, Any],
+                tool_call_id: str,
+                iteration: int,
+            ) -> RuntimeToolResult:
+                nonlocal tool_calls_used
+                tool_calls_used += 1
+                if tool_calls_used > max_tool_calls:
+                    raise RuntimeToolError(
+                        tool_name,
+                        f"Agent tool call budget exhausted: {max_tool_calls}.",
+                        code="tool_denied",
+                    )
+                try:
+                    return await call_workflow_runtime_tool(
+                        tool_name=tool_name,
+                        arguments=arguments,
+                        node=node,
+                        title=title,
+                        metadata={
+                            "agent_kind": kind,
+                            "agent_node_id": node.id,
+                            "tool_call_id": tool_call_id,
+                            "iteration": iteration,
+                            "agent_strategy_v2": True,
+                            "knowledge_read_enabled": include_knowledge_read,
+                            "knowledge_write_enabled": include_knowledge_write,
+                            "knowledge_base_ids": list(knowledge_base_ids or []),
+                            "external_xpert_tools": list(external_xpert_tools or []),
+                            "toolset_resources": list(toolset_resources or []),
+                            "max_tool_depth": max_tool_depth,
+                        },
+                        pipeline=pipeline,
+                        middleware_context=middleware_context,
+                        middleware_specs=middleware_specs,
+                    )
+                except RuntimeInterrupt:
+                    raise
+                except RuntimeToolError:
+                    raise
+                except PermissionError as exc:
+                    raise RuntimeToolError(
+                        tool_name, str(exc), code="tool_denied"
+                    ) from exc
+                except RuntimeMiddlewareFatalError as exc:
+                    raise RuntimeToolError(
+                        tool_name, str(exc), code="tool_denied"
+                    ) from exc
+                except ValueError as exc:
+                    raise RuntimeToolError(
+                        tool_name, str(exc), code="capability_not_found"
+                    ) from exc
+                except Exception as exc:
+                    raise RuntimeToolError(
+                        tool_name,
+                        workflow_error_summary(exc),
+                        code="tool_call_error",
+                    ) from exc
+
+            try:
+                runner = AgentStrategyRunner(
+                    model_client=model_client,
+                    tool_executor=execute_tool,
+                    tools=available_tools,
+                    model_id=model_id,
+                    system_prompt=system_prompt,
+                    user_prompt=user_prompt,
+                    strategy=strategy,  # type: ignore[arg-type]
+                    max_iterations=max_iterations,
+                    temperature=temperature,
+                    max_tokens=WORKFLOW_AGENT_MAX_TOKENS,
+                    parallel_tool_calls=parallel_tool_calls,
+                    history_messages=history_messages,
+                )
+                result = await runner.run()
+            except RuntimeInterrupt:
+                raise
+            except AgentStrategyError as exc:
+                await record_agent_strategy_events(
+                    exc.events,
+                    run_id=run_id,
+                    checkpoint_prefix=checkpoint_prefix,
+                    node=node,
+                    model_id=model_id,
+                )
+                raise
+            await record_agent_strategy_events(
+                result.events,
+                run_id=run_id,
+                checkpoint_prefix=checkpoint_prefix,
+                node=node,
+                model_id=model_id,
+            )
+            return result
 
         async def run_react_lite_agent(
             *,
@@ -7463,6 +7947,12 @@ async def _run_workflow_response(
                             except ValueError:
                                 max_iterations = WORKFLOW_AGENT_MAX_ITERATIONS_DEFAULT
                             max_iterations = min(max(max_iterations, 1), 20)
+                            agent_strategy = str(
+                                node.data.get("agentStrategy") or "auto"
+                            ).strip()
+                            parallel_tool_calls = workflow_truthy(
+                                node.data.get("parallelToolCalls")
+                            )
 
                             async def run_direct_agent() -> str:
                                 if not get_llm_gateway_config()[0]:
@@ -7488,18 +7978,59 @@ async def _run_workflow_response(
                                     }
                                 )
                             elif agent_mode == "tool_first":
-                                output, agent_events = await run_react_lite_agent(
-                                    node=node,
-                                    title=title,
-                                    kind=kind,
-                                    model_id=model_id,
-                                    system_prompt="你是模镜工作流中的 ReAct-Lite Agent。",
-                                    user_prompt=instruction,
-                                    tool_names_raw=node.data.get("toolNames"),
-                                    max_iterations=max_iterations,
-                                    temperature=temperature,
-                                    output_variable=output_variable,
-                                )
+                                if WORKFLOW_AGENT_STRATEGY_V2_ENABLED:
+                                    try:
+                                        strategy_result = await run_agent_strategy_v2(
+                                            node=node,
+                                            title=title,
+                                            kind=kind,
+                                            model_id=model_id,
+                                            system_prompt="你是模镜工作流中的任务执行 Agent。",
+                                            user_prompt=instruction,
+                                            tool_names_raw=node.data.get("toolNames"),
+                                            strategy=agent_strategy,
+                                            max_iterations=max_iterations,
+                                            temperature=temperature,
+                                            parallel_tool_calls=parallel_tool_calls,
+                                            output_variable=output_variable,
+                                            run_id=workflow_run.run_id,
+                                            checkpoint_prefix="agent",
+                                        )
+                                    except AgentStrategyError as strategy_exc:
+                                        for agent_event in agent_strategy_node_events(
+                                            strategy_exc.events,
+                                            node=node,
+                                            title=title,
+                                            kind=kind,
+                                            output_variable=output_variable,
+                                            run_id=workflow_run.run_id,
+                                            max_iterations=max_iterations,
+                                        ):
+                                            yield sse_payload(agent_event)
+                                        raise
+                                    output = strategy_result.answer
+                                    agent_events = agent_strategy_node_events(
+                                        strategy_result.events,
+                                        node=node,
+                                        title=title,
+                                        kind=kind,
+                                        output_variable=output_variable,
+                                        run_id=workflow_run.run_id,
+                                        max_iterations=max_iterations,
+                                    )
+                                else:
+                                    output, agent_events = await run_react_lite_agent(
+                                        node=node,
+                                        title=title,
+                                        kind=kind,
+                                        model_id=model_id,
+                                        system_prompt="你是模镜工作流中的 ReAct-Lite Agent。",
+                                        user_prompt=instruction,
+                                        tool_names_raw=node.data.get("toolNames"),
+                                        max_iterations=max_iterations,
+                                        temperature=temperature,
+                                        output_variable=output_variable,
+                                    )
                                 variables[output_variable] = output
                                 for agent_event in agent_events:
                                     yield sse_payload(agent_event)
@@ -7711,6 +8242,9 @@ async def _run_workflow_response(
                                 )
                             ).strip()
                         tool_mode = str(node.data.get("toolMode") or "none").strip()
+                        agent_strategy = str(
+                            node.data.get("agentStrategy") or "auto"
+                        ).strip()
                         enable_file_understanding = workflow_truthy(
                             node.data.get("enableFileUnderstanding")
                         )
@@ -8150,6 +8684,27 @@ async def _run_workflow_response(
                             raise ValueError(
                                 "workflow_agent exceptionHandling must be none, fail, or empty_output."
                             )
+                        strategy_v2_runtime_compatible = not any(
+                            (
+                                memory_read_enabled,
+                                memory_write_enabled,
+                                knowledge_read_enabled,
+                                knowledge_write_enabled,
+                                bool(external_xpert_tools),
+                                bool(toolset_resources),
+                                datax_enabled,
+                                todo_spec is not None,
+                                sandbox_enabled,
+                                skills_enabled,
+                                browser_enabled,
+                                client_tools_enabled,
+                                office_automation_enabled,
+                                automation_enabled,
+                                xpert_authoring_enabled,
+                                skill_creator_enabled,
+                                hitl_spec is not None,
+                            )
+                        )
 
                         workflow_agent_run = await run_registry.create_run(
                             "workflow_agent",
@@ -8166,6 +8721,10 @@ async def _run_workflow_response(
                                 "agent_name": agent_name,
                                 "model_id": model_id,
                                 "tool_mode": tool_mode,
+                                "agent_strategy": agent_strategy,
+                                "strategy_v2_enabled": WORKFLOW_AGENT_STRATEGY_V2_ENABLED,
+                                "strategy_v2_runtime_compatible": strategy_v2_runtime_compatible,
+                                "parallel_tool_calls": parallel_tool_calls,
                                 "output_variable": output_variable,
                                 "retry_on_failure": retry_on_failure,
                                 "fallback_model_id": fallback_model_id or None,
@@ -8241,6 +8800,10 @@ async def _run_workflow_response(
                                 "agent_name": agent_name,
                                 "model_id": model_id,
                                 "tool_mode": tool_mode,
+                                "agent_strategy": agent_strategy,
+                                "strategy_v2_enabled": WORKFLOW_AGENT_STRATEGY_V2_ENABLED,
+                                "strategy_v2_runtime_compatible": strategy_v2_runtime_compatible,
+                                "parallel_tool_calls": parallel_tool_calls,
                                 "output_variable": output_variable,
                                 "retry_on_failure": retry_on_failure,
                                 "fallback_model_id": fallback_model_id or None,
@@ -8371,6 +8934,7 @@ async def _run_workflow_response(
                             )
 
                         last_error: Exception | None = None
+                        last_strategy_result: AgentStrategyResult | None = None
                         success = False
                         output = ""
                         final_resume_state = task_state.get("agent_resume_state")
@@ -8659,68 +9223,152 @@ async def _run_workflow_response(
                                             agent_context,
                                         )
                                 else:
-                                    output, agent_events = await run_react_lite_agent(
-                                        node=node,
-                                        title=title,
-                                        kind=kind,
-                                        model_id=attempt_model_id,
-                                        system_prompt=role_prompt,
-                                        user_prompt=task_input,
-                                        tool_names_raw=node.data.get("toolNames"),
-                                        max_iterations=max_iterations,
-                                        temperature=0.7,
-                                        output_variable=output_variable,
-                                        parallel_tool_calls=parallel_tool_calls,
-                                        max_tool_concurrency=max_tool_concurrency,
-                                        max_tool_calls=max_tool_calls,
-                                        max_tool_depth=max_tool_depth,
-                                        run_id=workflow_agent_run.run_id,
-                                        include_mcp=(tool_mode == "mcp_tools"),
-                                        include_memory_read=memory_read_enabled,
-                                        include_memory_write=memory_write_enabled,
-                                        include_knowledge_read=knowledge_read_enabled,
-                                        include_knowledge_write=(
-                                            knowledge_write_enabled
-                                            or knowledge_writer_spec is not None
-                                        ),
-                                        knowledge_base_ids=knowledge_base_ids,
-                                        external_xpert_tools=external_xpert_tools,
-                                        toolset_resources=toolset_resources,
-                                        include_datax=datax_enabled,
-                                        include_datax_proposals=datax_allow_proposals,
-                                        include_todo=todo_spec is not None,
-                                        include_sandbox=sandbox_enabled,
-                                        include_skills=skills_enabled,
-                                        include_browser=browser_enabled,
-                                        include_client=client_tools_enabled,
-                                        include_office=office_automation_enabled,
-                                        include_automation=automation_enabled,
-                                        include_xpert_authoring=xpert_authoring_enabled,
-                                        include_skill_creator=skill_creator_enabled,
-                                        client_tools_config=(
-                                            dict(client_tools_spec.config)
-                                            if client_tools_spec is not None
-                                            else {}
-                                        ),
-                                        office_automation_config=(
-                                            dict(office_automation_spec.config)
-                                            if office_automation_spec is not None
-                                            else {}
-                                        ),
-                                        pipeline=agent_pipeline,
-                                        middleware_context=agent_context,
-                                        middleware_specs=agent_specs,
-                                        selector_spec=selector_spec,
-                                        history_messages=history_messages,
-                                        resume_state=(
-                                            task_state.get("agent_resume_state")
-                                            if isinstance(
-                                                task_state.get("agent_resume_state"),
-                                                dict,
+                                    if (
+                                        WORKFLOW_AGENT_STRATEGY_V2_ENABLED
+                                        and strategy_v2_runtime_compatible
+                                    ):
+                                        try:
+                                            strategy_result = await run_agent_strategy_v2(
+                                                node=node,
+                                                title=title,
+                                                kind=kind,
+                                                model_id=attempt_model_id,
+                                                system_prompt=role_prompt,
+                                                user_prompt=task_input,
+                                                tool_names_raw=node.data.get("toolNames"),
+                                                strategy=agent_strategy,
+                                                max_iterations=max_iterations,
+                                                temperature=0.7,
+                                                parallel_tool_calls=parallel_tool_calls,
+                                                output_variable=output_variable,
+                                                max_tool_calls=max_tool_calls,
+                                                max_tool_depth=max_tool_depth,
+                                                run_id=workflow_agent_run.run_id,
+                                                checkpoint_prefix="workflow_agent",
+                                                include_mcp=(tool_mode == "mcp_tools"),
+                                                include_memory_read=memory_read_enabled,
+                                                include_memory_write=memory_write_enabled,
+                                                include_knowledge_read=knowledge_read_enabled,
+                                                include_knowledge_write=(
+                                                    knowledge_write_enabled
+                                                    or knowledge_writer_spec is not None
+                                                ),
+                                                knowledge_base_ids=knowledge_base_ids,
+                                                external_xpert_tools=external_xpert_tools,
+                                                toolset_resources=toolset_resources,
+                                                include_datax=datax_enabled,
+                                                include_datax_proposals=datax_allow_proposals,
+                                                include_todo=todo_spec is not None,
+                                                include_sandbox=sandbox_enabled,
+                                                include_skills=skills_enabled,
+                                                include_browser=browser_enabled,
+                                                include_client=client_tools_enabled,
+                                                include_office=office_automation_enabled,
+                                                include_automation=automation_enabled,
+                                                include_xpert_authoring=xpert_authoring_enabled,
+                                                include_skill_creator=skill_creator_enabled,
+                                                client_tools_config=(
+                                                    dict(client_tools_spec.config)
+                                                    if client_tools_spec is not None
+                                                    else {}
+                                                ),
+                                                office_automation_config=(
+                                                    dict(office_automation_spec.config)
+                                                    if office_automation_spec is not None
+                                                    else {}
+                                                ),
+                                                pipeline=agent_pipeline,
+                                                middleware_context=agent_context,
+                                                middleware_specs=agent_specs,
+                                                selector_spec=selector_spec,
+                                                history_messages=history_messages,
                                             )
-                                            else None
-                                        ),
-                                    )
+                                        except AgentStrategyError as strategy_exc:
+                                            for agent_event in agent_strategy_node_events(
+                                                strategy_exc.events,
+                                                node=node,
+                                                title=title,
+                                                kind=kind,
+                                                output_variable=output_variable,
+                                                run_id=workflow_agent_run.run_id,
+                                                max_iterations=max_iterations,
+                                            ):
+                                                yield sse_payload(agent_event)
+                                            raise
+                                        output = strategy_result.answer
+                                        last_strategy_result = strategy_result
+                                        agent_events = agent_strategy_node_events(
+                                            strategy_result.events,
+                                            node=node,
+                                            title=title,
+                                            kind=kind,
+                                            output_variable=output_variable,
+                                            run_id=workflow_agent_run.run_id,
+                                            max_iterations=max_iterations,
+                                        )
+                                    else:
+                                        output, agent_events = await run_react_lite_agent(
+                                            node=node,
+                                            title=title,
+                                            kind=kind,
+                                            model_id=attempt_model_id,
+                                            system_prompt=role_prompt,
+                                            user_prompt=task_input,
+                                            tool_names_raw=node.data.get("toolNames"),
+                                            max_iterations=max_iterations,
+                                            temperature=0.7,
+                                            output_variable=output_variable,
+                                            parallel_tool_calls=parallel_tool_calls,
+                                            max_tool_concurrency=max_tool_concurrency,
+                                            max_tool_calls=max_tool_calls,
+                                            max_tool_depth=max_tool_depth,
+                                            run_id=workflow_agent_run.run_id,
+                                            include_mcp=(tool_mode == "mcp_tools"),
+                                            include_memory_read=memory_read_enabled,
+                                            include_memory_write=memory_write_enabled,
+                                            include_knowledge_read=knowledge_read_enabled,
+                                            include_knowledge_write=(
+                                                knowledge_write_enabled
+                                                or knowledge_writer_spec is not None
+                                            ),
+                                            knowledge_base_ids=knowledge_base_ids,
+                                            external_xpert_tools=external_xpert_tools,
+                                            toolset_resources=toolset_resources,
+                                            include_datax=datax_enabled,
+                                            include_datax_proposals=datax_allow_proposals,
+                                            include_todo=todo_spec is not None,
+                                            include_sandbox=sandbox_enabled,
+                                            include_skills=skills_enabled,
+                                            include_browser=browser_enabled,
+                                            include_client=client_tools_enabled,
+                                            include_office=office_automation_enabled,
+                                            include_automation=automation_enabled,
+                                            include_xpert_authoring=xpert_authoring_enabled,
+                                            include_skill_creator=skill_creator_enabled,
+                                            client_tools_config=(
+                                                dict(client_tools_spec.config)
+                                                if client_tools_spec is not None
+                                                else {}
+                                            ),
+                                            office_automation_config=(
+                                                dict(office_automation_spec.config)
+                                                if office_automation_spec is not None
+                                                else {}
+                                            ),
+                                            pipeline=agent_pipeline,
+                                            middleware_context=agent_context,
+                                            middleware_specs=agent_specs,
+                                            selector_spec=selector_spec,
+                                            history_messages=history_messages,
+                                            resume_state=(
+                                                task_state.get("agent_resume_state")
+                                                if isinstance(
+                                                    task_state.get("agent_resume_state"),
+                                                    dict,
+                                                )
+                                                else None
+                                            ),
+                                        )
                                     for agent_event in agent_events:
                                         yield sse_payload(agent_event)
                                     if structured_spec is None and ralph_spec is None:
@@ -8989,8 +9637,21 @@ async def _run_workflow_response(
                                         "model_id": attempt_model_id,
                                         "fallback_used": fallback_used,
                                         "error": workflow_error_summary(attempt_exc),
+                                        "error_classification": (
+                                            attempt_exc.code
+                                            if isinstance(
+                                                attempt_exc,
+                                                AgentStrategyError,
+                                            )
+                                            else attempt_exc.__class__.__name__
+                                        ),
                                     },
                                 )
+                                if (
+                                    isinstance(attempt_exc, AgentStrategyError)
+                                    and not attempt_exc.retry_safe
+                                ):
+                                    break
 
                         if not success:
                             if exception_handling == "empty_output":
@@ -9199,6 +9860,26 @@ async def _run_workflow_response(
                                 "model_id": model_id,
                                 "output_disabled": disable_output,
                                 "exception_handling": exception_handling,
+                                "agent_strategy": (
+                                    last_strategy_result.strategy
+                                    if last_strategy_result is not None
+                                    else None
+                                ),
+                                "tool_calls_attempted": (
+                                    last_strategy_result.tool_calls_attempted
+                                    if last_strategy_result is not None
+                                    else 0
+                                ),
+                                "tool_calls_executed": (
+                                    last_strategy_result.tool_calls_executed
+                                    if last_strategy_result is not None
+                                    else 0
+                                ),
+                                "token_usage": (
+                                    last_strategy_result.usage.to_dict()
+                                    if last_strategy_result is not None
+                                    else {}
+                                ),
                             },
                         )
                         await run_registry.record_checkpoint(
@@ -9210,6 +9891,16 @@ async def _run_workflow_response(
                                 "node_id": node.id,
                                 "output_variable": output_variable,
                                 "output_disabled": disable_output,
+                                "agent_strategy": (
+                                    last_strategy_result.strategy
+                                    if last_strategy_result is not None
+                                    else None
+                                ),
+                                "token_usage": (
+                                    last_strategy_result.usage.to_dict()
+                                    if last_strategy_result is not None
+                                    else {}
+                                ),
                             },
                         )
                     except RuntimeInterrupt:

--- a/server/tests/test_agent_strategies.py
+++ b/server/tests/test_agent_strategies.py
@@ -1,0 +1,488 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import httpx
+import pytest
+
+from server.xpert_runtime import RuntimeTool, RuntimeToolError, RuntimeToolResult
+from server.xpert_runtime.agent_strategy import (
+    AgentModelError,
+    AgentModelTurn,
+    AgentStrategyError,
+    AgentStrategyRunner,
+    AgentToolCall,
+    AgentUsage,
+    OpenAICompatibleAgentModelClient,
+    build_tool_bindings,
+    parse_chat_completion,
+    parse_react_decision,
+    summarize_arguments,
+    truncate_observation,
+)
+
+
+class FakeModelClient:
+    def __init__(self, responses: list[AgentModelTurn | Exception]) -> None:
+        self.responses = list(responses)
+        self.requests: list[dict[str, Any]] = []
+
+    async def complete(self, **kwargs: Any) -> AgentModelTurn:
+        self.requests.append(kwargs)
+        response = self.responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
+def runtime_tool(name: str = "fetch") -> RuntimeTool:
+    return RuntimeTool(
+        name=name,
+        description="Fetch a document",
+        input_schema={
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+            "required": ["query"],
+        },
+    )
+
+
+def tool_turn(
+    *calls: tuple[str, str, str],
+    usage: AgentUsage | None = None,
+) -> AgentModelTurn:
+    return AgentModelTurn(
+        tool_calls=[
+            AgentToolCall(call_id=call_id, name=name, raw_arguments=arguments)
+            for call_id, name, arguments in calls
+        ],
+        finish_reason="tool_calls",
+        usage=usage or AgentUsage(),
+    )
+
+
+def answer_turn(answer: str, usage: AgentUsage | None = None) -> AgentModelTurn:
+    return AgentModelTurn(
+        content=answer,
+        finish_reason="stop",
+        usage=usage or AgentUsage(),
+    )
+
+
+def make_runner(
+    model_client: FakeModelClient,
+    tool_executor,
+    **kwargs: Any,
+) -> AgentStrategyRunner:
+    return AgentStrategyRunner(
+        model_client=model_client,
+        tool_executor=tool_executor,
+        tools=kwargs.pop("tools", [runtime_tool()]),
+        model_id="test-model",
+        system_prompt="You are a test agent.",
+        user_prompt="Find the answer.",
+        max_iterations=kwargs.pop("max_iterations", 3),
+        **kwargs,
+    )
+
+
+def test_parse_chat_completion_preserves_tool_calls_and_usage() -> None:
+    turn = parse_chat_completion(
+        {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {
+                                    "name": "fetch",
+                                    "arguments": '{"query":"docs"}',
+                                },
+                            }
+                        ],
+                    },
+                    "finish_reason": "tool_calls",
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 4,
+                "total_tokens": 14,
+            },
+        }
+    )
+
+    assert turn.tool_calls[0].call_id == "call_1"
+    assert turn.tool_calls[0].raw_arguments == '{"query":"docs"}'
+    assert turn.usage.total_tokens == 14
+
+
+@pytest.mark.asyncio
+async def test_openai_adapter_sends_standard_tool_call_fields() -> None:
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.update(json.loads(request.content.decode("utf-8")))
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {
+                        "message": {"role": "assistant", "content": "done"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 4, "completion_tokens": 1, "total_tokens": 5},
+            },
+        )
+
+    client = OpenAICompatibleAgentModelClient(
+        endpoint="https://gateway.test/v1/chat/completions",
+        headers={"Authorization": "Bearer test"},
+        client_kwargs={"transport": httpx.MockTransport(handler)},
+    )
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "fetch",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+
+    turn = await client.complete(
+        model_id="test-model",
+        messages=[{"role": "user", "content": "hello"}],
+        temperature=0.2,
+        max_tokens=100,
+        tools=tools,
+        tool_choice="auto",
+        parallel_tool_calls=True,
+    )
+
+    assert captured["tools"] == tools
+    assert captured["tool_choice"] == "auto"
+    assert captured["parallel_tool_calls"] is True
+    assert captured["stream"] is False
+    assert turn.content == "done"
+    assert turn.usage.total_tokens == 5
+
+
+def test_tool_binding_aliases_invalid_function_name_and_rejects_bad_schema() -> None:
+    binding = build_tool_bindings([runtime_tool("server/fetch.page")])[0]
+    assert binding.alias.startswith("tool_1_")
+    assert binding.tool.name == "server/fetch.page"
+
+    with pytest.raises(AgentStrategyError) as exc_info:
+        build_tool_bindings(
+            [
+                RuntimeTool(
+                    name="bad",
+                    input_schema={"type": "array", "items": {"type": "string"}},
+                )
+            ]
+        )
+    assert exc_info.value.code == "invalid_tool_schema"
+
+
+@pytest.mark.asyncio
+async def test_function_calling_round_trip_preserves_tool_call_id_and_usage() -> None:
+    model = FakeModelClient(
+        [
+            tool_turn(
+                ("call_1", "fetch", '{"query":"agent"}'),
+                usage=AgentUsage(prompt_tokens=10, completion_tokens=3, total_tokens=13),
+            ),
+            answer_turn(
+                "final answer",
+                usage=AgentUsage(prompt_tokens=15, completion_tokens=2, total_tokens=17),
+            ),
+        ]
+    )
+    calls: list[tuple[str, dict[str, Any], str, int]] = []
+
+    async def execute(name: str, arguments: dict[str, Any], call_id: str, iteration: int):
+        calls.append((name, arguments, call_id, iteration))
+        return RuntimeToolResult(output="tool output", metadata={"content_types": ["text"]})
+
+    result = await make_runner(model, execute, strategy="function_calling").run()
+
+    assert result.answer == "final answer"
+    assert result.usage.total_tokens == 30
+    assert result.events[-1].metadata["usage"]["total_tokens"] == 30
+    assert result.events[1].metadata["usage"]["total_tokens"] == 13
+    assert calls == [("fetch", {"query": "agent"}, "call_1", 1)]
+    second_messages = model.requests[1]["messages"]
+    assert second_messages[-2]["tool_calls"][0]["id"] == "call_1"
+    assert second_messages[-1] == {
+        "role": "tool",
+        "tool_call_id": "call_1",
+        "name": "fetch",
+        "content": "tool output",
+    }
+
+
+@pytest.mark.asyncio
+async def test_argument_validation_is_recoverable_without_invoking_tool() -> None:
+    model = FakeModelClient(
+        [
+            tool_turn(("call_bad", "fetch", "{}")),
+            tool_turn(("call_good", "fetch", '{"query":"fixed"}')),
+            answer_turn("fixed answer"),
+        ]
+    )
+    calls: list[dict[str, Any]] = []
+
+    async def execute(name: str, arguments: dict[str, Any], call_id: str, iteration: int):
+        calls.append(arguments)
+        return RuntimeToolResult(output="ok")
+
+    result = await make_runner(model, execute, strategy="function_calling").run()
+
+    assert result.answer == "fixed answer"
+    assert calls == [{"query": "fixed"}]
+    assert any(event.status == "rejected" for event in result.events)
+
+
+@pytest.mark.asyncio
+async def test_tool_execution_error_is_a_recoverable_observation() -> None:
+    model = FakeModelClient(
+        [
+            tool_turn(("call_1", "fetch", '{"query":"fail"}')),
+            answer_turn("recovered answer"),
+        ]
+    )
+
+    async def execute(name: str, arguments: dict[str, Any], call_id: str, iteration: int):
+        raise RuntimeToolError(name, "temporary failure", code="tool_execution_error")
+
+    result = await make_runner(model, execute, strategy="function_calling").run()
+
+    assert result.answer == "recovered answer"
+    assert result.tool_calls_attempted == 1
+    assert result.tool_calls_executed == 0
+    assert "temporary failure" in model.requests[1]["messages"][-1]["content"]
+
+
+@pytest.mark.asyncio
+async def test_auto_falls_back_to_react_only_for_unsupported_tools() -> None:
+    model = FakeModelClient(
+        [
+            AgentModelError(
+                "unknown parameter: tools",
+                status_code=400,
+                param="tools",
+            ),
+            answer_turn("FinalAnswer: react answer"),
+        ]
+    )
+
+    async def execute(*args: Any):
+        raise AssertionError("tool should not be called")
+
+    result = await make_runner(model, execute, strategy="auto").run()
+
+    assert result.strategy == "react"
+    assert result.answer == "react answer"
+    assert any(event.event_type == "strategy_fallback" for event in result.events)
+    assert "tools" in model.requests[0]
+    assert "tools" not in model.requests[1]
+
+
+@pytest.mark.asyncio
+async def test_auto_does_not_fallback_for_auth_error() -> None:
+    model = FakeModelClient(
+        [AgentModelError("unauthorized", status_code=401, code="unauthorized")]
+    )
+
+    async def execute(*args: Any):
+        raise AssertionError("tool should not be called")
+
+    with pytest.raises(AgentStrategyError) as exc_info:
+        await make_runner(model, execute, strategy="auto").run()
+
+    assert exc_info.value.code == "model_error"
+    assert len(model.requests) == 1
+
+
+@pytest.mark.asyncio
+async def test_react_hides_thought_and_invokes_tool() -> None:
+    model = FakeModelClient(
+        [
+            answer_turn(
+                '<think>private</think>Thought: use tool\nAction: '
+                '{"action":"fetch","action_input":{"query":"docs"}}'
+            ),
+            answer_turn("FinalAnswer: complete"),
+        ]
+    )
+    calls: list[str] = []
+
+    async def execute(name: str, arguments: dict[str, Any], call_id: str, iteration: int):
+        calls.append(name)
+        return RuntimeToolResult(output="observation")
+
+    result = await make_runner(model, execute, strategy="react").run()
+
+    assert result.answer == "complete"
+    assert calls == ["fetch"]
+    assert all("private" not in event.message for event in result.events)
+
+
+@pytest.mark.asyncio
+async def test_react_recovers_from_malformed_action_json() -> None:
+    model = FakeModelClient(
+        [
+            answer_turn('Action: {"action":"fetch","action_input":'),
+            answer_turn("FinalAnswer: corrected"),
+        ]
+    )
+
+    async def execute(*args: Any):
+        raise AssertionError("malformed action must not invoke a tool")
+
+    result = await make_runner(model, execute, strategy="react").run()
+
+    assert result.answer == "corrected"
+    assert result.tool_calls_attempted == 0
+    assert any(
+        event.event_type == "model_round" and event.status == "warning"
+        for event in result.events
+    )
+
+
+@pytest.mark.asyncio
+async def test_parallel_tool_calls_execute_concurrently_but_keep_message_order() -> None:
+    model = FakeModelClient(
+        [
+            tool_turn(
+                ("call_1", "first", '{"query":"one"}'),
+                ("call_2", "second", '{"query":"two"}'),
+            ),
+            answer_turn("done"),
+        ]
+    )
+    active = 0
+    max_active = 0
+
+    async def execute(name: str, arguments: dict[str, Any], call_id: str, iteration: int):
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        await asyncio.sleep(0.01)
+        active -= 1
+        return RuntimeToolResult(output=name)
+
+    result = await make_runner(
+        model,
+        execute,
+        strategy="function_calling",
+        parallel_tool_calls=True,
+        tools=[runtime_tool("first"), runtime_tool("second")],
+    ).run()
+
+    assert result.answer == "done"
+    assert max_active == 2
+    tool_messages = [
+        message for message in model.requests[1]["messages"] if message["role"] == "tool"
+    ]
+    assert [message["tool_call_id"] for message in tool_messages] == ["call_1", "call_2"]
+
+
+@pytest.mark.asyncio
+async def test_iteration_limit_runs_one_answer_only_summary_call() -> None:
+    model = FakeModelClient(
+        [
+            tool_turn(("call_1", "fetch", '{"query":"one"}')),
+            answer_turn("summary after limit"),
+        ]
+    )
+
+    async def execute(name: str, arguments: dict[str, Any], call_id: str, iteration: int):
+        return RuntimeToolResult(output="tool result")
+
+    result = await make_runner(
+        model,
+        execute,
+        strategy="function_calling",
+        max_iterations=1,
+    ).run()
+
+    assert result.answer == "summary after limit"
+    assert model.requests[-1]["tool_choice"] == "none"
+    assert model.requests[-1]["parallel_tool_calls"] is False
+    assert any(event.metadata.get("final_summary") for event in result.events)
+
+
+@pytest.mark.asyncio
+async def test_terminal_tool_result_finishes_without_another_model_call() -> None:
+    model = FakeModelClient(
+        [tool_turn(("call_terminal", "finish", '{"query":"done"}'))]
+    )
+
+    async def execute(name: str, arguments: dict[str, Any], call_id: str, iteration: int):
+        return RuntimeToolResult(output="terminal result")
+
+    terminal_tool = runtime_tool("finish")
+    terminal_tool.terminal = True
+    result = await make_runner(
+        model,
+        execute,
+        strategy="function_calling",
+        tools=[terminal_tool],
+    ).run()
+
+    assert result.answer == "terminal result"
+    assert result.tool_calls_executed == 1
+    assert len(model.requests) == 1
+
+
+@pytest.mark.asyncio
+async def test_policy_denial_is_fatal_and_not_retry_safe() -> None:
+    model = FakeModelClient([tool_turn(("call_1", "fetch", '{"query":"x"}'))])
+
+    async def execute(name: str, arguments: dict[str, Any], call_id: str, iteration: int):
+        raise RuntimeToolError(name, "denied", code="tool_denied")
+
+    with pytest.raises(AgentStrategyError) as exc_info:
+        await make_runner(model, execute, strategy="function_calling").run()
+
+    assert exc_info.value.code == "tool_denied"
+    assert exc_info.value.retry_safe is False
+
+
+def test_capability_and_schema_errors_are_not_retry_safe() -> None:
+    assert AgentStrategyError(
+        "missing tool",
+        code="capability_not_found",
+    ).retry_safe is False
+    assert AgentStrategyError(
+        "bad schema",
+        code="invalid_tool_schema",
+    ).retry_safe is False
+
+
+def test_argument_summary_redacts_secrets_and_observation_truncates() -> None:
+    summary = summarize_arguments(
+        {"query": "docs", "api_key": "secret", "nested": {"password": "hidden"}}
+    )
+    assert "docs" in summary
+    assert "secret" not in summary
+    assert "hidden" not in summary
+    assert "***" in summary
+
+    truncated = truncate_observation("x" * 20, limit=10)
+    assert truncated.startswith("x" * 10)
+    assert "已截断" in truncated
+
+
+def test_parse_react_decision_rejects_thought_only() -> None:
+    decision = parse_react_decision("Thought: still thinking")
+    assert decision.kind == "invalid"

--- a/server/tests/test_workflow_agent_task_node.py
+++ b/server/tests/test_workflow_agent_task_node.py
@@ -16,6 +16,11 @@ from server.xpert_runtime import (
     RuntimeToolResult,
     WorkflowExecutionStore,
 )
+from server.xpert_runtime.agent_strategy import (
+    AgentModelError,
+    AgentModelTurn,
+    AgentToolCall,
+)
 from server.xpert_runtime.todo_store import RuntimeTodoStore
 
 
@@ -27,6 +32,13 @@ async def client():
         base_url="http://testserver",
     ) as async_client:
         yield async_client
+
+
+@pytest.fixture(autouse=True)
+def default_to_legacy_agent_strategy(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep pre-V2 integration cases on their original runtime path."""
+
+    monkeypatch.setattr(main_module, "WORKFLOW_AGENT_STRATEGY_V2_ENABLED", False)
 
 
 @pytest.mark.asyncio
@@ -801,6 +813,7 @@ async def test_workflow_agent_mcp_tool_mode_uses_runtime_toolset(
     client: httpx.AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setattr(main_module, "WORKFLOW_AGENT_STRATEGY_V2_ENABLED", False)
     provider, restore_provider = _install_fake_tool_provider()
     responses = iter(
         [
@@ -915,6 +928,7 @@ async def test_workflow_agent_executes_safe_parallel_tool_batch_in_decision_orde
     client: httpx.AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setattr(main_module, "WORKFLOW_AGENT_STRATEGY_V2_ENABLED", False)
     provider, restore_provider = _install_fake_tool_provider()
     provider.tools[0].parallel_safe = True
     provider.tools.append(
@@ -990,6 +1004,7 @@ async def test_workflow_agent_terminal_tool_ends_without_model_summary(
     client: httpx.AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setattr(main_module, "WORKFLOW_AGENT_STRATEGY_V2_ENABLED", False)
     provider, restore_provider = _install_fake_tool_provider()
     provider.tools[0].terminal = True
     decisions: list[str] = []
@@ -1044,6 +1059,7 @@ async def test_workflow_agent_tool_policy_denial_does_not_crash_workflow(
     client: httpx.AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setattr(main_module, "WORKFLOW_AGENT_STRATEGY_V2_ENABLED", False)
     provider, restore_provider = _install_fake_tool_provider()
 
     async def fake_collect_chat_completion_text(*args, **kwargs):
@@ -1144,6 +1160,7 @@ async def test_legacy_agent_tool_first_uses_runtime_toolset(
     client: httpx.AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setattr(main_module, "WORKFLOW_AGENT_STRATEGY_V2_ENABLED", False)
     provider, restore_provider = _install_fake_tool_provider()
     responses = iter(
         [
@@ -1222,6 +1239,286 @@ async def test_legacy_agent_tool_first_uses_runtime_toolset(
     assert agent_end["output"] == "legacy final"
     assert len(provider.calls) == 1
     assert provider.calls[0].tool_name == "fetch"
+
+
+def _agent_strategy_workflow(
+    overrides: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    data: dict[str, Any] = {
+        "kind": "agent",
+        "agentMode": "tool_first",
+        "instruction": "请处理：{{user_input}}",
+        "modelId": "test/model",
+        "toolNames": "fetch",
+        "maxIterations": "3",
+        "outputVariable": "agent_output",
+    }
+    data.update(overrides or {})
+    return {
+        "id": "agent-v2-workflow",
+        "title": "agent v2 workflow",
+        "nodes": [
+            {
+                "id": "input",
+                "type": "input",
+                "data": {"kind": "input", "variableName": "user_input"},
+            },
+            {"id": "agent", "type": "agent", "data": data},
+            {
+                "id": "output",
+                "type": "output",
+                "data": {"kind": "output", "outputVariable": "agent_output"},
+            },
+        ],
+        "edges": [
+            {"id": "e1", "source": "input", "target": "agent"},
+            {"id": "e2", "source": "agent", "target": "output"},
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_agent_strategy_v2_function_calling_uses_runtime_toolset(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider, restore_provider = _install_fake_tool_provider()
+
+    class FakeAgentModelClient:
+        def __init__(self, **kwargs: Any) -> None:
+            self.responses = iter(
+                [
+                    AgentModelTurn(
+                        tool_calls=[
+                            AgentToolCall(
+                                call_id="call_v2",
+                                name="fetch",
+                                raw_arguments='{"query":"v2 agent"}',
+                            )
+                        ],
+                        finish_reason="tool_calls",
+                    ),
+                    AgentModelTurn(content="v2 final", finish_reason="stop"),
+                ]
+            )
+
+        async def complete(self, **kwargs: Any) -> AgentModelTurn:
+            return next(self.responses)
+
+    monkeypatch.setattr(main_module, "WORKFLOW_AGENT_STRATEGY_V2_ENABLED", True)
+    monkeypatch.setattr(main_module, "OpenAICompatibleAgentModelClient", FakeAgentModelClient)
+    monkeypatch.setattr(
+        main_module,
+        "get_llm_gateway_config",
+        lambda: ("http://test-gateway.local/v1/chat/completions", "test-key"),
+    )
+    monkeypatch.setattr(main_module, "workflow_mcp_provider", provider)
+    try:
+        response = await client.post(
+            "/api/workflow/run",
+            json={
+                "workflow": _agent_strategy_workflow(
+                    {"agentStrategy": "function_calling"}
+                ),
+                "inputs": {"user_input": "v2"},
+            },
+        )
+    finally:
+        restore_provider()
+
+    assert response.status_code == 200, response.text
+    events = _parse_sse_events(response.text)
+    agent_end = next(
+        event
+        for event in events
+        if event.get("event") == "node_end" and event.get("node_id") == "agent"
+    )
+    assert agent_end["output"] == "v2 final"
+    assert len(provider.calls) == 1
+    assert provider.calls[0].arguments == {"query": "v2 agent"}
+    assert any(
+        event.get("event") == "node_delta"
+        and event.get("node_id") == "agent"
+        and event.get("strategy") == "function_calling"
+        for event in events
+    )
+
+
+@pytest.mark.asyncio
+async def test_workflow_agent_strategy_v2_react_uses_runtime_toolset(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider, restore_provider = _install_fake_tool_provider()
+
+    class FakeAgentModelClient:
+        def __init__(self, **kwargs: Any) -> None:
+            self.responses = iter(
+                [
+                    AgentModelTurn(
+                        content=(
+                            "Thought: use fetch\n"
+                            'Action: {"action":"fetch","action_input":{"query":"react"}}'
+                        )
+                    ),
+                    AgentModelTurn(content="FinalAnswer: react final"),
+                ]
+            )
+
+        async def complete(self, **kwargs: Any) -> AgentModelTurn:
+            return next(self.responses)
+
+    monkeypatch.setattr(main_module, "WORKFLOW_AGENT_STRATEGY_V2_ENABLED", True)
+    monkeypatch.setattr(main_module, "OpenAICompatibleAgentModelClient", FakeAgentModelClient)
+    monkeypatch.setattr(
+        main_module,
+        "get_llm_gateway_config",
+        lambda: ("http://test-gateway.local/v1/chat/completions", "test-key"),
+    )
+    monkeypatch.setattr(main_module, "workflow_mcp_provider", provider)
+    workflow = _workflow_agent_strategy_workflow(
+        {
+            "toolMode": "mcp_tools",
+            "agentStrategy": "react",
+            "toolNames": "fetch",
+        }
+    )
+    try:
+        response = await client.post(
+            "/api/workflow/run",
+            json={"workflow": workflow, "inputs": {"user_input": "react"}},
+        )
+    finally:
+        restore_provider()
+
+    assert response.status_code == 200, response.text
+    events = _parse_sse_events(response.text)
+    agent_end = next(
+        event
+        for event in events
+        if event.get("event") == "node_end"
+        and event.get("node_id") == "workflow_agent"
+    )
+    assert agent_end["output"] == "react final"
+    assert len(provider.calls) == 1
+    assert provider.calls[0].arguments == {"query": "react"}
+
+
+@pytest.mark.asyncio
+async def test_agent_strategy_v2_auto_safely_falls_back_to_react(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider, restore_provider = _install_fake_tool_provider()
+
+    class FakeAgentModelClient:
+        def __init__(self, **kwargs: Any) -> None:
+            self.responses = iter(
+                [
+                    AgentModelError(
+                        "unknown parameter: tools",
+                        status_code=400,
+                        param="tools",
+                    ),
+                    AgentModelTurn(content="FinalAnswer: auto fallback"),
+                ]
+            )
+
+        async def complete(self, **kwargs: Any) -> AgentModelTurn:
+            response = next(self.responses)
+            if isinstance(response, Exception):
+                raise response
+            return response
+
+    monkeypatch.setattr(main_module, "WORKFLOW_AGENT_STRATEGY_V2_ENABLED", True)
+    monkeypatch.setattr(main_module, "OpenAICompatibleAgentModelClient", FakeAgentModelClient)
+    monkeypatch.setattr(
+        main_module,
+        "get_llm_gateway_config",
+        lambda: ("http://test-gateway.local/v1/chat/completions", "test-key"),
+    )
+    monkeypatch.setattr(main_module, "workflow_mcp_provider", provider)
+    try:
+        response = await client.post(
+            "/api/workflow/run",
+            json={
+                "workflow": _agent_strategy_workflow(),
+                "inputs": {"user_input": "auto"},
+            },
+        )
+    finally:
+        restore_provider()
+
+    assert response.status_code == 200, response.text
+    events = _parse_sse_events(response.text)
+    agent_end = next(
+        event
+        for event in events
+        if event.get("event") == "node_end" and event.get("node_id") == "agent"
+    )
+    assert agent_end["output"] == "auto fallback"
+    assert provider.calls == []
+    assert any(
+        event.get("event") == "node_delta"
+        and event.get("strategy") == "react"
+        and "回退" in str(event.get("output"))
+        for event in events
+    )
+
+
+@pytest.mark.asyncio
+async def test_workflow_agent_v2_missing_whitelist_tool_stops_before_model(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider, restore_provider = _install_fake_tool_provider()
+    model_client_inits = 0
+
+    class FakeAgentModelClient:
+        def __init__(self, **kwargs: Any) -> None:
+            nonlocal model_client_inits
+            model_client_inits += 1
+
+        async def complete(self, **kwargs: Any) -> AgentModelTurn:
+            raise AssertionError("model must not be called for a missing whitelist tool")
+
+    monkeypatch.setattr(main_module, "WORKFLOW_AGENT_STRATEGY_V2_ENABLED", True)
+    monkeypatch.setattr(main_module, "OpenAICompatibleAgentModelClient", FakeAgentModelClient)
+    monkeypatch.setattr(
+        main_module,
+        "get_llm_gateway_config",
+        lambda: ("http://test-gateway.local/v1/chat/completions", "test-key"),
+    )
+    monkeypatch.setattr(main_module, "workflow_mcp_provider", provider)
+    workflow = _workflow_agent_strategy_workflow(
+        {
+            "toolMode": "mcp_tools",
+            "toolNames": "missing-tool",
+            "retryOnFailure": "true",
+            "fallbackModelId": "fallback/model",
+            "exceptionHandling": "empty_output",
+        }
+    )
+    try:
+        response = await client.post(
+            "/api/workflow/run",
+            json={"workflow": workflow, "inputs": {"user_input": "missing"}},
+        )
+    finally:
+        restore_provider()
+
+    assert response.status_code == 200, response.text
+    events = _parse_sse_events(response.text)
+    workflow_meta = next(
+        event for event in events if event.get("event") == "workflow_meta"
+    )
+    child_run = await _workflow_agent_run(client, workflow_meta["run_id"])
+    checkpoint_types = await _checkpoint_types(client, child_run["run_id"])
+    assert model_client_inits == 0
+    assert provider.calls == []
+    assert checkpoint_types.count("workflow_agent.failed_attempt") == 1
+    assert "workflow_agent.retry" not in checkpoint_types
+    assert "workflow_agent.fallback_model" not in checkpoint_types
 
 
 def _parse_sse_events(sse_text: str) -> list[dict]:

--- a/server/tests/test_workflow_native_validate.py
+++ b/server/tests/test_workflow_native_validate.py
@@ -796,6 +796,39 @@ async def test_validate_agent_invalid_mode(client: httpx.AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
+async def test_validate_agent_strategy_and_parallel_tool_calls(
+    client: httpx.AsyncClient,
+) -> None:
+    workflow = linear_workflow()
+    workflow["nodes"][1] = {
+        "id": "agent",
+        "type": "agent",
+        "data": {
+            "kind": "agent",
+            "agentMode": "tool_first",
+            "agentStrategy": "unsupported",
+            "parallelToolCalls": "sometimes",
+            "instruction": "????{{user_input}}",
+            "modelId": "deepseek/deepseek-chat",
+            "outputVariable": "agent_output",
+        },
+    }
+    workflow["nodes"][2]["data"]["outputVariable"] = "agent_output"
+    workflow["edges"] = [
+        {"id": "e1", "source": "input", "target": "agent"},
+        {"id": "e2", "source": "agent", "target": "output"},
+    ]
+
+    data = await validate(client, workflow)
+
+    assert data["valid"] is False
+    assert {
+        "invalid_agent_strategy",
+        "invalid_parallel_tool_calls",
+    }.issubset(issue_codes(data))
+
+
+@pytest.mark.asyncio
 async def test_validate_agent_task_ok(client: httpx.AsyncClient) -> None:
     workflow = linear_workflow()
     workflow["nodes"][1] = {
@@ -1635,6 +1668,41 @@ async def test_validate_workflow_agent_node_ok(client: httpx.AsyncClient) -> Non
 
     assert data["valid"] is True
     assert data["issues"] == []
+
+
+@pytest.mark.asyncio
+async def test_validate_workflow_agent_strategy_and_parallel_tool_calls(
+    client: httpx.AsyncClient,
+) -> None:
+    workflow = linear_workflow()
+    workflow["nodes"][1] = {
+        "id": "workflow_agent",
+        "type": "workflow_agent",
+        "data": {
+            "kind": "workflow_agent",
+            "agentName": "research-agent",
+            "modelId": "deepseek/deepseek-chat",
+            "rolePrompt": "????????",
+            "taskInput": "????{{user_input}}",
+            "toolMode": "mcp_tools",
+            "agentStrategy": "unsupported",
+            "parallelToolCalls": "sometimes",
+            "outputVariable": "agent_output",
+        },
+    }
+    workflow["nodes"][2]["data"]["outputVariable"] = "agent_output"
+    workflow["edges"] = [
+        {"id": "e1", "source": "input", "target": "workflow_agent"},
+        {"id": "e2", "source": "workflow_agent", "target": "output"},
+    ]
+
+    data = await validate(client, workflow)
+
+    assert data["valid"] is False
+    assert {
+        "invalid_workflow_agent_strategy",
+        "invalid_workflow_agent_parallel_tool_calls",
+    }.issubset(issue_codes(data))
 
 
 @pytest.mark.asyncio

--- a/server/workflow_native/validate.py
+++ b/server/workflow_native/validate.py
@@ -851,17 +851,41 @@ def validate_node_configuration(
                 )
             )
 
+        agent_strategy = str(data.get("agentStrategy") or "auto").strip()
+        if agent_strategy not in {"auto", "function_calling", "react"}:
+            issues.append(
+                ValidationIssue(
+                    code="invalid_agent_strategy",
+                    message=(
+                        "Agent agentStrategy must be auto, function_calling, or react."
+                    ),
+                    node_id=node.id,
+                )
+            )
+
+        parallel_tool_calls = str(
+            data.get("parallelToolCalls") or "false"
+        ).strip().lower()
+        if parallel_tool_calls not in {"true", "false"}:
+            issues.append(
+                ValidationIssue(
+                    code="invalid_parallel_tool_calls",
+                    message="Agent parallelToolCalls must be true or false.",
+                    node_id=node.id,
+                )
+            )
+
         max_iterations = str(data.get("maxIterations") or "").strip()
         if max_iterations:
             try:
                 max_iterations_value = int(max_iterations)
             except ValueError:
                 max_iterations_value = 0
-            if max_iterations_value < 1:
+            if max_iterations_value < 1 or max_iterations_value > 20:
                 issues.append(
                     ValidationIssue(
                         code="invalid_max_iterations",
-                        message="Agent maxIterations must be a positive integer.",
+                        message="Agent maxIterations must be between 1 and 20.",
                         node_id=node.id,
                     )
                 )
@@ -928,6 +952,31 @@ def validate_node_configuration(
                 ValidationIssue(
                     code="invalid_workflow_agent_tool_mode",
                     message="Workflow agent toolMode must be none or mcp_tools.",
+                    node_id=node.id,
+                )
+            )
+
+        agent_strategy = str(data.get("agentStrategy") or "auto").strip()
+        if agent_strategy not in {"auto", "function_calling", "react"}:
+            issues.append(
+                ValidationIssue(
+                    code="invalid_workflow_agent_strategy",
+                    message=(
+                        "Workflow agent agentStrategy must be auto, "
+                        "function_calling, or react."
+                    ),
+                    node_id=node.id,
+                )
+            )
+
+        parallel_tool_calls = str(
+            data.get("parallelToolCalls") or "false"
+        ).strip().lower()
+        if parallel_tool_calls not in {"true", "false"}:
+            issues.append(
+                ValidationIssue(
+                    code="invalid_workflow_agent_parallel_tool_calls",
+                    message="Workflow agent parallelToolCalls must be true or false.",
                     node_id=node.id,
                 )
             )

--- a/server/xpert_runtime/agent_strategy/__init__.py
+++ b/server/xpert_runtime/agent_strategy/__init__.py
@@ -1,0 +1,43 @@
+from .model_client import OpenAICompatibleAgentModelClient, parse_chat_completion
+from .models import (
+    AgentModelError,
+    AgentModelTurn,
+    AgentStrategyError,
+    AgentStrategyEvent,
+    AgentStrategyName,
+    AgentStrategyResult,
+    AgentToolCall,
+    AgentUsage,
+)
+from .react import ReActDecision, build_react_prompt, parse_react_decision, strip_think_blocks
+from .runner import (
+    AgentStrategyRunner,
+    build_tool_bindings,
+    format_tool_observation,
+    normalize_tool_schema,
+    summarize_arguments,
+    truncate_observation,
+)
+
+__all__ = [
+    "AgentModelError",
+    "AgentModelTurn",
+    "AgentStrategyError",
+    "AgentStrategyEvent",
+    "AgentStrategyName",
+    "AgentStrategyResult",
+    "AgentStrategyRunner",
+    "AgentToolCall",
+    "AgentUsage",
+    "OpenAICompatibleAgentModelClient",
+    "ReActDecision",
+    "build_react_prompt",
+    "build_tool_bindings",
+    "format_tool_observation",
+    "normalize_tool_schema",
+    "parse_chat_completion",
+    "parse_react_decision",
+    "strip_think_blocks",
+    "summarize_arguments",
+    "truncate_observation",
+]

--- a/server/xpert_runtime/agent_strategy/model_client.py
+++ b/server/xpert_runtime/agent_strategy/model_client.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from .models import AgentModelError, AgentModelTurn, AgentToolCall, AgentUsage
+
+
+class OpenAICompatibleAgentModelClient:
+    """Small Chat Completions adapter dedicated to agent tool-call turns."""
+
+    def __init__(
+        self,
+        *,
+        endpoint: str,
+        headers: dict[str, str],
+        client_kwargs: dict[str, Any] | None = None,
+    ) -> None:
+        self.endpoint = endpoint
+        self.headers = dict(headers)
+        self.client_kwargs = dict(client_kwargs or {})
+
+    async def complete(
+        self,
+        *,
+        model_id: str,
+        messages: list[dict[str, Any]],
+        temperature: float,
+        max_tokens: int,
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: str | None = None,
+        parallel_tool_calls: bool | None = None,
+    ) -> AgentModelTurn:
+        payload: dict[str, Any] = {
+            "model": model_id,
+            "messages": messages,
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+            "stream": False,
+        }
+        if tools is not None:
+            payload["tools"] = tools
+        if tool_choice is not None:
+            payload["tool_choice"] = tool_choice
+        if parallel_tool_calls is not None:
+            payload["parallel_tool_calls"] = parallel_tool_calls
+
+        async with httpx.AsyncClient(**self.client_kwargs) as client:
+            response = await client.post(
+                self.endpoint,
+                headers=self.headers,
+                json=payload,
+            )
+
+        if response.status_code >= 400:
+            raise _model_error(response)
+        try:
+            data = response.json()
+        except ValueError as exc:
+            raise AgentModelError("模型返回了无法解析的 JSON 响应。") from exc
+        if not isinstance(data, dict):
+            raise AgentModelError("模型返回了无法解析的响应对象。")
+        return parse_chat_completion(data)
+
+
+def parse_chat_completion(payload: dict[str, Any]) -> AgentModelTurn:
+    choices = payload.get("choices")
+    if not isinstance(choices, list) or not choices:
+        raise AgentModelError("模型响应缺少 choices。")
+    choice = choices[0]
+    if not isinstance(choice, dict):
+        raise AgentModelError("模型响应 choices[0] 格式错误。")
+    message = choice.get("message")
+    if not isinstance(message, dict):
+        message = choice.get("delta")
+    if not isinstance(message, dict):
+        raise AgentModelError("模型响应缺少 assistant message。")
+
+    calls: list[AgentToolCall] = []
+    raw_calls = message.get("tool_calls")
+    if isinstance(raw_calls, list):
+        for index, raw_call in enumerate(raw_calls):
+            if not isinstance(raw_call, dict):
+                continue
+            function = raw_call.get("function")
+            if not isinstance(function, dict):
+                continue
+            name = str(function.get("name") or "").strip()
+            arguments = function.get("arguments")
+            if isinstance(arguments, str):
+                raw_arguments = arguments
+            elif isinstance(arguments, dict):
+                import json
+
+                raw_arguments = json.dumps(arguments, ensure_ascii=False)
+            else:
+                raw_arguments = "{}"
+            calls.append(
+                AgentToolCall(
+                    call_id=str(raw_call.get("id") or f"call_{index + 1}"),
+                    name=name,
+                    raw_arguments=raw_arguments,
+                )
+            )
+
+    usage_raw = payload.get("usage")
+    usage = AgentUsage()
+    if isinstance(usage_raw, dict):
+        usage = AgentUsage(
+            prompt_tokens=_safe_int(usage_raw.get("prompt_tokens")),
+            completion_tokens=_safe_int(usage_raw.get("completion_tokens")),
+            total_tokens=_safe_int(usage_raw.get("total_tokens")),
+        )
+
+    return AgentModelTurn(
+        content=_content_text(message.get("content")),
+        tool_calls=calls,
+        finish_reason=(
+            str(choice.get("finish_reason"))
+            if choice.get("finish_reason") is not None
+            else None
+        ),
+        usage=usage,
+        raw=payload,
+    )
+
+
+def _content_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    parts: list[str] = []
+    for item in content:
+        if isinstance(item, str):
+            parts.append(item)
+        elif isinstance(item, dict):
+            text = item.get("text")
+            if isinstance(text, str):
+                parts.append(text)
+    return "".join(parts)
+
+
+def _model_error(response: httpx.Response) -> AgentModelError:
+    message = f"模型网关请求失败：HTTP {response.status_code}"
+    code: str | None = None
+    param: str | None = None
+    try:
+        data = response.json()
+    except ValueError:
+        data = None
+    if isinstance(data, dict):
+        error = data.get("error")
+        if isinstance(error, dict):
+            if error.get("message"):
+                message = str(error["message"])
+            if error.get("code") is not None:
+                code = str(error["code"])
+            if error.get("param") is not None:
+                param = str(error["param"])
+        elif data.get("message"):
+            message = str(data["message"])
+    return AgentModelError(
+        message,
+        status_code=response.status_code,
+        code=code,
+        param=param,
+    )
+
+
+def _safe_int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0

--- a/server/xpert_runtime/agent_strategy/models.py
+++ b/server/xpert_runtime/agent_strategy/models.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal, Protocol
+
+
+AgentStrategyName = Literal["auto", "function_calling", "react"]
+
+
+@dataclass(slots=True)
+class AgentToolCall:
+    call_id: str
+    name: str
+    raw_arguments: str
+
+
+@dataclass(slots=True)
+class AgentUsage:
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+
+    def add(self, other: "AgentUsage") -> None:
+        self.prompt_tokens += other.prompt_tokens
+        self.completion_tokens += other.completion_tokens
+        self.total_tokens += other.total_tokens
+
+    def to_dict(self) -> dict[str, int]:
+        return {
+            "prompt_tokens": self.prompt_tokens,
+            "completion_tokens": self.completion_tokens,
+            "total_tokens": self.total_tokens,
+        }
+
+
+@dataclass(slots=True)
+class AgentModelTurn:
+    content: str = ""
+    tool_calls: list[AgentToolCall] = field(default_factory=list)
+    finish_reason: str | None = None
+    usage: AgentUsage = field(default_factory=AgentUsage)
+    raw: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class AgentStrategyEvent:
+    event_type: str
+    strategy: str
+    iteration: int = 0
+    status: str = "info"
+    message: str = ""
+    tool_name: str | None = None
+    tool_call_id: str | None = None
+    arguments_summary: str | None = None
+    output_preview: str | None = None
+    duration_ms: float | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class AgentStrategyResult:
+    answer: str
+    strategy: Literal["function_calling", "react"]
+    events: list[AgentStrategyEvent] = field(default_factory=list)
+    usage: AgentUsage = field(default_factory=AgentUsage)
+    tool_calls_attempted: int = 0
+    tool_calls_executed: int = 0
+
+
+class AgentModelClient(Protocol):
+    async def complete(
+        self,
+        *,
+        model_id: str,
+        messages: list[dict[str, Any]],
+        temperature: float,
+        max_tokens: int,
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: str | None = None,
+        parallel_tool_calls: bool | None = None,
+    ) -> AgentModelTurn:
+        ...
+
+
+class AgentModelError(RuntimeError):
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int | None = None,
+        code: str | None = None,
+        param: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.message = message
+        self.status_code = status_code
+        self.code = code
+        self.param = param
+
+    def is_function_calling_unsupported(self) -> bool:
+        if self.status_code not in {400, 422}:
+            return False
+        param = (self.param or "").lower()
+        message = self.message.lower()
+        tooling_terms = (
+            "tools",
+            "tool_choice",
+            "parallel_tool_calls",
+            "function_call",
+            "functions",
+        )
+        unsupported_terms = (
+            "unsupported",
+            "not support",
+            "unrecognized",
+            "unknown parameter",
+            "extra inputs are not permitted",
+            "not allowed",
+        )
+        return param in tooling_terms or (
+            any(term in message for term in tooling_terms)
+            and any(term in message for term in unsupported_terms)
+        )
+
+
+class AgentStrategyError(RuntimeError):
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str = "agent_strategy_error",
+        events: list[AgentStrategyEvent] | None = None,
+        usage: AgentUsage | None = None,
+        tool_calls_attempted: int = 0,
+        tool_calls_executed: int = 0,
+    ) -> None:
+        super().__init__(message)
+        self.message = message
+        self.code = code
+        self.events = list(events or [])
+        self.usage = usage or AgentUsage()
+        self.tool_calls_attempted = tool_calls_attempted
+        self.tool_calls_executed = tool_calls_executed
+
+    @property
+    def retry_safe(self) -> bool:
+        return self.tool_calls_attempted == 0 and self.code not in {
+            "capability_not_found",
+            "invalid_tool_schema",
+            "tool_denied",
+        }

--- a/server/xpert_runtime/agent_strategy/react.py
+++ b/server/xpert_runtime/agent_strategy/react.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Any, Literal
+
+
+@dataclass(slots=True)
+class ReActDecision:
+    kind: Literal["action", "answer", "invalid"]
+    answer: str = ""
+    action: str = ""
+    action_input: dict[str, Any] | None = None
+    error: str = ""
+
+
+def build_react_prompt(
+    *,
+    system_prompt: str,
+    tools_text: str,
+    tool_names: list[str],
+) -> str:
+    names = json.dumps(tool_names, ensure_ascii=False)
+    return (
+        f"{system_prompt.strip()}\n\n"
+        "你可以使用下列工具完成任务。需要工具时，每轮只调用一个工具；"
+        "不要展示隐藏推理。严格使用以下控制格式：\n"
+        'Action: {"action":"工具名","action_input":{"参数":"值"}}\n'
+        "工具结果会以 Observation 返回。完成时输出：\n"
+        "FinalAnswer: 最终答案\n\n"
+        f"允许的工具名：{names}\n"
+        f"工具定义：\n{tools_text}"
+    )
+
+
+def parse_react_decision(raw_response: str) -> ReActDecision:
+    cleaned = strip_think_blocks(raw_response).strip()
+    answer_match = re.search(r"final\s*answer\s*:\s*", cleaned, re.IGNORECASE)
+    if answer_match:
+        answer = cleaned[answer_match.end() :].strip()
+        if answer:
+            return ReActDecision(kind="answer", answer=answer)
+        return ReActDecision(kind="invalid", error="FinalAnswer 为空。")
+
+    action_match = re.search(r"action\s*:\s*", cleaned, re.IGNORECASE)
+    if action_match:
+        fragment = cleaned[action_match.end() :].lstrip()
+        try:
+            value, _ = json.JSONDecoder().raw_decode(fragment)
+        except ValueError:
+            return ReActDecision(kind="invalid", error="Action JSON 无法解析。")
+        if not isinstance(value, dict):
+            return ReActDecision(kind="invalid", error="Action 必须是 JSON 对象。")
+        action = str(value.get("action") or "").strip()
+        action_input = value.get("action_input")
+        if not action:
+            return ReActDecision(kind="invalid", error="Action 缺少工具名。")
+        if not isinstance(action_input, dict):
+            return ReActDecision(kind="invalid", error="action_input 必须是 JSON 对象。")
+        return ReActDecision(
+            kind="action",
+            action=action,
+            action_input=dict(action_input),
+        )
+
+    if not cleaned:
+        return ReActDecision(kind="invalid", error="模型返回为空。")
+    if re.search(r"thought\s*:", cleaned, re.IGNORECASE):
+        return ReActDecision(kind="invalid", error="模型只返回了 Thought，缺少 Action 或 FinalAnswer。")
+    return ReActDecision(kind="answer", answer=cleaned)
+
+
+def strip_think_blocks(value: str) -> str:
+    cleaned = value
+    previous = None
+    while cleaned != previous:
+        previous = cleaned
+        cleaned = re.sub(
+            r"<think>.*?</think>",
+            "",
+            cleaned,
+            flags=re.IGNORECASE | re.DOTALL,
+        )
+    cleaned = re.sub(r"<think>.*$", "", cleaned, flags=re.IGNORECASE | re.DOTALL)
+    return cleaned

--- a/server/xpert_runtime/agent_strategy/runner.py
+++ b/server/xpert_runtime/agent_strategy/runner.py
@@ -1,0 +1,743 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import re
+import time
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+
+from ..toolset import RuntimeTool, RuntimeToolError, RuntimeToolResult
+from .models import (
+    AgentModelClient,
+    AgentModelError,
+    AgentStrategyError,
+    AgentStrategyEvent,
+    AgentStrategyName,
+    AgentStrategyResult,
+    AgentToolCall,
+    AgentUsage,
+)
+from .react import build_react_prompt, parse_react_decision
+
+
+ToolExecutor = Callable[[str, dict[str, Any], str, int], Awaitable[RuntimeToolResult]]
+
+MAX_TOOL_CALLS_PER_ROUND = 8
+MAX_OBSERVATION_CHARS = 16_000
+SENSITIVE_KEY_PATTERN = re.compile(
+    r"(?:api[_-]?key|authorization|cookie|password|secret|token)",
+    re.IGNORECASE,
+)
+FUNCTION_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+
+
+@dataclass(slots=True)
+class ToolBinding:
+    alias: str
+    tool: RuntimeTool
+    schema: dict[str, Any]
+    validator: Draft202012Validator
+
+
+@dataclass(slots=True)
+class ToolOutcome:
+    call_id: str
+    alias: str
+    tool_name: str
+    observation: str
+    event: AgentStrategyEvent
+    attempted: bool = False
+    executed: bool = False
+
+
+class AgentStrategyRunner:
+    def __init__(
+        self,
+        *,
+        model_client: AgentModelClient,
+        tool_executor: ToolExecutor,
+        tools: list[RuntimeTool],
+        model_id: str,
+        system_prompt: str,
+        user_prompt: str,
+        strategy: AgentStrategyName = "auto",
+        max_iterations: int = 5,
+        temperature: float = 0.7,
+        max_tokens: int = 1024,
+        parallel_tool_calls: bool = False,
+        history_messages: list[dict[str, Any]] | None = None,
+    ) -> None:
+        if strategy not in {"auto", "function_calling", "react"}:
+            raise ValueError(f"Unsupported agent strategy: {strategy}")
+        self.model_client = model_client
+        self.tool_executor = tool_executor
+        self.model_id = model_id
+        self.system_prompt = system_prompt
+        self.user_prompt = user_prompt
+        self.requested_strategy = strategy
+        self.max_iterations = min(max(int(max_iterations), 1), 20)
+        self.temperature = min(max(float(temperature), 0.0), 2.0)
+        self.max_tokens = max(int(max_tokens), 1)
+        self.parallel_tool_calls = bool(parallel_tool_calls)
+        self.history_messages = [
+            deepcopy(message)
+            for message in list(history_messages or [])
+            if str(message.get("role") or "") in {"user", "assistant"}
+            and str(message.get("content") or "").strip()
+        ]
+        self.events: list[AgentStrategyEvent] = []
+        self.usage = AgentUsage()
+        self.tool_calls_attempted = 0
+        self.tool_calls_executed = 0
+        self.bindings = build_tool_bindings(tools)
+        self.binding_by_alias = {binding.alias: binding for binding in self.bindings}
+        self.binding_by_name = {binding.tool.name: binding for binding in self.bindings}
+
+    async def run(self) -> AgentStrategyResult:
+        try:
+            if self.requested_strategy == "react":
+                return await self._run_react()
+            if self.requested_strategy == "function_calling":
+                return await self._run_function_calling()
+            try:
+                return await self._run_function_calling()
+            except AgentModelError as exc:
+                if self.tool_calls_attempted or not exc.is_function_calling_unsupported():
+                    raise
+                self.events.append(
+                    AgentStrategyEvent(
+                        event_type="strategy_fallback",
+                        strategy="react",
+                        status="warning",
+                        message="模型不支持原生 Function Calling，已安全回退 ReAct。",
+                        metadata={"reason": exc.message, "status_code": exc.status_code},
+                    )
+                )
+                return await self._run_react()
+        except AgentStrategyError:
+            raise
+        except AgentModelError as exc:
+            raise self._error(exc.message, code="model_error") from exc
+        except Exception as exc:
+            if hasattr(exc, "continuation") and hasattr(exc, "approval_id"):
+                raise
+            raise self._error(str(exc) or exc.__class__.__name__) from exc
+
+    async def _run_function_calling(self) -> AgentStrategyResult:
+        self.events.append(
+            AgentStrategyEvent(
+                event_type="strategy_selected",
+                strategy="function_calling",
+                message="使用原生 Function Calling 策略。",
+            )
+        )
+        tool_definitions = [binding_to_openai_tool(binding) for binding in self.bindings]
+        messages: list[dict[str, Any]] = [
+            {"role": "system", "content": self.system_prompt},
+            *deepcopy(self.history_messages),
+            {"role": "user", "content": self.user_prompt},
+        ]
+
+        for iteration in range(1, self.max_iterations + 1):
+            turn = await self.model_client.complete(
+                model_id=self.model_id,
+                messages=deepcopy(messages),
+                temperature=self.temperature,
+                max_tokens=self.max_tokens,
+                tools=deepcopy(tool_definitions),
+                tool_choice="auto",
+                parallel_tool_calls=self.parallel_tool_calls,
+            )
+            self.usage.add(turn.usage)
+            self.events.append(
+                AgentStrategyEvent(
+                    event_type="model_round",
+                    strategy="function_calling",
+                    iteration=iteration,
+                    message=f"Function Calling 第 {iteration} 轮完成。",
+                    metadata={
+                        "finish_reason": turn.finish_reason,
+                        "usage": turn.usage.to_dict(),
+                    },
+                )
+            )
+            if not turn.tool_calls:
+                answer = turn.content.strip()
+                if not answer:
+                    raise self._error("模型没有返回答案或工具调用。", code="empty_model_response")
+                return self._result(answer, "function_calling")
+
+            messages.append(_assistant_tool_call_message(turn.content, turn.tool_calls))
+            outcomes = await self._execute_function_call_batch(turn.tool_calls, iteration)
+            for outcome in outcomes:
+                messages.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": outcome.call_id,
+                        "name": outcome.alias,
+                        "content": outcome.observation,
+                    }
+                )
+            terminal_outcome = next(
+                (
+                    outcome
+                    for outcome in outcomes
+                    if outcome.executed
+                    and (self.binding_by_alias.get(outcome.alias) is not None)
+                    and self.binding_by_alias[outcome.alias].tool.terminal
+                ),
+                None,
+            )
+            if terminal_outcome is not None:
+                return self._result(
+                    terminal_outcome.observation,
+                    "function_calling",
+                )
+
+        final_turn = await self.model_client.complete(
+            model_id=self.model_id,
+            messages=deepcopy(messages),
+            temperature=self.temperature,
+            max_tokens=self.max_tokens,
+            tools=deepcopy(tool_definitions),
+            tool_choice="none",
+            parallel_tool_calls=False,
+        )
+        self.usage.add(final_turn.usage)
+        self.events.append(
+            AgentStrategyEvent(
+                event_type="model_round",
+                strategy="function_calling",
+                iteration=self.max_iterations,
+                message="Function Calling 已执行禁止工具的最终总结。",
+                metadata={
+                    "finish_reason": final_turn.finish_reason,
+                    "final_summary": True,
+                    "usage": final_turn.usage.to_dict(),
+                },
+            )
+        )
+        if final_turn.tool_calls or not final_turn.content.strip():
+            self.events.append(
+                AgentStrategyEvent(
+                    event_type="iteration_limit",
+                    strategy="function_calling",
+                    iteration=self.max_iterations,
+                    status="warning",
+                    message=f"达到最大工具循环次数 {self.max_iterations}。",
+                )
+            )
+            raise self._error(
+                f"Agent 达到最大工具循环次数 {self.max_iterations}，且未生成最终答案。",
+                code="iteration_limit",
+            )
+        return self._result(final_turn.content.strip(), "function_calling")
+
+    async def _run_react(self) -> AgentStrategyResult:
+        self.events.append(
+            AgentStrategyEvent(
+                event_type="strategy_selected",
+                strategy="react",
+                message="使用 ReAct 策略。",
+            )
+        )
+        tools_text = "\n".join(
+            f"- {binding.tool.name}: {binding.tool.description or '无描述'} "
+            f"schema={json.dumps(binding.schema, ensure_ascii=False)}"
+            for binding in self.bindings
+        )
+        react_system_prompt = build_react_prompt(
+            system_prompt=self.system_prompt,
+            tools_text=tools_text,
+            tool_names=[binding.tool.name for binding in self.bindings],
+        )
+        messages: list[dict[str, Any]] = [
+            {"role": "system", "content": react_system_prompt},
+            *deepcopy(self.history_messages),
+            {"role": "user", "content": self.user_prompt},
+        ]
+
+        for iteration in range(1, self.max_iterations + 1):
+            turn = await self.model_client.complete(
+                model_id=self.model_id,
+                messages=deepcopy(messages),
+                temperature=self.temperature,
+                max_tokens=self.max_tokens,
+            )
+            self.usage.add(turn.usage)
+            decision = parse_react_decision(turn.content)
+            self.events.append(
+                AgentStrategyEvent(
+                    event_type="model_round",
+                    strategy="react",
+                    iteration=iteration,
+                    status="warning" if decision.kind == "invalid" else "info",
+                    message=f"ReAct 第 {iteration} 轮：{decision.kind}。",
+                    metadata={"usage": turn.usage.to_dict()},
+                )
+            )
+            if decision.kind == "answer":
+                return self._result(decision.answer.strip(), "react")
+            if decision.kind == "invalid":
+                messages.append({"role": "assistant", "content": turn.content})
+                messages.append(
+                    {
+                        "role": "user",
+                        "content": (
+                            f"Observation: 格式错误：{decision.error}\n"
+                            "请只返回一个 Action JSON，或返回 FinalAnswer。"
+                        ),
+                    }
+                )
+                continue
+
+            outcome = await self._execute_tool_call(
+                AgentToolCall(
+                    call_id=f"react_{iteration}",
+                    name=decision.action,
+                    raw_arguments=json.dumps(decision.action_input or {}, ensure_ascii=False),
+                ),
+                iteration,
+                react_names=True,
+            )
+            self.events.append(outcome.event)
+            self.tool_calls_attempted += int(outcome.attempted)
+            self.tool_calls_executed += int(outcome.executed)
+            binding = self.binding_by_name.get(outcome.tool_name)
+            if outcome.executed and binding is not None and binding.tool.terminal:
+                return self._result(outcome.observation, "react")
+            messages.append({"role": "assistant", "content": turn.content})
+            messages.append(
+                {
+                    "role": "user",
+                    "content": (
+                        f"Observation: {outcome.observation}\n"
+                        "继续时返回一个 Action JSON；完成时返回 FinalAnswer。"
+                    ),
+                }
+            )
+
+        messages.append(
+            {
+                "role": "user",
+                "content": (
+                    f"工具循环已达到上限 {self.max_iterations}。"
+                    "不得再调用工具，只返回 FinalAnswer。"
+                ),
+            }
+        )
+        final_turn = await self.model_client.complete(
+            model_id=self.model_id,
+            messages=deepcopy(messages),
+            temperature=self.temperature,
+            max_tokens=self.max_tokens,
+        )
+        self.usage.add(final_turn.usage)
+        self.events.append(
+            AgentStrategyEvent(
+                event_type="model_round",
+                strategy="react",
+                iteration=self.max_iterations,
+                message="ReAct 已执行禁止工具的最终总结。",
+                metadata={
+                    "final_summary": True,
+                    "usage": final_turn.usage.to_dict(),
+                },
+            )
+        )
+        decision = parse_react_decision(final_turn.content)
+        if decision.kind == "answer" and decision.answer.strip():
+            return self._result(decision.answer.strip(), "react")
+        self.events.append(
+            AgentStrategyEvent(
+                event_type="iteration_limit",
+                strategy="react",
+                iteration=self.max_iterations,
+                status="warning",
+                message=f"达到最大工具循环次数 {self.max_iterations}。",
+            )
+        )
+        raise self._error(
+            f"Agent 达到最大工具循环次数 {self.max_iterations}，且未生成最终答案。",
+            code="iteration_limit",
+        )
+
+    async def _execute_function_call_batch(
+        self,
+        calls: list[AgentToolCall],
+        iteration: int,
+    ) -> list[ToolOutcome]:
+        limited_calls = calls[:MAX_TOOL_CALLS_PER_ROUND]
+        overflow = calls[MAX_TOOL_CALLS_PER_ROUND:]
+        if self.parallel_tool_calls and len(limited_calls) > 1:
+            outcomes = list(
+                await asyncio.gather(
+                    *(self._execute_tool_call(call, iteration) for call in limited_calls)
+                )
+            )
+        else:
+            outcomes = []
+            for call in limited_calls:
+                outcomes.append(await self._execute_tool_call(call, iteration))
+
+        for call in overflow:
+            binding = self.binding_by_alias.get(call.name)
+            tool_name = binding.tool.name if binding else call.name
+            outcomes.append(
+                self._rejected_outcome(
+                    call,
+                    iteration,
+                    tool_name=tool_name,
+                    message=f"单轮工具调用不能超过 {MAX_TOOL_CALLS_PER_ROUND} 个。",
+                )
+            )
+        for outcome in outcomes:
+            self.events.append(outcome.event)
+            self.tool_calls_attempted += int(outcome.attempted)
+            self.tool_calls_executed += int(outcome.executed)
+        return outcomes
+
+    async def _execute_tool_call(
+        self,
+        call: AgentToolCall,
+        iteration: int,
+        *,
+        react_names: bool = False,
+    ) -> ToolOutcome:
+        binding = (
+            self.binding_by_name.get(call.name)
+            if react_names
+            else self.binding_by_alias.get(call.name)
+        )
+        if binding is None:
+            return self._rejected_outcome(
+                call,
+                iteration,
+                tool_name=call.name,
+                message=f"工具不可用：{call.name}",
+            )
+        try:
+            arguments = json.loads(call.raw_arguments or "{}")
+        except ValueError:
+            return self._rejected_outcome(
+                call,
+                iteration,
+                tool_name=binding.tool.name,
+                message="工具参数不是有效 JSON。",
+            )
+        if not isinstance(arguments, dict):
+            return self._rejected_outcome(
+                call,
+                iteration,
+                tool_name=binding.tool.name,
+                message="工具参数必须是 JSON 对象。",
+            )
+        validation_errors = sorted(
+            binding.validator.iter_errors(arguments),
+            key=lambda error: list(error.absolute_path),
+        )
+        if validation_errors:
+            details = "; ".join(_validation_error_text(error) for error in validation_errors[:3])
+            return self._rejected_outcome(
+                call,
+                iteration,
+                tool_name=binding.tool.name,
+                message=f"工具参数校验失败：{details}",
+                arguments=arguments,
+            )
+
+        started_at = time.perf_counter()
+        try:
+            result = await self.tool_executor(
+                binding.tool.name,
+                arguments,
+                call.call_id,
+                iteration,
+            )
+        except RuntimeToolError as exc:
+            duration_ms = (time.perf_counter() - started_at) * 1000
+            if exc.code in {"tool_denied", "capability_not_found"}:
+                self.events.append(
+                    AgentStrategyEvent(
+                        event_type="tool_call",
+                        strategy=self._active_strategy(react_names),
+                        iteration=iteration,
+                        status="failed",
+                        message=f"工具 {binding.tool.name} 被运行时拒绝：{exc.message}",
+                        tool_name=binding.tool.name,
+                        tool_call_id=call.call_id,
+                        arguments_summary=summarize_arguments(arguments),
+                        duration_ms=duration_ms,
+                        metadata={"error_code": exc.code},
+                    )
+                )
+                raise self._error(exc.message, code=exc.code, attempted_increment=1) from exc
+            observation = truncate_observation(f"工具执行失败：{exc.message}")
+            return ToolOutcome(
+                call_id=call.call_id,
+                alias=binding.alias,
+                tool_name=binding.tool.name,
+                observation=observation,
+                attempted=True,
+                executed=False,
+                event=AgentStrategyEvent(
+                    event_type="tool_call",
+                    strategy=self._active_strategy(react_names),
+                    iteration=iteration,
+                    status="failed",
+                    message=f"工具 {binding.tool.name} 执行失败，可由模型恢复。",
+                    tool_name=binding.tool.name,
+                    tool_call_id=call.call_id,
+                    arguments_summary=summarize_arguments(arguments),
+                    output_preview=observation[:300],
+                    duration_ms=duration_ms,
+                    metadata={"error_code": exc.code},
+                ),
+            )
+        except Exception as exc:
+            if hasattr(exc, "continuation") and hasattr(exc, "approval_id"):
+                raise
+            raise self._error(
+                str(exc) or exc.__class__.__name__,
+                code="tool_system_error",
+                attempted_increment=1,
+            ) from exc
+
+        duration_ms = (time.perf_counter() - started_at) * 1000
+        observation = format_tool_observation(result)
+        status = "failed" if result.is_error else "completed"
+        return ToolOutcome(
+            call_id=call.call_id,
+            alias=binding.alias,
+            tool_name=binding.tool.name,
+            observation=observation,
+            attempted=True,
+            executed=not result.is_error,
+            event=AgentStrategyEvent(
+                event_type="tool_call",
+                strategy=self._active_strategy(react_names),
+                iteration=iteration,
+                status=status,
+                message=f"工具 {binding.tool.name} {status}。",
+                tool_name=binding.tool.name,
+                tool_call_id=call.call_id,
+                arguments_summary=summarize_arguments(arguments),
+                output_preview=observation[:300],
+                duration_ms=duration_ms,
+                metadata={
+                    "content_types": list(result.metadata.get("content_types", [])),
+                    "is_error": result.is_error,
+                },
+            ),
+        )
+
+    def _rejected_outcome(
+        self,
+        call: AgentToolCall,
+        iteration: int,
+        *,
+        tool_name: str,
+        message: str,
+        arguments: dict[str, Any] | None = None,
+    ) -> ToolOutcome:
+        observation = truncate_observation(message)
+        return ToolOutcome(
+            call_id=call.call_id,
+            alias=call.name,
+            tool_name=tool_name,
+            observation=observation,
+            attempted=False,
+            executed=False,
+            event=AgentStrategyEvent(
+                event_type="tool_call",
+                strategy="react" if call.call_id.startswith("react_") else "function_calling",
+                iteration=iteration,
+                status="rejected",
+                message=message,
+                tool_name=tool_name,
+                tool_call_id=call.call_id,
+                arguments_summary=summarize_arguments(arguments or {}),
+                output_preview=observation[:300],
+            ),
+        )
+
+    def _active_strategy(self, react_names: bool) -> str:
+        return "react" if react_names else "function_calling"
+
+    def _result(
+        self,
+        answer: str,
+        strategy: str,
+    ) -> AgentStrategyResult:
+        self.events.append(
+            AgentStrategyEvent(
+                event_type="final_answer",
+                strategy=strategy,
+                status="completed",
+                message=f"Agent 已生成最终答案（{len(answer)} 字符）。",
+                metadata={
+                    "answer_length": len(answer),
+                    "usage": self.usage.to_dict(),
+                },
+            )
+        )
+        return AgentStrategyResult(
+            answer=answer,
+            strategy=strategy,  # type: ignore[arg-type]
+            events=list(self.events),
+            usage=self.usage,
+            tool_calls_attempted=self.tool_calls_attempted,
+            tool_calls_executed=self.tool_calls_executed,
+        )
+
+    def _error(
+        self,
+        message: str,
+        *,
+        code: str = "agent_strategy_error",
+        attempted_increment: int = 0,
+    ) -> AgentStrategyError:
+        attempted = self.tool_calls_attempted + attempted_increment
+        return AgentStrategyError(
+            message,
+            code=code,
+            events=list(self.events),
+            usage=self.usage,
+            tool_calls_attempted=attempted,
+            tool_calls_executed=self.tool_calls_executed,
+        )
+
+
+def build_tool_bindings(tools: list[RuntimeTool]) -> list[ToolBinding]:
+    bindings: list[ToolBinding] = []
+    used_aliases: set[str] = set()
+    for index, tool in enumerate(tools, start=1):
+        if not tool.name:
+            continue
+        schema = normalize_tool_schema(tool.input_schema)
+        try:
+            Draft202012Validator.check_schema(schema)
+        except SchemaError as exc:
+            raise AgentStrategyError(
+                f"工具 {tool.name} 的 JSON Schema 无效：{exc.message}",
+                code="invalid_tool_schema",
+            ) from exc
+        alias = tool.name if FUNCTION_NAME_PATTERN.fullmatch(tool.name) else _tool_alias(tool.name, index)
+        if alias in used_aliases:
+            alias = _tool_alias(tool.name, index, force_hash=True)
+        used_aliases.add(alias)
+        bindings.append(
+            ToolBinding(
+                alias=alias,
+                tool=tool,
+                schema=schema,
+                validator=Draft202012Validator(schema),
+            )
+        )
+    return bindings
+
+
+def normalize_tool_schema(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict) or not value:
+        return {"type": "object", "properties": {}}
+    schema = deepcopy(value)
+    if "type" not in schema and ("properties" in schema or "required" in schema):
+        schema["type"] = "object"
+    if schema.get("type") != "object":
+        raise AgentStrategyError(
+            "工具输入 Schema 的根类型必须是 object。",
+            code="invalid_tool_schema",
+        )
+    schema.setdefault("properties", {})
+    return schema
+
+
+def binding_to_openai_tool(binding: ToolBinding) -> dict[str, Any]:
+    return {
+        "type": "function",
+        "function": {
+            "name": binding.alias,
+            "description": binding.tool.description or f"调用 {binding.tool.name}",
+            "parameters": deepcopy(binding.schema),
+        },
+    }
+
+
+def format_tool_observation(result: RuntimeToolResult) -> str:
+    parts: list[str] = []
+    output = str(result.output or "").strip()
+    if output:
+        parts.append(output)
+    content_types_raw = result.metadata.get("content_types", [])
+    content_types = [str(item) for item in content_types_raw] if isinstance(content_types_raw, list) else []
+    non_text_types = sorted({item for item in content_types if item != "text"})
+    if non_text_types:
+        parts.append("工具还返回了非文本内容：" + ", ".join(non_text_types))
+    if not parts:
+        parts.append("工具执行完成，但没有返回文本内容。")
+    if result.is_error:
+        parts.insert(0, "工具报告执行错误。")
+    return truncate_observation("\n".join(parts))
+
+
+def truncate_observation(value: str, limit: int = MAX_OBSERVATION_CHARS) -> str:
+    if len(value) <= limit:
+        return value
+    omitted = len(value) - limit
+    return value[:limit] + f"\n[工具结果已截断，省略 {omitted} 个字符]"
+
+
+def summarize_arguments(arguments: dict[str, Any]) -> str:
+    redacted = _redact(arguments)
+    serialized = json.dumps(redacted, ensure_ascii=False, separators=(",", ":"))
+    return serialized if len(serialized) <= 500 else serialized[:500] + "…"
+
+
+def _redact(value: Any, key: str = "") -> Any:
+    if key and SENSITIVE_KEY_PATTERN.search(key):
+        return "***"
+    if isinstance(value, dict):
+        return {str(item_key): _redact(item_value, str(item_key)) for item_key, item_value in value.items()}
+    if isinstance(value, list):
+        return [_redact(item) for item in value]
+    return value
+
+
+def _assistant_tool_call_message(content: str, calls: list[AgentToolCall]) -> dict[str, Any]:
+    return {
+        "role": "assistant",
+        "content": content or None,
+        "tool_calls": [
+            {
+                "id": call.call_id,
+                "type": "function",
+                "function": {
+                    "name": call.name,
+                    "arguments": call.raw_arguments,
+                },
+            }
+            for call in calls
+        ],
+    }
+
+
+def _tool_alias(name: str, index: int, *, force_hash: bool = False) -> str:
+    safe = re.sub(r"[^A-Za-z0-9_-]+", "_", name).strip("_-") or "tool"
+    digest = hashlib.sha256(name.encode("utf-8")).hexdigest()[:8]
+    prefix = f"tool_{index}_"
+    suffix = f"_{digest}" if force_hash or safe != name else ""
+    available = 64 - len(prefix) - len(suffix)
+    return f"{prefix}{safe[:available]}{suffix}"
+
+
+def _validation_error_text(error: Any) -> str:
+    path = "$"
+    for part in error.absolute_path:
+        path += f"[{part}]" if isinstance(part, int) else f".{part}"
+    return f"{path}: {error.message}"


### PR DESCRIPTION
## What

- add a shared Agent Strategy runtime for `agent.tool_first` and `workflow_agent.mcp_tools`
- support `auto`, native OpenAI-compatible Function Calling, and Dify-style ReAct
- preserve Runtime Toolset, middleware, policy, audit, checkpoint, whitelist, and rollback behavior
- add strategy UI/config validation, focused integration coverage, and Dify Apache-2.0 attribution

## Safety and compatibility

- `auto` falls back to ReAct only for explicit 400/422 tool-parameter incompatibility before any real tool attempt
- after a real tool attempt, whole-run retry and fallback-model switching are disabled
- tool input schemas and arguments use Draft 2020-12 validation; observations are bounded and sensitive argument values are redacted
- V2 initially takes over ordinary registered MCP tools; resumable HITL and advanced Runtime resources remain on ReAct-Lite
- set `WORKFLOW_AGENT_STRATEGY_V2_ENABLED=false` and restart for immediate rollback
- no changes to `/api/chat`, Dify proxy, or `agent_task`

## Verification

- manual independent-preview acceptance: passed
- focused backend: **137 passed**
- frontend: `npm.cmd run build` passed
- Python syntax: `py_compile` passed
- full backend baseline: **1042 passed, 55 failed, 8 skipped**; failures are existing Windows/local-environment constraints (POSIX sockets/`os.fchmod`, MCP subprocesses, CRLF-sensitive built-in Skill digests, and subprocess dependency-path isolation), outside this PR's files

## Upstream reference

Behavioral adaptation from Dify Agent 0.0.42; no `dify_plugin` dependency and no line-by-line SDK copy. Package SHA-256 and Apache-2.0 attribution are recorded in `THIRD_PARTY_NOTICES.md`.
