### PR TITLE
feature: 完成 MCP 第六批有状态 SaaS 适配

### DIFF
--- a/client/src/components/McpApprovalDialog.tsx
+++ b/client/src/components/McpApprovalDialog.tsx
@@ -1,0 +1,256 @@
+import { useEffect, useId, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+export interface McpApprovalTargetPreview {
+  action_label: string;
+  resource: {
+    type: string;
+    label: string;
+    id_suffix: string;
+  };
+  changes: Array<{
+    field: string;
+    summary: string;
+  }>;
+  content: {
+    bytes: number;
+    sha256_prefix: string;
+  } | null;
+  impact: string;
+  destructive: boolean;
+}
+
+export interface McpCatalogApprovalRequest {
+  code: "approval_required";
+  message: string;
+  approval_id: string;
+  summary?: string;
+  argument_digest: string;
+  expires_at: number | string;
+  idempotency_key?: string;
+  target_preview?: McpApprovalTargetPreview;
+}
+
+interface McpApprovalDialogProps {
+  approval: McpCatalogApprovalRequest;
+  busy: boolean;
+  onCancel: () => void | Promise<void>;
+  onConfirm: () => void | Promise<void>;
+}
+
+function expiryMilliseconds(value: number | string) {
+  if (typeof value === "number") return value > 10_000_000_000 ? value : value * 1000;
+  const numeric = Number(value);
+  if (Number.isFinite(numeric)) return numeric > 10_000_000_000 ? numeric : numeric * 1000;
+  return Date.parse(value);
+}
+
+function formatBytes(bytes: number) {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KiB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)} MiB`;
+}
+
+function shorten(value: string) {
+  if (value.length <= 18) return value;
+  return `${value.slice(0, 10)}…${value.slice(-6)}`;
+}
+
+export default function McpApprovalDialog({
+  approval,
+  busy,
+  onCancel,
+  onConfirm,
+}: McpApprovalDialogProps) {
+  const titleId = useId();
+  const descriptionId = useId();
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  const cancelButtonRef = useRef<HTMLButtonElement | null>(null);
+  const cancelHandlerRef = useRef(onCancel);
+  const busyRef = useRef(busy);
+  const expiresAt = useMemo(
+    () => expiryMilliseconds(approval.expires_at),
+    [approval.expires_at],
+  );
+  const [now, setNow] = useState(() => Date.now());
+  const secondsLeft = Number.isFinite(expiresAt)
+    ? Math.max(0, Math.ceil((expiresAt - now) / 1000))
+    : 0;
+  const expired = secondsLeft <= 0;
+  const preview = approval.target_preview;
+  const confirmationBlocked = expired || preview?.destructive === true;
+
+  useEffect(() => {
+    cancelHandlerRef.current = onCancel;
+  }, [onCancel]);
+
+  useEffect(() => {
+    busyRef.current = busy;
+  }, [busy]);
+
+  useEffect(() => {
+    const timer = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(timer);
+  }, [approval.approval_id]);
+
+  useEffect(() => {
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    const root = document.getElementById("root");
+    const previousRootInert = root?.inert ?? false;
+    const previousOverflow = document.body.style.overflow;
+    if (root) root.inert = true;
+    document.body.style.overflow = "hidden";
+    const focusTimer = window.setTimeout(() => cancelButtonRef.current?.focus(), 0);
+
+    function handleKeyDown(event: KeyboardEvent) {
+      const dialog = dialogRef.current;
+      if (!dialog) return;
+      if (event.key === "Escape" && !busyRef.current) {
+        event.preventDefault();
+        void cancelHandlerRef.current();
+        return;
+      }
+      if (event.key !== "Tab") return;
+      const focusable = Array.from(
+        dialog.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+        ),
+      );
+      if (!focusable.length) {
+        event.preventDefault();
+        dialog.focus();
+        return;
+      }
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.clearTimeout(focusTimer);
+      document.removeEventListener("keydown", handleKeyDown);
+      if (root) root.inert = previousRootInert;
+      document.body.style.overflow = previousOverflow;
+      previouslyFocused?.focus();
+    };
+  }, [approval.approval_id]);
+
+  return createPortal(
+    <div
+      aria-describedby={descriptionId}
+      aria-labelledby={titleId}
+      aria-modal="true"
+      className="fixed inset-0 z-[100] flex items-end justify-center bg-slate-950/85 p-3 backdrop-blur-sm sm:items-center sm:p-6"
+      role="dialog"
+    >
+      <div
+        className="surface-card max-h-[92dvh] w-full max-w-xl overflow-y-auto rounded-lg border border-amber-300/25 p-5 sm:p-6"
+        ref={dialogRef}
+        tabIndex={-1}
+      >
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p className="text-sm font-semibold text-amber-100">一次性写入审批</p>
+            <h2 className="mt-2 text-xl font-semibold text-white" id={titleId}>
+              {preview?.action_label ?? "确认本次受控操作"}
+            </h2>
+          </div>
+          <span className="rounded-full border border-amber-300/25 bg-amber-300/10 px-2.5 py-1 text-xs font-semibold text-amber-100">
+            {expired ? "审批已过期" : `${secondsLeft} 秒后失效`}
+          </span>
+        </div>
+
+        <div className="mt-4 space-y-3" id={descriptionId}>
+          {preview ? (
+            <>
+              <section className="rounded-lg border border-white/10 bg-white/[0.045] p-4">
+                <p className="text-xs font-semibold text-slate-400">目标资源</p>
+                <p className="mt-2 text-sm font-semibold text-white">{preview.resource.label}</p>
+                <p className="mt-1 text-xs text-slate-400">
+                  {preview.resource.type} · 标识尾号 {preview.resource.id_suffix || "未提供"}
+                </p>
+              </section>
+
+              <section className="rounded-lg border border-white/10 bg-white/[0.045] p-4">
+                <p className="text-xs font-semibold text-slate-400">本次变更摘要</p>
+                {preview.changes.length > 0 ? (
+                  <dl className="mt-2 space-y-2">
+                    {preview.changes.map((change, index) => (
+                      <div className="grid gap-1 sm:grid-cols-[8rem_1fr]" key={`${change.field}-${index}`}>
+                        <dt className="text-xs font-semibold text-slate-300">{change.field}</dt>
+                        <dd className="text-sm leading-5 text-white">{change.summary}</dd>
+                      </div>
+                    ))}
+                  </dl>
+                ) : (
+                  <p className="mt-2 text-sm text-slate-300">服务端已冻结本次参数，未返回正文。</p>
+                )}
+                {preview.content ? (
+                  <p className="mt-3 text-xs text-slate-400">
+                    内容体积 {formatBytes(preview.content.bytes)} · SHA-256 前缀 {preview.content.sha256_prefix}
+                  </p>
+                ) : null}
+              </section>
+
+              <section className="rounded-lg border border-amber-300/20 bg-amber-300/[0.07] p-4">
+                <p className="text-xs font-semibold text-amber-100">影响范围</p>
+                <p className="mt-2 text-sm leading-6 text-slate-200">{preview.impact}</p>
+                <p className={`mt-2 text-xs font-semibold ${preview.destructive ? "text-rose-200" : "text-emerald-200"}`}>
+                  {preview.destructive ? "终止性操作已被前端阻断" : "非终止性写入 · 仅执行一次"}
+                </p>
+              </section>
+            </>
+          ) : (
+            <p className="rounded-lg border border-white/10 bg-white/[0.045] p-4 text-sm leading-6 text-slate-300">
+              {approval.summary ?? approval.message}
+            </p>
+          )}
+        </div>
+
+        <div className="mt-3 rounded-lg bg-black/15 p-3 text-[11px] leading-5 text-slate-500">
+          <p>确认绑定当前项目、会话、工具和冻结参数，只能使用一次；页面不会展示原始参数或正文。</p>
+          {approval.idempotency_key ? (
+            <p className="mt-1 font-mono">幂等键：{shorten(approval.idempotency_key)}</p>
+          ) : null}
+          <p className="mt-1 break-all font-mono">参数摘要：{shorten(approval.argument_digest)}</p>
+        </div>
+
+        <p aria-live="polite" className="mt-3 min-h-5 text-xs text-rose-200" role="status">
+          {expired
+            ? "审批已过期，请取消后重新发起预览。"
+            : preview?.destructive
+              ? "本批不允许终止性操作，无法确认执行。"
+              : ""}
+        </p>
+
+        <div className="mt-4 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+          <button
+            className="min-h-11 rounded-full border border-white/10 px-4 py-2 text-sm font-semibold text-slate-200 transition hover:bg-white/[0.06] disabled:opacity-50"
+            disabled={busy}
+            onClick={() => void onCancel()}
+            ref={cancelButtonRef}
+            type="button"
+          >
+            取消本次操作
+          </button>
+          <button
+            className="min-h-11 rounded-full bg-amber-300 px-4 py-2 text-sm font-semibold text-ink-950 transition hover:bg-amber-200 disabled:cursor-not-allowed disabled:opacity-45"
+            disabled={busy || confirmationBlocked}
+            onClick={() => void onConfirm()}
+            type="button"
+          >
+            {busy ? "正在确认…" : "确认写入一次"}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/client/src/components/McpCredentialPanel.tsx
+++ b/client/src/components/McpCredentialPanel.tsx
@@ -3,6 +3,8 @@ import type {
   McpCredentialField,
   McpCredentialVerification,
   McpDatabasePreflightStatus,
+  McpSaasPolicy,
+  McpSaasAccountStatus,
   McpSettingField,
 } from "../data/mcpAdaptationPlan";
 
@@ -18,7 +20,7 @@ interface CredentialSummary {
 
 interface McpCredentialPanelProps {
   projectId: string;
-  mode?: "service" | "database";
+  mode?: "service" | "database" | "saas";
   credentialFields: McpCredentialField[];
   settingFields: McpSettingField[];
   initialBindings: Record<string, string>;
@@ -27,7 +29,10 @@ interface McpCredentialPanelProps {
   initiallyConfigured: boolean;
   credentialVerification: McpCredentialVerification;
   databasePreflightStatus?: McpDatabasePreflightStatus;
+  saasPolicy?: McpSaasPolicy | null;
+  accountStatus?: McpSaasAccountStatus;
   disabled?: boolean;
+  connectionPending?: boolean;
   onConfigured: (configured: boolean) => void;
   onConfigurationSaved?: (
     settings: Record<string, string | number | boolean>,
@@ -36,10 +41,22 @@ interface McpCredentialPanelProps {
   onSessionInvalidated: () => void;
 }
 
+interface UnbindResponse {
+  ok: true;
+  project_id: string;
+  disconnected: boolean;
+  revoked_credentials: number;
+}
+
 async function responseError(response: Response) {
   try {
-    const payload = (await response.json()) as { detail?: string };
-    return payload.detail ?? response.statusText;
+    const payload = (await response.json()) as {
+      detail?: string | { message?: string };
+      error?: string;
+    };
+    if (typeof payload.detail === "string") return payload.detail;
+    if (payload.detail?.message) return payload.detail.message;
+    return payload.error ?? response.statusText;
   } catch {
     return response.statusText;
   }
@@ -76,6 +93,70 @@ const databasePreflightVerifiedCopy = {
   className: "border-emerald-300/25 bg-emerald-300/[0.08] text-emerald-100",
 };
 
+const saasPreflightCopy: Record<
+  McpDatabasePreflightStatus,
+  { label: string; className: string }
+> = {
+  "not-applicable": {
+    label: "等待账号配置",
+    className: "border-slate-300/20 bg-slate-300/[0.06] text-slate-300",
+  },
+  blocked: {
+    label: "账号连接已阻断",
+    className: "border-rose-300/25 bg-rose-300/[0.08] text-rose-100",
+  },
+  "awaiting-workspace": {
+    label: "等待账号范围",
+    className: "border-amber-300/25 bg-amber-300/[0.08] text-amber-100",
+  },
+  "awaiting-configuration": {
+    label: "等待保存账号与资源范围",
+    className: "border-amber-300/25 bg-amber-300/[0.08] text-amber-100",
+  },
+  unverified: {
+    label: "配置已保存，等待连接预检",
+    className: "border-amber-300/25 bg-amber-300/[0.08] text-amber-100",
+  },
+  verifying: {
+    label: "正在验证账号与资源范围",
+    className: "border-cyan-300/25 bg-cyan-300/[0.08] text-cyan-100",
+  },
+  verified: {
+    label: "账号、权限与资源范围预检通过",
+    className: "border-emerald-300/25 bg-emerald-300/[0.08] text-emerald-100",
+  },
+  failed: {
+    label: "账号预检失败，请检查凭据与资源 ID",
+    className: "border-rose-300/25 bg-rose-300/[0.08] text-rose-100",
+  },
+};
+
+const saasAccountCopy: Record<
+  McpSaasAccountStatus,
+  { label: string; className: string }
+> = {
+  "not-applicable": {
+    label: "账号状态不适用",
+    className: "border-slate-300/20 bg-slate-300/[0.06] text-slate-300",
+  },
+  blocked: {
+    label: "账号绑定已阻断",
+    className: "border-rose-300/25 bg-rose-300/[0.08] text-rose-100",
+  },
+  unbound: {
+    label: "账号尚未绑定",
+    className: "border-slate-300/20 bg-slate-300/[0.06] text-slate-300",
+  },
+  unverified: {
+    label: "账号已配置，尚未验证",
+    className: "border-amber-300/25 bg-amber-300/[0.08] text-amber-100",
+  },
+  verified: {
+    label: "账号绑定已验证",
+    className: "border-emerald-300/25 bg-emerald-300/[0.08] text-emerald-100",
+  },
+};
+
 function visibleSettingOptions(projectId: string, field: McpSettingField) {
   if (projectId !== "dbhub" || field.key !== "engine") return field.options;
   return field.options.filter(
@@ -101,6 +182,14 @@ function dbhubDefaultPort(engine: string) {
   if (normalized === "postgres" || normalized === "postgresql") return "5432";
   if (normalized === "mysql" || normalized === "mariadb") return "3306";
   return "";
+}
+
+function writeRetryModeLabel(mode: string) {
+  const labels: Record<string, string> = {
+    never: "不自动重试",
+    "idempotency-key-only": "仅复用幂等结果，不重新发出写入",
+  };
+  return labels[mode] ?? "服务端受控且不自动重试";
 }
 
 function hasCustomizedDbhubPort(
@@ -129,7 +218,10 @@ export default function McpCredentialPanel({
   initiallyConfigured,
   credentialVerification,
   databasePreflightStatus = "not-applicable",
+  saasPolicy = null,
+  accountStatus = "not-applicable",
   disabled = false,
+  connectionPending = false,
   onConfigured,
   onConfigurationSaved,
   onSessionInvalidated,
@@ -155,6 +247,13 @@ export default function McpCredentialPanel({
   const [creating, setCreating] = useState(false);
   const [pendingRevoke, setPendingRevoke] = useState<CredentialSummary | null>(null);
   const [revoking, setRevoking] = useState(false);
+  const [tenantConfirmed, setTenantConfirmed] = useState(
+    mode !== "saas" || initiallyConfigured,
+  );
+  const [accountBound, setAccountBound] = useState(initiallyConfigured);
+  const [showUnbindConfirmation, setShowUnbindConfirmation] = useState(false);
+  const [revokeOnUnbind, setRevokeOnUnbind] = useState(false);
+  const [unbinding, setUnbinding] = useState(false);
   const [message, setMessage] = useState(
     initiallyConfigured ? "配置已保存，可建立受控连接。" : "",
   );
@@ -181,7 +280,9 @@ export default function McpCredentialPanel({
 
   useEffect(() => {
     setBindings(initialBindings);
-  }, [initialBindings]);
+    setAccountBound(initiallyConfigured);
+    if (mode === "saas" && initiallyConfigured) setTenantConfirmed(true);
+  }, [initialBindings, initiallyConfigured, mode]);
 
   useEffect(() => {
     setSettings(
@@ -200,8 +301,9 @@ export default function McpCredentialPanel({
   const complete = useMemo(
     () =>
       credentialFields.every((field) => !field.required || Boolean(bindings[field.key])) &&
-      settingFields.every((field) => !field.required || Boolean(settings[field.key]?.trim())),
-    [bindings, credentialFields, settingFields, settings],
+      settingFields.every((field) => !field.required || Boolean(settings[field.key]?.trim())) &&
+      (mode !== "saas" || tenantConfirmed),
+    [bindings, credentialFields, mode, settingFields, settings, tenantConfirmed],
   );
 
   function startCreating(field: McpCredentialField) {
@@ -279,6 +381,48 @@ export default function McpCredentialPanel({
     }
   }
 
+  async function unbindAccount() {
+    if (mode !== "saas" || unbinding || !saasPolicy?.account_unbind_supported) return;
+    setUnbinding(true);
+    setError("");
+    setMessage("");
+    try {
+      const response = await fetch(`/api/mcp/catalog/${projectId}/unbind`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ revoke_credentials: revokeOnUnbind }),
+      });
+      if (!response.ok) throw new Error(await responseError(response));
+      const result = (await response.json()) as UnbindResponse;
+      setBindings({});
+      setSettings(
+        Object.fromEntries(
+          settingFields.map((field) => [
+            field.key,
+            String(field.default ?? ""),
+          ]),
+        ),
+      );
+      setTenantConfirmed(false);
+      setAccountBound(false);
+      setShowUnbindConfirmation(false);
+      setRevokeOnUnbind(false);
+      if (result.revoked_credentials > 0) await loadCredentials();
+      setMessage(
+        result.revoked_credentials > 0
+          ? `账号已解绑，并撤销 ${result.revoked_credentials} 条模镜加密凭据。上游 Token 仍需在服务商后台单独撤销。`
+          : "账号已解绑；会话、审批和资源配置已清除，加密凭据仍保留在模镜中。",
+      );
+      onConfigured(false);
+      onConfigurationSaved?.({}, {});
+      onSessionInvalidated();
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : "账号解绑失败。");
+    } finally {
+      setUnbinding(false);
+    }
+  }
+
   async function save() {
     if (!complete || saving || disabled) return;
     setSaving(true);
@@ -306,9 +450,12 @@ export default function McpCredentialPanel({
       setMessage(
         mode === "database"
           ? "数据库配置已保存；连接时会自动校验目标并执行代表性只读预检。"
+          : mode === "saas"
+            ? "账号与资源范围已保存；连接时会验证凭据、最小权限和目标资源。"
           : "连接配置已保存；首次成功调用后才会标记凭据已验证。",
       );
       onConfigurationSaved?.(typedSettings, bindings);
+      if (mode === "saas") setAccountBound(true);
       onConfigured(true);
     } catch (reason) {
       setError(reason instanceof Error ? reason.message : "目录配置保存失败。");
@@ -319,9 +466,11 @@ export default function McpCredentialPanel({
   }
 
   const isDatabase = mode === "database";
+  const isSaas = mode === "saas";
   const isSupabase = projectId === "supabase-mcp";
-  const verification =
-    isDatabase &&
+  const verification = isSaas
+    ? saasPreflightCopy[databasePreflightStatus]
+    : isDatabase &&
     databasePreflightStatus === "verified" &&
     credentialVerification !== "missing" &&
     credentialVerification !== "not-required" &&
@@ -331,26 +480,73 @@ export default function McpCredentialPanel({
 
   return (
     <section
-      aria-label={isDatabase ? "MCP 数据库连接配置" : "MCP 加密凭据配置"}
+      aria-label={
+        isSaas
+          ? "MCP SaaS 账号与加密凭据配置"
+          : isDatabase
+            ? "MCP 数据库连接配置"
+            : "MCP 加密凭据配置"
+      }
       className="relative mt-4 border-t border-white/10 pt-4"
     >
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
           <h3 className="text-sm font-semibold text-white">
-            {isDatabase ? "数据库连接与加密凭据" : "加密凭据"}
+            {isSaas
+              ? "账号范围与加密凭据"
+              : isDatabase
+                ? "数据库连接与加密凭据"
+                : "加密凭据"}
           </h3>
           <p className="mt-1 max-w-2xl text-xs leading-5 text-slate-400">
-            {isDatabase
+            {isSaas
+              ? "凭据与资源 ID 只在当前卡片管理。页面不接收任意 URL、Header、命令或环境变量，也不跳转外站登录；明文只提交一次。"
+              : isDatabase
               ? isSupabase
                 ? "20 位小写英文字母 project_ref（不含数字）与 PAT 只在当前卡片管理，不使用远程 OAuth；凭据明文只提交一次。"
                 : "连接字段与凭据只在当前卡片管理。请分别填写受控字段，不要粘贴 DSN、URI 或宿主路径；凭据明文只提交一次。"
               : "在当前 MCP 卡片内独立创建和管理。明文只提交一次，服务端加密保存后仅返回掩码。"}
           </p>
         </div>
-        <span className={`rounded-full border px-3 py-1.5 text-xs font-semibold ${verification.className}`}>
-          {verification.label}
-        </span>
+        <div className="flex flex-wrap justify-end gap-2">
+          {isSaas ? (
+            <span className={`rounded-full border px-3 py-1.5 text-xs font-semibold ${saasAccountCopy[accountStatus].className}`}>
+              {saasAccountCopy[accountStatus].label}
+            </span>
+          ) : null}
+          <span className={`rounded-full border px-3 py-1.5 text-xs font-semibold ${verification.className}`}>
+            {verification.label}
+          </span>
+        </div>
       </div>
+
+      {isSaas && saasPolicy ? (
+        <div className="mt-3 rounded-lg border border-cyan-300/15 bg-cyan-300/[0.05] p-3 text-xs">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <p className="font-semibold text-cyan-100">受控账号边界</p>
+            <span className="rounded-full border border-cyan-300/20 bg-cyan-300/10 px-2.5 py-1 font-semibold text-cyan-50">
+              {saasPolicy.provider}
+            </span>
+          </div>
+          <dl className="mt-3 grid gap-2 sm:grid-cols-2">
+            <div className="rounded-lg bg-black/15 p-2.5">
+              <dt className="text-slate-400">固定上游主机</dt>
+              <dd className="mt-1 break-words font-semibold text-slate-100">
+                {saasPolicy.fixed_hosts.join("、") || "由服务端固定"}
+              </dd>
+            </div>
+            <div className="rounded-lg bg-black/15 p-2.5">
+              <dt className="text-slate-400">调用护栏</dt>
+              <dd className="mt-1 font-semibold text-slate-100">
+                每分钟 {saasPolicy.rate_limit_per_minute} 次 · 最多并发 {saasPolicy.max_concurrent_calls}
+              </dd>
+            </div>
+          </dl>
+          <p className="mt-2 leading-5 text-slate-400">
+            只读调用最多重试 {saasPolicy.read_retry_limit} 次；写入策略为“{writeRetryModeLabel(saasPolicy.write_retry_mode)}”，限流或结果未知时不会自动重试。
+          </p>
+        </div>
+      ) : null}
 
       <div className="mt-3 space-y-4">
         {credentialFields.map((field) => {
@@ -408,7 +604,7 @@ export default function McpCredentialPanel({
                 {selected ? (
                   <button
                     className="min-h-11 rounded-lg border border-rose-300/25 px-3 py-2 text-xs font-semibold text-rose-100 transition hover:bg-rose-300/10 disabled:cursor-not-allowed disabled:opacity-45"
-                    disabled={revoking}
+                    disabled={connectionPending || revoking}
                     onClick={() => setPendingRevoke(selected)}
                     type="button"
                   >
@@ -479,9 +675,13 @@ export default function McpCredentialPanel({
         {settingFields.length > 0 ? (
           <div>
             <h4 className="text-xs font-semibold text-white">
-              {isDatabase ? "数据库连接字段" : "服务配置"}
+              {isSaas ? "账号与资源范围" : isDatabase ? "数据库连接字段" : "服务配置"}
             </h4>
-            {isDatabase ? (
+            {isSaas ? (
+              <p className="mt-1 text-xs leading-5 text-slate-400">
+                仅填写服务端声明的账号或资源 ID。当前没有资源发现接口，因此这里不会虚构资源选择器，也不会接受资源 URL。
+              </p>
+            ) : isDatabase ? (
               <p className="mt-1 text-xs leading-5 text-slate-400">
                 {isSupabase
                   ? "project_ref 仅接受 20 位小写英文字母，不含数字；页面不会接收 API URL、OAuth 回调或完整连接串。"
@@ -565,6 +765,30 @@ export default function McpCredentialPanel({
             </div>
           </div>
         ) : null}
+
+        {isSaas ? (
+          <label className="flex min-h-11 cursor-pointer items-start gap-3 rounded-lg border border-amber-300/20 bg-amber-300/[0.07] p-3">
+            <input
+              checked={tenantConfirmed}
+              className="mt-0.5 h-5 w-5 shrink-0 accent-cyan-300"
+              disabled={disabled}
+              onChange={(event) => {
+                setTenantConfirmed(event.target.checked);
+                setMessage("");
+                onConfigured(false);
+              }}
+              type="checkbox"
+            />
+            <span>
+              <span className="block text-xs font-semibold text-amber-100">
+                我确认这是固定 tenant/owner 的单租户实例
+              </span>
+              <span className="mt-1 block text-xs leading-5 text-slate-400">
+                多用户或多租户共享部署尚未开放；切换账号或资源范围前应先解绑当前账号。
+              </span>
+            </span>
+          </label>
+        ) : null}
       </div>
 
       {pendingRevoke ? (
@@ -576,7 +800,7 @@ export default function McpCredentialPanel({
           <div className="mt-3 flex flex-wrap gap-2">
             <button
               className="min-h-11 rounded-lg bg-rose-300 px-3 py-2 text-xs font-semibold text-ink-950 disabled:opacity-45"
-              disabled={revoking}
+              disabled={connectionPending || revoking}
               onClick={() => void revokeCredential()}
               type="button"
             >
@@ -594,6 +818,79 @@ export default function McpCredentialPanel({
         </div>
       ) : null}
 
+      {isSaas && saasPolicy?.account_unbind_supported && accountBound ? (
+        <div className="mt-4 border-t border-white/10 pt-4">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="max-w-2xl">
+              <p className="text-xs font-semibold text-white">账号解绑</p>
+              <p className="mt-1 text-xs leading-5 text-slate-400">
+                解绑会断开会话、作废审批并清除账号与资源配置。默认保留模镜内的加密凭据，便于之后重新绑定。
+              </p>
+            </div>
+            <button
+              aria-controls={`${projectId}-unbind-confirmation`}
+              aria-expanded={showUnbindConfirmation}
+              className="min-h-11 rounded-lg border border-rose-300/25 px-3 py-2 text-xs font-semibold text-rose-100 transition hover:bg-rose-300/10 disabled:opacity-45"
+              disabled={connectionPending || unbinding}
+              onClick={() => setShowUnbindConfirmation((current) => !current)}
+              type="button"
+            >
+              {showUnbindConfirmation ? "收起解绑确认" : "解绑当前账号"}
+            </button>
+          </div>
+
+          {showUnbindConfirmation ? (
+            <div
+              className="mt-3 rounded-lg border border-rose-300/20 bg-rose-300/[0.07] p-3"
+              id={`${projectId}-unbind-confirmation`}
+            >
+              <p className="text-xs font-semibold text-rose-100">再次确认解绑账号</p>
+              <p className="mt-1 text-xs leading-5 text-slate-300">
+                当前账号快照与所有未完成写入审批都会失效。已发出的上游操作不会被撤回。
+              </p>
+              <label className="mt-3 flex min-h-11 cursor-pointer items-start gap-3 rounded-lg border border-white/10 bg-black/15 p-3">
+                <input
+                  checked={revokeOnUnbind}
+                  className="mt-0.5 h-5 w-5 shrink-0 accent-rose-300"
+                  disabled={connectionPending || unbinding}
+                  onChange={(event) => setRevokeOnUnbind(event.target.checked)}
+                  type="checkbox"
+                />
+                <span>
+                  <span className="block text-xs font-semibold text-slate-100">
+                    同时撤销此账号绑定的模镜加密凭据
+                  </span>
+                  <span className="mt-1 block text-xs leading-5 text-slate-400">
+                    只删除模镜内的加密副本，不等于撤销服务商后台的 Token；如需彻底失效，请同时在上游后台撤销。
+                  </span>
+                </span>
+              </label>
+              <div className="mt-3 flex flex-col-reverse gap-2 sm:flex-row">
+                <button
+                  className="min-h-11 rounded-lg border border-white/15 px-3 py-2 text-xs font-semibold text-slate-200"
+                  disabled={connectionPending || unbinding}
+                  onClick={() => {
+                    setShowUnbindConfirmation(false);
+                    setRevokeOnUnbind(false);
+                  }}
+                  type="button"
+                >
+                  取消
+                </button>
+                <button
+                  className="min-h-11 rounded-lg bg-rose-300 px-3 py-2 text-xs font-semibold text-ink-950 disabled:opacity-45"
+                  disabled={unbinding}
+                  onClick={() => void unbindAccount()}
+                  type="button"
+                >
+                  {unbinding ? "正在解绑…" : "确认解绑账号"}
+                </button>
+              </div>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
       <div className="mt-3 flex flex-wrap items-center gap-3">
         <button
           className="min-h-11 rounded-lg border border-brand-300/35 bg-brand-300/10 px-4 py-2 text-xs font-semibold text-brand-100 transition hover:bg-brand-300/15 disabled:cursor-not-allowed disabled:opacity-45"
@@ -608,7 +905,11 @@ export default function McpCredentialPanel({
           className={`text-xs ${error ? "text-rose-200" : "text-emerald-200"}`}
           role="status"
         >
-          {error || message || (!complete ? "请先创建或选择凭据，并完成必填配置。" : "")}
+          {error || message || (!complete
+            ? isSaas && !tenantConfirmed
+              ? "请完成凭据与必填资源配置，并确认单租户边界。"
+              : "请先创建或选择凭据，并完成必填配置。"
+            : "")}
         </span>
       </div>
     </section>

--- a/client/src/components/McpServerCard.tsx
+++ b/client/src/components/McpServerCard.tsx
@@ -2,10 +2,12 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import McpWorkspacePanel, {
-  type McpApprovalRequest,
   type McpWorkspace,
 } from "./McpWorkspacePanel";
 import McpCredentialPanel from "./McpCredentialPanel";
+import McpApprovalDialog, {
+  type McpCatalogApprovalRequest,
+} from "./McpApprovalDialog";
 import {
   mcpCatalogSources,
   mcpRequirementLabels,
@@ -52,6 +54,28 @@ interface ToolCallResult {
   is_error: boolean;
   raw: Record<string, unknown>;
   artifacts?: Array<Record<string, unknown>>;
+  idempotency_key?: string;
+  idempotent_replay?: boolean;
+  unknown_outcome?: boolean;
+}
+
+interface CatalogOperationError {
+  code: "approval_required" | "provider_rate_limited" | "unknown_outcome" | string;
+  message: string;
+  approval_id?: string;
+  summary?: string;
+  argument_digest?: string;
+  expires_at?: number | string;
+  idempotency_key?: string;
+  retry_after_seconds?: number;
+  target_preview?: McpCatalogApprovalRequest["target_preview"];
+}
+
+interface ToolOperationNotice {
+  kind: "rate-limited" | "unknown-outcome" | "idempotent-replay" | "completed";
+  message: string;
+  idempotencyKey?: string;
+  retryAfterSeconds?: number;
 }
 
 interface InstalledMcpRecord {
@@ -94,6 +118,37 @@ const databasePreflightCopy: Record<
     label: "数据源验证失败，请检查受控配置",
     className: "text-rose-100",
   },
+};
+
+const saasPreflightCopy: Record<
+  McpCatalogAdapterStatus["preflight_status"],
+  { label: string; className: string }
+> = {
+  "not-applicable": { label: "等待账号配置", className: "text-slate-300" },
+  blocked: { label: "账号适配已阻断", className: "text-rose-100" },
+  "awaiting-workspace": { label: "等待资源范围", className: "text-amber-100" },
+  "awaiting-configuration": {
+    label: "等待保存账号与资源范围",
+    className: "text-amber-100",
+  },
+  unverified: { label: "配置已保存，等待连接预检", className: "text-amber-100" },
+  verifying: { label: "正在验证账号、权限和资源范围", className: "text-cyan-100" },
+  verified: {
+    label: "账号、最小权限与资源范围预检通过",
+    className: "text-emerald-100",
+  },
+  failed: { label: "账号预检失败，请检查受控配置", className: "text-rose-100" },
+};
+
+const saasAccountStatusCopy: Record<
+  NonNullable<McpCatalogAdapterStatus["account_status"]>,
+  { label: string; className: string }
+> = {
+  "not-applicable": { label: "不适用", className: "text-slate-300" },
+  blocked: { label: "账号绑定已阻断", className: "text-rose-100" },
+  unbound: { label: "尚未绑定账号", className: "text-slate-300" },
+  unverified: { label: "账号已配置，尚未验证", className: "text-amber-100" },
+  verified: { label: "账号绑定已验证", className: "text-emerald-100" },
 };
 
 interface McpServerCardProps {
@@ -164,6 +219,84 @@ function contentToMarkdown(result: ToolCallResult | null) {
     .join("\n\n");
 }
 
+function isCatalogOperationError(value: unknown): value is CatalogOperationError {
+  return Boolean(
+    value &&
+    typeof value === "object" &&
+    typeof (value as CatalogOperationError).code === "string" &&
+    typeof (value as CatalogOperationError).message === "string",
+  );
+}
+
+function approvalFromError(
+  detail: CatalogOperationError,
+): McpCatalogApprovalRequest | null {
+  if (
+    detail.code !== "approval_required" ||
+    !detail.approval_id ||
+    !detail.argument_digest ||
+    detail.expires_at === undefined
+  ) return null;
+  return {
+    code: "approval_required",
+    message: detail.message,
+    approval_id: detail.approval_id,
+    summary: detail.summary,
+    argument_digest: detail.argument_digest,
+    expires_at: detail.expires_at,
+    idempotency_key: detail.idempotency_key,
+    target_preview: detail.target_preview,
+  };
+}
+
+function noticeFromError(detail: CatalogOperationError): ToolOperationNotice | null {
+  if (detail.code === "provider_rate_limited") {
+    return {
+      kind: "rate-limited",
+      message: detail.message || "上游服务已限流。写入不会自动重试，请稍后重新预览。",
+      retryAfterSeconds: detail.retry_after_seconds,
+    };
+  }
+  if (detail.code === "unknown_outcome") {
+    return {
+      kind: "unknown-outcome",
+      message: detail.message || "写入结果未知，禁止自动重试。请先核对上游资源状态。",
+      idempotencyKey: detail.idempotency_key,
+    };
+  }
+  return null;
+}
+
+function noticeFromResult(result: ToolCallResult): ToolOperationNotice | null {
+  if (result.unknown_outcome) {
+    return {
+      kind: "unknown-outcome",
+      message: "写入结果未知，禁止自动重试。请先核对上游资源状态。",
+      idempotencyKey: result.idempotency_key,
+    };
+  }
+  if (result.idempotent_replay) {
+    return {
+      kind: "idempotent-replay",
+      message: "检测到重复确认，本次复用了已有结果，没有再次写入。",
+      idempotencyKey: result.idempotency_key,
+    };
+  }
+  if (result.idempotency_key) {
+    return {
+      kind: "completed",
+      message: "本次写入已按幂等键完成；重复确认不会再次写入。",
+      idempotencyKey: result.idempotency_key,
+    };
+  }
+  return null;
+}
+
+function shortIdempotencyKey(value?: string) {
+  if (!value) return "";
+  return value.length > 18 ? `${value.slice(0, 10)}…${value.slice(-6)}` : value;
+}
+
 export default function McpServerCard({
   project,
   adapterStatus,
@@ -178,6 +311,7 @@ export default function McpServerCard({
     {},
   );
   const [toolResults, setToolResults] = useState<Record<string, ToolCallResult>>({});
+  const [toolNotices, setToolNotices] = useState<Record<string, ToolOperationNotice>>({});
   const [runningTool, setRunningTool] = useState<string | null>(null);
   const [boundWorkspace, setBoundWorkspace] = useState<McpWorkspace | null>(null);
   const [catalogConfigured, setCatalogConfigured] = useState(
@@ -189,12 +323,10 @@ export default function McpServerCard({
   const [catalogBindings, setCatalogBindings] = useState<Record<string, string>>(
     adapterStatus?.credential_bindings ?? {},
   );
-  const [pendingApproval, setPendingApproval] = useState<McpApprovalRequest | null>(null);
+  const [pendingApproval, setPendingApproval] = useState<McpCatalogApprovalRequest | null>(null);
   const [approvalBusy, setApprovalBusy] = useState(false);
   const approvalCallbackRef = useRef<(() => void) | null>(null);
   const approvalToolRef = useRef<string | null>(null);
-  const approvalDialogRef = useRef<HTMLDivElement | null>(null);
-  const approvalCancelRef = useRef<HTMLButtonElement | null>(null);
   const [isInstallOpen, setIsInstallOpen] = useState(false);
   const [installState, setInstallState] = useState<InstallState>("checking");
   const [installError, setInstallError] = useState("");
@@ -207,7 +339,14 @@ export default function McpServerCard({
   const requiredCapabilities =
     adapterStatus?.required_capabilities ?? project.requiredCapabilities;
   const limitations = adapterStatus?.limitations ?? project.adaptationLimitations;
-  const canConnect = adapterStatus?.executable === true && availability === "ready";
+  const isStatefulSaas = wave === 6;
+  const statefulSaasGateEnabled =
+    !isStatefulSaas || adapterStatus?.stateful_saas_gate_enabled === true;
+  const canConnect =
+    adapterStatus?.feature_enabled === true &&
+    adapterStatus.executable === true &&
+    availability === "ready" &&
+    statefulSaasGateEnabled;
   const workspacePolicy = adapterStatus?.workspace_policy ?? null;
   const databasePolicy = adapterStatus?.database_policy ?? null;
   const databasePreflight = adapterStatus?.preflight_status ?? "not-applicable";
@@ -245,45 +384,6 @@ export default function McpServerCard({
     adapterStatus?.configuration_values,
     adapterStatus?.credential_bindings,
   ]);
-
-  useEffect(() => {
-    if (!pendingApproval) return;
-    const previouslyFocused = document.activeElement as HTMLElement | null;
-    const focusTimer = window.setTimeout(() => approvalCancelRef.current?.focus(), 0);
-
-    function handleApprovalKeyDown(event: KeyboardEvent) {
-      const dialog = approvalDialogRef.current;
-      if (!dialog) return;
-      if (event.key === "Escape" && !approvalCancelRef.current?.disabled) {
-        event.preventDefault();
-        void cancelApproval();
-        return;
-      }
-      if (event.key !== "Tab") return;
-      const focusable = Array.from(
-        dialog.querySelectorAll<HTMLElement>(
-          'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
-        ),
-      );
-      if (!focusable.length) return;
-      const first = focusable[0];
-      const last = focusable[focusable.length - 1];
-      if (event.shiftKey && document.activeElement === first) {
-        event.preventDefault();
-        last.focus();
-      } else if (!event.shiftKey && document.activeElement === last) {
-        event.preventDefault();
-        first.focus();
-      }
-    }
-
-    document.addEventListener("keydown", handleApprovalKeyDown);
-    return () => {
-      window.clearTimeout(focusTimer);
-      document.removeEventListener("keydown", handleApprovalKeyDown);
-      previouslyFocused?.focus();
-    };
-  }, [pendingApproval?.approval_id]);
 
   useEffect(() => {
     let cancelled = false;
@@ -346,7 +446,7 @@ export default function McpServerCard({
   async function readErrorDetail(response: Response) {
     try {
       const data = (await response.json()) as {
-        detail?: string | McpApprovalRequest;
+        detail?: string | CatalogOperationError;
         error?: string;
       };
       return data.detail ?? data.error ?? response.statusText;
@@ -367,6 +467,7 @@ export default function McpServerCard({
     setError("");
     setTools([]);
     setToolResults({});
+    setToolNotices({});
     try {
       const response = await fetch(`/api/mcp/catalog/${project.id}/connect`, {
         method: "POST",
@@ -400,6 +501,7 @@ export default function McpServerCard({
     setSessionId(null);
     setTools([]);
     setToolResults({});
+    setToolNotices({});
     setFormValues({});
     setError("");
     setState("idle");
@@ -454,6 +556,16 @@ export default function McpServerCard({
     if (!sessionId) return;
     setRunningTool(tool.name);
     setError("");
+    setToolResults((current) => {
+      const next = { ...current };
+      delete next[tool.name];
+      return next;
+    });
+    setToolNotices((current) => {
+      const next = { ...current };
+      delete next[tool.name];
+      return next;
+    });
     try {
       const response = await fetch(
         `/api/mcp/catalog/${project.id}/tools/${encodeURIComponent(tool.name)}/call`,
@@ -465,20 +577,30 @@ export default function McpServerCard({
           }),
         },
       );
-      if (response.status === 409) {
+      if (!response.ok) {
         const detail = await readErrorDetail(response);
-        if (typeof detail !== "string" && detail.code === "approval_required") {
-          approvalToolRef.current = tool.name;
-          showApproval(detail, () => {
-            setToolResults((current) => ({ ...current }));
-            if (boundWorkspace) void refreshBoundWorkspace(boundWorkspace.workspace_id);
-          });
-          return;
+        if (typeof detail !== "string" && isCatalogOperationError(detail)) {
+          const approval = approvalFromError(detail);
+          if (approval) {
+            approvalToolRef.current = tool.name;
+            showApproval(approval, () => {
+              setToolResults((current) => ({ ...current }));
+              if (boundWorkspace) void refreshBoundWorkspace(boundWorkspace.workspace_id);
+            });
+            return;
+          }
+          const notice = noticeFromError(detail);
+          if (notice) {
+            setToolNotices((current) => ({ ...current, [tool.name]: notice }));
+            return;
+          }
         }
+        throw new Error(typeof detail === "string" ? detail : detail.message);
       }
-      if (!response.ok) throw new Error(await readError(response));
       const data = (await response.json()) as ToolCallResult;
       setToolResults((current) => ({ ...current, [tool.name]: data }));
+      const notice = noticeFromResult(data);
+      if (notice) setToolNotices((current) => ({ ...current, [tool.name]: notice }));
       if (boundWorkspace) await refreshBoundWorkspace(boundWorkspace.workspace_id);
     } catch (exc) {
       setError(exc instanceof Error ? exc.message : "工具执行失败");
@@ -493,6 +615,7 @@ export default function McpServerCard({
     setSessionId(null);
     setTools([]);
     setToolResults({});
+    setToolNotices({});
     setFormValues({});
     setError("");
     setState("idle");
@@ -514,7 +637,7 @@ export default function McpServerCard({
     onConnectionChange?.();
   }
 
-  function showApproval(approval: McpApprovalRequest, onConfirmed: () => void) {
+  function showApproval(approval: McpCatalogApprovalRequest, onConfirmed: () => void) {
     approvalCallbackRef.current = onConfirmed;
     setPendingApproval(approval);
   }
@@ -528,18 +651,43 @@ export default function McpServerCard({
         `/api/mcp/catalog/${project.id}/approvals/${pendingApproval.approval_id}/confirm`,
         { method: "POST" },
       );
-      if (!response.ok) throw new Error(await readError(response));
+      if (!response.ok) {
+        const detail = await readErrorDetail(response);
+        if (typeof detail !== "string" && isCatalogOperationError(detail)) {
+          const notice = noticeFromError(detail);
+          if (notice && approvalToolRef.current) {
+            setToolNotices((current) => ({
+              ...current,
+              [approvalToolRef.current as string]: notice,
+            }));
+            setPendingApproval(null);
+            approvalCallbackRef.current = null;
+            approvalToolRef.current = null;
+            return;
+          }
+        }
+        throw new Error(typeof detail === "string" ? detail : detail.message);
+      }
       const data = (await response.json()) as ToolCallResult;
       if (approvalToolRef.current) {
         const toolName = approvalToolRef.current;
         setToolResults((current) => ({ ...current, [toolName]: data }));
+        const notice = noticeFromResult(data);
+        if (notice) setToolNotices((current) => ({ ...current, [toolName]: notice }));
       }
       setPendingApproval(null);
       approvalCallbackRef.current?.();
       approvalCallbackRef.current = null;
       approvalToolRef.current = null;
     } catch (exc) {
-      setError(exc instanceof Error ? exc.message : "确认操作失败");
+      setPendingApproval(null);
+      approvalCallbackRef.current = null;
+      approvalToolRef.current = null;
+      setError(
+        exc instanceof Error
+          ? `${exc.message} 请重新发起预览，不要重复提交旧审批。`
+          : "确认操作失败，请重新发起预览。",
+      );
     } finally {
       setApprovalBusy(false);
     }
@@ -915,6 +1063,79 @@ export default function McpServerCard({
         </section>
       ) : null}
 
+      {wave === 6 ? (
+        <section
+          aria-label="有状态 SaaS 账号与工具策略"
+          className="relative mt-3 rounded-lg border border-violet-300/20 bg-violet-300/[0.055] p-3 text-xs"
+        >
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <h3 className="font-semibold text-violet-100">账号与写入安全状态</h3>
+            {availability === "blocked" ? (
+              <span className="rounded-full border border-rose-300/25 bg-rose-300/[0.08] px-2.5 py-1 font-semibold text-rose-100">
+                所有入口关闭
+              </span>
+            ) : (
+              <div className="flex flex-wrap gap-2">
+                <span className="rounded-full border border-emerald-300/25 bg-emerald-300/[0.08] px-2.5 py-1 font-semibold text-emerald-100">
+                  只读直接执行
+                </span>
+                <span className="rounded-full border border-amber-300/25 bg-amber-300/[0.08] px-2.5 py-1 font-semibold text-amber-100">
+                  写入 · 预览并确认
+                </span>
+              </div>
+            )}
+          </div>
+          <dl className="mt-3 grid gap-2 sm:grid-cols-3">
+            <div className="rounded-lg bg-black/15 p-2.5">
+              <dt className="text-slate-400">目录功能门禁</dt>
+              <dd
+                aria-live="polite"
+                className={`mt-1 font-semibold ${
+                  availability === "blocked" || !statefulSaasGateEnabled
+                    ? "text-rose-100"
+                    : "text-emerald-100"
+                }`}
+              >
+                {availability === "blocked"
+                  ? "适配受阻，配置与工具入口关闭"
+                  : statefulSaasGateEnabled
+                    ? "有状态 SaaS 门禁已开启"
+                    : "有状态 SaaS 总开关未开启"}
+              </dd>
+            </div>
+            <div className="rounded-lg bg-black/15 p-2.5">
+              <dt className="text-slate-400">账号绑定</dt>
+              <dd
+                aria-live="polite"
+                className={`mt-1 font-semibold ${
+                  saasAccountStatusCopy[adapterStatus?.account_status ?? "not-applicable"].className
+                }`}
+              >
+                {saasAccountStatusCopy[adapterStatus?.account_status ?? "not-applicable"].label}
+              </dd>
+            </div>
+            <div className="rounded-lg bg-black/15 p-2.5">
+              <dt className="text-slate-400">账号预检</dt>
+              <dd
+                aria-live="polite"
+                className={`mt-1 font-semibold ${saasPreflightCopy[databasePreflight].className}`}
+              >
+                {saasPreflightCopy[databasePreflight].label}
+              </dd>
+            </div>
+          </dl>
+          {adapterStatus?.saas_policy ? (
+            <p className="mt-2 leading-5 text-slate-400">
+              固定主机：{adapterStatus.saas_policy.fixed_hosts.join("、")}；每分钟最多 {adapterStatus.saas_policy.rate_limit_per_minute} 次、并发 {adapterStatus.saas_policy.max_concurrent_calls}。限流和结果未知时写入不自动重试。
+            </p>
+          ) : (
+            <p className="mt-2 leading-5 text-slate-400">
+              当前条目没有可执行账号契约；不会收集凭据、资源 ID 或工具参数。
+            </p>
+          )}
+        </section>
+      ) : null}
+
       {adapterStatus?.executable && adapterStatus.runtime_image ? (
         <div className="relative mt-3 rounded-lg border border-emerald-300/20 bg-emerald-300/[0.06] p-3 text-xs">
           <div className="flex flex-wrap items-center justify-between gap-2">
@@ -948,18 +1169,21 @@ export default function McpServerCard({
 
       {canConnect && needsCatalogConfiguration && adapterStatus ? (
         <McpCredentialPanel
+          connectionPending={state === "connecting"}
           credentialFields={adapterStatus.credential_fields}
           disabled={state === "connected" || state === "connecting"}
           initialBindings={adapterStatus.credential_bindings}
           initialSettings={adapterStatus.configuration_values}
           initiallyConfigured={adapterStatus.configured}
           credentialVerification={adapterStatus.credential_verification}
+          accountStatus={adapterStatus.account_status}
           databasePreflightStatus={adapterStatus.preflight_status}
-          mode={wave === 5 ? "database" : "service"}
+          mode={wave === 5 ? "database" : wave === 6 ? "saas" : "service"}
           onConfigurationSaved={handleConfigurationSaved}
           onConfigured={setCatalogConfigured}
           onSessionInvalidated={invalidateCredentialSession}
           projectId={project.id}
+          saasPolicy={adapterStatus.saas_policy}
           settingFields={adapterStatus.setting_fields}
           workspaceId={boundWorkspace?.workspace_id ?? null}
         />
@@ -995,6 +1219,10 @@ export default function McpServerCard({
           >
             {!adapterStatus && availability === "ready"
               ? "同步服务端状态..."
+              : isStatefulSaas && availability === "ready" && !statefulSaasGateEnabled
+                ? "SaaS 门禁未开启"
+              : adapterStatus && availability === "ready" && !adapterStatus.feature_enabled
+                ? "项目开关未开启"
               : availability === "adapting"
                 ? "正在适配"
                 : availability === "blocked"
@@ -1078,7 +1306,7 @@ export default function McpServerCard({
         </div>
       ) : null}
 
-      {state === "connected" ? (
+      {state === "connected" && canConnect ? (
         <div className="relative mt-5 space-y-4 border-t border-white/10 pt-4">
           <div className="flex items-center justify-between gap-3">
             <h3 className="text-sm font-semibold text-white">工具清单</h3>
@@ -1095,6 +1323,16 @@ export default function McpServerCard({
               const properties = tool.inputSchema.properties ?? {};
               const markdown = contentToMarkdown(toolResults[tool.name] ?? null);
               const toolPolicy = adapterStatus?.tool_policies[tool.name];
+              const isApprovedWrite =
+                toolPolicy?.effect === "state-write" && toolPolicy.requires_approval;
+              const policyClosed = Boolean(
+                toolPolicy?.sensitive ||
+                toolPolicy?.terminal ||
+                (isStatefulSaas &&
+                  (!toolPolicy ||
+                    (toolPolicy.effect === "state-write" && !toolPolicy.requires_approval))),
+              );
+              const notice = toolNotices[tool.name];
               return (
                 <div className="min-w-0 rounded-lg border border-white/10 bg-white/[0.045] p-4" key={tool.name}>
                   <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
@@ -1102,20 +1340,41 @@ export default function McpServerCard({
                       <p className="font-semibold text-white">{tool.title ?? tool.name}</p>
                       <div className="mt-1 flex flex-wrap items-center gap-2">
                         <p className="text-xs text-brand-100">{tool.name}</p>
-                        {toolPolicy?.read_only ? (
+                        {toolPolicy?.read_only || toolPolicy?.effect === "read" ? (
                           <span className="rounded-full border border-emerald-300/25 bg-emerald-300/[0.08] px-2 py-0.5 text-[11px] font-semibold text-emerald-100">
-                            只读工具
+                            只读
+                          </span>
+                        ) : null}
+                        {isApprovedWrite ? (
+                          <span className="rounded-full border border-amber-300/25 bg-amber-300/[0.08] px-2 py-0.5 text-[11px] font-semibold text-amber-100">
+                            写入 · 需确认
+                          </span>
+                        ) : null}
+                        {toolPolicy?.effect === "artifact-create" ? (
+                          <span className="rounded-full border border-cyan-300/25 bg-cyan-300/[0.08] px-2 py-0.5 text-[11px] font-semibold text-cyan-100">
+                            生成产物
+                          </span>
+                        ) : null}
+                        {policyClosed ? (
+                          <span className="rounded-full border border-rose-300/25 bg-rose-300/[0.08] px-2 py-0.5 text-[11px] font-semibold text-rose-100">
+                            策略关闭
                           </span>
                         ) : null}
                       </div>
                     </div>
                     <button
                       className="min-h-11 w-fit rounded-full bg-hire-300 px-4 py-2 text-xs font-semibold text-ink-950 transition hover:bg-hire-200 disabled:cursor-not-allowed disabled:opacity-50"
-                      disabled={runningTool === tool.name}
+                      disabled={runningTool === tool.name || policyClosed}
                       onClick={() => void callTool(tool)}
                       type="button"
                     >
-                      {runningTool === tool.name ? "执行中..." : "执行"}
+                      {runningTool === tool.name
+                        ? "执行中..."
+                        : policyClosed
+                          ? "工具已关闭"
+                          : isApprovedWrite
+                            ? "预览并确认"
+                            : "执行"}
                     </button>
                   </div>
                   {tool.description ? (
@@ -1134,6 +1393,40 @@ export default function McpServerCard({
                       这个工具不需要参数。
                     </p>
                   )}
+                  {notice ? (
+                    <div
+                      aria-live="polite"
+                      className={`mt-3 rounded-lg border p-3 text-xs leading-5 ${
+                        notice.kind === "unknown-outcome"
+                          ? "border-rose-300/25 bg-rose-300/[0.08] text-rose-100"
+                          : notice.kind === "rate-limited"
+                            ? "border-amber-300/25 bg-amber-300/[0.08] text-amber-100"
+                            : notice.kind === "idempotent-replay"
+                              ? "border-cyan-300/25 bg-cyan-300/[0.08] text-cyan-100"
+                              : "border-emerald-300/25 bg-emerald-300/[0.08] text-emerald-100"
+                      }`}
+                      role="status"
+                    >
+                      <p className="font-semibold">
+                        {notice.kind === "unknown-outcome"
+                          ? "结果未知 · 禁止自动重试"
+                          : notice.kind === "rate-limited"
+                            ? "上游限流 · 写入未自动重试"
+                            : notice.kind === "idempotent-replay"
+                              ? "幂等重放 · 未重复写入"
+                              : "写入已完成"}
+                      </p>
+                      <p className="mt-1 text-slate-300">{notice.message}</p>
+                      {notice.retryAfterSeconds !== undefined ? (
+                        <p className="mt-1 text-slate-400">建议等待 {notice.retryAfterSeconds} 秒后重新发起预览。</p>
+                      ) : null}
+                      {notice.idempotencyKey ? (
+                        <p className="mt-1 font-mono text-slate-400">
+                          幂等键：{shortIdempotencyKey(notice.idempotencyKey)}
+                        </p>
+                      ) : null}
+                    </div>
+                  ) : null}
                   {markdown ? (
                     <div className="prose prose-invert mt-4 max-h-[32rem] min-w-0 max-w-none overflow-auto rounded-lg border border-white/10 bg-ink-950/70 p-4 [overflow-wrap:anywhere] prose-pre:max-w-full prose-pre:overflow-x-auto prose-pre:bg-slate-950 prose-code:break-words prose-code:text-brand-100 prose-table:block prose-table:max-w-full prose-table:overflow-x-auto">
                       <ReactMarkdown remarkPlugins={[remarkGfm]}>
@@ -1149,53 +1442,12 @@ export default function McpServerCard({
       ) : null}
 
       {pendingApproval ? (
-        <div
-          aria-describedby={`mcp-approval-description-${project.id}`}
-          aria-labelledby={`mcp-approval-${project.id}`}
-          aria-modal="true"
-          className="fixed inset-0 z-[90] flex items-center justify-center bg-slate-950/82 p-4 backdrop-blur-sm"
-          role="dialog"
-        >
-          <div
-            className="surface-card max-h-[90vh] w-full max-w-lg overflow-y-auto rounded-lg border border-amber-300/25 p-6"
-            ref={approvalDialogRef}
-            tabIndex={-1}
-          >
-            <p className="text-sm font-semibold text-amber-100">一次性写入确认</p>
-            <h2 className="mt-2 text-xl font-semibold text-white" id={`mcp-approval-${project.id}`}>
-              确认本次受控操作
-            </h2>
-            <p
-              className="mt-4 rounded-lg border border-white/10 bg-white/[0.045] p-4 text-sm leading-6 text-slate-300"
-              id={`mcp-approval-description-${project.id}`}
-            >
-              {pendingApproval.summary}
-            </p>
-            <div className="mt-3 text-[11px] leading-5 text-slate-500">
-              <p>确认仅对当前会话、工作区版本和参数摘要有效，5 分钟后自动失效。</p>
-              <p className="mt-1 break-all font-mono">摘要：{pendingApproval.argument_digest}</p>
-            </div>
-            <div className="mt-5 flex flex-wrap justify-end gap-2">
-              <button
-                className="min-h-11 rounded-full border border-white/10 px-4 py-2 text-sm font-semibold text-slate-200"
-                disabled={approvalBusy}
-                onClick={() => void cancelApproval()}
-                ref={approvalCancelRef}
-                type="button"
-              >
-                取消
-              </button>
-              <button
-                className="min-h-11 rounded-full bg-amber-300 px-4 py-2 text-sm font-semibold text-ink-950 disabled:opacity-50"
-                disabled={approvalBusy}
-                onClick={() => void confirmApproval()}
-                type="button"
-              >
-                {approvalBusy ? "执行中…" : "确认并执行一次"}
-              </button>
-            </div>
-          </div>
-        </div>
+        <McpApprovalDialog
+          approval={pendingApproval}
+          busy={approvalBusy}
+          onCancel={cancelApproval}
+          onConfirm={confirmApproval}
+        />
       ) : null}
 
       {isInstallOpen ? (

--- a/client/src/data/mcpAdaptationPlan.ts
+++ b/client/src/data/mcpAdaptationPlan.ts
@@ -12,6 +12,12 @@ export type McpCredentialVerification =
   | "unverified"
   | "verified"
   | "verification-failed";
+export type McpSaasAccountStatus =
+  | "not-applicable"
+  | "blocked"
+  | "unbound"
+  | "unverified"
+  | "verified";
 export type McpDatabasePreflightStatus =
   | "not-applicable"
   | "blocked"
@@ -32,6 +38,17 @@ export interface McpDatabasePolicy {
   statement_timeout_seconds: number;
   operation_timeout_seconds: number;
   preflight_checks: string[];
+}
+
+export interface McpSaasPolicy {
+  provider: string;
+  fixed_hosts: string[];
+  preflight_checks: string[];
+  rate_limit_per_minute: number;
+  max_concurrent_calls: number;
+  read_retry_limit: number;
+  write_retry_mode: string;
+  account_unbind_supported: boolean;
 }
 
 export interface McpWorkspacePolicy {
@@ -105,6 +122,9 @@ export interface McpCatalogAdapterStatus {
   resource_limits: Record<string, string>;
   workspace_policy: McpWorkspacePolicy | null;
   database_policy: McpDatabasePolicy | null;
+  saas_policy?: McpSaasPolicy | null;
+  stateful_saas_gate_enabled?: boolean;
+  account_status?: McpSaasAccountStatus;
   preflight_status: McpDatabasePreflightStatus;
   tool_policies: Record<
     string,
@@ -162,6 +182,11 @@ export const mcpCapabilityLabels: Record<string, string> = {
   "native-read-only-mode": "数据库原生只读模式",
   "query-row-timeout-limits": "查询行数与超时硬限制",
   "database-preflight": "连接时数据源安全预检",
+  "fixed-saas-contract": "固定 SaaS 工具契约",
+  "tenant-owner-scoped-account-binding": "单租户账号范围绑定",
+  "remote-resource-approval": "远程资源写入审批",
+  "idempotent-write-ledger": "幂等写入账本",
+  "provider-rate-limits": "上游限流护栏",
   "maintained-upstream-contract": "持续维护的上游工具契约",
   "tenant-isolated-state": "租户隔离的持久状态",
   "query-limits": "查询超时与结果限制",
@@ -322,10 +347,21 @@ const waveMetadata: Record<
     ],
   },
   6: {
-    connectionKind: "remote-mcp",
+    connectionKind: "sandboxed-stdio",
     risk: "high",
-    requiredCapabilities: ["修改操作审批", "账号解绑"],
-    limitations: ["等待修改操作预览、审批、幂等和账号解绑验证。"],
+    requiredCapabilities: [
+      "fixed-saas-contract",
+      "tenant-owner-scoped-account-binding",
+      "remote-resource-approval",
+      "idempotent-write-ledger",
+      "provider-rate-limits",
+      "account-unbinding",
+      "schema-drift-recovery",
+    ],
+    limitations: [
+      "账号凭据与资源范围只在当前卡片配置；服务端固定上游主机，不接受任意 URL、Header、命令或环境变量。",
+      "写入先返回目标与影响预览，再以一次性审批和幂等键执行；限流或结果未知时不会自动重试。",
+    ],
   },
   7: {
     connectionKind: "sandboxed-stdio",
@@ -421,6 +457,46 @@ const waveFiveReadyDetails: Record<string, string[]> = {
 const waveFiveSingleTenantLimitation =
   "当前仅支持部署时固定 tenant/owner 的单租户本地实例；多用户共享部署未开放。";
 
+const waveSixReadyIds = new Set([
+  "airtable-mcp",
+  "asana-mcp",
+  "gitlab-mcp",
+  "notion-mcp-server",
+]);
+
+const waveSixReadyDetails: Record<string, string[]> = {
+  "airtable-mcp": [
+    "仅绑定一个受控 Base ID；读工具直接执行，记录创建和更新必须先预览目标与影响并逐次确认。",
+    "Personal Access Token 在当前卡片加密保存；上游主机、凭据注入位置和资源范围由服务端固定。",
+  ],
+  "asana-mcp": [
+    "仅绑定一个工作区与一个项目；查询可直接执行，任务和协作信息修改必须逐次预览并确认。",
+    "Personal Access Token 在当前卡片加密保存；不会跳转 OAuth，也不会接收任意 API URL。",
+  ],
+  "gitlab-mcp": [
+    "首批仅连接 gitlab.com，并绑定一个项目 ID；自建 GitLab 地址和任意主机输入保持关闭。",
+    "Personal Access Token 在当前卡片加密保存；Issue、合并请求等写入必须逐次预览并确认。",
+  ],
+  "notion-mcp-server": [
+    "仅绑定一个固定 Data Source ID；Integration 必须在 Notion 中被显式共享到该 Data Source。",
+    "首批写入只允许在该 Data Source 内新建页面或更新页面属性，并且必须逐次预览目标与影响后确认。",
+  ],
+};
+
+const waveSixBlockedDetails: Record<string, string[]> = {
+  "mcp-cn-commerce": [
+    "上游覆盖多个电商平台，依赖各平台 OAuth、商家授权和短期 Token，无法在本批固定为单一可核验账号契约。",
+    "已阻断配置、凭据、连接和工具入口；等待第 10 批账号授权、刷新与撤销能力完成后再评估。",
+  ],
+  "mem0-mcp": [
+    "已归档的本地实现无法继续锁定生产版本；当前远程实现尚不能满足固定工具 schema 与租户 Scope 隔离要求。",
+    "已阻断配置、凭据、连接和写入入口；等待状态化记忆的数据保留、删除与租户隔离契约完成后再评估。",
+  ],
+};
+
+const waveSixSingleTenantLimitation =
+  "当前仅支持部署时固定 tenant/owner 的单租户实例；多租户共享部署保持关闭。";
+
 function buildAdaptationPlan() {
   const records: Record<string, McpAdaptationRecord> = {};
   for (const projectId of localStdioIds) {
@@ -445,6 +521,10 @@ function buildAdaptationPlan() {
             ? "blocked"
             : wave === 5
               ? waveFiveReadyIds.has(projectId)
+                ? "ready"
+                : "blocked"
+            : wave === 6
+              ? waveSixReadyIds.has(projectId)
                 ? "ready"
                 : "blocked"
             : wave <= 4
@@ -503,6 +583,13 @@ function buildAdaptationPlan() {
               ? [
                   ...waveFiveReadyDetails[projectId],
                   waveFiveSingleTenantLimitation,
+                ]
+            : waveSixBlockedDetails[projectId]
+              ? [...waveSixBlockedDetails[projectId]]
+            : waveSixReadyDetails[projectId]
+              ? [
+                  ...waveSixReadyDetails[projectId],
+                  waveSixSingleTenantLimitation,
                 ]
             : [...metadata.limitations],
       };

--- a/client/src/data/mcpProjects.ts
+++ b/client/src/data/mcpProjects.ts
@@ -387,8 +387,8 @@ const originalMcpProjectSeeds: McpProjectSeed[] = [
     installMode: "manual",
     installCommand: "npx -y @notionhq/notion-mcp-server",
     installNote:
-      "需要 Notion Integration Token。当前模镜 MCP 子进程不会透传业务密钥，暂保留为手动配置。",
-    tags: ["Notion 官方", "知识库", "需要 Token"],
+      "在卡片内加密保存 Integration Token，并填写显式共享给该 Integration 的 Data Source ID；写入仅限其中的新建页面与页面属性更新。",
+    tags: ["Notion 官方", "知识库", "受控写入"],
   },
   {
     id: "blender-mcp",
@@ -462,8 +462,8 @@ const originalMcpProjectSeeds: McpProjectSeed[] = [
     installMode: "manual",
     installCommand: "pip install mcp-cn-commerce",
     installNote:
-      "不同平台需要各自的 App Key、Secret 和 Access Token。凭证必须由服务端 Secret 管理，不能写入前端或仓库。",
-    tags: ["中国电商", "只读经营数据", "多平台"],
+      "依赖多平台 OAuth、商家授权和短期 Token；第 10 批授权与撤销能力完成前不开放配置或连接。",
+    tags: ["中国电商", "多平台授权", "适配受阻"],
   },
   {
     id: "memory-mcp",
@@ -1722,6 +1722,7 @@ function normalizeMcpProject(seed: McpProjectSeed): McpProject {
   const isCredentialSandbox = isBundledSandbox && adaptation.wave === 4;
   const isDatabaseSandbox = isBundledSandbox && adaptation.wave === 5;
   const isDatabaseFileSandbox = isDatabaseSandbox && seed.id === "duckdb-mcp";
+  const isStatefulSaas = isReady && adaptation.wave === 6;
   const requirements: McpRequirement[] = isCredentialSandbox
     ? ["token"]
     : isDatabaseSandbox
@@ -1730,6 +1731,8 @@ function normalizeMcpProject(seed: McpProjectSeed): McpProject {
         : isDatabaseFileSandbox
           ? []
           : ["database-credentials"]
+    : isStatefulSaas
+      ? ["token", "account-binding", "remote-transport"]
     : isReady
     ? []
     : (seed.requirements ?? originalRequirements[seed.id] ?? ["external-runtime"]);
@@ -1745,7 +1748,9 @@ function normalizeMcpProject(seed: McpProjectSeed): McpProject {
       : isPublicSandbox
         ? "内置公网适配器由服务端固定部署，不接受自定义命令、端点或 Header。"
         : isDatabaseSandbox
-          ? "内置数据库适配器由服务端固定部署，不接受 DSN、URI、命令或宿主路径。"
+        ? "内置数据库适配器由服务端固定部署，不接受 DSN、URI、命令或宿主路径。"
+        : isStatefulSaas
+          ? "内置有状态 SaaS 适配器由服务端固定部署，不接受任意 URL、Header、命令或环境变量。"
         : isBundledSandbox
           ? "内置隔离适配器由服务端固定部署，无需安装命令。"
         : "当前版本仅收录资料，不提供本地 stdio 安装或外站认证入口。",
@@ -1761,6 +1766,12 @@ function normalizeMcpProject(seed: McpProjectSeed): McpProject {
         ? seed.id === "supabase-mcp"
           ? "在当前卡片填写 20 位小写英文字母 project_ref（不含数字）并保存加密 PAT；仅使用本地 stdio 和项目范围只读能力，不跳转远程 OAuth。"
           : "在当前卡片分别填写主机、端口、库名、TLS 和用户名，并保存加密数据库凭据；连接时自动执行目标校验和代表性只读预检。"
+      : isStatefulSaas
+        ? seed.id === "gitlab-mcp"
+          ? "在当前卡片加密保存 Personal Access Token 并填写项目 ID；首批主机固定为 gitlab.com，写入先预览目标再逐次确认。"
+          : seed.id === "notion-mcp-server"
+            ? "在当前卡片加密保存 Integration Token，并填写已显式共享给该 Integration 的 Data Source ID；写入仅限该范围内的新建页面与页面属性更新。"
+          : "在当前卡片加密保存账号凭据并填写服务端声明的资源 ID；连接预检通过后，写入先预览目标再逐次确认。"
       : isBundledSandbox
         ? "适配器随断网 Python 沙箱镜像固定部署；浏览器不会提交命令、目录或环境变量。"
       : seed.installNote,
@@ -1790,6 +1801,17 @@ function normalizeMcpProject(seed: McpProjectSeed): McpProject {
               : "分别填写卡片提供的主机、端口、库名、TLS 和用户名；不粘贴 DSN、URI、命令或环境变量。",
             "在当前卡片创建并选择对应的加密数据库凭据。凭据按项目和固定槽位隔离，保存后不回显明文。",
             "保存配置后连接只读 sidecar；连接时会自动校验目标并执行代表性只读预检。写入和管理工具始终关闭。",
+          ]
+      : isStatefulSaas
+        ? [
+            "在当前卡片添加并选择专属加密凭据；明文只提交一次，不能跨 MCP 或槽位复用。",
+            seed.id === "gitlab-mcp"
+              ? "填写服务端提供的项目 ID 字段；主机固定为 gitlab.com，不输入 URL、Header、命令或环境变量。"
+              : seed.id === "notion-mcp-server"
+                ? "填写固定 Data Source ID，并先在 Notion 中将该 Data Source 显式共享给 Integration；页面不接收 Notion URL。"
+              : "填写服务端提供的账号与资源 ID 字段；当前没有资源发现接口，因此只显示受控 ID 输入，不虚构选择器。",
+            "确认单租户边界并保存配置，然后连接并等待账号预检通过。只读工具可直接执行，写入工具必须查看目标与影响摘要后一次性确认。",
+            "出现限流或结果未知时不要重复点击；先核对上游状态。解绑可只断开账号，也可同时撤销模镜内的加密凭据。",
           ]
       : seed.configGuide ??
         (isLocalStdio

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -201,6 +201,48 @@ services:
       retries: 8
       start_period: 30s
 
+  mcp-saas:
+    build:
+      context: ./server/sandbox_sidecar
+      dockerfile: Dockerfile.saas
+    image: modelmirror-mcp-saas:wave6-v1
+    container_name: modelmirror-mcp-saas
+    networks:
+      - mcp_saas_egress
+    environment:
+      MCP_SAAS_MAX_SESSIONS: "4"
+      MCP_SAAS_SOCKET_PATH: /run/modelmirror-saas-mcp/saas-mcp.sock
+      MCP_SAAS_WORKSPACE_ROOT: /workspaces
+      MCP_SAAS_ALLOWED_ADAPTERS: airtable-mcp,asana-mcp,gitlab-mcp,notion-mcp-server
+      MCP_PUBLIC_ALLOW_SYNTHETIC_DNS: "true"
+    user: "65532:65532"
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    pids_limit: 96
+    mem_limit: 768m
+    cpus: 1.5
+    tmpfs:
+      - /tmp:rw,nosuid,noexec,size=64m,uid=65532,gid=65532,mode=0700
+      - /workspaces:rw,nosuid,noexec,size=128m,uid=65532,gid=65532,mode=0700
+    volumes:
+      - mcp_saas_socket:/run/modelmirror-saas-mcp
+    restart: unless-stopped
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import json,socket; s=socket.socket(socket.AF_UNIX); s.connect('/run/modelmirror-saas-mcp/saas-mcp.sock'); s.sendall(b'{\"action\":\"health\"}\\n'); assert json.loads(s.recv(4096))['ok']",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 8
+      start_period: 30s
+
   mcp-database:
     build:
       context: ./server/sandbox_sidecar
@@ -361,6 +403,8 @@ services:
         condition: service_healthy
       mcp-token:
         condition: service_healthy
+      mcp-saas:
+        condition: service_healthy
       mcp-database:
         condition: service_healthy
       mcp-database-local:
@@ -408,6 +452,12 @@ services:
       MCP_PUBLIC_SOCKET_PATH: /run/modelmirror-public-mcp/public-mcp.sock
       MCP_FILES_SOCKET_PATH: /run/modelmirror-files-mcp/files-mcp.sock
       MCP_TOKEN_SOCKET_PATH: /run/modelmirror-token-mcp/token-mcp.sock
+      MCP_SAAS_SOCKET_PATH: /run/modelmirror-saas-mcp/saas-mcp.sock
+      MCP_CATALOG_STATEFUL_SAAS_SINGLE_USER_ACK: ${MCP_CATALOG_STATEFUL_SAAS_SINGLE_USER_ACK:-false}
+      MCP_CATALOG_ENABLE_AIRTABLE_MCP: ${MCP_CATALOG_ENABLE_AIRTABLE_MCP:-false}
+      MCP_CATALOG_ENABLE_ASANA_MCP: ${MCP_CATALOG_ENABLE_ASANA_MCP:-false}
+      MCP_CATALOG_ENABLE_GITLAB_MCP: ${MCP_CATALOG_ENABLE_GITLAB_MCP:-false}
+      MCP_CATALOG_ENABLE_NOTION_MCP_SERVER: ${MCP_CATALOG_ENABLE_NOTION_MCP_SERVER:-false}
       MCP_DATABASE_SOCKET_PATH: /run/modelmirror-database-mcp/database-mcp.sock
       MCP_DATABASE_LOCAL_SOCKET_PATH: /run/modelmirror-database-local-mcp/database-mcp.sock
       MCP_CATALOG_STORAGE_DIR: /app/mcp/storage
@@ -440,6 +490,7 @@ services:
       - mcp_public_socket:/run/modelmirror-public-mcp
       - mcp_files_socket:/run/modelmirror-files-mcp
       - mcp_token_socket:/run/modelmirror-token-mcp
+      - mcp_saas_socket:/run/modelmirror-saas-mcp
       - mcp_database_socket:/run/modelmirror-database-mcp
       - mcp_database_local_socket:/run/modelmirror-database-local-mcp
       - mcp_file_inputs:/app/mcp-file-inputs
@@ -602,6 +653,7 @@ volumes:
   mcp_public_socket:
   mcp_files_socket:
   mcp_token_socket:
+  mcp_saas_socket:
   mcp_database_socket:
   mcp_database_local_socket:
   mcp_file_inputs:
@@ -620,4 +672,6 @@ networks:
   mcp_public_egress:
     driver: bridge
   mcp_database_egress:
+    driver: bridge
+  mcp_saas_egress:
     driver: bridge

--- a/docs/MCP_CATALOG_ROADMAP.md
+++ b/docs/MCP_CATALOG_ROADMAP.md
@@ -1,6 +1,6 @@
 # MCP 目录扩充与适配路线
 
-最后更新日期：2026-08-06
+最后更新日期：2026-08-07
 维护人：模镜团队
 
 ## 1. 目标与当前范围
@@ -15,11 +15,11 @@
 - [Awesome-MCP-ZH](https://github.com/yzfly/Awesome-MCP-ZH)
 - [awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers)
 
-截至 2026-08-06，目录仍冻结为 100 个 MCP 条目、18 个分类。批次 0—4 已验收的 32 项保持不变；批次 5 的 DBHub、MongoDB、ClickHouse、Redis、DuckDB 与 Supabase 已标记为 `ready`。PostgreSQL、SQLite、Cognee、Graphiti 与 Hindsight 新增为 `blocked`，连同 Airbnb、BibiGPT、Manim 与 Snyk 共 9 项阻断，其余 53 项保持 `planned`。当前状态精确为 **38 ready / 53 planned / 9 blocked**。
+截至 2026-08-07，目录仍冻结为 100 个 MCP 条目、18 个分类。批次 0—5 已验收的 38 项保持不变；批次 6 的 Airtable、Asana、GitLab.com 与 Notion 已完成固定适配。中国电商经营 MCP 因八个平台的 OAuth/商家授权、短期 Token 与敏感订单数据边界尚未逐平台验收，Mem0 因本地上游归档并迁移到未锁定版本的托管远程 MCP，二者标记为 `blocked`。当前状态精确为 **42 ready / 47 planned / 11 blocked**。
 
 ## 2. 当前边界与明确不实现
 
-批次 1–5 只增加固定适配器：批次 1 使用完全断网计算 sidecar，批次 2 使用独立公网 sidecar，批次 3 使用受控上传工作区和完全断网的文件处理 sidecar，批次 4 使用固定 Token 槽和只读出口 sidecar，批次 5 使用结构化数据库配置及相互隔离的远程/本地数据库 sidecar。五批都不扩大账号授权、任意连接或任意执行能力：
+批次 1–6 只增加固定适配器：批次 1 使用完全断网计算 sidecar，批次 2 使用独立公网 sidecar，批次 3 使用受控上传工作区和完全断网的文件处理 sidecar，批次 4 使用固定 Token 槽和只读出口 sidecar，批次 5 使用结构化数据库配置及相互隔离的远程/本地数据库 sidecar，批次 6 使用固定 SaaS 服务、账号作用域和资源级一次性审批 sidecar。六批都不扩大任意连接或任意执行能力：
 
 - 不接受用户指定的 Python 包、解释器、命令、工作目录或其他额外运行时。
 - 不实现 OAuth 回调、刷新或外站登录；批次 4—5 的卡片可把明文 Secret 单次提交到服务端加密库，但连接配置只接受不透明 `credential_id`，保存后不再返回或显示明文。
@@ -28,6 +28,8 @@
 - Fetch 的用户 URL 只是工具参数，只允许公网 HTTPS，并逐次执行 DNS、SSRF、重定向和响应大小校验；它不是自定义 MCP 连接入口。
 - 批次 3 客户端只能提交不透明 `workspace_id`、文件 ID 和产物名，不能提交宿主路径、`cwd`、环境变量或 URI；输入文件封存后只读。
 - 批次 5 客户端只能提交清单声明的数据库类型、主机名、端口、库名、用户名、严格 TLS 模式或 Supabase `project_ref`；DBHub 首批仅支持 PostgreSQL、MySQL 与 MariaDB，SQL Server 保持关闭；不接受 DSN、数据库 URI、SSH 隧道、Header、环境变量名或任意连接参数。
+- 批次 6 只接受清单声明的 Personal Access Token / Internal Integration Token 与固定资源 ID；不接受服务 URL、任意 Host、Header、环境变量、OAuth 回调或外站登录。GitLab 首批只连接 `gitlab.com`，自建 GitLab 保持未开放。
+- 批次 6 的真实账号执行还需部署者显式设置单用户本地实例确认门禁；当前 API 没有逐请求认证主体传播，多用户共享部署不得开启。
 - 不接管 Blender、Zotero、Obsidian、JetBrains、Xcode、Ghidra 等桌面宿主。
 - 不提供用户自定义 MCP 连接。
 - 不提供 MCP Builder、可视化生成器或发布市场流程。
@@ -47,7 +49,7 @@
 数据层必须满足以下约束：
 
 1. 前端条目不得包含可执行 `command`、MCP URL、Header 或环境变量配置。
-2. `ready` 后端适配器必须有固定命令或端点、独立功能开关和显式工具策略；现有 7 项以兼容策略保持行为不变，批次 1—5 的 31 项使用完整的逐工具策略。
+2. `ready` 后端适配器必须有固定命令或端点、独立功能开关和显式工具策略；现有 7 项以兼容策略保持行为不变，批次 1—6 的 35 项使用完整的逐工具策略。
 3. `planned` 后端适配器不得包含可执行命令或端点，环境开关不能绕过状态门禁。
 4. 前端不得保存真实 Secret，也不得在仓库内出现真实凭证。
 5. 上游清单只用于发现项目；能否连接必须按模镜运行边界重新核验。
@@ -81,7 +83,7 @@
 | 3 | `basic-memory-mcp`、`excel-mcp-server`、`git-mcp`、`manim-mcp`、`markitdown-mcp` | 5 | **已完成门槛判定**：Basic Memory、Excel、Git、MarkItDown 可用；Manim 因任意 Python 场景执行依赖第 8 批隔离而阻断 |
 | 4 | AgentQL、Brave、Exa、Firecrawl、Perplexity、Tavily、Axiom、Figma Context、Google Maps、Grafana、Graphlit、Kagi、Pinecone、Shodan、Snyk、VirusTotal | 16 | **已完成门槛判定**：15 项通过加密凭据槽、固定出口域、只读工具和 Secret 泄漏测试；Snyk 因本地构建执行依赖第 8 批隔离而阻断 |
 | 5 | DBHub、PostgreSQL、MongoDB、ClickHouse、Cognee、Graphiti、Hindsight、Redis、SQLite、DuckDB、Supabase | 11 | **已完成门槛判定**：DBHub、MongoDB、ClickHouse、Redis、DuckDB、Supabase 通过结构化配置、租户凭据、协议级只读、预检与查询限制；PostgreSQL、SQLite 因归档实现受阻，三项状态化记忆转入第 5B 计划 |
-| 6 | Airtable、Asana、GitLab、中国电商经营、Notion、Mem0 | 6 | 修改预览与审批、幂等、限流、账号解绑 |
+| 6 | Airtable、Asana、GitLab、中国电商经营、Notion、Mem0 | 6 | **已完成门槛判定**：Airtable、Asana、GitLab.com、Notion 通过固定作用域、真实预检、资源级审批、限流与解绑；中国电商与 Mem0 因授权/托管契约受阻 |
 | 7 | Chrome DevTools、Playwright、Puppeteer、Selenium | 4 | 临时浏览器、目标域、上传下载与会话清理边界 |
 | 8 | MCP Run Python、MCP Python Interpreter | 2 | 一次性断网容器、无宿主挂载、无 Docker socket、进程资源限制 |
 | 9 | Apify、Bright Data、Browserbase、E2B、Stripe、Terraform、Aiven、Alpaca、AWS KB、ElevenLabs、MiniMax、S3、Kubernetes、Semgrep | 14 | 费用/资源上限、目标预览、终止性操作强制审批 |
@@ -129,10 +131,22 @@
 - PostgreSQL 官方参考实现因归档和 npm 弃用保持 `blocked`，可使用受控 DBHub PostgreSQL 模式；SQLite 官方实现因归档且暴露写工具保持 `blocked`。Cognee、Graphiti 与 Hindsight 属于有状态记忆系统，转入“第 5B 批：状态化记忆”，在独立持久卷、模型/费用、租户数据保留与通用写审批完成前不连接。
 - 本批不开放任何数据库写入、删除、DDL 或状态化记忆写工具，也不复用批次 3 的文件工作区审批冒充数据库审批。后续写能力必须另行实现数据库目标和状态绑定的一次性审批。
 
+批次 6 的执行结论：
+
+- 独立 `modelmirror-mcp-saas:wave6-v1` 只运行仓库内置的固定 REST 兼容契约，运行时不下载上游代码。sidecar 为非 root、只读根文件系统、无宿主目录与 Docker socket、移除 capabilities，并仅通过私有 Unix socket 接收服务端生成的短期配置。
+- Airtable 锁定兼容上游 MCP v1.14.0，Asana 锁定 v1.6.0，Notion 锁定 v2.5.0；三者均按 MIT 契约独立实现。GitLab 归档参考 MCP 0.6.2 不进入镜像，首批仅以自有固定 REST 契约访问 `gitlab.com`。每项只连接编译进镜像的官方 HTTPS Host，禁止重定向和任意 URL/Header。
+- Airtable 绑定固定 Base，Asana 绑定 Workspace/Project，GitLab 绑定数字 Project ID，Notion 绑定固定 Data Source。连接时先执行账号身份与目标资源只读预检；预检失败不保留可调用会话。Token 由卡片内加密凭据槽保存，不使用 OAuth，也没有外站登录入口。
+- 只读调用遇到 `429`、`502`、`503` 或 `504` 时最多有界重试两次，并遵守封顶后的 `Retry-After`；写调用不自动重试。明确的限流或提供商拒绝作为终止性失败返回，只有 `-32008`、发送后超时或连接中断等歧义结果才标记 `unknown_outcome`，要求用户先到服务商核对。
+- `create`、`update` 与 `comment` 类工具均为 `state-write + requires_approval`。一次性审批冻结租户、所有者、项目、会话、工具/Schema、规范化参数、配置版本、凭据版本、账号预检摘要、目标资源预览和服务端幂等键；连接时完整工具名与 `inputSchema` 摘要必须匹配冻结契约。5 分钟过期，重连、重配、凭据轮换、账号或策略漂移、重复确认都会失效。删除、归档、合并、仓库写入、批量写入和其他终止性工具不暴露。
+- 目录会话在管理器发布前即绑定目录所有者，通用会话接口不能发现、调用或断开。连接、配置、调用、确认、解绑与凭据撤销共享生命周期门禁：连接中拒绝重配，解绑/撤销开始后拒绝新调用和旧审批确认，并先等待活动读取结束再断开子进程。
+- 项目级解绑会作废待审批、清除作用域和本地执行账本，并可撤销该卡片的本地加密凭据。移除本地 Token 不等于在服务商后台撤销，界面会明确提示用户自行完成上游撤销。
+- 当前目录服务仍是部署时固定 `tenant/owner` 的单例，因此真实 SaaS 能力除项目开关外还要求 `MCP_CATALOG_STATEFUL_SAAS_SINGLE_USER_ACK=true`；默认关闭，多用户部署继续视为发布阻断。
+- `mcp-cn-commerce` v0.1.5 覆盖八个平台和 114 个工具，各平台授权、域名、短期 Token 与订单/售后敏感数据无法作为单一契约验收，保持 `blocked`。Mem0 本地 v0.2.1 已归档，官方迁移到无固定版本的托管远程 MCP；在 OAuth、Schema 锁定和租户记忆作用域完成前保持 `blocked`。
+
 ## 6. 验收、发布和回退
 
 - 每个项目必须通过初始化、工具发现、代表性调用、超时、重连、断开与清理测试；Schema 漂移视为阻断。
-- 安全测试按批次覆盖 Secret 泄漏、SSRF、重定向、路径越界、ZIP Slip、链接与压缩炸弹、跨项目/产物/租户越权、沙箱逃逸、TLS 降级、SQL 多语句及写入旁路、查询超时/行数、权限撤销、审批绕过和高风险操作默认关闭。
+- 安全测试按批次覆盖 Secret 泄漏、SSRF、重定向、路径越界、ZIP Slip、链接与压缩炸弹、跨项目/产物/租户越权、沙箱逃逸、TLS 降级、SQL 多语句及写入旁路、查询超时/行数、权限撤销、审批绕过、参数/配置/凭据漂移、限流、重试、幂等重放、未知写入结果、账号解绑和高风险操作默认关闭。
 - 前端必须显示中文批次、状态、连接方式、风险、限制和门槛；后端未返回 `executable=true` 时按钮不可连接。
 - 每个项目有独立服务端开关。回退只关闭开关、断开会话并清理沙箱，不删除目录条目或凭据。
 - 运行日志只记录项目 ID、状态、耗时、错误类别和策略事件，不记录 Secret、完整参数或工具返回正文。
@@ -148,7 +162,7 @@
 
 主要风险是上游项目快速变化、条目说明过期，以及把“已收录”误解为“当前可安全运行”。前端必须持续使用明确的状态标签和禁用按钮表达边界。
 
-批次 0–4 不引入数据库迁移；批次 5 只把旧凭据 JSON 元数据显式迁移到 `local/local` 作用域，不接触外部数据库 schema 或数据。批次 2 回退时关闭对应公网项目开关并停止 `mcp-public`；批次 3 回退时关闭四个文件项目开关、撤销审批并停止 `mcp-files`；批次 4 回退时关闭 15 个 Token 项目的独立功能开关、断开目录会话并停止 `mcp-token`；批次 5 回退时关闭六个数据库项目开关、断开会话、停止远程和本地数据库 sidecar，并清理临时 DuckDB 工作区。回退不删除卡片专属加密凭据，也不修改或删除外部数据库数据；持久 Basic Memory 数据同样不自动删除。Airbnb、BibiGPT、Manim、Snyk、PostgreSQL、SQLite、Cognee、Graphiti 与 Hindsight 本来就不可执行。旧版 `/api/mcp/*` 接口保持兼容，但目录会话不能使用无项目策略的直接调用端点：
+批次 0–4 不引入数据库迁移；批次 5 只把旧凭据 JSON 元数据显式迁移到 `local/local` 作用域，不接触外部数据库 schema 或数据。批次 2 回退时关闭对应公网项目开关并停止 `mcp-public`；批次 3 回退时关闭四个文件项目开关、撤销审批并停止 `mcp-files`；批次 4 回退时关闭 15 个 Token 项目的独立功能开关、断开目录会话并停止 `mcp-token`；批次 5 回退时关闭六个数据库项目开关、断开会话、停止远程和本地数据库 sidecar，并清理临时 DuckDB 工作区；批次 6 回退时关闭四个 SaaS 项目开关和全局单用户确认门禁、执行项目解绑并停止 `mcp-saas`。回退不自动删除外部 SaaS 数据，也不声称撤销服务商 Token；卡片专属加密凭据仅在用户选择撤销时删除。Airbnb、BibiGPT、Manim、Snyk、PostgreSQL、SQLite、Cognee、Graphiti、Hindsight、中国电商经营 MCP 与 Mem0 本来就不可执行。旧版 `/api/mcp/*` 接口保持兼容，但目录会话不能使用无项目策略的直接调用端点：
 
 - `server/mcp/catalog.py`
 - `server/mcp/sandbox_proxy.py`
@@ -156,6 +170,7 @@
 - `server/mcp/file_proxy.py`
 - `server/mcp/token_proxy.py`
 - `server/mcp/database_proxy.py`
+- `server/mcp/saas_proxy.py`
 - `server/mcp/workspace.py`
 - `server/sandbox_sidecar/`
 - `client/src/data/mcpProjects.ts`

--- a/docs/MCP_INTEGRATION.md
+++ b/docs/MCP_INTEGRATION.md
@@ -83,7 +83,7 @@ Agent 画布使用 `toolset_resource -> workflow_agent` 的 `toolset` 绑定边�
 目录适配器安全默认值：
 
 - 前端不能提交 `server_command`、MCP URL、Header、环境变量名或工作目录。
-- 当前目录状态为 **38 ready / 53 planned / 9 blocked**；planned 与 blocked 项没有可执行命令或端点，设置环境功能开关也不能绕过状态门槛。
+- 当前目录状态为 **42 ready / 47 planned / 11 blocked**；planned 与 blocked 项没有可执行命令或端点，设置环境功能开关也不能绕过状态门槛。
 - 新适配器若没有显式工具读写与审批策略，工具调用会 fail-closed。
 - 日志只记录项目 ID、工具名、状态和耗时，不记录参数、返回正文或 Secret。
 
@@ -135,6 +135,17 @@ Agent 画布使用 `toolset_resource -> workflow_agent` 的 `toolset` 绑定边�
 - `postgres-mcp` 与 `sqlite-mcp` 因归档或弃用的上游实现保持 `blocked`。Cognee、Graphiti、Hindsight 转入第 5B 状态化记忆计划；其持久卷、模型与费用、数据保留及写入审批尚未完成，因此没有连接入口。
 - Wave 5 首轮只开放读取、结构浏览和受限查询，不开放写入审批。数据库写审批不能复用依赖文件 manifest 的批次 3 审批；后续必须绑定租户、数据库目标、会话、配置/凭据版本、冻结参数和数据库状态。
 
+批次 6 的四个可用有状态 SaaS 适配器通过固定 `saas_proxy.py` 接入独立 `mcp-saas` sidecar：
+
+- `airtable-mcp`、`asana-mcp`、`gitlab-mcp` 与 `notion-mcp-server` 只运行仓库内置固定 REST 契约，不动态下载或执行上游 MCP 代码。GitLab 首批仅允许 `gitlab.com`；自建域名、任意 URL、Header、环境变量与 OAuth 回调全部关闭。
+- 每张卡片在本地创建和选择加密 PAT / Integration Token，并保存固定 Base、Workspace/Project、数字 GitLab Project ID 或 Notion Data Source 作用域。连接前执行账号身份与目标资源的代表性只读预检；传输、凭据、账号和目标预检状态分别展示。
+- 真实 SaaS 执行要求对应的 `MCP_CATALOG_ENABLE_<PROJECT_ID>=true` 与 `MCP_CATALOG_STATEFUL_SAAS_SINGLE_USER_ACK=true` 同时满足；Compose 中五个门禁均默认关闭。当前目录 API 仍使用部署时固定 `tenant/owner`，尚无逐请求认证主体，因此多用户共享部署不得开启。
+- 只读工具遇到上游 `429` 或临时 `5xx` 时最多有界重试两次，并遵守封顶后的 `Retry-After`。写工具不自动重试：明确的限流或提供商拒绝会作为终止性失败返回，只有 `-32008`、发送后超时或连接中断等歧义结果才标记 `unknown_outcome` 并要求先到服务商核对。
+- `create`、`update`、`comment` 工具均先返回 409 `approval_required`。审批不是文件工作区审批：它绑定租户、所有者、项目、会话、工具/Schema、冻结参数、配置与凭据版本、账号预检摘要、目标资源预览和服务端幂等键；连接时还会核对完整工具名与 `inputSchema` 摘要。5 分钟过期，重连、重配、轮换、状态漂移或重放都会失效。删除、归档、合并、仓库写入和批量终止性操作不暴露。
+- 目录会话在管理器发布前即绑定目录所有者，通用会话列表、调用和断开接口不能发现或操作它。连接建立、调用、审批确认、解绑和凭据撤销共享生命周期门禁；连接中不能重配，解绑或撤销开始后不能排队新调用或确认旧审批。
+- 卡片内“解绑账号”会先阻止新调用并等待活动读取结束，再断开会话、撤销待审批并清除配置、预检与本地执行账本；可选择撤销该卡片的本地加密凭据。它不等于在 Airtable、Asana、GitLab 或 Notion 后台撤销 Token，用户仍需在服务商后台完成上游撤销。
+- `mcp-cn-commerce` 保持 `blocked`：八个平台、114 个工具、OAuth/商家授权、短期 Token 和订单/售后敏感数据尚未逐平台验收。`mem0-mcp` 保持 `blocked`：本地上游已归档，官方迁移到无固定版本的托管远程 MCP；OAuth、Schema 锁定和租户记忆作用域尚未完成。两项都不显示凭据、登录或连接入口。
+
 兼容层仍保留以下默认值：
 
 - 后端只接受 `list[str]` 形式的命令，不使用 shell。
@@ -185,6 +196,7 @@ npm view @example/mcp-server version
 | PUT | `/api/mcp/catalog/{project_id}/configuration` | 只接受清单允许的设置、`credential_id` 绑定和适用条目的 `workspace_id`；数据库不接受 DSN/URI |
 | POST | `/api/mcp/catalog/{project_id}/connect` | 按项目 ID 建立受控会话；数据库项目须先通过目标、TLS、认证与只读预检 |
 | DELETE | `/api/mcp/catalog/{project_id}/session` | 断开该目录项目的会话 |
+| POST | `/api/mcp/catalog/{project_id}/unbind` | 解绑当前 SaaS 账号：断开会话、作废审批并清除作用域；可选择撤销本地卡片凭据，但不声称撤销上游 Token |
 | POST | `/api/mcp/catalog/{project_id}/tools/{tool_name}/call` | 经项目工具策略调用已连接工具 |
 | GET/POST | `/api/mcp/catalog/{project_id}/workspaces` | 列出或创建当前项目的受控工作区 |
 | POST | `/api/mcp/catalog/{project_id}/workspaces/{workspace_id}/files` | 上传多文件、目录相对路径或安全 ZIP |
@@ -431,6 +443,7 @@ python server/mcp/test_manager.py
 | `server/mcp/file_proxy.py` | 把批次 3 固定项目 ID 和服务端工作区 ID 代理到断网文件 sidecar。 |
 | `server/mcp/token_proxy.py` | 移除短期凭据环境并把批次 4 固定项目 ID 与配置单次传给私有 sidecar。 |
 | `server/mcp/database_proxy.py` | 移除短期数据库配置环境，按固定项目路由到批次 5 的远程或断网本地 Unix socket。 |
+| `server/mcp/saas_proxy.py` | 移除短期 SaaS 配置环境，把批次 6 固定项目与账号作用域单次传给私有 sidecar。 |
 | `server/mcp/workspace.py` | 工作区、上传/ZIP 校验、封存 manifest、产物与保留期管理。 |
 | `server/sandbox_sidecar/compute_mcp.py` | 批次 1 的三个内置 Python MCP 工具契约。 |
 | `server/sandbox_sidecar/public_mcp.py` | 批次 2 的内置公网 MCP 兼容契约。 |
@@ -446,6 +459,9 @@ python server/mcp/test_manager.py
 | `server/sandbox_sidecar/database_contracts.py` | 批次 5 的结构化目标、凭据槽、工具白名单、协议只读和预检契约。 |
 | `server/sandbox_sidecar/database_server.py` | 批次 5 远程/本地数据库会话、限制、清理与 fail-closed 网关。 |
 | `server/sandbox_sidecar/Dockerfile.database` | `modelmirror-mcp-database:wave5-v1` 固定依赖镜像。 |
+| `server/sandbox_sidecar/saas_contracts.py` | 批次 6 的固定服务、作用域、凭据槽、工具 Schema、读写与幂等契约。 |
+| `server/sandbox_sidecar/saas_server.py` | 批次 6 的预检、限流、有界只读重试、写入未知结果与会话清理网关。 |
+| `server/sandbox_sidecar/Dockerfile.saas` | `modelmirror-mcp-saas:wave6-v1` 独立固定契约镜像。 |
 | `server/toolsets/` | Toolset/凭据 Store、版本发布、Schema 漂移与固定版本 Provider。 |
 | `client/src/pages/ToolsetsPage.tsx` | MCP Toolset 创建、连接、工具配置、测试和发布管理页。 |
 | `server/tests/test_toolset_*.py` | Toolset Store、API、连接、固定版本与安全回归。 |
@@ -460,6 +476,7 @@ python server/mcp/test_manager.py
 | `server/tests/test_mcp_file_workspaces.py` | 批次 3 路径/ZIP、租户隔离、产物越权和一次性审批安全测试。 |
 | `server/tests/test_mcp_token_sidecar.py` | 批次 4 清单一致性、配置契约、Secret 传递、工具过滤和 URL 预检测试。 |
 | `server/tests/test_mcp_database_sidecar.py` | 批次 5 配置、租户凭据、TLS/只读预检、协议旁路、行数与超时测试。 |
+| `server/tests/test_mcp_saas_sidecar.py` | 批次 6 固定 Host、Schema、预检、审批、限流、幂等、未知写入结果与解绑测试。 |
 | `server/mcp/smoke_file_adapters.py` | 四个文件适配器初始化、发现、代表调用、重连、源文件不变和清理 smoke。 |
 | `client/src/components/McpServerCard.tsx` | 前端连接、工具表单、执行结果组件。 |
 | `client/src/components/McpWorkspacePanel.tsx` | 中文工作区上传、封存、绑定、容量/到期、产物下载和清理面板。 |

--- a/server/mcp/catalog.py
+++ b/server/mcp/catalog.py
@@ -16,6 +16,7 @@ import ipaddress
 import inspect
 import json
 import logging
+import math
 import os
 import re
 import sys
@@ -27,6 +28,7 @@ from typing import Any, Callable, Literal, Protocol
 
 from fastapi import APIRouter, File, Form, HTTPException, UploadFile
 from fastapi.responses import FileResponse
+from mcp.shared.exceptions import McpError
 from pydantic import BaseModel, ConfigDict, Field
 
 from mcp.types import CallToolResult, Tool
@@ -77,6 +79,7 @@ AdapterPreparationKind = Literal["installer", "bundled"]
 CatalogToolEffect = Literal["read", "artifact-create", "state-write", "terminal"]
 CatalogSettingKind = Literal["text", "integer", "enum", "slug", "hostname"]
 CatalogDatabaseMode = Literal["remote-read-only", "local-file-read-only"]
+CatalogApprovalContextKind = Literal["workspace", "remote-resource"]
 
 logger = logging.getLogger("modelmirror.mcp.catalog")
 
@@ -103,6 +106,31 @@ class CatalogApprovalRequiredError(CatalogAdapterPolicyError):
     def __init__(self, payload: dict[str, Any]) -> None:
         super().__init__("该操作需要一次性确认。")
         self.payload = payload
+
+
+class CatalogUnknownOutcomeError(CatalogAdapterPolicyError):
+    """Raised when a state-changing remote request may have been accepted."""
+
+    def __init__(self, idempotency_key: str) -> None:
+        super().__init__("远程写入结果未知；为避免重复修改，系统不会自动重试。")
+        self.idempotency_key = idempotency_key
+
+
+class CatalogProviderRejectedError(CatalogAdapterPolicyError):
+    """Raised when the provider proves that a remote write did not complete."""
+
+    def __init__(self, reason: str, idempotency_key: str) -> None:
+        normalized_reason = (
+            "rate_limited" if reason == "rate_limited" else "provider_rejected"
+        )
+        message = (
+            "上游服务已限流，本次写入未执行且不会自动重试。"
+            if normalized_reason == "rate_limited"
+            else "上游服务已明确拒绝本次写入，系统不会自动重试。"
+        )
+        super().__init__(message)
+        self.reason = normalized_reason
+        self.idempotency_key = idempotency_key
 
 
 @dataclass(frozen=True, slots=True)
@@ -211,6 +239,29 @@ class CatalogDatabasePolicy:
 
 
 @dataclass(frozen=True, slots=True)
+class CatalogSaaSPolicy:
+    """Public guardrails for a fixed, stateful SaaS account adapter."""
+
+    provider: str
+    fixed_hosts: tuple[str, ...]
+    tool_schema_sha256: str
+    preflight_checks: tuple[str, ...] = (
+        "authentication",
+        "account-identity",
+        "resource-scope",
+        "tool-schema",
+    )
+    rate_limit_per_minute: int = 30
+    max_concurrent_calls: int = 1
+    read_retry_limit: int = 2
+    write_retry_mode: str = "idempotency-key-only"
+    account_unbind_supported: bool = True
+
+    def to_public(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
 class CatalogAdapterManifest:
     project_id: str
     wave: int
@@ -236,6 +287,7 @@ class CatalogAdapterManifest:
     tool_policies: dict[str, CatalogToolPolicy] = field(default_factory=dict)
     workspace_policy: CatalogWorkspacePolicy | None = None
     database_policy: CatalogDatabasePolicy | None = None
+    saas_policy: CatalogSaaSPolicy | None = None
     legacy_unrestricted_calls: bool = False
     enabled_by_default: bool = False
     operation_timeout: float = 30.0
@@ -258,8 +310,21 @@ class CatalogAdapterManifest:
         return (
             self.availability == "ready"
             and self.feature_enabled
+            and (
+                self.saas_policy is None
+                or self.stateful_saas_gate_enabled
+            )
             and bool(self.server_command or self.endpoint)
         )
+
+    @property
+    def stateful_saas_gate_enabled(self) -> bool:
+        if self.saas_policy is None:
+            return True
+        return os.getenv(
+            "MCP_CATALOG_STATEFUL_SAAS_SINGLE_USER_ACK",
+            "",
+        ).strip().lower() in {"1", "true", "yes", "on"}
 
     def to_public(
         self,
@@ -317,6 +382,12 @@ class CatalogAdapterManifest:
                 if self.database_policy is not None
                 else None
             ),
+            "saas_policy": (
+                self.saas_policy.to_public()
+                if self.saas_policy is not None
+                else None
+            ),
+            "stateful_saas_gate_enabled": self.stateful_saas_gate_enabled,
         }
 
 
@@ -365,6 +436,11 @@ TOKEN_SANDBOX_PROXY = (
 DATABASE_SANDBOX_PROXY = (
     sys.executable,
     str(Path(__file__).resolve().with_name("database_proxy.py")),
+)
+SAAS_SANDBOX_PROXY = (
+    sys.executable,
+    "-m",
+    "mcp.saas_proxy",
 )
 WAVE_ONE_ADAPTERS: dict[str, tuple[str, tuple[str, ...]]] = {
     "calculator-mcp": (
@@ -825,6 +901,144 @@ WAVE_FIVE_ADAPTERS: dict[str, WaveFiveAdapterSpec] = {
             "远程 OAuth、迁移、函数、分支、项目管理和其他修改操作继续保留到后续批次。",
         ),
         network_policy="allowlist:api.supabase.com,supabase.com",
+    ),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class WaveSixAdapterSpec:
+    adapter_version: str
+    provider: str
+    fixed_hosts: tuple[str, ...]
+    rate_limit_per_minute: int
+    tool_schema_sha256: str
+    read_tools: tuple[str, ...]
+    write_tools: tuple[str, ...]
+    credential_policies: tuple[CatalogCredentialSlotPolicy, ...]
+    setting_policies: tuple[CatalogSettingPolicy, ...]
+    limitations: tuple[str, ...] = ()
+
+
+WAVE_SIX_ADAPTERS: dict[str, WaveSixAdapterSpec] = {
+    "airtable-mcp": WaveSixAdapterSpec(
+        "wave6-v1",
+        "Airtable",
+        ("api.airtable.com",),
+        240,
+        "5fce8249d6fcfa6b57f17d6c4d996c0c1ac5b8299584547923c2f18b14ca86c4",
+        ("list_tables", "list_records", "get_record"),
+        ("create_record", "update_record"),
+        (
+            _credential(
+                "personal_access_token",
+                "Airtable Personal Access Token",
+                "仅用于访问配置中固定的 Base。",
+            ),
+        ),
+        (
+            CatalogSettingPolicy(
+                "base_id",
+                "Airtable Base ID",
+                "只填写固定 Base 标识，不接受 URL、Workspace 或任意端点。",
+                required=True,
+                pattern=r"^app[A-Za-z0-9]{14}$",
+            ),
+        ),
+        ("删除记录、修改表结构、批量写入和任意 Base 访问均关闭。",),
+    ),
+    "asana-mcp": WaveSixAdapterSpec(
+        "wave6-v1",
+        "Asana",
+        ("app.asana.com",),
+        120,
+        "c935b8d982352d5e8379fe32a84986a4dd45c7d8635a6bb95838d26680f37d86",
+        ("list_projects", "list_tasks", "get_task"),
+        ("create_task", "update_task", "add_comment"),
+        (
+            _credential(
+                "personal_access_token",
+                "Asana Personal Access Token",
+                "仅用于配置中固定的 Workspace 与 Project。",
+            ),
+        ),
+        (
+            CatalogSettingPolicy(
+                "workspace_gid",
+                "Asana Workspace GID",
+                "固定账号工作区；不接受 URL。",
+                required=True,
+                pattern=r"^[1-9][0-9]{0,31}$",
+            ),
+            CatalogSettingPolicy(
+                "project_gid",
+                "Asana Project GID",
+                "所有任务读写均限制在该项目。",
+                required=True,
+                pattern=r"^[1-9][0-9]{0,31}$",
+            ),
+        ),
+        ("删除任务或项目、批量修改和跨 Workspace 操作均关闭。",),
+    ),
+    "gitlab-mcp": WaveSixAdapterSpec(
+        "wave6-v1-gitlab-com-only",
+        "GitLab",
+        ("gitlab.com",),
+        300,
+        "c5525a94bbe3dd3c4f83381f6138375243000102d31b28360641acc3cddb6dd9",
+        (
+            "list_issues", "get_issue", "list_merge_requests",
+            "get_merge_request", "get_repository_file",
+        ),
+        ("create_issue", "update_issue", "add_issue_note"),
+        (
+            _credential(
+                "personal_access_token",
+                "GitLab Personal Access Token",
+                "仅用于 gitlab.com 上配置中固定的 Project。",
+            ),
+        ),
+        (
+            CatalogSettingPolicy(
+                "project_id",
+                "GitLab Project ID",
+                "首批只接受 gitlab.com 的数字 Project ID；自建实例继续阻断。",
+                kind="integer",
+                required=True,
+                minimum=1,
+                maximum=9_999_999_999,
+            ),
+        ),
+        ("仅支持 gitlab.com；合并、仓库写入、流水线触发和删除操作全部关闭。",),
+    ),
+    "notion-mcp-server": WaveSixAdapterSpec(
+        "wave6-v1",
+        "Notion",
+        ("api.notion.com",),
+        150,
+        "4c5a2edc829d7d8823dd6e2270d52c6bc8bc67f9a4cba55b6edc59be4a70da80",
+        ("query_data_source", "retrieve_page"),
+        ("create_page", "update_page_properties"),
+        (
+            _credential(
+                "integration_token",
+                "Notion Integration Token",
+                "仅用于 Integration 已授权且配置中固定的 Data Source。",
+            ),
+        ),
+        (
+            CatalogSettingPolicy(
+                "data_source_id",
+                "Notion Data Source ID",
+                "只填写已共享给 Integration 的固定 Data Source ID。",
+                required=True,
+                pattern=(
+                    r"^(?:[0-9a-fA-F]{32}|"
+                    r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+                    r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$"
+                ),
+            ),
+        ),
+        ("仅开放固定 Data Source；归档、删除、Schema 修改、任意搜索和跨作用域写入均关闭。",),
     ),
 }
 
@@ -1413,6 +1627,108 @@ def build_catalog_manifests() -> dict[str, CatalogAdapterManifest]:
             filesystem_policy="blocked:no-runtime",
         )
 
+    for project_id, spec in WAVE_SIX_ADAPTERS.items():
+        manifests[project_id] = CatalogAdapterManifest(
+            project_id=project_id,
+            wave=6,
+            availability="ready",
+            connection_kind="sandboxed-stdio",
+            risk="high",
+            required_capabilities=(
+                "fixed-saas-contract",
+                "tenant-owner-scoped-account-binding",
+                "remote-resource-approval",
+                "idempotent-write-ledger",
+                "provider-rate-limits",
+                "account-unbinding",
+                "schema-drift-recovery",
+            ),
+            limitations=(
+                *spec.limitations,
+                "只允许部署时固定 tenant/owner 的单用户本地实例；多用户共享部署保持关闭。",
+                "本批只接受用户预先创建的 Token，不提供 OAuth 或外站登录入口。",
+            ),
+            adapter_version=spec.adapter_version,
+            runtime_image="modelmirror-mcp-saas:wave6-v1",
+            network_policy="allowlist:" + ",".join(spec.fixed_hosts),
+            filesystem_policy="read-only-empty-workspace",
+            resource_limits=(
+                ("cpu", "1.5 cores / 60 CPU seconds per session process"),
+                ("memory", "768 MiB sidecar"),
+                ("processes", "maximum 4 sessions / 96 sidecar PIDs"),
+                ("operation_timeout", "30 seconds"),
+                ("tool_output", "256 KiB"),
+            ),
+            server_command=(*SAAS_SANDBOX_PROXY, project_id),
+            preparation_kind="bundled",
+            allowed_settings=tuple(item.key for item in spec.setting_policies),
+            credential_slots=tuple(item.key for item in spec.credential_policies),
+            setting_policies=spec.setting_policies,
+            credential_policies=spec.credential_policies,
+            tool_policies={
+                **{
+                    name: CatalogToolPolicy(read_only=True, effect="read")
+                    for name in spec.read_tools
+                },
+                **{
+                    name: CatalogToolPolicy(
+                        read_only=False,
+                        requires_approval=True,
+                        effect="state-write",
+                    )
+                    for name in spec.write_tools
+                },
+            },
+            saas_policy=CatalogSaaSPolicy(
+                provider=spec.provider,
+                fixed_hosts=spec.fixed_hosts,
+                tool_schema_sha256=spec.tool_schema_sha256,
+                rate_limit_per_minute=spec.rate_limit_per_minute,
+            ),
+            enabled_by_default=False,
+            operation_timeout=30.0,
+            max_output_bytes=256 * 1024,
+        )
+
+    manifests["mcp-cn-commerce"] = CatalogAdapterManifest(
+        project_id="mcp-cn-commerce",
+        wave=6,
+        availability="blocked",
+        connection_kind="sandboxed-stdio",
+        risk="high",
+        required_capabilities=(
+            "per-platform-fixed-contracts",
+            "conditional-credential-slots",
+            "shop-scope-preflight",
+        ),
+        limitations=(
+            "上游同时覆盖多个平台，各平台凭据、域名和店铺作用域不同；当前不能用单一宽泛契约安全连接。",
+            "完成逐平台固定字段、固定域名与独立 smoke 前，不显示凭据、连接或外站登录入口。",
+        ),
+        adapter_version="blocked:platform-contract-matrix",
+        network_policy="blocked:no-fixed-platform-contract",
+        filesystem_policy="blocked:no-runtime",
+    )
+    manifests["mem0-mcp"] = CatalogAdapterManifest(
+        project_id="mem0-mcp",
+        wave=6,
+        availability="blocked",
+        connection_kind="sandboxed-stdio",
+        risk="high",
+        required_capabilities=(
+            "tenant-isolated-memory-namespace",
+            "state-write-approval",
+            "retention-and-unbind-policy",
+        ),
+        limitations=(
+            "长期记忆涉及持久状态、用户命名空间与删除语义；当前账户/保留策略尚未完成生产核验。",
+            "完成命名空间隔离、写入幂等和数据清理验收前，不提供连接或写入入口。",
+        ),
+        adapter_version="blocked:stateful-memory-policy",
+        network_policy="blocked:no-production-runtime",
+        filesystem_policy="blocked:no-runtime",
+    )
+
     manifests["snyk-mcp"] = CatalogAdapterManifest(
         project_id="snyk-mcp",
         wave=4,
@@ -1496,12 +1812,44 @@ class CatalogWorkspaceCreateRequest(BaseModel):
     display_name: str = Field(default="", max_length=120)
 
 
+class CatalogUnbindRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    revoke_credentials: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class CatalogConfigurationSnapshot:
+    revision: str
+    digest: str
+
+
+@dataclass(frozen=True, slots=True)
+class CatalogAccountSnapshot:
+    digest: str
+    tool_schema_sha256: str
+    verified_at: float
+
+
+@dataclass(slots=True)
+class CatalogExecutionLedgerEntry:
+    approval_id: str
+    tenant_id: str
+    owner_id: str
+    project_id: str
+    idempotency_key: str
+    state: Literal["started", "completed", "unknown", "rejected"]
+    result: dict[str, Any] | None = None
+
+
 @dataclass(slots=True)
 class CatalogApproval:
     approval_id: str
     tenant_id: str
+    owner_id: str
     project_id: str
     session_id: str
+    context_kind: CatalogApprovalContextKind
     workspace_id: str
     workspace_manifest_sha256: str
     tool_name: str
@@ -1509,6 +1857,14 @@ class CatalogApproval:
     argument_digest: str
     summary: str
     expires_at: float
+    configuration_revision: str = ""
+    configuration_digest: str = ""
+    credential_snapshot_digest: str = ""
+    account_snapshot_digest: str = ""
+    tool_schema_sha256: str = ""
+    tool_policy_digest: str = ""
+    idempotency_key: str = ""
+    target_preview: dict[str, Any] = field(default_factory=dict)
     used: bool = False
 
 
@@ -1563,23 +1919,60 @@ class MCPCatalogService:
         self.workspace_store = workspace_store
         self.tenant_id = str(tenant_id or "local")
         self.owner_id = str(owner_id or "local")
-        self._sessions: dict[tuple[str, str], str] = {}
+        self._sessions: dict[tuple[str, str, str], str] = {}
         self._configurations: dict[
-            tuple[str, str], CatalogConfigurationRequest
+            tuple[str, str, str], CatalogConfigurationRequest
         ] = {}
         self._credential_snapshots: dict[
-            tuple[str, str], dict[str, tuple[str, float]]
+            tuple[str, str, str], dict[str, tuple[str, float]]
         ] = {}
-        self._credential_verification: dict[tuple[str, str], str] = {}
-        self._preflight_status: dict[tuple[str, str], str] = {}
-        self._approvals: dict[tuple[str, str], CatalogApproval] = {}
+        self._configuration_snapshots: dict[
+            tuple[str, str, str], CatalogConfigurationSnapshot
+        ] = {}
+        self._account_snapshots: dict[
+            tuple[str, str, str], CatalogAccountSnapshot
+        ] = {}
+        self._credential_verification: dict[tuple[str, str, str], str] = {}
+        self._preflight_status: dict[tuple[str, str, str], str] = {}
+        self._approvals: dict[tuple[str, str, str], CatalogApproval] = {}
+        self._execution_ledger: dict[
+            tuple[str, str, str], CatalogExecutionLedgerEntry
+        ] = {}
+        self._approval_locks: dict[
+            tuple[str, str, str], asyncio.Lock
+        ] = {}
+        self._call_locks: dict[
+            tuple[str, str, str], asyncio.Lock
+        ] = {}
+        self._connecting_scopes: set[tuple[str, str, str]] = set()
+        self._unbinding_scopes: set[tuple[str, str, str]] = set()
         self._lock = asyncio.Lock()
 
-    def _scope_key(self, project_id: str) -> tuple[str, str]:
-        return (self.tenant_id, str(project_id or "").strip())
+    def _scope_key(self, project_id: str) -> tuple[str, str, str]:
+        return (
+            self.tenant_id,
+            self.owner_id,
+            str(project_id or "").strip(),
+        )
 
-    def _approval_key(self, approval_id: str) -> tuple[str, str]:
-        return (self.tenant_id, str(approval_id or "").strip())
+    def _approval_key(self, approval_id: str) -> tuple[str, str, str]:
+        return (
+            self.tenant_id,
+            self.owner_id,
+            str(approval_id or "").strip(),
+        )
+
+    def _session_owner(self, project_id: str) -> str:
+        """Bind catalog sessions before they become visible to generic routes."""
+
+        return ":".join(
+            (
+                "catalog",
+                self.tenant_id,
+                self.owner_id,
+                str(project_id or "").strip(),
+            )
+        )
 
     def _credential_call(
         self,
@@ -1635,6 +2028,16 @@ class MCPCatalogService:
             item["workspace_id"] = (
                 configuration.workspace_id if configuration else None
             )
+            if manifest.saas_policy is None:
+                item["account_status"] = "not-applicable"
+            elif manifest.availability == "blocked":
+                item["account_status"] = "blocked"
+            elif configuration is None:
+                item["account_status"] = "unbound"
+            elif scope_key in self._account_snapshots:
+                item["account_status"] = "verified"
+            else:
+                item["account_status"] = "unverified"
             if not manifest.credential_policies:
                 item["credential_verification"] = "not-required"
             elif configuration is None:
@@ -1644,7 +2047,7 @@ class MCPCatalogService:
                     scope_key,
                     "unverified",
                 )
-            if manifest.database_policy is None:
+            if manifest.database_policy is None and manifest.saas_policy is None:
                 item["preflight_status"] = "not-applicable"
             elif manifest.availability == "blocked":
                 item["preflight_status"] = "blocked"
@@ -1729,6 +2132,10 @@ class MCPCatalogService:
             )
 
         scope_key = self._scope_key(manifest.project_id)
+        if scope_key in self._unbinding_scopes:
+            raise CatalogAdapterPolicyError("账号正在解绑，请等待操作完成。")
+        if scope_key in self._connecting_scopes:
+            raise CatalogAdapterPolicyError("连接正在建立，请等待完成后再更新目录配置。")
         if (
             manifest.credential_policies or manifest.database_policy is not None
         ) and scope_key in self._sessions:
@@ -1822,10 +2229,14 @@ class MCPCatalogService:
         normalized = request.model_copy(deep=True)
         normalized.settings = normalized_settings
         self._configurations[scope_key] = normalized
+        self._configuration_snapshots[scope_key] = self._snapshot_configuration(
+            normalized
+        )
         self._credential_snapshots.pop(scope_key, None)
+        self._account_snapshots.pop(scope_key, None)
         if manifest.credential_policies:
             self._credential_verification[scope_key] = "unverified"
-        if manifest.database_policy is not None:
+        if manifest.database_policy is not None or manifest.saas_policy is not None:
             self._preflight_status[scope_key] = "unverified"
         self._revoke_approvals(manifest.project_id)
         return {
@@ -1839,13 +2250,34 @@ class MCPCatalogService:
     async def connect(self, project_id: str) -> dict[str, Any]:
         manifest = self._require_executable(project_id)
         scope_key = self._scope_key(manifest.project_id)
+        if scope_key in self._unbinding_scopes:
+            raise CatalogAdapterPolicyError("账号正在解绑，请等待操作完成。")
+        if scope_key in self._connecting_scopes:
+            raise CatalogAdapterPolicyError("该目录连接正在建立，请等待当前操作完成。")
+        self._connecting_scopes.add(scope_key)
+        try:
+            return await self._connect_with_lifecycle_lock(manifest, scope_key)
+        finally:
+            self._connecting_scopes.discard(scope_key)
+
+    async def _connect_with_lifecycle_lock(
+        self,
+        manifest: CatalogAdapterManifest,
+        scope_key: tuple[str, str, str],
+    ) -> dict[str, Any]:
+        session_owner = self._session_owner(manifest.project_id)
         started_at = time.monotonic()
         async with self._lock:
+            if scope_key in self._unbinding_scopes:
+                raise CatalogAdapterPolicyError("账号正在解绑，请等待操作完成。")
             existing = self._sessions.get(scope_key)
             if existing:
                 try:
                     await self._ensure_credentials_fresh(manifest.project_id)
-                    tools = await self.manager.list_tools(existing)
+                    tools = await self.manager.list_tools(
+                        existing,
+                        session_owner=session_owner,
+                    )
                     return self._connection_payload(manifest, existing, tools)
                 except MCPSessionNotFoundError:
                     self._sessions.pop(scope_key, None)
@@ -1930,7 +2362,11 @@ class MCPCatalogService:
                     handshake_name = (
                         "MCP_DATABASE_HANDSHAKE_B64"
                         if manifest.database_policy is not None
-                        else "MCP_TOKEN_HANDSHAKE_B64"
+                        else (
+                            "MCP_SAAS_HANDSHAKE_B64"
+                            if manifest.saas_policy is not None
+                            else "MCP_TOKEN_HANDSHAKE_B64"
+                        )
                     )
                     environment[handshake_name] = base64.urlsafe_b64encode(
                         handshake_payload
@@ -1946,18 +2382,28 @@ class MCPCatalogService:
                         else 1
                     ),
                     "operation_timeout": manifest.operation_timeout,
+                    "session_owner": session_owner,
                 }
                 if environment:
                     profile["environment"] = environment
                 session_id = await self.manager.connect_profile(**profile)
                 if manifest.credential_policies or manifest.database_policy is not None:
-                    await self.manager.scrub_session_environment(session_id)
+                    await self.manager.scrub_session_environment(
+                        session_id,
+                        session_owner=session_owner,
+                    )
             else:
-                session_id = await self.manager.connect(list(manifest.server_command))
+                session_id = await self.manager.connect(
+                    list(manifest.server_command),
+                    session_owner=session_owner,
+                )
             try:
-                if manifest.database_policy is not None:
+                if manifest.database_policy is not None or manifest.saas_policy is not None:
                     self._preflight_status[scope_key] = "verifying"
-                tools = await self.manager.list_tools(session_id)
+                tools = await self.manager.list_tools(
+                    session_id,
+                    session_owner=session_owner,
+                )
                 if manifest.legacy_unrestricted_calls:
                     await self.registry.register_session_tools(
                         session_id=session_id,
@@ -1965,18 +2411,70 @@ class MCPCatalogService:
                         tools=tools,
                     )
             except Exception:
-                if manifest.database_policy is not None:
+                if manifest.database_policy is not None or manifest.saas_policy is not None:
                     self._preflight_status[scope_key] = "failed"
-                await self.manager.disconnect(session_id)
+                await self.manager.disconnect(
+                    session_id,
+                    session_owner=session_owner,
+                )
                 raise
+            account_snapshot: CatalogAccountSnapshot | None = None
+            if manifest.saas_policy is not None:
+                configuration_snapshot = self._configuration_snapshots.get(scope_key)
+                if configuration_snapshot is None:
+                    await self.manager.disconnect(
+                        session_id,
+                        session_owner=session_owner,
+                    )
+                    self._preflight_status[scope_key] = "failed"
+                    raise CatalogAdapterPolicyError("SaaS 配置快照缺失，请重新保存配置。")
+                schema_digest = self._tool_schema_digest(tools)
+                expected_tools = set(manifest.tool_policies)
+                if (
+                    {tool.name for tool in tools} != expected_tools
+                    or schema_digest
+                    != manifest.saas_policy.tool_schema_sha256
+                ):
+                    await self.manager.disconnect(
+                        session_id,
+                        session_owner=session_owner,
+                    )
+                    self._preflight_status[scope_key] = "failed"
+                    raise CatalogAdapterPolicyError(
+                        "SaaS 工具清单或输入 Schema 发生漂移，连接已阻断。"
+                    )
+                account_material = {
+                    "project_id": manifest.project_id,
+                    "configuration": configuration_snapshot.digest,
+                    "credentials": self._credential_snapshot_digest(snapshots),
+                    "tool_schema": schema_digest,
+                }
+                account_snapshot = CatalogAccountSnapshot(
+                    digest=self._sha256_json(account_material),
+                    tool_schema_sha256=schema_digest,
+                    verified_at=time.time(),
+                )
+            if scope_key in self._unbinding_scopes:
+                await self.manager.disconnect(
+                    session_id,
+                    session_owner=session_owner,
+                )
+                self._preflight_status[scope_key] = "unverified"
+                raise CatalogAdapterPolicyError(
+                    "账号解绑已开始，本次连接未发布。"
+                )
+            # Publish catalog ownership only after all provider preflight and
+            # fixed tools/inputSchema checks have succeeded.
             self._sessions[scope_key] = session_id
             if manifest.credential_policies:
                 self._credential_snapshots[scope_key] = snapshots
-            if manifest.database_policy is not None:
+            if account_snapshot is not None:
+                self._account_snapshots[scope_key] = account_snapshot
+            if manifest.database_policy is not None or manifest.saas_policy is not None:
                 self._preflight_status[scope_key] = "verified"
                 if manifest.credential_policies:
-                    # Database children complete a real authenticated read-only
-                    # preflight before MCP initialization succeeds.
+                    # Database and stateful SaaS children complete an
+                    # authenticated read-only preflight before initialization.
                     self._credential_verification[scope_key] = "verified"
             payload = self._connection_payload(manifest, session_id, tools)
             logger.info(
@@ -1987,25 +2485,56 @@ class MCPCatalogService:
             )
             return payload
 
-    async def disconnect(self, project_id: str) -> dict[str, Any]:
-        manifest = self.get_manifest(project_id)
+    async def _disconnect_with_scope_locked(
+        self,
+        manifest: CatalogAdapterManifest,
+    ) -> dict[str, Any]:
         scope_key = self._scope_key(manifest.project_id)
         async with self._lock:
-            session_id = self._sessions.pop(scope_key, None)
-            self._credential_snapshots.pop(scope_key, None)
-            if manifest.database_policy is not None:
-                self._preflight_status[scope_key] = "unverified"
+            session_id = self._sessions.get(scope_key)
         if session_id is None:
             raise MCPSessionNotFoundError(
                 f"MCP catalog session not found: {manifest.project_id}"
             )
         try:
-            await self.manager.disconnect(session_id)
+            await self.manager.disconnect(
+                session_id,
+                session_owner=self._session_owner(manifest.project_id),
+            )
         finally:
             await self.registry.unregister_session(session_id)
+            async with self._lock:
+                if self._sessions.get(scope_key) == session_id:
+                    self._sessions.pop(scope_key, None)
+                    self._credential_snapshots.pop(scope_key, None)
+                    self._account_snapshots.pop(scope_key, None)
+                    if (
+                        manifest.database_policy is not None
+                        or manifest.saas_policy is not None
+                    ):
+                        self._preflight_status[scope_key] = "unverified"
         self._revoke_approvals(manifest.project_id)
         logger.info("MCP catalog disconnect project=%s", manifest.project_id)
         return {"ok": True, "project_id": manifest.project_id}
+
+    async def disconnect(self, project_id: str) -> dict[str, Any]:
+        manifest = self.get_manifest(project_id)
+        scope_key = self._scope_key(manifest.project_id)
+        lock = self._approval_locks.setdefault(scope_key, asyncio.Lock())
+        async with lock:
+            if any(
+                entry.tenant_id == self.tenant_id
+                and entry.owner_id == self.owner_id
+                and entry.project_id == manifest.project_id
+                and entry.state == "started"
+                for entry in self._execution_ledger.values()
+            ):
+                raise CatalogAdapterPolicyError(
+                    "远程写入仍在执行，当前不能断开会话；请等待结果确定。"
+                )
+            call_lock = self._call_locks.setdefault(scope_key, asyncio.Lock())
+            async with call_lock:
+                return await self._disconnect_with_scope_locked(manifest)
 
     async def call_tool(
         self,
@@ -2015,6 +2544,8 @@ class MCPCatalogService:
     ) -> dict[str, Any]:
         manifest = self._require_executable(project_id)
         scope_key = self._scope_key(manifest.project_id)
+        if scope_key in self._unbinding_scopes:
+            raise CatalogAdapterPolicyError("账号正在解绑，当前不能调用工具。")
         session_id = self._sessions.get(scope_key)
         if session_id is None:
             raise CatalogAdapterUnavailableError("请先连接该 MCP 适配器。")
@@ -2059,58 +2590,181 @@ class MCPCatalogService:
         manifest = self._require_executable(project_id)
         scope_key = self._scope_key(manifest.project_id)
         approval_key = self._approval_key(approval_id)
-        approval = self._approvals.get(approval_key)
-        if (
-            approval is None
-            or approval.tenant_id != self.tenant_id
-            or approval.project_id != manifest.project_id
-        ):
-            raise CatalogAdapterPolicyError("一次性确认不存在或已经失效。")
-        if approval.used or approval.expires_at <= time.time():
+        lock = self._approval_locks.setdefault(scope_key, asyncio.Lock())
+        async with lock:
+            if scope_key in self._unbinding_scopes:
+                raise CatalogAdapterPolicyError(
+                    "账号解绑或凭据撤销正在进行，当前不能确认写入。"
+                )
+            approval = self._approvals.get(approval_key)
+            ledger = self._execution_ledger.get(approval_key)
+            if approval is None and ledger is not None:
+                if ledger.state == "completed" and ledger.result is not None:
+                    replay = json.loads(json.dumps(ledger.result, ensure_ascii=False))
+                    replay["idempotency_key"] = ledger.idempotency_key
+                    replay["idempotent_replay"] = True
+                    replay["unknown_outcome"] = False
+                    return replay
+                if ledger.state in {"started", "unknown"}:
+                    raise CatalogUnknownOutcomeError(ledger.idempotency_key)
+            if (
+                approval is None
+                or approval.tenant_id != self.tenant_id
+                or approval.owner_id != self.owner_id
+                or approval.project_id != manifest.project_id
+            ):
+                raise CatalogAdapterPolicyError("一次性确认不存在或已经失效。")
+            if approval.used or approval.expires_at <= time.time():
+                self._approvals.pop(approval_key, None)
+                raise CatalogAdapterPolicyError("一次性确认已经使用或过期。")
+            if approval.context_kind == "workspace":
+                if self.workspace_store is None:
+                    raise CatalogAdapterPolicyError("MCP 文件工作区当前不可用。")
+                workspace = self.workspace_store.require_sealed(
+                    manifest.project_id,
+                    approval.workspace_id,
+                    tenant_id=self.tenant_id,
+                )
+                if workspace.manifest_sha256 != approval.workspace_manifest_sha256:
+                    raise CatalogAdapterPolicyError("工作区内容已经变化，请重新发起操作。")
+            else:
+                await self._ensure_credentials_fresh(manifest.project_id)
+                configuration_snapshot = self._configuration_snapshots.get(scope_key)
+                account_snapshot = self._account_snapshots.get(scope_key)
+                credential_digest = self._credential_snapshot_digest(
+                    self._credential_snapshots.get(scope_key, {})
+                )
+                policy = manifest.tool_policies.get(approval.tool_name)
+                if (
+                    configuration_snapshot is None
+                    or configuration_snapshot.revision != approval.configuration_revision
+                    or configuration_snapshot.digest != approval.configuration_digest
+                    or credential_digest != approval.credential_snapshot_digest
+                    or account_snapshot is None
+                    or account_snapshot.digest != approval.account_snapshot_digest
+                    or account_snapshot.tool_schema_sha256 != approval.tool_schema_sha256
+                    or policy is None
+                    or self._tool_policy_digest(policy) != approval.tool_policy_digest
+                ):
+                    self._approvals.pop(approval_key, None)
+                    raise CatalogAdapterPolicyError(
+                        "账号、配置、凭据或工具策略已经变化，请重新发起操作。"
+                    )
+            session_id = self._sessions.get(scope_key)
+            if (
+                approval.tool_name != "__delete_workspace__"
+                and (not session_id or session_id != approval.session_id)
+            ):
+                raise CatalogAdapterPolicyError("MCP 会话已经变化，请重新发起操作。")
+            approval.used = True
             self._approvals.pop(approval_key, None)
-            raise CatalogAdapterPolicyError("一次性确认已经使用或过期。")
-        if self.workspace_store is None:
-            raise CatalogAdapterPolicyError("MCP 文件工作区当前不可用。")
-        workspace = self.workspace_store.require_sealed(
-            manifest.project_id,
-            approval.workspace_id,
-            tenant_id=self.tenant_id,
-        )
-        if workspace.manifest_sha256 != approval.workspace_manifest_sha256:
-            raise CatalogAdapterPolicyError("工作区内容已经变化，请重新发起操作。")
-        approval.used = True
-        self._approvals.pop(approval_key, None)
+            if approval.context_kind == "remote-resource":
+                ledger = CatalogExecutionLedgerEntry(
+                    approval_id=approval.approval_id,
+                    tenant_id=self.tenant_id,
+                    owner_id=self.owner_id,
+                    project_id=manifest.project_id,
+                    idempotency_key=approval.idempotency_key,
+                    state="started",
+                )
+                self._execution_ledger[approval_key] = ledger
+
         if approval.tool_name == "__delete_workspace__":
             if scope_key in self._sessions:
                 await self.disconnect(manifest.project_id)
+            assert self.workspace_store is not None
             self.workspace_store.delete(
                 manifest.project_id,
                 approval.workspace_id,
                 tenant_id=self.tenant_id,
             )
             self._configurations.pop(scope_key, None)
-            return {"ok": True, "project_id": manifest.project_id, "workspace_id": approval.workspace_id}
-        session_id = self._sessions.get(scope_key)
-        if not session_id or session_id != approval.session_id:
-            raise CatalogAdapterPolicyError("MCP 会话已经变化，请重新发起操作。")
-        return await self._execute_tool(
-            manifest,
-            session_id=session_id,
-            tool_name=approval.tool_name,
-            arguments=approval.arguments,
-        )
+            self._configuration_snapshots.pop(scope_key, None)
+            return {
+                "ok": True,
+                "project_id": manifest.project_id,
+                "workspace_id": approval.workspace_id,
+            }
+        assert session_id is not None
+        if approval.context_kind != "remote-resource":
+            return await self._execute_tool(
+                manifest,
+                session_id=session_id,
+                tool_name=approval.tool_name,
+                arguments=approval.arguments,
+            )
+        assert ledger is not None
+        execution_arguments = dict(approval.arguments)
+        execution_arguments["__modelmirror_idempotency_key"] = approval.idempotency_key
+        try:
+            result = await self._execute_tool(
+                manifest,
+                session_id=session_id,
+                tool_name=approval.tool_name,
+                arguments=execution_arguments,
+            )
+        except Exception as exc:
+            if isinstance(exc, McpError):
+                rpc_error = exc.error
+                rpc_data = rpc_error.data if isinstance(rpc_error.data, dict) else {}
+                rpc_reason = str(rpc_data.get("reason") or "")
+                if rpc_error.code == -32009 and rpc_reason in {
+                    "rate_limited",
+                    "provider_rejected",
+                }:
+                    ledger.state = "rejected"
+                    raise CatalogProviderRejectedError(
+                        rpc_reason,
+                        approval.idempotency_key,
+                    ) from exc
+                if rpc_error.code == -32008 and rpc_reason == "unknown_outcome":
+                    ledger.state = "unknown"
+                    raise CatalogUnknownOutcomeError(approval.idempotency_key) from exc
+            if isinstance(
+                exc,
+                (CatalogAdapterPolicyError, MCPSessionNotFoundError),
+            ):
+                # These failures happen before the manager can send the frozen
+                # write, so they are terminal local rejections rather than an
+                # ambiguous provider outcome.
+                ledger.state = "rejected"
+                raise
+            ledger.state = "unknown"
+            raise CatalogUnknownOutcomeError(approval.idempotency_key) from exc
+        if result.get("is_error"):
+            # A state-changing request reached the provider boundary, but an
+            # MCP error result does not prove whether the provider committed
+            # the change. Keep the one-shot ledger fail-closed and never label
+            # the operation completed or resend it automatically.
+            ledger.state = "unknown"
+            raise CatalogUnknownOutcomeError(approval.idempotency_key)
+        result["idempotency_key"] = approval.idempotency_key
+        result["idempotent_replay"] = False
+        result["unknown_outcome"] = False
+        ledger.state = "completed"
+        ledger.result = json.loads(json.dumps(result, ensure_ascii=False))
+        return result
 
-    def cancel_approval(self, project_id: str, approval_id: str) -> dict[str, Any]:
+    async def cancel_approval(
+        self,
+        project_id: str,
+        approval_id: str,
+    ) -> dict[str, Any]:
+        manifest = self.get_manifest(project_id)
+        scope_key = self._scope_key(manifest.project_id)
         approval_key = self._approval_key(approval_id)
-        approval = self._approvals.get(approval_key)
-        if (
-            approval is None
-            or approval.tenant_id != self.tenant_id
-            or approval.project_id != project_id
-        ):
-            raise CatalogAdapterPolicyError("一次性确认不存在或已经失效。")
-        self._approvals.pop(approval_key, None)
-        return {"ok": True, "approval_id": approval.approval_id}
+        lock = self._approval_locks.setdefault(scope_key, asyncio.Lock())
+        async with lock:
+            approval = self._approvals.get(approval_key)
+            if (
+                approval is None
+                or approval.tenant_id != self.tenant_id
+                or approval.owner_id != self.owner_id
+                or approval.project_id != manifest.project_id
+            ):
+                raise CatalogAdapterPolicyError("一次性确认不存在或已经失效。")
+            self._approvals.pop(approval_key, None)
+            return {"ok": True, "approval_id": approval.approval_id}
 
     async def _execute_tool(
         self,
@@ -2123,10 +2777,36 @@ class MCPCatalogService:
 
         scope_key = self._scope_key(manifest.project_id)
         started_at = time.monotonic()
+        tool_policy = manifest.tool_policies.get(tool_name)
+        retry_on_failure = not (
+            manifest.saas_policy is not None
+            and tool_policy is not None
+            and tool_policy.effect == "state-write"
+        )
         try:
-            result = await self.manager.call_tool(session_id, tool_name, arguments)
+            call_lock = self._call_locks.setdefault(scope_key, asyncio.Lock())
+            async with call_lock:
+                if scope_key in self._unbinding_scopes:
+                    raise CatalogAdapterPolicyError(
+                        "账号解绑或凭据撤销正在进行，当前不能调用工具。"
+                    )
+                if retry_on_failure:
+                    result = await self.manager.call_tool(
+                        session_id,
+                        tool_name,
+                        arguments,
+                        session_owner=self._session_owner(manifest.project_id),
+                    )
+                else:
+                    result = await self.manager.call_tool(
+                        session_id,
+                        tool_name,
+                        arguments,
+                        retry_on_failure=False,
+                        session_owner=self._session_owner(manifest.project_id),
+                    )
         except Exception:
-            if manifest.credential_policies:
+            if manifest.credential_policies and manifest.saas_policy is None:
                 self._credential_verification[scope_key] = "verification-failed"
             if manifest.database_policy is not None:
                 self._preflight_status[scope_key] = "failed"
@@ -2141,7 +2821,7 @@ class MCPCatalogService:
             result,
             max_output_bytes=manifest.max_output_bytes,
         )
-        if manifest.credential_policies:
+        if manifest.credential_policies and manifest.saas_policy is None:
             self._credential_verification[scope_key] = (
                 "verification-failed" if payload["is_error"] else "verified"
             )
@@ -2181,46 +2861,92 @@ class MCPCatalogService:
         arguments: dict[str, Any],
         workspace_id: str | None = None,
     ) -> dict[str, Any]:
-        configuration = self._configurations.get(
-            self._scope_key(manifest.project_id)
-        )
+        scope_key = self._scope_key(manifest.project_id)
+        configuration = self._configurations.get(scope_key)
         bound_workspace_id = str(
             workspace_id or (configuration.workspace_id if configuration else "") or ""
         )
-        if not bound_workspace_id or self.workspace_store is None:
-            raise CatalogAdapterPolicyError("该操作缺少有效的受控工作区。")
-        workspace = self.workspace_store.require_sealed(
-            manifest.project_id,
-            bound_workspace_id,
-            tenant_id=self.tenant_id,
-        )
-        canonical = json.dumps(
-            arguments,
-            ensure_ascii=False,
-            sort_keys=True,
-            separators=(",", ":"),
-        )
+        frozen_arguments, canonical = self._freeze_arguments(arguments)
         digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+        context_kind: CatalogApprovalContextKind
+        workspace_manifest_sha256 = ""
+        configuration_revision = ""
+        configuration_digest = ""
+        credential_snapshot_digest = ""
+        account_snapshot_digest = ""
+        tool_schema_sha256 = ""
+        target_preview: dict[str, Any] = {}
+        if bound_workspace_id:
+            if self.workspace_store is None:
+                raise CatalogAdapterPolicyError("MCP 文件工作区当前不可用。")
+            workspace = self.workspace_store.require_sealed(
+                manifest.project_id,
+                bound_workspace_id,
+                tenant_id=self.tenant_id,
+            )
+            context_kind = "workspace"
+            workspace_manifest_sha256 = workspace.manifest_sha256
+            summary = self._approval_summary(
+                tool_name,
+                frozen_arguments,
+                workspace.display_name,
+            )
+        elif manifest.saas_policy is not None:
+            configuration_snapshot = self._configuration_snapshots.get(scope_key)
+            account_snapshot = self._account_snapshots.get(scope_key)
+            if configuration_snapshot is None or account_snapshot is None:
+                raise CatalogAdapterPolicyError("SaaS 账号尚未完成配置与预检。")
+            context_kind = "remote-resource"
+            configuration_revision = configuration_snapshot.revision
+            configuration_digest = configuration_snapshot.digest
+            credential_snapshot_digest = self._credential_snapshot_digest(
+                self._credential_snapshots.get(scope_key, {})
+            )
+            account_snapshot_digest = account_snapshot.digest
+            tool_schema_sha256 = account_snapshot.tool_schema_sha256
+            target_preview = self._target_preview(
+                manifest,
+                tool_name,
+                frozen_arguments,
+            )
+            summary = str(target_preview["impact"])
+        else:
+            raise CatalogAdapterPolicyError("该操作缺少有效的受控审批上下文。")
+        policy = manifest.tool_policies.get(tool_name)
+        if policy is None:
+            raise CatalogAdapterPolicyError("工具审批策略不存在。")
         approval = CatalogApproval(
             approval_id=f"mcpauth_{uuid.uuid4().hex}",
             tenant_id=self.tenant_id,
+            owner_id=self.owner_id,
             project_id=manifest.project_id,
             session_id=session_id,
+            context_kind=context_kind,
             workspace_id=bound_workspace_id,
-            workspace_manifest_sha256=workspace.manifest_sha256,
+            workspace_manifest_sha256=workspace_manifest_sha256,
             tool_name=tool_name,
-            arguments=json.loads(canonical),
+            arguments=frozen_arguments,
             argument_digest=digest,
-            summary=self._approval_summary(tool_name, arguments, workspace.display_name),
+            summary=summary,
             expires_at=time.time() + 300,
+            configuration_revision=configuration_revision,
+            configuration_digest=configuration_digest,
+            credential_snapshot_digest=credential_snapshot_digest,
+            account_snapshot_digest=account_snapshot_digest,
+            tool_schema_sha256=tool_schema_sha256,
+            tool_policy_digest=self._tool_policy_digest(policy),
+            idempotency_key=f"mcpidem_{uuid.uuid4().hex}",
+            target_preview=target_preview,
         )
         self._approvals[self._approval_key(approval.approval_id)] = approval
         return {
             "code": "approval_required",
-            "message": "该操作会写入持久记忆或生成新的表格产物，请确认后执行。",
+            "message": "该操作会修改持久状态；参数和账号上下文已由服务端冻结，请确认后执行。",
             "approval_id": approval.approval_id,
             "summary": approval.summary,
             "argument_digest": approval.argument_digest,
+            "idempotency_key": approval.idempotency_key,
+            "target_preview": approval.target_preview or None,
             "expires_at": approval.expires_at,
         }
 
@@ -2245,10 +2971,208 @@ class MCPCatalogService:
         detail = "，".join(visible) if visible else "参数已由服务端冻结"
         return f"在工作区“{workspace_name}”执行 {tool_name}：{detail}。"
 
+    @classmethod
+    def _freeze_arguments(
+        cls,
+        arguments: dict[str, Any],
+    ) -> tuple[dict[str, Any], str]:
+        cls._validate_json_value(arguments)
+        canonical = json.dumps(
+            arguments,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        )
+        if len(canonical.encode("utf-8")) > 128 * 1024:
+            raise CatalogAdapterPolicyError("工具参数超过 128 KiB 上限。")
+        return json.loads(canonical), canonical
+
+    @classmethod
+    def _validate_json_value(cls, value: Any, *, depth: int = 0) -> None:
+        if depth > 8:
+            raise CatalogAdapterPolicyError("工具参数嵌套层级超过上限。")
+        if value is None or isinstance(value, (str, bool, int)):
+            return
+        if isinstance(value, float):
+            if not math.isfinite(value):
+                raise CatalogAdapterPolicyError("工具参数不能包含非有限数字。")
+            return
+        if isinstance(value, list):
+            if len(value) > 2_000:
+                raise CatalogAdapterPolicyError("工具参数数组项目过多。")
+            for child in value:
+                cls._validate_json_value(child, depth=depth + 1)
+            return
+        if isinstance(value, dict):
+            if len(value) > 500:
+                raise CatalogAdapterPolicyError("工具参数字段过多。")
+            for raw_key, child in value.items():
+                key = str(raw_key)
+                if not key or len(key) > 160 or key.startswith("__modelmirror_"):
+                    raise CatalogAdapterPolicyError("工具参数包含保留或无效字段。")
+                cls._validate_json_value(child, depth=depth + 1)
+            return
+        raise CatalogAdapterPolicyError("工具参数必须是可验证的 JSON 值。")
+
+    @staticmethod
+    def _sha256_json(value: Any) -> str:
+        encoded = json.dumps(
+            value,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+    @classmethod
+    def _snapshot_configuration(
+        cls,
+        configuration: CatalogConfigurationRequest,
+    ) -> CatalogConfigurationSnapshot:
+        digest = cls._sha256_json(
+            {
+                "settings": configuration.settings,
+                "credential_bindings": configuration.credential_bindings,
+                "workspace_id": configuration.workspace_id,
+            }
+        )
+        return CatalogConfigurationSnapshot(
+            revision=f"mcpcfg_{uuid.uuid4().hex}",
+            digest=digest,
+        )
+
+    @classmethod
+    def _credential_snapshot_digest(
+        cls,
+        snapshots: dict[str, tuple[str, float]],
+    ) -> str:
+        return cls._sha256_json(
+            [
+                {"slot": slot, "credential_id": value[0], "updated_at": value[1]}
+                for slot, value in sorted(snapshots.items())
+            ]
+        )
+
+    @classmethod
+    def _tool_schema_digest(cls, tools: list[Tool]) -> str:
+        return cls._sha256_json(
+            [
+                {
+                    "name": tool.name,
+                    "inputSchema": tool.inputSchema,
+                }
+                for tool in sorted(tools, key=lambda item: item.name)
+            ]
+        )
+
+    @classmethod
+    def _tool_policy_digest(cls, policy: CatalogToolPolicy) -> str:
+        return cls._sha256_json(asdict(policy))
+
+    def _target_preview(
+        self,
+        manifest: CatalogAdapterManifest,
+        tool_name: str,
+        arguments: dict[str, Any],
+    ) -> dict[str, Any]:
+        configuration = self._configurations.get(self._scope_key(manifest.project_id))
+        settings = configuration.settings if configuration is not None else {}
+        action_labels = {
+            "create_record": "创建 Airtable 记录",
+            "update_record": "更新 Airtable 记录",
+            "create_task": "创建 Asana 任务",
+            "update_task": "更新 Asana 任务",
+            "add_comment": "添加 Asana 评论",
+            "create_issue": "创建 GitLab Issue",
+            "update_issue": "更新 GitLab Issue",
+            "add_issue_note": "添加 GitLab Issue 评论",
+            "create_page": "创建 Notion 页面",
+            "update_page_properties": "更新 Notion 页面属性",
+        }
+        resource_types = {
+            "airtable-mcp": "Airtable Base",
+            "asana-mcp": "Asana Project",
+            "gitlab-mcp": "GitLab Project",
+            "notion-mcp-server": "Notion Data Source",
+        }
+        scope_keys = {
+            "airtable-mcp": "base_id",
+            "asana-mcp": "project_gid",
+            "gitlab-mcp": "project_id",
+            "notion-mcp-server": "data_source_id",
+        }
+        target_keys = (
+            "record_id",
+            "task_gid",
+            "issue_iid",
+            "page_id",
+            "table_id",
+        )
+        scope_value = str(settings.get(scope_keys.get(manifest.project_id, ""), ""))
+        target_value = next(
+            (
+                str(arguments[key])
+                for key in target_keys
+                if key in arguments and str(arguments[key])
+            ),
+            scope_value,
+        )
+        id_suffix = target_value[-6:] if target_value else ""
+        content_keys = {
+            "content", "body", "comment", "text", "description", "notes",
+            "fields", "properties", "updates",
+        }
+        changes: list[dict[str, str]] = []
+        content_values: list[Any] = []
+        for key, value in arguments.items():
+            if key in content_keys:
+                content_values.append(value)
+                continue
+            if key in target_keys:
+                continue
+            if len(changes) >= 8:
+                break
+            if isinstance(value, (str, int, float, bool)):
+                summary = str(value)[:120]
+            elif isinstance(value, (list, dict)):
+                summary = f"{len(value)} 项"
+            else:
+                continue
+            changes.append({"field": key[:80], "summary": summary})
+        content: dict[str, Any] | None = None
+        if content_values:
+            encoded = json.dumps(
+                content_values,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+            content = {
+                "bytes": len(encoded),
+                "sha256_prefix": hashlib.sha256(encoded).hexdigest()[:12],
+            }
+        action_label = action_labels.get(tool_name, f"执行 {tool_name}")
+        resource_type = resource_types.get(manifest.project_id, "远程资源")
+        return {
+            "action_label": action_label,
+            "resource": {
+                "type": resource_type,
+                "label": f"{resource_type} …{scope_value[-6:]}" if scope_value else resource_type,
+                "id_suffix": id_suffix,
+            },
+            "changes": changes,
+            "content": content,
+            "impact": f"将在已绑定的 {resource_type} 中{action_label}；仅执行一次，不自动重试。",
+            "destructive": False,
+        }
+
     def _revoke_approvals(self, project_id: str) -> None:
         for approval_key, approval in list(self._approvals.items()):
             if (
                 approval.tenant_id == self.tenant_id
+                and approval.owner_id == self.owner_id
                 and approval.project_id == project_id
             ):
                 self._approvals.pop(approval_key, None)
@@ -2384,21 +3308,118 @@ class MCPCatalogService:
     async def clear_sessions(self) -> None:
         async with self._lock:
             tenant_keys = [
-                key for key in self._sessions if key[0] == self.tenant_id
+                key
+                for key in self._sessions
+                if key[:2] == (self.tenant_id, self.owner_id)
             ]
-            sessions = [self._sessions.pop(key) for key in tenant_keys]
+            sessions = [
+                (key[2], self._sessions.pop(key))
+                for key in tenant_keys
+            ]
             for key in tenant_keys:
                 self._credential_snapshots.pop(key, None)
+                self._account_snapshots.pop(key, None)
                 self._preflight_status.pop(key, None)
-        for session_id in sessions:
+        for project_id, session_id in sessions:
             try:
-                await self.manager.disconnect(session_id)
+                await self.manager.disconnect(
+                    session_id,
+                    session_owner=self._session_owner(project_id),
+                )
             except Exception:
                 pass
             await self.registry.unregister_session(session_id)
         for approval_key in list(self._approvals):
-            if approval_key[0] == self.tenant_id:
+            if approval_key[:2] == (self.tenant_id, self.owner_id):
                 self._approvals.pop(approval_key, None)
+
+    async def unbind(
+        self,
+        project_id: str,
+        request: CatalogUnbindRequest,
+    ) -> dict[str, Any]:
+        manifest = self.get_manifest(project_id)
+        if manifest.saas_policy is None or manifest.availability != "ready":
+            raise CatalogAdapterPolicyError("该目录项目不支持 SaaS 账号解绑。")
+        if request.revoke_credentials and self.credential_revoker is None:
+            raise CatalogAdapterUnavailableError("目录凭据存储当前不可用。")
+        scope_key = self._scope_key(manifest.project_id)
+        if scope_key in self._unbinding_scopes:
+            raise CatalogAdapterPolicyError("账号解绑已经在进行中。")
+        self._unbinding_scopes.add(scope_key)
+        approval_lock = self._approval_locks.setdefault(scope_key, asyncio.Lock())
+        call_lock = self._call_locks.setdefault(scope_key, asyncio.Lock())
+        disconnected = False
+        revoked = 0
+        try:
+            # A connect that passed its initial tombstone check owns _lock for
+            # its full preflight. Wait for it to publish or clean up before
+            # inspecting the bound session and credentials.
+            async with self._lock:
+                pass
+            async with approval_lock:
+                project_ledgers = [
+                    (ledger_key, entry)
+                    for ledger_key, entry in self._execution_ledger.items()
+                    if entry.tenant_id == self.tenant_id
+                    and entry.owner_id == self.owner_id
+                    and entry.project_id == manifest.project_id
+                ]
+                if any(entry.state == "started" for _, entry in project_ledgers):
+                    raise CatalogAdapterPolicyError(
+                        "远程写入仍在执行，当前不能解绑账号；请等待结果确定。"
+                    )
+
+                async with call_lock:
+                    configuration = self._configurations.get(scope_key)
+                    credential_ids = sorted(
+                        set(configuration.credential_bindings.values())
+                        if configuration is not None
+                        else set()
+                    )
+                    # Stop the child before touching vault records. Calls that
+                    # were queued behind call_lock then fail against a removed
+                    # manager session instead of reusing the child's old token.
+                    if scope_key in self._sessions:
+                        try:
+                            await self._disconnect_with_scope_locked(manifest)
+                            disconnected = True
+                        except MCPSessionNotFoundError:
+                            self._sessions.pop(scope_key, None)
+
+                    if request.revoke_credentials:
+                        assert self.credential_revoker is not None
+                        for credential_id in credential_ids:
+                            self._credential_call(
+                                self.credential_revoker,
+                                credential_id,
+                            )
+                            revoked += 1
+
+                    self._revoke_approvals(manifest.project_id)
+                    self._configurations.pop(scope_key, None)
+                    self._configuration_snapshots.pop(scope_key, None)
+                    self._credential_snapshots.pop(scope_key, None)
+                    self._account_snapshots.pop(scope_key, None)
+                    self._credential_verification[scope_key] = "missing"
+                    self._preflight_status[scope_key] = "awaiting-configuration"
+                    for ledger_key, entry in project_ledgers:
+                        if entry.state == "completed":
+                            self._execution_ledger.pop(ledger_key, None)
+        finally:
+            self._unbinding_scopes.discard(scope_key)
+        logger.info(
+            "MCP catalog unbind project=%s disconnected=%s revoked_credentials=%d",
+            manifest.project_id,
+            disconnected,
+            revoked,
+        )
+        return {
+            "ok": True,
+            "project_id": manifest.project_id,
+            "disconnected": disconnected,
+            "revoked_credentials": revoked,
+        }
 
     def list_credentials(self, project_id: str) -> dict[str, Any]:
         manifest = self._require_credential_adapter(project_id)
@@ -2461,16 +3482,60 @@ class MCPCatalogService:
         slot = str(getattr(public, "catalog_slot", ""))
         if slot not in manifest.credential_slots:
             raise CatalogAdapterPolicyError("凭据槽不属于当前目录项目。")
-        revoked = self._credential_call(self.credential_revoker, credential_id)
         scope_key = self._scope_key(manifest.project_id)
         configuration = self._configurations.get(scope_key)
-        if configuration and credential_id in configuration.credential_bindings.values():
-            if scope_key in self._sessions:
-                await self.disconnect(manifest.project_id)
-            self._configurations.pop(scope_key, None)
-            self._credential_snapshots.pop(scope_key, None)
-            self._credential_verification[scope_key] = "missing"
-            self._preflight_status[scope_key] = "unverified"
+        bound = bool(
+            configuration
+            and credential_id in configuration.credential_bindings.values()
+        )
+        if not bound:
+            revoked = self._credential_call(self.credential_revoker, credential_id)
+        else:
+            if scope_key in self._unbinding_scopes:
+                raise CatalogAdapterPolicyError("账号解绑或凭据撤销已经在进行中。")
+            self._unbinding_scopes.add(scope_key)
+            approval_lock = self._approval_locks.setdefault(
+                scope_key,
+                asyncio.Lock(),
+            )
+            call_lock = self._call_locks.setdefault(scope_key, asyncio.Lock())
+            try:
+                # Drain a connect that may already hold decrypted credentials.
+                async with self._lock:
+                    pass
+                async with approval_lock:
+                    if any(
+                        entry.tenant_id == self.tenant_id
+                        and entry.owner_id == self.owner_id
+                        and entry.project_id == manifest.project_id
+                        and entry.state == "started"
+                        for entry in self._execution_ledger.values()
+                    ):
+                        raise CatalogAdapterPolicyError(
+                            "远程写入仍在执行，当前不能撤销凭据。"
+                        )
+                    async with call_lock:
+                        # The tombstone and call lock prevent any new use of
+                        # the child while the local vault mutation is applied.
+                        # If the vault rejects the revoke, session/config stay
+                        # intact and become callable again after this method.
+                        revoked = self._credential_call(
+                            self.credential_revoker,
+                            credential_id,
+                        )
+                        try:
+                            if scope_key in self._sessions:
+                                await self._disconnect_with_scope_locked(manifest)
+                        finally:
+                            self._revoke_approvals(manifest.project_id)
+                            self._configurations.pop(scope_key, None)
+                            self._configuration_snapshots.pop(scope_key, None)
+                            self._credential_snapshots.pop(scope_key, None)
+                            self._account_snapshots.pop(scope_key, None)
+                            self._credential_verification[scope_key] = "missing"
+                            self._preflight_status[scope_key] = "unverified"
+            finally:
+                self._unbinding_scopes.discard(scope_key)
         logger.info(
             "MCP catalog credential revoked project=%s slot=%s",
             manifest.project_id,
@@ -2486,11 +3551,12 @@ class MCPCatalogService:
             return
         async with self._lock:
             for scope_key, session_id in list(self._sessions.items()):
-                if scope_key[0] != self.tenant_id:
+                if scope_key[:2] != (self.tenant_id, self.owner_id):
                     continue
                 if session_id in cleaned:
                     self._sessions.pop(scope_key, None)
                     self._credential_snapshots.pop(scope_key, None)
+                    self._account_snapshots.pop(scope_key, None)
                     self._preflight_status[scope_key] = "unverified"
 
     @staticmethod
@@ -2577,16 +3643,25 @@ class MCPCatalogService:
                     break
         if not stale:
             return
-        session_id = self._sessions.pop(scope_key, None)
-        self._credential_snapshots.pop(scope_key, None)
         self._credential_verification[scope_key] = "unverified"
         self._preflight_status[scope_key] = "unverified"
         self._revoke_approvals(project_id)
+        session_id = self._sessions.get(scope_key)
         if session_id is not None:
             try:
-                await self.manager.disconnect(session_id)
+                await self.manager.disconnect(
+                    session_id,
+                    session_owner=self._session_owner(project_id),
+                )
             finally:
                 await self.registry.unregister_session(session_id)
+                if self._sessions.get(scope_key) == session_id:
+                    self._sessions.pop(scope_key, None)
+                    self._credential_snapshots.pop(scope_key, None)
+                    self._account_snapshots.pop(scope_key, None)
+        else:
+            self._credential_snapshots.pop(scope_key, None)
+            self._account_snapshots.pop(scope_key, None)
         raise CatalogAdapterPolicyError(
             "绑定凭据已撤销、轮换或不可用，会话已断开；请重新保存配置并连接。"
         )
@@ -2610,10 +3685,10 @@ class MCPCatalogService:
 
         clean = str(session_id or "")
         for scope_key, active_session_id in self._sessions.items():
-            if scope_key[0] != self.tenant_id:
+            if scope_key[:2] != (self.tenant_id, self.owner_id):
                 continue
             if active_session_id == clean:
-                return scope_key[1]
+                return scope_key[2]
         return None
 
     def _connection_payload(
@@ -2639,7 +3714,7 @@ class MCPCatalogService:
                     self._scope_key(manifest.project_id),
                     "unverified",
                 )
-                if manifest.database_policy is not None
+                if manifest.database_policy is not None or manifest.saas_policy is not None
                 else "not-applicable"
             ),
         }
@@ -2718,6 +3793,28 @@ def get_mcp_catalog_service() -> MCPCatalogService:
 def _raise_http_error(exc: Exception) -> None:
     if isinstance(exc, CatalogApprovalRequiredError):
         raise HTTPException(status_code=409, detail=exc.payload) from exc
+    if isinstance(exc, CatalogUnknownOutcomeError):
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": "unknown_outcome",
+                "message": str(exc),
+                "idempotency_key": exc.idempotency_key,
+            },
+        ) from exc
+    if isinstance(exc, CatalogProviderRejectedError):
+        raise HTTPException(
+            status_code=429 if exc.reason == "rate_limited" else 409,
+            detail={
+                "code": (
+                    "provider_rate_limited"
+                    if exc.reason == "rate_limited"
+                    else "provider_rejected"
+                ),
+                "message": str(exc),
+                "idempotency_key": exc.idempotency_key,
+            },
+        ) from exc
     if isinstance(exc, CatalogAdapterNotFoundError):
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     if isinstance(exc, CatalogAdapterUnavailableError):
@@ -2802,6 +3899,18 @@ async def configure_catalog_adapter(
         raise
 
 
+@router.post("/api/mcp/catalog/{project_id}/unbind")
+async def unbind_catalog_adapter(
+    project_id: str,
+    request: CatalogUnbindRequest,
+) -> dict[str, Any]:
+    try:
+        return await get_mcp_catalog_service().unbind(project_id, request)
+    except Exception as exc:
+        _raise_http_error(exc)
+        raise
+
+
 @router.post("/api/mcp/catalog/{project_id}/connect")
 async def connect_catalog_adapter(project_id: str) -> dict[str, Any]:
     try:
@@ -2849,7 +3958,7 @@ async def confirm_catalog_approval(project_id: str, approval_id: str) -> dict[st
 @router.delete("/api/mcp/catalog/{project_id}/approvals/{approval_id}")
 async def cancel_catalog_approval(project_id: str, approval_id: str) -> dict[str, Any]:
     try:
-        return get_mcp_catalog_service().cancel_approval(project_id, approval_id)
+        return await get_mcp_catalog_service().cancel_approval(project_id, approval_id)
     except Exception as exc:
         _raise_http_error(exc)
         raise

--- a/server/mcp/manager.py
+++ b/server/mcp/manager.py
@@ -100,6 +100,7 @@ class ManagedMCPSession:
     reconnect_attempts: int = 1
     operation_timeout: float = 30.0
     working_directory: str = ""
+    session_owner: str = ""
     queue: asyncio.Queue[SessionCommand] = field(default_factory=asyncio.Queue)
     task: asyncio.Task[None] | None = None
     tools_count: int = 0
@@ -132,11 +133,19 @@ class MCPClientManager:
         self._cleanup_callback: Callable[[list[str]], Awaitable[None]] | None = None
         self.sandbox_root.mkdir(parents=True, exist_ok=True)
 
-    async def connect(self, server_command: list[str]) -> str:
+    async def connect(
+        self,
+        server_command: list[str],
+        *,
+        session_owner: str = "",
+    ) -> str:
         """Start an MCP server owner task and return a session id."""
 
         validate_server_command(server_command)
-        managed = self._new_managed_session(server_command)
+        managed = self._new_managed_session(
+            server_command,
+            session_owner=session_owner,
+        )
         return await self._start_managed_session(managed)
 
     async def connect_profile(
@@ -151,6 +160,7 @@ class MCPClientManager:
         reconnect_attempts: int = 1,
         operation_timeout: float | None = None,
         working_directory: str = "",
+        session_owner: str = "",
     ) -> str:
         """Connect an MCP profile without exposing credentials in summaries."""
 
@@ -171,6 +181,7 @@ class MCPClientManager:
             reconnect_attempts=reconnect_attempts,
             operation_timeout=operation_timeout,
             working_directory=working_directory,
+            session_owner=session_owner,
         )
         return await self._start_managed_session(managed)
 
@@ -189,10 +200,15 @@ class MCPClientManager:
             self._sessions[managed.session_id] = managed
         return managed.session_id
 
-    async def list_tools(self, session_id: str) -> list[Tool]:
+    async def list_tools(
+        self,
+        session_id: str,
+        *,
+        session_owner: str = "",
+    ) -> list[Tool]:
         """Return tools exposed by the MCP server for ``session_id``."""
 
-        managed = await self._get_session(session_id)
+        managed = await self._get_session(session_id, session_owner=session_owner)
         try:
             tools = await self._send_command(managed, "list_tools")
         except Exception as exc:
@@ -206,13 +222,16 @@ class MCPClientManager:
         session_id: str,
         tool_name: str,
         arguments: dict[str, Any] | None = None,
+        *,
+        retry_on_failure: bool = True,
+        session_owner: str = "",
     ) -> CallToolResult:
         """Call a named MCP tool with JSON-like arguments."""
 
         if not tool_name.strip():
             raise ValueError("tool_name 不能为空。")
 
-        managed = await self._get_session(session_id)
+        managed = await self._get_session(session_id, session_owner=session_owner)
         try:
             return await self._send_command(
                 managed,
@@ -221,6 +240,8 @@ class MCPClientManager:
                 arguments=arguments or {},
             )
         except Exception as exc:
+            if not retry_on_failure:
+                raise
             managed = await self._restart_once(managed, exc)
             return await self._send_command(
                 managed,
@@ -229,21 +250,39 @@ class MCPClientManager:
                 arguments=arguments or {},
             )
 
-    async def disconnect(self, session_id: str) -> None:
+    async def disconnect(
+        self,
+        session_id: str,
+        *,
+        session_owner: str = "",
+    ) -> None:
         """Disconnect and clean up a session if it exists."""
 
         async with self._lock:
-            managed = self._sessions.pop(session_id, None)
+            managed = self._sessions.get(session_id)
+            if managed is None or managed.session_owner != str(session_owner or ""):
+                managed = None
+            else:
+                self._sessions.pop(session_id, None)
         if managed is None:
             raise MCPSessionNotFoundError(f"MCP session not found: {session_id}")
         await self._stop_session(managed)
 
-    async def get_sessions_summary(self) -> list[dict[str, Any]]:
+    async def get_sessions_summary(
+        self,
+        *,
+        session_owner: str = "",
+    ) -> list[dict[str, Any]]:
         """Return serializable metadata for active sessions."""
 
         now_mono = time.monotonic()
         async with self._lock:
-            sessions = list(self._sessions.values())
+            owner = str(session_owner or "")
+            sessions = [
+                managed
+                for managed in self._sessions.values()
+                if managed.session_owner == owner
+            ]
 
         return [
             {
@@ -278,13 +317,23 @@ class MCPClientManager:
             await self._stop_session(managed)
         return cleaned_ids
 
-    async def scrub_session_environment(self, session_id: str) -> None:
+    async def scrub_session_environment(
+        self,
+        session_id: str,
+        *,
+        session_owner: str = "",
+    ) -> None:
         """Drop short-lived child configuration after a proxy has initialized."""
 
         async with self._lock:
             managed = self._sessions.get(str(session_id or ""))
-            if managed is None:
-                raise MCPSessionNotFoundError(session_id)
+            if (
+                managed is None
+                or managed.session_owner != str(session_owner or "")
+            ):
+                raise MCPSessionNotFoundError(
+                    f"MCP session not found: {session_id}"
+                )
             managed.environment.clear()
 
     def start_ttl_cleanup(
@@ -337,6 +386,7 @@ class MCPClientManager:
         reconnect_attempts: int = 1,
         operation_timeout: float | None = None,
         working_directory: str = "",
+        session_owner: str = "",
     ) -> ManagedMCPSession:
         now_epoch = time.time()
         now_mono = time.monotonic()
@@ -354,6 +404,7 @@ class MCPClientManager:
                 min(float(operation_timeout or self.operation_timeout), 300.0),
             ),
             working_directory=str(working_directory or "").strip(),
+            session_owner=str(session_owner or ""),
             created_at=now_epoch,
             created_monotonic_at=now_mono,
             last_used_at=now_mono,
@@ -545,6 +596,7 @@ class MCPClientManager:
             reconnect_attempts=managed.reconnect_attempts,
             operation_timeout=managed.operation_timeout,
             working_directory=managed.working_directory,
+            session_owner=managed.session_owner,
         )
         ready: asyncio.Future[None] = asyncio.get_running_loop().create_future()
         restarted.task = asyncio.create_task(self._session_worker(restarted, ready))
@@ -553,10 +605,18 @@ class MCPClientManager:
             self._sessions[old_session_id] = restarted
         return restarted
 
-    async def _get_session(self, session_id: str) -> ManagedMCPSession:
+    async def _get_session(
+        self,
+        session_id: str,
+        *,
+        session_owner: str = "",
+    ) -> ManagedMCPSession:
         async with self._lock:
             managed = self._sessions.get(session_id)
-        if managed is None:
+        if (
+            managed is None
+            or managed.session_owner != str(session_owner or "")
+        ):
             raise MCPSessionNotFoundError(f"MCP session not found: {session_id}")
         return managed
 

--- a/server/mcp/saas_proxy.py
+++ b/server/mcp/saas_proxy.py
@@ -1,0 +1,125 @@
+"""One-shot credential proxy for fixed Wave 6 stateful SaaS adapters."""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import socket
+import sys
+import threading
+from pathlib import Path
+
+
+ALLOWED_ADAPTERS = {
+    "airtable-mcp",
+    "asana-mcp",
+    "gitlab-mcp",
+    "notion-mcp-server",
+}
+SOCKET_PATH = Path(
+    os.getenv(
+        "MCP_SAAS_SOCKET_PATH",
+        "/run/modelmirror-saas-mcp/saas-mcp.sock",
+    )
+)
+HANDSHAKE_LIMIT = 4096
+CONFIGURATION_LIMIT = 64 * 1024
+
+
+def _copy_stdin(sock: socket.socket) -> None:
+    try:
+        while True:
+            chunk = os.read(sys.stdin.fileno(), 64 * 1024)
+            if not chunk:
+                break
+            sock.sendall(chunk)
+    except (BrokenPipeError, ConnectionError, OSError):
+        pass
+    finally:
+        try:
+            sock.shutdown(socket.SHUT_WR)
+        except OSError:
+            pass
+
+
+def _load_configuration() -> dict[str, object]:
+    encoded = os.environ.pop("MCP_SAAS_HANDSHAKE_B64", "")
+    if not encoded or len(encoded) > CONFIGURATION_LIMIT * 2:
+        raise ValueError("missing_saas_configuration")
+    raw = base64.urlsafe_b64decode(encoded.encode("ascii"))
+    if len(raw) > CONFIGURATION_LIMIT:
+        raise ValueError("saas_configuration_too_large")
+    payload = json.loads(raw.decode("utf-8"))
+    if not isinstance(payload, dict) or set(payload) != {"settings", "credentials"}:
+        raise ValueError("invalid_saas_configuration")
+    if not isinstance(payload["settings"], dict) or not isinstance(
+        payload["credentials"], dict
+    ):
+        raise ValueError("invalid_saas_configuration")
+    return payload
+
+
+def run(adapter_id: str) -> int:
+    if adapter_id not in ALLOWED_ADAPTERS:
+        print("MCP SaaS adapter is not allowed.", file=sys.stderr)
+        return 64
+    if not SOCKET_PATH.is_absolute():
+        print("MCP SaaS socket path must be absolute.", file=sys.stderr)
+        return 78
+    try:
+        configuration = _load_configuration()
+    except (ValueError, UnicodeError, json.JSONDecodeError):
+        print("MCP SaaS configuration is missing or invalid.", file=sys.stderr)
+        return 78
+
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        sock.settimeout(10)
+        sock.connect(str(SOCKET_PATH))
+        request = json.dumps(
+            {
+                "action": "mcp_stdio",
+                "adapter_id": adapter_id,
+                "configuration": configuration,
+            },
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        configuration = {}
+        sock.sendall(request + b"\n")
+        raw = sock.makefile("rb", buffering=0).readline(HANDSHAKE_LIMIT + 1)
+        if not raw or len(raw) > HANDSHAKE_LIMIT:
+            print("MCP SaaS sidecar handshake failed.", file=sys.stderr)
+            return 69
+        response = json.loads(raw.decode("utf-8"))
+        if not isinstance(response, dict) or response.get("ok") is not True:
+            code = str(response.get("code") or "saas_sidecar_unavailable")
+            print(f"MCP SaaS sidecar rejected the session: {code}", file=sys.stderr)
+            return 69
+        sock.settimeout(None)
+        input_thread = threading.Thread(target=_copy_stdin, args=(sock,), daemon=True)
+        input_thread.start()
+        while True:
+            chunk = sock.recv(64 * 1024)
+            if not chunk:
+                break
+            sys.stdout.buffer.write(chunk)
+            sys.stdout.buffer.flush()
+        return 0
+    except (ConnectionError, OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"MCP SaaS proxy unavailable: {type(exc).__name__}", file=sys.stderr)
+        return 69
+    finally:
+        sock.close()
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: saas_proxy.py ADAPTER_ID", file=sys.stderr)
+        return 64
+    return run(sys.argv[1].strip())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/server/sandbox_sidecar/Dockerfile.saas
+++ b/server/sandbox_sidecar/Dockerfile.saas
@@ -1,0 +1,24 @@
+FROM python:3.12-slim@sha256:401f6e1a67dad31a1bd78e9ad22d0ee0a3b52154e6bd30e90be696bb6a3d7461
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    MCP_SAAS_SOCKET_PATH=/run/modelmirror-saas-mcp/saas-mcp.sock \
+    MCP_SAAS_MAX_SESSIONS=6
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd --gid 65532 sandbox \
+    && useradd --uid 65532 --gid 65532 --home-dir /workspaces --no-create-home sandbox \
+    && mkdir -p /opt/modelmirror/sandbox_sidecar /workspaces /run/modelmirror-saas-mcp \
+    && chown -R sandbox:sandbox /workspaces /run/modelmirror-saas-mcp
+
+WORKDIR /opt/modelmirror
+COPY requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir --retries 5 --timeout 120 -r requirements.txt
+COPY __init__.py engine.py landlock_exec.py safe_http.py saas_contracts.py saas_mcp.py saas_server.py smoke_saas_adapters.py ./sandbox_sidecar/
+COPY THIRD_PARTY_NOTICES.md /usr/share/doc/modelmirror-mcp-saas/THIRD_PARTY_NOTICES.md
+
+USER 65532:65532
+RUN python -m sandbox_sidecar.smoke_saas_adapters
+CMD ["python", "-m", "sandbox_sidecar.saas_server"]

--- a/server/sandbox_sidecar/THIRD_PARTY_NOTICES.md
+++ b/server/sandbox_sidecar/THIRD_PARTY_NOTICES.md
@@ -101,3 +101,20 @@ license files: MCP Python SDK (MIT), certifi (MPL-2.0), clickhouse-connect
 (Apache-2.0), DuckDB (MIT), httpx (BSD-3-Clause), psycopg (LGPL-3.0), PyMongo
 (Apache-2.0), PyMySQL (MIT), redis-py (MIT), and SQLGlot (MIT). Debian package
 notices remain under `/usr/share/doc`.
+
+The `modelmirror-mcp-saas:wave6-v1` image implements independent, fixed API
+contracts after reviewing the following upstream MCP servers.  It does not
+install or copy their server packages and cannot accept provider URLs, command
+lines or arbitrary HTTP headers from clients:
+
+- Airtable MCP Server v1.14.0 (`domdomegg/airtable-mcp-server`): MIT License.
+- Asana MCP Server v1.6.0 (`roychri/mcp-server-asana`): MIT License.
+- Archived GitLab reference server package 0.6.2
+  (`modelcontextprotocol/servers-archived`): MIT License.  The adapter is an
+  independently implemented, project-scoped GitLab.com REST contract.
+- Notion MCP Server v2.5.0 (`makenotion/notion-mcp-server`): MIT License.
+
+The Chinese commerce bundle and archived Mem0 local MCP server are not present
+in the image.  Their OAuth/account-lifecycle and remotely versioned contract
+requirements remain blocked.  The SaaS image's only direct Python runtime
+dependency beyond CPython is the pinned MCP Python SDK 1.27.2 (MIT).

--- a/server/sandbox_sidecar/saas_contracts.py
+++ b/server/sandbox_sidecar/saas_contracts.py
@@ -1,0 +1,175 @@
+"""Fixed executable contracts for the Wave 6 stateful SaaS adapters.
+
+Only this private sidecar module knows provider hosts, credential slots and
+tool effects.  The catalog may display localized metadata, but it cannot add
+hosts, headers, tools or executable configuration at runtime.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Final
+
+
+MAX_ARGUMENT_BYTES: Final = 256 * 1024
+MAX_OUTPUT_BYTES: Final = 256 * 1024
+IDEMPOTENCY_KEY_PATTERN: Final = re.compile(r"^mcpidem_[0-9a-f]{32}$")
+
+
+@dataclass(frozen=True, slots=True)
+class SaaSToolContract:
+    effect: str
+
+
+@dataclass(frozen=True, slots=True)
+class SaaSAdapterContract:
+    host: str
+    credential_fields: tuple[str, ...]
+    setting_fields: tuple[str, ...]
+    tools: dict[str, SaaSToolContract]
+    minimum_interval_seconds: float
+
+    @property
+    def read_tools(self) -> frozenset[str]:
+        return frozenset(name for name, policy in self.tools.items() if policy.effect == "read")
+
+    @property
+    def write_tools(self) -> frozenset[str]:
+        return frozenset(
+            name for name, policy in self.tools.items() if policy.effect == "state-write"
+        )
+
+
+def _tools(*, read: tuple[str, ...], write: tuple[str, ...]) -> dict[str, SaaSToolContract]:
+    return {
+        **{name: SaaSToolContract("read") for name in read},
+        **{name: SaaSToolContract("state-write") for name in write},
+    }
+
+
+SAAS_ADAPTERS: Final[dict[str, SaaSAdapterContract]] = {
+    "airtable-mcp": SaaSAdapterContract(
+        host="api.airtable.com",
+        credential_fields=("personal_access_token",),
+        setting_fields=("base_id",),
+        tools=_tools(
+            read=("list_tables", "list_records", "get_record"),
+            write=("create_record", "update_record"),
+        ),
+        # Airtable documents 5 requests/second per base.  Leave headroom.
+        minimum_interval_seconds=0.25,
+    ),
+    "asana-mcp": SaaSAdapterContract(
+        host="app.asana.com",
+        credential_fields=("personal_access_token",),
+        setting_fields=("workspace_gid", "project_gid"),
+        tools=_tools(
+            read=("list_projects", "list_tasks", "get_task"),
+            write=("create_task", "update_task", "add_comment"),
+        ),
+        # Free domains receive 150 requests/minute.  Cap at 120/minute.
+        minimum_interval_seconds=0.5,
+    ),
+    "gitlab-mcp": SaaSAdapterContract(
+        host="gitlab.com",
+        credential_fields=("personal_access_token",),
+        setting_fields=("project_id",),
+        tools=_tools(
+            read=(
+                "list_issues",
+                "get_issue",
+                "list_merge_requests",
+                "get_merge_request",
+                "get_repository_file",
+            ),
+            write=("create_issue", "update_issue", "add_issue_note"),
+        ),
+        # GitLab.com currently allows much more, but five/second is sufficient.
+        minimum_interval_seconds=0.2,
+    ),
+    "notion-mcp-server": SaaSAdapterContract(
+        host="api.notion.com",
+        credential_fields=("integration_token",),
+        setting_fields=("data_source_id",),
+        tools=_tools(
+            read=("query_data_source", "retrieve_page"),
+            write=("create_page", "update_page_properties"),
+        ),
+        # Notion documents an average of three requests/second per integration.
+        minimum_interval_seconds=0.4,
+    ),
+}
+
+
+# Filled from offline tools/list discovery.  A mismatch blocks image release.
+SAAS_SCHEMA_SHA256: Final[dict[str, str]] = {
+    "airtable-mcp": "5fce8249d6fcfa6b57f17d6c4d996c0c1ac5b8299584547923c2f18b14ca86c4",
+    "asana-mcp": "c935b8d982352d5e8379fe32a84986a4dd45c7d8635a6bb95838d26680f37d86",
+    "gitlab-mcp": "c5525a94bbe3dd3c4f83381f6138375243000102d31b28360641acc3cddb6dd9",
+    "notion-mcp-server": "4c5a2edc829d7d8823dd6e2270d52c6bc8bc67f9a4cba55b6edc59be4a70da80",
+}
+
+
+def _credential(value: object) -> str:
+    if not isinstance(value, str) or not value or len(value) > 20_000:
+        raise ValueError("invalid_credential")
+    if any(character in value for character in ("\x00", "\r", "\n")):
+        raise ValueError("invalid_credential")
+    return value
+
+
+def _opaque_gid(value: object, *, name: str) -> str:
+    clean = str(value or "").strip()
+    if not re.fullmatch(r"[1-9][0-9]{0,31}", clean):
+        raise ValueError(f"invalid_{name}")
+    return clean
+
+
+def validate_configuration(
+    adapter_id: str,
+    configuration: object,
+) -> tuple[SaaSAdapterContract, dict[str, str], dict[str, str]]:
+    """Return a normalized fixed configuration or fail closed."""
+
+    contract = SAAS_ADAPTERS.get(adapter_id)
+    if contract is None:
+        raise ValueError("mcp_adapter_denied")
+    if not isinstance(configuration, dict):
+        raise ValueError("invalid_configuration")
+    raw_credentials = configuration.get("credentials")
+    raw_settings = configuration.get("settings")
+    if not isinstance(raw_credentials, dict) or not isinstance(raw_settings, dict):
+        raise ValueError("invalid_configuration")
+    if set(raw_credentials) != set(contract.credential_fields):
+        raise ValueError("configuration_contract_mismatch")
+    if set(raw_settings) != set(contract.setting_fields):
+        raise ValueError("configuration_contract_mismatch")
+
+    credentials = {name: _credential(raw_credentials.get(name)) for name in contract.credential_fields}
+    settings: dict[str, str]
+    if adapter_id == "airtable-mcp":
+        base_id = str(raw_settings.get("base_id") or "").strip()
+        if not re.fullmatch(r"app[A-Za-z0-9]{14}", base_id):
+            raise ValueError("invalid_base_id")
+        settings = {"base_id": base_id}
+    elif adapter_id == "asana-mcp":
+        settings = {
+            "workspace_gid": _opaque_gid(raw_settings.get("workspace_gid"), name="workspace_gid"),
+            "project_gid": _opaque_gid(raw_settings.get("project_gid"), name="project_gid"),
+        }
+    elif adapter_id == "gitlab-mcp":
+        settings = {"project_id": _opaque_gid(raw_settings.get("project_id"), name="project_id")}
+    else:
+        data_source_id = str(raw_settings.get("data_source_id") or "").strip().replace("-", "")
+        if not re.fullmatch(r"[0-9a-fA-F]{32}", data_source_id):
+            raise ValueError("invalid_data_source_id")
+        settings = {"data_source_id": data_source_id.lower()}
+    return contract, credentials, settings
+
+
+def validate_idempotency_key(value: object) -> str:
+    clean = str(value or "").strip()
+    if not IDEMPOTENCY_KEY_PATTERN.fullmatch(clean):
+        raise ValueError("invalid_idempotency_key")
+    return clean

--- a/server/sandbox_sidecar/saas_mcp.py
+++ b/server/sandbox_sidecar/saas_mcp.py
@@ -1,0 +1,786 @@
+"""Reviewed MCP implementations for four fixed Wave 6 SaaS providers."""
+
+from __future__ import annotations
+
+import base64
+import http.client
+import json
+import os
+import re
+import ssl
+import sys
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import quote, urlencode
+
+from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
+
+from .saas_contracts import MAX_ARGUMENT_BYTES, MAX_OUTPUT_BYTES, SAAS_ADAPTERS
+from .safe_http import (
+    NetworkPolicyError,
+    ResponseLimitError,
+    _PinnedHTTPSConnection,
+    resolve_public_addresses,
+    validate_public_https_url,
+)
+
+
+RETRYABLE_READ_STATUSES = frozenset({429, 502, 503, 504})
+MAX_READ_RETRIES = 2
+MAX_RETRY_AFTER_SECONDS = 5.0
+NOTION_VERSION = "2025-09-03"
+OFFLINE_SMOKE = os.getenv("MCP_SAAS_OFFLINE_SMOKE", "").strip().lower() in {
+    "1",
+    "true",
+    "yes",
+}
+UNKNOWN_WRITE_OUTCOME_MARKER = "modelmirror_unknown_write_outcome"
+ALLOWED_PROVIDER_HEADERS: dict[str, frozenset[str]] = {
+    "api.airtable.com": frozenset({"authorization", "content-type"}),
+    "app.asana.com": frozenset({"authorization", "content-type"}),
+    "gitlab.com": frozenset({"private-token", "content-type"}),
+    "api.notion.com": frozenset(
+        {"authorization", "notion-version", "content-type"}
+    ),
+}
+
+READ_ONLY = ToolAnnotations(
+    readOnlyHint=True,
+    destructiveHint=False,
+    idempotentHint=True,
+    openWorldHint=True,
+)
+STATE_WRITE = ToolAnnotations(
+    readOnlyHint=False,
+    destructiveHint=False,
+    idempotentHint=False,
+    openWorldHint=True,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class HttpResult:
+    status: int
+    headers: dict[str, str]
+    body: bytes
+
+
+class UnknownWriteOutcome(RuntimeError):
+    """The write may have reached the provider, so callers must not retry it."""
+
+
+class FixedHTTPSClient:
+    """HTTPS-only client with DNS pinning, fixed host and no redirects."""
+
+    def __init__(self, host: str, *, minimum_interval_seconds: float) -> None:
+        if host not in ALLOWED_PROVIDER_HEADERS:
+            raise NetworkPolicyError("saas_http_host_denied")
+        self.host = host
+        self.minimum_interval_seconds = max(float(minimum_interval_seconds), 0.0)
+        self._lock = threading.Lock()
+        self._next_request_at = 0.0
+
+    def _throttle(self) -> None:
+        with self._lock:
+            now = time.monotonic()
+            wait = max(self._next_request_at - now, 0.0)
+            self._next_request_at = max(now, self._next_request_at) + self.minimum_interval_seconds
+        if wait:
+            time.sleep(wait)
+
+    def request(
+        self,
+        path: str,
+        *,
+        method: str,
+        headers: dict[str, str],
+        body: bytes | None = None,
+    ) -> HttpResult:
+        method = method.upper()
+        if method not in {"GET", "POST", "PATCH", "PUT"}:
+            raise NetworkPolicyError("saas_http_method_denied")
+        if not path.startswith("/") or "\r" in path or "\n" in path or len(path) > 16_384:
+            raise NetworkPolicyError("saas_http_path_denied")
+        if body is not None and len(body) > MAX_ARGUMENT_BYTES:
+            raise ValueError("saas_request_too_large")
+        url = f"https://{self.host}{path}"
+        _, host, port, normalized_path = validate_public_https_url(
+            url, allowed_hosts=frozenset({self.host})
+        )
+        addresses = resolve_public_addresses(host, port)
+        self._throttle()
+        request_headers = {
+            "Accept": "application/json",
+            "User-Agent": "ModelMirror-MCP-SaaS/1.0",
+            "Connection": "close",
+        }
+        for raw_name, raw_value in headers.items():
+            name = str(raw_name).strip()
+            value = str(raw_value).strip()
+            if (
+                name.lower() not in ALLOWED_PROVIDER_HEADERS[self.host]
+                or not value
+                or "\r" in value
+                or "\n" in value
+                or len(value) > 20_000
+            ):
+                raise NetworkPolicyError("saas_http_header_denied")
+            request_headers[name] = value
+        connection = _PinnedHTTPSConnection(host, addresses[0], port=port, timeout=12.0)
+        try:
+            connection.request(method, normalized_path, body=body, headers=request_headers)
+            response = connection.getresponse()
+            response_headers = {
+                str(name).lower(): str(value) for name, value in response.getheaders()
+            }
+            if 300 <= response.status < 400:
+                response.read(min(MAX_OUTPUT_BYTES, 64 * 1024))
+                raise NetworkPolicyError("saas_redirect_denied")
+            content_length = response_headers.get("content-length")
+            if content_length:
+                try:
+                    if int(content_length) > MAX_OUTPUT_BYTES:
+                        raise ResponseLimitError("saas_response_too_large")
+                except ValueError:
+                    pass
+            chunks: list[bytes] = []
+            total = 0
+            while True:
+                chunk = response.read(min(64 * 1024, MAX_OUTPUT_BYTES + 1 - total))
+                if not chunk:
+                    break
+                total += len(chunk)
+                if total > MAX_OUTPUT_BYTES:
+                    raise ResponseLimitError("saas_response_too_large")
+                chunks.append(chunk)
+            return HttpResult(int(response.status), response_headers, b"".join(chunks))
+        except (OSError, ssl.SSLError, http.client.HTTPException) as exc:
+            raise NetworkPolicyError("saas_https_failed") from exc
+        finally:
+            connection.close()
+
+
+def _retry_delay(headers: dict[str, str], attempt: int) -> float:
+    raw = headers.get("retry-after", "").strip()
+    try:
+        value = float(raw)
+    except ValueError:
+        value = 0.25 * (2**attempt)
+    return min(max(value, 0.0), MAX_RETRY_AFTER_SECONDS)
+
+
+def _decode_json(result: HttpResult, provider: str) -> Any:
+    if not 200 <= result.status < 300:
+        raise RuntimeError(f"{provider}_http_{result.status}")
+    if not result.body:
+        return {}
+    try:
+        payload = json.loads(result.body.decode("utf-8"))
+    except (UnicodeError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"{provider}_invalid_response") from exc
+    encoded = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    if len(encoded) > MAX_OUTPUT_BYTES:
+        raise ResponseLimitError("saas_response_too_large")
+    return payload
+
+
+def _request_json(
+    client: FixedHTTPSClient,
+    provider: str,
+    path: str,
+    *,
+    method: str = "GET",
+    headers: dict[str, str],
+    payload: object | None = None,
+    read_operation: bool,
+) -> Any:
+    body = None
+    request_headers = dict(headers)
+    if payload is not None:
+        body = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+        if len(body) > MAX_ARGUMENT_BYTES:
+            raise ValueError("saas_request_too_large")
+        request_headers["Content-Type"] = "application/json"
+    attempts = MAX_READ_RETRIES + 1 if read_operation else 1
+    last_result: HttpResult | None = None
+    for attempt in range(attempts):
+        try:
+            result = client.request(path, method=method, headers=request_headers, body=body)
+        except NetworkPolicyError as exc:
+            if not read_operation:
+                raise UnknownWriteOutcome(UNKNOWN_WRITE_OUTCOME_MARKER) from exc
+            raise
+        if not read_operation and (result.status == 408 or result.status >= 500):
+            raise UnknownWriteOutcome(UNKNOWN_WRITE_OUTCOME_MARKER)
+        last_result = result
+        if result.status not in RETRYABLE_READ_STATUSES or not read_operation:
+            return _decode_json(result, provider)
+        if attempt + 1 < attempts:
+            time.sleep(_retry_delay(result.headers, attempt))
+    assert last_result is not None
+    return _decode_json(last_result, provider)
+
+
+def _load_configuration(adapter_id: str) -> tuple[dict[str, str], dict[str, str]]:
+    raw = os.environ.pop("MCP_SAAS_HANDSHAKE_B64", "")
+    if not raw:
+        raise RuntimeError("saas_configuration_missing")
+    try:
+        payload = json.loads(base64.urlsafe_b64decode(raw.encode("ascii")).decode("utf-8"))
+    except (ValueError, UnicodeError, json.JSONDecodeError) as exc:
+        raise RuntimeError("saas_configuration_invalid") from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError("saas_configuration_invalid")
+    credentials = payload.get("credentials")
+    settings = payload.get("settings")
+    if not isinstance(credentials, dict) or not isinstance(settings, dict):
+        raise RuntimeError("saas_configuration_invalid")
+    contract = SAAS_ADAPTERS[adapter_id]
+    if set(credentials) != set(contract.credential_fields) or set(settings) != set(contract.setting_fields):
+        raise RuntimeError("saas_configuration_invalid")
+    return (
+        {name: str(credentials[name]) for name in contract.credential_fields},
+        {name: str(settings[name]) for name in contract.setting_fields},
+    )
+
+
+def _text(value: object, name: str, maximum: int = 8_000, *, optional: bool = False) -> str:
+    clean = str(value or "").strip()
+    if (not clean and not optional) or len(clean) > maximum or "\x00" in clean:
+        raise ValueError(f"invalid_{name}")
+    return clean
+
+
+def _gid(value: object, name: str) -> str:
+    clean = str(value or "").strip()
+    if not re.fullmatch(r"[1-9][0-9]{0,31}", clean):
+        raise ValueError(f"invalid_{name}")
+    return clean
+
+
+def _airtable_table(value: object) -> str:
+    clean = str(value or "").strip()
+    if not re.fullmatch(r"tbl[A-Za-z0-9]{14}", clean):
+        raise ValueError("invalid_table_id")
+    return clean
+
+
+def _airtable_record(value: object) -> str:
+    clean = str(value or "").strip()
+    if not re.fullmatch(r"rec[A-Za-z0-9]{14}", clean):
+        raise ValueError("invalid_record_id")
+    return clean
+
+
+def _page_id(value: object) -> str:
+    clean = str(value or "").strip().replace("-", "")
+    if not re.fullmatch(r"[0-9a-fA-F]{32}", clean):
+        raise ValueError("invalid_page_id")
+    return clean.lower()
+
+
+def _object(value: object, name: str, *, allow_empty: bool = False) -> dict[str, Any]:
+    if not isinstance(value, dict) or (not value and not allow_empty):
+        raise ValueError(f"invalid_{name}")
+    encoded = json.dumps(value, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    if len(encoded) > MAX_ARGUMENT_BYTES:
+        raise ValueError(f"invalid_{name}")
+    return value
+
+
+def _data(payload: Any, provider: str) -> Any:
+    if not isinstance(payload, dict) or "data" not in payload:
+        raise RuntimeError(f"{provider}_invalid_response")
+    return payload["data"]
+
+
+def build_airtable() -> FastMCP:
+    credentials, settings = _load_configuration("airtable-mcp")
+    token = credentials.pop("personal_access_token")
+    base_id = settings["base_id"]
+    client = FixedHTTPSClient(
+        "api.airtable.com",
+        minimum_interval_seconds=SAAS_ADAPTERS["airtable-mcp"].minimum_interval_seconds,
+    )
+    headers = {"Authorization": f"Bearer {token}"}
+    if not OFFLINE_SMOKE:
+        _request_json(client, "airtable", "/v0/meta/whoami", headers=headers, read_operation=True)
+        _request_json(
+            client,
+            "airtable",
+            f"/v0/meta/bases/{base_id}/tables",
+            headers=headers,
+            read_operation=True,
+        )
+    mcp = FastMCP("ModelMirror Airtable Scoped")
+
+    @mcp.tool(annotations=READ_ONLY)
+    def list_tables() -> Any:
+        """列出已绑定 Base 中可读取的表结构。"""
+        return _request_json(
+            client,
+            "airtable",
+            f"/v0/meta/bases/{base_id}/tables",
+            headers=headers,
+            read_operation=True,
+        )
+
+    @mcp.tool(annotations=READ_ONLY)
+    def list_records(table_id: str, page_size: int = 100, offset: str = "") -> Any:
+        """分页读取已绑定 Base 中指定表的记录。"""
+        table = _airtable_table(table_id)
+        count = max(1, min(int(page_size), 100))
+        query: dict[str, object] = {"pageSize": count}
+        if offset:
+            query["offset"] = _text(offset, "offset", 1_000)
+        return _request_json(
+            client,
+            "airtable",
+            f"/v0/{base_id}/{table}?{urlencode(query)}",
+            headers=headers,
+            read_operation=True,
+        )
+
+    @mcp.tool(annotations=READ_ONLY)
+    def get_record(table_id: str, record_id: str) -> Any:
+        """读取已绑定 Base 中的一条记录。"""
+        table = _airtable_table(table_id)
+        record = _airtable_record(record_id)
+        return _request_json(
+            client,
+            "airtable",
+            f"/v0/{base_id}/{table}/{record}",
+            headers=headers,
+            read_operation=True,
+        )
+
+    @mcp.tool(annotations=STATE_WRITE)
+    def create_record(table_id: str, fields: dict[str, Any]) -> Any:
+        """经确认后在已绑定 Base 中创建一条记录。"""
+        table = _airtable_table(table_id)
+        return _request_json(
+            client,
+            "airtable",
+            f"/v0/{base_id}/{table}",
+            method="POST",
+            headers=headers,
+            payload={"fields": _object(fields, "fields")},
+            read_operation=False,
+        )
+
+    @mcp.tool(annotations=STATE_WRITE)
+    def update_record(table_id: str, record_id: str, fields: dict[str, Any]) -> Any:
+        """经确认后更新已绑定 Base 中的一条记录。"""
+        table = _airtable_table(table_id)
+        record = _airtable_record(record_id)
+        return _request_json(
+            client,
+            "airtable",
+            f"/v0/{base_id}/{table}/{record}",
+            method="PATCH",
+            headers=headers,
+            payload={"fields": _object(fields, "fields")},
+            read_operation=False,
+        )
+
+    return mcp
+
+
+def build_asana() -> FastMCP:
+    credentials, settings = _load_configuration("asana-mcp")
+    token = credentials.pop("personal_access_token")
+    workspace_gid = settings["workspace_gid"]
+    project_gid = settings["project_gid"]
+    client = FixedHTTPSClient(
+        "app.asana.com",
+        minimum_interval_seconds=SAAS_ADAPTERS["asana-mcp"].minimum_interval_seconds,
+    )
+    headers = {"Authorization": f"Bearer {token}"}
+
+    def request(path: str, *, method: str = "GET", payload: object | None = None, read: bool) -> Any:
+        return _request_json(
+            client,
+            "asana",
+            f"/api/1.0{path}",
+            method=method,
+            headers=headers,
+            payload=payload,
+            read_operation=read,
+        )
+
+    def project() -> dict[str, Any]:
+        value = _data(request(f"/projects/{project_gid}?opt_fields=gid,name,workspace", read=True), "asana")
+        if not isinstance(value, dict):
+            raise RuntimeError("asana_invalid_project")
+        workspace = value.get("workspace")
+        if not isinstance(workspace, dict) or str(workspace.get("gid")) != workspace_gid:
+            raise RuntimeError("asana_project_scope_mismatch")
+        return value
+
+    def scoped_task(task_gid: str) -> dict[str, Any]:
+        task = _data(
+            request(
+                f"/tasks/{_gid(task_gid, 'task_gid')}?opt_fields=gid,name,completed,due_on,notes,projects",
+                read=True,
+            ),
+            "asana",
+        )
+        if not isinstance(task, dict):
+            raise RuntimeError("asana_invalid_task")
+        projects = task.get("projects")
+        if not isinstance(projects, list) or project_gid not in {
+            str(item.get("gid")) for item in projects if isinstance(item, dict)
+        }:
+            raise RuntimeError("asana_task_scope_mismatch")
+        return task
+
+    if not OFFLINE_SMOKE:
+        _data(request("/users/me?opt_fields=gid,name", read=True), "asana")
+        _data(request(f"/workspaces/{workspace_gid}?opt_fields=gid,name", read=True), "asana")
+        project()
+    mcp = FastMCP("ModelMirror Asana Scoped")
+
+    @mcp.tool(annotations=READ_ONLY)
+    def list_projects(limit: int = 100, offset: str = "") -> Any:
+        """列出已绑定工作区中的项目；固定项目始终单独校验。"""
+        count = max(1, min(int(limit), 100))
+        query: dict[str, object] = {"limit": count, "archived": "false", "opt_fields": "gid,name,archived"}
+        if offset:
+            query["offset"] = _text(offset, "offset", 1_000)
+        return request(f"/workspaces/{workspace_gid}/projects?{urlencode(query)}", read=True)
+
+    @mcp.tool(annotations=READ_ONLY)
+    def list_tasks(limit: int = 100, offset: str = "") -> Any:
+        """分页列出已绑定项目中的任务。"""
+        count = max(1, min(int(limit), 100))
+        query: dict[str, object] = {
+            "limit": count,
+            "opt_fields": "gid,name,completed,due_on,modified_at",
+        }
+        if offset:
+            query["offset"] = _text(offset, "offset", 1_000)
+        return request(f"/projects/{project_gid}/tasks?{urlencode(query)}", read=True)
+
+    @mcp.tool(annotations=READ_ONLY)
+    def get_task(task_gid: str) -> Any:
+        """读取已绑定项目内的一项任务。"""
+        return {"data": scoped_task(task_gid)}
+
+    @mcp.tool(annotations=STATE_WRITE)
+    def create_task(name: str, notes: str = "", due_on: str = "") -> Any:
+        """经确认后在已绑定项目中创建任务。"""
+        data: dict[str, Any] = {
+            "workspace": workspace_gid,
+            "projects": [project_gid],
+            "name": _text(name, "name", 500),
+        }
+        if notes:
+            data["notes"] = _text(notes, "notes", 20_000)
+        if due_on:
+            value = _text(due_on, "due_on", 10)
+            if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", value):
+                raise ValueError("invalid_due_on")
+            data["due_on"] = value
+        return request("/tasks", method="POST", payload={"data": data}, read=False)
+
+    @mcp.tool(annotations=STATE_WRITE)
+    def update_task(
+        task_gid: str,
+        name: str = "",
+        notes: str = "",
+        completed: bool | None = None,
+        due_on: str = "",
+    ) -> Any:
+        """经确认后更新已绑定项目内的一项任务。"""
+        task_id = _gid(task_gid, "task_gid")
+        scoped_task(task_id)
+        data: dict[str, Any] = {}
+        if name:
+            data["name"] = _text(name, "name", 500)
+        if notes:
+            data["notes"] = _text(notes, "notes", 20_000)
+        if completed is not None:
+            data["completed"] = bool(completed)
+        if due_on:
+            value = _text(due_on, "due_on", 10)
+            if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", value):
+                raise ValueError("invalid_due_on")
+            data["due_on"] = value
+        if not data:
+            raise ValueError("asana_update_empty")
+        return request(f"/tasks/{task_id}", method="PUT", payload={"data": data}, read=False)
+
+    @mcp.tool(annotations=STATE_WRITE)
+    def add_comment(task_gid: str, text: str) -> Any:
+        """经确认后向已绑定项目内的一项任务添加评论。"""
+        task_id = _gid(task_gid, "task_gid")
+        scoped_task(task_id)
+        return request(
+            f"/tasks/{task_id}/stories",
+            method="POST",
+            payload={"data": {"text": _text(text, "text", 20_000)}},
+            read=False,
+        )
+
+    return mcp
+
+
+def build_gitlab() -> FastMCP:
+    credentials, settings = _load_configuration("gitlab-mcp")
+    token = credentials.pop("personal_access_token")
+    project_id = settings["project_id"]
+    client = FixedHTTPSClient(
+        "gitlab.com",
+        minimum_interval_seconds=SAAS_ADAPTERS["gitlab-mcp"].minimum_interval_seconds,
+    )
+    headers = {"PRIVATE-TOKEN": token}
+
+    def request(path: str, *, method: str = "GET", payload: object | None = None, read: bool) -> Any:
+        return _request_json(
+            client,
+            "gitlab",
+            f"/api/v4{path}",
+            method=method,
+            headers=headers,
+            payload=payload,
+            read_operation=read,
+        )
+
+    if not OFFLINE_SMOKE:
+        request("/user", read=True)
+        token_info = request("/personal_access_tokens/self", read=True)
+        scopes = token_info.get("scopes") if isinstance(token_info, dict) else None
+        if not isinstance(scopes, list) or "api" not in {str(item) for item in scopes}:
+            raise RuntimeError("gitlab_api_scope_required")
+        project = request(f"/projects/{project_id}", read=True)
+        if not isinstance(project, dict) or str(project.get("id")) != project_id:
+            raise RuntimeError("gitlab_project_scope_mismatch")
+    mcp = FastMCP("ModelMirror GitLab.com Scoped")
+
+    def _issue_iid(value: object) -> str:
+        return _gid(value, "issue_iid")
+
+    def _merge_iid(value: object) -> str:
+        return _gid(value, "merge_request_iid")
+
+    @mcp.tool(annotations=READ_ONLY)
+    def list_issues(state: str = "opened", per_page: int = 50, page: int = 1) -> Any:
+        """分页列出已绑定 GitLab.com 项目的 Issue。"""
+        if state not in {"opened", "closed", "all"}:
+            raise ValueError("invalid_state")
+        query = urlencode({"state": state, "per_page": max(1, min(int(per_page), 100)), "page": max(1, min(int(page), 10_000))})
+        return request(f"/projects/{project_id}/issues?{query}", read=True)
+
+    @mcp.tool(annotations=READ_ONLY)
+    def get_issue(issue_iid: str) -> Any:
+        """读取已绑定项目中的一个 Issue。"""
+        return request(f"/projects/{project_id}/issues/{_issue_iid(issue_iid)}", read=True)
+
+    @mcp.tool(annotations=READ_ONLY)
+    def list_merge_requests(state: str = "opened", per_page: int = 50, page: int = 1) -> Any:
+        """分页列出已绑定项目中的合并请求。"""
+        if state not in {"opened", "closed", "merged", "all"}:
+            raise ValueError("invalid_state")
+        query = urlencode({"state": state, "per_page": max(1, min(int(per_page), 100)), "page": max(1, min(int(page), 10_000))})
+        return request(f"/projects/{project_id}/merge_requests?{query}", read=True)
+
+    @mcp.tool(annotations=READ_ONLY)
+    def get_merge_request(merge_request_iid: str) -> Any:
+        """读取已绑定项目中的一个合并请求。"""
+        return request(
+            f"/projects/{project_id}/merge_requests/{_merge_iid(merge_request_iid)}",
+            read=True,
+        )
+
+    @mcp.tool(annotations=READ_ONLY)
+    def get_repository_file(file_path: str, ref: str = "HEAD") -> Any:
+        """读取已绑定项目内指定 ref 的单个仓库文件。"""
+        path = _text(file_path, "file_path", 1_024)
+        if path.startswith(("/", "\\")) or any(part in {"", ".", ".."} for part in re.split(r"[/\\]", path)):
+            raise ValueError("invalid_file_path")
+        revision = _text(ref, "ref", 255)
+        return request(
+            f"/projects/{project_id}/repository/files/{quote(path, safe='')}?{urlencode({'ref': revision})}",
+            read=True,
+        )
+
+    @mcp.tool(annotations=STATE_WRITE)
+    def create_issue(title: str, description: str = "") -> Any:
+        """经确认后在已绑定项目中创建 Issue。"""
+        data: dict[str, Any] = {"title": _text(title, "title", 500)}
+        if description:
+            data["description"] = _text(description, "description", 40_000)
+        return request(f"/projects/{project_id}/issues", method="POST", payload=data, read=False)
+
+    @mcp.tool(annotations=STATE_WRITE)
+    def update_issue(
+        issue_iid: str,
+        title: str = "",
+        description: str = "",
+        state_event: str = "",
+    ) -> Any:
+        """经确认后更新、关闭或重新打开已绑定项目中的 Issue。"""
+        iid = _issue_iid(issue_iid)
+        request(f"/projects/{project_id}/issues/{iid}", read=True)
+        data: dict[str, Any] = {}
+        if title:
+            data["title"] = _text(title, "title", 500)
+        if description:
+            data["description"] = _text(description, "description", 40_000)
+        if state_event:
+            if state_event not in {"close", "reopen"}:
+                raise ValueError("invalid_state_event")
+            data["state_event"] = state_event
+        if not data:
+            raise ValueError("gitlab_update_empty")
+        return request(
+            f"/projects/{project_id}/issues/{iid}",
+            method="PUT",
+            payload=data,
+            read=False,
+        )
+
+    @mcp.tool(annotations=STATE_WRITE)
+    def add_issue_note(issue_iid: str, body: str) -> Any:
+        """经确认后向已绑定项目中的 Issue 添加评论。"""
+        iid = _issue_iid(issue_iid)
+        request(f"/projects/{project_id}/issues/{iid}", read=True)
+        return request(
+            f"/projects/{project_id}/issues/{iid}/notes",
+            method="POST",
+            payload={"body": _text(body, "body", 40_000)},
+            read=False,
+        )
+
+    return mcp
+
+
+def build_notion() -> FastMCP:
+    credentials, settings = _load_configuration("notion-mcp-server")
+    token = credentials.pop("integration_token")
+    data_source_id = settings["data_source_id"]
+    client = FixedHTTPSClient(
+        "api.notion.com",
+        minimum_interval_seconds=SAAS_ADAPTERS["notion-mcp-server"].minimum_interval_seconds,
+    )
+    headers = {"Authorization": f"Bearer {token}", "Notion-Version": NOTION_VERSION}
+
+    def request(path: str, *, method: str = "GET", payload: object | None = None, read: bool) -> Any:
+        return _request_json(
+            client,
+            "notion",
+            f"/v1{path}",
+            method=method,
+            headers=headers,
+            payload=payload,
+            read_operation=read,
+        )
+
+    if not OFFLINE_SMOKE:
+        request("/users/me", read=True)
+        source = request(f"/data_sources/{data_source_id}", read=True)
+        actual_source = (
+            str(source.get("id", "")).replace("-", "").lower()
+            if isinstance(source, dict)
+            else ""
+        )
+        if actual_source != data_source_id:
+            raise RuntimeError("notion_data_source_scope_mismatch")
+    mcp = FastMCP("ModelMirror Notion Scoped")
+
+    def scoped_page(page_id: str) -> dict[str, Any]:
+        normalized = _page_id(page_id)
+        page = request(f"/pages/{normalized}", read=True)
+        if not isinstance(page, dict):
+            raise RuntimeError("notion_invalid_page")
+        parent = page.get("parent")
+        parent_id = ""
+        if isinstance(parent, dict):
+            parent_id = str(parent.get("data_source_id") or "").replace("-", "").lower()
+        if parent_id != data_source_id:
+            raise RuntimeError("notion_page_scope_mismatch")
+        return page
+
+    @mcp.tool(annotations=READ_ONLY)
+    def query_data_source(
+        page_size: int = 100,
+        start_cursor: str = "",
+        filter: dict[str, Any] | None = None,
+        sorts: list[dict[str, Any]] | None = None,
+    ) -> Any:
+        """查询已绑定的 Notion Data Source。"""
+        payload: dict[str, Any] = {"page_size": max(1, min(int(page_size), 100))}
+        if start_cursor:
+            payload["start_cursor"] = _text(start_cursor, "start_cursor", 1_000)
+        if filter is not None:
+            payload["filter"] = _object(filter, "filter")
+        if sorts is not None:
+            if not isinstance(sorts, list) or len(sorts) > 20:
+                raise ValueError("invalid_sorts")
+            payload["sorts"] = sorts
+        return request(
+            f"/data_sources/{data_source_id}/query",
+            method="POST",
+            payload=payload,
+            read=True,
+        )
+
+    @mcp.tool(annotations=READ_ONLY)
+    def retrieve_page(page_id: str) -> Any:
+        """读取绑定页面，或读取绑定数据库中的一条页面记录。"""
+        return scoped_page(page_id)
+
+    @mcp.tool(annotations=STATE_WRITE)
+    def create_page(properties: dict[str, Any]) -> Any:
+        """经确认后在已绑定 Data Source 中创建页面。"""
+        parent = {"type": "data_source_id", "data_source_id": data_source_id}
+        values = _object(properties, "properties")
+        return request(
+            "/pages",
+            method="POST",
+            payload={"parent": parent, "properties": _object(values, "properties")},
+            read=False,
+        )
+
+    @mcp.tool(annotations=STATE_WRITE)
+    def update_page_properties(page_id: str, properties: dict[str, Any]) -> Any:
+        """经确认后更新绑定范围内页面的属性。"""
+        normalized = _page_id(page_id)
+        scoped_page(normalized)
+        return request(
+            f"/pages/{normalized}",
+            method="PATCH",
+            payload={"properties": _object(properties, "properties")},
+            read=False,
+        )
+
+    return mcp
+
+
+BUILDERS = {
+    "airtable-mcp": build_airtable,
+    "asana-mcp": build_asana,
+    "gitlab-mcp": build_gitlab,
+    "notion-mcp-server": build_notion,
+}
+
+
+def main() -> int:
+    if len(sys.argv) != 2 or sys.argv[1] not in BUILDERS:
+        return 2
+    adapter_id = sys.argv[1]
+    try:
+        server = BUILDERS[adapter_id]()
+    except Exception as exc:
+        print(f"MODELMIRROR_SAAS_FAILED:{type(exc).__name__}", file=sys.stderr, flush=True)
+        return 1
+    print(f"MODELMIRROR_SAAS_READY:{adapter_id}", file=sys.stderr, flush=True)
+    server.run(transport="stdio")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/server/sandbox_sidecar/saas_server.py
+++ b/server/sandbox_sidecar/saas_server.py
@@ -1,0 +1,573 @@
+"""Unix-socket gateway for fixed Wave 6 stateful SaaS adapters."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import os
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from .engine import SandboxEngineError
+from .saas_contracts import (
+    MAX_ARGUMENT_BYTES,
+    MAX_OUTPUT_BYTES,
+    SAAS_ADAPTERS,
+    SaaSAdapterContract,
+    validate_configuration,
+    validate_idempotency_key,
+)
+
+
+SOCKET_PATH = Path(os.getenv("MCP_SAAS_SOCKET_PATH", "/run/modelmirror-saas-mcp/saas-mcp.sock"))
+MAX_REQUEST_BYTES = 256 * 1024
+MAX_MCP_MESSAGE_BYTES = 256 * 1024
+TOOL_CALL_TIMEOUT_SECONDS = 20
+MAX_SESSIONS = max(1, min(int(os.getenv("MCP_SAAS_MAX_SESSIONS", "6")), 6))
+SEMAPHORE = asyncio.Semaphore(MAX_SESSIONS)
+PRIVATE_IDEMPOTENCY_FIELD = "__modelmirror_idempotency_key"
+PRIVATE_FIELD_PREFIX = "__modelmirror_"
+UNKNOWN_WRITE_OUTCOME_MARKER = "modelmirror_unknown_write_outcome"
+
+
+def _allowed_adapters() -> frozenset[str]:
+    raw = os.getenv("MCP_SAAS_ALLOWED_ADAPTERS", "").strip()
+    if not raw:
+        return frozenset(SAAS_ADAPTERS)
+    requested = {item.strip() for item in raw.split(",") if item.strip()}
+    return frozenset(requested & set(SAAS_ADAPTERS))
+
+
+ALLOWED_ADAPTERS = _allowed_adapters()
+
+
+def _rpc_error(
+    request_id: object,
+    code: int,
+    message: str,
+    *,
+    data: dict[str, object] | None = None,
+) -> bytes:
+    error: dict[str, object] = {"code": code, "message": message}
+    if data is not None:
+        error["data"] = data
+    return (
+        json.dumps(
+            {"jsonrpc": "2.0", "id": request_id, "error": error},
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        + b"\n"
+    )
+
+
+def _reject_private_fields(value: object, *, depth: int = 0) -> None:
+    if depth > 12:
+        raise ValueError("arguments_too_deep")
+    if isinstance(value, dict):
+        for raw_key, child in value.items():
+            if str(raw_key).lower().startswith(PRIVATE_FIELD_PREFIX):
+                raise ValueError("reserved_argument_field")
+            _reject_private_fields(child, depth=depth + 1)
+    elif isinstance(value, list):
+        for child in value:
+            _reject_private_fields(child, depth=depth + 1)
+
+
+def _prepare_tool_call(
+    contract: SaaSAdapterContract,
+    tool_name: object,
+    arguments: object,
+    used_idempotency_keys: set[str],
+) -> tuple[dict[str, Any], str | None]:
+    if not isinstance(tool_name, str) or tool_name not in contract.tools:
+        raise ValueError("tool_denied")
+    if not isinstance(arguments, dict):
+        raise ValueError("invalid_tool_arguments")
+    encoded = json.dumps(arguments, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    if len(encoded) > MAX_ARGUMENT_BYTES:
+        raise ValueError("arguments_too_large")
+    clean_arguments = dict(arguments)
+    effect = contract.tools[tool_name].effect
+    key: str | None = None
+    if effect == "state-write":
+        key = validate_idempotency_key(clean_arguments.pop(PRIVATE_IDEMPOTENCY_FIELD, None))
+        if key in used_idempotency_keys:
+            raise ValueError("idempotency_key_replayed")
+    elif PRIVATE_IDEMPOTENCY_FIELD in clean_arguments:
+        raise ValueError("unexpected_idempotency_key")
+    _reject_private_fields(clean_arguments)
+    if key is not None:
+        # Reserve before execution.  An ambiguous upstream result must never be
+        # retried automatically under the same approval/execution identity.
+        used_idempotency_keys.add(key)
+    return clean_arguments, key
+
+
+async def _terminate_timed_out_call(
+    request_id: object,
+    process: asyncio.subprocess.Process,
+    client: asyncio.StreamWriter,
+    write_lock: asyncio.Lock,
+    call_requests: set[object],
+    call_deadlines: dict[object, asyncio.Task[None]],
+    suppressed_requests: set[object],
+    write_call: bool,
+) -> None:
+    await asyncio.sleep(TOOL_CALL_TIMEOUT_SECONDS)
+    current = asyncio.current_task()
+    async with write_lock:
+        if current is None or call_deadlines.get(request_id) is not current:
+            return
+        call_deadlines.pop(request_id, None)
+        call_requests.discard(request_id)
+        suppressed_requests.add(request_id)
+        if write_call:
+            message = "SaaS 写入调用超时；远端结果未知且不得自动重试。"
+            data = {"reason": "unknown_outcome", "retryable": False}
+        else:
+            message = "SaaS 读取调用超时，会话已安全终止。"
+            data = {"reason": "timeout", "retryable": False}
+        client.write(_rpc_error(request_id, -32008, message, data=data))
+        await client.drain()
+    if process.returncode is None:
+        process.kill()
+        await process.wait()
+
+
+async def _client_to_child(
+    source: asyncio.StreamReader,
+    destination: asyncio.StreamWriter,
+    client: asyncio.StreamWriter,
+    contract: SaaSAdapterContract,
+    list_requests: set[object],
+    call_requests: set[object],
+    write_call_requests: set[object],
+    call_deadlines: dict[object, asyncio.Task[None]],
+    suppressed_requests: set[object],
+    used_idempotency_keys: set[str],
+    process: asyncio.subprocess.Process,
+    write_lock: asyncio.Lock,
+) -> None:
+    while True:
+        raw = await source.readline()
+        if not raw:
+            break
+        if len(raw) > MAX_MCP_MESSAGE_BYTES:
+            raise SandboxEngineError("MCP request too large.", code="mcp_message_too_large")
+        try:
+            payload = json.loads(raw.decode("utf-8"))
+        except (UnicodeError, json.JSONDecodeError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        request_id = payload.get("id")
+        method = payload.get("method")
+        if method == "tools/list" and request_id is not None:
+            if not isinstance(request_id, (str, int)) or isinstance(request_id, bool):
+                async with write_lock:
+                    client.write(_rpc_error(None, -32600, "MCP 请求 ID 无效。"))
+                    await client.drain()
+                continue
+            list_requests.add(request_id)
+        elif method == "tools/call":
+            if not isinstance(request_id, (str, int)) or isinstance(request_id, bool):
+                async with write_lock:
+                    client.write(_rpc_error(None, -32600, "工具调用必须提供有效请求 ID。"))
+                    await client.drain()
+                continue
+            if request_id in list_requests or request_id in call_requests:
+                async with write_lock:
+                    client.write(_rpc_error(request_id, -32600, "MCP 请求 ID 重复。"))
+                    await client.drain()
+                continue
+            params = payload.get("params")
+            tool_name = params.get("name") if isinstance(params, dict) else None
+            arguments = params.get("arguments", {}) if isinstance(params, dict) else {}
+            try:
+                clean_arguments, _ = _prepare_tool_call(
+                    contract, tool_name, arguments, used_idempotency_keys
+                )
+            except ValueError as exc:
+                code = str(exc)
+                message = (
+                    "写入执行标识无效或已使用，未执行远程操作。"
+                    if code in {"invalid_idempotency_key", "idempotency_key_replayed"}
+                    else "工具或参数未通过 SaaS 适配器策略。"
+                )
+                async with write_lock:
+                    client.write(_rpc_error(request_id, -32602, message))
+                    await client.drain()
+                continue
+            assert isinstance(params, dict)
+            params["arguments"] = clean_arguments
+            raw = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8") + b"\n"
+            call_requests.add(request_id)
+            write_call = contract.tools[tool_name].effect == "state-write"
+            if write_call:
+                write_call_requests.add(request_id)
+            deadline = asyncio.create_task(
+                _terminate_timed_out_call(
+                    request_id,
+                    process,
+                    client,
+                    write_lock,
+                    call_requests,
+                    call_deadlines,
+                    suppressed_requests,
+                    write_call,
+                )
+            )
+            call_deadlines[request_id] = deadline
+        destination.write(raw)
+        await destination.drain()
+
+
+async def _child_to_client(
+    source: asyncio.StreamReader,
+    destination: asyncio.StreamWriter,
+    contract: SaaSAdapterContract,
+    list_requests: set[object],
+    call_requests: set[object],
+    write_call_requests: set[object],
+    call_deadlines: dict[object, asyncio.Task[None]],
+    suppressed_requests: set[object],
+    write_lock: asyncio.Lock,
+) -> None:
+    while True:
+        raw = await source.readline()
+        if not raw:
+            break
+        if len(raw) > MAX_MCP_MESSAGE_BYTES or len(raw) > MAX_OUTPUT_BYTES + 16 * 1024:
+            raise SandboxEngineError("MCP output too large.", code="mcp_output_too_large")
+        output = raw
+        try:
+            payload = json.loads(raw.decode("utf-8"))
+            request_id = payload.get("id") if isinstance(payload, dict) else None
+            if request_id in suppressed_requests:
+                suppressed_requests.discard(request_id)
+                continue
+            if request_id in list_requests:
+                list_requests.discard(request_id)
+                result = payload.get("result") if isinstance(payload, dict) else None
+                tools = result.get("tools") if isinstance(result, dict) else None
+                if isinstance(tools, list):
+                    result["tools"] = [
+                        item
+                        for item in tools
+                        if isinstance(item, dict) and item.get("name") in contract.tools
+                    ]
+                    output = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8") + b"\n"
+            elif request_id in call_requests:
+                call_requests.discard(request_id)
+                write_call = request_id in write_call_requests
+                write_call_requests.discard(request_id)
+                deadline = call_deadlines.pop(request_id, None)
+                if deadline is not None:
+                    deadline.cancel()
+                result = payload.get("result") if isinstance(payload, dict) else None
+                failed_result = isinstance(result, dict) and (
+                    result.get("isError") is True or result.get("is_error") is True
+                )
+                unknown_write_outcome = write_call and (
+                    (isinstance(payload, dict) and "error" in payload) or failed_result
+                ) and UNKNOWN_WRITE_OUTCOME_MARKER.encode("ascii") in raw
+                if unknown_write_outcome:
+                    output = _rpc_error(
+                        request_id,
+                        -32008,
+                        "SaaS 写入结果未知且不得自动重试。",
+                        data={"reason": "unknown_outcome", "retryable": False},
+                    )
+                elif write_call and (
+                    (isinstance(payload, dict) and "error" in payload) or failed_result
+                ):
+                    reason = (
+                        "rate_limited"
+                        if b"_http_429" in raw
+                        else "provider_rejected"
+                    )
+                    output = _rpc_error(
+                        request_id,
+                        -32009,
+                        "SaaS 写入未完成，远端已拒绝请求。",
+                        data={"reason": reason, "retryable": False},
+                    )
+                elif isinstance(payload, dict) and "error" in payload:
+                    error = payload.get("error")
+                    code = error.get("code", -32603) if isinstance(error, dict) else -32603
+                    payload["error"] = {"code": code, "message": "SaaS 目录操作失败。"}
+                    output = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8") + b"\n"
+                elif isinstance(payload, dict):
+                    if failed_result:
+                        result.pop("structuredContent", None)
+                        result.pop("structured_content", None)
+                        result["content"] = [{"type": "text", "text": "SaaS 目录操作失败。"}]
+                        output = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8") + b"\n"
+        except (UnicodeError, json.JSONDecodeError):
+            pass
+        async with write_lock:
+            destination.write(output)
+            await destination.drain()
+
+
+async def _wait_for_child_ready(
+    stream: asyncio.StreamReader | None,
+    process: asyncio.subprocess.Process,
+    adapter_id: str,
+) -> None:
+    if stream is None:
+        raise SandboxEngineError("SaaS child stderr unavailable.", code="preflight_failed")
+    expected = f"MODELMIRROR_SAAS_READY:{adapter_id}"
+    for _ in range(8):
+        try:
+            raw = await asyncio.wait_for(stream.readline(), timeout=15)
+        except asyncio.TimeoutError as exc:
+            raise SandboxEngineError("SaaS preflight timed out.", code="preflight_timeout") from exc
+        if not raw:
+            break
+        line = raw.decode("utf-8", errors="replace").strip()
+        if line == expected:
+            return
+        if line.startswith("MODELMIRROR_SAAS_FAILED:"):
+            break
+    if process.returncode is None:
+        process.terminate()
+        try:
+            await asyncio.wait_for(process.wait(), timeout=1)
+        except asyncio.TimeoutError:
+            process.kill()
+            await process.wait()
+    raise SandboxEngineError("SaaS credential or scope preflight failed.", code="preflight_failed")
+
+
+async def _drain_stderr(stream: asyncio.StreamReader | None) -> None:
+    if stream is None:
+        return
+    while await stream.read(4096):
+        pass
+
+
+async def _stdio(
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+    request: dict[str, Any],
+) -> None:
+    adapter_id = str(request.get("adapter_id") or "").strip()
+    if adapter_id not in ALLOWED_ADAPTERS:
+        raise SandboxEngineError("SaaS adapter disabled.", code="mcp_adapter_denied")
+    try:
+        contract, credentials, settings = validate_configuration(
+            adapter_id, request.get("configuration")
+        )
+    except ValueError as exc:
+        raise SandboxEngineError("SaaS adapter configuration denied.", code=str(exc)) from exc
+    request["configuration"] = None
+
+    async with SEMAPHORE:
+        temp_root = Path(tempfile.mkdtemp(prefix=f"mcp-saas-{adapter_id[:12]}-"))
+        work_dir = temp_root / "work"
+        work_dir.mkdir(mode=0o700)
+        encoded_configuration = base64.urlsafe_b64encode(
+            json.dumps(
+                {"credentials": credentials, "settings": settings},
+                ensure_ascii=False,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        ).decode("ascii")
+        credentials.clear()
+        settings.clear()
+        env = {
+            "PATH": "/usr/local/bin:/usr/bin:/bin",
+            "PYTHONPATH": "/opt/modelmirror",
+            "PYTHONDONTWRITEBYTECODE": "1",
+            "PYTHONNOUSERSITE": "1",
+            "PYTHONUNBUFFERED": "1",
+            "HOME": str(work_dir),
+            "TMPDIR": str(work_dir),
+            "LANG": "C.UTF-8",
+            "LC_ALL": "C.UTF-8",
+            "TZ": "UTC",
+            "NO_PROXY": "*",
+            "no_proxy": "*",
+            "DO_NOT_TRACK": "1",
+            "MCP_SAAS_HANDSHAKE_B64": encoded_configuration,
+        }
+        encoded_configuration = ""
+        command = [
+            sys.executable,
+            str(Path(__file__).with_name("landlock_exec.py")),
+            str(temp_root),
+            "--",
+            sys.executable,
+            "-m",
+            "sandbox_sidecar.saas_mcp",
+            adapter_id,
+        ]
+        process: asyncio.subprocess.Process | None = None
+        tasks: list[asyncio.Task[None]] = []
+        handshake_sent = False
+        try:
+            process = await asyncio.create_subprocess_exec(
+                *command,
+                cwd=str(work_dir),
+                env=env,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                start_new_session=True,
+                limit=MAX_MCP_MESSAGE_BYTES + 1,
+            )
+            env.clear()
+            if process.stdin is None or process.stdout is None:
+                raise SandboxEngineError("SaaS MCP stdio unavailable.", code="mcp_stdio_unavailable")
+            await _wait_for_child_ready(process.stderr, process, adapter_id)
+            writer.write(
+                json.dumps(
+                    {
+                        "ok": True,
+                        "adapter_id": adapter_id,
+                        "protocol": "modelmirror-mcp-saas-stdio-v1",
+                        "preflight": "verified",
+                        "tools": sorted(contract.tools),
+                        "effects": {name: policy.effect for name, policy in contract.tools.items()},
+                        "limits": {
+                            "timeout_seconds": TOOL_CALL_TIMEOUT_SECONDS,
+                            "argument_bytes": MAX_ARGUMENT_BYTES,
+                            "output_bytes": MAX_OUTPUT_BYTES,
+                        },
+                    },
+                    ensure_ascii=False,
+                    separators=(",", ":"),
+                ).encode("utf-8")
+                + b"\n"
+            )
+            await writer.drain()
+            handshake_sent = True
+            list_requests: set[object] = set()
+            call_requests: set[object] = set()
+            write_call_requests: set[object] = set()
+            call_deadlines: dict[object, asyncio.Task[None]] = {}
+            suppressed_requests: set[object] = set()
+            used_idempotency_keys: set[str] = set()
+            write_lock = asyncio.Lock()
+            tasks = [
+                asyncio.create_task(
+                    _client_to_child(
+                        reader,
+                        process.stdin,
+                        writer,
+                        contract,
+                        list_requests,
+                        call_requests,
+                        write_call_requests,
+                        call_deadlines,
+                        suppressed_requests,
+                        used_idempotency_keys,
+                        process,
+                        write_lock,
+                    )
+                ),
+                asyncio.create_task(
+                    _child_to_client(
+                        process.stdout,
+                        writer,
+                        contract,
+                        list_requests,
+                        call_requests,
+                        write_call_requests,
+                        call_deadlines,
+                        suppressed_requests,
+                        write_lock,
+                    )
+                ),
+                asyncio.create_task(_drain_stderr(process.stderr)),
+            ]
+            done, pending = await asyncio.wait(tasks[:2], return_when=asyncio.FIRST_COMPLETED)
+            for task in done:
+                task.result()
+            for task in pending:
+                task.cancel()
+        finally:
+            if "call_deadlines" in locals():
+                for deadline in call_deadlines.values():
+                    deadline.cancel()
+                if call_deadlines:
+                    await asyncio.gather(*call_deadlines.values(), return_exceptions=True)
+                call_deadlines.clear()
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            if tasks:
+                await asyncio.gather(*tasks, return_exceptions=True)
+            if process is not None and process.returncode is None:
+                process.terminate()
+                try:
+                    await asyncio.wait_for(process.wait(), timeout=2)
+                except asyncio.TimeoutError:
+                    process.kill()
+                    await process.wait()
+            shutil.rmtree(temp_root, ignore_errors=True)
+            if handshake_sent:
+                writer.close()
+                try:
+                    await asyncio.wait_for(writer.wait_closed(), timeout=1)
+                except (asyncio.TimeoutError, ConnectionError, OSError):
+                    pass
+
+
+async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+    try:
+        raw = await reader.readline()
+        if not raw or len(raw) > MAX_REQUEST_BYTES:
+            raise SandboxEngineError("SaaS sidecar request invalid.", code="invalid_request")
+        request = json.loads(raw.decode("utf-8"))
+        if not isinstance(request, dict):
+            raise SandboxEngineError("SaaS sidecar request must be an object.", code="invalid_request")
+        action = str(request.get("action") or "").strip()
+        if action == "mcp_stdio":
+            await _stdio(reader, writer, request)
+            return
+        if action != "health":
+            raise SandboxEngineError("SaaS sidecar action denied.", code="action_denied")
+        response = {
+            "ok": True,
+            "protocol": "modelmirror-mcp-saas-stdio-v1",
+            "mcp_saas_adapters": sorted(ALLOWED_ADAPTERS),
+            "mcp_saas_max_sessions": MAX_SESSIONS,
+            "mcp_message_limit_bytes": MAX_MCP_MESSAGE_BYTES,
+        }
+    except SandboxEngineError as exc:
+        response = {"ok": False, "error": "saas_sidecar_rejected", "code": exc.code}
+    except Exception:
+        response = {
+            "ok": False,
+            "error": "saas_sidecar_internal_error",
+            "code": "saas_sidecar_internal_error",
+        }
+    writer.write(json.dumps(response, ensure_ascii=False).encode("utf-8") + b"\n")
+    await writer.drain()
+    writer.close()
+    try:
+        await asyncio.wait_for(writer.wait_closed(), timeout=1)
+    except (asyncio.TimeoutError, ConnectionError, OSError):
+        pass
+
+
+async def main() -> None:
+    SOCKET_PATH.parent.mkdir(parents=True, exist_ok=True)
+    SOCKET_PATH.unlink(missing_ok=True)
+    server = await asyncio.start_unix_server(
+        handle, path=str(SOCKET_PATH), limit=MAX_MCP_MESSAGE_BYTES + 1
+    )
+    os.chmod(SOCKET_PATH, 0o660)
+    async with server:
+        await server.serve_forever()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/server/sandbox_sidecar/smoke_saas_adapters.py
+++ b/server/sandbox_sidecar/smoke_saas_adapters.py
@@ -1,0 +1,119 @@
+"""Offline initialization and tool-schema smoke for Wave 6 SaaS adapters."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+from .saas_contracts import SAAS_ADAPTERS, SAAS_SCHEMA_SHA256
+
+
+CONFIGURATIONS: dict[str, dict[str, dict[str, str]]] = {
+    "airtable-mcp": {
+        "credentials": {"personal_access_token": "offline-airtable-token"},
+        "settings": {"base_id": "app12345678901234"},
+    },
+    "asana-mcp": {
+        "credentials": {"personal_access_token": "offline-asana-token"},
+        "settings": {"workspace_gid": "1200000000000001", "project_gid": "1200000000000002"},
+    },
+    "gitlab-mcp": {
+        "credentials": {"personal_access_token": "offline-gitlab-token"},
+        "settings": {"project_id": "123456"},
+    },
+    "notion-mcp-server": {
+        "credentials": {"integration_token": "offline-notion-token"},
+        "settings": {"data_source_id": "0123456789abcdef0123456789abcdef"},
+    },
+}
+
+
+async def discover(adapter_id: str) -> tuple[set[str], str]:
+    encoded = base64.urlsafe_b64encode(
+        json.dumps(CONFIGURATIONS[adapter_id], separators=(",", ":")).encode("utf-8")
+    ).decode("ascii")
+    with tempfile.TemporaryDirectory(prefix=f"mcp-saas-smoke-{adapter_id[:12]}-") as root:
+        workspace = Path(root)
+        work_dir = workspace / "work"
+        work_dir.mkdir(mode=0o700)
+        env = {
+            "PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"),
+            "PYTHONPATH": os.environ.get("PYTHONPATH", "/opt/modelmirror"),
+            "PYTHONDONTWRITEBYTECODE": "1",
+            "PYTHONNOUSERSITE": "1",
+            "PYTHONUNBUFFERED": "1",
+            "HOME": str(work_dir),
+            "TMPDIR": str(work_dir),
+            "LANG": "C.UTF-8",
+            "LC_ALL": "C.UTF-8",
+            "TZ": "UTC",
+            "MCP_SAAS_OFFLINE_SMOKE": "1",
+            "MCP_SAAS_HANDSHAKE_B64": encoded,
+        }
+        params = StdioServerParameters(
+            command=sys.executable,
+            args=[
+                str(Path(__file__).with_name("landlock_exec.py")),
+                str(workspace),
+                "--",
+                sys.executable,
+                "-m",
+                "sandbox_sidecar.saas_mcp",
+                adapter_id,
+            ],
+            env=env,
+            cwd=work_dir,
+        )
+        async with stdio_client(params) as (read_stream, write_stream):
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+                response = await session.list_tools()
+    names = {tool.name for tool in response.tools}
+    reviewed = [
+        {"name": tool.name, "inputSchema": tool.inputSchema}
+        for tool in sorted(response.tools, key=lambda item: item.name)
+    ]
+    encoded_schema = json.dumps(
+        reviewed, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    if b"__modelmirror_" in encoded_schema:
+        raise RuntimeError(f"{adapter_id} leaked private execution fields in tools/list")
+    return names, hashlib.sha256(encoded_schema).hexdigest()
+
+
+async def main() -> None:
+    discovered_digests: dict[str, str] = {}
+    for adapter_id, contract in SAAS_ADAPTERS.items():
+        names, digest = await asyncio.wait_for(discover(adapter_id), timeout=20)
+        expected_names = set(contract.tools)
+        if names != expected_names:
+            raise RuntimeError(
+                f"{adapter_id} tool drift: expected={sorted(expected_names)} discovered={sorted(names)}"
+            )
+        discovered_digests[adapter_id] = digest
+        print(
+            f"{adapter_id}: initialized, tools={len(names)}, schema_sha256={digest}",
+            flush=True,
+        )
+    if set(SAAS_SCHEMA_SHA256) != set(SAAS_ADAPTERS):
+        raise RuntimeError("SaaS schema snapshot coverage mismatch")
+    mismatches = {
+        adapter_id: digest
+        for adapter_id, digest in discovered_digests.items()
+        if SAAS_SCHEMA_SHA256.get(adapter_id) != digest
+    }
+    if mismatches:
+        raise RuntimeError(f"SaaS reviewed tool schema drifted: {mismatches}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/server/tests/test_mcp_catalog.py
+++ b/server/tests/test_mcp_catalog.py
@@ -1,16 +1,19 @@
 from __future__ import annotations
 
+import asyncio
 import base64
 import json
 import re
+from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
 import httpx
 import pytest
-from fastapi import FastAPI
-from mcp.types import CallToolResult, TextContent, Tool
+from fastapi import FastAPI, HTTPException
+from mcp.shared.exceptions import McpError
+from mcp.types import CallToolResult, ErrorData, TextContent, Tool
 from pydantic import ValidationError
 
 from server.mcp import catalog
@@ -22,12 +25,17 @@ from server.mcp.catalog import (
     WAVE_THREE_ADAPTERS,
     WAVE_FOUR_ADAPTERS,
     WAVE_FIVE_ADAPTERS,
+    WAVE_SIX_ADAPTERS,
     WAVE_PROJECTS,
     CatalogAdapterManifest,
     CatalogConfigurationRequest,
+    CatalogConfigurationSnapshot,
     CatalogCredentialCreateRequest,
+    CatalogUnknownOutcomeError,
+    CatalogUnbindRequest,
     MCPCatalogService,
 )
+from server.sandbox_sidecar.saas_contracts import SAAS_SCHEMA_SHA256
 from server.toolsets.credentials import CredentialStore
 
 
@@ -38,29 +46,64 @@ class FakeManager:
     def __init__(self) -> None:
         self.commands: list[list[str]] = []
         self.calls: list[tuple[str, str, dict[str, Any]]] = []
+        self.retry_on_failure: list[bool] = []
         self.disconnected: list[str] = []
         self.sessions: set[str] = set()
+        self.session_owners: dict[str, str] = {}
         self.profiles: list[dict[str, Any]] = []
         self.scrubbed: list[str] = []
         self.call_is_error = False
+        self.call_error: Exception | None = None
+        self.call_gate: asyncio.Event | None = None
+        self.connect_gate: asyncio.Event | None = None
+        self.connect_started = asyncio.Event()
+        self.disconnect_gate: asyncio.Event | None = None
+        self.disconnect_started = asyncio.Event()
+        self.tools: list[Tool] = [Tool(name="echo", description="Echo", inputSchema={})]
 
-    async def connect(self, command: list[str]) -> str:
+    async def connect(
+        self,
+        command: list[str],
+        *,
+        session_owner: str = "",
+    ) -> str:
         self.commands.append(list(command))
         session_id = f"session-{len(self.commands)}"
         self.sessions.add(session_id)
+        self.session_owners[session_id] = session_owner
         return session_id
 
     async def connect_profile(self, **kwargs: Any) -> str:
         self.profiles.append(dict(kwargs))
-        return await self.connect(list(kwargs.get("server_command") or []))
+        self.connect_started.set()
+        if self.connect_gate is not None:
+            await self.connect_gate.wait()
+        return await self.connect(
+            list(kwargs.get("server_command") or []),
+            session_owner=str(kwargs.get("session_owner") or ""),
+        )
 
-    async def list_tools(self, session_id: str) -> list[Tool]:
-        if session_id not in self.sessions:
+    async def list_tools(
+        self,
+        session_id: str,
+        *,
+        session_owner: str = "",
+    ) -> list[Tool]:
+        if (
+            session_id not in self.sessions
+            or self.session_owners.get(session_id, "") != session_owner
+        ):
             raise catalog.MCPSessionNotFoundError(session_id)
-        return [Tool(name="echo", description="Echo", inputSchema={})]
+        return list(self.tools)
 
-    async def scrub_session_environment(self, session_id: str) -> None:
+    async def scrub_session_environment(
+        self,
+        session_id: str,
+        *,
+        session_owner: str = "",
+    ) -> None:
         assert session_id in self.sessions
+        assert self.session_owners.get(session_id, "") == session_owner
         self.scrubbed.append(session_id)
 
     async def call_tool(
@@ -68,17 +111,39 @@ class FakeManager:
         session_id: str,
         tool_name: str,
         arguments: dict[str, Any],
+        *,
+        retry_on_failure: bool = True,
+        session_owner: str = "",
     ) -> CallToolResult:
+        if self.session_owners.get(session_id, "") != session_owner:
+            raise catalog.MCPSessionNotFoundError(session_id)
         self.calls.append((session_id, tool_name, dict(arguments)))
+        self.retry_on_failure.append(retry_on_failure)
+        if self.call_gate is not None:
+            await self.call_gate.wait()
+        if self.call_error is not None:
+            raise self.call_error
         return CallToolResult(
             content=[TextContent(type="text", text=str(arguments.get("value", "ok")))],
             isError=self.call_is_error,
         )
 
-    async def disconnect(self, session_id: str) -> None:
-        if session_id not in self.sessions:
+    async def disconnect(
+        self,
+        session_id: str,
+        *,
+        session_owner: str = "",
+    ) -> None:
+        if (
+            session_id not in self.sessions
+            or self.session_owners.get(session_id, "") != session_owner
+        ):
             raise catalog.MCPSessionNotFoundError(session_id)
+        self.disconnect_started.set()
+        if self.disconnect_gate is not None:
+            await self.disconnect_gate.wait()
         self.sessions.remove(session_id)
+        self.session_owners.pop(session_id, None)
         self.disconnected.append(session_id)
 
 
@@ -140,6 +205,10 @@ def make_service(
         "cred_pinecone": ("pinecone-assistant-mcp", "api_key"),
         "cred_dbhub": ("dbhub", "password"),
         "cred_supabase": ("supabase-mcp", "access_token"),
+        "cred_airtable": ("airtable-mcp", "personal_access_token"),
+        "cred_asana": ("asana-mcp", "personal_access_token"),
+        "cred_gitlab": ("gitlab-mcp", "personal_access_token"),
+        "cred_notion": ("notion-mcp-server", "integration_token"),
     }
 
     def credential_validator(credential_id: str) -> SimpleNamespace:
@@ -194,15 +263,15 @@ def test_catalog_freezes_100_projects_and_maps_all_waves_once() -> None:
     assert sum(
         manifest.availability == "ready"
         for manifest in CATALOG_ADAPTERS.values()
-    ) == 38
+    ) == 42
     assert sum(
         manifest.availability == "planned"
         for manifest in CATALOG_ADAPTERS.values()
-    ) == 53
+    ) == 47
     assert sum(
         manifest.availability == "blocked"
         for manifest in CATALOG_ADAPTERS.values()
-    ) == 9
+    ) == 11
     assert {manifest.availability for manifest in CATALOG_ADAPTERS.values()} == {
         "ready",
         "planned",
@@ -246,7 +315,7 @@ def test_frontend_catalog_ids_match_backend_registry_and_never_submit_commands()
 def test_planned_adapter_cannot_be_enabled_by_environment(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    manifest = CATALOG_ADAPTERS["airtable-mcp"]
+    manifest = CATALOG_ADAPTERS["chrome-devtools-mcp"]
     monkeypatch.setenv(manifest.feature_flag, "true")
 
     assert manifest.feature_enabled is True
@@ -271,9 +340,9 @@ async def test_catalog_api_hides_execution_details_and_rejects_planned_connect()
             assert response.status_code == 200
             payload = response.json()
             assert payload["total"] == 100
-            assert payload["ready"] == 38
-            assert payload["planned"] == 53
-            assert payload["blocked"] == 9
+            assert payload["ready"] == 42
+            assert payload["planned"] == 47
+            assert payload["blocked"] == 11
             serialized = response.text.lower()
             assert "server_command" not in serialized
             assert "install_command" not in serialized
@@ -365,9 +434,10 @@ async def test_wave_one_adapter_uses_bundled_sandbox_profile() -> None:
             "server_command": list(
                 CATALOG_ADAPTERS["calculator-mcp"].server_command
             ),
-            "network_policy": "disabled",
-            "reconnect_attempts": 1,
-            "operation_timeout": 10.0,
+                "network_policy": "disabled",
+                "reconnect_attempts": 1,
+                "operation_timeout": 10.0,
+                "session_owner": "catalog:local:local:calculator-mcp",
         }
     ]
     public = next(
@@ -400,9 +470,10 @@ async def test_wave_two_adapter_uses_fixed_public_sidecar_profile() -> None:
         {
             "transport": "stdio",
             "server_command": list(CATALOG_ADAPTERS["fetch-mcp"].server_command),
-            "network_policy": "validated-public-https:user-supplied-host",
-            "reconnect_attempts": 1,
-            "operation_timeout": 45.0,
+                "network_policy": "validated-public-https:user-supplied-host",
+                "reconnect_attempts": 1,
+                "operation_timeout": 45.0,
+                "session_owner": "catalog:local:local:fetch-mcp",
         }
     ]
     public = next(
@@ -827,3 +898,628 @@ async def test_future_ready_adapter_requires_explicit_tool_policy() -> None:
 
     with pytest.raises(catalog.CatalogAdapterPolicyError, match="显式读写"):
         await service.call_tool(manifest.project_id, "echo", {})
+
+
+def _enable_wave_six(monkeypatch: pytest.MonkeyPatch, project_id: str) -> None:
+    monkeypatch.setenv("MCP_CATALOG_STATEFUL_SAAS_SINGLE_USER_ACK", "true")
+    monkeypatch.setenv(
+        f"MCP_CATALOG_ENABLE_{project_id.upper().replace('-', '_')}",
+        "true",
+    )
+
+
+def _install_fake_wave_six_schema(
+    service: MCPCatalogService,
+    manager: FakeManager,
+    project_id: str,
+) -> CatalogAdapterManifest:
+    manifest = service.manifests[project_id]
+    tools = [
+        Tool(name=name, description=name, inputSchema={"type": "object"})
+        for name in manifest.tool_policies
+    ]
+    manager.tools = tools
+    assert manifest.saas_policy is not None
+    service.manifests[project_id] = replace(
+        manifest,
+        saas_policy=replace(
+            manifest.saas_policy,
+            tool_schema_sha256=service._tool_schema_digest(tools),
+        ),
+    )
+    return service.manifests[project_id]
+
+
+def test_wave_six_freezes_four_ready_and_two_blocked_contracts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    assert set(WAVE_SIX_ADAPTERS) == {
+        "airtable-mcp",
+        "asana-mcp",
+        "gitlab-mcp",
+        "notion-mcp-server",
+    }
+    for project_id, spec in WAVE_SIX_ADAPTERS.items():
+        manifest = CATALOG_ADAPTERS[project_id]
+        assert manifest.availability == "ready"
+        assert manifest.runtime_image == "modelmirror-mcp-saas:wave6-v1"
+        assert manifest.server_command == (
+            catalog.sys.executable,
+            "-m",
+            "mcp.saas_proxy",
+            project_id,
+        )
+        assert manifest.saas_policy is not None
+        assert manifest.saas_policy.fixed_hosts == spec.fixed_hosts
+        assert manifest.saas_policy.tool_schema_sha256 == SAAS_SCHEMA_SHA256[project_id]
+        assert (
+            manifest.saas_policy.rate_limit_per_minute
+            == spec.rate_limit_per_minute
+        )
+        assert manifest.executable is False
+        monkeypatch.setenv(manifest.feature_flag, "true")
+        assert manifest.executable is False
+        monkeypatch.setenv("MCP_CATALOG_STATEFUL_SAAS_SINGLE_USER_ACK", "true")
+        assert manifest.executable is True
+        monkeypatch.delenv(manifest.feature_flag)
+        monkeypatch.delenv("MCP_CATALOG_STATEFUL_SAAS_SINGLE_USER_ACK")
+        for tool_name in spec.write_tools:
+            policy = manifest.tool_policies[tool_name]
+            assert policy.read_only is False
+            assert policy.requires_approval is True
+            assert policy.effect == "state-write"
+        assert not {
+            "delete_record",
+            "delete_task",
+            "delete_issue",
+            "merge_merge_request",
+            "delete_page",
+        } & set(manifest.tool_policies)
+
+    assert CATALOG_ADAPTERS["mcp-cn-commerce"].availability == "blocked"
+    assert CATALOG_ADAPTERS["mem0-mcp"].availability == "blocked"
+    notion = CATALOG_ADAPTERS["notion-mcp-server"]
+    assert notion.allowed_settings == ("data_source_id",)
+    assert notion.saas_policy is not None
+    assert notion.saas_policy.fixed_hosts == ("api.notion.com",)
+
+
+@pytest.mark.asyncio
+async def test_wave_six_connect_rejects_input_schema_drift(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_wave_six(monkeypatch, "airtable-mcp")
+    service, manager, _, _ = make_service()
+    manifest = CATALOG_ADAPTERS["airtable-mcp"]
+    manager.tools = [
+        Tool(name=name, description=name, inputSchema={"type": "object"})
+        for name in manifest.tool_policies
+    ]
+    service.configure(
+        "airtable-mcp",
+        CatalogConfigurationRequest(
+            settings={"base_id": "appABCDEFGHIJKLMN"},
+            credential_bindings={"personal_access_token": "cred_airtable"},
+        ),
+    )
+
+    with pytest.raises(catalog.CatalogAdapterPolicyError, match="Schema"):
+        await service.connect("airtable-mcp")
+
+    assert service._scope_key("airtable-mcp") not in service._sessions
+    assert not manager.sessions
+
+
+@pytest.mark.asyncio
+async def test_wave_six_remote_approval_freezes_context_and_replays_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_wave_six(monkeypatch, "airtable-mcp")
+    service, manager, _, _ = make_service()
+    manifest = _install_fake_wave_six_schema(service, manager, "airtable-mcp")
+    service.configure(
+        "airtable-mcp",
+        CatalogConfigurationRequest(
+            settings={"base_id": "appABCDEFGHIJKLMN"},
+            credential_bindings={"personal_access_token": "cred_airtable"},
+        ),
+    )
+    connected = await service.connect("airtable-mcp")
+    assert manager.profiles[-1]["session_owner"] == service._session_owner(
+        "airtable-mcp"
+    )
+    status = service.list_adapters()["adapters"]
+    airtable = next(item for item in status if item["project_id"] == "airtable-mcp")
+    assert airtable["account_status"] == "verified"
+    assert airtable["preflight_status"] == "verified"
+
+    with pytest.raises(catalog.CatalogApprovalRequiredError) as captured:
+        await service.call_tool(
+            "airtable-mcp",
+            "update_record",
+            {
+                "table_id": "tblPublic",
+                "record_id": "rec123456789",
+                "fields": {"secret_note": "正文不应进入审批摘要"},
+            },
+        )
+    approval = captured.value.payload
+    assert approval["target_preview"]["resource"]["id_suffix"] == "456789"
+    assert "正文不应进入审批摘要" not in json.dumps(
+        approval["target_preview"], ensure_ascii=False
+    )
+    assert re.fullmatch(r"mcpidem_[0-9a-f]{32}", approval["idempotency_key"])
+    assert manager.calls == []
+
+    manager.call_gate = asyncio.Event()
+    first_task = asyncio.create_task(
+        service.confirm_approval("airtable-mcp", approval["approval_id"])
+    )
+    while not manager.calls:
+        await asyncio.sleep(0)
+    with pytest.raises(CatalogUnknownOutcomeError):
+        await service.confirm_approval("airtable-mcp", approval["approval_id"])
+    with pytest.raises(catalog.CatalogAdapterPolicyError):
+        await service.cancel_approval("airtable-mcp", approval["approval_id"])
+    with pytest.raises(catalog.CatalogAdapterPolicyError, match="写入仍在执行"):
+        await service.disconnect("airtable-mcp")
+    with pytest.raises(catalog.CatalogAdapterPolicyError, match="写入仍在执行"):
+        await service.unbind(
+            "airtable-mcp",
+            CatalogUnbindRequest(revoke_credentials=False),
+        )
+    revoked_while_writing: list[str] = []
+    service.credential_revoker = lambda credential_id: revoked_while_writing.append(
+        credential_id
+    )
+    with pytest.raises(catalog.CatalogAdapterPolicyError, match="写入仍在执行"):
+        await service.revoke_credential("airtable-mcp", "cred_airtable")
+    assert revoked_while_writing == []
+    assert service._scope_key("airtable-mcp") in service._sessions
+    manager.call_gate.set()
+    first = await first_task
+    manager.call_gate = None
+    assert first["idempotent_replay"] is False
+    assert manager.calls[-1][0] == connected["session_id"]
+    assert manager.calls[-1][2]["__modelmirror_idempotency_key"] == approval["idempotency_key"]
+    assert manager.retry_on_failure == [False]
+    replay = await service.confirm_approval(
+        "airtable-mcp",
+        approval["approval_id"],
+    )
+    assert replay["idempotent_replay"] is True
+    assert len(manager.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_wave_six_approval_rejects_drift_and_marks_unknown_outcome(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_wave_six(monkeypatch, "gitlab-mcp")
+    service, manager, _, _ = make_service()
+    manifest = _install_fake_wave_six_schema(service, manager, "gitlab-mcp")
+    service.configure(
+        "gitlab-mcp",
+        CatalogConfigurationRequest(
+            settings={"project_id": 12345},
+            credential_bindings={"personal_access_token": "cred_gitlab"},
+        ),
+    )
+    await service.connect("gitlab-mcp")
+
+    async def request_approval() -> dict[str, Any]:
+        with pytest.raises(catalog.CatalogApprovalRequiredError) as captured:
+            await service.call_tool(
+                "gitlab-mcp",
+                "create_issue",
+                {"title": "安全复核", "description": "frozen"},
+            )
+        return captured.value.payload
+
+    drifted = await request_approval()
+    scope_key = service._scope_key("gitlab-mcp")
+    current = service._configuration_snapshots[scope_key]
+    service._configuration_snapshots[scope_key] = CatalogConfigurationSnapshot(
+        revision="mcpcfg_changed",
+        digest=current.digest,
+    )
+    with pytest.raises(catalog.CatalogAdapterPolicyError, match="已经变化"):
+        await service.confirm_approval("gitlab-mcp", drifted["approval_id"])
+
+    service._configuration_snapshots[scope_key] = current
+    unknown = await request_approval()
+    manager.call_error = RuntimeError("sidecar unknown outcome")
+    with pytest.raises(CatalogUnknownOutcomeError) as captured_unknown:
+        await service.confirm_approval("gitlab-mcp", unknown["approval_id"])
+    assert captured_unknown.value.idempotency_key == unknown["idempotency_key"]
+    with pytest.raises(CatalogUnknownOutcomeError):
+        await service.confirm_approval("gitlab-mcp", unknown["approval_id"])
+    assert len(manager.calls) == 1
+
+    manager.call_error = None
+    manager.call_is_error = True
+    rejected = await request_approval()
+    with pytest.raises(CatalogUnknownOutcomeError) as rejected_result:
+        await service.confirm_approval("gitlab-mcp", rejected["approval_id"])
+    assert rejected_result.value.idempotency_key == rejected["idempotency_key"]
+    assert len(manager.calls) == 2
+    await service.unbind(
+        "gitlab-mcp",
+        CatalogUnbindRequest(revoke_credentials=False),
+    )
+    with pytest.raises(CatalogUnknownOutcomeError):
+        await service.confirm_approval("gitlab-mcp", rejected["approval_id"])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("reason", "expected_code", "expected_status"),
+    [
+        ("rate_limited", "provider_rate_limited", 429),
+        ("provider_rejected", "provider_rejected", 409),
+    ],
+)
+async def test_wave_six_definite_provider_rejection_is_not_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+    reason: str,
+    expected_code: str,
+    expected_status: int,
+) -> None:
+    _enable_wave_six(monkeypatch, "gitlab-mcp")
+    service, manager, _, _ = make_service()
+    _install_fake_wave_six_schema(service, manager, "gitlab-mcp")
+    service.configure(
+        "gitlab-mcp",
+        CatalogConfigurationRequest(
+            settings={"project_id": 12345},
+            credential_bindings={"personal_access_token": "cred_gitlab"},
+        ),
+    )
+    await service.connect("gitlab-mcp")
+    with pytest.raises(catalog.CatalogApprovalRequiredError) as approval_required:
+        await service.call_tool(
+            "gitlab-mcp",
+            "create_issue",
+            {"title": "安全复核", "description": "frozen"},
+        )
+    approval = approval_required.value.payload
+    manager.call_error = McpError(
+        ErrorData(
+            code=-32009,
+            message="SaaS write rejected",
+            data={"reason": reason, "retryable": False},
+        )
+    )
+
+    with pytest.raises(catalog.CatalogProviderRejectedError) as rejected:
+        await service.confirm_approval("gitlab-mcp", approval["approval_id"])
+    assert rejected.value.reason == reason
+    ledger = service._execution_ledger[service._approval_key(approval["approval_id"])]
+    assert ledger.state == "rejected"
+    assert len(manager.calls) == 1
+    with pytest.raises(catalog.CatalogAdapterPolicyError, match="不存在或已经失效"):
+        await service.confirm_approval("gitlab-mcp", approval["approval_id"])
+
+    with pytest.raises(HTTPException) as response:
+        catalog._raise_http_error(rejected.value)
+    assert response.value.status_code == expected_status
+    assert response.value.detail["code"] == expected_code
+    assert response.value.detail["idempotency_key"] == approval["idempotency_key"]
+
+
+@pytest.mark.asyncio
+async def test_wave_six_unbind_clears_session_configuration_and_pending_approval(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_wave_six(monkeypatch, "asana-mcp")
+    service, manager, _, _ = make_service()
+    manifest = _install_fake_wave_six_schema(service, manager, "asana-mcp")
+    service.configure(
+        "asana-mcp",
+        CatalogConfigurationRequest(
+            settings={"workspace_gid": "100", "project_gid": "200"},
+            credential_bindings={"personal_access_token": "cred_asana"},
+        ),
+    )
+    await service.connect("asana-mcp")
+    with pytest.raises(catalog.CatalogApprovalRequiredError) as captured:
+        await service.call_tool("asana-mcp", "create_task", {"name": "Review"})
+    result = await service.unbind(
+        "asana-mcp",
+        CatalogUnbindRequest(revoke_credentials=False),
+    )
+    assert result == {
+        "ok": True,
+        "project_id": "asana-mcp",
+        "disconnected": True,
+        "revoked_credentials": 0,
+    }
+    adapter = next(
+        item
+        for item in service.list_adapters()["adapters"]
+        if item["project_id"] == "asana-mcp"
+    )
+    assert adapter["account_status"] == "unbound"
+    assert adapter["configured"] is False
+    with pytest.raises(catalog.CatalogAdapterPolicyError):
+        await service.confirm_approval("asana-mcp", captured.value.payload["approval_id"])
+
+    guarded, guarded_manager, _, _ = make_service()
+    _install_fake_wave_six_schema(guarded, guarded_manager, "asana-mcp")
+    guarded.configure(
+        "asana-mcp",
+        CatalogConfigurationRequest(
+            settings={"workspace_gid": "100", "project_gid": "200"},
+            credential_bindings={"personal_access_token": "cred_asana"},
+        ),
+    )
+    await guarded.connect("asana-mcp")
+    guarded_scope = guarded._scope_key("asana-mcp")
+    with pytest.raises(catalog.CatalogAdapterUnavailableError):
+        await guarded.unbind(
+            "asana-mcp",
+            CatalogUnbindRequest(revoke_credentials=True),
+        )
+    assert guarded_scope in guarded._sessions
+    assert guarded_scope in guarded._configurations
+
+    revoked: list[str] = []
+
+    def revoke_failure_after_disconnect(credential_id: str) -> SimpleNamespace:
+        assert credential_id == "cred_asana"
+        assert guarded_scope not in guarded._sessions
+        assert guarded_scope in guarded._configurations
+        raise RuntimeError("vault unavailable")
+
+    guarded.credential_revoker = revoke_failure_after_disconnect
+    with pytest.raises(RuntimeError, match="vault unavailable"):
+        await guarded.unbind(
+            "asana-mcp",
+            CatalogUnbindRequest(revoke_credentials=True),
+        )
+    assert guarded_scope not in guarded._sessions
+    assert guarded_scope in guarded._configurations
+
+    def revoke_before_cleanup(credential_id: str) -> SimpleNamespace:
+        assert guarded_scope not in guarded._sessions
+        assert guarded_scope in guarded._configurations
+        revoked.append(credential_id)
+        return SimpleNamespace(credential_id=credential_id, status="revoked")
+
+    guarded.credential_revoker = revoke_before_cleanup
+    revoked_result = await guarded.unbind(
+        "asana-mcp",
+        CatalogUnbindRequest(revoke_credentials=True),
+    )
+    assert revoked_result["revoked_credentials"] == 1
+    assert revoked == ["cred_asana"]
+
+
+@pytest.mark.asyncio
+async def test_wave_six_unbind_blocks_new_calls_and_waits_for_active_read(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_wave_six(monkeypatch, "asana-mcp")
+    service, manager, _, _ = make_service()
+    manifest = _install_fake_wave_six_schema(service, manager, "asana-mcp")
+    configuration = CatalogConfigurationRequest(
+        settings={"workspace_gid": "100", "project_gid": "200"},
+        credential_bindings={"personal_access_token": "cred_asana"},
+    )
+    service.configure("asana-mcp", configuration)
+    await service.connect("asana-mcp")
+
+    with pytest.raises(catalog.CatalogApprovalRequiredError) as captured:
+        await service.call_tool("asana-mcp", "create_task", {"name": "Review"})
+    approval_id = captured.value.payload["approval_id"]
+
+    manager.call_gate = asyncio.Event()
+    active_read = asyncio.create_task(
+        service.call_tool("asana-mcp", "list_tasks", {})
+    )
+    while not manager.calls:
+        await asyncio.sleep(0)
+
+    queued_execute_started = asyncio.Event()
+    original_execute_tool = service._execute_tool
+
+    async def tracked_execute_tool(
+        tracked_manifest: CatalogAdapterManifest,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        queued_execute_started.set()
+        return await original_execute_tool(tracked_manifest, **kwargs)
+
+    monkeypatch.setattr(service, "_execute_tool", tracked_execute_tool)
+    queued_read = asyncio.create_task(
+        service.call_tool("asana-mcp", "list_tasks", {})
+    )
+    await queued_execute_started.wait()
+
+    async with service._lock:
+        unbind_task = asyncio.create_task(
+            service.unbind(
+                "asana-mcp",
+                CatalogUnbindRequest(revoke_credentials=False),
+            )
+        )
+        scope_key = service._scope_key("asana-mcp")
+        while scope_key not in service._unbinding_scopes:
+            await asyncio.sleep(0)
+
+        with pytest.raises(catalog.CatalogAdapterPolicyError, match="不能确认写入"):
+            await service.confirm_approval("asana-mcp", approval_id)
+
+    with pytest.raises(catalog.CatalogAdapterPolicyError, match="正在解绑"):
+        await service.call_tool("asana-mcp", "list_tasks", {})
+    with pytest.raises(catalog.CatalogAdapterPolicyError, match="正在解绑"):
+        service.configure("asana-mcp", configuration)
+    with pytest.raises(catalog.CatalogAdapterPolicyError, match="正在解绑"):
+        await service.connect("asana-mcp")
+    assert len(manager.calls) == 1
+
+    manager.call_gate.set()
+    await active_read
+    with pytest.raises(catalog.CatalogAdapterPolicyError, match="不能调用工具"):
+        await queued_read
+    result = await unbind_task
+    assert result["disconnected"] is True
+    assert scope_key not in service._unbinding_scopes
+    assert scope_key not in service._sessions
+
+
+@pytest.mark.asyncio
+async def test_wave_six_unbind_cancels_connect_before_session_publication(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_wave_six(monkeypatch, "asana-mcp")
+    service, manager, _, _ = make_service()
+    _install_fake_wave_six_schema(service, manager, "asana-mcp")
+    service.configure(
+        "asana-mcp",
+        CatalogConfigurationRequest(
+            settings={"workspace_gid": "100", "project_gid": "200"},
+            credential_bindings={"personal_access_token": "cred_asana"},
+        ),
+    )
+    manager.connect_gate = asyncio.Event()
+    connect_task = asyncio.create_task(service.connect("asana-mcp"))
+    await manager.connect_started.wait()
+
+    unbind_task = asyncio.create_task(
+        service.unbind(
+            "asana-mcp",
+            CatalogUnbindRequest(revoke_credentials=False),
+        )
+    )
+    scope_key = service._scope_key("asana-mcp")
+    while scope_key not in service._unbinding_scopes:
+        await asyncio.sleep(0)
+    assert not unbind_task.done()
+
+    manager.connect_gate.set()
+    with pytest.raises(catalog.CatalogAdapterPolicyError, match="未发布"):
+        await connect_task
+    unbound = await unbind_task
+    assert unbound["disconnected"] is False
+    assert scope_key not in service._sessions
+    assert scope_key not in service._configurations
+    assert not manager.sessions
+
+
+@pytest.mark.asyncio
+async def test_wave_six_configuration_cannot_change_while_connecting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_wave_six(monkeypatch, "asana-mcp")
+    service, manager, _, _ = make_service()
+    _install_fake_wave_six_schema(service, manager, "asana-mcp")
+    original = CatalogConfigurationRequest(
+        settings={"workspace_gid": "100", "project_gid": "200"},
+        credential_bindings={"personal_access_token": "cred_asana"},
+    )
+    replacement = CatalogConfigurationRequest(
+        settings={"workspace_gid": "300", "project_gid": "400"},
+        credential_bindings={"personal_access_token": "cred_asana"},
+    )
+    service.configure("asana-mcp", original)
+    manager.connect_gate = asyncio.Event()
+    connect_task = asyncio.create_task(service.connect("asana-mcp"))
+    await manager.connect_started.wait()
+
+    scope_key = service._scope_key("asana-mcp")
+    assert scope_key in service._connecting_scopes
+    with pytest.raises(catalog.CatalogAdapterPolicyError, match="连接正在建立"):
+        service.configure("asana-mcp", replacement)
+    with pytest.raises(catalog.CatalogAdapterPolicyError, match="连接正在建立"):
+        await service.connect("asana-mcp")
+
+    handshake = manager.profiles[-1]["environment"]["MCP_SAAS_HANDSHAKE_B64"]
+    handshake_payload = json.loads(base64.urlsafe_b64decode(handshake).decode("utf-8"))
+    assert handshake_payload["settings"] == original.settings
+    assert service._configurations[scope_key].settings == original.settings
+
+    manager.connect_gate.set()
+    await connect_task
+    assert scope_key not in service._connecting_scopes
+    assert service._configurations[scope_key].settings == original.settings
+
+
+@pytest.mark.asyncio
+async def test_wave_six_bound_credential_revoke_drains_calls_and_is_fail_safe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_wave_six(monkeypatch, "asana-mcp")
+    service, manager, _, _ = make_service()
+    _install_fake_wave_six_schema(service, manager, "asana-mcp")
+    configuration = CatalogConfigurationRequest(
+        settings={"workspace_gid": "100", "project_gid": "200"},
+        credential_bindings={"personal_access_token": "cred_asana"},
+    )
+    service.configure("asana-mcp", configuration)
+    await service.connect("asana-mcp")
+    scope_key = service._scope_key("asana-mcp")
+
+    def fail_revoke(_: str) -> SimpleNamespace:
+        raise RuntimeError("vault unavailable")
+
+    service.credential_revoker = fail_revoke
+    with pytest.raises(RuntimeError, match="vault unavailable"):
+        await service.revoke_credential("asana-mcp", "cred_asana")
+    assert scope_key in service._sessions
+    assert scope_key in service._configurations
+    assert scope_key not in service._unbinding_scopes
+
+    revoked: list[str] = []
+
+    def revoke(credential_id: str) -> SimpleNamespace:
+        revoked.append(credential_id)
+        return SimpleNamespace(
+            credential_id=credential_id,
+            name="Asana",
+            kind="provider_key",
+            masked_value="****",
+            status="revoked",
+            catalog_project_id="asana-mcp",
+            catalog_slot="personal_access_token",
+        )
+
+    service.credential_revoker = revoke
+    manager.call_gate = asyncio.Event()
+    active_read = asyncio.create_task(
+        service.call_tool("asana-mcp", "list_tasks", {})
+    )
+    while not manager.calls:
+        await asyncio.sleep(0)
+    revoke_task = asyncio.create_task(
+        service.revoke_credential("asana-mcp", "cred_asana")
+    )
+    while scope_key not in service._unbinding_scopes:
+        await asyncio.sleep(0)
+    assert revoked == []
+    with pytest.raises(catalog.CatalogAdapterPolicyError, match="正在解绑"):
+        await service.call_tool("asana-mcp", "list_tasks", {})
+
+    manager.call_gate.set()
+    await active_read
+    revoked_public = await revoke_task
+    assert revoked_public["status"] == "revoked"
+    assert revoked == ["cred_asana"]
+    assert scope_key not in service._sessions
+    assert scope_key not in service._configurations
+
+
+def test_catalog_scope_keys_include_tenant_and_owner() -> None:
+    service, _, _, _ = make_service()
+    service.tenant_id = "tenant-a"
+    service.owner_id = "owner-a"
+    assert service._scope_key("airtable-mcp") == (
+        "tenant-a",
+        "owner-a",
+        "airtable-mcp",
+    )
+    assert service._approval_key("approval") == (
+        "tenant-a",
+        "owner-a",
+        "approval",
+    )

--- a/server/tests/test_mcp_file_workspaces.py
+++ b/server/tests/test_mcp_file_workspaces.py
@@ -254,21 +254,43 @@ class FakeManager:
     def __init__(self) -> None:
         self.calls: list[tuple[str, str, dict[str, Any]]] = []
         self.sessions: set[str] = set()
+        self.session_owner = ""
 
-    async def connect_profile(self, **_: Any) -> str:
+    async def connect_profile(self, **kwargs: Any) -> str:
         self.sessions.add("file-session")
+        self.session_owner = str(kwargs.get("session_owner") or "")
         return "file-session"
 
-    async def list_tools(self, session_id: str) -> list[Tool]:
+    async def list_tools(
+        self,
+        session_id: str,
+        *,
+        session_owner: str = "",
+    ) -> list[Tool]:
         assert session_id in self.sessions
+        assert session_owner == self.session_owner
         return [Tool(name="write_note", description="write", inputSchema={})]
 
-    async def call_tool(self, session_id: str, tool_name: str, arguments: dict[str, Any]) -> CallToolResult:
+    async def call_tool(
+        self,
+        session_id: str,
+        tool_name: str,
+        arguments: dict[str, Any],
+        *,
+        session_owner: str = "",
+    ) -> CallToolResult:
         assert session_id in self.sessions
+        assert session_owner == self.session_owner
         self.calls.append((session_id, tool_name, arguments))
         return CallToolResult(content=[TextContent(type="text", text="ok")])
 
-    async def disconnect(self, session_id: str) -> None:
+    async def disconnect(
+        self,
+        session_id: str,
+        *,
+        session_owner: str = "",
+    ) -> None:
+        assert session_owner == self.session_owner
         self.sessions.remove(session_id)
 
 

--- a/server/tests/test_mcp_manager_retry.py
+++ b/server/tests/test_mcp_manager_retry.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from mcp.types import CallToolResult, TextContent
+
+from server.mcp.manager import (
+    MCPClientManager,
+    MCPSessionNotFoundError,
+    ManagedMCPSession,
+)
+
+
+@pytest.mark.asyncio
+async def test_call_tool_can_disable_restart_and_resend(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    manager = MCPClientManager(sandbox_root=tmp_path)
+    managed = manager._new_managed_session(["python"], session_id="session-write")
+    manager._sessions[managed.session_id] = managed
+    sends: list[str] = []
+    restarts: list[Exception] = []
+
+    async def fail_after_send(
+        current: ManagedMCPSession,
+        operation: str,
+        **_: Any,
+    ) -> CallToolResult:
+        assert current is managed
+        sends.append(operation)
+        raise RuntimeError("response lost after provider boundary")
+
+    async def restart(
+        current: ManagedMCPSession,
+        error: Exception,
+    ) -> ManagedMCPSession:
+        restarts.append(error)
+        return current
+
+    monkeypatch.setattr(manager, "_send_command", fail_after_send)
+    monkeypatch.setattr(manager, "_restart_once", restart)
+
+    with pytest.raises(RuntimeError, match="response lost"):
+        await manager.call_tool(
+            managed.session_id,
+            "create_record",
+            {"value": "one-shot"},
+            retry_on_failure=False,
+        )
+
+    assert sends == ["call_tool"]
+    assert restarts == []
+
+
+@pytest.mark.asyncio
+async def test_call_tool_keeps_existing_read_retry_default(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    manager = MCPClientManager(sandbox_root=tmp_path)
+    managed = manager._new_managed_session(["python"], session_id="session-read")
+    manager._sessions[managed.session_id] = managed
+    sends = 0
+    restarts = 0
+
+    async def fail_then_succeed(
+        current: ManagedMCPSession,
+        operation: str,
+        **_: Any,
+    ) -> CallToolResult:
+        nonlocal sends
+        assert current is managed
+        assert operation == "call_tool"
+        sends += 1
+        if sends == 1:
+            raise RuntimeError("transient read failure")
+        return CallToolResult(
+            content=[TextContent(type="text", text="ok")],
+            isError=False,
+        )
+
+    async def restart(
+        current: ManagedMCPSession,
+        error: Exception,
+    ) -> ManagedMCPSession:
+        nonlocal restarts
+        assert current is managed
+        assert "transient read failure" in str(error)
+        restarts += 1
+        return current
+
+    monkeypatch.setattr(manager, "_send_command", fail_then_succeed)
+    monkeypatch.setattr(manager, "_restart_once", restart)
+
+    result = await manager.call_tool(
+        managed.session_id,
+        "list_records",
+        {},
+    )
+
+    assert result.isError is False
+    assert sends == 2
+    assert restarts == 1
+
+
+@pytest.mark.asyncio
+async def test_owned_catalog_session_is_hidden_from_generic_manager_calls(
+    tmp_path: Path,
+) -> None:
+    manager = MCPClientManager(sandbox_root=tmp_path)
+    owner = "catalog:local:local:airtable-mcp"
+    managed = manager._new_managed_session(
+        ["python"],
+        session_id="session-owned",
+        session_owner=owner,
+    )
+    manager._sessions[managed.session_id] = managed
+
+    assert await manager.get_sessions_summary() == []
+    owned = await manager.get_sessions_summary(session_owner=owner)
+    assert [item["session_id"] for item in owned] == [managed.session_id]
+
+    with pytest.raises(MCPSessionNotFoundError, match="session not found"):
+        await manager.list_tools(managed.session_id)
+    with pytest.raises(MCPSessionNotFoundError, match="session not found"):
+        await manager.call_tool(managed.session_id, "create_record", {})
+    with pytest.raises(MCPSessionNotFoundError, match="session not found"):
+        await manager.scrub_session_environment(managed.session_id)
+    with pytest.raises(MCPSessionNotFoundError, match="session not found"):
+        await manager.disconnect(managed.session_id)
+
+    assert managed.session_id in manager._sessions
+    await manager.disconnect(managed.session_id, session_owner=owner)
+    assert managed.session_id not in manager._sessions

--- a/server/tests/test_mcp_saas_sidecar.py
+++ b/server/tests/test_mcp_saas_sidecar.py
@@ -1,0 +1,454 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import pytest
+
+from server.sandbox_sidecar import saas_mcp, saas_server
+from server.sandbox_sidecar.saas_contracts import (
+    SAAS_ADAPTERS,
+    SAAS_SCHEMA_SHA256,
+    validate_configuration,
+)
+from server.sandbox_sidecar.safe_http import NetworkPolicyError
+
+
+EXPECTED_TOOLS = {
+    "airtable-mcp": {
+        "list_tables",
+        "list_records",
+        "get_record",
+        "create_record",
+        "update_record",
+    },
+    "asana-mcp": {
+        "list_projects",
+        "list_tasks",
+        "get_task",
+        "create_task",
+        "update_task",
+        "add_comment",
+    },
+    "gitlab-mcp": {
+        "list_issues",
+        "get_issue",
+        "list_merge_requests",
+        "get_merge_request",
+        "get_repository_file",
+        "create_issue",
+        "update_issue",
+        "add_issue_note",
+    },
+    "notion-mcp-server": {
+        "query_data_source",
+        "retrieve_page",
+        "create_page",
+        "update_page_properties",
+    },
+}
+
+
+class MemoryWriter:
+    def __init__(self) -> None:
+        self.data = bytearray()
+
+    def write(self, value: bytes) -> None:
+        self.data.extend(value)
+
+    async def drain(self) -> None:
+        return None
+
+
+def reader_for(*messages: dict[str, object]) -> asyncio.StreamReader:
+    reader = asyncio.StreamReader()
+    for message in messages:
+        reader.feed_data(json.dumps(message, separators=(",", ":")).encode() + b"\n")
+    reader.feed_eof()
+    return reader
+
+
+def test_contracts_are_fixed_and_have_no_terminal_or_delete_tools() -> None:
+    assert set(SAAS_ADAPTERS) == set(EXPECTED_TOOLS)
+    assert set(SAAS_SCHEMA_SHA256) == set(SAAS_ADAPTERS)
+    assert all(SAAS_SCHEMA_SHA256.values())
+    for adapter_id, contract in SAAS_ADAPTERS.items():
+        assert set(contract.tools) == EXPECTED_TOOLS[adapter_id]
+        assert {policy.effect for policy in contract.tools.values()} <= {"read", "state-write"}
+        assert not any("delete" in name.lower() for name in contract.tools)
+        assert contract.host in {
+            "api.airtable.com",
+            "app.asana.com",
+            "gitlab.com",
+            "api.notion.com",
+        }
+
+
+@pytest.mark.parametrize(
+    ("adapter_id", "configuration", "expected_settings"),
+    [
+        (
+            "airtable-mcp",
+            {
+                "credentials": {"personal_access_token": "secret"},
+                "settings": {"base_id": "app12345678901234"},
+            },
+            {"base_id": "app12345678901234"},
+        ),
+        (
+            "asana-mcp",
+            {
+                "credentials": {"personal_access_token": "secret"},
+                "settings": {"workspace_gid": "12001", "project_gid": "12002"},
+            },
+            {"workspace_gid": "12001", "project_gid": "12002"},
+        ),
+        (
+            "gitlab-mcp",
+            {
+                "credentials": {"personal_access_token": "secret"},
+                "settings": {"project_id": "42"},
+            },
+            {"project_id": "42"},
+        ),
+        (
+            "notion-mcp-server",
+            {
+                "credentials": {"integration_token": "secret"},
+                "settings": {"data_source_id": "01234567-89ab-cdef-0123-456789abcdef"},
+            },
+            {"data_source_id": "0123456789abcdef0123456789abcdef"},
+        ),
+    ],
+)
+def test_configuration_is_exact_and_normalized(
+    adapter_id: str,
+    configuration: dict[str, Any],
+    expected_settings: dict[str, str],
+) -> None:
+    _, credentials, settings = validate_configuration(adapter_id, configuration)
+    assert set(credentials) == set(SAAS_ADAPTERS[adapter_id].credential_fields)
+    assert settings == expected_settings
+
+
+def test_configuration_rejects_extra_fields_urls_and_wrong_scope() -> None:
+    with pytest.raises(ValueError, match="configuration_contract_mismatch"):
+        validate_configuration(
+            "gitlab-mcp",
+            {
+                "credentials": {"personal_access_token": "secret"},
+                "settings": {"project_id": "42", "url": "https://evil.example"},
+            },
+        )
+    with pytest.raises(ValueError, match="invalid_project_id"):
+        validate_configuration(
+            "gitlab-mcp",
+            {
+                "credentials": {"personal_access_token": "secret"},
+                "settings": {"project_id": "https://gitlab.example/project"},
+            },
+        )
+    with pytest.raises(ValueError, match="configuration_contract_mismatch"):
+        validate_configuration(
+            "notion-mcp-server",
+            {
+                "credentials": {"integration_token": "secret"},
+                "settings": {
+                    "scope_type": "page",
+                    "scope_id": "0123456789abcdef0123456789abcdef",
+                },
+            },
+        )
+
+
+def test_write_idempotency_key_is_private_one_shot_and_stripped() -> None:
+    contract = SAAS_ADAPTERS["airtable-mcp"]
+    used: set[str] = set()
+    key = "mcpidem_" + "a" * 32
+    arguments, returned = saas_server._prepare_tool_call(
+        contract,
+        "create_record",
+        {
+            "table_id": "tbl12345678901234",
+            "fields": {"Name": "Ada"},
+            "__modelmirror_idempotency_key": key,
+        },
+        used,
+    )
+    assert returned == key
+    assert key in used
+    assert "__modelmirror_idempotency_key" not in arguments
+    with pytest.raises(ValueError, match="idempotency_key_replayed"):
+        saas_server._prepare_tool_call(
+            contract,
+            "create_record",
+            {
+                "table_id": "tbl12345678901234",
+                "fields": {"Name": "Ada"},
+                "__modelmirror_idempotency_key": key,
+            },
+            used,
+        )
+    with pytest.raises(ValueError, match="invalid_idempotency_key"):
+        saas_server._prepare_tool_call(
+            contract,
+            "update_record",
+            {"table_id": "tbl12345678901234", "record_id": "rec12345678901234"},
+            used,
+        )
+
+
+def test_reserved_fields_are_rejected_recursively() -> None:
+    with pytest.raises(ValueError, match="reserved_argument_field"):
+        saas_server._prepare_tool_call(
+            SAAS_ADAPTERS["gitlab-mcp"],
+            "list_issues",
+            {"filter": {"__modelmirror_header": "PRIVATE-TOKEN"}},
+            set(),
+        )
+
+
+class FakeClient:
+    def __init__(self, responses: list[saas_mcp.HttpResult]) -> None:
+        self.responses = responses
+        self.calls = 0
+
+    def request(self, *args: Any, **kwargs: Any) -> saas_mcp.HttpResult:
+        response = self.responses[min(self.calls, len(self.responses) - 1)]
+        self.calls += 1
+        return response
+
+
+def test_read_retries_only_reviewed_statuses_and_caps_retry_after(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    waits: list[float] = []
+    monkeypatch.setattr(saas_mcp.time, "sleep", waits.append)
+    client = FakeClient(
+        [
+            saas_mcp.HttpResult(429, {"retry-after": "99"}, b"{}"),
+            saas_mcp.HttpResult(503, {}, b"{}"),
+            saas_mcp.HttpResult(200, {}, b'{"ok":true}'),
+        ]
+    )
+    result = saas_mcp._request_json(  # type: ignore[arg-type]
+        client,
+        "test",
+        "/fixed",
+        headers={"Authorization": "Bearer secret"},
+        read_operation=True,
+    )
+    assert result == {"ok": True}
+    assert client.calls == 3
+    assert waits[0] == saas_mcp.MAX_RETRY_AFTER_SECONDS
+
+
+def test_write_never_retries() -> None:
+    client = FakeClient([saas_mcp.HttpResult(503, {"retry-after": "1"}, b"{}")])
+    with pytest.raises(
+        saas_mcp.UnknownWriteOutcome,
+        match=saas_mcp.UNKNOWN_WRITE_OUTCOME_MARKER,
+    ):
+        saas_mcp._request_json(  # type: ignore[arg-type]
+            client,
+            "test",
+            "/fixed",
+            method="POST",
+            headers={"Authorization": "Bearer secret"},
+            payload={"value": 1},
+            read_operation=False,
+        )
+    assert client.calls == 1
+
+
+def test_definite_write_rejection_is_not_retried_or_marked_unknown() -> None:
+    client = FakeClient([saas_mcp.HttpResult(400, {}, b"{}")])
+    with pytest.raises(RuntimeError, match="test_http_400"):
+        saas_mcp._request_json(  # type: ignore[arg-type]
+            client,
+            "test",
+            "/fixed",
+            method="POST",
+            headers={"Authorization": "Bearer secret"},
+            payload={"value": 1},
+            read_operation=False,
+        )
+    assert client.calls == 1
+
+
+def test_write_network_failure_is_an_unknown_outcome() -> None:
+    class FailingClient:
+        @staticmethod
+        def request(*args: Any, **kwargs: Any) -> saas_mcp.HttpResult:
+            raise NetworkPolicyError("saas_https_failed")
+
+    with pytest.raises(
+        saas_mcp.UnknownWriteOutcome,
+        match=saas_mcp.UNKNOWN_WRITE_OUTCOME_MARKER,
+    ):
+        saas_mcp._request_json(  # type: ignore[arg-type]
+            FailingClient(),
+            "test",
+            "/fixed",
+            method="POST",
+            headers={"Authorization": "Bearer secret"},
+            payload={"value": 1},
+            read_operation=False,
+        )
+
+
+def test_fixed_http_client_rejects_redirects(monkeypatch: pytest.MonkeyPatch) -> None:
+    class Response:
+        status = 302
+
+        @staticmethod
+        def getheaders() -> list[tuple[str, str]]:
+            return [("Location", "https://evil.example/")]
+
+        @staticmethod
+        def read(_: int) -> bytes:
+            return b""
+
+    class Connection:
+        def request(self, *args: Any, **kwargs: Any) -> None:
+            return None
+
+        @staticmethod
+        def getresponse() -> Response:
+            return Response()
+
+        @staticmethod
+        def close() -> None:
+            return None
+
+    monkeypatch.setattr(saas_mcp, "resolve_public_addresses", lambda host, port: ("93.184.216.34",))
+    monkeypatch.setattr(saas_mcp, "_PinnedHTTPSConnection", lambda *args, **kwargs: Connection())
+    client = saas_mcp.FixedHTTPSClient("api.airtable.com", minimum_interval_seconds=0)
+    with pytest.raises(NetworkPolicyError, match="saas_redirect_denied"):
+        client.request("/v0/meta/whoami", method="GET", headers={"Authorization": "Bearer secret"})
+
+
+def test_fixed_http_client_rejects_unreviewed_headers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        saas_mcp,
+        "resolve_public_addresses",
+        lambda host, port: ("93.184.216.34",),
+    )
+    client = saas_mcp.FixedHTTPSClient("api.airtable.com", minimum_interval_seconds=0)
+    with pytest.raises(NetworkPolicyError, match="saas_http_header_denied"):
+        client.request(
+            "/v0/meta/whoami",
+            method="GET",
+            headers={"X-Request-Id": "client-controlled"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_gateway_filters_unreviewed_tool_discovery() -> None:
+    output = MemoryWriter()
+    await saas_server._child_to_client(  # type: ignore[arg-type]
+        reader_for(
+            {
+                "jsonrpc": "2.0",
+                "id": 7,
+                "result": {
+                    "tools": [
+                        {"name": "list_tables", "inputSchema": {}},
+                        {"name": "delete_everything", "inputSchema": {}},
+                    ]
+                },
+            }
+        ),
+        output,
+        SAAS_ADAPTERS["airtable-mcp"],
+        {7},
+        set(),
+        set(),
+        {},
+        set(),
+        asyncio.Lock(),
+    )
+    payload = json.loads(bytes(output.data).decode("utf-8"))
+    assert [tool["name"] for tool in payload["result"]["tools"]] == ["list_tables"]
+
+
+@pytest.mark.asyncio
+async def test_gateway_maps_ambiguous_write_failure_to_unknown_outcome() -> None:
+    output = MemoryWriter()
+    await saas_server._child_to_client(  # type: ignore[arg-type]
+        reader_for(
+            {
+                "jsonrpc": "2.0",
+                "id": 8,
+                "result": {
+                    "isError": True,
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": saas_mcp.UNKNOWN_WRITE_OUTCOME_MARKER,
+                        }
+                    ],
+                },
+            }
+        ),
+        output,
+        SAAS_ADAPTERS["airtable-mcp"],
+        set(),
+        {8},
+        {8},
+        {},
+        set(),
+        asyncio.Lock(),
+    )
+    payload = json.loads(bytes(output.data).decode("utf-8"))
+    assert payload["error"]["code"] == -32008
+    assert payload["error"]["data"] == {
+        "reason": "unknown_outcome",
+        "retryable": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_gateway_maps_definite_write_failure_to_json_rpc_error() -> None:
+    output = MemoryWriter()
+    await saas_server._child_to_client(  # type: ignore[arg-type]
+        reader_for(
+            {
+                "jsonrpc": "2.0",
+                "id": 10,
+                "result": {
+                    "isError": True,
+                    "content": [{"type": "text", "text": "airtable_http_429"}],
+                },
+            }
+        ),
+        output,
+        SAAS_ADAPTERS["airtable-mcp"],
+        set(),
+        {10},
+        {10},
+        {},
+        set(),
+        asyncio.Lock(),
+    )
+    payload = json.loads(bytes(output.data).decode("utf-8"))
+    assert payload["error"]["code"] == -32009
+    assert payload["error"]["data"] == {
+        "reason": "rate_limited",
+        "retryable": False,
+    }
+
+
+def test_timeout_error_has_machine_readable_unknown_outcome() -> None:
+    payload = json.loads(
+        saas_server._rpc_error(
+            9,
+            -32008,
+            "timeout",
+            data={"reason": "unknown_outcome", "retryable": False},
+        )
+    )
+    assert payload["error"]["data"] == {"reason": "unknown_outcome", "retryable": False}


### PR DESCRIPTION
## 改动摘要

完成 MCP 第六批有状态 SaaS 适配，目录总量继续冻结为 100 项：

- Airtable、Asana、GitLab.com、Notion 标记为 ready。
- mcp-cn-commerce、Mem0 因 OAuth/商家授权、上游归档与契约锁定限制保持 blocked。
- 目录状态更新为 42 ready / 47 planned / 11 blocked。
- 新增独立 mcp-saas sidecar，固定服务商、域名、方法、字段及工具 schema；不接受任意 URL、Header、环境变量、命令或工作目录。
- 新增远程资源写入审批、账号/配置/凭据快照、一次性幂等账本、歧义结果分类以及安全解绑。
- 写操作不自动重试；明确区分限流/提供商拒绝与 unknown outcome。
- 前端新增卡片内账号及加密凭据配置、账号预检状态、中文目标影响摘要、审批弹层和解绑入口。
- 增加单租户本地部署双重门禁；当前不宣称多用户共享隔离。
- 自定义连接、MCP Builder、OAuth 和外站登录仍不进入本批。

## 安全边界

- Airtable、Asana、GitLab.com、Notion 使用固定官方 HTTPS 主机和受控 REST 契约。
- 连接时执行账号与固定资源只读预检。
- state-write 工具必须经过一次性审批；terminal 工具首批关闭。
- 配置、凭据、账号、策略或 schema 漂移会使审批失效。
- 解绑会阻止新调用、排空会话并撤销待处理审批。
- 日志不记录 Secret、完整参数、正文或完整外部资源 ID。

## 验证

最终变基到最新 origin/main（PR #109，59bc4b9）后：

- 151 passed：MCP、Toolset、审批、SaaS sidecar 与管理器重试相关测试。
- npm.cmd run build：通过（仅保留既有 Vite 大 chunk 警告）。
- git diff --check origin/main...HEAD：通过。
- 独立 SaaS 镜像构建及离线 schema/security smoke：通过。
- 共享集成栈仅定向重建 mcp-saas、server、client；其余容器 ID 未变化。
- mcp-saas、server healthy，/api/health 正常，/mcps 返回 200。
- 人工验收已通过。

## 已知限制

- PR 不包含任何真实 Token/PAT；真实服务商访问仍由部署者提供凭据，并以连接时预检结果为准。
- 当前仅开放部署时固定 tenant/owner 的单租户本地模式，多用户共享部署保持关闭。
- mcp-cn-commerce 与 Mem0 仅展示中文阻断原因，不可连接。
