### PR TITLE
feature: 建立 Skill Creator V1 基础能力

### DIFF
--- a/client/src/components/authoring/SkillDraftPanel.tsx
+++ b/client/src/components/authoring/SkillDraftPanel.tsx
@@ -7,6 +7,9 @@ interface SkillDraft {
   description: string;
   status: "draft" | "installed" | "archived";
   revision: number;
+  content_revision: number;
+  content_digest: string;
+  install_state: "not_installed" | "current" | "outdated";
   installed_skill_id?: string | null;
   file_count?: number;
   skill_markdown?: string;
@@ -34,6 +37,7 @@ export default function SkillDraftPanel({ onInstalled }: { onInstalled?: () => v
 
   const load = useCallback(async () => {
     setLoading(true);
+    setError("");
     try {
       const response = await fetch("/api/skills/drafts?limit=200");
       if (!response.ok) throw new Error(await readError(response));
@@ -72,12 +76,15 @@ export default function SkillDraftPanel({ onInstalled }: { onInstalled?: () => v
       const response = await fetch(`/api/skills/drafts/${selected.draft_id}/${actionName}`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ revision: selected.revision }),
+        body: JSON.stringify({
+          expected_revision: selected.revision,
+          expected_digest: selected.content_digest,
+        }),
       });
       if (!response.ok) throw new Error(await readError(response));
-      const payload = (await response.json()) as SkillDraft | { draft?: SkillDraft };
-      if ("draft" in payload && payload.draft) setSelected(payload.draft);
-      else if ("draft_id" in payload) setSelected(payload);
+      const detailResponse = await fetch(`/api/skills/drafts/${selected.draft_id}`);
+      if (!detailResponse.ok) throw new Error(await readError(detailResponse));
+      setSelected((await detailResponse.json()) as SkillDraft);
       setNotice(
         actionName === "install"
           ? "Skill 已显式安装，可由 skills_runtime 在 Sandbox 中使用。"
@@ -125,7 +132,7 @@ export default function SkillDraftPanel({ onInstalled }: { onInstalled?: () => v
             </div>
             <p className="mt-3 text-sm leading-6 text-slate-300">{selected.description}</p>
             <div className="mt-3 flex flex-wrap gap-2 text-xs text-slate-400">
-              <span>{1 + Object.keys(selected.files ?? {}).length} 文件</span>
+              <span>{selected.file_count ?? 1 + Object.keys(selected.files ?? {}).length} 文件</span>
               <span>revision {selected.revision}</span>
               {selected.installed_skill_id ? <span className="text-emerald-200">已安装为 {selected.installed_skill_id}</span> : null}
             </div>

--- a/client/src/pages/SkillBrowserPage.tsx
+++ b/client/src/pages/SkillBrowserPage.tsx
@@ -973,8 +973,7 @@ export default function SkillBrowserPage() {
 
   useEffect(() => {
     document.title = "模镜 - Skill 技能货架";
-    void loadInstalledSkills();
-    void loadBuiltinSkills();
+    void refreshSkillResources();
   }, []);
 
   useEffect(() => {
@@ -1170,6 +1169,11 @@ export default function SkillBrowserPage() {
     }
   }
 
+  async function refreshSkillResources() {
+    setError("");
+    await Promise.all([loadInstalledSkills(), loadBuiltinSkills()]);
+  }
+
   function locateRecommendedSkill(project: SkillProject) {
     setSearchQuery(project.name);
     setSelectedCategory("all");
@@ -1334,7 +1338,7 @@ export default function SkillBrowserPage() {
           <button
             className="w-fit rounded-full border border-white/10 px-4 py-2 text-sm font-semibold text-slate-300 transition hover:border-hire-300/30 hover:bg-hire-300/10 hover:text-hire-100 disabled:opacity-50"
             disabled={isLoadingInstalled || isLoadingBuiltin}
-            onClick={() => void Promise.all([loadInstalledSkills(), loadBuiltinSkills()])}
+            onClick={() => void refreshSkillResources()}
             type="button"
           >
             {isLoadingInstalled || isLoadingBuiltin ? "刷新中..." : "刷新资源"}

--- a/scripts/audit_workspace_skill_drafts.py
+++ b/scripts/audit_workspace_skill_drafts.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from server.skills.package_validation import validate_skill_package
+
+
+def _default_snapshot() -> Path:
+    runtime_dir = os.getenv("AGENT_TASK_STORAGE_DIR", "").strip()
+    storage_dir = Path(runtime_dir) if runtime_dir else REPO_ROOT / "server" / "skills" / "storage"
+    return storage_dir / "skill_drafts.json"
+
+
+def audit_snapshot(snapshot_path: Path) -> tuple[dict[str, Any], int]:
+    """Audit one draft snapshot without instantiating or mutating its Store."""
+
+    report: dict[str, Any] = {
+        "version": "workspace-skill-draft-audit-v1",
+        "snapshot_exists": snapshot_path.is_file(),
+        "record_count": 0,
+        "valid_count": 0,
+        "invalid_count": 0,
+        "quarantine_count": 0,
+        "error_codes": {},
+        "warning_codes": {},
+    }
+    if not snapshot_path.is_file():
+        return report, 0
+    try:
+        raw = json.loads(snapshot_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        report["storage_error"] = type(exc).__name__
+        return report, 2
+    if not isinstance(raw, dict) or not isinstance(raw.get("items", []), list):
+        report["storage_error"] = "invalid_top_level"
+        return report, 2
+
+    errors: Counter[str] = Counter()
+    warnings: Counter[str] = Counter()
+    items = raw.get("items", [])
+    report["record_count"] = len(items)
+    quarantine = raw.get("quarantine", [])
+    report["quarantine_count"] = len(quarantine) if isinstance(quarantine, list) else 0
+
+    for record in items:
+        if not isinstance(record, dict):
+            errors["record_not_object"] += 1
+            report["invalid_count"] += 1
+            continue
+        result = validate_skill_package(
+            root_name=record.get("slug"),
+            skill_markdown=record.get("skill_markdown"),
+            files=record.get("files", {}),
+        )
+        for issue in result.issues:
+            (errors if issue.severity == "error" else warnings)[issue.code] += 1
+        stored_digest = record.get("content_digest")
+        if (
+            isinstance(stored_digest, str)
+            and result.content_digest
+            and stored_digest.lower() != result.content_digest.lower()
+        ):
+            errors["content_digest_mismatch"] += 1
+        if result.valid and not (
+            isinstance(stored_digest, str)
+            and result.content_digest
+            and stored_digest.lower() != result.content_digest.lower()
+        ):
+            report["valid_count"] += 1
+        else:
+            report["invalid_count"] += 1
+
+    report["error_codes"] = dict(sorted(errors.items()))
+    report["warning_codes"] = dict(sorted(warnings.items()))
+    return report, 1 if report["invalid_count"] or errors else 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Read-only audit for Workspace Skill draft snapshots."
+    )
+    parser.add_argument("--snapshot", type=Path, default=_default_snapshot())
+    args = parser.parse_args()
+    report, exit_code = audit_snapshot(args.snapshot.resolve())
+    print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/server/skills/__init__.py
+++ b/server/skills/__init__.py
@@ -1,2 +1,26 @@
 """Skill package management for ModelMirror."""
 
+from .package_validation import (
+    VALIDATOR_VERSION,
+    SkillPackageIssue,
+    SkillPackageV2,
+    SkillPackageValidationResult,
+    compute_package_digest,
+    compute_skill_content_digest,
+    compute_skill_package_digest,
+    scan_skill_package_credentials,
+    validate_skill_package,
+)
+
+__all__ = [
+    "VALIDATOR_VERSION",
+    "SkillPackageIssue",
+    "SkillPackageV2",
+    "SkillPackageValidationResult",
+    "compute_package_digest",
+    "compute_skill_content_digest",
+    "compute_skill_package_digest",
+    "scan_skill_package_credentials",
+    "validate_skill_package",
+]
+

--- a/server/skills/api.py
+++ b/server/skills/api.py
@@ -70,6 +70,11 @@ class SkillPayload(BaseModel):
     sub_path: str
     installed_at: float
     source_ref: str | None = None
+    source_kind: str = "git"
+    source_id: str | None = None
+    source_revision: int | None = None
+    content_digest: str = ""
+    package_subpath: str = ""
 
 
 class InstalledSkillsResponse(BaseModel):
@@ -82,14 +87,24 @@ class SkillContentResponse(BaseModel):
 
 
 class SkillDraftActionRequest(BaseModel):
-    revision: int = Field(ge=1)
+    expected_revision: int = Field(ge=1)
+    expected_digest: str = Field(
+        min_length=64,
+        max_length=64,
+        pattern=r"^[0-9a-fA-F]{64}$",
+    )
 
 
 class SkillDraftPatchRequest(BaseModel):
-    revision: int = Field(ge=1)
+    expected_revision: int = Field(ge=1)
+    expected_digest: str = Field(
+        min_length=64,
+        max_length=64,
+        pattern=r"^[0-9a-fA-F]{64}$",
+    )
     name: str | None = Field(default=None, min_length=1, max_length=120)
-    slug: str | None = Field(default=None, min_length=1, max_length=80)
-    description: str | None = Field(default=None, max_length=1000)
+    slug: str | None = Field(default=None, min_length=1, max_length=64)
+    description: str | None = Field(default=None, max_length=1024)
     skill_markdown: str | None = Field(default=None, max_length=1_048_576)
     files: dict[str, str] | None = None
 
@@ -267,6 +282,11 @@ def _payload_from_skill(skill: InstalledSkill) -> SkillPayload:
         sub_path=skill.sub_path,
         installed_at=skill.installed_at,
         source_ref=skill.source_ref,
+        source_kind=skill.source_kind,
+        source_id=skill.source_id,
+        source_revision=skill.source_revision,
+        content_digest=skill.content_digest,
+        package_subpath=skill.package_subpath,
     )
 
 
@@ -284,7 +304,15 @@ def _raise_draft_error(exc: Exception) -> None:
     if isinstance(exc, SkillDraftConflictError):
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     if isinstance(exc, SkillDraftValidationError):
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        issues = getattr(exc, "issues", None)
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "skill_package_invalid",
+                "message": str(exc),
+                "issues": issues if isinstance(issues, list) else [],
+            },
+        ) from exc
     raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 
@@ -297,7 +325,7 @@ async def list_skill_drafts(
         get_skill_draft_store().list, status=status, limit=limit
     )
     return {
-        "version": "workspace-skill-drafts-v1",
+        "version": "workspace-skill-drafts-v2",
         "items": [WorkspaceSkillDraftStore.serialize(item) for item in items],
         "total": len(items),
     }
@@ -318,7 +346,8 @@ async def patch_skill_draft(draft_id: str, payload: SkillDraftPatchRequest):
         item = await asyncio.to_thread(
             get_skill_draft_store().update,
             draft_id,
-            revision=payload.revision,
+            expected_revision=payload.expected_revision,
+            expected_digest=payload.expected_digest,
             name=payload.name,
             slug=payload.slug,
             description=payload.description,
@@ -333,18 +362,23 @@ async def patch_skill_draft(draft_id: str, payload: SkillDraftPatchRequest):
 @router.post("/drafts/{draft_id}/validate")
 async def validate_skill_draft(draft_id: str, payload: SkillDraftActionRequest):
     try:
-        item = await asyncio.to_thread(get_skill_draft_store().require, draft_id)
-        if item.revision != payload.revision:
+        store = get_skill_draft_store()
+        item = await asyncio.to_thread(store.require, draft_id)
+        if (
+            item.revision != payload.expected_revision
+            or item.content_digest.lower() != payload.expected_digest.lower()
+        ):
             raise SkillDraftConflictError(
                 "Skill draft changed. Reload it before validation."
             )
         result = await asyncio.to_thread(
-            get_skill_draft_store().validate_draft, draft_id
+            store.validate_draft, draft_id
         )
         await asyncio.to_thread(
-            get_skill_draft_store().set_validation,
+            store.set_validation,
             draft_id,
-            revision=payload.revision,
+            expected_revision=payload.expected_revision,
+            expected_digest=payload.expected_digest,
             validation=result,
         )
         return result
@@ -356,24 +390,23 @@ async def validate_skill_draft(draft_id: str, payload: SkillDraftActionRequest):
 async def install_skill_draft(draft_id: str, payload: SkillDraftActionRequest):
     try:
         store = get_skill_draft_store()
-        item = await asyncio.to_thread(store.require, draft_id)
-        if item.revision != payload.revision:
-            raise SkillDraftConflictError(
-                "Skill draft changed. Reload it before installation."
+        manager = get_skill_manager()
+
+        def _install_locked(item):
+            return manager.install_workspace_draft(
+                draft_id=item.draft_id,
+                slug=item.slug,
+                skill_markdown=item.skill_markdown,
+                files=item.files,
+                source_revision=item.content_revision,
             )
-        await asyncio.to_thread(store.validate_draft, draft_id)
-        installed = await asyncio.to_thread(
-            get_skill_manager().install_workspace_draft,
-            draft_id=item.draft_id,
-            slug=item.slug,
-            skill_markdown=item.skill_markdown,
-            files=item.files,
-        )
-        updated = await asyncio.to_thread(
-            store.mark_installed,
+
+        updated, installed = await asyncio.to_thread(
+            store.install_current,
             draft_id,
-            revision=payload.revision,
-            skill_id=installed.skill_id,
+            expected_revision=payload.expected_revision,
+            expected_digest=payload.expected_digest,
+            installer=_install_locked,
         )
         return {
             "draft": WorkspaceSkillDraftStore.serialize(updated),
@@ -391,7 +424,8 @@ async def archive_skill_draft(draft_id: str, payload: SkillDraftActionRequest):
         item = await asyncio.to_thread(
             get_skill_draft_store().archive,
             draft_id,
-            revision=payload.revision,
+            expected_revision=payload.expected_revision,
+            expected_digest=payload.expected_digest,
         )
         return WorkspaceSkillDraftStore.serialize(item)
     except SkillDraftError as exc:
@@ -419,12 +453,38 @@ async def install_skill(payload: SkillInstallRequest) -> SkillPayload:
 @router.delete("/{skill_id}")
 async def uninstall_skill(skill_id: str) -> dict[str, bool]:
     try:
-        await asyncio.to_thread(get_skill_manager().uninstall_skill, skill_id)
+        manager = get_skill_manager()
+        installed_before = next(
+            (
+                item
+                for item in await asyncio.to_thread(manager.list_installed_skills)
+                if item.skill_id == skill_id
+            ),
+            None,
+        )
+        try:
+            await asyncio.to_thread(manager.uninstall_skill, skill_id)
+        except SkillNotFoundError:
+            # A previous attempt may have removed the global files before the
+            # Workspace draft projection could be persisted.  Repair that
+            # projection idempotently before deciding this is a true 404.
+            repaired = await asyncio.to_thread(
+                get_skill_draft_store().mark_uninstalled_skill, skill_id
+            )
+            if repaired is None:
+                raise
+            return {"ok": True}
+        if installed_before and installed_before.source_kind == "workspace_draft":
+            await asyncio.to_thread(
+                get_skill_draft_store().mark_uninstalled_skill, skill_id
+            )
         return {"ok": True}
     except SkillNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except SkillValidationError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except SkillDraftError as exc:
+        _raise_draft_error(exc)
 
 
 @router.get("/{skill_id}/content", response_model=SkillContentResponse)

--- a/server/skills/draft_store.py
+++ b/server/skills/draft_store.py
@@ -1,18 +1,28 @@
 from __future__ import annotations
 
+import hashlib
+import hmac
 import json
 import os
 import posixpath
-import re
 import threading
 import time
 import uuid
 from dataclasses import asdict, dataclass, field
 from pathlib import Path, PurePosixPath
-from typing import Any, Literal
+from typing import Any, Callable, Literal, TypeVar
+
+from .package_validation import (
+    VALIDATOR_VERSION as PACKAGE_VALIDATOR_VERSION,
+    compute_package_digest,
+    scan_skill_package_credentials,
+    validate_skill_package,
+)
 
 
 SkillDraftStatus = Literal["draft", "installed", "archived"]
+SkillDraftInstallState = Literal["not_installed", "current", "outdated"]
+InstallResultT = TypeVar("InstallResultT")
 
 
 class SkillDraftError(Exception):
@@ -31,6 +41,22 @@ class SkillDraftValidationError(SkillDraftError):
     pass
 
 
+class SkillDraftStorageError(SkillDraftError):
+    pass
+
+
+@dataclass(slots=True, frozen=True)
+class SkillDraftRevision:
+    """Immutable content snapshot for one workspace Skill draft revision."""
+
+    draft_id: str
+    revision: int
+    content_digest: str
+    package: dict[str, Any]
+    source_proposal_id: str | None = None
+    created_at: float = field(default_factory=time.time)
+
+
 @dataclass(slots=True)
 class WorkspaceSkillDraft:
     draft_id: str
@@ -41,8 +67,14 @@ class WorkspaceSkillDraft:
     files: dict[str, str] = field(default_factory=dict)
     status: SkillDraftStatus = "draft"
     revision: int = 1
+    content_revision: int = 1
+    content_digest: str = ""
     source_proposal_id: str | None = None
     installed_skill_id: str | None = None
+    installed_content_revision: int | None = None
+    installed_content_digest: str | None = None
+    install_state: SkillDraftInstallState = "not_installed"
+    needs_review: bool = False
     validation: dict[str, Any] = field(default_factory=dict)
     created_at: float = field(default_factory=time.time)
     updated_at: float = field(default_factory=time.time)
@@ -51,6 +83,8 @@ class WorkspaceSkillDraft:
 class WorkspaceSkillDraftStore:
     """File-backed, reviewable Skill packages that are not installed by default."""
 
+    SCHEMA_VERSION = 2
+    VALIDATOR_VERSION = PACKAGE_VALIDATOR_VERSION
     MAX_FILES = 40
     MAX_FILE_BYTES = 1024 * 1024
     MAX_TOTAL_BYTES = 5 * 1024 * 1024
@@ -63,8 +97,12 @@ class WorkspaceSkillDraftStore:
             storage_dir or runtime_dir or package_dir / "storage"
         )
         self.snapshot_path = self.storage_dir / "skill_drafts.json"
+        self.backup_path = self.storage_dir / "skill_drafts.v1.backup.json"
         self._lock = threading.RLock()
         self._items: dict[str, WorkspaceSkillDraft] = {}
+        self._revisions: dict[str, dict[int, SkillDraftRevision]] = {}
+        self._quarantine: list[dict[str, Any]] = []
+        self._load_error: str | None = None
         self._load()
 
     def create(
@@ -84,17 +122,27 @@ class WorkspaceSkillDraftStore:
             skill_markdown=skill_markdown,
             files=files or {},
         )
+        digest = self.compute_content_digest(**normalized)
         now = time.time()
         item = WorkspaceSkillDraft(
             draft_id=f"skilldraft_{uuid.uuid4().hex}",
             source_proposal_id=source_proposal_id,
+            content_digest=digest,
             created_at=now,
             updated_at=now,
             **normalized,
         )
+        snapshot = self._snapshot_from_item(item, created_at=now)
         with self._lock:
+            self._ensure_writable_unlocked()
             self._items[item.draft_id] = item
-            self._save_unlocked()
+            self._revisions[item.draft_id] = {item.content_revision: snapshot}
+            try:
+                self._save_unlocked()
+            except BaseException:
+                self._items.pop(item.draft_id, None)
+                self._revisions.pop(item.draft_id, None)
+                raise
         return self._copy(item)
 
     def require(self, draft_id: str) -> WorkspaceSkillDraft:
@@ -103,6 +151,48 @@ class WorkspaceSkillDraftStore:
             if item is None:
                 raise SkillDraftNotFoundError(f"Skill draft not found: {draft_id}")
             return self._copy(item)
+
+    def require_revision_snapshot(
+        self,
+        draft_id: str,
+        *,
+        revision: int | None = None,
+        content_digest: str | None = None,
+    ) -> SkillDraftRevision:
+        """Return a copy of an immutable content revision.
+
+        When ``revision`` is omitted the current content revision is returned.
+        ``content_digest`` is an optional optimistic consistency check.
+        """
+
+        with self._lock:
+            item = self._require_unlocked(draft_id)
+            selected_revision = item.content_revision if revision is None else int(revision)
+            snapshot = self._revisions.get(draft_id, {}).get(selected_revision)
+            if snapshot is None:
+                raise SkillDraftNotFoundError(
+                    f"Skill draft content revision not found: {draft_id}@{selected_revision}"
+                )
+            if content_digest is not None and not self._digests_equal(
+                snapshot.content_digest, content_digest
+            ):
+                raise SkillDraftConflictError(
+                    "Skill draft content changed. Reload it before applying this operation."
+                )
+            return self._copy_revision(snapshot)
+
+    def list_revision_snapshots(self, draft_id: str) -> list[SkillDraftRevision]:
+        with self._lock:
+            self._require_unlocked(draft_id)
+            snapshots = sorted(
+                self._revisions.get(draft_id, {}).values(),
+                key=lambda item: item.revision,
+            )
+            return [self._copy_revision(item) for item in snapshots]
+
+    def list_quarantined(self) -> list[dict[str, Any]]:
+        with self._lock:
+            return self._json_copy(self._quarantine)
 
     def list(
         self, *, status: str | None = None, limit: int = 100
@@ -118,7 +208,9 @@ class WorkspaceSkillDraftStore:
         self,
         draft_id: str,
         *,
-        revision: int,
+        revision: int | None = None,
+        expected_revision: int | None = None,
+        expected_digest: str | None = None,
         name: str | None = None,
         slug: str | None = None,
         description: str | None = None,
@@ -126,10 +218,18 @@ class WorkspaceSkillDraftStore:
         files: dict[str, str] | None = None,
     ) -> WorkspaceSkillDraft:
         with self._lock:
+            self._ensure_writable_unlocked()
             item = self._require_unlocked(draft_id)
-            self._require_revision(item, revision)
+            self._require_expected_state(
+                item,
+                revision=revision,
+                expected_revision=expected_revision,
+                expected_digest=expected_digest,
+            )
             if item.status == "archived":
                 raise SkillDraftConflictError("Archived Skill drafts cannot be edited.")
+            previous = self._copy(item)
+            previous_revisions = dict(self._revisions.get(item.draft_id, {}))
             normalized = self.validate_package(
                 name=item.name if name is None else name,
                 slug=item.slug if slug is None else slug,
@@ -139,67 +239,269 @@ class WorkspaceSkillDraftStore:
                 ),
                 files=item.files if files is None else files,
             )
+            digest = self.compute_content_digest(**normalized)
+            content_changed = not self._digests_equal(item.content_digest, digest)
             for key, value in normalized.items():
                 setattr(item, key, value)
-            item.status = "draft"
-            item.installed_skill_id = None
-            item.validation = {}
+            if content_changed:
+                item.content_revision += 1
+                item.content_digest = digest
+                item.validation = {}
+                item.needs_review = False
+                item.status = "draft"
+                item.install_state = (
+                    "outdated" if item.installed_skill_id else "not_installed"
+                )
+                self._revisions.setdefault(item.draft_id, {})[
+                    item.content_revision
+                ] = self._snapshot_from_item(item)
             item.revision += 1
             item.updated_at = time.time()
-            self._save_unlocked()
+            try:
+                self._save_unlocked()
+            except BaseException:
+                self._items[draft_id] = previous
+                self._revisions[draft_id] = previous_revisions
+                raise
             return self._copy(item)
 
     def set_validation(
-        self, draft_id: str, *, revision: int, validation: dict[str, Any]
+        self,
+        draft_id: str,
+        *,
+        revision: int | None = None,
+        expected_revision: int | None = None,
+        expected_digest: str | None = None,
+        validation: dict[str, Any],
     ) -> WorkspaceSkillDraft:
         with self._lock:
+            self._ensure_writable_unlocked()
             item = self._require_unlocked(draft_id)
-            self._require_revision(item, revision)
-            item.validation = dict(validation)
+            self._require_expected_state(
+                item,
+                revision=revision,
+                expected_revision=expected_revision,
+                expected_digest=expected_digest,
+            )
+            previous = self._copy(item)
+            bound_validation = self._bound_validation(item, validation)
+            item.validation = bound_validation
+            item.needs_review = not bool(bound_validation.get("valid", False))
             item.updated_at = time.time()
-            self._save_unlocked()
+            try:
+                self._save_unlocked()
+            except BaseException:
+                self._items[draft_id] = previous
+                raise
             return self._copy(item)
 
     def mark_installed(
-        self, draft_id: str, *, revision: int, skill_id: str
+        self,
+        draft_id: str,
+        *,
+        revision: int | None = None,
+        expected_revision: int | None = None,
+        expected_digest: str | None = None,
+        skill_id: str,
     ) -> WorkspaceSkillDraft:
         with self._lock:
+            self._ensure_writable_unlocked()
             item = self._require_unlocked(draft_id)
-            self._require_revision(item, revision)
+            self._require_expected_state(
+                item,
+                revision=revision,
+                expected_revision=expected_revision,
+                expected_digest=expected_digest,
+            )
+            previous = self._copy(item)
             item.status = "installed"
             item.installed_skill_id = str(skill_id).strip()
+            item.installed_content_revision = item.content_revision
+            item.installed_content_digest = item.content_digest
+            item.install_state = "current"
             item.revision += 1
             item.updated_at = time.time()
-            self._save_unlocked()
+            try:
+                self._save_unlocked()
+            except BaseException:
+                self._items[draft_id] = previous
+                raise
             return self._copy(item)
 
-    def archive(self, draft_id: str, *, revision: int) -> WorkspaceSkillDraft:
+    def mark_uninstalled_skill(
+        self, skill_id: str
+    ) -> WorkspaceSkillDraft | None:
+        """Clear a Workspace draft's install projection after global uninstall.
+
+        This server-owned reconciliation intentionally does not accept a client
+        revision.  A retry can repair the draft state after the filesystem was
+        already removed but persistence failed.
+        """
+
+        normalized_skill_id = str(skill_id or "").strip()
+        if not normalized_skill_id:
+            return None
         with self._lock:
+            self._ensure_writable_unlocked()
+            matches = [
+                item
+                for item in self._items.values()
+                if item.installed_skill_id == normalized_skill_id
+            ]
+            if not matches:
+                return None
+            if len(matches) != 1:
+                raise SkillDraftStorageError(
+                    "Multiple Workspace drafts reference the same installed Skill ID."
+                )
+            item = matches[0]
+            previous = self._copy(item)
+            item.installed_skill_id = None
+            item.installed_content_revision = None
+            item.installed_content_digest = None
+            item.install_state = "not_installed"
+            if item.status != "archived":
+                item.status = "draft"
+            item.revision += 1
+            item.updated_at = time.time()
+            try:
+                self._save_unlocked()
+            except BaseException:
+                self._items[item.draft_id] = previous
+                raise
+            return self._copy(item)
+
+    def install_current(
+        self,
+        draft_id: str,
+        *,
+        expected_revision: int,
+        expected_digest: str,
+        installer: Callable[[WorkspaceSkillDraft], InstallResultT],
+    ) -> tuple[WorkspaceSkillDraft, InstallResultT]:
+        """Validate and install one immutable draft state under the store lock.
+
+        Holding the lock across the installer callback prevents a concurrent draft
+        edit from landing between validation and the global filesystem install.
+        The callback receives a detached copy and must return an object exposing
+        ``skill_id`` and ``content_digest``.  If saving the installed marker fails,
+        the in-memory draft is restored; the installer's receipt makes a retry
+        idempotent.
+        """
+
+        with self._lock:
+            self._ensure_writable_unlocked()
             item = self._require_unlocked(draft_id)
-            self._require_revision(item, revision)
+            self._require_expected_state(
+                item,
+                revision=None,
+                expected_revision=expected_revision,
+                expected_digest=expected_digest,
+            )
+            if item.status == "archived":
+                raise SkillDraftConflictError("Archived Skill drafts cannot be installed.")
+
+            validation = self._validate_item_unlocked(item)
+            install_result = installer(self._copy(item))
+            installed_skill_id = str(getattr(install_result, "skill_id", "")).strip()
+            installed_digest = str(
+                getattr(install_result, "content_digest", "")
+            ).strip()
+            if not installed_skill_id:
+                raise SkillDraftStorageError(
+                    "Workspace Skill installer did not return a stable skill ID."
+                )
+            if not self._digests_equal(installed_digest, item.content_digest):
+                raise SkillDraftStorageError(
+                    "Installed Workspace Skill digest does not match the reviewed draft."
+                )
+
+            previous = self._copy(item)
+            try:
+                item.validation = self._bound_validation(item, validation)
+                item.needs_review = False
+                item.status = "installed"
+                item.installed_skill_id = installed_skill_id
+                item.installed_content_revision = item.content_revision
+                item.installed_content_digest = item.content_digest
+                item.install_state = "current"
+                item.revision += 1
+                item.updated_at = time.time()
+                self._save_unlocked()
+            except BaseException:
+                self._items[draft_id] = previous
+                raise
+            return self._copy(item), install_result
+
+    def archive(
+        self,
+        draft_id: str,
+        *,
+        revision: int | None = None,
+        expected_revision: int | None = None,
+        expected_digest: str | None = None,
+    ) -> WorkspaceSkillDraft:
+        with self._lock:
+            self._ensure_writable_unlocked()
+            item = self._require_unlocked(draft_id)
+            self._require_expected_state(
+                item,
+                revision=revision,
+                expected_revision=expected_revision,
+                expected_digest=expected_digest,
+            )
+            previous = self._copy(item)
             item.status = "archived"
             item.revision += 1
             item.updated_at = time.time()
-            self._save_unlocked()
+            try:
+                self._save_unlocked()
+            except BaseException:
+                self._items[draft_id] = previous
+                raise
             return self._copy(item)
 
     def validate_draft(self, draft_id: str) -> dict[str, Any]:
         item = self.require(draft_id)
-        normalized = self.validate_package(
+        return self._validate_item_unlocked(item)
+
+    def _validate_item_unlocked(self, item: WorkspaceSkillDraft) -> dict[str, Any]:
+        self.validate_package(
             name=item.name,
             slug=item.slug,
             description=item.description,
             skill_markdown=item.skill_markdown,
             files=item.files,
         )
-        return {
-            "valid": True,
-            "issues": [],
-            "file_count": 1 + len(normalized["files"]),
-            "total_bytes": self._total_bytes(
-                normalized["skill_markdown"], normalized["files"]
-            ),
-        }
+        result = validate_skill_package(
+            root_name=item.slug,
+            skill_markdown=item.skill_markdown,
+            files=item.files,
+        )
+        validation = result.to_dict()
+        validation.update(
+            {
+                "validator_version": self.VALIDATOR_VERSION,
+                "content_revision": item.content_revision,
+                "content_digest": item.content_digest,
+                "stale": False,
+            }
+        )
+        return validation
+
+    def _bound_validation(
+        self, item: WorkspaceSkillDraft, validation: dict[str, Any]
+    ) -> dict[str, Any]:
+        bound_validation = self._json_copy(dict(validation))
+        bound_validation.update(
+            {
+                "validator_version": self.VALIDATOR_VERSION,
+                "content_revision": item.content_revision,
+                "content_digest": item.content_digest,
+                "stale": False,
+            }
+        )
+        return bound_validation
 
     @classmethod
     def validate_package(
@@ -211,41 +513,46 @@ class WorkspaceSkillDraftStore:
         skill_markdown: str,
         files: dict[str, str],
     ) -> dict[str, Any]:
-        clean_name = str(name or "").strip()
-        clean_slug = re.sub(r"[^a-z0-9-]+", "-", str(slug or "").lower()).strip("-")
-        clean_description = str(description or "").strip()
-        markdown = str(skill_markdown or "")
-        if not clean_name or len(clean_name) > 120:
-            raise SkillDraftValidationError("Skill name is required and limited to 120 characters.")
-        if not clean_slug or len(clean_slug) > 80:
-            raise SkillDraftValidationError("Skill slug is required and limited to 80 characters.")
-        if len(clean_description) > 1000:
-            raise SkillDraftValidationError("Skill description is limited to 1,000 characters.")
-        if not markdown.strip() or len(markdown.encode("utf-8")) > cls.MAX_FILE_BYTES:
-            raise SkillDraftValidationError("SKILL.md is required and limited to 1MB.")
-        frontmatter = cls._parse_frontmatter(markdown)
-        if not frontmatter.get("name") or not frontmatter.get("description"):
-            raise SkillDraftValidationError(
-                "SKILL.md frontmatter must include name and description."
+        result = validate_skill_package(
+            root_name=slug,
+            skill_markdown=skill_markdown,
+            files=files,
+        )
+        if not result.valid or result.package is None:
+            messages = [
+                issue.message for issue in result.issues if issue.severity == "error"
+            ]
+            error = SkillDraftValidationError(
+                "; ".join(messages[:5]) or "Skill package validation failed."
             )
-        if not isinstance(files, dict) or len(files) > cls.MAX_FILES - 1:
-            raise SkillDraftValidationError("A Skill package can contain at most 40 files.")
-        clean_files: dict[str, str] = {}
-        for raw_path, raw_content in files.items():
-            path = cls._validate_path(raw_path)
-            content = str(raw_content)
-            if len(content.encode("utf-8")) > cls.MAX_FILE_BYTES:
-                raise SkillDraftValidationError(f"Skill file exceeds 1MB: {path}")
-            clean_files[path] = content
-        if cls._total_bytes(markdown, clean_files) > cls.MAX_TOTAL_BYTES:
-            raise SkillDraftValidationError("Skill package exceeds 5MB.")
+            error.issues = [issue.to_dict() for issue in result.issues]  # type: ignore[attr-defined]
+            raise error
+        package = result.package
+        # ``name`` and ``description`` remain accepted for V1 callers, while
+        # canonical V2 metadata is always derived from validated frontmatter.
+        del name, description
         return {
-            "name": clean_name,
-            "slug": clean_slug,
-            "description": clean_description or frontmatter["description"][:1000],
-            "skill_markdown": markdown,
-            "files": clean_files,
+            "name": package.name,
+            "slug": package.root_name,
+            "description": package.description,
+            "skill_markdown": package.skill_markdown,
+            "files": dict(package.files),
         }
+
+    @classmethod
+    def compute_content_digest(
+        cls,
+        *,
+        name: str,
+        slug: str,
+        description: str,
+        skill_markdown: str,
+        files: dict[str, str],
+    ) -> str:
+        """Use the unified V2 package digest over canonical paths and raw bytes."""
+
+        del name, slug, description
+        return compute_package_digest(skill_markdown, files)
 
     @classmethod
     def _validate_path(cls, raw_path: Any) -> str:
@@ -303,11 +610,57 @@ class WorkspaceSkillDraftStore:
             len(value.encode("utf-8")) for value in files.values()
         )
 
+    def _snapshot_from_item(
+        self, item: WorkspaceSkillDraft, *, created_at: float | None = None
+    ) -> SkillDraftRevision:
+        return SkillDraftRevision(
+            draft_id=item.draft_id,
+            revision=item.content_revision,
+            content_digest=item.content_digest,
+            package=self._package_from_item(item),
+            source_proposal_id=item.source_proposal_id,
+            created_at=time.time() if created_at is None else created_at,
+        )
+
+    @staticmethod
+    def _package_from_item(item: WorkspaceSkillDraft) -> dict[str, Any]:
+        return {
+            "name": item.name,
+            "slug": item.slug,
+            "description": item.description,
+            "skill_markdown": item.skill_markdown,
+            "files": dict(item.files),
+        }
+
     def _require_unlocked(self, draft_id: str) -> WorkspaceSkillDraft:
         item = self._items.get(draft_id)
         if item is None:
             raise SkillDraftNotFoundError(f"Skill draft not found: {draft_id}")
         return item
+
+    def _require_expected_state(
+        self,
+        item: WorkspaceSkillDraft,
+        *,
+        revision: int | None,
+        expected_revision: int | None,
+        expected_digest: str | None,
+    ) -> None:
+        if revision is not None and expected_revision is not None:
+            if int(revision) != int(expected_revision):
+                raise SkillDraftConflictError(
+                    "Conflicting expected Skill draft revisions were supplied."
+                )
+        selected_revision = expected_revision if expected_revision is not None else revision
+        if selected_revision is None:
+            raise SkillDraftConflictError("Expected Skill draft revision is required.")
+        self._require_revision(item, int(selected_revision))
+        if expected_digest is not None and not self._digests_equal(
+            item.content_digest, expected_digest
+        ):
+            raise SkillDraftConflictError(
+                "Skill draft content changed. Reload it before applying this operation."
+            )
 
     @staticmethod
     def _require_revision(item: WorkspaceSkillDraft, revision: int) -> None:
@@ -316,36 +669,571 @@ class WorkspaceSkillDraftStore:
                 "Skill draft changed. Reload it before applying this operation."
             )
 
+    @staticmethod
+    def _digests_equal(left: str, right: str) -> bool:
+        return bool(left) and bool(right) and hmac.compare_digest(
+            left.lower(), right.lower()
+        )
+
     def _load(self) -> None:
         with self._lock:
             if not self.snapshot_path.exists():
                 return
             try:
-                raw = json.loads(self.snapshot_path.read_text(encoding="utf-8"))
-                items = raw.get("items", []) if isinstance(raw, dict) else []
-                self._items = {
-                    item["draft_id"]: WorkspaceSkillDraft(**item)
-                    for item in items
-                    if isinstance(item, dict) and item.get("draft_id")
+                raw_bytes = self.snapshot_path.read_bytes()
+            except OSError as exc:
+                self._load_error = f"Unable to read Skill draft storage: {exc}"
+                return
+            try:
+                raw = json.loads(raw_bytes.decode("utf-8"))
+            except (UnicodeDecodeError, ValueError, json.JSONDecodeError) as exc:
+                self._backup_original_unlocked(raw_bytes, corrupted=True)
+                self._load_error = f"Skill draft storage is not valid UTF-8 JSON: {exc}"
+                return
+            if not isinstance(raw, dict) or not isinstance(raw.get("items", []), list):
+                self._backup_original_unlocked(raw_bytes, corrupted=True)
+                self._load_error = "Skill draft storage must contain an items array."
+                return
+
+            raw_version = raw.get("version", 1)
+            try:
+                version = int(raw_version)
+            except (TypeError, ValueError):
+                version = -1
+            if version not in {1, self.SCHEMA_VERSION}:
+                self._backup_original_unlocked(raw_bytes, corrupted=True)
+                self._load_error = f"Unsupported Skill draft storage version: {raw_version}"
+                return
+            if version == 1:
+                self._backup_original_unlocked(raw_bytes)
+
+            migrated = version == 1
+            existing_quarantine = raw.get("quarantine", [])
+            if version == self.SCHEMA_VERSION and isinstance(existing_quarantine, list):
+                for index, entry in enumerate(existing_quarantine):
+                    safe_entry = self._sanitize_quarantine_entry(entry, index=index)
+                    self._quarantine.append(safe_entry)
+                    if not isinstance(entry, dict) or entry != safe_entry:
+                        migrated = True
+            for index, record in enumerate(raw.get("items", [])):
+                if not isinstance(record, dict):
+                    self._quarantine_record(
+                        kind="item",
+                        index=index,
+                        reason_code="record_not_object",
+                        reason="Skill draft record must be an object.",
+                        record=record,
+                    )
+                    migrated = True
+                    continue
+                try:
+                    item = self._decode_item(record, version=version)
+                    if item.draft_id in self._items:
+                        raise ValueError(f"Duplicate draft_id: {item.draft_id}")
+                except (KeyError, TypeError, ValueError) as exc:
+                    self._quarantine_record(
+                        kind="item",
+                        index=index,
+                        reason_code="invalid_record",
+                        reason=str(exc),
+                        record=record,
+                    )
+                    migrated = True
+                    continue
+                self._items[item.draft_id] = item
+
+            if version == self.SCHEMA_VERSION:
+                revisions = raw.get("revisions", [])
+                if not isinstance(revisions, list):
+                    revisions = []
+                    migrated = True
+                for index, record in enumerate(revisions):
+                    if not isinstance(record, dict):
+                        self._quarantine_record(
+                            kind="revision",
+                            index=index,
+                            reason_code="record_not_object",
+                            reason="Skill revision record must be an object.",
+                            record=record,
+                        )
+                        migrated = True
+                        continue
+                    try:
+                        snapshot = self._decode_revision(record)
+                        if snapshot.draft_id not in self._items:
+                            raise ValueError(
+                                f"Revision references missing draft_id: {snapshot.draft_id}"
+                            )
+                        existing = self._revisions.setdefault(snapshot.draft_id, {})
+                        if snapshot.revision in existing:
+                            raise ValueError(
+                                f"Duplicate content revision: {snapshot.draft_id}@{snapshot.revision}"
+                            )
+                    except (KeyError, TypeError, ValueError) as exc:
+                        self._quarantine_record(
+                            kind="revision",
+                            index=index,
+                            reason_code="invalid_revision",
+                            reason=str(exc),
+                            record=record,
+                        )
+                        migrated = True
+                        continue
+                    existing[snapshot.revision] = snapshot
+
+            for item in self._items.values():
+                snapshots = self._revisions.setdefault(item.draft_id, {})
+                current = snapshots.get(item.content_revision)
+                if current is None or not self._digests_equal(
+                    current.content_digest, item.content_digest
+                ):
+                    snapshots[item.content_revision] = self._snapshot_from_item(
+                        item, created_at=item.updated_at
+                    )
+                    item.needs_review = item.needs_review or version == self.SCHEMA_VERSION
+                    migrated = True
+
+            if migrated:
+                self._save_unlocked()
+
+    def _decode_item(self, record: dict[str, Any], *, version: int) -> WorkspaceSkillDraft:
+        draft_id = self._required_text(record, "draft_id")
+        name = self._required_text(record, "name")
+        slug = self._required_text(record, "slug")
+        description = self._text(record.get("description", ""), "description")
+        skill_markdown = self._required_text(record, "skill_markdown")
+        files = self._text_files(record.get("files", {}))
+        status = record.get("status", "draft")
+        if status not in {"draft", "installed", "archived"}:
+            raise ValueError(f"Invalid Skill draft status: {status}")
+        revision = self._positive_int(record.get("revision", 1), "revision")
+        content_revision = self._positive_int(
+            record.get("content_revision", 1), "content_revision"
+        )
+        package = {
+            "name": name,
+            "slug": slug,
+            "description": description,
+            "skill_markdown": skill_markdown,
+            "files": files,
+        }
+        self._reject_persisted_credentials(
+            metadata=(name, slug, description),
+            skill_markdown=skill_markdown,
+            files=files,
+        )
+        actual_digest = self.compute_content_digest(**package)
+        stored_digest = record.get("content_digest")
+        if version == self.SCHEMA_VERSION:
+            if not isinstance(stored_digest, str) or not self._digests_equal(
+                stored_digest, actual_digest
+            ):
+                raise ValueError("Skill draft content_digest does not match its package.")
+
+        installed_skill_id = self._optional_text(record.get("installed_skill_id"))
+        installed_content_revision = self._optional_positive_int(
+            record.get("installed_content_revision"), "installed_content_revision"
+        )
+        installed_content_digest = self._optional_text(
+            record.get("installed_content_digest")
+        )
+        if version == 1:
+            install_state: SkillDraftInstallState
+            if installed_skill_id and status == "installed":
+                install_state = "current"
+                installed_content_revision = content_revision
+                installed_content_digest = actual_digest
+            elif installed_skill_id:
+                install_state = "outdated"
+            else:
+                install_state = "not_installed"
+        else:
+            install_state = record.get("install_state", "not_installed")
+            if install_state not in {"not_installed", "current", "outdated"}:
+                raise ValueError(f"Invalid Skill install_state: {install_state}")
+
+        validation = record.get("validation", {})
+        if not isinstance(validation, dict):
+            raise TypeError("Skill draft validation must be an object.")
+        validation_credentials = scan_skill_package_credentials(
+            skill_markdown=json.dumps(validation, ensure_ascii=False)
+        )
+        if validation_credentials:
+            validation = {}
+        needs_review = bool(record.get("needs_review", False)) or bool(
+            validation_credentials
+        )
+        if version == 1 and validation:
+            validation = self._json_copy(validation)
+            validation.update(
+                {
+                    "validator_version": "legacy-v1-unbound",
+                    "content_revision": content_revision,
+                    "content_digest": actual_digest,
+                    "stale": True,
                 }
-            except (OSError, TypeError, ValueError, json.JSONDecodeError):
-                self._items = {}
+            )
+            needs_review = True
+        elif version == self.SCHEMA_VERSION and validation:
+            validation = self._json_copy(validation)
+            binding_matches = (
+                validation.get("validator_version") == self.VALIDATOR_VERSION
+                and validation.get("content_revision") == content_revision
+                and self._digests_equal(
+                    str(validation.get("content_digest") or ""), actual_digest
+                )
+                and validation.get("stale") is False
+            )
+            if not binding_matches:
+                validation["stale"] = True
+                needs_review = True
+        try:
+            self.validate_package(**package)
+        except SkillDraftValidationError:
+            needs_review = True
+
+        created_at = self._timestamp(record.get("created_at", time.time()), "created_at")
+        updated_at = self._timestamp(record.get("updated_at", created_at), "updated_at")
+        return WorkspaceSkillDraft(
+            draft_id=draft_id,
+            name=name,
+            slug=slug,
+            description=description,
+            skill_markdown=skill_markdown,
+            files=files,
+            status=status,
+            revision=revision,
+            content_revision=content_revision,
+            content_digest=actual_digest,
+            source_proposal_id=self._optional_text(record.get("source_proposal_id")),
+            installed_skill_id=installed_skill_id,
+            installed_content_revision=installed_content_revision,
+            installed_content_digest=installed_content_digest,
+            install_state=install_state,
+            needs_review=needs_review,
+            validation=self._json_copy(validation),
+            created_at=created_at,
+            updated_at=updated_at,
+        )
+
+    def _decode_revision(self, record: dict[str, Any]) -> SkillDraftRevision:
+        draft_id = self._required_text(record, "draft_id")
+        revision = self._positive_int(record.get("revision"), "revision")
+        content_digest = self._required_text(record, "content_digest")
+        package = record.get("package")
+        if not isinstance(package, dict):
+            raise TypeError("Skill revision package must be an object.")
+        normalized_package = {
+            "name": self._required_text(package, "name"),
+            "slug": self._required_text(package, "slug"),
+            "description": self._text(package.get("description", ""), "description"),
+            "skill_markdown": self._required_text(package, "skill_markdown"),
+            "files": self._text_files(package.get("files", {})),
+        }
+        self._reject_persisted_credentials(
+            metadata=(
+                normalized_package["name"],
+                normalized_package["slug"],
+                normalized_package["description"],
+            ),
+            skill_markdown=normalized_package["skill_markdown"],
+            files=normalized_package["files"],
+        )
+        actual_digest = self.compute_content_digest(**normalized_package)
+        if not self._digests_equal(content_digest, actual_digest):
+            raise ValueError("Skill revision content_digest does not match its package.")
+        return SkillDraftRevision(
+            draft_id=draft_id,
+            revision=revision,
+            content_digest=actual_digest,
+            package=normalized_package,
+            source_proposal_id=self._optional_text(record.get("source_proposal_id")),
+            created_at=self._timestamp(record.get("created_at", time.time()), "created_at"),
+        )
+
+    @staticmethod
+    def _required_text(record: dict[str, Any], key: str) -> str:
+        if key not in record:
+            raise KeyError(f"Missing required Skill draft field: {key}")
+        return WorkspaceSkillDraftStore._text(record[key], key, required=True)
+
+    @staticmethod
+    def _text(value: Any, field_name: str, *, required: bool = False) -> str:
+        if not isinstance(value, str):
+            raise TypeError(f"Skill draft {field_name} must be text.")
+        if required and not value.strip():
+            raise ValueError(f"Skill draft {field_name} cannot be empty.")
+        return value
+
+    @staticmethod
+    def _optional_text(value: Any) -> str | None:
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            raise TypeError("Optional Skill draft identifiers must be text.")
+        clean = value.strip()
+        return clean or None
+
+    @staticmethod
+    def _text_files(value: Any) -> dict[str, str]:
+        if not isinstance(value, dict):
+            raise TypeError("Skill draft files must be an object.")
+        files: dict[str, str] = {}
+        for path, content in value.items():
+            if not isinstance(path, str) or not isinstance(content, str):
+                raise TypeError("Skill draft file paths and contents must be text.")
+            files[path] = content
+        return files
+
+    @staticmethod
+    def _positive_int(value: Any, field_name: str) -> int:
+        if isinstance(value, bool):
+            raise TypeError(f"Skill draft {field_name} must be a positive integer.")
+        try:
+            result = int(value)
+        except (TypeError, ValueError) as exc:
+            raise TypeError(
+                f"Skill draft {field_name} must be a positive integer."
+            ) from exc
+        if result < 1:
+            raise ValueError(f"Skill draft {field_name} must be a positive integer.")
+        return result
+
+    @classmethod
+    def _optional_positive_int(cls, value: Any, field_name: str) -> int | None:
+        if value is None:
+            return None
+        return cls._positive_int(value, field_name)
+
+    @staticmethod
+    def _timestamp(value: Any, field_name: str) -> float:
+        if isinstance(value, bool):
+            raise TypeError(f"Skill draft {field_name} must be a timestamp.")
+        try:
+            return float(value)
+        except (TypeError, ValueError) as exc:
+            raise TypeError(f"Skill draft {field_name} must be a timestamp.") from exc
+
+    def _quarantine_record(
+        self,
+        *,
+        kind: str,
+        index: int,
+        reason_code: str,
+        reason: str,
+        record: Any,
+    ) -> None:
+        del reason
+        self._quarantine.append(
+            self._safe_quarantine_metadata(
+                kind=kind,
+                index=index,
+                reason_code=reason_code,
+                record=record,
+                quarantined_at=time.time(),
+            )
+        )
+
+    @staticmethod
+    def _reject_persisted_credentials(
+        *,
+        metadata: tuple[str, ...] = (),
+        skill_markdown: str,
+        files: dict[str, str],
+    ) -> None:
+        issues = scan_skill_package_credentials(
+            skill_markdown="\n".join((*metadata, skill_markdown)),
+            files=files,
+        )
+        if not issues:
+            return
+        codes = ",".join(sorted({issue.code for issue in issues}))
+        raise ValueError(f"credential_scan_blocked:{codes}")
+
+    @classmethod
+    def _safe_quarantine_metadata(
+        cls,
+        *,
+        kind: str,
+        index: int,
+        reason_code: str,
+        record: Any,
+        quarantined_at: float,
+    ) -> dict[str, Any]:
+        try:
+            raw = json.dumps(
+                record,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        except (TypeError, UnicodeEncodeError):
+            raw = type(record).__name__.encode("ascii", errors="replace")
+        safe_kind = kind if kind in {"item", "revision"} else "unknown"
+        safe_reason_code = (
+            reason_code
+            if reason_code
+            in {
+                "record_not_object",
+                "invalid_record",
+                "invalid_revision",
+                "legacy_quarantine",
+            }
+            else "legacy_quarantine"
+        )
+        return {
+            "kind": safe_kind,
+            "index": max(0, int(index)),
+            "reason_code": safe_reason_code,
+            "record_sha256": hashlib.sha256(raw).hexdigest(),
+            "record_size_bytes": len(raw),
+            "quarantined_at": float(quarantined_at),
+        }
+
+    @classmethod
+    def _sanitize_quarantine_entry(
+        cls, entry: Any, *, index: int
+    ) -> dict[str, Any]:
+        if not isinstance(entry, dict):
+            return cls._safe_quarantine_metadata(
+                kind="unknown",
+                index=index,
+                reason_code="legacy_quarantine",
+                record=entry,
+                quarantined_at=time.time(),
+            )
+        timestamp = entry.get("quarantined_at", time.time())
+        try:
+            safe_timestamp = float(timestamp)
+        except (TypeError, ValueError):
+            safe_timestamp = time.time()
+        raw_index = entry.get("index", index)
+        try:
+            safe_index = int(raw_index)
+        except (TypeError, ValueError):
+            safe_index = index
+        existing_digest = str(entry.get("record_sha256") or "").lower()
+        existing_size = entry.get("record_size_bytes")
+        if (
+            "record" not in entry
+            and len(existing_digest) == 64
+            and all(character in "0123456789abcdef" for character in existing_digest)
+            and isinstance(existing_size, int)
+            and existing_size >= 0
+        ):
+            safe_kind = (
+                str(entry.get("kind"))
+                if entry.get("kind") in {"item", "revision"}
+                else "unknown"
+            )
+            reason_code = str(entry.get("reason_code") or "legacy_quarantine")
+            if reason_code not in {
+                "record_not_object",
+                "invalid_record",
+                "invalid_revision",
+                "legacy_quarantine",
+            }:
+                reason_code = "legacy_quarantine"
+            return {
+                "kind": safe_kind,
+                "index": max(0, safe_index),
+                "reason_code": reason_code,
+                "record_sha256": existing_digest,
+                "record_size_bytes": existing_size,
+                "quarantined_at": safe_timestamp,
+            }
+        if "record" in entry:
+            record = entry.get("record")
+        else:
+            # Hash the complete legacy entry if its original record is unavailable.
+            record = entry
+        return cls._safe_quarantine_metadata(
+            kind=str(entry.get("kind") or "unknown"),
+            index=safe_index,
+            reason_code=str(entry.get("reason_code") or "legacy_quarantine"),
+            record=record,
+            quarantined_at=safe_timestamp,
+        )
+
+    def _backup_original_unlocked(
+        self, raw_bytes: bytes, *, corrupted: bool = False
+    ) -> None:
+        backup_path = (
+            self.storage_dir / "skill_drafts.corrupt.backup.json"
+            if corrupted
+            else self.backup_path
+        )
+        if backup_path.exists():
+            return
+        self.storage_dir.mkdir(parents=True, exist_ok=True)
+        temp_path = backup_path.with_name(
+            f"{backup_path.name}.tmp.{os.getpid()}.{uuid.uuid4().hex}"
+        )
+        try:
+            with temp_path.open("xb") as handle:
+                handle.write(raw_bytes)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temp_path, backup_path)
+        finally:
+            try:
+                temp_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+
+    def _ensure_writable_unlocked(self) -> None:
+        if self._load_error:
+            raise SkillDraftStorageError(
+                f"Skill draft storage is quarantined and cannot be overwritten: {self._load_error}"
+            )
 
     def _save_unlocked(self) -> None:
+        self._ensure_writable_unlocked()
         self.storage_dir.mkdir(parents=True, exist_ok=True)
-        temp_path = self.snapshot_path.with_suffix(".tmp")
-        temp_path.write_text(
-            json.dumps(
-                {"version": 1, "items": [asdict(item) for item in self._items.values()]},
-                ensure_ascii=False,
-                indent=2,
-            ),
-            encoding="utf-8",
+        temp_path = self.snapshot_path.with_name(
+            f"{self.snapshot_path.name}.tmp.{os.getpid()}.{uuid.uuid4().hex}"
         )
-        os.replace(temp_path, self.snapshot_path)
+        payload = {
+            "version": self.SCHEMA_VERSION,
+            "items": [
+                asdict(item)
+                for item in sorted(self._items.values(), key=lambda item: item.draft_id)
+            ],
+            "revisions": [
+                asdict(snapshot)
+                for draft_id in sorted(self._revisions)
+                for snapshot in sorted(
+                    self._revisions[draft_id].values(),
+                    key=lambda item: item.revision,
+                )
+            ],
+            "quarantine": self._quarantine,
+        }
+        serialized = json.dumps(payload, ensure_ascii=False, indent=2).encode("utf-8")
+        try:
+            with temp_path.open("xb") as handle:
+                handle.write(serialized)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temp_path, self.snapshot_path)
+        finally:
+            try:
+                temp_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+
+    @staticmethod
+    def _json_copy(value: Any) -> Any:
+        return json.loads(json.dumps(value, ensure_ascii=False))
 
     @staticmethod
     def _copy(item: WorkspaceSkillDraft) -> WorkspaceSkillDraft:
         return WorkspaceSkillDraft(
-            **json.loads(json.dumps(asdict(item), ensure_ascii=False))
+            **WorkspaceSkillDraftStore._json_copy(asdict(item))
+        )
+
+    @staticmethod
+    def _copy_revision(item: SkillDraftRevision) -> SkillDraftRevision:
+        return SkillDraftRevision(
+            **WorkspaceSkillDraftStore._json_copy(asdict(item))
         )

--- a/server/skills/package_validation.py
+++ b/server/skills/package_validation.py
@@ -1,0 +1,1244 @@
+from __future__ import annotations
+
+import ast
+import copy
+import hashlib
+import json
+import math
+import posixpath
+import re
+import unicodedata
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+from typing import Any, Literal, Mapping
+from urllib.parse import unquote, urlsplit
+
+import yaml
+from yaml.nodes import MappingNode
+from yaml.tokens import AliasToken, AnchorToken
+
+
+VALIDATOR_VERSION = "skill-package-v2.1"
+
+MAX_FILES = 40
+MAX_FILE_BYTES = 1024 * 1024
+MAX_TOTAL_BYTES = 5 * 1024 * 1024
+MAX_PATH_CHARS = 240
+MAX_PATH_SEGMENT_BYTES = 255
+ALLOWED_ROOTS = frozenset({"scripts", "references", "assets", "agents"})
+SUPPORTED_FRONTMATTER_FIELDS = frozenset(
+    {
+        "name",
+        "description",
+        "license",
+        "compatibility",
+        "metadata",
+        "allowed-tools",
+    }
+)
+
+IssueSeverity = Literal["error", "warning"]
+
+
+@dataclass(frozen=True, slots=True)
+class SkillPackageIssue:
+    code: str
+    message: str
+    severity: IssueSeverity = "error"
+    path: str | None = None
+    field: str | None = None
+    line: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            key: value
+            for key, value in {
+                "code": self.code,
+                "message": self.message,
+                "severity": self.severity,
+                "path": self.path,
+                "field": self.field,
+                "line": self.line,
+            }.items()
+            if value is not None
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class SkillPackageV2:
+    """A validated, UTF-8-only Skill package.
+
+    ``allowed_tools`` is retained as package metadata. It never grants runtime
+    permissions; ModelMirror's runtime policy remains authoritative.
+    """
+
+    root_name: str
+    name: str
+    description: str
+    skill_markdown: str
+    files: dict[str, str]
+    content_digest: str
+    file_count: int
+    total_bytes: int
+    license: str | None = None
+    compatibility: str | None = None
+    metadata: dict[str, Any] | None = None
+    allowed_tools: tuple[str, ...] = ()
+    version: int = 2
+
+    def to_dict(self, *, include_content: bool = True) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "version": self.version,
+            "root_name": self.root_name,
+            "name": self.name,
+            "description": self.description,
+            "license": self.license,
+            "compatibility": self.compatibility,
+            "metadata": copy.deepcopy(self.metadata or {}),
+            "allowed_tools": list(self.allowed_tools),
+            "content_digest": self.content_digest,
+            "file_count": self.file_count,
+            "total_bytes": self.total_bytes,
+        }
+        if include_content:
+            result["skill_markdown"] = self.skill_markdown
+            result["files"] = dict(self.files)
+        else:
+            result["file_paths"] = ["SKILL.md", *sorted(self.files)]
+        return result
+
+
+@dataclass(frozen=True, slots=True)
+class SkillPackageValidationResult:
+    valid: bool
+    issues: tuple[SkillPackageIssue, ...]
+    package: SkillPackageV2 | None
+    file_count: int = 0
+    total_bytes: int = 0
+    validator_version: str = VALIDATOR_VERSION
+
+    @property
+    def content_digest(self) -> str | None:
+        return self.package.content_digest if self.package else None
+
+    def to_dict(self, *, include_package: bool = False) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "valid": self.valid,
+            "validator_version": self.validator_version,
+            "issues": [issue.to_dict() for issue in self.issues],
+            "content_digest": self.content_digest,
+            "file_count": self.file_count,
+            "total_bytes": self.total_bytes,
+        }
+        if include_package and self.package is not None:
+            result["package"] = self.package.to_dict()
+        return result
+
+
+class _DuplicateYamlKeyError(yaml.YAMLError):
+    pass
+
+
+class _StrictSafeLoader(yaml.SafeLoader):
+    pass
+
+
+def _construct_unique_mapping(
+    loader: _StrictSafeLoader, node: MappingNode, deep: bool = False
+) -> dict[Any, Any]:
+    if not isinstance(node, MappingNode):
+        raise yaml.constructor.ConstructorError(
+            None, None, "expected a mapping", node.start_mark
+        )
+    mapping: dict[Any, Any] = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        try:
+            duplicate = key in mapping
+        except TypeError as exc:
+            raise yaml.constructor.ConstructorError(
+                "while constructing a mapping",
+                node.start_mark,
+                "found an unhashable key",
+                key_node.start_mark,
+            ) from exc
+        if duplicate:
+            raise _DuplicateYamlKeyError("duplicate mapping key")
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+_StrictSafeLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _construct_unique_mapping
+)
+
+
+_SKILL_NAME_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+_MARKDOWN_LINK_RE = re.compile(r"!?\[[^\]\n]*\]\(([^)\n]+)\)")
+_FENCED_CODE_RE = re.compile(r"```.*?```|~~~.*?~~~", re.DOTALL)
+_INLINE_CODE_RE = re.compile(r"`[^`\n]*`")
+_INLINE_RESOURCE_PATH_RE = re.compile(
+    r"(?<![A-Za-z0-9._+@/-])(?P<path>(?:scripts|references|assets|agents)/"
+    r"[A-Za-z0-9][A-Za-z0-9._+@/-]*\.[A-Za-z0-9]{1,12}"
+    r"(?:#[A-Za-z0-9._-]+)?)(?=$|[\s'\"),;:])"
+)
+_WINDOWS_DRIVE_RE = re.compile(r"^[A-Za-z]:[/\\]")
+_WINDOWS_RESERVED_NAMES = frozenset(
+    {"con", "prn", "aux", "nul", "clock$"}
+    | {f"com{index}" for index in range(1, 10)}
+    | {f"lpt{index}" for index in range(1, 10)}
+)
+_JS_NON_CODE_RE = re.compile(
+    r"//[^\n]*|/\*.*?\*/|'(?:\\.|[^'\\])*'|\"(?:\\.|[^\"\\])*\"|`(?:\\.|[^`\\])*`",
+    re.DOTALL,
+)
+_JS_MISSING_ASSIGNMENT_RE = re.compile(
+    r"\b(?:const|let|var)\s+[A-Za-z_$][A-Za-z0-9_$]*\s*=(?!=|>)"
+    r"\s*(?=[;,\n\}]|$)",
+    re.MULTILINE,
+)
+_JS_MISSING_DECLARATION_NAME_RE = re.compile(
+    r"\b(?:const|let|var)\s*=(?!=|>)"
+)
+
+_PRIVATE_KEY_RE = re.compile(
+    r"-----BEGIN (?:RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----"
+)
+_TOKEN_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\bgh[opurs]_[A-Za-z0-9]{30,}\b"),
+    re.compile(r"\bgithub_pat_[A-Za-z0-9_]{30,}\b"),
+    re.compile(r"\bsk-[A-Za-z0-9_-]{20,}\b"),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+    re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{20,}\b"),
+)
+_SECRET_ASSIGNMENT_RE = re.compile(
+    r"(?i)\b[A-Za-z0-9_-]*(?:api[_-]?key|access[_-]?key|secret(?:[_-]?key)?|password|passwd|"
+    r"(?:auth|access|refresh|private)[_-]?token|client[_-]?secret|token)\b\s*[:=]\s*"
+    r"(?P<value>[^\s,;#]+)"
+)
+_CREDENTIAL_URL_RE = re.compile(
+    r"(?i)\b(?:https?|ssh|ftp)://[^\s/:@]+:[^\s/@]+@[^\s]+"
+)
+_PLACEHOLDER_PARTS = (
+    "placeholder",
+    "example",
+    "changeme",
+    "replace-me",
+    "replace_me",
+    "your-",
+    "your_",
+    "<",
+    "${",
+    "{{",
+    "os.environ",
+    "process.env",
+    "getenv(",
+    "redacted",
+    "dummy",
+    "test-only",
+)
+
+
+def validate_skill_package(
+    *,
+    root_name: Any,
+    skill_markdown: Any,
+    files: Any,
+) -> SkillPackageValidationResult:
+    """Validate untrusted Skill package content without executing it.
+
+    Validation failures are returned as structured issues. The result only
+    exposes package content when every blocking check has passed, which keeps
+    detected credentials out of downstream snapshots and logs by default.
+    """
+
+    issues: list[SkillPackageIssue] = []
+    clean_root = _validate_root_name(root_name, issues)
+
+    markdown_text, markdown_bytes = _decode_utf8_text(
+        skill_markdown, path="SKILL.md", issues=issues
+    )
+    raw_files = files if isinstance(files, Mapping) else None
+    if raw_files is None:
+        issues.append(
+            SkillPackageIssue(
+                code="package_files_type",
+                message="Skill package files must be a path-to-text mapping.",
+                field="files",
+            )
+        )
+        raw_files = {}
+    elif len(raw_files) + 1 > MAX_FILES:
+        issues.append(
+            SkillPackageIssue(
+                code="package_file_count_exceeded",
+                message=f"A Skill package can contain at most {MAX_FILES} files.",
+                field="files",
+            )
+        )
+
+    clean_files: dict[str, str] = {}
+    content_bytes: dict[str, bytes] = {}
+    seen_paths: dict[str, str] = {_path_identity("SKILL.md"): "SKILL.md"}
+    if clean_root is not None:
+        _scan_credentials("skill-root", clean_root, issues)
+    if markdown_text is not None and markdown_bytes is not None:
+        content_bytes["SKILL.md"] = markdown_bytes
+        if not markdown_text.strip():
+            issues.append(
+                SkillPackageIssue(
+                    code="skill_markdown_empty",
+                    message="SKILL.md must not be empty.",
+                    path="SKILL.md",
+                )
+            )
+        if len(markdown_bytes) > MAX_FILE_BYTES:
+            issues.append(
+                SkillPackageIssue(
+                    code="file_size_exceeded",
+                    message=f"Each Skill file is limited to {MAX_FILE_BYTES} bytes.",
+                    path="SKILL.md",
+                )
+            )
+
+    sortable_items: list[tuple[str, Any]] = []
+    for raw_path, raw_content in raw_files.items():
+        sortable_items.append((raw_path if isinstance(raw_path, str) else "", (raw_path, raw_content)))
+    sortable_items.sort(key=lambda item: item[0])
+    for _, (raw_path, raw_content) in sortable_items:
+        path_credential_issues: list[SkillPackageIssue] = []
+        if isinstance(raw_path, str):
+            _scan_credentials(None, raw_path, path_credential_issues)
+        if path_credential_issues:
+            issues.extend(path_credential_issues)
+            continue
+        path = _validate_file_path(raw_path, issues)
+        if path is None:
+            continue
+        identity = _path_identity(path)
+        previous = seen_paths.get(identity)
+        if previous is not None:
+            issues.append(
+                SkillPackageIssue(
+                    code="file_path_case_collision",
+                    message="Skill package paths must be unique across case and Unicode normalization.",
+                    path=path,
+                    field="files",
+                )
+            )
+            continue
+        seen_paths[identity] = path
+        text, encoded = _decode_utf8_text(raw_content, path=path, issues=issues)
+        if text is None or encoded is None:
+            continue
+        if len(encoded) > MAX_FILE_BYTES:
+            issues.append(
+                SkillPackageIssue(
+                    code="file_size_exceeded",
+                    message=f"Each Skill file is limited to {MAX_FILE_BYTES} bytes.",
+                    path=path,
+                )
+            )
+        clean_files[path] = text
+        content_bytes[path] = encoded
+
+    _check_file_directory_conflicts(content_bytes, issues)
+    total_bytes = sum(len(value) for value in content_bytes.values())
+    attempted_file_count = 1 + len(raw_files)
+    if total_bytes > MAX_TOTAL_BYTES:
+        issues.append(
+            SkillPackageIssue(
+                code="package_size_exceeded",
+                message=f"A Skill package is limited to {MAX_TOTAL_BYTES} bytes.",
+            )
+        )
+
+    frontmatter: dict[str, Any] | None = None
+    issues.extend(
+        scan_skill_package_credentials(
+            skill_markdown=markdown_text,
+            files=clean_files,
+        )
+    )
+    if markdown_text is not None:
+        frontmatter = _parse_skill_frontmatter(markdown_text, issues)
+    for path, text in clean_files.items():
+        _check_static_syntax(path, text, issues)
+
+    parsed = _validate_frontmatter(frontmatter, clean_root, issues)
+    if markdown_text is not None:
+        all_text = {"SKILL.md": markdown_text, **clean_files}
+        _check_local_references(all_text, issues)
+
+    blocking = any(issue.severity == "error" for issue in issues)
+    if blocking or markdown_text is None or parsed is None or clean_root is None:
+        return SkillPackageValidationResult(
+            valid=False,
+            issues=tuple(issues),
+            package=None,
+            file_count=attempted_file_count,
+            total_bytes=total_bytes,
+        )
+
+    digest = compute_skill_content_digest(content_bytes)
+    package = SkillPackageV2(
+        root_name=clean_root,
+        name=parsed["name"],
+        description=parsed["description"],
+        license=parsed["license"],
+        compatibility=parsed["compatibility"],
+        metadata=copy.deepcopy(parsed["metadata"]),
+        allowed_tools=parsed["allowed_tools"],
+        skill_markdown=markdown_text,
+        files=dict(clean_files),
+        content_digest=digest,
+        file_count=len(content_bytes),
+        total_bytes=total_bytes,
+    )
+    return SkillPackageValidationResult(
+        valid=True,
+        issues=tuple(issues),
+        package=package,
+        file_count=package.file_count,
+        total_bytes=package.total_bytes,
+    )
+
+
+def compute_skill_content_digest(files: Mapping[str, str | bytes]) -> str:
+    """Hash canonical paths and exact UTF-8 bytes with unambiguous framing."""
+
+    encoded_files: list[tuple[bytes, bytes]] = []
+    for path, content in files.items():
+        path_bytes = str(path).encode("utf-8")
+        content_bytes = content if isinstance(content, bytes) else content.encode("utf-8")
+        encoded_files.append((path_bytes, content_bytes))
+    encoded_files.sort(key=lambda item: item[0])
+    digest = hashlib.sha256(b"modelmirror-skill-package-v2\0")
+    for path_bytes, content_bytes in encoded_files:
+        digest.update(len(path_bytes).to_bytes(8, "big"))
+        digest.update(path_bytes)
+        digest.update(len(content_bytes).to_bytes(8, "big"))
+        digest.update(content_bytes)
+    return digest.hexdigest()
+
+
+def compute_package_digest(
+    skill_markdown: str | bytes, files: Mapping[str, str | bytes]
+) -> str:
+    """Compute the one canonical digest for a Skill package's content."""
+
+    if any(_path_identity(str(path)) == _path_identity("SKILL.md") for path in files):
+        raise ValueError("files must not contain SKILL.md")
+    return compute_skill_content_digest({"SKILL.md": skill_markdown, **dict(files)})
+
+
+# Descriptive compatibility alias for callers that include the domain in names.
+compute_skill_package_digest = compute_package_digest
+
+
+def scan_skill_package_credentials(
+    *,
+    skill_markdown: Any = None,
+    files: Any = None,
+) -> tuple[SkillPackageIssue, ...]:
+    """Scan complete or partial package content without returning raw values."""
+
+    issues: list[SkillPackageIssue] = []
+    markdown_text = _credential_scan_text(skill_markdown)
+    if markdown_text is not None:
+        _scan_credentials("SKILL.md", markdown_text, issues)
+    if isinstance(files, Mapping):
+        sortable: list[tuple[str, Any, Any]] = []
+        for raw_path, raw_content in files.items():
+            sort_key = raw_path if isinstance(raw_path, str) else ""
+            sortable.append((sort_key, raw_path, raw_content))
+        for _, raw_path, raw_content in sorted(sortable, key=lambda item: item[0]):
+            if isinstance(raw_path, str):
+                _scan_credentials(None, raw_path, issues)
+            content = _credential_scan_text(raw_content)
+            if content is None:
+                continue
+            path = _credential_issue_path(raw_path)
+            _scan_credentials(path, content, issues)
+    return tuple(issues)
+
+
+def _credential_scan_text(value: Any) -> str | None:
+    if isinstance(value, str):
+        try:
+            value.encode("utf-8", errors="strict")
+        except UnicodeEncodeError:
+            return None
+        return value
+    if isinstance(value, bytes):
+        try:
+            return value.decode("utf-8", errors="strict")
+        except UnicodeDecodeError:
+            return None
+    return None
+
+
+def _credential_issue_path(value: Any) -> str | None:
+    if not isinstance(value, str) or not value or len(value) > 512:
+        return None
+    if any(ord(character) < 32 for character in value):
+        return None
+    path_issues: list[SkillPackageIssue] = []
+    _scan_credentials(None, value, path_issues)
+    if path_issues:
+        return None
+    return value
+
+
+def _validate_root_name(value: Any, issues: list[SkillPackageIssue]) -> str | None:
+    if not isinstance(value, str):
+        issues.append(
+            SkillPackageIssue(
+                code="root_name_type",
+                message="Skill root directory name must be text.",
+                field="root_name",
+            )
+        )
+        return None
+    root = value.strip()
+    if root != value or not _SKILL_NAME_RE.fullmatch(root) or len(root) > 64:
+        issues.append(
+            SkillPackageIssue(
+                code="root_name_invalid",
+                message="Skill root directory must be 1-64 lowercase letters, digits, or hyphen-separated words.",
+                field="root_name",
+            )
+        )
+        return None
+    if _is_windows_reserved_segment(root):
+        issues.append(
+            SkillPackageIssue(
+                code="root_name_windows_reserved",
+                message="Skill root directory uses a Windows-reserved name.",
+                field="root_name",
+            )
+        )
+        return None
+    return root
+
+
+def _decode_utf8_text(
+    value: Any,
+    *,
+    path: str,
+    issues: list[SkillPackageIssue],
+) -> tuple[str | None, bytes | None]:
+    if isinstance(value, bytes):
+        try:
+            return value.decode("utf-8", errors="strict"), value
+        except UnicodeDecodeError:
+            issues.append(
+                SkillPackageIssue(
+                    code="file_invalid_utf8",
+                    message="Skill package files must contain valid UTF-8 text.",
+                    path=path,
+                )
+            )
+            return None, None
+    if not isinstance(value, str):
+        issues.append(
+            SkillPackageIssue(
+                code="file_content_type",
+                message="Skill package files must contain UTF-8 text.",
+                path=path,
+            )
+        )
+        return None, None
+    try:
+        encoded = value.encode("utf-8", errors="strict")
+    except UnicodeEncodeError:
+        issues.append(
+            SkillPackageIssue(
+                code="file_invalid_utf8",
+                message="Skill package files must contain valid UTF-8 text.",
+                path=path,
+            )
+        )
+        return None, None
+    return value, encoded
+
+
+def _validate_file_path(
+    value: Any, issues: list[SkillPackageIssue]
+) -> str | None:
+    if not isinstance(value, str):
+        issues.append(
+            SkillPackageIssue(
+                code="file_path_type",
+                message="Skill package paths must be text.",
+                field="files",
+            )
+        )
+        return None
+    if (
+        not value
+        or value != value.strip()
+        or "\\" in value
+        or value.startswith("/")
+        or _WINDOWS_DRIVE_RE.match(value)
+        or "\x00" in value
+        or any(ord(character) < 32 for character in value)
+    ):
+        issues.append(
+            SkillPackageIssue(
+                code="file_path_unsafe",
+                message="Skill package path is unsafe or non-canonical.",
+                field="files",
+            )
+        )
+        return None
+    if len(value) > MAX_PATH_CHARS:
+        issues.append(
+            SkillPackageIssue(
+                code="file_path_too_long",
+                message=f"Skill package paths are limited to {MAX_PATH_CHARS} characters.",
+                field="files",
+            )
+        )
+        return None
+    normalized = posixpath.normpath(value)
+    path = PurePosixPath(value)
+    if (
+        normalized != value
+        or normalized in {".", ".."}
+        or ".." in path.parts
+        or any(not part or part.startswith(".") for part in path.parts)
+        or any(":" in part for part in path.parts)
+        or not path.parts
+        or path.parts[0] not in ALLOWED_ROOTS
+    ):
+        issues.append(
+            SkillPackageIssue(
+                code="file_path_unsafe",
+                message="Skill package path is unsafe or non-canonical.",
+                field="files",
+            )
+        )
+        return None
+    if any(
+        part.endswith((".", " "))
+        or len(part.encode("utf-8")) > MAX_PATH_SEGMENT_BYTES
+        or _is_windows_reserved_segment(part)
+        for part in path.parts
+    ):
+        issues.append(
+            SkillPackageIssue(
+                code="file_path_windows_unsafe",
+                message="Skill package path is not portable to Windows filesystems.",
+                field="files",
+            )
+        )
+        return None
+    if path.parts[0] == "agents" and value != "agents/openai.yaml":
+        issues.append(
+            SkillPackageIssue(
+                code="agents_file_unsupported",
+                message="Only agents/openai.yaml is supported under agents/.",
+                path=value,
+            )
+        )
+        return None
+    return value
+
+
+def _is_windows_reserved_segment(segment: str) -> bool:
+    basename = segment.rstrip(". ").split(".", 1)[0].casefold()
+    return basename in _WINDOWS_RESERVED_NAMES
+
+
+def _path_identity(path: str) -> str:
+    return unicodedata.normalize("NFC", path).casefold()
+
+
+def _check_file_directory_conflicts(
+    content: Mapping[str, bytes], issues: list[SkillPackageIssue]
+) -> None:
+    identities = {_path_identity(path): path for path in content}
+    for path in sorted(content):
+        parts = PurePosixPath(path).parts
+        for index in range(1, len(parts)):
+            parent = "/".join(parts[:index])
+            if _path_identity(parent) in identities:
+                issues.append(
+                    SkillPackageIssue(
+                        code="file_directory_conflict",
+                        message="A package path cannot be both a file and a directory.",
+                        path=path,
+                    )
+                )
+                break
+
+
+def _parse_skill_frontmatter(
+    markdown: str, issues: list[SkillPackageIssue]
+) -> dict[str, Any] | None:
+    lines = markdown.splitlines()
+    if not lines or lines[0] != "---":
+        issues.append(
+            SkillPackageIssue(
+                code="frontmatter_missing",
+                message="SKILL.md must begin with YAML frontmatter.",
+                path="SKILL.md",
+            )
+        )
+        return None
+    closing_index = next(
+        (index for index, line in enumerate(lines[1:], start=1) if line == "---"),
+        None,
+    )
+    if closing_index is None:
+        issues.append(
+            SkillPackageIssue(
+                code="frontmatter_unterminated",
+                message="SKILL.md YAML frontmatter must end with a standalone --- line.",
+                path="SKILL.md",
+            )
+        )
+        return None
+    if not "\n".join(lines[closing_index + 1 :]).strip():
+        issues.append(
+            SkillPackageIssue(
+                code="skill_body_empty",
+                message="SKILL.md must contain instructions after its frontmatter.",
+                path="SKILL.md",
+            )
+        )
+    yaml_text = "\n".join(lines[1:closing_index])
+    try:
+        parsed = _strict_yaml_load(yaml_text)
+    except _DuplicateYamlKeyError:
+        issues.append(
+            SkillPackageIssue(
+                code="frontmatter_duplicate_key",
+                message="SKILL.md frontmatter contains a duplicate YAML key.",
+                path="SKILL.md",
+            )
+        )
+        return None
+    except (yaml.YAMLError, RecursionError):
+        issues.append(
+            SkillPackageIssue(
+                code="frontmatter_invalid_yaml",
+                message="SKILL.md frontmatter is not valid safe YAML.",
+                path="SKILL.md",
+            )
+        )
+        return None
+    if not isinstance(parsed, dict):
+        issues.append(
+            SkillPackageIssue(
+                code="frontmatter_type",
+                message="SKILL.md frontmatter must be a YAML mapping.",
+                path="SKILL.md",
+            )
+        )
+        return None
+    if any(not isinstance(key, str) for key in parsed):
+        issues.append(
+            SkillPackageIssue(
+                code="frontmatter_key_type",
+                message="SKILL.md frontmatter keys must be text.",
+                path="SKILL.md",
+            )
+        )
+        return None
+    return parsed
+
+
+def _validate_frontmatter(
+    frontmatter: dict[str, Any] | None,
+    root_name: str | None,
+    issues: list[SkillPackageIssue],
+) -> dict[str, Any] | None:
+    if frontmatter is None:
+        return None
+    for key in sorted(frontmatter):
+        if key not in SUPPORTED_FRONTMATTER_FIELDS:
+            issues.append(
+                SkillPackageIssue(
+                    code="frontmatter_field_unsupported",
+                    message="Unsupported frontmatter fields are ignored by ModelMirror.",
+                    severity="warning",
+                    path="SKILL.md",
+                    field=key,
+                )
+            )
+
+    name = frontmatter.get("name")
+    if not isinstance(name, str):
+        issues.append(
+            SkillPackageIssue(
+                code="frontmatter_name_type",
+                message="Frontmatter name must be text.",
+                path="SKILL.md",
+                field="name",
+            )
+        )
+    elif not _SKILL_NAME_RE.fullmatch(name) or len(name) > 64:
+        issues.append(
+            SkillPackageIssue(
+                code="frontmatter_name_invalid",
+                message="Frontmatter name must be 1-64 lowercase letters, digits, or hyphen-separated words.",
+                path="SKILL.md",
+                field="name",
+            )
+        )
+    elif root_name is not None and name != root_name:
+        issues.append(
+            SkillPackageIssue(
+                code="skill_name_root_mismatch",
+                message="Frontmatter name must exactly match the Skill root directory.",
+                path="SKILL.md",
+                field="name",
+            )
+        )
+
+    description = frontmatter.get("description")
+    if not isinstance(description, str):
+        issues.append(
+            SkillPackageIssue(
+                code="frontmatter_description_type",
+                message="Frontmatter description must be text.",
+                path="SKILL.md",
+                field="description",
+            )
+        )
+    elif not description.strip() or description != description.strip() or len(description) > 1024:
+        issues.append(
+            SkillPackageIssue(
+                code="frontmatter_description_invalid",
+                message="Frontmatter description must contain 1-1024 trimmed characters.",
+                path="SKILL.md",
+                field="description",
+            )
+        )
+
+    license_value = _optional_text_field(frontmatter, "license", issues)
+    compatibility = _optional_text_field(frontmatter, "compatibility", issues)
+    metadata = frontmatter.get("metadata", {})
+    if not isinstance(metadata, dict) or not _is_json_safe(metadata):
+        issues.append(
+            SkillPackageIssue(
+                code="frontmatter_metadata_type",
+                message="Frontmatter metadata must be a JSON-compatible mapping with text keys.",
+                path="SKILL.md",
+                field="metadata",
+            )
+        )
+        metadata = {}
+
+    allowed_tools = _parse_allowed_tools(frontmatter.get("allowed-tools"), issues)
+    if any(issue.severity == "error" for issue in issues):
+        return None
+    return {
+        "name": name,
+        "description": description,
+        "license": license_value,
+        "compatibility": compatibility,
+        "metadata": copy.deepcopy(metadata),
+        "allowed_tools": allowed_tools,
+    }
+
+
+def _optional_text_field(
+    frontmatter: Mapping[str, Any],
+    field: str,
+    issues: list[SkillPackageIssue],
+) -> str | None:
+    value = frontmatter.get(field)
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip() or value != value.strip():
+        issues.append(
+            SkillPackageIssue(
+                code=f"frontmatter_{field}_type",
+                message=f"Frontmatter {field} must be non-empty trimmed text.",
+                path="SKILL.md",
+                field=field,
+            )
+        )
+        return None
+    return value
+
+
+def _parse_allowed_tools(
+    value: Any, issues: list[SkillPackageIssue]
+) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        tools = tuple(part for part in value.split() if part)
+    elif isinstance(value, list) and all(
+        isinstance(item, str) and item.strip() == item and item for item in value
+    ):
+        tools = tuple(value)
+    else:
+        issues.append(
+            SkillPackageIssue(
+                code="frontmatter_allowed_tools_type",
+                message="Frontmatter allowed-tools must be text or a list of non-empty text values.",
+                path="SKILL.md",
+                field="allowed-tools",
+            )
+        )
+        return ()
+    if not tools or any(len(tool) > 128 for tool in tools):
+        issues.append(
+            SkillPackageIssue(
+                code="frontmatter_allowed_tools_invalid",
+                message="Frontmatter allowed-tools entries must contain 1-128 characters.",
+                path="SKILL.md",
+                field="allowed-tools",
+            )
+        )
+        return ()
+    return tools
+
+
+def _is_json_safe(value: Any, *, depth: int = 0) -> bool:
+    if depth > 20:
+        return False
+    if value is None or isinstance(value, (str, bool, int)):
+        return True
+    if isinstance(value, float):
+        return math.isfinite(value)
+    if isinstance(value, list):
+        return all(_is_json_safe(item, depth=depth + 1) for item in value)
+    if isinstance(value, dict):
+        return all(
+            isinstance(key, str) and _is_json_safe(item, depth=depth + 1)
+            for key, item in value.items()
+        )
+    return False
+
+
+def _strict_yaml_load(text: str) -> Any:
+    for token in yaml.scan(text, Loader=_StrictSafeLoader):
+        if isinstance(token, (AliasToken, AnchorToken)):
+            raise yaml.YAMLError("YAML aliases and anchors are not supported")
+    return yaml.load(text, Loader=_StrictSafeLoader)
+
+
+def _load_strict_yaml(text: str) -> bool:
+    try:
+        _strict_yaml_load(text)
+    except (yaml.YAMLError, TypeError, ValueError, RecursionError):
+        return False
+    return True
+
+
+def _check_static_syntax(
+    path: str, content: str, issues: list[SkillPackageIssue]
+) -> None:
+    suffix = PurePosixPath(path).suffix.lower()
+    valid = True
+    code = ""
+    message = ""
+    line: int | None = None
+    if suffix == ".py":
+        try:
+            ast.parse(content, filename=path)
+        except (SyntaxError, ValueError, RecursionError, MemoryError) as exc:
+            valid = False
+            code = "python_syntax_invalid"
+            message = "Python file failed static syntax validation."
+            line = exc.lineno if isinstance(exc, SyntaxError) else None
+    elif suffix == ".json":
+        try:
+            json.loads(content)
+        except (json.JSONDecodeError, UnicodeError, RecursionError):
+            valid = False
+            code = "json_syntax_invalid"
+            message = "JSON file failed static syntax validation."
+    elif suffix in {".yaml", ".yml"}:
+        if not _load_strict_yaml(content):
+            valid = False
+            code = "yaml_syntax_invalid"
+            message = "YAML file failed strict safe syntax validation."
+    elif suffix in {".js", ".mjs", ".cjs"}:
+        valid, line = _javascript_lexically_valid(content)
+        if valid:
+            line = _javascript_obvious_syntax_issue_line(content)
+            valid = line is None
+        code = "javascript_syntax_invalid"
+        message = "JavaScript file failed conservative static syntax validation."
+    if not valid:
+        issues.append(
+            SkillPackageIssue(
+                code=code,
+                message=message,
+                path=path,
+                line=line,
+            )
+        )
+
+
+def _javascript_lexically_valid(content: str) -> tuple[bool, int | None]:
+    """Conservatively check JS delimiters/comments/strings without execution."""
+
+    matching = {")": "(", "]": "[", "}": "{"}
+    stack: list[tuple[str, int]] = []
+    state = "normal"
+    escaped = False
+    regex_class = False
+    line = 1
+    state_line = 1
+    previous_significant: str | None = None
+    index = 0
+    while index < len(content):
+        character = content[index]
+        following = content[index + 1] if index + 1 < len(content) else ""
+        if character == "\n":
+            line += 1
+        if state == "line_comment":
+            if character == "\n":
+                state = "normal"
+            index += 1
+            continue
+        if state == "block_comment":
+            if character == "*" and following == "/":
+                state = "normal"
+                index += 2
+                continue
+            index += 1
+            continue
+        if state in {"single", "double", "template"}:
+            delimiter = {"single": "'", "double": '"', "template": "`"}[state]
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == delimiter:
+                state = "normal"
+                previous_significant = delimiter
+            elif character == "\n" and state != "template":
+                return False, state_line
+            index += 1
+            continue
+        if state == "regex":
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == "[":
+                regex_class = True
+            elif character == "]":
+                regex_class = False
+            elif character == "/" and not regex_class:
+                state = "normal"
+                previous_significant = "/"
+            elif character == "\n":
+                return False, state_line
+            index += 1
+            continue
+
+        if character == "/" and following == "/":
+            state = "line_comment"
+            index += 2
+            continue
+        if character == "/" and following == "*":
+            state = "block_comment"
+            state_line = line
+            index += 2
+            continue
+        if character in {"'", '"', "`"}:
+            state = {"'": "single", '"': "double", "`": "template"}[character]
+            state_line = line
+            escaped = False
+            index += 1
+            continue
+        if character == "/" and (
+            previous_significant is None
+            or previous_significant in "=(:,![{;?&|+-*%^~<>"
+        ):
+            state = "regex"
+            state_line = line
+            escaped = False
+            regex_class = False
+            index += 1
+            continue
+        if character in "([{":
+            stack.append((character, line))
+        elif character in ")]}":
+            if not stack or stack[-1][0] != matching[character]:
+                return False, line
+            stack.pop()
+        if not character.isspace():
+            previous_significant = character
+        index += 1
+    if state in {"single", "double", "template", "block_comment", "regex"}:
+        return False, state_line
+    if stack:
+        return False, stack[-1][1]
+    return True, None
+
+
+def _javascript_obvious_syntax_issue_line(content: str) -> int | None:
+    def mask(match: re.Match[str]) -> str:
+        value = match.group(0)
+        replacement = ["\n" if character == "\n" else " " for character in value]
+        if not value.startswith(("//", "/*")):
+            for index, character in enumerate(value):
+                if character != "\n":
+                    replacement[index] = "0"
+                    break
+        return "".join(replacement)
+
+    visible_code = _JS_NON_CODE_RE.sub(mask, content)
+    matches = [
+        match
+        for pattern in (
+            _JS_MISSING_ASSIGNMENT_RE,
+            _JS_MISSING_DECLARATION_NAME_RE,
+        )
+        if (match := pattern.search(visible_code)) is not None
+    ]
+    if not matches:
+        return None
+    first = min(matches, key=lambda match: match.start())
+    return visible_code.count("\n", 0, first.start()) + 1
+
+
+def _scan_credentials(
+    path: str | None, content: str, issues: list[SkillPackageIssue]
+) -> None:
+    emitted: set[str] = set()
+    for line_number, line in enumerate(content.splitlines(), start=1):
+        checks: list[tuple[str, bool, str]] = [
+            (
+                "credential_private_key",
+                bool(_PRIVATE_KEY_RE.search(line)),
+                "Private key material is not allowed in Skill packages.",
+            ),
+            (
+                "credential_token",
+                any(pattern.search(line) for pattern in _TOKEN_PATTERNS),
+                "A high-confidence access token was detected in the Skill package.",
+            ),
+            (
+                "credential_url",
+                bool(_CREDENTIAL_URL_RE.search(line)),
+                "A URL containing embedded credentials was detected.",
+            ),
+        ]
+        assignment = _SECRET_ASSIGNMENT_RE.search(line)
+        assignment_detected = False
+        if assignment:
+            candidate = assignment.group("value").strip("\"'`").lower()
+            assignment_detected = (
+                len(candidate) >= 8
+                and not all(character in "x*-_" for character in candidate)
+                and not any(part in candidate for part in _PLACEHOLDER_PARTS)
+            )
+        checks.append(
+            (
+                "credential_assignment",
+                assignment_detected,
+                "A hard-coded credential assignment was detected.",
+            )
+        )
+        for code, matched, message in checks:
+            if matched and code not in emitted:
+                issues.append(
+                    SkillPackageIssue(
+                        code=code,
+                        message=message,
+                        path=path,
+                        line=line_number,
+                    )
+                )
+                emitted.add(code)
+
+
+def _check_local_references(
+    files: Mapping[str, str], issues: list[SkillPackageIssue]
+) -> None:
+    exact_paths = set(files)
+    folded_paths = {_path_identity(path): path for path in exact_paths}
+    emitted: set[tuple[str, str, str]] = set()
+    for source_path in sorted(files):
+        if PurePosixPath(source_path).suffix.lower() not in {".md", ".markdown"}:
+            continue
+        without_fences = _FENCED_CODE_RE.sub("", files[source_path])
+        raw_targets = []
+        for inline_match in _INLINE_CODE_RE.finditer(without_fences):
+            inline_content = inline_match.group(0)[1:-1]
+            raw_targets.extend(
+                match.group("path")
+                for match in _INLINE_RESOURCE_PATH_RE.finditer(inline_content)
+            )
+        scrubbed = _INLINE_CODE_RE.sub("", without_fences)
+        raw_targets.extend(
+            match.group(1).strip() for match in _MARKDOWN_LINK_RE.finditer(scrubbed)
+        )
+        for raw_target_value in raw_targets:
+            raw_target = raw_target_value.strip()
+            if raw_target.startswith("<") and ">" in raw_target:
+                raw_target = raw_target[1 : raw_target.index(">")]
+            else:
+                raw_target = raw_target.split(maxsplit=1)[0]
+            target = unquote(raw_target).strip()
+            if not target or target.startswith("#"):
+                continue
+            if _WINDOWS_DRIVE_RE.match(target) or target.startswith(("/", "\\")):
+                key = (source_path, target, "local_reference_unsafe")
+                if key not in emitted:
+                    issues.append(
+                        SkillPackageIssue(
+                            code="local_reference_unsafe",
+                            message="Local Skill references must stay inside the package.",
+                            path=source_path,
+                        )
+                    )
+                    emitted.add(key)
+                continue
+            parsed = urlsplit(target)
+            if parsed.scheme or parsed.netloc:
+                continue
+            target_path = parsed.path
+            if not target_path:
+                continue
+            resolved = posixpath.normpath(
+                posixpath.join(posixpath.dirname(source_path), target_path)
+            )
+            if resolved == ".." or resolved.startswith("../"):
+                code = "local_reference_unsafe"
+                message = "Local Skill references must stay inside the package."
+            elif resolved not in exact_paths:
+                if _path_identity(resolved) in folded_paths:
+                    code = "local_reference_case_mismatch"
+                    message = "Local Skill reference casing must exactly match its package path."
+                else:
+                    code = "local_reference_missing"
+                    message = "A local Skill reference does not exist in the package."
+            else:
+                continue
+            key = (source_path, resolved, code)
+            if key not in emitted:
+                issues.append(
+                    SkillPackageIssue(code=code, message=message, path=source_path)
+                )
+                emitted.add(key)
+
+
+__all__ = [
+    "ALLOWED_ROOTS",
+    "MAX_FILE_BYTES",
+    "MAX_FILES",
+    "MAX_TOTAL_BYTES",
+    "SUPPORTED_FRONTMATTER_FIELDS",
+    "VALIDATOR_VERSION",
+    "SkillPackageIssue",
+    "SkillPackageV2",
+    "SkillPackageValidationResult",
+    "compute_package_digest",
+    "compute_skill_content_digest",
+    "compute_skill_package_digest",
+    "scan_skill_package_credentials",
+    "validate_skill_package",
+]

--- a/server/skills/skill_manager.py
+++ b/server/skills/skill_manager.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
@@ -9,11 +10,13 @@ import tempfile
 import threading
 import time
 import uuid
-from dataclasses import dataclass, asdict
+from dataclasses import asdict, dataclass, replace
 from pathlib import Path
+from typing import Literal
 from urllib.parse import urlparse
 
 from .draft_store import SkillDraftValidationError, WorkspaceSkillDraftStore
+from .package_validation import compute_package_digest
 
 
 class SkillManagerError(Exception):
@@ -43,6 +46,35 @@ class InstalledSkill:
     sub_path: str
     installed_at: float
     source_ref: str | None = None
+    source_kind: str = "git"
+    source_id: str | None = None
+    source_revision: int | None = None
+    content_digest: str = ""
+    package_subpath: str = ""
+
+
+@dataclass(frozen=True)
+class SkillInstallReceipt:
+    """Crash-recovery record for a Workspace draft install transaction.
+
+    The receipt intentionally contains metadata and filesystem basenames only;
+    Skill contents remain in the staging directory and installed package.
+    """
+
+    version: int
+    transaction_id: str
+    phase: Literal["prepared", "swapped", "committed"]
+    skill_id: str
+    source_id: str
+    source_revision: int | None
+    content_digest: str
+    package_subpath: str
+    staging_name: str
+    backup_name: str
+    previous_metadata: dict[str, object] | None
+    installed_metadata: dict[str, object]
+    created_at: float
+    previous_content_digest: str | None = None
 
 
 class SkillManager:
@@ -160,13 +192,26 @@ class SkillManager:
         slug: str,
         skill_markdown: str,
         files: dict[str, str],
+        source_revision: int | None = None,
     ) -> InstalledSkill:
-        """Explicitly install a reviewed Workspace Skill draft.
+        """Install or explicitly upgrade one reviewed Workspace Skill draft.
 
-        This path never overwrites an installed Skill. A changed draft must be
-        installed as a new package after another explicit user action.
+        A draft owns one stable Skill id. Retrying the same package digest is
+        idempotent; changed content is swapped atomically and can be recovered
+        from a persisted transaction receipt after process interruption.
         """
 
+        clean_draft_id = str(draft_id or "").strip()
+        if not clean_draft_id or len(clean_draft_id) > 200:
+            raise SkillValidationError("Workspace Skill draft id is invalid.")
+        if source_revision is not None and (
+            isinstance(source_revision, bool)
+            or not isinstance(source_revision, int)
+            or source_revision < 1
+        ):
+            raise SkillValidationError(
+                "Workspace Skill source revision must be positive."
+            )
         frontmatter = WorkspaceSkillDraftStore._parse_frontmatter(skill_markdown)
         try:
             normalized = WorkspaceSkillDraftStore.validate_package(
@@ -181,42 +226,149 @@ class SkillManager:
         clean_slug = normalized["slug"]
         skill_markdown = normalized["skill_markdown"]
         files = normalized["files"]
-        suffix = re.sub(r"[^a-z0-9]+", "", draft_id.lower())[-12:]
-        skill_id = self._validate_skill_id(f"workspace-{clean_slug}-{suffix}")
+        content_digest = compute_package_digest(skill_markdown, files)
+        deterministic_skill_id = self._workspace_skill_id(clean_draft_id)
         with self._lock:
             self._ensure_dirs()
             installed = self._read_metadata()
-            if skill_id in installed:
-                raise SkillInstallError(
-                    "This Workspace Skill draft is already installed."
-                )
+            skill_id = self._find_workspace_skill_id(installed, clean_draft_id)
+            skill_id = skill_id or deterministic_skill_id
+            self._recover_workspace_install_receipt(skill_id, clean_draft_id)
+            installed = self._read_metadata()
+            skill_id = self._find_workspace_skill_id(installed, clean_draft_id) or skill_id
             target_dir = self._safe_skill_dir(skill_id)
-            if target_dir.exists():
-                raise SkillInstallError("Workspace Skill target already exists.")
-            temp_dir = Path(
-                tempfile.mkdtemp(prefix=f"{skill_id}-", dir=str(self.tmp_dir))
+            previous_record = installed.get(skill_id)
+            previous_metadata = (
+                self._installed_skill_from_record(previous_record)
+                if previous_record is not None
+                else None
             )
+            previous_content_digest = ""
+            if target_dir.exists() and previous_record is None:
+                raise SkillInstallError(
+                    "Workspace Skill target exists without installed metadata."
+                )
+            if previous_metadata is not None:
+                try:
+                    current_package_dir = self._resolve_package_directory(
+                        skill_id, previous_record
+                    )
+                    previous_content_digest = self._directory_content_digest(
+                        current_package_dir
+                    )
+                except SkillNotFoundError:
+                    previous_content_digest = ""
+                if (
+                    previous_content_digest == content_digest
+                    and previous_metadata.content_digest == content_digest
+                    and previous_metadata.package_subpath == clean_slug
+                    and (target_dir / clean_slug / "SKILL.md").is_file()
+                ):
+                    return previous_metadata
+
+            transaction_id = uuid.uuid4().hex
+            staging_dir = self.installed_dir / (
+                f".{skill_id}.staging-{transaction_id}"
+            )
+            backup_dir = self.installed_dir / (
+                f".{skill_id}.backup-{transaction_id}"
+            )
+            package_dir = staging_dir / clean_slug
+            metadata: InstalledSkill | None = None
+            receipt: SkillInstallReceipt | None = None
+            swapped = False
+            metadata_write_attempted = False
             try:
-                (temp_dir / "SKILL.md").write_text(skill_markdown, encoding="utf-8")
+                package_dir.mkdir(parents=True, exist_ok=False)
+                (package_dir / "SKILL.md").write_bytes(
+                    skill_markdown.encode("utf-8")
+                )
                 for relative_path, content in files.items():
-                    target = temp_dir.joinpath(*relative_path.split("/"))
+                    target = package_dir.joinpath(*relative_path.split("/"))
                     target.parent.mkdir(parents=True, exist_ok=True)
-                    target.write_text(content, encoding="utf-8")
-                shutil.copytree(temp_dir, target_dir)
+                    target.write_bytes(content.encode("utf-8"))
                 metadata = self._parse_skill_metadata(
                     skill_id,
-                    f"workspace://draft/{draft_id}",
+                    f"workspace://draft/{clean_draft_id}",
                     "",
-                    target_dir / "SKILL.md",
+                    package_dir / "SKILL.md",
+                    source_kind="workspace_draft",
+                    source_id=clean_draft_id,
+                    source_revision=source_revision,
+                    content_digest=content_digest,
+                    package_subpath=clean_slug,
                 )
+                receipt = SkillInstallReceipt(
+                    version=1,
+                    transaction_id=transaction_id,
+                    phase="prepared",
+                    skill_id=skill_id,
+                    source_id=clean_draft_id,
+                    source_revision=source_revision,
+                    content_digest=content_digest,
+                    package_subpath=clean_slug,
+                    staging_name=staging_dir.name,
+                    backup_name=backup_dir.name,
+                    previous_metadata=(
+                        dict(previous_record)
+                        if previous_record is not None
+                        else None
+                    ),
+                    installed_metadata=asdict(metadata),
+                    created_at=time.time(),
+                    previous_content_digest=previous_content_digest or None,
+                )
+                self._write_install_receipt(receipt)
+                if target_dir.exists():
+                    target_dir.rename(backup_dir)
+                staging_dir.rename(target_dir)
+                swapped = True
+                receipt = replace(receipt, phase="swapped")
+                self._write_install_receipt(receipt)
                 installed[skill_id] = asdict(metadata)
+                metadata_write_attempted = True
                 self._write_metadata(installed)
-                return metadata
+                receipt = replace(receipt, phase="committed")
+                self._write_install_receipt(receipt)
             except Exception:
-                shutil.rmtree(target_dir, ignore_errors=True)
+                rollback_error: Exception | None = None
+                try:
+                    if backup_dir.exists():
+                        self._remove_directory_if_present(target_dir)
+                        backup_dir.rename(target_dir)
+                    elif (swapped or previous_record is None) and target_dir.exists():
+                        self._remove_directory_if_present(target_dir)
+                    if metadata_write_attempted:
+                        restored = self._read_metadata()
+                        if previous_record is None:
+                            restored.pop(skill_id, None)
+                        else:
+                            restored[skill_id] = dict(previous_record)
+                        self._write_metadata(restored)
+                    self._remove_directory_if_present(staging_dir)
+                    self._remove_directory_if_present(backup_dir)
+                    self._receipt_path(skill_id).unlink(missing_ok=True)
+                except Exception as exc:
+                    rollback_error = exc
+                if rollback_error is not None:
+                    raise SkillInstallError(
+                        "Workspace Skill installation failed and rollback is "
+                        "incomplete; retry the same installation to recover."
+                    ) from rollback_error
                 raise
-            finally:
-                shutil.rmtree(temp_dir, ignore_errors=True)
+            else:
+                try:
+                    self._remove_directory_if_present(backup_dir)
+                    self._remove_directory_if_present(staging_dir)
+                    self._receipt_path(skill_id).unlink(missing_ok=True)
+                except Exception as exc:
+                    raise SkillInstallError(
+                        "Workspace Skill was installed, but transaction cleanup is "
+                        "incomplete; retry the same installation to recover."
+                    ) from exc
+                if metadata is None:
+                    raise SkillInstallError("Workspace Skill metadata was not created.")
+                return metadata
 
     def install_plugin_skill(
         self,
@@ -276,7 +428,7 @@ class SkillManager:
             self._ensure_dirs()
             installed = self._read_metadata()
             if skill_id in installed:
-                return InstalledSkill(**installed[skill_id])
+                return self._installed_skill_from_record(installed[skill_id])
             target_dir = self._safe_skill_dir(skill_id)
             if target_dir.exists():
                 raise SkillInstallError("Plugin Skill target already exists.")
@@ -295,6 +447,9 @@ class SkillManager:
                     f"plugin://{plugin_id}/v{plugin_version}",
                     clean_skill_slug,
                     target_dir / "SKILL.md",
+                    source_kind="plugin",
+                    source_id=plugin_id,
+                    source_revision=plugin_version,
                 )
                 installed[skill_id] = asdict(metadata)
                 self._write_metadata(installed)
@@ -325,7 +480,7 @@ class SkillManager:
 
         with self._lock:
             return [
-                InstalledSkill(**item)
+                self._installed_skill_from_record(item)
                 for item in sorted(
                     self._read_metadata().values(),
                     key=lambda value: float(value.get("installed_at", 0)),
@@ -342,11 +497,10 @@ class SkillManager:
             if normalized_skill_id not in installed:
                 raise SkillNotFoundError(f"Skill '{normalized_skill_id}' is not installed")
 
-            skill_md = self._safe_skill_dir(normalized_skill_id) / "SKILL.md"
-            if not skill_md.exists():
-                raise SkillNotFoundError(
-                    f"Skill '{normalized_skill_id}' is missing SKILL.md"
-                )
+            package_dir = self._resolve_package_directory(
+                normalized_skill_id, installed[normalized_skill_id]
+            )
+            skill_md = package_dir / "SKILL.md"
             return skill_md.read_text(encoding="utf-8", errors="replace")
 
     def get_skill_directory(self, skill_id: str) -> Path:
@@ -357,12 +511,287 @@ class SkillManager:
             installed = self._read_metadata()
             if normalized_skill_id not in installed:
                 raise SkillNotFoundError(f"Skill '{normalized_skill_id}' is not installed")
-            target = self._safe_skill_dir(normalized_skill_id)
-            if not target.exists() or not target.is_dir():
-                raise SkillNotFoundError(
-                    f"Skill '{normalized_skill_id}' directory is unavailable"
+            return self._resolve_package_directory(
+                normalized_skill_id, installed[normalized_skill_id]
+            )
+
+    @staticmethod
+    def _workspace_skill_id(draft_id: str) -> str:
+        digest = hashlib.sha256(draft_id.encode("utf-8")).hexdigest()[:20]
+        return f"workspace-{digest}"
+
+    def _find_workspace_skill_id(
+        self,
+        installed: dict[str, dict[str, object]],
+        draft_id: str,
+    ) -> str | None:
+        expected_url = f"workspace://draft/{draft_id}"
+        matches: list[str] = []
+        for candidate_id, record in installed.items():
+            item = self._installed_skill_from_record(record)
+            if (
+                item.source_kind == "workspace_draft"
+                and item.source_id == draft_id
+            ) or item.repo_url == expected_url:
+                matches.append(candidate_id)
+        if len(matches) > 1:
+            raise SkillInstallError(
+                "Workspace Skill draft has multiple installed mappings."
+            )
+        return matches[0] if matches else None
+
+    def _installed_skill_from_record(
+        self, record: dict[str, object]
+    ) -> InstalledSkill:
+        repo_url = str(record.get("repo_url") or "")
+        source_kind = str(record.get("source_kind") or "").strip()
+        source_id_value = record.get("source_id")
+        source_id = (
+            str(source_id_value).strip() if source_id_value is not None else None
+        )
+        source_revision_value = record.get("source_revision")
+        source_revision = (
+            int(source_revision_value)
+            if isinstance(source_revision_value, int)
+            and not isinstance(source_revision_value, bool)
+            and source_revision_value > 0
+            else None
+        )
+        if not source_kind:
+            if repo_url.startswith("workspace://draft/"):
+                source_kind = "workspace_draft"
+                source_id = source_id or repo_url.removeprefix("workspace://draft/")
+            elif repo_url.startswith("plugin://"):
+                source_kind = "plugin"
+                source_id = source_id or repo_url.removeprefix("plugin://").split(
+                    "/", 1
+                )[0]
+            else:
+                source_kind = "git"
+        content_digest = str(record.get("content_digest") or "").lower()
+        if not re.fullmatch(r"[a-f0-9]{64}", content_digest):
+            content_digest = ""
+        package_subpath = str(record.get("package_subpath") or "").strip()
+        try:
+            package_subpath = self._validate_sub_path(package_subpath)
+        except SkillValidationError:
+            package_subpath = ""
+        source_ref_value = record.get("source_ref")
+        return InstalledSkill(
+            skill_id=str(record.get("skill_id") or ""),
+            name=str(record.get("name") or ""),
+            description=str(record.get("description") or ""),
+            repo_url=repo_url,
+            sub_path=str(record.get("sub_path") or ""),
+            installed_at=float(record.get("installed_at") or 0),
+            source_ref=(
+                str(source_ref_value) if source_ref_value is not None else None
+            ),
+            source_kind=source_kind,
+            source_id=source_id,
+            source_revision=source_revision,
+            content_digest=content_digest,
+            package_subpath=package_subpath,
+        )
+
+    def _resolve_package_directory(
+        self, skill_id: str, record: dict[str, object]
+    ) -> Path:
+        target = self._safe_skill_dir(skill_id)
+        if not target.exists() or not target.is_dir():
+            raise SkillNotFoundError(f"Skill '{skill_id}' directory is unavailable")
+        item = self._installed_skill_from_record(record)
+        if item.package_subpath:
+            nested = (target / item.package_subpath).resolve()
+            if target.resolve() not in nested.parents:
+                raise SkillValidationError(
+                    f"Unsafe package path for Skill '{skill_id}'"
                 )
+            if (nested / "SKILL.md").is_file():
+                return nested
+        if (target / "SKILL.md").is_file():
             return target
+        candidates = [
+            child
+            for child in target.iterdir()
+            if child.is_dir()
+            and target.resolve() in child.resolve().parents
+            and (child / "SKILL.md").is_file()
+        ]
+        if len(candidates) == 1:
+            return candidates[0]
+        raise SkillNotFoundError(f"Skill '{skill_id}' is missing SKILL.md")
+
+    @staticmethod
+    def _directory_content_digest(package_dir: Path) -> str:
+        skill_md = package_dir / "SKILL.md"
+        if not skill_md.is_file():
+            raise SkillNotFoundError("Installed Skill package is missing SKILL.md")
+        files: dict[str, bytes] = {}
+        for path in package_dir.rglob("*"):
+            if path.is_file() and path != skill_md:
+                files[path.relative_to(package_dir).as_posix()] = path.read_bytes()
+        return compute_package_digest(skill_md.read_bytes(), files)
+
+    def _receipt_path(self, skill_id: str) -> Path:
+        normalized_skill_id = self._validate_skill_id(skill_id)
+        return self.installed_dir / f".workspace-install-{normalized_skill_id}.receipt.json"
+
+    def _write_install_receipt(self, receipt: SkillInstallReceipt) -> None:
+        path = self._receipt_path(receipt.skill_id)
+        temporary_path = path.with_name(f"{path.name}.{uuid.uuid4().hex}.tmp")
+        try:
+            encoded = json.dumps(
+                asdict(receipt), ensure_ascii=False, indent=2
+            ).encode("utf-8")
+            with temporary_path.open("xb") as handle:
+                handle.write(encoded)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary_path, path)
+        finally:
+            temporary_path.unlink(missing_ok=True)
+
+    def _read_install_receipt(self, skill_id: str) -> SkillInstallReceipt | None:
+        path = self._receipt_path(skill_id)
+        if not path.exists():
+            return None
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise SkillInstallError("Workspace Skill install receipt is invalid.") from exc
+        if not isinstance(raw, dict):
+            raise SkillInstallError("Workspace Skill install receipt is invalid.")
+        try:
+            receipt = SkillInstallReceipt(**raw)
+        except (TypeError, ValueError) as exc:
+            raise SkillInstallError("Workspace Skill install receipt is invalid.") from exc
+        expected_staging = f".{receipt.skill_id}.staging-{receipt.transaction_id}"
+        expected_backup = f".{receipt.skill_id}.backup-{receipt.transaction_id}"
+        if (
+            receipt.version != 1
+            or receipt.skill_id != skill_id
+            or receipt.phase not in {"prepared", "swapped", "committed"}
+            or not re.fullmatch(r"[a-f0-9]{32}", receipt.transaction_id)
+            or not re.fullmatch(r"[a-f0-9]{64}", receipt.content_digest)
+            or (
+                receipt.previous_content_digest is not None
+                and (
+                    not isinstance(receipt.previous_content_digest, str)
+                    or not re.fullmatch(
+                        r"[a-f0-9]{64}", receipt.previous_content_digest
+                    )
+                )
+            )
+            or receipt.staging_name != expected_staging
+            or receipt.backup_name != expected_backup
+            or not isinstance(receipt.installed_metadata, dict)
+            or (
+                receipt.previous_metadata is not None
+                and not isinstance(receipt.previous_metadata, dict)
+            )
+            or (
+                receipt.source_revision is not None
+                and (
+                    isinstance(receipt.source_revision, bool)
+                    or not isinstance(receipt.source_revision, int)
+                    or receipt.source_revision < 1
+                )
+            )
+        ):
+            raise SkillInstallError("Workspace Skill install receipt is invalid.")
+        self._validate_sub_path(receipt.package_subpath)
+        installed_item = self._installed_skill_from_record(
+            receipt.installed_metadata
+        )
+        if (
+            installed_item.skill_id != receipt.skill_id
+            or installed_item.source_kind != "workspace_draft"
+            or installed_item.source_id != receipt.source_id
+            or installed_item.source_revision != receipt.source_revision
+            or installed_item.content_digest != receipt.content_digest
+            or installed_item.package_subpath != receipt.package_subpath
+        ):
+            raise SkillInstallError("Workspace Skill install receipt is invalid.")
+        return receipt
+
+    def _transaction_dir(self, name: str, expected_prefix: str) -> Path:
+        if Path(name).name != name or not name.startswith(expected_prefix):
+            raise SkillInstallError("Workspace Skill install receipt path is invalid.")
+        target = (self.installed_dir / name).resolve()
+        if target.parent != self.installed_dir.resolve():
+            raise SkillInstallError("Workspace Skill install receipt path is invalid.")
+        return target
+
+    def _recover_workspace_install_receipt(
+        self, skill_id: str, draft_id: str
+    ) -> None:
+        receipt = self._read_install_receipt(skill_id)
+        if receipt is None:
+            return
+        if receipt.source_id != draft_id:
+            raise SkillInstallError(
+                "Workspace Skill install receipt belongs to another draft."
+            )
+        target_dir = self._safe_skill_dir(skill_id)
+        staging_dir = self._transaction_dir(
+            receipt.staging_name, f".{skill_id}.staging-"
+        )
+        backup_dir = self._transaction_dir(
+            receipt.backup_name, f".{skill_id}.backup-"
+        )
+        target_matches = False
+        package_dir = target_dir / receipt.package_subpath
+        if (package_dir / "SKILL.md").is_file():
+            target_matches = (
+                self._directory_content_digest(package_dir) == receipt.content_digest
+            )
+        installed = self._read_metadata()
+        if target_matches:
+            installed[skill_id] = dict(receipt.installed_metadata)
+            self._write_metadata(installed)
+        else:
+            previous_target_matches = False
+            previous_digest = receipt.previous_content_digest
+            if receipt.previous_metadata is not None and previous_digest:
+                try:
+                    previous_package_dir = self._resolve_package_directory(
+                        skill_id, receipt.previous_metadata
+                    )
+                    previous_target_matches = (
+                        self._directory_content_digest(previous_package_dir)
+                        == previous_digest
+                    )
+                except SkillNotFoundError:
+                    previous_target_matches = False
+            if previous_target_matches:
+                installed[skill_id] = dict(receipt.previous_metadata or {})
+                self._write_metadata(installed)
+            elif backup_dir.exists():
+                self._remove_directory_if_present(target_dir)
+                backup_dir.rename(target_dir)
+                if receipt.previous_metadata is None:
+                    installed.pop(skill_id, None)
+                else:
+                    installed[skill_id] = dict(receipt.previous_metadata)
+                self._write_metadata(installed)
+            elif receipt.previous_metadata is not None:
+                raise SkillInstallError(
+                    "Workspace Skill upgrade backup is unavailable; retry recovery "
+                    "after restoring the backup."
+                )
+            else:
+                self._remove_directory_if_present(target_dir)
+                installed.pop(skill_id, None)
+                self._write_metadata(installed)
+        self._remove_directory_if_present(staging_dir)
+        self._remove_directory_if_present(backup_dir)
+        self._receipt_path(skill_id).unlink(missing_ok=True)
+
+    @staticmethod
+    def _remove_directory_if_present(path: Path) -> None:
+        if path.exists():
+            shutil.rmtree(path)
 
     def _ensure_dirs(self) -> None:
         self.installed_dir.mkdir(parents=True, exist_ok=True)
@@ -388,10 +817,11 @@ class SkillManager:
         payload = {"skills": skills}
         temporary_path = self.installed_dir / f".installed-{uuid.uuid4().hex}.json.tmp"
         try:
-            temporary_path.write_text(
-                json.dumps(payload, ensure_ascii=False, indent=2),
-                encoding="utf-8",
-            )
+            encoded = json.dumps(payload, ensure_ascii=False, indent=2).encode("utf-8")
+            with temporary_path.open("xb") as handle:
+                handle.write(encoded)
+                handle.flush()
+                os.fsync(handle.fileno())
             os.replace(temporary_path, self.metadata_path)
         finally:
             temporary_path.unlink(missing_ok=True)
@@ -477,6 +907,12 @@ class SkillManager:
         sub_path: str,
         skill_md: Path,
         source_ref: str | None = None,
+        *,
+        source_kind: str = "git",
+        source_id: str | None = None,
+        source_revision: int | None = None,
+        content_digest: str | None = None,
+        package_subpath: str = "",
     ) -> InstalledSkill:
         content = skill_md.read_text(encoding="utf-8", errors="replace")
         frontmatter = self._parse_frontmatter(content)
@@ -500,6 +936,11 @@ class SkillManager:
             sub_path=sub_path,
             installed_at=time.time(),
             source_ref=source_ref,
+            source_kind=source_kind,
+            source_id=source_id or f"{repo_url}#{sub_path}",
+            source_revision=source_revision,
+            content_digest=content_digest or "",
+            package_subpath=package_subpath,
         )
 
     @staticmethod

--- a/server/tests/test_agent_workspace_skills.py
+++ b/server/tests/test_agent_workspace_skills.py
@@ -44,6 +44,9 @@ def test_library_contains_only_the_16_digest_verified_builtins(
     assert [member.skill_id for member in default.members] == [
         skill.skill_id for skill in skills
     ]
+    assert [member.digest for member in default.members] == [
+        skill.digest for skill in skills
+    ]
     assert "external" not in {skill.skill_id for skill in skills}
 
 

--- a/server/tests/test_skill_package_validation.py
+++ b/server/tests/test_skill_package_validation.py
@@ -1,0 +1,494 @@
+from __future__ import annotations
+
+from server.skills.package_validation import (
+    MAX_FILE_BYTES,
+    MAX_TOTAL_BYTES,
+    VALIDATOR_VERSION,
+    compute_package_digest,
+    compute_skill_content_digest,
+    scan_skill_package_credentials,
+    validate_skill_package,
+)
+
+
+def _skill_markdown(
+    *,
+    name: str = "analyze-data",
+    description: str = "Analyze tabular data and explain the results when users request a data review.",
+    extra: str = "",
+    body: str = "# Analyze data\n\nFollow the requested analysis workflow.",
+) -> str:
+    return (
+        "---\n"
+        f"name: {name}\n"
+        f"description: {description}\n"
+        f"{extra}"
+        "---\n\n"
+        f"{body}\n"
+    )
+
+
+def _codes(result) -> set[str]:
+    return {issue.code for issue in result.issues}
+
+
+def test_validates_complete_utf8_package_and_retains_optional_metadata() -> None:
+    markdown = _skill_markdown(
+        extra=(
+            "license: MIT\n"
+            "compatibility: ModelMirror private agents\n"
+            "metadata:\n"
+            "  category: analytics\n"
+            "  stable: true\n"
+            "allowed-tools:\n"
+            "  - Read\n"
+            "  - Grep\n"
+        ),
+        body=(
+            "# Analyze data\n\n"
+            "Read [the method](references/method.md), then run the helper when needed."
+        ),
+    )
+    files = {
+        "references/method.md": "# Method\n\nUse the deterministic checks.\n",
+        "scripts/check.py": "def check(value: int) -> int:\n    return value + 1\n",
+        "assets/schema.json": '{"type":"object","properties":{}}',
+        "assets/config.yaml": "enabled: true\nlimits:\n  rows: 10\n",
+        "scripts/check.js": "const rx = /[)]/g;\nexport function check(v) { return rx.test(v); }\n",
+        "agents/openai.yaml": "interface:\n  display_name: Analyze data\n",
+    }
+
+    result = validate_skill_package(
+        root_name="analyze-data", skill_markdown=markdown, files=files
+    )
+
+    assert result.valid is True
+    assert result.validator_version == VALIDATOR_VERSION
+    assert result.issues == ()
+    assert result.package is not None
+    assert result.package.name == "analyze-data"
+    assert result.package.description.startswith("Analyze tabular data")
+    assert result.package.license == "MIT"
+    assert result.package.compatibility == "ModelMirror private agents"
+    assert result.package.metadata == {"category": "analytics", "stable": True}
+    assert result.package.allowed_tools == ("Read", "Grep")
+    assert result.package.file_count == 1 + len(files)
+    assert result.package.content_digest == result.content_digest
+    assert len(result.package.content_digest) == 64
+
+
+def test_digest_is_order_independent_and_sensitive_to_exact_utf8_bytes() -> None:
+    first = compute_skill_content_digest(
+        {"SKILL.md": "alpha\n", "references/a.md": "café\n"}
+    )
+    reordered = compute_skill_content_digest(
+        {"references/a.md": "café\n", "SKILL.md": "alpha\n"}
+    )
+    crlf = compute_skill_content_digest(
+        {"SKILL.md": b"alpha\r\n", "references/a.md": "café\n"}
+    )
+
+    assert first == reordered
+    assert first != crlf
+    assert first == compute_package_digest(
+        "alpha\n", {"references/a.md": "café\n"}
+    )
+
+
+def test_rejects_duplicate_frontmatter_keys_including_nested_metadata() -> None:
+    markdown = (
+        "---\n"
+        "name: analyze-data\n"
+        "description: Analyze data when users ask for a review.\n"
+        "metadata:\n"
+        "  owner: first\n"
+        "  owner: second\n"
+        "---\n\n"
+        "# Analyze data\n"
+    )
+
+    result = validate_skill_package(
+        root_name="analyze-data", skill_markdown=markdown, files={}
+    )
+
+    assert result.valid is False
+    assert "frontmatter_duplicate_key" in _codes(result)
+    assert result.package is None
+
+
+def test_rejects_unsafe_yaml_tags_and_non_mapping_frontmatter() -> None:
+    tagged = validate_skill_package(
+        root_name="analyze-data",
+        skill_markdown=(
+            "---\n"
+            "name: analyze-data\n"
+            "description: !!python/object/apply:os.system [echo unsafe]\n"
+            "---\n\n# Analyze data\n"
+        ),
+        files={},
+    )
+    sequence = validate_skill_package(
+        root_name="analyze-data",
+        skill_markdown="---\n- name\n- description\n---\n\n# Analyze data\n",
+        files={},
+    )
+
+    assert "frontmatter_invalid_yaml" in _codes(tagged)
+    assert "frontmatter_type" in _codes(sequence)
+
+
+def test_enforces_frontmatter_types_name_format_description_and_root_match() -> None:
+    wrong_types = validate_skill_package(
+        root_name="analyze-data",
+        skill_markdown=(
+            "---\n"
+            "name: true\n"
+            "description: [not, text]\n"
+            "metadata:\n"
+            "  released: 2026-08-06\n"
+            "allowed-tools:\n"
+            "  - Read\n"
+            "  - 7\n"
+            "---\n\n# Analyze data\n"
+        ),
+        files={},
+    )
+    mismatch = validate_skill_package(
+        root_name="analyze-data",
+        skill_markdown=_skill_markdown(name="review-data"),
+        files={},
+    )
+    invalid_name = validate_skill_package(
+        root_name="analyze-data",
+        skill_markdown=_skill_markdown(name="Analyze Data"),
+        files={},
+    )
+
+    assert {
+        "frontmatter_name_type",
+        "frontmatter_description_type",
+        "frontmatter_metadata_type",
+        "frontmatter_allowed_tools_type",
+    } <= _codes(wrong_types)
+    assert "skill_name_root_mismatch" in _codes(mismatch)
+    assert "frontmatter_name_invalid" in _codes(invalid_name)
+
+
+def test_rejects_unsafe_paths_case_collisions_and_agents_extras() -> None:
+    files = {
+        "../outside.txt": "no",
+        "references\\windows.md": "no",
+        "references/Guide.md": "# Guide\n",
+        "references/guide.md": "# duplicate\n",
+        "agents/custom.yaml": "enabled: true\n",
+        "assets/a": "file",
+        "assets/a/nested.txt": "nested",
+    }
+
+    result = validate_skill_package(
+        root_name="analyze-data", skill_markdown=_skill_markdown(), files=files
+    )
+
+    assert result.valid is False
+    assert {
+        "file_path_unsafe",
+        "file_path_case_collision",
+        "agents_file_unsupported",
+        "file_directory_conflict",
+    } <= _codes(result)
+
+
+def test_rejects_windows_reserved_trailing_and_oversized_paths() -> None:
+    result = validate_skill_package(
+        root_name="analyze-data",
+        skill_markdown=_skill_markdown(),
+        files={
+            "assets/CON.txt": "reserved",
+            "references/trailing./guide.md": "trailing dot",
+            f"assets/{'数' * 100}.txt": "oversized component",
+            f"references/{'a' * 80}/{'b' * 80}/{'c' * 80}.md": "long path",
+        },
+    )
+    reserved_root = validate_skill_package(
+        root_name="con",
+        skill_markdown=_skill_markdown(name="con"),
+        files={},
+    )
+
+    assert result.valid is False
+    assert {
+        "file_path_windows_unsafe",
+        "file_path_too_long",
+    } <= _codes(result)
+    assert "root_name_windows_reserved" in _codes(reserved_root)
+
+
+def test_rejects_invalid_utf8_and_enforces_file_and_package_limits() -> None:
+    invalid_utf8 = validate_skill_package(
+        root_name="analyze-data",
+        skill_markdown=_skill_markdown(),
+        files={"assets/data.txt": b"\xff\xfe"},
+    )
+    too_many = validate_skill_package(
+        root_name="analyze-data",
+        skill_markdown=_skill_markdown(),
+        files={f"assets/file-{index}.txt": "x" for index in range(40)},
+    )
+    too_large_file = validate_skill_package(
+        root_name="analyze-data",
+        skill_markdown=_skill_markdown(),
+        files={"assets/large.txt": "x" * (MAX_FILE_BYTES + 1)},
+    )
+    package_too_large = validate_skill_package(
+        root_name="analyze-data",
+        skill_markdown=_skill_markdown(),
+        files={f"assets/chunk-{index}.txt": "x" * 900_000 for index in range(6)},
+    )
+
+    assert "file_invalid_utf8" in _codes(invalid_utf8)
+    assert "package_file_count_exceeded" in _codes(too_many)
+    assert "file_size_exceeded" in _codes(too_large_file)
+    assert "package_size_exceeded" in _codes(package_too_large)
+    assert MAX_TOTAL_BYTES < 6 * 900_000
+
+
+def test_detects_missing_case_mismatched_and_escaping_local_references() -> None:
+    markdown = _skill_markdown(
+        body=(
+            "# Analyze data\n\n"
+            "Read [missing](references/missing.md), "
+            "[wrong case](references/GUIDE.md), and "
+            "[outside](../../outside.md).\n\n"
+            "External [documentation](https://example.com/guide) is allowed."
+        )
+    )
+    result = validate_skill_package(
+        root_name="analyze-data",
+        skill_markdown=markdown,
+        files={"references/guide.md": "# Guide\n"},
+    )
+
+    assert {
+        "local_reference_missing",
+        "local_reference_case_mismatch",
+        "local_reference_unsafe",
+    } <= _codes(result)
+
+
+def test_detects_missing_resource_referenced_as_an_inline_code_path() -> None:
+    result = validate_skill_package(
+        root_name="analyze-data",
+        skill_markdown=_skill_markdown(
+            body=(
+                "# Analyze data\n\n"
+                "Read `references/missing.md` and run "
+                "`python scripts/analyze.py --mode safe`.\n"
+                "Do not treat `https://example.com/references/external.md` as local."
+            )
+        ),
+        files={},
+    )
+
+    assert result.valid is False
+    assert "local_reference_missing" in _codes(result)
+    missing_issues = [
+        issue for issue in result.issues if issue.code == "local_reference_missing"
+    ]
+    assert len(missing_issues) == 2
+
+
+def test_static_syntax_checks_do_not_execute_package_files(tmp_path) -> None:
+    marker = tmp_path / "must-not-exist"
+    files = {
+        "scripts/broken.py": f"open({str(marker)!r}, 'w').write('ran')\ndef broken(:\n",
+        "assets/broken.json": '{"missing": }',
+        "assets/broken.yaml": "item: one\nitem: two\n",
+        "scripts/broken.js": "export function broken() { return [1, 2; }\n",
+    }
+
+    result = validate_skill_package(
+        root_name="analyze-data", skill_markdown=_skill_markdown(), files=files
+    )
+
+    assert result.valid is False
+    assert {
+        "python_syntax_invalid",
+        "json_syntax_invalid",
+        "yaml_syntax_invalid",
+        "javascript_syntax_invalid",
+    } <= _codes(result)
+    assert marker.exists() is False
+
+
+def test_javascript_check_rejects_obvious_missing_operand_without_scanning_strings() -> None:
+    invalid = validate_skill_package(
+        root_name="analyze-data",
+        skill_markdown=_skill_markdown(),
+        files={"scripts/broken.js": "const value = ;\n"},
+    )
+    valid = validate_skill_package(
+        root_name="analyze-data",
+        skill_markdown=_skill_markdown(),
+        files={
+            "scripts/example.js": (
+                'const sample = "const value = ;";\n'
+                "const pattern = /=;/;\n"
+            )
+        },
+    )
+
+    assert "javascript_syntax_invalid" in _codes(invalid)
+    assert valid.valid is True
+
+
+def test_rejects_yaml_aliases_before_recursive_metadata_traversal() -> None:
+    result = validate_skill_package(
+        root_name="analyze-data",
+        skill_markdown=(
+            "---\n"
+            "name: analyze-data\n"
+            "description: Analyze data when users ask for a review.\n"
+            "metadata:\n"
+            "  defaults: &defaults [one, two]\n"
+            "  copied: *defaults\n"
+            "---\n\n# Analyze data\n"
+        ),
+        files={},
+    )
+
+    assert result.valid is False
+    assert "frontmatter_invalid_yaml" in _codes(result)
+
+
+def test_deep_yaml_is_a_structured_validation_error_not_a_recursion_crash() -> None:
+    nested_value = "[" * 2_000 + "value" + "]" * 2_000
+    markdown = (
+        "---\n"
+        "name: analyze-data\n"
+        f"description: {nested_value}\n"
+        "---\n\n# Analyze data\n"
+    )
+
+    result = validate_skill_package(
+        root_name="analyze-data",
+        skill_markdown=markdown,
+        files={"assets/deep.yaml": nested_value},
+    )
+
+    assert result.valid is False
+    assert {"frontmatter_invalid_yaml", "yaml_syntax_invalid"} <= _codes(result)
+
+
+def test_blocks_credentials_without_echoing_secret_or_returning_content() -> None:
+    secret = "sk-abcdefghijklmnopqrstuvwxyz1234567890"
+    result = validate_skill_package(
+        root_name="analyze-data",
+        skill_markdown=_skill_markdown(),
+        files={
+            "references/private.md": (
+                f"token: {secret}\n"
+                "password = real-production-password\n"
+                "https://service-user:real-password@example.com/path\n"
+                "-----BEGIN PRIVATE KEY-----\n"
+            )
+        },
+    )
+
+    assert result.valid is False
+    assert result.package is None
+    assert result.file_count == 2
+    assert result.total_bytes > 0
+    assert {
+        "credential_token",
+        "credential_assignment",
+        "credential_url",
+        "credential_private_key",
+    } <= _codes(result)
+    serialized = json_text = str(result.to_dict(include_package=True))
+    assert secret not in serialized
+    assert "real-production-password" not in json_text
+
+
+def test_blocks_prefixed_secret_variables_and_tokens_hidden_in_paths() -> None:
+    prefixed = validate_skill_package(
+        root_name="analyze-data",
+        skill_markdown=_skill_markdown(),
+        files={
+            "references/config.md": (
+                'DIFY_API_KEY="dify-live-secret-abcdefghijklmnopqrstuvwxyz"\n'
+            )
+        },
+    )
+    path_secret = validate_skill_package(
+        root_name="analyze-data",
+        skill_markdown=_skill_markdown(),
+        files={
+            "assets/sk-abcdefghijklmnopqrstuvwxyz1234567890.json": "{invalid json"
+        },
+    )
+
+    assert "credential_assignment" in _codes(prefixed)
+    assert "credential_token" in _codes(path_secret)
+    assert prefixed.package is None
+    assert path_secret.package is None
+
+
+def test_placeholders_are_not_mistaken_for_hard_coded_credentials() -> None:
+    result = validate_skill_package(
+        root_name="analyze-data",
+        skill_markdown=_skill_markdown(),
+        files={
+            "references/config.md": (
+                "api_key = ${ANALYTICS_API_KEY}\n"
+                "password: YOUR-PASSWORD\n"
+                "client_secret = <replace-me>\n"
+            )
+        },
+    )
+
+    assert result.valid is True
+    assert not any(code.startswith("credential_") for code in _codes(result))
+
+
+def test_credential_scanner_supports_partial_update_payloads_without_echo() -> None:
+    secret = "github_pat_abcdefghijklmnopqrstuvwxyz1234567890"
+
+    issues = scan_skill_package_credentials(
+        files={"scripts/config.py": f"client_secret = '{secret}'\n"}
+    )
+
+    assert {issue.code for issue in issues} == {
+        "credential_token",
+        "credential_assignment",
+    }
+    assert secret not in str([issue.to_dict() for issue in issues])
+
+
+def test_blocks_prefixed_secret_variables_and_credentials_in_paths_without_echo() -> None:
+    path_secret = "sk-abcdefghijklmnopqrstuvwxyz1234567890"
+    result = validate_skill_package(
+        root_name="analyze-data",
+        skill_markdown=_skill_markdown(),
+        files={
+            "scripts/config.py": 'DIFY_API_KEY = "dify-live-secret-123456789"\n',
+            f"assets/{path_secret}.txt": "safe text\n",
+        },
+    )
+
+    assert result.valid is False
+    assert {"credential_assignment", "credential_token"} <= _codes(result)
+    assert path_secret not in str(result.to_dict(include_package=True))
+
+
+def test_unknown_frontmatter_field_is_warning_not_install_metadata() -> None:
+    result = validate_skill_package(
+        root_name="analyze-data",
+        skill_markdown=_skill_markdown(extra="custom-field: ignored\n"),
+        files={},
+    )
+
+    assert result.valid is True
+    assert _codes(result) == {"frontmatter_field_unsupported"}
+    assert result.issues[0].severity == "warning"
+    assert result.package is not None
+    assert "custom-field" not in result.package.to_dict()

--- a/server/tests/test_workspace_skill_drafts.py
+++ b/server/tests/test_workspace_skill_drafts.py
@@ -1,26 +1,30 @@
 from __future__ import annotations
 
+import json
+import threading
 from pathlib import Path
+from types import SimpleNamespace
 
 import httpx
 import pytest
 from fastapi import FastAPI
+from scripts.audit_workspace_skill_drafts import audit_snapshot
 
 from server.skills import api as skills_api
 from server.skills.draft_store import (
     SkillDraftConflictError,
+    SkillDraftStorageError,
     SkillDraftValidationError,
     WorkspaceSkillDraftStore,
 )
 from server.skills.skill_manager import (
-    SkillInstallError,
     SkillManager,
     SkillValidationError,
 )
 
 
 SKILL_MD = """---
-name: Safe Helper
+name: safe-helper
 description: A reviewed workspace helper.
 ---
 
@@ -31,7 +35,7 @@ Run the local script only after explicit installation.
 def test_skill_draft_persists_and_rejects_unsafe_paths(tmp_path: Path) -> None:
     store = WorkspaceSkillDraftStore(tmp_path / "drafts")
     draft = store.create(
-        name="Safe Helper",
+        name="safe-helper",
         slug="safe-helper",
         description="A reviewed workspace helper.",
         skill_markdown=SKILL_MD,
@@ -45,19 +49,19 @@ def test_skill_draft_persists_and_rejects_unsafe_paths(tmp_path: Path) -> None:
     restored = WorkspaceSkillDraftStore(tmp_path / "drafts").require(draft.draft_id)
     assert restored.files["scripts/run.py"] == "print('safe')\n"
 
-    with pytest.raises(SkillDraftValidationError, match="Unsafe Skill file path"):
+    with pytest.raises(SkillDraftValidationError, match="unsafe or non-canonical"):
         WorkspaceSkillDraftStore.validate_package(
-            name="Unsafe",
-            slug="unsafe",
-            description="Unsafe",
+            name="safe-helper",
+            slug="safe-helper",
+            description="A reviewed workspace helper.",
             skill_markdown=SKILL_MD,
             files={"../escape.py": "print('no')"},
         )
     with pytest.raises(SkillDraftValidationError, match="agents/openai.yaml"):
         WorkspaceSkillDraftStore.validate_package(
-            name="Unsafe",
-            slug="unsafe",
-            description="Unsafe",
+            name="safe-helper",
+            slug="safe-helper",
+            description="A reviewed workspace helper.",
             skill_markdown=SKILL_MD,
             files={"agents/other.yaml": "name: no"},
         )
@@ -72,7 +76,7 @@ def test_skill_install_is_explicit_revisioned_and_never_overwrites(
         tmp_dir=tmp_path / "tmp",
     )
     draft = store.create(
-        name="Safe Helper",
+        name="safe-helper",
         slug="safe-helper",
         description="A reviewed workspace helper.",
         skill_markdown=SKILL_MD,
@@ -93,17 +97,18 @@ def test_skill_install_is_explicit_revisioned_and_never_overwrites(
     assert marked.status == "installed"
     assert marked.installed_skill_id == installed.skill_id
     assert manager.list_installed_skills()[0].skill_id == installed.skill_id
-    with pytest.raises(SkillInstallError, match="already installed"):
+    repeated = manager.install_workspace_draft(
+        draft_id=draft.draft_id,
+        slug=draft.slug,
+        skill_markdown=draft.skill_markdown,
+        files=draft.files,
+    )
+    assert repeated.skill_id == installed.skill_id
+    assert len(manager.list_installed_skills()) == 1
+    with pytest.raises(SkillValidationError, match="unsafe or non-canonical"):
         manager.install_workspace_draft(
-            draft_id=draft.draft_id,
-            slug=draft.slug,
-            skill_markdown=draft.skill_markdown,
-            files=draft.files,
-        )
-    with pytest.raises(SkillValidationError, match="Unsafe Skill file path"):
-        manager.install_workspace_draft(
-            draft_id="unsafe-draft",
-            slug="unsafe",
+            draft_id="safe-helper-draft",
+            slug="safe-helper",
             skill_markdown=SKILL_MD,
             files={"../escape.py": "print('no')"},
         )
@@ -121,7 +126,7 @@ async def test_workspace_skill_draft_api_requires_current_revision(
         tmp_dir=tmp_path / "tmp",
     )
     draft = store.create(
-        name="Safe Helper",
+        name="safe-helper",
         slug="safe-helper",
         description="A reviewed workspace helper.",
         skill_markdown=SKILL_MD,
@@ -144,17 +149,424 @@ async def test_workspace_skill_draft_api_requires_current_revision(
 
             stale = await client.post(
                 f"/api/skills/drafts/{draft.draft_id}/install",
-                json={"revision": draft.revision + 1},
+                json={
+                    "expected_revision": draft.revision + 1,
+                    "expected_digest": draft.content_digest,
+                },
             )
             assert stale.status_code == 409
 
             installed = await client.post(
                 f"/api/skills/drafts/{draft.draft_id}/install",
-                json={"revision": draft.revision},
+                json={
+                    "expected_revision": draft.revision,
+                    "expected_digest": draft.content_digest,
+                },
             )
             assert installed.status_code == 200, installed.text
             assert installed.json()["draft"]["status"] == "installed"
             assert len(manager.list_installed_skills()) == 1
+
+            installed_skill_id = installed.json()["installed"]["skill_id"]
+            removed = await client.delete(f"/api/skills/{installed_skill_id}")
+            assert removed.status_code == 200, removed.text
+            after_uninstall = store.require(draft.draft_id)
+            assert after_uninstall.status == "draft"
+            assert after_uninstall.install_state == "not_installed"
+            assert after_uninstall.installed_skill_id is None
+
+            reinstalled = await client.post(
+                f"/api/skills/drafts/{draft.draft_id}/install",
+                json={
+                    "expected_revision": after_uninstall.revision,
+                    "expected_digest": after_uninstall.content_digest,
+                },
+            )
+            assert reinstalled.status_code == 200, reinstalled.text
+            assert reinstalled.json()["draft"]["install_state"] == "current"
     finally:
         skills_api._skill_draft_store = previous_store
         skills_api._skill_manager = previous_manager
+
+
+def test_skill_draft_content_revisions_are_immutable_and_digest_guarded(
+    tmp_path: Path,
+) -> None:
+    store = WorkspaceSkillDraftStore(tmp_path / "drafts")
+    created = store.create(
+        name="safe-helper",
+        slug="safe-helper",
+        description="A reviewed workspace helper.",
+        skill_markdown=SKILL_MD,
+        files={"scripts/run.py": "print('v1')\n"},
+    )
+
+    assert created.content_revision == 1
+    assert len(created.content_digest) == 64
+    first = store.require_revision_snapshot(
+        created.draft_id,
+        revision=1,
+        content_digest=created.content_digest,
+    )
+
+    updated = store.update(
+        created.draft_id,
+        expected_revision=created.revision,
+        expected_digest=created.content_digest,
+        files={"scripts/run.py": "print('v2')\n"},
+    )
+
+    assert updated.revision == created.revision + 1
+    assert updated.content_revision == 2
+    assert updated.content_digest != created.content_digest
+    assert store.require_revision_snapshot(created.draft_id, revision=1) == first
+    assert store.require_revision_snapshot(created.draft_id, revision=1).package[
+        "files"
+    ]["scripts/run.py"] == "print('v1')\n"
+    assert store.require_revision_snapshot(created.draft_id, revision=2).package[
+        "files"
+    ]["scripts/run.py"] == "print('v2')\n"
+
+    with pytest.raises(SkillDraftConflictError, match="content changed"):
+        store.update(
+            created.draft_id,
+            expected_revision=updated.revision,
+            expected_digest=created.content_digest,
+            description="stale writer",
+        )
+
+
+def test_validation_is_bound_to_content_and_install_identity_survives_edit(
+    tmp_path: Path,
+) -> None:
+    store = WorkspaceSkillDraftStore(tmp_path / "drafts")
+    created = store.create(
+        name="safe-helper",
+        slug="safe-helper",
+        description="A reviewed workspace helper.",
+        skill_markdown=SKILL_MD,
+        files={"scripts/run.py": "print('v1')\n"},
+    )
+    validated = store.set_validation(
+        created.draft_id,
+        expected_revision=created.revision,
+        expected_digest=created.content_digest,
+        validation={"valid": True, "issues": []},
+    )
+
+    assert validated.validation["validator_version"]
+    assert validated.validation["content_revision"] == created.content_revision
+    assert validated.validation["content_digest"] == created.content_digest
+    restored = WorkspaceSkillDraftStore(tmp_path / "drafts").require(created.draft_id)
+    assert restored.validation["stale"] is False
+    assert restored.needs_review is False
+    installed = store.mark_installed(
+        created.draft_id,
+        expected_revision=validated.revision,
+        expected_digest=validated.content_digest,
+        skill_id="workspace-safe-helper",
+    )
+    assert installed.install_state == "current"
+    assert installed.installed_content_revision == 1
+    assert installed.installed_content_digest == installed.content_digest
+
+    edited = store.update(
+        installed.draft_id,
+        expected_revision=installed.revision,
+        expected_digest=installed.content_digest,
+        files={"scripts/run.py": "print('v2')\n"},
+    )
+    assert edited.status == "draft"
+    assert edited.install_state == "outdated"
+    assert edited.installed_skill_id == installed.installed_skill_id
+    assert edited.installed_content_digest == installed.content_digest
+    assert edited.validation == {}
+
+
+def test_v1_migration_is_lossless_per_record_and_quarantines_only_bad_items(
+    tmp_path: Path,
+) -> None:
+    storage_dir = tmp_path / "drafts"
+    storage_dir.mkdir()
+    valid_record = {
+        "draft_id": "skilldraft_valid",
+        "name": "safe-helper",
+        "slug": "safe-helper",
+        "description": "A reviewed workspace helper.",
+        "skill_markdown": SKILL_MD,
+        "files": {"scripts/run.py": "print('safe')\n"},
+        "status": "installed",
+        "revision": 4,
+        "source_proposal_id": "proposal_1",
+        "installed_skill_id": "workspace-safe-helper",
+        "validation": {"valid": True, "issues": []},
+        "created_at": 10.0,
+        "updated_at": 20.0,
+    }
+    bad_record = {
+        "draft_id": "skilldraft_bad",
+        "name": "broken",
+        "slug": "broken",
+        "description": "broken",
+        "skill_markdown": 123,
+        "files": {},
+    }
+    duplicate_slug_record = {
+        **valid_record,
+        "draft_id": "skilldraft_duplicate_slug",
+        "status": "draft",
+        "revision": 2,
+        "installed_skill_id": None,
+        "validation": {},
+    }
+    original = {
+        "version": 1,
+        "items": [valid_record, duplicate_slug_record, bad_record],
+    }
+    snapshot_path = storage_dir / "skill_drafts.json"
+    snapshot_path.write_text(json.dumps(original), encoding="utf-8")
+
+    store = WorkspaceSkillDraftStore(storage_dir)
+    restored = store.require("skilldraft_valid")
+
+    assert restored.revision == 4
+    assert restored.content_revision == 1
+    assert restored.install_state == "current"
+    assert restored.installed_content_digest == restored.content_digest
+    assert restored.validation["stale"] is True
+    assert restored.needs_review is True
+    assert len(store.list_revision_snapshots(restored.draft_id)) == 1
+    quarantined = store.list_quarantined()
+    assert len(quarantined) == 1
+    assert "record" not in quarantined[0]
+    assert len(quarantined[0]["record_sha256"]) == 64
+    assert json.loads((storage_dir / "skill_drafts.v1.backup.json").read_text()) == original
+    migrated = json.loads(snapshot_path.read_text(encoding="utf-8"))
+    assert migrated["version"] == 2
+    assert [item["draft_id"] for item in migrated["items"]] == [
+        "skilldraft_duplicate_slug",
+        "skilldraft_valid",
+    ]
+
+
+def test_v1_migration_does_not_copy_credentials_into_v2_records(
+    tmp_path: Path,
+) -> None:
+    storage_dir = tmp_path / "drafts"
+    storage_dir.mkdir()
+    leaked_secret = "dify-live-secret-1234567890"
+    record = {
+        "draft_id": "skilldraft_secret",
+        "name": "secret-helper",
+        "slug": "secret-helper",
+        "description": f'DIFY_API_KEY="{leaked_secret}"',
+        "skill_markdown": """---
+name: secret-helper
+description: A legacy draft containing blocked content.
+---
+
+Never persist credentials.
+""",
+        "files": {"scripts/run.py": "print('safe')\n"},
+    }
+    snapshot_path = storage_dir / "skill_drafts.json"
+    snapshot_path.write_text(
+        json.dumps({"version": 1, "items": [record]}),
+        encoding="utf-8",
+    )
+
+    store = WorkspaceSkillDraftStore(storage_dir)
+
+    assert store.list() == []
+    quarantine = store.list_quarantined()
+    assert len(quarantine) == 1
+    assert quarantine[0]["reason_code"] == "invalid_record"
+    assert "record" not in quarantine[0]
+    migrated_text = snapshot_path.read_text(encoding="utf-8")
+    assert leaked_secret not in migrated_text
+    assert "DIFY_API_KEY" not in migrated_text
+    assert leaked_secret in (storage_dir / "skill_drafts.v1.backup.json").read_text(
+        encoding="utf-8"
+    )
+
+
+def test_install_current_serializes_edit_against_reviewed_digest(tmp_path: Path) -> None:
+    store = WorkspaceSkillDraftStore(tmp_path / "drafts")
+    created = store.create(
+        name="safe-helper",
+        slug="safe-helper",
+        description="A reviewed workspace helper.",
+        skill_markdown=SKILL_MD,
+        files={"scripts/run.py": "print('v1')\n"},
+    )
+    install_started = threading.Event()
+    release_install = threading.Event()
+    edit_started = threading.Event()
+    outcomes: dict[str, object] = {}
+
+    def installer(item):
+        install_started.set()
+        assert release_install.wait(timeout=2)
+        return SimpleNamespace(
+            skill_id="workspace-safe-helper",
+            content_digest=item.content_digest,
+        )
+
+    def run_install() -> None:
+        outcomes["installed"] = store.install_current(
+            created.draft_id,
+            expected_revision=created.revision,
+            expected_digest=created.content_digest,
+            installer=installer,
+        )
+
+    def run_edit() -> None:
+        edit_started.set()
+        try:
+            store.update(
+                created.draft_id,
+                expected_revision=created.revision,
+                expected_digest=created.content_digest,
+                files={"scripts/run.py": "print('v2')\n"},
+            )
+        except Exception as exc:  # noqa: BLE001 - captured for cross-thread assertion
+            outcomes["edit_error"] = exc
+
+    install_thread = threading.Thread(target=run_install)
+    edit_thread = threading.Thread(target=run_edit)
+    install_thread.start()
+    assert install_started.wait(timeout=2)
+    edit_thread.start()
+    assert edit_started.wait(timeout=2)
+    release_install.set()
+    install_thread.join(timeout=2)
+    edit_thread.join(timeout=2)
+
+    assert not install_thread.is_alive()
+    assert not edit_thread.is_alive()
+    assert "installed" in outcomes
+    assert isinstance(outcomes.get("edit_error"), SkillDraftConflictError)
+    restored = store.require(created.draft_id)
+    assert restored.install_state == "current"
+    assert restored.content_digest == created.content_digest
+
+
+def test_all_draft_mutations_restore_memory_when_atomic_save_fails(
+    tmp_path: Path,
+) -> None:
+    def fail_save() -> None:
+        raise OSError("simulated disk full")
+
+    empty_store = WorkspaceSkillDraftStore(tmp_path / "create")
+    empty_store._save_unlocked = fail_save  # type: ignore[method-assign]
+    with pytest.raises(OSError, match="disk full"):
+        empty_store.create(
+            name="safe-helper",
+            slug="safe-helper",
+            description="A reviewed workspace helper.",
+            skill_markdown=SKILL_MD,
+        )
+    assert empty_store.list() == []
+
+    actions = (
+        lambda store, item: store.update(
+            item.draft_id,
+            expected_revision=item.revision,
+            expected_digest=item.content_digest,
+            files={"scripts/run.py": "print('changed')\n"},
+        ),
+        lambda store, item: store.set_validation(
+            item.draft_id,
+            expected_revision=item.revision,
+            expected_digest=item.content_digest,
+            validation={"valid": True, "issues": []},
+        ),
+        lambda store, item: store.mark_installed(
+            item.draft_id,
+            expected_revision=item.revision,
+            expected_digest=item.content_digest,
+            skill_id="workspace-safe-helper",
+        ),
+        lambda store, item: store.archive(
+            item.draft_id,
+            expected_revision=item.revision,
+            expected_digest=item.content_digest,
+        ),
+        lambda store, item: store.mark_uninstalled_skill(
+            "workspace-safe-helper"
+        ),
+        lambda store, item: store.install_current(
+            item.draft_id,
+            expected_revision=item.revision,
+            expected_digest=item.content_digest,
+            installer=lambda current: SimpleNamespace(
+                skill_id="workspace-safe-helper",
+                content_digest=current.content_digest,
+            ),
+        ),
+    )
+    for index, action in enumerate(actions):
+        store = WorkspaceSkillDraftStore(tmp_path / f"mutation-{index}")
+        created = store.create(
+            name="safe-helper",
+            slug="safe-helper",
+            description="A reviewed workspace helper.",
+            skill_markdown=SKILL_MD,
+            files={"scripts/run.py": "print('safe')\n"},
+        )
+        if index == 4:
+            created = store.mark_installed(
+                created.draft_id,
+                expected_revision=created.revision,
+                expected_digest=created.content_digest,
+                skill_id="workspace-safe-helper",
+            )
+        snapshots_before = store.list_revision_snapshots(created.draft_id)
+        store._save_unlocked = fail_save  # type: ignore[method-assign]
+        with pytest.raises(OSError, match="disk full"):
+            action(store, created)
+        assert store.require(created.draft_id) == created
+        assert store.list_revision_snapshots(created.draft_id) == snapshots_before
+
+
+def test_corrupt_top_level_snapshot_is_backed_up_and_never_overwritten(
+    tmp_path: Path,
+) -> None:
+    storage_dir = tmp_path / "drafts"
+    storage_dir.mkdir()
+    snapshot_path = storage_dir / "skill_drafts.json"
+    snapshot_path.write_text("{not-json", encoding="utf-8")
+    store = WorkspaceSkillDraftStore(storage_dir)
+
+    with pytest.raises(SkillDraftStorageError, match="cannot be overwritten"):
+        store.create(
+            name="safe-helper",
+            slug="safe-helper",
+            description="A reviewed workspace helper.",
+            skill_markdown=SKILL_MD,
+        )
+
+    assert snapshot_path.read_text(encoding="utf-8") == "{not-json"
+    assert (storage_dir / "skill_drafts.corrupt.backup.json").read_text(
+        encoding="utf-8"
+    ) == "{not-json"
+
+
+def test_workspace_draft_audit_is_read_only(tmp_path: Path) -> None:
+    storage_dir = tmp_path / "drafts"
+    store = WorkspaceSkillDraftStore(storage_dir)
+    store.create(
+        name="safe-helper",
+        slug="safe-helper",
+        description="A reviewed workspace helper.",
+        skill_markdown=SKILL_MD,
+        files={"scripts/run.py": "print('safe')\n"},
+    )
+    before = store.snapshot_path.read_bytes()
+
+    report, exit_code = audit_snapshot(store.snapshot_path)
+
+    assert exit_code == 0
+    assert report["record_count"] == 1
+    assert report["valid_count"] == 1
+    assert store.snapshot_path.read_bytes() == before

--- a/server/tests/test_workspace_skill_install_upgrade.py
+++ b/server/tests/test_workspace_skill_install_upgrade.py
@@ -1,0 +1,372 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from server.skills.package_validation import compute_package_digest
+from server.skills.skill_manager import (
+    SkillInstallError,
+    SkillInstallReceipt,
+    SkillManager,
+)
+
+
+def _skill_markdown(name: str = "safe-helper", version: str = "v1") -> str:
+    return f"""---
+name: {name}
+description: A reviewed workspace helper.
+---
+
+# Safe Helper
+
+Run the reviewed {version} workflow.
+"""
+
+
+def _manager(tmp_path: Path) -> SkillManager:
+    return SkillManager(
+        installed_dir=tmp_path / "installed",
+        tmp_dir=tmp_path / "tmp",
+    )
+
+
+def test_workspace_install_is_stable_nested_idempotent_and_upgradeable(
+    tmp_path: Path,
+) -> None:
+    manager = _manager(tmp_path)
+    files_v1 = {"scripts/run.py": "print('v1')\n"}
+    markdown_v1 = _skill_markdown()
+
+    first = manager.install_workspace_draft(
+        draft_id="skilldraft_stable",
+        slug="safe-helper",
+        skill_markdown=markdown_v1,
+        files=files_v1,
+        source_revision=1,
+    )
+    retried = manager.install_workspace_draft(
+        draft_id="skilldraft_stable",
+        slug="safe-helper",
+        skill_markdown=markdown_v1,
+        files=files_v1,
+        source_revision=1,
+    )
+
+    assert retried == first
+    assert first.source_kind == "workspace_draft"
+    assert first.source_id == "skilldraft_stable"
+    assert first.source_revision == 1
+    assert first.content_digest == compute_package_digest(markdown_v1, files_v1)
+    assert first.package_subpath == "safe-helper"
+    assert manager.get_skill_directory(first.skill_id) == (
+        tmp_path / "installed" / first.skill_id / "safe-helper"
+    )
+    assert manager.get_skill_content(first.skill_id) == markdown_v1
+
+    files_v2 = {
+        "scripts/run.py": "print('v2')\n",
+        "references/guide.md": "# V2 guide\n",
+    }
+    markdown_v2 = _skill_markdown(name="renamed-helper", version="v2")
+    upgraded = manager.install_workspace_draft(
+        draft_id="skilldraft_stable",
+        slug="renamed-helper",
+        skill_markdown=markdown_v2,
+        files=files_v2,
+        source_revision=2,
+    )
+
+    assert upgraded.skill_id == first.skill_id
+    assert upgraded.source_revision == 2
+    assert upgraded.content_digest == compute_package_digest(markdown_v2, files_v2)
+    assert upgraded.content_digest != first.content_digest
+    assert upgraded.package_subpath == "renamed-helper"
+    assert manager.get_skill_directory(first.skill_id) == (
+        tmp_path / "installed" / first.skill_id / "renamed-helper"
+    )
+    assert not (tmp_path / "installed" / first.skill_id / "safe-helper").exists()
+    assert manager.get_skill_content(first.skill_id) == markdown_v2
+    assert not list((tmp_path / "installed").glob(".*.staging-*"))
+    assert not list((tmp_path / "installed").glob(".*.backup-*"))
+    assert not list((tmp_path / "installed").glob("*.receipt.json"))
+
+
+def test_workspace_upgrade_failure_rolls_back_package_and_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = _manager(tmp_path)
+    original = manager.install_workspace_draft(
+        draft_id="skilldraft_rollback",
+        slug="safe-helper",
+        skill_markdown=_skill_markdown(),
+        files={"scripts/run.py": "print('v1')\n"},
+        source_revision=1,
+    )
+    original_content = manager.get_skill_content(original.skill_id)
+
+    original_write_metadata = manager._write_metadata
+    write_count = 0
+
+    def fail_metadata_write(skills: dict[str, dict[str, object]]) -> None:
+        nonlocal write_count
+        write_count += 1
+        if write_count == 1:
+            raise OSError("simulated workspace metadata failure")
+        original_write_metadata(skills)
+
+    monkeypatch.setattr(manager, "_write_metadata", fail_metadata_write)
+    with pytest.raises(OSError, match="simulated workspace metadata failure"):
+        manager.install_workspace_draft(
+            draft_id="skilldraft_rollback",
+            slug="safe-helper",
+            skill_markdown=_skill_markdown(version="v2"),
+            files={"scripts/run.py": "print('v2')\n"},
+            source_revision=2,
+        )
+
+    assert manager.get_skill_content(original.skill_id) == original_content
+    assert manager.list_installed_skills() == [original]
+    assert not list((tmp_path / "installed").glob(".*.staging-*"))
+    assert not list((tmp_path / "installed").glob(".*.backup-*"))
+    assert not list((tmp_path / "installed").glob("*.receipt.json"))
+
+
+def test_workspace_exception_after_metadata_commit_restores_previous_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = _manager(tmp_path)
+    original = manager.install_workspace_draft(
+        draft_id="skilldraft_metadata_committed",
+        slug="safe-helper",
+        skill_markdown=_skill_markdown(),
+        files={"scripts/run.py": "print('v1')\n"},
+        source_revision=1,
+    )
+    original_receipt_write = manager._write_install_receipt
+
+    def fail_committed_receipt(receipt: SkillInstallReceipt) -> None:
+        if receipt.phase == "committed":
+            raise OSError("simulated committed receipt failure")
+        original_receipt_write(receipt)
+
+    monkeypatch.setattr(manager, "_write_install_receipt", fail_committed_receipt)
+    with pytest.raises(OSError, match="simulated committed receipt failure"):
+        manager.install_workspace_draft(
+            draft_id="skilldraft_metadata_committed",
+            slug="safe-helper",
+            skill_markdown=_skill_markdown(version="v2"),
+            files={"scripts/run.py": "print('v2')\n"},
+            source_revision=2,
+        )
+
+    assert manager.list_installed_skills() == [original]
+    assert manager.get_skill_content(original.skill_id) == _skill_markdown()
+    assert not list((tmp_path / "installed").glob("*.receipt.json"))
+
+
+def test_workspace_rollback_failure_keeps_receipt_for_safe_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = _manager(tmp_path)
+    original = manager.install_workspace_draft(
+        draft_id="skilldraft_rollback_retry",
+        slug="safe-helper",
+        skill_markdown=_skill_markdown(),
+        files={"scripts/run.py": "print('v1')\n"},
+        source_revision=1,
+    )
+
+    def fail_all_metadata_writes(_skills: dict[str, dict[str, object]]) -> None:
+        raise OSError("simulated persistent metadata failure")
+
+    monkeypatch.setattr(manager, "_write_metadata", fail_all_metadata_writes)
+    markdown_v2 = _skill_markdown(version="v2")
+    files_v2 = {"scripts/run.py": "print('v2')\n"}
+    with pytest.raises(SkillInstallError, match="rollback is incomplete"):
+        manager.install_workspace_draft(
+            draft_id="skilldraft_rollback_retry",
+            slug="safe-helper",
+            skill_markdown=markdown_v2,
+            files=files_v2,
+            source_revision=2,
+        )
+
+    assert list((tmp_path / "installed").glob("*.receipt.json"))
+    assert manager.get_skill_content(original.skill_id) == _skill_markdown()
+
+    recovered_manager = _manager(tmp_path)
+    recovered = recovered_manager.install_workspace_draft(
+        draft_id="skilldraft_rollback_retry",
+        slug="safe-helper",
+        skill_markdown=markdown_v2,
+        files=files_v2,
+        source_revision=2,
+    )
+    assert recovered.skill_id == original.skill_id
+    assert recovered.content_digest == compute_package_digest(markdown_v2, files_v2)
+    assert not list((tmp_path / "installed").glob("*.receipt.json"))
+
+
+def test_workspace_retry_repairs_tampered_installed_files(tmp_path: Path) -> None:
+    manager = _manager(tmp_path)
+    markdown = _skill_markdown()
+    files = {"scripts/run.py": "print('reviewed')\n"}
+    installed = manager.install_workspace_draft(
+        draft_id="skilldraft_tampered",
+        slug="safe-helper",
+        skill_markdown=markdown,
+        files=files,
+        source_revision=1,
+    )
+    script = manager.get_skill_directory(installed.skill_id) / "scripts/run.py"
+    script.write_text("print('tampered')\n", encoding="utf-8")
+
+    repaired = manager.install_workspace_draft(
+        draft_id="skilldraft_tampered",
+        slug="safe-helper",
+        skill_markdown=markdown,
+        files=files,
+        source_revision=1,
+    )
+
+    assert repaired.skill_id == installed.skill_id
+    assert script.read_text(encoding="utf-8") == files["scripts/run.py"]
+    assert repaired.content_digest == compute_package_digest(markdown, files)
+
+
+def test_workspace_upgrade_switch_failure_restores_backed_up_package(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = _manager(tmp_path)
+    original = manager.install_workspace_draft(
+        draft_id="skilldraft_switch_failure",
+        slug="safe-helper",
+        skill_markdown=_skill_markdown(),
+        files={"scripts/run.py": "print('v1')\n"},
+        source_revision=1,
+    )
+    original_content = manager.get_skill_content(original.skill_id)
+    original_rename = Path.rename
+
+    def fail_staging_switch(path: Path, target: Path) -> Path:
+        if ".staging-" in path.name:
+            raise OSError("simulated workspace directory switch failure")
+        return original_rename(path, target)
+
+    monkeypatch.setattr(Path, "rename", fail_staging_switch)
+    with pytest.raises(OSError, match="simulated workspace directory switch failure"):
+        manager.install_workspace_draft(
+            draft_id="skilldraft_switch_failure",
+            slug="safe-helper",
+            skill_markdown=_skill_markdown(version="v2"),
+            files={"scripts/run.py": "print('v2')\n"},
+            source_revision=2,
+        )
+
+    assert manager.get_skill_content(original.skill_id) == original_content
+    assert manager.list_installed_skills() == [original]
+    assert not list((tmp_path / "installed").glob(".*.staging-*"))
+    assert not list((tmp_path / "installed").glob(".*.backup-*"))
+    assert not list((tmp_path / "installed").glob("*.receipt.json"))
+
+
+def test_workspace_receipt_recovers_interrupted_swap_and_retry_is_safe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = _manager(tmp_path)
+    original = manager.install_workspace_draft(
+        draft_id="skilldraft_recovery",
+        slug="safe-helper",
+        skill_markdown=_skill_markdown(),
+        files={"scripts/run.py": "print('v1')\n"},
+        source_revision=1,
+    )
+    markdown_v2 = _skill_markdown(version="v2")
+    files_v2 = {"scripts/run.py": "print('v2')\n"}
+
+    def interrupt_after_swap(_skills: dict[str, dict[str, object]]) -> None:
+        raise KeyboardInterrupt("simulated process interruption")
+
+    monkeypatch.setattr(manager, "_write_metadata", interrupt_after_swap)
+    with pytest.raises(KeyboardInterrupt, match="simulated process interruption"):
+        manager.install_workspace_draft(
+            draft_id="skilldraft_recovery",
+            slug="safe-helper",
+            skill_markdown=markdown_v2,
+            files=files_v2,
+            source_revision=2,
+        )
+
+    assert list((tmp_path / "installed").glob("*.receipt.json"))
+    assert list((tmp_path / "installed").glob(".*.backup-*"))
+
+    recovered_manager = _manager(tmp_path)
+    recovered = recovered_manager.install_workspace_draft(
+        draft_id="skilldraft_recovery",
+        slug="safe-helper",
+        skill_markdown=markdown_v2,
+        files=files_v2,
+        source_revision=2,
+    )
+
+    assert recovered.skill_id == original.skill_id
+    assert recovered.source_revision == 2
+    assert recovered.content_digest == compute_package_digest(markdown_v2, files_v2)
+    assert recovered_manager.get_skill_content(recovered.skill_id) == markdown_v2
+    assert recovered_manager.install_workspace_draft(
+        draft_id="skilldraft_recovery",
+        slug="safe-helper",
+        skill_markdown=markdown_v2,
+        files=files_v2,
+        source_revision=2,
+    ) == recovered
+    assert not list((tmp_path / "installed").glob("*.receipt.json"))
+    assert not list((tmp_path / "installed").glob(".*.backup-*"))
+
+
+def test_legacy_installed_metadata_and_root_layout_remain_readable(
+    tmp_path: Path,
+) -> None:
+    installed_dir = tmp_path / "installed"
+    skill_id = "workspace-safe-helper-legacy"
+    package_dir = installed_dir / skill_id
+    package_dir.mkdir(parents=True)
+    markdown = _skill_markdown()
+    (package_dir / "SKILL.md").write_text(markdown, encoding="utf-8")
+    (installed_dir / "installed.json").write_text(
+        json.dumps(
+            {
+                "skills": {
+                    skill_id: {
+                        "skill_id": skill_id,
+                        "name": "safe-helper",
+                        "description": "A reviewed workspace helper.",
+                        "repo_url": "workspace://draft/skilldraft_legacy",
+                        "sub_path": "",
+                        "installed_at": 1.0,
+                        "source_ref": None,
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    manager = _manager(tmp_path)
+    restored = manager.list_installed_skills()[0]
+
+    assert restored.skill_id == skill_id
+    assert restored.source_kind == "workspace_draft"
+    assert restored.source_id == "skilldraft_legacy"
+    assert restored.source_revision is None
+    assert restored.content_digest == ""
+    assert restored.package_subpath == ""
+    assert manager.get_skill_directory(skill_id) == package_dir
+    assert manager.get_skill_content(skill_id) == markdown

--- a/server/tests/test_xpert_runtime_authoring.py
+++ b/server/tests/test_xpert_runtime_authoring.py
@@ -21,6 +21,7 @@ from server.xpert_runtime.authoring_service import AuthoringService
 from server.xpert_runtime.authoring_store import (
     AuthoringProposalConflictError,
     AuthoringProposalStore,
+    AuthoringProposalValidationError,
 )
 from server.xpert_runtime.authoring_toolset import (
     AuthoringToolsetProvider,
@@ -40,11 +41,11 @@ def _service(tmp_path: Path) -> AuthoringService:
 
 def _skill_payload() -> dict:
     return {
-        "name": "Report Builder",
+        "name": "report-builder",
         "slug": "report-builder",
         "description": "Build a reviewed local report.",
         "skill_markdown": (
-            "---\nname: Report Builder\n"
+            "---\nname: report-builder\n"
             "description: Build a reviewed local report.\n---\n\n"
             "Use the staged script to create the report.\n"
         ),
@@ -81,6 +82,97 @@ def test_proposals_persist_and_reject_stale_revisions(tmp_path: Path) -> None:
     assert "Helper" not in json.dumps(
         AuthoringProposalStore.serialize(restored), ensure_ascii=False
     )
+
+
+def test_skill_proposal_blocks_credentials_before_persistence(tmp_path: Path) -> None:
+    store = AuthoringProposalStore(tmp_path)
+    secret = "sk-abcdefghijklmnopqrstuvwxyz1234567890"
+
+    with pytest.raises(
+        AuthoringProposalValidationError, match="credential"
+    ) as caught:
+        store.create(
+            kind="skill_create",
+            title="Unsafe Skill proposal",
+            payload={
+                "name": "Unsafe Skill",
+                "slug": "unsafe-skill",
+                "description": "Use when a private task needs unsafe handling.",
+                "skill_markdown": (
+                    "---\n"
+                    "name: unsafe-skill\n"
+                    "description: Use when a private task needs unsafe handling.\n"
+                    "---\n\n# Unsafe\n"
+                ),
+                "files": {"references/config.md": f"api_key = {secret}\n"},
+            },
+            source_type="conversation",
+            source_id="conversation-secret",
+        )
+
+    assert caught.value.code == "skill_credentials_blocked"
+    assert {
+        issue["code"] for issue in caught.value.issues
+    } >= {"credential_token"}
+    snapshot = tmp_path / "authoring_proposals.json"
+    assert not snapshot.exists() or secret not in snapshot.read_text(encoding="utf-8")
+
+
+def test_legacy_skill_proposal_credentials_are_removed_during_load(
+    tmp_path: Path,
+) -> None:
+    secret = "sk-abcdefghijklmnopqrstuvwxyz1234567890"
+    unsafe = {
+        "proposal_id": "proposal_unsafe",
+        "kind": "skill_create",
+        "title": "Legacy unsafe proposal",
+        "payload": {
+            "skill": {
+                "files": {"references/config.md": f"api_key = {secret}\n"}
+            }
+        },
+        "source_type": "conversation",
+        "source_id": "legacy-run",
+    }
+    # This safe record is intentionally not a valid V2 package: migration only
+    # removes historical credential material and must not delete other drafts.
+    safe_legacy = {
+        "proposal_id": "proposal_safe_legacy",
+        "kind": "skill_create",
+        "title": "Legacy safe proposal",
+        "payload": {"skill": {"skill_markdown": "legacy partial draft"}},
+        "source_type": "conversation",
+        "source_id": "legacy-run",
+    }
+    snapshot = tmp_path / "authoring_proposals.json"
+    snapshot.write_text(
+        json.dumps({"version": 1, "items": [unsafe, safe_legacy]}),
+        encoding="utf-8",
+    )
+
+    store = AuthoringProposalStore(tmp_path)
+
+    assert [item.proposal_id for item in store.list()] == ["proposal_safe_legacy"]
+    api_payload = json.dumps(
+        [
+            AuthoringProposalStore.serialize(item, include_payload=True)
+            for item in store.list()
+        ],
+        ensure_ascii=False,
+    )
+    assert secret not in api_payload
+    migrated = snapshot.read_text(encoding="utf-8")
+    assert secret not in migrated
+    payload = json.loads(migrated)
+    assert payload["version"] == 2
+    assert len(payload["quarantine"]) == 1
+    assert set(payload["quarantine"][0]) == {
+        "index",
+        "reason_code",
+        "record_sha256",
+        "record_size_bytes",
+        "quarantined_at",
+    }
 
 
 def test_approval_creates_xpert_draft_without_publishing(tmp_path: Path) -> None:
@@ -172,6 +264,61 @@ def test_skill_approval_only_creates_workspace_draft(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_skill_authoring_tools_publish_a_typed_package_contract(
+    tmp_path: Path,
+) -> None:
+    service = _service(tmp_path)
+    tools = await AuthoringToolsetProvider(service, "skill").list_tools()
+    schemas = {tool.name: tool.input_schema for tool in tools}
+
+    create_package = schemas["skill_authoring_propose_create"]["properties"]["skill"]
+    update_package = schemas["skill_authoring_propose_update"]["properties"]["skill"]
+
+    assert create_package["additionalProperties"] is False
+    assert create_package["required"] == [
+        "name",
+        "slug",
+        "description",
+        "skill_markdown",
+    ]
+    assert create_package["properties"]["slug"]["pattern"].startswith("^")
+    assert create_package["properties"]["files"]["maxProperties"] == 39
+    assert "required" not in update_package
+    assert update_package["additionalProperties"] is False
+    create_tool = next(
+        tool for tool in tools if tool.name == "skill_authoring_propose_create"
+    )
+    assert create_tool.read_only is False
+    assert create_tool.parallel_safe is False
+
+
+@pytest.mark.asyncio
+async def test_skill_authoring_tool_preserves_structured_validation_code(
+    tmp_path: Path,
+) -> None:
+    service = _service(tmp_path)
+    provider = AuthoringToolsetProvider(service, "skill")
+    skill = _skill_payload()
+    skill["description"] = "This does not match the validated package."
+
+    with pytest.raises(RuntimeToolError) as caught:
+        await provider.call_tool(
+            RuntimeToolCall(
+                "skill_authoring_propose_create",
+                {"title": "Create mismatched package", "skill": skill},
+                {
+                    "runtime_run_type": "workflow",
+                    "run_id": "run-structured-error",
+                    "skill_creator_config": {"allow_create": True},
+                },
+            )
+        )
+
+    assert caught.value.code == "skill_package_invalid"
+    assert service.proposal_store.list() == []
+
+
+@pytest.mark.asyncio
 async def test_authoring_tools_are_scoped_and_proposal_only(tmp_path: Path) -> None:
     service = _service(tmp_path)
     target = service.xpert_store.create_xpert(name="Target", slug="target")
@@ -229,10 +376,10 @@ async def test_authoring_catalog_returns_summaries_without_draft_content(
     service = _service(tmp_path)
     xpert = service.xpert_store.create_xpert(name="Catalog Xpert")
     skill = service.skill_draft_store.create(
-        name="Catalog Skill",
+        name="catalog-skill",
         slug="catalog-skill",
         description="Safe summary",
-        skill_markdown="---\nname: Catalog Skill\ndescription: Safe summary\n---\n\n# Secret instructions",
+        skill_markdown="---\nname: catalog-skill\ndescription: Safe summary\n---\n\n# Secret instructions",
         files={"references/private.md": "private reference"},
     )
     metadata = {

--- a/server/xpert_runtime/authoring_api.py
+++ b/server/xpert_runtime/authoring_api.py
@@ -47,7 +47,16 @@ def _api_error(exc: Exception) -> HTTPException:
         return HTTPException(status_code=404, detail=str(exc))
     if isinstance(exc, AuthoringProposalConflictError):
         return HTTPException(status_code=409, detail=str(exc))
-    if isinstance(exc, (AuthoringProposalValidationError, ValueError, TypeError)):
+    if isinstance(exc, AuthoringProposalValidationError):
+        return HTTPException(
+            status_code=400,
+            detail={
+                "code": getattr(exc, "code", "authoring_validation"),
+                "message": str(exc),
+                "issues": list(getattr(exc, "issues", []) or [])[:20],
+            },
+        )
+    if isinstance(exc, (ValueError, TypeError)):
         return HTTPException(status_code=400, detail=str(exc))
     return HTTPException(status_code=500, detail=str(exc))
 

--- a/server/xpert_runtime/authoring_service.py
+++ b/server/xpert_runtime/authoring_service.py
@@ -7,13 +7,16 @@ from typing import Any
 
 try:
     from server.prompts.store import PromptProfileStore
-    from server.skills.draft_store import WorkspaceSkillDraftStore
+    from server.skills.draft_store import (
+        SkillDraftValidationError,
+        WorkspaceSkillDraftStore,
+    )
     from server.xperts.models import XpertDefinition, XpertDraft
     from server.xperts.store import XpertStore, default_xpert_workflow
     from server.xperts.validation import validate_xpert_definition
 except ModuleNotFoundError:
     from prompts.store import PromptProfileStore
-    from skills.draft_store import WorkspaceSkillDraftStore
+    from skills.draft_store import SkillDraftValidationError, WorkspaceSkillDraftStore
     from xperts.models import XpertDefinition, XpertDraft
     from xperts.store import XpertStore, default_xpert_workflow
     from xperts.validation import validate_xpert_definition
@@ -66,10 +69,32 @@ class AuthoringService:
         try:
             details = self._validate_payload(proposal)
             validation = {"valid": True, "issues": [], **details}
+        except SkillDraftValidationError as exc:
+            validation = self._skill_validation_result(exc)
+        except AuthoringProposalValidationError as exc:
+            issues = list(getattr(exc, "issues", []) or [])
+            if not issues:
+                issues = [
+                    {
+                        "code": getattr(exc, "code", "authoring_validation"),
+                        "severity": "error",
+                        "message": str(exc)[:500],
+                    }
+                ]
+            validation = {
+                "valid": False,
+                "issues": issues[:20],
+            }
         except Exception as exc:
             validation = {
                 "valid": False,
-                "issues": [{"code": "authoring_validation", "message": str(exc)[:500]}],
+                "issues": [
+                    {
+                        "code": "authoring_validation",
+                        "severity": "error",
+                        "message": str(exc)[:500],
+                    }
+                ],
             }
         return self.proposal_store.set_validation(
             proposal_id, revision=revision, validation=validation
@@ -94,6 +119,18 @@ class AuthoringService:
                     operator=operator,
                     error=str(exc),
                 )
+            except SkillDraftValidationError as exc:
+                validation = self._skill_validation_result(exc)
+                self.proposal_store.set_validation(
+                    proposal_id,
+                    revision=revision,
+                    validation=validation,
+                )
+                raise AuthoringProposalValidationError(
+                    str(exc),
+                    code="skill_package_invalid",
+                    issues=list(validation.get("issues") or []),
+                ) from exc
             validation = {"valid": True, "issues": [], **details}
             proposal = self.proposal_store.set_validation(
                 proposal_id, revision=revision, validation=validation
@@ -265,6 +302,27 @@ class AuthoringService:
             "total_bytes": WorkspaceSkillDraftStore._total_bytes(
                 normalized["skill_markdown"], normalized["files"]
             ),
+            "validator_version": WorkspaceSkillDraftStore.VALIDATOR_VERSION,
+            "content_digest": WorkspaceSkillDraftStore.compute_content_digest(
+                **normalized
+            ),
+        }
+
+    @staticmethod
+    def _skill_validation_result(exc: SkillDraftValidationError) -> dict[str, Any]:
+        issues = getattr(exc, "issues", None)
+        if not isinstance(issues, list) or not issues:
+            issues = [
+                {
+                    "code": "skill_package_validation",
+                    "severity": "error",
+                    "message": str(exc)[:500],
+                }
+            ]
+        return {
+            "valid": False,
+            "validator_version": WorkspaceSkillDraftStore.VALIDATOR_VERSION,
+            "issues": issues[:20],
         }
 
     def _validate_xpert_candidate(self, candidate: XpertDefinition) -> Any:
@@ -329,9 +387,14 @@ class AuthoringService:
         else:
             target_id = proposal.target_id or str(skill.get("draft_id") or "")
             target = self.skill_draft_store.require(target_id)
+            if proposal.base_revision != target.revision:
+                raise AuthoringProposalConflictError(
+                    "Target Skill draft changed after this proposal was created."
+                )
             item = self.skill_draft_store.update(
                 target_id,
-                revision=target.revision,
+                expected_revision=int(proposal.base_revision or 0),
+                expected_digest=target.content_digest,
                 name=skill.get("name"),
                 slug=skill.get("slug"),
                 description=skill.get("description"),

--- a/server/xpert_runtime/authoring_store.py
+++ b/server/xpert_runtime/authoring_store.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import threading
@@ -8,6 +9,17 @@ import uuid
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Literal
+
+try:
+    from server.skills.package_validation import (
+        scan_skill_package_credentials,
+        validate_skill_package,
+    )
+except ModuleNotFoundError:
+    from skills.package_validation import (
+        scan_skill_package_credentials,
+        validate_skill_package,
+    )
 
 
 ProposalKind = Literal[
@@ -39,7 +51,16 @@ class AuthoringProposalConflictError(AuthoringProposalError):
 
 
 class AuthoringProposalValidationError(AuthoringProposalError):
-    pass
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str = "authoring_validation",
+        issues: list[dict[str, Any]] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.issues = list(issues or [])
 
 
 @dataclass(slots=True)
@@ -81,6 +102,7 @@ class AuthoringProposalStore:
         self.snapshot_path = self.storage_dir / "authoring_proposals.json"
         self._lock = threading.RLock()
         self._items: dict[str, AuthoringProposal] = {}
+        self._quarantine: list[dict[str, Any]] = []
         self._load()
 
     def create(
@@ -111,11 +133,21 @@ class AuthoringProposalStore:
             raise AuthoringProposalValidationError(
                 "Proposal title is required and limited to 200 characters."
             )
+        if kind in {"skill_create", "skill_update"}:
+            title_issues = scan_skill_package_credentials(
+                skill_markdown=clean_title
+            )
+            if title_issues:
+                raise AuthoringProposalValidationError(
+                    "Skill proposal title contains blocked credential material.",
+                    code="skill_credentials_blocked",
+                    issues=[issue.to_dict() for issue in title_issues],
+                )
         if not clean_source_type or not clean_source_id:
             raise AuthoringProposalValidationError(
                 "Proposal source_type and source_id are required."
             )
-        clean_payload = self._validate_payload(payload)
+        clean_payload = self._validate_payload(payload, kind=kind)
         with self._lock:
             if source_run_id:
                 run_count = sum(
@@ -211,9 +243,19 @@ class AuthoringProposalStore:
                 clean_title = str(title).strip()
                 if not clean_title or len(clean_title) > 200:
                     raise AuthoringProposalValidationError("Invalid proposal title.")
+                if item.kind in {"skill_create", "skill_update"}:
+                    title_issues = scan_skill_package_credentials(
+                        skill_markdown=clean_title
+                    )
+                    if title_issues:
+                        raise AuthoringProposalValidationError(
+                            "Skill proposal title contains blocked credential material.",
+                            code="skill_credentials_blocked",
+                            issues=[issue.to_dict() for issue in title_issues],
+                        )
                 item.title = clean_title
             if payload is not None:
-                next_payload = self._validate_payload(payload)
+                next_payload = self._validate_payload(payload, kind=item.kind)
                 payload_changed = next_payload != item.payload
                 if item.source_type == "meta_planner" and payload_changed:
                     report = next_payload.get("meta_planner_report")
@@ -304,7 +346,12 @@ class AuthoringProposalStore:
                 "Proposal changed. Reload it before applying this operation."
             )
 
-    def _validate_payload(self, payload: dict[str, Any]) -> dict[str, Any]:
+    def _validate_payload(
+        self,
+        payload: dict[str, Any],
+        *,
+        kind: ProposalKind | None = None,
+    ) -> dict[str, Any]:
         if not isinstance(payload, dict):
             raise AuthoringProposalValidationError("Proposal payload must be an object.")
         try:
@@ -316,7 +363,88 @@ class AuthoringProposalStore:
             ) from exc
         if len(encoded.encode("utf-8")) > self.MAX_PAYLOAD_BYTES:
             raise AuthoringProposalValidationError("Proposal payload is too large.")
+        if kind in {"skill_create", "skill_update"}:
+            self._validate_skill_payload_before_persist(kind, decoded)
         return decoded
+
+    @staticmethod
+    def _validate_skill_payload_before_persist(
+        kind: ProposalKind,
+        payload: dict[str, Any],
+    ) -> None:
+        skill = payload.get("skill") if isinstance(payload.get("skill"), dict) else payload
+        markdown = skill.get("skill_markdown") or skill.get("SKILL.md")
+        files = skill.get("files")
+        payload_text = "\n".join(AuthoringProposalStore._iter_text(payload))
+        credential_issues = scan_skill_package_credentials(
+            skill_markdown=payload_text,
+            files=files,
+        )
+        if credential_issues:
+            codes = ", ".join(sorted({issue.code for issue in credential_issues}))
+            raise AuthoringProposalValidationError(
+                f"Skill proposal contains blocked credential material ({codes}).",
+                code="skill_credentials_blocked",
+                issues=[issue.to_dict() for issue in credential_issues],
+            )
+
+        if kind != "skill_create":
+            return
+        result = validate_skill_package(
+            root_name=skill.get("slug"),
+            skill_markdown=markdown,
+            files=files or {},
+        )
+        if result.valid and result.package is not None:
+            mismatches: list[dict[str, Any]] = []
+            if skill.get("name") != result.package.name:
+                mismatches.append(
+                    {
+                        "code": "skill_package_name_mismatch",
+                        "severity": "error",
+                        "field": "name",
+                        "message": "Package name must match SKILL.md frontmatter name.",
+                    }
+                )
+            if skill.get("description") != result.package.description:
+                mismatches.append(
+                    {
+                        "code": "skill_package_description_mismatch",
+                        "severity": "error",
+                        "field": "description",
+                        "message": "Package description must match SKILL.md frontmatter description.",
+                    }
+                )
+            if not mismatches:
+                return
+            raise AuthoringProposalValidationError(
+                "Skill proposal metadata does not match SKILL.md.",
+                code="skill_package_invalid",
+                issues=mismatches,
+            )
+        details = "; ".join(
+            f"{issue.code}: {issue.message}" for issue in result.issues[:8]
+        )
+        raise AuthoringProposalValidationError(
+            details or "Skill proposal package validation failed.",
+            code="skill_package_invalid",
+            issues=[issue.to_dict() for issue in result.issues],
+        )
+
+    @staticmethod
+    def _iter_text(value: Any):
+        if isinstance(value, str):
+            yield value
+            return
+        if isinstance(value, dict):
+            for key, item in value.items():
+                if isinstance(key, str):
+                    yield key
+                yield from AuthoringProposalStore._iter_text(item)
+            return
+        if isinstance(value, list):
+            for item in value:
+                yield from AuthoringProposalStore._iter_text(item)
 
     def _load(self) -> None:
         with self._lock:
@@ -325,26 +453,118 @@ class AuthoringProposalStore:
             try:
                 raw = json.loads(self.snapshot_path.read_text(encoding="utf-8"))
                 items = raw.get("items", []) if isinstance(raw, dict) else []
-                self._items = {
-                    item["proposal_id"]: AuthoringProposal(**item)
-                    for item in items
-                    if isinstance(item, dict) and item.get("proposal_id")
-                }
+                if not isinstance(items, list):
+                    raise ValueError("Authoring proposal items must be a list.")
             except (OSError, TypeError, ValueError, json.JSONDecodeError):
                 self._items = {}
+                return
+
+            sanitized = False
+            for index, record in enumerate(items):
+                if not isinstance(record, dict) or not record.get("proposal_id"):
+                    self._quarantine.append(
+                        self._safe_quarantine_record(record, index=index)
+                    )
+                    sanitized = True
+                    continue
+                try:
+                    item = AuthoringProposal(**record)
+                except (TypeError, ValueError):
+                    self._quarantine.append(
+                        self._safe_quarantine_record(record, index=index)
+                    )
+                    sanitized = True
+                    continue
+                if item.kind in {"skill_create", "skill_update"}:
+                    searchable_text = "\n".join(self._iter_text(record))
+                    issues = scan_skill_package_credentials(
+                        skill_markdown=searchable_text,
+                        files=(
+                            item.payload.get("skill", {}).get("files")
+                            if isinstance(item.payload.get("skill"), dict)
+                            else item.payload.get("files")
+                        ),
+                    )
+                    if issues:
+                        self._quarantine.append(
+                            self._safe_quarantine_record(record, index=index)
+                        )
+                        sanitized = True
+                        continue
+                if item.proposal_id in self._items:
+                    self._quarantine.append(
+                        self._safe_quarantine_record(record, index=index)
+                    )
+                    sanitized = True
+                    continue
+                self._items[item.proposal_id] = item
+
+            existing_quarantine = raw.get("quarantine", []) if isinstance(raw, dict) else []
+            if isinstance(existing_quarantine, list):
+                for index, entry in enumerate(existing_quarantine):
+                    if not isinstance(entry, dict):
+                        sanitized = True
+                        continue
+                    digest = str(entry.get("record_sha256") or "").lower()
+                    size = entry.get("record_size_bytes")
+                    if (
+                        len(digest) == 64
+                        and all(character in "0123456789abcdef" for character in digest)
+                        and isinstance(size, int)
+                        and size >= 0
+                    ):
+                        self._quarantine.append(
+                            {
+                                "index": index,
+                                "reason_code": "blocked_or_invalid_proposal",
+                                "record_sha256": digest,
+                                "record_size_bytes": size,
+                                "quarantined_at": time.time(),
+                            }
+                        )
+                    else:
+                        sanitized = True
+            if sanitized:
+                self._save_unlocked()
+
+    @staticmethod
+    def _safe_quarantine_record(record: Any, *, index: int) -> dict[str, Any]:
+        try:
+            encoded = json.dumps(
+                record,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        except (TypeError, UnicodeEncodeError):
+            encoded = type(record).__name__.encode("ascii", errors="replace")
+        return {
+            "index": max(0, int(index)),
+            "reason_code": "blocked_or_invalid_proposal",
+            "record_sha256": hashlib.sha256(encoded).hexdigest(),
+            "record_size_bytes": len(encoded),
+            "quarantined_at": time.time(),
+        }
 
     def _save_unlocked(self) -> None:
         self.storage_dir.mkdir(parents=True, exist_ok=True)
-        temp_path = self.snapshot_path.with_suffix(".tmp")
-        temp_path.write_text(
-            json.dumps(
-                {"version": 1, "items": [asdict(item) for item in self._items.values()]},
-                ensure_ascii=False,
-                indent=2,
-            ),
-            encoding="utf-8",
+        temp_path = self.snapshot_path.with_name(
+            f"{self.snapshot_path.name}.{uuid.uuid4().hex}.tmp"
         )
-        os.replace(temp_path, self.snapshot_path)
+        payload = {
+            "version": 2,
+            "items": [asdict(item) for item in self._items.values()],
+            "quarantine": self._quarantine,
+        }
+        try:
+            encoded = json.dumps(payload, ensure_ascii=False, indent=2).encode("utf-8")
+            with temp_path.open("xb") as handle:
+                handle.write(encoded)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temp_path, self.snapshot_path)
+        finally:
+            temp_path.unlink(missing_ok=True)
 
     @staticmethod
     def _copy(item: AuthoringProposal) -> AuthoringProposal:

--- a/server/xpert_runtime/authoring_toolset.py
+++ b/server/xpert_runtime/authoring_toolset.py
@@ -5,7 +5,10 @@ import re
 from typing import Any, Literal
 
 from .authoring_service import AuthoringService
-from .authoring_store import AuthoringProposalStore
+from .authoring_store import (
+    AuthoringProposalStore,
+    AuthoringProposalValidationError,
+)
 from .capabilities import CapabilityRegistry
 from .toolset import RuntimeTool, RuntimeToolCall, RuntimeToolError, RuntimeToolResult
 
@@ -103,11 +106,13 @@ class AuthoringToolsetProvider:
                     "required": ["title", "skill"],
                     "properties": {
                         "title": {"type": "string", "maxLength": 200},
-                        "skill": {"type": "object"},
+                        "skill": self._skill_package_schema(require_complete=True),
                     },
                     "additionalProperties": False,
                 },
                 "authoring",
+                read_only=False,
+                parallel_safe=False,
             ),
             RuntimeTool(
                 "skill_authoring_propose_update",
@@ -119,17 +124,21 @@ class AuthoringToolsetProvider:
                         "title": {"type": "string", "maxLength": 200},
                         "draft_id": {"type": "string"},
                         "base_revision": {"type": "integer", "minimum": 1},
-                        "skill": {"type": "object"},
+                        "skill": self._skill_package_schema(require_complete=False),
                     },
                     "additionalProperties": False,
                 },
                 "authoring",
+                read_only=False,
+                parallel_safe=False,
             ),
             RuntimeTool(
                 "skill_authoring_validate_proposal",
                 "Validate a pending Skill proposal without applying it.",
                 self._proposal_schema(),
                 "authoring",
+                read_only=False,
+                parallel_safe=False,
             ),
         ]
 
@@ -202,6 +211,12 @@ class AuthoringToolsetProvider:
                 payload = AuthoringProposalStore.serialize(proposal)
         except RuntimeToolError:
             raise
+        except AuthoringProposalValidationError as exc:
+            raise RuntimeToolError(
+                call.tool_name,
+                str(exc)[:500],
+                code=getattr(exc, "code", "authoring_validation"),
+            ) from exc
         except Exception as exc:
             raise RuntimeToolError(
                 call.tool_name, str(exc)[:500], code="authoring_error"
@@ -325,6 +340,55 @@ class AuthoringToolsetProvider:
             },
             "additionalProperties": False,
         }
+
+    @staticmethod
+    def _skill_package_schema(*, require_complete: bool) -> dict[str, Any]:
+        """Return the explicit Workspace Skill package contract exposed to models."""
+
+        schema: dict[str, Any] = {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 64,
+                    "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+                },
+                "slug": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 64,
+                    "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+                },
+                "description": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 1024,
+                },
+                "skill_markdown": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 1_048_576,
+                },
+                "files": {
+                    "type": "object",
+                    "maxProperties": 39,
+                    "additionalProperties": {
+                        "type": "string",
+                        "maxLength": 1_048_576,
+                    },
+                },
+            },
+            "additionalProperties": False,
+        }
+        if require_complete:
+            schema["required"] = [
+                "name",
+                "slug",
+                "description",
+                "skill_markdown",
+            ]
+        return schema
 
 
 def register_authoring_toolset_capabilities(


### PR DESCRIPTION
## 本轮目标

建立 Claude 对齐 Skill Creator V1 的第一阶段基础能力：统一 Skill 包合同、不可变草稿版本，以及可安全重试和回滚的 Workspace Skill 安装升级。

本 PR 保留现有 `proposal → draft → 显式安装` 安全边界，不提前启用独立 Creator 工作台、自动评测或创建入口。

## 主要变更

### 1. Skill Package V2 与统一验证

- 新增严格的 `SkillPackageV2` 合同和统一验证器。
- 校验 frontmatter、kebab-case 名称、说明、路径、大小写冲突、缺失引用、UTF-8 文本、脚本语法和文件限额。
- proposal/draft 写盘前执行凭据扫描，阻断内容不进入有效快照或 API 回显。
- 基于排序路径和原始字节生成稳定 SHA-256 `content_digest`。

### 2. 不可变草稿版本

- 新增不可变 `SkillDraftRevision`。
- 草稿写入使用 `expected_revision + expected_digest` 乐观并发控制。
- 验证结果绑定验证器版本、revision 和 digest。
- V1 数据逐项迁移；损坏记录单独隔离，避免单条异常清空整个 Store。
- 编辑已安装草稿时标记为 outdated，不丢失既有安装身份。

### 3. 原子安装、升级与回滚

- Workspace Skill 使用稳定 `skill_id` 和规范目录布局。
- 同 digest 安装幂等；新 digest 明确执行升级。
- 升级采用 staging、backup、replace 和 metadata 事务，并通过安装回执支持中断恢复。
- 任一步骤失败时恢复旧目录和旧元数据。
- 安装元数据保存来源 revision 与内容 digest；本地 Skill 不伪造 Git SHA。

### 4. 页面与审计信息

- 工作区草稿界面显示 revision、digest、当前/过期安装状态和安全提示。
- 增加草稿离线审计脚本及完整回归覆盖。

## 验证

- Skill Creator、Workspace Draft、安装升级及 Agent Workspace/Workflow 定向回归：172 项通过。
- 前端 Vitest：7 个文件、24 项测试通过。
- 前端类型检查与生产构建通过。
- Matrix Oasis 独立模块验证：83/83 通过。
- 共享栈 server/client 定向重建后：
  - 关键 API 与 Skill、Agent、经典/原生工作流入口正常。
  - 16 个内置 Skill 与 SkillSet 成员摘要一致。
  - `agent-creation` 无 digest mismatch。
  - 桌面和窄屏页面无控制台错误或横向溢出。

后端全量测试为 1331 通过、1 项既有失败：旧 server 测试镜像的 Node/TS loader 无法加载 matcher TypeScript 金标模块，与本 PR 无关。

## 范围边界

- 本 PR 仅包含 Skill Creator Foundation 的 17 个相关路径。
- 不包含共享验收工作树中定向叠加的 #105、#106、#107 或 #108 内容。
- 不包含 Creator Session/工作台、运行沉淀、baseline 对照评测、上传、SkillHub、外部市场或公共发布能力。
- `SKILL_CREATOR_V2_ENABLED` 仍保持关闭，待串行 PR 完成闭环后再启用。
