### PR TITLE
feature: 完成 MCP 第 5 批数据库只读适配

### DIFF
--- a/client/src/components/McpCredentialPanel.tsx
+++ b/client/src/components/McpCredentialPanel.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import type {
   McpCredentialField,
   McpCredentialVerification,
+  McpDatabasePreflightStatus,
   McpSettingField,
 } from "../data/mcpAdaptationPlan";
 
@@ -17,14 +18,21 @@ interface CredentialSummary {
 
 interface McpCredentialPanelProps {
   projectId: string;
+  mode?: "service" | "database";
   credentialFields: McpCredentialField[];
   settingFields: McpSettingField[];
   initialBindings: Record<string, string>;
   initialSettings: Record<string, string | number | boolean>;
+  workspaceId?: string | null;
   initiallyConfigured: boolean;
   credentialVerification: McpCredentialVerification;
+  databasePreflightStatus?: McpDatabasePreflightStatus;
   disabled?: boolean;
   onConfigured: (configured: boolean) => void;
+  onConfigurationSaved?: (
+    settings: Record<string, string | number | boolean>,
+    bindings: Record<string, string>,
+  ) => void;
   onSessionInvalidated: () => void;
 }
 
@@ -63,16 +71,67 @@ const verificationCopy: Record<
   },
 };
 
+const databasePreflightVerifiedCopy = {
+  label: "当前连接已通过自动数据源预检",
+  className: "border-emerald-300/25 bg-emerald-300/[0.08] text-emerald-100",
+};
+
+function visibleSettingOptions(projectId: string, field: McpSettingField) {
+  if (projectId !== "dbhub" || field.key !== "engine") return field.options;
+  return field.options.filter(
+    (option) => !["sqlserver", "mssql"].includes(option.value.toLowerCase()),
+  );
+}
+
+function initialSettingValue(
+  projectId: string,
+  field: McpSettingField,
+  initialSettings: Record<string, string | number | boolean>,
+) {
+  const value = String(initialSettings[field.key] ?? field.default ?? "");
+  if (field.kind !== "enum") return value;
+  const options = visibleSettingOptions(projectId, field);
+  return options.some((option) => option.value === value)
+    ? value
+    : (options[0]?.value ?? "");
+}
+
+function dbhubDefaultPort(engine: string) {
+  const normalized = engine.trim().toLowerCase();
+  if (normalized === "postgres" || normalized === "postgresql") return "5432";
+  if (normalized === "mysql" || normalized === "mariadb") return "3306";
+  return "";
+}
+
+function hasCustomizedDbhubPort(
+  projectId: string,
+  settingFields: McpSettingField[],
+  initialSettings: Record<string, string | number | boolean>,
+) {
+  if (projectId !== "dbhub") return false;
+  const engineField = settingFields.find((field) => field.key === "engine");
+  const portField = settingFields.find((field) => field.key === "port");
+  if (!engineField || !portField) return false;
+  const engine = initialSettingValue(projectId, engineField, initialSettings);
+  const port = initialSettingValue(projectId, portField, initialSettings).trim();
+  const defaultPort = dbhubDefaultPort(engine);
+  return Boolean(port && defaultPort && port !== defaultPort);
+}
+
 export default function McpCredentialPanel({
   projectId,
+  mode = "service",
   credentialFields,
   settingFields,
   initialBindings,
   initialSettings,
+  workspaceId = null,
   initiallyConfigured,
   credentialVerification,
+  databasePreflightStatus = "not-applicable",
   disabled = false,
   onConfigured,
+  onConfigurationSaved,
   onSessionInvalidated,
 }: McpCredentialPanelProps) {
   const [credentials, setCredentials] = useState<CredentialSummary[]>([]);
@@ -81,9 +140,12 @@ export default function McpCredentialPanel({
     Object.fromEntries(
       settingFields.map((field) => [
         field.key,
-        String(initialSettings[field.key] ?? field.default ?? ""),
+        initialSettingValue(projectId, field, initialSettings),
       ]),
     ),
+  );
+  const [dbhubPortCustomized, setDbhubPortCustomized] = useState(() =>
+    hasCustomizedDbhubPort(projectId, settingFields, initialSettings),
   );
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -126,11 +188,14 @@ export default function McpCredentialPanel({
       Object.fromEntries(
         settingFields.map((field) => [
           field.key,
-          String(initialSettings[field.key] ?? field.default ?? ""),
+          initialSettingValue(projectId, field, initialSettings),
         ]),
       ),
     );
-  }, [initialSettings, settingFields]);
+    setDbhubPortCustomized(
+      hasCustomizedDbhubPort(projectId, settingFields, initialSettings),
+    );
+  }, [initialSettings, projectId, settingFields]);
 
   const complete = useMemo(
     () =>
@@ -231,10 +296,19 @@ export default function McpCredentialPanel({
       const response = await fetch(`/api/mcp/catalog/${projectId}/configuration`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ settings: typedSettings, credential_bindings: bindings }),
+        body: JSON.stringify({
+          settings: typedSettings,
+          credential_bindings: bindings,
+          workspace_id: workspaceId,
+        }),
       });
       if (!response.ok) throw new Error(await responseError(response));
-      setMessage("连接配置已保存；首次成功调用后才会标记凭据已验证。");
+      setMessage(
+        mode === "database"
+          ? "数据库配置已保存；连接时会自动校验目标并执行代表性只读预检。"
+          : "连接配置已保存；首次成功调用后才会标记凭据已验证。",
+      );
+      onConfigurationSaved?.(typedSettings, bindings);
       onConfigured(true);
     } catch (reason) {
       setError(reason instanceof Error ? reason.message : "目录配置保存失败。");
@@ -244,18 +318,33 @@ export default function McpCredentialPanel({
     }
   }
 
-  const verification = verificationCopy[credentialVerification];
+  const isDatabase = mode === "database";
+  const isSupabase = projectId === "supabase-mcp";
+  const verification =
+    isDatabase &&
+    databasePreflightStatus === "verified" &&
+    credentialVerification !== "missing" &&
+    credentialVerification !== "not-required" &&
+    credentialVerification !== "verification-failed"
+      ? databasePreflightVerifiedCopy
+      : verificationCopy[credentialVerification];
 
   return (
     <section
-      aria-label="MCP 加密凭据配置"
+      aria-label={isDatabase ? "MCP 数据库连接配置" : "MCP 加密凭据配置"}
       className="relative mt-4 border-t border-white/10 pt-4"
     >
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
-          <h3 className="text-sm font-semibold text-white">加密凭据</h3>
+          <h3 className="text-sm font-semibold text-white">
+            {isDatabase ? "数据库连接与加密凭据" : "加密凭据"}
+          </h3>
           <p className="mt-1 max-w-2xl text-xs leading-5 text-slate-400">
-            在当前 MCP 卡片内独立创建和管理。明文只提交一次，服务端加密保存后仅返回掩码。
+            {isDatabase
+              ? isSupabase
+                ? "20 位小写英文字母 project_ref（不含数字）与 PAT 只在当前卡片管理，不使用远程 OAuth；凭据明文只提交一次。"
+                : "连接字段与凭据只在当前卡片管理。请分别填写受控字段，不要粘贴 DSN、URI 或宿主路径；凭据明文只提交一次。"
+              : "在当前 MCP 卡片内独立创建和管理。明文只提交一次，服务端加密保存后仅返回掩码。"}
           </p>
         </div>
         <span className={`rounded-full border px-3 py-1.5 text-xs font-semibold ${verification.className}`}>
@@ -286,8 +375,9 @@ export default function McpCredentialPanel({
                   </span>
                 </label>
                 <button
+                  aria-controls={`${fieldId}-create`}
                   aria-expanded={isCreating}
-                  className="rounded-lg border border-brand-300/30 bg-brand-300/10 px-3 py-2 text-xs font-semibold text-brand-100 transition hover:bg-brand-300/15 disabled:cursor-not-allowed disabled:opacity-45"
+                  className="min-h-11 rounded-lg border border-brand-300/30 bg-brand-300/10 px-3 py-2 text-xs font-semibold text-brand-100 transition hover:bg-brand-300/15 disabled:cursor-not-allowed disabled:opacity-45"
                   disabled={disabled || creating}
                   onClick={() => (isCreating ? stopCreating() : startCreating(field))}
                   type="button"
@@ -298,7 +388,7 @@ export default function McpCredentialPanel({
 
               <div className="mt-2 flex flex-col gap-2 sm:flex-row">
                 <select
-                  className="min-w-0 flex-1 rounded-lg border border-white/10 bg-ink-950 px-3 py-2 text-sm text-white outline-none transition focus:border-brand-300/50 focus-visible:ring-2 focus-visible:ring-brand-300/30 disabled:opacity-50"
+                  className="min-h-11 min-w-0 flex-1 rounded-lg border border-white/10 bg-ink-950 px-3 py-2 text-sm text-white outline-none transition focus:border-brand-300/50 focus-visible:ring-2 focus-visible:ring-brand-300/30 disabled:opacity-50"
                   disabled={disabled || loading}
                   id={fieldId}
                   onChange={(event) => {
@@ -317,7 +407,7 @@ export default function McpCredentialPanel({
                 </select>
                 {selected ? (
                   <button
-                    className="rounded-lg border border-rose-300/25 px-3 py-2 text-xs font-semibold text-rose-100 transition hover:bg-rose-300/10 disabled:cursor-not-allowed disabled:opacity-45"
+                    className="min-h-11 rounded-lg border border-rose-300/25 px-3 py-2 text-xs font-semibold text-rose-100 transition hover:bg-rose-300/10 disabled:cursor-not-allowed disabled:opacity-45"
                     disabled={revoking}
                     onClick={() => setPendingRevoke(selected)}
                     type="button"
@@ -334,7 +424,7 @@ export default function McpCredentialPanel({
               ) : null}
 
               {isCreating ? (
-                <div className="mt-3 rounded-lg bg-white/[0.04] p-3">
+                <div className="mt-3 rounded-lg bg-white/[0.04] p-3" id={`${fieldId}-create`}>
                   <p className="text-xs font-semibold text-white">新增加密凭据</p>
                   <p className="mt-1 text-xs leading-5 text-slate-400">
                     该凭据只允许用于 {field.label}，不能被其他 MCP 或 Toolset 选择。
@@ -344,17 +434,17 @@ export default function McpCredentialPanel({
                       凭据名称
                       <input
                         autoComplete="off"
-                        className="mt-1 w-full rounded-lg border border-white/10 bg-ink-950 px-3 py-2 text-sm text-white outline-none focus:border-brand-300/50"
+                        className="mt-1 min-h-11 w-full rounded-lg border border-white/10 bg-ink-950 px-3 py-2 text-sm text-white outline-none focus:border-brand-300/50"
                         maxLength={160}
                         onChange={(event) => setCredentialName(event.target.value)}
                         value={credentialName}
                       />
                     </label>
                     <label className="text-xs font-semibold text-slate-300">
-                      Token / API Key
+                      {field.label}（明文仅本次提交）
                       <input
                         autoComplete="new-password"
-                        className="mt-1 w-full rounded-lg border border-white/10 bg-ink-950 px-3 py-2 text-sm text-white outline-none focus:border-brand-300/50"
+                        className="mt-1 min-h-11 w-full rounded-lg border border-white/10 bg-ink-950 px-3 py-2 text-sm text-white outline-none focus:border-brand-300/50"
                         maxLength={20_000}
                         onChange={(event) => setCredentialValue(event.target.value)}
                         placeholder="仅本次提交，保存后不可查看"
@@ -365,7 +455,7 @@ export default function McpCredentialPanel({
                   </div>
                   <div className="mt-3 flex flex-wrap gap-2">
                     <button
-                      className="rounded-lg bg-brand-300 px-3 py-2 text-xs font-semibold text-ink-950 transition hover:bg-brand-200 disabled:cursor-not-allowed disabled:opacity-45"
+                      className="min-h-11 rounded-lg bg-brand-300 px-3 py-2 text-xs font-semibold text-ink-950 transition hover:bg-brand-200 disabled:cursor-not-allowed disabled:opacity-45"
                       disabled={creating || !credentialName.trim() || !credentialValue}
                       onClick={() => void createCredential()}
                       type="button"
@@ -373,7 +463,7 @@ export default function McpCredentialPanel({
                       {creating ? "正在加密保存…" : "加密保存并选择"}
                     </button>
                     <button
-                      className="rounded-lg border border-white/15 px-3 py-2 text-xs font-semibold text-slate-200 transition hover:bg-white/[0.06]"
+                      className="min-h-11 rounded-lg border border-white/15 px-3 py-2 text-xs font-semibold text-slate-200 transition hover:bg-white/[0.06]"
                       onClick={stopCreating}
                       type="button"
                     >
@@ -388,7 +478,16 @@ export default function McpCredentialPanel({
 
         {settingFields.length > 0 ? (
           <div>
-            <h4 className="text-xs font-semibold text-white">服务配置</h4>
+            <h4 className="text-xs font-semibold text-white">
+              {isDatabase ? "数据库连接字段" : "服务配置"}
+            </h4>
+            {isDatabase ? (
+              <p className="mt-1 text-xs leading-5 text-slate-400">
+                {isSupabase
+                  ? "project_ref 仅接受 20 位小写英文字母，不含数字；页面不会接收 API URL、OAuth 回调或完整连接串。"
+                  : "主机、端口、库名、TLS 和用户名按字段独立校验；页面不会生成或展示完整连接串。"}
+              </p>
+            ) : null}
             <div className="mt-2 grid gap-3 sm:grid-cols-2">
               {settingFields.map((field) => {
                 const fieldId = `${projectId}-${field.key}-setting`;
@@ -402,36 +501,59 @@ export default function McpCredentialPanel({
                     </span>
                     {field.kind === "enum" ? (
                       <select
-                        className="mt-2 w-full rounded-lg border border-white/10 bg-ink-950 px-3 py-2 text-sm text-white outline-none focus:border-brand-300/50"
+                        className="mt-2 min-h-11 w-full rounded-lg border border-white/10 bg-ink-950 px-3 py-2 text-sm text-white outline-none focus:border-brand-300/50"
                         disabled={disabled}
                         id={fieldId}
                         onChange={(event) => {
-                          setSettings((current) => ({ ...current, [field.key]: event.target.value }));
+                          const nextValue = event.target.value;
+                          setSettings((current) => {
+                            const next = { ...current, [field.key]: nextValue };
+                            if (
+                              projectId === "dbhub" &&
+                              field.key === "engine" &&
+                              !dbhubPortCustomized
+                            ) {
+                              const defaultPort = dbhubDefaultPort(nextValue);
+                              if (defaultPort) next.port = defaultPort;
+                            }
+                            return next;
+                          });
                           setMessage("");
                           onConfigured(false);
                         }}
                         value={settings[field.key] ?? ""}
                       >
                         <option value="">请选择</option>
-                        {field.options.map((option) => (
+                        {visibleSettingOptions(projectId, field).map((option) => (
                           <option key={option.value} value={option.value}>{option.label}</option>
                         ))}
                       </select>
                     ) : (
                       <input
                         autoComplete="off"
-                        className="mt-2 w-full rounded-lg border border-white/10 bg-ink-950 px-3 py-2 text-sm text-white outline-none transition focus:border-brand-300/50 focus-visible:ring-2 focus-visible:ring-brand-300/30 disabled:opacity-50"
+                        className="mt-2 min-h-11 w-full rounded-lg border border-white/10 bg-ink-950 px-3 py-2 text-sm text-white outline-none transition focus:border-brand-300/50 focus-visible:ring-2 focus-visible:ring-brand-300/30 disabled:opacity-50"
                         disabled={disabled}
                         id={fieldId}
                         max={field.maximum ?? undefined}
                         maxLength={253}
                         min={field.minimum ?? undefined}
                         onChange={(event) => {
+                          if (projectId === "dbhub" && field.key === "port") {
+                            setDbhubPortCustomized(true);
+                          }
                           setSettings((current) => ({ ...current, [field.key]: event.target.value }));
                           setMessage("");
                           onConfigured(false);
                         }}
-                        placeholder={field.allowed_hostname_suffixes[0] ? `example${field.allowed_hostname_suffixes[0]}` : undefined}
+                        placeholder={
+                          field.key === "project_ref"
+                            ? "abcdefghijklmnopqrst"
+                            : field.allowed_hostname_suffixes[0]
+                            ? `example${field.allowed_hostname_suffixes[0]}`
+                            : field.kind === "hostname"
+                              ? "db.example.com"
+                              : undefined
+                        }
                         spellCheck={false}
                         type={field.kind === "integer" ? "number" : "text"}
                         value={settings[field.key] ?? ""}
@@ -453,7 +575,7 @@ export default function McpCredentialPanel({
           </p>
           <div className="mt-3 flex flex-wrap gap-2">
             <button
-              className="rounded-lg bg-rose-300 px-3 py-2 text-xs font-semibold text-ink-950 disabled:opacity-45"
+              className="min-h-11 rounded-lg bg-rose-300 px-3 py-2 text-xs font-semibold text-ink-950 disabled:opacity-45"
               disabled={revoking}
               onClick={() => void revokeCredential()}
               type="button"
@@ -461,7 +583,7 @@ export default function McpCredentialPanel({
               {revoking ? "正在撤销…" : "确认撤销凭据"}
             </button>
             <button
-              className="rounded-lg border border-white/15 px-3 py-2 text-xs font-semibold text-slate-200"
+              className="min-h-11 rounded-lg border border-white/15 px-3 py-2 text-xs font-semibold text-slate-200"
               disabled={revoking}
               onClick={() => setPendingRevoke(null)}
               type="button"
@@ -474,7 +596,7 @@ export default function McpCredentialPanel({
 
       <div className="mt-3 flex flex-wrap items-center gap-3">
         <button
-          className="rounded-lg border border-brand-300/35 bg-brand-300/10 px-4 py-2 text-xs font-semibold text-brand-100 transition hover:bg-brand-300/15 disabled:cursor-not-allowed disabled:opacity-45"
+          className="min-h-11 rounded-lg border border-brand-300/35 bg-brand-300/10 px-4 py-2 text-xs font-semibold text-brand-100 transition hover:bg-brand-300/15 disabled:cursor-not-allowed disabled:opacity-45"
           disabled={!complete || saving || disabled}
           onClick={() => void save()}
           type="button"

--- a/client/src/components/McpServerCard.tsx
+++ b/client/src/components/McpServerCard.tsx
@@ -58,6 +58,44 @@ interface InstalledMcpRecord {
   project_id: string;
 }
 
+const databasePreflightCopy: Record<
+  McpCatalogAdapterStatus["preflight_status"],
+  { label: string; className: string }
+> = {
+  "not-applicable": {
+    label: "不适用",
+    className: "text-slate-300",
+  },
+  blocked: {
+    label: "数据源验证已阻断",
+    className: "text-rose-100",
+  },
+  "awaiting-workspace": {
+    label: "等待封存并绑定数据库文件",
+    className: "text-amber-100",
+  },
+  "awaiting-configuration": {
+    label: "等待保存连接字段和加密凭据",
+    className: "text-amber-100",
+  },
+  unverified: {
+    label: "配置已保存，等待连接预检",
+    className: "text-amber-100",
+  },
+  verifying: {
+    label: "正在验证数据库目标与只读能力",
+    className: "text-cyan-100",
+  },
+  verified: {
+    label: "数据源预检与代表性只读调用通过",
+    className: "text-emerald-100",
+  },
+  failed: {
+    label: "数据源验证失败，请检查受控配置",
+    className: "text-rose-100",
+  },
+};
+
 interface McpServerCardProps {
   project: McpProject;
   adapterStatus?: McpCatalogAdapterStatus;
@@ -145,10 +183,18 @@ export default function McpServerCard({
   const [catalogConfigured, setCatalogConfigured] = useState(
     adapterStatus?.configured ?? false,
   );
+  const [catalogSettings, setCatalogSettings] = useState<
+    Record<string, string | number | boolean>
+  >(adapterStatus?.configuration_values ?? {});
+  const [catalogBindings, setCatalogBindings] = useState<Record<string, string>>(
+    adapterStatus?.credential_bindings ?? {},
+  );
   const [pendingApproval, setPendingApproval] = useState<McpApprovalRequest | null>(null);
   const [approvalBusy, setApprovalBusy] = useState(false);
   const approvalCallbackRef = useRef<(() => void) | null>(null);
   const approvalToolRef = useRef<string | null>(null);
+  const approvalDialogRef = useRef<HTMLDivElement | null>(null);
+  const approvalCancelRef = useRef<HTMLButtonElement | null>(null);
   const [isInstallOpen, setIsInstallOpen] = useState(false);
   const [installState, setInstallState] = useState<InstallState>("checking");
   const [installError, setInstallError] = useState("");
@@ -163,6 +209,8 @@ export default function McpServerCard({
   const limitations = adapterStatus?.limitations ?? project.adaptationLimitations;
   const canConnect = adapterStatus?.executable === true && availability === "ready";
   const workspacePolicy = adapterStatus?.workspace_policy ?? null;
+  const databasePolicy = adapterStatus?.database_policy ?? null;
+  const databasePreflight = adapterStatus?.preflight_status ?? "not-applicable";
   const needsCatalogConfiguration = Boolean(
     adapterStatus?.credential_fields.length || adapterStatus?.setting_fields.length,
   );
@@ -190,7 +238,52 @@ export default function McpServerCard({
 
   useEffect(() => {
     setCatalogConfigured(adapterStatus?.configured ?? false);
-  }, [adapterStatus?.configured]);
+    setCatalogSettings(adapterStatus?.configuration_values ?? {});
+    setCatalogBindings(adapterStatus?.credential_bindings ?? {});
+  }, [
+    adapterStatus?.configured,
+    adapterStatus?.configuration_values,
+    adapterStatus?.credential_bindings,
+  ]);
+
+  useEffect(() => {
+    if (!pendingApproval) return;
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    const focusTimer = window.setTimeout(() => approvalCancelRef.current?.focus(), 0);
+
+    function handleApprovalKeyDown(event: KeyboardEvent) {
+      const dialog = approvalDialogRef.current;
+      if (!dialog) return;
+      if (event.key === "Escape" && !approvalCancelRef.current?.disabled) {
+        event.preventDefault();
+        void cancelApproval();
+        return;
+      }
+      if (event.key !== "Tab") return;
+      const focusable = Array.from(
+        dialog.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+        ),
+      );
+      if (!focusable.length) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
+
+    document.addEventListener("keydown", handleApprovalKeyDown);
+    return () => {
+      window.clearTimeout(focusTimer);
+      document.removeEventListener("keydown", handleApprovalKeyDown);
+      previouslyFocused?.focus();
+    };
+  }, [pendingApproval?.approval_id]);
 
   useEffect(() => {
     let cancelled = false;
@@ -406,6 +499,21 @@ export default function McpServerCard({
     onConnectionChange?.();
   }
 
+  function handleWorkspaceBound(workspace: McpWorkspace | null) {
+    setBoundWorkspace(workspace);
+    if (workspacePolicy?.required) setCatalogConfigured(Boolean(workspace));
+    onConnectionChange?.();
+  }
+
+  function handleConfigurationSaved(
+    settings: Record<string, string | number | boolean>,
+    bindings: Record<string, string>,
+  ) {
+    setCatalogSettings(settings);
+    setCatalogBindings(bindings);
+    onConnectionChange?.();
+  }
+
   function showApproval(approval: McpApprovalRequest, onConfirmed: () => void) {
     approvalCallbackRef.current = onConfirmed;
     setPendingApproval(approval);
@@ -473,7 +581,7 @@ export default function McpServerCard({
             只能选择已封存工作区中的文件，不能输入宿主路径或 URI。
           </span>
           <select
-            className="mt-2 w-full rounded-lg border border-white/10 bg-ink-950 px-3 py-2 text-sm text-white outline-none transition focus:border-brand-300/50"
+            className="mt-2 min-h-11 w-full rounded-lg border border-white/10 bg-ink-950 px-3 py-2 text-sm text-white outline-none transition focus:border-brand-300/50"
             onChange={(event) => updateField(tool.name, key, event.target.value)}
             value={value || boundWorkspace?.files[0]?.file_id || ""}
           >
@@ -504,7 +612,7 @@ export default function McpServerCard({
             只能选择已封存工作区内的目录，不接受手工路径。
           </span>
           <select
-            className="mt-2 w-full rounded-lg border border-white/10 bg-ink-950 px-3 py-2 text-sm text-white outline-none transition focus:border-brand-300/50"
+            className="mt-2 min-h-11 w-full rounded-lg border border-white/10 bg-ink-950 px-3 py-2 text-sm text-white outline-none transition focus:border-brand-300/50"
             onChange={(event) => updateField(tool.name, key, event.target.value)}
             value={value}
           >
@@ -529,7 +637,7 @@ export default function McpServerCard({
           </span>
           <input
             autoComplete="off"
-            className="mt-2 w-full rounded-lg border border-white/10 bg-ink-950 px-3 py-2 text-sm text-white outline-none transition focus:border-brand-300/50"
+            className="mt-2 min-h-11 w-full rounded-lg border border-white/10 bg-ink-950 px-3 py-2 text-sm text-white outline-none transition focus:border-brand-300/50"
             maxLength={120}
             onChange={(event) =>
               updateField(tool.name, key, event.target.value.replace(/[\\/:]/g, ""))
@@ -557,7 +665,7 @@ export default function McpServerCard({
 
         {property.enum?.length ? (
           <select
-            className="mt-2 w-full rounded-lg border border-white/10 bg-ink-950 px-3 py-2 text-sm text-white outline-none transition focus:border-brand-300/50"
+            className="mt-2 min-h-11 w-full rounded-lg border border-white/10 bg-ink-950 px-3 py-2 text-sm text-white outline-none transition focus:border-brand-300/50"
             onChange={(event) => updateField(tool.name, key, event.target.value)}
             value={value}
           >
@@ -569,7 +677,7 @@ export default function McpServerCard({
           </select>
         ) : type === "boolean" ? (
           <select
-            className="mt-2 w-full rounded-lg border border-white/10 bg-ink-950 px-3 py-2 text-sm text-white outline-none transition focus:border-brand-300/50"
+            className="mt-2 min-h-11 w-full rounded-lg border border-white/10 bg-ink-950 px-3 py-2 text-sm text-white outline-none transition focus:border-brand-300/50"
             onChange={(event) => updateField(tool.name, key, event.target.value)}
             value={value}
           >
@@ -584,7 +692,7 @@ export default function McpServerCard({
           />
         ) : (
           <input
-            className="mt-2 w-full rounded-lg border border-white/10 bg-ink-950 px-3 py-2 text-sm text-white outline-none transition focus:border-brand-300/50"
+            className="mt-2 min-h-11 w-full rounded-lg border border-white/10 bg-ink-950 px-3 py-2 text-sm text-white outline-none transition focus:border-brand-300/50"
             onChange={(event) => updateField(tool.name, key, event.target.value)}
             type={type === "number" || type === "integer" ? "number" : "text"}
             value={value}
@@ -720,6 +828,10 @@ export default function McpServerCard({
               ? "不需要 OAuth、Token、桌面宿主或外部运行时；文件只进入断网受控工作区。"
             : wave === 4
               ? "需要在当前卡片的“加密凭据”区域保存 Token；凭据仅绑定当前 MCP，并通过固定出口的只读 sidecar 建立隔离 stdio 会话。"
+            : wave === 5
+              ? project.id === "duckdb-mcp"
+                ? "无需 Token 或远程数据库凭据；只读取当前卡片中上传、封存并绑定的本地 DuckDB 文件。"
+                : "数据库连接按只读策略运行；连接字段与加密凭据均在当前卡片独立配置，不接受完整连接串。"
             : "不需要 OAuth、Token、额外运行时或桌面宿主，可由当前模镜后端以本地 stdio 启动。"}
         </div>
       )}
@@ -743,6 +855,66 @@ export default function McpServerCard({
         ))}
       </div>
 
+      {wave === 5 ? (
+        <section
+          aria-label="数据库安全与验证状态"
+          className="relative mt-3 rounded-lg border border-emerald-300/20 bg-emerald-300/[0.055] p-3 text-xs"
+        >
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <h3 className="font-semibold text-emerald-100">数据库安全状态</h3>
+            <div className="flex flex-wrap gap-2">
+              <span
+                className={`rounded-full border px-2.5 py-1 font-semibold ${
+                  availability === "blocked"
+                    ? "border-rose-300/25 bg-rose-300/[0.08] text-rose-100"
+                    : "border-emerald-300/25 bg-emerald-300/[0.08] text-emerald-100"
+                }`}
+              >
+                {availability === "blocked" ? "连接关闭" : "只读连接"}
+              </span>
+              <span className="rounded-full border border-slate-300/20 bg-slate-300/[0.06] px-2.5 py-1 font-semibold text-slate-200">
+                写入工具关闭
+              </span>
+            </div>
+          </div>
+          <dl className="mt-3 grid gap-2 sm:grid-cols-2">
+            <div className="rounded-lg bg-black/15 p-2.5">
+              <dt className="text-slate-400">传输通道</dt>
+              <dd aria-live="polite" className="mt-1 font-semibold text-slate-100">
+                {availability === "blocked"
+                  ? "未启动，连接入口关闭"
+                  : state === "connecting"
+                    ? "正在建立隔离 stdio"
+                    : state === "connected" || adapterStatus?.connected
+                      ? "隔离 stdio 已连接"
+                      : state === "error"
+                        ? "连接失败"
+                        : "尚未连接"}
+              </dd>
+            </div>
+            <div className="rounded-lg bg-black/15 p-2.5">
+              <dt className="text-slate-400">数据源验证</dt>
+              <dd
+                aria-live="polite"
+                className={`mt-1 font-semibold ${databasePreflightCopy[databasePreflight].className}`}
+              >
+                {databasePreflightCopy[databasePreflight].label}
+              </dd>
+            </div>
+          </dl>
+          {databasePolicy ? (
+            <p className="mt-2 leading-5 text-slate-400">
+              单次查询默认最多 {databasePolicy.max_rows_default} 行，硬上限 {databasePolicy.max_rows_hard} 行，语句超时 {databasePolicy.statement_timeout_seconds} 秒
+              {databasePolicy.tls_required ? "；远程连接强制严格 TLS 校验。" : "；本地封存数据文件断网读取。"}
+            </p>
+          ) : (
+            <p className="mt-2 leading-5 text-slate-400">
+              当前条目未达到数据库运行门槛，不会启动连接或收集凭据。
+            </p>
+          )}
+        </section>
+      ) : null}
+
       {adapterStatus?.executable && adapterStatus.runtime_image ? (
         <div className="relative mt-3 rounded-lg border border-emerald-300/20 bg-emerald-300/[0.06] p-3 text-xs">
           <div className="flex flex-wrap items-center justify-between gap-2">
@@ -763,8 +935,11 @@ export default function McpServerCard({
 
       {workspacePolicy && canConnect ? (
         <McpWorkspacePanel
+          boundWorkspaceId={adapterStatus?.workspace_id ?? null}
+          configurationSettings={catalogSettings}
+          credentialBindings={catalogBindings}
           onApprovalRequired={showApproval}
-          onBound={setBoundWorkspace}
+          onBound={handleWorkspaceBound}
           policy={workspacePolicy}
           projectId={project.id}
           refreshKey={boundWorkspace?.artifacts.map((item) => item.artifact_id).join(",") ?? ""}
@@ -779,17 +954,21 @@ export default function McpServerCard({
           initialSettings={adapterStatus.configuration_values}
           initiallyConfigured={adapterStatus.configured}
           credentialVerification={adapterStatus.credential_verification}
+          databasePreflightStatus={adapterStatus.preflight_status}
+          mode={wave === 5 ? "database" : "service"}
+          onConfigurationSaved={handleConfigurationSaved}
           onConfigured={setCatalogConfigured}
           onSessionInvalidated={invalidateCredentialSession}
           projectId={project.id}
           settingFields={adapterStatus.setting_fields}
+          workspaceId={boundWorkspace?.workspace_id ?? null}
         />
       ) : null}
 
       <div className="relative mt-auto flex flex-wrap items-center gap-2 pt-5">
         {canConnect ? (
           <button
-            className="rounded-full bg-brand-300 px-4 py-2 text-sm font-semibold text-ink-950 shadow-[0_0_24px_rgba(34,211,238,0.18)] transition duration-200 hover:bg-brand-200 disabled:cursor-not-allowed disabled:opacity-45"
+            className="min-h-11 rounded-full bg-brand-300 px-4 py-2 text-sm font-semibold text-ink-950 shadow-[0_0_24px_rgba(34,211,238,0.18)] transition duration-200 hover:bg-brand-200 disabled:cursor-not-allowed disabled:opacity-45"
             disabled={
               state === "connecting" ||
               state === "connected" ||
@@ -810,7 +989,7 @@ export default function McpServerCard({
           </button>
         ) : (
           <button
-            className="cursor-not-allowed rounded-full border border-amber-300/25 bg-amber-300/10 px-4 py-2 text-sm font-semibold text-amber-100 opacity-75"
+            className="min-h-11 cursor-not-allowed rounded-full border border-amber-300/25 bg-amber-300/10 px-4 py-2 text-sm font-semibold text-amber-100 opacity-75"
             disabled
             type="button"
           >
@@ -825,7 +1004,7 @@ export default function McpServerCard({
         )}
         {state === "connected" ? (
           <button
-            className="rounded-full border border-rose-300/30 bg-rose-300/10 px-4 py-2 text-sm font-semibold text-rose-100 transition hover:bg-rose-300/15"
+            className="min-h-11 rounded-full border border-rose-300/30 bg-rose-300/10 px-4 py-2 text-sm font-semibold text-rose-100 transition hover:bg-rose-300/15"
             onClick={() => void disconnect()}
             type="button"
           >
@@ -834,7 +1013,7 @@ export default function McpServerCard({
         ) : null}
         {canInstall ? (
           <button
-            className={`rounded-full border px-4 py-2 text-sm font-semibold transition duration-200 disabled:cursor-not-allowed disabled:opacity-60 ${
+            className={`min-h-11 rounded-full border px-4 py-2 text-sm font-semibold transition duration-200 disabled:cursor-not-allowed disabled:opacity-60 ${
               installState === "installed"
                 ? "border-emerald-300/35 bg-emerald-300/12 text-emerald-100"
                 : "border-white/10 bg-white/[0.055] text-slate-100 hover:border-brand-300/35 hover:bg-brand-300/10 hover:text-brand-100"
@@ -857,7 +1036,7 @@ export default function McpServerCard({
           </button>
         ) : null}
         <button
-          className="rounded-full border border-white/10 bg-white/[0.04] px-3 py-2 text-xs font-semibold text-slate-300 transition duration-200 hover:border-hire-300/35 hover:bg-hire-300/10 hover:text-hire-100"
+          className="min-h-11 rounded-full border border-white/10 bg-white/[0.04] px-3 py-2 text-xs font-semibold text-slate-300 transition duration-200 hover:border-hire-300/35 hover:bg-hire-300/10 hover:text-hire-100"
           onClick={() => setIsInstallOpen(true)}
           type="button"
         >
@@ -915,15 +1094,23 @@ export default function McpServerCard({
             tools.map((tool) => {
               const properties = tool.inputSchema.properties ?? {};
               const markdown = contentToMarkdown(toolResults[tool.name] ?? null);
+              const toolPolicy = adapterStatus?.tool_policies[tool.name];
               return (
-                <div className="rounded-lg border border-white/10 bg-white/[0.045] p-4" key={tool.name}>
+                <div className="min-w-0 rounded-lg border border-white/10 bg-white/[0.045] p-4" key={tool.name}>
                   <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
                     <div>
                       <p className="font-semibold text-white">{tool.title ?? tool.name}</p>
-                      <p className="mt-1 text-xs text-brand-100">{tool.name}</p>
+                      <div className="mt-1 flex flex-wrap items-center gap-2">
+                        <p className="text-xs text-brand-100">{tool.name}</p>
+                        {toolPolicy?.read_only ? (
+                          <span className="rounded-full border border-emerald-300/25 bg-emerald-300/[0.08] px-2 py-0.5 text-[11px] font-semibold text-emerald-100">
+                            只读工具
+                          </span>
+                        ) : null}
+                      </div>
                     </div>
                     <button
-                      className="w-fit rounded-full bg-hire-300 px-3 py-1.5 text-xs font-semibold text-ink-950 transition hover:bg-hire-200 disabled:cursor-not-allowed disabled:opacity-50"
+                      className="min-h-11 w-fit rounded-full bg-hire-300 px-4 py-2 text-xs font-semibold text-ink-950 transition hover:bg-hire-200 disabled:cursor-not-allowed disabled:opacity-50"
                       disabled={runningTool === tool.name}
                       onClick={() => void callTool(tool)}
                       type="button"
@@ -948,7 +1135,7 @@ export default function McpServerCard({
                     </p>
                   )}
                   {markdown ? (
-                    <div className="prose prose-invert mt-4 max-w-none rounded-lg border border-white/10 bg-ink-950/70 p-4 prose-pre:bg-slate-950 prose-code:text-brand-100">
+                    <div className="prose prose-invert mt-4 max-h-[32rem] min-w-0 max-w-none overflow-auto rounded-lg border border-white/10 bg-ink-950/70 p-4 [overflow-wrap:anywhere] prose-pre:max-w-full prose-pre:overflow-x-auto prose-pre:bg-slate-950 prose-code:break-words prose-code:text-brand-100 prose-table:block prose-table:max-w-full prose-table:overflow-x-auto">
                       <ReactMarkdown remarkPlugins={[remarkGfm]}>
                         {markdown}
                       </ReactMarkdown>
@@ -963,17 +1150,25 @@ export default function McpServerCard({
 
       {pendingApproval ? (
         <div
+          aria-describedby={`mcp-approval-description-${project.id}`}
           aria-labelledby={`mcp-approval-${project.id}`}
           aria-modal="true"
           className="fixed inset-0 z-[90] flex items-center justify-center bg-slate-950/82 p-4 backdrop-blur-sm"
           role="dialog"
         >
-          <div className="surface-card w-full max-w-lg rounded-lg border border-amber-300/25 p-6">
+          <div
+            className="surface-card max-h-[90vh] w-full max-w-lg overflow-y-auto rounded-lg border border-amber-300/25 p-6"
+            ref={approvalDialogRef}
+            tabIndex={-1}
+          >
             <p className="text-sm font-semibold text-amber-100">一次性写入确认</p>
             <h2 className="mt-2 text-xl font-semibold text-white" id={`mcp-approval-${project.id}`}>
               确认本次受控操作
             </h2>
-            <p className="mt-4 rounded-lg border border-white/10 bg-white/[0.045] p-4 text-sm leading-6 text-slate-300">
+            <p
+              className="mt-4 rounded-lg border border-white/10 bg-white/[0.045] p-4 text-sm leading-6 text-slate-300"
+              id={`mcp-approval-description-${project.id}`}
+            >
               {pendingApproval.summary}
             </p>
             <div className="mt-3 text-[11px] leading-5 text-slate-500">
@@ -982,15 +1177,16 @@ export default function McpServerCard({
             </div>
             <div className="mt-5 flex flex-wrap justify-end gap-2">
               <button
-                className="rounded-full border border-white/10 px-4 py-2 text-sm font-semibold text-slate-200"
+                className="min-h-11 rounded-full border border-white/10 px-4 py-2 text-sm font-semibold text-slate-200"
                 disabled={approvalBusy}
                 onClick={() => void cancelApproval()}
+                ref={approvalCancelRef}
                 type="button"
               >
                 取消
               </button>
               <button
-                className="rounded-full bg-amber-300 px-4 py-2 text-sm font-semibold text-ink-950 disabled:opacity-50"
+                className="min-h-11 rounded-full bg-amber-300 px-4 py-2 text-sm font-semibold text-ink-950 disabled:opacity-50"
                 disabled={approvalBusy}
                 onClick={() => void confirmApproval()}
                 type="button"
@@ -1024,7 +1220,7 @@ export default function McpServerCard({
               </div>
               <button
                 aria-label="关闭安装说明"
-                className="rounded-full border border-white/10 bg-white/[0.06] px-3 py-1.5 text-sm font-semibold text-slate-200 transition hover:bg-white/10"
+                className="min-h-11 rounded-full border border-white/10 bg-white/[0.06] px-3 py-2 text-sm font-semibold text-slate-200 transition hover:bg-white/10"
                 onClick={() => setIsInstallOpen(false)}
                 type="button"
               >

--- a/client/src/components/McpWorkspacePanel.tsx
+++ b/client/src/components/McpWorkspacePanel.tsx
@@ -45,6 +45,9 @@ export interface McpApprovalRequest {
 interface McpWorkspacePanelProps {
   projectId: string;
   policy: McpWorkspacePolicy;
+  configurationSettings?: Record<string, string | number | boolean>;
+  credentialBindings?: Record<string, string>;
+  boundWorkspaceId?: string | null;
   onBound: (workspace: McpWorkspace | null) => void;
   onApprovalRequired: (
     approval: McpApprovalRequest,
@@ -112,6 +115,9 @@ async function responseDetail(response: Response) {
 export default function McpWorkspacePanel({
   projectId,
   policy,
+  configurationSettings = {},
+  credentialBindings = {},
+  boundWorkspaceId = null,
   onBound,
   onApprovalRequired,
   refreshKey = "",
@@ -138,7 +144,7 @@ export default function McpWorkspacePanel({
   useEffect(() => {
     setPendingUpload(null);
     void load();
-  }, [projectId, refreshKey]);
+  }, [boundWorkspaceId, projectId, refreshKey]);
 
   async function load(preferredId = "") {
     setError("");
@@ -150,15 +156,25 @@ export default function McpWorkspacePanel({
     }
     const payload = (await response.json()) as { items: McpWorkspace[] };
     setItems(payload.items);
+    const restoredBoundId = payload.items.some(
+      (item) => item.workspace_id === boundWorkspaceId && item.status === "sealed",
+    )
+      ? boundWorkspaceId ?? ""
+      : "";
     const nextId =
       preferredId ||
+      restoredBoundId ||
       selectedId ||
       payload.items.find((item) => item.status === "sealed")?.workspace_id ||
       payload.items[0]?.workspace_id ||
       "";
     setSelectedId(nextId);
     const next = payload.items.find((item) => item.workspace_id === nextId) ?? null;
-    if (!next || next.status !== "sealed") onBound(null);
+    if (next?.status === "sealed" && next.workspace_id === restoredBoundId) {
+      onBound(next);
+    } else {
+      onBound(null);
+    }
   }
 
   async function createWorkspace() {
@@ -259,8 +275,8 @@ export default function McpWorkspacePanel({
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             workspace_id: workspace.workspace_id,
-            settings: {},
-            credential_bindings: {},
+            settings: configurationSettings,
+            credential_bindings: credentialBindings,
           }),
         },
       );
@@ -269,7 +285,7 @@ export default function McpWorkspacePanel({
       }
       await load(workspace.workspace_id);
       onBound(workspace);
-      setMessage("工作区已封存并绑定，可以连接适配器。输入文件之后保持只读。 ");
+      setMessage("工作区已封存并绑定，可以连接适配器。已保存的连接字段和加密凭据保持不变。");
     } catch (exc) {
       setError(exc instanceof Error ? exc.message : "工作区封存失败");
     } finally {
@@ -296,7 +312,7 @@ export default function McpWorkspacePanel({
       if (!response.ok) throw new Error(String(await responseDetail(response)));
       onBound(null);
       await load();
-      setMessage("工作区及临时产物已清理。 ");
+      setMessage("工作区及临时产物已清理。");
     } catch (exc) {
       setError(exc instanceof Error ? exc.message : "清理工作区失败");
     } finally {
@@ -305,10 +321,16 @@ export default function McpWorkspacePanel({
   }
 
   return (
-    <section className="relative mt-4 rounded-lg border border-cyan-300/20 bg-cyan-300/[0.055] p-3">
+    <section
+      aria-busy={Boolean(busy)}
+      aria-labelledby={`${projectId}-workspace-heading`}
+      className="relative mt-4 rounded-lg border border-cyan-300/20 bg-cyan-300/[0.055] p-3"
+    >
       <div className="flex flex-wrap items-start justify-between gap-2">
         <div>
-          <p className="text-xs font-semibold text-cyan-100">受控文件工作区</p>
+          <h3 className="text-xs font-semibold text-cyan-100" id={`${projectId}-workspace-heading`}>
+            受控文件工作区
+          </h3>
           <p className="mt-1 text-[11px] leading-5 text-slate-400">
             不上传宿主路径；输入封存后只读，产物独立保存并可清理。
           </p>
@@ -318,15 +340,22 @@ export default function McpWorkspacePanel({
         </span>
       </div>
 
-      <div className="mt-3 flex gap-2">
+      <label
+        className="mt-3 block text-xs font-semibold text-slate-200"
+        htmlFor={`${projectId}-workspace-name`}
+      >
+        工作区名称
+      </label>
+      <div className="mt-2 flex gap-2">
         <input
-          className="min-w-0 flex-1 rounded-md border border-white/10 bg-ink-950 px-2.5 py-2 text-xs text-white outline-none focus:border-cyan-300/50"
+          className="min-h-11 min-w-0 flex-1 rounded-md border border-white/10 bg-ink-950 px-2.5 py-2 text-xs text-white outline-none focus:border-cyan-300/50"
+          id={`${projectId}-workspace-name`}
           onChange={(event) => setDisplayName(event.target.value)}
           placeholder="工作区名称"
           value={displayName}
         />
         <button
-          className="rounded-md bg-cyan-300 px-3 py-2 text-xs font-semibold text-ink-950 disabled:opacity-50"
+          className="min-h-11 rounded-md bg-cyan-300 px-3 py-2 text-xs font-semibold text-ink-950 disabled:opacity-50"
           disabled={Boolean(busy)}
           onClick={() => void createWorkspace()}
           type="button"
@@ -336,21 +365,24 @@ export default function McpWorkspacePanel({
       </div>
 
       {items.length ? (
-        <select
-          className="mt-2 w-full rounded-md border border-white/10 bg-ink-950 px-2.5 py-2 text-xs text-white outline-none focus:border-cyan-300/50"
-          onChange={(event) => {
-            setSelectedId(event.target.value);
-            setPendingUpload(null);
-            onBound(null);
-          }}
-          value={selectedId}
-        >
-          {items.map((item) => (
-            <option key={item.workspace_id} value={item.workspace_id}>
-              {item.display_name} · {item.status === "sealed" ? "已封存" : "上传中"}
-            </option>
-          ))}
-        </select>
+        <label className="mt-3 block text-xs font-semibold text-slate-200">
+          选择工作区
+          <select
+            className="mt-2 min-h-11 w-full rounded-md border border-white/10 bg-ink-950 px-2.5 py-2 text-xs text-white outline-none focus:border-cyan-300/50"
+            onChange={(event) => {
+              setSelectedId(event.target.value);
+              setPendingUpload(null);
+              onBound(null);
+            }}
+            value={selectedId}
+          >
+            {items.map((item) => (
+              <option key={item.workspace_id} value={item.workspace_id}>
+                {item.display_name} · {item.status === "sealed" ? "已封存" : "上传中"}
+              </option>
+            ))}
+          </select>
+        </label>
       ) : null}
 
       {selected ? (
@@ -362,11 +394,12 @@ export default function McpWorkspacePanel({
 
           {selected.status === "uploading" ? (
             <div className="mt-3 flex flex-wrap gap-2">
-              <label className="cursor-pointer rounded-md border border-white/10 bg-white/[0.06] px-3 py-2 text-xs font-semibold text-slate-200 hover:border-cyan-300/40">
+              <label className="relative inline-flex min-h-11 cursor-pointer items-center overflow-hidden rounded-md border border-white/10 bg-white/[0.06] px-3 py-2 text-xs font-semibold text-slate-200 hover:border-cyan-300/40 focus-within:ring-2 focus-within:ring-cyan-300/50">
                 {busy === "upload" ? "上传中…" : "选择文件或 ZIP"}
                 <input
                   accept={accept}
-                  className="hidden"
+                  aria-label="选择文件或 ZIP"
+                  className="absolute inset-0 h-full w-full cursor-pointer opacity-0 disabled:cursor-not-allowed"
                   disabled={Boolean(busy)}
                   multiple
                   onChange={(event) => {
@@ -376,12 +409,12 @@ export default function McpWorkspacePanel({
                   type="file"
                 />
               </label>
-              <label className="cursor-pointer rounded-md border border-white/10 bg-white/[0.06] px-3 py-2 text-xs font-semibold text-slate-200 hover:border-cyan-300/40">
+              <label className="relative inline-flex min-h-11 cursor-pointer items-center overflow-hidden rounded-md border border-white/10 bg-white/[0.06] px-3 py-2 text-xs font-semibold text-slate-200 hover:border-cyan-300/40 focus-within:ring-2 focus-within:ring-cyan-300/50">
                 选择文件夹
                 <input
                   accept={accept}
                   aria-label="选择文件夹"
-                  className="hidden"
+                  className="absolute inset-0 h-full w-full cursor-pointer opacity-0 disabled:cursor-not-allowed"
                   disabled={Boolean(busy)}
                   multiple
                   onChange={(event) => {
@@ -432,7 +465,7 @@ export default function McpWorkspacePanel({
               <div className="mt-3 flex flex-wrap gap-2">
                 {pendingUpload.files.length ? (
                   <button
-                    className="rounded-md bg-amber-200 px-3 py-2 text-xs font-semibold text-ink-950 hover:bg-amber-100 focus-visible:outline-amber-200 disabled:opacity-50"
+                    className="min-h-11 rounded-md bg-amber-200 px-3 py-2 text-xs font-semibold text-ink-950 hover:bg-amber-100 focus-visible:outline-amber-200 disabled:opacity-50"
                     disabled={Boolean(busy)}
                     onClick={() =>
                       void uploadFiles(
@@ -446,7 +479,7 @@ export default function McpWorkspacePanel({
                   </button>
                 ) : null}
                 <button
-                  className="rounded-md border border-white/15 px-3 py-2 text-xs font-semibold text-slate-200 hover:border-white/30 disabled:opacity-50"
+                  className="min-h-11 rounded-md border border-white/15 px-3 py-2 text-xs font-semibold text-slate-200 hover:border-white/30 disabled:opacity-50"
                   disabled={Boolean(busy)}
                   onClick={() => setPendingUpload(null)}
                   type="button"
@@ -470,7 +503,7 @@ export default function McpWorkspacePanel({
 
           <div className="mt-3 flex flex-wrap gap-2">
             <button
-              className="rounded-md bg-emerald-300 px-3 py-2 text-xs font-semibold text-ink-950 disabled:opacity-50"
+              className="min-h-11 rounded-md bg-emerald-300 px-3 py-2 text-xs font-semibold text-ink-950 disabled:opacity-50"
               disabled={Boolean(busy)}
               onClick={() => void sealAndBind()}
               type="button"
@@ -478,7 +511,7 @@ export default function McpWorkspacePanel({
               {busy === "seal" ? "绑定中…" : selected.status === "sealed" ? "绑定此工作区" : "封存并绑定"}
             </button>
             <button
-              className="rounded-md border border-rose-300/25 px-3 py-2 text-xs font-semibold text-rose-100 disabled:opacity-50"
+              className="min-h-11 rounded-md border border-rose-300/25 px-3 py-2 text-xs font-semibold text-rose-100 disabled:opacity-50"
               disabled={Boolean(busy)}
               onClick={() => void removeWorkspace()}
               type="button"
@@ -493,7 +526,7 @@ export default function McpWorkspacePanel({
               <div className="mt-2 flex flex-wrap gap-2">
                 {selected.artifacts.map((artifact) => (
                   <a
-                    className="rounded-md border border-brand-300/20 bg-brand-300/10 px-2.5 py-1.5 text-[11px] text-brand-100 hover:bg-brand-300/15"
+                    className="inline-flex min-h-11 items-center rounded-md border border-brand-300/20 bg-brand-300/10 px-2.5 py-1.5 text-[11px] text-brand-100 hover:bg-brand-300/15"
                     href={`/api/mcp/catalog/${projectId}/workspaces/${selected.workspace_id}/artifacts/${artifact.artifact_id}/download`}
                     key={artifact.artifact_id}
                   >
@@ -506,8 +539,14 @@ export default function McpWorkspacePanel({
         </div>
       ) : null}
 
-      {message ? <p className="mt-2 text-[11px] leading-5 text-emerald-100">{message}</p> : null}
-      {error ? <p className="mt-2 text-[11px] leading-5 text-rose-100">{error}</p> : null}
+      <div aria-live="polite" aria-relevant="text" role="status">
+        {message ? <p className="mt-2 text-[11px] leading-5 text-emerald-100">{message}</p> : null}
+      </div>
+      {error ? (
+        <p className="mt-2 text-[11px] leading-5 text-rose-100" role="alert">
+          {error}
+        </p>
+      ) : null}
     </section>
   );
 }

--- a/client/src/data/mcpAdaptationPlan.ts
+++ b/client/src/data/mcpAdaptationPlan.ts
@@ -12,6 +12,27 @@ export type McpCredentialVerification =
   | "unverified"
   | "verified"
   | "verification-failed";
+export type McpDatabasePreflightStatus =
+  | "not-applicable"
+  | "blocked"
+  | "awaiting-workspace"
+  | "awaiting-configuration"
+  | "unverified"
+  | "verifying"
+  | "verified"
+  | "failed";
+
+export interface McpDatabasePolicy {
+  mode: "remote-read-only" | "local-file-read-only";
+  engine: string;
+  read_only: boolean;
+  tls_required: boolean;
+  max_rows_default: number;
+  max_rows_hard: number;
+  statement_timeout_seconds: number;
+  operation_timeout_seconds: number;
+  preflight_checks: string[];
+}
 
 export interface McpWorkspacePolicy {
   required: boolean;
@@ -75,6 +96,7 @@ export interface McpCatalogAdapterStatus {
   configured_credential_slots: string[];
   configuration_values: Record<string, string | number | boolean>;
   credential_bindings: Record<string, string>;
+  workspace_id?: string | null;
   credential_verification: McpCredentialVerification;
   adapter_version: string;
   runtime_image: string;
@@ -82,6 +104,8 @@ export interface McpCatalogAdapterStatus {
   filesystem_policy: string;
   resource_limits: Record<string, string>;
   workspace_policy: McpWorkspacePolicy | null;
+  database_policy: McpDatabasePolicy | null;
+  preflight_status: McpDatabasePreflightStatus;
   tool_policies: Record<
     string,
     {
@@ -132,6 +156,14 @@ export const mcpCapabilityLabels: Record<string, string> = {
   "fixed-egress-policy": "固定服务出口域名",
   "read-only-tool-policy": "只读工具策略",
   "database-read-only-policy": "数据库只读策略",
+  "database-target-validation": "数据库目标校验",
+  "tenant-scoped-credential-binding": "租户级加密凭据绑定",
+  "structured-database-configuration": "结构化数据库连接字段",
+  "native-read-only-mode": "数据库原生只读模式",
+  "query-row-timeout-limits": "查询行数与超时硬限制",
+  "database-preflight": "连接时数据源安全预检",
+  "maintained-upstream-contract": "持续维护的上游工具契约",
+  "tenant-isolated-state": "租户隔离的持久状态",
   "query-limits": "查询超时与结果限制",
   "mutating-tool-approval": "修改操作审批",
   "account-unbinding": "账号解绑",
@@ -165,6 +197,16 @@ export const mcpIsolationLabels: Record<string, string> = {
   "blocked:arbitrary-code-execution": "已阻断：需要任意代码执行隔离",
   "blocked:no-runtime": "已阻断：不启动运行时",
   "blocked:local-build-execution": "已阻断：可能执行本地构建链",
+  "database-read-only-remote": "远程数据库仅允许受控只读连接",
+  "sealed-database-read-only": "封存数据库文件只读；不接入云端数据源",
+  "blocked:archived-upstream": "已阻断：上游实现已经归档",
+  "blocked:stateful-memory-runtime": "已阻断：需要状态化记忆运行时与写入隔离",
+  "database-egress:validated-host,admin-private-allowlist":
+    "数据库目标逐次校验；私网目标仅允许服务端管理员白名单",
+  "sealed-database-input-read-only,no-artifact-write":
+    "封存数据库输入只读；不允许写入原文件或生成旁路产物",
+  "allowlist:api.supabase.com,supabase.com": "仅允许 Supabase 官方 API 域名",
+  "blocked:no-production-runtime": "已阻断：没有生产级运行时",
 };
 
 export function formatMcpCapability(capability: string) {
@@ -268,8 +310,16 @@ const waveMetadata: Record<
   5: {
     connectionKind: "sandboxed-stdio",
     risk: "high",
-    requiredCapabilities: ["数据库只读策略", "查询限制"],
-    limitations: ["等待只读账号、TLS、查询超时和结果行数限制验证。"],
+    requiredCapabilities: [
+      "数据库只读策略",
+      "加密凭据绑定",
+      "数据库目标校验",
+      "查询超时与结果限制",
+    ],
+    limitations: [
+      "浏览器只提交受控的主机、端口、库名、TLS 和用户名字段；不接受 DSN、URI、命令、环境变量或宿主路径。",
+      "首轮仅发现并调用只读工具，写入、删除、迁移、管理和任意命令能力全部关闭。",
+    ],
   },
   6: {
     connectionKind: "remote-mcp",
@@ -309,6 +359,68 @@ const waveMetadata: Record<
   },
 };
 
+const waveFiveReadyIds = new Set([
+  "dbhub",
+  "mongodb-mcp",
+  "clickhouse-mcp",
+  "redis-mcp",
+  "duckdb-mcp",
+  "supabase-mcp",
+]);
+
+const waveFiveBlockedDetails: Record<string, string[]> = {
+  "postgres-mcp": [
+    "官方 PostgreSQL 参考实现已经归档，不再作为生产运行时部署。需要 PostgreSQL 时可使用本批受控的 DBHub 只读适配器。",
+    "连接入口保持关闭；不接受数据库 URI，也不会回退到未锁定的社区包。",
+  ],
+  "sqlite-mcp": [
+    "官方 SQLite 参考实现已经归档且包含写入能力，不满足本批生产只读门槛。",
+    "连接与本地路径输入保持关闭；后续只能基于封存副本和维护中的固定适配器重新评估。",
+  ],
+  "cognee-mcp": [
+    "Cognee 会组合 LLM、Embedding、图数据库与持久写入，不属于普通数据库只读查询。",
+    "转入后续“状态化记忆”适配；在模型调用、数据保留和写入隔离通过前不开放连接。",
+  ],
+  "graphiti-mcp": [
+    "Graphiti 需要图数据库、模型调用和时序知识写入，无法使用本批只读数据库 sidecar。",
+    "转入后续“状态化记忆”适配；当前不提供凭据、连接或初始化入口。",
+  ],
+  "hindsight-mcp": [
+    "Hindsight 的 retain、recall 与 reflect 依赖持久记忆写入及模型能力，不属于只读数据库工具。",
+    "转入后续“状态化记忆”适配；数据生命周期与写入审批完成前保持阻断。",
+  ],
+};
+
+const waveFiveReadyDetails: Record<string, string[]> = {
+  dbhub: [
+    "固定 DBHub 1.2.0，仅开放 PostgreSQL、MySQL 与 MariaDB 的只读查询；关闭 SQLite、SSH 隧道和自定义工具。",
+    "连接参数由服务端生成，查询强制超时和行数上限，浏览器不能提交 DSN 或 URI。",
+  ],
+  "mongodb-mcp": [
+    "固定 MongoDB MCP 2.0.0 并启用只读模式，仅开放集合、索引、结构和受控查询能力。",
+    "Atlas 管理、创建、更新和删除工具全部关闭；连接时自动执行目标校验和代表性只读预检。",
+  ],
+  "clickhouse-mcp": [
+    "固定 ClickHouse MCP 0.4.1，服务端强制只读会话、查询超时与结果上限。",
+    "写访问、DROP、TRUNCATE 与 chDB 全部关闭；连接时自动验证目标与代表性只读能力。",
+  ],
+  "redis-mcp": [
+    "固定 Redis MCP 0.5.1，仅允许只读 ACL 与工具白名单覆盖的键空间读取和检索。",
+    "任意命令、写键、删除、过期时间修改和管理操作均不可发现或调用。",
+  ],
+  "duckdb-mcp": [
+    "固定 DuckDB MCP 1.0.7，仅打开封存工作区中的本地 .duckdb 文件，输入始终只读。",
+    "运行环境默认断网，不开放 MotherDuck、Token、宿主路径或任意文件 URI。",
+  ],
+  "supabase-mcp": [
+    "固定 Supabase MCP 0.9.0，仅支持项目范围内的 stdio、PAT 与只读数据库能力。",
+    "远程 OAuth、组织管理、迁移和写入工具继续关闭，留待第 10 批授权适配。",
+  ],
+};
+
+const waveFiveSingleTenantLimitation =
+  "当前仅支持部署时固定 tenant/owner 的单租户本地实例；多用户共享部署未开放。";
+
 function buildAdaptationPlan() {
   const records: Record<string, McpAdaptationRecord> = {};
   for (const projectId of localStdioIds) {
@@ -331,6 +443,10 @@ function buildAdaptationPlan() {
         availability:
           projectId === "bibigpt-mcp" || projectId === "airbnb-mcp" || projectId === "manim-mcp" || projectId === "snyk-mcp"
             ? "blocked"
+            : wave === 5
+              ? waveFiveReadyIds.has(projectId)
+                ? "ready"
+                : "blocked"
             : wave <= 4
               ? "ready"
               : "planned",
@@ -338,7 +454,14 @@ function buildAdaptationPlan() {
           projectId === "bibigpt-mcp"
             ? "remote-mcp"
             : metadata.connectionKind,
-        risk: projectId === "manim-mcp" || projectId === "snyk-mcp" ? "critical" : metadata.risk,
+        risk:
+          projectId === "manim-mcp" ||
+          projectId === "snyk-mcp" ||
+          projectId === "cognee-mcp" ||
+          projectId === "graphiti-mcp" ||
+          projectId === "hindsight-mcp"
+            ? "critical"
+            : metadata.risk,
         requiredCapabilities:
           projectId === "bibigpt-mcp"
             ? ["OAuth PKCE", "授权撤销与解绑", "最小 Scope 审核"]
@@ -348,6 +471,10 @@ function buildAdaptationPlan() {
               ? ["一次性代码沙箱", "进程资源上限"]
             : projectId === "snyk-mcp"
               ? ["一次性代码沙箱", "受控文件授权", "终止性操作审批"]
+            : projectId === "postgres-mcp" || projectId === "sqlite-mcp"
+              ? ["维护中的固定上游契约", "数据库只读策略", "查询超时与结果限制"]
+            : projectId === "cognee-mcp" || projectId === "graphiti-mcp" || projectId === "hindsight-mcp"
+              ? ["状态化记忆运行时", "模型与向量服务隔离", "持久写入审批与数据保留"]
             : [...metadata.requiredCapabilities],
         limitations:
           projectId === "bibigpt-mcp"
@@ -369,6 +496,13 @@ function buildAdaptationPlan() {
               ? [
                   "Snyk MCP 会读取本地项目，并可能启动 Gradle、Maven 等构建链，超出本批 Token 只读远程检索边界。",
                   "保留第 4 批编号但关闭连接、安装与外站登录；等待第 8 批一次性代码执行隔离后再适配。",
+                ]
+            : waveFiveBlockedDetails[projectId]
+              ? [...waveFiveBlockedDetails[projectId]]
+            : waveFiveReadyDetails[projectId]
+              ? [
+                  ...waveFiveReadyDetails[projectId],
+                  waveFiveSingleTenantLimitation,
                 ]
             : [...metadata.limitations],
       };

--- a/client/src/data/mcpProjects.ts
+++ b/client/src/data/mcpProjects.ts
@@ -282,18 +282,17 @@ const originalMcpProjectSeeds: McpProjectSeed[] = [
     repoUrl: "https://github.com/bytebase/dbhub",
     category: "数据库",
     description:
-      "用统一 MCP Server 连接 PostgreSQL、MySQL、MariaDB、SQL Server 和 SQLite。",
+      "用统一只读 MCP 适配器查询 PostgreSQL、MySQL 和 MariaDB。",
     readmeSummary:
-      "Bytebase 社区项目，提供只读模式、行数限制、查询超时、SSH 隧道和多数据库连接。",
+      "Bytebase 社区项目；模镜固定 1.2.0，只开放只读查询、行数限制和查询超时。",
     stars: 0,
     language: "TypeScript",
     verifiedAt: "2026-08-02",
     installMode: "manual",
-    installCommand:
-      'npx @bytebase/dbhub@latest --transport stdio --dsn "<database-dsn>"',
+    installCommand: "服务端固定适配器管理连接参数；浏览器不接收 DSN 或 URI。",
     installNote:
-      "必须提供数据库 DSN，且凭证不应写入前端或仓库。请在受控运行环境中配置 Secret 后再连接。",
-    tags: ["多数据库", "只读护栏", "需要 DSN"],
+      "在卡片内分别填写受控连接字段并保存加密数据库凭据；写入、SSH 与自定义工具均关闭。",
+    tags: ["多数据库", "固定 1.2.0", "只读查询"],
   },
   {
     id: "filesystem-mcp",
@@ -934,15 +933,15 @@ const expandedMcpProjectSeeds: McpProjectSeed[] = [
   plannedMcp({
     id: "supabase-mcp",
     name: "Supabase MCP",
-    repoName: "supabase-community/supabase-mcp",
-    repoUrl: "https://github.com/supabase-community/supabase-mcp",
+    repoName: "supabase/mcp",
+    repoUrl: "https://github.com/supabase/mcp",
     category: "数据库",
-    description: "查询 Supabase 项目、数据库结构、SQL、日志和开发资源。",
-    readmeSummary: "Supabase 社区官方 MCP 集成，为项目开发和排障提供结构化工具。",
+    description: "在指定 Supabase 项目内只读查询数据库结构、扩展和数据。",
+    readmeSummary: "Supabase 社区官方 MCP；模镜固定 0.9.0、项目范围、PAT stdio 与只读能力。",
     language: "TypeScript",
-    tags: ["Supabase", "Postgres", "项目管理"],
+    tags: ["Supabase", "固定 0.9.0", "项目只读"],
     requirements: ["token", "account-binding", "database-credentials", "remote-transport"],
-    usageExamples: ["检查数据库表结构", "查询项目日志和迁移状态"],
+    usageExamples: ["检查数据库表结构与扩展", "执行受限的只读 SQL 查询"],
     sources: ["awesome-mcp-zh", "awesome-mcp-servers"],
   }),
   plannedMcp({
@@ -951,10 +950,10 @@ const expandedMcpProjectSeeds: McpProjectSeed[] = [
     repoName: "mongodb-js/mongodb-mcp-server",
     repoUrl: "https://github.com/mongodb-js/mongodb-mcp-server",
     category: "数据库",
-    description: "浏览 MongoDB 数据库、集合和索引，并执行受控查询与管理操作。",
-    readmeSummary: "MongoDB 官方 MCP Server，支持 Atlas 与自托管 MongoDB 场景。",
+    description: "浏览 MongoDB 数据库、集合和索引，并执行受控只读查询与聚合。",
+    readmeSummary: "MongoDB 官方 MCP Server；模镜固定 2.0.0，只开放自托管数据库读取能力。",
     language: "TypeScript",
-    tags: ["MongoDB 官方", "Atlas", "文档数据库"],
+    tags: ["MongoDB 官方", "固定 2.0.0", "只读模式"],
     requirements: ["database-credentials", "token", "system-permission"],
     usageExamples: ["查看集合结构和索引", "执行只读聚合查询"],
     sources: ["awesome-mcp-zh", "awesome-mcp-servers"],
@@ -965,12 +964,12 @@ const expandedMcpProjectSeeds: McpProjectSeed[] = [
     repoName: "redis/mcp-redis",
     repoUrl: "https://github.com/redis/mcp-redis",
     category: "数据库",
-    description: "读取和管理 Redis 键、数据结构与向量搜索能力。",
-    readmeSummary: "Redis 官方 MCP Server，可连接 Redis 数据库并暴露常用数据操作工具。",
+    description: "通过只读 ACL 检查 Redis 键空间、数据结构与向量检索结果。",
+    readmeSummary: "Redis 官方 MCP Server；模镜固定 0.5.1，并以只读工具白名单过滤操作。",
     language: "Python",
-    tags: ["Redis 官方", "缓存", "向量搜索"],
+    tags: ["Redis 官方", "固定 0.5.1", "只读 ACL"],
     requirements: ["external-runtime", "database-credentials", "system-permission"],
-    usageExamples: ["检查键空间和缓存内容", "在 Redis 中执行向量检索"],
+    usageExamples: ["分页检查键空间和缓存内容", "读取 Hash、List、Set 与有序集合"],
     sources: ["awesome-mcp-zh", "awesome-mcp-servers"],
   }),
   plannedMcp({
@@ -980,9 +979,9 @@ const expandedMcpProjectSeeds: McpProjectSeed[] = [
     repoUrl: "https://github.com/ClickHouse/mcp-clickhouse",
     category: "数据库",
     description: "查询 ClickHouse 数据库、表结构和分析数据。",
-    readmeSummary: "ClickHouse 官方 MCP 集成，面向高性能分析数据库的探索与只读查询。",
+    readmeSummary: "ClickHouse 官方 MCP；模镜固定 0.4.1，强制只读会话并关闭 chDB。",
     language: "Python",
-    tags: ["ClickHouse 官方", "OLAP", "分析查询"],
+    tags: ["ClickHouse 官方", "固定 0.4.1", "只读 OLAP"],
     requirements: ["external-runtime", "database-credentials", "system-permission"],
     usageExamples: ["查看数据表与字段", "执行聚合分析查询"],
     sources: ["awesome-mcp-zh", "awesome-mcp-servers"],
@@ -1175,12 +1174,12 @@ const expandedMcpProjectSeeds: McpProjectSeed[] = [
     repoName: "motherduckdb/mcp-server-motherduck",
     repoUrl: "https://github.com/motherduckdb/mcp-server-motherduck",
     category: "数据分析",
-    description: "使用 DuckDB 或 MotherDuck 对本地与云端数据执行分析查询。",
-    readmeSummary: "MotherDuck 官方 MCP Server，面向 SQL 分析、数据探索和结果解释。",
+    description: "只读分析封存工作区内的本地 DuckDB 数据库文件。",
+    readmeSummary: "MotherDuck 官方 MCP Server；模镜固定 1.0.7，仅开放断网本地 DuckDB 子集。",
     language: "Python",
-    tags: ["MotherDuck 官方", "DuckDB", "SQL 分析"],
-    requirements: ["external-runtime", "token", "database-credentials"],
-    usageExamples: ["分析 CSV 或 Parquet 数据", "执行交互式 SQL 探索"],
+    tags: ["DuckDB", "固定 1.0.7", "封存文件只读"],
+    requirements: ["external-runtime"],
+    usageExamples: ["查看本地 DuckDB 的表结构", "对封存数据执行只读 SQL 分析"],
     sources: ["awesome-mcp-zh", "awesome-mcp-servers"],
   }),
   plannedMcp({
@@ -1721,8 +1720,16 @@ function normalizeMcpProject(seed: McpProjectSeed): McpProject {
   const isPublicSandbox = isBundledSandbox && adaptation.wave === 2;
   const isFileSandbox = isBundledSandbox && adaptation.wave === 3;
   const isCredentialSandbox = isBundledSandbox && adaptation.wave === 4;
+  const isDatabaseSandbox = isBundledSandbox && adaptation.wave === 5;
+  const isDatabaseFileSandbox = isDatabaseSandbox && seed.id === "duckdb-mcp";
   const requirements: McpRequirement[] = isCredentialSandbox
     ? ["token"]
+    : isDatabaseSandbox
+      ? seed.id === "supabase-mcp"
+        ? ["token"]
+        : isDatabaseFileSandbox
+          ? []
+          : ["database-credentials"]
     : isReady
     ? []
     : (seed.requirements ?? originalRequirements[seed.id] ?? ["external-runtime"]);
@@ -1737,6 +1744,8 @@ function normalizeMcpProject(seed: McpProjectSeed): McpProject {
       ? seed.installCommand
       : isPublicSandbox
         ? "内置公网适配器由服务端固定部署，不接受自定义命令、端点或 Header。"
+        : isDatabaseSandbox
+          ? "内置数据库适配器由服务端固定部署，不接受 DSN、URI、命令或宿主路径。"
         : isBundledSandbox
           ? "内置隔离适配器由服务端固定部署，无需安装命令。"
         : "当前版本仅收录资料，不提供本地 stdio 安装或外站认证入口。",
@@ -1746,6 +1755,12 @@ function normalizeMcpProject(seed: McpProjectSeed): McpProject {
         ? "先在卡片中创建受控工作区并上传文件；封存后输入只读，写入和持久记忆操作由一次性确认保护。"
       : isCredentialSandbox
         ? "直接在当前卡片的“加密凭据”区域保存 Token；凭据按项目和固定槽位隔离，固定出口、只读工具与撤销失效均由服务端执行。"
+      : isDatabaseFileSandbox
+        ? "先上传并封存本地 DuckDB 文件；适配器断网运行且只读打开数据文件，不接入 MotherDuck 或宿主路径。"
+      : isDatabaseSandbox
+        ? seed.id === "supabase-mcp"
+          ? "在当前卡片填写 20 位小写英文字母 project_ref（不含数字）并保存加密 PAT；仅使用本地 stdio 和项目范围只读能力，不跳转远程 OAuth。"
+          : "在当前卡片分别填写主机、端口、库名、TLS 和用户名，并保存加密数据库凭据；连接时自动执行目标校验和代表性只读预检。"
       : isBundledSandbox
         ? "适配器随断网 Python 沙箱镜像固定部署；浏览器不会提交命令、目录或环境变量。"
       : seed.installNote,
@@ -1762,6 +1777,20 @@ function normalizeMcpProject(seed: McpProjectSeed): McpProject {
           "凭据自动绑定当前 MCP 和固定槽位，不能跨项目复用；如有 Stack、区域等字段，仅填写卡片提供的受控配置。",
           "保存配置后连接 Server；连接只代表传输可用，首次只读工具调用成功后才标记凭据已验证。撤销凭据会立即断开关联会话。",
         ]
+      : isDatabaseFileSandbox
+        ? [
+            "在当前卡片新建受控工作区，上传本地 .duckdb 文件；页面不会读取或提交宿主目录路径。",
+            "完成预检后封存并绑定工作区。封存输入只读，适配器默认断网且不连接 MotherDuck。",
+            "连接 Server 时会自动执行表结构和代表性只读预检；“传输通道”和“数据源验证”会分别显示。",
+          ]
+      : isDatabaseSandbox
+        ? [
+            seed.id === "supabase-mcp"
+              ? "填写 20 位小写英文字母 project_ref（不含数字），并在“加密数据库凭据”中保存当前项目的 PAT；不使用远程 OAuth。"
+              : "分别填写卡片提供的主机、端口、库名、TLS 和用户名；不粘贴 DSN、URI、命令或环境变量。",
+            "在当前卡片创建并选择对应的加密数据库凭据。凭据按项目和固定槽位隔离，保存后不回显明文。",
+            "保存配置后连接只读 sidecar；连接时会自动校验目标并执行代表性只读预检。写入和管理工具始终关闭。",
+          ]
       : seed.configGuide ??
         (isLocalStdio
         ? [

--- a/client/src/pages/McpBrowserPage.tsx
+++ b/client/src/pages/McpBrowserPage.tsx
@@ -182,7 +182,7 @@ export default function McpBrowserPage() {
             </p>
           </div>
           <button
-            className="mt-4 w-full rounded-full border border-brand-300/25 bg-brand-300/10 px-4 py-2 text-sm font-semibold text-brand-100 transition hover:bg-brand-300/15"
+            className="mt-4 min-h-11 w-full rounded-full border border-brand-300/25 bg-brand-300/10 px-4 py-2 text-sm font-semibold text-brand-100 transition hover:bg-brand-300/15"
             onClick={() => void refreshRuntime()}
             type="button"
           >
@@ -268,7 +268,7 @@ export default function McpBrowserPage() {
 
         <div className="mb-5 flex flex-wrap gap-2">
           <button
-            className={`rounded-full px-4 py-2 text-sm font-semibold transition ${
+            className={`min-h-11 rounded-full px-4 py-2 text-sm font-semibold transition ${
               activeView === "servers"
                 ? "bg-hire-300 text-ink-950"
                 : "border border-white/10 bg-white/[0.055] text-slate-200 hover:border-hire-300/30"
@@ -279,7 +279,7 @@ export default function McpBrowserPage() {
             工具货架
           </button>
           <button
-            className={`rounded-full px-4 py-2 text-sm font-semibold transition ${
+            className={`min-h-11 rounded-full px-4 py-2 text-sm font-semibold transition ${
               activeView === "registry"
                 ? "bg-brand-300 text-ink-950"
                 : "border border-white/10 bg-white/[0.055] text-slate-200 hover:border-brand-300/30"
@@ -329,7 +329,7 @@ export default function McpBrowserPage() {
               </label>
               <div className="mt-2 flex flex-col gap-2 sm:flex-row">
                 <input
-                  className="min-w-0 flex-1 rounded-lg border border-white/10 bg-ink-950/70 px-3 py-2.5 text-sm text-white outline-none placeholder:text-slate-400 focus:border-brand-300/60"
+                  className="min-h-11 min-w-0 flex-1 rounded-lg border border-white/10 bg-ink-950/70 px-3 py-2.5 text-sm text-white outline-none placeholder:text-slate-400 focus:border-brand-300/60"
                   id="mcp-search"
                   onChange={(event) => setQuery(event.target.value)}
                   placeholder="搜索名称、仓库、用途或标签"
@@ -338,7 +338,7 @@ export default function McpBrowserPage() {
                 />
                 {query || selectedCategory !== "全部" || availabilityFilter !== "all" ? (
                   <button
-                    className="rounded-lg border border-white/10 bg-white/[0.055] px-4 py-2.5 text-sm font-semibold text-slate-200 transition hover:border-brand-300/35 hover:text-brand-100"
+                    className="min-h-11 rounded-lg border border-white/10 bg-white/[0.055] px-4 py-2.5 text-sm font-semibold text-slate-200 transition hover:border-brand-300/35 hover:text-brand-100"
                     onClick={() => {
                       setQuery("");
                       setSelectedCategory("全部");
@@ -368,7 +368,7 @@ export default function McpBrowserPage() {
                     return (
                       <button
                         aria-pressed={isSelected}
-                        className={`rounded-full border px-3 py-1.5 text-xs font-semibold transition ${
+                        className={`min-h-11 rounded-full border px-3 py-1.5 text-xs font-semibold transition ${
                           isSelected
                             ? value === "planned" || value === "blocked"
                               ? "border-amber-300/60 bg-amber-300 text-ink-950"
@@ -399,7 +399,7 @@ export default function McpBrowserPage() {
                   return (
                     <button
                       aria-pressed={isSelected}
-                      className={`rounded-full border px-3 py-1.5 text-xs font-semibold transition ${
+                      className={`min-h-11 rounded-full border px-3 py-1.5 text-xs font-semibold transition ${
                         isSelected
                           ? "border-hire-300/60 bg-hire-300 text-ink-950"
                           : "border-white/10 bg-white/[0.045] text-slate-300 hover:border-hire-300/35 hover:text-hire-100"
@@ -457,7 +457,7 @@ export default function McpBrowserPage() {
               {visibleProjects.length < filteredProjects.length ? (
                 <div className="mt-6 flex justify-center">
                   <button
-                    className="rounded-lg border border-brand-300/30 bg-brand-300/10 px-5 py-2.5 text-sm font-semibold text-brand-100 transition hover:bg-brand-300/15 focus:outline-none focus:ring-2 focus:ring-brand-300/50"
+                    className="min-h-11 rounded-lg border border-brand-300/30 bg-brand-300/10 px-5 py-2.5 text-sm font-semibold text-brand-100 transition hover:bg-brand-300/15 focus:outline-none focus:ring-2 focus:ring-brand-300/50"
                     onClick={() =>
                       setVisibleCount((count) => count + INITIAL_VISIBLE_COUNT)
                     }
@@ -475,7 +475,7 @@ export default function McpBrowserPage() {
                 尝试缩短关键词、切换分类，或清除当前筛选条件查看完整目录。
               </p>
               <button
-                className="mt-4 rounded-full bg-brand-300 px-4 py-2 text-sm font-semibold text-ink-950 transition hover:bg-brand-200"
+                className="mt-4 min-h-11 rounded-full bg-brand-300 px-4 py-2 text-sm font-semibold text-ink-950 transition hover:bg-brand-200"
                 onClick={() => {
                   setQuery("");
                   setSelectedCategory("全部");

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -201,6 +201,92 @@ services:
       retries: 8
       start_period: 30s
 
+  mcp-database:
+    build:
+      context: ./server/sandbox_sidecar
+      dockerfile: Dockerfile.database
+    image: modelmirror-mcp-database:wave5-v1
+    container_name: modelmirror-mcp-database
+    command: ["python", "-m", "sandbox_sidecar.database_server"]
+    networks:
+      - mcp_database_egress
+    environment:
+      MCP_DATABASE_MAX_SESSIONS: "6"
+      MCP_DATABASE_SOCKET_PATH: /run/modelmirror-database-mcp/database-mcp.sock
+      MCP_DATABASE_WORKSPACE_ROOT: /workspaces
+      MCP_DATABASE_ALLOWED_ADAPTERS: dbhub,mongodb-mcp,clickhouse-mcp,redis-mcp,supabase-mcp
+      MCP_DATABASE_PRIVATE_HOST_ALLOWLIST: ${MCP_DATABASE_PRIVATE_HOST_ALLOWLIST:-}
+    user: "65532:65532"
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    pids_limit: 128
+    mem_limit: 1g
+    cpus: 1.5
+    tmpfs:
+      - /tmp:rw,nosuid,noexec,size=64m,uid=65532,gid=65532,mode=0700
+      - /workspaces:rw,nosuid,noexec,size=128m,uid=65532,gid=65532,mode=0700
+    volumes:
+      - mcp_database_socket:/run/modelmirror-database-mcp
+    restart: unless-stopped
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import json,socket; s=socket.socket(socket.AF_UNIX); s.connect('/run/modelmirror-database-mcp/database-mcp.sock'); s.sendall(b'{\"action\":\"health\"}\\n'); assert json.loads(s.recv(4096))['ok']",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 8
+      start_period: 30s
+
+  mcp-database-local:
+    build:
+      context: ./server/sandbox_sidecar
+      dockerfile: Dockerfile.database
+    image: modelmirror-mcp-database:wave5-v1
+    container_name: modelmirror-mcp-database-local
+    command: ["python", "-m", "sandbox_sidecar.database_server"]
+    network_mode: none
+    environment:
+      MCP_DATABASE_MAX_SESSIONS: "4"
+      MCP_DATABASE_SOCKET_PATH: /run/modelmirror-database-local-mcp/database-mcp.sock
+      MCP_DATABASE_WORKSPACE_ROOT: /workspaces
+      MCP_DATABASE_INPUT_ROOT: /inputs
+      MCP_DATABASE_ALLOWED_ADAPTERS: duckdb-mcp
+    user: "65532:65532"
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    pids_limit: 96
+    mem_limit: 1g
+    cpus: 1.5
+    tmpfs:
+      - /tmp:rw,nosuid,noexec,size=64m,uid=65532,gid=65532,mode=0700
+      - /workspaces:rw,nosuid,noexec,size=64m,uid=65532,gid=65532,mode=0700
+    volumes:
+      - mcp_database_local_socket:/run/modelmirror-database-local-mcp
+      - mcp_file_inputs:/inputs:ro
+    restart: unless-stopped
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import json,socket; s=socket.socket(socket.AF_UNIX); s.connect('/run/modelmirror-database-local-mcp/database-mcp.sock'); s.sendall(b'{\"action\":\"health\"}\\n'); assert json.loads(s.recv(4096))['ok']",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 8
+      start_period: 30s
+
   omniroute:
     image: diegosouzapw/omniroute:3.8.48@sha256:badb560971fdc23c2fb84b3e8695116239ff215b4cca4b07076201a8efae7f0d
     container_name: modelmirror-omniroute
@@ -275,6 +361,10 @@ services:
         condition: service_healthy
       mcp-token:
         condition: service_healthy
+      mcp-database:
+        condition: service_healthy
+      mcp-database-local:
+        condition: service_healthy
       new-api:
         condition: service_healthy
     env_file:
@@ -296,6 +386,9 @@ services:
       WORLD_LABS_API_KEY: ${WORLD_LABS_API_KEY:-}
       WORLD_STORAGE_DIR: /app/world/storage/world_records.json
       MODELMIRROR_DEFAULT_TENANT_ID: ${MODELMIRROR_DEFAULT_TENANT_ID:-local}
+      MODELMIRROR_DEFAULT_OWNER_ID: ${MODELMIRROR_DEFAULT_OWNER_ID:-local}
+      MODEL_MIRROR_REQUIRE_EXTERNAL_CREDENTIAL_MASTER_KEY: ${MODEL_MIRROR_REQUIRE_EXTERNAL_CREDENTIAL_MASTER_KEY:-false}
+      MODEL_MIRROR_CREDENTIAL_MASTER_KEY: ${MODEL_MIRROR_CREDENTIAL_MASTER_KEY:-}
       RAG_STORAGE_DIR: /app/rag/storage
       RAG_UPLOAD_DIR: /app/rag/uploads
       CHROMA_DB_PATH: /app/rag/storage/chroma_db
@@ -315,6 +408,8 @@ services:
       MCP_PUBLIC_SOCKET_PATH: /run/modelmirror-public-mcp/public-mcp.sock
       MCP_FILES_SOCKET_PATH: /run/modelmirror-files-mcp/files-mcp.sock
       MCP_TOKEN_SOCKET_PATH: /run/modelmirror-token-mcp/token-mcp.sock
+      MCP_DATABASE_SOCKET_PATH: /run/modelmirror-database-mcp/database-mcp.sock
+      MCP_DATABASE_LOCAL_SOCKET_PATH: /run/modelmirror-database-local-mcp/database-mcp.sock
       MCP_CATALOG_STORAGE_DIR: /app/mcp/storage
       MCP_FILE_INPUT_ROOT: /app/mcp-file-inputs
       MCP_FILE_OUTPUT_ROOT: /app/mcp-file-outputs
@@ -345,6 +440,8 @@ services:
       - mcp_public_socket:/run/modelmirror-public-mcp
       - mcp_files_socket:/run/modelmirror-files-mcp
       - mcp_token_socket:/run/modelmirror-token-mcp
+      - mcp_database_socket:/run/modelmirror-database-mcp
+      - mcp_database_local_socket:/run/modelmirror-database-local-mcp
       - mcp_file_inputs:/app/mcp-file-inputs
       - mcp_file_outputs:/app/mcp-file-outputs
       - mcp_memory:/app/mcp-memory
@@ -505,6 +602,8 @@ volumes:
   mcp_public_socket:
   mcp_files_socket:
   mcp_token_socket:
+  mcp_database_socket:
+  mcp_database_local_socket:
   mcp_file_inputs:
   mcp_file_outputs:
   mcp_memory:
@@ -519,4 +618,6 @@ networks:
     driver: bridge
     internal: true
   mcp_public_egress:
+    driver: bridge
+  mcp_database_egress:
     driver: bridge

--- a/docs/MCP_CATALOG_ROADMAP.md
+++ b/docs/MCP_CATALOG_ROADMAP.md
@@ -15,18 +15,19 @@
 - [Awesome-MCP-ZH](https://github.com/yzfly/Awesome-MCP-ZH)
 - [awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers)
 
-截至 2026-08-06，目录仍冻结为 100 个 MCP 条目、18 个分类。批次 0—3 已验收的 17 项保持不变；批次 4 的 AgentQL、Brave、Exa、Firecrawl、Perplexity、Tavily、Axiom、Figma Context、Google Maps、Grafana、Graphlit、Kagi、Pinecone、Shodan、VirusTotal 已标记为 `ready`。Airbnb、BibiGPT、Manim 与 Snyk 标记为 `blocked`，其余 64 项保持 `planned`。当前状态精确为 32 ready / 64 planned / 4 blocked。
+截至 2026-08-06，目录仍冻结为 100 个 MCP 条目、18 个分类。批次 0—4 已验收的 32 项保持不变；批次 5 的 DBHub、MongoDB、ClickHouse、Redis、DuckDB 与 Supabase 已标记为 `ready`。PostgreSQL、SQLite、Cognee、Graphiti 与 Hindsight 新增为 `blocked`，连同 Airbnb、BibiGPT、Manim 与 Snyk 共 9 项阻断，其余 53 项保持 `planned`。当前状态精确为 **38 ready / 53 planned / 9 blocked**。
 
 ## 2. 当前边界与明确不实现
 
-批次 1–4 只增加固定适配器：批次 1 使用完全断网计算 sidecar，批次 2 使用独立公网 sidecar，批次 3 使用受控上传工作区和完全断网的文件处理 sidecar，批次 4 使用固定 Token 槽和只读出口 sidecar。四批都不扩大账号授权、任意连接或任意执行能力：
+批次 1–5 只增加固定适配器：批次 1 使用完全断网计算 sidecar，批次 2 使用独立公网 sidecar，批次 3 使用受控上传工作区和完全断网的文件处理 sidecar，批次 4 使用固定 Token 槽和只读出口 sidecar，批次 5 使用结构化数据库配置及相互隔离的远程/本地数据库 sidecar。五批都不扩大账号授权、任意连接或任意执行能力：
 
 - 不接受用户指定的 Python 包、解释器、命令、工作目录或其他额外运行时。
-- 不实现 OAuth 回调、刷新或外站登录；批次 4 只能选择既有加密 `credential_id`，目录页不接受或显示明文 Token / API Key。
+- 不实现 OAuth 回调、刷新或外站登录；批次 4—5 的卡片可把明文 Secret 单次提交到服务端加密库，但连接配置只接受不透明 `credential_id`，保存后不再返回或显示明文。
 - 不打开外站认证登录页，也不提供认证按钮或深链。
 - 不把 Streamable HTTP、SSE 或任意 MCP URL 暴露为目录配置；批次 2 仅由固定 stdio 适配器访问受控公共 HTTPS 服务。
 - Fetch 的用户 URL 只是工具参数，只允许公网 HTTPS，并逐次执行 DNS、SSRF、重定向和响应大小校验；它不是自定义 MCP 连接入口。
 - 批次 3 客户端只能提交不透明 `workspace_id`、文件 ID 和产物名，不能提交宿主路径、`cwd`、环境变量或 URI；输入文件封存后只读。
+- 批次 5 客户端只能提交清单声明的数据库类型、主机名、端口、库名、用户名、严格 TLS 模式或 Supabase `project_ref`；DBHub 首批仅支持 PostgreSQL、MySQL 与 MariaDB，SQL Server 保持关闭；不接受 DSN、数据库 URI、SSH 隧道、Header、环境变量名或任意连接参数。
 - 不接管 Blender、Zotero、Obsidian、JetBrains、Xcode、Ghidra 等桌面宿主。
 - 不提供用户自定义 MCP 连接。
 - 不提供 MCP Builder、可视化生成器或发布市场流程。
@@ -46,7 +47,7 @@
 数据层必须满足以下约束：
 
 1. 前端条目不得包含可执行 `command`、MCP URL、Header 或环境变量配置。
-2. `ready` 后端适配器必须有固定命令或端点、独立功能开关和显式工具策略；现有 7 项以兼容策略保持行为不变，批次 1—4 的 25 项使用完整的逐工具策略。
+2. `ready` 后端适配器必须有固定命令或端点、独立功能开关和显式工具策略；现有 7 项以兼容策略保持行为不变，批次 1—5 的 31 项使用完整的逐工具策略。
 3. `planned` 后端适配器不得包含可执行命令或端点，环境开关不能绕过状态门禁。
 4. 前端不得保存真实 Secret，也不得在仓库内出现真实凭证。
 5. 上游清单只用于发现项目；能否连接必须按模镜运行边界重新核验。
@@ -79,7 +80,7 @@
 | 2 | `bibigpt-mcp`、`fetch-mcp`、`quickchart-mcp`、`airbnb-mcp`、`geowire-mcp` | 5 | **已完成门槛判定**：Fetch、QuickChart、GeoWire 可用；BibiGPT 因 OAuth、Airbnb 因上游 schema 漂移受阻 |
 | 3 | `basic-memory-mcp`、`excel-mcp-server`、`git-mcp`、`manim-mcp`、`markitdown-mcp` | 5 | **已完成门槛判定**：Basic Memory、Excel、Git、MarkItDown 可用；Manim 因任意 Python 场景执行依赖第 8 批隔离而阻断 |
 | 4 | AgentQL、Brave、Exa、Firecrawl、Perplexity、Tavily、Axiom、Figma Context、Google Maps、Grafana、Graphlit、Kagi、Pinecone、Shodan、Snyk、VirusTotal | 16 | **已完成门槛判定**：15 项通过加密凭据槽、固定出口域、只读工具和 Secret 泄漏测试；Snyk 因本地构建执行依赖第 8 批隔离而阻断 |
-| 5 | DBHub、PostgreSQL、MongoDB、ClickHouse、Cognee、Graphiti、Hindsight、Redis、SQLite、DuckDB、Supabase | 11 | 只读账号、TLS、查询超时、行数限制、写入审批 |
+| 5 | DBHub、PostgreSQL、MongoDB、ClickHouse、Cognee、Graphiti、Hindsight、Redis、SQLite、DuckDB、Supabase | 11 | **已完成门槛判定**：DBHub、MongoDB、ClickHouse、Redis、DuckDB、Supabase 通过结构化配置、租户凭据、协议级只读、预检与查询限制；PostgreSQL、SQLite 因归档实现受阻，三项状态化记忆转入第 5B 计划 |
 | 6 | Airtable、Asana、GitLab、中国电商经营、Notion、Mem0 | 6 | 修改预览与审批、幂等、限流、账号解绑 |
 | 7 | Chrome DevTools、Playwright、Puppeteer、Selenium | 4 | 临时浏览器、目标域、上传下载与会话清理边界 |
 | 8 | MCP Run Python、MCP Python Interpreter | 2 | 一次性断网容器、无宿主挂载、无 Docker socket、进程资源限制 |
@@ -117,13 +118,25 @@
 - Axiom 采用已归档 v0.05 的 Token 只读契约；Brave 与 Google Maps 锁定 archived reference server 契约。Figma 图片下载、Firecrawl/Tavily 长任务、Graphlit 写入、Perplexity 深度研究、Pinecone 文件管理及所有修改/删除工具均关闭。
 - Snyk 1.15.2 会读取本地项目并可能启动 Gradle、Maven 等构建链，保留第 4 批编号但为 `blocked`；不提供安装、连接或外站登录入口，等待第 8 批一次性代码执行隔离。
 
+批次 5 的执行结论：
+
+- `modelmirror-mcp-database:wave5-v1` 由两个相互隔离的服务运行：远程 sidecar 仅承载 DBHub、MongoDB、ClickHouse、Redis 与 Supabase 的固定目标协议；本地 sidecar 运行在 `network_mode: none`，只读取 DuckDB 封存工作区。两者均为非 root、只读根文件系统、移除 capabilities、禁止 Docker socket，并通过独立 Unix socket 与 server 通信。
+- 远程条目只接受服务端清单声明的结构化字段；服务端在私有握手内生成驱动配置，客户端和日志均看不到 DSN、密码、Header 或环境变量名。DuckDB 只接受不透明 `workspace_id` 与 `.duckdb` 文件 ID，不接受宿主路径或 MotherDuck/S3 等远程切库能力。
+- 目录凭据按 `tenant_id + owner_id + project_id + slot` 隔离；跨租户或所有者查询统一表现为不存在。旧凭据记录安全迁移到显式 `local/local`；生产环境可强制要求外部 `MODEL_MIRROR_CREDENTIAL_MASTER_KEY`，本地开发仍可使用既有自动生成密钥模式。当前服务端只使用部署时固定的 tenant/owner，尚无逐请求身份传播，因此 Wave 5 仅面向单租户本地部署；多用户共享部署仍为发布阻断。
+- “只读”由 sidecar 协议网关和数据库原生会话共同执行，不依赖前端提示或工具名称。SQL 仅允许单语句读取，MongoDB 拒绝 `$out`、`$merge`、`$where`、`$function`，Redis 不暴露 raw command、Lua、CONFIG、DEBUG 或 KEYS，DuckDB 禁止 ATTACH、COPY、INSTALL、LOAD、外部访问和扩展自动加载。
+- 连接预检覆盖结构化字段、目标解析、严格 TLS、认证、原生只读模式和查询限制。默认返回 200 行、硬上限 1000 行，数据库 statement timeout 为 15 秒，目录调用超时 20 秒，内联结果最多 256 KiB；超时或预检失败时不保留可调用会话。
+- Supabase 使用固定本地 stdio 适配器、Personal Access Token 与 20 位小写字母 `project_ref`，并固定调用官方 `/database/query/read-only` 端点，只开放指定项目的表、扩展和只读 SQL 能力；本批不使用 OAuth，不显示外站登录入口，也不开放迁移、函数、分支或项目管理。
+- PostgreSQL 官方参考实现因归档和 npm 弃用保持 `blocked`，可使用受控 DBHub PostgreSQL 模式；SQLite 官方实现因归档且暴露写工具保持 `blocked`。Cognee、Graphiti 与 Hindsight 属于有状态记忆系统，转入“第 5B 批：状态化记忆”，在独立持久卷、模型/费用、租户数据保留与通用写审批完成前不连接。
+- 本批不开放任何数据库写入、删除、DDL 或状态化记忆写工具，也不复用批次 3 的文件工作区审批冒充数据库审批。后续写能力必须另行实现数据库目标和状态绑定的一次性审批。
+
 ## 6. 验收、发布和回退
 
 - 每个项目必须通过初始化、工具发现、代表性调用、超时、重连、断开与清理测试；Schema 漂移视为阻断。
-- 安全测试按批次覆盖 Secret 泄漏、SSRF、重定向、路径越界、ZIP Slip、链接与压缩炸弹、跨项目/产物越权、沙箱逃逸、权限撤销、审批绕过和高风险操作默认关闭。
+- 安全测试按批次覆盖 Secret 泄漏、SSRF、重定向、路径越界、ZIP Slip、链接与压缩炸弹、跨项目/产物/租户越权、沙箱逃逸、TLS 降级、SQL 多语句及写入旁路、查询超时/行数、权限撤销、审批绕过和高风险操作默认关闭。
 - 前端必须显示中文批次、状态、连接方式、风险、限制和门槛；后端未返回 `executable=true` 时按钮不可连接。
 - 每个项目有独立服务端开关。回退只关闭开关、断开会话并清理沙箱，不删除目录条目或凭据。
 - 运行日志只记录项目 ID、状态、耗时、错误类别和策略事件，不记录 Secret、完整参数或工具返回正文。
+- 共享栈重建必须先确认时间窗口和基线；存在并行工作树冲突时先启动独立预览项目。人工验收通过后还要重新 fetch 并核对 `origin/main`、冲突、工作树状态和实际变更文件，确认无误后才提交 PR。
 
 ## 7. 明确不进入本路线的远期能力
 
@@ -135,13 +148,14 @@
 
 主要风险是上游项目快速变化、条目说明过期，以及把“已收录”误解为“当前可安全运行”。前端必须持续使用明确的状态标签和禁用按钮表达边界。
 
-批次 0–4 不引入数据库迁移。批次 2 回退时关闭对应公网项目开关并停止 `mcp-public`；批次 3 回退时关闭四个文件项目开关、撤销审批并停止 `mcp-files`；批次 4 回退时关闭 15 个 Token 项目的独立功能开关、断开目录会话并停止 `mcp-token`，不自动删除卡片专属加密凭据。临时工作区可清理，持久 Basic Memory 数据不自动删除；Airbnb、BibiGPT、Manim 与 Snyk 本来就不可执行。旧版 `/api/mcp/*` 接口保持兼容，但目录会话不能使用无项目策略的直接调用端点：
+批次 0–4 不引入数据库迁移；批次 5 只把旧凭据 JSON 元数据显式迁移到 `local/local` 作用域，不接触外部数据库 schema 或数据。批次 2 回退时关闭对应公网项目开关并停止 `mcp-public`；批次 3 回退时关闭四个文件项目开关、撤销审批并停止 `mcp-files`；批次 4 回退时关闭 15 个 Token 项目的独立功能开关、断开目录会话并停止 `mcp-token`；批次 5 回退时关闭六个数据库项目开关、断开会话、停止远程和本地数据库 sidecar，并清理临时 DuckDB 工作区。回退不删除卡片专属加密凭据，也不修改或删除外部数据库数据；持久 Basic Memory 数据同样不自动删除。Airbnb、BibiGPT、Manim、Snyk、PostgreSQL、SQLite、Cognee、Graphiti 与 Hindsight 本来就不可执行。旧版 `/api/mcp/*` 接口保持兼容，但目录会话不能使用无项目策略的直接调用端点：
 
 - `server/mcp/catalog.py`
 - `server/mcp/sandbox_proxy.py`
 - `server/mcp/public_proxy.py`
 - `server/mcp/file_proxy.py`
 - `server/mcp/token_proxy.py`
+- `server/mcp/database_proxy.py`
 - `server/mcp/workspace.py`
 - `server/sandbox_sidecar/`
 - `client/src/data/mcpProjects.ts`

--- a/docs/MCP_INTEGRATION.md
+++ b/docs/MCP_INTEGRATION.md
@@ -31,7 +31,7 @@ Agent 画布使用 `toolset_resource -> workflow_agent` 的 `toolset` 绑定边�
 
 - OpenAPI 支持 JSON/YAML 文本、UTF-8 文件和受控 URL 导入；只解析本地 `$ref`，不远程抓取引用。
 - OData 支持 v4 CSDL metadata，EntitySet 查询由字段枚举、过滤操作、排序、分页和键值 DSL 编译，不允许模型直接提交 `$filter` 或任意 URL。
-- none、API Key、Bearer、Basic 和 OAuth2 client credentials 共用 `CredentialStore`；凭据明文不进入 Toolset 定义或版本。
+- none、API Key、Bearer、Basic 和 OAuth2 client credentials 共用 `CredentialStore`；凭据明文不进入 Toolset 定义或版本。目录凭据额外绑定租户、所有者、项目和槽位，旧记录只迁移到显式 `local/local`，不会成为全局凭据。
 - 默认网络策略只允许公网 HTTP/HTTPS，逐次 DNS 校验并阻断回环、私网、link-local、reserved、云元数据、URL credentials 和跨域重定向。
 - 新导入操作默认关闭。草稿 refresh 只生成漂移报告，不改变旧版本；写操作默认 `requires_approval=true`。
 - 管理测试的写操作需要显式确认，发布 Xpert 还必须绑定覆盖该工具的 HITL 中间件。
@@ -83,7 +83,7 @@ Agent 画布使用 `toolset_resource -> workflow_agent` 的 `toolset` 绑定边�
 目录适配器安全默认值：
 
 - 前端不能提交 `server_command`、MCP URL、Header、环境变量名或工作目录。
-- 当前目录状态为 32 ready / 64 planned / 4 blocked；planned 与 blocked 项没有可执行命令或端点，设置环境功能开关也不能绕过状态门槛。
+- 当前目录状态为 **38 ready / 53 planned / 9 blocked**；planned 与 blocked 项没有可执行命令或端点，设置环境功能开关也不能绕过状态门槛。
 - 新适配器若没有显式工具读写与审批策略，工具调用会 fail-closed。
 - 日志只记录项目 ID、工具名、状态和耗时，不记录参数、返回正文或 Secret。
 
@@ -124,6 +124,17 @@ Agent 画布使用 `toolset_resource -> workflow_agent` 的 `toolset` 绑定边�
 - 只读工具通过项目级 `/api/mcp/catalog/{project_id}/tools/{tool_name}/call` 调用；目录会话使用通用直接调用接口会返回 403，避免跳过凭据状态和工具策略。
 - Snyk 保持 `blocked`：其本地项目扫描可能执行 Gradle/Maven，必须等待第 8 批一次性代码执行与文件授权隔离。
 
+批次 5 的六个可用数据库适配器通过固定 `database_proxy.py` 接入远程与本地两个隔离 sidecar：
+
+- `dbhub`、`mongodb-mcp`、`clickhouse-mcp`、`redis-mcp` 与 `supabase-mcp` 使用远程数据库 sidecar；`duckdb-mcp` 使用 `network_mode: none` 的本地 sidecar 和封存 `.duckdb` 工作区。两个服务共享固定镜像 `modelmirror-mcp-database:wave5-v1`，但不共享网络能力或会话。
+- 配置表单由 `database_policy`、`setting_fields` 和 `credential_fields` 驱动，只接受数据库类型、主机、端口、库名、用户名、严格 TLS 模式或 Supabase `project_ref`。DBHub 首批仅开放 PostgreSQL、MySQL 与 MariaDB；SQL Server 因无法可靠核验 direct grant/application role 的有效写权限而不进入本批。客户端不能提交 DSN、数据库 URI、SSH 隧道、任意驱动参数、命令、Header、环境变量或工作目录。
+- 目录凭据固定绑定 `tenant_id + owner_id + project_id + slot`。跨作用域读取、解析、轮换或撤销统一返回不存在；生产可设置 `MODEL_MIRROR_REQUIRE_EXTERNAL_CREDENTIAL_MASTER_KEY=true` 强制使用外部主密钥，默认本地开发行为保持兼容。当前 API 服务实例使用部署时固定的 tenant/owner，尚未接入逐请求身份传播，因此本批只按单租户本地部署发布；多用户部署继续视为阻断。
+- 连接成功前执行目标、TLS、认证、原生只读模式和查询限制预检；预检失败不创建目录会话。SQL 网关只接受单条读取语句并叠加数据库原生只读会话，非 SQL 协议则使用固定命令/阶段白名单，不能依赖工具名宣称只读。
+- 默认最多返回 200 行、硬上限 1000 行，数据库 statement timeout 为 15 秒，目录调用超时 20 秒，MCP 结果最多 256 KiB。MongoDB 写入/代码阶段、Redis raw command/Lua/管理命令、DuckDB 外部访问与扩展加载均在 sidecar 再次拒绝。
+- Supabase 使用 Personal Access Token 和固定项目 `project_ref` 的本地 stdio 路径，并固定调用官方 Management API 的 `/database/query/read-only` 端点；不使用 OAuth，也没有外站登录按钮，迁移、函数、分支和项目管理继续关闭。
+- `postgres-mcp` 与 `sqlite-mcp` 因归档或弃用的上游实现保持 `blocked`。Cognee、Graphiti、Hindsight 转入第 5B 状态化记忆计划；其持久卷、模型与费用、数据保留及写入审批尚未完成，因此没有连接入口。
+- Wave 5 首轮只开放读取、结构浏览和受限查询，不开放写入审批。数据库写审批不能复用依赖文件 manifest 的批次 3 审批；后续必须绑定租户、数据库目标、会话、配置/凭据版本、冻结参数和数据库状态。
+
 兼容层仍保留以下默认值：
 
 - 后端只接受 `list[str]` 形式的命令，不使用 shell。
@@ -151,6 +162,7 @@ server/mcp/catalog.py
 3. 为适配器声明连接形态、允许的非敏感配置字段、凭据槽、网络/文件权限和独立功能开关。
 4. 发现全部工具并逐个标记只读、敏感、终止性和审批要求；未知工具默认不可调用。
 5. 通过初始化、代表性调用、超时、重连、清理、安全和回退 Smoke 后，才能把状态从 `adapting` 改为 `ready`。
+6. 共享集成栈重建前必须由维护者确认时间窗口和基线；若其他工作树仍在开发，先使用独立预览项目验收。人工验收通过后再次核对最新 `origin/main`、工作树状态、冲突和变更范围，再提交并创建 PR。
 
 核验 npm 包示例：
 
@@ -170,8 +182,8 @@ npm view @example/mcp-server version
 | GET/POST | `/api/mcp/catalog/{project_id}/credentials` | 列出当前卡片的脱敏凭据，或创建绑定当前项目与固定槽位的加密凭据 |
 | DELETE | `/api/mcp/catalog/{project_id}/credentials/{credential_id}` | 撤销当前卡片凭据，并立即断开关联会话、清除失效配置 |
 | POST | `/api/mcp/catalog/{project_id}/prepare` | 使用后端固定安装配置准备已验收适配器 |
-| PUT | `/api/mcp/catalog/{project_id}/configuration` | 只接受清单允许的设置和 `credential_id` 绑定 |
-| POST | `/api/mcp/catalog/{project_id}/connect` | 按项目 ID 建立受控会话 |
+| PUT | `/api/mcp/catalog/{project_id}/configuration` | 只接受清单允许的设置、`credential_id` 绑定和适用条目的 `workspace_id`；数据库不接受 DSN/URI |
+| POST | `/api/mcp/catalog/{project_id}/connect` | 按项目 ID 建立受控会话；数据库项目须先通过目标、TLS、认证与只读预检 |
 | DELETE | `/api/mcp/catalog/{project_id}/session` | 断开该目录项目的会话 |
 | POST | `/api/mcp/catalog/{project_id}/tools/{tool_name}/call` | 经项目工具策略调用已连接工具 |
 | GET/POST | `/api/mcp/catalog/{project_id}/workspaces` | 列出或创建当前项目的受控工作区 |
@@ -418,6 +430,7 @@ python server/mcp/test_manager.py
 | `server/mcp/public_proxy.py` | 把批次 2 固定项目 ID 的 stdio 流代理到公网策略 sidecar。 |
 | `server/mcp/file_proxy.py` | 把批次 3 固定项目 ID 和服务端工作区 ID 代理到断网文件 sidecar。 |
 | `server/mcp/token_proxy.py` | 移除短期凭据环境并把批次 4 固定项目 ID 与配置单次传给私有 sidecar。 |
+| `server/mcp/database_proxy.py` | 移除短期数据库配置环境，按固定项目路由到批次 5 的远程或断网本地 Unix socket。 |
 | `server/mcp/workspace.py` | 工作区、上传/ZIP 校验、封存 manifest、产物与保留期管理。 |
 | `server/sandbox_sidecar/compute_mcp.py` | 批次 1 的三个内置 Python MCP 工具契约。 |
 | `server/sandbox_sidecar/public_mcp.py` | 批次 2 的内置公网 MCP 兼容契约。 |
@@ -430,6 +443,9 @@ python server/mcp/test_manager.py
 | `server/sandbox_sidecar/token_server.py` | 批次 4 Unix-socket 生命周期、工具过滤、URL 预检和进程清理网关。 |
 | `server/sandbox_sidecar/token_builtin.py` | Axiom、Grafana Cloud、Kagi 与 Pinecone Assistant 最小只读兼容契约。 |
 | `server/sandbox_sidecar/Dockerfile.token` | `modelmirror-mcp-token:wave4-v1` 精确 npm lockfile 镜像。 |
+| `server/sandbox_sidecar/database_contracts.py` | 批次 5 的结构化目标、凭据槽、工具白名单、协议只读和预检契约。 |
+| `server/sandbox_sidecar/database_server.py` | 批次 5 远程/本地数据库会话、限制、清理与 fail-closed 网关。 |
+| `server/sandbox_sidecar/Dockerfile.database` | `modelmirror-mcp-database:wave5-v1` 固定依赖镜像。 |
 | `server/toolsets/` | Toolset/凭据 Store、版本发布、Schema 漂移与固定版本 Provider。 |
 | `client/src/pages/ToolsetsPage.tsx` | MCP Toolset 创建、连接、工具配置、测试和发布管理页。 |
 | `server/tests/test_toolset_*.py` | Toolset Store、API、连接、固定版本与安全回归。 |
@@ -443,6 +459,7 @@ python server/mcp/test_manager.py
 | `server/tests/test_mcp_public_adapters.py` | 批次 2 SSRF、DNS、robots、响应上限、工具契约与容器隔离测试。 |
 | `server/tests/test_mcp_file_workspaces.py` | 批次 3 路径/ZIP、租户隔离、产物越权和一次性审批安全测试。 |
 | `server/tests/test_mcp_token_sidecar.py` | 批次 4 清单一致性、配置契约、Secret 传递、工具过滤和 URL 预检测试。 |
+| `server/tests/test_mcp_database_sidecar.py` | 批次 5 配置、租户凭据、TLS/只读预检、协议旁路、行数与超时测试。 |
 | `server/mcp/smoke_file_adapters.py` | 四个文件适配器初始化、发现、代表调用、重连、源文件不变和清理 smoke。 |
 | `client/src/components/McpServerCard.tsx` | 前端连接、工具表单、执行结果组件。 |
 | `client/src/components/McpWorkspacePanel.tsx` | 中文工作区上传、封存、绑定、容量/到期、产物下载和清理面板。 |
@@ -454,4 +471,4 @@ python server/mcp/test_manager.py
 
 `/mcps` 同时展示已通过生产验收的 Server 和按批次排队的生态项目。待适配条目只能展示中文用途、接入条件、批次和安全门槛；只有后端返回 `ready + executable` 才能连接。
 
-来源同步、安全运行时、OAuth / Secret 代理、用户自定义连接和 MCP Builder 的阶段计划见 [MCP_CATALOG_ROADMAP.md](./MCP_CATALOG_ROADMAP.md)。
+来源同步、安全运行时及后续 OAuth / Secret 代理计划见 [MCP_CATALOG_ROADMAP.md](./MCP_CATALOG_ROADMAP.md)。用户自定义连接和 MCP Builder 仍为未排期远期能力，不进入当前批次。

--- a/server/main.py
+++ b/server/main.py
@@ -808,6 +808,7 @@ mcp_catalog_service = MCPCatalogService(
     credential_revoker=toolset_credential_store.revoke,
     workspace_store=mcp_catalog_workspace_store,
     tenant_id=os.getenv("MODELMIRROR_DEFAULT_TENANT_ID", "local"),
+    owner_id=os.getenv("MODELMIRROR_DEFAULT_OWNER_ID", "local"),
 )
 configure_mcp_catalog(mcp_catalog_service)
 toolset_service = ToolsetService(

--- a/server/mcp/catalog.py
+++ b/server/mcp/catalog.py
@@ -13,6 +13,7 @@ import asyncio
 import base64
 import hashlib
 import ipaddress
+import inspect
 import json
 import logging
 import os
@@ -75,6 +76,7 @@ AdapterRisk = Literal["low", "medium", "high", "critical"]
 AdapterPreparationKind = Literal["installer", "bundled"]
 CatalogToolEffect = Literal["read", "artifact-create", "state-write", "terminal"]
 CatalogSettingKind = Literal["text", "integer", "enum", "slug", "hostname"]
+CatalogDatabaseMode = Literal["remote-read-only", "local-file-read-only"]
 
 logger = logging.getLogger("modelmirror.mcp.catalog")
 
@@ -175,6 +177,40 @@ class CatalogCredentialSlotPolicy:
 
 
 @dataclass(frozen=True, slots=True)
+class CatalogDatabasePolicy:
+    """Public, non-secret guardrails for a fixed database adapter."""
+
+    mode: CatalogDatabaseMode
+    engine: str
+    read_only: bool = True
+    tls_required: bool = True
+    max_rows_default: int = 200
+    max_rows_hard: int = 1_000
+    statement_timeout_seconds: int = 15
+    operation_timeout_seconds: int = 20
+    preflight_checks: tuple[str, ...] = (
+        "dns-policy",
+        "tls-verification",
+        "authentication",
+        "native-read-only-mode",
+        "query-limits",
+    )
+
+    def to_public(self) -> dict[str, Any]:
+        return {
+            "mode": self.mode,
+            "engine": self.engine,
+            "read_only": self.read_only,
+            "tls_required": self.tls_required,
+            "max_rows_default": self.max_rows_default,
+            "max_rows_hard": self.max_rows_hard,
+            "statement_timeout_seconds": self.statement_timeout_seconds,
+            "operation_timeout_seconds": self.operation_timeout_seconds,
+            "preflight_checks": list(self.preflight_checks),
+        }
+
+
+@dataclass(frozen=True, slots=True)
 class CatalogAdapterManifest:
     project_id: str
     wave: int
@@ -199,6 +235,7 @@ class CatalogAdapterManifest:
     credential_policies: tuple[CatalogCredentialSlotPolicy, ...] = ()
     tool_policies: dict[str, CatalogToolPolicy] = field(default_factory=dict)
     workspace_policy: CatalogWorkspacePolicy | None = None
+    database_policy: CatalogDatabasePolicy | None = None
     legacy_unrestricted_calls: bool = False
     enabled_by_default: bool = False
     operation_timeout: float = 30.0
@@ -275,6 +312,11 @@ class CatalogAdapterManifest:
                 if self.workspace_policy is not None
                 else None
             ),
+            "database_policy": (
+                self.database_policy.to_public()
+                if self.database_policy is not None
+                else None
+            ),
         }
 
 
@@ -319,6 +361,10 @@ FILE_SANDBOX_PROXY = (
 TOKEN_SANDBOX_PROXY = (
     sys.executable,
     str(Path(__file__).resolve().with_name("token_proxy.py")),
+)
+DATABASE_SANDBOX_PROXY = (
+    sys.executable,
+    str(Path(__file__).resolve().with_name("database_proxy.py")),
 )
 WAVE_ONE_ADAPTERS: dict[str, tuple[str, tuple[str, ...]]] = {
     "calculator-mcp": (
@@ -563,6 +609,222 @@ WAVE_FOUR_ADAPTERS: dict[str, WaveFourAdapterSpec] = {
         (_credential("api_key", "VirusTotal API Key", "仅用于读取既有分析报告和关系。"),),
         network_policy="allowlist:www.virustotal.com",
         limitations=("不上传样本、不触发重新扫描；URL 工具只读取 VirusTotal 已缓存报告。",),
+    ),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class WaveFiveAdapterSpec:
+    adapter_version: str
+    tools: tuple[str, ...]
+    database_policy: CatalogDatabasePolicy
+    credential_policies: tuple[CatalogCredentialSlotPolicy, ...] = ()
+    setting_policies: tuple[CatalogSettingPolicy, ...] = ()
+    limitations: tuple[str, ...] = ()
+    network_policy: str = "database-egress:validated-host,admin-private-allowlist"
+    workspace_extensions: tuple[str, ...] = ()
+
+
+def _database_host() -> CatalogSettingPolicy:
+    return CatalogSettingPolicy(
+        "host",
+        "数据库主机名",
+        "只填写主机名，不含协议、端口、路径或用户信息；IP 字面量会被拒绝。",
+        kind="hostname",
+        required=True,
+    )
+
+
+def _database_port(default: int) -> CatalogSettingPolicy:
+    return CatalogSettingPolicy(
+        "port",
+        "数据库端口",
+        "仅允许 1 到 65535 的固定 TCP 端口。",
+        kind="integer",
+        required=True,
+        default=default,
+        minimum=1,
+        maximum=65_535,
+    )
+
+
+def _database_name() -> CatalogSettingPolicy:
+    return CatalogSettingPolicy(
+        "database",
+        "数据库名称",
+        "只填写目标数据库名称，不接受连接串或路径。",
+        required=True,
+        pattern=r"^[A-Za-z0-9_.$-]{1,128}$",
+    )
+
+
+def _database_username(*, required: bool = True) -> CatalogSettingPolicy:
+    return CatalogSettingPolicy(
+        "username",
+        "只读用户名",
+        "建议使用仅具有读取权限的独立数据库账号。",
+        required=required,
+        pattern=r"^[A-Za-z0-9_.-]{1,128}$",
+    )
+
+
+def _database_tls() -> CatalogSettingPolicy:
+    return CatalogSettingPolicy(
+        "tls_mode",
+        "TLS 校验模式",
+        "本批固定进行证书链和主机名校验，不允许明文或跳过校验。",
+        kind="enum",
+        required=True,
+        default="verify-full",
+        options=(("verify-full", "严格校验证书和主机名"),),
+    )
+
+
+WAVE_FIVE_ADAPTERS: dict[str, WaveFiveAdapterSpec] = {
+    "dbhub": WaveFiveAdapterSpec(
+        "1.2.0-read-only-contract-v1",
+        ("list_schemas", "list_tables", "describe_table", "execute_sql"),
+        CatalogDatabasePolicy(mode="remote-read-only", engine="dbhub"),
+        (_credential("password", "数据库密码", "仅用于建立受控的只读数据库会话。"),),
+        (
+            CatalogSettingPolicy(
+                "engine",
+                "数据库类型",
+                "首批仅支持已审计的远程数据库驱动。",
+                kind="enum",
+                required=True,
+                options=(
+                    ("postgresql", "PostgreSQL"),
+                    ("mysql", "MySQL"),
+                    ("mariadb", "MariaDB"),
+                ),
+            ),
+            _database_host(),
+            _database_port(5432),
+            _database_name(),
+            _database_username(),
+            _database_tls(),
+        ),
+        (
+            "由服务端生成固定连接配置；不接受 DSN、SSH 隧道、多数据源、SQLite 路径或自定义工具。",
+            "只开放结构浏览和单语句只读查询，同时要求数据库侧只读账号。",
+        ),
+    ),
+    "mongodb-mcp": WaveFiveAdapterSpec(
+        "2.0.0-read-only-contract-v1",
+        (
+            "list_collections", "collection_schema", "collection_indexes",
+            "find", "aggregate", "count_documents",
+        ),
+        CatalogDatabasePolicy(mode="remote-read-only", engine="mongodb"),
+        (_credential("password", "MongoDB 密码", "仅用于既有数据库的只读访问。"),),
+        (
+            _database_host(),
+            _database_port(27017),
+            _database_name(),
+            _database_username(),
+            _database_tls(),
+            CatalogSettingPolicy(
+                "auth_source",
+                "认证数据库",
+                "默认使用 admin；不接受连接 URI。",
+                required=True,
+                default="admin",
+                pattern=r"^[A-Za-z0-9_.$-]{1,128}$",
+            ),
+        ),
+        (
+            "固定启用上游只读模式并关闭请求覆盖；Atlas 管理、临时用户和写入工具全部不开放。",
+            "聚合管道拒绝 $out、$merge、$where、$function 等写入或代码执行阶段。",
+        ),
+    ),
+    "clickhouse-mcp": WaveFiveAdapterSpec(
+        "0.4.1-read-only-contract-v1",
+        ("list_databases", "list_tables", "run_query"),
+        CatalogDatabasePolicy(mode="remote-read-only", engine="clickhouse"),
+        (_credential("password", "ClickHouse 密码", "仅用于只读查询会话。"),),
+        (
+            _database_host(),
+            _database_port(8443),
+            _database_name(),
+            _database_username(),
+            _database_tls(),
+        ),
+        (
+            "固定关闭写访问和 chDB；remote、url、file 等可绕过目标边界的表函数会被拒绝。",
+            "数据库用户仍须配置 readonly=1，并受 15 秒查询超时和 1000 行硬上限约束。",
+        ),
+    ),
+    "redis-mcp": WaveFiveAdapterSpec(
+        "0.5.1-read-only-contract-v1",
+        (
+            "scan_keys", "get_value", "get_type", "get_ttl", "hash_get_all",
+            "list_range", "set_members", "sorted_set_range",
+        ),
+        CatalogDatabasePolicy(mode="remote-read-only", engine="redis"),
+        (_credential("password", "Redis 密码", "仅用于受限 ACL 只读账号。"),),
+        (
+            _database_host(),
+            _database_port(6380),
+            _database_tls(),
+            _database_username(required=False),
+            CatalogSettingPolicy(
+                "database",
+                "Redis 数据库编号",
+                "仅允许 0 到 15。",
+                kind="integer",
+                required=True,
+                default=0,
+                minimum=0,
+                maximum=15,
+            ),
+        ),
+        (
+            "必须同时使用 Redis 只读 ACL；不开放 raw command、Lua、CONFIG、DEBUG、KEYS 或任何写入命令。",
+            "SCAN 和集合读取均使用固定分页与返回数量上限。",
+        ),
+    ),
+    "duckdb-mcp": WaveFiveAdapterSpec(
+        "1.0.7-local-read-only-contract-v1",
+        ("list_schemas", "list_tables", "describe_table", "query"),
+        CatalogDatabasePolicy(
+            mode="local-file-read-only",
+            engine="duckdb",
+            tls_required=False,
+            preflight_checks=(
+                "sealed-workspace",
+                "file-integrity",
+                "native-read-only-mode",
+                "query-limits",
+            ),
+        ),
+        limitations=(
+            "只允许封存工作区内的 .duckdb 文件标识，进程断网且不能读取兄弟工作区或宿主路径。",
+            "固定禁用 ATTACH、COPY、INSTALL、LOAD、外部访问和扩展自动加载；MotherDuck、S3 与远程切库不开放。",
+        ),
+        network_policy="disabled",
+        workspace_extensions=(".duckdb",),
+    ),
+    "supabase-mcp": WaveFiveAdapterSpec(
+        "0.9.0-stdio-pat-read-only-v1",
+        ("list_tables", "list_extensions", "execute_sql"),
+        CatalogDatabasePolicy(mode="remote-read-only", engine="supabase"),
+        (_credential("access_token", "Supabase Personal Access Token", "仅用于指定项目的只读能力。"),),
+        (
+            CatalogSettingPolicy(
+                "project_ref",
+                "Supabase 项目标识",
+                "只填写固定 project ref，不接受 API URL。",
+                kind="slug",
+                required=True,
+                pattern=r"^[a-z]{20}$",
+            ),
+        ),
+        (
+            "仅支持本地 stdio、PAT 和指定项目；固定启用只读模式并限制为数据库、调试和文档能力。",
+            "远程 OAuth、迁移、函数、分支、项目管理和其他修改操作继续保留到后续批次。",
+        ),
+        network_policy="allowlist:api.supabase.com,supabase.com",
     ),
 }
 
@@ -1034,6 +1296,123 @@ def build_catalog_manifests() -> dict[str, CatalogAdapterManifest]:
             max_output_bytes=256 * 1024,
         )
 
+    for project_id, spec in WAVE_FIVE_ADAPTERS.items():
+        workspace_policy = None
+        filesystem_policy = "read-only-empty-workspace"
+        if spec.workspace_extensions:
+            workspace_policy = CatalogWorkspacePolicy(
+                persistent=False,
+                accepted_extensions=spec.workspace_extensions,
+            )
+            filesystem_policy = "sealed-database-input-read-only,no-artifact-write"
+        manifests[project_id] = CatalogAdapterManifest(
+            project_id=project_id,
+            wave=5,
+            availability="ready",
+            connection_kind="sandboxed-stdio",
+            risk="high",
+            required_capabilities=(
+                "tenant-scoped-credential-binding",
+                "structured-database-configuration",
+                "native-read-only-mode",
+                "query-row-timeout-limits",
+                "database-preflight",
+                "schema-drift-recovery",
+            ),
+            limitations=(
+                *spec.limitations,
+                "当前仅支持部署时固定 tenant/owner 的单租户本地实例；多用户共享部署保持关闭。",
+            ),
+            adapter_version=spec.adapter_version,
+            runtime_image="modelmirror-mcp-database:wave5-v1",
+            network_policy=spec.network_policy,
+            filesystem_policy=filesystem_policy,
+            resource_limits=(
+                ("cpu", "1.5 cores / 60 CPU seconds per session process"),
+                ("memory", "1 GiB sidecar"),
+                ("processes", "maximum 6 sessions / 128 sidecar PIDs"),
+                ("statement_timeout", "15 seconds"),
+                ("operation_timeout", "20 seconds"),
+                ("rows", "200 default / 1000 hard maximum"),
+                ("tool_output", "256 KiB"),
+            ),
+            server_command=(*DATABASE_SANDBOX_PROXY, project_id),
+            preparation_kind="bundled",
+            allowed_settings=tuple(item.key for item in spec.setting_policies),
+            credential_slots=tuple(item.key for item in spec.credential_policies),
+            setting_policies=spec.setting_policies,
+            credential_policies=spec.credential_policies,
+            tool_policies={
+                name: CatalogToolPolicy(read_only=True, effect="read")
+                for name in spec.tools
+            },
+            workspace_policy=workspace_policy,
+            database_policy=spec.database_policy,
+            enabled_by_default=True,
+            operation_timeout=20.0,
+            max_output_bytes=256 * 1024,
+        )
+
+    blocked_wave_five: dict[str, tuple[AdapterRisk, str, tuple[str, ...]]] = {
+        "postgres-mcp": (
+            "high",
+            "0.6.2-blocked:archived-deprecated",
+            (
+                "官方参考实现已经归档且 npm 包已弃用，因此不能标记为生产可用。",
+                "需要 PostgreSQL 时请使用本批受控的 DBHub PostgreSQL 配置；本条目不提供连接按钮。",
+            ),
+        ),
+        "sqlite-mcp": (
+            "high",
+            "0.6.2-blocked:archived-write-tools",
+            (
+                "官方实现已归档，并公开 write_query、create_table 等写入工具，缺少持续安全维护。",
+                "等待维护中的受控 SQLite 驱动与文件沙箱完成前，连接和宿主路径读取全部关闭。",
+            ),
+        ),
+        "cognee-mcp": (
+            "critical",
+            "0.5.5-blocked:stateful-memory-runtime",
+            (
+                "Cognee 依赖 LLM、Embedding、图与向量存储，remember 和 forget 会修改持久状态。",
+                "转入第 5B 状态化记忆计划；完成独立持久卷、费用、保留和写入审批前不连接。",
+            ),
+        ),
+        "graphiti-mcp": (
+            "critical",
+            "mcp-v1.0.2-blocked:experimental-stateful-memory",
+            (
+                "官方 MCP 仍标为 experimental，并要求 FalkorDB 或 Neo4j 以及 LLM、Embedding。",
+                "add_episode、删除和 clear_graph 不属于只读数据库能力，转入第 5B 状态化记忆计划。",
+            ),
+        ),
+        "hindsight-mcp": (
+            "critical",
+            "0.8.6-blocked:stateful-memory-runtime",
+            (
+                "Hindsight 是完整记忆服务，包含模型下载、retain、更新、清空和删除等有状态能力。",
+                "转入第 5B 状态化记忆计划；预烘焙模型、租户隔离、持久卷和审批完成前不连接。",
+            ),
+        ),
+    }
+    for project_id, (risk, adapter_version, limitations) in blocked_wave_five.items():
+        manifests[project_id] = CatalogAdapterManifest(
+            project_id=project_id,
+            wave=5,
+            availability="blocked",
+            connection_kind="sandboxed-stdio",
+            risk=risk,
+            required_capabilities=(
+                "maintained-upstream-contract",
+                "tenant-isolated-state",
+                "native-read-only-mode",
+            ),
+            limitations=limitations,
+            adapter_version=adapter_version,
+            network_policy="blocked:no-production-runtime",
+            filesystem_policy="blocked:no-runtime",
+        )
+
     manifests["snyk-mcp"] = CatalogAdapterManifest(
         project_id="snyk-mcp",
         wave=4,
@@ -1120,6 +1499,7 @@ class CatalogWorkspaceCreateRequest(BaseModel):
 @dataclass(slots=True)
 class CatalogApproval:
     approval_id: str
+    tenant_id: str
     project_id: str
     session_id: str
     workspace_id: str
@@ -1139,9 +1519,18 @@ class MCPCatalogService:
         "command",
         "server_command",
         "url",
+        "uri",
         "endpoint",
+        "dsn",
+        "connection_string",
+        "connection_uri",
         "headers",
         "environment",
+        "password",
+        "token",
+        "api_key",
+        "certificate_path",
+        "ssl_cert",
         "cwd",
         "working_directory",
     }
@@ -1160,6 +1549,7 @@ class MCPCatalogService:
         credential_revoker: Callable[[str], Any] | None = None,
         workspace_store: MCPCatalogWorkspaceStore | None = None,
         tenant_id: str = "local",
+        owner_id: str = "local",
     ) -> None:
         self.manager = manager
         self.installer = installer
@@ -1172,12 +1562,45 @@ class MCPCatalogService:
         self.credential_revoker = credential_revoker
         self.workspace_store = workspace_store
         self.tenant_id = str(tenant_id or "local")
-        self._sessions: dict[str, str] = {}
-        self._configurations: dict[str, CatalogConfigurationRequest] = {}
-        self._credential_snapshots: dict[str, dict[str, tuple[str, float]]] = {}
-        self._credential_verification: dict[str, str] = {}
-        self._approvals: dict[str, CatalogApproval] = {}
+        self.owner_id = str(owner_id or "local")
+        self._sessions: dict[tuple[str, str], str] = {}
+        self._configurations: dict[
+            tuple[str, str], CatalogConfigurationRequest
+        ] = {}
+        self._credential_snapshots: dict[
+            tuple[str, str], dict[str, tuple[str, float]]
+        ] = {}
+        self._credential_verification: dict[tuple[str, str], str] = {}
+        self._preflight_status: dict[tuple[str, str], str] = {}
+        self._approvals: dict[tuple[str, str], CatalogApproval] = {}
         self._lock = asyncio.Lock()
+
+    def _scope_key(self, project_id: str) -> tuple[str, str]:
+        return (self.tenant_id, str(project_id or "").strip())
+
+    def _approval_key(self, approval_id: str) -> tuple[str, str]:
+        return (self.tenant_id, str(approval_id or "").strip())
+
+    def _credential_call(
+        self,
+        callback: Callable[..., Any],
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        """Call tenant-aware vaults while keeping old injected test doubles valid."""
+
+        scoped = {"tenant_id": self.tenant_id, "owner_id": self.owner_id, **kwargs}
+        try:
+            parameters = inspect.signature(callback).parameters
+        except (TypeError, ValueError):
+            parameters = {}
+        accepts_keywords = any(
+            parameter.kind is inspect.Parameter.VAR_KEYWORD
+            for parameter in parameters.values()
+        )
+        if accepts_keywords or "tenant_id" in parameters or "owner_id" in parameters:
+            return callback(*args, **scoped)
+        return callback(*args, **kwargs)
 
     def get_manifest(self, project_id: str) -> CatalogAdapterManifest:
         manifest = self.manifests.get(str(project_id or "").strip())
@@ -1190,11 +1613,12 @@ class MCPCatalogService:
     def list_adapters(self) -> dict[str, Any]:
         adapters: list[dict[str, Any]] = []
         for project_id, manifest in sorted(self.manifests.items()):
+            scope_key = self._scope_key(project_id)
             item = manifest.to_public(
-                connected=project_id in self._sessions,
-                session_id=self._sessions.get(project_id),
+                connected=scope_key in self._sessions,
+                session_id=self._sessions.get(scope_key),
             )
-            configuration = self._configurations.get(project_id)
+            configuration = self._configurations.get(scope_key)
             item["configured"] = configuration is not None
             item["configured_settings"] = (
                 sorted(configuration.settings) if configuration else []
@@ -1208,13 +1632,31 @@ class MCPCatalogService:
             item["credential_bindings"] = (
                 dict(configuration.credential_bindings) if configuration else {}
             )
+            item["workspace_id"] = (
+                configuration.workspace_id if configuration else None
+            )
             if not manifest.credential_policies:
                 item["credential_verification"] = "not-required"
             elif configuration is None:
                 item["credential_verification"] = "missing"
             else:
                 item["credential_verification"] = self._credential_verification.get(
-                    project_id,
+                    scope_key,
+                    "unverified",
+                )
+            if manifest.database_policy is None:
+                item["preflight_status"] = "not-applicable"
+            elif manifest.availability == "blocked":
+                item["preflight_status"] = "blocked"
+            elif configuration is None:
+                item["preflight_status"] = (
+                    "awaiting-workspace"
+                    if manifest.workspace_policy is not None
+                    else "awaiting-configuration"
+                )
+            else:
+                item["preflight_status"] = self._preflight_status.get(
+                    scope_key,
                     "unverified",
                 )
             adapters.append(item)
@@ -1286,14 +1728,17 @@ class MCPCatalogService:
                 "该 MCP 仍处于待适配状态，当前不能提交配置。"
             )
 
-        if manifest.credential_policies and manifest.project_id in self._sessions:
+        scope_key = self._scope_key(manifest.project_id)
+        if (
+            manifest.credential_policies or manifest.database_policy is not None
+        ) and scope_key in self._sessions:
             raise CatalogAdapterPolicyError("请先断开当前会话，再更新目录配置。")
 
         supplied_setting_keys = set(request.settings)
         supplied_credential_slots = set(request.credential_bindings)
         if {key.lower() for key in supplied_setting_keys} & self._RESERVED_CONFIGURATION_KEYS:
             raise CatalogAdapterPolicyError(
-                "目录配置不能包含命令、URL、Header、环境变量或工作目录。"
+                "目录配置不能包含命令、DSN、URL、Header、原始密钥、证书路径、环境变量或工作目录。"
             )
         unknown_settings = supplied_setting_keys - set(manifest.allowed_settings)
         unknown_slots = supplied_credential_slots - set(manifest.credential_slots)
@@ -1331,7 +1776,10 @@ class MCPCatalogService:
             if self.credential_validator is None:
                 raise CatalogAdapterPolicyError("目录凭据存储当前不可用。")
             try:
-                credential = self.credential_validator(credential_id)
+                credential = self._credential_call(
+                    self.credential_validator,
+                    credential_id,
+                )
             except Exception as exc:
                 raise CatalogAdapterPolicyError(
                     f"凭据绑定不存在或不可用：{credential_id}"
@@ -1373,10 +1821,12 @@ class MCPCatalogService:
 
         normalized = request.model_copy(deep=True)
         normalized.settings = normalized_settings
-        self._configurations[manifest.project_id] = normalized
-        self._credential_snapshots.pop(manifest.project_id, None)
+        self._configurations[scope_key] = normalized
+        self._credential_snapshots.pop(scope_key, None)
         if manifest.credential_policies:
-            self._credential_verification[manifest.project_id] = "unverified"
+            self._credential_verification[scope_key] = "unverified"
+        if manifest.database_policy is not None:
+            self._preflight_status[scope_key] = "unverified"
         self._revoke_approvals(manifest.project_id)
         return {
             "project_id": manifest.project_id,
@@ -1388,16 +1838,17 @@ class MCPCatalogService:
 
     async def connect(self, project_id: str) -> dict[str, Any]:
         manifest = self._require_executable(project_id)
+        scope_key = self._scope_key(manifest.project_id)
         started_at = time.monotonic()
         async with self._lock:
-            existing = self._sessions.get(manifest.project_id)
+            existing = self._sessions.get(scope_key)
             if existing:
                 try:
                     await self._ensure_credentials_fresh(manifest.project_id)
                     tools = await self.manager.list_tools(existing)
                     return self._connection_payload(manifest, existing, tools)
                 except MCPSessionNotFoundError:
-                    self._sessions.pop(manifest.project_id, None)
+                    self._sessions.pop(scope_key, None)
 
             if manifest.transport != "stdio" or not manifest.server_command:
                 raise CatalogAdapterUnavailableError(
@@ -1405,8 +1856,9 @@ class MCPCatalogService:
                 )
             if manifest.connection_kind == "sandboxed-stdio":
                 environment: dict[str, str] = {}
+                configuration = self._configurations.get(scope_key)
+                workspace_id = ""
                 if manifest.workspace_policy is not None:
-                    configuration = self._configurations.get(manifest.project_id)
                     workspace_id = str(
                         configuration.workspace_id if configuration else ""
                     ).strip()
@@ -1422,22 +1874,27 @@ class MCPCatalogService:
                         )
                     except CatalogWorkspaceError as exc:
                         raise CatalogAdapterPolicyError(str(exc)) from exc
-                    environment["MCP_FILE_WORKSPACE_ID"] = workspace_id
+                    if manifest.database_policy is None:
+                        environment["MCP_FILE_WORKSPACE_ID"] = workspace_id
+                if manifest.database_policy is not None and configuration is None:
+                    raise CatalogAdapterPolicyError("请先保存受控数据库配置。")
+                secrets: dict[str, str] = {}
+                snapshots: dict[str, tuple[str, float]] = {}
                 if manifest.credential_policies:
-                    configuration = self._configurations.get(manifest.project_id)
                     if configuration is None:
                         raise CatalogAdapterPolicyError("请先绑定所需凭据并保存配置。")
                     if self.credential_resolver is None or self.credential_validator is None:
                         raise CatalogAdapterPolicyError("目录凭据存储当前不可用。")
-                    secrets: dict[str, str] = {}
-                    snapshots: dict[str, tuple[str, float]] = {}
                     for policy in manifest.credential_policies:
                         credential_id = configuration.credential_bindings.get(policy.key, "")
                         if not credential_id:
                             if policy.required:
                                 raise CatalogAdapterPolicyError(f"缺少凭据绑定：{policy.key}")
                             continue
-                        public = self.credential_validator(credential_id)
+                        public = self._credential_call(
+                            self.credential_validator,
+                            credential_id,
+                        )
                         if getattr(public, "status", "") != "active":
                             raise CatalogAdapterPolicyError("绑定凭据已撤销或不可用，请重新配置。")
                         if (
@@ -1447,39 +1904,59 @@ class MCPCatalogService:
                             raise CatalogAdapterPolicyError(
                                 "绑定凭据不属于当前目录项目或固定槽位。"
                             )
-                        secrets[policy.key] = self.credential_resolver(credential_id)
+                        secrets[policy.key] = self._credential_call(
+                            self.credential_resolver,
+                            credential_id,
+                        )
                         snapshots[policy.key] = (
                             credential_id,
                             float(getattr(public, "updated_at", 0.0)),
                         )
-                    token_payload = json.dumps(
-                        {
-                            "settings": configuration.settings,
-                            "credentials": secrets,
-                        },
+                if manifest.credential_policies or manifest.database_policy is not None:
+                    assert configuration is not None
+                    handshake_configuration: dict[str, Any] = {
+                        "settings": configuration.settings,
+                        "credentials": secrets,
+                    }
+                    if manifest.database_policy is not None:
+                        handshake_configuration["workspace_id"] = workspace_id or None
+                    handshake_payload = json.dumps(
+                        handshake_configuration,
                         ensure_ascii=False,
                         separators=(",", ":"),
                     ).encode("utf-8")
-                    if len(token_payload) > 64 * 1024:
+                    if len(handshake_payload) > 64 * 1024:
                         raise CatalogAdapterPolicyError("目录凭据配置超过内部传输上限。")
-                    environment["MCP_TOKEN_HANDSHAKE_B64"] = base64.urlsafe_b64encode(
-                        token_payload
+                    handshake_name = (
+                        "MCP_DATABASE_HANDSHAKE_B64"
+                        if manifest.database_policy is not None
+                        else "MCP_TOKEN_HANDSHAKE_B64"
+                    )
+                    environment[handshake_name] = base64.urlsafe_b64encode(
+                        handshake_payload
                     ).decode("ascii")
                 profile: dict[str, Any] = {
                     "transport": "stdio",
                     "server_command": list(manifest.server_command),
                     "network_policy": manifest.network_policy,
-                    "reconnect_attempts": 0 if manifest.credential_policies else 1,
+                    "reconnect_attempts": (
+                        0
+                        if manifest.credential_policies
+                        or manifest.database_policy is not None
+                        else 1
+                    ),
                     "operation_timeout": manifest.operation_timeout,
                 }
                 if environment:
                     profile["environment"] = environment
                 session_id = await self.manager.connect_profile(**profile)
-                if manifest.credential_policies:
+                if manifest.credential_policies or manifest.database_policy is not None:
                     await self.manager.scrub_session_environment(session_id)
             else:
                 session_id = await self.manager.connect(list(manifest.server_command))
             try:
+                if manifest.database_policy is not None:
+                    self._preflight_status[scope_key] = "verifying"
                 tools = await self.manager.list_tools(session_id)
                 if manifest.legacy_unrestricted_calls:
                     await self.registry.register_session_tools(
@@ -1488,11 +1965,19 @@ class MCPCatalogService:
                         tools=tools,
                     )
             except Exception:
+                if manifest.database_policy is not None:
+                    self._preflight_status[scope_key] = "failed"
                 await self.manager.disconnect(session_id)
                 raise
-            self._sessions[manifest.project_id] = session_id
+            self._sessions[scope_key] = session_id
             if manifest.credential_policies:
-                self._credential_snapshots[manifest.project_id] = snapshots
+                self._credential_snapshots[scope_key] = snapshots
+            if manifest.database_policy is not None:
+                self._preflight_status[scope_key] = "verified"
+                if manifest.credential_policies:
+                    # Database children complete a real authenticated read-only
+                    # preflight before MCP initialization succeeds.
+                    self._credential_verification[scope_key] = "verified"
             payload = self._connection_payload(manifest, session_id, tools)
             logger.info(
                 "MCP catalog connect project=%s tools=%d duration_ms=%d",
@@ -1504,9 +1989,12 @@ class MCPCatalogService:
 
     async def disconnect(self, project_id: str) -> dict[str, Any]:
         manifest = self.get_manifest(project_id)
+        scope_key = self._scope_key(manifest.project_id)
         async with self._lock:
-            session_id = self._sessions.pop(manifest.project_id, None)
-            self._credential_snapshots.pop(manifest.project_id, None)
+            session_id = self._sessions.pop(scope_key, None)
+            self._credential_snapshots.pop(scope_key, None)
+            if manifest.database_policy is not None:
+                self._preflight_status[scope_key] = "unverified"
         if session_id is None:
             raise MCPSessionNotFoundError(
                 f"MCP catalog session not found: {manifest.project_id}"
@@ -1526,7 +2014,8 @@ class MCPCatalogService:
         arguments: dict[str, Any],
     ) -> dict[str, Any]:
         manifest = self._require_executable(project_id)
-        session_id = self._sessions.get(manifest.project_id)
+        scope_key = self._scope_key(manifest.project_id)
+        session_id = self._sessions.get(scope_key)
         if session_id is None:
             raise CatalogAdapterUnavailableError("请先连接该 MCP 适配器。")
         await self._ensure_credentials_fresh(manifest.project_id)
@@ -1536,6 +2025,10 @@ class MCPCatalogService:
             if policy is None:
                 raise CatalogAdapterPolicyError(
                     "该工具尚未完成显式读写与审批策略分类。"
+                )
+            if manifest.database_policy is not None and not policy.read_only:
+                raise CatalogAdapterPolicyError(
+                    "第 5 批数据库适配器仅允许已审计的只读工具。"
                 )
             if policy.sensitive or policy.terminal or policy.effect == "terminal":
                 raise CatalogAdapterPolicyError(
@@ -1564,11 +2057,17 @@ class MCPCatalogService:
         approval_id: str,
     ) -> dict[str, Any]:
         manifest = self._require_executable(project_id)
-        approval = self._approvals.get(str(approval_id or ""))
-        if approval is None or approval.project_id != manifest.project_id:
+        scope_key = self._scope_key(manifest.project_id)
+        approval_key = self._approval_key(approval_id)
+        approval = self._approvals.get(approval_key)
+        if (
+            approval is None
+            or approval.tenant_id != self.tenant_id
+            or approval.project_id != manifest.project_id
+        ):
             raise CatalogAdapterPolicyError("一次性确认不存在或已经失效。")
         if approval.used or approval.expires_at <= time.time():
-            self._approvals.pop(approval.approval_id, None)
+            self._approvals.pop(approval_key, None)
             raise CatalogAdapterPolicyError("一次性确认已经使用或过期。")
         if self.workspace_store is None:
             raise CatalogAdapterPolicyError("MCP 文件工作区当前不可用。")
@@ -1580,18 +2079,18 @@ class MCPCatalogService:
         if workspace.manifest_sha256 != approval.workspace_manifest_sha256:
             raise CatalogAdapterPolicyError("工作区内容已经变化，请重新发起操作。")
         approval.used = True
-        self._approvals.pop(approval.approval_id, None)
+        self._approvals.pop(approval_key, None)
         if approval.tool_name == "__delete_workspace__":
-            if manifest.project_id in self._sessions:
+            if scope_key in self._sessions:
                 await self.disconnect(manifest.project_id)
             self.workspace_store.delete(
                 manifest.project_id,
                 approval.workspace_id,
                 tenant_id=self.tenant_id,
             )
-            self._configurations.pop(manifest.project_id, None)
+            self._configurations.pop(scope_key, None)
             return {"ok": True, "project_id": manifest.project_id, "workspace_id": approval.workspace_id}
-        session_id = self._sessions.get(manifest.project_id)
+        session_id = self._sessions.get(scope_key)
         if not session_id or session_id != approval.session_id:
             raise CatalogAdapterPolicyError("MCP 会话已经变化，请重新发起操作。")
         return await self._execute_tool(
@@ -1602,10 +2101,15 @@ class MCPCatalogService:
         )
 
     def cancel_approval(self, project_id: str, approval_id: str) -> dict[str, Any]:
-        approval = self._approvals.get(str(approval_id or ""))
-        if approval is None or approval.project_id != project_id:
+        approval_key = self._approval_key(approval_id)
+        approval = self._approvals.get(approval_key)
+        if (
+            approval is None
+            or approval.tenant_id != self.tenant_id
+            or approval.project_id != project_id
+        ):
             raise CatalogAdapterPolicyError("一次性确认不存在或已经失效。")
-        self._approvals.pop(approval.approval_id, None)
+        self._approvals.pop(approval_key, None)
         return {"ok": True, "approval_id": approval.approval_id}
 
     async def _execute_tool(
@@ -1617,12 +2121,15 @@ class MCPCatalogService:
         arguments: dict[str, Any],
     ) -> dict[str, Any]:
 
+        scope_key = self._scope_key(manifest.project_id)
         started_at = time.monotonic()
         try:
             result = await self.manager.call_tool(session_id, tool_name, arguments)
         except Exception:
             if manifest.credential_policies:
-                self._credential_verification[manifest.project_id] = "verification-failed"
+                self._credential_verification[scope_key] = "verification-failed"
+            if manifest.database_policy is not None:
+                self._preflight_status[scope_key] = "failed"
             raise
         logger.info(
             "MCP catalog call project=%s tool=%s duration_ms=%d",
@@ -1635,10 +2142,14 @@ class MCPCatalogService:
             max_output_bytes=manifest.max_output_bytes,
         )
         if manifest.credential_policies:
-            self._credential_verification[manifest.project_id] = (
+            self._credential_verification[scope_key] = (
                 "verification-failed" if payload["is_error"] else "verified"
             )
-        configuration = self._configurations.get(manifest.project_id)
+        if manifest.database_policy is not None:
+            self._preflight_status[scope_key] = (
+                "failed" if payload["is_error"] else "verified"
+            )
+        configuration = self._configurations.get(scope_key)
         if (
             self.workspace_store is not None
             and configuration is not None
@@ -1670,7 +2181,9 @@ class MCPCatalogService:
         arguments: dict[str, Any],
         workspace_id: str | None = None,
     ) -> dict[str, Any]:
-        configuration = self._configurations.get(manifest.project_id)
+        configuration = self._configurations.get(
+            self._scope_key(manifest.project_id)
+        )
         bound_workspace_id = str(
             workspace_id or (configuration.workspace_id if configuration else "") or ""
         )
@@ -1690,6 +2203,7 @@ class MCPCatalogService:
         digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
         approval = CatalogApproval(
             approval_id=f"mcpauth_{uuid.uuid4().hex}",
+            tenant_id=self.tenant_id,
             project_id=manifest.project_id,
             session_id=session_id,
             workspace_id=bound_workspace_id,
@@ -1700,7 +2214,7 @@ class MCPCatalogService:
             summary=self._approval_summary(tool_name, arguments, workspace.display_name),
             expires_at=time.time() + 300,
         )
-        self._approvals[approval.approval_id] = approval
+        self._approvals[self._approval_key(approval.approval_id)] = approval
         return {
             "code": "approval_required",
             "message": "该操作会写入持久记忆或生成新的表格产物，请确认后执行。",
@@ -1732,9 +2246,12 @@ class MCPCatalogService:
         return f"在工作区“{workspace_name}”执行 {tool_name}：{detail}。"
 
     def _revoke_approvals(self, project_id: str) -> None:
-        for approval_id, approval in list(self._approvals.items()):
-            if approval.project_id == project_id:
-                self._approvals.pop(approval_id, None)
+        for approval_key, approval in list(self._approvals.items()):
+            if (
+                approval.tenant_id == self.tenant_id
+                and approval.project_id == project_id
+            ):
+                self._approvals.pop(approval_key, None)
 
     def list_workspaces(self, project_id: str) -> dict[str, Any]:
         manifest = self._require_file_workspace(project_id)
@@ -1816,20 +2333,22 @@ class MCPCatalogService:
             workspace_id,
             tenant_id=self.tenant_id,
         )
+        scope_key = self._scope_key(manifest.project_id)
         if item.persistent:
             raise CatalogApprovalRequiredError(
                 self._create_approval(
                     manifest,
-                    session_id=self._sessions.get(manifest.project_id, "workspace-management"),
+                    session_id=self._sessions.get(scope_key, "workspace-management"),
                     tool_name="__delete_workspace__",
                     arguments={"workspace_id": workspace_id},
                     workspace_id=workspace_id,
                 )
             )
-        if self._configurations.get(manifest.project_id, CatalogConfigurationRequest()).workspace_id == workspace_id:
-            if manifest.project_id in self._sessions:
+        if self._configurations.get(scope_key, CatalogConfigurationRequest()).workspace_id == workspace_id:
+            if scope_key in self._sessions:
                 await self.disconnect(manifest.project_id)
-            self._configurations.pop(manifest.project_id, None)
+            self._configurations.pop(scope_key, None)
+            self._preflight_status.pop(scope_key, None)
         self.workspace_store.delete(
             manifest.project_id,
             workspace_id,
@@ -1864,16 +2383,22 @@ class MCPCatalogService:
 
     async def clear_sessions(self) -> None:
         async with self._lock:
-            sessions = list(self._sessions.values())
-            self._sessions.clear()
-            self._credential_snapshots.clear()
+            tenant_keys = [
+                key for key in self._sessions if key[0] == self.tenant_id
+            ]
+            sessions = [self._sessions.pop(key) for key in tenant_keys]
+            for key in tenant_keys:
+                self._credential_snapshots.pop(key, None)
+                self._preflight_status.pop(key, None)
         for session_id in sessions:
             try:
                 await self.manager.disconnect(session_id)
             except Exception:
                 pass
             await self.registry.unregister_session(session_id)
-        self._approvals.clear()
+        for approval_key in list(self._approvals):
+            if approval_key[0] == self.tenant_id:
+                self._approvals.pop(approval_key, None)
 
     def list_credentials(self, project_id: str) -> dict[str, Any]:
         manifest = self._require_credential_adapter(project_id)
@@ -1881,7 +2406,7 @@ class MCPCatalogService:
             raise CatalogAdapterUnavailableError("目录凭据存储当前不可用。")
         credentials = [
             self._public_credential(item)
-            for item in self.credential_lister()
+            for item in self._credential_call(self.credential_lister)
             if getattr(item, "catalog_project_id", "") == manifest.project_id
         ]
         return {
@@ -1901,7 +2426,8 @@ class MCPCatalogService:
             raise CatalogAdapterPolicyError("凭据槽不属于当前目录项目。")
         if self.credential_creator is None:
             raise CatalogAdapterUnavailableError("目录凭据存储当前不可用。")
-        record, _ = self.credential_creator(
+        record, _ = self._credential_call(
+            self.credential_creator,
             name=request.name,
             value=request.value,
             kind="provider_key",
@@ -1924,7 +2450,10 @@ class MCPCatalogService:
         if self.credential_validator is None or self.credential_revoker is None:
             raise CatalogAdapterUnavailableError("目录凭据存储当前不可用。")
         try:
-            public = self.credential_validator(credential_id)
+            public = self._credential_call(
+                self.credential_validator,
+                credential_id,
+            )
         except Exception as exc:
             raise CatalogAdapterPolicyError("目录凭据不存在或不可用。") from exc
         if getattr(public, "catalog_project_id", "") != manifest.project_id:
@@ -1932,14 +2461,16 @@ class MCPCatalogService:
         slot = str(getattr(public, "catalog_slot", ""))
         if slot not in manifest.credential_slots:
             raise CatalogAdapterPolicyError("凭据槽不属于当前目录项目。")
-        revoked = self.credential_revoker(credential_id)
-        configuration = self._configurations.get(manifest.project_id)
+        revoked = self._credential_call(self.credential_revoker, credential_id)
+        scope_key = self._scope_key(manifest.project_id)
+        configuration = self._configurations.get(scope_key)
         if configuration and credential_id in configuration.credential_bindings.values():
-            if manifest.project_id in self._sessions:
+            if scope_key in self._sessions:
                 await self.disconnect(manifest.project_id)
-            self._configurations.pop(manifest.project_id, None)
-            self._credential_snapshots.pop(manifest.project_id, None)
-            self._credential_verification[manifest.project_id] = "missing"
+            self._configurations.pop(scope_key, None)
+            self._credential_snapshots.pop(scope_key, None)
+            self._credential_verification[scope_key] = "missing"
+            self._preflight_status[scope_key] = "unverified"
         logger.info(
             "MCP catalog credential revoked project=%s slot=%s",
             manifest.project_id,
@@ -1954,10 +2485,13 @@ class MCPCatalogService:
         if not cleaned:
             return
         async with self._lock:
-            for project_id, session_id in list(self._sessions.items()):
+            for scope_key, session_id in list(self._sessions.items()):
+                if scope_key[0] != self.tenant_id:
+                    continue
                 if session_id in cleaned:
-                    self._sessions.pop(project_id, None)
-                    self._credential_snapshots.pop(project_id, None)
+                    self._sessions.pop(scope_key, None)
+                    self._credential_snapshots.pop(scope_key, None)
+                    self._preflight_status[scope_key] = "unverified"
 
     @staticmethod
     def _validate_setting(
@@ -2018,7 +2552,8 @@ class MCPCatalogService:
         return clean
 
     async def _ensure_credentials_fresh(self, project_id: str) -> None:
-        snapshots = self._credential_snapshots.get(project_id)
+        scope_key = self._scope_key(project_id)
+        snapshots = self._credential_snapshots.get(scope_key)
         if not snapshots:
             return
         stale = False
@@ -2027,7 +2562,10 @@ class MCPCatalogService:
         else:
             for credential_id, expected_updated_at in snapshots.values():
                 try:
-                    public = self.credential_validator(credential_id)
+                    public = self._credential_call(
+                        self.credential_validator,
+                        credential_id,
+                    )
                     stale = (
                         getattr(public, "status", "") != "active"
                         or float(getattr(public, "updated_at", 0.0))
@@ -2039,9 +2577,10 @@ class MCPCatalogService:
                     break
         if not stale:
             return
-        session_id = self._sessions.pop(project_id, None)
-        self._credential_snapshots.pop(project_id, None)
-        self._credential_verification[project_id] = "unverified"
+        session_id = self._sessions.pop(scope_key, None)
+        self._credential_snapshots.pop(scope_key, None)
+        self._credential_verification[scope_key] = "unverified"
+        self._preflight_status[scope_key] = "unverified"
         self._revoke_approvals(project_id)
         if session_id is not None:
             try:
@@ -2070,9 +2609,11 @@ class MCPCatalogService:
         """Return the catalog owner so generic call routes can fail closed."""
 
         clean = str(session_id or "")
-        for project_id, active_session_id in self._sessions.items():
+        for scope_key, active_session_id in self._sessions.items():
+            if scope_key[0] != self.tenant_id:
+                continue
             if active_session_id == clean:
-                return project_id
+                return scope_key[1]
         return None
 
     def _connection_payload(
@@ -2086,9 +2627,20 @@ class MCPCatalogService:
             "session_id": session_id,
             "tools_count": len(tools),
             "credential_verification": (
-                self._credential_verification.get(manifest.project_id, "unverified")
+                self._credential_verification.get(
+                    self._scope_key(manifest.project_id),
+                    "unverified",
+                )
                 if manifest.credential_policies
                 else "not-required"
+            ),
+            "preflight_status": (
+                self._preflight_status.get(
+                    self._scope_key(manifest.project_id),
+                    "unverified",
+                )
+                if manifest.database_policy is not None
+                else "not-applicable"
             ),
         }
 

--- a/server/mcp/database_proxy.py
+++ b/server/mcp/database_proxy.py
@@ -1,0 +1,143 @@
+"""Credential-aware stdio proxy for fixed Wave 5 database adapters.
+
+The API process supplies one short-lived, base64 encoded configuration through
+the child environment.  The proxy removes it before opening the private Unix
+socket and never accepts commands, connection strings, endpoints or environment
+variable names from a catalog client.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import socket
+import sys
+import threading
+from pathlib import Path
+
+
+ALLOWED_ADAPTERS = {
+    "dbhub",
+    "mongodb-mcp",
+    "clickhouse-mcp",
+    "redis-mcp",
+    "duckdb-mcp",
+    "supabase-mcp",
+}
+REMOTE_SOCKET_PATH = Path(
+    os.getenv(
+        "MCP_DATABASE_SOCKET_PATH",
+        "/run/modelmirror-database-mcp/database-mcp.sock",
+    )
+)
+LOCAL_SOCKET_PATH = Path(
+    os.getenv(
+        "MCP_DATABASE_LOCAL_SOCKET_PATH",
+        "/run/modelmirror-database-local-mcp/database-mcp.sock",
+    )
+)
+HANDSHAKE_LIMIT = 4096
+CONFIGURATION_LIMIT = 64 * 1024
+
+
+def _copy_stdin(sock: socket.socket) -> None:
+    try:
+        while True:
+            chunk = os.read(sys.stdin.fileno(), 64 * 1024)
+            if not chunk:
+                break
+            sock.sendall(chunk)
+    except (BrokenPipeError, ConnectionError, OSError):
+        pass
+    finally:
+        try:
+            sock.shutdown(socket.SHUT_WR)
+        except OSError:
+            pass
+
+
+def _load_configuration() -> dict[str, object]:
+    encoded = os.environ.pop("MCP_DATABASE_HANDSHAKE_B64", "")
+    if not encoded or len(encoded) > CONFIGURATION_LIMIT * 2:
+        raise ValueError("missing_database_configuration")
+    raw = base64.urlsafe_b64decode(encoded.encode("ascii"))
+    if len(raw) > CONFIGURATION_LIMIT:
+        raise ValueError("database_configuration_too_large")
+    payload = json.loads(raw.decode("utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("invalid_database_configuration")
+    if not isinstance(payload.get("settings"), dict):
+        raise ValueError("invalid_database_settings")
+    if not isinstance(payload.get("credentials"), dict):
+        raise ValueError("invalid_database_credentials")
+    workspace_id = payload.get("workspace_id")
+    if workspace_id is not None and not isinstance(workspace_id, str):
+        raise ValueError("invalid_database_workspace")
+    return payload
+
+
+def run(adapter_id: str) -> int:
+    if adapter_id not in ALLOWED_ADAPTERS:
+        print("MCP database adapter is not allowed.", file=sys.stderr)
+        return 64
+    socket_path = LOCAL_SOCKET_PATH if adapter_id == "duckdb-mcp" else REMOTE_SOCKET_PATH
+    if not socket_path.is_absolute():
+        print("MCP database socket path must be absolute.", file=sys.stderr)
+        return 78
+    try:
+        configuration = _load_configuration()
+    except (ValueError, UnicodeError, json.JSONDecodeError):
+        print("MCP database configuration is missing or invalid.", file=sys.stderr)
+        return 78
+
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        sock.settimeout(10)
+        sock.connect(str(socket_path))
+        request = json.dumps(
+            {
+                "action": "mcp_stdio",
+                "adapter_id": adapter_id,
+                "configuration": configuration,
+            },
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        configuration = {}
+        sock.sendall(request + b"\n")
+        raw = sock.makefile("rb", buffering=0).readline(HANDSHAKE_LIMIT + 1)
+        if not raw or len(raw) > HANDSHAKE_LIMIT:
+            print("MCP database sidecar handshake failed.", file=sys.stderr)
+            return 69
+        response = json.loads(raw.decode("utf-8"))
+        if not isinstance(response, dict) or response.get("ok") is not True:
+            code = str(response.get("code") or "database_sidecar_unavailable")
+            print(f"MCP database sidecar rejected the session: {code}", file=sys.stderr)
+            return 69
+        sock.settimeout(None)
+        input_thread = threading.Thread(target=_copy_stdin, args=(sock,), daemon=True)
+        input_thread.start()
+        while True:
+            chunk = sock.recv(64 * 1024)
+            if not chunk:
+                break
+            sys.stdout.buffer.write(chunk)
+            sys.stdout.buffer.flush()
+        return 0
+    except (ConnectionError, OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"MCP database proxy unavailable: {type(exc).__name__}", file=sys.stderr)
+        return 69
+    finally:
+        sock.close()
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: database_proxy.py ADAPTER_ID", file=sys.stderr)
+        return 64
+    return run(sys.argv[1].strip())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/server/mcp/smoke_database_adapters.py
+++ b/server/mcp/smoke_database_adapters.py
@@ -1,0 +1,559 @@
+"""Offline contract and policy smoke for Wave-5 database adapters.
+
+This harness deliberately needs no database credentials or reachable database.
+Live adapter smoke is performed separately against disposable containers; this
+file guards the fixed tool surface and the fail-closed input policy first.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import json
+import os
+import socket
+import tempfile
+from pathlib import Path
+
+try:
+    from server.sandbox_sidecar.database_contracts import (
+        DATABASE_ADAPTERS,
+        bounded_rows,
+        install_pinned_getaddrinfo,
+        resolve_allowed_addresses,
+        validate_configuration,
+        validate_document,
+        validate_readonly_sql,
+    )
+except ModuleNotFoundError as error:
+    if error.name != "server":
+        raise
+    from sandbox_sidecar.database_contracts import (
+        DATABASE_ADAPTERS,
+        bounded_rows,
+        install_pinned_getaddrinfo,
+        resolve_allowed_addresses,
+        validate_configuration,
+        validate_document,
+        validate_readonly_sql,
+    )
+
+
+EXPECTED_TOOLS = {
+    "dbhub": {"list_schemas", "list_tables", "describe_table", "execute_sql"},
+    "mongodb-mcp": {
+        "list_collections",
+        "collection_schema",
+        "collection_indexes",
+        "find",
+        "aggregate",
+        "count_documents",
+    },
+    "clickhouse-mcp": {"list_databases", "list_tables", "run_query"},
+    "redis-mcp": {
+        "scan_keys",
+        "get_value",
+        "get_type",
+        "get_ttl",
+        "hash_get_all",
+        "list_range",
+        "set_members",
+        "sorted_set_range",
+    },
+    "duckdb-mcp": {"list_schemas", "list_tables", "describe_table", "query"},
+    "supabase-mcp": {"list_tables", "list_extensions", "execute_sql"},
+}
+
+EXPECTED_SCHEMA_SHA256 = {
+    "dbhub": "ea513fa4c4e822da4f057d1a598f7cbb959c7cbbfc074c459d4b11c641828c05",
+    "mongodb-mcp": "131babe9cc1bce134d5a03bea187879190a0e3174d11a649fd00d4e3e2ba5f22",
+    "clickhouse-mcp": "dcc776fb7a9f04f0ee74edffe03df72411f009e5ae5404eb00cb73d17fd1a4b2",
+    "redis-mcp": "c92964bae88277fbd6b007afcacd42813db5f98ac44efe82389613870fb89b9f",
+    "duckdb-mcp": "bcbc5ab6f79efe935694536b71e6558c7dce1e06a594ddb654c1b1b06bb13285",
+    "supabase-mcp": "18bb488393b8a255825639a1dbbf4b77e70fca2398f6838210869caca172bbba",
+}
+
+
+VALID_CONFIGURATIONS = {
+    "dbhub": {
+        "settings": {
+            "engine": "postgresql",
+            "host": "db.example.com",
+            "port": 5432,
+            "database": "analytics",
+            "tls_mode": "verify-full",
+            "username": "readonly",
+        },
+        "credentials": {"password": "dummy"},
+    },
+    "mongodb-mcp": {
+        "settings": {
+            "host": "mongo.example.com",
+            "port": 27017,
+            "database": "analytics",
+            "tls_mode": "verify-full",
+            "username": "readonly",
+            "auth_source": "admin",
+        },
+        "credentials": {"password": "dummy"},
+    },
+    "clickhouse-mcp": {
+        "settings": {
+            "host": "clickhouse.example.com",
+            "port": 8443,
+            "database": "analytics",
+            "tls_mode": "verify-full",
+            "username": "readonly",
+        },
+        "credentials": {"password": "dummy"},
+    },
+    "redis-mcp": {
+        "settings": {
+            "host": "redis.example.com",
+            "port": 6380,
+            "database": 0,
+            "tls_mode": "verify-full",
+        },
+        "credentials": {"password": "dummy"},
+    },
+    "duckdb-mcp": {
+        "settings": {},
+        "credentials": {},
+        "workspace_id": "mcpws_0123456789abcdef0123456789abcdef",
+    },
+    "supabase-mcp": {
+        "settings": {"project_ref": "abcdefghijklmnopqrst"},
+        "credentials": {"access_token": "dummy"},
+    },
+}
+
+
+def _must_reject(function: object, *args: object, **kwargs: object) -> None:
+    try:
+        function(*args, **kwargs)  # type: ignore[operator]
+    except ValueError:
+        return
+    raise RuntimeError(f"policy bypass was accepted: {getattr(function, '__name__', function)}")
+
+
+async def _schema_smoke() -> None:
+    try:
+        from server.sandbox_sidecar.database_mcp import BUILDERS
+    except ModuleNotFoundError as error:
+        if error.name != "server":
+            raise
+        from sandbox_sidecar.database_mcp import BUILDERS
+
+    for adapter_id, builder in BUILDERS.items():
+        tools = await builder(None).list_tools()
+        schemas = {tool.name: tool.inputSchema for tool in tools}
+        digest = hashlib.sha256(
+            json.dumps(schemas, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        ).hexdigest()
+        if digest != EXPECTED_SCHEMA_SHA256[adapter_id]:
+            raise RuntimeError(
+                f"inputSchema drift for {adapter_id}: expected "
+                f"{EXPECTED_SCHEMA_SHA256[adapter_id]}, got {digest}"
+            )
+        for tool in tools:
+            annotations = tool.annotations
+            if annotations is None or annotations.readOnlyHint is not True:
+                raise RuntimeError(f"non-read-only annotation for {adapter_id}.{tool.name}")
+            if annotations.destructiveHint is not False or annotations.openWorldHint is not False:
+                raise RuntimeError(f"unsafe annotation drift for {adapter_id}.{tool.name}")
+        if adapter_id == "duckdb-mcp":
+            for tool in tools:
+                marker = (
+                    tool.inputSchema.get("properties", {})
+                    .get("database_file_id", {})
+                    .get("x-modelmirror-input")
+                )
+                if marker != "workspace-file":
+                    raise RuntimeError(f"DuckDB workspace selector drift for {tool.name}")
+
+
+async def _duckdb_adapter_smoke() -> dict[str, object]:
+    try:
+        from server.sandbox_sidecar.database_mcp import (
+            DatabaseContext,
+            _preflight_duckdb,
+            build_duckdb,
+        )
+    except ModuleNotFoundError as error:
+        if error.name != "server":
+            raise
+        from sandbox_sidecar.database_mcp import (
+            DatabaseContext,
+            _preflight_duckdb,
+            build_duckdb,
+        )
+
+    import duckdb
+
+    workspace_id = "mcpws_0123456789abcdef0123456789abcdef"
+    environment_keys = (
+        "MCP_DATABASE_CHILD_CONFIGURATION_B64",
+        "MCP_DATABASE_PINNED_DNS_B64",
+        "MCP_DATABASE_INPUT_ROOT",
+    )
+    previous_environment = {key: os.environ.get(key) for key in environment_keys}
+    original_getaddrinfo = socket.getaddrinfo
+    try:
+        with tempfile.TemporaryDirectory(prefix="modelmirror-duckdb-smoke-") as temporary:
+            input_root = Path(temporary)
+            workspace_root = input_root / workspace_id
+            workspace_root.mkdir()
+            database_path = workspace_root / "reviewed.duckdb"
+            connection = duckdb.connect(str(database_path))
+            try:
+                connection.execute("CREATE TABLE smoke(id INTEGER, label VARCHAR)")
+                connection.execute("INSERT INTO smoke VALUES (1, 'ok'), (2, 'bounded')")
+            finally:
+                connection.close()
+
+            configuration = {
+                "settings": {},
+                "credentials": {},
+                "workspace_id": workspace_id,
+            }
+            os.environ["MCP_DATABASE_CHILD_CONFIGURATION_B64"] = base64.urlsafe_b64encode(
+                json.dumps(configuration, separators=(",", ":")).encode("utf-8")
+            ).decode("ascii")
+            os.environ["MCP_DATABASE_PINNED_DNS_B64"] = base64.urlsafe_b64encode(
+                json.dumps({"host": None, "addresses": []}, separators=(",", ":")).encode(
+                    "utf-8"
+                )
+            ).decode("ascii")
+            os.environ["MCP_DATABASE_INPUT_ROOT"] = str(input_root)
+
+            context = DatabaseContext("duckdb-mcp")
+            _preflight_duckdb(context)
+            database_file_id = next(iter(context._duckdb_files))
+            result = await build_duckdb(context).call_tool(
+                "query",
+                {
+                    "database_file_id": database_file_id,
+                    "query": "SELECT id, label FROM smoke ORDER BY id",
+                    "max_rows": 1,
+                    "timeout_seconds": 15,
+                },
+            )
+            structured = (
+                result[1]
+                if isinstance(result, tuple) and len(result) == 2 and isinstance(result[1], dict)
+                else result
+            )
+            if not isinstance(structured, dict):
+                raise RuntimeError(f"DuckDB tool did not return structured content: {result!r}")
+            if (
+                structured.get("columns") != ["id", "label"]
+                or structured.get("rows") != [{"id": 1, "label": "ok"}]
+                or structured.get("row_count") != 1
+                or structured.get("truncated") is not True
+            ):
+                raise RuntimeError(f"DuckDB actual tool call drift: {result!r}")
+            return structured
+    finally:
+        socket.getaddrinfo = original_getaddrinfo  # type: ignore[assignment]
+        for key, value in previous_environment.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+async def _gateway_redaction_smoke() -> None:
+    try:
+        from server.sandbox_sidecar.database_server import (
+            _child_to_client,
+            _terminate_timed_out_call,
+        )
+    except ModuleNotFoundError as error:
+        if error.name != "server":
+            raise
+        from sandbox_sidecar.database_server import (
+            _child_to_client,
+            _terminate_timed_out_call,
+        )
+
+    class Writer:
+        def __init__(self) -> None:
+            self.output = bytearray()
+
+        def write(self, value: bytes) -> None:
+            self.output.extend(value)
+
+        async def drain(self) -> None:
+            return None
+
+    reader = asyncio.StreamReader()
+    reader.feed_data(
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 7,
+                "error": {
+                    "code": -32603,
+                    "message": "password=secret host=/inputs/private.duckdb",
+                },
+            }
+        ).encode("utf-8")
+        + b"\n"
+    )
+    reader.feed_eof()
+    writer = Writer()
+    await _child_to_client(
+        reader,
+        writer,  # type: ignore[arg-type]
+        "dbhub",
+        set(),
+        {7},
+        {},
+        set(),
+        asyncio.Lock(),
+    )
+    output = writer.output.decode("utf-8")
+    decoded = json.loads(output)
+    if (
+        "secret" in output
+        or "/inputs/" in output
+        or decoded.get("error", {}).get("code") != -32603
+    ):
+        raise RuntimeError("database gateway error redaction failed")
+
+    class Process:
+        def __init__(self) -> None:
+            self.returncode: int | None = None
+            self.killed = False
+
+        def kill(self) -> None:
+            self.killed = True
+            self.returncode = -9
+
+        async def wait(self) -> int:
+            assert self.returncode is not None
+            return self.returncode
+
+    timeout_writer = Writer()
+    process = Process()
+    call_requests: set[object] = {11}
+    deadlines: dict[object, asyncio.Task[None]] = {}
+    suppressed: set[object] = set()
+    timeout_task = asyncio.create_task(
+        _terminate_timed_out_call(
+            11,
+            process,  # type: ignore[arg-type]
+            timeout_writer,  # type: ignore[arg-type]
+            asyncio.Lock(),
+            call_requests,
+            deadlines,
+            suppressed,
+            timeout_seconds=0.001,
+        )
+    )
+    deadlines[11] = timeout_task
+    await timeout_task
+    timeout_payload = json.loads(timeout_writer.output.decode("utf-8"))
+    if (
+        not process.killed
+        or process.returncode != -9
+        or call_requests
+        or 11 not in suppressed
+        or timeout_payload.get("error", {}).get("code") != -32001
+    ):
+        raise RuntimeError("database gateway hard timeout did not terminate the child")
+
+
+def _pinned_dns_smoke() -> None:
+    original = socket.getaddrinfo
+    try:
+        install_pinned_getaddrinfo("db.example.com", ("93.184.216.34",))
+        records = socket.getaddrinfo("db.example.com", 5432, type=socket.SOCK_STREAM)
+        if {record[4][0] for record in records} != {"93.184.216.34"}:
+            raise RuntimeError("pinned DNS did not preserve the reviewed address")
+        try:
+            socket.getaddrinfo("rebound.example.com", 5432, type=socket.SOCK_STREAM)
+        except socket.gaierror:
+            pass
+        else:
+            raise RuntimeError("pinned DNS allowed a different hostname")
+    finally:
+        socket.getaddrinfo = original  # type: ignore[assignment]
+
+
+def _private_dns_smoke() -> None:
+    original_getaddrinfo = socket.getaddrinfo
+    previous_allowlist = os.environ.pop("MCP_DATABASE_PRIVATE_HOST_ALLOWLIST", None)
+    try:
+        socket.getaddrinfo = lambda *args, **kwargs: [  # type: ignore[assignment]
+            (socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", ("10.20.30.40", 5432))
+        ]
+        _must_reject(resolve_allowed_addresses, "db.example.com", 5432)
+
+        os.environ["MCP_DATABASE_PRIVATE_HOST_ALLOWLIST"] = "db.example.com"
+        if resolve_allowed_addresses("db.example.com", 5432) != ("10.20.30.40",):
+            raise RuntimeError("administrator RFC1918 allowlist did not apply exactly")
+
+        for denied_address in (
+            "127.0.0.1",
+            "169.254.169.254",
+            "0.0.0.0",
+            "::1",
+            "fe80::1",
+            "ff02::1",
+        ):
+            family = socket.AF_INET6 if ":" in denied_address else socket.AF_INET
+            socket.getaddrinfo = lambda *args, _address=denied_address, _family=family, **kwargs: [  # type: ignore[assignment]
+                (
+                    _family,
+                    socket.SOCK_STREAM,
+                    socket.IPPROTO_TCP,
+                    "",
+                    (_address, 5432, 0, 0) if _family == socket.AF_INET6 else (_address, 5432),
+                )
+            ]
+            try:
+                resolve_allowed_addresses("db.example.com", 5432)
+            except ValueError:
+                pass
+            else:
+                raise RuntimeError(
+                    f"administrator private allowlist accepted forbidden address: {denied_address}"
+                )
+
+        socket.getaddrinfo = lambda *args, **kwargs: [  # type: ignore[assignment]
+            (socket.AF_INET6, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", ("fd00::123", 5432, 0, 0))
+        ]
+        if resolve_allowed_addresses("db.example.com", 5432) != ("fd00::123",):
+            raise RuntimeError("administrator IPv6 ULA allowlist did not apply exactly")
+    finally:
+        socket.getaddrinfo = original_getaddrinfo  # type: ignore[assignment]
+        if previous_allowlist is not None:
+            os.environ["MCP_DATABASE_PRIVATE_HOST_ALLOWLIST"] = previous_allowlist
+
+
+def main() -> None:
+    if set(DATABASE_ADAPTERS) != set(EXPECTED_TOOLS):
+        raise RuntimeError("Wave-5 database adapter ID drift")
+    for adapter_id, expected in EXPECTED_TOOLS.items():
+        actual = set(DATABASE_ADAPTERS[adapter_id].tools)
+        if actual != expected:
+            raise RuntimeError(f"tool schema drift for {adapter_id}: {sorted(actual)}")
+        validate_configuration(adapter_id, VALID_CONFIGURATIONS[adapter_id])
+
+    sqlserver_configuration = json.loads(json.dumps(VALID_CONFIGURATIONS["dbhub"]))
+    sqlserver_configuration["settings"]["engine"] = "sqlserver"
+    _must_reject(validate_configuration, "dbhub", sqlserver_configuration)
+
+    for adapter_id in ("dbhub", "mongodb-mcp", "clickhouse-mcp", "redis-mcp"):
+        unsafe_tls = json.loads(json.dumps(VALID_CONFIGURATIONS[adapter_id]))
+        unsafe_tls["settings"]["tls_mode"] = "require"
+        _must_reject(validate_configuration, adapter_id, unsafe_tls)
+        unsafe_ip = json.loads(json.dumps(VALID_CONFIGURATIONS[adapter_id]))
+        unsafe_ip["settings"]["host"] = "203.0.113.8"
+        _must_reject(validate_configuration, adapter_id, unsafe_ip)
+
+    unsafe_configuration = json.loads(json.dumps(VALID_CONFIGURATIONS["dbhub"]))
+    unsafe_configuration["settings"]["dsn"] = "postgresql://user:secret@host/db"
+    _must_reject(validate_configuration, "dbhub", unsafe_configuration)
+    unsafe_configuration = json.loads(json.dumps(VALID_CONFIGURATIONS["redis-mcp"]))
+    unsafe_configuration["environment"] = {"REDIS_URL": "redis://host"}
+    _must_reject(validate_configuration, "redis-mcp", unsafe_configuration)
+    unsafe_configuration = json.loads(json.dumps(VALID_CONFIGURATIONS["supabase-mcp"]))
+    unsafe_configuration["settings"]["project_ref"] = "abcdefghijklmno12345"
+    _must_reject(validate_configuration, "supabase-mcp", unsafe_configuration)
+    _must_reject(
+        validate_configuration,
+        "duckdb-mcp",
+        {"settings": {}, "credentials": {}, "workspace_id": "../../host"},
+    )
+
+    safe_queries = (
+        ("SELECT id, name FROM users WHERE id = 1", "postgres"),
+        ('SELECT "name" FROM "users"', "postgres"),
+        ("SELECT `name` FROM `users`", "mysql"),
+        ("WITH recent AS (SELECT id FROM events) SELECT * FROM recent", "postgres"),
+        ("SELECT count() FROM events", "clickhouse"),
+        ("SELECT * FROM local_table", "duckdb"),
+    )
+    for query, dialect in safe_queries:
+        validate_readonly_sql(query, dialect=dialect)
+    for query, dialect in (
+        ("SELECT 1; DELETE FROM users", "postgres"),
+        ("WITH changed AS (DELETE FROM users RETURNING *) SELECT * FROM changed", "postgres"),
+        ("SELECT * INTO copied FROM users", "tsql"),
+        ("SELECT pg_read_file('/etc/passwd')", "postgres"),
+        ("SELECT pg_advisory_lock(1)", "postgres"),
+        ("SELECT pg_try_advisory_lock(1)", "postgres"),
+        ('SELECT "pg_sleep"(1)', "postgres"),
+        ('SELECT U&"pg\\005fsleep"(1)', "postgres"),
+        ('SELECT U&"safe_name" UESCAPE \'!\'', "postgres"),
+        ("SELECT `get_lock`('modelmirror', 10)", "mysql"),
+        ("SELECT `get\\_lock`('modelmirror', 10)", "mysql"),
+        ('SELECT "pg_advisory_xact_lock"(1)', "postgres"),
+        ('SELECT "pg_try_advisory_xact_lock_shared"(1)', "postgres"),
+        ("SELECT dblink_connect('host=external.example.com')", "postgres"),
+        ("SELECT dblink_send_query('x', 'SELECT 1')", "postgres"),
+        ("SELECT GET_LOCK('modelmirror', 15)", "mysql"),
+        ("SELECT /*!50000 SLEEP(1) */ 1", "mysql"),
+        ("SELECT /*M!100100 SLEEP(1) */ 1", "mysql"),
+        ("SELECT /*+ MAX_EXECUTION_TIME(999999) */ 1", "mysql"),
+        ("SELECT * FROM OPENQUERY(remote_server, 'SELECT 1')", "tsql"),
+        ("SELECT count() FROM events SETTINGS max_execution_time=0", "clickhouse"),
+        ("SELECT * FROM users FOR SHARE", "postgres"),
+        ("SELECT * FROM users FOR KEY SHARE", "postgres"),
+        ("SELECT * FROM users FOR UPDATE", "postgres"),
+        ("SELECT * FROM url('http://169.254.169.254/latest/meta-data')", "clickhouse"),
+        ("SELECT * FROM postgresql('private.internal', 'db', 't', 'u', 'p')", "clickhouse"),
+        (
+            "SELECT * FROM urlCluster('cluster', "
+            "'http://169.254.169.254/latest/meta-data/', 'CSV', 'x String')",
+            "clickhouse",
+        ),
+        ("SELECT * FROM iceberg('http://169.254.169.254/bucket')", "clickhouse"),
+        ("SELECT * FROM read_parquet('https://example.com/private.parquet')", "duckdb"),
+        ("SELECT * FROM postgres_scan('host=private.internal')", "duckdb"),
+        ("ATTACH 'host.db' AS host", "duckdb"),
+    ):
+        _must_reject(validate_readonly_sql, query, dialect=dialect)
+
+    validate_document({"status": "ok", "score": {"$gte": 1}})
+    validate_document([{"$match": {"status": "ok"}}, {"$limit": 5}], pipeline=True)
+    _must_reject(validate_document, [{"$out": "copied"}], pipeline=True)
+    _must_reject(validate_document, {"$where": "sleep(1000)"})
+    _must_reject(validate_document, [{"$project": {"x": {"$function": {}}}}], pipeline=True)
+
+    rows, truncated = bounded_rows([{"id": value} for value in range(1_050)], max_rows=1_000)
+    if len(rows) != 1_000 or not truncated:
+        raise RuntimeError("row limit policy failed")
+
+    _private_dns_smoke()
+    _pinned_dns_smoke()
+    asyncio.run(_schema_smoke())
+    asyncio.run(_gateway_redaction_smoke())
+    duckdb_result = asyncio.run(_duckdb_adapter_smoke())
+
+    print(
+        json.dumps(
+            {
+                "ok": True,
+                "adapters": {key: sorted(value) for key, value in EXPECTED_TOOLS.items()},
+                "configuration_policy": "passed",
+                "sql_bypass_policy": "passed",
+                "mongodb_bypass_policy": "passed",
+                "row_output_policy": "passed",
+                "input_schema_snapshots": "passed",
+                "pinned_dns_policy": "passed",
+                "private_dns_policy": "passed",
+                "error_redaction": "passed",
+                "hard_timeout": "passed",
+                "duckdb_actual_call": duckdb_result,
+            },
+            ensure_ascii=False,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/server/mcp/workspace.py
+++ b/server/mcp/workspace.py
@@ -32,6 +32,7 @@ ARTIFACT_TTL_SECONDS = 7 * 24 * 60 * 60
 
 FILE_PROJECTS = {
     "basic-memory-mcp",
+    "duckdb-mcp",
     "excel-mcp-server",
     "git-mcp",
     "markitdown-mcp",
@@ -39,6 +40,7 @@ FILE_PROJECTS = {
 
 PROJECT_EXTENSIONS: dict[str, set[str] | None] = {
     "basic-memory-mcp": {".md", ".markdown", ".txt"},
+    "duckdb-mcp": {".duckdb"},
     "excel-mcp-server": {".xlsx", ".xls", ".csv", ".tsv", ".json"},
     "git-mcp": None,
     "markitdown-mcp": {

--- a/server/sandbox_sidecar/Dockerfile.database
+++ b/server/sandbox_sidecar/Dockerfile.database
@@ -1,0 +1,26 @@
+FROM python:3.12-slim@sha256:401f6e1a67dad31a1bd78e9ad22d0ee0a3b52154e6bd30e90be696bb6a3d7461
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    MCP_DATABASE_SOCKET_PATH=/run/modelmirror-database-mcp/database-mcp.sock \
+    MCP_DATABASE_INPUT_ROOT=/inputs
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd --gid 65532 sandbox \
+    && useradd --uid 65532 --gid 65532 --home-dir /tmp --no-create-home sandbox \
+    && mkdir -p /opt/modelmirror/sandbox_sidecar /inputs \
+        /run/modelmirror-database-mcp /run/modelmirror-database-local-mcp \
+    && chown -R sandbox:sandbox \
+        /run/modelmirror-database-mcp /run/modelmirror-database-local-mcp
+
+WORKDIR /opt/modelmirror
+COPY database-requirements.lock ./database-requirements.lock
+RUN pip install --no-cache-dir --retries 5 --timeout 120 -r database-requirements.lock
+
+COPY __init__.py engine.py landlock_exec.py database_contracts.py database_landlock_exec.py database_mcp.py database_server.py ./sandbox_sidecar/
+COPY THIRD_PARTY_NOTICES.md /usr/share/doc/modelmirror-mcp-database/THIRD_PARTY_NOTICES.md
+
+USER 65532:65532
+CMD ["python", "-m", "sandbox_sidecar.database_server"]

--- a/server/sandbox_sidecar/THIRD_PARTY_NOTICES.md
+++ b/server/sandbox_sidecar/THIRD_PARTY_NOTICES.md
@@ -78,3 +78,26 @@ server is Apache-2.0; the other reviewed contracts are MIT.
 Snyk MCP 1.15.2 was reviewed under Apache-2.0 but is not included. It remains
 blocked because local project scanning can invoke host-language build tools and
 therefore requires the later one-shot code-execution isolation boundary.
+
+The `modelmirror-mcp-database:wave5-v1` image implements independent, fixed
+read-only compatibility contracts after reviewing these upstream projects. It
+does not install their MCP server packages and never downloads runtime code:
+
+- DBHub 1.2.0 (`bytebase/dbhub`): MIT License.
+- MongoDB MCP Server 2.0.0 (`mongodb-js/mongodb-mcp-server`): Apache-2.0.
+- ClickHouse MCP 0.4.1 (`ClickHouse/mcp-clickhouse`): Apache-2.0.
+- Redis MCP Server 0.5.1 (`redis/mcp-redis`): MIT License.
+- MotherDuck MCP Server 1.0.7 (`motherduckdb/mcp-server-motherduck`): MIT
+  License. Only an isolated local DuckDB-compatible subset is implemented.
+- Supabase MCP Server 0.9.0 (`supabase-community/supabase-mcp`): Apache-2.0.
+  Only project-scoped local stdio with a PAT is represented; OAuth is absent.
+
+The archived PostgreSQL and SQLite reference servers are not bundled. Cognee,
+Graphiti and Hindsight are also absent because their stateful memory, model and
+storage requirements remain blocked for a later isolation batch.
+
+Pinned direct Python dependencies retain their installed package metadata and
+license files: MCP Python SDK (MIT), certifi (MPL-2.0), clickhouse-connect
+(Apache-2.0), DuckDB (MIT), httpx (BSD-3-Clause), psycopg (LGPL-3.0), PyMongo
+(Apache-2.0), PyMySQL (MIT), redis-py (MIT), and SQLGlot (MIT). Debian package
+notices remain under `/usr/share/doc`.

--- a/server/sandbox_sidecar/database-requirements.lock
+++ b/server/sandbox_sidecar/database-requirements.lock
@@ -1,0 +1,12 @@
+# Wave-5 database sidecar dependency lock. Runtime installation happens only
+# while building modelmirror-mcp-database:wave5-v1; sessions never download.
+mcp==1.27.2
+certifi==2026.7.22
+clickhouse-connect==0.10.0
+duckdb==1.4.3
+httpx==0.28.1
+psycopg[binary]==3.2.13
+pymongo==4.15.5
+PyMySQL==1.1.2
+redis==7.1.0
+sqlglot==28.10.0

--- a/server/sandbox_sidecar/database_contracts.py
+++ b/server/sandbox_sidecar/database_contracts.py
@@ -1,0 +1,572 @@
+"""Private Wave-5 database adapter contracts and fail-closed input policy.
+
+The catalog sends structured settings and credential slots.  This module
+never accepts a DSN, URL, command, environment map, header map, or working
+directory.  It is intentionally independent from the public catalog metadata
+so a modified browser cannot select an executable or weaken the runtime
+policy.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+import os
+import re
+import socket
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+MAX_ARGUMENT_BYTES = 128 * 1024
+MAX_QUERY_BYTES = 32 * 1024
+MAX_OUTPUT_BYTES = 256 * 1024
+DEFAULT_MAX_ROWS = 200
+HARD_MAX_ROWS = 1_000
+DEFAULT_TIMEOUT_SECONDS = 15
+HARD_TIMEOUT_SECONDS = 15
+
+WORKSPACE_PATTERN = re.compile(r"mcpws_[0-9a-f]{32}")
+FILE_ID_PATTERN = re.compile(r"mcpf_[0-9a-f]{24}")
+HOST_LABEL = re.compile(r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?")
+SAFE_IDENTIFIER = re.compile(r"[A-Za-z0-9_$][A-Za-z0-9_$.-]{0,127}")
+SAFE_USERNAME = re.compile(r"[A-Za-z0-9_$][A-Za-z0-9_$.+@-]{0,253}")
+PROJECT_REF = re.compile(r"[a-z]{20}")
+
+ADMIN_PRIVATE_NETWORKS = (
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("fc00::/7"),
+)
+
+TLS_MODES = frozenset({"verify-full"})
+FORBIDDEN_CONFIGURATION_KEYS = frozenset(
+    {
+        "command",
+        "commands",
+        "argv",
+        "url",
+        "uri",
+        "dsn",
+        "connection_string",
+        "environment",
+        "env",
+        "headers",
+        "header",
+        "cwd",
+        "working_directory",
+        "socket_path",
+        "allowlist",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class DatabaseAdapterContract:
+    adapter_id: str
+    tools: frozenset[str]
+    required_settings: frozenset[str]
+    optional_settings: frozenset[str]
+    required_credentials: frozenset[str]
+    optional_credentials: frozenset[str] = frozenset()
+    workspace_required: bool = False
+
+
+DATABASE_ADAPTERS: dict[str, DatabaseAdapterContract] = {
+    "dbhub": DatabaseAdapterContract(
+        "dbhub",
+        frozenset({"list_schemas", "list_tables", "describe_table", "execute_sql"}),
+        frozenset({"engine", "host", "port", "database", "tls_mode", "username"}),
+        frozenset(),
+        frozenset({"password"}),
+    ),
+    "mongodb-mcp": DatabaseAdapterContract(
+        "mongodb-mcp",
+        frozenset(
+            {
+                "list_collections",
+                "collection_schema",
+                "collection_indexes",
+                "find",
+                "aggregate",
+                "count_documents",
+            }
+        ),
+        frozenset({"host", "port", "database", "tls_mode", "username", "auth_source"}),
+        frozenset(),
+        frozenset({"password"}),
+    ),
+    "clickhouse-mcp": DatabaseAdapterContract(
+        "clickhouse-mcp",
+        frozenset({"list_databases", "list_tables", "run_query"}),
+        frozenset({"host", "port", "database", "tls_mode", "username"}),
+        frozenset(),
+        frozenset({"password"}),
+    ),
+    "redis-mcp": DatabaseAdapterContract(
+        "redis-mcp",
+        frozenset(
+            {
+                "scan_keys",
+                "get_value",
+                "get_type",
+                "get_ttl",
+                "hash_get_all",
+                "list_range",
+                "set_members",
+                "sorted_set_range",
+            }
+        ),
+        frozenset({"host", "port", "tls_mode", "database"}),
+        frozenset({"username"}),
+        frozenset({"password"}),
+    ),
+    "duckdb-mcp": DatabaseAdapterContract(
+        "duckdb-mcp",
+        frozenset({"list_schemas", "list_tables", "describe_table", "query"}),
+        frozenset(),
+        frozenset(),
+        frozenset(),
+        workspace_required=True,
+    ),
+    "supabase-mcp": DatabaseAdapterContract(
+        "supabase-mcp",
+        frozenset({"list_tables", "list_extensions", "execute_sql"}),
+        frozenset({"project_ref"}),
+        frozenset(),
+        frozenset({"access_token"}),
+    ),
+}
+
+
+@dataclass(slots=True)
+class ValidatedConfiguration:
+    contract: DatabaseAdapterContract
+    settings: dict[str, str | int]
+    credentials: dict[str, str]
+    workspace_id: str | None
+
+    def clear_secrets(self) -> None:
+        self.credentials.clear()
+
+
+def _reject_forbidden_keys(value: object, *, depth: int = 0) -> None:
+    if depth > 8:
+        raise ValueError("configuration_too_deep")
+    if isinstance(value, Mapping):
+        for raw_key, child in value.items():
+            key = str(raw_key).strip().lower()
+            if key in FORBIDDEN_CONFIGURATION_KEYS:
+                raise ValueError("forbidden_configuration_field")
+            _reject_forbidden_keys(child, depth=depth + 1)
+    elif isinstance(value, list):
+        for child in value:
+            _reject_forbidden_keys(child, depth=depth + 1)
+
+
+def _normalize_host(value: object) -> str:
+    raw = str(value or "").strip().rstrip(".")
+    try:
+        ipaddress.ip_address(raw.strip("[]"))
+    except ValueError:
+        pass
+    else:
+        raise ValueError("ip_literal_denied")
+    if not raw or len(raw) > 253 or any(char in raw for char in "/\\@?#:\r\n\x00"):
+        raise ValueError("invalid_host")
+    try:
+        ascii_host = raw.encode("idna").decode("ascii").lower()
+    except UnicodeError as exc:
+        raise ValueError("invalid_host") from exc
+    labels = ascii_host.split(".")
+    if len(labels) < 2 or any(not HOST_LABEL.fullmatch(label) for label in labels):
+        raise ValueError("invalid_host")
+    return ascii_host
+
+
+def _safe_text(value: object, *, pattern: re.Pattern[str], code: str) -> str:
+    clean = str(value or "").strip()
+    if not pattern.fullmatch(clean) or "://" in clean or "\x00" in clean:
+        raise ValueError(code)
+    return clean
+
+
+def _integer(value: object, *, minimum: int, maximum: int, code: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(code)
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(code) from exc
+    if parsed < minimum or parsed > maximum:
+        raise ValueError(code)
+    return parsed
+
+
+def validate_configuration(adapter_id: str, configuration: object) -> ValidatedConfiguration:
+    contract = DATABASE_ADAPTERS.get(str(adapter_id or "").strip())
+    if contract is None:
+        raise ValueError("mcp_adapter_denied")
+    if not isinstance(configuration, dict):
+        raise ValueError("invalid_configuration")
+    encoded = json.dumps(configuration, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    if len(encoded) > MAX_ARGUMENT_BYTES:
+        raise ValueError("configuration_too_large")
+    if set(configuration) - {"settings", "credentials", "workspace_id"}:
+        raise ValueError("configuration_contract_mismatch")
+    _reject_forbidden_keys(configuration)
+
+    raw_settings = configuration.get("settings")
+    raw_credentials = configuration.get("credentials")
+    if not isinstance(raw_settings, dict) or not isinstance(raw_credentials, dict):
+        raise ValueError("invalid_configuration")
+    setting_keys = set(raw_settings)
+    credential_keys = set(raw_credentials)
+    if not contract.required_settings.issubset(setting_keys):
+        raise ValueError("configuration_contract_mismatch")
+    if setting_keys - contract.required_settings - contract.optional_settings:
+        raise ValueError("configuration_contract_mismatch")
+    if not contract.required_credentials.issubset(credential_keys):
+        raise ValueError("configuration_contract_mismatch")
+    if credential_keys - contract.required_credentials - contract.optional_credentials:
+        raise ValueError("configuration_contract_mismatch")
+
+    credentials: dict[str, str] = {}
+    for key in credential_keys:
+        value = raw_credentials.get(key)
+        if not isinstance(value, str) or not value or len(value) > 20_000 or "\x00" in value:
+            raise ValueError("invalid_credential")
+        credentials[str(key)] = value
+
+    settings: dict[str, str | int] = {}
+    if adapter_id in {"dbhub", "mongodb-mcp", "clickhouse-mcp", "redis-mcp"}:
+        settings["host"] = _normalize_host(raw_settings.get("host"))
+        settings["port"] = _integer(raw_settings.get("port"), minimum=1, maximum=65535, code="invalid_port")
+        tls_mode = str(raw_settings.get("tls_mode") or "").strip().lower()
+        if tls_mode not in TLS_MODES:
+            raise ValueError("invalid_tls_mode")
+        settings["tls_mode"] = tls_mode
+
+    if adapter_id == "dbhub":
+        engine = str(raw_settings.get("engine") or "").strip().lower()
+        if engine not in {"postgresql", "mysql", "mariadb"}:
+            raise ValueError("invalid_engine")
+        settings.update(
+            engine=engine,
+            database=_safe_text(raw_settings.get("database"), pattern=SAFE_IDENTIFIER, code="invalid_database"),
+            username=_safe_text(raw_settings.get("username"), pattern=SAFE_USERNAME, code="invalid_username"),
+        )
+    elif adapter_id == "mongodb-mcp":
+        settings.update(
+            database=_safe_text(raw_settings.get("database"), pattern=SAFE_IDENTIFIER, code="invalid_database"),
+            username=_safe_text(raw_settings.get("username"), pattern=SAFE_USERNAME, code="invalid_username"),
+            auth_source=_safe_text(raw_settings.get("auth_source"), pattern=SAFE_IDENTIFIER, code="invalid_auth_source"),
+        )
+    elif adapter_id == "clickhouse-mcp":
+        settings.update(
+            database=_safe_text(raw_settings.get("database"), pattern=SAFE_IDENTIFIER, code="invalid_database"),
+            username=_safe_text(raw_settings.get("username"), pattern=SAFE_USERNAME, code="invalid_username"),
+        )
+    elif adapter_id == "redis-mcp":
+        settings["database"] = _integer(raw_settings.get("database"), minimum=0, maximum=15, code="invalid_database")
+        username = str(raw_settings.get("username") or "").strip()
+        if username:
+            settings["username"] = _safe_text(username, pattern=SAFE_USERNAME, code="invalid_username")
+    elif adapter_id == "supabase-mcp":
+        settings["project_ref"] = _safe_text(
+            raw_settings.get("project_ref"), pattern=PROJECT_REF, code="invalid_project_ref"
+        )
+
+    workspace_raw = str(configuration.get("workspace_id") or "").strip()
+    workspace_id: str | None = workspace_raw or None
+    if contract.workspace_required:
+        if not workspace_id or not WORKSPACE_PATTERN.fullmatch(workspace_id):
+            raise ValueError("workspace_required")
+    elif workspace_id is not None:
+        raise ValueError("workspace_not_allowed")
+    return ValidatedConfiguration(contract, settings, credentials, workspace_id)
+
+
+def _admin_private_host_allowlist() -> frozenset[str]:
+    raw = os.getenv("MCP_DATABASE_PRIVATE_HOST_ALLOWLIST", "")
+    values: set[str] = set()
+    for item in raw.split(","):
+        clean = item.strip()
+        if not clean:
+            continue
+        # Invalid administrator entries are ignored; they never broaden access.
+        try:
+            values.add(_normalize_host(clean))
+        except ValueError:
+            continue
+    return frozenset(values)
+
+
+def resolve_allowed_addresses(host: str, port: int) -> tuple[str, ...]:
+    normalized = _normalize_host(host)
+    admin_allowed = normalized in _admin_private_host_allowlist()
+    try:
+        records = socket.getaddrinfo(normalized, port, type=socket.SOCK_STREAM)
+    except socket.gaierror as exc:
+        raise ValueError("database_host_unresolved") from exc
+    addresses: set[str] = set()
+    for record in records:
+        raw_address = record[4][0]
+        try:
+            address = ipaddress.ip_address(raw_address)
+        except ValueError as exc:
+            raise ValueError("database_host_unresolved") from exc
+        # IPv4-mapped IPv6 addresses inherit the IPv4 classification.
+        effective = (
+            address.ipv4_mapped
+            if isinstance(address, ipaddress.IPv6Address) and address.ipv4_mapped is not None
+            else address
+        )
+        if (
+            effective.is_loopback
+            or effective.is_link_local
+            or effective.is_multicast
+            or effective.is_unspecified
+            or effective.is_reserved
+        ):
+            raise ValueError("database_host_private")
+        if not effective.is_global:
+            private_allowed = admin_allowed and any(
+                effective.version == network.version and effective in network
+                for network in ADMIN_PRIVATE_NETWORKS
+            )
+            if not private_allowed:
+                raise ValueError("database_host_private")
+        addresses.add(address.compressed)
+    if not addresses:
+        raise ValueError("database_host_unresolved")
+    return tuple(sorted(addresses))
+
+
+def install_pinned_getaddrinfo(host: str | None, addresses: tuple[str, ...]) -> None:
+    """Pin Python network clients to the sidecar-reviewed DNS answer.
+
+    Drivers continue receiving the original hostname, so TLS uses that value
+    for SNI and hostname verification.  Only socket address resolution is
+    replaced.  Any attempt to resolve a different host fails closed.
+    """
+
+    normalized_host = _normalize_host(host) if host is not None else None
+    parsed_addresses: tuple[ipaddress.IPv4Address | ipaddress.IPv6Address, ...] = tuple(
+        ipaddress.ip_address(value) for value in addresses
+    )
+    if normalized_host is None and parsed_addresses:
+        raise ValueError("invalid_pinned_dns")
+    if normalized_host is not None and not parsed_addresses:
+        raise ValueError("invalid_pinned_dns")
+
+    def pinned_getaddrinfo(
+        requested_host: object,
+        requested_port: object,
+        family: int = 0,
+        type: int = 0,
+        proto: int = 0,
+        flags: int = 0,
+    ) -> list[tuple[int, int, int, str, tuple[Any, ...]]]:
+        del flags
+        requested = str(requested_host or "").strip().rstrip(".").lower()
+        allowed_ip = False
+        try:
+            requested_address = ipaddress.ip_address(requested.strip("[]"))
+            allowed_ip = requested_address in parsed_addresses
+        except ValueError:
+            requested_address = None
+        if not allowed_ip and (normalized_host is None or requested != normalized_host):
+            raise socket.gaierror(socket.EAI_NONAME, "database DNS target denied")
+        try:
+            port = int(requested_port)
+        except (TypeError, ValueError) as exc:
+            raise socket.gaierror(socket.EAI_SERVICE, "database port denied") from exc
+        results: list[tuple[int, int, int, str, tuple[Any, ...]]] = []
+        for address in parsed_addresses:
+            address_family = socket.AF_INET6 if address.version == 6 else socket.AF_INET
+            if family not in {0, socket.AF_UNSPEC, address_family}:
+                continue
+            socket_type = type or socket.SOCK_STREAM
+            protocol = proto or socket.IPPROTO_TCP
+            sockaddr: tuple[Any, ...]
+            if address.version == 6:
+                sockaddr = (address.compressed, port, 0, 0)
+            else:
+                sockaddr = (address.compressed, port)
+            results.append((address_family, socket_type, protocol, "", sockaddr))
+        if not results:
+            raise socket.gaierror(socket.EAI_NONAME, "database DNS family denied")
+        return results
+
+    socket.getaddrinfo = pinned_getaddrinfo  # type: ignore[assignment]
+
+
+_SQL_COMMENT_OR_LITERAL = re.compile(
+    r"(?:--[^\r\n]*|/\*.*?\*/|'(?:''|[^'])*'|"
+    r"(?P<dollar>\$(?:[A-Za-z_][A-Za-z0-9_]*)?\$).*?(?P=dollar))",
+    re.DOTALL,
+)
+_SQL_QUOTED_IDENTIFIER = re.compile(r'\"(?:\"\"|[^\"])*\"|`(?:``|[^`])*`')
+_SQL_MUTATION = re.compile(
+    r"\b(?:insert|into|update|delete|merge|replace|upsert|create|alter|drop|truncate|grant|revoke|comment|rename|call|execute|exec|prepare|deallocate|copy|attach|detach|install|load|vacuum|analyze|optimize|set|reset|use|lock|unlock|begin|commit|rollback|savepoint|release)\b",
+    re.IGNORECASE,
+)
+_SQL_EXTERNAL_OR_DANGEROUS = re.compile(
+    r"\b(?:into\s+(?:out|dump)?file|load_file|sleep|benchmark|sys_exec|sys_eval|get_lock|release_lock|is_free_lock|is_used_lock|pg_sleep|pg_advisory_lock|pg_try_advisory_lock|pg_advisory_unlock|pg_advisory_unlock_all|pg_advisory_lock_shared|pg_try_advisory_lock_shared|pg_advisory_unlock_shared|pg_advisory_xact_lock|pg_try_advisory_xact_lock|pg_advisory_xact_lock_shared|pg_try_advisory_xact_lock_shared|pg_notify|pg_logical_emit_message|set_config|dblink|dblink_exec|dblink_connect|dblink_connect_u|dblink_disconnect|dblink_send_query|dblink_get_result|dblink_cancel_query|dblink_error_message|dblink_open|dblink_close|lo_import|lo_export|pg_read_file|pg_read_binary_file|pg_ls_dir|pg_stat_file|pg_reload_conf|pg_terminate_backend|pg_cancel_backend|nextval|setval|xp_cmdshell|sp_execute_external_script|sp_getapplock|sp_releaseapplock|openquery|openrowset|opendatasource|bulk\s+insert|read_csv|read_json|read_parquet|read_ndjson|read_blob|csv_scan|json_scan|parquet_scan|sqlite_scan|postgres_scan|mysql_scan|glob|httpfs|url|s3|s3Cluster|hdfs|remote|remoteSecure|file|executable|mysql|postgresql|mongodb|redis|jdbc|odbc|azureBlobStorage|gcs)\s*\(",
+    re.IGNORECASE,
+)
+_SQL_QUERY_MODIFIERS = re.compile(
+    r"\bsettings\b|\buescape\b|\bfor\s+(?:no\s+key\s+update|key\s+share|share|update)\b",
+    re.IGNORECASE,
+)
+
+
+def validate_readonly_sql(query: object, *, dialect: str) -> str:
+    if not isinstance(query, str):
+        raise ValueError("invalid_query")
+    clean = query.strip()
+    raw = clean.encode("utf-8")
+    if not clean or len(raw) > MAX_QUERY_BYTES or "\x00" in clean:
+        raise ValueError("invalid_query")
+    def normalize_quoted_identifier(match: re.Match[str]) -> str:
+        quoted = match.group(0)
+        quote = quoted[0]
+        inner = quoted[1:-1].replace(quote * 2, quote)
+        if (
+            match.start() >= 2
+            and clean[match.start() - 2 : match.start()].lower() == "u&"
+        ):
+            raise ValueError("unicode_quoted_identifier_denied")
+        if not SAFE_IDENTIFIER.fullmatch(inner):
+            raise ValueError("unsafe_quoted_identifier")
+        return inner
+
+    normalized_identifiers = _SQL_QUOTED_IDENTIFIER.sub(normalize_quoted_identifier, clean)
+
+    def scrub_comment_or_literal(match: re.Match[str]) -> str:
+        token = match.group(0)
+        lowered = token.lower()
+        if token.startswith("/*!") or lowered.startswith("/*m!") or token.startswith("/*+"):
+            raise ValueError("dangerous_comment_denied")
+        return " "
+
+    scrubbed = _SQL_COMMENT_OR_LITERAL.sub(
+        scrub_comment_or_literal, normalized_identifiers
+    ).strip()
+    if scrubbed.endswith(";"):
+        scrubbed = scrubbed[:-1].rstrip()
+        clean = clean.rstrip()[:-1].rstrip()
+    if ";" in scrubbed:
+        raise ValueError("multiple_statements_denied")
+    if not re.match(r"^(?:select|with)\b", scrubbed, re.IGNORECASE):
+        raise ValueError("readonly_query_required")
+    if (
+        _SQL_MUTATION.search(scrubbed)
+        or _SQL_EXTERNAL_OR_DANGEROUS.search(scrubbed)
+        or _SQL_QUERY_MODIFIERS.search(scrubbed)
+    ):
+        raise ValueError("dangerous_query_denied")
+    # The lexical gate above remains active even if sqlglot accepts a vendor
+    # extension.  The AST pass catches writable CTEs and non-query roots.
+    try:
+        import sqlglot
+        from sqlglot import expressions as exp
+    except ImportError as exc:
+        raise ValueError("query_parser_unavailable") from exc
+    try:
+        statements = sqlglot.parse(clean, read=dialect)
+    except Exception as exc:
+        raise ValueError("query_parse_failed") from exc
+    if len(statements) != 1 or statements[0] is None:
+        raise ValueError("multiple_statements_denied")
+    statement = statements[0]
+    forbidden_types = tuple(
+        item
+        for item in (
+            getattr(exp, "DML", None),
+            getattr(exp, "DDL", None),
+            getattr(exp, "Command", None),
+            getattr(exp, "Copy", None),
+            getattr(exp, "Into", None),
+            getattr(exp, "Set", None),
+            getattr(exp, "Use", None),
+            getattr(exp, "Transaction", None),
+        )
+        if item is not None
+    )
+    if forbidden_types and any(isinstance(node, forbidden_types) for node in statement.walk()):
+        raise ValueError("dangerous_query_denied")
+    if dialect.lower() == "clickhouse":
+        for table in statement.find_all(exp.Table):
+            if not isinstance(table.this, exp.Identifier):
+                raise ValueError("clickhouse_table_function_denied")
+    if statement.find(exp.Select) is None:
+        raise ValueError("readonly_query_required")
+    return clean
+
+
+MONGO_DENIED_OPERATORS = frozenset(
+    {"$out", "$merge", "$where", "$function", "$accumulator", "$currentOp", "$listSessions", "$listLocalSessions"}
+)
+
+
+def validate_document(value: object, *, pipeline: bool = False) -> Any:
+    encoded = json.dumps(value, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    if len(encoded) > MAX_ARGUMENT_BYTES:
+        raise ValueError("document_too_large")
+    if pipeline and not isinstance(value, list):
+        raise ValueError("invalid_pipeline")
+    if not pipeline and not isinstance(value, dict):
+        raise ValueError("invalid_document")
+
+    def walk(item: object, depth: int) -> None:
+        if depth > 12:
+            raise ValueError("document_too_deep")
+        if isinstance(item, dict):
+            for raw_key, child in item.items():
+                key = str(raw_key)
+                if key in MONGO_DENIED_OPERATORS or "\x00" in key or len(key) > 200:
+                    raise ValueError("dangerous_mongo_operator")
+                if key == "$regex" and (not isinstance(child, str) or len(child) > 500):
+                    raise ValueError("unsafe_regex")
+                walk(child, depth + 1)
+        elif isinstance(item, list):
+            if len(item) > 1_000:
+                raise ValueError("document_too_large")
+            for child in item:
+                walk(child, depth + 1)
+        elif isinstance(item, str) and len(item) > 20_000:
+            raise ValueError("document_value_too_large")
+
+    walk(value, 0)
+    return value
+
+
+def bounded_rows(value: object, *, max_rows: object = DEFAULT_MAX_ROWS) -> tuple[Any, bool]:
+    limit = _integer(max_rows, minimum=1, maximum=HARD_MAX_ROWS, code="invalid_row_limit")
+    truncated = False
+    if isinstance(value, list) and len(value) > limit:
+        value = value[:limit]
+        truncated = True
+    encoded = json.dumps(value, ensure_ascii=False, default=str, separators=(",", ":")).encode("utf-8")
+    if len(encoded) <= MAX_OUTPUT_BYTES:
+        return value, truncated
+    if not isinstance(value, list):
+        raise ValueError("output_too_large")
+    kept: list[Any] = []
+    for item in value:
+        candidate = kept + [item]
+        if len(json.dumps(candidate, ensure_ascii=False, default=str, separators=(",", ":")).encode("utf-8")) > MAX_OUTPUT_BYTES:
+            break
+        kept.append(item)
+    return kept, True
+
+
+def clamp_timeout(value: object = DEFAULT_TIMEOUT_SECONDS) -> int:
+    return _integer(value, minimum=1, maximum=HARD_TIMEOUT_SECONDS, code="invalid_timeout")
+
+
+def clamp_rows(value: object = DEFAULT_MAX_ROWS) -> int:
+    return _integer(value, minimum=1, maximum=HARD_MAX_ROWS, code="invalid_row_limit")

--- a/server/sandbox_sidecar/database_landlock_exec.py
+++ b/server/sandbox_sidecar/database_landlock_exec.py
@@ -1,0 +1,151 @@
+"""Landlock and rlimit launcher for one Wave-5 database MCP process."""
+
+from __future__ import annotations
+
+import ctypes
+import os
+import platform
+import resource
+import sys
+from pathlib import Path
+
+from .landlock_exec import (
+    ACCESS_FS_EXECUTE,
+    ACCESS_FS_MAKE_BLOCK,
+    ACCESS_FS_MAKE_CHAR,
+    ACCESS_FS_MAKE_DIR,
+    ACCESS_FS_MAKE_FIFO,
+    ACCESS_FS_MAKE_REG,
+    ACCESS_FS_MAKE_SOCK,
+    ACCESS_FS_MAKE_SYM,
+    ACCESS_FS_READ_DIR,
+    ACCESS_FS_READ_FILE,
+    ACCESS_FS_REFER,
+    ACCESS_FS_REMOVE_DIR,
+    ACCESS_FS_REMOVE_FILE,
+    ACCESS_FS_TRUNCATE,
+    ACCESS_FS_WRITE_FILE,
+    LANDLOCK_CREATE_RULESET_VERSION,
+    LANDLOCK_RULE_PATH_BENEATH,
+    PR_SET_NO_NEW_PRIVS,
+    PathBeneathAttr,
+    RulesetAttr,
+)
+
+
+READ_EXECUTE = ACCESS_FS_EXECUTE | ACCESS_FS_READ_FILE | ACCESS_FS_READ_DIR
+WRITE_ACCESS = (
+    READ_EXECUTE
+    | ACCESS_FS_WRITE_FILE
+    | ACCESS_FS_REMOVE_DIR
+    | ACCESS_FS_REMOVE_FILE
+    | ACCESS_FS_MAKE_DIR
+    | ACCESS_FS_MAKE_REG
+    | ACCESS_FS_MAKE_SOCK
+    | ACCESS_FS_MAKE_FIFO
+    | ACCESS_FS_MAKE_SYM
+    | ACCESS_FS_REFER
+    | ACCESS_FS_TRUNCATE
+)
+HANDLED_ACCESS = WRITE_ACCESS | ACCESS_FS_MAKE_CHAR | ACCESS_FS_MAKE_BLOCK
+
+
+def _syscalls() -> tuple[int, int, int]:
+    if platform.machine().lower() in {"x86_64", "amd64", "aarch64", "arm64"}:
+        return 444, 445, 446
+    raise RuntimeError("Unsupported Landlock architecture.")
+
+
+def _apply(read_roots: list[Path], write_roots: list[Path]) -> None:
+    create_nr, add_nr, restrict_nr = _syscalls()
+    libc = ctypes.CDLL(None, use_errno=True)
+    abi = libc.syscall(create_nr, 0, 0, LANDLOCK_CREATE_RULESET_VERSION)
+    if abi < 1:
+        raise RuntimeError("Landlock is unavailable.")
+    supported = HANDLED_ACCESS
+    if abi < 2:
+        supported &= ~ACCESS_FS_REFER
+    if abi < 3:
+        supported &= ~ACCESS_FS_TRUNCATE
+    ruleset_fd = libc.syscall(
+        create_nr,
+        ctypes.byref(RulesetAttr(supported)),
+        ctypes.sizeof(RulesetAttr),
+        0,
+    )
+    if ruleset_fd < 0:
+        raise RuntimeError("Landlock ruleset creation failed.")
+
+    def add(path: Path, access: int) -> None:
+        if not path.exists():
+            return
+        descriptor = os.open(path, os.O_PATH | os.O_CLOEXEC)
+        try:
+            attribute = PathBeneathAttr(access & supported, descriptor, 0)
+            if libc.syscall(
+                add_nr,
+                ruleset_fd,
+                LANDLOCK_RULE_PATH_BENEATH,
+                ctypes.byref(attribute),
+                0,
+            ) < 0:
+                raise RuntimeError("Landlock path rule failed.")
+        finally:
+            os.close(descriptor)
+
+    try:
+        for root in read_roots:
+            add(root, READ_EXECUTE)
+        for root in write_roots:
+            add(root, WRITE_ACCESS)
+        for path in (Path("/dev/null"), Path("/dev/urandom"), Path("/dev/random")):
+            add(path, ACCESS_FS_READ_FILE | ACCESS_FS_WRITE_FILE)
+        if libc.prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0:
+            raise RuntimeError("no_new_privs failed.")
+        if libc.syscall(restrict_nr, ruleset_fd, 0) != 0:
+            raise RuntimeError("Landlock restrict_self failed.")
+    finally:
+        os.close(ruleset_fd)
+
+
+def main() -> int:
+    if len(sys.argv) < 3 or sys.argv[1] != "--":
+        print("usage: database_landlock_exec.py -- COMMAND [ARGS...]", file=sys.stderr)
+        return 64
+    adapter_id = os.getenv("MCP_DATABASE_ADAPTER_ID", "")
+    workspace_id = os.getenv("MCP_DATABASE_WORKSPACE_ID", "")
+    input_base = Path(os.getenv("MCP_DATABASE_INPUT_ROOT", "/inputs")).resolve()
+    temp_root = Path(os.getenv("TMPDIR", "/tmp")).resolve()
+    read_roots = [
+        Path("/usr"),
+        Path("/bin"),
+        Path("/lib"),
+        Path("/lib64"),
+        Path("/etc"),
+        Path("/opt/modelmirror"),
+    ]
+    if adapter_id == "duckdb-mcp":
+        input_root = (input_base / workspace_id).resolve()
+        if input_root.parent != input_base or not input_root.is_dir():
+            print("database workspace unavailable", file=sys.stderr)
+            return 126
+        read_roots.append(input_root)
+    try:
+        temp_root.mkdir(parents=True, exist_ok=True)
+        resource.setrlimit(resource.RLIMIT_CPU, (60, 60))
+        resource.setrlimit(resource.RLIMIT_AS, (768 * 1024 * 1024, 768 * 1024 * 1024))
+        resource.setrlimit(resource.RLIMIT_FSIZE, (16 * 1024 * 1024, 16 * 1024 * 1024))
+        resource.setrlimit(resource.RLIMIT_NOFILE, (128, 128))
+        if hasattr(resource, "RLIMIT_NPROC"):
+            resource.setrlimit(resource.RLIMIT_NPROC, (32, 32))
+        _apply(read_roots, [temp_root])
+    except Exception as exc:
+        print(f"database sandbox isolation failed: {type(exc).__name__}", file=sys.stderr)
+        return 126
+    os.chdir(temp_root)
+    os.execvpe(sys.argv[2], sys.argv[2:], os.environ)
+    return 127
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/server/sandbox_sidecar/database_mcp.py
+++ b/server/sandbox_sidecar/database_mcp.py
@@ -1,0 +1,1078 @@
+"""Built-in, fixed-tool Wave-5 database MCP adapters.
+
+Each process serves exactly one reviewed adapter.  Remote connection material
+arrives through a private sidecar handshake, is removed from the environment
+at startup, and is never included in tool results or error messages.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import contextlib
+import datetime as dt
+import decimal
+import hashlib
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Annotated, Any, Iterable, Iterator
+
+from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
+from pydantic import Field
+
+from .database_contracts import (
+    DATABASE_ADAPTERS,
+    FILE_ID_PATTERN,
+    MAX_OUTPUT_BYTES,
+    SAFE_IDENTIFIER,
+    ValidatedConfiguration,
+    bounded_rows,
+    clamp_rows,
+    clamp_timeout,
+    install_pinned_getaddrinfo,
+    resolve_allowed_addresses,
+    validate_configuration,
+    validate_document,
+    validate_readonly_sql,
+)
+
+
+READ_ONLY = ToolAnnotations(
+    readOnlyHint=True,
+    destructiveHint=False,
+    idempotentHint=True,
+    openWorldHint=False,
+)
+DatabaseFileId = Annotated[
+    str,
+    Field(
+        description="从当前封存工作区选择 .duckdb 文件；不接受路径或 URI。",
+        json_schema_extra={"x-modelmirror-input": "workspace-file"},
+    ),
+]
+
+
+def opaque_file_id(workspace_id: str, relative_path: str) -> str:
+    digest = hashlib.sha256(f"{workspace_id}:{relative_path}".encode("utf-8")).hexdigest()[:24]
+    return f"mcpf_{digest}"
+
+
+def _load_configuration(adapter_id: str) -> ValidatedConfiguration:
+    encoded = os.environ.pop("MCP_DATABASE_CHILD_CONFIGURATION_B64", "")
+    if not encoded or len(encoded) > 256 * 1024:
+        raise RuntimeError("数据库配置握手缺失。")
+    try:
+        raw = base64.urlsafe_b64decode(encoded.encode("ascii"))
+        payload = json.loads(raw.decode("utf-8"))
+    except (ValueError, UnicodeError, json.JSONDecodeError) as exc:
+        raise RuntimeError("数据库配置握手无效。") from exc
+    return validate_configuration(adapter_id, payload)
+
+
+def _safe_identifier(value: object, label: str) -> str:
+    clean = str(value or "").strip()
+    if not SAFE_IDENTIFIER.fullmatch(clean):
+        raise ValueError(f"{label} 标识无效。")
+    return clean
+
+
+def _json_value(value: Any) -> Any:
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, decimal.Decimal):
+        return str(value)
+    if isinstance(value, (dt.date, dt.datetime, dt.time)):
+        return value.isoformat()
+    if isinstance(value, bytes):
+        try:
+            return value.decode("utf-8")
+        except UnicodeDecodeError:
+            return {"encoding": "base64", "data": base64.b64encode(value).decode("ascii")}
+    if isinstance(value, dict):
+        return {str(key): _json_value(child) for key, child in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_json_value(child) for child in value]
+    return str(value)
+
+
+def _bounded_sequence(rows: Iterable[Any], max_rows: int) -> tuple[list[Any], bool]:
+    values: list[Any] = []
+    used_bytes = 2
+    for item in rows:
+        if len(values) >= max_rows:
+            return values, True
+        normalized = _json_value(item)
+        encoded = json.dumps(
+            normalized, ensure_ascii=False, default=str, separators=(",", ":")
+        ).encode("utf-8")
+        if used_bytes + len(encoded) + 1 > MAX_OUTPUT_BYTES - 16 * 1024:
+            return values, True
+        values.append(normalized)
+        used_bytes += len(encoded) + 1
+    return values, False
+
+
+def _result_payload(columns: list[str], rows: Iterable[Any], max_rows: int) -> dict[str, Any]:
+    normalized: list[dict[str, Any]] = []
+    for row in rows:
+        if len(normalized) >= max_rows:
+            return {
+                "columns": columns,
+                "rows": normalized,
+                "row_count": len(normalized),
+                "truncated": True,
+            }
+        if isinstance(row, dict):
+            item = {str(key): _json_value(value) for key, value in row.items()}
+        else:
+            item = {
+                column: _json_value(row[index] if index < len(row) else None)
+                for index, column in enumerate(columns)
+            }
+        candidate = normalized + [item]
+        if len(
+            json.dumps(candidate, ensure_ascii=False, default=str, separators=(",", ":")).encode("utf-8")
+        ) > MAX_OUTPUT_BYTES - 16 * 1024:
+            return {
+                "columns": columns,
+                "rows": normalized,
+                "row_count": len(normalized),
+                "truncated": True,
+            }
+        normalized.append(item)
+    return {
+        "columns": columns,
+        "rows": normalized,
+        "row_count": len(normalized),
+        "truncated": False,
+    }
+
+
+def _sql_wrapper(query: str, max_rows: int, *, engine: str) -> str:
+    clean = query.rstrip().rstrip(";").rstrip()
+    return f"SELECT * FROM ({clean}) AS modelmirror_readonly LIMIT {max_rows + 1}"
+
+
+class DatabaseContext:
+    def __init__(self, adapter_id: str) -> None:
+        self.adapter_id = adapter_id
+        self.configuration = _load_configuration(adapter_id)
+        self.settings = self.configuration.settings
+        self.credentials = self.configuration.credentials
+        self.workspace_id = self.configuration.workspace_id
+        self.resolved_addresses: tuple[str, ...] = ()
+        target_host: str | None = None
+        if "host" in self.settings:
+            target_host = str(self.settings["host"])
+        elif adapter_id == "supabase-mcp":
+            target_host = "api.supabase.com"
+        encoded_pins = os.environ.pop("MCP_DATABASE_PINNED_DNS_B64", "")
+        if encoded_pins:
+            try:
+                pin_payload = json.loads(base64.urlsafe_b64decode(encoded_pins.encode("ascii")))
+                if not isinstance(pin_payload, dict) or set(pin_payload) != {"host", "addresses"}:
+                    raise ValueError("invalid_pinned_dns")
+                if pin_payload.get("host") != target_host or not isinstance(pin_payload.get("addresses"), list):
+                    raise ValueError("invalid_pinned_dns")
+                self.resolved_addresses = tuple(str(item) for item in pin_payload["addresses"])
+            except (ValueError, UnicodeError, json.JSONDecodeError) as exc:
+                raise RuntimeError("数据库 DNS 固定握手无效。") from exc
+        elif target_host is not None:
+            # Direct invocation is supported for image diagnostics only.  The
+            # production sidecar always supplies its reviewed DNS answer.
+            port = int(self.settings.get("port") or 443)
+            self.resolved_addresses = resolve_allowed_addresses(target_host, port)
+        install_pinned_getaddrinfo(target_host, self.resolved_addresses)
+        self._duckdb_files: dict[str, Path] = {}
+        if adapter_id == "duckdb-mcp":
+            self._index_duckdb_files()
+
+    def _index_duckdb_files(self) -> None:
+        assert self.workspace_id is not None
+        base = Path(os.getenv("MCP_DATABASE_INPUT_ROOT", "/inputs")).resolve()
+        root = (base / self.workspace_id).resolve()
+        if root.parent != base or not root.is_dir() or root.is_symlink():
+            raise RuntimeError("封存 DuckDB 工作区不可用。")
+        for path in sorted(root.rglob("*")):
+            if path.is_symlink() or not path.is_file() or path.suffix.lower() != ".duckdb":
+                continue
+            resolved = path.resolve()
+            if root not in resolved.parents:
+                continue
+            relative = path.relative_to(root).as_posix()
+            self._duckdb_files[opaque_file_id(self.workspace_id, relative)] = path
+        if not self._duckdb_files:
+            raise RuntimeError("封存工作区中没有 .duckdb 文件。")
+
+    def duckdb_file(self, file_id: str) -> Path:
+        if not FILE_ID_PATTERN.fullmatch(str(file_id or "")):
+            raise ValueError("必须选择当前封存工作区中的 DuckDB 文件。")
+        path = self._duckdb_files.get(file_id)
+        if path is None or not path.is_file() or path.is_symlink():
+            raise ValueError("所选 DuckDB 文件不存在。")
+        return path
+
+
+@contextlib.contextmanager
+def _dbhub_cursor(
+    context: DatabaseContext,
+    *,
+    timeout_seconds: int,
+) -> Iterator[tuple[Any, str]]:
+    settings = context.settings
+    engine = str(settings["engine"])
+    host = str(settings["host"])
+    port = int(settings["port"])
+    database = str(settings["database"])
+    username = str(settings["username"])
+    password = context.credentials["password"]
+    tls_mode = str(settings["tls_mode"])
+    connection: Any = None
+    cursor: Any = None
+    try:
+        if engine == "postgresql":
+            import psycopg
+
+            connection = psycopg.connect(
+                host=host,
+                hostaddr=context.resolved_addresses[0],
+                port=port,
+                dbname=database,
+                user=username,
+                password=password,
+                sslmode=tls_mode,
+                connect_timeout=min(timeout_seconds, 10),
+                options=(
+                    "-c default_transaction_read_only=on "
+                    f"-c statement_timeout={timeout_seconds * 1000} -c lock_timeout=3000"
+                ),
+                autocommit=False,
+            )
+            cursor = connection.cursor()
+            cursor.execute("BEGIN READ ONLY")
+            placeholder = "%s"
+        elif engine in {"mysql", "mariadb"}:
+            import certifi
+            import pymysql
+
+            ssl: dict[str, Any] | None = None
+            ssl = {"check_hostname": True, "ca": certifi.where()}
+            connection = pymysql.connect(
+                host=host,
+                port=port,
+                database=database,
+                user=username,
+                password=password,
+                connect_timeout=min(timeout_seconds, 10),
+                read_timeout=timeout_seconds,
+                write_timeout=timeout_seconds,
+                ssl=ssl,
+                autocommit=False,
+                local_infile=False,
+            )
+            cursor = connection.cursor()
+            # Fail closed if the server cannot establish a read-only transaction.
+            cursor.execute("SET SESSION TRANSACTION READ ONLY")
+            try:
+                cursor.execute(f"SET SESSION MAX_EXECUTION_TIME={timeout_seconds * 1000}")
+            except Exception:
+                cursor.execute(f"SET SESSION max_statement_time={timeout_seconds}")
+            cursor.execute("START TRANSACTION READ ONLY")
+            placeholder = "%s"
+        else:
+            raise RuntimeError("unsupported_database_engine")
+        yield cursor, placeholder
+    finally:
+        if connection is not None:
+            try:
+                connection.rollback()
+            except Exception:
+                pass
+        if cursor is not None:
+            try:
+                cursor.close()
+            except Exception:
+                pass
+        if connection is not None:
+            try:
+                connection.close()
+            except Exception:
+                pass
+
+
+def _cursor_payload(cursor: Any, max_rows: int) -> dict[str, Any]:
+    columns = [str(item[0]) for item in (cursor.description or [])]
+    def rows() -> Iterator[Any]:
+        if not columns:
+            return
+        for _ in range(max_rows + 1):
+            item = cursor.fetchone()
+            if item is None:
+                return
+            yield item
+    return _result_payload(columns, rows(), max_rows)
+
+
+def _preflight_dbhub(context: DatabaseContext) -> None:
+    engine = str(context.settings["engine"])
+    with _dbhub_cursor(context, timeout_seconds=10) as (cursor, _):
+        if engine == "postgresql":
+            cursor.execute("SELECT current_setting('transaction_read_only')")
+            value = str(cursor.fetchone()[0]).lower()
+            if value not in {"on", "true", "1"}:
+                raise RuntimeError("database_readonly_preflight_failed")
+        elif engine in {"mysql", "mariadb"}:
+            try:
+                cursor.execute("SELECT @@transaction_read_only")
+            except Exception:
+                cursor.execute("SELECT @@tx_read_only")
+            if int(cursor.fetchone()[0]) != 1:
+                raise RuntimeError("database_readonly_preflight_failed")
+        else:
+            raise RuntimeError("unsupported_database_engine")
+        cursor.execute("SELECT 1")
+        if int(cursor.fetchone()[0]) != 1:
+            raise RuntimeError("database_preflight_failed")
+
+
+def build_dbhub(context: DatabaseContext) -> FastMCP:
+    mcp = FastMCP("ModelMirror DBHub Read Only")
+
+    @mcp.tool(annotations=READ_ONLY)
+    def list_schemas(max_rows: int = 200) -> dict[str, Any]:
+        """列出当前受控数据库账号可见的 schema。"""
+        limit = clamp_rows(max_rows)
+        with _dbhub_cursor(context, timeout_seconds=15) as (cursor, _):
+            cursor.execute(
+                _sql_wrapper(
+                    "SELECT schema_name FROM information_schema.schemata ORDER BY schema_name",
+                    limit,
+                    engine=str(context.settings["engine"]),
+                )
+            )
+            return _cursor_payload(cursor, limit)
+
+    @mcp.tool(annotations=READ_ONLY)
+    def list_tables(schema: str = "", max_rows: int = 200) -> dict[str, Any]:
+        """列出当前数据库中的表和视图，可按 schema 收窄。"""
+        limit = clamp_rows(max_rows)
+        schema_name = _safe_identifier(schema, "Schema") if schema else ""
+        engine = str(context.settings["engine"])
+        with _dbhub_cursor(context, timeout_seconds=15) as (cursor, placeholder):
+            query = "SELECT table_schema, table_name, table_type FROM information_schema.tables"
+            params: tuple[Any, ...] = ()
+            if schema_name:
+                query += f" WHERE table_schema = {placeholder}"
+                params = (schema_name,)
+            query += " ORDER BY table_schema, table_name"
+            cursor.execute(_sql_wrapper(query, limit, engine=engine), params)
+            return _cursor_payload(cursor, limit)
+
+    @mcp.tool(annotations=READ_ONLY)
+    def describe_table(schema: str, table: str, max_rows: int = 200) -> dict[str, Any]:
+        """读取指定表的列定义，不执行 DDL。"""
+        limit = clamp_rows(max_rows)
+        schema_name = _safe_identifier(schema, "Schema")
+        table_name = _safe_identifier(table, "表")
+        engine = str(context.settings["engine"])
+        with _dbhub_cursor(context, timeout_seconds=15) as (cursor, placeholder):
+            query = (
+                "SELECT column_name, data_type, is_nullable, column_default, ordinal_position "
+                "FROM information_schema.columns "
+                f"WHERE table_schema = {placeholder} AND table_name = {placeholder} "
+                "ORDER BY ordinal_position"
+            )
+            cursor.execute(_sql_wrapper(query, limit, engine=engine), (schema_name, table_name))
+            return _cursor_payload(cursor, limit)
+
+    @mcp.tool(annotations=READ_ONLY)
+    def execute_sql(query: str, max_rows: int = 200, timeout_seconds: int = 15) -> dict[str, Any]:
+        """在只读事务中执行单条 SELECT/WITH 查询。"""
+        limit = clamp_rows(max_rows)
+        timeout = clamp_timeout(timeout_seconds)
+        engine = str(context.settings["engine"])
+        dialect = {"postgresql": "postgres", "mysql": "mysql", "mariadb": "mysql"}[engine]
+        clean = validate_readonly_sql(query, dialect=dialect)
+        with _dbhub_cursor(context, timeout_seconds=timeout) as (cursor, _):
+            cursor.execute(_sql_wrapper(clean, limit, engine=engine))
+            return _cursor_payload(cursor, limit)
+
+    return mcp
+
+
+@contextlib.contextmanager
+def _mongo_database(context: DatabaseContext, timeout: int = 15) -> Iterator[Any]:
+    import certifi
+    import pymongo
+
+    tls_mode = str(context.settings["tls_mode"])
+    client = pymongo.MongoClient(
+        host=str(context.settings["host"]),
+        port=int(context.settings["port"]),
+        username=str(context.settings["username"]),
+        password=context.credentials["password"],
+        authSource=str(context.settings["auth_source"]),
+        directConnection=True,
+        tls=True,
+        tlsCAFile=certifi.where(),
+        tlsAllowInvalidCertificates=False,
+        tlsAllowInvalidHostnames=False,
+        serverSelectionTimeoutMS=min(timeout, 10) * 1000,
+        connectTimeoutMS=min(timeout, 10) * 1000,
+        socketTimeoutMS=timeout * 1000,
+        retryWrites=False,
+        appname="ModelMirror-Wave5-ReadOnly",
+    )
+    try:
+        database = client[str(context.settings["database"])]
+        database.command({"ping": 1}, maxTimeMS=min(timeout, 10) * 1000)
+        yield database
+    finally:
+        client.close()
+
+
+def _mongo_collection(value: str) -> str:
+    clean = _safe_identifier(value, "集合")
+    if clean.startswith("system."):
+        raise ValueError("系统集合不可访问。")
+    return clean
+
+
+def build_mongodb(context: DatabaseContext) -> FastMCP:
+    mcp = FastMCP("ModelMirror MongoDB Read Only")
+
+    @mcp.tool(annotations=READ_ONLY)
+    def list_collections(max_rows: int = 200) -> dict[str, Any]:
+        """列出当前绑定数据库中的非系统集合。"""
+        limit = clamp_rows(max_rows)
+        with _mongo_database(context) as database:
+            rows = [
+                {"name": name}
+                for name in sorted(database.list_collection_names())
+                if not name.startswith("system.")
+            ]
+        values, truncated = bounded_rows(rows, max_rows=limit)
+        return {"collections": values, "count": len(values), "truncated": truncated}
+
+    @mcp.tool(annotations=READ_ONLY)
+    def collection_schema(collection: str, sample_size: int = 100) -> dict[str, Any]:
+        """从最多 200 份文档推断字段与 BSON 类型，不修改集合。"""
+        name = _mongo_collection(collection)
+        sample = max(1, min(int(sample_size), 200))
+        fields: dict[str, set[str]] = {}
+        with _mongo_database(context) as database:
+            for document in database[name].find({}, limit=sample, max_time_ms=15_000):
+                for key, value in document.items():
+                    fields.setdefault(str(key), set()).add(type(value).__name__)
+        return {"collection": name, "fields": [{"name": key, "types": sorted(types)} for key, types in sorted(fields.items())]}
+
+    @mcp.tool(annotations=READ_ONLY)
+    def collection_indexes(collection: str, max_rows: int = 200) -> dict[str, Any]:
+        """读取集合索引元数据。"""
+        name = _mongo_collection(collection)
+        limit = clamp_rows(max_rows)
+        with _mongo_database(context) as database:
+            rows = database[name].list_indexes()
+            values, truncated = _bounded_sequence(rows, limit)
+        return {"collection": name, "indexes": values, "truncated": truncated}
+
+    @mcp.tool(annotations=READ_ONLY)
+    def find(
+        collection: str,
+        filter: dict[str, Any] | None = None,
+        projection: dict[str, Any] | None = None,
+        sort: dict[str, int] | None = None,
+        limit: int = 200,
+    ) -> dict[str, Any]:
+        """在当前数据库集合中执行结构化只读查询。"""
+        name = _mongo_collection(collection)
+        row_limit = clamp_rows(limit)
+        query_filter = validate_document(filter or {})
+        query_projection = validate_document(projection or {})
+        query_sort = validate_document(sort or {})
+        sort_items: list[tuple[str, int]] = []
+        for key, direction in query_sort.items():
+            if int(direction) not in {-1, 1}:
+                raise ValueError("排序方向只能是 1 或 -1。")
+            sort_items.append((str(key), int(direction)))
+        with _mongo_database(context) as database:
+            cursor = database[name].find(query_filter, query_projection or None, max_time_ms=15_000)
+            if sort_items:
+                cursor = cursor.sort(sort_items)
+            values, truncated = _bounded_sequence(cursor.limit(row_limit + 1), row_limit)
+        return {"collection": name, "documents": values, "count": len(values), "truncated": truncated}
+
+    @mcp.tool(annotations=READ_ONLY)
+    def aggregate(collection: str, pipeline: list[dict[str, Any]], limit: int = 200) -> dict[str, Any]:
+        """执行不含 $out、$merge、脚本或服务端 JavaScript 的聚合。"""
+        name = _mongo_collection(collection)
+        row_limit = clamp_rows(limit)
+        clean_pipeline = list(validate_document(pipeline, pipeline=True))
+        clean_pipeline.append({"$limit": row_limit + 1})
+        with _mongo_database(context) as database:
+            rows = database[name].aggregate(clean_pipeline, maxTimeMS=15_000, allowDiskUse=False)
+            values, truncated = _bounded_sequence(rows, row_limit)
+        return {"collection": name, "documents": values, "count": len(values), "truncated": truncated}
+
+    @mcp.tool(annotations=READ_ONLY)
+    def count_documents(collection: str, filter: dict[str, Any] | None = None) -> dict[str, Any]:
+        """统计结构化筛选命中的文档数量。"""
+        name = _mongo_collection(collection)
+        query_filter = validate_document(filter or {})
+        with _mongo_database(context) as database:
+            count = database[name].count_documents(query_filter, maxTimeMS=15_000)
+        return {"collection": name, "count": int(count)}
+
+    return mcp
+
+
+def _preflight_mongodb(context: DatabaseContext) -> None:
+    allowed_database = str(context.settings["database"])
+    denied_actions = {
+        "insert",
+        "update",
+        "remove",
+        "createCollection",
+        "createIndex",
+        "dropCollection",
+        "dropDatabase",
+        "dropIndex",
+        "renameCollectionSameDB",
+        "bypassDocumentValidation",
+        "convertToCapped",
+        "collMod",
+    }
+    with _mongo_database(context, timeout=10) as database:
+        status = database.command(
+            {"connectionStatus": 1, "showPrivileges": True}, maxTimeMS=10_000
+        )
+        auth_info = status.get("authInfo") if isinstance(status, dict) else None
+        roles = auth_info.get("authenticatedUserRoles") if isinstance(auth_info, dict) else None
+        if not isinstance(roles, list) or not roles:
+            raise RuntimeError("database_readonly_preflight_failed")
+        role_scopes = {
+            (str(item.get("role")), str(item.get("db")))
+            for item in roles
+            if isinstance(item, dict)
+        }
+        if role_scopes != {("read", allowed_database)}:
+            raise RuntimeError("database_readonly_preflight_failed")
+        privileges = auth_info.get("authenticatedUserPrivileges", [])
+        if not isinstance(privileges, list):
+            raise RuntimeError("database_readonly_preflight_failed")
+        for privilege in privileges:
+            actions = privilege.get("actions", []) if isinstance(privilege, dict) else []
+            if set(map(str, actions)) & denied_actions:
+                raise RuntimeError("database_readonly_preflight_failed")
+        database.list_collection_names(filter={"name": {"$not": {"$regex": "^system\\."}}})
+
+
+@contextlib.contextmanager
+def _clickhouse_client(context: DatabaseContext, timeout: int = 15) -> Iterator[Any]:
+    import clickhouse_connect
+
+    tls_mode = str(context.settings["tls_mode"])
+    client = clickhouse_connect.get_client(
+        host=str(context.settings["host"]),
+        port=int(context.settings["port"]),
+        username=str(context.settings["username"]),
+        password=context.credentials["password"],
+        database=str(context.settings["database"]),
+        secure=True,
+        verify=True,
+        connect_timeout=min(timeout, 10),
+        send_receive_timeout=timeout,
+        query_limit=1_001,
+        settings={
+            "readonly": 1,
+            "max_execution_time": timeout,
+            "max_result_rows": 1_001,
+            "max_result_bytes": MAX_OUTPUT_BYTES,
+            "result_overflow_mode": "throw",
+        },
+        product_name="ModelMirror-Wave5-ReadOnly",
+    )
+    try:
+        yield client
+    finally:
+        client.close()
+
+
+def _clickhouse_payload(result: Any, max_rows: int) -> dict[str, Any]:
+    return _result_payload([str(item) for item in result.column_names], list(result.result_rows), max_rows)
+
+
+def build_clickhouse(context: DatabaseContext) -> FastMCP:
+    mcp = FastMCP("ModelMirror ClickHouse Read Only")
+
+    @mcp.tool(annotations=READ_ONLY)
+    def list_databases() -> dict[str, Any]:
+        """返回当前固定数据库作用域，不枚举其他数据库。"""
+        return {"databases": [{"name": str(context.settings["database"]), "scope": "configured"}]}
+
+    @mcp.tool(annotations=READ_ONLY)
+    def list_tables(max_rows: int = 200) -> dict[str, Any]:
+        """列出当前固定 ClickHouse 数据库中的表。"""
+        limit = clamp_rows(max_rows)
+        database = str(context.settings["database"])
+        with _clickhouse_client(context) as client:
+            result = client.query(
+                "SELECT name, engine, total_rows, total_bytes FROM system.tables "
+                "WHERE database = {database:String} ORDER BY name LIMIT {limit:UInt32}",
+                parameters={"database": database, "limit": limit + 1},
+            )
+        return _clickhouse_payload(result, limit)
+
+    @mcp.tool(annotations=READ_ONLY)
+    def run_query(query: str, max_rows: int = 200, timeout_seconds: int = 15) -> dict[str, Any]:
+        """以 readonly=1 执行单条 ClickHouse SELECT/WITH 查询。"""
+        limit = clamp_rows(max_rows)
+        timeout = clamp_timeout(timeout_seconds)
+        clean = validate_readonly_sql(query, dialect="clickhouse")
+        with _clickhouse_client(context, timeout) as client:
+            result = client.query(
+                _sql_wrapper(clean, limit, engine="clickhouse"),
+                settings={
+                    "readonly": 1,
+                    "max_execution_time": timeout,
+                    "max_result_rows": limit + 1,
+                    "max_result_bytes": MAX_OUTPUT_BYTES,
+                    "result_overflow_mode": "throw",
+                },
+            )
+        return _clickhouse_payload(result, limit)
+
+    return mcp
+
+
+def _preflight_clickhouse(context: DatabaseContext) -> None:
+    with _clickhouse_client(context, timeout=10) as client:
+        readonly = client.query("SELECT getSetting('readonly')").first_row[0]
+        if int(readonly) not in {1, 2}:
+            raise RuntimeError("database_readonly_preflight_failed")
+        if int(client.query("SELECT 1").first_row[0]) != 1:
+            raise RuntimeError("database_preflight_failed")
+
+
+@contextlib.contextmanager
+def _redis_client(context: DatabaseContext, timeout: int = 15) -> Iterator[Any]:
+    import redis
+
+    tls_mode = str(context.settings["tls_mode"])
+    client = redis.Redis(
+        host=str(context.settings["host"]),
+        port=int(context.settings["port"]),
+        db=int(context.settings["database"]),
+        username=str(context.settings.get("username") or "") or None,
+        password=context.credentials["password"],
+        ssl=True,
+        ssl_cert_reqs="required",
+        ssl_check_hostname=True,
+        socket_connect_timeout=min(timeout, 10),
+        socket_timeout=timeout,
+        retry_on_timeout=False,
+        health_check_interval=0,
+        decode_responses=False,
+        client_name="ModelMirror-Wave5-ReadOnly",
+    )
+    try:
+        client.ping()
+        yield client
+    finally:
+        client.close()
+
+
+def _redis_key(value: str, *, allow_pattern: bool = False) -> str:
+    clean = str(value or "")
+    if not clean or len(clean.encode("utf-8")) > 1_024 or any(char in clean for char in "\r\n\x00"):
+        raise ValueError("Redis 键无效。")
+    if not allow_pattern and any(char in clean for char in "*?["):
+        raise ValueError("该工具不接受键通配符。")
+    return clean
+
+
+def _redis_values(values: list[Any], limit: int) -> tuple[list[Any], bool]:
+    result, truncated = _bounded_sequence(values, limit)
+    return result, truncated
+
+
+def build_redis(context: DatabaseContext) -> FastMCP:
+    mcp = FastMCP("ModelMirror Redis Read Only")
+
+    @mcp.tool(annotations=READ_ONLY)
+    def scan_keys(pattern: str = "*", limit: int = 200) -> dict[str, Any]:
+        """以 SCAN 分页读取键名；不使用阻塞式 KEYS。"""
+        clean = _redis_key(pattern, allow_pattern=True)
+        row_limit = clamp_rows(limit)
+        keys: list[Any] = []
+        cursor = 0
+        with _redis_client(context) as client:
+            for _ in range(100):
+                cursor, page = client.scan(cursor=cursor, match=clean, count=min(row_limit + 1, 500))
+                keys.extend(page)
+                if cursor == 0 or len(keys) > row_limit:
+                    break
+        values, truncated = _redis_values(keys, row_limit)
+        return {"keys": values, "count": len(values), "truncated": truncated or cursor != 0}
+
+    @mcp.tool(annotations=READ_ONLY)
+    def get_value(key: str) -> dict[str, Any]:
+        """读取字符串键；其他类型请使用对应只读工具。"""
+        clean = _redis_key(key)
+        with _redis_client(context) as client:
+            value = client.get(clean)
+        return {"key": clean, "value": _json_value(value), "found": value is not None}
+
+    @mcp.tool(annotations=READ_ONLY)
+    def get_type(key: str) -> dict[str, Any]:
+        """读取键的数据类型。"""
+        clean = _redis_key(key)
+        with _redis_client(context) as client:
+            value = client.type(clean)
+        return {"key": clean, "type": _json_value(value)}
+
+    @mcp.tool(annotations=READ_ONLY)
+    def get_ttl(key: str) -> dict[str, Any]:
+        """读取键的剩余生存时间，不修改过期时间。"""
+        clean = _redis_key(key)
+        with _redis_client(context) as client:
+            value = client.ttl(clean)
+        return {"key": clean, "ttl_seconds": int(value)}
+
+    @mcp.tool(annotations=READ_ONLY)
+    def hash_get_all(key: str, limit: int = 200) -> dict[str, Any]:
+        """读取哈希字段和值，结果受行数和输出上限约束。"""
+        clean = _redis_key(key)
+        row_limit = clamp_rows(limit)
+        with _redis_client(context) as client:
+            rows: list[dict[str, Any]] = []
+            cursor = 0
+            for _ in range(100):
+                cursor, page = client.hscan(
+                    clean, cursor=cursor, count=min(row_limit + 1, 500)
+                )
+                rows.extend(
+                    {"field": _json_value(field), "value": _json_value(value)}
+                    for field, value in page.items()
+                )
+                if cursor == 0 or len(rows) > row_limit:
+                    break
+        values, output_truncated = _bounded_sequence(rows, row_limit)
+        return {
+            "key": clean,
+            "entries": values,
+            "truncated": output_truncated or cursor != 0,
+        }
+
+    @mcp.tool(annotations=READ_ONLY)
+    def list_range(key: str, start: int = 0, limit: int = 200) -> dict[str, Any]:
+        """读取列表片段。"""
+        clean = _redis_key(key)
+        row_limit = clamp_rows(limit)
+        start_value = max(0, min(int(start), 10_000_000))
+        with _redis_client(context) as client:
+            raw = client.lrange(clean, start_value, start_value + row_limit)
+        values, truncated = _redis_values(raw, row_limit)
+        return {"key": clean, "values": values, "truncated": truncated}
+
+    @mcp.tool(annotations=READ_ONLY)
+    def set_members(key: str, limit: int = 200) -> dict[str, Any]:
+        """用 SSCAN 读取集合成员。"""
+        clean = _redis_key(key)
+        row_limit = clamp_rows(limit)
+        members: list[Any] = []
+        cursor = 0
+        with _redis_client(context) as client:
+            for _ in range(100):
+                cursor, page = client.sscan(clean, cursor=cursor, count=min(row_limit + 1, 500))
+                members.extend(page)
+                if cursor == 0 or len(members) > row_limit:
+                    break
+        values, truncated = _redis_values(members, row_limit)
+        return {"key": clean, "members": values, "truncated": truncated or cursor != 0}
+
+    @mcp.tool(annotations=READ_ONLY)
+    def sorted_set_range(key: str, start: int = 0, limit: int = 200) -> dict[str, Any]:
+        """读取有序集合片段及分数。"""
+        clean = _redis_key(key)
+        row_limit = clamp_rows(limit)
+        start_value = max(0, min(int(start), 10_000_000))
+        with _redis_client(context) as client:
+            raw = client.zrange(clean, start_value, start_value + row_limit, withscores=True)
+        rows = [{"member": _json_value(member), "score": float(score)} for member, score in raw]
+        values, truncated = bounded_rows(rows, max_rows=row_limit)
+        return {"key": clean, "members": values, "truncated": truncated}
+
+    return mcp
+
+
+def _preflight_redis(context: DatabaseContext) -> None:
+    import redis
+
+    with _redis_client(context, timeout=10) as client:
+        connection = client.connection_pool.get_connection()
+        try:
+            for command in (
+                ("SET", "__modelmirror_acl_probe__", "denied"),
+                ("DEL", "__modelmirror_acl_probe__"),
+                ("EVAL", "return 1", "0"),
+                ("FLUSHDB",),
+            ):
+                connection.send_command("MULTI")
+                if connection.read_response() not in {b"OK", "OK"}:
+                    raise RuntimeError("database_readonly_preflight_failed")
+                allowed = False
+                try:
+                    connection.send_command(*command)
+                    response = connection.read_response()
+                    allowed = response in {b"QUEUED", "QUEUED"}
+                except redis.exceptions.ResponseError:
+                    allowed = False
+                finally:
+                    connection.send_command("DISCARD")
+                    try:
+                        connection.read_response()
+                    except redis.exceptions.ResponseError:
+                        pass
+                if allowed:
+                    raise RuntimeError("database_readonly_preflight_failed")
+        finally:
+            client.connection_pool.release(connection)
+
+
+@contextlib.contextmanager
+def _duckdb_connection(context: DatabaseContext, file_id: str) -> Iterator[Any]:
+    import duckdb
+
+    path = context.duckdb_file(file_id)
+    connection = duckdb.connect(
+        str(path),
+        read_only=True,
+        config={
+            "enable_external_access": "false",
+            "allow_unsigned_extensions": "false",
+            "threads": "1",
+            "memory_limit": "256MB",
+            "max_temp_directory_size": "0KB",
+        },
+    )
+    try:
+        yield connection
+    finally:
+        connection.close()
+
+
+def _duckdb_payload(cursor: Any, max_rows: int) -> dict[str, Any]:
+    columns = [str(item[0]) for item in (cursor.description or [])]
+    def rows() -> Iterator[Any]:
+        if not columns:
+            return
+        for _ in range(max_rows + 1):
+            item = cursor.fetchone()
+            if item is None:
+                return
+            yield item
+    return _result_payload(columns, rows(), max_rows)
+
+
+def build_duckdb(context: DatabaseContext) -> FastMCP:
+    mcp = FastMCP("ModelMirror DuckDB Read Only")
+
+    @mcp.tool(annotations=READ_ONLY)
+    def list_schemas(database_file_id: DatabaseFileId, max_rows: int = 200) -> dict[str, Any]:
+        """列出所选封存 DuckDB 文件中的 schema。"""
+        limit = clamp_rows(max_rows)
+        with _duckdb_connection(context, database_file_id) as connection:
+            cursor = connection.execute(
+                "SELECT schema_name FROM information_schema.schemata ORDER BY schema_name LIMIT ?",
+                [limit + 1],
+            )
+            return _duckdb_payload(cursor, limit)
+
+    @mcp.tool(annotations=READ_ONLY)
+    def list_tables(database_file_id: DatabaseFileId, schema: str = "", max_rows: int = 200) -> dict[str, Any]:
+        """列出所选 DuckDB 文件中的表和视图。"""
+        limit = clamp_rows(max_rows)
+        schema_name = _safe_identifier(schema, "Schema") if schema else ""
+        with _duckdb_connection(context, database_file_id) as connection:
+            query = "SELECT table_schema, table_name, table_type FROM information_schema.tables"
+            params: list[Any] = []
+            if schema_name:
+                query += " WHERE table_schema = ?"
+                params.append(schema_name)
+            query += " ORDER BY table_schema, table_name LIMIT ?"
+            params.append(limit + 1)
+            return _duckdb_payload(connection.execute(query, params), limit)
+
+    @mcp.tool(annotations=READ_ONLY)
+    def describe_table(database_file_id: DatabaseFileId, schema: str, table: str, max_rows: int = 200) -> dict[str, Any]:
+        """读取所选 DuckDB 文件中的表结构。"""
+        limit = clamp_rows(max_rows)
+        schema_name = _safe_identifier(schema, "Schema")
+        table_name = _safe_identifier(table, "表")
+        with _duckdb_connection(context, database_file_id) as connection:
+            cursor = connection.execute(
+                "SELECT column_name, data_type, is_nullable, column_default, ordinal_position "
+                "FROM information_schema.columns WHERE table_schema = ? AND table_name = ? "
+                "ORDER BY ordinal_position LIMIT ?",
+                [schema_name, table_name, limit + 1],
+            )
+            return _duckdb_payload(cursor, limit)
+
+    @mcp.tool(annotations=READ_ONLY)
+    def query(database_file_id: DatabaseFileId, query: str, max_rows: int = 200, timeout_seconds: int = 15) -> dict[str, Any]:
+        """在只读连接中执行单条 SELECT/WITH；禁止文件、网络与扩展访问。"""
+        limit = clamp_rows(max_rows)
+        clamp_timeout(timeout_seconds)  # Process-level timeout is enforced by the sidecar gateway.
+        clean = validate_readonly_sql(query, dialect="duckdb")
+        with _duckdb_connection(context, database_file_id) as connection:
+            return _duckdb_payload(connection.execute(_sql_wrapper(clean, limit, engine="duckdb")), limit)
+
+    return mcp
+
+
+def _preflight_duckdb(context: DatabaseContext) -> None:
+    if len(context._duckdb_files) > 64:
+        raise RuntimeError("duckdb_file_limit_exceeded")
+    for file_id in context._duckdb_files:
+        with _duckdb_connection(context, file_id) as connection:
+            if int(connection.execute("SELECT 1").fetchone()[0]) != 1:
+                raise RuntimeError("database_preflight_failed")
+
+
+def _supabase_query(context: DatabaseContext, query: str, timeout: int) -> Any:
+    import httpx
+
+    project_ref = str(context.settings["project_ref"])
+    url = f"https://api.supabase.com/v1/projects/{project_ref}/database/query/read-only"
+    headers = {
+        "Authorization": f"Bearer {context.credentials['access_token']}",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "User-Agent": "ModelMirror-Wave5-ReadOnly/1",
+    }
+    with httpx.Client(
+        timeout=httpx.Timeout(timeout, connect=min(timeout, 10)),
+        follow_redirects=False,
+        trust_env=False,
+    ) as client:
+        with client.stream("POST", url, headers=headers, json={"query": query}) as response:
+            if response.is_redirect:
+                raise ValueError("Supabase 重定向已被安全策略拒绝。")
+            if response.status_code >= 400:
+                raise ValueError(f"Supabase 只读请求失败（HTTP {response.status_code}）。")
+            content_length = response.headers.get("content-length")
+            if content_length and int(content_length) > MAX_OUTPUT_BYTES:
+                raise ValueError("Supabase 响应超过 256 KiB 上限。")
+            chunks: list[bytes] = []
+            total = 0
+            for chunk in response.iter_bytes():
+                total += len(chunk)
+                if total > MAX_OUTPUT_BYTES:
+                    raise ValueError("Supabase 响应超过 256 KiB 上限。")
+                chunks.append(chunk)
+            content = b"".join(chunks)
+    try:
+        return json.loads(content.decode("utf-8"))
+    except (ValueError, UnicodeError) as exc:
+        raise ValueError("Supabase 返回了无效 JSON。") from exc
+
+
+def _supabase_payload(value: Any, max_rows: int) -> dict[str, Any]:
+    rows = value if isinstance(value, list) else value.get("result", value) if isinstance(value, dict) else []
+    if not isinstance(rows, list):
+        rows = [rows]
+    values, truncated = _bounded_sequence(rows, max_rows)
+    return {"rows": values, "row_count": len(values), "truncated": truncated}
+
+
+def build_supabase(context: DatabaseContext) -> FastMCP:
+    mcp = FastMCP("ModelMirror Supabase Read Only")
+
+    @mcp.tool(annotations=READ_ONLY)
+    def list_tables(max_rows: int = 200) -> dict[str, Any]:
+        """列出绑定 Supabase 项目中的普通表，不访问其他项目。"""
+        limit = clamp_rows(max_rows)
+        query = _sql_wrapper(
+            "SELECT table_schema, table_name, table_type FROM information_schema.tables "
+            "WHERE table_schema NOT IN ('pg_catalog', 'information_schema') "
+            "ORDER BY table_schema, table_name",
+            limit,
+            engine="postgresql",
+        )
+        return _supabase_payload(_supabase_query(context, query, 15), limit)
+
+    @mcp.tool(annotations=READ_ONLY)
+    def list_extensions(max_rows: int = 200) -> dict[str, Any]:
+        """读取绑定 Supabase 项目中已安装扩展的元数据。"""
+        limit = clamp_rows(max_rows)
+        query = _sql_wrapper(
+            "SELECT extname, extversion FROM pg_extension ORDER BY extname",
+            limit,
+            engine="postgresql",
+        )
+        return _supabase_payload(_supabase_query(context, query, 15), limit)
+
+    @mcp.tool(annotations=READ_ONLY)
+    def execute_sql(query: str, max_rows: int = 200, timeout_seconds: int = 15) -> dict[str, Any]:
+        """对绑定项目执行经词法与 AST 审核的单条只读 SELECT/WITH。"""
+        limit = clamp_rows(max_rows)
+        timeout = clamp_timeout(timeout_seconds)
+        clean = validate_readonly_sql(query, dialect="postgres")
+        wrapped = _sql_wrapper(clean, limit, engine="postgresql")
+        return _supabase_payload(_supabase_query(context, wrapped, timeout), limit)
+
+    return mcp
+
+
+def _preflight_supabase(context: DatabaseContext) -> None:
+    value = _supabase_query(context, "SELECT 1 AS modelmirror_preflight", 10)
+    payload = _supabase_payload(value, 1)
+    if not payload["rows"]:
+        raise RuntimeError("database_preflight_failed")
+
+
+BUILDERS = {
+    "dbhub": build_dbhub,
+    "mongodb-mcp": build_mongodb,
+    "clickhouse-mcp": build_clickhouse,
+    "redis-mcp": build_redis,
+    "duckdb-mcp": build_duckdb,
+    "supabase-mcp": build_supabase,
+}
+
+PREFLIGHTS = {
+    "dbhub": _preflight_dbhub,
+    "mongodb-mcp": _preflight_mongodb,
+    "clickhouse-mcp": _preflight_clickhouse,
+    "redis-mcp": _preflight_redis,
+    "duckdb-mcp": _preflight_duckdb,
+    "supabase-mcp": _preflight_supabase,
+}
+
+
+ADAPTER_TOOL_NAMES = {adapter_id: tuple(sorted(contract.tools)) for adapter_id, contract in DATABASE_ADAPTERS.items()}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("adapter_id", choices=sorted(BUILDERS))
+    arguments = parser.parse_args()
+    try:
+        context = DatabaseContext(arguments.adapter_id)
+        PREFLIGHTS[arguments.adapter_id](context)
+    except Exception:
+        print(
+            f"database adapter preflight failed: {arguments.adapter_id}",
+            file=sys.stderr,
+        )
+        return 69
+    BUILDERS[arguments.adapter_id](context).run(transport="stdio")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/server/sandbox_sidecar/database_server.py
+++ b/server/sandbox_sidecar/database_server.py
@@ -1,0 +1,536 @@
+"""Private Unix-socket gateway for fixed Wave-5 database MCP adapters."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import os
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from .database_contracts import (
+    DATABASE_ADAPTERS,
+    FORBIDDEN_CONFIGURATION_KEYS,
+    MAX_ARGUMENT_BYTES,
+    MAX_OUTPUT_BYTES,
+    WORKSPACE_PATTERN,
+    resolve_allowed_addresses,
+    validate_configuration,
+    validate_document,
+    validate_readonly_sql,
+)
+from .engine import SandboxEngineError
+
+
+SOCKET_PATH = Path(
+    os.getenv("MCP_DATABASE_SOCKET_PATH", "/run/modelmirror-database-mcp/database-mcp.sock")
+)
+INPUT_ROOT = Path(os.getenv("MCP_DATABASE_INPUT_ROOT", "/inputs"))
+MAX_REQUEST_BYTES = 128 * 1024
+MAX_MCP_MESSAGE_BYTES = 256 * 1024
+TOOL_CALL_TIMEOUT_SECONDS = 15
+MAX_SESSIONS = max(1, min(int(os.getenv("MCP_DATABASE_MAX_SESSIONS", "6")), 12))
+SEMAPHORE = asyncio.Semaphore(MAX_SESSIONS)
+
+
+def _allowed_adapters() -> frozenset[str]:
+    raw = os.getenv("MCP_DATABASE_ALLOWED_ADAPTERS", "").strip()
+    if not raw:
+        return frozenset(DATABASE_ADAPTERS)
+    requested = {item.strip() for item in raw.split(",") if item.strip()}
+    # Unknown administrator entries never broaden the compiled allowlist.
+    return frozenset(requested & set(DATABASE_ADAPTERS))
+
+
+ALLOWED_ADAPTERS = _allowed_adapters()
+
+
+def _rpc_error(request_id: object, code: int, message: str) -> bytes:
+    return (
+        json.dumps(
+            {"jsonrpc": "2.0", "id": request_id, "error": {"code": code, "message": message}},
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        + b"\n"
+    )
+
+
+def _walk_argument_keys(value: object, *, depth: int = 0) -> None:
+    if depth > 12:
+        raise ValueError("arguments_too_deep")
+    if isinstance(value, dict):
+        for raw_key, child in value.items():
+            key = str(raw_key).strip().lower()
+            if key in FORBIDDEN_CONFIGURATION_KEYS:
+                raise ValueError("forbidden_argument_field")
+            _walk_argument_keys(child, depth=depth + 1)
+    elif isinstance(value, list):
+        for child in value:
+            _walk_argument_keys(child, depth=depth + 1)
+
+
+def _validate_tool_arguments(adapter_id: str, tool_name: str, arguments: object) -> None:
+    if not isinstance(arguments, dict):
+        raise ValueError("invalid_tool_arguments")
+    encoded = json.dumps(arguments, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    if len(encoded) > MAX_ARGUMENT_BYTES:
+        raise ValueError("arguments_too_large")
+    _walk_argument_keys(arguments)
+    if tool_name in {"execute_sql", "run_query", "query"}:
+        dialect = {
+            "dbhub": "postgres",
+            "clickhouse-mcp": "clickhouse",
+            "duckdb-mcp": "duckdb",
+            "supabase-mcp": "postgres",
+        }[adapter_id]
+        # DBHub repeats the gate with the exact selected engine in the child.
+        validate_readonly_sql(arguments.get("query"), dialect=dialect)
+    if adapter_id == "mongodb-mcp":
+        if tool_name == "aggregate":
+            validate_document(arguments.get("pipeline"), pipeline=True)
+        for field in ("filter", "projection", "sort"):
+            if field in arguments and arguments[field] is not None:
+                validate_document(arguments[field])
+
+
+async def _terminate_timed_out_call(
+    request_id: object,
+    process: asyncio.subprocess.Process,
+    client: asyncio.StreamWriter,
+    write_lock: asyncio.Lock,
+    call_requests: set[object],
+    call_deadlines: dict[object, asyncio.Task[None]],
+    suppressed_requests: set[object],
+    *,
+    timeout_seconds: float = TOOL_CALL_TIMEOUT_SECONDS,
+) -> None:
+    """Fail one timed-out call and terminate its entire isolated child session."""
+
+    await asyncio.sleep(timeout_seconds)
+    current = asyncio.current_task()
+    async with write_lock:
+        if current is None or call_deadlines.get(request_id) is not current:
+            return
+        call_deadlines.pop(request_id, None)
+        call_requests.discard(request_id)
+        suppressed_requests.add(request_id)
+        client.write(
+            _rpc_error(
+                request_id,
+                -32001,
+                "数据库只读调用超过 15 秒，已终止会话。",
+            )
+        )
+        await client.drain()
+    if process.returncode is None:
+        process.kill()
+        await process.wait()
+
+
+async def _client_to_child(
+    source: asyncio.StreamReader,
+    destination: asyncio.StreamWriter,
+    client: asyncio.StreamWriter,
+    adapter_id: str,
+    list_requests: set[object],
+    call_requests: set[object],
+    call_deadlines: dict[object, asyncio.Task[None]],
+    suppressed_requests: set[object],
+    process: asyncio.subprocess.Process,
+    write_lock: asyncio.Lock,
+) -> None:
+    contract = DATABASE_ADAPTERS[adapter_id]
+    while True:
+        raw = await source.readline()
+        if not raw:
+            break
+        if len(raw) > MAX_MCP_MESSAGE_BYTES:
+            raise SandboxEngineError("MCP request exceeds 256 KiB.", code="mcp_message_too_large")
+        try:
+            payload = json.loads(raw.decode("utf-8"))
+        except (UnicodeError, json.JSONDecodeError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        request_id = payload.get("id")
+        method = payload.get("method")
+        if method == "tools/list" and request_id is not None:
+            if not isinstance(request_id, (str, int)) or isinstance(request_id, bool):
+                async with write_lock:
+                    client.write(_rpc_error(None, -32600, "MCP 请求 ID 无效。"))
+                    await client.drain()
+                continue
+            list_requests.add(request_id)
+        elif method == "tools/call":
+            if not isinstance(request_id, (str, int)) or isinstance(request_id, bool):
+                async with write_lock:
+                    client.write(_rpc_error(None, -32600, "工具调用必须提供有效请求 ID。"))
+                    await client.drain()
+                continue
+            if request_id in list_requests or request_id in call_requests:
+                async with write_lock:
+                    client.write(_rpc_error(request_id, -32600, "MCP 请求 ID 重复。"))
+                    await client.drain()
+                continue
+            params = payload.get("params")
+            tool_name = params.get("name") if isinstance(params, dict) else None
+            arguments = params.get("arguments", {}) if isinstance(params, dict) else {}
+            if tool_name not in contract.tools:
+                async with write_lock:
+                    client.write(_rpc_error(request_id, -32601, "该工具未通过数据库只读策略审核。"))
+                    await client.drain()
+                continue
+            try:
+                _validate_tool_arguments(adapter_id, str(tool_name), arguments)
+            except ValueError:
+                async with write_lock:
+                    client.write(_rpc_error(request_id, -32602, "工具参数未通过数据库安全策略。"))
+                    await client.drain()
+                continue
+            call_requests.add(request_id)
+            deadline = asyncio.create_task(
+                _terminate_timed_out_call(
+                    request_id,
+                    process,
+                    client,
+                    write_lock,
+                    call_requests,
+                    call_deadlines,
+                    suppressed_requests,
+                )
+            )
+            call_deadlines[request_id] = deadline
+        destination.write(raw)
+        await destination.drain()
+
+
+async def _child_to_client(
+    source: asyncio.StreamReader,
+    destination: asyncio.StreamWriter,
+    adapter_id: str,
+    list_requests: set[object],
+    call_requests: set[object],
+    call_deadlines: dict[object, asyncio.Task[None]],
+    suppressed_requests: set[object],
+    write_lock: asyncio.Lock,
+) -> None:
+    contract = DATABASE_ADAPTERS[adapter_id]
+    while True:
+        raw = await source.readline()
+        if not raw:
+            break
+        if len(raw) > MAX_MCP_MESSAGE_BYTES or len(raw) > MAX_OUTPUT_BYTES + 16 * 1024:
+            raise SandboxEngineError("MCP output exceeds 256 KiB.", code="mcp_output_too_large")
+        output = raw
+        try:
+            payload = json.loads(raw.decode("utf-8"))
+            request_id = payload.get("id") if isinstance(payload, dict) else None
+            if request_id in suppressed_requests:
+                suppressed_requests.discard(request_id)
+                continue
+            if request_id in list_requests:
+                list_requests.discard(request_id)
+                result = payload.get("result")
+                tools = result.get("tools") if isinstance(result, dict) else None
+                if isinstance(tools, list):
+                    result["tools"] = [
+                        item
+                        for item in tools
+                        if isinstance(item, dict) and item.get("name") in contract.tools
+                    ]
+                    output = (
+                        json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+                        + b"\n"
+                    )
+            elif request_id in call_requests:
+                call_requests.discard(request_id)
+                deadline = call_deadlines.pop(request_id, None)
+                if deadline is not None:
+                    deadline.cancel()
+                if isinstance(payload, dict) and "error" in payload:
+                    error = payload.get("error")
+                    code = error.get("code", -32603) if isinstance(error, dict) else -32603
+                    payload["error"] = {"code": code, "message": "数据库只读调用失败。"}
+                    output = (
+                        json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+                        + b"\n"
+                    )
+                elif isinstance(payload, dict):
+                    result = payload.get("result")
+                    if isinstance(result, dict) and (
+                        result.get("isError") is True or result.get("is_error") is True
+                    ):
+                        result.pop("structuredContent", None)
+                        result.pop("structured_content", None)
+                        result["content"] = [
+                            {"type": "text", "text": "数据库只读调用失败。"}
+                        ]
+                        output = (
+                            json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+                            + b"\n"
+                        )
+        except (UnicodeError, json.JSONDecodeError):
+            pass
+        async with write_lock:
+            destination.write(output)
+            await destination.drain()
+
+
+async def _drain_stderr(stream: asyncio.StreamReader | None) -> None:
+    if stream is None:
+        return
+    while await stream.read(4096):
+        pass
+
+
+async def _stdio(
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+    request: dict[str, Any],
+) -> None:
+    adapter_id = str(request.get("adapter_id") or "").strip()
+    if adapter_id not in ALLOWED_ADAPTERS:
+        raise SandboxEngineError("Database adapter is disabled in this sidecar.", code="mcp_adapter_denied")
+    try:
+        validated = validate_configuration(adapter_id, request.get("configuration"))
+    except ValueError as exc:
+        raise SandboxEngineError("Database adapter configuration denied.", code=str(exc)) from exc
+    request["configuration"] = None
+    if "host" in validated.settings:
+        try:
+            addresses = resolve_allowed_addresses(
+                str(validated.settings["host"]), int(validated.settings["port"])
+            )
+        except ValueError as exc:
+            raise SandboxEngineError("Database target denied.", code=str(exc)) from exc
+    else:
+        addresses = resolve_allowed_addresses("api.supabase.com", 443) if adapter_id == "supabase-mcp" else ()
+
+    if adapter_id == "duckdb-mcp":
+        assert validated.workspace_id is not None
+        input_root = (INPUT_ROOT / validated.workspace_id).resolve()
+        if input_root.parent != INPUT_ROOT.resolve() or not input_root.is_dir() or input_root.is_symlink():
+            raise SandboxEngineError("DuckDB workspace unavailable.", code="workspace_unavailable")
+        if not any(
+            path.is_file() and not path.is_symlink() and path.suffix.lower() == ".duckdb"
+            for path in input_root.rglob("*")
+        ):
+            raise SandboxEngineError("DuckDB workspace has no reviewed database file.", code="duckdb_file_missing")
+
+    async with SEMAPHORE:
+        temp_root = Path(tempfile.mkdtemp(prefix=f"mcp-database-{adapter_id[:12]}-"))
+        payload = {
+            "settings": dict(validated.settings),
+            "credentials": dict(validated.credentials),
+        }
+        if validated.workspace_id is not None:
+            payload["workspace_id"] = validated.workspace_id
+        encoded_configuration = base64.urlsafe_b64encode(
+            json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+        ).decode("ascii")
+        payload = {}
+        validated.clear_secrets()
+        env = {
+            "PATH": "/usr/local/bin:/usr/bin:/bin",
+            "PYTHONPATH": "/opt/modelmirror",
+            "PYTHONDONTWRITEBYTECODE": "1",
+            "PYTHONNOUSERSITE": "1",
+            "PYTHONUNBUFFERED": "1",
+            "HOME": str(temp_root),
+            "TMPDIR": str(temp_root),
+            "LANG": "C.UTF-8",
+            "LC_ALL": "C.UTF-8",
+            "TZ": "UTC",
+            "NO_PROXY": "*",
+            "no_proxy": "*",
+            "DO_NOT_TRACK": "1",
+            "MCP_DATABASE_ADAPTER_ID": adapter_id,
+            "MCP_DATABASE_WORKSPACE_ID": validated.workspace_id or "",
+            "MCP_DATABASE_INPUT_ROOT": str(INPUT_ROOT),
+            "MCP_DATABASE_CHILD_CONFIGURATION_B64": encoded_configuration,
+            "MCP_DATABASE_PINNED_DNS_B64": base64.urlsafe_b64encode(
+                json.dumps(
+                    {
+                        "host": (
+                            str(validated.settings["host"])
+                            if "host" in validated.settings
+                            else "api.supabase.com" if adapter_id == "supabase-mcp" else None
+                        ),
+                        "addresses": list(addresses),
+                    },
+                    separators=(",", ":"),
+                ).encode("utf-8")
+            ).decode("ascii"),
+        }
+        encoded_configuration = ""
+        command = [
+            sys.executable,
+            "-m",
+            "sandbox_sidecar.database_landlock_exec",
+            "--",
+            sys.executable,
+            "-m",
+            "sandbox_sidecar.database_mcp",
+            adapter_id,
+        ]
+        process: asyncio.subprocess.Process | None = None
+        tasks: list[asyncio.Task[None]] = []
+        handshake_sent = False
+        try:
+            process = await asyncio.create_subprocess_exec(
+                *command,
+                cwd=str(temp_root),
+                env=env,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                start_new_session=True,
+                limit=MAX_MCP_MESSAGE_BYTES + 1,
+            )
+            env.clear()
+            if process.stdin is None or process.stdout is None:
+                raise SandboxEngineError("Database MCP stdio unavailable.", code="mcp_stdio_unavailable")
+            writer.write(
+                json.dumps(
+                    {
+                        "ok": True,
+                        "adapter_id": adapter_id,
+                        "protocol": "modelmirror-mcp-database-stdio-v1",
+                        "read_only": True,
+                        "tools": sorted(validated.contract.tools),
+                        "target_policy": "sealed-workspace" if adapter_id == "duckdb-mcp" else "resolved-public-or-admin-allowlist",
+                        "resolved_address_count": len(addresses),
+                        "limits": {
+                            "max_rows": 1_000,
+                            "default_rows": 200,
+                            "timeout_seconds": 15,
+                            "output_bytes": MAX_OUTPUT_BYTES,
+                        },
+                    },
+                    ensure_ascii=False,
+                    separators=(",", ":"),
+                ).encode("utf-8")
+                + b"\n"
+            )
+            await writer.drain()
+            handshake_sent = True
+            list_requests: set[object] = set()
+            call_requests: set[object] = set()
+            call_deadlines: dict[object, asyncio.Task[None]] = {}
+            suppressed_requests: set[object] = set()
+            write_lock = asyncio.Lock()
+            tasks = [
+                asyncio.create_task(
+                    _client_to_child(
+                        reader,
+                        process.stdin,
+                        writer,
+                        adapter_id,
+                        list_requests,
+                        call_requests,
+                        call_deadlines,
+                        suppressed_requests,
+                        process,
+                        write_lock,
+                    )
+                ),
+                asyncio.create_task(
+                    _child_to_client(
+                        process.stdout,
+                        writer,
+                        adapter_id,
+                        list_requests,
+                        call_requests,
+                        call_deadlines,
+                        suppressed_requests,
+                        write_lock,
+                    )
+                ),
+                asyncio.create_task(_drain_stderr(process.stderr)),
+            ]
+            done, pending = await asyncio.wait(tasks[:2], return_when=asyncio.FIRST_COMPLETED)
+            for task in done:
+                task.result()
+            for task in pending:
+                task.cancel()
+        finally:
+            if "call_deadlines" in locals():
+                for deadline in call_deadlines.values():
+                    deadline.cancel()
+                if call_deadlines:
+                    await asyncio.gather(*call_deadlines.values(), return_exceptions=True)
+                call_deadlines.clear()
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            if tasks:
+                await asyncio.gather(*tasks, return_exceptions=True)
+            if process is not None and process.returncode is None:
+                process.terminate()
+                try:
+                    await asyncio.wait_for(process.wait(), timeout=2)
+                except asyncio.TimeoutError:
+                    process.kill()
+                    await process.wait()
+            shutil.rmtree(temp_root, ignore_errors=True)
+            if handshake_sent:
+                writer.close()
+                try:
+                    await asyncio.wait_for(writer.wait_closed(), timeout=1)
+                except (asyncio.TimeoutError, ConnectionError, OSError):
+                    pass
+
+
+async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+    try:
+        raw = await reader.readline()
+        if not raw or len(raw) > MAX_REQUEST_BYTES:
+            raise SandboxEngineError("Database sidecar request invalid.", code="invalid_request")
+        request = json.loads(raw.decode("utf-8"))
+        if not isinstance(request, dict):
+            raise SandboxEngineError("Database sidecar request must be an object.", code="invalid_request")
+        action = str(request.get("action") or "").strip()
+        if action == "mcp_stdio":
+            await _stdio(reader, writer, request)
+            return
+        if action != "health":
+            raise SandboxEngineError("Database sidecar action denied.", code="action_denied")
+        response = {
+            "ok": True,
+            "protocol": "modelmirror-mcp-database-stdio-v1",
+            "mcp_database_adapters": sorted(ALLOWED_ADAPTERS),
+            "mcp_database_max_sessions": MAX_SESSIONS,
+            "read_only": True,
+            "mcp_message_limit_bytes": MAX_MCP_MESSAGE_BYTES,
+        }
+    except SandboxEngineError as exc:
+        response = {"ok": False, "error": "database_sidecar_rejected", "code": exc.code}
+    except Exception:
+        response = {"ok": False, "error": "database_sidecar_internal_error", "code": "database_sidecar_internal_error"}
+    writer.write(json.dumps(response, ensure_ascii=False).encode("utf-8") + b"\n")
+    await writer.drain()
+    writer.close()
+    try:
+        await asyncio.wait_for(writer.wait_closed(), timeout=1)
+    except (asyncio.TimeoutError, ConnectionError, OSError):
+        pass
+
+
+async def main() -> None:
+    SOCKET_PATH.parent.mkdir(parents=True, exist_ok=True)
+    SOCKET_PATH.unlink(missing_ok=True)
+    server = await asyncio.start_unix_server(
+        handle, path=str(SOCKET_PATH), limit=MAX_MCP_MESSAGE_BYTES + 1
+    )
+    os.chmod(SOCKET_PATH, 0o660)
+    async with server:
+        await server.serve_forever()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/server/tests/test_mcp_catalog.py
+++ b/server/tests/test_mcp_catalog.py
@@ -21,6 +21,7 @@ from server.mcp.catalog import (
     WAVE_TWO_ADAPTERS,
     WAVE_THREE_ADAPTERS,
     WAVE_FOUR_ADAPTERS,
+    WAVE_FIVE_ADAPTERS,
     WAVE_PROJECTS,
     CatalogAdapterManifest,
     CatalogConfigurationRequest,
@@ -137,6 +138,8 @@ def make_service(
         "cred_agentql": ("agentql-mcp", "api_key"),
         "cred_grafana": ("grafana-mcp", "service_token"),
         "cred_pinecone": ("pinecone-assistant-mcp", "api_key"),
+        "cred_dbhub": ("dbhub", "password"),
+        "cred_supabase": ("supabase-mcp", "access_token"),
     }
 
     def credential_validator(credential_id: str) -> SimpleNamespace:
@@ -180,18 +183,26 @@ def test_catalog_freezes_100_projects_and_maps_all_waves_once() -> None:
     }
     assert set(WAVE_THREE_ADAPTERS) == set(WAVE_PROJECTS[3]) - {"manim-mcp"}
     assert set(WAVE_FOUR_ADAPTERS) == set(WAVE_PROJECTS[4]) - {"snyk-mcp"}
+    assert set(WAVE_FIVE_ADAPTERS) == {
+        "dbhub",
+        "mongodb-mcp",
+        "clickhouse-mcp",
+        "redis-mcp",
+        "duckdb-mcp",
+        "supabase-mcp",
+    }
     assert sum(
         manifest.availability == "ready"
         for manifest in CATALOG_ADAPTERS.values()
-    ) == 32
+    ) == 38
     assert sum(
         manifest.availability == "planned"
         for manifest in CATALOG_ADAPTERS.values()
-    ) == 64
+    ) == 53
     assert sum(
         manifest.availability == "blocked"
         for manifest in CATALOG_ADAPTERS.values()
-    ) == 4
+    ) == 9
     assert {manifest.availability for manifest in CATALOG_ADAPTERS.values()} == {
         "ready",
         "planned",
@@ -235,7 +246,7 @@ def test_frontend_catalog_ids_match_backend_registry_and_never_submit_commands()
 def test_planned_adapter_cannot_be_enabled_by_environment(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    manifest = CATALOG_ADAPTERS["dbhub"]
+    manifest = CATALOG_ADAPTERS["airtable-mcp"]
     monkeypatch.setenv(manifest.feature_flag, "true")
 
     assert manifest.feature_enabled is True
@@ -260,9 +271,9 @@ async def test_catalog_api_hides_execution_details_and_rejects_planned_connect()
             assert response.status_code == 200
             payload = response.json()
             assert payload["total"] == 100
-            assert payload["ready"] == 32
-            assert payload["planned"] == 64
-            assert payload["blocked"] == 4
+            assert payload["ready"] == 38
+            assert payload["planned"] == 53
+            assert payload["blocked"] == 9
             serialized = response.text.lower()
             assert "server_command" not in serialized
             assert "install_command" not in serialized
@@ -588,6 +599,126 @@ def test_wave_four_settings_and_snyk_fail_closed() -> None:
     assert snyk.wave == 4
     assert snyk.server_command == ()
     assert snyk.executable is False
+
+
+@pytest.mark.asyncio
+async def test_wave_five_database_adapter_uses_structured_scoped_handshake() -> None:
+    service, manager, installer, registry = make_service()
+    configured = service.configure(
+        "dbhub",
+        CatalogConfigurationRequest(
+            settings={
+                "engine": "postgresql",
+                "host": "database.example.com",
+                "port": 5432,
+                "database": "analytics",
+                "username": "readonly",
+                "tls_mode": "verify-full",
+            },
+            credential_bindings={"password": "cred_dbhub"},
+        ),
+    )
+    assert configured["configured_settings"] == [
+        "database", "engine", "host", "port", "tls_mode", "username",
+    ]
+
+    connected = await service.connect("dbhub")
+    assert connected["tools_count"] == 1
+    assert connected["preflight_status"] == "verified"
+    assert connected["credential_verification"] == "verified"
+    assert installer.calls == []
+    assert registry.registered == []
+    profile = manager.profiles[0]
+    assert profile["server_command"] == list(CATALOG_ADAPTERS["dbhub"].server_command)
+    assert profile["reconnect_attempts"] == 0
+    assert profile["operation_timeout"] == 20.0
+    assert manager.scrubbed == [connected["session_id"]]
+    assert set(profile["environment"]) == {"MCP_DATABASE_HANDSHAKE_B64"}
+    handshake = json.loads(
+        base64.urlsafe_b64decode(
+            profile["environment"]["MCP_DATABASE_HANDSHAKE_B64"]
+        ).decode("utf-8")
+    )
+    assert handshake == {
+        "settings": {
+            "engine": "postgresql",
+            "host": "database.example.com",
+            "port": 5432,
+            "database": "analytics",
+            "username": "readonly",
+            "tls_mode": "verify-full",
+        },
+        "credentials": {"password": "secret-for-cred_dbhub"},
+        "workspace_id": None,
+    }
+    serialized = json.dumps(service.list_adapters(), ensure_ascii=False)
+    assert "secret-for-cred_dbhub" not in serialized
+    assert "server_command" not in serialized
+    public = next(
+        item
+        for item in service.list_adapters()["adapters"]
+        if item["project_id"] == "dbhub"
+    )
+    assert public["database_policy"]["read_only"] is True
+    assert public["database_policy"]["max_rows_hard"] == 1000
+    assert public["preflight_status"] == "verified"
+    assert public["credential_verification"] == "verified"
+    assert all(
+        policy["read_only"] and policy["effect"] == "read"
+        for policy in public["tool_policies"].values()
+    )
+
+
+def test_wave_five_rejects_connection_strings_and_raw_secrets() -> None:
+    service, _, _, _ = make_service()
+    for forbidden, value in (
+        ("dsn", "postgresql://readonly:secret@database.example.com/app"),
+        ("connection_uri", "mongodb://database.example.com/app"),
+        ("password", "raw-secret"),
+        ("certificate_path", "C:/private/client.pem"),
+    ):
+        with pytest.raises(catalog.CatalogAdapterPolicyError, match="不能包含命令"):
+            service.configure(
+                "dbhub",
+                CatalogConfigurationRequest(settings={forbidden: value}),
+            )
+
+
+def test_wave_five_status_and_blocked_subbatch_are_exact() -> None:
+    blocked = {
+        "postgres-mcp",
+        "sqlite-mcp",
+        "cognee-mcp",
+        "graphiti-mcp",
+        "hindsight-mcp",
+    }
+    assert {
+        project_id
+        for project_id in WAVE_PROJECTS[5]
+        if CATALOG_ADAPTERS[project_id].availability == "blocked"
+    } == blocked
+    for project_id in blocked:
+        manifest = CATALOG_ADAPTERS[project_id]
+        assert manifest.server_command == ()
+        assert manifest.executable is False
+        assert manifest.network_policy == "blocked:no-production-runtime"
+    duckdb = CATALOG_ADAPTERS["duckdb-mcp"]
+    assert duckdb.workspace_policy is not None
+    assert duckdb.workspace_policy.accepted_extensions == (".duckdb",)
+    assert duckdb.credential_policies == ()
+    assert duckdb.network_policy == "disabled"
+    dbhub = CATALOG_ADAPTERS["dbhub"]
+    engine_policy = next(item for item in dbhub.setting_policies if item.key == "engine")
+    assert {value for value, _ in engine_policy.options} == {
+        "postgresql", "mysql", "mariadb",
+    }
+    supabase = CATALOG_ADAPTERS["supabase-mcp"]
+    assert set(supabase.tool_policies) == {
+        "list_tables", "list_extensions", "execute_sql",
+    }
+    assert supabase.setting_policies[0].key == "project_ref"
+    assert supabase.setting_policies[0].pattern == r"^[a-z]{20}$"
+    assert supabase.credential_policies[0].key == "access_token"
 
 
 def test_bibigpt_is_fail_closed_until_oauth_wave() -> None:

--- a/server/tests/test_mcp_database_sidecar.py
+++ b/server/tests/test_mcp_database_sidecar.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+import base64
+import json
+import socket
+
+import pytest
+
+from server.mcp import database_proxy
+from server.sandbox_sidecar import database_contracts
+from server.sandbox_sidecar.database_contracts import (
+    DATABASE_ADAPTERS,
+    bounded_rows,
+    resolve_allowed_addresses,
+    validate_configuration,
+    validate_document,
+    validate_readonly_sql,
+)
+from server.sandbox_sidecar.database_mcp import ADAPTER_TOOL_NAMES
+
+
+EXPECTED_TOOLS = {
+    "dbhub": {"list_schemas", "list_tables", "describe_table", "execute_sql"},
+    "mongodb-mcp": {
+        "list_collections",
+        "collection_schema",
+        "collection_indexes",
+        "find",
+        "aggregate",
+        "count_documents",
+    },
+    "clickhouse-mcp": {"list_databases", "list_tables", "run_query"},
+    "redis-mcp": {
+        "scan_keys",
+        "get_value",
+        "get_type",
+        "get_ttl",
+        "hash_get_all",
+        "list_range",
+        "set_members",
+        "sorted_set_range",
+    },
+    "duckdb-mcp": {"list_schemas", "list_tables", "describe_table", "query"},
+    "supabase-mcp": {"list_tables", "list_extensions", "execute_sql"},
+}
+
+
+def dbhub_configuration() -> dict[str, object]:
+    return {
+        "settings": {
+            "engine": "postgresql",
+            "host": "database.example.com",
+            "port": 5432,
+            "database": "analytics",
+            "tls_mode": "verify-full",
+            "username": "readonly",
+        },
+        "credentials": {"password": "secret"},
+        "workspace_id": None,
+    }
+
+
+def test_database_contract_and_proxy_allowlists_are_exact() -> None:
+    assert set(DATABASE_ADAPTERS) == set(EXPECTED_TOOLS)
+    assert database_proxy.ALLOWED_ADAPTERS == set(EXPECTED_TOOLS)
+    assert {
+        adapter_id: set(tool_names)
+        for adapter_id, tool_names in ADAPTER_TOOL_NAMES.items()
+    } == EXPECTED_TOOLS
+
+
+def test_database_configuration_is_structured_and_tls_is_strict() -> None:
+    validated = validate_configuration("dbhub", dbhub_configuration())
+    assert validated.settings["host"] == "database.example.com"
+    assert validated.settings["tls_mode"] == "verify-full"
+    assert validated.credentials == {"password": "secret"}
+
+    for key, value in (
+        ("dsn", "postgresql://readonly:secret@database.example.com/app"),
+        ("url", "https://database.example.com"),
+        ("environment", {"PGPASSWORD": "secret"}),
+        ("cwd", "/host"),
+    ):
+        invalid = dbhub_configuration()
+        assert isinstance(invalid["settings"], dict)
+        invalid["settings"][key] = value  # type: ignore[index]
+        with pytest.raises(ValueError):
+            validate_configuration("dbhub", invalid)
+
+    for weak_mode in ("disable", "require", "verify-ca"):
+        invalid = dbhub_configuration()
+        assert isinstance(invalid["settings"], dict)
+        invalid["settings"]["tls_mode"] = weak_mode  # type: ignore[index]
+        with pytest.raises(ValueError, match="invalid_tls_mode"):
+            validate_configuration("dbhub", invalid)
+
+    unsupported = dbhub_configuration()
+    assert isinstance(unsupported["settings"], dict)
+    unsupported["settings"]["engine"] = "sqlserver"  # type: ignore[index]
+    with pytest.raises(ValueError, match="invalid_engine"):
+        validate_configuration("dbhub", unsupported)
+
+
+def test_database_configuration_rejects_ip_literals_and_private_dns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    literal = dbhub_configuration()
+    assert isinstance(literal["settings"], dict)
+    literal["settings"]["host"] = "203.0.113.10"  # type: ignore[index]
+    with pytest.raises(ValueError, match="ip_literal_denied"):
+        validate_configuration("dbhub", literal)
+
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda *_args, **_kwargs: [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.20.30.40", 5432))
+        ],
+    )
+    monkeypatch.delenv("MCP_DATABASE_PRIVATE_HOST_ALLOWLIST", raising=False)
+    with pytest.raises(ValueError, match="database_host_private"):
+        resolve_allowed_addresses("database.internal", 5432)
+    monkeypatch.setenv(
+        "MCP_DATABASE_PRIVATE_HOST_ALLOWLIST",
+        "database.internal",
+    )
+    assert resolve_allowed_addresses("database.internal", 5432) == ("10.20.30.40",)
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "SELECT 1; DELETE FROM users",
+        "WITH removed AS (DELETE FROM users RETURNING *) SELECT * FROM removed",
+        "SELECT * FROM read_csv('https://example.com/private.csv')",
+        "SELECT pg_read_file('/etc/passwd')",
+        "SELECT * INTO copied FROM users",
+        "SELECT pg_advisory_lock(1)",
+        'SELECT "pg_sleep"(1)',
+        r'SELECT U&"pg\005fsleep"(1)',
+        "SELECT `get_lock`('modelmirror', 15)",
+        "SELECT /*!50000 SLEEP(1) */ 1",
+        "SELECT /*M!100100 SLEEP(1) */ 1",
+        "SELECT /*+ MAX_EXECUTION_TIME(999999) */ 1",
+        "SELECT pg_advisory_xact_lock(1)",
+        "SELECT pg_try_advisory_xact_lock(1)",
+        "SELECT dblink_connect('host=external.example.com')",
+        "SELECT * FROM OPENQUERY(remote, 'UPDATE t SET value=1')",
+        "SELECT GET_LOCK('modelmirror', 15)",
+        "COPY users TO '/tmp/users.csv'",
+        "INSTALL httpfs",
+    ],
+)
+def test_database_sql_policy_denies_mutation_and_external_access(query: str) -> None:
+    with pytest.raises(ValueError):
+        validate_readonly_sql(query, dialect="postgres")
+
+
+def test_database_sql_and_document_policy_allow_bounded_reads() -> None:
+    query = "WITH recent AS (SELECT id FROM events) SELECT * FROM recent"
+    try:
+        import sqlglot  # noqa: F401
+    except ImportError:
+        # The general server image deliberately does not carry database-sidecar
+        # dependencies.  Missing the locked parser must fail closed; the
+        # database image smoke covers the positive parsing and execution path.
+        with pytest.raises(ValueError, match="query_parser_unavailable"):
+            validate_readonly_sql(query, dialect="postgres")
+    else:
+        assert validate_readonly_sql(query, dialect="postgres").startswith("WITH")
+    assert validate_document({"status": "active", "count": {"$gte": 1}}) == {
+        "status": "active",
+        "count": {"$gte": 1},
+    }
+    for dangerous in (
+        [{"$out": "copied"}],
+        [{"$merge": {"into": "copied"}}],
+        [{"$project": {"value": {"$function": {"body": "return 1"}}}}],
+    ):
+        with pytest.raises(ValueError, match="dangerous_mongo_operator"):
+            validate_document(dangerous, pipeline=True)
+    rows, truncated = bounded_rows(list(range(1100)), max_rows=1000)
+    assert len(rows) == 1000
+    assert truncated is True
+
+
+def test_duckdb_configuration_requires_only_an_opaque_workspace() -> None:
+    value = validate_configuration(
+        "duckdb-mcp",
+        {
+            "settings": {},
+            "credentials": {},
+            "workspace_id": "mcpws_0123456789abcdef0123456789abcdef",
+        },
+    )
+    assert value.workspace_id == "mcpws_0123456789abcdef0123456789abcdef"
+    for forbidden in ("/host/database.duckdb", "mcpws_bad", None):
+        with pytest.raises(ValueError):
+            validate_configuration(
+                "duckdb-mcp",
+                {"settings": {}, "credentials": {}, "workspace_id": forbidden},
+            )
+
+
+def test_supabase_project_ref_is_exactly_twenty_lowercase_letters() -> None:
+    valid = {
+        "settings": {"project_ref": "abcdefghijklmnopqrst"},
+        "credentials": {"access_token": "secret"},
+    }
+    assert validate_configuration("supabase-mcp", valid).settings["project_ref"] == (
+        "abcdefghijklmnopqrst"
+    )
+    for project_ref in ("abcdefghijklmnopqrs1", "ABCDEFGHIJKLMNOPQRST", "short"):
+        invalid = json.loads(json.dumps(valid))
+        invalid["settings"]["project_ref"] = project_ref
+        with pytest.raises(ValueError, match="invalid_project_ref"):
+            validate_configuration("supabase-mcp", invalid)
+
+
+def test_database_proxy_consumes_one_shot_configuration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    raw = json.dumps(dbhub_configuration(), separators=(",", ":")).encode("utf-8")
+    monkeypatch.setenv(
+        "MCP_DATABASE_HANDSHAKE_B64",
+        base64.urlsafe_b64encode(raw).decode("ascii"),
+    )
+    assert database_proxy._load_configuration() == dbhub_configuration()
+    assert "MCP_DATABASE_HANDSHAKE_B64" not in database_proxy.os.environ

--- a/server/tests/test_mcp_file_workspaces.py
+++ b/server/tests/test_mcp_file_workspaces.py
@@ -305,6 +305,8 @@ async def test_state_write_requires_bound_one_time_approval(tmp_path: Path) -> N
         "basic-memory-mcp",
         CatalogConfigurationRequest(workspace_id=workspace.workspace_id),
     )
+    public = service.list_adapters()["adapters"][0]
+    assert public["workspace_id"] == workspace.workspace_id
     await service.connect("basic-memory-mcp")
 
     with pytest.raises(CatalogApprovalRequiredError) as captured:
@@ -365,7 +367,7 @@ async def test_approval_expires_on_reconfigure_session_and_workspace_drift(tmp_p
         return str(captured.value.payload["approval_id"])
 
     expired = await request_approval()
-    service._approvals[expired].expires_at = time.time() - 1
+    service._approvals[service._approval_key(expired)].expires_at = time.time() - 1
     with pytest.raises(CatalogAdapterPolicyError):
         await service.confirm_approval("basic-memory-mcp", expired)
 
@@ -375,10 +377,10 @@ async def test_approval_expires_on_reconfigure_session_and_workspace_drift(tmp_p
         await service.confirm_approval("basic-memory-mcp", reconfigured)
 
     session_changed = await request_approval()
-    service._sessions["basic-memory-mcp"] = "replacement-session"
+    service._sessions[service._scope_key("basic-memory-mcp")] = "replacement-session"
     with pytest.raises(CatalogAdapterPolicyError):
         await service.confirm_approval("basic-memory-mcp", session_changed)
-    service._sessions["basic-memory-mcp"] = "file-session"
+    service._sessions[service._scope_key("basic-memory-mcp")] = "file-session"
 
     workspace_drift = await request_approval()
     unexpected = store.input_root / workspace.workspace_id / "unexpected.txt"

--- a/server/tests/test_mcp_integration.py
+++ b/server/tests/test_mcp_integration.py
@@ -103,7 +103,8 @@ async def test_catalog_session_rejects_generic_call_and_disconnect(
     client: httpx.AsyncClient,
 ) -> None:
     session_id = await mcp_manager.connect([sys.executable, str(MOCK_SERVER)])
-    mcp_catalog_service._sessions["context7"] = session_id
+    scope_key = mcp_catalog_service._scope_key("context7")
+    mcp_catalog_service._sessions[scope_key] = session_id
     try:
         call = await client.post(
             f"/api/mcp/{session_id}/call",
@@ -114,7 +115,7 @@ async def test_catalog_session_rejects_generic_call_and_disconnect(
         assert disconnected.status_code == 403
         assert session_id in mcp_manager._sessions
     finally:
-        mcp_catalog_service._sessions.pop("context7", None)
+        mcp_catalog_service._sessions.pop(scope_key, None)
         await mcp_manager.disconnect(session_id)
         await tool_registry.unregister_session(session_id)
 

--- a/server/tests/test_toolset_store.py
+++ b/server/tests/test_toolset_store.py
@@ -7,7 +7,9 @@ import pytest
 from cryptography.fernet import Fernet
 
 from server.toolsets.credentials import (
+    CredentialNotFoundError,
     CredentialStore,
+    CredentialStoreError,
     CredentialUnavailableError,
 )
 from server.toolsets.store import (
@@ -151,3 +153,142 @@ def test_credentials_are_encrypted_rotatable_and_report_key_loss(
     assert wrong_key_store.list()[0].status == "unavailable"
     with pytest.raises(CredentialUnavailableError):
         wrong_key_store.resolve(record.credential_id)
+
+
+def test_credentials_are_isolated_by_tenant_and_owner(tmp_path: Path) -> None:
+    store = CredentialStore(
+        tmp_path / "scoped-credentials",
+        master_key=Fernet.generate_key(),
+    )
+    owned, _ = store.create(
+        name="Tenant A database password",
+        value="tenant-a-secret",
+        tenant_id="tenant-a",
+        owner_id="user-a",
+        catalog_project_id="postgres-mcp",
+        catalog_slot="password",
+    )
+    sibling, _ = store.create(
+        name="Tenant A second owner",
+        value="tenant-a-user-b-secret",
+        tenant_id="tenant-a",
+        owner_id="user-b",
+        catalog_project_id="postgres-mcp",
+        catalog_slot="password",
+    )
+    other_tenant, _ = store.create(
+        name="Tenant B database password",
+        value="tenant-b-secret",
+        tenant_id="tenant-b",
+        owner_id="user-a",
+        catalog_project_id="postgres-mcp",
+        catalog_slot="password",
+    )
+
+    assert store.list() == []
+    assert [
+        item.credential_id
+        for item in store.list(tenant_id="tenant-a", owner_id="user-a")
+    ] == [owned.credential_id]
+    assert store.resolve(
+        owned.credential_id,
+        tenant_id="tenant-a",
+        owner_id="user-a",
+    ) == "tenant-a-secret"
+
+    for tenant_id, owner_id in (
+        ("tenant-a", "user-b"),
+        ("tenant-b", "user-a"),
+        ("local", "local"),
+    ):
+        with pytest.raises(CredentialNotFoundError):
+            store.get_public(
+                owned.credential_id,
+                tenant_id=tenant_id,
+                owner_id=owner_id,
+            )
+        with pytest.raises(CredentialNotFoundError):
+            store.resolve(
+                owned.credential_id,
+                tenant_id=tenant_id,
+                owner_id=owner_id,
+            )
+        with pytest.raises(CredentialNotFoundError):
+            store.rotate(
+                owned.credential_id,
+                value="cross-scope-rotation",
+                tenant_id=tenant_id,
+                owner_id=owner_id,
+            )
+        with pytest.raises(CredentialNotFoundError):
+            store.revoke(
+                owned.credential_id,
+                tenant_id=tenant_id,
+                owner_id=owner_id,
+            )
+
+    assert store.get_public(
+        owned.credential_id,
+        tenant_id="tenant-a",
+        owner_id="user-a",
+    ).status == "active"
+    assert sibling.credential_id != owned.credential_id
+    assert other_tenant.credential_id != owned.credential_id
+
+
+def test_legacy_credentials_migrate_to_explicit_local_scope(tmp_path: Path) -> None:
+    storage_dir = tmp_path / "legacy-credentials"
+    master_key = Fernet.generate_key()
+    original = CredentialStore(storage_dir, master_key=master_key)
+    record, _ = original.create(name="Legacy", value="legacy-secret")
+    storage_path = storage_dir / "credentials.json"
+    payload = json.loads(storage_path.read_text(encoding="utf-8"))
+    payload["version"] = "modelmirror-credentials-v1"
+    payload["credentials"][0].pop("tenant_id")
+    payload["credentials"][0].pop("owner_id")
+    storage_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    migrated = CredentialStore(storage_dir, master_key=master_key)
+    public = migrated.get_public(record.credential_id)
+    assert public.tenant_id == "local"
+    assert public.owner_id == "local"
+    assert migrated.resolve(record.credential_id) == "legacy-secret"
+    with pytest.raises(CredentialNotFoundError):
+        migrated.resolve(
+            record.credential_id,
+            tenant_id="another-tenant",
+            owner_id="local",
+        )
+
+    persisted = json.loads(storage_path.read_text(encoding="utf-8"))
+    assert persisted["version"] == "modelmirror-credentials-v2"
+    assert persisted["credentials"][0]["tenant_id"] == "local"
+    assert persisted["credentials"][0]["owner_id"] == "local"
+
+
+def test_external_master_key_can_be_required_without_breaking_dev_default(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("MODEL_MIRROR_CREDENTIAL_MASTER_KEY", raising=False)
+    monkeypatch.setenv(
+        "MODEL_MIRROR_REQUIRE_EXTERNAL_CREDENTIAL_MASTER_KEY",
+        "true",
+    )
+    with pytest.raises(CredentialStoreError, match="external credential master key"):
+        CredentialStore(tmp_path / "required-key")
+
+    external_key = Fernet.generate_key().decode("ascii")
+    monkeypatch.setenv("MODEL_MIRROR_CREDENTIAL_MASTER_KEY", external_key)
+    external = CredentialStore(tmp_path / "external-key")
+    record, _ = external.create(name="External", value="external-secret")
+    assert external.resolve(record.credential_id) == "external-secret"
+    assert not external.master_key_path.exists()
+
+    monkeypatch.delenv(
+        "MODEL_MIRROR_REQUIRE_EXTERNAL_CREDENTIAL_MASTER_KEY",
+        raising=False,
+    )
+    monkeypatch.delenv("MODEL_MIRROR_CREDENTIAL_MASTER_KEY", raising=False)
+    development = CredentialStore(tmp_path / "development-default")
+    assert development.master_key_path.exists()

--- a/server/toolsets/credentials.py
+++ b/server/toolsets/credentials.py
@@ -39,6 +39,7 @@ class CredentialStore:
         storage_dir: str | Path | None = None,
         *,
         master_key: str | bytes | None = None,
+        require_external_master_key: bool | None = None,
     ) -> None:
         package_dir = Path(__file__).resolve().parent
         self.storage_dir = Path(
@@ -50,6 +51,13 @@ class CredentialStore:
         self.storage_path = self.storage_dir / "credentials.json"
         self.master_key_path = self.storage_dir / "credential-master.key"
         self._lock = threading.RLock()
+        self.require_external_master_key = (
+            self._environment_flag(
+                "MODEL_MIRROR_REQUIRE_EXTERNAL_CREDENTIAL_MASTER_KEY"
+            )
+            if require_external_master_key is None
+            else bool(require_external_master_key)
+        )
         self._fernet = Fernet(self._resolve_master_key(master_key))
         self._ensure_storage_unlocked()
 
@@ -59,11 +67,15 @@ class CredentialStore:
         name: str,
         value: str,
         kind: Literal["header", "environment", "provider_key", "generic"] = "generic",
+        tenant_id: str = "local",
+        owner_id: str = "local",
         catalog_project_id: str = "",
         catalog_slot: str = "",
     ) -> tuple[CredentialRecord, str]:
         clean_name = self._required_text(name, "name", 160)
         clean_value = self._required_text(value, "value", 20_000)
+        clean_tenant_id = self._scope_text(tenant_id, "tenant_id", 120)
+        clean_owner_id = self._scope_text(owner_id, "owner_id", 160)
         clean_catalog_project_id = str(catalog_project_id or "").strip()
         clean_catalog_slot = str(catalog_slot or "").strip()
         if bool(clean_catalog_project_id) != bool(clean_catalog_slot):
@@ -80,6 +92,8 @@ class CredentialStore:
             prefix=self._prefix(clean_value),
             masked_value=self._mask(clean_value),
             ciphertext=self._fernet.encrypt(clean_value.encode("utf-8")).decode("ascii"),
+            tenant_id=clean_tenant_id,
+            owner_id=clean_owner_id,
             catalog_project_id=clean_catalog_project_id,
             catalog_slot=clean_catalog_slot,
             created_at=now,
@@ -91,20 +105,54 @@ class CredentialStore:
             self._write_unlocked(items)
         return self._public(record), clean_value
 
-    def list(self) -> list[CredentialRecord]:
+    def list(
+        self,
+        *,
+        tenant_id: str = "local",
+        owner_id: str = "local",
+    ) -> list[CredentialRecord]:
+        clean_tenant_id = self._scope_text(tenant_id, "tenant_id", 120)
+        clean_owner_id = self._scope_text(owner_id, "owner_id", 160)
         with self._lock:
-            items = self._read_unlocked()
+            items = [
+                item
+                for item in self._read_unlocked()
+                if item.tenant_id == clean_tenant_id
+                and item.owner_id == clean_owner_id
+            ]
         items.sort(key=lambda item: (-item.updated_at, item.credential_id))
         return [self._public_with_runtime_status(item) for item in items]
 
-    def get_public(self, credential_id: str) -> CredentialRecord:
+    def get_public(
+        self,
+        credential_id: str,
+        *,
+        tenant_id: str = "local",
+        owner_id: str = "local",
+    ) -> CredentialRecord:
         with self._lock:
-            record = self._find_unlocked(self._read_unlocked(), credential_id)
+            record = self._find_unlocked(
+                self._read_unlocked(),
+                credential_id,
+                tenant_id=self._scope_text(tenant_id, "tenant_id", 120),
+                owner_id=self._scope_text(owner_id, "owner_id", 160),
+            )
         return self._public_with_runtime_status(record)
 
-    def resolve(self, credential_id: str) -> str:
+    def resolve(
+        self,
+        credential_id: str,
+        *,
+        tenant_id: str = "local",
+        owner_id: str = "local",
+    ) -> str:
         with self._lock:
-            record = self._find_unlocked(self._read_unlocked(), credential_id)
+            record = self._find_unlocked(
+                self._read_unlocked(),
+                credential_id,
+                tenant_id=self._scope_text(tenant_id, "tenant_id", 120),
+                owner_id=self._scope_text(owner_id, "owner_id", 160),
+            )
         if record.status != "active":
             raise CredentialUnavailableError("Credential is not active.")
         try:
@@ -119,11 +167,18 @@ class CredentialStore:
         credential_id: str,
         *,
         value: str,
+        tenant_id: str = "local",
+        owner_id: str = "local",
     ) -> tuple[CredentialRecord, str]:
         clean_value = self._required_text(value, "value", 20_000)
         with self._lock:
             items = self._read_unlocked()
-            record = self._find_unlocked(items, credential_id)
+            record = self._find_unlocked(
+                items,
+                credential_id,
+                tenant_id=self._scope_text(tenant_id, "tenant_id", 120),
+                owner_id=self._scope_text(owner_id, "owner_id", 160),
+            )
             record.ciphertext = self._fernet.encrypt(
                 clean_value.encode("utf-8")
             ).decode("ascii")
@@ -134,10 +189,21 @@ class CredentialStore:
             self._write_unlocked(items)
             return self._public(record), clean_value
 
-    def revoke(self, credential_id: str) -> CredentialRecord:
+    def revoke(
+        self,
+        credential_id: str,
+        *,
+        tenant_id: str = "local",
+        owner_id: str = "local",
+    ) -> CredentialRecord:
         with self._lock:
             items = self._read_unlocked()
-            record = self._find_unlocked(items, credential_id)
+            record = self._find_unlocked(
+                items,
+                credential_id,
+                tenant_id=self._scope_text(tenant_id, "tenant_id", 120),
+                owner_id=self._scope_text(owner_id, "owner_id", 160),
+            )
             record.status = "revoked"
             record.updated_at = time.time()
             self._write_unlocked(items)
@@ -149,6 +215,10 @@ class CredentialStore:
         environment_key = os.getenv("MODEL_MIRROR_CREDENTIAL_MASTER_KEY", "").strip()
         if environment_key:
             return self._normalize_key(environment_key)
+        if self.require_external_master_key:
+            raise CredentialStoreError(
+                "An external credential master key is required by runtime policy."
+            )
         self.storage_dir.mkdir(parents=True, exist_ok=True)
         if self.master_key_path.exists():
             raw = self.master_key_path.read_bytes().strip()
@@ -183,13 +253,23 @@ class CredentialStore:
         try:
             payload = json.loads(self.storage_path.read_text(encoding="utf-8"))
             raw = payload.get("credentials", []) if isinstance(payload, dict) else []
-            return [CredentialRecord.model_validate(item) for item in raw]
+            items = [CredentialRecord.model_validate(item) for item in raw]
+            if any(
+                isinstance(item, dict)
+                and ("tenant_id" not in item or "owner_id" not in item)
+                for item in raw
+            ):
+                # Persist the safe local ownership assigned by model defaults so
+                # the migration is explicit and future readers cannot interpret
+                # a missing owner as a wildcard.
+                self._write_unlocked(items)
+            return items
         except (OSError, json.JSONDecodeError, ValueError) as exc:
             raise CredentialStoreError("Credential storage is unreadable.") from exc
 
     def _write_unlocked(self, items: list[CredentialRecord]) -> None:
         payload = {
-            "version": "modelmirror-credentials-v1",
+            "version": "modelmirror-credentials-v2",
             "credentials": [item.model_dump(mode="json") for item in items],
         }
         temporary = self.storage_path.with_suffix(".tmp")
@@ -201,11 +281,21 @@ class CredentialStore:
 
     @staticmethod
     def _find_unlocked(
-        items: list[CredentialRecord], credential_id: str
+        items: list[CredentialRecord],
+        credential_id: str,
+        *,
+        tenant_id: str,
+        owner_id: str,
     ) -> CredentialRecord:
         for item in items:
-            if item.credential_id == credential_id:
+            if (
+                item.credential_id == credential_id
+                and item.tenant_id == tenant_id
+                and item.owner_id == owner_id
+            ):
                 return item
+        # Deliberately use the same not-found error for a missing record and a
+        # cross-scope lookup so callers cannot probe another owner's vault.
         raise CredentialNotFoundError(f"Credential not found: {credential_id}")
 
     @staticmethod
@@ -245,3 +335,16 @@ class CredentialStore:
         if len(text) > limit:
             raise CredentialStoreError(f"{field_name} exceeds {limit} characters.")
         return text
+
+    @staticmethod
+    def _scope_text(value: str, field_name: str, limit: int) -> str:
+        text = str(value or "").strip()
+        if not text or len(text) > limit:
+            raise CredentialStoreError(
+                f"{field_name} must contain between 1 and {limit} characters."
+            )
+        return text
+
+    @staticmethod
+    def _environment_flag(name: str) -> bool:
+        return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}

--- a/server/toolsets/models.py
+++ b/server/toolsets/models.py
@@ -149,6 +149,11 @@ class CredentialRecord(BaseModel):
     masked_value: str = ""
     ciphertext: str
     status: Literal["active", "unavailable", "revoked"] = "active"
+    # Older vault records predate tenant-aware catalog credentials.  Defaulting
+    # both dimensions to ``local`` keeps those records usable only in the
+    # original single-user scope instead of turning them into global secrets.
+    tenant_id: str = Field(default="local", min_length=1, max_length=120)
+    owner_id: str = Field(default="local", min_length=1, max_length=160)
     catalog_project_id: str = Field(default="", max_length=120)
     catalog_slot: str = Field(default="", max_length=80)
     created_at: float


### PR DESCRIPTION
## 改动概览

完成 MCP 第 5 批数据库与知识存储适配，在冻结的 100 条目录基线上新增 6 个生产级只读适配器：

- DBHub（PostgreSQL / MySQL / MariaDB）
- MongoDB MCP
- ClickHouse MCP
- Redis MCP
- DuckDB MCP
- Supabase MCP

PostgreSQL MCP、SQLite MCP、Cognee、Graphiti 与 Hindsight 保持 blocked，并展示明确的中文阻断原因。目录总状态更新为 38 ready / 53 planned / 9 blocked。

## 核心实现

- 新增远程数据库与断网本地数据库 sidecar，固定镜像、工具 schema、资源限制和 Unix socket 协议。
- 远程连接强制 TLS、DNS 固定、IP/SSRF 防护、目标预检和数据库原生只读校验。
- DuckDB 只接受封存工作区中的不透明文件 ID，断网、只读打开。
- SQL、MongoDB、Redis 与 Supabase 均采用协议级只读门禁；不开放写入、DDL/DML、外部 table function 或任意命令。
- 凭据增加 tenant/owner/project/slot 隔离与外部主密钥 fail-closed 选项。
- 前端新增卡片内结构化数据库配置、加密凭据、数据源预检状态、中文风险说明及移动端/键盘可访问性。
- 保持自定义连接、MCP Builder、OAuth、桌面桥接和数据库写入能力关闭。

## 用户影响

用户可在 MCP 目录卡片内完成受控字段配置和加密凭据绑定，连接时自动执行目标与只读能力预检。未通过预检的项目不会建立会话，也不会执行查询。

当前发布范围仍限定为部署时固定 tenant/owner 的单租户本地实例；多用户共享部署未开放。

## 验证

- 前端生产构建通过：`npm.cmd run build`
- Wave 5 重点测试：61 passed
- 全量后端：1286 passed，1 个既有 Skill Finder Node/TypeScript 环境失败；已在干净 `origin/main@8d90ef5` 原样复现
- Compose 静态配置检查通过
- 数据库镜像 smoke 通过：固定 schema、SQL/Mongo 绕过、DNS pin、输出限制、超时强杀及 DuckDB 实际调用
- 共享栈仅定向重建 database sidecar、server、client；既有 Coding、newAPI 与其他 MCP 容器保持不变
- `/mcps` 人工连接验收通过
