### PR TITLE
feature: 添加内置双语 Xpert Benchmark 目录

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -362,6 +362,33 @@ cd client
 npm.cmd run build
 ```
 
+### 8.5 Benchmark Catalog 与生成护栏
+
+- Benchmark 产品层只能统一 Manifest、目录和任务来源；不得复制
+  `XpertEvaluationStore`、`KnowledgeEvaluationStore` 或 Agent Workspace/Penguin Runtime。
+- 内置 Pack 必须是仓库可证明来源的自有合成数据，固定 source、license、版本和规范化
+  SHA-256；不得在运行时联网下载或静默更新。
+- Agent 标准 Pack 的核心门禁只允许 `exact_match`、`contains` 和 `json_schema`。
+  LLM Judge 只能作为附加维度，不能决定标准回归是否通过。
+- Catalog Pack 不可编辑。实例化必须在一个 Store 原子写入中创建草稿和完全一致的不可变
+  v1；后续草稿修改不得改写 v1，并应把 calibration 标记为 stale。
+- 旧 Dataset 缺少元数据时必须按 `origin=manual` 兼容读取，不得要求破坏性离线迁移。
+- 后续定向生成必须固定目标 revision/version、能力摘要、模型、资源版本和 Dataset revision；
+  生成结果只能进入待审核草稿，不得批准 Proposal、修改线上 Xpert 或自动发布。
+- 校准只能验证评分契约、重复、泄漏、难度和基线表现，不得使用当前回答或 Top-K 结果
+  改写预先固定的 Gold。
+- Benchmark API、报告和 checkpoint 不得保存完整 Prompt、知识正文、工具参数/结果、隐藏
+  推理、路径、凭据或未选择的会话内容。
+- `server/Dockerfile` 必须复制 `benchmarks/`。每轮在完成非 Docker 验证后停止，等待用户
+  确认共享栈空闲，再执行 `--build --force-recreate` 和人工验收。
+- 修改 Benchmark Catalog 或 Dataset 元数据时至少运行：
+
+```bash
+python -m pytest server/tests/test_benchmark_catalog.py server/tests/test_xpert_evaluations.py -q
+cd client
+npm.cmd run build
+```
+
 ## 9. MCP 开发规则
 
 MCP 原生集成属于后端进程管理和工具执行能力，开发时必须：

--- a/client/src/components/evaluations/BenchmarkCatalogPanel.tsx
+++ b/client/src/components/evaluations/BenchmarkCatalogPanel.tsx
@@ -1,0 +1,223 @@
+import { useEffect, useState } from "react";
+import {
+  BookOpenCheck,
+  CheckCircle2,
+  Languages,
+  Layers3,
+  LoaderCircle,
+  Plus,
+  ShieldCheck,
+} from "lucide-react";
+
+interface BenchmarkManifestSummary {
+  pack_id: string;
+  version: number;
+  kind: "agent_response" | "knowledge_retrieval";
+  name: string;
+  description: string;
+  locales: string[];
+  coverage: string[];
+  difficulty: "basic" | "intermediate" | "advanced" | "mixed";
+  metric_policy: {
+    core?: string[];
+    llm_judge?: string;
+  };
+  source: string;
+  license: string;
+  case_count: number;
+  checksum: string;
+}
+
+interface InstantiatedDataset {
+  dataset_id: string;
+  name: string;
+  published_version: number;
+  case_count: number;
+}
+
+interface BenchmarkCatalogPanelProps {
+  onInstantiated: (dataset: InstantiatedDataset) => Promise<void> | void;
+}
+
+function readError(payload: unknown, fallback: string) {
+  if (payload && typeof payload === "object") {
+    const detail = (payload as { detail?: unknown }).detail;
+    if (typeof detail === "string") return detail;
+  }
+  return fallback;
+}
+
+function difficultyLabel(value: BenchmarkManifestSummary["difficulty"]) {
+  if (value === "basic") return "基础";
+  if (value === "intermediate") return "进阶";
+  if (value === "advanced") return "高级";
+  return "混合";
+}
+
+export default function BenchmarkCatalogPanel({
+  onInstantiated,
+}: BenchmarkCatalogPanelProps) {
+  const [packs, setPacks] = useState<BenchmarkManifestSummary[]>([]);
+  const [busyPackId, setBusyPackId] = useState("");
+  const [error, setError] = useState("");
+  const [notice, setNotice] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    async function loadCatalog() {
+      setError("");
+      try {
+        const response = await fetch("/api/benchmarks/catalog?kind=agent_response");
+        const payload = await response.json().catch(() => null);
+        if (!response.ok) {
+          throw new Error(readError(payload, `目录加载失败：${response.status}`));
+        }
+        if (!cancelled) {
+          setPacks((payload as { items?: BenchmarkManifestSummary[] })?.items ?? []);
+        }
+      } catch (caught) {
+        if (!cancelled) {
+          setError(caught instanceof Error ? caught.message : "标准基准目录暂不可用。");
+        }
+      }
+    }
+    void loadCatalog();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  async function instantiate(pack: BenchmarkManifestSummary) {
+    setBusyPackId(pack.pack_id);
+    setError("");
+    setNotice("");
+    try {
+      const response = await fetch(
+        `/api/benchmarks/catalog/${encodeURIComponent(pack.pack_id)}/instantiate`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({}),
+        },
+      );
+      const payload = await response.json().catch(() => null);
+      if (!response.ok) {
+        throw new Error(readError(payload, `实例化失败：${response.status}`));
+      }
+      const dataset = payload as InstantiatedDataset;
+      setNotice(`${pack.name} 已添加并发布为数据集 v${dataset.published_version}。`);
+      await onInstantiated(dataset);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "添加标准基准失败。");
+    } finally {
+      setBusyPackId("");
+    }
+  }
+
+  return (
+    <section className="min-w-0">
+      <div className="flex flex-col gap-3 border-b border-white/10 pb-4 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <div className="flex items-center gap-2 text-sm font-semibold text-white">
+            <BookOpenCheck className="h-4 w-4 text-cyan-200" />
+            标准 Benchmark
+          </div>
+          <p className="mt-1 max-w-3xl text-xs leading-5 text-slate-400">
+            ModelMirror 自有中英双语合成基准。实例化会创建可编辑数据集，并自动发布与目录 Pack 完全一致的 v1。
+          </p>
+        </div>
+        <div className="flex items-center gap-2 text-[11px] text-slate-500">
+          <ShieldCheck className="h-4 w-4 text-emerald-300" />
+          核心门禁仅使用确定性指标
+        </div>
+      </div>
+
+      {error || notice ? (
+        <div
+          className={`mt-4 rounded-md border px-3 py-2 text-sm ${
+            error
+              ? "border-rose-300/25 bg-rose-300/10 text-rose-100"
+              : "border-emerald-300/25 bg-emerald-300/10 text-emerald-100"
+          }`}
+        >
+          {error || notice}
+        </div>
+      ) : null}
+
+      <div className="mt-5 grid gap-4 xl:grid-cols-2">
+        {packs.map((pack) => (
+          <article
+            className="flex min-h-[260px] flex-col rounded-md border border-white/10 bg-white/[0.025] p-5"
+            key={pack.pack_id}
+          >
+            <div className="flex items-start justify-between gap-4">
+              <div className="min-w-0">
+                <h2 className="text-base font-semibold text-white">{pack.name}</h2>
+                <p className="mt-2 text-xs leading-5 text-slate-400">{pack.description}</p>
+              </div>
+              <span className="shrink-0 rounded border border-cyan-300/20 bg-cyan-300/10 px-2 py-1 text-[10px] font-semibold text-cyan-100">
+                v{pack.version}
+              </span>
+            </div>
+
+            <div className="mt-4 grid grid-cols-3 gap-2 text-[11px]">
+              <div className="rounded bg-white/[0.035] p-2 text-slate-500">
+                <Layers3 className="mb-1 h-3.5 w-3.5 text-slate-300" />
+                <strong className="block text-slate-200">{pack.case_count} 条</strong>
+                用例
+              </div>
+              <div className="rounded bg-white/[0.035] p-2 text-slate-500">
+                <Languages className="mb-1 h-3.5 w-3.5 text-slate-300" />
+                <strong className="block text-slate-200">中 / EN</strong>
+                语言
+              </div>
+              <div className="rounded bg-white/[0.035] p-2 text-slate-500">
+                <CheckCircle2 className="mb-1 h-3.5 w-3.5 text-slate-300" />
+                <strong className="block text-slate-200">{difficultyLabel(pack.difficulty)}</strong>
+                难度
+              </div>
+            </div>
+
+            <div className="mt-4 flex flex-wrap gap-1.5">
+              {pack.coverage.map((item) => (
+                <span
+                  className="rounded border border-white/10 bg-black/10 px-2 py-1 text-[10px] text-slate-400"
+                  key={item}
+                >
+                  {item}
+                </span>
+              ))}
+            </div>
+
+            <div className="mt-auto flex items-end justify-between gap-4 pt-5">
+              <div className="min-w-0 text-[10px] leading-4 text-slate-500">
+                <p>{(pack.metric_policy.core ?? []).join(" · ")}</p>
+                <p className="truncate" title={pack.source}>{pack.pack_id} · {pack.license}</p>
+                <p className="truncate" title={pack.checksum}>SHA-256 {pack.checksum.slice(0, 12)}</p>
+              </div>
+              <button
+                className="inline-flex shrink-0 items-center gap-2 rounded-md bg-cyan-300 px-3 py-2 text-xs font-semibold text-ink-950 disabled:cursor-wait disabled:opacity-50"
+                disabled={Boolean(busyPackId)}
+                onClick={() => void instantiate(pack)}
+                type="button"
+              >
+                {busyPackId === pack.pack_id ? (
+                  <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Plus className="h-3.5 w-3.5" />
+                )}
+                添加到工作区
+              </button>
+            </div>
+          </article>
+        ))}
+      </div>
+
+      {!error && packs.length === 0 ? (
+        <div className="grid min-h-[320px] place-items-center text-sm text-slate-500">
+          <LoaderCircle className="h-5 w-5 animate-spin" />
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/client/src/pages/XpertEvaluationsPage.tsx
+++ b/client/src/pages/XpertEvaluationsPage.tsx
@@ -4,6 +4,7 @@ import {
   AlertTriangle,
   BarChart3,
   Beaker,
+  BookOpenCheck,
   CheckCircle2,
   Clock3,
   Database,
@@ -17,6 +18,7 @@ import {
   Square,
   XCircle,
 } from "lucide-react";
+import BenchmarkCatalogPanel from "../components/evaluations/BenchmarkCatalogPanel";
 import PageContainer from "../components/PageContainer";
 import { models } from "../data/models";
 import { listXpertVersions, listXperts } from "../utils/xpertApi";
@@ -50,6 +52,12 @@ interface DatasetSummary {
   published_version: number | null;
   case_count: number;
   version_count: number;
+  origin?: "manual" | "catalog" | "generated" | string;
+  catalog_ref?: {
+    pack_id?: string;
+    version?: number;
+    checksum?: string;
+  };
   updated_at: number;
 }
 
@@ -159,6 +167,8 @@ interface AuthoringProposalSummary {
   status: string;
 }
 
+type EvaluationWorkspaceView = "catalog" | "datasets" | "reports";
+
 const defaultCases: EvaluationCase[] = [
   {
     name: "基础回答",
@@ -240,6 +250,9 @@ export default function XpertEvaluationsPage() {
   const [busy, setBusy] = useState("");
   const [error, setError] = useState("");
   const [notice, setNotice] = useState("");
+  const [workspaceView, setWorkspaceView] = useState<EvaluationWorkspaceView>(
+    runId ? "reports" : "catalog",
+  );
 
   const selectedItem = useMemo(
     () => run?.items?.find((item) => item.item_id === selectedItemId) ?? run?.items?.[0] ?? null,
@@ -252,7 +265,10 @@ export default function XpertEvaluationsPage() {
   }, []);
 
   useEffect(() => {
-    if (runId) void loadRun(runId);
+    if (runId) {
+      setWorkspaceView("reports");
+      void loadRun(runId);
+    }
   }, [runId]);
 
   useEffect(() => {
@@ -335,6 +351,17 @@ export default function XpertEvaluationsPage() {
     setCasesText(JSON.stringify(detail.cases ?? [], null, 2));
     const preferred = detail.published_version ?? versions.items?.[0]?.version ?? 0;
     setDatasetVersion(preferred);
+  }
+
+  async function openInstantiatedDataset(item: {
+    dataset_id: string;
+    name: string;
+    published_version: number;
+  }) {
+    await loadWorkspace();
+    await selectDataset(item.dataset_id);
+    setWorkspaceView("datasets");
+    setNotice(`${item.name} 已加入工作区，并固定发布为 v${item.published_version}。`);
   }
 
   async function loadRun(id: string, silent = false) {
@@ -505,6 +532,7 @@ export default function XpertEvaluationsPage() {
       );
       setRun(created);
       setRuns((current) => [created, ...current]);
+      setWorkspaceView("reports");
       navigate(`/agents/evaluations/${created.run_id}`, { replace: true });
       setNotice("评测已排队，执行快照不会随草稿变化。");
     } catch (caught) {
@@ -559,6 +587,78 @@ export default function XpertEvaluationsPage() {
         </div>
       ) : null}
 
+      <nav aria-label="评测工作台视图" className="mb-5 flex flex-wrap gap-1 border-b border-white/10" role="tablist">
+        {([
+          ["catalog", "标准基准", BookOpenCheck],
+          ["datasets", "我的评测集", Database],
+          ["reports", "运行报告", BarChart3],
+        ] as const).map(([view, label, Icon]) => (
+          <button
+            aria-selected={workspaceView === view}
+            className={`inline-flex items-center gap-2 border-b-2 px-4 py-3 text-sm font-semibold transition ${
+              workspaceView === view
+                ? "border-cyan-300 text-cyan-100"
+                : "border-transparent text-slate-400 hover:text-slate-200"
+            }`}
+            key={view}
+            onClick={() => setWorkspaceView(view)}
+            role="tab"
+            type="button"
+          >
+            <Icon className="h-4 w-4" />
+            {label}
+          </button>
+        ))}
+      </nav>
+
+      {workspaceView === "catalog" ? (
+        <BenchmarkCatalogPanel onInstantiated={openInstantiatedDataset} />
+      ) : workspaceView === "reports" ? (
+        <section className="grid min-w-0 gap-5 lg:grid-cols-[340px_minmax(0,1fr)]">
+          <aside className="min-w-0 border-r border-white/10 pr-5">
+            <div className="flex items-center gap-2 text-sm font-semibold text-white">
+              <Clock3 className="h-4 w-4 text-cyan-200" />运行记录
+            </div>
+            <div className="mt-4 max-h-[560px] space-y-2 overflow-y-auto pr-1">
+              {runs.map((item) => (
+                <button
+                  className={`w-full rounded-md border p-3 text-left transition ${
+                    run?.run_id === item.run_id
+                      ? "border-cyan-300/35 bg-cyan-300/10"
+                      : "border-white/10 bg-white/[0.025] hover:border-white/20"
+                  }`}
+                  key={item.run_id}
+                  onClick={() => {
+                    navigate(`/agents/evaluations/${item.run_id}`);
+                    void loadRun(item.run_id);
+                  }}
+                  type="button"
+                >
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="truncate text-xs font-semibold text-slate-200">
+                      {item.dataset?.name ?? "Evaluation"}
+                    </span>
+                    <span className={`rounded border px-1.5 py-0.5 text-[10px] ${statusTone(item.status)}`}>
+                      {item.status}
+                    </span>
+                  </div>
+                  <p className="mt-2 text-[10px] text-slate-500">{formatTime(item.created_at)}</p>
+                </button>
+              ))}
+              {runs.length === 0 ? (
+                <p className="rounded-md border border-dashed border-white/10 p-4 text-xs text-slate-500">
+                  暂无评测运行。
+                </p>
+              ) : null}
+            </div>
+          </aside>
+          <div className="grid min-h-[280px] place-items-center rounded-md border border-dashed border-white/10 px-6 text-center text-sm leading-6 text-slate-500">
+            {run
+              ? "已选择运行。完整指标、基线对比和逐样例结果显示在下方。"
+              : "选择一条运行记录查看完整评测报告。"}
+          </div>
+        </section>
+      ) : (
       <div className="grid min-w-0 gap-5 2xl:grid-cols-[280px_minmax(0,1fr)_minmax(420px,0.9fr)]">
         <aside className="min-w-0 border-r border-white/10 pr-5">
           <div className="flex items-center gap-2 text-sm font-semibold text-white">
@@ -575,7 +675,10 @@ export default function XpertEvaluationsPage() {
               <button className={`w-full rounded-md border p-3 text-left transition ${dataset?.dataset_id === item.dataset_id ? "border-cyan-300/35 bg-cyan-300/10" : "border-white/10 bg-white/[0.025] hover:border-white/20"}`} key={item.dataset_id} onClick={() => void selectDataset(item.dataset_id)} type="button">
                 <div className="flex items-start justify-between gap-2">
                   <span className="truncate text-sm font-semibold text-slate-100">{item.name}</span>
-                  <span className="shrink-0 text-[10px] text-slate-500">r{item.revision}</span>
+                  <span className="flex shrink-0 items-center gap-1.5 text-[10px] text-slate-500">
+                    {item.origin === "catalog" ? <span className="text-cyan-200">标准</span> : null}
+                    r{item.revision}
+                  </span>
                 </div>
                 <div className="mt-2 flex items-center justify-between text-[11px] text-slate-500">
                   <span>{item.case_count} 用例</span>
@@ -724,8 +827,9 @@ export default function XpertEvaluationsPage() {
           </section>
         </aside>
       </div>
+      )}
 
-      {run ? (
+      {workspaceView === "reports" && run ? (
         <section className="mt-7 border-t border-white/10 pt-6">
           <div className="flex flex-wrap items-center justify-between gap-3">
             <div>

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,0 +1,109 @@
+# ModelMirror Benchmark
+
+最后更新日期：2026-08-07
+
+## 1. 定位
+
+Benchmark 产品层为 Xpert Evaluator、Knowledge Evaluation 和后续 Agent Workspace
+适配提供统一目录与来源元数据。它不创建新的正式数据集 Store：
+
+- Agent/Xpert 数据集继续由 `XpertEvaluationStore` 保存。
+- RAG 数据集继续由 `KnowledgeEvaluationStore` 保存。
+- 后续生成与校准任务只在 `BenchmarkJobStore` 保存任务状态，不复制正式数据集。
+
+当前已交付 `EVOAGENTX-BENCHMARK-CATALOG-01`。定向生成、RAG 标准 Pack、RAG
+定向生成和 Agent Workspace 适配仍为后续独立轮次。
+
+## 2. 统一 Manifest
+
+每个目录 Pack 使用 `BenchmarkManifest`：
+
+| 字段 | 含义 |
+| --- | --- |
+| `pack_id / version / kind` | 稳定 Pack 标识、不可变版本和评测类型。 |
+| `locales` | Pack 覆盖语言。 |
+| `coverage / difficulty` | 能力覆盖与难度摘要。 |
+| `metric_policy` | 核心确定性指标及附加指标边界。 |
+| `target_requirements` | 可运行目标与副作用要求。 |
+| `source / license` | 数据来源和许可证声明。 |
+| `case_count / checksum` | 用例数量和规范化 SHA-256。 |
+
+目录 Pack 不可编辑。checksum 基于规范化用例计算，启动时会验证用例 ID、评分契约和
+指标白名单。
+
+## 3. 内置 Agent Pack
+
+| Pack | 用例数 | 核心指标 | 覆盖 |
+| --- | ---: | --- | --- |
+| `mm-agent-instruction-bilingual-v1` | 20 | exact / contains | 指令、格式、排序、转换、负向约束。 |
+| `mm-agent-structured-json-bilingual-v1` | 16 | JSON Schema | 对象、数组、嵌套、布尔、空值和 Unicode。 |
+| `mm-agent-multiturn-bilingual-v1` | 16 | exact | 上下文召回、更新优先、实体和干扰信息。 |
+| `mm-agent-abstention-bilingual-v1` | 12 | JSON Schema | 缺失证据、冲突证据、单位不足和可验证弃答。 |
+
+全部 64 条用例均为 ModelMirror 自有中英双语合成内容，不引入网络下载、外部 Provider
+或第三方受版权保护语料。核心分数只使用 `exact_match`、`contains` 和
+`json_schema`；LLM Judge 不参与目录核心门禁。
+
+## 4. 实例化与版本
+
+“添加到工作区”执行一个原子操作：
+
+1. 校验 Pack manifest、case ID、确定性指标和 checksum。
+2. 在 `XpertEvaluationStore` 创建可编辑 Dataset 草稿。
+3. 自动发布与目录 Pack 完全一致的不可变 v1。
+4. 返回 Dataset，后续编辑只改变草稿并形成新的显式版本。
+
+Dataset 兼容新增：
+
+- `origin`：旧数据默认 `manual`，目录实例为 `catalog`。
+- `catalog_ref`：固定 Pack ID、版本和 checksum。
+- `provenance`：安全来源、许可证和语言摘要。
+- `coverage`：能力、难度和指标策略。
+- `calibration`：目录实例以 checksum 完整性标记为 `calibrated`；用例编辑后转为
+  `stale`。
+
+这些字段也固定到 DatasetVersion。旧 JSON Store 无需离线迁移，读取时自动补安全默认值。
+
+## 5. API
+
+```text
+GET  /api/benchmarks/capabilities
+GET  /api/benchmarks/catalog?kind=agent_response
+GET  /api/benchmarks/catalog/{pack_id}
+POST /api/benchmarks/catalog/{pack_id}/instantiate
+```
+
+目录列表返回 Manifest 摘要；详情返回固定用例。接口不返回完整 Xpert Prompt、工具结果、
+知识正文、凭据、物理路径或 Runtime Store 数据。
+
+## 6. 前端
+
+`/agents/evaluations` 按以下视图组织：
+
+- 标准基准：浏览 Pack 并添加到工作区。
+- 我的评测集：编辑、导入、发布及配置基线/候选。
+- 运行报告：查看运行记录、总体指标和逐样例结果。
+
+实例化完成后自动进入新 Dataset 草稿。v1 已发布，可立即选择固定版本运行；继续编辑不会
+改写 v1。
+
+## 7. 安全与后续边界
+
+- Pack 内容与 checksum 随仓库版本发布，不在运行时联网更新。
+- 标准核心 Benchmark 不执行真实副作用、HITL、Browser、Sandbox 写入或外部实时数据。
+- 目录实例化不运行 Xpert、不批准 Proposal，也不修改线上资源。
+- 后续定向生成默认创建待审核草稿，并必须完成同 revision 的受限校准后才可发布。
+- RAG Benchmark 使用 `KnowledgeEvaluationStore`，不会复制到 Xpert Dataset Store。
+- General Agent Workspace 最终只接目录和运行摘要，不替换 Penguin Benchmark Runtime。
+
+## 8. 回归
+
+```bash
+python -m pytest server/tests/test_benchmark_catalog.py -q
+python -m pytest server/tests/test_xpert_evaluations.py -q
+cd client
+npm.cmd run build
+```
+
+新增后端包必须同步复制到 `server/Dockerfile`，并在共享栈空闲后通过真实镜像重建验证。
+

--- a/docs/EVOAGENTX_ALIGNMENT.md
+++ b/docs/EVOAGENTX_ALIGNMENT.md
@@ -181,8 +181,24 @@ Evaluator 不批准 Proposal、不写 Xpert 草稿、不发布版本。完整契
 
 完整契约见 [EVOAGENTX_EVOLUTION.md](./EVOAGENTX_EVOLUTION.md)。
 
-### 下一步：进化收益与技术债审计
+### `EVOAGENTX-BENCHMARK-CATALOG-01`：已实现
 
-Meta Planner、Evaluator、Prompt Evolution 和 Structure Evolution 已形成第一阶段闭环。
-暂停继续增加优化器或自动发布能力，先用真实 Dataset 审计质量提升、运行成本、稳定性、
-过拟合风险和维护负担，再决定后续路线。
+- 已交付四个 ModelMirror 自有中英双语合成 Pack，共 64 条固定用例。
+- 核心回归仅使用 exact、contains 和 JSON Schema，不把 LLM Judge 作为门禁。
+- Catalog Pack 不可编辑；实例化复用 `XpertEvaluationStore` 并自动发布一致的 v1。
+- Dataset 已兼容 origin、catalog provenance、coverage 和 calibration 状态。
+- `/agents/evaluations` 已增加标准基准、我的评测集和运行报告视图。
+
+### 当前路线：Benchmark 闭环
+
+Meta Planner、Evaluator、Prompt Evolution 和 Structure Evolution 已形成第一阶段闭环，
+但缺少可重复标准数据与针对性生成。当前按以下独立轮次补齐后再做收益审计：
+
+1. 已完成标准 Xpert Benchmark 目录。
+2. 下一轮实现 Xpert/Prompt/Profile/结构目标的一键生成与受限校准。
+3. 随后实现标准 RAG Pack 与版本化 Gold 引用。
+4. 再实现知识库定向 Benchmark 生成。
+5. 最后只对 General Agent Workspace 做目录和运行摘要适配，不替换 Penguin Runtime。
+
+每轮在共享栈空闲并完成 Docker 人工验收后独立提交。完整共享契约见
+[BENCHMARKS.md](./BENCHMARKS.md)。

--- a/docs/EVOAGENTX_EVALUATOR.md
+++ b/docs/EVOAGENTX_EVALUATOR.md
@@ -1,6 +1,6 @@
 # EvoAgentX Xpert Evaluator
 
-最后更新日期：2026-07-25
+最后更新日期：2026-08-07
 
 ## 1. 定位
 
@@ -27,6 +27,8 @@ Evaluator 只评价固定快照。它不会批准 Authoring Proposal、修改 Xp
 - `server/evaluations/executor.py`
 - `server/evaluations/metrics.py`
 - `server/evaluations/api.py`
+- `server/benchmarks/`
+- `client/src/components/evaluations/BenchmarkCatalogPanel.tsx`
 - `client/src/pages/XpertEvaluationsPage.tsx`
 
 ## 2. 版本化数据集
@@ -45,6 +47,17 @@ Evaluator 只评价固定快照。它不会批准 Authoring Proposal、修改 Xp
 
 数据可通过管理页面人工编辑、JSON/CSV 导入，或从用户显式选择的 Xpert 会话
 导入。会话导入不复制附件、记忆、物理路径或内部 Runtime 上下文。
+
+### 2.1 标准 Benchmark 目录
+
+`EVOAGENTX-BENCHMARK-CATALOG-01` 增加四个 ModelMirror 自有中英双语合成 Pack，
+共 64 条固定用例。目录核心门禁只使用 `exact_match`、`contains` 和
+`json_schema`，不依赖 LLM Judge 或外部数据。
+
+目录 Pack 不可编辑。“添加到工作区”会在原 `XpertEvaluationStore` 中原子创建
+Dataset，并自动发布与 Pack 完全一致的 v1。Dataset 的 `origin`、`catalog_ref`、
+`provenance`、`coverage` 和 `calibration` 会固定到不可变版本；旧数据读取时默认为
+`origin=manual`。完整契约见 [BENCHMARKS.md](./BENCHMARKS.md)。
 
 ## 3. 固定快照
 
@@ -139,6 +152,10 @@ GET/POST  /api/xpert-evaluations/runs
 GET       /api/xpert-evaluations/runs/{run_id}
 POST      /api/xpert-evaluations/runs/{run_id}/cancel
 GET       /api/xpert-evaluations/capabilities
+GET       /api/benchmarks/capabilities
+GET       /api/benchmarks/catalog
+GET       /api/benchmarks/catalog/{pack_id}
+POST      /api/benchmarks/catalog/{pack_id}/instantiate
 ```
 
 列表只返回摘要。可信管理面的 detail 会移除 workflow、Prompt、完整 Tool 配置和
@@ -150,8 +167,9 @@ GET       /api/xpert-evaluations/capabilities
 - `/agents/evaluations/:runId`
 
 Meta Planner V2 候选提供“评测候选”入口，并固定当前 Proposal revision。
-Xpert Studio 的已发布版本提供“版本回归评测”入口。工作台支持数据集编辑/导入、
-发布、基线与候选选择、模型策略、预算、预检、运行、取消和报告查看。
+Xpert Studio 的已发布版本提供“版本回归评测”入口。工作台按“标准基准 / 我的评测集 /
+运行报告”组织，支持目录实例化、数据集编辑/导入、发布、基线与候选选择、模型策略、
+预算、预检、运行、取消和报告查看。
 
 ## 9. 安全边界
 
@@ -167,6 +185,7 @@ Xpert Studio 的已发布版本提供“版本回归评测”入口。工作台�
 
 ```bash
 python -m pytest server/tests/test_xpert_evaluations.py -q
+python -m pytest server/tests/test_benchmark_catalog.py -q
 python -m pytest server/tests/test_meta_agent.py server/tests/test_xpert_publish.py -q
 cd client
 npm.cmd run build

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # 模镜项目文档中心
 
-最后更新日期：2026-07-28
+最后更新日期：2026-08-07
 维护人：模镜团队
 
 ## 文档状态规则
@@ -43,6 +43,7 @@
 | [MCP_CATALOG_ROADMAP.md](./MCP_CATALOG_ROADMAP.md) | 规划 | MCP 中文目录边界、安全适配、自定义连接与 Builder 远期路线。 |
 | [SKILL_INTEGRATION.md](./SKILL_INTEGRATION.md) | 当前 | Skill 安装、注入和供应链边界。 |
 | [META_AGENT.md](./META_AGENT.md) | 当前 | Meta Planner 当前契约。 |
+| [BENCHMARKS.md](./BENCHMARKS.md) | 当前 | 标准 Benchmark 目录、数据来源、实例化和后续生成边界。 |
 | [workflow-native-design.md](./workflow-native-design.md) | 当前设计记录 | classic/shared 能力增量和 native 实验边界。 |
 
 ## 冻结与内部兼容文档

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -35,6 +35,7 @@ COPY prompts ./prompts
 COPY plugins ./plugins
 COPY xperts ./xperts
 COPY evaluations ./evaluations
+COPY benchmarks ./benchmarks
 COPY evolutions ./evolutions
 COPY workflow_native ./workflow_native
 COPY world ./world

--- a/server/benchmarks/__init__.py
+++ b/server/benchmarks/__init__.py
@@ -1,0 +1,14 @@
+from .api import configure_benchmarks, get_benchmark_catalog, router
+from .catalog import BenchmarkCatalog, BenchmarkCatalogError, BenchmarkPackNotFoundError
+from .models import BenchmarkManifest, BenchmarkPack
+
+__all__ = [
+    "BenchmarkCatalog",
+    "BenchmarkCatalogError",
+    "BenchmarkManifest",
+    "BenchmarkPack",
+    "BenchmarkPackNotFoundError",
+    "configure_benchmarks",
+    "get_benchmark_catalog",
+    "router",
+]

--- a/server/benchmarks/api.py
+++ b/server/benchmarks/api.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Query
+
+try:
+    from server.evaluations.store import EvaluationStateError, XpertEvaluationStore
+except ModuleNotFoundError:
+    from evaluations.store import EvaluationStateError, XpertEvaluationStore
+
+from .catalog import BenchmarkCatalog, BenchmarkCatalogError, BenchmarkPackNotFoundError
+from .models import InstantiateBenchmarkRequest
+
+
+router = APIRouter(prefix="/api/benchmarks", tags=["benchmarks"])
+_catalog: BenchmarkCatalog | None = None
+_evaluation_store: XpertEvaluationStore | None = None
+
+
+def configure_benchmarks(evaluation_store: XpertEvaluationStore) -> BenchmarkCatalog:
+    global _catalog, _evaluation_store
+    _catalog = BenchmarkCatalog()
+    _evaluation_store = evaluation_store
+    return _catalog
+
+
+def get_benchmark_catalog() -> BenchmarkCatalog:
+    if _catalog is None:
+        raise RuntimeError("Benchmark catalog is not configured.")
+    return _catalog
+
+
+def _require_evaluation_store() -> XpertEvaluationStore:
+    if _evaluation_store is None:
+        raise RuntimeError("Benchmark catalog is not configured.")
+    return _evaluation_store
+
+
+@router.get("/capabilities")
+async def get_capabilities() -> dict[str, Any]:
+    return get_benchmark_catalog().capabilities()
+
+
+@router.get("/catalog")
+async def list_catalog(
+    kind: str | None = Query(default=None, pattern="^(agent_response|knowledge_retrieval)$"),
+) -> dict[str, Any]:
+    items = get_benchmark_catalog().list_packs(kind=kind)
+    return {"items": items, "total": len(items)}
+
+
+@router.get("/catalog/{pack_id}")
+async def get_catalog_pack(pack_id: str) -> dict[str, Any]:
+    try:
+        return get_benchmark_catalog().pack_payload(pack_id)
+    except BenchmarkPackNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.post("/catalog/{pack_id}/instantiate")
+async def instantiate_catalog_pack(
+    pack_id: str,
+    payload: InstantiateBenchmarkRequest,
+) -> dict[str, Any]:
+    try:
+        return get_benchmark_catalog().instantiate(
+            pack_id,
+            store=_require_evaluation_store(),
+            name=payload.name,
+            description=payload.description,
+        )
+    except BenchmarkPackNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except (BenchmarkCatalogError, EvaluationStateError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/server/benchmarks/builtin_packs.py
+++ b/server/benchmarks/builtin_packs.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+SOURCE = "ModelMirror-authored bilingual synthetic benchmark; no external dataset."
+LICENSE = "LicenseRef-ModelMirror-Project"
+
+
+def _exact_case(
+    case_id: str,
+    locale: str,
+    name: str,
+    message: str,
+    answer: str,
+    *tags: str,
+) -> dict[str, Any]:
+    return {
+        "case_id": case_id,
+        "name": name,
+        "message": message,
+        "tags": [locale, *tags],
+        "expected": {"exact_answer": answer},
+        "weights": {"exact_match": 1.0},
+    }
+
+
+def _schema_case(
+    case_id: str,
+    locale: str,
+    name: str,
+    message: str,
+    properties: dict[str, Any],
+    *tags: str,
+) -> dict[str, Any]:
+    return {
+        "case_id": case_id,
+        "name": name,
+        "message": message,
+        "tags": [locale, *tags],
+        "expected": {
+            "json_schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "type": "object",
+                "properties": properties,
+                "required": list(properties),
+                "additionalProperties": False,
+            }
+        },
+        "weights": {"json_schema": 1.0},
+    }
+
+
+def _contains_case(
+    case_id: str,
+    locale: str,
+    name: str,
+    message: str,
+    fragments: list[str],
+    *tags: str,
+) -> dict[str, Any]:
+    return {
+        "case_id": case_id,
+        "name": name,
+        "message": message,
+        "tags": [locale, *tags],
+        "expected": {"contains": fragments},
+        "weights": {"contains": 1.0},
+    }
+
+
+def _history_case(
+    case_id: str,
+    locale: str,
+    name: str,
+    messages: list[dict[str, str]],
+    question: str,
+    answer: str,
+    *tags: str,
+) -> dict[str, Any]:
+    return {
+        "case_id": case_id,
+        "name": name,
+        "message": question,
+        "messages": messages,
+        "tags": [locale, *tags],
+        "expected": {"exact_answer": answer},
+        "weights": {"exact_match": 1.0},
+    }
+
+
+def _instruction_following_cases() -> list[dict[str, Any]]:
+    return [
+        _exact_case("if-zh-01", "zh-CN", "固定短语", "只输出：晨星。不要添加标点或解释。", "晨星", "literal"),
+        _exact_case("if-zh-02", "zh-CN", "大写转换", "将 mm-42 转为大写，只输出转换结果。", "MM-42", "transform"),
+        _exact_case("if-zh-03", "zh-CN", "数字排序", "将 7、2、9、2 升序排列，用英文逗号连接且不要空格。", "2,2,7,9", "ordering"),
+        _contains_case("if-zh-04", "zh-CN", "必含术语", "用一句简短的话描述评测流程，必须同时包含“输入”和“输出”。", ["输入", "输出"], "required_terms"),
+        _exact_case("if-zh-05", "zh-CN", "标签包裹", "把词语蓝图放在一对方括号中，只输出结果。", "[蓝图]", "format"),
+        _exact_case("if-zh-06", "zh-CN", "布尔判断", "若 18 能被 3 整除，只输出 true，否则只输出 false。", "true", "reasoning"),
+        _exact_case("if-zh-07", "zh-CN", "取首字母", "取“模型 镜像 评测”三个词的首字，连续输出且不加空格。", "模镜评", "transform"),
+        _exact_case("if-zh-08", "zh-CN", "去重保序", "对 A,B,A,C,B 去重并保留首次出现顺序，用逗号连接。", "A,B,C", "ordering"),
+        _exact_case("if-zh-09", "zh-CN", "算术约束", "计算 (12-5)*3，只输出十进制整数。", "21", "reasoning"),
+        _exact_case("if-zh-10", "zh-CN", "禁止前后缀", "回答代号 K9；不得出现“答案”、冒号、句号或代码块。", "K9", "negative_constraint"),
+        _exact_case("if-en-01", "en", "Literal phrase", "Output exactly: north-star. Add no punctuation or explanation.", "north-star", "literal"),
+        _exact_case("if-en-02", "en", "Lowercase conversion", "Convert DELTA_7 to lowercase and output only the result.", "delta_7", "transform"),
+        _exact_case("if-en-03", "en", "Numeric ordering", "Sort 8, 1, 5, 1 ascending. Join with commas and no spaces.", "1,1,5,8", "ordering"),
+        _contains_case("if-en-04", "en", "Required terms", "Write one short sentence about evaluation that includes both evidence and review.", ["evidence", "review"], "required_terms"),
+        _exact_case("if-en-05", "en", "Wrapper format", "Wrap the word verified in one pair of angle brackets. Output only the result.", "<verified>", "format"),
+        _exact_case("if-en-06", "en", "Boolean decision", "If 25 is divisible by 5 output only true; otherwise output only false.", "true", "reasoning"),
+        _exact_case("if-en-07", "en", "Initial letters", "Take the initials of Model Mirror Benchmark and output them without spaces.", "MMB", "transform"),
+        _exact_case("if-en-08", "en", "Stable deduplication", "Deduplicate red,blue,red,green,blue while preserving first occurrence. Join with commas.", "red,blue,green", "ordering"),
+        _exact_case("if-en-09", "en", "Arithmetic constraint", "Calculate (15-6)*4 and output only the decimal integer.", "36", "reasoning"),
+        _exact_case("if-en-10", "en", "Forbidden prefix", "Return code Q7. Do not include labels, colons, punctuation, or a code fence.", "Q7", "negative_constraint"),
+    ]
+
+
+def _structured_output_cases() -> list[dict[str, Any]]:
+    return [
+        _schema_case("json-zh-01", "zh-CN", "状态对象", "只输出 JSON 对象：status 为 ready，count 为 3。", {"status": {"const": "ready"}, "count": {"const": 3}}, "flat"),
+        _schema_case("json-zh-02", "zh-CN", "布尔对象", "只输出 JSON：enabled 为 true，mode 为 safe。", {"enabled": {"const": True}, "mode": {"const": "safe"}}, "boolean"),
+        _schema_case("json-zh-03", "zh-CN", "数组对象", "只输出 JSON，items 必须依次为甲、乙、丙。", {"items": {"const": ["甲", "乙", "丙"]}}, "array"),
+        _schema_case("json-zh-04", "zh-CN", "嵌套对象", "只输出 JSON，result 内含 code=200 与 ok=true。", {"result": {"const": {"code": 200, "ok": True}}}, "nested"),
+        _schema_case("json-zh-05", "zh-CN", "空值对象", "只输出 JSON，value 为 null，reason 为 missing。", {"value": {"const": None}, "reason": {"const": "missing"}}, "null"),
+        _schema_case("json-zh-06", "zh-CN", "数值对象", "只输出 JSON，total 为 12.5，currency 为 CNY。", {"total": {"const": 12.5}, "currency": {"const": "CNY"}}, "number"),
+        _schema_case("json-zh-07", "zh-CN", "双层数组", "只输出 JSON，matrix 为 [[1,2],[3,4]]。", {"matrix": {"const": [[1, 2], [3, 4]]}}, "array", "nested"),
+        _schema_case("json-zh-08", "zh-CN", " Unicode 对象", "只输出 JSON，language 为 zh-CN，text 为 模镜。", {"language": {"const": "zh-CN"}, "text": {"const": "模镜"}}, "unicode"),
+        _schema_case("json-en-01", "en", "Status object", "Return only JSON with status=ready and count=3.", {"status": {"const": "ready"}, "count": {"const": 3}}, "flat"),
+        _schema_case("json-en-02", "en", "Boolean object", "Return only JSON with enabled=false and mode=review.", {"enabled": {"const": False}, "mode": {"const": "review"}}, "boolean"),
+        _schema_case("json-en-03", "en", "Array object", "Return only JSON whose items are alpha, beta, gamma in that order.", {"items": {"const": ["alpha", "beta", "gamma"]}}, "array"),
+        _schema_case("json-en-04", "en", "Nested object", "Return only JSON with result containing code=201 and ok=true.", {"result": {"const": {"code": 201, "ok": True}}}, "nested"),
+        _schema_case("json-en-05", "en", "Null object", "Return only JSON with value=null and reason=unknown.", {"value": {"const": None}, "reason": {"const": "unknown"}}, "null"),
+        _schema_case("json-en-06", "en", "Numeric object", "Return only JSON with total=19.75 and currency=USD.", {"total": {"const": 19.75}, "currency": {"const": "USD"}}, "number"),
+        _schema_case("json-en-07", "en", "Matrix object", "Return only JSON with matrix=[[2,4],[6,8]].", {"matrix": {"const": [[2, 4], [6, 8]]}}, "array", "nested"),
+        _schema_case("json-en-08", "en", "Escaped text", "Return only JSON with label set to line-one and separator set to slash.", {"label": {"const": "line-one"}, "separator": {"const": "slash"}}, "string"),
+    ]
+
+
+def _multi_turn_cases() -> list[dict[str, Any]]:
+    return [
+        _history_case("ctx-zh-01", "zh-CN", "代号召回", [{"role": "user", "content": "本次任务代号是松针。"}, {"role": "assistant", "content": "已记录。"}], "只输出任务代号。", "松针", "recall"),
+        _history_case("ctx-zh-02", "zh-CN", "更新值优先", [{"role": "user", "content": "首选颜色是红色。"}, {"role": "assistant", "content": "明白。"}, {"role": "user", "content": "更正：首选颜色改为蓝色。"}], "只输出当前首选颜色。", "蓝色", "conflict"),
+        _history_case("ctx-zh-03", "zh-CN", "人物属性", [{"role": "user", "content": "林舟负责测试，周岚负责设计。"}, {"role": "assistant", "content": "职责已记录。"}], "只输出负责测试的人名。", "林舟", "entity"),
+        _history_case("ctx-zh-04", "zh-CN", "数字召回", [{"role": "user", "content": "迭代预算是 48 点。"}, {"role": "assistant", "content": "收到。"}], "只输出预算数字。", "48", "recall"),
+        _history_case("ctx-zh-05", "zh-CN", "否定更新", [{"role": "user", "content": "允许导出 PDF。"}, {"role": "assistant", "content": "已记录。"}, {"role": "user", "content": "最终决定：不要导出 PDF。"}], "若当前允许导出 PDF 只输出 yes，否则只输出 no。", "no", "conflict"),
+        _history_case("ctx-zh-06", "zh-CN", "列表定位", [{"role": "user", "content": "顺序是采集、校验、发布。"}, {"role": "assistant", "content": "顺序已保存。"}], "只输出第二个步骤。", "校验", "ordering"),
+        _history_case("ctx-zh-07", "zh-CN", "跨轮别名", [{"role": "user", "content": "把项目 Nebula 简称为 N7。"}, {"role": "assistant", "content": "后续将使用该简称。"}], "只输出 Nebula 的简称。", "N7", "alias"),
+        _history_case("ctx-zh-08", "zh-CN", "干扰信息", [{"role": "user", "content": "测试环境端口是 7100，生产环境端口是 9100。"}, {"role": "assistant", "content": "两个端口已区分。"}], "只输出生产环境端口。", "9100", "selection"),
+        _history_case("ctx-en-01", "en", "Code recall", [{"role": "user", "content": "The task codename is cedar."}, {"role": "assistant", "content": "Recorded."}], "Output only the task codename.", "cedar", "recall"),
+        _history_case("ctx-en-02", "en", "Latest value wins", [{"role": "user", "content": "The preferred region is east."}, {"role": "assistant", "content": "Understood."}, {"role": "user", "content": "Correction: the preferred region is west."}], "Output only the current preferred region.", "west", "conflict"),
+        _history_case("ctx-en-03", "en", "Owner lookup", [{"role": "user", "content": "Mira owns testing and Owen owns design."}, {"role": "assistant", "content": "The ownership is noted."}], "Output only the person who owns testing.", "Mira", "entity"),
+        _history_case("ctx-en-04", "en", "Number recall", [{"role": "user", "content": "The iteration budget is 72 points."}, {"role": "assistant", "content": "Recorded."}], "Output only the budget number.", "72", "recall"),
+        _history_case("ctx-en-05", "en", "Negated update", [{"role": "user", "content": "CSV export is allowed."}, {"role": "assistant", "content": "Noted."}, {"role": "user", "content": "Final decision: disable CSV export."}], "Output only yes if CSV export is currently allowed, otherwise output only no.", "no", "conflict"),
+        _history_case("ctx-en-06", "en", "Sequence lookup", [{"role": "user", "content": "The order is collect, validate, publish."}, {"role": "assistant", "content": "Order saved."}], "Output only the second step.", "validate", "ordering"),
+        _history_case("ctx-en-07", "en", "Alias recall", [{"role": "user", "content": "Use R4 as the short name for project River."}, {"role": "assistant", "content": "I will use that alias."}], "Output only River's short name.", "R4", "alias"),
+        _history_case("ctx-en-08", "en", "Distractor selection", [{"role": "user", "content": "The staging port is 7300 and the production port is 9300."}, {"role": "assistant", "content": "The ports are distinguished."}], "Output only the production port.", "9300", "selection"),
+    ]
+
+
+def _abstention_cases() -> list[dict[str, Any]]:
+    schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+            "answer": {"type": "null"},
+            "status": {"const": "insufficient_evidence"},
+        },
+        "required": ["answer", "status"],
+        "additionalProperties": False,
+    }
+    specs = [
+        ("abstain-zh-01", "zh-CN", "缺失日期", "已知资料只说明项目名为北辰。资料没有上线日期。询问：上线日期是什么？"),
+        ("abstain-zh-02", "zh-CN", "缺失负责人", "证据仅包含预算 30 万元，没有负责人信息。询问：负责人是谁？"),
+        ("abstain-zh-03", "zh-CN", "相邻事实不可推断", "资料说明 A 城气温 20 度，没有 B 城数据。询问：B 城气温是多少？"),
+        ("abstain-zh-04", "zh-CN", "冲突无裁决", "来源一称版本为 4，来源二称版本为 5，没有时间或权威标识。询问：最终版本是多少？"),
+        ("abstain-zh-05", "zh-CN", "缺失单位", "资料只记录数值 18，没有单位。询问：该长度是多少米？"),
+        ("abstain-zh-06", "zh-CN", "未提供外部事实", "上下文没有任何关于星河公司的信息。询问：星河公司的 CEO 是谁？"),
+        ("abstain-en-01", "en", "Missing date", "The evidence only names the project Aurora. It provides no launch date. Question: What is the launch date?"),
+        ("abstain-en-02", "en", "Missing owner", "The evidence contains a budget of 40,000 but no owner. Question: Who owns the project?"),
+        ("abstain-en-03", "en", "Unsupported neighbor fact", "The evidence gives City A a temperature of 20 C and has no data for City B. Question: What is City B's temperature?"),
+        ("abstain-en-04", "en", "Unresolved conflict", "Source one says version 4 and source two says version 5. Neither has a date or authority marker. Question: What is the final version?"),
+        ("abstain-en-05", "en", "Missing unit", "The evidence records only the value 18 and gives no unit. Question: What is the length in meters?"),
+        ("abstain-en-06", "en", "Absent external fact", "The context contains no information about Northwind Labs. Question: Who is the CEO of Northwind Labs?"),
+    ]
+    return [
+        {
+            "case_id": case_id,
+            "name": name,
+            "message": (
+                f"{message} 证据不足时只输出 JSON，answer 为 null，status 为 insufficient_evidence。"
+                if locale == "zh-CN"
+                else f"{message} When evidence is insufficient, return only JSON with answer null and status insufficient_evidence."
+            ),
+            "tags": [locale, "abstention", "insufficient_evidence"],
+            "expected": {"json_schema": schema},
+            "weights": {"json_schema": 1.0},
+        }
+        for case_id, locale, name, message in specs
+    ]
+
+
+def _manifest(
+    pack_id: str,
+    name: str,
+    description: str,
+    coverage: list[str],
+    difficulty: str,
+) -> dict[str, Any]:
+    return {
+        "pack_id": pack_id,
+        "version": 1,
+        "kind": "agent_response",
+        "name": name,
+        "description": description,
+        "locales": ["zh-CN", "en"],
+        "coverage": coverage,
+        "difficulty": difficulty,
+        "metric_policy": {
+            "core": ["exact_match", "contains", "json_schema"],
+            "llm_judge": "optional_only",
+        },
+        "target_requirements": {
+            "runtime": "xpert_evaluator",
+            "side_effects": False,
+            "interactive_waits": False,
+        },
+        "source": SOURCE,
+        "license": LICENSE,
+    }
+
+
+def builtin_pack_specs() -> list[dict[str, Any]]:
+    return [
+        {
+            "manifest": _manifest(
+                "mm-agent-instruction-bilingual-v1",
+                "中英双语：指令与约束遵循",
+                "20 个可重复样例，覆盖格式、长度、排序、转换和负向约束。",
+                ["instruction_following", "format", "ordering", "negative_constraints"],
+                "mixed",
+            ),
+            "cases": _instruction_following_cases(),
+        },
+        {
+            "manifest": _manifest(
+                "mm-agent-structured-json-bilingual-v1",
+                "中英双语：JSON 与结构化输出",
+                "16 个严格 JSON Schema 样例，覆盖对象、数组、嵌套、布尔和空值。",
+                ["structured_output", "json_schema", "nested_data", "unicode"],
+                "intermediate",
+            ),
+            "cases": _structured_output_cases(),
+        },
+        {
+            "manifest": _manifest(
+                "mm-agent-multiturn-bilingual-v1",
+                "中英双语：多轮上下文与冲突处理",
+                "16 个多轮样例，覆盖召回、更新优先、实体选择和干扰信息。",
+                ["multi_turn", "context_recall", "conflict_resolution", "entity_selection"],
+                "mixed",
+            ),
+            "cases": _multi_turn_cases(),
+        },
+        {
+            "manifest": _manifest(
+                "mm-agent-abstention-bilingual-v1",
+                "中英双语：证据不足与可验证弃答",
+                "12 个严格弃答样例，覆盖缺失、冲突、单位不足和外部事实缺口。",
+                ["abstention", "insufficient_evidence", "conflicting_evidence"],
+                "intermediate",
+            ),
+            "cases": _abstention_cases(),
+        },
+    ]

--- a/server/benchmarks/catalog.py
+++ b/server/benchmarks/catalog.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from typing import Any
+
+try:
+    from server.evaluations.store import EvaluationStateError, XpertEvaluationStore
+except ModuleNotFoundError:
+    from evaluations.store import EvaluationStateError, XpertEvaluationStore
+
+from .builtin_packs import builtin_pack_specs
+from .models import BenchmarkManifest, BenchmarkPack
+
+
+class BenchmarkCatalogError(RuntimeError):
+    pass
+
+
+class BenchmarkPackNotFoundError(BenchmarkCatalogError):
+    pass
+
+
+class BenchmarkCatalog:
+    VERSION = "modelmirror-benchmark-catalog-v1"
+    ALLOWED_CORE_METRICS = {"exact_match", "contains", "json_schema"}
+
+    def __init__(self) -> None:
+        self._packs = self._load_builtin_packs()
+
+    def capabilities(self) -> dict[str, Any]:
+        counts: dict[str, int] = {}
+        for pack in self._packs.values():
+            kind = pack.manifest.kind
+            counts[kind] = counts.get(kind, 0) + 1
+        return {
+            "version": self.VERSION,
+            "kinds": sorted(counts),
+            "pack_counts": counts,
+            "locales": ["en", "zh-CN"],
+            "core_metrics": sorted(self.ALLOWED_CORE_METRICS),
+            "catalog_editable": False,
+            "instantiation": {
+                "agent_response": "xpert_evaluation_dataset_v1",
+                "knowledge_retrieval": "planned",
+            },
+        }
+
+    def list_packs(self, *, kind: str | None = None) -> list[dict[str, Any]]:
+        items = [
+            pack.manifest.model_dump(mode="json")
+            for pack in self._packs.values()
+            if kind is None or pack.manifest.kind == kind
+        ]
+        items.sort(key=lambda item: (item["kind"], item["pack_id"], item["version"]))
+        return items
+
+    def get_pack(self, pack_id: str) -> BenchmarkPack:
+        pack = self._packs.get(pack_id)
+        if pack is None:
+            raise BenchmarkPackNotFoundError("Benchmark pack not found.")
+        return pack.model_copy(deep=True)
+
+    def pack_payload(self, pack_id: str) -> dict[str, Any]:
+        pack = self.get_pack(pack_id)
+        return {
+            **pack.manifest.model_dump(mode="json"),
+            "cases": copy.deepcopy(pack.cases),
+        }
+
+    def instantiate(
+        self,
+        pack_id: str,
+        *,
+        store: XpertEvaluationStore,
+        name: str | None = None,
+        description: str | None = None,
+    ) -> dict[str, Any]:
+        pack = self.get_pack(pack_id)
+        if pack.manifest.kind != "agent_response":
+            raise BenchmarkCatalogError(
+                "This benchmark kind cannot be instantiated by Xpert Evaluator."
+            )
+        return store.instantiate_catalog_dataset(
+            name=name or pack.manifest.name,
+            description=(
+                pack.manifest.description if description is None else description
+            ),
+            cases=copy.deepcopy(pack.cases),
+            catalog_ref={
+                "pack_id": pack.manifest.pack_id,
+                "version": pack.manifest.version,
+                "checksum": pack.manifest.checksum,
+            },
+            provenance={
+                "source": pack.manifest.source,
+                "license": pack.manifest.license,
+                "locales": pack.manifest.locales,
+            },
+            coverage={
+                "areas": pack.manifest.coverage,
+                "difficulty": pack.manifest.difficulty,
+                "metric_policy": pack.manifest.metric_policy,
+                "target_requirements": pack.manifest.target_requirements,
+            },
+            release_notes=(
+                f"Instantiated from {pack.manifest.pack_id} "
+                f"v{pack.manifest.version}."
+            ),
+        )
+
+    @classmethod
+    def _load_builtin_packs(cls) -> dict[str, BenchmarkPack]:
+        packs: dict[str, BenchmarkPack] = {}
+        for spec in builtin_pack_specs():
+            cases = [XpertEvaluationStore.normalize_case(case) for case in spec["cases"]]
+            cls._validate_cases(cases)
+            checksum = cls._checksum(cases)
+            manifest = BenchmarkManifest.model_validate(
+                {
+                    **spec["manifest"],
+                    "case_count": len(cases),
+                    "checksum": checksum,
+                }
+            )
+            if manifest.pack_id in packs:
+                raise BenchmarkCatalogError(
+                    f"Duplicate benchmark pack id: {manifest.pack_id}"
+                )
+            packs[manifest.pack_id] = BenchmarkPack(manifest=manifest, cases=cases)
+        return packs
+
+    @classmethod
+    def _validate_cases(cls, cases: list[dict[str, Any]]) -> None:
+        case_ids = [str(case.get("case_id") or "") for case in cases]
+        if len(case_ids) != len(set(case_ids)):
+            raise BenchmarkCatalogError("Benchmark case ids must be unique within a pack.")
+        for case in cases:
+            expected = dict(case.get("expected") or {})
+            weights = dict(case.get("weights") or {})
+            if expected.get("rubric") or expected.get("citation_ids"):
+                raise BenchmarkCatalogError(
+                    "Built-in agent packs may only use deterministic expectations."
+                )
+            if weights and not set(weights).issubset(cls.ALLOWED_CORE_METRICS):
+                raise BenchmarkCatalogError("Unsupported core metric in benchmark pack.")
+            if not any(
+                expected.get(field) not in (None, [], {}, "")
+                for field in ("exact_answer", "contains", "json_schema")
+            ):
+                raise EvaluationStateError(
+                    "Every benchmark case requires a deterministic expectation."
+                )
+
+    @staticmethod
+    def _checksum(value: Any) -> str:
+        payload = json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()

--- a/server/benchmarks/models.py
+++ b/server/benchmarks/models.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+BenchmarkKind = Literal["agent_response", "knowledge_retrieval"]
+
+
+class BenchmarkManifest(BaseModel):
+    pack_id: str = Field(min_length=1, max_length=120)
+    version: int = Field(ge=1)
+    kind: BenchmarkKind
+    name: str = Field(min_length=1, max_length=160)
+    description: str = Field(default="", max_length=2_000)
+    locales: list[str] = Field(min_length=1, max_length=10)
+    coverage: list[str] = Field(min_length=1, max_length=30)
+    difficulty: Literal["basic", "intermediate", "advanced", "mixed"]
+    metric_policy: dict[str, Any]
+    target_requirements: dict[str, Any]
+    source: str = Field(min_length=1, max_length=500)
+    license: str = Field(min_length=1, max_length=120)
+    case_count: int = Field(ge=1, le=500)
+    checksum: str = Field(min_length=64, max_length=64)
+
+
+class BenchmarkPack(BaseModel):
+    manifest: BenchmarkManifest
+    cases: list[dict[str, Any]] = Field(min_length=1, max_length=500)
+
+
+class InstantiateBenchmarkRequest(BaseModel):
+    name: str | None = Field(default=None, min_length=1, max_length=160)
+    description: str | None = Field(default=None, max_length=2_000)
+

--- a/server/evaluations/store.py
+++ b/server/evaluations/store.py
@@ -45,7 +45,17 @@ class XpertEvaluationStore:
         self._lock = threading.RLock()
         self._data = self._load()
 
-    def create_dataset(self, name: str, description: str = "") -> dict[str, Any]:
+    def create_dataset(
+        self,
+        name: str,
+        description: str = "",
+        *,
+        origin: str = "manual",
+        catalog_ref: dict[str, Any] | None = None,
+        provenance: dict[str, Any] | None = None,
+        coverage: dict[str, Any] | None = None,
+        calibration: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
         now = time.time()
         dataset = {
             "dataset_id": f"xeval_dataset_{uuid.uuid4().hex}",
@@ -56,6 +66,13 @@ class XpertEvaluationStore:
             "published_version": None,
             "cases": [],
             "versions": [],
+            "origin": str(origin or "manual")[:80],
+            "catalog_ref": copy.deepcopy(catalog_ref or {}),
+            "provenance": copy.deepcopy(provenance or {}),
+            "coverage": copy.deepcopy(coverage or {}),
+            "calibration": copy.deepcopy(
+                calibration or {"status": "pending", "updated_at": None}
+            ),
             "created_at": now,
             "updated_at": now,
         }
@@ -63,6 +80,70 @@ class XpertEvaluationStore:
             self._data["datasets"][dataset["dataset_id"]] = dataset
             self._save_unlocked()
         return copy.deepcopy(dataset)
+
+    def instantiate_catalog_dataset(
+        self,
+        *,
+        name: str,
+        description: str,
+        cases: list[dict[str, Any]],
+        catalog_ref: dict[str, Any],
+        provenance: dict[str, Any],
+        coverage: dict[str, Any],
+        release_notes: str,
+    ) -> dict[str, Any]:
+        normalized = [self.normalize_case(item) for item in cases]
+        if not normalized:
+            raise EvaluationStateError("Benchmark pack must contain at least one case.")
+        if len(normalized) > self.MAX_DATASET_CASES:
+            raise EvaluationStateError("A dataset may contain at most 500 cases.")
+        case_ids = [str(item["case_id"]) for item in normalized]
+        if len(case_ids) != len(set(case_ids)):
+            raise EvaluationStateError("Benchmark case ids must be unique.")
+
+        now = time.time()
+        dataset_id = f"xeval_dataset_{uuid.uuid4().hex}"
+        dataset = {
+            "dataset_id": dataset_id,
+            "name": self._required(name, "name", 160),
+            "description": str(description or "").strip()[:2_000],
+            "status": "draft",
+            "revision": 1,
+            "published_version": 1,
+            "cases": copy.deepcopy(normalized),
+            "versions": [],
+            "origin": "catalog",
+            "catalog_ref": copy.deepcopy(catalog_ref),
+            "provenance": copy.deepcopy(provenance),
+            "coverage": copy.deepcopy(coverage),
+            "calibration": {
+                "status": "calibrated",
+                "mode": "catalog_integrity",
+                "checksum": str(catalog_ref.get("checksum") or "")[:64],
+                "updated_at": now,
+            },
+            "created_at": now,
+            "updated_at": now,
+        }
+        version = {
+            "dataset_id": dataset_id,
+            "version": 1,
+            "draft_revision": 1,
+            "name": dataset["name"],
+            "description": dataset["description"],
+            "cases": copy.deepcopy(normalized),
+            "case_count": len(normalized),
+            "release_notes": str(release_notes or "").strip()[:2_000],
+            "checksum": self._checksum(normalized),
+            **self._metadata_payload(dataset),
+            "published_at": now,
+        }
+        dataset["versions"] = [version]
+        self._touch(dataset)
+        with self._lock:
+            self._data["datasets"][dataset_id] = dataset
+            self._save_unlocked()
+        return self.dataset_payload(dataset, include_cases=True)
 
     def list_datasets(self, *, status: str | None = None) -> list[dict[str, Any]]:
         with self._lock:
@@ -124,6 +205,16 @@ class XpertEvaluationStore:
             if len(by_id) > self.MAX_DATASET_CASES:
                 raise EvaluationStateError("A dataset may contain at most 500 cases.")
             item["cases"] = list(by_id.values())
+            calibration = dict(item.get("calibration") or {})
+            if calibration.get("status") == "calibrated":
+                calibration.update(
+                    {
+                        "status": "stale",
+                        "reason": "dataset_cases_changed",
+                        "updated_at": time.time(),
+                    }
+                )
+                item["calibration"] = calibration
             self._touch(item)
             self._save_unlocked()
             return copy.deepcopy(item)
@@ -152,6 +243,7 @@ class XpertEvaluationStore:
                 "case_count": len(cases),
                 "release_notes": str(release_notes or "").strip()[:2_000],
                 "checksum": self._checksum(cases),
+                **self._metadata_payload(item),
                 "published_at": time.time(),
             }
             item.setdefault("versions", []).append(version)
@@ -173,7 +265,9 @@ class XpertEvaluationStore:
         item = self.require_dataset(dataset_id)
         for snapshot in item.get("versions") or []:
             if int(snapshot.get("version") or 0) == int(version):
-                return copy.deepcopy(snapshot)
+                payload = copy.deepcopy(snapshot)
+                self._ensure_metadata(payload, fallback=item)
+                return payload
         raise EvaluationNotFoundError("Evaluation dataset version not found.")
 
     def create_run(
@@ -363,6 +457,11 @@ class XpertEvaluationStore:
     @staticmethod
     def dataset_payload(item: dict[str, Any], *, include_cases: bool) -> dict[str, Any]:
         payload = copy.deepcopy(item)
+        payload.setdefault("origin", "manual")
+        payload.setdefault("catalog_ref", {})
+        payload.setdefault("provenance", {})
+        payload.setdefault("coverage", {})
+        payload.setdefault("calibration", {"status": "pending", "updated_at": None})
         payload["case_count"] = len(payload.get("cases") or [])
         payload["version_count"] = len(payload.get("versions") or [])
         payload.pop("versions", None)
@@ -432,11 +531,51 @@ class XpertEvaluationStore:
             raw = json.loads(self.path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
             return {"schema_version": 1, "datasets": {}, "runs": {}}
+        datasets = dict(raw.get("datasets") or {})
+        for item in datasets.values():
+            if not isinstance(item, dict):
+                continue
+            self._ensure_metadata(item)
+            for version in item.get("versions") or []:
+                if isinstance(version, dict):
+                    self._ensure_metadata(version, fallback=item)
         return {
             "schema_version": 1,
-            "datasets": dict(raw.get("datasets") or {}),
+            "datasets": datasets,
             "runs": dict(raw.get("runs") or {}),
         }
+
+    @staticmethod
+    def _metadata_payload(item: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "origin": str(item.get("origin") or "manual"),
+            "catalog_ref": copy.deepcopy(item.get("catalog_ref") or {}),
+            "provenance": copy.deepcopy(item.get("provenance") or {}),
+            "coverage": copy.deepcopy(item.get("coverage") or {}),
+            "calibration": copy.deepcopy(
+                item.get("calibration")
+                or {"status": "pending", "updated_at": None}
+            ),
+        }
+
+    @staticmethod
+    def _ensure_metadata(
+        item: dict[str, Any],
+        *,
+        fallback: dict[str, Any] | None = None,
+    ) -> None:
+        source = fallback or {}
+        item.setdefault("origin", str(source.get("origin") or "manual"))
+        item.setdefault("catalog_ref", copy.deepcopy(source.get("catalog_ref") or {}))
+        item.setdefault("provenance", copy.deepcopy(source.get("provenance") or {}))
+        item.setdefault("coverage", copy.deepcopy(source.get("coverage") or {}))
+        item.setdefault(
+            "calibration",
+            copy.deepcopy(
+                source.get("calibration")
+                or {"status": "pending", "updated_at": None}
+            ),
+        )
 
     def _save_unlocked(self) -> None:
         self.storage_dir.mkdir(parents=True, exist_ok=True)

--- a/server/main.py
+++ b/server/main.py
@@ -72,6 +72,14 @@ except ModuleNotFoundError:
     )
 
 try:
+    from server.benchmarks import (
+        configure_benchmarks,
+        router as benchmarks_router,
+    )
+except ModuleNotFoundError:
+    from benchmarks import configure_benchmarks, router as benchmarks_router
+
+try:
     from server.evolutions import (
         configure_xpert_evolutions,
         get_xpert_evolution_executor,
@@ -780,6 +788,7 @@ app.include_router(toolsets_router)
 app.include_router(prompt_profiles_router)
 app.include_router(plugins_router)
 app.include_router(xpert_evaluations_router)
+app.include_router(benchmarks_router)
 app.include_router(xpert_evolutions_router)
 app.include_router(model_router_router)
 app.include_router(model_catalog_router)
@@ -13531,6 +13540,7 @@ configure_xpert_evaluations(
     judge_runner=run_xpert_evaluation_judge,
     run_registry=run_registry,
 )
+configure_benchmarks(get_xpert_evaluation_store())
 
 
 async def run_xpert_evolution_optimizer(

--- a/server/tests/test_benchmark_catalog.py
+++ b/server/tests/test_benchmark_catalog.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from server.benchmarks import api as benchmark_api
+from server.benchmarks.catalog import BenchmarkCatalog
+from server.evaluations.store import XpertEvaluationStore
+
+
+EXPECTED_PACK_COUNTS = {
+    "mm-agent-instruction-bilingual-v1": 20,
+    "mm-agent-structured-json-bilingual-v1": 16,
+    "mm-agent-multiturn-bilingual-v1": 16,
+    "mm-agent-abstention-bilingual-v1": 12,
+}
+
+
+def test_builtin_agent_catalog_is_stable_bilingual_and_deterministic() -> None:
+    catalog = BenchmarkCatalog()
+    items = catalog.list_packs(kind="agent_response")
+
+    assert {item["pack_id"]: item["case_count"] for item in items} == EXPECTED_PACK_COUNTS
+    assert sum(item["case_count"] for item in items) == 64
+    assert all(item["locales"] == ["zh-CN", "en"] for item in items)
+    assert all(len(item["checksum"]) == 64 for item in items)
+    assert catalog.capabilities()["core_metrics"] == [
+        "contains",
+        "exact_match",
+        "json_schema",
+    ]
+
+    for item in items:
+        pack = catalog.get_pack(item["pack_id"])
+        assert pack.manifest.checksum == item["checksum"]
+        assert pack.manifest.source.startswith("ModelMirror-authored")
+        assert pack.manifest.license == "LicenseRef-ModelMirror-Project"
+        locales = {locale for case in pack.cases for locale in case.get("tags", [])}
+        assert {"zh-CN", "en"}.issubset(locales)
+        for case in pack.cases:
+            expected = case["expected"]
+            assert not expected.get("rubric")
+            assert not expected.get("citation_ids")
+            assert set(case.get("weights") or {}).issubset(
+                {"exact_match", "contains", "json_schema"}
+            )
+
+
+def test_catalog_instantiation_atomically_publishes_immutable_v1(tmp_path: Path) -> None:
+    catalog = BenchmarkCatalog()
+    store = XpertEvaluationStore(tmp_path)
+    dataset = catalog.instantiate(
+        "mm-agent-instruction-bilingual-v1",
+        store=store,
+    )
+
+    assert dataset["origin"] == "catalog"
+    assert dataset["published_version"] == 1
+    assert dataset["case_count"] == 20
+    assert dataset["catalog_ref"]["pack_id"] == "mm-agent-instruction-bilingual-v1"
+    assert dataset["calibration"]["status"] == "calibrated"
+    first = store.get_dataset_version(dataset["dataset_id"], 1)
+    assert first["checksum"] == dataset["catalog_ref"]["checksum"]
+    assert first["origin"] == "catalog"
+
+    changed = store.put_cases(
+        dataset["dataset_id"],
+        revision=dataset["revision"],
+        cases=[
+            {
+                "case_id": "local-extra",
+                "message": "Output exactly local.",
+                "expected": {"exact_answer": "local"},
+            }
+        ],
+    )
+    assert changed["calibration"]["status"] == "stale"
+    assert len(changed["cases"]) == 21
+    assert store.get_dataset_version(dataset["dataset_id"], 1)["case_count"] == 20
+
+    restored = XpertEvaluationStore(tmp_path)
+    restored_dataset = restored.dataset_payload(
+        restored.require_dataset(dataset["dataset_id"]), include_cases=False
+    )
+    assert restored_dataset["origin"] == "catalog"
+    assert restored_dataset["catalog_ref"] == dataset["catalog_ref"]
+
+
+def test_legacy_dataset_defaults_to_manual_origin(tmp_path: Path) -> None:
+    payload = {
+        "schema_version": 1,
+        "datasets": {
+            "legacy": {
+                "dataset_id": "legacy",
+                "name": "Legacy",
+                "description": "",
+                "status": "draft",
+                "revision": 1,
+                "published_version": None,
+                "cases": [],
+                "versions": [],
+                "created_at": 1,
+                "updated_at": 1,
+            }
+        },
+        "runs": {},
+    }
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "xpert_evaluations.json").write_text(
+        json.dumps(payload), encoding="utf-8"
+    )
+
+    item = XpertEvaluationStore(tmp_path).list_datasets()[0]
+    assert item["origin"] == "manual"
+    assert item["catalog_ref"] == {}
+    assert item["provenance"] == {}
+    assert item["coverage"] == {}
+    assert item["calibration"]["status"] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_benchmark_api_returns_catalog_and_instantiates_dataset(
+    tmp_path: Path,
+) -> None:
+    app = FastAPI()
+    app.include_router(benchmark_api.router)
+    benchmark_api.configure_benchmarks(XpertEvaluationStore(tmp_path))
+    transport = httpx.ASGITransport(app=app)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        catalog_response = await client.get(
+            "/api/benchmarks/catalog", params={"kind": "agent_response"}
+        )
+        assert catalog_response.status_code == 200
+        assert catalog_response.json()["total"] == 4
+
+        detail_response = await client.get(
+            "/api/benchmarks/catalog/mm-agent-structured-json-bilingual-v1"
+        )
+        assert detail_response.status_code == 200
+        assert detail_response.json()["case_count"] == 16
+
+        create_response = await client.post(
+            "/api/benchmarks/catalog/mm-agent-multiturn-bilingual-v1/instantiate",
+            json={},
+        )
+        assert create_response.status_code == 200
+        created = create_response.json()
+        assert created["published_version"] == 1
+        assert created["case_count"] == 16
+
+    serialized = json.dumps(
+        {
+            "catalog": catalog_response.json(),
+            "detail": detail_response.json(),
+            "created": created,
+        }
+    ).lower()
+    for forbidden in (
+        "stored_path",
+        "api_key",
+        "openrouter_api_key",
+        "embedding",
+        "runtime store",
+    ):
+        assert forbidden not in serialized


### PR DESCRIPTION
## 概要

- 新增统一 Benchmark Manifest 与只读目录 API。
- 内置 4 个 ModelMirror 自有中英双语合成 Pack，共 64 条可重复用例。
- 核心门禁仅使用 exact、contains、JSON Schema 确定性指标。
- 标准 Pack 可一键实例化为可编辑 Dataset，并自动发布完全一致的不可变 v1。
- Evaluation Dataset 增加 origin、catalog_ref、provenance、coverage、calibration 兼容字段；旧数据默认按 manual 读取。
- `/agents/evaluations` 增加“标准基准 / 我的评测集 / 运行报告”工作区。
- 更新 Benchmark、EvoAgentX Evaluator、路线与 Harness 文档。

## 验证

- Benchmark/Evaluator 重点测试：`9 passed`
- 扩展回归：`52 passed`
- 前端生产构建：通过
- 后端 `compileall`：通过
- `git diff --check` 与敏感信息扫描：通过
- 全量 Windows 基线对比：
  - 当前：`1231 passed, 95 failed, 10 skipped`
  - PR #109 基线：`1229 passed, 93 failed, 10 skipped`
  - 差异用例单独复测通过；Sandbox 项确认由 Windows 临时路径长度导致
- 独立 Docker 预览栈完成 API、目录实例化、页面渲染和交互验收；未重建共享栈

## 安全与兼容

- Pack 全部为仓库自有合成内容，不依赖外部数据集或网络。
- API 不返回密钥、路径、Prompt、工具结果或运行存储。
- 不提交 Runtime 数据、构建产物、环境文件或 API key。
