### PR TITLE
feature: 添加 Windows Coding 项目直接写回闭环

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -71,3 +71,31 @@ jobs:
           CODING_PROJECT_UPLOAD_ROOT: ${{ runner.temp }}/modelmirror-project-uploads
       - name: Validate Docker Compose configuration
         run: docker compose config --quiet
+
+  coding-project-host-windows:
+    name: Windows Project Host
+    runs-on: windows-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+      - name: Set up Python 3.12
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: server/requirements.txt
+      - name: Install backend dependencies
+        run: python -m pip install -r server/requirements.txt
+      - name: Run Windows Project Host tests
+        run: >-
+          python -m pytest
+          server/tests/test_coding_project_host_windows.py
+          server/tests/test_coding_project_host.py::test_host_commit_windows_native_apply_commit_and_undo
+          server/tests/test_coding_project_host.py::test_host_commit_windows_private_object_cleanup_rejects_replacement
+          -q -ra -p no:cacheprovider
+        env:
+          CODING_PROJECT_UPLOAD_ROOT: ${{ runner.temp }}/modelmirror-project-uploads
+          PYTHONDONTWRITEBYTECODE: "1"

--- a/client/src/components/CodingApplyPanel.tsx
+++ b/client/src/components/CodingApplyPanel.tsx
@@ -11,6 +11,7 @@ import type {
   CodingApplyResult,
   CodingCapabilities,
   CodingDraftChanges,
+  CodingProjectSummary,
   CodingVerification,
 } from "../types/coding";
 import { CodingApiError } from "../utils/codingApi";
@@ -24,7 +25,7 @@ interface CodingApplyPanelProps {
   onClose: () => Promise<void>;
   onRevert: () => Promise<void>;
   result: CodingApplyResult | null;
-  selectedProject?: boolean;
+  selectedProject: CodingProjectSummary | null;
   verification: CodingVerification | null;
 }
 
@@ -43,6 +44,16 @@ const reasonText: Record<string, string> = {
     "所选项目仍连接远程平台。移除远程连接并确认项目状态后再试。",
   project_changed:
     "所选项目的版本已经变化。为避免覆盖现有内容，本次写入已停止。",
+  project_host_offline:
+    "本地项目助手连接已断开。当前状态和操作区会保留，重新连接后可继续。",
+  project_host_protocol_readonly:
+    "当前助手版本只支持查看和下载。请更新助手后重新连接，再决定是否写入。",
+  project_host_unavailable:
+    "本地项目助手连接已断开。当前状态和操作区会保留，重新连接后可继续。",
+  project_host_writeback_disabled:
+    "本地项目写入已关闭。当前修改仍可查看和下载。",
+  project_host_writeback_unavailable:
+    "本地项目助手暂时不能执行写入。当前状态和操作区会保留，重新连接后可继续。",
   project_writer_not_configured:
     "本地项目写入服务尚未配置，仍可查看和下载当前修改。",
   project_writer_timeout:
@@ -56,6 +67,8 @@ const reasonText: Record<string, string> = {
   session_frozen: "修改已经写入，本次草稿已锁定。",
   snapshot_mismatch:
     "目标项目与当前草稿版本不一致，请刷新状态或重新开始修改。",
+  operation_result_unknown:
+    "本次操作的结果暂时无法确认。当前状态和操作区会保留，重新连接后将继续核对。",
   target_changed:
     "目标项目已有其他修改，为避免覆盖内容，本次操作已停止。",
   target_not_ready:
@@ -87,7 +100,7 @@ function gateMessage(
   capability: CodingCapabilities["apply"],
   changes: CodingDraftChanges,
   verification: CodingVerification | null,
-  selectedProject: boolean,
+  selectedProject: CodingProjectSummary | null,
 ) {
   if (!capability?.available) {
     return (
@@ -122,9 +135,9 @@ function gateMessage(
     );
   }
   if (qualityWarnings.length) {
-    return `${qualityWarnings.join("，")}。你可以先修正，也可以确认风险后继续写入${selectedProject ? "所选本地项目" : "专用副本"}。`;
+    return `${qualityWarnings.join("，")}。你可以先修正，也可以确认风险后继续写入${Boolean(selectedProject) ? "所选本地项目" : "专用副本"}。`;
   }
-  return `检查结果正常，可以写入${selectedProject ? "所选本地项目" : "专用项目副本"}。`;
+  return `检查结果正常，可以写入${Boolean(selectedProject) ? "所选本地项目" : "专用项目副本"}。`;
 }
 
 export default function CodingApplyPanel({
@@ -136,7 +149,7 @@ export default function CodingApplyPanel({
   onClose,
   onRevert,
   result,
-  selectedProject = false,
+  selectedProject,
   verification,
 }: CodingApplyPanelProps) {
   const [action, setAction] = useState<ActionState>("idle");
@@ -154,10 +167,13 @@ export default function CodingApplyPanel({
     nextAction: Exclude<ActionState, "idle">,
     callback: () => Promise<void>,
   ) => {
+    if (action !== "idle") return;
     setAction(nextAction);
     setMessage("");
     try {
       await callback();
+      setConfirmApply(false);
+      setConfirmClose(false);
     } catch (requestError) {
       setMessage(describeError(requestError));
     } finally {
@@ -167,9 +183,16 @@ export default function CodingApplyPanel({
 
   const hasAppliedCopy = Boolean(result?.apply_id);
   const failedAttempt = result?.state === "failed" && !hasAppliedCopy;
+  const operationResultUnknown =
+    result?.state === "failed" &&
+    result.reason === "operation_result_unknown";
+  const applyResultUnknown = operationResultUnknown && !hasAppliedCopy;
+  const revertResultUnknown = operationResultUnknown && hasAppliedCopy;
   const hardRetryFailure = Boolean(
     failedAttempt && hardRetryFailures.has(result?.reason ?? ""),
   );
+  const operationPending =
+    result?.state === "applying" || result?.state === "reverting";
   const verificationAllowsApply =
     verification?.revision === changes.revision &&
     verification.stale === false &&
@@ -185,34 +208,43 @@ export default function CodingApplyPanel({
     verification?.state === "running" && verification.stale === false;
   const canApply =
     !hardRetryFailure &&
+    !operationPending &&
     capability?.available === true &&
     !verificationRunning;
-  const gateCopy = hardRetryFailure
+  const gateCopy = operationPending
+    ? result?.state === "reverting"
+      ? "正在核对撤销结果，请等待状态更新；当前页面和 Diff 会继续保留。"
+      : "正在核对写入结果，请等待状态更新；当前页面和 Diff 会继续保留。"
+    : hardRetryFailure
     ? reasonText[result?.reason ?? ""] ??
-      `上次操作的结果无法确认，请由开发者检查${selectedProject ? "所选本地项目" : "专用项目副本"}。`
+      `上次操作的结果无法确认，请由开发者检查${Boolean(selectedProject) ? "所选本地项目" : "专用项目副本"}。`
+    : applyResultUnknown
+      ? "上次结果暂时无法确认。重新连接后可核对原操作；只有确认尚未写入时，系统才会继续本次写入。"
     : failedAttempt
       ? `${reasonText[result?.reason ?? ""] ?? "上次写入没有完成。"} 你可以在问题处理后重试当前草稿。`
       : gateMessage(capability, changes, verification, selectedProject);
   const isApplied = result?.state === "applied";
   const isReverted = result?.state === "reverted";
-  const failedAfterApply = result?.state === "failed" && hasAppliedCopy;
+  const failedAfterApply =
+    result?.state === "failed" && hasAppliedCopy && !revertResultUnknown;
   const technicalReason =
     result?.reason || capability?.reason || (message ? "request_failed" : "");
 
-  if (isApplied || isReverted || failedAfterApply) {
+  if (isApplied || isReverted || failedAfterApply || revertResultUnknown) {
     return (
       <section
+        aria-busy={action !== "idle"}
         aria-labelledby="coding-apply-title"
         className={`mt-5 rounded-lg border p-4 ${
           isReverted
             ? "border-slate-300/15 bg-white/[0.025]"
-            : failedAfterApply
+            : failedAfterApply || revertResultUnknown
               ? "border-amber-300/20 bg-amber-300/[0.055]"
               : "border-emerald-300/20 bg-emerald-300/[0.055]"
         }`}
       >
         <div className="flex items-start gap-3">
-          {failedAfterApply ? (
+          {failedAfterApply || revertResultUnknown ? (
             <CircleAlert
               aria-hidden="true"
               className="mt-0.5 shrink-0 text-amber-200"
@@ -230,24 +262,33 @@ export default function CodingApplyPanel({
           <div className="min-w-0">
             <h3 className="text-sm font-semibold text-white" id="coding-apply-title">
               {isReverted
-                ? selectedProject
+                ? Boolean(selectedProject)
                   ? "本次写入已撤销"
                   : "本次应用已撤销"
+                : revertResultUnknown
+                  ? "撤销结果待核对"
                 : failedAfterApply
                   ? "无法安全撤销"
-                  : selectedProject
+                  : Boolean(selectedProject)
                     ? "修改已写入"
                     : "修改已应用"}
             </h3>
-            <p aria-live="polite" className="mt-1 text-xs leading-5 text-slate-300">
+            <p
+              aria-atomic="true"
+              aria-live="polite"
+              className="mt-1 text-xs leading-5 text-slate-300"
+              role="status"
+            >
               {isReverted
-                ? selectedProject
+                ? Boolean(selectedProject)
                   ? "所选本地项目已恢复到写入前的状态。"
                   : "专用项目副本已恢复到应用前的状态。当前项目目录始终没有改变。"
+                : revertResultUnknown
+                  ? "上次撤销结果暂时无法确认。重新连接后可核对原操作；系统不会盲目重复撤销。"
                 : failedAfterApply
                   ? reasonText[result?.reason ?? ""] ??
-                    `${selectedProject ? "所选本地项目" : "专用项目副本"}发生了其他变化，本次操作已停止。`
-                  : selectedProject
+                    `${Boolean(selectedProject) ? "所选本地项目" : "专用项目副本"}发生了其他变化，本次操作已停止。`
+                  : Boolean(selectedProject)
                     ? `已将 ${result?.file_count ?? changes.file_count} 个文件写入所选本地项目。尚未创建本地版本，也没有上传。`
                     : `已将 ${result?.file_count ?? changes.file_count} 个文件写入专用项目副本。没有提交，也没有上传；当前项目目录没有改变。`}
             </p>
@@ -255,10 +296,12 @@ export default function CodingApplyPanel({
         </div>
 
         <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:flex-wrap">
-          {isApplied && result?.can_revert ? (
+          {(isApplied && result?.can_revert) || revertResultUnknown ? (
             <button
-              className="inline-flex min-h-10 items-center justify-center gap-2 rounded-lg border border-amber-300/30 px-3 text-sm font-semibold text-amber-100 transition hover:bg-amber-300/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-200/70 disabled:cursor-not-allowed disabled:opacity-50"
-              disabled={disabled || action !== "idle"}
+              className="inline-flex min-h-11 items-center justify-center gap-2 rounded-lg border border-amber-300/30 px-3 text-sm font-semibold text-amber-100 transition hover:bg-amber-300/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-200/70 disabled:cursor-not-allowed disabled:opacity-50"
+              disabled={
+                disabled || action !== "idle" || capability?.available !== true
+              }
               onClick={() => void runAction("reverting", onRevert)}
               type="button"
             >
@@ -271,21 +314,27 @@ export default function CodingApplyPanel({
               ) : (
                 <Undo2 aria-hidden="true" size={16} />
               )}
-              {selectedProject ? "撤销本次写入" : "撤销本次应用"}
+              {revertResultUnknown
+                ? "核对本次撤销"
+                : Boolean(selectedProject)
+                  ? "撤销本次写入"
+                  : "撤销本次应用"}
             </button>
           ) : null}
-          <button
-            className="inline-flex min-h-10 items-center justify-center gap-2 rounded-lg border border-white/15 px-3 text-sm font-semibold text-slate-200 transition hover:bg-white/[0.06] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50 disabled:cursor-not-allowed disabled:opacity-50"
-            disabled={disabled || action !== "idle"}
-            onClick={() => setConfirmClose(true)}
-            type="button"
-          >
-            <X aria-hidden="true" size={16} />
-            结束本次修改
-          </button>
+          {!revertResultUnknown ? (
+            <button
+              className="inline-flex min-h-11 items-center justify-center gap-2 rounded-lg border border-white/15 px-3 text-sm font-semibold text-slate-200 transition hover:bg-white/[0.06] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50 disabled:cursor-not-allowed disabled:opacity-50"
+              disabled={disabled || action !== "idle"}
+              onClick={() => setConfirmClose(true)}
+              type="button"
+            >
+              <X aria-hidden="true" size={16} />
+              结束本次修改
+            </button>
+          ) : null}
         </div>
 
-        {confirmClose ? (
+        {confirmClose && !revertResultUnknown ? (
           <div
             aria-live="polite"
             className="mt-4 rounded-lg bg-white/[0.045] p-3 text-sm text-slate-200"
@@ -294,20 +343,22 @@ export default function CodingApplyPanel({
             <p className="mt-1 text-xs leading-5 text-slate-400">
               {isReverted
                 ? "结束后会释放代码助手，你可以开始新的修改。"
-                : selectedProject
+                : Boolean(selectedProject)
                   ? "结束后页面将不能再撤销；所选本地项目中的修改会继续保留。"
                   : "结束后页面将不能再撤销；专用项目副本中的内容会继续保留。"}
             </p>
             <div className="mt-3 flex flex-col gap-2 sm:flex-row">
               <button
-                className="min-h-9 rounded-lg border border-white/15 px-3 text-xs font-semibold hover:bg-white/[0.06] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50"
+                className="min-h-11 rounded-lg border border-white/15 px-3 text-xs font-semibold hover:bg-white/[0.06] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50 disabled:cursor-not-allowed disabled:opacity-50"
+                disabled={action !== "idle"}
                 onClick={() => setConfirmClose(false)}
                 type="button"
               >
                 继续保留本页
               </button>
               <button
-                className="inline-flex min-h-9 items-center justify-center gap-2 rounded-lg bg-slate-200 px-3 text-xs font-semibold text-ink-950 hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+                className="inline-flex min-h-11 items-center justify-center gap-2 rounded-lg bg-slate-200 px-3 text-xs font-semibold text-ink-950 hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white disabled:cursor-not-allowed disabled:opacity-50"
+                disabled={action !== "idle"}
                 onClick={() => void runAction("closing", onClose)}
                 type="button"
               >
@@ -324,7 +375,7 @@ export default function CodingApplyPanel({
           </div>
         ) : null}
 
-        {message || error ? (
+        {(message || error) && !operationResultUnknown ? (
           <div
             className="mt-3 flex items-start gap-2 rounded-lg bg-rose-300/10 px-3 py-2 text-xs leading-5 text-rose-100"
             role="alert"
@@ -352,6 +403,7 @@ export default function CodingApplyPanel({
 
   return (
     <section
+      aria-busy={operationPending || action !== "idle"}
       aria-labelledby="coding-apply-title"
       className="mt-5 rounded-lg border border-white/10 bg-white/[0.025] p-4"
     >
@@ -373,7 +425,9 @@ export default function CodingApplyPanel({
         )}
         <div className="min-w-0 flex-1">
           <h3 className="text-sm font-semibold text-white" id="coding-apply-title">
-            {selectedProject ? "写入所选本地项目" : "应用到本地项目副本"}
+            {Boolean(selectedProject)
+              ? "写入所选本地项目"
+              : "应用到本地项目副本"}
           </h3>
           <p
             aria-live="polite"
@@ -391,13 +445,19 @@ export default function CodingApplyPanel({
       </div>
 
       <button
-        className="mt-4 inline-flex min-h-10 w-full items-center justify-center gap-2 rounded-lg bg-emerald-200 px-3 text-sm font-semibold text-emerald-950 transition hover:bg-emerald-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-100 disabled:cursor-not-allowed disabled:bg-slate-700 disabled:text-slate-400 sm:w-auto"
+        className="mt-4 inline-flex min-h-11 w-full items-center justify-center gap-2 rounded-lg bg-emerald-200 px-3 text-sm font-semibold text-emerald-950 transition hover:bg-emerald-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-100 disabled:cursor-not-allowed disabled:bg-slate-700 disabled:text-slate-400 sm:w-auto"
         disabled={!canApply || disabled || action !== "idle"}
         onClick={() => setConfirmApply(true)}
         type="button"
       >
         <FolderCheck aria-hidden="true" size={16} />
-        {selectedProject ? "写入所选本地项目" : "应用到本地项目副本"}
+        {applyResultUnknown
+          ? Boolean(selectedProject)
+            ? "核对本次写入"
+            : "核对本次应用"
+          : Boolean(selectedProject)
+            ? "写入所选本地项目"
+            : "应用到本地项目副本"}
       </button>
 
       {confirmApply ? (
@@ -410,10 +470,31 @@ export default function CodingApplyPanel({
           }`}
         >
           <p className="font-semibold">
-            {hasQualityRisks
+            {applyResultUnknown
+              ? "核对上一次写入结果吗？"
+              : hasQualityRisks
               ? `仍要写入 ${changes.file_count} 个文件吗？`
               : `确认写入 ${changes.file_count} 个文件吗？`}
           </p>
+          {Boolean(selectedProject) ? (
+            <dl className="mt-3 grid min-w-0 gap-2 rounded-lg border border-white/10 bg-black/15 p-3 text-xs sm:grid-cols-[4rem_minmax(0,1fr)]">
+              <dt className="text-slate-400">项目</dt>
+              <dd className="min-w-0 break-all font-semibold text-white">
+                {selectedProject?.name}
+              </dd>
+              <dt className="text-slate-400">当前分支</dt>
+              <dd className="min-w-0">
+                <code className="block break-all text-cyan-100">
+                  {selectedProject?.branch ?? "暂时无法确认"}
+                </code>
+              </dd>
+            </dl>
+          ) : null}
+          {applyResultUnknown ? (
+            <p className="mt-2 text-xs leading-5 text-cyan-100/85">
+              系统会先核对原操作；只有明确确认尚未写入时，才会继续同一次写入，不会盲目重复修改项目。
+            </p>
+          ) : null}
           {hasQualityRisks ? (
             <p className="mt-2 text-xs leading-5 text-amber-100/85">
               检查结果未全部通过，写入后可能需要继续修正。文件与仓库安全边界仍会再次检查。
@@ -425,31 +506,37 @@ export default function CodingApplyPanel({
             }`}
           >
             <li>
-              {selectedProject
-                ? "修改会直接写入你在页面顶部选择的本地项目。"
+              {Boolean(selectedProject)
+                ? "修改会直接写入上方确认的本地项目，不会上传到远程平台。"
                 : "修改会写入预先准备的专用项目副本。"}
             </li>
-            <li>不会自动创建本地版本，也不会上传到远程平台。</li>
             <li>
-              {selectedProject
+              {Boolean(selectedProject)
+                ? "本次只写入文件，不会自动创建本地版本。"
+                : "不会自动创建本地版本，也不会上传到远程平台。"}
+            </li>
+            <li>
+              {Boolean(selectedProject)
                 ? "写入前会再次确认项目版本和现有文件，发现外部改动会立即停止。"
                 : "你当前使用的项目目录不会改变。"}
             </li>
           </ul>
           <div className="mt-3 flex flex-col gap-2 sm:flex-row">
             <button
-              className="min-h-9 rounded-lg border border-white/15 px-3 text-xs font-semibold hover:bg-white/[0.06] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50"
+              className="min-h-11 rounded-lg border border-white/15 px-3 text-xs font-semibold hover:bg-white/[0.06] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50 disabled:cursor-not-allowed disabled:opacity-50"
+              disabled={action !== "idle"}
               onClick={() => setConfirmApply(false)}
               type="button"
             >
               返回检查
             </button>
             <button
-              className={`inline-flex min-h-9 items-center justify-center gap-2 rounded-lg px-3 text-xs font-semibold focus-visible:outline-none focus-visible:ring-2 ${
+              className={`inline-flex min-h-11 items-center justify-center gap-2 rounded-lg px-3 text-xs font-semibold focus-visible:outline-none focus-visible:ring-2 disabled:cursor-not-allowed disabled:opacity-50 ${
                 hasQualityRisks
                   ? "bg-amber-200 text-amber-950 hover:bg-amber-100 focus-visible:ring-amber-100"
                   : "bg-emerald-200 text-emerald-950 hover:bg-emerald-100 focus-visible:ring-emerald-100"
               }`}
+              disabled={action !== "idle" || !canApply}
               onClick={() =>
                 void runAction("applying", () => onApply(hasQualityRisks))
               }
@@ -462,11 +549,13 @@ export default function CodingApplyPanel({
                   size={14}
                 />
               ) : null}
-              {hasQualityRisks
-                ? selectedProject
+              {applyResultUnknown
+                ? "核对并继续本次写入"
+                : hasQualityRisks
+                ? Boolean(selectedProject)
                   ? "了解风险并写入"
                   : "了解风险并应用"
-                : selectedProject
+                : Boolean(selectedProject)
                   ? "确认写入"
                   : "确认应用"}
             </button>
@@ -474,7 +563,7 @@ export default function CodingApplyPanel({
         </div>
       ) : null}
 
-      {message || error ? (
+      {(message || error) && !operationResultUnknown ? (
         <div
           className="mt-3 flex items-start gap-2 rounded-lg bg-rose-300/10 px-3 py-2 text-xs leading-5 text-rose-100"
           role="alert"

--- a/client/src/components/CodingChangesPanel.tsx
+++ b/client/src/components/CodingChangesPanel.tsx
@@ -15,7 +15,7 @@ import {
   Undo2,
   X,
 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import CodingApplyPanel from "./CodingApplyPanel";
 import CodingPublishPanel from "./CodingPublishPanel";
 import CodingVerificationPanel from "./CodingVerificationPanel";
@@ -25,6 +25,7 @@ import type {
   CodingCommitResult,
   CodingDraftChanges,
   CodingDraftFile,
+  CodingProjectSummary,
   CodingPublishResult,
   CodingVerification,
 } from "../types/coding";
@@ -62,6 +63,7 @@ interface CodingChangesPanelProps {
   publishCapability: CodingCapabilities["publish"];
   publishError: string;
   publishResult: CodingPublishResult | null;
+  selectedProject: CodingProjectSummary | null;
   sessionId: string | null;
   verification: CodingVerification | null;
   verificationAvailable: boolean;
@@ -152,6 +154,18 @@ const commitReasonText: Record<string, string> = {
     "项目版本正在更新，当前修改暂时不能保存为本地版本。",
   project_changed:
     "所选项目的版本已经变化。为避免覆盖现有内容，本次保存已停止。",
+  operation_result_unknown:
+    "本次操作的结果暂时无法确认。当前状态会保留，重新连接后将继续核对。",
+  project_host_offline:
+    "本地项目助手连接已断开。当前状态和操作区会保留，重新连接后可继续。",
+  project_host_protocol_readonly:
+    "当前助手版本只支持查看和下载。请更新助手后重新连接，再决定是否保存本地版本。",
+  project_host_unavailable:
+    "本地项目助手当前不可用。当前状态和操作区会保留，重新连接后可继续。",
+  project_host_writeback_disabled:
+    "本地项目写入已关闭。当前修改仍可查看和下载。",
+  project_host_writeback_unavailable:
+    "本地项目助手暂时不能保存本地版本。当前状态会保留，重新连接后可继续。",
   project_writer_not_configured:
     "本地项目写入尚未配置，修改仍可查看、下载和撤销写入。",
   project_writer_timeout:
@@ -194,7 +208,7 @@ interface CodingCommitPanelProps {
   onUndo: () => Promise<void>;
   publishLocked: boolean;
   result: CodingCommitResult | null;
-  selectedProject: boolean;
+  selectedProject: CodingProjectSummary | null;
 }
 
 function CodingCommitPanel({
@@ -228,6 +242,8 @@ function CodingCommitPanel({
     changes.revision,
     result?.commit_id,
     result?.message,
+    result?.reason,
+    result?.state,
     result?.suggested_message,
   ]);
 
@@ -243,15 +259,24 @@ function CodingCommitPanel({
     normalizedMessage.length <= maxChars &&
     subjectLength <= 120;
   const committed = result?.state === "committed";
+  const operationResultUnknown = result?.reason === "operation_result_unknown";
+  const commitResultUnknown =
+    operationResultUnknown && result?.state === "failed" && !result.commit_id;
+  const undoResultUnknown =
+    operationResultUnknown && result?.state === "committed" && Boolean(result.commit_id);
   const waiting =
     action !== "idle" ||
     result?.state === "committing" ||
     result?.state === "undoing";
+  const selectedProjectName = selectedProject?.name ?? "所选本地项目";
+  const selectedProjectBranch = result?.commit_id
+    ? result.branch
+    : selectedProject?.branch;
   const unavailableCopy =
     commitReasonText[capability?.reason ?? ""] ??
     `当前不能创建本地版本，修改仍安全保留在${selectedProject ? "所选项目" : "专用项目副本"}中。`;
   const resultError =
-    result?.state === "failed"
+    result?.state === "failed" && !operationResultUnknown
       ? commitReasonText[result.reason ?? ""] ??
         "本次保存没有完成。修改仍保留，可以使用相同说明重试。"
       : "";
@@ -262,6 +287,7 @@ function CodingCommitPanel({
     nextAction: Exclude<CommitAction, "idle">,
     callback: () => Promise<void>,
   ) => {
+    if (action !== "idle") return;
     setAction(nextAction);
     setLocalError("");
     try {
@@ -278,25 +304,49 @@ function CodingCommitPanel({
   if (committed) {
     return (
       <section
+        aria-busy={waiting}
         aria-labelledby="coding-commit-title"
         className="mt-5 rounded-lg border border-cyan-300/20 bg-cyan-300/[0.055] p-4"
       >
         <div className="flex items-start gap-3">
-          <CheckCircle2
-            aria-hidden="true"
-            className="mt-0.5 shrink-0 text-cyan-200"
-            size={18}
-          />
+          {undoResultUnknown ? (
+            <CircleAlert
+              aria-hidden="true"
+              className="mt-0.5 shrink-0 text-amber-200"
+              size={18}
+            />
+          ) : (
+            <CheckCircle2
+              aria-hidden="true"
+              className="mt-0.5 shrink-0 text-cyan-200"
+              size={18}
+            />
+          )}
           <div className="min-w-0 flex-1">
             <h3 className="text-sm font-semibold text-white" id="coding-commit-title">
-              已保存一个本地版本
+              {undoResultUnknown ? "撤销结果待核对" : "已保存一个本地版本"}
             </h3>
-            <p aria-live="polite" className="mt-1 text-xs leading-5 text-slate-300">
-              {publishLocked
+            <p
+              aria-atomic="true"
+              aria-live="polite"
+              className="mt-1 text-xs leading-5 text-slate-300"
+              role="status"
+            >
+              {undoResultUnknown
+                ? "上次撤销本地版本的结果暂时无法确认。重新连接后请核对原操作；系统不会新建另一条撤销。"
+                : publishLocked
                 ? "这份本地版本已进入 GitHub 发布流程，不能再撤销或继续追加修改。"
-                : selectedProject
-                  ? "这份版本只保存在你选择的本地项目中，不会自动上传到远程平台。"
-                  : "这份版本目前只保存在专用项目副本中，不会自动上传到远程平台。"}
+                : selectedProject ? (
+                    <>
+                      这份版本只保存在“
+                      <span className="break-all font-semibold text-slate-200">
+                        {selectedProjectName}
+                      </span>
+                      ”的本地分支中，不会上传到远程平台。
+                    </>
+                  ) : (
+                    "这份版本目前只保存在专用项目副本中，不会自动上传到远程平台。"
+                  )}
             </p>
             <dl className="mt-3 grid min-w-0 gap-2 text-xs sm:grid-cols-[88px_minmax(0,1fr)]">
               <dt className="text-slate-500">版本说明</dt>
@@ -305,55 +355,88 @@ function CodingCommitPanel({
               </dd>
               <dt className="text-slate-500">本地编号</dt>
               <dd className="min-w-0">
-                <code className="rounded bg-black/25 px-2 py-1 text-cyan-100">
+                <code className="break-all rounded bg-black/25 px-2 py-1 text-cyan-100">
                   {result.short_sha}
+                </code>
+              </dd>
+              <dt className="text-slate-500">本地分支</dt>
+              <dd className="min-w-0">
+                <code className="break-all rounded bg-black/25 px-2 py-1 text-cyan-100">
+                  {result.branch}
                 </code>
               </dd>
             </dl>
           </div>
         </div>
 
-        <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:flex-wrap">
-          {onContinue && !publishLocked ? (
+        {undoResultUnknown ? (
+          <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:flex-wrap">
             <button
-              className="inline-flex min-h-10 w-full items-center justify-center gap-2 rounded-lg bg-cyan-300 px-3 text-sm font-semibold text-ink-950 transition hover:bg-cyan-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-100 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto"
-              disabled={disabled || waiting}
-              onClick={() => void runAction("closing", onContinue)}
+              className="inline-flex min-h-11 w-full items-center justify-center gap-2 rounded-lg bg-amber-200 px-3 text-sm font-semibold text-amber-950 transition hover:bg-amber-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-100 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto"
+              disabled={disabled || waiting || capability?.available !== true}
+              onClick={() => void runAction("undoing", onUndo)}
               type="button"
             >
-              {action === "closing" ? (
-                <LoaderCircle aria-hidden="true" className="animate-spin motion-reduce:animate-none" size={14} />
-              ) : null}
-              继续修改
+              {action === "undoing" ? (
+                <LoaderCircle
+                  aria-hidden="true"
+                  className="animate-spin motion-reduce:animate-none"
+                  size={14}
+                />
+              ) : (
+                <Undo2 aria-hidden="true" size={16} />
+              )}
+              {action === "undoing" ? "正在核对本次撤销" : "核对本次撤销"}
             </button>
-          ) : null}
-          {!publishLocked ? (
+          </div>
+        ) : (
+          <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:flex-wrap">
+            {onContinue && !publishLocked ? (
+              <button
+                className="inline-flex min-h-11 w-full items-center justify-center gap-2 rounded-lg bg-cyan-300 px-3 text-sm font-semibold text-ink-950 transition hover:bg-cyan-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-100 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto"
+                disabled={disabled || waiting}
+                onClick={() => void runAction("closing", onContinue)}
+                type="button"
+              >
+                {action === "closing" ? (
+                  <LoaderCircle aria-hidden="true" className="animate-spin motion-reduce:animate-none" size={14} />
+                ) : null}
+                继续修改
+              </button>
+            ) : null}
+            {!publishLocked ? (
+              <button
+                className="inline-flex min-h-11 w-full items-center justify-center gap-2 rounded-lg border border-amber-300/30 px-3 text-sm font-semibold text-amber-100 transition hover:bg-amber-300/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-200/70 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto"
+                disabled={
+                  disabled ||
+                  waiting ||
+                  !result.can_undo ||
+                  capability?.available !== true
+                }
+                onClick={() => {
+                  setConfirmUndo(true);
+                  setConfirmClose(false);
+                }}
+                type="button"
+              >
+                <Undo2 aria-hidden="true" size={16} />
+                撤销本地提交
+              </button>
+            ) : null}
             <button
-              className="inline-flex min-h-10 w-full items-center justify-center gap-2 rounded-lg border border-amber-300/30 px-3 text-sm font-semibold text-amber-100 transition hover:bg-amber-300/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-200/70 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto"
-              disabled={disabled || waiting || !result.can_undo}
+              className="inline-flex min-h-11 w-full items-center justify-center gap-2 rounded-lg border border-white/15 px-3 text-sm font-semibold text-slate-200 transition hover:bg-white/[0.06] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto"
+              disabled={disabled || waiting}
               onClick={() => {
-                setConfirmUndo(true);
-                setConfirmClose(false);
+                setConfirmClose(true);
+                setConfirmUndo(false);
               }}
               type="button"
             >
-              <Undo2 aria-hidden="true" size={16} />
-              撤销本地提交
+              <X aria-hidden="true" size={16} />
+              结束本次修改
             </button>
-          ) : null}
-          <button
-            className="inline-flex min-h-10 w-full items-center justify-center gap-2 rounded-lg border border-white/15 px-3 text-sm font-semibold text-slate-200 transition hover:bg-white/[0.06] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto"
-            disabled={disabled || waiting}
-            onClick={() => {
-              setConfirmClose(true);
-              setConfirmUndo(false);
-            }}
-            type="button"
-          >
-            <X aria-hidden="true" size={16} />
-            结束本次修改
-          </button>
-        </div>
+          </div>
+        )}
 
         {confirmUndo ? (
           <div
@@ -362,18 +445,34 @@ function CodingCommitPanel({
           >
             <p className="font-semibold">撤销这条本地版本记录吗？</p>
             <p className="mt-1 text-xs leading-5 text-amber-100/80">
-              文件修改会继续保留，你可以修改说明后重新保存，或再撤销已应用的修改。
+              {selectedProject ? (
+                <>
+                  将从“
+                  <span className="break-all font-semibold text-amber-50">
+                    {selectedProjectName}
+                  </span>
+                  ”的分支{" "}
+                  <code className="break-all font-mono text-amber-50">
+                    {result.branch}
+                  </code>{" "}
+                  撤销这条记录。文件修改会继续保留，不会上传任何内容。
+                </>
+              ) : (
+                "文件修改会继续保留，你可以修改说明后重新保存，或再撤销已应用的修改。"
+              )}
             </p>
             <div className="mt-3 flex flex-col gap-2 sm:flex-row">
               <button
-                className="min-h-9 rounded-lg border border-white/15 px-3 text-xs font-semibold hover:bg-white/[0.06] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50"
+                className="min-h-11 rounded-lg border border-white/15 px-3 text-xs font-semibold hover:bg-white/[0.06] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50 disabled:cursor-not-allowed disabled:opacity-50"
+                disabled={action !== "idle"}
                 onClick={() => setConfirmUndo(false)}
                 type="button"
               >
                 保留本地版本
               </button>
               <button
-                className="inline-flex min-h-9 items-center justify-center gap-2 rounded-lg bg-amber-200 px-3 text-xs font-semibold text-amber-950 hover:bg-amber-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-100"
+                className="inline-flex min-h-11 items-center justify-center gap-2 rounded-lg bg-amber-200 px-3 text-xs font-semibold text-amber-950 hover:bg-amber-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-100 disabled:cursor-not-allowed disabled:opacity-50"
+                disabled={action !== "idle" || capability?.available !== true}
                 onClick={() => void runAction("undoing", onUndo)}
                 type="button"
               >
@@ -401,14 +500,16 @@ function CodingCommitPanel({
             </p>
             <div className="mt-3 flex flex-col gap-2 sm:flex-row">
               <button
-                className="min-h-9 rounded-lg border border-white/15 px-3 text-xs font-semibold hover:bg-white/[0.06] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50"
+                className="min-h-11 rounded-lg border border-white/15 px-3 text-xs font-semibold hover:bg-white/[0.06] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50 disabled:cursor-not-allowed disabled:opacity-50"
+                disabled={action !== "idle"}
                 onClick={() => setConfirmClose(false)}
                 type="button"
               >
                 继续留在本页
               </button>
               <button
-                className="inline-flex min-h-9 items-center justify-center gap-2 rounded-lg bg-slate-200 px-3 text-xs font-semibold text-ink-950 hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+                className="inline-flex min-h-11 items-center justify-center gap-2 rounded-lg bg-slate-200 px-3 text-xs font-semibold text-ink-950 hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white disabled:cursor-not-allowed disabled:opacity-50"
+                disabled={action !== "idle"}
                 onClick={() => void runAction("closing", onClose)}
                 type="button"
               >
@@ -425,7 +526,7 @@ function CodingCommitPanel({
           </div>
         ) : null}
 
-        {localError || error ? (
+        {!operationResultUnknown && (localError || error) ? (
           <p
             aria-live="assertive"
             className="mt-3 rounded-lg bg-rose-300/10 px-3 py-2 text-xs leading-5 text-rose-100"
@@ -440,6 +541,7 @@ function CodingCommitPanel({
 
   return (
     <section
+      aria-busy={waiting}
       aria-labelledby="coding-commit-title"
       className="mt-5 rounded-lg border border-white/10 bg-white/[0.025] p-4"
     >
@@ -460,12 +562,36 @@ function CodingCommitPanel({
           <p className="mt-1 text-xs leading-5 text-slate-400">
             {capability?.available
               ? selectedProject
-                ? "填写版本说明后，在所选本地项目中保存一个可找回的版本。不会自动上传。"
+                ? "填写版本说明后，在上方确认的项目当前分支保存一个可找回的本地版本。不会上传。"
                 : "填写版本说明后创建本地提交。它只保存在专用副本，不会自动上传，也不会改变你当前使用的项目目录。"
               : unavailableCopy}
           </p>
         </div>
       </div>
+
+      {result?.state === "committing" || result?.state === "undoing" ? (
+        <p
+          aria-atomic="true"
+          aria-live="polite"
+          className="mt-4 rounded-lg bg-cyan-300/10 px-3 py-2 text-xs leading-5 text-cyan-100"
+          role="status"
+        >
+          {result.state === "undoing"
+            ? "正在核对本地版本撤销结果，请勿重复操作。"
+            : "正在核对本地版本保存结果，请勿重复操作。"}
+        </p>
+      ) : null}
+
+      {commitResultUnknown ? (
+        <p
+          aria-atomic="true"
+          aria-live="polite"
+          className="mt-4 rounded-lg bg-amber-300/10 px-3 py-2 text-xs leading-5 text-amber-100"
+          role="status"
+        >
+          上次保存结果暂时无法确认。重新连接后可核对原操作；只有确认尚未提交时，系统才会继续同一次保存。
+        </p>
+      ) : null}
 
       {result?.state === "undone" ? (
         <p
@@ -485,7 +611,9 @@ function CodingCommitPanel({
       <textarea
         aria-describedby="coding-commit-message-help"
         className="mt-2 min-h-24 w-full min-w-0 resize-y rounded-lg border border-white/10 bg-ink-950/75 px-3 py-2 text-sm leading-6 text-white outline-none transition placeholder:text-slate-500 hover:border-white/20 focus:border-cyan-300/70 focus:ring-4 focus:ring-cyan-300/10 disabled:cursor-not-allowed disabled:opacity-60"
-        disabled={!capability?.available || disabled || waiting}
+        disabled={
+          !capability?.available || disabled || waiting || commitResultUnknown
+        }
         id="coding-commit-message"
         maxLength={maxChars}
         onChange={(event) => {
@@ -508,44 +636,73 @@ function CodingCommitPanel({
       </div>
 
       <button
-        className="mt-4 inline-flex min-h-10 w-full items-center justify-center gap-2 rounded-lg bg-cyan-300 px-3 text-sm font-semibold text-ink-950 transition hover:bg-cyan-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-100 disabled:cursor-not-allowed disabled:bg-slate-700 disabled:text-slate-400 sm:w-auto"
+        className="mt-4 inline-flex min-h-11 w-full items-center justify-center gap-2 rounded-lg bg-cyan-300 px-3 text-sm font-semibold text-ink-950 transition hover:bg-cyan-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-100 disabled:cursor-not-allowed disabled:bg-slate-700 disabled:text-slate-400 sm:w-auto"
         disabled={!capability?.available || disabled || waiting || !validMessage}
         onClick={() => setConfirmCommit(true)}
         type="button"
       >
         <Save aria-hidden="true" size={16} />
-        创建本地提交
+        {commitResultUnknown ? "核对本次保存" : "创建本地提交"}
       </button>
 
       {confirmCommit ? (
         <div
-          aria-live="polite"
+          aria-labelledby="coding-commit-confirm-title"
           className="mt-4 rounded-lg border border-cyan-300/15 bg-cyan-300/[0.065] p-3 text-sm text-cyan-50"
+          role="group"
         >
-          <p className="font-semibold">确认保存 {changes.file_count} 个文件吗？</p>
+          <p className="font-semibold" id="coding-commit-confirm-title">
+            {commitResultUnknown
+              ? "核对上一次保存结果吗？"
+              : `确认保存 ${changes.file_count} 个文件吗？`}
+          </p>
+          {commitResultUnknown ? (
+            <p className="mt-2 text-xs leading-5 text-cyan-100/85">
+              系统会先核对原操作；只有明确确认尚未提交时，才会继续使用相同说明完成同一次保存。
+            </p>
+          ) : null}
           <ul className="mt-2 space-y-1 text-xs leading-5 text-cyan-100/80">
             <li>
-              {selectedProject
-                ? "会在所选本地项目中创建一条本地版本记录。"
-                : "会在专用项目副本中创建一条本地版本记录。"}
+              {selectedProject ? (
+                <>
+                  会在“
+                  <span className="break-all font-semibold text-cyan-50">
+                    {selectedProjectName}
+                  </span>
+                  ”的分支{" "}
+                  <code className="break-all font-mono text-cyan-50">
+                    {selectedProjectBranch ?? "暂时无法确认"}
+                  </code>{" "}
+                  创建一条本地版本记录。
+                </>
+              ) : (
+                "会在专用项目副本中创建一条本地版本记录。"
+              )}
             </li>
             <li>
               {selectedProject
-                ? "不会自动上传，也不会创建 GitHub PR。"
+                ? "只会修改这个本地项目；不会上传，不会访问远程仓库，也不会创建 GitHub PR。"
                 : "不会提交到你当前使用的项目目录，也不会自动上传；发布到 GitHub 需要另行确认。"}
             </li>
             <li>保存后仍可安全撤销记录，文件修改会继续保留。</li>
           </ul>
           <div className="mt-3 flex flex-col gap-2 sm:flex-row">
             <button
-              className="min-h-9 rounded-lg border border-white/15 px-3 text-xs font-semibold hover:bg-white/[0.06] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50"
+              className="min-h-11 rounded-lg border border-white/15 px-3 text-xs font-semibold hover:bg-white/[0.06] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50 disabled:cursor-not-allowed disabled:opacity-50"
+              disabled={action !== "idle"}
               onClick={() => setConfirmCommit(false)}
               type="button"
             >
               返回修改说明
             </button>
             <button
-              className="inline-flex min-h-9 items-center justify-center gap-2 rounded-lg bg-cyan-200 px-3 text-xs font-semibold text-cyan-950 hover:bg-cyan-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-100"
+              className="inline-flex min-h-11 items-center justify-center gap-2 rounded-lg bg-cyan-200 px-3 text-xs font-semibold text-cyan-950 hover:bg-cyan-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-100 disabled:cursor-not-allowed disabled:opacity-50"
+              disabled={
+                action !== "idle" ||
+                capability?.available !== true ||
+                !validMessage ||
+                (Boolean(selectedProject) && !selectedProjectBranch)
+              }
               onClick={() =>
                 void runAction("committing", () => onCommit(normalizedMessage))
               }
@@ -558,13 +715,13 @@ function CodingCommitPanel({
                   size={14}
                 />
               ) : null}
-              确认保存到本地
+              {commitResultUnknown ? "核对并继续本次保存" : "确认保存到本地"}
             </button>
           </div>
         </div>
       ) : null}
 
-      {resultError || localError || error ? (
+      {!operationResultUnknown && (resultError || localError || error) ? (
         <p
           aria-live="assertive"
           className="mt-3 rounded-lg bg-rose-300/10 px-3 py-2 text-xs leading-5 text-rose-100"
@@ -618,6 +775,7 @@ export default function CodingChangesPanel({
   publishCapability,
   publishError,
   publishResult,
+  selectedProject,
   sessionId,
   verification,
   verificationAvailable,
@@ -630,6 +788,9 @@ export default function CodingChangesPanel({
   const [diffs, setDiffs] = useState<Record<string, string>>({});
   const [diffLoading, setDiffLoading] = useState("");
   const [message, setMessage] = useState("");
+  const actionInFlightRef = useRef(false);
+  const writebackInFlightRef = useRef(false);
+  const [writebackBusy, setWritebackBusy] = useState(false);
 
   useEffect(() => {
     setExpandedPath(null);
@@ -650,6 +811,8 @@ export default function CodingChangesPanel({
     nextAction: Exclude<ActionState, "idle">,
     callback: () => Promise<void>,
   ) => {
+    if (actionInFlightRef.current || writebackInFlightRef.current) return;
+    actionInFlightRef.current = true;
     setAction(nextAction);
     setMessage("");
     try {
@@ -660,7 +823,20 @@ export default function CodingChangesPanel({
     } catch (error) {
       setMessage(describeReviewError(error));
     } finally {
+      actionInFlightRef.current = false;
       setAction("idle");
+    }
+  };
+
+  const runWritebackAction = async (callback: () => Promise<void>) => {
+    if (writebackInFlightRef.current || actionInFlightRef.current) return;
+    writebackInFlightRef.current = true;
+    setWritebackBusy(true);
+    try {
+      await callback();
+    } finally {
+      writebackInFlightRef.current = false;
+      setWritebackBusy(false);
     }
   };
 
@@ -693,7 +869,13 @@ export default function CodingChangesPanel({
   const completedWithoutChanges = Boolean(
     changes && changes.revision > 0 && !hasChanges,
   );
-  const isActing = action !== "idle";
+  const isActing = action !== "idle" || writebackBusy;
+  const serverWritebackActive = Boolean(
+    applyResult?.state === "applying" ||
+      applyResult?.state === "reverting" ||
+      commitResult?.state === "committing" ||
+      commitResult?.state === "undoing",
+  );
   const verificationRunning =
     verification?.stale === false &&
     ["awaiting_confirmation", "running"].includes(
@@ -947,19 +1129,27 @@ export default function CodingChangesPanel({
                   verification={verification}
                 />
 
-                {commitResult?.state !== "committed" ? (
+                {commitResult?.state !== "committed" &&
+                commitResult?.reason !== "operation_result_unknown" ? (
                   <CodingApplyPanel
                     capability={applyCapability}
                     changes={changes}
                     disabled={
-                      disabled || readOnly || isActing || verificationRunning
+                      disabled ||
+                      readOnly ||
+                      isActing ||
+                      writebackBusy ||
+                      serverWritebackActive ||
+                      verificationRunning
                     }
                     error={applyError}
-                    onApply={onApply}
-                    onClose={onClose}
-                    onRevert={onRevert}
+                    onApply={(confirmQualityRisks) =>
+                      runWritebackAction(() => onApply(confirmQualityRisks))
+                    }
+                    onClose={() => runWritebackAction(onClose)}
+                    onRevert={() => runWritebackAction(onRevert)}
                     result={applyResult}
-                    selectedProject={localWriteback}
+                    selectedProject={localWriteback ? selectedProject : null}
                     verification={verification}
                   />
                 ) : null}
@@ -968,15 +1158,27 @@ export default function CodingChangesPanel({
                   applyResult={applyResult}
                   capability={commitCapability}
                   changes={changes}
-                  disabled={disabled || readOnly || isActing}
+                  disabled={
+                    disabled ||
+                    readOnly ||
+                    isActing ||
+                    writebackBusy ||
+                    serverWritebackActive
+                  }
                   error={commitError}
-                  onCommit={onCommit}
-                  onContinue={onContinue}
-                  onClose={onClose}
-                  onUndo={onUndoCommit}
+                  onCommit={(commitMessage) =>
+                    runWritebackAction(() => onCommit(commitMessage))
+                  }
+                  onContinue={
+                    onContinue
+                      ? () => runWritebackAction(onContinue)
+                      : undefined
+                  }
+                  onClose={() => runWritebackAction(onClose)}
+                  onUndo={() => runWritebackAction(onUndoCommit)}
                   publishLocked={Boolean(publishResult?.publish_id)}
                   result={commitResult}
-                  selectedProject={localWriteback}
+                  selectedProject={localWriteback ? selectedProject : null}
                 />
 
                 {!localWriteback ? (
@@ -996,7 +1198,7 @@ export default function CodingChangesPanel({
 
             <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:flex-wrap">
               <button
-                className="inline-flex min-h-10 items-center justify-center gap-2 rounded-lg border border-white/15 px-3 text-sm font-semibold text-slate-200 transition hover:border-cyan-300/45 hover:bg-cyan-300/10 hover:text-cyan-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300/70 disabled:cursor-not-allowed disabled:opacity-50"
+                className="inline-flex min-h-11 items-center justify-center gap-2 rounded-lg border border-white/15 px-3 text-sm font-semibold text-slate-200 transition hover:border-cyan-300/45 hover:bg-cyan-300/10 hover:text-cyan-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300/70 disabled:cursor-not-allowed disabled:opacity-50"
                 disabled={disabled || readOnly || frozen || isActing}
                 onClick={() =>
                   void runAction("checking", onValidate)
@@ -1015,7 +1217,7 @@ export default function CodingChangesPanel({
                 检查修改
               </button>
               <button
-                className="inline-flex min-h-10 items-center justify-center gap-2 rounded-lg bg-cyan-300 px-3 text-sm font-semibold text-ink-950 transition hover:bg-cyan-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-100 disabled:cursor-not-allowed disabled:bg-slate-700 disabled:text-slate-400"
+                className="inline-flex min-h-11 items-center justify-center gap-2 rounded-lg bg-cyan-300 px-3 text-sm font-semibold text-ink-950 transition hover:bg-cyan-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-100 disabled:cursor-not-allowed disabled:bg-slate-700 disabled:text-slate-400"
                 disabled={
                   disabled ||
                   isActing
@@ -1035,7 +1237,7 @@ export default function CodingChangesPanel({
                 下载 Diff
               </button>
               <button
-                className="inline-flex min-h-10 items-center justify-center gap-2 rounded-lg px-3 text-sm font-semibold text-rose-100 transition hover:bg-rose-300/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-300/60 disabled:cursor-not-allowed disabled:opacity-50"
+                className="inline-flex min-h-11 items-center justify-center gap-2 rounded-lg px-3 text-sm font-semibold text-rose-100 transition hover:bg-rose-300/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-300/60 disabled:cursor-not-allowed disabled:opacity-50"
                 disabled={
                   disabled || readOnly || frozen || isActing || verificationRunning
                 }
@@ -1058,14 +1260,16 @@ export default function CodingChangesPanel({
                 </p>
                 <div className="mt-3 flex flex-col gap-2 sm:flex-row">
                   <button
-                    className="min-h-9 rounded-lg border border-white/15 px-3 text-xs font-semibold transition hover:bg-white/[0.06] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50"
+                    className="min-h-11 rounded-lg border border-white/15 px-3 text-xs font-semibold transition hover:bg-white/[0.06] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50 disabled:cursor-not-allowed disabled:opacity-50"
+                    disabled={isActing}
                     onClick={() => setConfirmDownload(false)}
                     type="button"
                   >
                     返回查看
                   </button>
                   <button
-                    className="inline-flex min-h-9 items-center justify-center gap-2 rounded-lg bg-amber-200 px-3 text-xs font-semibold text-amber-950 transition hover:bg-amber-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-100"
+                    className="inline-flex min-h-11 items-center justify-center gap-2 rounded-lg bg-amber-200 px-3 text-xs font-semibold text-amber-950 transition hover:bg-amber-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-100 disabled:cursor-not-allowed disabled:opacity-50"
+                    disabled={isActing}
                     onClick={() => {
                       setConfirmDownload(false);
                       void runAction("downloading", onDownload);
@@ -1090,14 +1294,16 @@ export default function CodingChangesPanel({
                 </p>
                 <div className="mt-3 flex flex-col gap-2 sm:flex-row">
                   <button
-                    className="min-h-9 rounded-lg border border-white/15 px-3 text-xs font-semibold transition hover:bg-white/[0.06] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50"
+                    className="min-h-11 rounded-lg border border-white/15 px-3 text-xs font-semibold transition hover:bg-white/[0.06] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50 disabled:cursor-not-allowed disabled:opacity-50"
+                    disabled={isActing}
                     onClick={() => setConfirmDiscard(false)}
                     type="button"
                   >
                     继续保留
                   </button>
                   <button
-                    className="inline-flex min-h-9 items-center justify-center gap-2 rounded-lg bg-rose-200 px-3 text-xs font-semibold text-rose-950 transition hover:bg-rose-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-100"
+                    className="inline-flex min-h-11 items-center justify-center gap-2 rounded-lg bg-rose-200 px-3 text-xs font-semibold text-rose-950 transition hover:bg-rose-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-100 disabled:cursor-not-allowed disabled:opacity-50"
+                    disabled={isActing}
                     onClick={() =>
                       void runAction("discarding", onDiscard)
                     }
@@ -1169,7 +1375,7 @@ export default function CodingChangesPanel({
             如果不再继续追问，可以结束当前任务并选择其他项目。本次回答不会保存。
           </p>
           <button
-            className="mt-3 inline-flex min-h-10 items-center justify-center gap-2 rounded-lg border border-white/15 px-3 text-sm font-semibold text-slate-200 transition hover:border-cyan-300/45 hover:bg-cyan-300/10 hover:text-cyan-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300/70 disabled:cursor-not-allowed disabled:opacity-50"
+            className="mt-3 inline-flex min-h-11 items-center justify-center gap-2 rounded-lg border border-white/15 px-3 text-sm font-semibold text-slate-200 transition hover:border-cyan-300/45 hover:bg-cyan-300/10 hover:text-cyan-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300/70 disabled:cursor-not-allowed disabled:opacity-50"
             disabled={disabled || readOnly || isActing}
             onClick={() => void runAction("closing", onClose)}
             type="button"

--- a/client/src/components/CodingRecoveryCard.tsx
+++ b/client/src/components/CodingRecoveryCard.tsx
@@ -6,8 +6,11 @@ import {
   RotateCcw,
   Trash2,
 } from "lucide-react";
-import { useEffect, useState } from "react";
-import type { CodingRecoveryStatus } from "../types/coding";
+import { useEffect, useRef, useState } from "react";
+import type {
+  CodingProjectKind,
+  CodingRecoveryStatus,
+} from "../types/coding";
 
 export type CodingRecoveryAction =
   | "idle"
@@ -40,21 +43,84 @@ const reasonText: Record<string, string> = {
     "这个项目已不在可选列表中，现在只允许下载或放弃。",
   project_source_unavailable:
     "暂时无法读取这个项目，这份修改仍安全保留，可以先下载备份。",
-  apply_recovery_conflict:
-    "专用项目副本后来发生了变化。为避免覆盖人工内容，现在只允许查看、下载或放弃。",
   commit_recovery_conflict:
     "本地版本状态后来发生了变化。为避免覆盖人工内容，现在只允许查看、下载或放弃。",
   recovery_conflict:
     "外部内容与上次记录不一致。为避免覆盖人工内容，现在只允许查看、下载或放弃。",
 };
 
-function stateText(state: CodingRecoveryStatus["state"]) {
-  if (state === "applied") return "修改已写入专用项目副本";
-  if (state === "committed") return "修改已保存为本地版本";
-  if (state === "undone") return "本地版本已撤销，文件修改仍保留";
-  if (state === "reverted") return "写入已撤销，修改记录仍保留";
+const projectHostOfflineReasons = new Set([
+  "project_host_offline",
+  "project_host_unavailable",
+]);
+
+const projectHostWritebackReasons = new Set([
+  "project_host_protocol_readonly",
+  "project_host_writeback_disabled",
+  "project_host_writeback_unavailable",
+  "project_operation_unavailable",
+]);
+
+function stateText(
+  state: CodingRecoveryStatus["state"],
+  projectKind: CodingProjectKind,
+) {
+  if (state === "applied") {
+    return projectKind === "host_git"
+      ? "修改已写入所选本地项目"
+      : "修改已写入专用项目副本";
+  }
+  if (state === "committed") {
+    return projectKind === "host_git"
+      ? "修改已在所选本地项目中保存为本地版本"
+      : "修改已保存为本地版本";
+  }
+  if (state === "undone") {
+    return projectKind === "host_git"
+      ? "所选本地项目的本地版本已撤销，文件修改仍保留"
+      : "本地版本已撤销，文件修改仍保留";
+  }
+  if (state === "reverted") {
+    return projectKind === "host_git"
+      ? "所选本地项目的写入已撤销，修改记录仍保留"
+      : "写入已撤销，修改记录仍保留";
+  }
   if (state === "conflict") return "需要人工确认外部变化";
   return "修改草稿尚未完成";
+}
+
+function recoveryReasonText(
+  recovery: CodingRecoveryStatus,
+  projectKind: CodingProjectKind,
+) {
+  const reason = recovery.reason ?? recovery.project?.writeback_reason ?? null;
+  if (projectKind === "host_git" && reason) {
+    if (projectHostOfflineReasons.has(reason)) {
+      return "本地项目助手连接已断开。请重新打开助手并恢复连接；这份 Diff 仍保留，可以先下载备份。";
+    }
+    if (projectHostWritebackReasons.has(reason)) {
+      return "当前助手不能继续执行写入。请使用支持写入的最新版助手重新连接；这份 Diff 仍保留，可以先下载备份。";
+    }
+    if (reason === "apply_recovery_conflict") {
+      return "所选本地项目后来发生了变化。为避免覆盖人工内容，现在只允许查看、下载或放弃。";
+    }
+  }
+  if (reason === "apply_recovery_conflict") {
+    return "专用项目副本后来发生了变化。为避免覆盖人工内容，现在只允许查看、下载或放弃。";
+  }
+  return reason
+    ? reasonText[reason] ?? "这份修改暂时不能继续处理，但仍可下载或放弃。"
+    : "你可以继续处理，也可以先下载 Diff 留作备份。";
+}
+
+function discardDescription(projectKind: CodingProjectKind) {
+  if (projectKind === "host_git") {
+    return "页面将不再提供继续或下载。放弃恢复记录不会改变所选本地项目中已经写入的文件或本地版本。";
+  }
+  if (projectKind === "local_clone") {
+    return "页面将不再提供继续或下载。已经写入受控项目副本的文件和本地版本不会被改变。";
+  }
+  return "页面将不再提供继续或下载。已经写入 ModelMirror 专用项目副本的文件和本地版本不会被改变。";
 }
 
 function formatSavedAt(value?: number) {
@@ -75,11 +141,23 @@ export default function CodingRecoveryCard({
   recovery,
 }: CodingRecoveryCardProps) {
   const [confirmDiscard, setConfirmDiscard] = useState(false);
-  const busy = action !== "idle";
-  const reason = recovery.reason
-    ? reasonText[recovery.reason] ??
-      "这份修改暂时不能继续处理，但仍可下载或放弃。"
-    : "你可以继续处理，也可以先下载 Diff 留作备份。";
+  const recoveryInFlightRef = useRef(false);
+  const [localBusy, setLocalBusy] = useState(false);
+  const busy = action !== "idle" || localBusy;
+  const projectKind = recovery.project?.kind ?? "builtin";
+  const reason = recoveryReasonText(recovery, projectKind);
+
+  const runRecoveryAction = async (callback: () => Promise<void>) => {
+    if (recoveryInFlightRef.current || action !== "idle") return;
+    recoveryInFlightRef.current = true;
+    setLocalBusy(true);
+    try {
+      await callback();
+    } finally {
+      recoveryInFlightRef.current = false;
+      setLocalBusy(false);
+    }
+  };
 
   useEffect(() => {
     setConfirmDiscard(false);
@@ -87,6 +165,7 @@ export default function CodingRecoveryCard({
 
   return (
     <section
+      aria-busy={busy}
       aria-labelledby="coding-recovery-title"
       className="mb-5 overflow-hidden rounded-lg border border-cyan-300/25 bg-cyan-300/[0.07]"
     >
@@ -111,16 +190,25 @@ export default function CodingRecoveryCard({
           >
             发现一份未完成的修改
           </h2>
-          <p className="mt-1 text-sm leading-6 text-slate-300">
-            {stateText(recovery.state)}，共 {recovery.file_count ?? 0} 个文件。
+          <p className="mt-1 break-words text-sm leading-6 text-slate-300">
+            {stateText(recovery.state, projectKind)}，共 {recovery.file_count ?? 0} 个文件。
             此前对话没有保存。
           </p>
           {recovery.project ? (
-            <p className="mt-1 text-xs font-medium text-cyan-100/90">
-              对应项目：{recovery.project.name}
-            </p>
+            <div className="mt-1 min-w-0 text-xs font-medium text-cyan-100/90">
+              <p className="min-w-0">
+                对应项目：
+                <span className="break-all">{recovery.project.name}</span>
+              </p>
+              {recovery.project.branch ? (
+                <p className="mt-0.5 min-w-0">
+                  记录分支：
+                  <span className="break-all">{recovery.project.branch}</span>
+                </p>
+              ) : null}
+            </div>
           ) : null}
-          <p className="mt-1 text-xs leading-5 text-slate-400">
+          <p className="mt-1 break-words text-xs leading-5 text-slate-400">
             {reason} 上次保存：{formatSavedAt(recovery.updated_at)}。
           </p>
         </div>
@@ -129,9 +217,9 @@ export default function CodingRecoveryCard({
       <div className="border-t border-white/10 px-4 py-4 sm:px-5">
         <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap">
           <button
-            className="inline-flex min-h-10 items-center justify-center gap-2 rounded-lg bg-cyan-300 px-4 text-sm font-semibold text-ink-950 transition hover:bg-cyan-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-100 disabled:cursor-not-allowed disabled:bg-slate-700 disabled:text-slate-400"
+            className="inline-flex min-h-11 items-center justify-center gap-2 rounded-lg bg-cyan-300 px-4 text-sm font-semibold text-ink-950 transition hover:bg-cyan-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-100 disabled:cursor-not-allowed disabled:bg-slate-700 disabled:text-slate-400"
             disabled={busy || recovery.can_resume !== true}
-            onClick={() => void onResume()}
+            onClick={() => void runRecoveryAction(onResume)}
             type="button"
           >
             {action === "resuming" ? (
@@ -146,9 +234,9 @@ export default function CodingRecoveryCard({
             继续上次修改
           </button>
           <button
-            className="inline-flex min-h-10 items-center justify-center gap-2 rounded-lg border border-white/15 px-4 text-sm font-semibold text-slate-200 transition hover:border-cyan-300/40 hover:bg-white/[0.055] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-200/70 disabled:cursor-not-allowed disabled:opacity-50"
+            className="inline-flex min-h-11 items-center justify-center gap-2 rounded-lg border border-white/15 px-4 text-sm font-semibold text-slate-200 transition hover:border-cyan-300/40 hover:bg-white/[0.055] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-200/70 disabled:cursor-not-allowed disabled:opacity-50"
             disabled={busy || recovery.can_download !== true}
-            onClick={() => void onDownload()}
+            onClick={() => void runRecoveryAction(onDownload)}
             type="button"
           >
             {action === "downloading" ? (
@@ -163,7 +251,7 @@ export default function CodingRecoveryCard({
             下载 Diff
           </button>
           <button
-            className="inline-flex min-h-10 items-center justify-center gap-2 rounded-lg px-4 text-sm font-semibold text-rose-100 transition hover:bg-rose-300/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-200/70 disabled:cursor-not-allowed disabled:opacity-50"
+            className="inline-flex min-h-11 items-center justify-center gap-2 rounded-lg px-4 text-sm font-semibold text-rose-100 transition hover:bg-rose-300/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-200/70 disabled:cursor-not-allowed disabled:opacity-50"
             disabled={busy}
             onClick={() => setConfirmDiscard(true)}
             type="button"
@@ -179,12 +267,12 @@ export default function CodingRecoveryCard({
             className="mt-4 rounded-lg bg-rose-300/10 p-3 text-sm text-rose-100"
           >
             <p className="font-semibold">确定放弃这份恢复记录吗？</p>
-            <p className="mt-1 text-xs leading-5 text-rose-100/80">
-              页面将不再提供继续或下载。已经写入专用项目副本的文件和本地版本不会被改变。
+            <p className="mt-1 break-words text-xs leading-5 text-rose-100/80">
+              {discardDescription(projectKind)}
             </p>
             <div className="mt-3 flex flex-col gap-2 sm:flex-row">
               <button
-                className="min-h-9 rounded-lg border border-white/15 px-3 text-xs font-semibold transition hover:bg-white/[0.06] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50"
+                className="min-h-11 rounded-lg border border-white/15 px-3 text-xs font-semibold transition hover:bg-white/[0.06] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50 disabled:cursor-not-allowed disabled:opacity-50"
                 disabled={busy}
                 onClick={() => setConfirmDiscard(false)}
                 type="button"
@@ -192,9 +280,9 @@ export default function CodingRecoveryCard({
                 继续保留
               </button>
               <button
-                className="inline-flex min-h-9 items-center justify-center gap-2 rounded-lg bg-rose-200 px-3 text-xs font-semibold text-rose-950 transition hover:bg-rose-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-100 disabled:cursor-not-allowed disabled:opacity-50"
+                className="inline-flex min-h-11 items-center justify-center gap-2 rounded-lg bg-rose-200 px-3 text-xs font-semibold text-rose-950 transition hover:bg-rose-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-100 disabled:cursor-not-allowed disabled:opacity-50"
                 disabled={busy}
-                onClick={() => void onDiscard()}
+                onClick={() => void runRecoveryAction(onDiscard)}
                 type="button"
               >
                 {action === "discarding" ? (
@@ -211,12 +299,20 @@ export default function CodingRecoveryCard({
         ) : null}
 
         {notice ? (
-          <p aria-live="polite" className="mt-3 text-sm text-cyan-100" role="status">
+          <p
+            aria-live="polite"
+            className="mt-3 break-words text-sm text-cyan-100"
+            role="status"
+          >
             {notice}
           </p>
         ) : null}
         {error ? (
-          <p aria-live="assertive" className="mt-3 text-sm text-rose-100" role="alert">
+          <p
+            aria-live="assertive"
+            className="mt-3 break-words text-sm text-rose-100"
+            role="alert"
+          >
             {error}
           </p>
         ) : null}

--- a/client/src/pages/CodingPage.tsx
+++ b/client/src/pages/CodingPage.tsx
@@ -65,6 +65,7 @@ import {
   getPendingCodingCommand,
   getCodingHistory,
   getCodingPatch,
+  getCodingProjectHost,
   getCodingProjects,
   getCodingPublishStatus,
   getCodingRecovery,
@@ -122,6 +123,21 @@ const BUILTIN_PROJECT: CodingProjectSummary = {
   reason: null,
   state: "available",
 };
+
+function mergeProjectCatalog(
+  current: CodingProjectSummary[],
+  incoming: CodingProjectSummary[],
+) {
+  return incoming.map((project) => {
+    if (project.kind !== "host_git") return project;
+    const previous = current.find((item) => item.id === project.id);
+    return {
+      ...project,
+      branch: project.branch ?? previous?.branch ?? null,
+      head: project.head ?? previous?.head ?? null,
+    };
+  });
+}
 
 function readStoredCodingSession(): StoredCodingSession | null {
   if (typeof window === "undefined") return null;
@@ -243,6 +259,16 @@ const projectReason: Record<string, string> = {
   git_remote_not_allowed:
     "项目仍连接远程平台。移除远程连接后才能开放本地写入。",
   project_not_found: "项目已从清单中移除。",
+  project_host_offline:
+    "本地项目助手连接已断开。重新连接前仍可查看和下载已有修改。",
+  project_host_protocol_readonly:
+    "当前助手版本只支持查看和下载；更新助手后才能直接写入。",
+  project_host_unavailable:
+    "本地项目助手当前不可用。重新连接前仍可查看和下载已有修改。",
+  project_host_writeback_disabled:
+    "本地项目写入已关闭，仍可查看、检查和下载修改。",
+  project_host_writeback_unavailable:
+    "本地项目助手暂时不能执行写入，重新连接后可继续。",
   project_source_unavailable: "本地项目服务暂时不可用。",
   snapshot_limit_exceeded: "项目文件数量或大小超出本轮限制。",
   project_writer_not_configured:
@@ -295,10 +321,12 @@ function CodingSidebar({
   isDraft,
   localDraftOnly,
   localWriteback,
+  localWritebackAvailable,
 }: {
   isDraft: boolean;
   localDraftOnly: boolean;
   localWriteback: boolean;
+  localWritebackAvailable: boolean;
 }) {
   return (
     <div>
@@ -318,7 +346,9 @@ function CodingSidebar({
             {localDraftOnly
               ? "所有修改只保存在临时副本；你可以查看并下载 Diff，本地项目不会被写入。"
               : localWriteback
-                ? "所有修改先保存在临时副本，只有你确认后才会写入所选本地项目。"
+                ? localWritebackAvailable
+                  ? "所有修改先保存在临时副本，只有你确认后才会写入所选本地项目。"
+                  : "已有写入状态和 Diff 会继续保留；当前只允许查看，恢复本地写入能力后才能核对或继续操作。"
               : isDraft
               ? "所有修改先保存在临时副本，只有你确认后才会写入专用项目副本。"
               : "只查看固定的 ModelMirror 项目代码。"}
@@ -336,7 +366,9 @@ function CodingSidebar({
             {localDraftOnly
               ? "检查不能联网，运行产生的文件会被丢弃；不会创建本地提交或 GitHub PR。"
               : localWriteback
-                ? "写入后可保存本地版本并安全撤销；不会自动上传，也不会创建 GitHub PR。"
+                ? localWritebackAvailable
+                  ? "写入后可保存本地版本并安全撤销；不会自动上传，也不会创建 GitHub PR。"
+                  : "已有本地状态不会被清除，也不会因为本地写入能力暂时不可用而误报为失败。"
               : isDraft
               ? "只有你再次确认，才会保存为本地提交；不会自动上传或合并，发布到 GitHub 还需单独确认。当前项目目录始终不受影响。"
               : "不会修改文件、生成变更或提交代码。"}
@@ -402,7 +434,7 @@ function CodingCommandConfirmation({
           </details>
           <div className="mt-4 flex flex-col gap-2 sm:flex-row">
             <button
-              className="inline-flex min-h-10 items-center justify-center rounded-lg border border-white/15 px-3 text-sm font-semibold text-slate-200 transition hover:bg-white/[0.05] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-300/60 disabled:cursor-not-allowed disabled:opacity-50"
+              className="inline-flex min-h-11 items-center justify-center rounded-lg border border-white/15 px-3 text-sm font-semibold text-slate-200 transition hover:bg-white/[0.05] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-300/60 disabled:cursor-not-allowed disabled:opacity-50"
               disabled={action !== "idle"}
               onClick={() => void onDecision("reject")}
               type="button"
@@ -410,7 +442,7 @@ function CodingCommandConfirmation({
               {action === "rejecting" ? "正在拒绝" : "暂不运行"}
             </button>
             <button
-              className="inline-flex min-h-10 items-center justify-center rounded-lg bg-cyan-200 px-3 text-sm font-semibold text-slate-950 transition hover:bg-cyan-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-100 disabled:cursor-not-allowed disabled:opacity-50"
+              className="inline-flex min-h-11 items-center justify-center rounded-lg bg-cyan-200 px-3 text-sm font-semibold text-slate-950 transition hover:bg-cyan-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-100 disabled:cursor-not-allowed disabled:opacity-50"
               disabled={action !== "idle"}
               onClick={() => void onDecision("allow_once")}
               type="button"
@@ -499,29 +531,118 @@ export default function CodingPage() {
   const pendingSessionStoreRef = useRef<StoredCodingSession | null>(null);
   const streamRenderTimerRef = useRef<number | null>(null);
   const initialDraftLoadSessionRef = useRef<string | null>(null);
+  const hostStatusSignatureRef = useRef<string | null>(null);
   const isDraftMode = capabilities?.mode === "draft";
   const selectedProject =
     projects.find((project) => project.id === selectedProjectId) ??
     (recovery?.project?.id === selectedProjectId ? recovery.project : null) ??
     (selectedProjectId === "modelmirror" ? BUILTIN_PROJECT : null);
-  const isLocalProject =
-    selectedProject?.kind === "local_clone" || selectedProject?.kind === "host_git";
+  const isHostProject = selectedProject?.kind === "host_git";
+  const isManifestProject = selectedProject?.kind === "local_clone";
+  const isLocalProject = isManifestProject || isHostProject;
+  const hostRuntimeReason =
+    capabilities?.project_host?.writeback_reason ??
+    capabilities?.project_host?.reason;
+  const hostProjectReason =
+    selectedProject?.writeback_reason ?? selectedProject?.reason;
+  const hostRuntimeWritebackAvailable = Boolean(
+    capabilities?.project_host?.enabled === true &&
+      capabilities?.project_host?.direct_writeback === true &&
+      capabilities?.project_host?.writeback_available !== false,
+  );
+  const hostWritebackReason =
+    hostRuntimeWritebackAvailable
+      ? hostProjectReason
+      : hostRuntimeReason ?? hostProjectReason;
+  const hostWritebackProtocolCapable = Boolean(
+    isHostProject &&
+      capabilities?.project_host?.enabled === true &&
+      ![
+        "project_host_not_configured",
+        "project_host_protocol_readonly",
+        "project_host_writeback_disabled",
+      ].includes(hostRuntimeReason ?? ""),
+  );
   const supportsVerification = selectedProject?.features.verification !== false;
   const supportsCommands = selectedProject?.features.commands === true;
-  const supportsApply = selectedProject?.features.apply !== false;
-  const supportsCommit = selectedProject?.features.commit !== false;
+  const projectSupportsApply = selectedProject?.features.apply === true;
+  const projectSupportsCommit = selectedProject?.features.commit === true;
+  const shouldLoadApplyState =
+    projectSupportsApply || Boolean(isHostProject && sessionId);
+  const shouldLoadCommitState =
+    projectSupportsCommit || Boolean(isHostProject && sessionId);
   const supportsPublish = selectedProject?.features.publish !== false;
+  const hostHasApplyState = Boolean(
+    isHostProject &&
+      applyResult &&
+      (applyResult.state !== "not_applied" ||
+        applyResult.apply_id ||
+        applyResult.reason === "operation_result_unknown"),
+  );
+  const hostHasCommitState = Boolean(
+    isHostProject &&
+      commitResult &&
+      (commitResult.state !== "not_committed" ||
+        commitResult.commit_id ||
+        commitResult.reason === "operation_result_unknown"),
+  );
+  const hostWritebackSurface = Boolean(
+    isHostProject &&
+      ((hostWritebackProtocolCapable &&
+        projectSupportsApply &&
+        projectSupportsCommit) ||
+        hostHasApplyState ||
+        hostHasCommitState),
+  );
+  const hostManagedDirtyState = Boolean(
+    isHostProject &&
+      selectedProject?.reason === "git_repository_dirty" &&
+      (hostHasApplyState || hostHasCommitState),
+  );
+  const hostWritebackRuntimeAvailable = Boolean(
+    isHostProject &&
+      hostRuntimeWritebackAvailable &&
+      selectedProject?.branch,
+  );
+  const hostApplyAvailable = Boolean(
+    hostWritebackRuntimeAvailable &&
+      ((selectedProject?.state === "available" && projectSupportsApply) ||
+        hostManagedDirtyState),
+  );
+  const hostCommitAvailable = Boolean(
+    hostWritebackRuntimeAvailable &&
+      ((selectedProject?.state === "available" && projectSupportsCommit) ||
+        hostManagedDirtyState),
+  );
   const localWriteback = Boolean(
-    isLocalProject && supportsApply && supportsCommit,
+    (isManifestProject && projectSupportsApply && projectSupportsCommit) ||
+      hostWritebackSurface,
+  );
+  const localWritebackAvailable = Boolean(
+    isHostProject
+      ? hostWritebackRuntimeAvailable &&
+          (hostApplyAvailable || hostCommitAvailable)
+      : isManifestProject
+        ? localWriteback &&
+          capabilities?.project_writeback?.available === true
+        : false,
   );
   const localDraftOnly = Boolean(isLocalProject && !localWriteback);
   const effectiveApplyCapability: CodingCapabilities["apply"] = localWriteback
     ? {
         allows_not_applicable: true,
         allows_quality_risk_confirmation: true,
-        available: capabilities?.project_writeback?.available === true,
-        configured: capabilities?.project_writeback?.configured === true,
-        reason: capabilities?.project_writeback?.reason,
+        available: isHostProject
+          ? hostApplyAvailable
+          : capabilities?.project_writeback?.available === true,
+        configured: isHostProject
+          ? hostWritebackProtocolCapable || hostHasApplyState
+          : capabilities?.project_writeback?.configured === true,
+        reason: isHostProject
+          ? hostApplyAvailable
+            ? undefined
+            : hostWritebackReason ?? "project_host_writeback_unavailable"
+          : capabilities?.project_writeback?.reason,
         requires_verification: false,
         supports_revert: true,
         target: "selected_local_repository",
@@ -529,10 +650,18 @@ export default function CodingPage() {
     : capabilities?.apply;
   const effectiveCommitCapability: CodingCapabilities["commit"] = localWriteback
     ? {
-        available: capabilities?.project_writeback?.available === true,
-        configured: capabilities?.project_writeback?.configured === true,
+        available: isHostProject
+          ? hostCommitAvailable
+          : capabilities?.project_writeback?.available === true,
+        configured: isHostProject
+          ? hostWritebackProtocolCapable || hostHasCommitState
+          : capabilities?.project_writeback?.configured === true,
         max_message_chars: 2_000,
-        reason: capabilities?.project_writeback?.reason,
+        reason: isHostProject
+          ? hostCommitAvailable
+            ? undefined
+            : hostWritebackReason ?? "project_host_writeback_unavailable"
+          : capabilities?.project_writeback?.reason,
         remote_operations: false,
         requires_apply: true,
         supports_undo: true,
@@ -563,8 +692,18 @@ export default function CodingPage() {
   const publishRunning =
     publishResult?.state === "publishing" ||
     publishResult?.state === "marking_ready";
+  const applyOperationActive = ["applying", "reverting"].includes(
+    applyResult?.state ?? "",
+  );
+  const commitOperationActive = ["committing", "undoing"].includes(
+    commitResult?.state ?? "",
+  );
   const sessionFrozen = Boolean(
     recoveryConflict ||
+      applyOperationActive ||
+      commitOperationActive ||
+      applyResult?.reason === "operation_result_unknown" ||
+      commitResult?.reason === "operation_result_unknown" ||
       recoveredState === "applied" ||
       recoveredState === "reverted" ||
       (applyResult?.apply_id &&
@@ -696,10 +835,23 @@ export default function CodingPage() {
       setRecovery(result.pending ? result : null);
       if (result.pending && result.project?.id) {
         setSelectedProjectId(result.project.id);
-        setProjects((current) => [
-          ...current.filter((project) => project.id !== result.project?.id),
-          result.project as CodingProjectSummary,
-        ]);
+        setProjects((current) => {
+          const recoveredProject = result.project as CodingProjectSummary;
+          const catalogProject = current.find(
+            (project) => project.id === recoveredProject.id,
+          );
+          if (!catalogProject) return [...current, recoveredProject];
+          return current.map((project) =>
+            project.id === recoveredProject.id
+              ? {
+                  ...recoveredProject,
+                  ...catalogProject,
+                  branch: catalogProject.branch ?? recoveredProject.branch,
+                  head: catalogProject.head ?? recoveredProject.head,
+                }
+              : project,
+          );
+        });
       }
     } catch (requestError) {
       setRecoveryError(describeError(requestError));
@@ -715,7 +867,10 @@ export default function CodingPage() {
       setCapabilities(result);
       try {
         const catalog = await getCodingProjects();
-        setProjects(catalog.projects.length ? catalog.projects : [BUILTIN_PROJECT]);
+        const nextProjects = catalog.projects.length
+          ? catalog.projects
+          : [BUILTIN_PROJECT];
+        setProjects((current) => mergeProjectCatalog(current, nextProjects));
         setProjectsError("");
       } catch (requestError) {
         setProjectsError(describeError(requestError));
@@ -749,8 +904,23 @@ export default function CodingPage() {
   }, [loadRecovery]);
 
   const refreshProjectCatalog = useCallback(
-    async (preferredProjectId?: string) => {
-      await loadCapabilities();
+    async (preferredProjectId?: string, quiet = false) => {
+      try {
+        const result = await getCodingCapabilities();
+        setCapabilities(result);
+        try {
+          const catalog = await getCodingProjects();
+          const nextProjects = catalog.projects.length
+            ? catalog.projects
+            : [BUILTIN_PROJECT];
+          setProjects((current) => mergeProjectCatalog(current, nextProjects));
+          setProjectsError("");
+        } catch (requestError) {
+          if (!quiet) setProjectsError(describeError(requestError));
+        }
+      } catch (requestError) {
+        if (!quiet) setProjectsError(describeError(requestError));
+      }
       if (preferredProjectId) {
         setSelectedProjectId(preferredProjectId);
         setError("");
@@ -758,7 +928,7 @@ export default function CodingPage() {
         setDraftNotice("");
       }
     },
-    [loadCapabilities],
+    [],
   );
 
   useEffect(() => {
@@ -778,7 +948,62 @@ export default function CodingPage() {
   }, [clearPendingStreamRender, loadCapabilities]);
 
   useEffect(() => {
-    if (!sessionId || projects.some((project) => project.id === selectedProjectId)) {
+    if (!isHostProject || capabilityState !== "ready") return;
+    let active = true;
+    const poll = async () => {
+      try {
+        const status = await getCodingProjectHost();
+        if (!active) return;
+        const signature = JSON.stringify([
+          status.host_id,
+          status.version,
+          status.available,
+          status.direct_writeback,
+          status.writeback_available,
+          status.writeback_reason,
+          status.reason,
+        ]);
+        const capability = capabilities?.project_host;
+        const capabilityChanged =
+          status.available !== capability?.available ||
+          status.direct_writeback !== capability?.direct_writeback ||
+          status.writeback_available !== capability?.writeback_available ||
+          status.writeback_reason !== capability?.writeback_reason;
+        const statusChanged =
+          hostStatusSignatureRef.current !== null &&
+          hostStatusSignatureRef.current !== signature;
+        hostStatusSignatureRef.current = signature;
+        if (capabilityChanged || statusChanged) {
+          await refreshProjectCatalog(undefined, true);
+          await loadRecovery();
+        }
+      } catch {
+        // Preserve the last trusted UI state until the next lightweight probe.
+      }
+    };
+    void poll();
+    const timer = window.setInterval(() => void poll(), 5_000);
+    return () => {
+      active = false;
+      window.clearInterval(timer);
+    };
+  }, [
+    capabilities?.project_host,
+    capabilityState,
+    isHostProject,
+    loadRecovery,
+    refreshProjectCatalog,
+  ]);
+
+  useEffect(() => {
+    const catalogProject = projects.find(
+      (project) => project.id === selectedProjectId,
+    );
+    const needsTrustedHostIdentity = Boolean(
+      catalogProject?.kind === "host_git" &&
+        (!catalogProject.branch || !catalogProject.head),
+    );
+    if (!sessionId || (catalogProject && !needsTrustedHostIdentity)) {
       return;
     }
     let active = true;
@@ -786,10 +1011,23 @@ export default function CodingPage() {
       .then((result) => {
         if (!active || !result.project) return;
         setSelectedProjectId(result.project.id);
-        setProjects((current) => [
-          ...current.filter((project) => project.id !== result.project?.id),
-          result.project as CodingProjectSummary,
-        ]);
+        setProjects((current) => {
+          const sessionProject = result.project as CodingProjectSummary;
+          const existing = current.find(
+            (project) => project.id === sessionProject.id,
+          );
+          if (!existing) return [...current, sessionProject];
+          const branch = existing.branch ?? sessionProject.branch;
+          const head = existing.head ?? sessionProject.head;
+          if (branch === existing.branch && head === existing.head) {
+            return current;
+          }
+          return current.map((project) =>
+            project.id === sessionProject.id
+              ? { ...sessionProject, ...project, branch, head }
+              : project,
+          );
+        });
       })
       .catch((requestError) => {
         if (
@@ -1117,7 +1355,7 @@ export default function CodingPage() {
   useEffect(() => {
     if (
       !isDraftMode ||
-      !supportsCommit ||
+      !shouldLoadCommitState ||
       !sessionId ||
       capabilities?.incremental?.enabled !== true
     ) {
@@ -1130,13 +1368,13 @@ export default function CodingPage() {
     isDraftMode,
     refreshCycleHistory,
     sessionId,
-    supportsCommit,
+    shouldLoadCommitState,
   ]);
 
   useEffect(() => {
     if (
       !isDraftMode ||
-      !supportsApply ||
+      !shouldLoadApplyState ||
       !sessionId ||
       !draftChanges?.files.length
     ) {
@@ -1170,13 +1408,13 @@ export default function CodingPage() {
     isDraftMode,
     resetExpiredSession,
     sessionId,
-    supportsApply,
+    shouldLoadApplyState,
   ]);
 
   useEffect(() => {
     if (
       !isDraftMode ||
-      !supportsCommit ||
+      !shouldLoadCommitState ||
       !sessionId ||
       !draftChanges?.files.length ||
       applyResult?.state !== "applied" ||
@@ -1214,7 +1452,143 @@ export default function CodingPage() {
     isDraftMode,
     resetExpiredSession,
     sessionId,
-    supportsCommit,
+    shouldLoadCommitState,
+  ]);
+
+  useEffect(() => {
+    if (
+      !sessionId ||
+      !draftChanges?.files.length ||
+      !applyOperationActive
+    ) {
+      return;
+    }
+    let active = true;
+    let polling = false;
+    const poll = async () => {
+      if (polling) return;
+      polling = true;
+      try {
+        const result = await getCodingApplyStatus(
+          sessionId,
+          draftChanges.revision,
+        );
+        if (active) {
+          setApplyResult(result);
+          setApplyError("");
+        }
+      } catch (requestError) {
+        if (!active) return;
+        if (
+          requestError instanceof CodingApiError &&
+          requestError.code === "session_not_found"
+        ) {
+          resetExpiredSession(sessionId);
+          return;
+        }
+        setApplyError(describeError(requestError));
+      } finally {
+        polling = false;
+      }
+    };
+    const timer = window.setInterval(() => void poll(), 3_000);
+    return () => {
+      active = false;
+      window.clearInterval(timer);
+    };
+  }, [
+    applyOperationActive,
+    draftChanges?.files.length,
+    draftChanges?.revision,
+    resetExpiredSession,
+    sessionId,
+  ]);
+
+  useEffect(() => {
+    if (
+      !sessionId ||
+      !draftChanges?.files.length ||
+      !commitOperationActive
+    ) {
+      return;
+    }
+    let active = true;
+    let polling = false;
+    const poll = async () => {
+      if (polling) return;
+      polling = true;
+      try {
+        const result = await getCodingCommitStatus(
+          sessionId,
+          draftChanges.revision,
+        );
+        if (active) {
+          setCommitResult(result);
+          setCommitError("");
+          if (result.state === "committed" || result.state === "undone") {
+            await refreshCycleHistory(sessionId);
+          }
+        }
+      } catch (requestError) {
+        if (!active) return;
+        if (
+          requestError instanceof CodingApiError &&
+          requestError.code === "session_not_found"
+        ) {
+          resetExpiredSession(sessionId);
+          return;
+        }
+        setCommitError(describeError(requestError));
+      } finally {
+        polling = false;
+      }
+    };
+    const timer = window.setInterval(() => void poll(), 3_000);
+    return () => {
+      active = false;
+      window.clearInterval(timer);
+    };
+  }, [
+    commitOperationActive,
+    draftChanges?.files.length,
+    draftChanges?.revision,
+    refreshCycleHistory,
+    resetExpiredSession,
+    sessionId,
+  ]);
+
+  useEffect(() => {
+    if (
+      !isHostProject ||
+      !applyResult ||
+      !["applied", "reverted", "failed"].includes(applyResult.state)
+    ) {
+      return;
+    }
+    void refreshProjectCatalog(undefined, true);
+  }, [
+    applyResult?.apply_id,
+    applyResult?.reason,
+    applyResult?.state,
+    isHostProject,
+    refreshProjectCatalog,
+  ]);
+
+  useEffect(() => {
+    if (
+      !isHostProject ||
+      !commitResult ||
+      !["committed", "undone", "failed"].includes(commitResult.state)
+    ) {
+      return;
+    }
+    void refreshProjectCatalog(undefined, true);
+  }, [
+    commitResult?.commit_id,
+    commitResult?.reason,
+    commitResult?.state,
+    isHostProject,
+    refreshProjectCatalog,
   ]);
 
   const recoverExpiredSession = useCallback(
@@ -1590,6 +1964,7 @@ export default function CodingPage() {
       setCommitError("");
       setPublishResult(null);
       setPublishError("");
+      await refreshCycleHistory(sessionId);
       setDraftNotice(
         localWriteback
           ? "本次写入已撤销，所选本地项目已恢复。"
@@ -1694,6 +2069,9 @@ export default function CodingPage() {
       draftChanges.revision,
       commitResult.commit_id,
     );
+    if (isHostProject) {
+      await refreshProjectCatalog(undefined, true);
+    }
     setCycleHistory(history);
     setDraftChanges(await getCodingChanges(sessionId));
     setVerification(null);
@@ -1742,6 +2120,7 @@ export default function CodingPage() {
       setApplyResult(
         await getCodingApplyStatus(sessionId, draftChanges.revision),
       );
+      await refreshCycleHistory(sessionId);
       setDraftNotice(
         localWriteback
           ? "本地版本记录已撤销，文件修改仍保留在所选项目中。"
@@ -1900,6 +2279,7 @@ export default function CodingPage() {
           isDraft={isDraftMode}
           localDraftOnly={localDraftOnly}
           localWriteback={localWriteback}
+          localWritebackAvailable={localWritebackAvailable}
         />
       }
     >
@@ -1922,14 +2302,18 @@ export default function CodingPage() {
                 )}
                 {isLocalProject
                   ? localWriteback
-                    ? "修改草稿，确认后写入所选项目"
+                    ? localWritebackAvailable
+                      ? "修改草稿，确认后写入所选项目"
+                      : "保留写入状态，当前只读"
                     : "修改草稿，不会写入项目"
                   : isDraftMode
                     ? "修改草稿，确认后可应用"
                     : "只读实验"}
               </span>
-              <span className="rounded-full border border-white/10 bg-white/[0.045] px-2.5 py-1 text-xs text-slate-300">
-                当前项目：{selectedProject?.name ?? "正在读取"}
+              <span className="inline-flex min-w-0 max-w-full rounded-full border border-white/10 bg-white/[0.045] px-2.5 py-1 text-xs text-slate-300">
+                <span className="min-w-0 break-all">
+                  当前项目：{selectedProject?.name ?? "正在读取"}
+                </span>
               </span>
             </div>
             <h1 className="mt-3 text-2xl font-semibold tracking-[-0.025em] text-white sm:text-3xl">
@@ -1939,14 +2323,16 @@ export default function CodingPage() {
               {isDraftMode
                 ? isLocalProject
                   ? localWriteback
-                    ? "描述希望调整的内容。代码助手会先在临时副本中准备修改；你可以逐个文件查看、运行检查，再决定是否写入所选本地项目并保存本地版本。"
+                    ? localWritebackAvailable
+                      ? "描述希望调整的内容。代码助手会先在临时副本中准备修改；你可以逐个文件查看、运行检查，再决定是否写入所选本地项目并保存本地版本。"
+                      : "所选项目已有写入状态会继续保留。当前可以查看和下载 Diff；恢复本地写入能力后，再核对原操作。"
                     : "描述希望调整的内容。代码助手会在隔离的临时副本中准备修改；你可以逐个文件查看并下载 Diff，本地项目不会被改变。"
                   : "描述希望调整的内容。代码助手会先在临时副本中准备修改；你可以逐个文件查看、运行项目验证，再决定下载 Diff、应用到专用项目副本或保存本地版本。"
                 : "你可以询问功能如何实现、页面与服务如何配合，或某段代码的作用。代码助手只能查看项目并回答，不会修改文件或执行命令。"}
             </p>
           </div>
           <button
-            className="inline-flex min-h-10 items-center justify-center gap-2 self-start rounded-lg border border-white/10 bg-white/[0.045] px-3 text-sm font-semibold text-slate-200 transition hover:border-cyan-300/35 hover:bg-cyan-300/10 hover:text-cyan-100 disabled:cursor-not-allowed disabled:opacity-50"
+            className="inline-flex min-h-11 items-center justify-center gap-2 self-start rounded-lg border border-white/10 bg-white/[0.045] px-3 text-sm font-semibold text-slate-200 transition hover:border-cyan-300/35 hover:bg-cyan-300/10 hover:text-cyan-100 disabled:cursor-not-allowed disabled:opacity-50"
             disabled={capabilityState === "loading" || isBusy}
             onClick={() => void loadCapabilities()}
             type="button"
@@ -2009,11 +2395,17 @@ export default function CodingPage() {
               ))}
             </select>
             <p className="mt-2 max-w-3xl text-xs leading-5 text-slate-400" id="coding-project-help">
-              {selectedProject?.state === "unavailable"
+              {selectedProject?.state === "unavailable" &&
+              !(isHostProject && (hostHasApplyState || hostHasCommitState))
                 ? projectReason[selectedProject.reason ?? ""] ??
                   "这个项目目前不能安全读取，请由开发者检查项目状态。"
                 : isLocalProject
-                  ? localWriteback
+                  ? isHostProject &&
+                    hostWritebackSurface &&
+                    !hostApplyAvailable &&
+                    !hostCommitAvailable
+                    ? "已有写入状态和 Diff 会继续保留；当前只允许查看和下载，恢复写入能力后可核对原操作。"
+                    : localWriteback
                     ? "可查看修改、确认离线检查、写入所选本地项目并保存本地版本；不会自动上传或创建 GitHub PR。"
                     : "可查看、准备修改、确认离线检查并下载 Diff；不会写入本地项目、创建提交或发布 PR。"
                   : "ModelMirror 提供修改审阅、项目验证、受控应用、本地提交和 GitHub 草稿 PR 的完整流程。"}
@@ -2022,7 +2414,18 @@ export default function CodingPage() {
               <p className="mt-1 text-xs leading-5 text-amber-100/80">
                 当前任务已绑定此项目。若本轮没有修改，可在下方结束当前任务；否则请先放弃或处理完现有修改。
               </p>
-            ) : isLocalProject && localDraftOnly && selectedProject?.writeback_reason ? (
+            ) : null}
+            {isHostProject &&
+            hostWritebackSurface &&
+            !hostApplyAvailable &&
+            !hostCommitAvailable ? (
+              <p className="mt-1 text-xs leading-5 text-amber-100/80">
+                {projectReason[hostWritebackReason ?? ""] ??
+                  "本地项目助手当前不能执行写入。已有状态仍会保留，重新连接或更新助手后可继续核对。"}
+              </p>
+            ) : isLocalProject &&
+              localDraftOnly &&
+              selectedProject?.writeback_reason ? (
               <p className="mt-1 text-xs leading-5 text-amber-100/80">
                 {projectReason[selectedProject.writeback_reason] ??
                   "此项目当前只开放修改草稿，仍可查看、检查和下载修改。"}
@@ -2239,7 +2642,7 @@ export default function CodingPage() {
               <div className="flex gap-2">
                 {isBusy ? (
                   <button
-                    className="inline-flex min-h-10 items-center justify-center gap-2 rounded-lg border border-rose-300/35 bg-rose-300/10 px-4 text-sm font-semibold text-rose-100 transition hover:bg-rose-300/20 disabled:cursor-not-allowed disabled:opacity-50"
+                    className="inline-flex min-h-11 items-center justify-center gap-2 rounded-lg border border-rose-300/35 bg-rose-300/10 px-4 text-sm font-semibold text-rose-100 transition hover:bg-rose-300/20 disabled:cursor-not-allowed disabled:opacity-50"
                     disabled={runState === "stopping"}
                     onClick={() => void stopTurn()}
                     type="button"
@@ -2249,7 +2652,7 @@ export default function CodingPage() {
                   </button>
                 ) : (
                   <button
-                    className="inline-flex min-h-10 items-center justify-center gap-2 rounded-lg bg-cyan-300 px-4 text-sm font-semibold text-ink-950 transition hover:bg-cyan-200 disabled:cursor-not-allowed disabled:bg-slate-700 disabled:text-slate-400"
+                    className="inline-flex min-h-11 items-center justify-center gap-2 rounded-lg bg-cyan-300 px-4 text-sm font-semibold text-ink-950 transition hover:bg-cyan-200 disabled:cursor-not-allowed disabled:bg-slate-700 disabled:text-slate-400"
                     disabled={
                       !workspaceAvailable ||
                       !prompt.trim() ||
@@ -2336,12 +2739,16 @@ export default function CodingPage() {
                 localWriteback={localWriteback}
                 loading={draftLoading}
                 readOnly={Boolean(recoveryConflict)}
+                selectedProject={localWriteback ? selectedProject : null}
                 onApply={applyDraft}
                 onClose={closeAppliedSession}
                 onCommit={commitAppliedDraft}
                 onContinue={
-                  !isLocalProject &&
-                  capabilities?.incremental?.available &&
+                  ((selectedProject?.kind === "builtin" &&
+                    capabilities?.incremental?.available) ||
+                    (selectedProject?.kind === "host_git" &&
+                      hostWritebackSurface &&
+                      capabilities?.incremental?.enabled)) &&
                   cycleHistory?.can_continue
                     ? continueAfterCommit
                     : undefined
@@ -2365,7 +2772,7 @@ export default function CodingPage() {
                 verificationAvailable={verificationAvailable}
                 verificationError={verificationError}
               />
-              {!isLocalProject ? (
+              {selectedProject?.kind !== "local_clone" ? (
                 <CodingHistoryPanel
                   disabled={isBusy}
                   history={cycleHistory}

--- a/client/src/types/coding.ts
+++ b/client/src/types/coding.ts
@@ -15,22 +15,28 @@ export type CodingProjectKind = "builtin" | "local_clone" | "host_git";
 
 export interface CodingProjectHostCapability {
   available: boolean;
-  direct_writeback: false;
+  direct_writeback: boolean;
   enabled: boolean;
   paired: boolean;
   platform: "windows";
   reason?: string;
   remembers_projects: true;
   selection: true;
+  writeback_available?: boolean;
+  writeback_reason?: string;
 }
 
 export interface CodingProjectHostStatus {
   available: boolean;
+  direct_writeback?: boolean;
   host_id: string | null;
   name: string | null;
   paired: boolean;
   platform: "windows";
+  reason?: string;
   version: string | null;
+  writeback_available?: boolean;
+  writeback_reason?: string;
 }
 
 export interface CodingProjectHostPairing {
@@ -403,7 +409,7 @@ export type CodingCommitState =
   | "failed";
 
 export interface CodingCommitResult {
-  branch: "coding/local-draft";
+  branch: string;
   can_undo: boolean;
   commit_id: string | null;
   commit_sha: string | null;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -38,8 +38,9 @@ Dify 不再承载 `/workflow` 或 `/rag` 主路径。仓库仍保留
 | Browser / Sandbox sidecar | 受控浏览器和无网络沙箱执行。 |
 | OmniRoute sidecar | 可选兼容、诊断和紧急回退；不是普通用户控制面。 |
 | OpenCode + 最小 ACP Worker | 实验性代码问答与修改草稿执行面；单实例、默认关闭。 |
-| Coding Project Source | 无网络的受控项目清单与单槽 Git HEAD 快照服务；只有它可读取项目根目录。 |
+| Coding Project Source | 无网络的受控项目清单与单槽 Git HEAD 快照服务；只有它可读取清单 `CODING_PROJECTS_ROOT`。 |
 | Coding Project Writer | 对清单中逐项目授权的无远程本地克隆执行原子写入、撤销、本地提交与对账。 |
+| Windows Project Host v2 | 在用户电脑上保存项目路径并执行受控原子写入、当前分支本地提交和精确对账；Server 只看到不透明项目 ID。 |
 | Coding Verifier | 用户手动触发的草稿项目验证执行面；无网络、固定命令、可选启动。 |
 | Coding Applier | 把满足门禁的草稿原子写入固定专用工作树；无网络、无 Git 操作、可选启动。 |
 | Coding Committer | 把已应用文件保存到独立本地仓库；无网络、固定分支、只写隔离 `.git`。 |
@@ -77,6 +78,9 @@ flowchart LR
   API -->|"独立 Unix socket"| WRITER["coding-project-writer"]
   WRITER -->|"确认后原子写入 / 本地提交"| ROOT
   WRITER -. "network_mode: none" .-> OFFLINE
+  API <-->|"配对 / WebSocket 操作元数据"| HOST["Windows Project Host v2"]
+  HOST -->|"拉取 90 秒单次负载 / no-store"| API
+  HOST -->|"原子文件事务 / 固定 Git plumbing"| HOSTREPO["用户明确选择的 Windows Git 项目"]
   CODER -->|"internal network"| GW
   CODER -->|"Patch + revision / Unix socket"| VERIFY["coding-verifier"]
   VERIFY -. "network_mode: none" .-> OFFLINE["无网络"]
@@ -169,11 +173,14 @@ flowchart LR
   物理路径。服务按固定清单校验干净独立 Git 克隆，通过 `git ls-tree` 与
   `git cat-file --batch` 从 HEAD blob 构造单槽快照，不读取工作区换行转换，也不运行
   Hook、过滤器、凭据助手或联网操作。租约释放或失败时清空快照卷。
-- 自定义项目默认只开放问答、临时文本草稿、Diff、轻量检查、离线验证、下载和项目
-  绑定恢复。version 3 清单可逐项目显式开放本地写入；此时只能写入无 remote、固定在
-  `coding/local-draft` 的独立克隆，并可在同一 Writer 内保存或撤销本地版本。
-  GitHub 发布、多轮提交和任意分支仍只适用于内置 ModelMirror 流程；停止 Project
-  Source 或 Writer 不得降低 ModelMirror 的既有能力。
+- 自定义项目有两条互不串扰的来源。清单 `local_clone` 由 Project Source 提供快照，
+  version 3 清单可逐项目显式开放容器 Writer；可写项目仍必须无 remote、固定在
+  `coding/local-draft`，只支持单轮本地版本且不发布。`host_git` 由 Windows Project
+  Host v2 选择，允许仓库已有 remote 并保留选择时的安全当前分支，但不读取 remote URL、
+  不执行远程命令或联网；它支持受控线性多轮本地提交，发布始终为 `false`。v1 助手及
+  `CODING_PROJECT_HOST_WRITEBACK_ENABLED=false` 只保留问答、草稿、Diff、验证和下载。
+  停止任一 Project Source、Writer 或 Project Host 不得降低其他项目来源和内置
+  ModelMirror 的既有能力。
 - Coding Verifier 是独立的可选进程边界。Worker 只向它发送当前 revision 的内部
   Patch、变化路径和快照指纹；Verifier 重新校验并应用到 1 GiB 临时副本。其根文件
   系统和基准快照只读，网络为 `none`，不接收模型密钥、宿主路径、Docker socket
@@ -200,20 +207,46 @@ flowchart LR
   缺失、损坏、schema 不兼容或密文被篡改时失败关闭，不生成新密钥覆盖旧记录。
 - 自定义项目的 ID、类型、显示名和基准 HEAD 保存在同一 SQLite 的独立认证加密上下文
   表中，不保存宿主路径，也不改变 recovery schema v3 的 `user_version`。旧记录没有
-  项目上下文时仍解释为内置 ModelMirror；项目被删除、变脏或 HEAD 改变时只允许下载
-  原始 Diff，不会把 Patch 应用到不同版本。
+  项目上下文时仍解释为内置 ModelMirror。`local_clone` 被删除或出现未受管的脏树/HEAD
+  变化时只允许下载原始 Diff；`host_git` 的合法 applied 脏树与 committed HEAD 前进则由
+  已认证 operation 日志和后述 `H0/Hk` 谱系精确对账，不能把 Patch 应用到不同版本。
 - Coding Project Writer 只在显式加载写回 overlay 后存在。它是唯一可写挂载受控项目
   根目录的执行面，使用 Project Source 已验证的不透明项目 ID 定位目标；Server、Runtime
   与浏览器都不接收物理路径。Writer 无网络、端口、Docker socket 或模型/Git 凭据，
   先在 tmpfs 预演 Patch，再按原文件哈希原子写入。提交使用临时索引、固定 Git plumbing
   与 compare-and-swap 引用更新，不运行 Hook、过滤器、签名或凭据助手。
+- Windows Project Host 是宿主路径的唯一持有者。项目 ID 到路径的映射、host token、
+  设备密钥和操作日志使用 Windows DPAPI 保护；Server、Runtime、Verifier、浏览器和模型
+  永不接收物理路径。v2 写入请求帧只发送 request、project、operation、action 以及 payload
+  ID、摘要、大小和到期时间；revision、分支、HEAD、Patch 和提交说明位于 host token 鉴权、
+  绑定 host/project/operation/action、短时单次消费的 HTTP envelope，或其他已绑定的
+  inventory/snapshot/回执消息中。回执缺失、畸形或断线只表示结果未知，必须按原
+  operation ID reconcile。
+- Helper 本地授权把 canonical path、项目根目录和 `.git` 目录的文件身份共同绑定到
+  project ID；identity 不公开也不上送 Server。同一路径整体替换仓库或替换 `.git` 会产生
+  新 ID，旧授权只作为 `project_reselection_required` 墓碑并拒绝写入。inspect、快照归档和
+  五类写操作会持有选择路径祖先、root、`.git`、关键 metadata leaf 与已发现 namespace
+  目录的 no-follow guard；这证明已绑定对象未被换绑，但不宣称锁住恶意同用户进程动态创建
+  的每一个新 object child。
+- 宿主 apply/revert 使用 Windows 句柄和文件身份绑定的可恢复事务；宿主 commit/undo 使用
+  私有对象目录、临时索引、受控 reflog 停放和 CAS 更新已保存的当前分支。实现拒绝
+  reparse/symlink/hardlink、配置 include、worktree/commondir、alternates、partial clone、
+  promisor、replace refs、grafts、过滤器、外部 excludes、Hook、签名和凭据助手；只支持
+  files refs 后端，`extensions.refStorage`/reftable 失败关闭。允许 remote 配置存在但不读取
+  其值、不执行 remote/fetch/push/ls-remote。生产默认构造在非 Windows 失败关闭；领域
+  测试可显式关闭平台门禁运行参考后端，但不构成 POSIX 产品支持。
 - 自定义项目写回支持新增、修改、删除及移动 UTF-8 普通文本；移动在内部表示为旧路径
   删除与新路径新增。目录、符号链接、二进制、敏感路径、越界路径、覆盖已有目标和超限
   Patch 继续失败关闭。应用、撤销、提交或撤销提交中断后，只在文件哈希、HEAD、索引和
-  Writer 日志精确一致时恢复，否则进入只读冲突态。
+  对应 Writer 或 Helper DPAPI 日志精确一致时恢复，否则进入只读冲突态。
 - 恢复会从镜像内不可变基准重新复核并应用 Patch，再创建全新 Agent 会话；问题、
   回答、计划、工具过程和原始命令输出从不持久化。基准或验证环境指纹变化会使
   结果过期；应用/提交状态无法精确对账时进入只读冲突态，不重复写入或覆盖人工内容。
+- `host_git` 多轮恢复将 Project Source/恢复上下文中的初始提交 `H0` 保持不变，并从已完成
+  CommitReceipt 线性推导当前轮父提交 `Hk`。恢复以首轮 apply 日志授权读取 `H0` 快照，
+  再分别对账当前轮操作和宿主 `Hk`；分支、父提交、路径、revision、指纹或操作链任一不符
+  都进入只读冲突。应用后合法脏树、提交后 HEAD 前进以及 Helper/Server 重启不会重新套用
+  初始“必须干净”资格。
 - Coding Publisher 只在显式加载发布 overlay 后存在。它只读挂载同一无远程独立仓库，
   复核固定分支、HEAD、线性提交链、恢复回执和 GitHub 基础分支；目标分支只允许不存在
   或精确指向任务 HEAD，禁止 force push、Hook、凭据助手和 URL 重写。
@@ -231,21 +264,27 @@ flowchart LR
 - 当前没有完整用户、组织、RBAC 或公网控制台安全模型。
 - 静态模型快照与实时目录需要定期校准，价格快照必须标注日期。
 - OmniRoute 是可选回退，不得成为普通用户必须理解的配置入口。
-- `/coding` 仅适用于本地单实例实验。部署者可登记最多 50 个受控的干净独立克隆，
-  但同一时刻仍只有一个项目租约和一个 Agent 会话。Draft 可新增、修改、删除或移动
-  临时 UTF-8 文本；默认不会写回宿主目录。只有清单 v3 逐项目授权、无 remote 且固定
-  分支的克隆可由用户确认后写入和保存本地版本。显式启用 ModelMirror 受控应用后，
-  只有轻量检查通过且当前项目验证
-  `passed`（纯文档允许 `not_applicable`）的 revision 才能写入固定专用工作树。
-  当前主工作树不挂载给 Applier 或 Committer。显式启用隔离本地提交时，系统只在
-  无远程独立克隆中创建本地提交。显式启用发布 overlay 后，只有线性提交链可以一次性
+- `/coding` 仅适用于本地单实例实验。部署者可登记最多 50 个清单项目，也可通过
+  Windows 助手逐个选择干净独立 Git 项目；同一时刻仍只有一个项目租约和一个 Agent
+  会话。清单 `local_clone` 的边界与既有 Writer 保持不变；`host_git` 仅在 v2 助手、
+  独立开关和项目资格同时满足时开放当前分支写入与线性多轮本地提交。两者都不支持发布。
+  Draft 可新增、修改、删除或移动临时 UTF-8 文本；模型处理本身不会写回宿主目录。
+  只有清单 v3 逐项目授权的 `local_clone` 或通过 v2 助手资格复核的 `host_git`，才可在
+  当前 revision 的原位确认后写入对应项目。语法/项目验证失败、未运行或环境未就绪属于
+  可再次确认的质量风险；路径、秘密、文件类型、项目身份、分支、HEAD 和对象身份属于
+  不可绕过的安全门禁。
+  当前主工作树不挂载给 Applier 或 Committer。内置 ModelMirror 的隔离 Committer 与
+  清单 `local_clone` 只在无远程独立克隆中创建本地提交；`host_git` 可保留 remote 配置，
+  但不读取其 URL 或执行远程操作。显式启用发布 overlay 后，只有内置 ModelMirror 的
+  线性提交链可以一次性
   推送到部署时固定的 GitHub.com 仓库并创建 Draft PR；用户再次确认才标记为 Ready，
   产品不提供合并、关闭 PR 或删除远程分支。
 - 应用成功后会话冻结；Diff、Patch 和验证结果仍可读。启用恢复 overlay 后，精确
   对账成功的应用、提交及其撤销能力可在重启后恢复；外部状态不明确时只允许查看和
   下载。有效本地提交存在时必须先撤销提交并保留文件，才可撤销应用。Agent 仍
-  不能使用 Shell、Git、测试命令或选择测试范围；自定义项目仍不能发布或多轮提交。
-  系统仍不提供任意绝对路径、任意仓库选择、
-  仓库/分支选择、force push、远端合并、目录操作、多 Agent、分布式
+  不能使用 Shell、Git、测试命令或选择测试范围；`local_clone` 仍不能多轮，所有
+  自定义项目都不能发布，只有 v2 `host_git` 可在保存的当前分支进行受控线性多轮。
+  系统仍不允许浏览器或 Agent 传入任意绝对路径、仓库或分支，也不提供 force push、
+  远端合并、目录操作、多 Agent、分布式
   Worker 或生产多租户。
 - Dify 代理属于 legacy compatibility；除非形成新的产品决策，不恢复为主路由。

--- a/docs/CODING_AGENT_INTEGRATION.md
+++ b/docs/CODING_AGENT_INTEGRATION.md
@@ -1,6 +1,6 @@
 # 代码助手接入说明
 
-最后更新日期：2026-08-05
+最后更新日期：2026-08-08
 维护人：模镜团队
 
 ## 当前状态
@@ -16,15 +16,19 @@ Diff、轻量检查结果和停止按钮。Draft 用户还可以手动启动独�
 固定 GitHub App 和发布 overlay 后，用户可把线性本地提交创建为 Draft PR，并再次
 确认是否标记为 Ready。
 
-ModelMirror 使用镜像内固定快照并保留完整闭环；自定义项目使用无网络 Project Source
-从干净独立克隆的 Git HEAD 生成单槽只读快照，开放问答、草稿、Diff、下载、恢复和
-逐次确认的离线项目检查。清单 version 3 可逐项目授权无 remote、固定分支的独立克隆；
-用户确认后，可把草稿原子写入所选项目并保存一个本地版本。
-Draft 默认不会写回任何宿主目录；受控应用也只允许写入预先创建的专用工作树，当前主工作树始终不挂载。
-系统只在用户确认后向固定独立克隆创建本地提交；远程发布也只允许固定 GitHub.com
+ModelMirror 使用镜像内固定快照并保留完整闭环。清单 `local_clone` 使用无网络 Project
+Source 从干净独立克隆的 Git HEAD 生成单槽只读快照；清单 version 3 可逐项目授权
+无 remote、固定 `coding/local-draft` 分支的独立克隆，经容器 Writer 完成单轮写入和
+本地版本。Windows `host_git` 由 Project Host v2 在系统选择器中授权；助手是物理路径的
+唯一持有者，在用户保存的当前分支执行原子写入、撤销、本地提交和最多 10 轮线性修改。
+它允许仓库已有 remote，但不读取 URL、不执行任何远程命令或联网，且始终不能发布。
+Draft 默认不会写回任何宿主目录。内置受控应用只允许写入预先创建的专用工作树，
+`local_clone` 只写清单授权的固定克隆；`host_git` 则由 Windows 助手在用户逐 revision
+确认后直接修改系统选择器授权的项目。Server 和容器始终不挂载该宿主路径。
+系统只在用户确认后向对应受控仓库创建本地提交；远程发布仍只允许固定 GitHub.com
 仓库、系统分支和 Draft PR，不提供合并、关闭或远端清理。草稿支持删除与移动普通
-UTF-8 文本，但不支持目录、符号链接、二进制、直接 Shell、未经确认的命令、任意仓库
-或分支选择、多 Agent、完整 ACP、
+UTF-8 文本，但不支持目录、符号链接、二进制、直接 Shell、未经确认的命令、浏览器或
+Agent 传入任意仓库/分支、remote 操作、多 Agent、完整 ACP、
 分布式 Worker、保存对话、多任务历史或生产级多租户。不要将该入口直接暴露到公网。
 
 ## 用户体验约束
@@ -51,9 +55,9 @@ UTF-8 文本，但不支持目录、符号链接、二进制、直接 Shell、�
 - “应用到本地项目副本”仅在门禁满足时启用；确认区必须说明文件数量、不会提交或
   上传、当前项目目录不改变。目标不匹配或已有修改时使用日常语言提示，技术原因
   默认折叠。
-- 对逐项目授权的自定义克隆，操作显示为“写入所选本地项目”；确认区明确真实所选项目
-  会改变、不会自动保存本地版本或上传，并说明发现外部修改会停止。未授权或 Writer
-  不可用只降级为查看、验证与下载。
+- 对逐项目授权的 `local_clone` 或 v2 `host_git`，操作显示为“写入所选本地项目”；
+  确认区明确项目名、当前分支、真实所选项目会改变、不会自动上传，并说明发现外部修改
+  会停止。项目级授权或对应执行面不可用只降级该项目为查看、验证与下载。
 - 应用成功后明确显示“修改已应用”，冻结输入与修改操作，但保留 Diff、验证和
   下载；提供“撤销本次应用”和“结束本次修改”。撤销不得覆盖之后的人工改动。
 - 独立本地仓库可用时，页面显示“保存一个可找回的本地版本”，预填系统建议并允许
@@ -80,6 +84,9 @@ flowchart LR
   PROJECTS -->|"当前项目单槽快照"| WORKER
   API -->|"独立私有 Unix socket"| WRITER["coding-project-writer"]
   WRITER -->|"确认后原子写入 / 本地提交"| ROOT
+  API <-->|"配对 / v2 WebSocket 元数据"| PHOST["Windows Project Host v2"]
+  API -->|"90 秒单次操作负载"| PHOST
+  PHOST -->|"本机原子写入 / 当前分支提交"| HOSTREPO["系统选择器授权的 Git 项目"]
   WORKER --> ACP["最小 ACP 客户端"]
   ACP --> OC["OpenCode 1.18.9"]
   SOURCE["只读基准快照 /opt/modelmirror-source"] -->|"会话创建时复制"| WORK["临时 /workspace"]
@@ -117,6 +124,14 @@ flowchart LR
 | --- | --- |
 | `GET /api/coding/capabilities` | 查询功能是否启用、当前模式及输入/草稿限制。 |
 | `GET /api/coding/projects` | 返回可选项目、状态、短 HEAD 和功能矩阵，不返回物理路径或 remote。 |
+| `GET /api/coding/project-host` | 返回 paired、available、protocol、direct_writeback、writeback_available 与原因；enabled 位于 capabilities，不返回路径。 |
+| `POST /api/coding/project-host/pairings` / `POST /api/coding/project-host/reconnect` | 创建一次性配对，或向当前已建立连接发送心跳并确认在线；离线助手需自行重连/重启，凭据被拒后由助手清除并要求重新配对。 |
+| `DELETE /api/coding/project-host/{host_id}` | 撤销助手授权；不修改、撤销或删除本地项目内容。 |
+| `POST /api/coding/projects/selections` / `GET /api/coding/projects/selections/{request_id}` | 让已配对助手打开系统项目选择器并低频查询结果。 |
+| `PATCH /api/coding/projects/{project_id}` / `DELETE /api/coding/projects/{project_id}` | 重命名或移除不透明项目授权，不接收物理路径。 |
+| `WS /api/coding/project-host/connect` | 助手心跳、inventory、snapshot 与操作控制元数据；写入请求帧只含 request/project/operation/action、payload ID/摘要/大小/到期时间，不承载 Patch、分支、HEAD 或提交正文。 |
+| `PUT /api/coding/project-host/transfers/{transfer_id}` | 助手上传有界 HEAD 快照；绑定 host/project/transfer。 |
+| `GET /api/coding/project-host/operations/{payload_id}` | 助手令牌读取 90 秒、单次消费、`no-store` 的操作负载；绑定 host/project/operation/action。 |
 | `POST /api/coding/sessions` | 创建临时问答或草稿记录；可选请求体只接受 `project_id`，省略时仍选择 ModelMirror。 |
 | `GET /api/coding/sessions/{id}` | 检查临时记录是否仍存在；不返回问题、回答或文件内容。 |
 | `POST /api/coding/sessions/{id}/turns` | 提交问题；请求体只允许 `prompt`。 |
@@ -133,8 +148,7 @@ flowchart LR
 | `POST /api/coding/sessions/{id}/verification/confirm` | 确认自定义项目当前 revision 的固定检查计划。 |
 | `GET /api/coding/sessions/{id}/commands/pending` | SSE 重连后查询当前待确认命令，不返回内部令牌。 |
 | `POST /api/coding/sessions/{id}/commands/{request_id}/decision` | 对一条代码助手命令选择 `allow_once` 或 `reject`。 |
-| `POST /api/coding/sessions/{id}/apply` | 应用指定 revision；请求体只允许 `revision`。Windows 绑定目录扫描较慢时最多等待 90 秒。 |
-| `POST /api/coding/sessions/{id}/commit` | 保存本地提交；Windows 绑定目录扫描较慢时最多等待 90 秒。 |
+| `POST /api/coding/sessions/{id}/apply` | 应用指定 revision；请求体只允许 `revision` 与可选严格布尔 `confirm_quality_risks`。确认只绑定该 revision，不能绕过硬安全策略。旧绑定目录执行面最多等待 90 秒；Project Host 等待上限为 150 秒，超时仍按结果未知处理。 |
 | `GET /api/coding/sessions/{id}/apply?revision=` | 查询应用、撤销状态和是否仍可撤销。 |
 | `POST /api/coding/sessions/{id}/apply/revert` | 安全撤销；请求体只允许 `revision` 与不透明 `apply_id`。 |
 | `POST /api/coding/sessions/{id}/close` | 结束已应用或已撤销的冻结会话，释放单会话 Runtime。 |
@@ -165,6 +179,9 @@ Draft、精确基础版本要求和 Ready 支持；不可用原因不影响本�
 会话开始事件、会话状态和恢复状态只携带项目 ID、显示名、来源、短 HEAD 与功能矩阵。
 `project_writeback` 公开 enabled、configured、available、固定目标、删除/移动、撤销和
 本地提交能力；项目列表只返回功能矩阵与安全原因码，不返回清单路径或物理项目路径。
+`project_host` 另公开配对/在线状态、协议、`direct_writeback`、`writeback_available`
+和脱敏原因；项目 `features` 仍按 `kind` 与对应执行面独立计算，不能用 Host 在线状态
+开启 `local_clone`，也不能用容器 Writer 健康状态开启 `host_git`。
 
 公共事件限定为：会话开始、分析开始、计划、回答增量、查阅状态、命令待确认、命令已处理、
 完成、失败、取消和心跳。服务端只保留有限内存事件，不持久化问题、完整回答、命令审批或工具输出。
@@ -195,7 +212,8 @@ FastAPI 的完整环境。源码变化后必须重建 `coding-runtime` 才会刷
 
 ## 受控本地项目草稿
 
-- 部署者只通过根目录 `.modelmirror-coding-projects.json` 登记最多 50 个项目。名称供
+- 清单 `local_clone` 由部署者通过根目录 `.modelmirror-coding-projects.json` 登记最多
+  50 个项目。名称供
   用户识别，路径只在 Project Source 内使用；API 返回由规范化相对路径生成的稳定
   不透明 ID，不返回根目录、相对路径、remote 或 Git 配置。
 - 项目必须是干净独立 Git 克隆，并拒绝 worktree 指针、alternates、子模块、符号链接
@@ -207,7 +225,7 @@ FastAPI 的完整环境。源码变化后必须重建 `coding-runtime` 才会刷
 - 仅根目录 UTF-8 `AGENTS.md`（最多 64 KiB）会显式带入会话；嵌套 AGENTS、OpenCode、
   MCP、插件、provider 和其他可执行配置均隐藏且不会生效。Runtime 还会复核项目 ID、
   HEAD、租约与快照指纹，避免跨项目串读。
-- 自定义项目沿用 20 个变化文件、单文件 512 KiB、Patch 1 MiB 限额，允许新增、修改、
+- `local_clone` 沿用 20 个变化文件、单文件 512 KiB、Patch 1 MiB 限额，允许新增、修改、
   删除或移动 UTF-8 普通文本。项目验证与逐次确认命令仅在临时副本中运行；只有 version 3
   逐项目授权、无 remote 且固定分支的独立克隆开放应用与本地提交，发布和多轮接口仍固定
   返回 `project_operation_unavailable`，不会误用 ModelMirror 的执行面。
@@ -271,7 +289,7 @@ FastAPI 的完整环境。源码变化后必须重建 `coding-runtime` 才会刷
 - 输出按步骤聚合、脱敏和截断。验证期间禁止新 Agent 轮次与放弃草稿，但 Diff 和
   Patch 保持可读；revision 变化后旧结果标记 stale。
 
-## 自定义项目受控写入与本地版本
+## 清单项目受控写入与本地版本
 
 - 清单 version 3 通过 `writeback.enabled=true` 逐项目授权。v1/v2、未声明授权、存在
   remote 或不在 `coding/local-draft` 分支的项目保持草稿能力，但不会显示写入入口。
@@ -291,6 +309,42 @@ FastAPI 的完整环境。源码变化后必须重建 `coding-runtime` 才会刷
   索引、工作区哈希和 Writer 日志精确一致才恢复操作；不明确时进入只读冲突态，不重复
   写入或提交。
 
+## Windows Project Host v2 直接写入
+
+- v2 协议为 `modelmirror-coding-project-host-v2`。只有服务端独立写回开关、助手在线、
+  协议为 v2 且所选项目通过资格复核时，`host_git.features.apply/commit` 才为 `true`；
+  v1、离线、过期配对或禁用写回时保留草稿、Diff、下载和最后可信回执，只关闭新动作。
+- Windows 助手使用 DPAPI 保存 host token、设备密钥、项目 ID 到路径的映射和独立操作日志。
+  日志最多 64 条、8 MiB、保留 7 天，包含操作意图、Patch、阶段、文件哈希和回执；不保存
+  模型对话、凭据、remote URL，Server 端也不保存宿主绝对路径。
+- 本地 registry 还保存 root 与 `.git` 的文件身份，并把 canonical path + 两个 identity 绑定
+  到 project ID；这些 identity 不离开 Helper。同一路径换成另一仓库或只替换 `.git` 后，旧
+  项目成为必须重新选择的只读墓碑，所有操作在构造写入引擎前拒绝。旧的 path-only 授权不会
+  被 inventory 或首次操作静默升级。
+- 写入请求帧只传 request/project/operation/action 以及 payload ID、摘要、大小和到期时间。
+  revision、分支、HEAD、Patch 与提交说明进入最多 1.2 MiB、90 秒、单次消费、
+  `Cache-Control: no-store` 的绑定 envelope；Helper 下载后再次核对 token、host、project、
+  operation、action、长度和 SHA-256。inventory、snapshot 与回执使用各自已绑定消息。
+- apply/revert 先在临时状态预演，并以 Windows no-follow 句柄、文件身份、原子 no-replace
+  移动、事务清单和持久 marker 完成全旧或全新恢复。路径越界、秘密、二进制、reparse、
+  symlink、hardlink、大小写冲突及人工同内容替换均失败关闭；生产写回仅支持 Windows。
+- commit/undo 只接受服务端已绑定的当前分支、父 HEAD、ApplyReceipt 和文件身份。助手使用
+  私有对象目录、临时索引、受控 reflog 停放与 compare-and-swap ref 更新；固定 Git 环境
+  禁止 Hook、filter、签名、credential helper、include、worktree/commondir、alternates、
+  partial clone、promisor、replace refs、grafts、外部 excludes 和 `extensions.refStorage`。
+  仅支持 files refs；reftable 等其他 refs 后端只读拒绝。remote 可存在，但不读取其配置值
+  或执行 remote/fetch/push。
+  宿主提交作者固定为 `ModelMirror Coding Assistant <coding@modelmirror.local>`，不接受浏览器、
+  Agent 或 Compose 的旧 Committer 作者变量覆盖。
+- 恢复把初始快照 `H0` 与当前轮父提交 `Hk` 分开。已完成轮次的 commit parent 必须严格
+  线性，首轮 apply 日志只用于授权重建 `H0`，当前 apply/commit/undo/revert 则绑定 `Hk`。
+  Helper、Server 或 Runtime 重启后只接受项目、分支、HEAD、索引、文件身份和回执精确
+  一致的结果；应用后的预期脏树不得重新套用初始干净资格。
+- `operation_result_unknown` 不等于失败。apply、revert、commit、undo 四个方向分别保留
+  原 operation ID 和最后可信状态；页面只提供“核对本次写入/撤销/保存”动作，禁止创建
+  新 revision 或发送新副作用 ID。仅活动态低频查询，终态立即停止；离线或 v1 降级不隐藏
+  Diff、下载和操作历史，也不把未知结果显示成红色失败。
+
 ## 受控应用与撤销
 
 - `coding-applier` 只存在于显式加载的独立 Compose overlay，使用非 root、只读
@@ -308,9 +362,10 @@ FastAPI 的完整环境。源码变化后必须重建 `coding-runtime` 才会刷
 - 成功后会话冻结，只允许查看变化、Diff、Patch、验证和应用结果。撤销只有在
   目标仍精确保持应用后状态时执行；新增文件只在这次撤销中删除。外部修改会使
   撤销失败，不会被覆盖。
-- 应用凭据仅存 Server 内存。会话关闭、过期或 Server 重启后不保证页面撤销；
-  应删除并从同一提交重建专用工作树。Applier 不可用不会影响 Draft、Diff、
-  Verifier、Patch 下载或核心服务健康。
+- 未启用 recovery overlay 时，应用凭据只存 Server 内存；会话关闭、过期或 Server 重启后
+  不保证页面撤销，此时应人工确认并从同一提交重建专用工作树。启用恢复后，加密意图、
+  公开回执与 Applier 日志精确一致可恢复撤销；不明确时只读冲突。Applier 不可用不会影响
+  Draft、Diff、Verifier、Patch 下载或核心服务健康。
 
 ## 隔离本地提交与撤销
 
@@ -351,11 +406,13 @@ FastAPI 的完整环境。源码变化后必须重建 `coding-runtime` 才会刷
 
 ## 多轮本地修改
 
-- 加载恢复 overlay 并设置 `CODING_INCREMENTAL_ENABLED=true` 后，同一任务最多可完成
+- 内置 ModelMirror 与 v2 `host_git` 在恢复可用且设置 `CODING_INCREMENTAL_ENABLED=true`
+  后，同一任务最多可完成
   10 轮修改、验证、应用和本地提交。每次提交成功后，用户必须明确点击“继续修改”才会
   开始下一轮；旧轮次保持只读。
 - 项目验证针对基准、此前全部已提交轮次和当前草稿的累计状态运行；应用和提交只处理
-  当前轮增量。目标仓库保持线性父子提交关系，不允许选择分支或改写旧轮次。
+  当前轮增量。目标仓库保持线性父子提交关系；`host_git` 固定使用选择时保存的当前分支，
+  浏览器和 Agent 不允许选择或切换分支，也不能改写旧轮次。清单 `local_clone` 仍为单轮。
 - 页面默认展示当前轮文件与 Diff，历史折叠显示，并可分别下载当前轮或全部累计修改。
   只允许撤销最新一轮；达到 10 轮后仍可查看、下载和结束任务。
 - 恢复 schema v3 保存已完成轮次、当前完整草稿和加密发布意图/回执；旧 v1/v2 记录
@@ -400,13 +457,16 @@ CODING_PROJECT_COMMANDS_ENABLED=false
 CODING_RUNNER_PACKS_ROOT=
 CODING_FILE_OPERATIONS_ENABLED=true
 CODING_PROJECT_WRITEBACK_ENABLED=false
+CODING_PROJECT_HOST_ENABLED=false
+CODING_PROJECT_HOST_WRITEBACK_ENABLED=false
 ```
 
 `CODING_AGENT_MODE` 默认为 `readonly`，只有显式设置为 `draft` 才开放临时编辑。
 `CODING_AGENT_GATEWAY_KEY` 只注入隔离 Worker，不注入 FastAPI。模型标识只允许
 字母、数字、点、下划线、斜线、冒号和短横线。
-多轮模式依赖恢复、Applier 和 Committer 同时可用；任一执行面缺失时 capabilities 会
-明确显示不可用，不会静默降级为可写多轮流程。恢复 overlay 默认开启该能力；设置
+内置多轮模式依赖恢复、Applier 和 Committer 同时可用；`host_git` 多轮依赖恢复与
+Project Host v2。对应执行面缺失时 capabilities 会明确显示不可用，不会静默改用另一
+项目来源的写入面。恢复 overlay 默认开启该能力；设置
 `CODING_INCREMENTAL_ENABLED=false` 可立即回到第六轮单次流程。
 发布功能还要求恢复、Applier、Committer 与无 remote 独立仓库均可用，并显式加载
 `docker-compose.coding-publish.yml`。App ID、安装 ID、仓库 ID、`owner/repository`
@@ -419,10 +479,17 @@ CODING_PROJECT_WRITEBACK_ENABLED=false
 Python 3.12、Node 22/npm 与已有锁定依赖。若设置该变量，必须使用部署者控制的绝对目录，
 每个 Pack 使用不可变版本 ID，且只读挂载给 Verifier。本轮未新增前端或后端第三方依赖；OpenCode 仍固定
 为 `1.18.9`（MIT），现有第三方声明无需新增条目。
-自定义项目写回还必须使用清单 v3，逐项目设置 `writeback.enabled=true`，并加载
+清单 `local_clone` 写回还必须使用清单 v3，逐项目设置 `writeback.enabled=true`，并加载
 `docker-compose.coding-writeback.yml`。目标必须无 remote 且固定在
 `coding/local-draft`；省略 overlay 或关闭 `CODING_PROJECT_WRITEBACK_ENABLED` 只会让
 写入/提交不可用，不影响草稿、验证、命令、下载或 ModelMirror 完整闭环。
+Windows `host_git` 需加载 `docker-compose.coding-project-host.yml`，由
+`CODING_PROJECT_HOST_ENABLED=true` 开启接入，并在绝对 `MODELMIRROR_DATA_ROOT` 对应的
+`server/.env` 设置 `CODING_PROJECT_HOST_WRITEBACK_ENABLED=true`。助手使用
+`scripts/build-coding-project-host.ps1` 从同一实现 HEAD 打包并单独启动；旧 v1 包严格只读。
+两种项目来源并存时必须在两者 overlay 后加载
+`docker-compose.coding-project-host-full.yml`。完整拓扑、40 MiB 包门禁、恢复 overlay 的
+legacy 变量约束和共享栈独占窗口见 [DEPLOYMENT.md](./DEPLOYMENT.md)。
 
 实现分支尚未合并时，基于实现 HEAD 创建的验收仓库不可能与 GitHub `main` 精确匹配。
 真实远端验收可由部署者临时把 `CODING_GITHUB_BASE_BRANCH` 固定为一个精确指向任务基线
@@ -556,10 +623,35 @@ docker compose -f docker-compose.yml -f docker-compose.coding-apply.yml -f docke
     不留下部分写入；正常撤销精确恢复，撤销前人工改文件时不得覆盖。
 37. 保存本地版本后核对固定作者、说明、父提交和文件集合；重复点击不新增提交。撤销提交
     保留文件，再撤销写入恢复基准。Server/Writer 在各操作回执前重启后不得重复写入或提交。
-38. 停止 Writer 或关闭项目授权，确认自定义项目仍可问答、修改草稿、验证、逐次确认命令、
+38. 停止 Writer 或关闭清单授权，确认 `local_clone` 仍可问答、修改草稿、验证、逐次确认命令、
     下载和恢复；项目 B 的随机标记始终不能被项目 A 的 Writer 请求读取或修改。
+39. 从同一实现 HEAD 打包并启动 v2 Windows 助手，使用中文与空格路径、随机当前分支、
+    已配置 remote 的两个独立项目 A/B。确认 Server、浏览器、响应、日志和恢复记录均不含
+    物理路径或 remote URL，且进程网络观测中没有 fetch、push、ls-remote 或凭据访问。
+40. 在 A 中对 3–5 个随机 UTF-8 文件完成新增、修改、删除和重命名；验证失败或未运行时
+    逐 revision 二次确认可继续，`.env`、秘密、二进制、越界、reparse/symlink/hardlink、
+    大小写冲突仍绝对拒绝。项目 B 与所有未选工作树保持不变。
+41. 依次核对 apply、当前分支 commit、undo（保留文件）和 revert（恢复精确初始内容），
+    再完成两轮 `H0→H1→H2` 线性提交；确认恢复上下文始终锚定 `H0`，第二轮父提交为 `H1`，
+    达到 10 轮后只禁止继续，不影响查看和下载。
+42. 在 Helper 接收前、宿主副作用后/回执前、Server 落盘前分别断线或重启 Helper、Server、
+    Runtime；超时页面只显示待核对，按原 operation ID 返回 applied/committed/undone/reverted，
+    任一文件最多写一次、任一轮最多产生一个可达提交。
+43. 应用后人工同内容替换或改写文件、切分支、推进 HEAD、改变索引；撤销和恢复必须进入
+    只读冲突且不覆盖人工对象。分别使用 v1 助手、禁用写回和完全离线，确认草稿、Diff、
+    下载、最后可信状态及 ModelMirror/`local_clone` 闭环保留，且没有写入控制请求。
+44. 验收前后核对主工作树、实现工作树、未选项目、remote 配置和网络均无意外变化；只有
+    人工确认的项目与分支包含预期文件和本地提交。以上真实助手与共享栈验收必须等用户确认
+    独占窗口和最新基线后执行，不能用单元测试或旧 v1 包替代。
 
 ## 回退
+
+先在绝对数据根对应的 `server/.env` 设置
+`CODING_PROJECT_HOST_WRITEBACK_ENABLED=false` 并重启或重建 Server，即保留第十二轮
+Project Host 只读项目选择、问答、草稿、Diff 和下载；已有宿主文件或本地提交不会自动
+撤销。再设置
+`CODING_PROJECT_HOST_ENABLED=false` 并在后续启动中省略
+`docker-compose.coding-project-host.yml` 可完全关闭助手，仍不会删除项目或授权外内容。
 
 先设置 `CODING_PROJECT_WRITEBACK_ENABLED=false` 并省略
 `docker-compose.coding-writeback.yml`，自定义项目立即回到草稿、验证、命令、下载和恢复；

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -24,6 +24,8 @@ Dify 不是部署依赖。`/workflow` 和 `/rag` 分别由 classic 工作流和�
 | `office-host` | 否 | `office` profile；实验性 Office Add-in host。 |
 | `coding-runtime` | 否 | `coding` profile；单实例代码问答与修改草稿执行面，无宿主端口。 |
 | `coding-verifier` | 否 | `coding-verify` profile；无网络的草稿项目验证执行面，无宿主端口。 |
+| `coding-project-source` | 否 | `coding-projects` 或 `coding-project-host` profile；把当前项目 HEAD 导入单槽快照，不向 Server 暴露路径。 |
+| `coding-project-writer` | 否 | `coding-writeback` profile；只写清单 v3 授权的 `local_clone`。 |
 | `coding-applier` | 否 | 独立 overlay 的 `coding-apply` profile；把已验证草稿写入固定专用工作树。 |
 | `coding-committer` | 否 | 独立 overlay 的 `coding-commit` profile；只在无远程独立仓库中创建本地提交。 |
 | `coding-publisher` | 否 | 独立 overlay 的 `coding-publish` profile；只读发布固定提交链。 |
@@ -31,6 +33,8 @@ Dify 不是部署依赖。`/workflow` 和 `/rag` 分别由 classic 工作流和�
 
 Coding 恢复没有新增常驻服务；`docker-compose.coding-recovery.yml` 只给 Server
 挂载独立加密存储，并提供一次性、无网络、只读的重建预检容器。
+Windows Project Host v2 是单独打包、由用户启动的便携 Windows 应用，不是 Compose
+服务，也不会随容器自动启动。
 
 启动默认栈：
 
@@ -193,9 +197,10 @@ Runtime 只经私有 socket 和单槽快照卷取得所选项目的 HEAD 内容�
 个文件、192 MiB，单文件 32 MiB；只读取根目录 UTF-8 `AGENTS.md`（最多 64 KiB），
 仓库内 OpenCode、插件、MCP、provider 和可执行配置均不会生效。
 
-自定义项目支持问答、结构化文本文件操作、Diff、轻量检查、确认后的离线验证、下载和
-重启恢复。只有清单 v3 显式授权且满足无 remote/固定分支条件的项目支持写入与本地提交；
-仍不支持 GitHub 发布或多轮提交。内置 ModelMirror 仍是默认项目并保留完整闭环；停止
+清单项目支持问答、结构化文本文件操作、Diff、轻量检查、确认后的离线验证、下载和
+重启恢复。只有清单 v3 显式授权且满足无 remote/固定分支条件的 `local_clone` 支持
+Writer 写入与单轮本地提交；仍不支持 GitHub 发布或多轮提交。内置 ModelMirror 仍是
+默认项目并保留完整闭环；停止
 Project Source 后也必须继续可用。共享栈重建前应先确认根路径为绝对路径、清单可解析、
 所有登记仓库符合其能力要求，并取得独占窗口；任一预检不通过时不要重建。
 
@@ -220,7 +225,7 @@ curl http://localhost:8000/api/coding/projects
 
 `CODING_FILE_OPERATIONS_ENABLED=false` 只关闭代码助手的删除/移动工具；既有新增、修改和
 只读能力不受影响。`CODING_PROJECT_WRITEBACK_ENABLED=false` 或省略 Writer overlay 会让
-自定义项目回到只读草稿、验证和下载，不会撤销已有本地文件或提交。应用/提交前 Writer
+清单项目回到只读草稿、验证和下载，不会撤销已有本地文件或提交。应用/提交前 Writer
 再次复核项目 ID、基准 HEAD、固定分支、remote、索引、工作区、Patch 和文件哈希；异常
 只影响所选项目写回能力，不得导致 ModelMirror 或其他自定义项目不可用。
 
@@ -232,6 +237,76 @@ curl http://localhost:8000/api/coding/projects
 
 若只需第二轮草稿能力，可省略 `coding-verify` profile。此时页面会明确提示验证
 服务未启动，但查看 Diff、轻量检查和下载仍可使用。
+
+#### Windows 本地项目助手直接写入
+
+`host_git` 不使用 `CODING_PROJECTS_ROOT` 或容器 Writer。Windows Project Host v2 是
+宿主项目路径的唯一持有者，在用户明确选择的干净独立 Git 项目内执行原子写入、撤销、
+当前分支本地提交、撤销提交和精确对账。项目可已有 remote，但助手不会读取或返回 URL，
+不会执行 fetch、push、ls-remote 或创建 PR。v1 助手和写回开关关闭时仍可选择项目、问答、
+生成草稿、查看/下载 Diff，但始终不显示写入入口。
+
+写回资格仅支持标准 files refs 后端，并在任何对象/status/事务命令前拒绝
+`extensions.refStorage`/reftable、replace refs、grafts、partial clone、promisor、alternates、
+配置 include/filter/credential 与外部 excludes。Helper 本地 DPAPI registry 绑定所选 root
+和 `.git` 的文件身份；旧 path-only 记录或同路径换仓必须由用户重新选择，不能自动继承授权。
+
+先固定绝对数据根，并在该根对应的 `${MODELMIRROR_DATA_ROOT}/server/.env` 中设置：
+
+```dotenv
+CODING_PROJECT_HOST_WRITEBACK_ENABLED=true
+```
+
+该变量由 base Compose 的 `server.env_file` 注入；只在 PowerShell 设置同名环境变量不会
+把它传给 `server`。`CODING_PROJECT_HOST_ENABLED` 则由 Project Host overlay 读取：
+
+```powershell
+$env:MODELMIRROR_DATA_ROOT = 'C:\absolute\path\to\stable\data\workspace'
+$env:CODING_PROJECT_HOST_ENABLED = 'true'
+docker compose -f docker-compose.yml -f docker-compose.coding-project-host.yml `
+  -f docker-compose.coding-commands.yml -p modelmirror `
+  --profile coding --profile coding-verify --profile coding-project-host config --quiet
+```
+
+这条命令只做配置预检。实际 `up -d --build --force-recreate` 必须等用户确认共享栈独占
+窗口和最新基线后，从批准的验收集成工作树执行。若清单 `local_clone` 与 Windows 助手
+同时启用，overlay 顺序固定为 base → `docker-compose.coding-projects.yml` →
+`docker-compose.coding-project-host.yml` → `docker-compose.coding-project-host-full.yml`，
+之后再追加当前部署已使用的 commands、writeback、recovery 等 overlay；缺少 full overlay
+会破坏 Project Source 的隔离列表或挂载合并。只使用其中一种项目来源时不要加载 full。
+
+当前 `docker-compose.coding-recovery.yml` 仍同时预检 legacy Applier/Committer 的
+`CODING_IMPLEMENTATION_WORKTREE` 和 `CODING_COMMIT_REPOSITORY`，且 Compose 会在 profile
+过滤前插值。因此不能把它描述为无需其他变量的全新 host-only recovery overlay；共享栈
+应继续提供现有受控目标变量并保留当前拓扑，或在后续拆出 host 专用恢复预检后再简化。
+不得用虚构路径绕过检查。
+
+便携助手必须与容器代码来自同一实现 HEAD，并在临时输出目录重新打包：
+
+```powershell
+$helperRoot = 'C:\tmp\modelmirror-project-host-v2'
+python -m venv "$helperRoot\venv"
+& .\scripts\build-coding-project-host.ps1 `
+  -Python "$helperRoot\venv\Scripts\python.exe" `
+  -OutputRoot "$helperRoot\package"
+```
+
+脚本会在传入的解释器环境中安装固定 `websockets==16.0`、`pyinstaller==6.14.1`；因此
+必须使用专用 venv，不能污染部署者默认 Python。它没有新增第三方依赖；生成
+`ModelMirrorProjectHost-windows-x64.zip`、打印 SHA-256，并在压缩包超过 40 MiB 时失败。
+产物、spec、build、dist 和助手日志不得提交。便携包不内置 Git；目标电脑必须预装
+Git for Windows 或兼容 `git.exe`，并让助手进程可从 `PATH` 找到。助手只接受
+`http://127.0.0.1:<port>`（默认 8000），不接受 `localhost`、非回环地址、HTTPS、认证信息、
+路径、query 或 fragment。完成容器重建后还必须启动这份 v2 助手，
+核对 `/api/coding/project-host` 的协议、`direct_writeback`、可用性和原因，再真实走一次
+“选择→快照→草稿→apply→commit→undo→revert”协议冒烟；旧便携包不能作为写回验收。
+
+重建前必须另行检查绝对 `MODELMIRROR_DATA_ROOT` 及其 `server/.env` 中 Coding 模型 Key
+和上述开关是否存在且非空，不得把值打印到终端或日志；当前 recovery preflight 不代替
+这项检查。把 `CODING_PROJECT_HOST_WRITEBACK_ENABLED=false` 写入该 `server/.env` 并在
+批准窗口内重启或重建 Server 后，即恢复第十二轮只读助手；设置
+`CODING_PROJECT_HOST_ENABLED=false` 并在后续启动中省略 Project Host overlay 可完全关闭
+助手。两种回退都不会自动撤销已写文件、删除本地提交或移除用户项目。
 
 #### 受控应用到专用工作树
 
@@ -267,8 +342,10 @@ Runtime 与 Verifier 也不能访问它的独立 socket。
 
 应用前目标必须仍与镜像基准完全一致：除 `.git` 外不能有修改、额外文件或符号
 链接。成功应用后页面可在当前会话内执行一次安全撤销；如果有人又编辑了目标，
-撤销会拒绝覆盖。Server 重启后不保证保留撤销凭据，此时应删除并从相同提交重新
-创建这个专用工作树。不要让自动清理脚本删除用户未确认的工作树。
+撤销会拒绝覆盖。未加载 `docker-compose.coding-recovery.yml` 时，Server 重启后不保证
+保留撤销凭据，此时应人工确认并从相同提交重建专用工作树；启用恢复后，加密意图、
+公开回执和 Applier 日志精确一致可恢复撤销，不明确则只读冲突。不要让自动清理脚本
+删除用户未确认的工作树。
 
 #### 保存为隔离本地提交
 
@@ -419,7 +496,8 @@ curl http://localhost:5173/studio
   不得自动创建新的付费会话。
 - 视频任务状态与连续轮询错误；临时网络错误不直接写成任务失败。
 - Browser、Sandbox、newAPI 和 server health。
-- 启用后检查 Coding capabilities、项目清单、Project Source/Worker/Verifier/Project Writer/Applier/Committer/Publisher health、
+- 启用后检查 Coding capabilities、项目清单、Project Host 协议/心跳/direct writeback、
+  Project Source/Worker/Verifier/Project Writer/Applier/Committer/Publisher health、
   出口域名拒绝、验证取消清理、快照指纹、恢复 pending/retention 和源码 Git 状态。Capabilities 与
   日志不得返回目标绝对路径、恢复密钥或密文负载。
 
@@ -446,7 +524,12 @@ curl http://localhost:5173/studio
   `MULTIMODAL_REALTIME_VOICE_ENABLED`；已有 STT/TTS、普通 Chat 和视频链路不受影响。
 - 智能调度：切回 `MODEL_ROUTER_ENGINE=sidecar` 或 default/newAPI，保留 SQLite。
 - OmniRoute：停止 profile，不删除 `omniroute-data`。
-- 代码助手：若只回退第十一轮，先设置 `CODING_PROJECT_WRITEBACK_ENABLED=false`、
+- 代码助手：若只回退第十三轮，在绝对数据根对应的 `server/.env` 设置
+  `CODING_PROJECT_HOST_WRITEBACK_ENABLED=false` 并重启或重建 Server，即可保留第十二轮
+  只读 Windows 助手；
+  再设置 `CODING_PROJECT_HOST_ENABLED=false` 并省略 `docker-compose.coding-project-host.yml`
+  可完全关闭助手。已有宿主文件、本地提交和授权不会被自动清理。若还要回退第十一轮，
+  设置 `CODING_PROJECT_WRITEBACK_ENABLED=false`、
   `CODING_FILE_OPERATIONS_ENABLED=false`
   并省略 `docker-compose.coding-writeback.yml`；这不会自动撤销已写入文件或已有本地
   提交。如需进一步关闭自定义项目，再设置 `CODING_PROJECTS_ENABLED=false` 并在后续

--- a/docs/HARNESS_ENGINEERING.md
+++ b/docs/HARNESS_ENGINEERING.md
@@ -270,8 +270,8 @@ curl http://localhost:5173/models
     Patch，把当前轮放入活动 Patch；项目验证使用两者的累计路径选择步骤。恢复时若只用
     当前轮路径复核，会把合法的混合验证结果误判为损坏。恢复验证必须使用基准与活动
     路径的去重并集，同时仍分别复核两段 Patch 的路径和 revision。
-12. **安全边界与质量建议必须分层。** 路径越界、秘密、符号链接、真实仓库写入、目标
-    指纹和远端基线属于不可覆盖的硬门禁；语法检查、项目验证和依赖可运行性属于质量
+12. **安全边界与质量建议必须分层。** 路径越界、秘密、符号链接、未经项目授权和逐次
+    确认的真实仓库写入、目标指纹和远端基线属于不可覆盖的硬门禁；语法检查、项目验证和依赖可运行性属于质量
     结论。质量结论未通过时应清楚告知风险并允许用户再次确认，不能用同一种“不可用”
     状态永久锁死下载或专用副本应用。
 13. **进程内对账必须优先复用已知操作。** Applier 已保存相同操作 ID 与回执时，应先
@@ -292,9 +292,11 @@ curl http://localhost:5173/models
     专用仓库，其任务提交父节点不会等于远端 `main`，严格基线检查必然拒绝。不得把
     “远端必须精确匹配”放宽为祖先或可快进判断；应先合并实现，或由部署者临时固定一个
     精确指向任务基线的验收分支。验收结束后恢复 `main` 并明确处理临时远端内容。
-18. **项目根目录只能由最小 Broker 看见。** 不得为了项目选择把整个宿主根目录挂载给
-    Server 或 Runtime；只有无网络 Project Source 可只读扫描清单，Runtime 只消费当前
-    租约的单槽快照。Broker 故障必须独立降级，内置 ModelMirror 不受影响。
+18. **项目根目录只能由最小宿主执行面看见。** 清单 `local_clone` 不得为了项目选择把整个
+    根目录挂载给 Server 或 Runtime；只有无网络 Project Source 可只读扫描清单，Runtime
+    只消费当前租约的单槽快照。`host_git` 的物理路径只保存在 Windows Helper 的 DPAPI
+    registry 中，Server、浏览器、Runtime 和模型仍只能看到不透明项目 ID。任一来源故障
+    必须独立降级，内置 ModelMirror 不受影响。
 19. **项目快照必须来自 Git HEAD blob。** 复制工作区会把 Windows CRLF、过滤器结果和
     未跟踪内容混入基准，导致指纹误报甚至泄露。固定 `ls-tree`/`cat-file` 只读取对象，
     不运行 Hook、clean/smudge、凭据助手或仓库命令；宿主仓库验收前后必须无变化。
@@ -310,19 +312,23 @@ curl http://localhost:5173/models
 23. **恢复项目上下文要向后兼容并保持加密。** 项目 ID、类型、显示名和 HEAD 进入独立
     认证加密表，不保存宿主路径、不改 recovery schema v3 `user_version`；旧记录视为
     ModelMirror。项目变化只降级为下载，不改写基线或借旧 Patch 恢复到新 HEAD。
-24. **前端先按项目功能矩阵裁剪请求。** 自定义项目不得轮询验证、应用、提交或发布；
-    否则固定 409 会触发重复刷新、操作区消失和误报不可用。活动会话或 pending 恢复存在
-    时锁定项目选择，切换永远不能成为清空草稿的隐式操作。
+24. **前端先按项目功能矩阵裁剪请求。** `local_clone`、`host_git` 和内置项目必须分别按
+    自身 features 与执行面可用性请求验证、应用、提交或发布，不能让一个全局 capability
+    覆盖项目级拒绝。状态查询仅用于 applying、reverting、committing、undoing 等活动态，
+    终态立即停止；活动会话或 pending 恢复存在时锁定项目选择，切换不能成为清空草稿的
+    隐式操作。
 25. **不要用 Windows junction 共享可删除依赖目录。** 临时 worktree 若把 `node_modules`
     junction 到实现目录，清理 worktree 时可能遍历并删除真实依赖。体积基线应使用独立
     依赖安装、既有构建产物或只读统计，清理前必须确认链接目标不会被递归处理。
-26. **写回资格必须逐项目显式授权。** “位于受控根目录”只证明可被 Broker 读取，不等于
-    可以写入。写回需要清单版本、逐项目开关、无 remote、固定分支和独立 `.git` 同时成立；
-    任一条件缺失只降级该项目的写入/提交能力，不得禁用问答、草稿、验证或下载。
-27. **恢复基准必须锚定保存的提交，不是当前工作区。** 用户确认写入或提交后，目标按设计
-    不再等于初始干净工作区；若 Project Source 仍只接受“当前 HEAD + 全目录干净”，重启会
-    把合法结果误报为项目变脏。恢复只能按已保存基准 HEAD 读取 Git 对象，并由 Writer 回执
-    证明后续状态，不能把预期副作用当作未授权改动。
+26. **写回资格必须逐项目显式授权。** “位于受控根目录”只证明 `local_clone` 可被 Broker
+    读取，不等于可以写入；它仍需要清单 v3、逐项目开关、无 remote、固定分支和独立
+    `.git`。`host_git` 则必须同时满足 v2 协议、服务端独立开关、助手在线、系统选择授权、
+    当前分支和项目资格。任一条件缺失只降级该项目的写入/提交能力，不得禁用问答、草稿、
+    Diff、验证或下载。
+27. **恢复基准必须锚定不可变 `H0`，当前轮写入绑定 `Hk`。** 用户确认写入或提交后，目标
+    按设计不再等于初始干净工作区；恢复以首轮操作日志授权读取保存的 `H0` 快照，再由线性
+    CommitReceipt 推导当前父提交 `Hk` 并对账活动操作。不能用当前工作区重写基准，也不能
+    把合法脏树、HEAD 前进或历史轮次当作未授权改动。
 28. **公开回执与执行面日志不能混为一种凭据。** API ApplyReceipt 面向会话、恢复和前端，
     Writer/Committer 日志还包含内部基准、父提交和操作阶段；两者时间或指纹字段不必相同。
     对账应分别校验各自 schema 并以不透明 ID 关联，不能拿公开回执直接伪造内部提交上下文。
@@ -334,3 +340,44 @@ curl http://localhost:5173/models
     只表示该项目符合静态资格；Writer 未配置或不可达时仍应隐藏写入入口并显示日常语言
     原因。反过来，Writer 健康也不能给未授权项目开放按钮；不能复用 ModelMirror 的 Applier
     capability，否则会把自定义项目错误路由到专用副本并造成状态区消失或重复请求。
+31. **Helper v1 与 v2 必须按协议能力降级。** 旧助手、写回开关关闭或瞬时离线都要保留
+    项目摘要、草稿、Diff、下载和最后可信操作状态，只关闭新写入动作。paired 与 available
+    不是同一状态；过期凭据要停止旧码重试并始终提供重置/重新配对入口。
+32. **副作用结果未知只能按原 ID 对账。** apply、revert、commit 和 undo 都要在副作用前
+    持久化 operation ID；超时、断线、畸形回执或 catalog 落盘失败统一进入待核对状态。
+    前端不得显示红色确定失败、生成新 revision 或重新发送新 ID，只能触发原方向 reconcile。
+33. **Windows 文件事务必须绑定对象而不是路径字符串。** `lstat/hash → replace/unlink` 存在
+    TOCTOU，会覆盖同内容人工替换或穿透 junction。生产写回要以 no-follow 句柄、file ID、
+    no-replace 移动、持久事务清单和可重入隔离完成；无法提供等价删除语义的平台失败关闭，
+    POSIX 领域测试不能被宣称为产品支持。
+34. **Git 安全边界是完整命名空间。** 只禁 remote 或 Hook 不够；objects、fanout、refs、
+    reflog、HEAD、index/index.lock、config、commondir、alternates、partial clone、promisor、
+    replace refs、grafts、refStorage/reftable、外部 excludes、filter、credential、签名与 URL
+    rewrite 都可能造成越界读写或联网。对象应在私有目录生成，reflog/索引按身份停放恢复，
+    ref 使用固定参数 CAS；不支持的 refs 后端在任何事务产物前拒绝，remote 配置可存在但不得
+    读取值。
+35. **路径授权必须绑定项目对象身份。** 仅用规范路径 HMAC 无法区分同一路径整体换仓或
+    `.git` 被替换。Helper 应在 DPAPI 本地状态保存 root/`.git` identity、让 project ID 随身份
+    变化，并在 inspect→archive→reinspect 及 apply/revert/commit/undo/reconcile 全程持有
+    no-follow guard；旧 path-only 授权只能要求重选，不能由 inventory 或首次操作静默补绑。
+36. **公开回执、Helper 日志和 catalog 各有独立职责。** 回执证明会话操作，DPAPI 日志证明
+    宿主阶段和对象身份，catalog 只提供脱敏可见性。只有严格回执与日志同时通过才推进
+    catalog HEAD/state；离线 catalog 隐去 branch/head 时可用当前会话可信身份补显示，但
+    不能用旧 catalog feature 重新开放动作。
+37. **Helper registry 落盘必须先成功再接受内存状态。** DPAPI、原子写盘或留存清理失败时
+    要回滚候选内存值，不能让本进程报告 HEAD 已推进、重启后又回到旧值。多 Helper 进程还
+    必须以单实例锁或跨进程 CAS 防止 last-writer-wins 丢失操作日志。
+38. **连接代际和心跳要独立于长操作。** Helper 必须主动心跳，并用 generation 或
+    connection_id 防止旧连接的 finally 把新连接标离线；snapshot、apply、commit 等长操作
+    不能饿死心跳。前端能力签名变化可静默刷新，但不得形成无延迟请求循环或整页闪烁。
+39. **容器配置通过不等于执行面可启动。** 新 Python 模块要同步 Dockerfile/PyInstaller
+    收集和只读挂载点；Compose overlay 合并要验证实际顺序，尤其两个 Project Source 来源
+    并存时需要 full compatibility overlay。容器重建还必须同步打包和启动同一 HEAD 的 v2
+    便携助手，不能用旧包或 Mock 冒烟替代。
+40. **未知结果 UI 必须保留唯一安全出口。** apply/revert/commit/undo 四种未知方向的 receipt
+    形态不同；界面要分别显示对应“核对本次操作”，锁住新修改和放弃，但保留 Diff、下载和
+    原操作核对。活动态轮询终止后应刷新 history/catalog，不能让成功状态因旧摘要退回只读。
+41. **共享栈验收必须晚于自动门禁且再次核对基线。** 多 worktree 共用 `-p modelmirror` 时，
+    任何 build/up/recreate 前都要取得用户确认的独占窗口；若 `origin/main` 前进，应在新验收
+    集成工作树定向引入批次并 range-diff。人工验收后还要再次核对主线、全 Diff、敏感信息
+    和禁止产物，才允许 push 或 PR。

--- a/docs/tasks/CODING_DIRECT_WRITEBACK_V13.md
+++ b/docs/tasks/CODING_DIRECT_WRITEBACK_V13.md
@@ -61,20 +61,88 @@
 ## 7. 验证、共享栈与回退
 
 - 自动验证覆盖协议、一次性负载、DPAPI 日志、原子应用、提交、撤销、故障注入、恢复对账、API、前端和旧能力回归。
-- 完成专项测试、`py_compile`、全量后端测试、前端生产构建、全部 Coding Compose 配置和 Windows 助手真实协议冒烟。
+- 完成专项测试、`py_compile`、全量后端测试、前端生产构建、全部 Coding Compose 配置和 Windows 助手独立打包/启动冒烟；真实 v2 配对与项目写入单列为人工验收。
 - 重建前重新确认 `origin/main`、实现 HEAD、绝对 `MODELMIRROR_DATA_ROOT`、对应 `server/.env` 和 Compose overlay 拓扑；不得打印密钥。
-- 若主线前进，在新验收集成工作树中定向引入 7 个提交并执行 range-diff，不从旧工作树覆盖共享栈。
+- 若主线前进，在新验收集成工作树中按下表定向引入本轮全部已记录提交（7 个计划批次及所有后置安全纠正），逐项核对 SHA 并执行 range-diff，不从旧工作树覆盖共享栈。
 - 设置 `CODING_PROJECT_HOST_WRITEBACK_ENABLED=false` 回到第十二轮；设置 `CODING_PROJECT_HOST_ENABLED=false` 完全关闭本地项目助手。
 - 人工验收失败时只新增对应修复提交，不压缩或重写已完成批次历史。
 
-## 8. 批次执行记录
+共享栈之外的实现和专项验证可以在本工作树、无网络测试容器及临时输出目录中完成；
+`docker compose up/build/recreate`、替换或启动正式便携助手、真实项目人工写入及 PR 均不在
+自动验证授权内。进入这些步骤前必须由用户再次确认独占时间窗口和最新 `origin/main`。
+
+## 8. 已实现边界与验证状态
+
+- `host_git` 与清单 `local_clone` 使用不同执行面。前者只由 Windows Project Host v2
+  在已选项目本地执行，后者继续由无网络容器 Writer 执行；任一执行面离线都不得串扰
+  另一类项目或内置 ModelMirror。
+- 写入请求帧只携带 request、project、operation、action 及 payload ID、摘要、大小、到期时间。
+  revision、分支、HEAD、Patch 和提交说明由助手使用 host token 经 90 秒、单次消费、
+  `no-store` 的绑定 envelope 拉取，并再次核对 host、project、operation、action、长度和摘要。
+- 助手以 DPAPI 加密日志、原子文件事务和固定 Git plumbing 执行 apply、revert、commit、
+  undo 与 reconcile；Windows 生产路径失败关闭，测试用 POSIX 后端不构成产品支持声明。
+- 本地提交保留选择时的安全当前分支；允许仓库配置 remote，但实现不读取 URL、不调用
+  remote/fetch/push/ls-remote，也不创建 GitHub PR。内置和清单项目的固定分支规则未放宽。
+- 多轮恢复把初始快照 `H0` 与当前轮父提交 `Hk` 分开；历史链、当前操作和助手日志逐项
+  精确匹配后才能继续。超时、断线或畸形回执统一显示“结果未知”，只能按原 ID 对账。
+- 已完成的分批专项验证包含 Project Host 文件事务、提交/撤销、命名空间隔离、一次性负载、
+  三类项目路由、重启恢复、多轮 `H0/Hk`、Windows 原生门禁、前端生产构建和 18 项前端测试。
+  最终自动门禁与基线同现失败见第 11 节；共享栈、真实 v2 配对和用户项目写入仍按第 12 节
+  明确标为未运行，不得从 Mock、单测、打包或 `--help` 冒烟推断完成。
+
+实现过程中已验证并固化的失败经验包括：健康不代表执行面可用；结果未知不能盲重放；
+写入后项目变脏不能再套初始资格；Windows 路径删除必须绑定对象身份；Git 安全边界还包含
+objects、refs、reflog、index、commondir、alternates 与 partial clone；catalog 的可见状态
+不能代替 `H0/Hk` 谱系和助手本地日志。
+
+## 9. 批次执行记录
 
 | 批次 | 本地提交 | 结果 |
 | --- | --- | --- |
-| 0 | 待提交 | 固定基线、L4 边界、停止条件与回退 |
-| 1 | 待提交 | Project Host v2、动态回执与 DPAPI 操作日志 |
-| 2 | 待提交 | 原子应用、故障恢复与安全撤销 |
-| 3 | 待提交 | 当前分支提交、撤销提交与线性多轮 |
-| 4 | 待提交 | 一次性负载、API 路由与恢复对账 |
-| 5 | 待提交 | 项目写入确认、活动态和离线体验 |
-| 6 | 待提交 | 文档、加固与整轮验证报告 |
+| 0 | `d946749` | 固定基线、L4 边界、停止条件与回退 |
+| 1 | `983a227` | Project Host v2、动态回执与 DPAPI 操作日志 |
+| 2 | `903cbf6` | 原子应用、故障恢复与安全撤销 |
+| 3 | `07b92b7` | 当前分支提交、撤销提交与线性多轮 |
+| 4 | `5d90900` | 一次性负载、API 路由与恢复对账 |
+| 5 | `fc068f8` | 项目写入确认、活动态、离线与未知结果体验 |
+| 6 | 本提交（待创建） | 文档、加固与整轮自动验证入口 |
+
+## 10. 后置安全纠正
+
+完整 Diff Review 触发以下停止条件纠正。它们均为独立提交，没有压缩、改写或伪装成新的
+计划批次；验收集成时必须与 0–6 批一起按顺序引入。
+
+| 本地提交 | 触发证据 | 文件范围 | 安全效果 | 专项验证 |
+| --- | --- | ---: | --- | --- |
+| `dd0ef4a` | Project Host 选择、快照与 Apply 可能在 partial clone/promisor 仓库触发 lazy fetch | 5 | 通用 Git 环境禁 lazy fetch；Helper/Apply 在对象命令前拒绝 partial clone、promisor、alternates/http-alternates | 新增 12 项定向全通过；Windows Helper 31 通过、1 跳过 |
+| `f6c29bc` | 同一路径替换仓库、危险 config/include/filter、replace refs 与元数据 reparse 可绕过选择身份 | 5 | DPAPI 本地记录绑定 root/`.git` identity；旧授权要求重选；inspect→archive→reinspect 与五类操作持有 no-follow guards；拒绝危险配置与 replace objects | Windows Helper + Host Apply 125 通过、3 跳过 |
+| `767522c` | 快照发布后首次采信 pathname identity；CommitEngine 漏拒 refStorage、grafts 和外部 excludes | 5 | 归档在发布前取得 identity并 no-replace 发布；上传/清理只认该 identity；commit/undo/reconcile 在创建事务产物前绑定 config/namespace 并拒绝不支持的 refs 后端与重定向 | 定向 12 通过；Windows Helper 81 通过、1 跳过；Snapshot 5 通过 |
+| `66fdbdf` | 上一门禁把 symbolic HEAD 错按 ASCII 解码，合法中文分支被拒 | 3 | HEAD 严格按 UTF-8 解码，非法字节仍失败关闭；安全 config 预检与事务 Git 环境分别验证 | 定向 2 通过；Host Apply + Commit 142 通过、3 跳过 |
+
+## 11. 最终自动门禁
+
+| 门禁 | 实际范围或命令 | 实际结果 | 状态 |
+| --- | --- | --- | --- |
+| Python 语法 | 本轮全部 16 个变更 Python 文件，缓存写入 `C:\tmp` | 通过；未向仓库写入 pycache | 通过 |
+| Project Host 专项 | 5 个 `test_coding_project_host*.py` 文件，无网络、源码只读容器 | 239 通过、9 个 Windows-only 跳过；对应 Windows Helper 原生 81 通过、1 个权限型跳过 | 通过 |
+| 全部 Coding 后端 | 34 个 `test_coding_*.py` 文件 | 617 通过、9 个平台型跳过 | 通过 |
+| 后端全量 | `server/tests/`，独立可写 detached 工作树 + 无网络容器 | 1413 通过、9 跳过、8 失败；8 项在 PR #104 基线逐项同现，均属于 Agent Workspace/Skill Finder 禁止范围 | 基线失败，非 v13 回归 |
+| 前端测试 | `npm.cmd run test -- --run` | 7 个测试文件、18 项通过 | 通过 |
+| 前端生产构建 | `npm.cmd run build`；CodingPage gzip 基线 33,780 bytes | 构建通过；37,721 bytes，增量 3,941 < 8,192 | 通过 |
+| Compose 配置 | 临时数据根、占位 `.env`，11 组 base/legacy/projects/host/full 最大组合，仅 `config --quiet` | 11/11 通过；未执行 up/build/run | 通过 |
+| Windows Helper 包 | 专用 venv；`websockets==16.0`、`pyinstaller==6.14.1`；解包后隐藏 `--help` | ZIP 13,782,607 bytes（13.144 MiB）；SHA256 `4E56D08C2E642C6E237A64E60B44BF3E7CBEC3DDB80A3F1B1C2AED8C8EFAFBEE`；退出码 0 | 通过 |
+| 范围/敏感/产物 | 每提交文件数、`git diff --check`、禁止路径/扩展、依赖与 notices 不变、新增行凭据模式 | 本提交完成后共 11 个本地提交且每个 ≤5 文件；26 个变更路径，无禁止模块/产物/凭据模式命中；requirements、package/lock 与 notices 无漂移 | 通过 |
+| 真实 v2 协议 | 正式便携包配对、选择项目、断线重连 | 未运行；需要用户窗口 | 未运行 |
+
+## 12. 未执行的共享栈与人工验收
+
+- 未执行任何共享项目的 `docker compose up/build/force-recreate/run`；本轮 Compose 仅做临时
+  `config --quiet`，不代表正式数据根、正式 `.env` 或运行中容器已验收。
+- 未替换或启动正式安装的 Windows Helper，未执行真实 v2 配对、正式 8000/5173 健康检查，
+  未在真实用户项目中执行 apply/commit/undo/revert，也未完成 Helper/Server/Runtime 重启与网络
+  观测。打包、单测和 `--help` 均不能替代这些人工证据。
+- 未 fetch 后重新确认最新 `origin/main`，未创建最终验收集成工作树，未 push，未创建 PR。
+- 用户确认独占窗口后，先记录最新 `origin/main`；若已前进，创建新集成工作树，按第 9、10 节
+  顺序引入全部提交并 range-diff。随后只核对正式绝对 `MODELMIRROR_DATA_ROOT` 及对应
+  `server/.env` 的键存在/非空（不打印值），再按实际同时启用的 manifest/host 拓扑加载 overlay、
+  配置预检、重建和人工随机项目验收。验收后再次 fetch/核对基线与范围，才可 push/PR。

--- a/docs/tasks/CODING_DIRECT_WRITEBACK_V13.md
+++ b/docs/tasks/CODING_DIRECT_WRITEBACK_V13.md
@@ -1,0 +1,80 @@
+# 任务卡：CODING-DIRECT-WRITEBACK-V13
+
+> 第十三轮为 Windows 本地项目助手增加受控直接写入与当前分支本地提交能力。风险等级为 L4；任何物理路径泄露、跨项目写入、部分写入、重复提交、未确认副作用或不明确结果被自动覆盖时必须立即停止。
+
+## 1. 基线与单一目标
+
+- 基线：PR #104 合并提交 `952f8094c38b29baffa5de3a5b0caa94e501f45f`。
+- 分支：`codex/coding-direct-writeback-v13`。
+- 工作树：`C:\tmp\modelmirror-coding-v13`。
+- 单一目标：把当前完整草稿受控应用到 Windows 助手所选的干净独立 Git 项目，并在用户当前分支创建可安全撤销的本地提交。
+- 自动验证完成后停止；共享栈重建、人工验收、推送和 PR 必须等待用户明确授权。
+
+## 2. 允许与禁止范围
+
+- 允许修改 Coding Project Host、宿主写入领域、Coding Runtime/API、Coding 前端、专项测试、可选配置及 Coding/Harness 文档。
+- 禁止修改 MCP、Skill、Chat、RAG、Xpert、工作流、多模态、模型目录及其测试或数据。
+- Server 和浏览器不得接收物理路径；Runtime、Verifier 和容器 Writer 不得获得宿主项目写权限。
+- Agent 不得获得 Shell、Git、remote、环境变量、stdin 或宿主路径能力。
+- 不提交 `.env`、令牌、宿主路径、恢复数据库、项目内容、便携包、构建产物、日志或缓存。
+
+## 3. 协议、数据与授权边界
+
+- Project Host v2 才能声明 direct writeback；旧 v1 助手严格保持只读兼容。
+- 每次 apply、revert、commit 和 undo 都绑定 host、project、revision、operation ID、保存的分支与 HEAD。
+- Patch 通过短时、单次、仅助手令牌可读取的负载通道传输；控制 WebSocket 不承载大 Patch。
+- 助手使用独立 DPAPI 加密操作日志保存意图、阶段、Patch、哈希和回执，不保存对话、密钥、remote URL 或工具日志。
+- 超时和断线只表示结果未知；必须先按原 operation ID 对账，禁止生成新的副作用 ID 重试。
+- `CODING_PROJECT_HOST_WRITEBACK_ENABLED=false` 为默认，关闭时完整保留第十二轮只读项目能力。
+
+## 4. 写入、提交与恢复规则
+
+- 应用前复核项目 ID、当前分支、HEAD、索引、工作区、触及文件和 Patch；只允许已授权项目内的安全文本变化。
+- 路径越界、秘密、二进制、符号链接、大小写冲突及完整性风险不可绕过；验证失败或环境未就绪可对当前 revision 明确确认后继续。
+- 多文件写入必须先预演并原子替换；失败只能恢复系统已知状态，检测到人工修改时进入只读冲突。
+- 提交使用临时索引、固定 Git plumbing 和 CAS 更新当前分支；禁止 Hook、签名、过滤器、凭据助手、配置 include 和 remote 操作。
+- 撤销提交保留文件；撤销应用恢复精确初始内容。应用后项目变脏是合法状态，恢复不得重新套用初始干净资格检查。
+- Helper 或 Server 重启后只有现场状态与加密日志精确一致才恢复；不明确时仅保留查看和下载 Diff。
+
+## 5. 七个批次与提交
+
+1. 任务契约：`docs: 定义 Coding 主机项目直接写入契约`
+2. 协议与日志：`feature: 添加 Coding 主机写入回执与加密操作日志`
+3. 原子应用：`feature: 添加 Coding 主机项目原子应用与撤销`
+4. 本地提交：`feature: 添加 Coding 主机项目本地提交与撤销`
+5. API 与恢复：`feature: 添加 Coding 主机写入恢复对账接口`
+6. 前端体验：`feature: 添加 Coding 自定义项目写入体验`
+7. 加固文档：`docs: 完成 Coding 主机项目闭环 harness`
+
+每批最多修改 5 个文件；固定执行文件范围检查、专项测试、`git diff --check`、完整 Diff Review、敏感信息和禁止产物扫描，通过后形成一个本地提交。
+
+## 6. 停止条件
+
+- v1 助手可接收写入请求，或 v2 能力协商可被伪造、降级绕过。
+- 浏览器或 Server 获得宿主路径，或任一执行面可访问未选项目。
+- Patch 可绕过路径、秘密、二进制、符号链接或限额策略。
+- 多文件应用可能留下部分修改，撤销可能覆盖人工内容，或 CRLF 产生无关整文件变化。
+- Hook、过滤器、凭据助手、remote 或非固定 Git 参数可能执行。
+- 超时、断线或重启可能导致重复应用、重复提交或结果未知时继续写入。
+- Helper 故障导致草稿、Diff、下载或 ModelMirror 原有闭环不可用。
+
+## 7. 验证、共享栈与回退
+
+- 自动验证覆盖协议、一次性负载、DPAPI 日志、原子应用、提交、撤销、故障注入、恢复对账、API、前端和旧能力回归。
+- 完成专项测试、`py_compile`、全量后端测试、前端生产构建、全部 Coding Compose 配置和 Windows 助手真实协议冒烟。
+- 重建前重新确认 `origin/main`、实现 HEAD、绝对 `MODELMIRROR_DATA_ROOT`、对应 `server/.env` 和 Compose overlay 拓扑；不得打印密钥。
+- 若主线前进，在新验收集成工作树中定向引入 7 个提交并执行 range-diff，不从旧工作树覆盖共享栈。
+- 设置 `CODING_PROJECT_HOST_WRITEBACK_ENABLED=false` 回到第十二轮；设置 `CODING_PROJECT_HOST_ENABLED=false` 完全关闭本地项目助手。
+- 人工验收失败时只新增对应修复提交，不压缩或重写已完成批次历史。
+
+## 8. 批次执行记录
+
+| 批次 | 本地提交 | 结果 |
+| --- | --- | --- |
+| 0 | 待提交 | 固定基线、L4 边界、停止条件与回退 |
+| 1 | 待提交 | Project Host v2、动态回执与 DPAPI 操作日志 |
+| 2 | 待提交 | 原子应用、故障恢复与安全撤销 |
+| 3 | 待提交 | 当前分支提交、撤销提交与线性多轮 |
+| 4 | 待提交 | 一次性负载、API 路由与恢复对账 |
+| 5 | 待提交 | 项目写入确认、活动态和离线体验 |
+| 6 | 待提交 | 文档、加固与整轮验证报告 |

--- a/server/coding_committer/engine.py
+++ b/server/coding_committer/engine.py
@@ -155,7 +155,10 @@ class CodingCommitterEngine:
                         code="already_undone",
                     )
                 if state == "committed" and reconciled is not None:
-                    return reconciled
+                    return _require_fixed_commit_branch(
+                        reconciled,
+                        code="operation_conflict",
+                    )
                 if state == "conflict":
                     raise CodingCommitError(
                         "Commit recovery state is ambiguous.",
@@ -173,9 +176,10 @@ class CodingCommitterEngine:
                 if key != "reason"
             }
             self._health_snapshot["available"] = True
-            return receipt
+            return _require_fixed_commit_branch(receipt, code="operation_conflict")
 
     def undo(self, receipt: CommitReceipt, apply_receipt: ApplyReceipt) -> CommitReceipt:
+        _require_fixed_commit_branch(receipt, code="operation_conflict")
         with self._lock:
             operation = self._operations.get(receipt.commit_id)
             if operation is None or operation.receipt != receipt:
@@ -200,7 +204,10 @@ class CodingCommitterEngine:
             )
             if state == "undone":
                 assert reconciled is not None
-                return receipt
+                return _require_fixed_commit_branch(
+                    receipt,
+                    code="operation_conflict",
+                )
             if state != "committed":
                 if state == "conflict":
                     self._assert_committed_state(receipt, apply_receipt)
@@ -236,7 +243,7 @@ class CodingCommitterEngine:
                 if key != "reason"
             }
             self._health_snapshot["available"] = True
-            return receipt
+            return _require_fixed_commit_branch(receipt, code="operation_conflict")
 
     def reconcile(
         self,
@@ -284,6 +291,7 @@ class CodingCommitterEngine:
                 code="operation_conflict",
             )
         receipt = operation.receipt
+        _require_fixed_commit_branch(receipt, code="operation_conflict")
         try:
             self._assert_committed_state(receipt, apply_receipt)
         except CodingCommitError:
@@ -367,6 +375,10 @@ class CodingCommitterEngine:
         return operations
 
     def _write_journal(self, operation: _Operation) -> None:
+        _require_fixed_commit_branch(
+            operation.receipt,
+            code="recovery_journal_unavailable",
+        )
         git_dir = self.target_root / ".git"
         journal_parent = self._journal_root.parent
         for directory in (journal_parent, self._journal_root):
@@ -801,6 +813,7 @@ class CodingCommitterEngine:
                 tree_sha=tree,
                 message=message,
                 files=tuple(item.path for item in apply_receipt.files),
+                branch=COMMIT_BRANCH,
             )
             prepared = _Operation(
                 apply_receipt=apply_receipt,
@@ -826,7 +839,7 @@ class CodingCommitterEngine:
             )
             self._operations[operation_id] = committed
             self._write_journal(committed)
-            return receipt
+            return _require_fixed_commit_branch(receipt, code="operation_conflict")
 
     def _move_head_and_index(
         self,
@@ -1130,7 +1143,23 @@ def _commit_receipt_from_journal(value: object) -> CommitReceipt:
     files = value["files"]
     if not isinstance(files, list) or any(not isinstance(path, str) for path in files):
         raise ValueError("Commit journal files are invalid")
-    return CommitReceipt(**{**value, "files": tuple(files)})
+    receipt = CommitReceipt(**{**value, "files": tuple(files)})
+    if receipt.branch != COMMIT_BRANCH:
+        raise ValueError("Commit journal branch is invalid")
+    return receipt
+
+
+def _require_fixed_commit_branch(
+    receipt: CommitReceipt,
+    *,
+    code: str,
+) -> CommitReceipt:
+    if receipt.branch != COMMIT_BRANCH:
+        raise CodingCommitError(
+            "Commit receipt branch is not allowed for the fixed repository.",
+            code=code,
+        )
+    return receipt
 
 
 def _validate_identity(value: str, field: str) -> str:

--- a/server/coding_project_host/host_apply_engine.py
+++ b/server/coding_project_host/host_apply_engine.py
@@ -11,7 +11,7 @@ import subprocess
 import tempfile
 import threading
 import time
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Literal
@@ -25,6 +25,10 @@ from .host_file_transaction import (
     FileMutation,
     HostFileTransaction,
     HostFileTransactionError,
+    _windows_close_handle,
+    _windows_handle_identity,
+    _windows_open_existing,
+    _windows_read_all,
     file_identity,
     move_directory_no_replace,
     read_regular,
@@ -35,11 +39,16 @@ from .operation_log import HostOperationJournal, HostOperationLogError
 
 GIT_TIMEOUT_SECONDS = 30
 FILE_ATTRIBUTE_REPARSE_POINT = 0x0400
+MAX_GIT_NAMESPACE_ENTRIES = 500_000
+MAX_GIT_CONFIG_BYTES = 2 * 1024 * 1024
+MAX_GIT_INDEX_BYTES = 32 * 1024 * 1024
+MAX_GIT_PACKED_REFS_BYTES = 16 * 1024 * 1024
 MutationHook = Callable[[str, int, str], None]
 _DANGEROUS_CONFIG = re.compile(
-    r"^(?:include(?:if)?\..+|filter\..+|credential\..+|"
-    r"diff\..*\.textconv|core\.worktree|extensions\.worktreeconfig|"
-    r"extensions\.partialclone|remote\..*\.(?:promisor|partialclonefilter))$",
+    r"^(?:(?:include(?:if)?|filter|credential|diff|url)(?:\..+)?|"
+    r"core\.(?:worktree|excludesfile)|"
+    r"extensions\.(?:worktreeconfig|partialclone|refstorage)|"
+    r"remote\..*\.(?:promisor|partialclonefilter))$",
     re.IGNORECASE,
 )
 
@@ -60,7 +69,7 @@ def _serialize_project_operation(method):
             raise HostApplyError("windows_required")
         with _project_process_lock(
             self.root,
-            preflight=self._validate_repository_layout,
+            preflight=self._guard_repository_configuration,
         ):
             return method(self, *args, **kwargs)
 
@@ -71,7 +80,7 @@ def _serialize_project_operation(method):
 def _project_process_lock(
     root: Path,
     *,
-    preflight: Callable[[], None] | None = None,
+    preflight: Callable[[], contextlib.AbstractContextManager[None]] | None = None,
 ):
     git = root / ".git"
     if (
@@ -81,9 +90,9 @@ def _project_process_lock(
         or not git.is_dir()
     ):
         raise HostApplyError("git_metadata_unsafe")
-    with _guard_directories((root, git)):
-        if preflight is not None:
-            preflight()
+    with _guard_directories((root, git)), (
+        preflight() if preflight is not None else contextlib.nullcontext()
+    ):
         directory = git / "modelmirror-transactions"
         if directory.exists():
             if _is_link_or_reparse(directory) or not directory.is_dir():
@@ -815,6 +824,8 @@ class HostGitApplyEngine:
         for path in paths:
             self._assert_path_chain(path)
         self._assert_case_safe(paths)
+        if len(_parent_paths_for_paths(paths)) > 64:
+            raise HostApplyError("too_many_created_directories")
         receipt_files = (
             {item.path: item for item in apply_receipt.files}
             if apply_receipt is not None
@@ -935,35 +946,142 @@ class HostGitApplyEngine:
         git = self.root / ".git"
         if not git.is_dir() or _is_link_or_reparse(git):
             raise HostApplyError("git_repository_required")
-        if (git / "commondir").exists():
+        if _path_entry_exists(git / "commondir"):
+            raise HostApplyError("git_shared_directory_not_allowed")
+        for metadata in (git / "config", git / "HEAD", git / "index"):
+            if _path_entry_exists(metadata) and _is_link_or_reparse(metadata):
+                raise HostApplyError("git_metadata_unsafe")
+
+    def _assert_repository_redirections_absent(self) -> None:
+        git = self.root / ".git"
+        if _path_entry_exists(git / "commondir"):
             raise HostApplyError("git_shared_directory_not_allowed")
         for name in ("alternates", "http-alternates"):
-            alternate = git / "objects" / "info" / name
-            try:
-                alternate.lstat()
-            except FileNotFoundError:
-                continue
-            except OSError as exc:
-                raise HostApplyError("git_inspection_failed") from exc
-            raise HostApplyError("git_alternates_not_allowed")
-        for metadata in (git / "config", git / "HEAD", git / "index"):
-            if metadata.exists() and _is_link_or_reparse(metadata):
+            if _path_entry_exists(git / "objects" / "info" / name):
+                raise HostApplyError("git_alternates_not_allowed")
+        for redirection in (git / "refs" / "replace", git / "info" / "grafts"):
+            if _path_entry_exists(redirection):
                 raise HostApplyError("git_metadata_unsafe")
-        configured = self._git(
-            "config",
-            "--local",
-            "--no-includes",
-            "--name-only",
-            "--list",
-        )
-        if configured.returncode != 0:
-            raise HostApplyError("git_inspection_failed")
+
+    @contextlib.contextmanager
+    def _guard_repository_configuration(self):
+        self._validate_repository_layout()
+        git = self.root / ".git"
+        config = git / "config"
         try:
-            names = configured.stdout.decode("utf-8", errors="strict").splitlines()
-        except UnicodeError as exc:
-            raise HostApplyError("git_encoding_not_supported") from exc
-        if any(_DANGEROUS_CONFIG.fullmatch(name) for name in names):
-            raise HostApplyError("git_config_unsafe")
+            namespaces = [git / "objects", git / "refs"]
+            if _path_entry_exists(git / "info"):
+                namespaces.append(git / "info")
+            with contextlib.ExitStack() as stack:
+                # Bind each direct namespace root before recursively walking
+                # it.  Nested redirection leaves are inspected only after
+                # their complete parent namespace has been validated and
+                # guarded, so a junction cannot redirect the preflight read.
+                stack.enter_context(_guard_directories(tuple(namespaces)))
+                directories = tuple(
+                    dict.fromkeys(
+                        directory
+                        for namespace in namespaces
+                        for directory in _safe_git_namespace(namespace)
+                    )
+                )
+                stack.enter_context(_guard_directories(directories))
+                for namespace in namespaces:
+                    _safe_git_namespace(namespace)
+                self._assert_repository_redirections_absent()
+                config_record = stack.enter_context(
+                    _guard_repository_regular(
+                        config,
+                        MAX_GIT_CONFIG_BYTES,
+                        required=True,
+                    )
+                )
+                head_record = stack.enter_context(
+                    _guard_repository_regular(git / "HEAD", 4096, required=True)
+                )
+                stack.enter_context(
+                    _guard_repository_regular(
+                        git / "index",
+                        MAX_GIT_INDEX_BYTES,
+                        required=True,
+                    )
+                )
+                stack.enter_context(
+                    _guard_repository_regular(
+                        git / "packed-refs",
+                        MAX_GIT_PACKED_REFS_BYTES,
+                        required=False,
+                    )
+                )
+                assert config_record is not None and head_record is not None
+                try:
+                    head = head_record[0].decode("ascii", errors="strict").strip()
+                except UnicodeError as exc:
+                    raise HostApplyError("git_encoding_not_supported") from exc
+                if head.startswith("ref: refs/heads/"):
+                    relative = head.removeprefix("ref: ")
+                    if (
+                        "\\" in relative
+                        or any(part in {"", ".", ".."} for part in relative.split("/"))
+                    ):
+                        raise HostApplyError("git_metadata_unsafe")
+                    stack.enter_context(
+                        _guard_repository_regular(
+                            git.joinpath(*relative.split("/")),
+                            4096,
+                            required=False,
+                        )
+                    )
+                with tempfile.TemporaryDirectory(prefix="modelmirror-git-config-") as safe_cwd:
+                    configured = subprocess.run(
+                        build_safe_git_command(
+                            self.root,
+                            (
+                                "config",
+                                "--file",
+                                str(config),
+                                "--no-includes",
+                                "--name-only",
+                                "--list",
+                            ),
+                        ),
+                        cwd=safe_cwd,
+                        env=build_safe_git_environment(),
+                        stdin=subprocess.DEVNULL,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                        check=False,
+                        timeout=GIT_TIMEOUT_SECONDS,
+                        creationflags=(
+                            getattr(subprocess, "CREATE_NO_WINDOW", 0)
+                            if os.name == "nt"
+                            else 0
+                        ),
+                    )
+                if configured.returncode != 0:
+                    raise HostApplyError("git_inspection_failed")
+                try:
+                    names = configured.stdout.decode(
+                        "utf-8",
+                        errors="strict",
+                    ).splitlines()
+                except UnicodeError as exc:
+                    raise HostApplyError("git_encoding_not_supported") from exc
+                if any(_DANGEROUS_CONFIG.fullmatch(name) for name in names):
+                    raise HostApplyError("git_config_unsafe")
+                yield
+                self._validate_repository_layout()
+                self._assert_repository_redirections_absent()
+                for namespace in namespaces:
+                    _safe_git_namespace(namespace)
+        except HostApplyError as exc:
+            if exc.code == "path_parent_invalid":
+                raise HostApplyError("git_metadata_unsafe") from exc
+            raise
+        except HostFileTransactionError as exc:
+            raise HostApplyError("git_metadata_unsafe") from exc
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise HostApplyError("git_inspection_failed") from exc
 
     def _assert_path_chain(self, relative: str) -> None:
         current = self.root
@@ -1589,6 +1707,144 @@ def _transaction_files(plan: Sequence[_PlannedFile]) -> tuple[FileMutation, ...]
     )
 
 
+@contextlib.contextmanager
+def _guard_repository_regular(
+    path: Path,
+    maximum_bytes: int,
+    *,
+    required: bool,
+):
+    if not _path_entry_exists(path):
+        if required:
+            raise HostFileTransactionError("path_unavailable")
+        yield None
+        return
+    if os.name == "nt":
+        handle = _windows_open_existing(
+            path,
+            access=0x80000000 | 0x00000080,
+            share=0x00000001,
+            allow_missing=False,
+        )
+        assert handle is not None
+        try:
+            identity = _windows_handle_identity(handle, require_directory=False)
+            metadata = os.stat(path, follow_symlinks=False)
+            if (
+                not stat.S_ISREG(metadata.st_mode)
+                or metadata.st_nlink != 1
+                or metadata.st_size > maximum_bytes
+                or file_identity(path) != identity
+            ):
+                raise HostFileTransactionError("path_unsafe")
+            content = _windows_read_all(handle)
+            if len(content) > maximum_bytes:
+                raise HostFileTransactionError("path_unsafe")
+            yield content, identity
+            current = os.stat(path, follow_symlinks=False)
+            if (
+                not stat.S_ISREG(current.st_mode)
+                or current.st_nlink != 1
+                or current.st_size > maximum_bytes
+                or file_identity(path) != identity
+                or _windows_handle_identity(handle, require_directory=False) != identity
+                or _windows_read_all(handle) != content
+            ):
+                raise HostFileTransactionError("transaction_conflict")
+        finally:
+            _windows_close_handle(handle)
+        return
+
+    descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+    try:
+        metadata = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_nlink != 1
+            or metadata.st_size > maximum_bytes
+            or metadata.st_dev <= 0
+            or metadata.st_ino <= 0
+        ):
+            raise HostFileTransactionError("path_unsafe")
+        identity = f"{metadata.st_dev:x}-{metadata.st_ino:x}"
+
+        def read_current() -> bytes:
+            os.lseek(descriptor, 0, os.SEEK_SET)
+            chunks: list[bytes] = []
+            remaining = maximum_bytes + 1
+            while remaining:
+                chunk = os.read(descriptor, min(remaining, 64 * 1024))
+                if not chunk:
+                    break
+                chunks.append(chunk)
+                remaining -= len(chunk)
+            value = b"".join(chunks)
+            if len(value) > maximum_bytes:
+                raise HostFileTransactionError("path_unsafe")
+            return value
+
+        content = read_current()
+        if file_identity(path) != identity:
+            raise HostFileTransactionError("transaction_conflict")
+        yield content, identity
+        current = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(current.st_mode)
+            or current.st_nlink != 1
+            or f"{current.st_dev:x}-{current.st_ino:x}" != identity
+            or file_identity(path) != identity
+            or read_current() != content
+        ):
+            raise HostFileTransactionError("transaction_conflict")
+    finally:
+        os.close(descriptor)
+
+
+def _safe_git_namespace(root: Path) -> tuple[Path, ...]:
+    if _is_link_or_reparse(root) or not root.is_dir():
+        raise HostApplyError("git_metadata_unsafe")
+    pending = [root]
+    directories: list[Path] = []
+    entries_seen = 0
+    while pending:
+        directory = pending.pop()
+        if _is_link_or_reparse(directory) or not directory.is_dir():
+            raise HostApplyError("git_metadata_unsafe")
+        directories.append(directory)
+        try:
+            children = list(os.scandir(directory))
+        except OSError as exc:
+            raise HostApplyError("git_metadata_unsafe") from exc
+        entries_seen += len(children)
+        if entries_seen > MAX_GIT_NAMESPACE_ENTRIES:
+            raise HostApplyError("git_metadata_unsafe")
+        for child in children:
+            candidate = Path(child.path)
+            try:
+                if child.is_symlink() or _is_link_or_reparse(candidate):
+                    raise HostApplyError("git_metadata_unsafe")
+                if child.is_dir(follow_symlinks=False):
+                    pending.append(candidate)
+                elif child.is_file(follow_symlinks=False):
+                    if os.stat(candidate, follow_symlinks=False).st_nlink != 1:
+                        raise HostApplyError("git_metadata_unsafe")
+                else:
+                    raise HostApplyError("git_metadata_unsafe")
+            except OSError as exc:
+                raise HostApplyError("git_metadata_unsafe") from exc
+    return tuple(directories)
+
+
+def _path_entry_exists(path: Path) -> bool:
+    try:
+        path.lstat()
+        return True
+    except FileNotFoundError:
+        return False
+    except OSError as exc:
+        raise HostApplyError("git_metadata_unsafe") from exc
+
+
 def _read_regular(path: Path) -> bytes | None:
     try:
         return read_regular(path)
@@ -1631,9 +1887,13 @@ def _sha256(content: bytes) -> str:
 
 
 def _parent_paths(plan: Sequence[_PlannedFile]) -> tuple[str, ...]:
+    return _parent_paths_for_paths(item.path for item in plan)
+
+
+def _parent_paths_for_paths(paths: Iterable[str]) -> tuple[str, ...]:
     values: set[str] = set()
-    for item in plan:
-        parts = PurePosixPath(item.path).parts[:-1]
+    for path in paths:
+        parts = PurePosixPath(path).parts[:-1]
         for index in range(1, len(parts) + 1):
             values.add(PurePosixPath(*parts[:index]).as_posix())
     return tuple(sorted(values, key=lambda value: (len(PurePosixPath(value).parts), value)))

--- a/server/coding_project_host/host_apply_engine.py
+++ b/server/coding_project_host/host_apply_engine.py
@@ -5,6 +5,7 @@ import ctypes
 import hashlib
 import functools
 import os
+import re
 import stat
 import subprocess
 import tempfile
@@ -35,6 +36,12 @@ from .operation_log import HostOperationJournal, HostOperationLogError
 GIT_TIMEOUT_SECONDS = 30
 FILE_ATTRIBUTE_REPARSE_POINT = 0x0400
 MutationHook = Callable[[str, int, str], None]
+_DANGEROUS_CONFIG = re.compile(
+    r"^(?:include(?:if)?\..+|filter\..+|credential\..+|"
+    r"diff\..*\.textconv|core\.worktree|extensions\.worktreeconfig|"
+    r"extensions\.partialclone|remote\..*\.(?:promisor|partialclonefilter))$",
+    re.IGNORECASE,
+)
 
 
 class HostApplyError(RuntimeError):
@@ -51,14 +58,21 @@ def _serialize_project_operation(method):
         # project lock or any other host-side artifact in production mode.
         if self.enforce_windows and os.name != "nt":
             raise HostApplyError("windows_required")
-        with _project_process_lock(self.root):
+        with _project_process_lock(
+            self.root,
+            preflight=self._validate_repository_layout,
+        ):
             return method(self, *args, **kwargs)
 
     return wrapped
 
 
 @contextlib.contextmanager
-def _project_process_lock(root: Path):
+def _project_process_lock(
+    root: Path,
+    *,
+    preflight: Callable[[], None] | None = None,
+):
     git = root / ".git"
     if (
         _is_link_or_reparse(root)
@@ -68,6 +82,8 @@ def _project_process_lock(root: Path):
     ):
         raise HostApplyError("git_metadata_unsafe")
     with _guard_directories((root, git)):
+        if preflight is not None:
+            preflight()
         directory = git / "modelmirror-transactions"
         if directory.exists():
             if _is_link_or_reparse(directory) or not directory.is_dir():
@@ -885,19 +901,6 @@ class HostGitApplyEngine:
             raise HostApplyError("git_index_dirty")
         if staged.returncode != 0:
             raise HostApplyError("git_inspection_failed")
-        forbidden = self._git(
-            "config",
-            "--local",
-            "--no-includes",
-            "--name-only",
-            "--get-regexp",
-            r"^(include\.|includeif\.|core\.worktree$|extensions\.worktreeconfig$|filter\.|credential\.|diff\..*\.textconv$)",
-        )
-        if forbidden.returncode == 0 and forbidden.stdout.strip():
-            raise HostApplyError("git_config_unsafe")
-        if forbidden.returncode not in {0, 1}:
-            raise HostApplyError("git_inspection_failed")
-
     def _git_stamp(
         self,
         branch: str,
@@ -934,12 +937,33 @@ class HostGitApplyEngine:
             raise HostApplyError("git_repository_required")
         if (git / "commondir").exists():
             raise HostApplyError("git_shared_directory_not_allowed")
-        alternates = git / "objects" / "info" / "alternates"
-        if _is_link_or_reparse(alternates) or (alternates.is_file() and alternates.stat().st_size):
+        for name in ("alternates", "http-alternates"):
+            alternate = git / "objects" / "info" / name
+            try:
+                alternate.lstat()
+            except FileNotFoundError:
+                continue
+            except OSError as exc:
+                raise HostApplyError("git_inspection_failed") from exc
             raise HostApplyError("git_alternates_not_allowed")
         for metadata in (git / "config", git / "HEAD", git / "index"):
             if metadata.exists() and _is_link_or_reparse(metadata):
                 raise HostApplyError("git_metadata_unsafe")
+        configured = self._git(
+            "config",
+            "--local",
+            "--no-includes",
+            "--name-only",
+            "--list",
+        )
+        if configured.returncode != 0:
+            raise HostApplyError("git_inspection_failed")
+        try:
+            names = configured.stdout.decode("utf-8", errors="strict").splitlines()
+        except UnicodeError as exc:
+            raise HostApplyError("git_encoding_not_supported") from exc
+        if any(_DANGEROUS_CONFIG.fullmatch(name) for name in names):
+            raise HostApplyError("git_config_unsafe")
 
     def _assert_path_chain(self, relative: str) -> None:
         current = self.root

--- a/server/coding_project_host/host_apply_engine.py
+++ b/server/coding_project_host/host_apply_engine.py
@@ -1,0 +1,2018 @@
+from __future__ import annotations
+
+import contextlib
+import ctypes
+import hashlib
+import functools
+import os
+import stat
+import subprocess
+import tempfile
+import threading
+import time
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Literal
+
+from server.coding_runtime.apply_models import ApplyFileReceipt, ApplyReceipt
+from server.coding_runtime.draft_workspace import DraftLimits, DraftPolicyError, DraftWorkspace
+from server.coding_runtime.patch_policy import PatchPolicyError, validate_patch
+from server.coding_runtime.projects import build_safe_git_command, build_safe_git_environment
+
+from .host_file_transaction import (
+    FileMutation,
+    HostFileTransaction,
+    HostFileTransactionError,
+    file_identity,
+    move_directory_no_replace,
+    read_regular,
+    remove_regular_exact,
+)
+from .operation_log import HostOperationJournal, HostOperationLogError
+
+
+GIT_TIMEOUT_SECONDS = 30
+FILE_ATTRIBUTE_REPARSE_POINT = 0x0400
+MutationHook = Callable[[str, int, str], None]
+
+
+class HostApplyError(RuntimeError):
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+def _serialize_project_operation(method):
+    @functools.wraps(method)
+    def wrapped(self, *args, **kwargs):
+        # Direct host writeback is a Windows-only product capability.  POSIX is
+        # used solely by isolated domain tests and must fail before creating a
+        # project lock or any other host-side artifact in production mode.
+        if self.enforce_windows and os.name != "nt":
+            raise HostApplyError("windows_required")
+        with _project_process_lock(self.root):
+            return method(self, *args, **kwargs)
+
+    return wrapped
+
+
+@contextlib.contextmanager
+def _project_process_lock(root: Path):
+    git = root / ".git"
+    if (
+        _is_link_or_reparse(root)
+        or not root.is_dir()
+        or _is_link_or_reparse(git)
+        or not git.is_dir()
+    ):
+        raise HostApplyError("git_metadata_unsafe")
+    with _guard_directories((root, git)):
+        directory = git / "modelmirror-transactions"
+        if directory.exists():
+            if _is_link_or_reparse(directory) or not directory.is_dir():
+                raise HostApplyError("transaction_conflict")
+        else:
+            try:
+                directory.mkdir()
+            except FileExistsError:
+                pass
+            if _is_link_or_reparse(directory) or not directory.is_dir():
+                raise HostApplyError("transaction_conflict")
+        with _guard_directories((directory,)):
+            lock_path = directory / ".project-operation.lock"
+            try:
+                stream = _open_project_lock_stream(lock_path)
+            except OSError as exc:
+                raise HostApplyError("transaction_conflict") from exc
+            deadline = time.monotonic() + 5.0
+            with stream:
+                stream.seek(0, os.SEEK_END)
+                if stream.tell() == 0:
+                    stream.write(b"\0")
+                    stream.flush()
+                while True:
+                    try:
+                        if os.name == "nt":
+                            import msvcrt
+
+                            stream.seek(0)
+                            msvcrt.locking(stream.fileno(), msvcrt.LK_NBLCK, 1)
+                        else:
+                            import fcntl
+
+                            fcntl.flock(
+                                stream.fileno(),
+                                fcntl.LOCK_EX | fcntl.LOCK_NB,
+                            )
+                        break
+                    except OSError as exc:
+                        if time.monotonic() >= deadline:
+                            raise HostApplyError("project_operation_busy") from exc
+                        time.sleep(0.05)
+                try:
+                    yield
+                finally:
+                    if os.name == "nt":
+                        import msvcrt
+
+                        stream.seek(0)
+                        msvcrt.locking(stream.fileno(), msvcrt.LK_UNLCK, 1)
+                    else:
+                        import fcntl
+
+                        fcntl.flock(stream.fileno(), fcntl.LOCK_UN)
+
+
+def _open_project_lock_stream(path: Path):
+    if os.name != "nt":
+        descriptor = os.open(
+            path,
+            os.O_RDWR | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0),
+            0o600,
+        )
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+            os.close(descriptor)
+            raise OSError("unsafe project lock")
+        return os.fdopen(descriptor, "r+b")
+
+    import msvcrt
+    from ctypes import wintypes
+
+    generic_read = 0x80000000
+    generic_write = 0x40000000
+    file_share_read = 0x00000001
+    file_share_write = 0x00000002
+    create_new = 1
+    open_existing = 3
+    file_flag_open_reparse_point = 0x00200000
+    file_attribute_directory = 0x00000010
+    file_attribute_reparse_point = 0x00000400
+    error_file_exists = 80
+    error_already_exists = 183
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+
+    class _ByHandleFileInformation(ctypes.Structure):
+        _fields_ = [
+            ("attributes", wintypes.DWORD),
+            ("creation_time", wintypes.FILETIME),
+            ("access_time", wintypes.FILETIME),
+            ("write_time", wintypes.FILETIME),
+            ("volume_serial", wintypes.DWORD),
+            ("size_high", wintypes.DWORD),
+            ("size_low", wintypes.DWORD),
+            ("links", wintypes.DWORD),
+            ("file_index_high", wintypes.DWORD),
+            ("file_index_low", wintypes.DWORD),
+        ]
+
+    kernel32.CreateFileW.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    ]
+    kernel32.CreateFileW.restype = wintypes.HANDLE
+    kernel32.GetFileInformationByHandle.argtypes = [
+        wintypes.HANDLE,
+        ctypes.POINTER(_ByHandleFileInformation),
+    ]
+    kernel32.GetFileInformationByHandle.restype = wintypes.BOOL
+    kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+    kernel32.CloseHandle.restype = wintypes.BOOL
+    invalid = ctypes.c_void_p(-1).value
+
+    handle = kernel32.CreateFileW(
+        str(path),
+        generic_read | generic_write,
+        file_share_read | file_share_write,
+        None,
+        create_new,
+        file_flag_open_reparse_point,
+        None,
+    )
+    if int(handle) == invalid:
+        error = ctypes.get_last_error()
+        if error not in {error_file_exists, error_already_exists}:
+            raise OSError(error, "project lock create failed")
+        handle = kernel32.CreateFileW(
+            str(path),
+            generic_read | generic_write,
+            file_share_read | file_share_write,
+            None,
+            open_existing,
+            file_flag_open_reparse_point,
+            None,
+        )
+    if int(handle) == invalid:
+        raise OSError(ctypes.get_last_error(), "project lock open failed")
+    try:
+        information = _ByHandleFileInformation()
+        if not kernel32.GetFileInformationByHandle(
+            handle,
+            ctypes.byref(information),
+        ):
+            raise OSError(ctypes.get_last_error(), "project lock inspect failed")
+        if (
+            information.attributes
+            & (file_attribute_directory | file_attribute_reparse_point)
+            or information.links != 1
+        ):
+            raise OSError("unsafe project lock")
+        descriptor = msvcrt.open_osfhandle(
+            int(handle),
+            os.O_RDWR | getattr(os, "O_BINARY", 0),
+        )
+        handle = None
+        return os.fdopen(descriptor, "r+b")
+    finally:
+        if handle is not None:
+            kernel32.CloseHandle(handle)
+
+
+@dataclass(frozen=True, slots=True)
+class _PlannedFile:
+    path: str
+    before: bytes | None
+    after: bytes | None
+    mode: int
+
+    @property
+    def before_sha256(self) -> str | None:
+        return _sha256(self.before) if self.before is not None else None
+
+    @property
+    def after_sha256(self) -> str | None:
+        return _sha256(self.after) if self.after is not None else None
+
+
+class HostGitApplyEngine:
+    """Apply one bounded text Patch to the helper-owned Git project.
+
+    The engine never enumerates remotes and never accepts a command or path from
+    the browser. It only inspects Git metadata plus files named by a validated
+    Patch, which avoids the latency and false positives of a whole-tree scan.
+    """
+
+    def __init__(
+        self,
+        project_root: Path,
+        project_id: str,
+        journal: HostOperationJournal,
+        *,
+        limits: DraftLimits | None = None,
+        mutation_hook: MutationHook | None = None,
+        enforce_windows: bool = True,
+    ) -> None:
+        root = Path(project_root)
+        if (
+            not root.is_absolute()
+            or _is_link_or_reparse(root)
+            or not root.is_dir()
+        ):
+            raise HostApplyError("project_path_invalid")
+        self.root = root.resolve(strict=True)
+        self.project_id = project_id
+        self.journal = journal
+        self.limits = limits or DraftLimits()
+        self.mutation_hook = mutation_hook
+        self.enforce_windows = enforce_windows
+        self._lock = threading.Lock()
+        self._validate_repository_layout()
+
+    @_serialize_project_operation
+    def apply(
+        self,
+        *,
+        operation_id: str,
+        revision: int,
+        branch: str,
+        expected_head: str,
+        snapshot_fingerprint: str,
+        patch: str,
+        paths: Sequence[str],
+    ) -> ApplyReceipt:
+        safe_paths = self._validate_patch(patch, paths)
+        patch_sha256 = _sha256(patch.encode("utf-8"))
+        with self._lock:
+            try:
+                record = self.journal.create(
+                    operation_id=operation_id,
+                    action="apply",
+                    project_id=self.project_id,
+                    revision=revision,
+                    branch=branch,
+                    expected_head=expected_head,
+                    patch_sha256=patch_sha256,
+                    patch=patch,
+                )
+            except HostOperationLogError as exc:
+                raise HostApplyError(exc.code) from exc
+            if record.state == "conflict":
+                raise HostApplyError("apply_conflict")
+            existing_receipt = (
+                _apply_receipt(record.apply_receipt)
+                if record.apply_receipt is not None
+                else None
+            )
+            if (
+                existing_receipt is not None
+                and existing_receipt.snapshot_fingerprint != snapshot_fingerprint
+            ):
+                raise HostApplyError("operation_conflict")
+            if record.state == "applied" and existing_receipt is not None:
+                self._assert_file_identities(
+                    record.file_identities,
+                    existing_receipt,
+                    applied=True,
+                )
+            plan = self._build_plan(
+                patch=patch,
+                paths=safe_paths,
+                branch=branch,
+                expected_head=expected_head,
+                apply_receipt=existing_receipt,
+                owned_operation_id=operation_id,
+            )
+            receipt = existing_receipt or self._receipt(
+                operation_id,
+                revision,
+                snapshot_fingerprint,
+                plan,
+            )
+            if record.state == "applied":
+                if self._settle_plan(
+                    plan,
+                    action="apply",
+                    branch=branch,
+                    expected_head=expected_head,
+                    operation_id=operation_id,
+                    created_directories=record.created_directories,
+                ) != "after":
+                    raise HostApplyError("apply_conflict")
+                self._finalize_created_directories(
+                    record.created_directories,
+                    operation_id,
+                )
+                self._assert_finalized_created_directories(
+                    record.created_directories,
+                    operation_id,
+                )
+                self._cleanup_committed_plan(
+                    plan,
+                    action="apply",
+                    branch=branch,
+                    expected_head=expected_head,
+                    operation_id=operation_id,
+                    created_directories=record.created_directories,
+                )
+                return receipt
+            if record.state == "prepared":
+                if self._settle_plan(
+                    plan,
+                    action="apply",
+                    branch=branch,
+                    expected_head=expected_head,
+                    operation_id=operation_id,
+                ) != "before":
+                    self._mark_conflict(operation_id)
+                    raise HostApplyError("apply_conflict")
+                record = self.journal.transition(
+                    operation_id,
+                    "applying",
+                    apply_receipt=_receipt_dict(receipt),
+                )
+            elif record.state not in {"applying", "applied"}:
+                raise HostApplyError("apply_conflict")
+
+            if record.state == "applying":
+                def commit_recovered_before_directory_prepare() -> None:
+                    self._finalize_created_directories(
+                        record.created_directories,
+                        operation_id,
+                    )
+                    self._finish_apply(operation_id, receipt)
+
+                recovered_state = self._settle_plan(
+                    plan,
+                    action="apply",
+                    branch=branch,
+                    expected_head=expected_head,
+                    operation_id=operation_id,
+                    created_directories=record.created_directories,
+                    commit_callback=commit_recovered_before_directory_prepare,
+                )
+                if recovered_state == "after":
+                    self._cleanup_committed_plan(
+                        plan,
+                        action="apply",
+                        branch=branch,
+                        expected_head=expected_head,
+                        operation_id=operation_id,
+                        created_directories=record.created_directories,
+                    )
+                    return receipt
+
+            created_directories = self._prepare_created_directories(
+                plan,
+                operation_id,
+                record.created_directories,
+            )
+            if created_directories != record.created_directories:
+                try:
+                    record = self.journal.transition(
+                        operation_id,
+                        record.state,
+                        created_directories=created_directories,
+                    )
+                except HostOperationLogError as exc:
+                    self._remove_created_directories(
+                        created_directories,
+                        operation_id,
+                    )
+                    raise HostApplyError(exc.code) from exc
+            self._publish_created_directories(
+                created_directories,
+                operation_id,
+            )
+
+            def commit_apply() -> None:
+                self._finalize_created_directories(
+                    created_directories,
+                    operation_id,
+                )
+                self._finish_apply(operation_id, receipt)
+
+            current = self._settle_plan(
+                plan,
+                action="apply",
+                branch=branch,
+                expected_head=expected_head,
+                operation_id=operation_id,
+                created_directories=created_directories,
+                commit_callback=(
+                    commit_apply if record.state == "applying" else None
+                ),
+            )
+            if current == "after":
+                self._cleanup_committed_plan(
+                    plan,
+                    action="apply",
+                    branch=branch,
+                    expected_head=expected_head,
+                    operation_id=operation_id,
+                    created_directories=created_directories,
+                )
+                return receipt
+            try:
+                self._write_plan(
+                    plan,
+                    action="apply",
+                    branch=branch,
+                    expected_head=expected_head,
+                    operation_id=operation_id,
+                    commit_callback=commit_apply,
+                    created_directories=created_directories,
+                )
+            except BaseException as exc:
+                if (
+                    isinstance(exc, HostApplyError)
+                    and exc.code == "transaction_rollback_failed"
+                ):
+                    self._mark_conflict(operation_id)
+                else:
+                    try:
+                        if self._classify_plan(plan) == "before":
+                            self._remove_created_directories(
+                                created_directories,
+                                operation_id,
+                            )
+                            if created_directories:
+                                self.journal.transition(
+                                    operation_id,
+                                    "applying",
+                                    created_directories=(),
+                                )
+                    except BaseException as cleanup_error:
+                        self._mark_conflict(operation_id)
+                        raise HostApplyError(
+                            "apply_rollback_failed"
+                        ) from cleanup_error
+                raise
+            self._cleanup_committed_plan(
+                plan,
+                action="apply",
+                branch=branch,
+                expected_head=expected_head,
+                operation_id=operation_id,
+                created_directories=created_directories,
+            )
+            return receipt
+
+    @_serialize_project_operation
+    def revert(
+        self,
+        *,
+        operation_id: str,
+        apply_receipt: ApplyReceipt,
+        branch: str,
+        expected_head: str,
+    ) -> ApplyReceipt:
+        with self._lock:
+            applied = self.journal.get(apply_receipt.apply_id)
+            existing_revert = self.journal.get(operation_id)
+            if (
+                applied is None
+                or applied.action != "apply"
+                or applied.state != "applied"
+                or applied.apply_receipt != _receipt_dict(apply_receipt)
+                or applied.branch != branch
+                or applied.expected_head != expected_head
+            ):
+                raise HostApplyError("revert_conflict")
+            if existing_revert is None or existing_revert.state == "prepared":
+                try:
+                    self._assert_file_identities(
+                        applied.file_identities,
+                        apply_receipt,
+                        applied=True,
+                    )
+                except HostApplyError as exc:
+                    raise HostApplyError("revert_conflict") from exc
+            safe_paths = self._validate_patch(
+                applied.patch,
+                tuple(item.path for item in apply_receipt.files),
+            )
+            try:
+                record = self.journal.create(
+                    operation_id=operation_id,
+                    action="revert",
+                    project_id=self.project_id,
+                    revision=apply_receipt.revision,
+                    branch=branch,
+                    expected_head=expected_head,
+                    patch_sha256=applied.patch_sha256,
+                    patch=applied.patch,
+                    apply_receipt=_receipt_dict(apply_receipt),
+                    created_directories=applied.created_directories,
+                    file_identities=applied.file_identities,
+                )
+            except HostOperationLogError as exc:
+                raise HostApplyError(exc.code) from exc
+            if record.state == "conflict":
+                raise HostApplyError("revert_conflict")
+
+            plan = self._build_plan(
+                patch=applied.patch,
+                paths=safe_paths,
+                branch=branch,
+                expected_head=expected_head,
+                apply_receipt=apply_receipt,
+                owned_operation_id=operation_id,
+            )
+            if record.state in {"reverting", "reverted"} and self._classify_plan(plan) == "after":
+                try:
+                    self._assert_file_identities(
+                        applied.file_identities,
+                        apply_receipt,
+                        applied=True,
+                    )
+                except HostApplyError as exc:
+                    self._mark_conflict(operation_id)
+                    raise HostApplyError("revert_conflict") from exc
+            expected = self._receipt(
+                apply_receipt.apply_id,
+                apply_receipt.revision,
+                apply_receipt.snapshot_fingerprint,
+                plan,
+            )
+            if expected.files != apply_receipt.files:
+                self._mark_conflict(operation_id)
+                raise HostApplyError("revert_conflict")
+            inverse = tuple(
+                _PlannedFile(item.path, item.after, item.before, item.mode)
+                for item in plan
+            )
+            if record.state == "prepared":
+                if self._classify_plan(plan) != "after":
+                    self._mark_conflict(operation_id)
+                    raise HostApplyError("revert_conflict")
+                record = self.journal.transition(operation_id, "reverting")
+            elif record.state not in {"reverting", "reverted"}:
+                raise HostApplyError("revert_conflict")
+
+            def commit_revert() -> None:
+                self._assert_receipt_state(apply_receipt, applied=False)
+                self._remove_created_directories(
+                    record.created_directories,
+                    apply_receipt.apply_id,
+                )
+                self._transition(operation_id, "reverted")
+
+            current = self._settle_plan(
+                inverse,
+                action="revert",
+                branch=branch,
+                expected_head=expected_head,
+                operation_id=operation_id,
+                created_directories=record.created_directories,
+                commit_callback=(
+                    commit_revert if record.state == "reverting" else None
+                ),
+            )
+            if current == "after":
+                self._cleanup_committed_plan(
+                    inverse,
+                    action="revert",
+                    branch=branch,
+                    expected_head=expected_head,
+                    operation_id=operation_id,
+                    created_directories=record.created_directories,
+                )
+                return apply_receipt
+            try:
+                self._write_plan(
+                    inverse,
+                    action="revert",
+                    branch=branch,
+                    expected_head=expected_head,
+                    operation_id=operation_id,
+                    commit_callback=commit_revert,
+                    created_directories=record.created_directories,
+                )
+            except HostApplyError as exc:
+                if exc.code == "transaction_rollback_failed":
+                    self._mark_conflict(operation_id)
+                raise
+            self._cleanup_committed_plan(
+                inverse,
+                action="revert",
+                branch=branch,
+                expected_head=expected_head,
+                operation_id=operation_id,
+                created_directories=record.created_directories,
+            )
+            return apply_receipt
+
+    @_serialize_project_operation
+    def reconcile_apply(
+        self,
+        *,
+        operation_id: str,
+        snapshot_fingerprint: str,
+    ) -> tuple[Literal["not_applied", "applied", "conflict"], ApplyReceipt | None]:
+        with self._lock:
+            record = self.journal.get(operation_id)
+            if record is None or record.action != "apply":
+                raise HostApplyError("operation_not_found")
+            if record.state == "conflict":
+                return "conflict", None
+            stored_receipt = (
+                _apply_receipt(record.apply_receipt)
+                if record.apply_receipt is not None
+                else None
+            )
+            if (
+                stored_receipt is not None
+                and stored_receipt.snapshot_fingerprint != snapshot_fingerprint
+            ):
+                return "conflict", None
+            if record.state in {"applying", "applied"} and stored_receipt is None:
+                return "conflict", None
+            if record.state == "applied" and stored_receipt is not None:
+                try:
+                    self._assert_file_identities(
+                        record.file_identities,
+                        stored_receipt,
+                        applied=True,
+                    )
+                except HostApplyError:
+                    self._mark_conflict(operation_id)
+                    return "conflict", None
+            try:
+                safe_paths = self._validate_patch(
+                    record.patch,
+                    _patch_paths(record.patch),
+                )
+                plan = self._build_plan(
+                    patch=record.patch,
+                    paths=safe_paths,
+                    branch=record.branch,
+                    expected_head=record.expected_head,
+                    apply_receipt=stored_receipt,
+                    owned_operation_id=operation_id,
+                )
+
+                def commit_recovered_apply() -> None:
+                    if stored_receipt is None:
+                        raise HostApplyError("apply_conflict")
+                    self._finalize_created_directories(
+                        record.created_directories,
+                        operation_id,
+                    )
+                    self._finish_apply(operation_id, stored_receipt)
+
+                state = self._settle_plan(
+                    plan,
+                    action="apply",
+                    branch=record.branch,
+                    expected_head=record.expected_head,
+                    operation_id=operation_id,
+                    created_directories=record.created_directories,
+                    commit_callback=(
+                        commit_recovered_apply
+                        if record.state == "applying"
+                        else None
+                    ),
+                )
+            except HostApplyError as exc:
+                if exc.code in {
+                    "git_locked",
+                    "git_inspection_failed",
+                    "path_unavailable",
+                    "project_operation_busy",
+                    "transaction_unavailable",
+                }:
+                    raise
+                self._mark_conflict(operation_id)
+                return "conflict", None
+            if state == "before":
+                if record.state == "applied":
+                    self._mark_conflict(operation_id)
+                    return "conflict", None
+                try:
+                    cleanup_receipts = record.created_directories
+                    if not cleanup_receipts:
+                        cleanup_receipts = self._recover_created_directory_stages(
+                            plan,
+                            operation_id,
+                        )
+                    self._remove_created_directories(
+                        cleanup_receipts,
+                        operation_id,
+                    )
+                    if record.created_directories:
+                        self.journal.transition(
+                            operation_id,
+                            record.state,
+                            created_directories=(),
+                        )
+                except (HostApplyError, HostOperationLogError):
+                    self._mark_conflict(operation_id)
+                    return "conflict", None
+                return "not_applied", None
+            if state == "after":
+                if stored_receipt is None:
+                    self._mark_conflict(operation_id)
+                    return "conflict", None
+                self._cleanup_committed_plan(
+                    plan,
+                    action="apply",
+                    branch=record.branch,
+                    expected_head=record.expected_head,
+                    operation_id=operation_id,
+                    created_directories=record.created_directories,
+                )
+                return "applied", stored_receipt
+            self._mark_conflict(operation_id)
+            return "conflict", None
+
+    def _build_plan(
+        self,
+        *,
+        patch: str,
+        paths: tuple[str, ...],
+        branch: str,
+        expected_head: str,
+        apply_receipt: ApplyReceipt | None = None,
+        owned_operation_id: str | None = None,
+    ) -> tuple[_PlannedFile, ...]:
+        self._assert_repository_state(
+            branch,
+            expected_head,
+            owned_operation_id=owned_operation_id,
+        )
+        for path in paths:
+            self._assert_path_chain(path)
+        self._assert_case_safe(paths)
+        receipt_files = (
+            {item.path: item for item in apply_receipt.files}
+            if apply_receipt is not None
+            else {}
+        )
+        if apply_receipt is not None and tuple(sorted(receipt_files)) != paths:
+            raise HostApplyError("operation_conflict")
+        canonical: dict[str, tuple[bytes | None, int]] = {}
+        working_before: dict[str, bytes | None] = {}
+        for path in paths:
+            baseline, mode = self._head_blob(expected_head, path)
+            current_path = self.root / PurePosixPath(path)
+            current = _read_regular(current_path)
+            prior = receipt_files.get(path)
+            if prior is not None:
+                if prior.existed_before:
+                    if baseline is None or prior.before_sha256 is None:
+                        raise HostApplyError("operation_conflict")
+                    current = _bytes_for_hash(baseline, prior.before_sha256)
+                elif baseline is not None or prior.before_sha256 is not None:
+                    raise HostApplyError("operation_conflict")
+                else:
+                    current = None
+            elif baseline is None:
+                if current is not None:
+                    raise HostApplyError("target_changed")
+            else:
+                current = self._match_checkout_bytes(baseline, current, path)
+            if current is not None:
+                self._validate_text(current, path)
+            canonical[path] = (baseline, mode)
+            working_before[path] = current
+
+        with tempfile.TemporaryDirectory(prefix="modelmirror-host-apply-") as value:
+            staging = Path(value)
+            for path, (baseline, mode) in canonical.items():
+                if baseline is None:
+                    continue
+                target = staging / PurePosixPath(path)
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_bytes(baseline)
+                with contextlib.suppress(OSError):
+                    target.chmod(mode)
+            self._git_apply(staging, patch)
+            result: list[_PlannedFile] = []
+            for path in paths:
+                staged = staging / PurePosixPath(path)
+                after = _read_regular(staged)
+                before = working_before[path]
+                if after is not None and before is not None and _uses_crlf(before):
+                    after = _to_crlf(after)
+                if after is not None:
+                    self._validate_text(after, path)
+                if before == after:
+                    raise HostApplyError("invalid_patch")
+                mode = canonical[path][1] if before is not None else 0o644
+                result.append(_PlannedFile(path, before, after, mode))
+        return tuple(result)
+
+    def _assert_repository_state(
+        self,
+        branch: str,
+        expected_head: str,
+        *,
+        owned_operation_id: str | None = None,
+    ) -> None:
+        self._validate_repository_layout()
+        full_ref = self._git_text("symbolic-ref", "--quiet", "HEAD")
+        if full_ref != f"refs/heads/{branch}":
+            raise HostApplyError("branch_changed")
+        if self._git_text("rev-parse", "--verify", "HEAD^{commit}").lower() != expected_head:
+            raise HostApplyError("head_changed")
+        index_lock = self.root / ".git" / "index.lock"
+        if index_lock.exists():
+            expected_lock = (
+                f"modelmirror-lock:{owned_operation_id}\n".encode("ascii")
+                if owned_operation_id is not None
+                else None
+            )
+            if expected_lock is None or _read_regular(index_lock) != expected_lock:
+                raise HostApplyError("git_index_locked")
+        staged = self._git("diff", "--cached", "--quiet", "--no-ext-diff", "HEAD", "--")
+        if staged.returncode == 1:
+            raise HostApplyError("git_index_dirty")
+        if staged.returncode != 0:
+            raise HostApplyError("git_inspection_failed")
+        forbidden = self._git(
+            "config",
+            "--local",
+            "--no-includes",
+            "--name-only",
+            "--get-regexp",
+            r"^(include\.|includeif\.|core\.worktree$|extensions\.worktreeconfig$|filter\.|credential\.|diff\..*\.textconv$)",
+        )
+        if forbidden.returncode == 0 and forbidden.stdout.strip():
+            raise HostApplyError("git_config_unsafe")
+        if forbidden.returncode not in {0, 1}:
+            raise HostApplyError("git_inspection_failed")
+
+    def _git_stamp(
+        self,
+        branch: str,
+        expected_head: str,
+        *,
+        owned_operation_id: str | None,
+    ) -> tuple[str, str, str]:
+        self._assert_repository_state(
+            branch,
+            expected_head,
+            owned_operation_id=owned_operation_id,
+        )
+        index = _read_regular(self.root / ".git" / "index")
+        if index is None:
+            raise HostApplyError("git_index_unavailable")
+        return branch, expected_head, _sha256(index)
+
+    def _validate_repository_layout(self) -> None:
+        if self.enforce_windows:
+            if os.name != "nt":
+                raise HostApplyError("windows_required")
+            if str(self.root).startswith("\\\\") or not self.root.drive:
+                raise HostApplyError("network_path_not_allowed")
+            import ctypes
+
+            if ctypes.windll.kernel32.GetDriveTypeW(
+                ctypes.c_wchar_p(f"{self.root.drive}\\")
+            ) == 4:
+                raise HostApplyError("network_path_not_allowed")
+        if _is_link_or_reparse(self.root):
+            raise HostApplyError("project_reparse_point_not_allowed")
+        git = self.root / ".git"
+        if not git.is_dir() or _is_link_or_reparse(git):
+            raise HostApplyError("git_repository_required")
+        if (git / "commondir").exists():
+            raise HostApplyError("git_shared_directory_not_allowed")
+        alternates = git / "objects" / "info" / "alternates"
+        if _is_link_or_reparse(alternates) or (alternates.is_file() and alternates.stat().st_size):
+            raise HostApplyError("git_alternates_not_allowed")
+        for metadata in (git / "config", git / "HEAD", git / "index"):
+            if metadata.exists() and _is_link_or_reparse(metadata):
+                raise HostApplyError("git_metadata_unsafe")
+
+    def _assert_path_chain(self, relative: str) -> None:
+        current = self.root
+        for part in PurePosixPath(relative).parts:
+            current = current / part
+            if not current.exists():
+                continue
+            if _is_link_or_reparse(current):
+                raise HostApplyError("symlink_not_allowed")
+            if current != self.root / PurePosixPath(relative) and not current.is_dir():
+                raise HostApplyError("path_parent_invalid")
+
+    def _assert_case_safe(self, paths: tuple[str, ...]) -> None:
+        folded = [path.casefold() for path in paths]
+        if len(folded) != len(set(folded)):
+            raise HostApplyError("path_case_conflict")
+        for relative in paths:
+            current = self.root
+            for part in PurePosixPath(relative).parts:
+                if current.is_dir():
+                    matches = [entry.name for entry in os.scandir(current) if entry.name.casefold() == part.casefold()]
+                    if len(matches) > 1 or (matches and matches[0] != part):
+                        raise HostApplyError("path_case_conflict")
+                current = current / part
+
+    def _head_blob(self, expected_head: str, path: str) -> tuple[bytes | None, int]:
+        tree = self._git(
+            "--literal-pathspecs",
+            "ls-tree",
+            "-z",
+            expected_head,
+            "--",
+            path,
+        )
+        if tree.returncode != 0:
+            raise HostApplyError("git_tree_unreadable")
+        if not tree.stdout:
+            return None, 0o644
+        records = [item for item in tree.stdout.split(b"\0") if item]
+        if len(records) != 1:
+            raise HostApplyError("git_tree_invalid")
+        try:
+            header, raw_path = records[0].split(b"\t", 1)
+            mode, object_type, object_id = header.split(b" ", 2)
+            decoded_path = raw_path.decode("utf-8", errors="strict")
+        except (UnicodeError, ValueError) as exc:
+            raise HostApplyError("git_tree_invalid") from exc
+        if decoded_path != path or object_type != b"blob" or mode not in {b"100644", b"100755"}:
+            raise HostApplyError("git_tree_unsafe")
+        blob = self._git("cat-file", "blob", object_id.decode("ascii"))
+        if blob.returncode != 0:
+            raise HostApplyError("git_object_unavailable")
+        return blob.stdout, 0o755 if mode == b"100755" else 0o644
+
+    def _git_apply(self, staging: Path, patch: str) -> None:
+        for check in (True, False):
+            arguments = ["apply"]
+            if check:
+                arguments.append("--check")
+            arguments.extend(("--whitespace=nowarn", "-"))
+            try:
+                completed = subprocess.run(
+                    build_safe_git_command(staging, tuple(arguments)),
+                    cwd=staging,
+                    env=build_safe_git_environment(),
+                    input=patch.encode("utf-8"),
+                    stdin=None,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    check=False,
+                    timeout=GIT_TIMEOUT_SECONDS,
+                    creationflags=(
+                        getattr(subprocess, "CREATE_NO_WINDOW", 0)
+                        if os.name == "nt"
+                        else 0
+                    ),
+                )
+            except (OSError, subprocess.TimeoutExpired) as exc:
+                raise HostApplyError("patch_apply_failed") from exc
+            if completed.returncode != 0:
+                raise HostApplyError("patch_apply_failed")
+
+    def _prepare_created_directories(
+        self,
+        plan: tuple[_PlannedFile, ...],
+        operation_id: str,
+        recorded: tuple[str, ...],
+    ) -> tuple[str, ...]:
+        expected_marker = _directory_owner_marker(operation_id)
+        recorded_by_path = {
+            value.split(":", 1)[1]: value for value in recorded
+        }
+        candidates = _parent_paths(plan)
+        if len(candidates) > 64:
+            raise HostApplyError("too_many_created_directories")
+        owned: list[str] = []
+        try:
+            for relative in candidates:
+                receipt = self._prepare_created_directory(
+                    relative,
+                    operation_id,
+                    expected_marker,
+                    recorded_by_path.get(relative),
+                )
+                if receipt is not None:
+                    owned.append(receipt)
+            if set(recorded_by_path) - set(candidates):
+                raise HostApplyError("operation_record_invalid")
+        except BaseException:
+            try:
+                self._remove_created_directories(tuple(owned), operation_id)
+            except BaseException as cleanup_error:
+                raise HostApplyError("apply_rollback_failed") from cleanup_error
+            raise
+        return tuple(owned)
+
+    def _publish_created_directories(
+        self,
+        receipts: tuple[str, ...],
+        operation_id: str,
+    ) -> None:
+        expected_marker = _directory_owner_marker(operation_id)
+        for receipt in receipts:
+            relative = receipt.split(":", 1)[1]
+            directory = self.root / PurePosixPath(relative)
+            stage = self._created_directory_stage(operation_id, relative)
+            if directory.exists():
+                if (
+                    stage.exists()
+                    or _directory_receipt(directory, relative, operation_id) != receipt
+                ):
+                    raise HostApplyError("created_directory_changed")
+                marker = directory / _directory_marker_name(operation_id)
+                if _read_regular(marker) != expected_marker:
+                    raise HostApplyError("operation_artifact_conflict")
+                continue
+            if _directory_receipt(stage, relative, operation_id) != receipt:
+                raise HostApplyError("created_directory_changed")
+            marker = stage / _directory_marker_name(operation_id)
+            if _read_regular(marker) != expected_marker:
+                raise HostApplyError("operation_artifact_conflict")
+            parent = directory.parent
+            if _is_link_or_reparse(parent) or not parent.is_dir():
+                raise HostApplyError("path_parent_invalid")
+            with _guard_directories((parent, stage.parent)):
+                try:
+                    move_directory_no_replace(
+                        stage,
+                        directory,
+                        expected_identity=_directory_id_from_receipt(receipt),
+                        owner_name=_directory_marker_name(operation_id),
+                        owner_content=expected_marker,
+                        owner_only=True,
+                    )
+                except HostFileTransactionError as exc:
+                    raise HostApplyError(exc.code) from exc
+            marker = directory / _directory_marker_name(operation_id)
+            with _guard_directories((directory,)):
+                if (
+                    _directory_receipt(directory, relative, operation_id) != receipt
+                    or tuple(directory.iterdir()) != (marker,)
+                    or _read_regular(marker) != expected_marker
+                ):
+                    raise HostApplyError("created_directory_changed")
+
+    def _prepare_created_directory(
+        self,
+        relative: str,
+        operation_id: str,
+        expected_marker: bytes,
+        prior: str | None,
+    ) -> str | None:
+        directory = self.root / PurePosixPath(relative)
+        marker = directory / _directory_marker_name(operation_id)
+        stage = self._created_directory_stage(operation_id, relative)
+        if prior is not None:
+            present = tuple(
+                candidate
+                for candidate in (directory, stage)
+                if candidate.exists()
+            )
+            if (
+                len(present) != 1
+                or _directory_receipt(present[0], relative, operation_id) != prior
+            ):
+                raise HostApplyError("created_directory_changed")
+            owned_marker = present[0] / _directory_marker_name(operation_id)
+            if _read_regular(owned_marker) != expected_marker:
+                raise HostApplyError("operation_artifact_conflict")
+            return prior
+        if directory.exists():
+            if stage.exists() or _is_link_or_reparse(stage):
+                raise HostApplyError("operation_artifact_conflict")
+            if _is_link_or_reparse(directory) or not directory.is_dir():
+                raise HostApplyError("path_parent_invalid")
+            marker_value = _read_regular(marker) if marker.exists() else None
+            if marker_value is not None:
+                raise HostApplyError("operation_artifact_conflict")
+            return None
+        stage_parent = stage.parent
+        if _is_link_or_reparse(stage_parent) or not stage_parent.is_dir():
+            raise HostApplyError("git_metadata_unsafe")
+        with _guard_directories((stage_parent,)):
+            _prepare_directory_stage(stage, expected_marker, operation_id)
+            return _directory_receipt(stage, relative, operation_id)
+
+    def _created_directory_stage(self, operation_id: str, relative: str) -> Path:
+        return (
+            self.root
+            / ".git"
+            / "modelmirror-transactions"
+            / _directory_stage_name(operation_id, relative)
+        )
+
+    def _recover_created_directory_stages(
+        self,
+        plan: tuple[_PlannedFile, ...],
+        operation_id: str,
+    ) -> tuple[str, ...]:
+        expected_marker = _directory_owner_marker(operation_id)
+        receipts: list[str] = []
+        for relative in _parent_paths(plan):
+            stage = self._created_directory_stage(operation_id, relative)
+            if not stage.exists():
+                continue
+            if _is_link_or_reparse(stage) or not stage.is_dir():
+                raise HostApplyError("operation_artifact_conflict")
+            marker = stage / _directory_marker_name(operation_id)
+            with _guard_directories((stage,)):
+                entries = tuple(stage.iterdir())
+                if (
+                    entries != (marker,)
+                    or _read_regular(marker) != expected_marker
+                ):
+                    raise HostApplyError("operation_artifact_conflict")
+                receipts.append(_directory_receipt(stage, relative, operation_id))
+        return tuple(receipts)
+
+    def _finalize_created_directories(
+        self,
+        receipts: tuple[str, ...],
+        operation_id: str,
+    ) -> None:
+        marker_value = _directory_owner_marker(operation_id)
+        for receipt in receipts:
+            relative = receipt.split(":", 1)[1]
+            directory = self.root / PurePosixPath(relative)
+            stage = self._created_directory_stage(operation_id, relative)
+            try:
+                directory_identity = file_identity(directory)
+            except HostFileTransactionError as exc:
+                raise HostApplyError("created_directory_changed") from exc
+            if (
+                stage.exists()
+                or _is_link_or_reparse(stage)
+                or directory_identity != _directory_id_from_receipt(receipt)
+            ):
+                raise HostApplyError("created_directory_changed")
+            marker = directory / _directory_marker_name(operation_id)
+            with _guard_directories((directory,)):
+                if marker.exists():
+                    if (
+                        _read_regular(marker) != marker_value
+                        or file_identity(marker) != _marker_id_from_receipt(receipt)
+                    ):
+                        raise HostApplyError("created_directory_changed")
+                    try:
+                        remove_regular_exact(
+                            marker,
+                            marker_value,
+                            expected_identity=_marker_id_from_receipt(receipt),
+                        )
+                    except HostFileTransactionError as exc:
+                        raise HostApplyError(exc.code) from exc
+                elif _is_link_or_reparse(marker):
+                    raise HostApplyError("created_directory_changed")
+
+    def _assert_finalized_created_directories(
+        self,
+        receipts: tuple[str, ...],
+        operation_id: str,
+    ) -> None:
+        for receipt in receipts:
+            relative = receipt.split(":", 1)[1]
+            directory = self.root / PurePosixPath(relative)
+            stage = self._created_directory_stage(operation_id, relative)
+            marker = directory / _directory_marker_name(operation_id)
+            if (
+                stage.exists()
+                or file_identity(directory) != _directory_id_from_receipt(receipt)
+                or marker.exists()
+            ):
+                raise HostApplyError("created_directory_changed")
+
+    def _remove_created_directories(
+        self,
+        receipts: tuple[str, ...],
+        operation_id: str,
+    ) -> None:
+        marker_value = _directory_owner_marker(operation_id)
+        for receipt in reversed(receipts):
+            relative = receipt.split(":", 1)[1]
+            directory = self.root / PurePosixPath(relative)
+            stage = self._created_directory_stage(operation_id, relative)
+            present = tuple(
+                candidate
+                for candidate in (directory, stage)
+                if candidate.exists()
+            )
+            if not present:
+                continue
+            if (
+                len(present) != 1
+                or file_identity(present[0]) != _directory_id_from_receipt(receipt)
+            ):
+                raise HostApplyError("created_directory_changed")
+            owned = present[0]
+            marker = owned / _directory_marker_name(operation_id)
+            with _guard_directories((owned,)):
+                entries = tuple(owned.iterdir())
+                if entries:
+                    if entries != (marker,) or _read_regular(marker) != marker_value:
+                        raise HostApplyError("created_directory_not_empty")
+                    try:
+                        remove_regular_exact(
+                            marker,
+                            marker_value,
+                            expected_identity=_marker_id_from_receipt(receipt),
+                        )
+                    except HostFileTransactionError as exc:
+                        raise HostApplyError(exc.code) from exc
+            _remove_empty_directory_exact(owned, receipt)
+
+    def _write_plan(
+        self,
+        plan: tuple[_PlannedFile, ...],
+        *,
+        action: str,
+        branch: str,
+        expected_head: str,
+        operation_id: str,
+        commit_callback: Callable[[], None],
+        created_directories: tuple[str, ...] = (),
+    ) -> None:
+        try:
+            self._transaction(
+                plan,
+                action=action,
+                branch=branch,
+                expected_head=expected_head,
+                operation_id=operation_id,
+                created_directories=created_directories,
+            ).apply(
+                _transaction_files(plan),
+                commit_callback=commit_callback,
+            )
+        except HostFileTransactionError as exc:
+            raise HostApplyError(exc.code) from exc
+
+    def _settle_plan(
+        self,
+        plan: tuple[_PlannedFile, ...],
+        *,
+        action: str,
+        branch: str,
+        expected_head: str,
+        operation_id: str,
+        created_directories: tuple[str, ...] = (),
+        commit_callback: Callable[[], None] | None = None,
+    ) -> Literal["before", "after"]:
+        try:
+            return self._transaction(
+                plan,
+                action=action,
+                branch=branch,
+                expected_head=expected_head,
+                operation_id=operation_id,
+                created_directories=created_directories,
+            ).settle(
+                _transaction_files(plan),
+                commit_callback=commit_callback,
+            )
+        except HostFileTransactionError as exc:
+            raise HostApplyError(exc.code) from exc
+
+    def _cleanup_committed_plan(
+        self,
+        plan: tuple[_PlannedFile, ...],
+        *,
+        action: str,
+        branch: str,
+        expected_head: str,
+        operation_id: str,
+        created_directories: tuple[str, ...] = (),
+    ) -> None:
+        try:
+            self._transaction(
+                plan,
+                action=action,
+                branch=branch,
+                expected_head=expected_head,
+                operation_id=operation_id,
+                created_directories=created_directories,
+            ).cleanup_committed(_transaction_files(plan))
+        except HostFileTransactionError as exc:
+            raise HostApplyError(exc.code) from exc
+
+    def _transaction(
+        self,
+        plan: tuple[_PlannedFile, ...],
+        *,
+        action: str,
+        branch: str,
+        expected_head: str,
+        operation_id: str,
+        created_directories: tuple[str, ...],
+    ) -> HostFileTransaction:
+        expected_stamp = self._git_stamp(
+            branch,
+            expected_head,
+            owned_operation_id=operation_id,
+        )
+        return HostFileTransaction(
+            self.root,
+            operation_id,
+            action,
+            expected_stamp,
+            lambda owned: self._git_stamp(
+                branch,
+                expected_head,
+                owned_operation_id=owned,
+            ),
+            created_directories=created_directories,
+            mutation_hook=self.mutation_hook,
+        )
+
+    def _classify_plan(self, plan: tuple[_PlannedFile, ...]) -> str:
+        states = {self._file_state(item.path, item.before, item.after) for item in plan}
+        if states == {"before"}:
+            return "before"
+        if states == {"after"}:
+            return "after"
+        if states <= {"before", "after"}:
+            return "mixed"
+        return "other"
+
+    def _file_state(self, path: str, before: bytes | None, after: bytes | None) -> str:
+        self._assert_path_chain(path)
+        current = _read_regular(self.root / PurePosixPath(path))
+        if current == before:
+            return "before"
+        if current == after:
+            return "after"
+        return "other"
+
+    def _receipt(
+        self,
+        operation_id: str,
+        revision: int,
+        snapshot_fingerprint: str,
+        plan: tuple[_PlannedFile, ...],
+    ) -> ApplyReceipt:
+        return ApplyReceipt(
+            apply_id=operation_id,
+            revision=revision,
+            snapshot_fingerprint=snapshot_fingerprint,
+            files=tuple(
+                ApplyFileReceipt(
+                    path=item.path,
+                    existed_before=item.before is not None,
+                    before_sha256=item.before_sha256,
+                    after_sha256=item.after_sha256,
+                )
+                for item in plan
+            ),
+        )
+
+    def _finish_apply(self, operation_id: str, receipt: ApplyReceipt) -> ApplyReceipt:
+        self._assert_receipt_state(receipt, applied=True)
+        file_identities = self._file_identity_receipts(receipt, applied=True)
+        self._transition(
+            operation_id,
+            "applied",
+            apply_receipt=_receipt_dict(receipt),
+            file_identities=file_identities,
+        )
+        return receipt
+
+    def _file_identity_receipts(
+        self,
+        receipt: ApplyReceipt,
+        *,
+        applied: bool,
+    ) -> tuple[str, ...]:
+        values: list[str] = []
+        for item in receipt.files:
+            expected_hash = item.after_sha256 if applied else item.before_sha256
+            target = self.root / PurePosixPath(item.path)
+            current = _read_regular(target)
+            if expected_hash is None:
+                if current is not None:
+                    raise HostApplyError("apply_conflict")
+                values.append(f"missing:{item.path}")
+                continue
+            if current is None or _sha256(current) != expected_hash:
+                raise HostApplyError("apply_conflict")
+            try:
+                identity = file_identity(target)
+            except HostFileTransactionError as exc:
+                raise HostApplyError("apply_conflict") from exc
+            values.append(f"{identity}:{item.path}")
+        return tuple(values)
+
+    def _assert_file_identities(
+        self,
+        identities: tuple[str, ...],
+        receipt: ApplyReceipt,
+        *,
+        applied: bool,
+    ) -> None:
+        if identities != self._file_identity_receipts(receipt, applied=applied):
+            raise HostApplyError("target_changed")
+
+    def _assert_receipt_state(self, receipt: ApplyReceipt, *, applied: bool) -> None:
+        for item in receipt.files:
+            expected_hash = item.after_sha256 if applied else item.before_sha256
+            current = _read_regular(self.root / PurePosixPath(item.path))
+            if (current is None) != (expected_hash is None) or (
+                current is not None and _sha256(current) != expected_hash
+            ):
+                raise HostApplyError("apply_conflict")
+
+    def _transition(self, operation_id: str, state: str, **kwargs: object) -> None:
+        try:
+            self.journal.transition(operation_id, state, **kwargs)
+        except HostOperationLogError as exc:
+            raise HostApplyError(exc.code) from exc
+
+    def _mark_conflict(self, operation_id: str) -> None:
+        with contextlib.suppress(HostOperationLogError):
+            self.journal.transition(operation_id, "conflict")
+
+    def _validate_patch(self, patch: str, paths: Sequence[str]) -> tuple[str, ...]:
+        try:
+            safe = validate_patch(patch, expected_paths=paths, limits=self.limits)
+        except PatchPolicyError as exc:
+            raise HostApplyError(exc.code) from exc
+        if len({path.casefold() for path in safe}) != len(safe):
+            raise HostApplyError("path_case_conflict")
+        for path in safe:
+            if any(
+                not _valid_windows_component(part)
+                for part in PurePosixPath(path).parts
+            ):
+                raise HostApplyError("forbidden_path")
+        return safe
+
+    def _validate_text(self, content: bytes, path: str) -> None:
+        if len(content) > self.limits.max_file_bytes or b"\0" in content:
+            raise HostApplyError("binary_file_not_allowed")
+        try:
+            text = content.decode("utf-8", errors="strict")
+            DraftWorkspace._reject_secrets(text, path)
+        except UnicodeError as exc:
+            raise HostApplyError("non_utf8_not_allowed") from exc
+        except DraftPolicyError as exc:
+            raise HostApplyError(exc.code) from exc
+
+    @staticmethod
+    def _match_checkout_bytes(baseline: bytes, current: bytes | None, path: str) -> bytes:
+        if current is None:
+            raise HostApplyError("target_changed")
+        if current == baseline:
+            return current
+        if _uses_crlf(current) and current.replace(b"\r\n", b"\n") == baseline:
+            return current
+        raise HostApplyError("target_changed")
+
+    def _git(self, *arguments: str) -> subprocess.CompletedProcess[bytes]:
+        try:
+            return subprocess.run(
+                build_safe_git_command(self.root, arguments),
+                cwd=self.root,
+                env=build_safe_git_environment(),
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+                timeout=GIT_TIMEOUT_SECONDS,
+                creationflags=(
+                    getattr(subprocess, "CREATE_NO_WINDOW", 0)
+                    if os.name == "nt"
+                    else 0
+                ),
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise HostApplyError("git_inspection_failed") from exc
+
+    def _git_text(self, *arguments: str) -> str:
+        result = self._git(*arguments)
+        if result.returncode != 0:
+            raise HostApplyError("git_inspection_failed")
+        try:
+            return result.stdout.decode("utf-8", errors="strict").strip()
+        except UnicodeError as exc:
+            raise HostApplyError("git_encoding_not_supported") from exc
+
+
+def _patch_paths(patch: str) -> tuple[str, ...]:
+    paths: list[str] = []
+    for line in patch.splitlines():
+        if line.startswith("diff --git a/") and " b/" in line:
+            left, right = line[len("diff --git a/") :].split(" b/", 1)
+            if left != right:
+                raise HostApplyError("invalid_patch")
+            paths.append(left)
+    return tuple(sorted(paths))
+
+
+def _transaction_files(plan: Sequence[_PlannedFile]) -> tuple[FileMutation, ...]:
+    return tuple(
+        FileMutation(item.path, item.before, item.after, item.mode) for item in plan
+    )
+
+
+def _read_regular(path: Path) -> bytes | None:
+    try:
+        return read_regular(path)
+    except HostFileTransactionError as exc:
+        code = "symlink_not_allowed" if exc.code == "path_unsafe" else "target_unavailable"
+        raise HostApplyError(code) from exc
+
+
+def _is_link_or_reparse(path: Path) -> bool:
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        return False
+    except OSError as exc:
+        raise HostApplyError("target_unavailable") from exc
+    return stat.S_ISLNK(metadata.st_mode) or _is_reparse(metadata)
+
+
+def _is_reparse(metadata: os.stat_result) -> bool:
+    return bool(getattr(metadata, "st_file_attributes", 0) & FILE_ATTRIBUTE_REPARSE_POINT)
+
+
+def _uses_crlf(content: bytes) -> bool:
+    return b"\r\n" in content and b"\r" not in content.replace(b"\r\n", b"")
+
+
+def _to_crlf(content: bytes) -> bytes:
+    return content.replace(b"\r\n", b"\n").replace(b"\n", b"\r\n")
+
+
+def _bytes_for_hash(canonical: bytes, expected_sha256: str) -> bytes:
+    for candidate in (canonical, _to_crlf(canonical)):
+        if _sha256(candidate) == expected_sha256:
+            return candidate
+    raise HostApplyError("operation_conflict")
+
+
+def _sha256(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def _parent_paths(plan: Sequence[_PlannedFile]) -> tuple[str, ...]:
+    values: set[str] = set()
+    for item in plan:
+        parts = PurePosixPath(item.path).parts[:-1]
+        for index in range(1, len(parts) + 1):
+            values.add(PurePosixPath(*parts[:index]).as_posix())
+    return tuple(sorted(values, key=lambda value: (len(PurePosixPath(value).parts), value)))
+
+
+def _directory_marker_name(operation_id: str) -> str:
+    return f".modelmirror-{operation_id}.dir-owner"
+
+
+def _directory_stage_name(operation_id: str, relative: str) -> str:
+    suffix = hashlib.sha256(relative.encode("utf-8")).hexdigest()[:16]
+    return f".modelmirror-{operation_id}-{suffix}.dir-stage"
+
+
+def _directory_owner_marker(operation_id: str) -> bytes:
+    return f"modelmirror-created:{operation_id}\n".encode("ascii")
+
+
+def _prepare_directory_stage(
+    stage: Path,
+    marker_value: bytes,
+    operation_id: str,
+) -> None:
+    marker = stage / _directory_marker_name(operation_id)
+    if stage.exists():
+        if _is_link_or_reparse(stage) or not stage.is_dir():
+            raise HostApplyError("operation_artifact_conflict")
+        with _guard_directories((stage,)):
+            entries = tuple(stage.iterdir())
+            if any(entry.name != marker.name or _is_link_or_reparse(entry) for entry in entries):
+                raise HostApplyError("operation_artifact_conflict")
+            if marker.exists() and _read_regular(marker) != marker_value:
+                raise HostApplyError("operation_artifact_conflict")
+    else:
+        try:
+            stage.mkdir()
+        except FileExistsError as exc:
+            raise HostApplyError("operation_artifact_conflict") from exc
+    if not marker.exists():
+        _write_exclusive(marker, marker_value, 0o600)
+    elif _read_regular(marker) != marker_value:
+        raise HostApplyError("operation_artifact_conflict")
+
+
+def _directory_receipt(
+    directory: Path,
+    relative: str,
+    operation_id: str,
+) -> str:
+    try:
+        directory_identity = file_identity(directory)
+        marker_identity = file_identity(
+            directory / _directory_marker_name(operation_id)
+        )
+    except HostFileTransactionError as exc:
+        raise HostApplyError("created_directory_changed") from exc
+    return f"{directory_identity}@{marker_identity}:{relative}"
+
+
+def _directory_id_from_receipt(receipt: str) -> str:
+    try:
+        identity_bundle, _relative = receipt.split(":", 1)
+        directory_identity, _marker_identity = identity_bundle.split("@", 1)
+    except ValueError as exc:
+        raise HostApplyError("operation_record_invalid") from exc
+    return directory_identity
+
+
+def _marker_id_from_receipt(receipt: str) -> str:
+    try:
+        identity_bundle, _relative = receipt.split(":", 1)
+        _directory_identity, marker_identity = identity_bundle.split("@", 1)
+    except ValueError as exc:
+        raise HostApplyError("operation_record_invalid") from exc
+    return marker_identity
+
+
+def _remove_empty_directory_exact(directory: Path, receipt: str) -> None:
+    try:
+        _identity_bundle, relative = receipt.split(":", 1)
+        identity = _directory_id_from_receipt(receipt)
+        device_text, inode_text = identity.split("-", 1)
+        expected_device = int(device_text, 16)
+        expected_inode = int(inode_text, 16)
+    except (ValueError, TypeError) as exc:
+        raise HostApplyError("operation_record_invalid") from exc
+    try:
+        current_identity = file_identity(directory)
+    except HostFileTransactionError as exc:
+        raise HostApplyError("created_directory_changed") from exc
+    if current_identity != _directory_id_from_receipt(receipt):
+        raise HostApplyError("created_directory_changed")
+    if os.name == "nt":
+        _windows_remove_empty_directory_exact(
+            directory,
+            expected_device=expected_device,
+            expected_inode=expected_inode,
+        )
+        return
+    parent_descriptor = os.open(
+        directory.parent,
+        os.O_RDONLY
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_NOFOLLOW", 0),
+    )
+    directory_descriptor = -1
+    try:
+        directory_descriptor = os.open(
+            directory.name,
+            os.O_RDONLY
+            | getattr(os, "O_DIRECTORY", 0)
+            | getattr(os, "O_NOFOLLOW", 0),
+            dir_fd=parent_descriptor,
+        )
+        metadata = os.fstat(directory_descriptor)
+        if (metadata.st_dev, metadata.st_ino) != (expected_device, expected_inode):
+            raise HostApplyError("created_directory_changed")
+        if os.listdir(directory_descriptor):
+            raise HostApplyError("created_directory_not_empty")
+        try:
+            os.rmdir(directory.name, dir_fd=parent_descriptor)
+        except OSError as exc:
+            raise HostApplyError("created_directory_not_empty") from exc
+    finally:
+        if directory_descriptor >= 0:
+            os.close(directory_descriptor)
+        os.close(parent_descriptor)
+
+
+def _windows_remove_empty_directory_exact(
+    directory: Path,
+    *,
+    expected_device: int,
+    expected_inode: int,
+) -> None:
+    from ctypes import wintypes
+
+    delete_access = 0x00010000
+    file_read_attributes = 0x00000080
+    file_share_read = 0x00000001
+    open_existing = 3
+    file_flag_open_reparse_point = 0x00200000
+    file_flag_backup_semantics = 0x02000000
+    file_disposition_info = 4
+    file_attribute_directory = 0x00000010
+    file_attribute_reparse_point = 0x00000400
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+
+    class _ByHandleFileInformation(ctypes.Structure):
+        _fields_ = [
+            ("attributes", wintypes.DWORD),
+            ("creation_time", wintypes.FILETIME),
+            ("access_time", wintypes.FILETIME),
+            ("write_time", wintypes.FILETIME),
+            ("volume_serial", wintypes.DWORD),
+            ("size_high", wintypes.DWORD),
+            ("size_low", wintypes.DWORD),
+            ("links", wintypes.DWORD),
+            ("file_index_high", wintypes.DWORD),
+            ("file_index_low", wintypes.DWORD),
+        ]
+
+    class _FileDispositionInfo(ctypes.Structure):
+        _fields_ = [("delete_file", wintypes.BOOLEAN)]
+
+    kernel32.CreateFileW.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    ]
+    kernel32.CreateFileW.restype = wintypes.HANDLE
+    kernel32.GetFileInformationByHandle.argtypes = [
+        wintypes.HANDLE,
+        ctypes.POINTER(_ByHandleFileInformation),
+    ]
+    kernel32.GetFileInformationByHandle.restype = wintypes.BOOL
+    kernel32.SetFileInformationByHandle.argtypes = [
+        wintypes.HANDLE,
+        ctypes.c_int,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+    ]
+    kernel32.SetFileInformationByHandle.restype = wintypes.BOOL
+    kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+    kernel32.CloseHandle.restype = wintypes.BOOL
+    handle = kernel32.CreateFileW(
+        str(directory),
+        delete_access | file_read_attributes,
+        file_share_read,
+        None,
+        open_existing,
+        file_flag_open_reparse_point | file_flag_backup_semantics,
+        None,
+    )
+    if int(handle) == ctypes.c_void_p(-1).value:
+        raise HostApplyError("created_directory_changed")
+    try:
+        information = _ByHandleFileInformation()
+        if not kernel32.GetFileInformationByHandle(
+            handle,
+            ctypes.byref(information),
+        ):
+            raise HostApplyError("created_directory_changed")
+        inode = (information.file_index_high << 32) | information.file_index_low
+        if (
+            not information.attributes & file_attribute_directory
+            or information.attributes & file_attribute_reparse_point
+            or inode != expected_inode
+        ):
+            raise HostApplyError("created_directory_changed")
+        if information.volume_serial != expected_device:
+            raise HostApplyError("created_directory_changed")
+        verified = _ByHandleFileInformation()
+        if not kernel32.GetFileInformationByHandle(
+            handle,
+            ctypes.byref(verified),
+        ):
+            raise HostApplyError("created_directory_changed")
+        verified_inode = (verified.file_index_high << 32) | verified.file_index_low
+        if (
+            not verified.attributes & file_attribute_directory
+            or verified.attributes & file_attribute_reparse_point
+            or verified.volume_serial != expected_device
+            or verified_inode != expected_inode
+        ):
+            raise HostApplyError("created_directory_changed")
+        disposition = _FileDispositionInfo(True)
+        if not kernel32.SetFileInformationByHandle(
+            handle,
+            file_disposition_info,
+            ctypes.byref(disposition),
+            ctypes.sizeof(disposition),
+        ):
+            raise HostApplyError("created_directory_not_empty")
+    finally:
+        kernel32.CloseHandle(handle)
+    if directory.exists():
+        raise HostApplyError("created_directory_not_empty")
+
+
+def _write_exclusive(path: Path, content: bytes, mode: int) -> None:
+    descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, mode)
+    try:
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(content)
+            stream.flush()
+            os.fsync(stream.fileno())
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.close(descriptor)
+        # The exact object may have been replaced after a failed write. Leave
+        # ambiguous evidence in place so recovery fails closed instead of
+        # deleting a user-created object by path.
+        raise
+
+
+@contextlib.contextmanager
+def _guard_directories(paths: Sequence[Path]):
+    unique = tuple(dict.fromkeys(Path(path) for path in paths))
+    for path in unique:
+        if _is_link_or_reparse(path) or not path.is_dir():
+            raise HostApplyError("path_parent_invalid")
+    if os.name == "nt":
+        import ctypes
+        from ctypes import wintypes
+
+        file_read_attributes = 0x0080
+        file_share_read = 0x00000001
+        open_existing = 3
+        file_flag_open_reparse_point = 0x00200000
+        file_flag_backup_semantics = 0x02000000
+        file_attribute_tag_info = 9
+
+        class _FileAttributeTagInfo(ctypes.Structure):
+            _fields_ = [
+                ("file_attributes", wintypes.DWORD),
+                ("reparse_tag", wintypes.DWORD),
+            ]
+
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        kernel32.CreateFileW.argtypes = [
+            wintypes.LPCWSTR,
+            wintypes.DWORD,
+            wintypes.DWORD,
+            wintypes.LPVOID,
+            wintypes.DWORD,
+            wintypes.DWORD,
+            wintypes.HANDLE,
+        ]
+        kernel32.CreateFileW.restype = wintypes.HANDLE
+        kernel32.GetFileInformationByHandleEx.argtypes = [
+            wintypes.HANDLE,
+            ctypes.c_int,
+            wintypes.LPVOID,
+            wintypes.DWORD,
+        ]
+        kernel32.GetFileInformationByHandleEx.restype = wintypes.BOOL
+        kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+        kernel32.CloseHandle.restype = wintypes.BOOL
+        handles: list[int] = []
+        try:
+            for path in unique:
+                handle = kernel32.CreateFileW(
+                    str(path),
+                    file_read_attributes,
+                    file_share_read,
+                    None,
+                    open_existing,
+                    file_flag_open_reparse_point | file_flag_backup_semantics,
+                    None,
+                )
+                value = int(handle) if handle is not None else 0
+                if value == ctypes.c_void_p(-1).value:
+                    raise HostApplyError("path_parent_unavailable")
+                info = _FileAttributeTagInfo()
+                if not kernel32.GetFileInformationByHandleEx(
+                    handle,
+                    file_attribute_tag_info,
+                    ctypes.byref(info),
+                    ctypes.sizeof(info),
+                ) or info.file_attributes & FILE_ATTRIBUTE_REPARSE_POINT:
+                    kernel32.CloseHandle(handle)
+                    raise HostApplyError("project_reparse_point_not_allowed")
+                handles.append(handle)
+            yield
+        finally:
+            for handle in reversed(handles):
+                kernel32.CloseHandle(handle)
+        return
+
+    descriptors: list[int] = []
+    identities: list[tuple[Path, int, int]] = []
+    try:
+        for path in unique:
+            flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+            descriptor = os.open(path, flags)
+            metadata = os.fstat(descriptor)
+            descriptors.append(descriptor)
+            identities.append((path, metadata.st_dev, metadata.st_ino))
+        yield
+        for path, device, inode in identities:
+            try:
+                metadata = path.lstat()
+            except FileNotFoundError:
+                continue
+            if metadata.st_dev != device or metadata.st_ino != inode:
+                raise HostApplyError("path_parent_changed")
+    finally:
+        for descriptor in reversed(descriptors):
+            os.close(descriptor)
+
+
+def _receipt_dict(receipt: ApplyReceipt) -> dict[str, object]:
+    return {
+        "apply_id": receipt.apply_id,
+        "revision": receipt.revision,
+        "snapshot_fingerprint": receipt.snapshot_fingerprint,
+        "files": [
+            {
+                "path": item.path,
+                "existed_before": item.existed_before,
+                "before_sha256": item.before_sha256,
+                "after_sha256": item.after_sha256,
+            }
+            for item in receipt.files
+        ],
+        "applied_at": receipt.applied_at,
+    }
+
+
+def _valid_windows_component(value: str) -> bool:
+    if (
+        not value
+        or value.endswith((" ", "."))
+        or any(character in '<>:"|?*' for character in value)
+    ):
+        return False
+    stem = value.split(".", 1)[0].casefold()
+    return stem not in {
+        "con",
+        "prn",
+        "aux",
+        "nul",
+        *(f"com{index}" for index in range(1, 10)),
+        *(f"lpt{index}" for index in range(1, 10)),
+    }
+
+
+def _apply_receipt(value: dict[str, object] | None) -> ApplyReceipt:
+    if not isinstance(value, dict):
+        raise HostApplyError("operation_record_invalid")
+    try:
+        files = tuple(ApplyFileReceipt(**item) for item in value["files"])
+        return ApplyReceipt(
+            apply_id=value["apply_id"],
+            revision=value["revision"],
+            snapshot_fingerprint=value["snapshot_fingerprint"],
+            files=files,
+            applied_at=value["applied_at"],
+        )
+    except (KeyError, TypeError, ValueError) as exc:
+        raise HostApplyError("operation_record_invalid") from exc

--- a/server/coding_project_host/host_apply_engine.py
+++ b/server/coding_project_host/host_apply_engine.py
@@ -1015,7 +1015,10 @@ class HostGitApplyEngine:
                 )
                 assert config_record is not None and head_record is not None
                 try:
-                    head = head_record[0].decode("ascii", errors="strict").strip()
+                    # Git stores a symbolic HEAD as UTF-8 ref bytes. Valid
+                    # branch names may contain non-ASCII characters, while an
+                    # invalid byte sequence must still fail closed.
+                    head = head_record[0].decode("utf-8", errors="strict").strip()
                 except UnicodeError as exc:
                     raise HostApplyError("git_encoding_not_supported") from exc
                 if head.startswith("ref: refs/heads/"):

--- a/server/coding_project_host/host_commit_engine.py
+++ b/server/coding_project_host/host_commit_engine.py
@@ -1,0 +1,2537 @@
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import os
+import re
+import stat
+import subprocess
+import tempfile
+import threading
+import zlib
+from collections.abc import Callable, Sequence
+from dataclasses import asdict
+from pathlib import Path, PurePosixPath
+
+from server.coding_runtime.apply_models import ApplyFileReceipt, ApplyReceipt
+from server.coding_runtime.commit_models import (
+    CommitReceipt,
+    normalize_commit_message,
+    validate_commit_branch,
+)
+from server.coding_runtime.draft_workspace import DraftPolicyError, DraftWorkspace
+from server.coding_runtime.projects import build_safe_git_command, build_safe_git_environment
+
+from .host_apply_engine import (
+    HostApplyError,
+    _guard_directories,
+    _is_link_or_reparse,
+    _project_process_lock,
+)
+from .host_file_transaction import (
+    HostFileTransactionError,
+    _guard_exact_regular_object,
+    _move_verified_no_replace,
+    _read_regular_with_identity,
+    _remove_empty_directory_exact,
+    _windows_close_handle,
+    _windows_handle_identity,
+    _windows_open_existing,
+    _windows_read_all,
+    _write_durable_no_replace,
+    file_identity,
+    read_regular,
+    remove_regular_exact,
+)
+from .operation_log import HostOperationJournal, HostOperationLogError, HostOperationRecord
+
+
+GIT_TIMEOUT_SECONDS = 30
+DEFAULT_AUTHOR_NAME = "ModelMirror Coding Assistant"
+DEFAULT_AUTHOR_EMAIL = "coding@modelmirror.local"
+MutationHook = Callable[[str], None]
+_OBJECT_ID = re.compile(r"^(?:[a-f0-9]{40}|[a-f0-9]{64})$")
+_IDENTITY = re.compile(r"^[a-f0-9]+-[a-f0-9]+$")
+_DANGEROUS_CONFIG = (
+    r"^(include|include[Ii]f|filter|credential|diff|url)(\.|$)"
+    r"|^remote\..*\.(promisor|partial[Cc]lone[Ff]ilter)$"
+    r"|^(core\.worktree|extensions\.(worktree[Cc]onfig|partial[Cc]lone))$"
+)
+_PERSISTED_CONFLICT_CODES = frozenset(
+    {
+        "apply_receipt_invalid",
+        "branch_changed",
+        "commit_conflict",
+        "commit_receipt_invalid",
+        "head_changed",
+        "index_changed",
+        "repository_config_unsafe",
+        "repository_unsafe",
+        "target_changed",
+        "undo_conflict",
+    }
+)
+MAX_GIT_NAMESPACE_ENTRIES = 500_000
+MAX_PRIVATE_OBJECTS = 10_000
+MAX_PRIVATE_OBJECT_BYTES = 8 * 1024 * 1024
+MAX_PRIVATE_OBJECT_CONTENT_BYTES = 64 * 1024 * 1024
+PRIVATE_OBJECT_OWNER_FILE = "modelmirror-owner"
+
+
+class HostCommitError(RuntimeError):
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+class HostGitCommitEngine:
+    """Create and undo a local commit without exposing paths or remote access.
+
+    The helper owns the physical path and this engine accepts only receipts that
+    were durably produced by the host apply engine.  Git commands are a closed
+    plumbing-only set; repository automation and remote commands are never run.
+    """
+
+    def __init__(
+        self,
+        project_root: Path,
+        project_id: str,
+        journal: HostOperationJournal,
+        *,
+        author_name: str = DEFAULT_AUTHOR_NAME,
+        author_email: str = DEFAULT_AUTHOR_EMAIL,
+        mutation_hook: MutationHook | None = None,
+        enforce_windows: bool = True,
+    ) -> None:
+        if enforce_windows and os.name != "nt":
+            raise HostCommitError("windows_required")
+        root = Path(project_root)
+        if not root.is_absolute() or not root.is_dir() or _is_link_or_reparse(root):
+            raise HostCommitError("project_path_invalid")
+        self.root = root.resolve(strict=True)
+        self.git = self.root / ".git"
+        self.project_id = project_id
+        self.journal = journal
+        self.author_name = _validate_identity(author_name)
+        self.author_email = _validate_identity(author_email)
+        if "@" not in self.author_email:
+            raise HostCommitError("invalid_author")
+        self.mutation_hook = mutation_hook
+        self.enforce_windows = enforce_windows
+        self._lock = threading.Lock()
+        self._validate_repository_layout()
+
+    def commit(
+        self,
+        *,
+        operation_id: str,
+        apply_receipt: ApplyReceipt,
+        branch: str,
+        expected_head: str,
+        message: str,
+    ) -> CommitReceipt:
+        safe_branch = _branch(branch)
+        try:
+            safe_message = normalize_commit_message(message)
+        except ValueError as exc:
+            raise HostCommitError("commit_message_invalid") from exc
+        if expected_head != _object_id(expected_head):
+            raise HostCommitError("commit_conflict")
+        with self._operation_lock():
+            applied = self._applied_record(apply_receipt, safe_branch, expected_head)
+            try:
+                record = self.journal.create(
+                    operation_id=operation_id,
+                    action="commit",
+                    project_id=self.project_id,
+                    revision=apply_receipt.revision,
+                    branch=safe_branch,
+                    expected_head=expected_head,
+                    patch_sha256=applied.patch_sha256,
+                    patch=applied.patch,
+                    apply_receipt=_apply_receipt_dict(apply_receipt),
+                    file_identities=applied.file_identities,
+                    commit_message=safe_message,
+                )
+            except HostOperationLogError as exc:
+                raise HostCommitError(exc.code) from exc
+            if record.state == "conflict":
+                self._settle_conflict(record)
+                raise HostCommitError("commit_conflict")
+            return self._resume_with_conflict(record)
+
+    def undo(
+        self,
+        *,
+        operation_id: str,
+        apply_receipt: ApplyReceipt,
+        commit_receipt: CommitReceipt,
+        branch: str,
+    ) -> CommitReceipt:
+        safe_branch = _branch(branch)
+        if commit_receipt.branch != safe_branch:
+            raise HostCommitError("undo_conflict")
+        with self._operation_lock():
+            applied = self._applied_record(
+                apply_receipt,
+                safe_branch,
+                commit_receipt.parent_sha,
+            )
+            self._assert_commit_receipt(commit_receipt, apply_receipt, safe_branch)
+            self._committed_record(commit_receipt, apply_receipt, safe_branch)
+            try:
+                record = self.journal.create(
+                    operation_id=operation_id,
+                    action="undo",
+                    project_id=self.project_id,
+                    revision=apply_receipt.revision,
+                    branch=safe_branch,
+                    expected_head=commit_receipt.commit_sha,
+                    patch_sha256=applied.patch_sha256,
+                    patch=applied.patch,
+                    apply_receipt=_apply_receipt_dict(apply_receipt),
+                    commit_receipt=_commit_receipt_dict(commit_receipt),
+                    file_identities=applied.file_identities,
+                )
+            except HostOperationLogError as exc:
+                raise HostCommitError(exc.code) from exc
+            if record.state == "conflict":
+                self._settle_conflict(record)
+                raise HostCommitError("undo_conflict")
+            return self._resume_with_conflict(record)
+
+    def reconcile(self, operation_id: str) -> tuple[str, CommitReceipt | None]:
+        with self._operation_lock():
+            try:
+                record = self.journal.get(operation_id)
+            except HostOperationLogError as exc:
+                raise HostCommitError(exc.code) from exc
+            if record is None:
+                return "not_committed", None
+            if record.project_id != self.project_id or record.action not in {"commit", "undo"}:
+                raise HostCommitError("operation_conflict")
+            if record.state == "conflict":
+                self._settle_conflict(record)
+                return "conflict", _optional_commit_receipt(record.commit_receipt)
+            try:
+                receipt = self._resume_with_conflict(record)
+                return ("committed" if record.action == "commit" else "undone"), receipt
+            except HostCommitError as exc:
+                if exc.code in _PERSISTED_CONFLICT_CODES:
+                    return "conflict", _optional_commit_receipt(record.commit_receipt)
+                raise
+
+    def _resume_with_conflict(self, record: HostOperationRecord) -> CommitReceipt:
+        record = self._bind_reflog_metadata(record)
+        # A process can stop after one or both reflogs were parked. Restore the
+        # exact journal-bound objects before any Git command or namespace scan;
+        # an ambiguous replacement is never overwritten.
+        terminal_without_parked_reflogs = (
+            record.state in {"committed", "undone"}
+            and not any(
+                _path_entry_exists(backup)
+                for _label, _source, backup in self._operation_reflog_paths(record)
+            )
+        )
+        if not terminal_without_parked_reflogs:
+            self._recover_reflogs(record)
+        if self._conflict_marker_present(record.operation_id):
+            self._mark_conflict(
+                record.operation_id,
+                "commit_conflict" if record.action == "commit" else "undo_conflict",
+            )
+            raise HostCommitError(
+                "commit_conflict" if record.action == "commit" else "undo_conflict"
+            )
+        try:
+            if record.action == "commit":
+                return self._resume_commit(record)
+            return self._resume_undo(record)
+        except HostCommitError as exc:
+            if exc.code in _PERSISTED_CONFLICT_CODES:
+                self._mark_conflict(record.operation_id, exc.code)
+            raise
+
+    def _bind_reflog_metadata(
+        self,
+        record: HostOperationRecord,
+    ) -> HostOperationRecord:
+        if record.reflog_metadata:
+            return record
+        if record.state != "prepared" or record.action not in {"commit", "undo"}:
+            raise HostCommitError("operation_log_unavailable")
+        self._notify("metadata_before_reflog_bind")
+        metadata = self._capture_reflog_metadata(record.branch)
+        return self._transition(
+            record.operation_id,
+            record.state,
+            reflog_metadata=metadata,
+        )
+
+    @contextlib.contextmanager
+    def _operation_lock(self):
+        if self.enforce_windows and os.name != "nt":
+            raise HostCommitError("windows_required")
+        try:
+            with _project_process_lock(self.root), self._lock:
+                yield
+        except HostApplyError as exc:
+            raise HostCommitError(exc.code) from exc
+
+    @contextlib.contextmanager
+    def _git_write_guards(
+        self,
+        branch: str,
+        *,
+        parked_record: HostOperationRecord | None = None,
+    ):
+        self._assert_repository_layout_and_branch(branch)
+        directories: list[Path] = []
+        try:
+            for namespace in (
+                self.git / "objects",
+                self.git / "refs",
+                self.git / "logs",
+            ):
+                if namespace.exists():
+                    directories.extend(_safe_git_namespace(namespace))
+            branch_parts = PurePosixPath(branch).parts[:-1]
+            current = self.git / "refs" / "heads"
+            for part in branch_parts:
+                current = current / part
+                if not current.is_dir() or _is_link_or_reparse(current):
+                    raise HostCommitError("repository_unsafe")
+                directories.append(current)
+            logs = self.git / "logs"
+            if logs.exists():
+                for base in (logs, logs / "refs", logs / "refs" / "heads"):
+                    if base.exists():
+                        if not base.is_dir() or _is_link_or_reparse(base):
+                            raise HostCommitError("repository_unsafe")
+                        directories.append(base)
+                current = logs / "refs" / "heads"
+                for part in branch_parts:
+                    current = current / part
+                    if current.exists():
+                        if not current.is_dir() or _is_link_or_reparse(current):
+                            raise HostCommitError("repository_unsafe")
+                        directories.append(current)
+            with contextlib.ExitStack() as stack:
+                stack.enter_context(_guard_directories(tuple(dict.fromkeys(directories))))
+                for metadata in (self.git / "config", self.git / "HEAD"):
+                    current_file = _read_regular_with_identity(metadata)
+                    if current_file is None:
+                        raise HostCommitError("repository_unsafe")
+                    stack.enter_context(
+                        _guard_exact_regular_object(
+                            metadata,
+                            current_file[0],
+                            expected_identity=current_file[1],
+                        )
+                    )
+                packed_refs = self.git / "packed-refs"
+                if packed_refs.exists():
+                    packed = _read_regular_with_identity(packed_refs)
+                    if packed is None:
+                        raise HostCommitError("repository_unsafe")
+                    stack.enter_context(
+                        _guard_exact_regular_object(
+                            packed_refs,
+                            packed[0],
+                            expected_identity=packed[1],
+                        )
+                    )
+                if parked_record is None:
+                    for reflog in (
+                        self.git / "logs" / "HEAD",
+                        self.git / "logs" / "refs" / "heads" / PurePosixPath(branch),
+                    ):
+                        if not reflog.exists():
+                            raise HostCommitError("repository_unsafe")
+                        stack.enter_context(_guard_mutable_regular_leaf(reflog))
+                else:
+                    self._assert_reflogs_parked(parked_record)
+                yield
+        except HostFileTransactionError as exc:
+            raise HostCommitError("repository_unsafe") from exc
+
+    def _resume_commit(self, record: HostOperationRecord) -> CommitReceipt:
+        if record.action != "commit" or record.commit_message is None:
+            raise HostCommitError("operation_conflict")
+        apply_receipt = _apply_receipt(record.apply_receipt)
+        if record.state == "committed":
+            receipt = _commit_receipt(record.commit_receipt)
+            self._assert_commit_receipt(receipt, apply_receipt, record.branch)
+            self._cleanup_index_backup(record)
+            if self._git_text("rev-parse", "--verify", "HEAD") != receipt.commit_sha:
+                raise HostCommitError("commit_not_current")
+            return receipt
+        applied = self._applied_record(apply_receipt, record.branch, record.expected_head)
+        if applied.file_identities != record.file_identities:
+            return self._conflict(record.operation_id, "target_changed")
+        receipt: CommitReceipt | None = None
+        should_transition = False
+        with self._parked_reflogs(record), self._git_write_guards(
+            record.branch,
+            parked_record=record,
+        ), self._guard_applied_files(
+            apply_receipt,
+            record.file_identities,
+        ) as contents:
+            receipt = _optional_commit_receipt(record.commit_receipt)
+            prepared_index: Path | None = None
+            try:
+                if receipt is None:
+                    self._assert_repository_state(
+                        branch=record.branch,
+                        allowed_heads=(record.expected_head,),
+                        expected_paths=tuple(item.path for item in apply_receipt.files),
+                        require_applied_status=True,
+                    )
+                    (
+                        tree,
+                        commit_sha,
+                        prepared_index,
+                        source_index,
+                        source_index_identity,
+                    ) = self._prepare_commit(
+                        record=record,
+                        apply_receipt=apply_receipt,
+                        contents=contents,
+                    )
+                    receipt = CommitReceipt(
+                        commit_id=record.operation_id,
+                        revision=record.revision,
+                        apply_id=apply_receipt.apply_id,
+                        commit_sha=commit_sha,
+                        parent_sha=record.expected_head,
+                        tree_sha=tree,
+                        message=record.commit_message,
+                        files=tuple(item.path for item in apply_receipt.files),
+                        branch=record.branch,
+                        committed_at=record.created_at,
+                    )
+                    record = self._stage_operation_index(
+                        record=record,
+                        prepared=prepared_index,
+                        state="committing",
+                        commit_receipt=receipt,
+                        old_tree=self._tree_for_commit(receipt.parent_sha),
+                        new_tree=receipt.tree_sha,
+                        source_index=source_index,
+                        source_index_identity=source_index_identity,
+                    )
+                    prepared_index = None
+                    self._notify("commit_after_receipt")
+                else:
+                    self._assert_commit_receipt(receipt, apply_receipt, record.branch)
+                state = self._metadata_state(record, receipt)
+                if record.state != "committing":
+                    return self._conflict(record.operation_id, "commit_conflict")
+                if state == "parent_parent":
+                    self._assert_applied_status(apply_receipt)
+                    self._advance_ref_with_index_lock(
+                        record=record,
+                        receipt=receipt,
+                        new_head=receipt.commit_sha,
+                        old_head=receipt.parent_sha,
+                        old_tree=self._tree_for_commit(receipt.parent_sha),
+                        expected_status=receipt.files,
+                        message="ModelMirror controlled host commit",
+                    )
+                    self._notify("commit_after_ref")
+                    state = "commit_parent"
+                if state == "commit_parent":
+                    transition_status = _commit_ref_transition_paths(apply_receipt)
+                    self._assert_status_paths(
+                        transition_status,
+                        "commit_conflict",
+                        index_path=self._operation_status_index(record),
+                    )
+                    self._publish_index_lock(
+                        record=record,
+                        branch=record.branch,
+                        expected_head=receipt.commit_sha,
+                        old_tree=self._tree_for_commit(receipt.parent_sha),
+                        new_tree=receipt.tree_sha,
+                        expected_status=transition_status,
+                    )
+                    self._notify("commit_after_index")
+                    state = "commit_commit"
+                if state != "commit_commit":
+                    return self._conflict(record.operation_id, "commit_conflict")
+                self._assert_post_commit(receipt)
+                should_transition = True
+            finally:
+                if prepared_index is not None:
+                    prepared_index.unlink(missing_ok=True)
+        if receipt is None:
+            raise HostCommitError("commit_receipt_invalid")
+        if should_transition:
+            self._transition(
+                record.operation_id,
+                "committed",
+                commit_receipt=_commit_receipt_dict(receipt),
+            )
+            self._notify("commit_after_journal")
+        self._cleanup_index_backup(record)
+        return receipt
+
+    def _resume_undo(self, record: HostOperationRecord) -> CommitReceipt:
+        if record.action != "undo":
+            raise HostCommitError("operation_conflict")
+        apply_receipt = _apply_receipt(record.apply_receipt)
+        receipt = _commit_receipt(record.commit_receipt)
+        self._assert_commit_receipt(receipt, apply_receipt, record.branch)
+        if record.state == "undone":
+            self._cleanup_index_backup(record)
+            if self._git_text("rev-parse", "--verify", "HEAD") != receipt.parent_sha:
+                raise HostCommitError("undo_not_current")
+            return receipt
+        self._committed_record(receipt, apply_receipt, record.branch)
+        applied = self._applied_record(apply_receipt, record.branch, receipt.parent_sha)
+        if applied.file_identities != record.file_identities:
+            return self._conflict(record.operation_id, "target_changed")
+        should_transition = False
+        with self._parked_reflogs(record), self._git_write_guards(
+            record.branch,
+            parked_record=record,
+        ), self._guard_applied_files(
+            apply_receipt,
+            record.file_identities,
+        ):
+            self._assert_repository_layout_and_branch(record.branch)
+            state = self._metadata_state(record, receipt)
+            if record.state == "prepared":
+                if state != "commit_commit" or self._status_paths():
+                    return self._conflict(record.operation_id, "undo_conflict")
+                parent_tree = self._tree_for_commit(receipt.parent_sha)
+                (
+                    parent_index,
+                    source_index,
+                    source_index_identity,
+                ) = self._prepare_undo_index(
+                    apply_receipt=apply_receipt,
+                    parent_sha=receipt.parent_sha,
+                    current_tree=receipt.tree_sha,
+                    parent_tree=parent_tree,
+                )
+                record = self._stage_operation_index(
+                    record=record,
+                    prepared=parent_index,
+                    state="undoing",
+                    commit_receipt=receipt,
+                    old_tree=receipt.tree_sha,
+                    new_tree=parent_tree,
+                    source_index=source_index,
+                    source_index_identity=source_index_identity,
+                )
+                self._notify("undo_after_intent")
+            if record.state != "undoing":
+                return self._conflict(record.operation_id, "undo_conflict")
+            if state == "commit_commit":
+                if self._status_paths():
+                    return self._conflict(record.operation_id, "undo_conflict")
+                self._advance_ref_with_index_lock(
+                    record=record,
+                    receipt=receipt,
+                    new_head=receipt.parent_sha,
+                    old_head=receipt.commit_sha,
+                    old_tree=receipt.tree_sha,
+                    expected_status=(),
+                    message="ModelMirror controlled host commit undo",
+                )
+                self._notify("undo_after_ref")
+                state = "parent_commit"
+            if state == "parent_commit":
+                self._assert_applied_status(apply_receipt, record=record)
+                self._publish_index_lock(
+                    record=record,
+                    branch=record.branch,
+                    expected_head=receipt.parent_sha,
+                    old_tree=receipt.tree_sha,
+                    new_tree=self._tree_for_commit(receipt.parent_sha),
+                    expected_status=receipt.files,
+                )
+                self._notify("undo_after_index")
+                state = "parent_parent"
+            if state != "parent_parent":
+                return self._conflict(record.operation_id, "undo_conflict")
+            self._assert_applied_status(apply_receipt)
+            should_transition = True
+        if should_transition:
+            self._transition(
+                record.operation_id,
+                "undone",
+                commit_receipt=_commit_receipt_dict(receipt),
+            )
+            self._notify("undo_after_journal")
+        self._cleanup_index_backup(record)
+        return receipt
+
+    def _prepare_commit(
+        self,
+        *,
+        record: HostOperationRecord,
+        apply_receipt: ApplyReceipt,
+        contents: dict[str, bytes],
+    ) -> tuple[str, str, Path, bytes, str]:
+        expected_tree = self._tree_for_commit(record.expected_head)
+        index, source_index, source_index_identity = self._copy_current_index(
+            expected_tree
+        )
+        try:
+            with self._private_object_store(record) as object_directory:
+                object_arguments = {
+                    "object_directory": object_directory,
+                    "alternate_object_directories": (self.git / "objects",),
+                }
+                for item in apply_receipt.files:
+                    if item.after_sha256 is None:
+                        self._git(
+                            "update-index",
+                            "--force-remove",
+                            "--",
+                            item.path,
+                            index_path=index,
+                            **object_arguments,
+                        )
+                        continue
+                    working = contents[item.path]
+                    mode, baseline = self._head_file(record.expected_head, item.path)
+                    if item.existed_before:
+                        if baseline is None or item.before_sha256 is None:
+                            raise HostCommitError("target_changed")
+                        blob = _canonical_blob(baseline, working, item.before_sha256)
+                    else:
+                        if baseline is not None:
+                            raise HostCommitError("target_changed")
+                        blob = working
+                        mode = "100644"
+                    object_id = self._git_text(
+                        "hash-object",
+                        "-w",
+                        "--no-filters",
+                        "--stdin",
+                        input_bytes=blob,
+                        **object_arguments,
+                    )
+                    self._git(
+                        "update-index",
+                        "--add",
+                        "--cacheinfo",
+                        mode,
+                        object_id,
+                        item.path,
+                        index_path=index,
+                        **object_arguments,
+                    )
+                tree = self._git_text(
+                    "write-tree",
+                    index_path=index,
+                    **object_arguments,
+                )
+                timestamp = int(record.created_at)
+                commit_sha = self._git_text(
+                    "commit-tree",
+                    tree,
+                    "-p",
+                    record.expected_head,
+                    input_bytes=(record.commit_message + "\n").encode("utf-8"),
+                    extra_environment={
+                        "GIT_AUTHOR_DATE": f"@{timestamp} +0000",
+                        "GIT_COMMITTER_DATE": f"@{timestamp} +0000",
+                    },
+                    **object_arguments,
+                )
+                self._notify("commit_before_object_publish")
+                self._publish_private_objects(object_directory)
+                self._assert_generated_objects_available(
+                    tree=tree,
+                    commit_sha=commit_sha,
+                    parent_sha=record.expected_head,
+                )
+            self._notify("commit_after_tree")
+            self._assert_object_namespace_safe()
+            return tree, commit_sha, index, source_index, source_index_identity
+        except BaseException:
+            index.unlink(missing_ok=True)
+            raise
+
+    def _stage_operation_index(
+        self,
+        *,
+        record: HostOperationRecord,
+        prepared: Path,
+        state: str,
+        commit_receipt: CommitReceipt,
+        old_tree: str,
+        new_tree: str,
+        source_index: bytes,
+        source_index_identity: str,
+    ) -> HostOperationRecord:
+        stage = self._index_stage(record.operation_id)
+        index = self.git / "index"
+        try:
+            replacement = prepared.read_bytes()
+            if self._tree_from_index_bytes(replacement) != new_tree:
+                raise HostCommitError("index_changed")
+            current = _read_regular_with_identity(index)
+            if current != (source_index, source_index_identity):
+                raise HostCommitError("index_changed")
+            original, before_identity = current
+            before_digest = hashlib.sha256(original).hexdigest()
+            if self._tree_from_index_bytes(original) != old_tree:
+                raise HostCommitError("index_changed")
+            if (self.git / "index.lock").exists():
+                raise HostCommitError("index_busy")
+            if stage.exists():
+                staged = _read_regular_with_identity(stage)
+                if staged is None or staged[0] != replacement:
+                    raise HostCommitError("index_changed")
+            else:
+                _write_durable_no_replace(stage, replacement, 0o600)
+                staged = _read_regular_with_identity(stage)
+            if staged is None:
+                raise HostCommitError("index_changed")
+            staged_content, staged_identity = staged
+            digest = hashlib.sha256(staged_content).hexdigest()
+            reflog_metadata = record.reflog_metadata
+            if not reflog_metadata:
+                raise HostCommitError("operation_log_unavailable")
+            with _guard_exact_regular_object(
+                index,
+                original,
+                expected_identity=before_identity,
+            ), _guard_exact_regular_object(
+                stage,
+                staged_content,
+                expected_identity=staged_identity,
+            ):
+                return self._transition(
+                    record.operation_id,
+                    state,
+                    commit_receipt=_commit_receipt_dict(commit_receipt),
+                    index_sha256=digest,
+                    index_before_sha256=before_digest,
+                    index_identity=staged_identity,
+                    index_before_identity=before_identity,
+                    reflog_metadata=reflog_metadata,
+                )
+        except HostFileTransactionError as exc:
+            raise HostCommitError("index_changed") from exc
+        finally:
+            prepared.unlink(missing_ok=True)
+
+    def _reflog_paths(self, branch: str) -> tuple[tuple[str, Path, Path], ...]:
+        transaction_root = self.git / "modelmirror-transactions"
+        return (
+            (
+                "HEAD",
+                self.git / "logs" / "HEAD",
+                transaction_root / "{operation_id}.head-reflog-before",
+            ),
+            (
+                "branch",
+                self.git / "logs" / "refs" / "heads" / PurePosixPath(branch),
+                transaction_root / "{operation_id}.branch-reflog-before",
+            ),
+        )
+
+    def _operation_reflog_paths(
+        self,
+        record: HostOperationRecord,
+    ) -> tuple[tuple[str, Path, Path], ...]:
+        return tuple(
+            (label, source, Path(str(backup).format(operation_id=record.operation_id)))
+            for label, source, backup in self._reflog_paths(record.branch)
+        )
+
+    def _capture_reflog_metadata(self, branch: str) -> tuple[str, ...]:
+        metadata: list[str] = []
+        with self._guard_reflog_directories(branch):
+            for label, source, _backup in self._reflog_paths(branch):
+                current = _read_regular_with_identity(source)
+                if current is None:
+                    raise HostCommitError("repository_unsafe")
+                content, identity = current
+                _assert_single_link_regular(source)
+                metadata.append(
+                    f"{label}:{hashlib.sha256(content).hexdigest()}@{identity}"
+                )
+        return tuple(metadata)
+
+    def _reflog_directories(self, branch: str) -> tuple[Path, ...]:
+        directories = [
+            self.git / "logs",
+            self.git / "logs" / "refs",
+            self.git / "logs" / "refs" / "heads",
+        ]
+        current = self.git / "logs" / "refs" / "heads"
+        for part in PurePosixPath(branch).parts[:-1]:
+            current = current / part
+            directories.append(current)
+        directories.append(self.git / "modelmirror-transactions")
+        return tuple(dict.fromkeys(directories))
+
+    @contextlib.contextmanager
+    def _guard_reflog_directories(self, branch: str):
+        directories = self._reflog_directories(branch)
+        try:
+            with _guard_directories(directories):
+                if any(
+                    not directory.is_dir() or _is_link_or_reparse(directory)
+                    for directory in directories
+                ):
+                    raise HostCommitError("repository_unsafe")
+                yield
+                if any(
+                    not directory.is_dir() or _is_link_or_reparse(directory)
+                    for directory in directories
+                ):
+                    raise HostCommitError("repository_unsafe")
+        except (HostApplyError, HostFileTransactionError) as exc:
+            raise HostCommitError("repository_unsafe") from exc
+
+    def _expected_reflogs(
+        self,
+        record: HostOperationRecord,
+    ) -> dict[str, tuple[str, str]]:
+        if not record.reflog_metadata:
+            return {}
+        if len(record.reflog_metadata) != 2:
+            raise HostCommitError("operation_log_unavailable")
+        expected: dict[str, tuple[str, str]] = {}
+        for item in record.reflog_metadata:
+            try:
+                label, value = item.split(":", 1)
+                digest, identity = value.split("@", 1)
+            except ValueError as exc:
+                raise HostCommitError("operation_log_unavailable") from exc
+            if label not in {"HEAD", "branch"} or label in expected:
+                raise HostCommitError("operation_log_unavailable")
+            expected[label] = (digest, identity)
+        if set(expected) != {"HEAD", "branch"}:
+            raise HostCommitError("operation_log_unavailable")
+        return expected
+
+    def _recover_reflogs(self, record: HostOperationRecord) -> None:
+        with self._guard_reflog_directories(record.branch):
+            self._recover_reflogs_guarded(record)
+
+    def _recover_reflogs_guarded(self, record: HostOperationRecord) -> None:
+        expected = self._expected_reflogs(record)
+        paths = self._operation_reflog_paths(record)
+        if not expected:
+            if any(_path_entry_exists(backup) for _label, _source, backup in paths):
+                raise HostCommitError("operation_log_unavailable")
+            return
+        restored: list[str] = []
+        try:
+            for label, source, backup in paths:
+                digest, identity = expected[label]
+                current = _read_regular_with_identity(source)
+                parked = _read_regular_with_identity(backup)
+                if current is not None and parked is None:
+                    if (
+                        current[1] != identity
+                        or hashlib.sha256(current[0]).hexdigest() != digest
+                    ):
+                        raise HostCommitError("operation_log_unavailable")
+                    _assert_single_link_regular(source)
+                    continue
+                if current is None and parked is not None:
+                    if (
+                        parked[1] != identity
+                        or hashlib.sha256(parked[0]).hexdigest() != digest
+                    ):
+                        raise HostCommitError("operation_log_unavailable")
+                    _assert_single_link_regular(backup)
+                    _move_verified_no_replace(
+                        backup,
+                        source,
+                        parked[0],
+                        expected_identity=identity,
+                    )
+                    recovered = _read_regular_with_identity(source)
+                    if recovered != parked:
+                        raise HostCommitError("operation_log_unavailable")
+                    _assert_single_link_regular(source)
+                    restored.append(label)
+                    continue
+                # Both present is ambiguous; neither present has lost durable
+                # evidence. Never replace or delete either pathname.
+                raise HostCommitError("operation_log_unavailable")
+        except HostFileTransactionError as exc:
+            raise HostCommitError("operation_log_unavailable") from exc
+        if restored:
+            self._notify("metadata_after_reflog_restore")
+
+    def _assert_reflogs_parked(self, record: HostOperationRecord) -> None:
+        expected = self._expected_reflogs(record)
+        if set(expected) != {"HEAD", "branch"}:
+            raise HostCommitError("operation_log_unavailable")
+        for label, source, backup in self._operation_reflog_paths(record):
+            if _path_entry_exists(source):
+                raise HostCommitError("repository_unsafe")
+            parked = _read_regular_with_identity(backup)
+            digest, identity = expected[label]
+            if (
+                parked is None
+                or parked[1] != identity
+                or hashlib.sha256(parked[0]).hexdigest() != digest
+            ):
+                raise HostCommitError("operation_log_unavailable")
+            _assert_single_link_regular(backup)
+
+    @contextlib.contextmanager
+    def _parked_reflogs(self, record: HostOperationRecord):
+        expected = self._expected_reflogs(record)
+        if set(expected) != {"HEAD", "branch"}:
+            raise HostCommitError("operation_log_unavailable")
+        self._recover_reflogs(record)
+        with self._guard_reflog_directories(record.branch):
+            try:
+                for label, source, backup in self._operation_reflog_paths(record):
+                    digest, identity = expected[label]
+                    current = _read_regular_with_identity(source)
+                    if (
+                        current is None
+                        or current[1] != identity
+                        or hashlib.sha256(current[0]).hexdigest() != digest
+                        or _path_entry_exists(backup)
+                    ):
+                        raise HostCommitError("repository_unsafe")
+                    _assert_single_link_regular(source)
+                    _move_verified_no_replace(
+                        source,
+                        backup,
+                        current[0],
+                        expected_identity=identity,
+                    )
+                    parked = _read_regular_with_identity(backup)
+                    if parked != current:
+                        raise HostCommitError("repository_unsafe")
+                    self._notify(f"metadata_after_{label.lower()}_reflog_park")
+                self._assert_reflogs_parked(record)
+                yield
+            except HostFileTransactionError as exc:
+                raise HostCommitError("repository_unsafe") from exc
+            finally:
+                # Python exceptions restore immediately; an actual process stop
+                # is recovered from the journal-bound backups on restart.
+                self._recover_reflogs_guarded(record)
+
+    def _assert_direct_branch_ref(
+        self,
+        branch: str,
+        expected_head: str,
+    ) -> tuple[bytes, str]:
+        path = self.git / "refs" / "heads" / PurePosixPath(branch)
+        current = _read_regular_with_identity(path)
+        if current is None or current[0] not in {
+            expected_head.encode("ascii"),
+            f"{expected_head}\n".encode("ascii"),
+        }:
+            raise HostCommitError("head_changed")
+        _assert_single_link_regular(path)
+        return current
+
+    def _update_ref_without_reflog(
+        self,
+        *,
+        record: HostOperationRecord,
+        new_head: str,
+        old_head: str,
+        message: str,
+    ) -> None:
+        self._assert_repository_redirections_absent()
+        self._assert_direct_branch_ref(record.branch, old_head)
+        self._assert_reflogs_parked(record)
+        try:
+            self._git(
+                "update-ref",
+                "--no-deref",
+                "--no-create-reflog",
+                "-m",
+                message,
+                f"refs/heads/{record.branch}",
+                new_head,
+                old_head,
+            )
+        except HostCommitError as exc:
+            raise HostCommitError("head_changed") from exc
+        self._notify("metadata_after_ref_update")
+        self._assert_reflogs_parked(record)
+        self._assert_direct_branch_ref(record.branch, new_head)
+
+    def _advance_ref_with_index_lock(
+        self,
+        *,
+        record: HostOperationRecord,
+        receipt: CommitReceipt,
+        new_head: str,
+        old_head: str,
+        old_tree: str,
+        expected_status: tuple[str, ...],
+        message: str,
+    ) -> None:
+        replacement = self._ensure_index_lock(record, old_tree)
+        index = self.git / "index"
+        lock = self.git / "index.lock"
+        head_path = self.git / "HEAD"
+        current_index = _read_regular_with_identity(index)
+        current_head = _read_regular_with_identity(head_path)
+        if current_index is None or current_head is None:
+            raise HostCommitError("repository_unsafe")
+        index_content, index_identity = current_index
+        head_content, head_identity = current_head
+        if index_identity != record.index_before_identity:
+            raise HostCommitError("index_changed")
+        try:
+            with _guard_exact_regular_object(
+                index,
+                index_content,
+                expected_identity=index_identity,
+            ), _guard_exact_regular_object(
+                lock,
+                replacement,
+                expected_identity=record.index_identity,
+            ), _guard_exact_regular_object(
+                head_path,
+                head_content,
+                expected_identity=head_identity,
+            ):
+                self._notify("metadata_before_ref")
+                self._assert_object_namespace_safe()
+                self._assert_repository_redirections_absent()
+                self._assert_direct_branch_ref(record.branch, old_head)
+                if (
+                    self._git_text("symbolic-ref", "--quiet", "HEAD")
+                    != f"refs/heads/{record.branch}"
+                    or self._git_text("rev-parse", "--verify", "HEAD") != old_head
+                    or self._real_index_tree() != old_tree
+                    or self._status_paths() != expected_status
+                ):
+                    raise HostCommitError("head_changed")
+                with self._guard_current_object_namespace():
+                    self._update_ref_without_reflog(
+                        record=record,
+                        new_head=new_head,
+                        old_head=old_head,
+                        message=message,
+                    )
+                if (
+                    self._git_text("symbolic-ref", "--quiet", "HEAD")
+                    != f"refs/heads/{record.branch}"
+                    or self._git_text("rev-parse", "--verify", "HEAD") != new_head
+                    or self._real_index_tree() != old_tree
+                ):
+                    raise HostCommitError("head_changed")
+        except HostFileTransactionError as exc:
+            raise HostCommitError("index_changed") from exc
+
+    def _publish_index_lock(
+        self,
+        *,
+        record: HostOperationRecord,
+        branch: str,
+        expected_head: str,
+        old_tree: str,
+        new_tree: str,
+        expected_status: tuple[str, ...],
+    ) -> None:
+        replacement = self._ensure_index_lock(record, old_tree)
+        index = self.git / "index"
+        lock = self.git / "index.lock"
+        backup = self._index_backup(record.operation_id)
+        current = _read_regular_with_identity(index)
+        parked = _read_regular_with_identity(backup)
+        if current is not None and parked is not None:
+            raise HostCommitError("index_changed")
+        original_record = current if current is not None else parked
+        if (
+            original_record is None
+            or original_record[1] != record.index_before_identity
+            or hashlib.sha256(original_record[0]).hexdigest()
+            != record.index_before_sha256
+            or self._tree_from_index_bytes(original_record[0]) != old_tree
+        ):
+            raise HostCommitError("index_changed")
+        original, original_identity = original_record
+        branch_ref = self.git / "refs" / "heads" / PurePosixPath(branch)
+        branch_ref_record = _read_regular_with_identity(branch_ref)
+        if branch_ref_record is None:
+            raise HostCommitError("repository_unsafe")
+        if branch_ref_record[0] not in {
+            expected_head.encode("ascii"),
+            f"{expected_head}\n".encode("ascii"),
+        }:
+            raise HostCommitError("head_changed")
+        try:
+            with _guard_exact_regular_object(
+                branch_ref,
+                branch_ref_record[0],
+                expected_identity=branch_ref_record[1],
+            ):
+                self._notify("metadata_before_index")
+                if _read_regular_with_identity(branch_ref) != branch_ref_record:
+                    raise HostCommitError("head_changed")
+                if (
+                    self._git_text("symbolic-ref", "--quiet", "HEAD")
+                    != f"refs/heads/{branch}"
+                    or self._git_text("rev-parse", "--verify", "HEAD")
+                    != expected_head
+                    or self._status_paths(
+                        index_path=(backup if current is None else None)
+                    )
+                    != expected_status
+                ):
+                    raise HostCommitError("index_changed")
+                if current is not None:
+                    _move_verified_no_replace(
+                        index,
+                        backup,
+                        original,
+                        expected_identity=original_identity,
+                    )
+                    parked = _read_regular_with_identity(backup)
+                    if parked != original_record:
+                        raise HostCommitError("index_changed")
+                _move_verified_no_replace(
+                    lock,
+                    index,
+                    replacement,
+                    expected_identity=record.index_identity,
+                )
+                if _read_regular_with_identity(branch_ref) != branch_ref_record:
+                    raise HostCommitError("head_changed")
+        except HostFileTransactionError as exc:
+            self._restore_parked_index(record, old_tree)
+            raise HostCommitError("index_changed") from exc
+        installed = _read_regular_with_identity(index)
+        if (
+            installed is None
+            or installed[1] != record.index_identity
+            or hashlib.sha256(installed[0]).hexdigest() != record.index_sha256
+            or self._tree_from_index_bytes(installed[0]) != new_tree
+        ):
+            raise HostCommitError("index_changed")
+
+    def _ensure_index_lock(self, record: HostOperationRecord, old_tree: str) -> bytes:
+        if (
+            record.index_sha256 is None
+            or record.index_before_sha256 is None
+            or record.index_identity is None
+            or record.index_before_identity is None
+        ):
+            raise HostCommitError("operation_conflict")
+        index = self.git / "index"
+        backup = self._index_backup(record.operation_id)
+        current = _read_regular_with_identity(index)
+        parked = _read_regular_with_identity(backup)
+        if current is not None and parked is not None:
+            raise HostCommitError("index_changed")
+        original = current if current is not None else parked
+        if (
+            original is None
+            or original[1] != record.index_before_identity
+            or hashlib.sha256(original[0]).hexdigest() != record.index_before_sha256
+            or self._tree_from_index_bytes(original[0]) != old_tree
+        ):
+            raise HostCommitError("index_changed")
+        stage = self._index_stage(record.operation_id)
+        lock = self.git / "index.lock"
+        if stage.exists() and lock.exists():
+            raise HostCommitError("index_changed")
+        artifact = stage if stage.exists() else lock
+        staged = _read_regular_with_identity(artifact)
+        if (
+            staged is None
+            or staged[1] != record.index_identity
+            or hashlib.sha256(staged[0]).hexdigest() != record.index_sha256
+        ):
+            raise HostCommitError("index_changed")
+        if artifact == stage:
+            try:
+                _move_verified_no_replace(
+                    stage,
+                    lock,
+                    staged[0],
+                    expected_identity=record.index_identity,
+                )
+            except HostFileTransactionError as exc:
+                raise HostCommitError("index_changed") from exc
+            moved = _read_regular_with_identity(lock)
+            if moved is None or moved != staged:
+                raise HostCommitError("index_changed")
+        return staged[0]
+
+    def _restore_parked_index(self, record: HostOperationRecord, old_tree: str) -> None:
+        index = self.git / "index"
+        backup = self._index_backup(record.operation_id)
+        if index.exists() or not backup.exists():
+            return
+        parked = _read_regular_with_identity(backup)
+        if (
+            parked is None
+            or parked[1] != record.index_before_identity
+            or hashlib.sha256(parked[0]).hexdigest() != record.index_before_sha256
+            or self._tree_from_index_bytes(parked[0]) != old_tree
+        ):
+            return
+        try:
+            _move_verified_no_replace(
+                backup,
+                index,
+                parked[0],
+                expected_identity=record.index_before_identity,
+            )
+        except HostFileTransactionError:
+            return
+
+    def _cleanup_index_backup(self, record: HostOperationRecord) -> None:
+        backup = self._index_backup(record.operation_id)
+        parked = _read_regular_with_identity(backup)
+        if parked is None:
+            return
+        if _read_regular_with_identity(self.git / "index") is None:
+            raise HostCommitError("index_cleanup_pending")
+        if parked[1] != record.index_before_identity:
+            raise HostCommitError("index_cleanup_pending")
+        if hashlib.sha256(parked[0]).hexdigest() != record.index_before_sha256:
+            raise HostCommitError("index_cleanup_pending")
+        try:
+            remove_regular_exact(
+                backup,
+                parked[0],
+                expected_identity=record.index_before_identity,
+            )
+        except HostFileTransactionError as exc:
+            raise HostCommitError("index_cleanup_pending") from exc
+
+    def _index_stage(self, operation_id: str) -> Path:
+        return self.git / "modelmirror-transactions" / f"{operation_id}.commit-index"
+
+    def _index_backup(self, operation_id: str) -> Path:
+        return self.git / "modelmirror-transactions" / f"{operation_id}.index-before"
+
+    def _index_conflict_artifact(self, operation_id: str) -> Path:
+        return self.git / "modelmirror-transactions" / f"{operation_id}.index-conflict"
+
+    def _conflict_marker(self, operation_id: str) -> Path:
+        return self.git / "modelmirror-transactions" / f"{operation_id}.commit-conflict"
+
+    def _metadata_state(
+        self,
+        record: HostOperationRecord,
+        receipt: CommitReceipt,
+    ) -> str:
+        self._assert_repository_layout_and_branch(receipt.branch)
+        head = self._git_text("rev-parse", "--verify", "HEAD")
+        parent_tree = self._tree_for_commit(receipt.parent_sha)
+        index = _read_regular_with_identity(self.git / "index")
+        if index is not None:
+            index_tree = self._tree_from_index_bytes(index[0])
+            if record.state in {"committing", "undoing"} and record.index_identity is not None:
+                old_tree = parent_tree if record.action == "commit" else receipt.tree_sha
+                new_tree = receipt.tree_sha if record.action == "commit" else parent_tree
+                expected_metadata = (
+                    (record.index_before_identity, record.index_before_sha256)
+                    if index_tree == old_tree
+                    else (record.index_identity, record.index_sha256)
+                    if index_tree == new_tree
+                    else (None, None)
+                )
+                if (
+                    expected_metadata[0] is None
+                    or index[1] != expected_metadata[0]
+                    or hashlib.sha256(index[0]).hexdigest() != expected_metadata[1]
+                ):
+                    return "conflict"
+        else:
+            # A hard stop can occur after the exact old index was parked but
+            # before the owned lock was published.  Recover only when both
+            # private artifacts still match the durable operation record.
+            backup = _read_regular_with_identity(self._index_backup(record.operation_id))
+            lock = _read_regular_with_identity(self.git / "index.lock")
+            old_tree = parent_tree if record.action == "commit" else receipt.tree_sha
+            if (
+                backup is None
+                or lock is None
+                or backup[1] != record.index_before_identity
+                or hashlib.sha256(backup[0]).hexdigest()
+                != record.index_before_sha256
+                or self._tree_from_index_bytes(backup[0]) != old_tree
+                or lock[1] != record.index_identity
+                or hashlib.sha256(lock[0]).hexdigest() != record.index_sha256
+            ):
+                return "conflict"
+            index_tree = old_tree
+        if head == receipt.parent_sha and index_tree == parent_tree:
+            return "parent_parent"
+        if head == receipt.parent_sha and index_tree == receipt.tree_sha:
+            return "parent_commit"
+        if head == receipt.commit_sha and index_tree == receipt.tree_sha:
+            return "commit_commit"
+        if head == receipt.commit_sha and index_tree == parent_tree:
+            return "commit_parent"
+        return "conflict"
+
+    def _assert_repository_state(
+        self,
+        *,
+        branch: str,
+        allowed_heads: Sequence[str],
+        expected_paths: tuple[str, ...],
+        require_applied_status: bool,
+    ) -> None:
+        self._assert_repository_layout_and_branch(branch)
+        if self._git_text("rev-parse", "--verify", "HEAD") not in allowed_heads:
+            raise HostCommitError("head_changed")
+        if (self.git / "index.lock").exists():
+            raise HostCommitError("index_busy")
+        if self._real_index_tree() != self._tree_for_commit(allowed_heads[0]):
+            raise HostCommitError("index_changed")
+        if require_applied_status:
+            paths = self._status_paths()
+            if paths != expected_paths:
+                raise HostCommitError("target_changed")
+
+    def _assert_repository_layout_and_branch(self, branch: str) -> None:
+        self._validate_repository_layout()
+        if self._git_text("symbolic-ref", "--quiet", "HEAD") != f"refs/heads/{branch}":
+            raise HostCommitError("branch_changed")
+        self._assert_no_dangerous_config()
+
+    def _assert_post_commit(self, receipt: CommitReceipt) -> None:
+        self._assert_repository_layout_and_branch(receipt.branch)
+        if (
+            self._git_text("rev-parse", "--verify", "HEAD") != receipt.commit_sha
+            or self._real_index_tree() != receipt.tree_sha
+            or self._status_paths()
+        ):
+            raise HostCommitError("commit_conflict")
+
+    def _assert_applied_status(
+        self,
+        apply_receipt: ApplyReceipt,
+        *,
+        record: HostOperationRecord | None = None,
+    ) -> None:
+        self._assert_status_paths(
+            tuple(item.path for item in apply_receipt.files),
+            "undo_conflict",
+            index_path=(self._operation_status_index(record) if record is not None else None),
+        )
+
+    def _assert_status_paths(
+        self,
+        expected: tuple[str, ...],
+        code: str,
+        *,
+        index_path: Path | None = None,
+    ) -> None:
+        if self._status_paths(index_path=index_path) != tuple(sorted(expected)):
+            raise HostCommitError(code)
+
+    def _status_paths(self, *, index_path: Path | None = None) -> tuple[str, ...]:
+        raw = self._git(
+            "status",
+            "--porcelain=v1",
+            "-z",
+            "--untracked-files=all",
+            "--no-renames",
+            index_path=index_path,
+        ).stdout
+        paths: list[str] = []
+        try:
+            for entry in raw.split(b"\0"):
+                if not entry:
+                    continue
+                if len(entry) < 4 or entry[2:3] != b" ":
+                    raise ValueError
+                paths.append(entry[3:].decode("utf-8", errors="strict"))
+        except (UnicodeDecodeError, ValueError) as exc:
+            raise HostCommitError("repository_unsafe") from exc
+        try:
+            normalized = tuple(
+                DraftWorkspace.normalize_relative_path(path) for path in paths
+            )
+        except DraftPolicyError as exc:
+            raise HostCommitError("repository_unsafe") from exc
+        return tuple(sorted(normalized))
+
+    def _operation_status_index(self, record: HostOperationRecord) -> Path | None:
+        if (self.git / "index").exists():
+            return None
+        backup = self._index_backup(record.operation_id)
+        return backup if backup.exists() else None
+
+    @contextlib.contextmanager
+    def _guard_applied_files(
+        self,
+        receipt: ApplyReceipt,
+        identities: tuple[str, ...],
+    ):
+        identity_map = _identity_map(identities)
+        contents: dict[str, bytes] = {}
+        try:
+            with contextlib.ExitStack() as stack:
+                for item in receipt.files:
+                    target = self.root / PurePosixPath(item.path)
+                    expected_identity = identity_map[item.path]
+                    if item.after_sha256 is None:
+                        if target.exists() or expected_identity != "missing":
+                            raise HostCommitError("target_changed")
+                        continue
+                    content = read_regular(target)
+                    if (
+                        content is None
+                        or hashlib.sha256(content).hexdigest() != item.after_sha256
+                        or expected_identity == "missing"
+                    ):
+                        raise HostCommitError("target_changed")
+                    stack.enter_context(
+                        _guard_exact_regular_object(
+                            target,
+                            content,
+                            expected_identity=expected_identity,
+                        )
+                    )
+                    contents[item.path] = content
+                yield contents
+                for item in receipt.files:
+                    if item.after_sha256 is None and (self.root / PurePosixPath(item.path)).exists():
+                        raise HostCommitError("target_changed")
+        except HostFileTransactionError as exc:
+            raise HostCommitError("target_changed") from exc
+
+    def _applied_record(
+        self,
+        receipt: ApplyReceipt,
+        branch: str,
+        expected_head: str,
+    ) -> HostOperationRecord:
+        try:
+            record = self.journal.get(receipt.apply_id)
+        except HostOperationLogError as exc:
+            raise HostCommitError(exc.code) from exc
+        if (
+            record is None
+            or record.action != "apply"
+            or record.state != "applied"
+            or record.project_id != self.project_id
+            or record.revision != receipt.revision
+            or record.branch != branch
+            or record.expected_head != expected_head
+            or record.apply_receipt != _apply_receipt_dict(receipt)
+            or not record.file_identities
+        ):
+            raise HostCommitError("apply_receipt_invalid")
+        return record
+
+    def _committed_record(
+        self,
+        receipt: CommitReceipt,
+        apply_receipt: ApplyReceipt,
+        branch: str,
+    ) -> HostOperationRecord:
+        try:
+            record = self.journal.get(receipt.commit_id)
+        except HostOperationLogError as exc:
+            raise HostCommitError(exc.code) from exc
+        if (
+            record is None
+            or record.action != "commit"
+            or record.state != "committed"
+            or record.project_id != self.project_id
+            or record.branch != branch
+            or record.apply_receipt != _apply_receipt_dict(apply_receipt)
+            or record.commit_receipt != _commit_receipt_dict(receipt)
+            or not record.file_identities
+        ):
+            raise HostCommitError("commit_receipt_invalid")
+        return record
+
+    def _assert_commit_receipt(
+        self,
+        receipt: CommitReceipt,
+        apply_receipt: ApplyReceipt,
+        branch: str,
+    ) -> None:
+        if (
+            receipt.branch != branch
+            or receipt.revision != apply_receipt.revision
+            or receipt.apply_id != apply_receipt.apply_id
+            or receipt.files != tuple(item.path for item in apply_receipt.files)
+        ):
+            raise HostCommitError("commit_receipt_invalid")
+
+    def _head_file(self, head: str, path: str) -> tuple[str, bytes | None]:
+        mode, object_id = self._head_entry(head, path)
+        if object_id is None:
+            return mode, None
+        return mode, self._git("cat-file", "blob", object_id).stdout
+
+    def _head_entry(self, head: str, path: str) -> tuple[str, str | None]:
+        raw = self._git("ls-tree", "-z", head, "--", path).stdout
+        if not raw:
+            return "100644", None
+        entries = [entry for entry in raw.split(b"\0") if entry]
+        if len(entries) != 1:
+            raise HostCommitError("repository_unsafe")
+        try:
+            metadata, encoded_path = entries[0].split(b"\t", 1)
+            mode, kind, object_id = metadata.decode("ascii").split(" ")
+            actual_path = encoded_path.decode("utf-8", errors="strict")
+        except (UnicodeDecodeError, ValueError) as exc:
+            raise HostCommitError("repository_unsafe") from exc
+        if actual_path != path or kind != "blob" or mode not in {"100644", "100755"}:
+            raise HostCommitError("repository_unsafe")
+        return mode, _object_id(object_id)
+
+    def _tree_for_commit(self, commit: str) -> str:
+        tree = self._git_text("rev-parse", "--verify", f"{commit}^{{tree}}")
+        return _object_id(tree)
+
+    def _tree_from_index_bytes(self, content: bytes) -> str:
+        descriptor, name = tempfile.mkstemp(prefix="modelmirror-index-check-")
+        index = Path(name)
+        try:
+            _write_all(descriptor, content)
+            os.fsync(descriptor)
+            os.close(descriptor)
+            descriptor = -1
+            with tempfile.TemporaryDirectory(
+                prefix="modelmirror-index-objects-"
+            ) as object_directory_name:
+                return self._git_text(
+                    "write-tree",
+                    index_path=index,
+                    object_directory=Path(object_directory_name),
+                    alternate_object_directories=(self.git / "objects",),
+                )
+        finally:
+            if descriptor >= 0:
+                os.close(descriptor)
+            index.unlink(missing_ok=True)
+
+    def _real_index_tree(self) -> str:
+        current = read_regular(self.git / "index")
+        if current is None:
+            raise HostCommitError("index_changed")
+        return self._tree_from_index_bytes(current)
+
+    def _copy_current_index(self, expected_tree: str) -> tuple[Path, bytes, str]:
+        current = _read_regular_with_identity(self.git / "index")
+        if current is None or self._tree_from_index_bytes(current[0]) != expected_tree:
+            raise HostCommitError("index_changed")
+        descriptor, name = tempfile.mkstemp(prefix="modelmirror-index-")
+        index = Path(name)
+        try:
+            _write_all(descriptor, current[0])
+            os.fsync(descriptor)
+            os.close(descriptor)
+            descriptor = -1
+            return index, current[0], current[1]
+        except BaseException:
+            if descriptor >= 0:
+                os.close(descriptor)
+            index.unlink(missing_ok=True)
+            raise
+
+    def _prepare_undo_index(
+        self,
+        *,
+        apply_receipt: ApplyReceipt,
+        parent_sha: str,
+        current_tree: str,
+        parent_tree: str,
+    ) -> tuple[Path, bytes, str]:
+        index, source, source_identity = self._copy_current_index(current_tree)
+        try:
+            for item in apply_receipt.files:
+                mode, object_id = self._head_entry(parent_sha, item.path)
+                if object_id is None:
+                    self._git(
+                        "update-index",
+                        "--force-remove",
+                        "--",
+                        item.path,
+                        index_path=index,
+                    )
+                else:
+                    self._git(
+                        "update-index",
+                        "--add",
+                        "--cacheinfo",
+                        mode,
+                        object_id,
+                        item.path,
+                        index_path=index,
+                    )
+            if self._git_text("write-tree", index_path=index) != parent_tree:
+                raise HostCommitError("index_changed")
+            return index, source, source_identity
+        except BaseException:
+            index.unlink(missing_ok=True)
+            raise
+
+    def _validate_repository_layout(self) -> None:
+        if self.enforce_windows and os.name != "nt":
+            raise HostCommitError("windows_required")
+        if self.enforce_windows:
+            if str(self.root).startswith("\\\\") or not self.root.drive:
+                raise HostCommitError("network_path_not_allowed")
+            import ctypes
+
+            if ctypes.windll.kernel32.GetDriveTypeW(
+                ctypes.c_wchar_p(f"{self.root.drive}\\")
+            ) == 4:
+                raise HostCommitError("network_path_not_allowed")
+        if _is_link_or_reparse(self.root) or not self.root.is_dir():
+            raise HostCommitError("project_path_invalid")
+        if _is_link_or_reparse(self.git) or not self.git.is_dir():
+            raise HostCommitError("repository_unsafe")
+        self._assert_repository_redirections_absent()
+        if _path_entry_exists(self.git / "refs" / "replace"):
+            raise HostCommitError("repository_unsafe")
+        required_directories = (
+            self.git / "objects",
+            self.git / "refs",
+            self.git / "refs" / "heads",
+        )
+        for directory in required_directories:
+            if not directory.is_dir() or _is_link_or_reparse(directory):
+                raise HostCommitError("repository_unsafe")
+        for directory in (
+            self.git / "logs",
+            self.git / "logs" / "refs",
+            self.git / "logs" / "refs" / "heads",
+        ):
+            if directory.exists() and (
+                not directory.is_dir() or _is_link_or_reparse(directory)
+            ):
+                raise HostCommitError("repository_unsafe")
+        for metadata in (self.git / "config", self.git / "HEAD"):
+            if not metadata.is_file() or _is_link_or_reparse(metadata):
+                raise HostCommitError("repository_unsafe")
+        index = self.git / "index"
+        if _is_link_or_reparse(index) or index.exists() and not index.is_file():
+            raise HostCommitError("repository_unsafe")
+        packed_refs = self.git / "packed-refs"
+        if packed_refs.exists() and (
+            not packed_refs.is_file() or _is_link_or_reparse(packed_refs)
+        ):
+            raise HostCommitError("repository_unsafe")
+
+    def _assert_no_dangerous_config(self) -> None:
+        result = self._git(
+            "config",
+            "--local",
+            "--no-includes",
+            "--name-only",
+            "--get-regexp",
+            _DANGEROUS_CONFIG,
+            allowed=(0, 1),
+            discard_output=True,
+        )
+        if result.returncode == 0:
+            raise HostCommitError("repository_config_unsafe")
+
+    def _assert_repository_redirections_absent(self) -> None:
+        for path in (
+            self.git / "commondir",
+            self.git / "objects" / "info" / "alternates",
+            self.git / "objects" / "info" / "http-alternates",
+        ):
+            if _path_entry_exists(path):
+                raise HostCommitError("repository_unsafe")
+
+    def _assert_object_namespace_safe(self) -> None:
+        _safe_git_namespace(self.git / "objects")
+
+    @contextlib.contextmanager
+    def _private_object_store(self, record: HostOperationRecord):
+        transaction_root = self.git / "modelmirror-transactions"
+        root = transaction_root / f"{record.operation_id}.private-objects"
+        owner = root / PRIVATE_OBJECT_OWNER_FILE
+        owner_content = f"{record.operation_id}\n".encode("ascii")
+        try:
+            with _guard_directories((transaction_root,)):
+                if not _path_entry_exists(root):
+                    os.mkdir(root, 0o700)
+                if not root.is_dir() or _is_link_or_reparse(root):
+                    raise HostCommitError("repository_unsafe")
+                _write_durable_no_replace(owner, owner_content, 0o600)
+                if read_regular(owner) != owner_content:
+                    raise HostCommitError("repository_unsafe")
+                _safe_git_namespace(root)
+            try:
+                yield root
+            finally:
+                self._cleanup_private_object_store(
+                    root,
+                    owner_content=owner_content,
+                )
+        except (HostApplyError, HostFileTransactionError, OSError) as exc:
+            raise HostCommitError("repository_unsafe") from exc
+
+    def _cleanup_private_object_store(
+        self,
+        root: Path,
+        *,
+        owner_content: bytes,
+    ) -> None:
+        if not root.is_dir() or _is_link_or_reparse(root):
+            raise HostCommitError("repository_unsafe")
+        _safe_git_namespace(root)
+        root_identity = file_identity(root)
+        owner = root / PRIVATE_OBJECT_OWNER_FILE
+        owner_record = _read_regular_with_identity(owner)
+        if owner_record is None or owner_record[0] != owner_content:
+            raise HostCommitError("repository_unsafe")
+        fanouts = tuple(
+            path for path in root.iterdir() if path.name != PRIVATE_OBJECT_OWNER_FILE
+        )
+        for fanout in fanouts:
+            if (
+                re.fullmatch(r"[a-f0-9]{2}", fanout.name) is None
+                or not fanout.is_dir()
+                or _is_link_or_reparse(fanout)
+            ):
+                raise HostCommitError("repository_unsafe")
+            fanout_identity = file_identity(fanout)
+            for entry in tuple(fanout.iterdir()):
+                object_id = fanout.name + entry.name
+                current = _read_regular_with_identity(entry)
+                if current is None or _OBJECT_ID.fullmatch(object_id) is None:
+                    raise HostCommitError("repository_unsafe")
+                _validate_loose_object(object_id, current[0])
+                if os.name == "nt":
+                    _windows_remove_private_loose_object(
+                        entry,
+                        current[0],
+                        expected_identity=current[1],
+                    )
+                else:
+                    remove_regular_exact(
+                        entry,
+                        current[0],
+                        expected_identity=current[1],
+                    )
+            _remove_empty_directory_exact(fanout, fanout_identity)
+        remove_regular_exact(
+            owner,
+            owner_record[0],
+            expected_identity=owner_record[1],
+        )
+        _remove_empty_directory_exact(root, root_identity)
+
+    def _publish_private_objects(self, private_root: Path) -> None:
+        if (
+            not private_root.is_absolute()
+            or not private_root.is_dir()
+            or _is_link_or_reparse(private_root)
+        ):
+            raise HostCommitError("repository_unsafe")
+        _safe_git_namespace(private_root)
+        objects: list[tuple[str, bytes]] = []
+        try:
+            fanouts = tuple(private_root.iterdir())
+        except OSError as exc:
+            raise HostCommitError("repository_unsafe") from exc
+        for fanout in fanouts:
+            if fanout.name == PRIVATE_OBJECT_OWNER_FILE:
+                owner = read_regular(fanout)
+                if owner is None or re.fullmatch(rb"[A-Za-z0-9_-]{20,64}\n", owner) is None:
+                    raise HostCommitError("repository_unsafe")
+                continue
+            if (
+                re.fullmatch(r"[a-f0-9]{2}", fanout.name) is None
+                or not fanout.is_dir()
+                or _is_link_or_reparse(fanout)
+            ):
+                raise HostCommitError("repository_unsafe")
+            try:
+                entries = tuple(fanout.iterdir())
+            except OSError as exc:
+                raise HostCommitError("repository_unsafe") from exc
+            for entry in entries:
+                object_id = fanout.name + entry.name
+                if (
+                    _OBJECT_ID.fullmatch(object_id) is None
+                    or not entry.is_file()
+                    or _is_link_or_reparse(entry)
+                ):
+                    raise HostCommitError("repository_unsafe")
+                content = read_regular(entry)
+                if content is None or len(content) > MAX_PRIVATE_OBJECT_BYTES:
+                    raise HostCommitError("repository_unsafe")
+                _validate_loose_object(object_id, content)
+                objects.append((object_id, content))
+        if len(objects) > MAX_PRIVATE_OBJECTS:
+            raise HostCommitError("repository_unsafe")
+        real_root = self.git / "objects"
+        try:
+            with _guard_directories((real_root,)):
+                self._assert_repository_redirections_absent()
+                self._assert_object_namespace_safe()
+                for object_id, content in sorted(objects):
+                    fanout = real_root / object_id[:2]
+                    if not _path_entry_exists(fanout):
+                        try:
+                            os.mkdir(fanout, 0o700)
+                        except FileExistsError:
+                            pass
+                        except OSError as exc:
+                            raise HostCommitError("repository_unsafe") from exc
+                    if not fanout.is_dir() or _is_link_or_reparse(fanout):
+                        raise HostCommitError("repository_unsafe")
+                    self._notify("commit_before_object_file_publish")
+                    with _guard_directories((fanout,)):
+                        self._assert_repository_redirections_absent()
+                        target = fanout / object_id[2:]
+                        _write_durable_no_replace(target, content, 0o444)
+                        published = _read_regular_with_identity(target)
+                        if published is None or published[0] != content:
+                            raise HostCommitError("repository_unsafe")
+                        _assert_single_link_regular(target)
+                self._assert_repository_redirections_absent()
+                self._assert_object_namespace_safe()
+        except (HostApplyError, HostFileTransactionError) as exc:
+            raise HostCommitError("repository_unsafe") from exc
+
+    def _assert_generated_objects_available(
+        self,
+        *,
+        tree: str,
+        commit_sha: str,
+        parent_sha: str,
+    ) -> None:
+        self._assert_repository_redirections_absent()
+        self._assert_object_namespace_safe()
+        if (
+            self._git_text("cat-file", "-t", tree) != "tree"
+            or self._git_text("cat-file", "-t", commit_sha) != "commit"
+            or self._git_text("rev-parse", "--verify", f"{commit_sha}^{{tree}}")
+            != tree
+            or self._git_text("rev-parse", "--verify", f"{commit_sha}^")
+            != parent_sha
+        ):
+            raise HostCommitError("repository_unsafe")
+
+    @contextlib.contextmanager
+    def _guard_current_object_namespace(self):
+        directories = _safe_git_namespace(self.git / "objects")
+        try:
+            with _guard_directories(directories):
+                self._assert_repository_redirections_absent()
+                yield
+                self._assert_repository_redirections_absent()
+                self._assert_object_namespace_safe()
+        except HostApplyError as exc:
+            raise HostCommitError("repository_unsafe") from exc
+
+    def _assert_reflog_single_link(self, branch: str) -> None:
+        path = self.git / "logs" / "refs" / "heads" / PurePosixPath(branch)
+        try:
+            metadata = path.stat(follow_symlinks=False)
+        except OSError as exc:
+            raise HostCommitError("repository_unsafe") from exc
+        if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+            raise HostCommitError("repository_unsafe")
+
+    def _git_text(self, *arguments: str, **kwargs: object) -> str:
+        return self._git(*arguments, **kwargs).stdout.decode("utf-8", errors="strict").strip()
+
+    def _git(
+        self,
+        *arguments: str,
+        index_path: Path | None = None,
+        input_bytes: bytes | None = None,
+        extra_environment: dict[str, str] | None = None,
+        object_directory: Path | None = None,
+        alternate_object_directories: tuple[Path, ...] = (),
+        allowed: Sequence[int] = (0,),
+        discard_output: bool = False,
+    ) -> subprocess.CompletedProcess[bytes]:
+        self._assert_repository_redirections_absent()
+        real_objects = self.git / "objects"
+        selected_objects = Path(object_directory or real_objects)
+        if (
+            not selected_objects.is_absolute()
+            or not selected_objects.is_dir()
+            or _is_link_or_reparse(selected_objects)
+            or any(Path(path) != real_objects for path in alternate_object_directories)
+        ):
+            raise HostCommitError("repository_unsafe")
+        environment = build_safe_git_environment()
+        if extra_environment:
+            environment.update(extra_environment)
+        environment.update(
+            {
+                "GIT_AUTHOR_NAME": self.author_name,
+                "GIT_AUTHOR_EMAIL": self.author_email,
+                "GIT_COMMITTER_NAME": self.author_name,
+                "GIT_COMMITTER_EMAIL": self.author_email,
+                "GIT_DIR": str(self.git),
+                "GIT_WORK_TREE": str(self.root),
+                "GIT_COMMON_DIR": str(self.git),
+                "GIT_OBJECT_DIRECTORY": str(selected_objects),
+                "GIT_ALTERNATE_OBJECT_DIRECTORIES": os.pathsep.join(
+                    str(Path(path)) for path in alternate_object_directories
+                ),
+                "GIT_NO_LAZY_FETCH": "1",
+                "GIT_NO_REPLACE_OBJECTS": "1",
+                "GIT_OPTIONAL_LOCKS": "0",
+            }
+        )
+        if index_path is not None:
+            environment["GIT_INDEX_FILE"] = str(index_path)
+        try:
+            safe_arguments = (
+                "-c",
+                "commit.gpgSign=false",
+                "-c",
+                "tag.gpgSign=false",
+                "-c",
+                "core.logAllRefUpdates=false",
+                "--literal-pathspecs",
+                *arguments,
+            )
+            result = subprocess.run(
+                build_safe_git_command(self.root, safe_arguments),
+                cwd=self.root,
+                env=environment,
+                stdin=None if input_bytes is not None else subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL if discard_output else subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                input=input_bytes,
+                check=False,
+                timeout=GIT_TIMEOUT_SECONDS,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise HostCommitError("git_unavailable") from exc
+        if result.returncode not in allowed:
+            raise HostCommitError("git_operation_failed")
+        return result
+
+    def _transition(
+        self,
+        operation_id: str,
+        state: str,
+        **kwargs: object,
+    ) -> HostOperationRecord:
+        try:
+            return self.journal.transition(operation_id, state, **kwargs)
+        except HostOperationLogError as exc:
+            raise HostCommitError(exc.code) from exc
+
+    def _mark_conflict(self, operation_id: str, code: str) -> None:
+        marker = self._conflict_marker(operation_id)
+        marker_content = f"{operation_id}\n".encode("ascii")
+        marker_ready = False
+        try:
+            current_marker = _read_regular_with_identity(marker)
+            if current_marker is None:
+                _write_durable_no_replace(marker, marker_content, 0o600)
+                current_marker = _read_regular_with_identity(marker)
+            marker_ready = current_marker is not None and current_marker[0] == marker_content
+        except (HostFileTransactionError, OSError, RuntimeError):
+            # The encrypted journal is an independent fail-closed channel.  A
+            # marker failure must not prevent a durable conflict transition.
+            marker_ready = False
+        try:
+            record = self.journal.get(operation_id)
+            if record is None:
+                raise HostCommitError("operation_log_unavailable")
+            if not marker_ready:
+                # With no filesystem fence, persist the journal fence before
+                # any ref/index cleanup.  Conflict reconciliation will retry
+                # cleanup idempotently if this process stops afterwards.
+                record = self.journal.transition(operation_id, "conflict")
+            self._settle_conflict(record, code=code)
+            if marker_ready:
+                self.journal.transition(operation_id, "conflict")
+        except HostCommitError:
+            raise
+        except (HostOperationLogError, OSError, RuntimeError) as exc:
+            raise HostCommitError("operation_log_unavailable") from exc
+
+    def _settle_conflict(
+        self,
+        record: HostOperationRecord,
+        *,
+        code: str | None = None,
+    ) -> None:
+        conflict_code = code or (
+            "commit_conflict" if record.action == "commit" else "undo_conflict"
+        )
+        self._recover_reflogs(record)
+        self._rollback_visible_ref(record, conflict_code)
+        self._quarantine_owned_index_artifact(record)
+
+    def _conflict_marker_present(self, operation_id: str) -> bool:
+        marker = self._conflict_marker(operation_id)
+        current = _read_regular_with_identity(marker)
+        if current is None:
+            return False
+        if current[0] != f"{operation_id}\n".encode("ascii"):
+            raise HostCommitError("operation_log_unavailable")
+        return True
+
+    def _rollback_visible_ref(self, record: HostOperationRecord, code: str) -> None:
+        """Best-effort CAS rollback when our ref moved but index did not.
+
+        External changes are never overwritten: rollback is attempted only
+        while the current branch, ref and logical index still match the exact
+        operation-owned transition.  Namespace failures simply leave the task
+        in the durable read-only conflict state.
+        """
+
+        if (
+            code not in _PERSISTED_CONFLICT_CODES
+            or record.commit_receipt is None
+            or record.index_before_identity is None
+            or record.index_before_sha256 is None
+        ):
+            return
+        receipt = _commit_receipt(record.commit_receipt)
+        if record.action == "commit":
+            visible_head = receipt.commit_sha
+            restored_head = receipt.parent_sha
+            old_tree: str | None = None
+        elif record.action == "undo":
+            visible_head = receipt.parent_sha
+            restored_head = receipt.commit_sha
+            old_tree = receipt.tree_sha
+        else:
+            return
+        try:
+            with self._parked_reflogs(record), self._git_write_guards(
+                record.branch,
+                parked_record=record,
+            ):
+                if old_tree is None:
+                    old_tree = self._tree_for_commit(receipt.parent_sha)
+                current_head = self._git_text("rev-parse", "--verify", "HEAD")
+                if current_head == restored_head:
+                    return
+                if current_head != visible_head:
+                    return
+                current_index = _read_regular_with_identity(self.git / "index")
+                using_backup = current_index is None
+                if current_index is None:
+                    current_index = _read_regular_with_identity(
+                        self._index_backup(record.operation_id)
+                    )
+                if (
+                    current_index is None
+                    or using_backup
+                    and current_index[1] != record.index_before_identity
+                    or using_backup
+                    and hashlib.sha256(current_index[0]).hexdigest()
+                    != record.index_before_sha256
+                    or self._tree_from_index_bytes(current_index[0]) != old_tree
+                ):
+                    return
+                with self._guard_current_object_namespace():
+                    self._update_ref_without_reflog(
+                        record=record,
+                        new_head=restored_head,
+                        old_head=visible_head,
+                        message="ModelMirror controlled host operation rollback",
+                    )
+        except HostCommitError:
+            return
+
+    def _quarantine_owned_index_artifact(self, record: HostOperationRecord) -> None:
+        if (
+            record.index_sha256 is None
+            or record.index_before_sha256 is None
+            or record.index_identity is None
+        ):
+            return
+        backup = self._index_backup(record.operation_id)
+        parked = _read_regular_with_identity(backup)
+        index = self.git / "index"
+        if not index.exists():
+            if (
+                parked is None
+                or parked[1] != record.index_before_identity
+                or hashlib.sha256(parked[0]).hexdigest()
+                != record.index_before_sha256
+            ):
+                raise HostCommitError("operation_log_unavailable")
+            try:
+                _move_verified_no_replace(
+                    backup,
+                    index,
+                    parked[0],
+                    expected_identity=record.index_before_identity,
+                )
+            except HostFileTransactionError as exc:
+                raise HostCommitError("operation_log_unavailable") from exc
+            restored = _read_regular_with_identity(index)
+            if (
+                restored is None
+                or restored[1] != record.index_before_identity
+                or hashlib.sha256(restored[0]).hexdigest()
+                != record.index_before_sha256
+            ):
+                raise HostCommitError("operation_log_unavailable")
+        stage = self._index_stage(record.operation_id)
+        lock = self.git / "index.lock"
+        destination = self._index_conflict_artifact(record.operation_id)
+        existing_destination = _read_regular_with_identity(destination)
+        for source in (stage, lock):
+            current = _read_regular_with_identity(source)
+            if current is None:
+                continue
+            if (
+                current[1] != record.index_identity
+                or hashlib.sha256(current[0]).hexdigest() != record.index_sha256
+            ):
+                # Never remove or move an index lock that is not provably ours.
+                continue
+            if existing_destination is not None:
+                if existing_destination != current:
+                    raise HostCommitError("operation_log_unavailable")
+                try:
+                    remove_regular_exact(
+                        source,
+                        current[0],
+                        expected_identity=record.index_identity,
+                    )
+                except HostFileTransactionError as exc:
+                    raise HostCommitError("operation_log_unavailable") from exc
+                continue
+            try:
+                _move_verified_no_replace(
+                    source,
+                    destination,
+                    current[0],
+                    expected_identity=record.index_identity,
+                )
+            except HostFileTransactionError as exc:
+                raise HostCommitError("operation_log_unavailable") from exc
+            existing_destination = current
+
+    def _conflict(self, operation_id: str, code: str):
+        self._mark_conflict(operation_id, code)
+        raise HostCommitError(code)
+
+    def _notify(self, phase: str) -> None:
+        if self.mutation_hook is not None:
+            self.mutation_hook(phase)
+
+
+def _path_entry_exists(path: Path) -> bool:
+    try:
+        path.lstat()
+    except FileNotFoundError:
+        return False
+    except OSError as exc:
+        raise HostCommitError("repository_unsafe") from exc
+    return True
+
+
+def _assert_single_link_regular(path: Path) -> None:
+    try:
+        metadata = os.stat(path, follow_symlinks=False)
+    except OSError as exc:
+        raise HostCommitError("repository_unsafe") from exc
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or _is_link_or_reparse(path)
+        or metadata.st_nlink != 1
+    ):
+        raise HostCommitError("repository_unsafe")
+
+
+def _windows_remove_private_loose_object(
+    path: Path,
+    expected: bytes,
+    *,
+    expected_identity: str,
+) -> None:
+    """Delete one operation-owned loose object through one no-follow handle.
+
+    Git marks loose objects read-only on Windows.  Clearing that bit by path
+    would let a concurrent pathname replacement redirect the attribute change
+    outside the private object store.  Keep identity, bytes, link count,
+    attribute update and delete disposition bound to the same handle instead.
+    """
+
+    if os.name != "nt":
+        raise HostFileTransactionError("transaction_cleanup_failed")
+
+    import ctypes
+    from ctypes import wintypes
+
+    generic_read = 0x80000000
+    delete_access = 0x00010000
+    file_read_attributes = 0x00000080
+    file_write_attributes = 0x00000100
+    file_share_read = 0x00000001
+    file_basic_info = 0
+    file_disposition_info = 4
+    file_attribute_readonly = 0x00000001
+    file_attribute_normal = 0x00000080
+
+    class _ByHandleFileInformation(ctypes.Structure):
+        _fields_ = [
+            ("attributes", wintypes.DWORD),
+            ("creation_time", wintypes.FILETIME),
+            ("access_time", wintypes.FILETIME),
+            ("write_time", wintypes.FILETIME),
+            ("volume_serial", wintypes.DWORD),
+            ("size_high", wintypes.DWORD),
+            ("size_low", wintypes.DWORD),
+            ("links", wintypes.DWORD),
+            ("file_index_high", wintypes.DWORD),
+            ("file_index_low", wintypes.DWORD),
+        ]
+
+    class _FileBasicInformation(ctypes.Structure):
+        _fields_ = [
+            ("creation_time", ctypes.c_longlong),
+            ("access_time", ctypes.c_longlong),
+            ("write_time", ctypes.c_longlong),
+            ("change_time", ctypes.c_longlong),
+            ("attributes", wintypes.DWORD),
+        ]
+
+    class _FileDispositionInformation(ctypes.Structure):
+        _fields_ = [("delete_file", wintypes.BOOLEAN)]
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.GetFileInformationByHandle.argtypes = [
+        wintypes.HANDLE,
+        ctypes.POINTER(_ByHandleFileInformation),
+    ]
+    kernel32.GetFileInformationByHandle.restype = wintypes.BOOL
+    kernel32.SetFileInformationByHandle.argtypes = [
+        wintypes.HANDLE,
+        ctypes.c_int,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+    ]
+    kernel32.SetFileInformationByHandle.restype = wintypes.BOOL
+
+    handle = _windows_open_existing(
+        path,
+        access=(
+            generic_read
+            | delete_access
+            | file_read_attributes
+            | file_write_attributes
+        ),
+        # Do not share write or delete access: once this handle opens, the
+        # verified pathname cannot be replaced before its handle-bound delete.
+        share=file_share_read,
+        allow_missing=False,
+    )
+    assert handle is not None
+
+    def inspect() -> tuple[str, int]:
+        identity = _windows_handle_identity(handle, require_directory=False)
+        information = _ByHandleFileInformation()
+        if not kernel32.GetFileInformationByHandle(
+            handle,
+            ctypes.byref(information),
+        ):
+            raise HostFileTransactionError("transaction_conflict")
+        if information.links != 1 or identity != expected_identity:
+            raise HostFileTransactionError("transaction_conflict")
+        if _windows_read_all(handle) != expected:
+            raise HostFileTransactionError("transaction_conflict")
+        return identity, int(information.attributes)
+
+    try:
+        identity, attributes = inspect()
+        if attributes & file_attribute_readonly:
+            updated_attributes = attributes & ~file_attribute_readonly
+            if updated_attributes == 0:
+                updated_attributes = file_attribute_normal
+            basic = _FileBasicInformation(attributes=updated_attributes)
+            if not kernel32.SetFileInformationByHandle(
+                handle,
+                file_basic_info,
+                ctypes.byref(basic),
+                ctypes.sizeof(basic),
+            ):
+                raise HostFileTransactionError("transaction_cleanup_failed")
+        verified_identity, _verified_attributes = inspect()
+        if verified_identity != identity:
+            raise HostFileTransactionError("transaction_conflict")
+        disposition = _FileDispositionInformation(True)
+        if not kernel32.SetFileInformationByHandle(
+            handle,
+            file_disposition_info,
+            ctypes.byref(disposition),
+            ctypes.sizeof(disposition),
+        ):
+            raise HostFileTransactionError("transaction_cleanup_failed")
+    finally:
+        _windows_close_handle(handle)
+
+    try:
+        path.lstat()
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        raise HostFileTransactionError("transaction_cleanup_failed") from exc
+    raise HostFileTransactionError("transaction_cleanup_failed")
+
+
+def _validate_loose_object(object_id: str, compressed: bytes) -> None:
+    try:
+        inflater = zlib.decompressobj()
+        payload = inflater.decompress(
+            compressed,
+            MAX_PRIVATE_OBJECT_CONTENT_BYTES + 1,
+        )
+        if (
+            len(payload) > MAX_PRIVATE_OBJECT_CONTENT_BYTES
+            or inflater.unconsumed_tail
+            or not inflater.eof
+            or inflater.unused_data
+        ):
+            raise ValueError("invalid loose object")
+        header, body = payload.split(b"\0", 1)
+        kind, encoded_size = header.split(b" ", 1)
+        if kind not in {b"blob", b"tree", b"commit"}:
+            raise ValueError("invalid loose object")
+        if int(encoded_size.decode("ascii")) != len(body):
+            raise ValueError("invalid loose object")
+        algorithm = hashlib.sha1 if len(object_id) == 40 else hashlib.sha256
+        if algorithm(payload).hexdigest() != object_id:
+            raise ValueError("invalid loose object")
+    except (UnicodeError, ValueError, zlib.error) as exc:
+        raise HostCommitError("repository_unsafe") from exc
+
+
+def _safe_git_namespace(root: Path) -> tuple[Path, ...]:
+    """Reject every link/reparse/special entry before Git traverses metadata."""
+
+    if _is_link_or_reparse(root) or not root.is_dir():
+        raise HostCommitError("repository_unsafe")
+    directories: list[Path] = []
+    pending = [root]
+    entries_seen = 0
+    while pending:
+        directory = pending.pop()
+        if _is_link_or_reparse(directory) or not directory.is_dir():
+            raise HostCommitError("repository_unsafe")
+        directories.append(directory)
+        try:
+            children = list(os.scandir(directory))
+        except OSError as exc:
+            raise HostCommitError("repository_unsafe") from exc
+        entries_seen += len(children)
+        if entries_seen > MAX_GIT_NAMESPACE_ENTRIES:
+            raise HostCommitError("repository_unsafe")
+        for child in children:
+            path = Path(child.path)
+            try:
+                if child.is_symlink() or _is_link_or_reparse(path):
+                    raise HostCommitError("repository_unsafe")
+                if child.is_dir(follow_symlinks=False):
+                    pending.append(path)
+                elif child.is_file(follow_symlinks=False):
+                    # DirEntry.stat() reports st_nlink=0 on some supported
+                    # Windows/Python combinations; a fresh path stat exposes
+                    # the real NTFS link count.
+                    if os.stat(path, follow_symlinks=False).st_nlink != 1:
+                        raise HostCommitError("repository_unsafe")
+                else:
+                    raise HostCommitError("repository_unsafe")
+            except OSError as exc:
+                raise HostCommitError("repository_unsafe") from exc
+    return tuple(directories)
+
+
+@contextlib.contextmanager
+def _guard_mutable_regular_leaf(path: Path):
+    """Hold a mutable reflog leaf without permitting path replacement."""
+
+    try:
+        initial = path.stat(follow_symlinks=False)
+    except OSError as exc:
+        raise HostFileTransactionError("transaction_conflict") from exc
+    if not stat.S_ISREG(initial.st_mode) or initial.st_nlink != 1:
+        raise HostFileTransactionError("transaction_conflict")
+    if os.name == "nt":
+        handle = _windows_open_existing(
+            path,
+            access=0x80000000 | 0x00000080,
+            # Git may append, but neither Git nor another process may replace
+            # the pathname while the controlled update is in flight.
+            share=0x00000001 | 0x00000002,
+            allow_missing=False,
+        )
+        assert handle is not None
+        try:
+            identity = _windows_handle_identity(handle, require_directory=False)
+            yield
+            if _windows_handle_identity(handle, require_directory=False) != identity:
+                raise HostFileTransactionError("transaction_conflict")
+        finally:
+            _windows_close_handle(handle)
+        return
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise HostFileTransactionError("transaction_conflict") from exc
+    try:
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise HostFileTransactionError("transaction_conflict")
+        identity = f"{metadata.st_dev:x}-{metadata.st_ino:x}"
+        yield
+        current = file_identity(path)
+        if current != identity:
+            raise HostFileTransactionError("transaction_conflict")
+    finally:
+        os.close(descriptor)
+
+
+def _validate_identity(value: str) -> str:
+    if (
+        not isinstance(value, str)
+        or not value
+        or len(value) > 200
+        or any(ord(character) < 32 or ord(character) == 127 for character in value)
+    ):
+        raise HostCommitError("invalid_author")
+    return value
+
+
+def _branch(value: str) -> str:
+    try:
+        return validate_commit_branch(value)
+    except ValueError as exc:
+        raise HostCommitError("branch_invalid") from exc
+
+
+def _object_id(value: str) -> str:
+    if not isinstance(value, str) or _OBJECT_ID.fullmatch(value) is None:
+        raise HostCommitError("repository_unsafe")
+    return value
+
+
+def _canonical_blob(baseline: bytes, working: bytes, before_sha256: str) -> bytes:
+    if hashlib.sha256(baseline).hexdigest() == before_sha256:
+        return working
+    crlf = baseline.replace(b"\r\n", b"\n").replace(b"\n", b"\r\n")
+    if hashlib.sha256(crlf).hexdigest() == before_sha256:
+        return working.replace(b"\r\n", b"\n")
+    raise HostCommitError("target_changed")
+
+
+def _commit_ref_transition_paths(receipt: ApplyReceipt) -> tuple[str, ...]:
+    """Exact porcelain path multiset while HEAD is new and index is old.
+
+    A newly added file is simultaneously deleted from the old index relative
+    to the new HEAD and untracked in the worktree, so porcelain emits it twice.
+    Other touched file states emit one record.  Comparing the exact multiset
+    preserves the no-unrelated-change gate without treating this intentional
+    hand-off state as a conflict.
+    """
+
+    paths = [item.path for item in receipt.files]
+    paths.extend(
+        item.path
+        for item in receipt.files
+        if not item.existed_before and item.after_sha256 is not None
+    )
+    return tuple(sorted(paths))
+
+
+def _write_all(descriptor: int, content: bytes) -> None:
+    offset = 0
+    while offset < len(content):
+        written = os.write(descriptor, content[offset:])
+        if written <= 0:
+            raise OSError("short write")
+        offset += written
+
+
+def _identity_map(values: tuple[str, ...]) -> dict[str, str]:
+    result: dict[str, str] = {}
+    try:
+        for value in values:
+            identity, path = value.split(":", 1)
+            normalized = DraftWorkspace.normalize_relative_path(path)
+            if (
+                normalized != path
+                or path in result
+                or identity != "missing" and _IDENTITY.fullmatch(identity) is None
+            ):
+                raise ValueError
+            result[path] = identity
+    except (DraftPolicyError, TypeError, ValueError) as exc:
+        raise HostCommitError("apply_receipt_invalid") from exc
+    return result
+
+
+def _apply_receipt_dict(receipt: ApplyReceipt) -> dict[str, object]:
+    return {
+        "apply_id": receipt.apply_id,
+        "revision": receipt.revision,
+        "snapshot_fingerprint": receipt.snapshot_fingerprint,
+        "files": [asdict(item) for item in receipt.files],
+        "applied_at": receipt.applied_at,
+    }
+
+
+def _commit_receipt_dict(receipt: CommitReceipt) -> dict[str, object]:
+    value = asdict(receipt)
+    value["files"] = list(receipt.files)
+    return value
+
+
+def _apply_receipt(value: dict[str, object] | None) -> ApplyReceipt:
+    if not isinstance(value, dict):
+        raise HostCommitError("apply_receipt_invalid")
+    try:
+        files = value["files"]
+        if not isinstance(files, list):
+            raise TypeError
+        return ApplyReceipt(
+            apply_id=value["apply_id"],
+            revision=value["revision"],
+            snapshot_fingerprint=value["snapshot_fingerprint"],
+            files=tuple(ApplyFileReceipt(**item) for item in files),
+            applied_at=value["applied_at"],
+        )
+    except (KeyError, TypeError, ValueError) as exc:
+        raise HostCommitError("apply_receipt_invalid") from exc
+
+
+def _commit_receipt(value: dict[str, object] | None) -> CommitReceipt:
+    if not isinstance(value, dict):
+        raise HostCommitError("commit_receipt_invalid")
+    try:
+        return CommitReceipt(
+            commit_id=value["commit_id"],
+            revision=value["revision"],
+            apply_id=value["apply_id"],
+            commit_sha=value["commit_sha"],
+            parent_sha=value["parent_sha"],
+            tree_sha=value["tree_sha"],
+            message=value["message"],
+            files=tuple(value["files"]),
+            branch=value["branch"],
+            committed_at=value["committed_at"],
+        )
+    except (KeyError, TypeError, ValueError) as exc:
+        raise HostCommitError("commit_receipt_invalid") from exc
+
+
+def _optional_commit_receipt(value: dict[str, object] | None) -> CommitReceipt | None:
+    return None if value is None else _commit_receipt(value)

--- a/server/coding_project_host/host_commit_engine.py
+++ b/server/coding_project_host/host_commit_engine.py
@@ -55,7 +55,8 @@ _IDENTITY = re.compile(r"^[a-f0-9]+-[a-f0-9]+$")
 _DANGEROUS_CONFIG = (
     r"^(include|include[Ii]f|filter|credential|diff|url)(\.|$)"
     r"|^remote\..*\.(promisor|partial[Cc]lone[Ff]ilter)$"
-    r"|^(core\.worktree|extensions\.(worktree[Cc]onfig|partial[Cc]lone))$"
+    r"|^(core\.(worktree|excludes[Ff]ile)|"
+    r"extensions\.(worktree[Cc]onfig|partial[Cc]lone|ref[Ss]torage))$"
 )
 _PERSISTED_CONFLICT_CODES = frozenset(
     {
@@ -72,6 +73,7 @@ _PERSISTED_CONFLICT_CODES = frozenset(
     }
 )
 MAX_GIT_NAMESPACE_ENTRIES = 500_000
+MAX_GIT_CONFIG_BYTES = 2 * 1024 * 1024
 MAX_PRIVATE_OBJECTS = 10_000
 MAX_PRIVATE_OBJECT_BYTES = 8 * 1024 * 1024
 MAX_PRIVATE_OBJECT_CONTENT_BYTES = 64 * 1024 * 1024
@@ -273,10 +275,58 @@ class HostGitCommitEngine:
         if self.enforce_windows and os.name != "nt":
             raise HostCommitError("windows_required")
         try:
-            with _project_process_lock(self.root), self._lock:
+            with _project_process_lock(
+                self.root,
+                preflight=self._guard_repository_preflight,
+            ), self._lock:
                 yield
         except HostApplyError as exc:
             raise HostCommitError(exc.code) from exc
+
+    @contextlib.contextmanager
+    def _guard_repository_preflight(self):
+        """Bind safe Git configuration before creating operation artifacts."""
+
+        self._validate_repository_layout()
+        config = self.git / "config"
+        namespaces = [self.git / "objects", self.git / "refs"]
+        if _path_entry_exists(self.git / "info"):
+            namespaces.append(self.git / "info")
+        try:
+            with contextlib.ExitStack() as stack:
+                stack.enter_context(_guard_directories(tuple(namespaces)))
+                directories = tuple(
+                    dict.fromkeys(
+                        directory
+                        for namespace in namespaces
+                        for directory in _safe_git_namespace(namespace)
+                    )
+                )
+                stack.enter_context(_guard_directories(directories))
+                current = _read_regular_with_identity(config)
+                if current is None:
+                    raise HostCommitError("repository_unsafe")
+                content, identity = current
+                if len(content) > MAX_GIT_CONFIG_BYTES:
+                    raise HostCommitError("repository_config_unsafe")
+                stack.enter_context(
+                    _guard_exact_regular_object(
+                        config,
+                        content,
+                        expected_identity=identity,
+                    )
+                )
+                self._assert_repository_redirections_absent()
+                self._assert_no_dangerous_config_file(config)
+                yield
+                self._validate_repository_layout()
+                self._assert_repository_redirections_absent()
+                for namespace in namespaces:
+                    _safe_git_namespace(namespace)
+        except HostCommitError:
+            raise
+        except (HostApplyError, HostFileTransactionError, OSError) as exc:
+            raise HostCommitError("repository_unsafe") from exc
 
     @contextlib.contextmanager
     def _git_write_guards(
@@ -292,6 +342,7 @@ class HostGitCommitEngine:
                 self.git / "objects",
                 self.git / "refs",
                 self.git / "logs",
+                self.git / "info",
             ):
                 if namespace.exists():
                     directories.extend(_safe_git_namespace(namespace))
@@ -1594,9 +1645,6 @@ class HostGitCommitEngine:
             raise HostCommitError("project_path_invalid")
         if _is_link_or_reparse(self.git) or not self.git.is_dir():
             raise HostCommitError("repository_unsafe")
-        self._assert_repository_redirections_absent()
-        if _path_entry_exists(self.git / "refs" / "replace"):
-            raise HostCommitError("repository_unsafe")
         required_directories = (
             self.git / "objects",
             self.git / "refs",
@@ -1610,7 +1658,15 @@ class HostGitCommitEngine:
             self.git / "logs" / "refs",
             self.git / "logs" / "refs" / "heads",
         ):
-            if directory.exists() and (
+            if _path_entry_exists(directory) and (
+                not directory.is_dir() or _is_link_or_reparse(directory)
+            ):
+                raise HostCommitError("repository_unsafe")
+        for directory in (
+            self.git / "objects" / "info",
+            self.git / "info",
+        ):
+            if _path_entry_exists(directory) and (
                 not directory.is_dir() or _is_link_or_reparse(directory)
             ):
                 raise HostCommitError("repository_unsafe")
@@ -1621,10 +1677,11 @@ class HostGitCommitEngine:
         if _is_link_or_reparse(index) or index.exists() and not index.is_file():
             raise HostCommitError("repository_unsafe")
         packed_refs = self.git / "packed-refs"
-        if packed_refs.exists() and (
+        if _path_entry_exists(packed_refs) and (
             not packed_refs.is_file() or _is_link_or_reparse(packed_refs)
         ):
             raise HostCommitError("repository_unsafe")
+        self._assert_repository_redirections_absent()
 
     def _assert_no_dangerous_config(self) -> None:
         result = self._git(
@@ -1640,11 +1697,49 @@ class HostGitCommitEngine:
         if result.returncode == 0:
             raise HostCommitError("repository_config_unsafe")
 
+    def _assert_no_dangerous_config_file(self, config: Path) -> None:
+        try:
+            with tempfile.TemporaryDirectory(prefix="modelmirror-git-config-") as safe_cwd:
+                result = subprocess.run(
+                    build_safe_git_command(
+                        self.root,
+                        (
+                            "config",
+                            "--file",
+                            str(config),
+                            "--no-includes",
+                            "--name-only",
+                            "--get-regexp",
+                            _DANGEROUS_CONFIG,
+                        ),
+                    ),
+                    cwd=safe_cwd,
+                    env=build_safe_git_environment(),
+                    stdin=subprocess.DEVNULL,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.PIPE,
+                    check=False,
+                    timeout=GIT_TIMEOUT_SECONDS,
+                    creationflags=(
+                        getattr(subprocess, "CREATE_NO_WINDOW", 0)
+                        if os.name == "nt"
+                        else 0
+                    ),
+                )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise HostCommitError("repository_unsafe") from exc
+        if result.returncode == 0:
+            raise HostCommitError("repository_config_unsafe")
+        if result.returncode != 1:
+            raise HostCommitError("repository_unsafe")
+
     def _assert_repository_redirections_absent(self) -> None:
         for path in (
             self.git / "commondir",
             self.git / "objects" / "info" / "alternates",
             self.git / "objects" / "info" / "http-alternates",
+            self.git / "refs" / "replace",
+            self.git / "info" / "grafts",
         ):
             if _path_entry_exists(path):
                 raise HostCommitError("repository_unsafe")

--- a/server/coding_project_host/host_file_transaction.py
+++ b/server/coding_project_host/host_file_transaction.py
@@ -1,0 +1,2314 @@
+from __future__ import annotations
+
+import contextlib
+import ctypes
+import hashlib
+import json
+import os
+import re
+import stat
+import tempfile
+from collections.abc import Callable, Iterator, Sequence
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Literal
+
+
+TRANSACTION_ROOT_NAME = "modelmirror-transactions"
+OWNER_FILE_NAME = "owner.marker"
+FILE_ATTRIBUTE_REPARSE_POINT = 0x0400
+Stamp = tuple[str, str, str]
+StampCallback = Callable[[str | None], Stamp]
+MutationHook = Callable[[str, int, str], None]
+CommitCallback = Callable[[], None]
+OPERATION_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]{20,64}$")
+
+
+class HostFileTransactionError(RuntimeError):
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+@dataclass(frozen=True, slots=True)
+class FileMutation:
+    path: str
+    before: bytes | None
+    after: bytes | None
+    mode: int = 0o644
+
+    @property
+    def key(self) -> str:
+        return hashlib.sha256(self.path.encode("utf-8")).hexdigest()[:24]
+
+
+class HostFileTransaction:
+    """Crash-recoverable, no-overwrite transaction for helper-owned files."""
+
+    def __init__(
+        self,
+        root: Path,
+        operation_id: str,
+        action: str,
+        expected_stamp: Stamp,
+        stamp_callback: StampCallback,
+        *,
+        created_directories: Sequence[str] = (),
+        mutation_hook: MutationHook | None = None,
+    ) -> None:
+        candidate = Path(root)
+        if (
+            not candidate.is_absolute()
+            or _is_link_or_reparse(candidate)
+            or not candidate.is_dir()
+            or OPERATION_ID_PATTERN.fullmatch(operation_id) is None
+            or action not in {"apply", "revert"}
+            or len(expected_stamp) != 3
+            or any(not isinstance(value, str) or not value for value in expected_stamp)
+        ):
+            raise HostFileTransactionError("transaction_parameters_invalid")
+        self.root = candidate
+        self.git = self.root / ".git"
+        if _is_link_or_reparse(self.git) or not self.git.is_dir():
+            raise HostFileTransactionError("git_metadata_unsafe")
+        self.operation_id = operation_id
+        self.action = action
+        self.expected_stamp = expected_stamp
+        self.stamp_callback = stamp_callback
+        self.created_directories = tuple(created_directories)
+        self.mutation_hook = mutation_hook
+        self.tx_root = self.git / TRANSACTION_ROOT_NAME
+        self.active_dir = self.tx_root / operation_id
+        self.cleanup_dir = self.tx_root / f"{operation_id}.cleanup"
+        self.rollback_dir = self.tx_root / f"{operation_id}.rollback"
+        self.tx_dir = self.active_dir
+        self._marker = f"modelmirror-lock:{operation_id}\n".encode("ascii")
+
+    def prepare(self, mutations: Sequence[FileMutation]) -> None:
+        files = self._validate_mutations(mutations)
+        self._select_transaction_dir()
+        if self.tx_dir == self.cleanup_dir:
+            raise HostFileTransactionError("transaction_already_committed")
+        if self.tx_dir == self.rollback_dir:
+            self._recover_rolled_back(files)
+            self._select_transaction_dir()
+        with self._git_locks():
+            self._assert_stamp()
+            with self._filesystem_guard(files):
+                if self._classify(files) != "before":
+                    raise HostFileTransactionError("target_changed")
+                self._prepare_transaction(files)
+            self._assert_stamp()
+
+    def settle(
+        self,
+        mutations: Sequence[FileMutation],
+        *,
+        commit_callback: CommitCallback | None = None,
+    ) -> Literal["before", "after"]:
+        files = self._validate_mutations(mutations)
+        self._select_transaction_dir()
+        if self.tx_dir == self.cleanup_dir:
+            with self._filesystem_guard(files):
+                self._validate_sealed_transaction(files)
+                if self._classify(files) != "after":
+                    raise HostFileTransactionError("transaction_conflict")
+            return "after"
+        if self.tx_dir == self.rollback_dir:
+            self._recover_rolled_back(files)
+            return "before"
+        if not self.active_dir.exists():
+            state = self._classify(files)
+            if state not in {"before", "after"}:
+                raise HostFileTransactionError("transaction_conflict")
+            if state == "after" and commit_callback is not None:
+                raise HostFileTransactionError("transaction_evidence_missing")
+            return state
+        with self._git_locks():
+            self._assert_stamp()
+            committed = False
+            with contextlib.ExitStack() as published_targets:
+                with self._filesystem_guard(files):
+                    manifest = self._resume_transaction(files)
+                    marker = self.active_dir / "commit.marker"
+                    if marker.exists():
+                        self._assert_exact(marker, _commit_marker(manifest))
+                        self._assert_committed_artifacts(files)
+                        if self._classify(files) != "after":
+                            raise HostFileTransactionError("transaction_conflict")
+                        published_targets.enter_context(
+                            _guard_published_targets(self.root, self.active_dir, files)
+                        )
+                        committed = True
+                    else:
+                        self._remove_partial(marker)
+                        self._rollback_locked(files)
+                        if self._classify(files) != "before":
+                            raise HostFileTransactionError("transaction_rollback_failed")
+                        self._seal_rollback(files)
+                        self._cleanup_rollback_locked(files)
+                if not committed:
+                    self._assert_stamp()
+                    return "before"
+                # Target handles remain protected while directory guards are
+                # released, so revert may remove empty parents without opening
+                # a same-content replacement window before the durable callback.
+                if commit_callback is not None:
+                    commit_callback()
+                self._assert_stamp()
+                self._seal_transaction(files)
+                return "after"
+
+    def apply(
+        self,
+        mutations: Sequence[FileMutation],
+        *,
+        commit_callback: CommitCallback,
+    ) -> None:
+        files = self._validate_mutations(mutations)
+        self._select_transaction_dir()
+        if self.tx_dir == self.cleanup_dir:
+            with self._filesystem_guard(files):
+                self._validate_sealed_transaction(files)
+                if self._classify(files) != "after":
+                    raise HostFileTransactionError("transaction_conflict")
+            return
+        if self.tx_dir == self.rollback_dir:
+            self._recover_rolled_back(files)
+            self._select_transaction_dir()
+        with self._git_locks():
+            self._assert_stamp()
+            committed = False
+            with contextlib.ExitStack() as published_targets:
+                with self._filesystem_guard(files):
+                    manifest = self._prepare_transaction(files)
+                    marker = self.active_dir / "commit.marker"
+                    if marker.exists():
+                        self._assert_exact(marker, _commit_marker(manifest))
+                        self._assert_committed_artifacts(files)
+                        if self._classify(files) != "after":
+                            raise HostFileTransactionError("transaction_conflict")
+                        committed = True
+                    else:
+                        self._remove_partial(marker)
+                        self._rollback_locked(files)
+                        if self._classify(files) != "before":
+                            raise HostFileTransactionError("target_changed")
+                    try:
+                        for index, item in enumerate(files) if not committed else ():
+                            self._assert_stamp()
+                            if self.mutation_hook is not None:
+                                self.mutation_hook(self.action, index, item.path)
+                            self._assert_stamp()
+                            target = self.root / PurePosixPath(item.path)
+                            backup = self.active_dir / f"before-{item.key}"
+                            stage = self.active_dir / f"after-{item.key}"
+                            if item.before is not None:
+                                _move_verified_no_replace(target, backup, item.before)
+                            elif target.exists():
+                                raise HostFileTransactionError("target_changed")
+                            if item.after is not None:
+                                _move_verified_no_replace(stage, target, item.after)
+                            elif target.exists():
+                                raise HostFileTransactionError("target_changed")
+                            self._assert_stamp()
+                            if _read_regular(target) != item.after:
+                                raise HostFileTransactionError("target_changed")
+                        if not committed:
+                            if self._classify(files) != "after":
+                                raise HostFileTransactionError("transaction_incomplete")
+                            self._assert_stamp()
+                            _write_durable_no_replace(
+                                marker,
+                                _commit_marker(manifest),
+                                0o600,
+                            )
+                            self._assert_committed_artifacts(files)
+                            committed = True
+                        published_targets.enter_context(
+                            _guard_published_targets(self.root, self.active_dir, files)
+                        )
+                    except BaseException:
+                        if marker.exists():
+                            # A durable marker is the commit point. Never roll it
+                            # back merely because the caller lost the acknowledgement.
+                            self._assert_exact(marker, _commit_marker(manifest))
+                            raise
+                        try:
+                            self._rollback_locked(files)
+                            self._seal_rollback(files)
+                            self._cleanup_rollback_locked(files)
+                        except BaseException as rollback_error:
+                            raise HostFileTransactionError(
+                                "transaction_rollback_failed"
+                            ) from rollback_error
+                        raise
+                if not committed:
+                    raise HostFileTransactionError("transaction_incomplete")
+                commit_callback()
+                self._assert_stamp()
+                self._seal_transaction(files)
+
+    def cleanup_committed(self, mutations: Sequence[FileMutation]) -> None:
+        files = self._validate_mutations(mutations)
+        self._select_transaction_dir()
+        if not self.tx_dir.exists():
+            return
+        if self.tx_dir != self.cleanup_dir:
+            raise HostFileTransactionError("transaction_not_settled")
+        with self._filesystem_guard(files):
+            if self._classify(files) != "after":
+                raise HostFileTransactionError("transaction_conflict")
+            self._cleanup_sealed_locked(files)
+
+    cleanup = cleanup_committed
+
+    def _validate_mutations(
+        self,
+        mutations: Sequence[FileMutation],
+    ) -> tuple[FileMutation, ...]:
+        files = tuple(mutations)
+        if not files or len(files) > 20:
+            raise HostFileTransactionError("transaction_parameters_invalid")
+        paths: list[str] = []
+        for item in files:
+            if not isinstance(item.path, str):
+                raise HostFileTransactionError("transaction_parameters_invalid")
+            pure = PurePosixPath(item.path)
+            if (
+                not item.path
+                or "\\" in item.path
+                or pure.is_absolute()
+                or pure.as_posix() != item.path
+                or any(part in {"", ".", ".."} for part in pure.parts)
+                or item.before is None and item.after is None
+                or item.before == item.after
+                or item.before is not None and not isinstance(item.before, bytes)
+                or item.after is not None and not isinstance(item.after, bytes)
+                or item.mode not in {0o644, 0o755}
+            ):
+                raise HostFileTransactionError("transaction_parameters_invalid")
+            paths.append(item.path)
+        if paths != sorted(paths) or len({path.casefold() for path in paths}) != len(paths):
+            raise HostFileTransactionError("transaction_parameters_invalid")
+        if len({item.key for item in files}) != len(files):
+            raise HostFileTransactionError("transaction_parameters_invalid")
+        return files
+
+    @contextlib.contextmanager
+    def _filesystem_guard(self, files: Sequence[FileMutation]) -> Iterator[None]:
+        parents = [self.root, self.git]
+        for item in files:
+            current = self.root
+            for part in PurePosixPath(item.path).parts[:-1]:
+                current = current / part
+                parents.append(current)
+        existing = tuple(path for path in parents if path.exists())
+        with _guard_directories(existing):
+            yield
+
+    def _prepare_transaction(self, files: Sequence[FileMutation]) -> bytes:
+        manifest = self._manifest(files)
+        if self.tx_root.exists():
+            _assert_directory(self.tx_root)
+        else:
+            self.tx_root.mkdir()
+            _assert_directory(self.tx_root)
+            _fsync_directory(self.git)
+        if self.active_dir.exists():
+            self.tx_dir = self.active_dir
+            self._validate_transaction(files)
+            return manifest
+        owner = _owner_marker(manifest)
+        # A hard stop may happen between directory creation and the first owner
+        # write.  A fresh random name makes that orphan inert: later attempts do
+        # not inspect or delete it, and therefore cannot mistake an unknown local
+        # directory for transaction evidence.
+        try:
+            staging = Path(
+                tempfile.mkdtemp(
+                    prefix=f".{self.operation_id}.preparing-",
+                    dir=self.tx_root,
+                )
+            )
+        except OSError as exc:
+            raise HostFileTransactionError("transaction_unavailable") from exc
+        _assert_directory(staging)
+        _fsync_directory(self.tx_root)
+        _write_durable_no_replace(staging / OWNER_FILE_NAME, owner, 0o600)
+        self.tx_dir = staging
+        with _guard_directories((self.tx_root, staging)):
+            self._assert_exact(staging / OWNER_FILE_NAME, owner)
+            _write_durable_no_replace(
+                staging / "manifest.json",
+                manifest,
+                0o600,
+            )
+            for item in files:
+                if item.after is None:
+                    continue
+                stage = staging / f"after-{item.key}"
+                identity = staging / f"after-id-{item.key}"
+                backup = staging / f"before-{item.key}"
+                target = self.root / PurePosixPath(item.path)
+                if stage.exists():
+                    self._assert_exact(stage, item.after)
+                    self._remove_partial(stage)
+                    continue
+                if backup.exists() or _read_regular(target) != item.before:
+                    # Preparation artifacts are never synthesized once a target
+                    # mutation may have started. Recovery must classify and either
+                    # roll back the exact known state or fail closed.
+                    self._remove_partial(stage)
+                    continue
+                _write_durable_no_replace(stage, item.after, item.mode)
+                _write_durable_no_replace(
+                    identity,
+                    _file_identity(stage),
+                    0o600,
+                )
+            for item in files:
+                if item.after is None:
+                    continue
+                stage = staging / f"after-{item.key}"
+                identity = staging / f"after-id-{item.key}"
+                if not identity.exists():
+                    if not stage.exists():
+                        raise HostFileTransactionError("transaction_conflict")
+                    _write_durable_no_replace(
+                        identity,
+                        _file_identity(stage),
+                        0o600,
+                    )
+        self._validate_transaction(files, directory=staging)
+        try:
+            move_directory_no_replace(
+                staging,
+                self.active_dir,
+                expected_identity=file_identity(staging),
+                owner_name=OWNER_FILE_NAME,
+                owner_content=owner,
+            )
+        except HostFileTransactionError:
+            if not self.active_dir.exists():
+                raise
+        self.tx_dir = self.active_dir
+        self._validate_transaction(files)
+        return manifest
+
+    def _resume_transaction(self, files: Sequence[FileMutation]) -> bytes:
+        """Finish only the non-mutating prepare phase after a hard crash."""
+        self.tx_dir = self.active_dir
+        return self._prepare_transaction(files)
+
+    def _validate_transaction(
+        self,
+        files: Sequence[FileMutation],
+        *,
+        directory: Path | None = None,
+    ) -> bytes:
+        _assert_directory(self.tx_root)
+        tx_dir = directory or self.tx_dir
+        _assert_directory(tx_dir)
+        manifest = self._manifest(files)
+        self._assert_exact(tx_dir / OWNER_FILE_NAME, _owner_marker(manifest))
+        self._assert_exact(tx_dir / "manifest.json", manifest)
+        allowed = {
+            OWNER_FILE_NAME,
+            "manifest.json",
+            "manifest.json.partial",
+            "commit.marker",
+            "commit.marker.partial",
+        }
+        for item in files:
+            allowed.update(
+                {
+                    f"before-{item.key}",
+                    f"after-{item.key}",
+                    f"after-{item.key}.partial",
+                    f"after-id-{item.key}",
+                    f"after-id-{item.key}.partial",
+                }
+            )
+        try:
+            entries = tuple(tx_dir.iterdir())
+        except OSError as exc:
+            raise HostFileTransactionError("transaction_unavailable") from exc
+        if any(entry.name not in allowed or _is_link_or_reparse(entry) for entry in entries):
+            raise HostFileTransactionError("transaction_conflict")
+        for item in files:
+            stage = tx_dir / f"after-{item.key}"
+            identity = tx_dir / f"after-id-{item.key}"
+            backup = tx_dir / f"before-{item.key}"
+            if stage.exists():
+                self._assert_exact(stage, item.after)
+            if item.after is not None:
+                recorded_identity = _read_file_identity(identity)
+                current_after = (
+                    stage
+                    if stage.exists()
+                    else self.root / PurePosixPath(item.path)
+                )
+                if _read_regular(current_after) == item.after:
+                    if _file_identity(current_after) != recorded_identity:
+                        raise HostFileTransactionError("transaction_conflict")
+                elif not backup.exists():
+                    raise HostFileTransactionError("transaction_conflict")
+            elif identity.exists():
+                raise HostFileTransactionError("transaction_conflict")
+            if backup.exists():
+                self._assert_exact(backup, item.before)
+        return manifest
+
+    def _rollback_locked(self, files: Sequence[FileMutation]) -> None:
+        marker = self.tx_dir / "commit.marker"
+        if marker.exists():
+            raise HostFileTransactionError("transaction_already_committed")
+        for item in reversed(tuple(files)):
+            target = self.root / PurePosixPath(item.path)
+            stage = self.tx_dir / f"after-{item.key}"
+            backup = self.tx_dir / f"before-{item.key}"
+            current = _read_regular(target)
+            missing_during_move = (
+                current is None
+                and item.before is not None
+                and backup.exists()
+            )
+            if current not in {item.before, item.after} and not missing_during_move:
+                raise HostFileTransactionError("transaction_conflict")
+            if backup.exists() and current == item.before:
+                # Once the original object is parked in backup, an object at
+                # the target path was created externally, even when bytes match.
+                raise HostFileTransactionError("transaction_conflict")
+            if current == item.after and item.after != item.before:
+                if stage.exists():
+                    # A stage file plus an after-image target is not a state
+                    # produced by our true no-replace rename. It may be a user
+                    # file; deleting either side would destroy evidence.
+                    raise HostFileTransactionError("transaction_conflict")
+                elif item.after is not None:
+                    identity_path = self.tx_dir / f"after-id-{item.key}"
+                    expected_identity = (
+                        _read_file_identity(identity_path).decode("ascii").strip()
+                    )
+                    _move_verified_no_replace(
+                        target,
+                        stage,
+                        item.after,
+                        expected_identity=expected_identity,
+                    )
+            current = _read_regular(target)
+            if item.before is not None and current is None:
+                if not backup.exists():
+                    raise HostFileTransactionError("transaction_conflict")
+                _move_verified_no_replace(backup, target, item.before)
+            elif item.before is None and current is not None:
+                raise HostFileTransactionError("transaction_conflict")
+            if _read_regular(target) != item.before:
+                raise HostFileTransactionError("transaction_conflict")
+            if backup.exists():
+                _remove_exact(backup, item.before)
+            if item.after is not None and not stage.exists():
+                _write_durable_no_replace(stage, item.after, item.mode)
+
+    def _assert_committed_artifacts(
+        self,
+        files: Sequence[FileMutation],
+    ) -> None:
+        for item in files:
+            backup = self.tx_dir / f"before-{item.key}"
+            stage = self.tx_dir / f"after-{item.key}"
+            identity = self.tx_dir / f"after-id-{item.key}"
+            if item.before is not None:
+                self._assert_exact(backup, item.before)
+            elif backup.exists():
+                raise HostFileTransactionError("transaction_conflict")
+            if stage.exists():
+                raise HostFileTransactionError("transaction_conflict")
+            if item.after is not None:
+                if _file_identity(self.root / PurePosixPath(item.path)) != _read_file_identity(identity):
+                    raise HostFileTransactionError("transaction_conflict")
+            elif identity.exists():
+                raise HostFileTransactionError("transaction_conflict")
+
+    def _cleanup_locked(
+        self,
+        files: Sequence[FileMutation],
+        *,
+        require_marker: bool,
+    ) -> None:
+        directory_identity = file_identity(self.tx_dir)
+        manifest = self._manifest(files)
+        marker = self.tx_dir / "commit.marker"
+        if require_marker:
+            self._assert_exact(marker, _commit_marker(manifest))
+        elif marker.exists():
+            raise HostFileTransactionError("transaction_already_committed")
+        self._validate_transaction(files)
+        for item in files:
+            for prefix, expected in (("before", item.before), ("after", item.after)):
+                artifact = self.tx_dir / f"{prefix}-{item.key}"
+                if artifact.exists():
+                    _remove_exact(artifact, expected)
+                self._remove_partial(artifact)
+            identity = self.tx_dir / f"after-id-{item.key}"
+            if identity.exists():
+                _remove_file_identity_artifact(identity)
+            self._remove_partial(identity)
+        self._remove_partial(marker)
+        if marker.exists():
+            _remove_exact(marker, _commit_marker(manifest))
+        self._remove_partial(self.tx_dir / "manifest.json")
+        _remove_exact(self.tx_dir / "manifest.json", manifest)
+        _remove_exact(self.tx_dir / OWNER_FILE_NAME, _owner_marker(manifest))
+        _remove_empty_directory_exact(self.tx_dir, directory_identity)
+
+    def _seal_rollback(self, files: Sequence[FileMutation]) -> None:
+        """Publish a durable before-state before deleting rollback evidence."""
+        self.tx_dir = self.active_dir
+        manifest = self._validate_transaction(files)
+        marker = self.active_dir / "commit.marker"
+        if marker.exists():
+            raise HostFileTransactionError("transaction_already_committed")
+        if self._classify(files) != "before":
+            raise HostFileTransactionError("transaction_rollback_failed")
+        for item in files:
+            backup = self.active_dir / f"before-{item.key}"
+            stage = self.active_dir / f"after-{item.key}"
+            if backup.exists():
+                raise HostFileTransactionError("transaction_rollback_failed")
+            if item.after is not None:
+                self._assert_exact(stage, item.after)
+            elif stage.exists():
+                raise HostFileTransactionError("transaction_conflict")
+        if self.rollback_dir.exists():
+            raise HostFileTransactionError("transaction_conflict")
+        move_directory_no_replace(
+            self.active_dir,
+            self.rollback_dir,
+            expected_identity=file_identity(self.active_dir),
+            owner_name=OWNER_FILE_NAME,
+            owner_content=_owner_marker(manifest),
+        )
+        _fsync_directory(self.tx_root)
+        self.tx_dir = self.rollback_dir
+
+    def _recover_rolled_back(self, files: Sequence[FileMutation]) -> None:
+        with self._git_locks():
+            self._assert_stamp()
+            with self._filesystem_guard(files):
+                self.tx_dir = self.rollback_dir
+                self._validate_rollback_transaction(files)
+                if self._classify(files) != "before":
+                    raise HostFileTransactionError("transaction_conflict")
+                self._cleanup_rollback_locked(files)
+            self._assert_stamp()
+
+    def _validate_rollback_transaction(
+        self,
+        files: Sequence[FileMutation],
+    ) -> bytes:
+        self.tx_dir = self.rollback_dir
+        _assert_directory(self.rollback_dir)
+        manifest = self._manifest(files)
+        owner_path = self.rollback_dir / OWNER_FILE_NAME
+        if owner_path.exists():
+            self._assert_exact(owner_path, _owner_marker(manifest))
+        elif tuple(self.rollback_dir.iterdir()):
+            raise HostFileTransactionError("transaction_conflict")
+        manifest_path = self.rollback_dir / "manifest.json"
+        if manifest_path.exists():
+            self._assert_exact(manifest_path, manifest)
+        marker = self.rollback_dir / "commit.marker"
+        if marker.exists() or marker.with_name("commit.marker.partial").exists():
+            raise HostFileTransactionError("transaction_conflict")
+        allowed = {
+            OWNER_FILE_NAME,
+            "manifest.json",
+            "manifest.json.partial",
+        }
+        for item in files:
+            allowed.update(
+                {
+                    f"after-{item.key}",
+                    f"after-{item.key}.partial",
+                    f"after-id-{item.key}",
+                    f"after-id-{item.key}.partial",
+                }
+            )
+        for entry in tuple(self.rollback_dir.iterdir()):
+            if entry.name not in allowed or _is_link_or_reparse(entry):
+                raise HostFileTransactionError("transaction_conflict")
+        for item in files:
+            stage = self.rollback_dir / f"after-{item.key}"
+            identity = self.rollback_dir / f"after-id-{item.key}"
+            if stage.exists():
+                self._assert_exact(stage, item.after)
+                if item.after is None:
+                    raise HostFileTransactionError("transaction_conflict")
+                if identity.exists() and _file_identity(stage) != _read_file_identity(identity):
+                    raise HostFileTransactionError("transaction_conflict")
+            if identity.exists():
+                _read_file_identity(identity)
+        return manifest
+
+    def _cleanup_rollback_locked(self, files: Sequence[FileMutation]) -> None:
+        self.tx_dir = self.rollback_dir
+        directory_identity = file_identity(self.rollback_dir)
+        manifest = self._validate_rollback_transaction(files)
+        for item in files:
+            stage = self.rollback_dir / f"after-{item.key}"
+            if stage.exists():
+                _remove_exact(stage, item.after)
+            self._remove_partial(stage)
+            identity = self.rollback_dir / f"after-id-{item.key}"
+            if identity.exists():
+                _remove_file_identity_artifact(identity)
+            self._remove_partial(identity)
+        manifest_path = self.rollback_dir / "manifest.json"
+        if manifest_path.exists():
+            _remove_exact(manifest_path, manifest)
+        self._remove_partial(manifest_path)
+        owner_path = self.rollback_dir / OWNER_FILE_NAME
+        if owner_path.exists():
+            _remove_exact(owner_path, _owner_marker(manifest))
+        _remove_empty_directory_exact(self.rollback_dir, directory_identity)
+        _fsync_directory(self.tx_root)
+
+    def _cleanup_incomplete(self, files: Sequence[FileMutation]) -> None:
+        directory_identity = file_identity(self.tx_dir)
+        for item in files:
+            for prefix, expected in (("after", item.after),):
+                artifact = self.tx_dir / f"{prefix}-{item.key}"
+                if artifact.exists():
+                    _remove_exact(artifact, expected)
+        manifest = self.tx_dir / "manifest.json"
+        if manifest.exists():
+            _remove_exact(manifest, self._manifest(files))
+        _remove_empty_directory_exact(self.tx_dir, directory_identity)
+
+    def _select_transaction_dir(self) -> None:
+        active = self.active_dir.exists()
+        sealed = self.cleanup_dir.exists()
+        rolled_back = self.rollback_dir.exists()
+        if sum((active, sealed, rolled_back)) > 1:
+            raise HostFileTransactionError("transaction_conflict")
+        self.tx_dir = (
+            self.cleanup_dir
+            if sealed
+            else self.rollback_dir
+            if rolled_back
+            else self.active_dir
+        )
+
+    def _seal_transaction(self, files: Sequence[FileMutation]) -> None:
+        """Atomically publish durable completion before releasing Git locks."""
+        self.tx_dir = self.active_dir
+        manifest = self._validate_transaction(files)
+        marker = self.active_dir / "commit.marker"
+        self._assert_exact(marker, _commit_marker(manifest))
+        self._assert_committed_artifacts(files)
+        if self._classify(files) != "after":
+            raise HostFileTransactionError("transaction_conflict")
+        if self.cleanup_dir.exists():
+            raise HostFileTransactionError("transaction_conflict")
+        move_directory_no_replace(
+            self.active_dir,
+            self.cleanup_dir,
+            expected_identity=file_identity(self.active_dir),
+            owner_name=OWNER_FILE_NAME,
+            owner_content=_owner_marker(manifest),
+        )
+        _fsync_directory(self.tx_root)
+        self.tx_dir = self.cleanup_dir
+
+    def _validate_sealed_transaction(self, files: Sequence[FileMutation]) -> bytes:
+        self.tx_dir = self.cleanup_dir
+        manifest = self._manifest(files)
+        owner_path = self.cleanup_dir / OWNER_FILE_NAME
+        if owner_path.exists():
+            self._assert_exact(owner_path, _owner_marker(manifest))
+        elif tuple(self.cleanup_dir.iterdir()):
+            raise HostFileTransactionError("transaction_conflict")
+        manifest_path = self.cleanup_dir / "manifest.json"
+        if manifest_path.exists():
+            self._assert_exact(manifest_path, manifest)
+        marker = self.cleanup_dir / "commit.marker"
+        if marker.exists():
+            self._assert_exact(marker, _commit_marker(manifest))
+        # A sealed name is created only after the callback and final stamp.
+        # During idempotent cleanup either metadata file may already be gone.
+        if not manifest_path.exists() and not marker.exists():
+            allowed = {
+                f"before-{item.key}" for item in files if item.before is not None
+            }
+            allowed.update(
+                f"after-id-{item.key}" for item in files if item.after is not None
+            )
+            allowed.update(
+                f"{name}.partial"
+                for name in ("manifest.json", "commit.marker")
+            )
+            if any(entry.name not in allowed for entry in self.cleanup_dir.iterdir()):
+                raise HostFileTransactionError("transaction_conflict")
+        return manifest
+
+    def _cleanup_sealed_locked(self, files: Sequence[FileMutation]) -> None:
+        self.tx_dir = self.cleanup_dir
+        directory_identity = file_identity(self.cleanup_dir)
+        manifest = self._validate_sealed_transaction(files)
+        allowed: set[str] = {
+            OWNER_FILE_NAME,
+            "manifest.json",
+            "manifest.json.partial",
+            "commit.marker",
+            "commit.marker.partial",
+        }
+        for item in files:
+            allowed.update(
+                {
+                    f"before-{item.key}",
+                    f"after-{item.key}",
+                    f"after-{item.key}.partial",
+                    f"after-id-{item.key}",
+                    f"after-id-{item.key}.partial",
+                }
+            )
+        for entry in tuple(self.cleanup_dir.iterdir()):
+            if entry.name not in allowed or _is_link_or_reparse(entry):
+                raise HostFileTransactionError("transaction_conflict")
+        for item in files:
+            backup = self.cleanup_dir / f"before-{item.key}"
+            stage = self.cleanup_dir / f"after-{item.key}"
+            if backup.exists():
+                _remove_exact(backup, item.before)
+            if stage.exists():
+                _remove_exact(stage, item.after)
+            self._remove_partial(stage)
+            identity = self.cleanup_dir / f"after-id-{item.key}"
+            if identity.exists():
+                if item.after is not None and _file_identity(
+                    self.root / PurePosixPath(item.path)
+                ) != _read_file_identity(identity):
+                    raise HostFileTransactionError("transaction_conflict")
+                _remove_file_identity_artifact(identity)
+            self._remove_partial(identity)
+        marker = self.cleanup_dir / "commit.marker"
+        if marker.exists():
+            _remove_exact(marker, _commit_marker(manifest))
+        self._remove_partial(marker)
+        manifest_path = self.cleanup_dir / "manifest.json"
+        if manifest_path.exists():
+            _remove_exact(manifest_path, manifest)
+        self._remove_partial(manifest_path)
+        owner_path = self.cleanup_dir / OWNER_FILE_NAME
+        if owner_path.exists():
+            _remove_exact(owner_path, _owner_marker(manifest))
+        _remove_empty_directory_exact(self.cleanup_dir, directory_identity)
+        _fsync_directory(self.tx_root)
+
+    @staticmethod
+    def _remove_partial(final: Path) -> None:
+        partial = final.with_name(f"{final.name}.partial")
+        if partial.exists():
+            _remove_protected_partial(partial)
+
+    def _manifest(self, files: Sequence[FileMutation]) -> bytes:
+        payload = {
+            "version": 1,
+            "operation_id": self.operation_id,
+            "action": self.action,
+            "branch": self.expected_stamp[0],
+            "head": self.expected_stamp[1],
+            "index_sha256": self.expected_stamp[2],
+            "created_directories": list(self.created_directories),
+            "files": [
+                {
+                    "path": item.path,
+                    "before_sha256": _sha256_or_none(item.before),
+                    "after_sha256": _sha256_or_none(item.after),
+                    "mode": item.mode,
+                    "key": item.key,
+                }
+                for item in files
+            ],
+        }
+        return json.dumps(
+            payload,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+
+    def _classify(self, files: Sequence[FileMutation]) -> str:
+        states: set[str] = set()
+        for item in files:
+            current = _read_regular(self.root / PurePosixPath(item.path))
+            if current == item.before:
+                states.add("before")
+            elif current == item.after:
+                states.add("after")
+            else:
+                states.add("other")
+        if states == {"before"}:
+            return "before"
+        if states == {"after"}:
+            return "after"
+        if states <= {"before", "after"}:
+            return "mixed"
+        return "other"
+
+    def _assert_stamp(self) -> None:
+        if self.stamp_callback(self.operation_id) != self.expected_stamp:
+            raise HostFileTransactionError("git_state_changed")
+
+    @contextlib.contextmanager
+    def _git_locks(self) -> Iterator[None]:
+        created: list[Path] = []
+        paths = self._git_lock_paths()
+        parents = [self.git]
+        for path in paths:
+            parents.extend(_ensure_safe_directory_chain(self.git, path.parent))
+        try:
+            with _guard_directories(tuple(dict.fromkeys(parents))):
+                for path in paths:
+                    if path.exists():
+                        # The helper holds its outer per-project process lock
+                        # before entering this module. Under that prerequisite,
+                        # an exact marker from this operation is stale crash
+                        # debris; a foreign marker is never removed.
+                        self._assert_exact(path, self._marker)
+                        _remove_exact(path, self._marker)
+                    try:
+                        _write_exclusive(path, self._marker, 0o600)
+                        created.append(path)
+                    except FileExistsError as exc:
+                        raise HostFileTransactionError("git_locked") from exc
+                yield
+        finally:
+            cleanup_error: BaseException | None = None
+            for path in reversed(created):
+                try:
+                    _remove_exact(path, self._marker)
+                except BaseException as exc:
+                    cleanup_error = cleanup_error or exc
+            if cleanup_error is not None:
+                raise cleanup_error
+
+    def _git_lock_paths(self) -> tuple[Path, ...]:
+        branch = PurePosixPath(self.expected_stamp[0])
+        if any(part in {"", ".", ".."} for part in branch.parts):
+            raise HostFileTransactionError("branch_invalid")
+        return (
+            self.git / "index.lock",
+            self.git / "HEAD.lock",
+            self.git / "refs" / "heads" / branch.with_name(f"{branch.name}.lock"),
+        )
+
+    @staticmethod
+    def _assert_exact(path: Path, expected: bytes | None) -> None:
+        if expected is None or _read_regular(path) != expected:
+            raise HostFileTransactionError("transaction_conflict")
+
+
+def read_regular(path: Path) -> bytes | None:
+    """Read one regular file through the same no-follow handle used for checks."""
+    result = _read_regular_with_identity(Path(path))
+    return None if result is None else result[0]
+
+
+def _read_regular_with_identity(path: Path) -> tuple[bytes, str] | None:
+    candidate = Path(path)
+    if os.name == "nt":
+        handle = _windows_open_existing(
+            candidate,
+            access=0x80000000 | 0x00000080,  # GENERIC_READ | FILE_READ_ATTRIBUTES
+            share=0x00000001 | 0x00000002 | 0x00000004,
+            allow_missing=True,
+        )
+        if handle is None:
+            return None
+        try:
+            identity = _windows_handle_identity(handle, require_directory=False)
+            return _windows_read_all(handle), identity
+        finally:
+            _windows_close_handle(handle)
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_BINARY", 0)
+    )
+    try:
+        descriptor = os.open(candidate, flags)
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        raise HostFileTransactionError("path_unavailable") from exc
+    try:
+        identity = _descriptor_identity(descriptor, require_directory=False)
+        chunks: list[bytes] = []
+        while True:
+            chunk = os.read(descriptor, 64 * 1024)
+            if not chunk:
+                break
+            chunks.append(chunk)
+        return b"".join(chunks), identity
+    except OSError as exc:
+        raise HostFileTransactionError("path_unavailable") from exc
+    finally:
+        os.close(descriptor)
+
+
+def _read_regular(path: Path) -> bytes | None:
+    return read_regular(path)
+
+
+def file_identity(path: Path) -> str:
+    """Return a stable, path-free identity for a real file or directory."""
+    candidate = Path(path)
+    if os.name == "nt":
+        handle = _windows_open_existing(
+            candidate,
+            access=0x00000080,  # FILE_READ_ATTRIBUTES
+            share=0x00000001 | 0x00000002 | 0x00000004,
+            allow_missing=False,
+            directory=True,
+        )
+        assert handle is not None
+        try:
+            return _windows_handle_identity(handle, require_directory=None)
+        finally:
+            _windows_close_handle(handle)
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(candidate, flags)
+    except OSError as exc:
+        raise HostFileTransactionError("path_unavailable") from exc
+    try:
+        return _descriptor_identity(descriptor, require_directory=None)
+    finally:
+        os.close(descriptor)
+
+
+def _descriptor_identity(
+    descriptor: int,
+    *,
+    require_directory: bool | None,
+) -> str:
+    if os.name == "nt":
+        import msvcrt
+
+        return _windows_handle_identity(
+            msvcrt.get_osfhandle(descriptor),
+            require_directory=require_directory,
+        )
+    try:
+        metadata = os.fstat(descriptor)
+    except OSError as exc:
+        raise HostFileTransactionError("path_unavailable") from exc
+    is_directory = stat.S_ISDIR(metadata.st_mode)
+    if (
+        not (stat.S_ISREG(metadata.st_mode) or is_directory)
+        or require_directory is not None
+        and is_directory != require_directory
+        or metadata.st_dev <= 0
+        or metadata.st_ino <= 0
+    ):
+        raise HostFileTransactionError("path_unsafe")
+    return f"{metadata.st_dev:x}-{metadata.st_ino:x}"
+
+
+def _validate_expected_identity(value: str | None) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or re.fullmatch(r"[a-f0-9]+-[a-f0-9]+", value) is None:
+        raise HostFileTransactionError("transaction_parameters_invalid")
+    return value
+
+
+@contextlib.contextmanager
+def _guard_exact_regular_object(
+    path: Path,
+    expected: bytes,
+    *,
+    expected_identity: str | None = None,
+    allow_delete_share: bool = False,
+) -> Iterator[str]:
+    identity = _validate_expected_identity(expected_identity)
+    if os.name == "nt":
+        share = 0x00000001 | (0x00000004 if allow_delete_share else 0)
+        handle = _windows_open_existing(
+            path,
+            access=0x80000000 | 0x00000080,
+            share=share,
+            allow_missing=False,
+        )
+        assert handle is not None
+        try:
+            current_identity = _windows_handle_identity(
+                handle,
+                require_directory=False,
+            )
+            if (
+                identity is not None
+                and current_identity != identity
+                or _windows_read_all(handle) != expected
+            ):
+                raise HostFileTransactionError("transaction_conflict")
+            yield current_identity
+            if (
+                _windows_handle_identity(handle, require_directory=False)
+                != current_identity
+                or _windows_read_all(handle) != expected
+            ):
+                raise HostFileTransactionError("transaction_conflict")
+        finally:
+            _windows_close_handle(handle)
+        return
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise HostFileTransactionError("transaction_conflict") from exc
+    try:
+        current_identity = _descriptor_identity(
+            descriptor,
+            require_directory=False,
+        )
+        if (
+            identity is not None
+            and current_identity != identity
+            or _read_descriptor(descriptor) != expected
+        ):
+            raise HostFileTransactionError("transaction_conflict")
+        yield current_identity
+        if (
+            _descriptor_identity(descriptor, require_directory=False)
+            != current_identity
+            or _read_descriptor(descriptor) != expected
+        ):
+            raise HostFileTransactionError("transaction_conflict")
+    finally:
+        os.close(descriptor)
+
+
+@contextlib.contextmanager
+def _guard_published_targets(
+    root: Path,
+    transaction_dir: Path,
+    files: Sequence[FileMutation],
+) -> Iterator[None]:
+    windows_handles: list[tuple[int, bytes, str]] = []
+    posix_descriptors: list[tuple[int, Path, bytes, str]] = []
+    try:
+        for item in files:
+            if item.after is None:
+                continue
+            target = root / PurePosixPath(item.path)
+            identity_path = transaction_dir / f"after-id-{item.key}"
+            expected_identity = _read_file_identity(identity_path).decode("ascii").strip()
+            if os.name == "nt":
+                handle = _windows_open_existing(
+                    target,
+                    access=0x80000000 | 0x00000080,
+                    # Deny all future writers and deleters until callback+seal.
+                    share=0x00000001,
+                    allow_missing=False,
+                )
+                assert handle is not None
+                try:
+                    if (
+                        _windows_handle_identity(handle, require_directory=False)
+                        != expected_identity
+                        or _windows_read_all(handle) != item.after
+                    ):
+                        raise HostFileTransactionError("transaction_conflict")
+                except BaseException:
+                    _windows_close_handle(handle)
+                    raise
+                windows_handles.append((handle, item.after, expected_identity))
+                continue
+            flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+            try:
+                descriptor = os.open(target, flags)
+            except OSError as exc:
+                raise HostFileTransactionError("transaction_conflict") from exc
+            try:
+                metadata = os.fstat(descriptor)
+                identity = f"{metadata.st_dev:x}-{metadata.st_ino:x}"
+                if not stat.S_ISREG(metadata.st_mode) or identity != expected_identity:
+                    raise HostFileTransactionError("transaction_conflict")
+                content = _read_descriptor(descriptor)
+                if content != item.after:
+                    raise HostFileTransactionError("transaction_conflict")
+            except BaseException:
+                os.close(descriptor)
+                raise
+            posix_descriptors.append((descriptor, target, item.after, expected_identity))
+        yield
+        for handle, expected, identity in windows_handles:
+            if (
+                _windows_handle_identity(handle, require_directory=False) != identity
+                or _windows_read_all(handle) != expected
+            ):
+                raise HostFileTransactionError("transaction_conflict")
+        for descriptor, target, expected, identity in posix_descriptors:
+            metadata = os.fstat(descriptor)
+            if (
+                f"{metadata.st_dev:x}-{metadata.st_ino:x}" != identity
+                or _read_descriptor(descriptor) != expected
+                or file_identity(target) != identity
+            ):
+                raise HostFileTransactionError("transaction_conflict")
+    finally:
+        for descriptor, _target, _expected, _identity in reversed(posix_descriptors):
+            os.close(descriptor)
+        for handle, _expected, _identity in reversed(windows_handles):
+            _windows_close_handle(handle)
+
+
+def _read_descriptor(descriptor: int) -> bytes:
+    os.lseek(descriptor, 0, os.SEEK_SET)
+    chunks: list[bytes] = []
+    while True:
+        chunk = os.read(descriptor, 64 * 1024)
+        if not chunk:
+            return b"".join(chunks)
+        chunks.append(chunk)
+
+
+def _write_exclusive(path: Path, content: bytes, mode: int) -> None:
+    descriptor = os.open(
+        path,
+        os.O_WRONLY
+        | os.O_CREAT
+        | os.O_EXCL
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_BINARY", 0),
+        mode,
+    )
+    created_identity = _descriptor_identity(descriptor, require_directory=False)
+    try:
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(content)
+            stream.flush()
+            os.fsync(stream.fileno())
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.close(descriptor)
+        # The write may have stopped at any byte.  Never unlink by path after
+        # releasing the descriptor: an external same-name file could already
+        # have replaced it.  Exact object identity makes best-effort cleanup
+        # safe; otherwise the partial remains as fail-closed crash evidence.
+        with contextlib.suppress(HostFileTransactionError):
+            partial = read_regular(path)
+            if partial is not None:
+                remove_regular_exact(
+                    path,
+                    partial,
+                    expected_identity=created_identity,
+                )
+        raise
+
+
+def _write_durable_no_replace(path: Path, content: bytes, mode: int) -> None:
+    """Publish a small transaction artifact through a recoverable partial."""
+    with _guard_directories((path.parent,)):
+        partial = path.with_name(f"{path.name}.partial")
+        if path.exists():
+            if _read_regular(path) != content:
+                raise HostFileTransactionError("transaction_conflict")
+            if partial.exists():
+                _remove_protected_partial(partial)
+            return
+        if partial.exists():
+            # The partial is inside a validated transaction directory and is never
+            # used as evidence. A hard crash may leave it empty or truncated.
+            _remove_protected_partial(partial)
+        _write_exclusive(partial, content, mode)
+        _fsync_directory(path.parent)
+        try:
+            _move_verified_no_replace(partial, path, content)
+        except BaseException:
+            if path.exists() and _read_regular(path) == content:
+                if partial.exists():
+                    _remove_protected_partial(partial)
+                return
+            raise
+        _fsync_directory(path.parent)
+
+
+def _remove_protected_partial(path: Path) -> None:
+    if not path.name.endswith(".partial"):
+        raise HostFileTransactionError("transaction_cleanup_failed")
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        raise HostFileTransactionError("transaction_cleanup_failed") from exc
+    if not stat.S_ISREG(metadata.st_mode) or _is_reparse(metadata):
+        raise HostFileTransactionError("transaction_conflict")
+    current = _read_regular_with_identity(path)
+    if current is None:
+        return
+    content, identity = current
+    _remove_exact(path, content, expected_identity=identity)
+    _fsync_directory(path.parent)
+
+
+def remove_regular_exact(
+    path: Path,
+    expected: bytes,
+    expected_identity: str | None = None,
+) -> None:
+    """Delete the exact regular file object without following replacements."""
+    _remove_exact(
+        Path(path),
+        expected,
+        expected_identity=expected_identity,
+    )
+
+
+def _remove_exact(
+    path: Path,
+    expected: bytes | None,
+    *,
+    expected_identity: str | None = None,
+) -> None:
+    if expected is None:
+        raise HostFileTransactionError("transaction_conflict")
+    identity = _validate_expected_identity(expected_identity)
+    if os.name == "nt":
+        _windows_delete_regular_exact(
+            path,
+            expected,
+            expected_identity=identity,
+        )
+        return
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        parent = os.open(path.parent, flags)
+    except OSError as exc:
+        raise HostFileTransactionError("transaction_cleanup_failed") from exc
+    descriptor: int | None = None
+    try:
+        try:
+            descriptor = os.open(
+                path.name,
+                os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+                dir_fd=parent,
+            )
+        except OSError as exc:
+            raise HostFileTransactionError("transaction_conflict") from exc
+        current_identity = _descriptor_identity(
+            descriptor,
+            require_directory=False,
+        )
+        if (
+            identity is not None
+            and current_identity != identity
+            or _read_descriptor(descriptor) != expected
+        ):
+            raise HostFileTransactionError("transaction_conflict")
+        try:
+            named = os.stat(path.name, dir_fd=parent, follow_symlinks=False)
+        except OSError as exc:
+            raise HostFileTransactionError("transaction_conflict") from exc
+        named_identity = f"{named.st_dev:x}-{named.st_ino:x}"
+        if (
+            not stat.S_ISREG(named.st_mode)
+            or named.st_dev <= 0
+            or named.st_ino <= 0
+            or named_identity != current_identity
+        ):
+            raise HostFileTransactionError("transaction_conflict")
+        try:
+            os.unlink(path.name, dir_fd=parent)
+            os.fsync(parent)
+        except OSError as exc:
+            raise HostFileTransactionError("transaction_cleanup_failed") from exc
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+        os.close(parent)
+
+
+def _remove_empty_directory_exact(path: Path, expected_identity: str) -> None:
+    identity = _validate_expected_identity(expected_identity)
+    assert identity is not None
+    if os.name == "nt":
+        _windows_delete_empty_directory_exact(path, identity)
+        return
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        parent = os.open(path.parent, flags)
+    except OSError as exc:
+        raise HostFileTransactionError("transaction_cleanup_failed") from exc
+    descriptor: int | None = None
+    try:
+        try:
+            descriptor = os.open(path.name, flags, dir_fd=parent)
+        except OSError as exc:
+            raise HostFileTransactionError("transaction_conflict") from exc
+        current_identity = _descriptor_identity(
+            descriptor,
+            require_directory=True,
+        )
+        if current_identity != identity:
+            raise HostFileTransactionError("transaction_conflict")
+        try:
+            named = os.stat(path.name, dir_fd=parent, follow_symlinks=False)
+        except OSError as exc:
+            raise HostFileTransactionError("transaction_conflict") from exc
+        if (
+            not stat.S_ISDIR(named.st_mode)
+            or named.st_dev <= 0
+            or named.st_ino <= 0
+            or f"{named.st_dev:x}-{named.st_ino:x}" != identity
+        ):
+            raise HostFileTransactionError("transaction_conflict")
+        try:
+            os.rmdir(path.name, dir_fd=parent)
+            os.fsync(parent)
+        except OSError as exc:
+            raise HostFileTransactionError("transaction_cleanup_failed") from exc
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+        os.close(parent)
+
+
+def _windows_open_existing(
+    path: Path,
+    *,
+    access: int,
+    share: int,
+    allow_missing: bool,
+    directory: bool = False,
+) -> int | None:
+    from ctypes import wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.CreateFileW.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    ]
+    kernel32.CreateFileW.restype = wintypes.HANDLE
+    flags = 0x00200000  # FILE_FLAG_OPEN_REPARSE_POINT
+    if directory:
+        flags |= 0x02000000  # FILE_FLAG_BACKUP_SEMANTICS
+    handle = kernel32.CreateFileW(
+        str(path),
+        access,
+        share,
+        None,
+        3,  # OPEN_EXISTING
+        flags,
+        None,
+    )
+    invalid = ctypes.c_void_p(-1).value
+    if handle is None or int(handle) == invalid:
+        error = ctypes.get_last_error()
+        if allow_missing and error in {2, 3}:
+            return None
+        raise HostFileTransactionError(
+            "path_unavailable" if allow_missing else "transaction_conflict"
+        )
+    return int(handle)
+
+
+def _windows_close_handle(handle: int) -> None:
+    from ctypes import wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+    kernel32.CloseHandle.restype = wintypes.BOOL
+    kernel32.CloseHandle(handle)
+
+
+def _windows_handle_identity(
+    handle: int,
+    *,
+    require_directory: bool | None,
+) -> str:
+    from ctypes import wintypes
+
+    class _ByHandleFileInformation(ctypes.Structure):
+        _fields_ = [
+            ("attributes", wintypes.DWORD),
+            ("creation_time", wintypes.FILETIME),
+            ("access_time", wintypes.FILETIME),
+            ("write_time", wintypes.FILETIME),
+            ("volume_serial", wintypes.DWORD),
+            ("size_high", wintypes.DWORD),
+            ("size_low", wintypes.DWORD),
+            ("links", wintypes.DWORD),
+            ("file_index_high", wintypes.DWORD),
+            ("file_index_low", wintypes.DWORD),
+        ]
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.GetFileInformationByHandle.argtypes = [
+        wintypes.HANDLE,
+        ctypes.POINTER(_ByHandleFileInformation),
+    ]
+    kernel32.GetFileInformationByHandle.restype = wintypes.BOOL
+    information = _ByHandleFileInformation()
+    if not kernel32.GetFileInformationByHandle(handle, ctypes.byref(information)):
+        raise HostFileTransactionError("path_unavailable")
+    is_directory = bool(information.attributes & 0x00000010)
+    file_index = (information.file_index_high << 32) | information.file_index_low
+    if (
+        information.attributes & FILE_ATTRIBUTE_REPARSE_POINT
+        or require_directory is not None
+        and is_directory != require_directory
+        or information.volume_serial == 0
+        or file_index == 0
+    ):
+        raise HostFileTransactionError("path_unsafe")
+    return f"{information.volume_serial:x}-{file_index:x}"
+
+
+def _windows_read_all(handle: int) -> bytes:
+    from ctypes import wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.GetFileSizeEx.argtypes = [
+        wintypes.HANDLE,
+        ctypes.POINTER(ctypes.c_longlong),
+    ]
+    kernel32.GetFileSizeEx.restype = wintypes.BOOL
+    kernel32.SetFilePointerEx.argtypes = [
+        wintypes.HANDLE,
+        ctypes.c_longlong,
+        ctypes.POINTER(ctypes.c_longlong),
+        wintypes.DWORD,
+    ]
+    kernel32.SetFilePointerEx.restype = wintypes.BOOL
+    kernel32.ReadFile.argtypes = [
+        wintypes.HANDLE,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        ctypes.POINTER(wintypes.DWORD),
+        wintypes.LPVOID,
+    ]
+    kernel32.ReadFile.restype = wintypes.BOOL
+    size = ctypes.c_longlong()
+    if not kernel32.GetFileSizeEx(handle, ctypes.byref(size)) or size.value < 0:
+        raise HostFileTransactionError("path_unavailable")
+    if not kernel32.SetFilePointerEx(handle, 0, None, 0):
+        raise HostFileTransactionError("path_unavailable")
+    remaining = size.value
+    chunks: list[bytes] = []
+    while remaining:
+        count = min(remaining, 64 * 1024)
+        buffer = (ctypes.c_ubyte * count)()
+        read = wintypes.DWORD()
+        if not kernel32.ReadFile(
+            handle,
+            buffer,
+            count,
+            ctypes.byref(read),
+            None,
+        ):
+            raise HostFileTransactionError("path_unavailable")
+        if read.value == 0:
+            raise HostFileTransactionError("path_unavailable")
+        chunks.append(bytes(buffer[: read.value]))
+        remaining -= read.value
+    return b"".join(chunks)
+
+
+def _windows_delete_regular_exact(
+    path: Path,
+    expected: bytes,
+    *,
+    expected_identity: str | None,
+) -> None:
+    from ctypes import wintypes
+
+    generic_read = 0x80000000
+    delete_access = 0x00010000
+    file_read_attributes = 0x00000080
+    file_share_read = 0x00000001
+    file_disposition_info = 4
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+
+    class _FileDispositionInfo(ctypes.Structure):
+        _fields_ = [("delete_file", wintypes.BOOLEAN)]
+
+    kernel32.SetFileInformationByHandle.argtypes = [
+        wintypes.HANDLE,
+        ctypes.c_int,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+    ]
+    kernel32.SetFileInformationByHandle.restype = wintypes.BOOL
+    handle = _windows_open_existing(
+        path,
+        access=generic_read | delete_access | file_read_attributes,
+        share=file_share_read,
+        allow_missing=False,
+    )
+    assert handle is not None
+    try:
+        identity = _windows_handle_identity(handle, require_directory=False)
+        if expected_identity is not None and identity != expected_identity:
+            raise HostFileTransactionError("transaction_conflict")
+        if _windows_read_all(handle) != expected:
+            raise HostFileTransactionError("transaction_conflict")
+        disposition = _FileDispositionInfo(True)
+        if not kernel32.SetFileInformationByHandle(
+            handle,
+            file_disposition_info,
+            ctypes.byref(disposition),
+            ctypes.sizeof(disposition),
+        ):
+            raise HostFileTransactionError("transaction_cleanup_failed")
+    finally:
+        _windows_close_handle(handle)
+    if path.exists():
+        raise HostFileTransactionError("transaction_cleanup_failed")
+
+
+def _windows_delete_empty_directory_exact(
+    path: Path,
+    expected_identity: str,
+) -> None:
+    from ctypes import wintypes
+
+    delete_access = 0x00010000
+    file_read_attributes = 0x00000080
+    file_share_read = 0x00000001
+    file_disposition_info = 4
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+
+    class _FileDispositionInfo(ctypes.Structure):
+        _fields_ = [("delete_file", wintypes.BOOLEAN)]
+
+    kernel32.SetFileInformationByHandle.argtypes = [
+        wintypes.HANDLE,
+        ctypes.c_int,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+    ]
+    kernel32.SetFileInformationByHandle.restype = wintypes.BOOL
+    handle = _windows_open_existing(
+        path,
+        access=delete_access | file_read_attributes,
+        share=file_share_read,
+        allow_missing=False,
+        directory=True,
+    )
+    assert handle is not None
+    try:
+        if (
+            _windows_handle_identity(handle, require_directory=True)
+            != expected_identity
+        ):
+            raise HostFileTransactionError("transaction_conflict")
+        disposition = _FileDispositionInfo(True)
+        if not kernel32.SetFileInformationByHandle(
+            handle,
+            file_disposition_info,
+            ctypes.byref(disposition),
+            ctypes.sizeof(disposition),
+        ):
+            raise HostFileTransactionError("transaction_cleanup_failed")
+    finally:
+        _windows_close_handle(handle)
+    if path.exists():
+        raise HostFileTransactionError("transaction_cleanup_failed")
+
+
+def _move_verified_no_replace(
+    source: Path,
+    destination: Path,
+    expected: bytes,
+    *,
+    expected_identity: str | None = None,
+) -> None:
+    expected_identity = _validate_expected_identity(expected_identity)
+    with _guard_directories((source.parent, destination.parent)):
+        if os.name == "nt":
+            _windows_move_verified_no_replace(
+                source,
+                destination,
+                expected,
+                expected_identity=expected_identity,
+            )
+            return
+        if _read_regular(source) != expected:
+            raise HostFileTransactionError("target_changed")
+        _posix_rename_no_replace(
+            source,
+            destination,
+            expected_identity=expected_identity,
+        )
+        if _read_regular(destination) != expected:
+            if not source.exists():
+                with contextlib.suppress(HostFileTransactionError):
+                    _posix_rename_no_replace(destination, source)
+            raise HostFileTransactionError("target_changed")
+    _fsync_directory(source.parent)
+    if destination.parent != source.parent:
+        _fsync_directory(destination.parent)
+
+
+def move_directory_no_replace(
+    source: Path,
+    destination: Path,
+    *,
+    expected_identity: str | None = None,
+    owner_name: str | None = None,
+    owner_content: bytes | None = None,
+    owner_only: bool = False,
+) -> None:
+    """Atomically move one real directory without replacing any destination."""
+    _move_directory_no_replace(
+        Path(source),
+        Path(destination),
+        expected_identity=expected_identity,
+        owner_name=owner_name,
+        owner_content=owner_content,
+        owner_only=owner_only,
+    )
+
+
+def _move_directory_no_replace(
+    source: Path,
+    destination: Path,
+    *,
+    expected_identity: str | None = None,
+    owner_name: str | None = None,
+    owner_content: bytes | None = None,
+    owner_only: bool = False,
+) -> None:
+    _assert_directory(source)
+    if destination.exists() or _is_link_or_reparse(destination):
+        raise HostFileTransactionError("transaction_conflict")
+    identity = _validate_expected_identity(expected_identity) or file_identity(source)
+    if (owner_name is None) != (owner_content is None):
+        raise HostFileTransactionError("transaction_parameters_invalid")
+    if owner_only and owner_name is None:
+        raise HostFileTransactionError("transaction_parameters_invalid")
+    if owner_name is not None and (
+        not isinstance(owner_content, bytes)
+        or owner_name in {"", ".", ".."}
+        or Path(owner_name).name != owner_name
+        or "/" in owner_name
+        or "\\" in owner_name
+    ):
+        raise HostFileTransactionError("transaction_parameters_invalid")
+    if os.name == "nt":
+        with _guard_directories((source.parent, destination.parent)):
+            _windows_move_directory_no_replace(
+                source,
+                destination,
+                expected_identity=identity,
+                owner_name=owner_name,
+                owner_content=owner_content,
+                owner_only=owner_only,
+            )
+    else:
+        with contextlib.ExitStack() as ownership:
+            owner_identity: str | None = None
+            if owner_name is not None:
+                assert owner_content is not None
+                owner_identity = ownership.enter_context(
+                    _guard_exact_regular_object(
+                        source / owner_name,
+                        owner_content,
+                        allow_delete_share=True,
+                    )
+                )
+                if owner_only and {
+                    entry.name for entry in source.iterdir()
+                } != {owner_name}:
+                    raise HostFileTransactionError("transaction_conflict")
+            with _guard_directories((source.parent, destination.parent)):
+                _posix_rename_no_replace(
+                    source,
+                    destination,
+                    expected_identity=identity,
+                )
+            if owner_name is not None:
+                assert owner_content is not None and owner_identity is not None
+                moved_owner = destination / owner_name
+                if (
+                    file_identity(moved_owner) != owner_identity
+                    or read_regular(moved_owner) != owner_content
+                ):
+                    raise HostFileTransactionError("transaction_conflict")
+    if file_identity(destination) != identity:
+        raise HostFileTransactionError("transaction_conflict")
+    _fsync_directory(destination.parent)
+
+
+def _posix_rename_no_replace(
+    source: Path,
+    destination: Path,
+    *,
+    expected_identity: str | None = None,
+) -> None:
+    import errno
+
+    library = ctypes.CDLL(None, use_errno=True)
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    source_parent = os.open(source.parent, flags)
+    destination_parent = os.open(destination.parent, flags)
+    try:
+        before = os.stat(source.name, dir_fd=source_parent, follow_symlinks=False)
+        if stat.S_ISLNK(before.st_mode):
+            raise HostFileTransactionError("path_unsafe")
+        before_identity = f"{before.st_dev:x}-{before.st_ino:x}"
+        if (
+            before.st_dev <= 0
+            or before.st_ino <= 0
+            or expected_identity is not None
+            and before_identity != expected_identity
+        ):
+            raise HostFileTransactionError("target_changed")
+        if hasattr(library, "renameat2"):
+            library.renameat2.argtypes = [
+                ctypes.c_int,
+                ctypes.c_char_p,
+                ctypes.c_int,
+                ctypes.c_char_p,
+                ctypes.c_uint,
+            ]
+            library.renameat2.restype = ctypes.c_int
+            result = library.renameat2(
+                source_parent,
+                os.fsencode(source.name),
+                destination_parent,
+                os.fsencode(destination.name),
+                1,  # RENAME_NOREPLACE
+            )
+        elif hasattr(library, "renameatx_np"):
+            library.renameatx_np.argtypes = [
+                ctypes.c_int,
+                ctypes.c_char_p,
+                ctypes.c_int,
+                ctypes.c_char_p,
+                ctypes.c_uint,
+            ]
+            library.renameatx_np.restype = ctypes.c_int
+            result = library.renameatx_np(
+                source_parent,
+                os.fsencode(source.name),
+                destination_parent,
+                os.fsencode(destination.name),
+                4,  # RENAME_EXCL
+            )
+        else:
+            raise HostFileTransactionError("atomic_rename_unsupported")
+        if result != 0:
+            error = ctypes.get_errno()
+            if error in {errno.EEXIST, errno.ENOTEMPTY, errno.ENOENT}:
+                raise HostFileTransactionError("target_changed")
+            if error in {errno.ENOSYS, errno.EINVAL, errno.ENOTSUP}:
+                raise HostFileTransactionError("atomic_rename_unsupported")
+            raise HostFileTransactionError("target_unavailable")
+        after = os.stat(
+            destination.name,
+            dir_fd=destination_parent,
+            follow_symlinks=False,
+        )
+        if (after.st_dev, after.st_ino) != (before.st_dev, before.st_ino):
+            raise HostFileTransactionError("path_parent_changed")
+        os.fsync(source_parent)
+        if source.parent != destination.parent:
+            os.fsync(destination_parent)
+    finally:
+        os.close(destination_parent)
+        os.close(source_parent)
+
+
+def _windows_move_verified_no_replace(
+    source: Path,
+    destination: Path,
+    expected: bytes,
+    *,
+    expected_identity: str | None = None,
+) -> None:
+    _windows_rename_handle_no_replace(
+        source,
+        destination,
+        expected=expected,
+        directory=False,
+        expected_identity=expected_identity,
+    )
+    if _read_regular(destination) != expected:
+        raise HostFileTransactionError("target_changed")
+
+
+def _windows_move_directory_no_replace(
+    source: Path,
+    destination: Path,
+    *,
+    expected_identity: str | None = None,
+    owner_name: str | None = None,
+    owner_content: bytes | None = None,
+    owner_only: bool = False,
+) -> None:
+    _windows_rename_handle_no_replace(
+        source,
+        destination,
+        expected=None,
+        directory=True,
+        expected_identity=expected_identity,
+        owner_name=owner_name,
+        owner_content=owner_content,
+        owner_only=owner_only,
+    )
+
+
+def _windows_rename_handle_no_replace(
+    source: Path,
+    destination: Path,
+    *,
+    expected: bytes | None,
+    directory: bool,
+    expected_identity: str | None = None,
+    owner_name: str | None = None,
+    owner_content: bytes | None = None,
+    owner_only: bool = False,
+) -> None:
+    from ctypes import wintypes
+
+    generic_read = 0x80000000
+    delete_access = 0x00010000
+    file_read_attributes = 0x00000080
+    file_share_read = 0x00000001
+    open_existing = 3
+    file_flag_open_reparse_point = 0x00200000
+    file_flag_backup_semantics = 0x02000000
+    file_rename_info = 3
+    file_attribute_directory = 0x00000010
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+
+    class _ByHandleFileInformation(ctypes.Structure):
+        _fields_ = [
+            ("attributes", wintypes.DWORD),
+            ("creation_time", wintypes.FILETIME),
+            ("access_time", wintypes.FILETIME),
+            ("write_time", wintypes.FILETIME),
+            ("volume_serial", wintypes.DWORD),
+            ("size_high", wintypes.DWORD),
+            ("size_low", wintypes.DWORD),
+            ("links", wintypes.DWORD),
+            ("file_index_high", wintypes.DWORD),
+            ("file_index_low", wintypes.DWORD),
+        ]
+
+    kernel32.CreateFileW.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    ]
+    kernel32.CreateFileW.restype = wintypes.HANDLE
+    kernel32.SetFileInformationByHandle.argtypes = [
+        wintypes.HANDLE,
+        ctypes.c_int,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+    ]
+    kernel32.SetFileInformationByHandle.restype = wintypes.BOOL
+    kernel32.GetFileInformationByHandle.argtypes = [
+        wintypes.HANDLE,
+        ctypes.POINTER(_ByHandleFileInformation),
+    ]
+    kernel32.GetFileInformationByHandle.restype = wintypes.BOOL
+    kernel32.GetFileSizeEx.argtypes = [wintypes.HANDLE, ctypes.POINTER(ctypes.c_longlong)]
+    kernel32.GetFileSizeEx.restype = wintypes.BOOL
+    kernel32.ReadFile.argtypes = [
+        wintypes.HANDLE,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        ctypes.POINTER(wintypes.DWORD),
+        wintypes.LPVOID,
+    ]
+    kernel32.ReadFile.restype = wintypes.BOOL
+    kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+    kernel32.CloseHandle.restype = wintypes.BOOL
+    handle = kernel32.CreateFileW(
+        str(source),
+        (generic_read if not directory else 0)
+        | delete_access
+        | file_read_attributes,
+        file_share_read,
+        None,
+        open_existing,
+        file_flag_open_reparse_point
+        | (file_flag_backup_semantics if directory else 0),
+        None,
+    )
+    invalid = ctypes.c_void_p(-1).value
+    if int(handle) == invalid:
+        raise HostFileTransactionError("target_changed")
+    try:
+        information = _ByHandleFileInformation()
+        if not kernel32.GetFileInformationByHandle(
+            handle,
+            ctypes.byref(information),
+        ):
+            raise HostFileTransactionError("target_changed")
+        if information.attributes & FILE_ATTRIBUTE_REPARSE_POINT:
+            raise HostFileTransactionError("path_unsafe")
+        if bool(information.attributes & file_attribute_directory) != directory:
+            raise HostFileTransactionError("path_unsafe")
+        identity = (
+            information.volume_serial,
+            (information.file_index_high << 32) | information.file_index_low,
+        )
+        identity_value = f"{identity[0]:x}-{identity[1]:x}"
+        if (
+            identity[0] == 0
+            or identity[1] == 0
+            or expected_identity is not None
+            and identity_value != expected_identity
+        ):
+            raise HostFileTransactionError("target_changed")
+        owner_identity: str | None = None
+        if owner_name is not None:
+            if not directory or owner_content is None:
+                raise HostFileTransactionError("transaction_parameters_invalid")
+            # Keep the source directory handle open while validating its owner,
+            # then close the child handle before the parent rename.  Windows
+            # rejects a directory rename while a child handle is held; the
+            # before/after identity checks still bind the moved directory to
+            # the exact owner object inspected under this source handle.
+            with _guard_exact_regular_object(
+                source / owner_name,
+                owner_content,
+                allow_delete_share=True,
+            ) as guarded_owner_identity:
+                owner_identity = guarded_owner_identity
+            if owner_only and {
+                entry.name for entry in source.iterdir()
+            } != {owner_name}:
+                raise HostFileTransactionError("transaction_conflict")
+        if not directory:
+            size = ctypes.c_longlong()
+            if not kernel32.GetFileSizeEx(handle, ctypes.byref(size)) or size.value < 0:
+                raise HostFileTransactionError("target_changed")
+            buffer = (ctypes.c_ubyte * size.value)()
+            read = wintypes.DWORD()
+            if size.value and not kernel32.ReadFile(
+                handle,
+                buffer,
+                size.value,
+                ctypes.byref(read),
+                None,
+            ):
+                raise HostFileTransactionError("target_changed")
+            content = bytes(buffer[: read.value]) if size.value else b""
+            if content != expected or read.value != size.value:
+                raise HostFileTransactionError("target_changed")
+        name = str(destination)
+
+        class _FileRenameInfo(ctypes.Structure):
+            _fields_ = [
+                ("ReplaceIfExists", wintypes.BOOLEAN),
+                ("RootDirectory", wintypes.HANDLE),
+                ("FileNameLength", wintypes.DWORD),
+                ("FileName", ctypes.c_wchar * (len(name) + 1)),
+            ]
+
+        info = _FileRenameInfo()
+        info.ReplaceIfExists = False
+        info.RootDirectory = None
+        info.FileNameLength = len(name.encode("utf-16-le"))
+        info.FileName = name
+        if not kernel32.SetFileInformationByHandle(
+            handle,
+            file_rename_info,
+            ctypes.byref(info),
+            ctypes.sizeof(info),
+        ):
+            raise HostFileTransactionError("target_changed")
+        moved_information = _ByHandleFileInformation()
+        if not kernel32.GetFileInformationByHandle(
+            handle,
+            ctypes.byref(moved_information),
+        ):
+            raise HostFileTransactionError("target_changed")
+        moved_identity = (
+            moved_information.volume_serial,
+            (moved_information.file_index_high << 32)
+            | moved_information.file_index_low,
+        )
+        if moved_identity != identity or moved_information.attributes & FILE_ATTRIBUTE_REPARSE_POINT:
+            raise HostFileTransactionError("path_parent_changed")
+        if owner_name is not None:
+            assert owner_content is not None and owner_identity is not None
+            moved_owner = destination / owner_name
+            if (
+                file_identity(moved_owner) != owner_identity
+                or read_regular(moved_owner) != owner_content
+            ):
+                raise HostFileTransactionError("transaction_conflict")
+    finally:
+        kernel32.CloseHandle(handle)
+    try:
+        destination_metadata = destination.lstat()
+    except OSError as exc:
+        raise HostFileTransactionError("target_changed") from exc
+    if _is_reparse(destination_metadata):
+        raise HostFileTransactionError("path_unsafe")
+    # CPython exposes the Windows file index as st_ino. Recheck when available;
+    # zero-valued legacy filesystems remain protected by the still-open handle.
+    if destination_metadata.st_ino and destination_metadata.st_ino != identity[1]:
+        raise HostFileTransactionError("path_parent_changed")
+
+
+def _fsync_directory(path: Path) -> None:
+    if os.name == "nt":
+        return
+    descriptor = os.open(
+        path,
+        os.O_RDONLY | getattr(os, "O_DIRECTORY", 0),
+    )
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _commit_marker(manifest: bytes) -> bytes:
+    return f"committed:{hashlib.sha256(manifest).hexdigest()}\n".encode("ascii")
+
+
+def _owner_marker(manifest: bytes) -> bytes:
+    return f"owned:{hashlib.sha256(manifest).hexdigest()}\n".encode("ascii")
+
+
+def _file_identity(path: Path) -> bytes:
+    current = _read_regular_with_identity(path)
+    if current is None:
+        raise HostFileTransactionError("path_unsafe")
+    _content, identity = current
+    return f"{identity}\n".encode("ascii")
+
+
+def _read_file_identity(path: Path) -> bytes:
+    value = _read_regular(path)
+    if value is None or re.fullmatch(rb"[a-f0-9]+-[a-f0-9]+\n", value) is None:
+        raise HostFileTransactionError("transaction_conflict")
+    return value
+
+
+def _remove_file_identity_artifact(path: Path) -> None:
+    current = _read_regular_with_identity(path)
+    if current is None:
+        raise HostFileTransactionError("transaction_conflict")
+    content, object_identity = current
+    if re.fullmatch(rb"[a-f0-9]+-[a-f0-9]+\n", content) is None:
+        raise HostFileTransactionError("transaction_conflict")
+    _remove_exact(
+        path,
+        content,
+        expected_identity=object_identity,
+    )
+
+
+def _sha256_or_none(content: bytes | None) -> str | None:
+    return hashlib.sha256(content).hexdigest() if content is not None else None
+
+
+def _assert_directory(path: Path) -> None:
+    try:
+        metadata = path.lstat()
+    except OSError as exc:
+        raise HostFileTransactionError("transaction_unavailable") from exc
+    if not stat.S_ISDIR(metadata.st_mode) or _is_reparse(metadata):
+        raise HostFileTransactionError("transaction_conflict")
+
+
+def _ensure_safe_directory_chain(root: Path, parent: Path) -> tuple[Path, ...]:
+    try:
+        relative = parent.relative_to(root)
+    except ValueError as exc:
+        raise HostFileTransactionError("git_metadata_unsafe") from exc
+    current = root
+    values = [root]
+    for part in relative.parts:
+        current = current / part
+        if not current.exists():
+            try:
+                current.mkdir()
+            except FileExistsError:
+                pass
+        _assert_directory(current)
+        values.append(current)
+    return tuple(values)
+
+
+def _is_link_or_reparse(path: Path) -> bool:
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        return False
+    except OSError as exc:
+        raise HostFileTransactionError("path_unavailable") from exc
+    return stat.S_ISLNK(metadata.st_mode) or _is_reparse(metadata)
+
+
+def _is_reparse(metadata: os.stat_result) -> bool:
+    return bool(getattr(metadata, "st_file_attributes", 0) & FILE_ATTRIBUTE_REPARSE_POINT)
+
+
+@contextlib.contextmanager
+def _guard_directories(paths: Sequence[Path]) -> Iterator[None]:
+    unique = tuple(dict.fromkeys(Path(path) for path in paths))
+    for path in unique:
+        _assert_directory(path)
+    if os.name == "nt":
+        from ctypes import wintypes
+
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        file_read_attributes = 0x0080
+        file_share_read = 0x00000001
+        open_existing = 3
+        flags = 0x00200000 | 0x02000000
+        file_attribute_tag_info = 9
+
+        class _FileAttributeTagInfo(ctypes.Structure):
+            _fields_ = [
+                ("file_attributes", wintypes.DWORD),
+                ("reparse_tag", wintypes.DWORD),
+            ]
+
+        class _ByHandleFileInformation(ctypes.Structure):
+            _fields_ = [
+                ("attributes", wintypes.DWORD),
+                ("creation_time", wintypes.FILETIME),
+                ("access_time", wintypes.FILETIME),
+                ("write_time", wintypes.FILETIME),
+                ("volume_serial", wintypes.DWORD),
+                ("size_high", wintypes.DWORD),
+                ("size_low", wintypes.DWORD),
+                ("links", wintypes.DWORD),
+                ("file_index_high", wintypes.DWORD),
+                ("file_index_low", wintypes.DWORD),
+            ]
+
+        kernel32.CreateFileW.argtypes = [
+            wintypes.LPCWSTR,
+            wintypes.DWORD,
+            wintypes.DWORD,
+            wintypes.LPVOID,
+            wintypes.DWORD,
+            wintypes.DWORD,
+            wintypes.HANDLE,
+        ]
+        kernel32.CreateFileW.restype = wintypes.HANDLE
+        kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+        kernel32.CloseHandle.restype = wintypes.BOOL
+        kernel32.GetFileInformationByHandleEx.argtypes = [
+            wintypes.HANDLE,
+            ctypes.c_int,
+            wintypes.LPVOID,
+            wintypes.DWORD,
+        ]
+        kernel32.GetFileInformationByHandleEx.restype = wintypes.BOOL
+        kernel32.GetFileInformationByHandle.argtypes = [
+            wintypes.HANDLE,
+            ctypes.POINTER(_ByHandleFileInformation),
+        ]
+        kernel32.GetFileInformationByHandle.restype = wintypes.BOOL
+        handles: list[int] = []
+        identities: list[tuple[Path, int, int]] = []
+        try:
+            for path in unique:
+                handle = kernel32.CreateFileW(
+                    str(path),
+                    file_read_attributes,
+                    file_share_read,
+                    None,
+                    open_existing,
+                    flags,
+                    None,
+                )
+                if int(handle) == ctypes.c_void_p(-1).value:
+                    raise HostFileTransactionError("path_parent_unavailable")
+                info = _FileAttributeTagInfo()
+                if not kernel32.GetFileInformationByHandleEx(
+                    handle,
+                    file_attribute_tag_info,
+                    ctypes.byref(info),
+                    ctypes.sizeof(info),
+                ) or info.file_attributes & FILE_ATTRIBUTE_REPARSE_POINT:
+                    kernel32.CloseHandle(handle)
+                    raise HostFileTransactionError("path_parent_changed")
+                identity = _ByHandleFileInformation()
+                if not kernel32.GetFileInformationByHandle(
+                    handle,
+                    ctypes.byref(identity),
+                ):
+                    kernel32.CloseHandle(handle)
+                    raise HostFileTransactionError("path_parent_changed")
+                handles.append(handle)
+                identities.append(
+                    (
+                        path,
+                        identity.volume_serial,
+                        (identity.file_index_high << 32) | identity.file_index_low,
+                    )
+                )
+            yield
+            for handle, (path, volume, file_index) in zip(handles, identities):
+                identity = _ByHandleFileInformation()
+                if not kernel32.GetFileInformationByHandle(
+                    handle,
+                    ctypes.byref(identity),
+                ):
+                    raise HostFileTransactionError("path_parent_changed")
+                current = path.lstat()
+                current_index = (identity.file_index_high << 32) | identity.file_index_low
+                if (
+                    identity.attributes & FILE_ATTRIBUTE_REPARSE_POINT
+                    or identity.volume_serial != volume
+                    or current_index != file_index
+                    or (current.st_ino and current.st_ino != file_index)
+                ):
+                    raise HostFileTransactionError("path_parent_changed")
+        finally:
+            for handle in reversed(handles):
+                kernel32.CloseHandle(handle)
+        return
+    descriptors: list[int] = []
+    identities: list[tuple[Path, int, int]] = []
+    try:
+        for path in unique:
+            descriptor = os.open(
+                path,
+                os.O_RDONLY
+                | getattr(os, "O_DIRECTORY", 0)
+                | getattr(os, "O_NOFOLLOW", 0),
+            )
+            metadata = os.fstat(descriptor)
+            descriptors.append(descriptor)
+            identities.append((path, metadata.st_dev, metadata.st_ino))
+        yield
+        for path, device, inode in identities:
+            try:
+                metadata = path.lstat()
+            except FileNotFoundError as exc:
+                raise HostFileTransactionError("path_parent_changed") from exc
+            if (metadata.st_dev, metadata.st_ino) != (device, inode):
+                raise HostFileTransactionError("path_parent_changed")
+    finally:
+        for descriptor in reversed(descriptors):
+            os.close(descriptor)

--- a/server/coding_project_host/operation_log.py
+++ b/server/coding_project_host/operation_log.py
@@ -11,7 +11,6 @@ import re
 import secrets
 import threading
 import time
-import unicodedata
 from dataclasses import asdict, dataclass, replace
 from contextlib import contextmanager
 from pathlib import Path
@@ -22,6 +21,7 @@ from server.coding_runtime.commit_models import (
     COMMIT_ID_PATTERN,
     GIT_OBJECT_ID_PATTERN,
     normalize_commit_message,
+    validate_commit_branch,
 )
 from server.coding_runtime.draft_workspace import DraftPolicyError, DraftWorkspace
 from server.coding_runtime.project_host import OBJECT_ID_PATTERN, PROJECT_ID_PATTERN
@@ -78,9 +78,7 @@ _ALLOWED_TRANSITIONS = frozenset(
         ("prepared", "reverting"),
         ("prepared", "reverted"),
         ("prepared", "committing"),
-        ("prepared", "committed"),
         ("prepared", "undoing"),
-        ("prepared", "undone"),
         ("prepared", "conflict"),
         ("applying", "applied"),
         ("applying", "conflict"),
@@ -119,6 +117,12 @@ class HostOperationRecord:
     created_at: float
     updated_at: float
     patch: str = ""
+    commit_message: str | None = None
+    index_sha256: str | None = None
+    index_before_sha256: str | None = None
+    index_identity: str | None = None
+    index_before_identity: str | None = None
+    reflog_metadata: tuple[str, ...] = ()
     apply_receipt: dict[str, Any] | None = None
     commit_receipt: dict[str, Any] | None = None
     created_directories: tuple[str, ...] = ()
@@ -158,6 +162,12 @@ class HostOperationJournal:
         expected_head: str,
         patch_sha256: str,
         patch: str = "",
+        commit_message: str | None = None,
+        index_sha256: str | None = None,
+        index_before_sha256: str | None = None,
+        index_identity: str | None = None,
+        index_before_identity: str | None = None,
+        reflog_metadata: tuple[str, ...] = (),
         apply_receipt: dict[str, Any] | None = None,
         commit_receipt: dict[str, Any] | None = None,
         created_directories: tuple[str, ...] = (),
@@ -176,6 +186,12 @@ class HostOperationJournal:
             created_at=now,
             updated_at=now,
             patch=patch,
+            commit_message=commit_message,
+            index_sha256=index_sha256,
+            index_before_sha256=index_before_sha256,
+            index_identity=index_identity,
+            index_before_identity=index_before_identity,
+            reflog_metadata=tuple(reflog_metadata),
             apply_receipt=copy.deepcopy(apply_receipt),
             commit_receipt=copy.deepcopy(commit_receipt),
             created_directories=tuple(created_directories),
@@ -217,6 +233,11 @@ class HostOperationJournal:
         *,
         apply_receipt: dict[str, Any] | None = None,
         commit_receipt: dict[str, Any] | None = None,
+        index_sha256: str | None = None,
+        index_before_sha256: str | None = None,
+        index_identity: str | None = None,
+        index_before_identity: str | None = None,
+        reflog_metadata: tuple[str, ...] | None = None,
         created_directories: tuple[str, ...] | None = None,
         file_identities: tuple[str, ...] | None = None,
     ) -> HostOperationRecord:
@@ -228,6 +249,36 @@ class HostOperationJournal:
                 current = records.get(operation_id)
                 if current is None:
                     raise HostOperationLogError("operation_not_found")
+                provided_index_metadata = (
+                    index_sha256 is not None,
+                    index_before_sha256 is not None,
+                    index_identity is not None,
+                    index_before_identity is not None,
+                )
+                if any(provided_index_metadata) and not all(provided_index_metadata):
+                    raise HostOperationLogError("operation_record_invalid")
+                if (
+                    index_sha256 is not None
+                    and current.index_sha256 is not None
+                    and current.index_sha256 != index_sha256
+                ) or (
+                    index_before_sha256 is not None
+                    and current.index_before_sha256 is not None
+                    and current.index_before_sha256 != index_before_sha256
+                ) or (
+                    index_identity is not None
+                    and current.index_identity is not None
+                    and current.index_identity != index_identity
+                ) or (
+                    index_before_identity is not None
+                    and current.index_before_identity is not None
+                    and current.index_before_identity != index_before_identity
+                ) or (
+                    reflog_metadata is not None
+                    and current.reflog_metadata
+                    and current.reflog_metadata != tuple(reflog_metadata)
+                ):
+                    raise HostOperationLogError("operation_conflict")
                 if state not in _ACTION_STATES[current.action]:
                     raise HostOperationLogError("operation_state_invalid")
                 if state == current.state:
@@ -249,6 +300,24 @@ class HostOperationJournal:
                         file_identities is not None
                         and current.file_identities
                         and current.file_identities != file_identities
+                    ) or (
+                        index_sha256 is not None
+                        and current.index_sha256 not in {None, index_sha256}
+                    ) or (
+                        index_before_sha256 is not None
+                        and current.index_before_sha256
+                        not in {None, index_before_sha256}
+                    ) or (
+                        index_identity is not None
+                        and current.index_identity not in {None, index_identity}
+                    ) or (
+                        index_before_identity is not None
+                        and current.index_before_identity
+                        not in {None, index_before_identity}
+                    ) or (
+                        reflog_metadata is not None
+                        and current.reflog_metadata
+                        and current.reflog_metadata != tuple(reflog_metadata)
                     ):
                         raise HostOperationLogError("operation_conflict")
                     if (
@@ -260,6 +329,10 @@ class HostOperationJournal:
                         )
                     ) or (
                         file_identities is not None and not current.file_identities
+                    ) or (
+                        index_sha256 is not None and current.index_sha256 is None
+                    ) or (
+                        reflog_metadata is not None and not current.reflog_metadata
                     ):
                         updated = replace(
                             current,
@@ -273,6 +346,31 @@ class HostOperationJournal:
                                 tuple(file_identities)
                                 if file_identities is not None
                                 else current.file_identities
+                            ),
+                            index_sha256=(
+                                index_sha256
+                                if index_sha256 is not None
+                                else current.index_sha256
+                            ),
+                            index_before_sha256=(
+                                index_before_sha256
+                                if index_before_sha256 is not None
+                                else current.index_before_sha256
+                            ),
+                            index_identity=(
+                                index_identity
+                                if index_identity is not None
+                                else current.index_identity
+                            ),
+                            index_before_identity=(
+                                index_before_identity
+                                if index_before_identity is not None
+                                else current.index_before_identity
+                            ),
+                            reflog_metadata=(
+                                tuple(reflog_metadata)
+                                if reflog_metadata is not None
+                                else current.reflog_metadata
                             ),
                         )
                         _validate_record(updated)
@@ -297,6 +395,31 @@ class HostOperationJournal:
                         copy.deepcopy(commit_receipt)
                         if commit_receipt is not None
                         else current.commit_receipt
+                    ),
+                    index_sha256=(
+                        index_sha256
+                        if index_sha256 is not None
+                        else current.index_sha256
+                    ),
+                    index_before_sha256=(
+                        index_before_sha256
+                        if index_before_sha256 is not None
+                        else current.index_before_sha256
+                    ),
+                    index_identity=(
+                        index_identity
+                        if index_identity is not None
+                        else current.index_identity
+                    ),
+                    index_before_identity=(
+                        index_before_identity
+                        if index_before_identity is not None
+                        else current.index_before_identity
+                    ),
+                    reflog_metadata=(
+                        tuple(reflog_metadata)
+                        if reflog_metadata is not None
+                        else current.reflog_metadata
                     ),
                     created_directories=(
                         tuple(created_directories)
@@ -361,6 +484,11 @@ class HostOperationJournal:
                         **value,
                         "file_identities": tuple(value["file_identities"]),
                     }
+                if "reflog_metadata" in value:
+                    value = {
+                        **value,
+                        "reflog_metadata": tuple(value["reflog_metadata"]),
+                    }
                 record = HostOperationRecord(**value)
                 _validate_record(record)
                 if record.operation_id in records:
@@ -397,8 +525,11 @@ class HostOperationJournal:
             sort_keys=True,
             separators=(",", ":"),
         ).encode("utf-8")
-        protected = self.protector.protect(plaintext)
-        encoded = OPERATION_LOG_MAGIC + base64.b64encode(protected)
+        try:
+            protected = self.protector.protect(plaintext)
+            encoded = OPERATION_LOG_MAGIC + base64.b64encode(protected)
+        except (OSError, RuntimeError, TypeError, ValueError) as exc:
+            raise HostOperationLogError("operation_log_unavailable") from exc
         if len(encoded) > MAX_OPERATION_LOG_BYTES:
             raise HostOperationLogError("operation_log_too_large")
         self.path.parent.mkdir(parents=True, exist_ok=True)
@@ -408,6 +539,8 @@ class HostOperationJournal:
         try:
             temporary.write_bytes(encoded)
             os.replace(temporary, self.path)
+        except OSError as exc:
+            raise HostOperationLogError("operation_log_unavailable") from exc
         finally:
             temporary.unlink(missing_ok=True)
 
@@ -474,6 +607,9 @@ def _validate_record(record: HostOperationRecord) -> None:
         or not isinstance(record.patch, str)
         or len(record.patch.encode("utf-8")) > MAX_OPERATION_PATCH_BYTES
         or record.state not in _ACTION_STATES[record.action]
+        or not _valid_commit_message(record)
+        or not _valid_index_metadata(record)
+        or not _valid_reflog_metadata(record)
         or not _valid_apply_receipt(record.apply_receipt, record)
         or not _valid_commit_receipt(record.commit_receipt, record)
         or not _valid_created_directories(record.created_directories)
@@ -484,24 +620,101 @@ def _validate_record(record: HostOperationRecord) -> None:
 
 
 def _valid_branch(value: Any) -> bool:
+    try:
+        return validate_commit_branch(value) == value
+    except (TypeError, ValueError):
+        return False
+
+
+def _valid_commit_message(record: HostOperationRecord) -> bool:
+    if record.action != "commit":
+        return record.commit_message is None
+    if not isinstance(record.commit_message, str):
+        return False
+    try:
+        message = normalize_commit_message(record.commit_message)
+    except (TypeError, ValueError):
+        return False
+    if message != record.commit_message:
+        return False
     return bool(
-        isinstance(value, str)
-        and value
-        and value == value.strip()
-        and value == unicodedata.normalize("NFC", value)
-        and len(value) <= 200
-        and not value.startswith(("-", "/"))
-        and not value.endswith((".", "/"))
-        and not value.endswith(".lock")
-        and ".." not in value
-        and "@{" not in value
-        and "//" not in value
-        and "\\" not in value
-        and not any(
-            character in " ~^:?*[" or unicodedata.category(character).startswith("C")
-            for character in value
-        )
+        record.commit_receipt is None
+        or isinstance(record.commit_receipt, dict)
+        and record.commit_receipt.get("message") == record.commit_message
     )
+
+
+def _valid_index_metadata(record: HostOperationRecord) -> bool:
+    sha256 = record.index_sha256
+    before_sha256 = record.index_before_sha256
+    identity = record.index_identity
+    before_identity = record.index_before_identity
+    present_metadata = (
+        sha256 is not None,
+        before_sha256 is not None,
+        identity is not None,
+        before_identity is not None,
+    )
+    if any(present_metadata) and not all(present_metadata):
+        return False
+    present = all(present_metadata)
+    if present:
+        if (
+            not isinstance(sha256, str)
+            or PATCH_SHA256_PATTERN.fullmatch(sha256) is None
+            or not isinstance(before_sha256, str)
+            or PATCH_SHA256_PATTERN.fullmatch(before_sha256) is None
+            or not isinstance(identity, str)
+            or re.fullmatch(r"[a-f0-9]+-[a-f0-9]+", identity) is None
+            or not isinstance(before_identity, str)
+            or re.fullmatch(r"[a-f0-9]+-[a-f0-9]+", before_identity) is None
+        ):
+            return False
+        for value in (identity, before_identity):
+            device_text, inode_text = value.split("-", 1)
+            if int(device_text, 16) == 0 or int(inode_text, 16) == 0:
+                return False
+    if record.action in {"apply", "revert"}:
+        return not present
+    if record.state == "prepared":
+        return not present
+    if record.state in {"committing", "committed", "undoing", "undone"}:
+        return present
+    return record.state == "conflict"
+
+
+def _valid_reflog_metadata(record: HostOperationRecord) -> bool:
+    value = record.reflog_metadata
+    if not isinstance(value, tuple):
+        return False
+    present = bool(value)
+    if present:
+        if len(value) != 2:
+            return False
+        for expected_label, item in zip(("HEAD", "branch"), value, strict=True):
+            if not isinstance(item, str) or not item.startswith(f"{expected_label}:"):
+                return False
+            digest_and_identity = item[len(expected_label) + 1 :]
+            if "@" not in digest_and_identity:
+                return False
+            digest, identity = digest_and_identity.split("@", 1)
+            if (
+                PATCH_SHA256_PATTERN.fullmatch(digest) is None
+                or re.fullmatch(r"[a-f0-9]+-[a-f0-9]+", identity) is None
+            ):
+                return False
+            device_text, inode_text = identity.split("-", 1)
+            if int(device_text, 16) == 0 or int(inode_text, 16) == 0:
+                return False
+    if record.action in {"apply", "revert"}:
+        return not present
+    if record.state == "prepared":
+        # Commit/undo bind the exact reflogs before any Git command. Older
+        # prepared records may still be upgraded in place during recovery.
+        return not present or record.action in {"commit", "undo"}
+    if record.state in {"committing", "committed", "undoing", "undone"}:
+        return present
+    return record.state == "conflict"
 
 
 def _valid_created_directories(value: Any) -> bool:
@@ -719,15 +932,18 @@ def _valid_receipt_requirements(record: HostOperationRecord) -> bool:
     if record.action == "revert":
         return record.apply_receipt is not None and record.commit_receipt is None
     if record.action == "commit":
-        return bool(
-            record.apply_receipt is not None
-            and (
-                record.state == "conflict"
-                or (record.state == "committed")
-                == (record.commit_receipt is not None)
-            )
-        )
-    return record.apply_receipt is not None and record.commit_receipt is not None
+        if record.apply_receipt is None or not record.file_identities:
+            return False
+        if record.state == "prepared":
+            return record.commit_receipt is None
+        if record.state in {"committing", "committed"}:
+            return record.commit_receipt is not None
+        return record.state == "conflict"
+    return bool(
+        record.apply_receipt is not None
+        and record.commit_receipt is not None
+        and record.file_identities
+    )
 
 
 def _same_intent(left: HostOperationRecord, right: HostOperationRecord) -> bool:
@@ -743,6 +959,7 @@ def _same_intent(left: HostOperationRecord, right: HostOperationRecord) -> bool:
             "expected_head",
             "patch_sha256",
             "patch",
+            "commit_message",
         )
         )
         and (
@@ -752,6 +969,26 @@ def _same_intent(left: HostOperationRecord, right: HostOperationRecord) -> bool:
         and (
             right.commit_receipt is None
             or left.commit_receipt == right.commit_receipt
+        )
+        and (
+            right.index_sha256 is None
+            or left.index_sha256 == right.index_sha256
+        )
+        and (
+            right.index_before_sha256 is None
+            or left.index_before_sha256 == right.index_before_sha256
+        )
+        and (
+            right.index_identity is None
+            or left.index_identity == right.index_identity
+        )
+        and (
+            right.index_before_identity is None
+            or left.index_before_identity == right.index_before_identity
+        )
+        and (
+            not right.reflog_metadata
+            or left.reflog_metadata == right.reflog_metadata
         )
         and (
             not right.created_directories

--- a/server/coding_project_host/operation_log.py
+++ b/server/coding_project_host/operation_log.py
@@ -121,6 +121,8 @@ class HostOperationRecord:
     patch: str = ""
     apply_receipt: dict[str, Any] | None = None
     commit_receipt: dict[str, Any] | None = None
+    created_directories: tuple[str, ...] = ()
+    file_identities: tuple[str, ...] = ()
 
 
 class HostOperationJournal:
@@ -158,6 +160,8 @@ class HostOperationJournal:
         patch: str = "",
         apply_receipt: dict[str, Any] | None = None,
         commit_receipt: dict[str, Any] | None = None,
+        created_directories: tuple[str, ...] = (),
+        file_identities: tuple[str, ...] = (),
     ) -> HostOperationRecord:
         now = self._clock()
         record = HostOperationRecord(
@@ -174,6 +178,8 @@ class HostOperationJournal:
             patch=patch,
             apply_receipt=copy.deepcopy(apply_receipt),
             commit_receipt=copy.deepcopy(commit_receipt),
+            created_directories=tuple(created_directories),
+            file_identities=tuple(file_identities),
         )
         _validate_record(record)
         with self._lock:
@@ -211,6 +217,8 @@ class HostOperationJournal:
         *,
         apply_receipt: dict[str, Any] | None = None,
         commit_receipt: dict[str, Any] | None = None,
+        created_directories: tuple[str, ...] | None = None,
+        file_identities: tuple[str, ...] | None = None,
     ) -> HostOperationRecord:
         if state not in _STATES:
             raise HostOperationLogError("operation_state_invalid")
@@ -229,8 +237,49 @@ class HostOperationJournal:
                     ) or (
                         commit_receipt is not None
                         and current.commit_receipt != commit_receipt
+                    ) or (
+                        created_directories is not None
+                        and current.created_directories
+                        and current.created_directories != created_directories
+                        and not (
+                            current.state == "applying"
+                            and not created_directories
+                        )
+                    ) or (
+                        file_identities is not None
+                        and current.file_identities
+                        and current.file_identities != file_identities
                     ):
                         raise HostOperationLogError("operation_conflict")
+                    if (
+                        created_directories is not None
+                        and (
+                            not current.created_directories
+                            or current.state == "applying"
+                            and not created_directories
+                        )
+                    ) or (
+                        file_identities is not None and not current.file_identities
+                    ):
+                        updated = replace(
+                            current,
+                            updated_at=self._clock(),
+                            created_directories=(
+                                tuple(created_directories)
+                                if created_directories is not None
+                                else current.created_directories
+                            ),
+                            file_identities=(
+                                tuple(file_identities)
+                                if file_identities is not None
+                                else current.file_identities
+                            ),
+                        )
+                        _validate_record(updated)
+                        candidate = {**records, operation_id: updated}
+                        self._persist_records(candidate)
+                        self._records = candidate
+                        return _clone_record(updated)
                     self._records = records
                     return _clone_record(current)
                 if (current.state, state) not in _ALLOWED_TRANSITIONS:
@@ -248,6 +297,16 @@ class HostOperationJournal:
                         copy.deepcopy(commit_receipt)
                         if commit_receipt is not None
                         else current.commit_receipt
+                    ),
+                    created_directories=(
+                        tuple(created_directories)
+                        if created_directories is not None
+                        else current.created_directories
+                    ),
+                    file_identities=(
+                        tuple(file_identities)
+                        if file_identities is not None
+                        else current.file_identities
                     ),
                 )
                 _validate_record(updated)
@@ -292,6 +351,16 @@ class HostOperationJournal:
             for value in raw_records:
                 if not isinstance(value, dict):
                     raise ValueError("invalid operation log")
+                if "created_directories" in value:
+                    value = {
+                        **value,
+                        "created_directories": tuple(value["created_directories"]),
+                    }
+                if "file_identities" in value:
+                    value = {
+                        **value,
+                        "file_identities": tuple(value["file_identities"]),
+                    }
                 record = HostOperationRecord(**value)
                 _validate_record(record)
                 if record.operation_id in records:
@@ -407,6 +476,8 @@ def _validate_record(record: HostOperationRecord) -> None:
         or record.state not in _ACTION_STATES[record.action]
         or not _valid_apply_receipt(record.apply_receipt, record)
         or not _valid_commit_receipt(record.commit_receipt, record)
+        or not _valid_created_directories(record.created_directories)
+        or not _valid_file_identities(record.file_identities, record)
         or not _valid_receipt_requirements(record)
     ):
         raise HostOperationLogError("operation_record_invalid")
@@ -431,6 +502,76 @@ def _valid_branch(value: Any) -> bool:
             for character in value
         )
     )
+
+
+def _valid_created_directories(value: Any) -> bool:
+    if not isinstance(value, tuple) or len(value) > 64:
+        return False
+    seen: set[str] = set()
+    for item in value:
+        if not isinstance(item, str) or ":" not in item:
+            return False
+        identity_bundle, path = item.split(":", 1)
+        identities = identity_bundle.split("@")
+        if len(identities) != 2 or any(
+            re.fullmatch(r"[a-f0-9]+-[a-f0-9]+", identity) is None
+            for identity in identities
+        ):
+            return False
+        for identity in identities:
+            device_text, inode_text = identity.split("-", 1)
+            if int(device_text, 16) == 0 or int(inode_text, 16) == 0:
+                return False
+        try:
+            normalized = DraftWorkspace.normalize_relative_path(path)
+        except (DraftPolicyError, TypeError, ValueError):
+            return False
+        if normalized != path or path == ".git" or path in seen:
+            return False
+        seen.add(path)
+    return True
+
+
+def _valid_file_identities(value: Any, record: HostOperationRecord) -> bool:
+    if not isinstance(value, tuple) or len(value) > 20:
+        return False
+    seen: set[str] = set()
+    for item in value:
+        if not isinstance(item, str) or ":" not in item:
+            return False
+        identity, path = item.split(":", 1)
+        if identity != "missing" and re.fullmatch(
+            r"[a-f0-9]+-[a-f0-9]+",
+            identity,
+        ) is None:
+            return False
+        if identity != "missing":
+            device_text, inode_text = identity.split("-", 1)
+            if int(device_text, 16) == 0 or int(inode_text, 16) == 0:
+                return False
+        try:
+            normalized = DraftWorkspace.normalize_relative_path(path)
+        except (DraftPolicyError, TypeError, ValueError):
+            return False
+        if normalized != path or path in seen:
+            return False
+        seen.add(path)
+    apply_files = (
+        tuple(item["path"] for item in record.apply_receipt["files"])
+        if record.apply_receipt is not None
+        else ()
+    )
+    identity_paths = tuple(item.split(":", 1)[1] for item in value)
+    if value and identity_paths != apply_files:
+        return False
+    if record.action == "apply":
+        if record.state == "applied":
+            return bool(value) and identity_paths == apply_files
+        if record.state in {"prepared", "applying"}:
+            return not value
+    if record.action == "revert" and record.state != "conflict":
+        return bool(value) and identity_paths == apply_files
+    return True
 
 
 def _valid_apply_receipt(
@@ -568,12 +709,12 @@ def _valid_commit_receipt(
 
 def _valid_receipt_requirements(record: HostOperationRecord) -> bool:
     if record.action == "apply":
-        return bool(
-            record.commit_receipt is None
-            and (
-                record.state == "conflict"
-                or (record.state == "applied") == (record.apply_receipt is not None)
-            )
+        if record.commit_receipt is not None:
+            return False
+        if record.state == "conflict":
+            return True
+        return (record.state in {"applying", "applied"}) == (
+            record.apply_receipt is not None
         )
     if record.action == "revert":
         return record.apply_receipt is not None and record.commit_receipt is None
@@ -590,7 +731,8 @@ def _valid_receipt_requirements(record: HostOperationRecord) -> bool:
 
 
 def _same_intent(left: HostOperationRecord, right: HostOperationRecord) -> bool:
-    return all(
+    return bool(
+        all(
         getattr(left, field) == getattr(right, field)
         for field in (
             "operation_id",
@@ -601,8 +743,23 @@ def _same_intent(left: HostOperationRecord, right: HostOperationRecord) -> bool:
             "expected_head",
             "patch_sha256",
             "patch",
-            "apply_receipt",
-            "commit_receipt",
+        )
+        )
+        and (
+            right.apply_receipt is None
+            or left.apply_receipt == right.apply_receipt
+        )
+        and (
+            right.commit_receipt is None
+            or left.commit_receipt == right.commit_receipt
+        )
+        and (
+            not right.created_directories
+            or left.created_directories == right.created_directories
+        )
+        and (
+            not right.file_identities
+            or left.file_identities == right.file_identities
         )
     )
 

--- a/server/coding_project_host/operation_log.py
+++ b/server/coding_project_host/operation_log.py
@@ -1,0 +1,611 @@
+from __future__ import annotations
+
+import base64
+import copy
+import hashlib
+import hmac
+import json
+import math
+import os
+import re
+import secrets
+import threading
+import time
+import unicodedata
+from dataclasses import asdict, dataclass, replace
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Callable, Iterator, Literal, Protocol
+
+from server.coding_runtime.apply_models import ApplyFileReceipt, ApplyReceipt
+from server.coding_runtime.commit_models import (
+    COMMIT_ID_PATTERN,
+    GIT_OBJECT_ID_PATTERN,
+    normalize_commit_message,
+)
+from server.coding_runtime.draft_workspace import DraftPolicyError, DraftWorkspace
+from server.coding_runtime.project_host import OBJECT_ID_PATTERN, PROJECT_ID_PATTERN
+
+
+OPERATION_LOG_MAGIC = b"MMCPHOP1\n"
+OPERATION_LOG_RETENTION_SECONDS = 7 * 24 * 60 * 60
+MAX_OPERATION_LOG_BYTES = 8 * 1024 * 1024
+MAX_OPERATION_PATCH_BYTES = 1024 * 1024
+MAX_OPERATION_RECORDS = 64
+OPERATION_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]{20,64}$")
+PATCH_SHA256_PATTERN = re.compile(r"^[a-f0-9]{64}$")
+
+HostOperationAction = Literal["apply", "revert", "commit", "undo"]
+HostOperationState = Literal[
+    "prepared",
+    "applying",
+    "applied",
+    "reverting",
+    "reverted",
+    "committing",
+    "committed",
+    "undoing",
+    "undone",
+    "conflict",
+]
+
+_ACTIONS = frozenset({"apply", "revert", "commit", "undo"})
+_STATES = frozenset(
+    {
+        "prepared",
+        "applying",
+        "applied",
+        "reverting",
+        "reverted",
+        "committing",
+        "committed",
+        "undoing",
+        "undone",
+        "conflict",
+    }
+)
+_TERMINAL_STATES = frozenset({"reverted", "undone", "conflict"})
+_ACTION_STATES = {
+    "apply": frozenset({"prepared", "applying", "applied", "conflict"}),
+    "revert": frozenset({"prepared", "reverting", "reverted", "conflict"}),
+    "commit": frozenset({"prepared", "committing", "committed", "conflict"}),
+    "undo": frozenset({"prepared", "undoing", "undone", "conflict"}),
+}
+_ALLOWED_TRANSITIONS = frozenset(
+    {
+        ("prepared", "applying"),
+        ("prepared", "applied"),
+        ("prepared", "reverting"),
+        ("prepared", "reverted"),
+        ("prepared", "committing"),
+        ("prepared", "committed"),
+        ("prepared", "undoing"),
+        ("prepared", "undone"),
+        ("prepared", "conflict"),
+        ("applying", "applied"),
+        ("applying", "conflict"),
+        ("reverting", "reverted"),
+        ("reverting", "conflict"),
+        ("committing", "committed"),
+        ("committing", "conflict"),
+        ("undoing", "undone"),
+        ("undoing", "conflict"),
+    }
+)
+
+
+class DataProtector(Protocol):
+    def protect(self, value: bytes) -> bytes: ...
+
+    def unprotect(self, value: bytes) -> bytes: ...
+
+
+class HostOperationLogError(RuntimeError):
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+@dataclass(frozen=True, slots=True)
+class HostOperationRecord:
+    operation_id: str
+    action: HostOperationAction
+    project_id: str
+    revision: int
+    branch: str
+    expected_head: str
+    patch_sha256: str
+    state: HostOperationState
+    created_at: float
+    updated_at: float
+    patch: str = ""
+    apply_receipt: dict[str, Any] | None = None
+    commit_receipt: dict[str, Any] | None = None
+
+
+class HostOperationJournal:
+    """DPAPI-backed, path-free operation journal for host side effects."""
+
+    def __init__(
+        self,
+        path: Path,
+        protector: DataProtector,
+        *,
+        clock: Callable[[], float] = time.time,
+    ) -> None:
+        self.path = Path(path)
+        self.protector = protector
+        self._clock = clock
+        self._lock = threading.RLock()
+        self._records: dict[str, HostOperationRecord] = {}
+        with self._file_lock():
+            loaded = self._load()
+            pruned = self._prune_records(loaded)
+            if pruned != loaded:
+                self._persist_records(pruned)
+            self._records = pruned
+
+    def create(
+        self,
+        *,
+        operation_id: str,
+        action: HostOperationAction,
+        project_id: str,
+        revision: int,
+        branch: str,
+        expected_head: str,
+        patch_sha256: str,
+        patch: str = "",
+        apply_receipt: dict[str, Any] | None = None,
+        commit_receipt: dict[str, Any] | None = None,
+    ) -> HostOperationRecord:
+        now = self._clock()
+        record = HostOperationRecord(
+            operation_id=operation_id,
+            action=action,
+            project_id=project_id,
+            revision=revision,
+            branch=branch,
+            expected_head=expected_head,
+            patch_sha256=patch_sha256,
+            state="prepared",
+            created_at=now,
+            updated_at=now,
+            patch=patch,
+            apply_receipt=copy.deepcopy(apply_receipt),
+            commit_receipt=copy.deepcopy(commit_receipt),
+        )
+        _validate_record(record)
+        with self._lock:
+            with self._file_lock():
+                current = self._prune_records(self._load())
+                existing = current.get(operation_id)
+                if existing is not None:
+                    if not _same_intent(existing, record):
+                        raise HostOperationLogError("operation_conflict")
+                    self._records = current
+                    return _clone_record(existing)
+                if len(current) >= MAX_OPERATION_RECORDS:
+                    raise HostOperationLogError("operation_log_full")
+                candidate = {**current, operation_id: record}
+                self._persist_records(candidate)
+                self._records = candidate
+                return _clone_record(record)
+
+    def get(self, operation_id: str) -> HostOperationRecord | None:
+        if OPERATION_ID_PATTERN.fullmatch(operation_id) is None:
+            raise HostOperationLogError("operation_id_invalid")
+        with self._lock:
+            with self._file_lock():
+                current = self._prune_records(self._load())
+                if current != self._records:
+                    self._persist_records(current)
+                self._records = current
+                record = current.get(operation_id)
+                return _clone_record(record) if record is not None else None
+
+    def transition(
+        self,
+        operation_id: str,
+        state: HostOperationState,
+        *,
+        apply_receipt: dict[str, Any] | None = None,
+        commit_receipt: dict[str, Any] | None = None,
+    ) -> HostOperationRecord:
+        if state not in _STATES:
+            raise HostOperationLogError("operation_state_invalid")
+        with self._lock:
+            with self._file_lock():
+                records = self._prune_records(self._load())
+                current = records.get(operation_id)
+                if current is None:
+                    raise HostOperationLogError("operation_not_found")
+                if state not in _ACTION_STATES[current.action]:
+                    raise HostOperationLogError("operation_state_invalid")
+                if state == current.state:
+                    if (
+                        apply_receipt is not None
+                        and current.apply_receipt != apply_receipt
+                    ) or (
+                        commit_receipt is not None
+                        and current.commit_receipt != commit_receipt
+                    ):
+                        raise HostOperationLogError("operation_conflict")
+                    self._records = records
+                    return _clone_record(current)
+                if (current.state, state) not in _ALLOWED_TRANSITIONS:
+                    raise HostOperationLogError("operation_state_invalid")
+                updated = replace(
+                    current,
+                    state=state,
+                    updated_at=self._clock(),
+                    apply_receipt=(
+                        copy.deepcopy(apply_receipt)
+                        if apply_receipt is not None
+                        else current.apply_receipt
+                    ),
+                    commit_receipt=(
+                        copy.deepcopy(commit_receipt)
+                        if commit_receipt is not None
+                        else current.commit_receipt
+                    ),
+                )
+                _validate_record(updated)
+                candidate = {**records, operation_id: updated}
+                self._persist_records(candidate)
+                self._records = candidate
+                return _clone_record(updated)
+
+    def remove(self, operation_id: str) -> None:
+        with self._lock:
+            with self._file_lock():
+                records = self._prune_records(self._load())
+                if operation_id not in records:
+                    self._records = records
+                    return
+                candidate = dict(records)
+                del candidate[operation_id]
+                self._persist_records(candidate)
+                self._records = candidate
+
+    def _load(self) -> dict[str, HostOperationRecord]:
+        if not self.path.exists():
+            return {}
+        try:
+            encoded = self.path.read_bytes()
+            if len(encoded) > MAX_OPERATION_LOG_BYTES or not encoded.startswith(
+                OPERATION_LOG_MAGIC
+            ):
+                raise ValueError("invalid operation log")
+            protected = base64.b64decode(
+                encoded[len(OPERATION_LOG_MAGIC) :], validate=True
+            )
+            payload = json.loads(
+                self.protector.unprotect(protected).decode("utf-8", errors="strict")
+            )
+            if not isinstance(payload, dict) or payload.get("version") != 1:
+                raise ValueError("invalid operation log")
+            raw_records = payload.get("records")
+            if not isinstance(raw_records, list) or len(raw_records) > MAX_OPERATION_RECORDS:
+                raise ValueError("invalid operation log")
+            records: dict[str, HostOperationRecord] = {}
+            for value in raw_records:
+                if not isinstance(value, dict):
+                    raise ValueError("invalid operation log")
+                record = HostOperationRecord(**value)
+                _validate_record(record)
+                if record.operation_id in records:
+                    raise ValueError("duplicate operation")
+                records[record.operation_id] = record
+            return records
+        except (OSError, TypeError, UnicodeError, ValueError, json.JSONDecodeError) as exc:
+            raise HostOperationLogError("operation_log_corrupt") from exc
+
+    def _prune_records(
+        self,
+        records: dict[str, HostOperationRecord],
+    ) -> dict[str, HostOperationRecord]:
+        cutoff = self._clock() - OPERATION_LOG_RETENTION_SECONDS
+        return {
+            operation_id: record
+            for operation_id, record in records.items()
+            if record.state not in _TERMINAL_STATES or record.updated_at >= cutoff
+        }
+
+    def _persist_records(self, records: dict[str, HostOperationRecord]) -> None:
+        payload = {
+            "version": 1,
+            "records": [
+                asdict(record)
+                for record in sorted(
+                    records.values(), key=lambda item: item.created_at
+                )
+            ],
+        }
+        plaintext = json.dumps(
+            payload,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        protected = self.protector.protect(plaintext)
+        encoded = OPERATION_LOG_MAGIC + base64.b64encode(protected)
+        if len(encoded) > MAX_OPERATION_LOG_BYTES:
+            raise HostOperationLogError("operation_log_too_large")
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        temporary = self.path.with_name(
+            f".{self.path.name}.{secrets.token_hex(8)}.tmp"
+        )
+        try:
+            temporary.write_bytes(encoded)
+            os.replace(temporary, self.path)
+        finally:
+            temporary.unlink(missing_ok=True)
+
+    @contextmanager
+    def _file_lock(self) -> Iterator[None]:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path = self.path.with_name(f"{self.path.name}.lock")
+        deadline = time.monotonic() + 5.0
+        with lock_path.open("a+b") as stream:
+            stream.seek(0, os.SEEK_END)
+            if stream.tell() == 0:
+                stream.write(b"\0")
+                stream.flush()
+            while True:
+                try:
+                    if os.name == "nt":
+                        import msvcrt
+
+                        stream.seek(0)
+                        msvcrt.locking(stream.fileno(), msvcrt.LK_NBLCK, 1)
+                    else:
+                        import fcntl
+
+                        fcntl.flock(stream.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    break
+                except OSError as exc:
+                    if time.monotonic() >= deadline:
+                        raise HostOperationLogError("operation_log_locked") from exc
+                    time.sleep(0.05)
+            try:
+                yield
+            finally:
+                if os.name == "nt":
+                    import msvcrt
+
+                    stream.seek(0)
+                    msvcrt.locking(stream.fileno(), msvcrt.LK_UNLCK, 1)
+                else:
+                    import fcntl
+
+                    fcntl.flock(stream.fileno(), fcntl.LOCK_UN)
+
+
+def _validate_record(record: HostOperationRecord) -> None:
+    if (
+        OPERATION_ID_PATTERN.fullmatch(record.operation_id) is None
+        or record.action not in _ACTIONS
+        or PROJECT_ID_PATTERN.fullmatch(record.project_id) is None
+        or type(record.revision) is not int
+        or record.revision < 0
+        or not _valid_branch(record.branch)
+        or OBJECT_ID_PATTERN.fullmatch(record.expected_head) is None
+        or PATCH_SHA256_PATTERN.fullmatch(record.patch_sha256) is None
+        or not hmac.compare_digest(
+            record.patch_sha256,
+            hashlib.sha256(record.patch.encode("utf-8")).hexdigest(),
+        )
+        or record.state not in _STATES
+        or type(record.created_at) not in {int, float}
+        or type(record.updated_at) not in {int, float}
+        or not math.isfinite(record.created_at)
+        or not math.isfinite(record.updated_at)
+        or record.updated_at < record.created_at
+        or not isinstance(record.patch, str)
+        or len(record.patch.encode("utf-8")) > MAX_OPERATION_PATCH_BYTES
+        or record.state not in _ACTION_STATES[record.action]
+        or not _valid_apply_receipt(record.apply_receipt, record)
+        or not _valid_commit_receipt(record.commit_receipt, record)
+        or not _valid_receipt_requirements(record)
+    ):
+        raise HostOperationLogError("operation_record_invalid")
+
+
+def _valid_branch(value: Any) -> bool:
+    return bool(
+        isinstance(value, str)
+        and value
+        and value == value.strip()
+        and value == unicodedata.normalize("NFC", value)
+        and len(value) <= 200
+        and not value.startswith(("-", "/"))
+        and not value.endswith((".", "/"))
+        and not value.endswith(".lock")
+        and ".." not in value
+        and "@{" not in value
+        and "//" not in value
+        and "\\" not in value
+        and not any(
+            character in " ~^:?*[" or unicodedata.category(character).startswith("C")
+            for character in value
+        )
+    )
+
+
+def _valid_apply_receipt(
+    value: Any,
+    record: HostOperationRecord,
+) -> bool:
+    if value is None:
+        return True
+    if not isinstance(value, dict) or set(value) != {
+        "apply_id",
+        "revision",
+        "snapshot_fingerprint",
+        "files",
+        "applied_at",
+    }:
+        return False
+    try:
+        files = value["files"]
+        if (
+            not isinstance(value["apply_id"], str)
+            or type(value["revision"]) is not int
+            or not isinstance(value["snapshot_fingerprint"], str)
+            or type(value["applied_at"]) not in {int, float}
+            or not isinstance(files, list)
+            or any(
+                not isinstance(item, dict)
+                or set(item)
+                != {"path", "existed_before", "before_sha256", "after_sha256"}
+                or not isinstance(item["path"], str)
+                or type(item["existed_before"]) is not bool
+                or item["before_sha256"] is not None
+                and not isinstance(item["before_sha256"], str)
+                or item["after_sha256"] is not None
+                and not isinstance(item["after_sha256"], str)
+                for item in files
+            )
+        ):
+            return False
+        receipt = ApplyReceipt(
+            apply_id=value["apply_id"],
+            revision=value["revision"],
+            snapshot_fingerprint=value["snapshot_fingerprint"],
+            files=tuple(
+                ApplyFileReceipt(**item)
+                for item in files
+            ),
+            applied_at=value["applied_at"],
+        )
+    except (KeyError, TypeError, ValueError):
+        return False
+    return bool(
+        receipt.revision == record.revision
+        and (record.action != "apply" or receipt.apply_id == record.operation_id)
+    )
+
+
+def _valid_commit_receipt(
+    value: Any,
+    record: HostOperationRecord,
+) -> bool:
+    if value is None:
+        return True
+    if not isinstance(value, dict) or set(value) != {
+        "commit_id",
+        "revision",
+        "apply_id",
+        "commit_sha",
+        "parent_sha",
+        "tree_sha",
+        "message",
+        "files",
+        "branch",
+        "committed_at",
+    }:
+        return False
+    try:
+        files = value["files"]
+        if (
+            not isinstance(value["commit_id"], str)
+            or type(value["revision"]) is not int
+            or not isinstance(value["apply_id"], str)
+            or any(
+                not isinstance(value[key], str)
+                for key in (
+                    "commit_sha",
+                    "parent_sha",
+                    "tree_sha",
+                    "message",
+                    "branch",
+                )
+            )
+            or type(value["committed_at"]) not in {int, float}
+            or not isinstance(files, list)
+            or any(not isinstance(path, str) for path in files)
+        ):
+            return False
+        safe_files = tuple(DraftWorkspace.normalize_relative_path(path) for path in files)
+        message = normalize_commit_message(value["message"])
+        committed_at = value["committed_at"]
+    except (DraftPolicyError, KeyError, TypeError, ValueError):
+        return False
+    object_ids = (value["commit_sha"], value["parent_sha"], value["tree_sha"])
+    apply_receipt = record.apply_receipt
+    apply_files = (
+        tuple(item["path"] for item in apply_receipt["files"])
+        if apply_receipt is not None
+        else ()
+    )
+    return bool(
+        COMMIT_ID_PATTERN.fullmatch(str(value["commit_id"]))
+        and type(value["revision"]) is int
+        and value["revision"] == record.revision
+        and re.fullmatch(r"^[A-Za-z0-9_-]{20,64}$", str(value["apply_id"]))
+        and all(GIT_OBJECT_ID_PATTERN.fullmatch(str(item)) for item in object_ids)
+        and value["commit_sha"] not in {value["parent_sha"], value["tree_sha"]}
+        and message == value["message"]
+        and safe_files
+        and len(safe_files) <= 20
+        and safe_files == tuple(files)
+        and safe_files == tuple(sorted(set(safe_files)))
+        and value["branch"] == record.branch
+        and safe_files == apply_files
+        and type(committed_at) in {int, float}
+        and math.isfinite(committed_at)
+        and committed_at >= 0
+        and (record.action != "commit" or value["commit_id"] == record.operation_id)
+        and (record.action != "commit" or value["parent_sha"] == record.expected_head)
+        and (record.action != "undo" or value["commit_sha"] == record.expected_head)
+        and (
+            apply_receipt is None
+            or value["apply_id"] == apply_receipt.get("apply_id")
+        )
+    )
+
+
+def _valid_receipt_requirements(record: HostOperationRecord) -> bool:
+    if record.action == "apply":
+        return bool(
+            record.commit_receipt is None
+            and (
+                record.state == "conflict"
+                or (record.state == "applied") == (record.apply_receipt is not None)
+            )
+        )
+    if record.action == "revert":
+        return record.apply_receipt is not None and record.commit_receipt is None
+    if record.action == "commit":
+        return bool(
+            record.apply_receipt is not None
+            and (
+                record.state == "conflict"
+                or (record.state == "committed")
+                == (record.commit_receipt is not None)
+            )
+        )
+    return record.apply_receipt is not None and record.commit_receipt is not None
+
+
+def _same_intent(left: HostOperationRecord, right: HostOperationRecord) -> bool:
+    return all(
+        getattr(left, field) == getattr(right, field)
+        for field in (
+            "operation_id",
+            "action",
+            "project_id",
+            "revision",
+            "branch",
+            "expected_head",
+            "patch_sha256",
+            "patch",
+            "apply_receipt",
+            "commit_receipt",
+        )
+    )
+
+
+def _clone_record(record: HostOperationRecord) -> HostOperationRecord:
+    return copy.deepcopy(record)

--- a/server/coding_project_host/windows_helper.py
+++ b/server/coding_project_host/windows_helper.py
@@ -2052,17 +2052,22 @@ def _guard_git_read_session(
 
                     if head is not None:
                         try:
-                            head_text = head.decode("ascii", errors="strict").strip()
+                            head_text = head.decode("utf-8", errors="strict").strip()
                         except UnicodeError as exc:
                             raise ProjectHostHelperError("git_encoding_not_supported") from exc
                         if head_text.startswith("ref: refs/heads/"):
                             relative = head_text.removeprefix("ref: ")
+                            branch = relative.removeprefix("refs/heads/")
                             if (
                                 not relative
                                 or "\\" in relative
                                 or any(part in {"", ".", ".."} for part in relative.split("/"))
                             ):
                                 raise ProjectHostHelperError("git_metadata_unsafe")
+                            try:
+                                validate_commit_branch(branch)
+                            except ValueError as exc:
+                                raise ProjectHostHelperError("git_metadata_unsafe") from exc
                             guard_leaf(
                                 "branch-ref",
                                 git_path.joinpath(*relative.split("/")),

--- a/server/coding_project_host/windows_helper.py
+++ b/server/coding_project_host/windows_helper.py
@@ -30,7 +30,18 @@ from server.coding_runtime.project_host import (
     PROJECT_HOST_V2_CAPABILITIES,
     PROJECT_ID_PATTERN,
 )
-from server.coding_project_host.operation_log import HostOperationJournal
+from server.coding_runtime.applier_client import _receipt_from_response, _receipt_to_payload
+from server.coding_runtime.committer_client import (
+    _commit_receipt_from_response,
+    _commit_receipt_to_payload,
+)
+from server.coding_runtime.commit_models import validate_commit_branch
+from server.coding_project_host.host_apply_engine import HostApplyError, HostGitApplyEngine
+from server.coding_project_host.host_commit_engine import HostCommitError, HostGitCommitEngine
+from server.coding_project_host.operation_log import (
+    HostOperationJournal,
+    HostOperationLogError,
+)
 from server.coding_runtime.host_snapshot import (
     HostSnapshotResult,
     create_host_snapshot_archive,
@@ -46,6 +57,10 @@ from server.coding_runtime.projects import (
 HELPER_VERSION = "1.1.0"
 STATE_MAGIC = b"MMCPH1\n"
 MAX_CONTROL_MESSAGE_BYTES = 256 * 1024
+MAX_OPERATION_PAYLOAD_BYTES = 1200 * 1024
+OPERATION_ACTIONS = frozenset({"apply", "revert", "commit", "undo", "reconcile"})
+OPERATION_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]{20,64}$")
+PAYLOAD_ID_PATTERN = re.compile(r"^phop_[a-f0-9]{32}$")
 DEFAULT_SERVER_URL = "http://127.0.0.1:8000"
 HEARTBEAT_INTERVAL_SECONDS = 20.0
 FILE_ATTRIBUTE_REPARSE_POINT = 0x0400
@@ -198,6 +213,43 @@ class ProjectHostRegistry:
             self._state["projects"][project_id] = dict(project)
             self._persist()
 
+    def update_project_head(
+        self,
+        project_id: str,
+        *,
+        branch: str,
+        expected_heads: set[str],
+        head: str,
+    ) -> None:
+        try:
+            normalized_branch = validate_commit_branch(branch)
+        except ValueError as exc:
+            raise ProjectHostHelperError("project_registry_invalid") from exc
+        if (
+            PROJECT_ID_PATTERN.fullmatch(project_id) is None
+            or OBJECT_ID_PATTERN.fullmatch(head) is None
+            or not expected_heads
+            or any(OBJECT_ID_PATTERN.fullmatch(item) is None for item in expected_heads)
+        ):
+            raise ProjectHostHelperError("project_registry_invalid")
+        with self._lock:
+            project = self._state["projects"].get(project_id)
+            if (
+                project is None
+                or project.get("branch") != normalized_branch
+                or project.get("head") not in expected_heads
+            ):
+                raise ProjectHostHelperError("project_changed")
+            if project["head"] == head:
+                return
+            previous = dict(project)
+            project["head"] = head
+            try:
+                self._persist()
+            except (OSError, ProjectHostHelperError):
+                self._state["projects"][project_id] = previous
+                raise
+
     def rename_project(self, project_id: str, name: str) -> None:
         normalized = _normalize_name(name)
         with self._lock:
@@ -220,38 +272,120 @@ class ProjectHostRegistry:
                 raise ProjectHostHelperError("project_not_found")
             return dict(value)
 
-    def create_snapshot(self, project_id: str, destination: Path) -> HostSnapshotResult:
+    def create_snapshot(
+        self,
+        project_id: str,
+        destination: Path,
+        *,
+        expected_head: str | None = None,
+        expected_branch: str | None = None,
+        managed_operation_id: str | None = None,
+    ) -> HostSnapshotResult:
         registered = self.project(project_id)
-        inspected = inspect_git_project(
-            registered["path"],
-            self.device_secret,
+        managed_recovery = bool(
+            expected_head
+            and expected_branch
+            and managed_operation_id is not None
+            and self.has_managed_operation(
+                project_id,
+                branch=expected_branch,
+                expected_head=expected_head,
+                operation_id=managed_operation_id,
+            )
+        )
+        inspected = (
+            inspect_git_project_for_recovery(
+                registered["path"],
+                self.device_secret,
+                expected_project_id=project_id,
+                expected_branch=str(expected_branch),
+                expected_head=str(expected_head),
+            )
+            if managed_recovery
+            else inspect_git_project(
+                registered["path"],
+                self.device_secret,
+            )
         )
         if inspected["project_id"] != project_id:
             raise ProjectHostHelperError("project_identity_changed")
+        if managed_operation_id is not None and not managed_recovery:
+            if (
+                expected_head is None
+                or expected_branch is None
+                or inspected.get("head") != expected_head
+                or inspected.get("branch") != expected_branch
+            ):
+                raise ProjectHostHelperError("project_changed")
         inspected["name"] = registered["name"]
-        self.remember_project(inspected)
+        if not managed_recovery:
+            self.remember_project(inspected)
         try:
             result = create_host_snapshot_archive(
                 Path(inspected["path"]),
                 destination,
                 project_id=project_id,
                 name=inspected["name"],
-                branch=inspected["branch"],
-                head=inspected["head"],
+                branch=str(expected_branch or inspected["branch"]),
+                head=str(expected_head or inspected["head"]),
             )
-            rechecked = inspect_git_project(
-                registered["path"],
-                self.device_secret,
+            rechecked = (
+                inspect_git_project_for_recovery(
+                    registered["path"],
+                    self.device_secret,
+                    expected_project_id=project_id,
+                    expected_branch=str(expected_branch),
+                    expected_head=str(expected_head),
+                )
+                if managed_recovery
+                else inspect_git_project(
+                    registered["path"],
+                    self.device_secret,
+                )
             )
             if any(
                 rechecked[key] != inspected[key]
-                for key in ("project_id", "branch", "head")
+                for key in (
+                    ("project_id", "branch")
+                    if managed_recovery
+                    else ("project_id", "branch", "head")
+                )
             ):
                 destination.unlink(missing_ok=True)
                 raise ProjectHostHelperError("project_changed")
             return result
         except Exception as exc:
             raise ProjectHostHelperError(getattr(exc, "code", "snapshot_failed")) from exc
+
+    def has_managed_operation(
+        self,
+        project_id: str,
+        *,
+        branch: str,
+        expected_head: str,
+        operation_id: str,
+    ) -> bool:
+        # The journal is loaded and authenticated by HostOperationJournal.  A
+        # matching durable intent is the only reason a helper may bypass the
+        # initial clean-worktree qualification after a managed writeback.
+        try:
+            record = self.operations.get(operation_id)
+        except HostOperationLogError:
+            return False
+        return bool(
+            record is not None
+            and record.action in {"apply", "commit"}
+            and record.project_id == project_id
+            and record.branch == branch
+            and record.expected_head == expected_head
+            and record.state
+            in {
+                "applying",
+                "applied",
+                "committing",
+                "committed",
+            }
+        )
 
     def _load(self) -> dict[str, Any]:
         if not self.path.exists():
@@ -364,6 +498,82 @@ def inspect_git_project(
         "name": _normalize_name(resolved.name),
         "branch": branch,
         "head": head,
+        "state": "available",
+        "reason": "",
+        "path": str(resolved),
+    }
+
+
+def inspect_git_project_for_recovery(
+    path: str | Path,
+    device_secret: bytes,
+    *,
+    expected_project_id: str,
+    expected_branch: str,
+    expected_head: str,
+    enforce_windows: bool = True,
+) -> dict[str, str]:
+    """Inspect only immutable identity needed to rebuild a managed baseline.
+
+    This deliberately does not require a clean worktree or current HEAD: an
+    applied draft is dirty by design and a committed task has advanced HEAD.
+    The caller must first prove a matching authenticated operation journal.
+    """
+    project_path = Path(path)
+    if not project_path.is_absolute() or not project_path.is_dir():
+        raise ProjectHostHelperError("project_path_invalid")
+    if enforce_windows:
+        _validate_windows_local_path(project_path)
+    elif project_path.is_symlink():
+        raise ProjectHostHelperError("project_reparse_point_not_allowed")
+    resolved = project_path.resolve(strict=True)
+    git_path = resolved / ".git"
+    if git_path.is_symlink() or git_path.is_file():
+        raise ProjectHostHelperError("git_worktree_not_allowed")
+    if not git_path.is_dir() or (git_path / "commondir").exists():
+        raise ProjectHostHelperError("git_shared_directory_not_allowed")
+    for name in ("alternates", "http-alternates"):
+        alternate = git_path / "objects" / "info" / name
+        if alternate.is_symlink() or (
+            alternate.is_file() and alternate.stat().st_size > 0
+        ):
+            raise ProjectHostHelperError("git_alternates_not_allowed")
+    branch = _git_text(
+        resolved,
+        "symbolic-ref",
+        "--quiet",
+        "--short",
+        "HEAD",
+        error_code="git_branch_required",
+    )
+    if branch != expected_branch or not _valid_branch(branch):
+        raise ProjectHostHelperError("project_changed")
+    historical_head = _git_text(
+        resolved,
+        "rev-parse",
+        "--verify",
+        f"{expected_head}^{{commit}}",
+        error_code="git_head_required",
+    ).lower()
+    if historical_head != expected_head or OBJECT_ID_PATTERN.fullmatch(historical_head) is None:
+        raise ProjectHostHelperError("project_changed")
+    tree = _run_git(resolved, "ls-tree", "-r", "-z", "--full-tree", expected_head)
+    if tree.returncode != 0:
+        raise ProjectHostHelperError("git_tree_unreadable")
+    try:
+        validate_git_tree(tree.stdout)
+    except Exception as exc:
+        raise ProjectHostHelperError(getattr(exc, "code", "git_tree_invalid")) from exc
+    canonical = os.path.normcase(str(resolved)).encode("utf-8", errors="strict")
+    digest = hmac.new(device_secret, canonical, hashlib.sha256).hexdigest()[:32]
+    project_id = f"hostgit_{digest}"
+    if project_id != expected_project_id:
+        raise ProjectHostHelperError("project_identity_changed")
+    return {
+        "project_id": project_id,
+        "name": _normalize_name(resolved.name),
+        "branch": branch,
+        "head": expected_head,
         "state": "available",
         "reason": "",
         "path": str(resolved),
@@ -596,6 +806,9 @@ class ProjectHostTransport:
         elif message_type == "snapshot_project":
             project_id = str(message.get("project_id") or "")
             transfer_id = str(message.get("transfer_id") or "")
+            expected_head = message.get("expected_head")
+            expected_branch = message.get("expected_branch")
+            managed_operation_id = message.get("managed_operation_id")
             if PROJECT_ID_PATTERN.fullmatch(project_id) is None or not re.fullmatch(
                 r"[a-f0-9]{32}", transfer_id
             ):
@@ -609,6 +822,17 @@ class ProjectHostTransport:
                     self.registry.create_snapshot,
                     project_id,
                     archive,
+                    expected_head=(
+                        str(expected_head) if expected_head is not None else None
+                    ),
+                    expected_branch=(
+                        str(expected_branch) if expected_branch is not None else None
+                    ),
+                    managed_operation_id=(
+                        str(managed_operation_id)
+                        if managed_operation_id is not None
+                        else None
+                    ),
                 )
                 await asyncio.to_thread(self._upload_snapshot, transfer_id, archive)
                 await websocket.send(
@@ -633,8 +857,542 @@ class ProjectHostTransport:
                 await self._error(websocket, request_id, exc.code)
             finally:
                 archive.unlink(missing_ok=True)
+        elif message_type == "execute_operation":
+            try:
+                if not self.direct_writeback:
+                    raise ProjectHostHelperError("project_host_writeback_disabled")
+                result = await asyncio.to_thread(
+                    self._handle_operation_message,
+                    message,
+                )
+                await websocket.send(
+                    json.dumps(
+                        {
+                            "type": "operation_result",
+                            "request_id": request_id,
+                            "project_id": str(message.get("project_id") or ""),
+                            "operation_id": str(message.get("operation_id") or ""),
+                            "action": str(message.get("action") or ""),
+                            "result": result,
+                        },
+                        ensure_ascii=False,
+                        separators=(",", ":"),
+                    )
+                )
+            except (ProjectHostHelperError, HostApplyError, HostCommitError) as exc:
+                await self._error(websocket, request_id, exc.code)
         else:
             raise ProjectHostHelperError("project_host_message_unsupported")
+
+    def _handle_operation_message(self, message: dict[str, Any]) -> dict[str, Any]:
+        expected_keys = {
+            "type",
+            "request_id",
+            "project_id",
+            "operation_id",
+            "action",
+            "payload_id",
+            "payload_sha256",
+            "payload_size",
+            "payload_expires_at",
+        }
+        project_id = str(message.get("project_id") or "")
+        operation_id = str(message.get("operation_id") or "")
+        action = str(message.get("action") or "")
+        payload_id = str(message.get("payload_id") or "")
+        digest = str(message.get("payload_sha256") or "")
+        size = message.get("payload_size")
+        expires_at = message.get("payload_expires_at")
+        if (
+            set(message) != expected_keys
+            or PROJECT_ID_PATTERN.fullmatch(project_id) is None
+            or OPERATION_ID_PATTERN.fullmatch(operation_id) is None
+            or action not in OPERATION_ACTIONS
+            or PAYLOAD_ID_PATTERN.fullmatch(payload_id) is None
+            or not re.fullmatch(r"[a-f0-9]{64}", digest)
+            or isinstance(size, bool)
+            or not isinstance(size, int)
+            or not 0 < size <= MAX_OPERATION_PAYLOAD_BYTES
+            or isinstance(expires_at, bool)
+            or not isinstance(expires_at, (int, float))
+            or not time.time() < float(expires_at) <= time.time() + 120.0
+        ):
+            raise ProjectHostHelperError("operation_request_invalid")
+        body = self._download_operation_payload(
+            payload_id=payload_id,
+            project_id=project_id,
+            operation_id=operation_id,
+            action=action,
+            expected_size=size,
+            expected_sha256=digest,
+        )
+        try:
+            envelope = json.loads(body.decode("utf-8", errors="strict"))
+        except (UnicodeError, json.JSONDecodeError) as exc:
+            raise ProjectHostHelperError("operation_payload_invalid") from exc
+        if (
+            not isinstance(envelope, dict)
+            or set(envelope)
+            != {
+                "version",
+                "host_id",
+                "project_id",
+                "operation_id",
+                "action",
+                "branch",
+                "head",
+                "payload",
+            }
+            or envelope.get("version") != 1
+            or envelope.get("project_id") != project_id
+            or envelope.get("operation_id") != operation_id
+            or envelope.get("action") != action
+            or not isinstance(envelope.get("payload"), dict)
+        ):
+            raise ProjectHostHelperError("operation_payload_mismatch")
+        credentials = self.registry.credentials
+        if credentials is None or envelope.get("host_id") != credentials[0]:
+            raise ProjectHostHelperError("operation_payload_mismatch")
+        registered = self.registry.project(project_id)
+        try:
+            branch = validate_commit_branch(str(envelope.get("branch") or ""))
+        except ValueError as exc:
+            raise ProjectHostHelperError("operation_payload_invalid") from exc
+        baseline_head = str(envelope.get("head") or "").lower()
+        if OBJECT_ID_PATTERN.fullmatch(baseline_head) is None:
+            raise ProjectHostHelperError("operation_payload_invalid")
+        result = self._execute_project_operation(
+            registered,
+            operation_id=operation_id,
+            action=action,
+            payload=envelope["payload"],
+            branch=branch,
+            baseline_head=baseline_head,
+        )
+        try:
+            self._update_registry_after_operation(
+                registered,
+                branch=branch,
+                baseline_head=baseline_head,
+                result=result,
+            )
+        except (OSError, ProjectHostHelperError) as exc:
+            raise ProjectHostHelperError("operation_result_unknown") from exc
+        return result
+
+    def _download_operation_payload(
+        self,
+        *,
+        payload_id: str,
+        project_id: str,
+        operation_id: str,
+        action: str,
+        expected_size: int,
+        expected_sha256: str,
+    ) -> bytes:
+        credentials = self.registry.credentials
+        if credentials is None:
+            raise ProjectHostHelperError("project_host_credentials_invalid")
+        host_id, token = credentials
+        parsed = urlsplit(self.server_url)
+        connection = http.client.HTTPConnection(
+            "127.0.0.1",
+            parsed.port or 80,
+            timeout=30,
+        )
+        try:
+            connection.request(
+                "GET",
+                f"/api/coding/project-host/operations/{payload_id}",
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "X-ModelMirror-Project-Host-Id": host_id,
+                    "X-ModelMirror-Project-Id": project_id,
+                    "X-ModelMirror-Operation-Id": operation_id,
+                    "X-ModelMirror-Operation-Action": action,
+                    "Accept": "application/json",
+                },
+            )
+            response = connection.getresponse()
+            content_length = response.getheader("Content-Length")
+            content_type = response.getheader("Content-Type") or ""
+            cache_control = response.getheader("Cache-Control") or ""
+            if response.status != 200:
+                response.read(64 * 1024)
+                raise ProjectHostHelperError("operation_payload_unavailable")
+            if (
+                content_length != str(expected_size)
+                or not content_type.lower().startswith("application/json")
+                or "no-store" not in cache_control.lower()
+            ):
+                raise ProjectHostHelperError("operation_payload_invalid")
+            body = response.read(expected_size + 1)
+        except (OSError, http.client.HTTPException) as exc:
+            raise ProjectHostHelperError("operation_payload_unavailable") from exc
+        finally:
+            connection.close()
+        if (
+            len(body) != expected_size
+            or hashlib.sha256(body).hexdigest() != expected_sha256
+        ):
+            raise ProjectHostHelperError("operation_payload_invalid")
+        return body
+
+    def _execute_project_operation(
+        self,
+        registered: dict[str, str],
+        *,
+        operation_id: str,
+        action: str,
+        payload: dict[str, Any],
+        branch: str,
+        baseline_head: str,
+    ) -> dict[str, Any]:
+        project_id = registered["project_id"]
+        root = Path(registered["path"])
+        apply_engine = HostGitApplyEngine(root, project_id, self.registry.operations)
+        commit_engine = HostGitCommitEngine(root, project_id, self.registry.operations)
+        try:
+            if action == "apply":
+                _require_payload_keys(
+                    payload,
+                    {
+                        "kind",
+                        "revision",
+                        "expected_head",
+                        "snapshot_fingerprint",
+                        "patch",
+                        "paths",
+                    },
+                    kind="apply",
+                )
+                _require_expected_head(payload, baseline_head)
+                receipt = apply_engine.apply(
+                    operation_id=operation_id,
+                    revision=int(payload["revision"]),
+                    branch=branch,
+                    expected_head=baseline_head,
+                    snapshot_fingerprint=str(payload["snapshot_fingerprint"]),
+                    patch=str(payload["patch"]),
+                    paths=_string_paths(payload["paths"]),
+                )
+                return {"state": "applied", "receipt": _receipt_to_payload(receipt)}
+            if action == "revert":
+                _require_payload_keys(
+                    payload,
+                    {"kind", "expected_head", "apply_receipt"},
+                    kind="revert",
+                )
+                _require_expected_head(payload, baseline_head)
+                receipt = _apply_receipt(payload.get("apply_receipt"))
+                _require_bound_apply_record(
+                    self.registry.operations,
+                    project_id=project_id,
+                    branch=branch,
+                    expected_head=baseline_head,
+                    receipt=receipt,
+                )
+                reverted = apply_engine.revert(
+                    operation_id=operation_id,
+                    apply_receipt=receipt,
+                    branch=branch,
+                    expected_head=baseline_head,
+                )
+                return {"state": "reverted", "receipt": _receipt_to_payload(reverted)}
+            if action == "commit":
+                _require_payload_keys(
+                    payload,
+                    {"kind", "expected_head", "apply_receipt", "message"},
+                    kind="commit",
+                )
+                _require_expected_head(payload, baseline_head)
+                apply_receipt = _apply_receipt(payload.get("apply_receipt"))
+                _require_bound_apply_record(
+                    self.registry.operations,
+                    project_id=project_id,
+                    branch=branch,
+                    expected_head=baseline_head,
+                    receipt=apply_receipt,
+                )
+                receipt = commit_engine.commit(
+                    operation_id=operation_id,
+                    apply_receipt=apply_receipt,
+                    branch=branch,
+                    expected_head=baseline_head,
+                    message=str(payload["message"]),
+                )
+                return {"state": "committed", "receipt": _commit_receipt_to_payload(receipt)}
+            if action == "undo":
+                _require_payload_keys(
+                    payload,
+                    {
+                        "kind",
+                        "expected_head",
+                        "apply_receipt",
+                        "commit_receipt",
+                    },
+                    kind="undo",
+                )
+                _require_expected_head(payload, baseline_head)
+                apply_receipt = _apply_receipt(payload.get("apply_receipt"))
+                commit_receipt = _commit_receipt(payload.get("commit_receipt"))
+                _require_bound_apply_record(
+                    self.registry.operations,
+                    project_id=project_id,
+                    branch=branch,
+                    expected_head=baseline_head,
+                    receipt=apply_receipt,
+                )
+                _require_bound_commit_record(
+                    self.registry.operations,
+                    project_id=project_id,
+                    branch=branch,
+                    apply_receipt=apply_receipt,
+                    receipt=commit_receipt,
+                )
+                receipt = commit_engine.undo(
+                    operation_id=operation_id,
+                    apply_receipt=apply_receipt,
+                    commit_receipt=commit_receipt,
+                    branch=branch,
+                )
+                return {"state": "undone", "receipt": _commit_receipt_to_payload(receipt)}
+            if action == "reconcile":
+                kind = payload.get("kind")
+                if kind == "apply":
+                    return self._reconcile_apply_operation(
+                        apply_engine,
+                        project_id=project_id,
+                        operation_id=operation_id,
+                        branch=branch,
+                        baseline_head=baseline_head,
+                        payload=payload,
+                    )
+                if kind == "commit":
+                    return self._reconcile_commit_operation(
+                        apply_engine,
+                        commit_engine,
+                        project_id=project_id,
+                        operation_id=operation_id,
+                        branch=branch,
+                        baseline_head=baseline_head,
+                        payload=payload,
+                    )
+        except (ValueError, TypeError, KeyError) as exc:
+            raise ProjectHostHelperError("operation_payload_invalid") from exc
+        raise ProjectHostHelperError("operation_request_invalid")
+
+    def _update_registry_after_operation(
+        self,
+        registered: dict[str, str],
+        *,
+        branch: str,
+        baseline_head: str,
+        result: dict[str, Any],
+    ) -> None:
+        state = result.get("state")
+        if state == "conflict":
+            return
+        head = baseline_head
+        expected_heads = {baseline_head}
+        if state in {"committed", "undone"}:
+            receipt_payload = (
+                result.get("commit_receipt")
+                if "commit_receipt" in result
+                else result.get("receipt")
+            )
+            receipt = _commit_receipt(receipt_payload)
+            head = receipt.commit_sha if state == "committed" else receipt.parent_sha
+            expected_heads.update({receipt.parent_sha, receipt.commit_sha})
+        elif state not in {
+            "applied",
+            "reverted",
+            "not_applied",
+            "not_committed",
+        }:
+            raise ProjectHostHelperError("operation_result_unknown")
+        self.registry.update_project_head(
+            registered["project_id"],
+            branch=branch,
+            expected_heads=expected_heads | {head},
+            head=head,
+        )
+
+    def _reconcile_apply_operation(
+        self,
+        engine: HostGitApplyEngine,
+        *,
+        project_id: str,
+        operation_id: str,
+        branch: str,
+        baseline_head: str,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        _require_payload_keys(
+            payload,
+            {
+                "kind",
+                "revision",
+                "expected_head",
+                "snapshot_fingerprint",
+                "patch_sha256",
+                "paths",
+            },
+            kind="apply",
+        )
+        _require_expected_head(payload, baseline_head)
+        record = self.registry.operations.get(operation_id)
+        if record is None:
+            return {"state": "not_applied", "receipt": None}
+        if (
+            record.action != "apply"
+            or record.project_id != project_id
+            or record.branch != branch
+            or record.expected_head != baseline_head
+            or record.patch_sha256 != payload.get("patch_sha256")
+            or record.revision != payload.get("revision")
+        ):
+            return {"state": "conflict", "receipt": None}
+        receipt = (
+            _apply_receipt(record.apply_receipt)
+            if record.apply_receipt is not None
+            else None
+        )
+        if receipt is not None and tuple(item.path for item in receipt.files) != _string_paths(
+            payload.get("paths")
+        ):
+            return {"state": "conflict", "receipt": None}
+        revert_id = _followup_operation_id("revert", operation_id)
+        revert_record = self.registry.operations.get(revert_id)
+        if revert_record is not None:
+            if (
+                receipt is None
+                or revert_record.action != "revert"
+                or revert_record.project_id != project_id
+                or revert_record.branch != branch
+                or revert_record.expected_head != baseline_head
+                or revert_record.apply_receipt != _receipt_to_payload(receipt)
+                or revert_record.state == "conflict"
+            ):
+                return {"state": "conflict", "receipt": None}
+            if revert_record.state != "reverted":
+                engine.revert(
+                    operation_id=revert_id,
+                    apply_receipt=receipt,
+                    branch=branch,
+                    expected_head=baseline_head,
+                )
+            return {"state": "not_applied", "receipt": None}
+        state, restored = engine.reconcile_apply(
+            operation_id=operation_id,
+            snapshot_fingerprint=str(payload["snapshot_fingerprint"]),
+        )
+        return {
+            "state": state,
+            "receipt": _receipt_to_payload(restored) if restored is not None else None,
+        }
+
+    def _reconcile_commit_operation(
+        self,
+        apply_engine: HostGitApplyEngine,
+        commit_engine: HostGitCommitEngine,
+        *,
+        project_id: str,
+        operation_id: str,
+        branch: str,
+        baseline_head: str,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        _require_payload_keys(
+            payload,
+            {
+                "kind",
+                "apply_operation_id",
+                "revision",
+                "expected_head",
+                "snapshot_fingerprint",
+                "patch_sha256",
+                "paths",
+                "apply_receipt",
+                "message",
+            },
+            kind="commit",
+        )
+        _require_expected_head(payload, baseline_head)
+        apply_operation_id = str(payload.get("apply_operation_id") or "")
+        if OPERATION_ID_PATTERN.fullmatch(apply_operation_id) is None:
+            raise ProjectHostHelperError("operation_payload_invalid")
+        apply_receipt = _apply_receipt(payload.get("apply_receipt"))
+        apply_record = self.registry.operations.get(apply_operation_id)
+        if (
+            apply_record is None
+            or apply_record.action != "apply"
+            or apply_record.project_id != project_id
+            or apply_record.branch != branch
+            or apply_record.expected_head != baseline_head
+            or apply_record.patch_sha256 != payload.get("patch_sha256")
+            or apply_record.revision != payload.get("revision")
+            or apply_record.apply_receipt != _receipt_to_payload(apply_receipt)
+            or tuple(item.path for item in apply_receipt.files)
+            != _string_paths(payload.get("paths"))
+        ):
+            raise ProjectHostHelperError("operation_conflict")
+        commit_record = self.registry.operations.get(operation_id)
+        if commit_record is None:
+            apply_state, restored_apply = apply_engine.reconcile_apply(
+                operation_id=apply_operation_id,
+                snapshot_fingerprint=str(payload["snapshot_fingerprint"]),
+            )
+            if apply_state != "applied" or restored_apply != apply_receipt:
+                raise ProjectHostHelperError("operation_conflict")
+            return {
+                "state": "not_committed",
+                "apply_receipt": _receipt_to_payload(apply_receipt),
+                "commit_receipt": None,
+            }
+        if (
+            commit_record.action != "commit"
+            or commit_record.project_id != project_id
+            or commit_record.branch != branch
+            or commit_record.expected_head != baseline_head
+            or commit_record.commit_message != payload.get("message")
+            or commit_record.revision != apply_receipt.revision
+            or commit_record.patch_sha256 != apply_record.patch_sha256
+            or commit_record.apply_receipt != _receipt_to_payload(apply_receipt)
+        ):
+            raise ProjectHostHelperError("operation_conflict")
+        undo_id = _followup_operation_id("undo", operation_id)
+        undo_record = self.registry.operations.get(undo_id)
+        if undo_record is not None:
+            stored_commit_receipt = (
+                _commit_receipt(commit_record.commit_receipt)
+                if commit_record.commit_receipt is not None
+                else None
+            )
+            if (
+                stored_commit_receipt is None
+                or undo_record.action != "undo"
+                or undo_record.project_id != project_id
+                or undo_record.branch != branch
+                or undo_record.expected_head != stored_commit_receipt.commit_sha
+                or undo_record.revision != apply_receipt.revision
+                or undo_record.patch_sha256 != apply_record.patch_sha256
+                or undo_record.apply_receipt != _receipt_to_payload(apply_receipt)
+                or undo_record.commit_receipt
+                != _commit_receipt_to_payload(stored_commit_receipt)
+            ):
+                raise ProjectHostHelperError("operation_conflict")
+        target_operation = undo_id if undo_record is not None else operation_id
+        state, receipt = commit_engine.reconcile(target_operation)
+        if state == "conflict":
+            raise ProjectHostHelperError("operation_conflict")
+        return {
+            "state": state,
+            "apply_receipt": _receipt_to_payload(apply_receipt),
+            "commit_receipt": (
+                _commit_receipt_to_payload(receipt) if receipt is not None else None
+            ),
+        }
 
     def _upload_snapshot(self, transfer_id: str, archive: Path) -> None:
         credentials = self.registry.credentials
@@ -749,6 +1507,108 @@ class ProjectHostWindow:
         if self.registry.credentials is not None:
             self._start()
         self.root.mainloop()
+
+
+def _require_bound_apply_record(
+    journal: HostOperationJournal,
+    *,
+    project_id: str,
+    branch: str,
+    expected_head: str,
+    receipt: Any,
+) -> None:
+    try:
+        record = journal.get(receipt.apply_id)
+    except HostOperationLogError as exc:
+        raise ProjectHostHelperError("operation_conflict") from exc
+    if (
+        record is None
+        or record.action != "apply"
+        or record.state != "applied"
+        or record.project_id != project_id
+        or record.branch != branch
+        or record.expected_head != expected_head
+        or record.revision != receipt.revision
+        or record.apply_receipt != _receipt_to_payload(receipt)
+    ):
+        raise ProjectHostHelperError("operation_conflict")
+
+
+def _require_bound_commit_record(
+    journal: HostOperationJournal,
+    *,
+    project_id: str,
+    branch: str,
+    apply_receipt: Any,
+    receipt: Any,
+) -> None:
+    try:
+        record = journal.get(receipt.commit_id)
+    except HostOperationLogError as exc:
+        raise ProjectHostHelperError("operation_conflict") from exc
+    if (
+        record is None
+        or record.action != "commit"
+        or record.state != "committed"
+        or record.project_id != project_id
+        or record.branch != branch
+        or record.expected_head != receipt.parent_sha
+        or record.revision != apply_receipt.revision
+        or record.apply_receipt != _receipt_to_payload(apply_receipt)
+        or record.commit_receipt != _commit_receipt_to_payload(receipt)
+    ):
+        raise ProjectHostHelperError("operation_conflict")
+
+
+def _require_payload_keys(
+    payload: dict[str, Any],
+    expected: set[str],
+    *,
+    kind: str,
+) -> None:
+    if set(payload) != expected or payload.get("kind") != kind:
+        raise ProjectHostHelperError("operation_payload_invalid")
+
+
+def _require_expected_head(payload: dict[str, Any], expected_head: str) -> None:
+    if payload.get("expected_head") != expected_head:
+        raise ProjectHostHelperError("project_changed")
+
+
+def _string_paths(value: Any) -> tuple[str, ...]:
+    if (
+        not isinstance(value, list)
+        or not 1 <= len(value) <= 20
+        or any(not isinstance(item, str) or not item for item in value)
+        or tuple(value) != tuple(sorted(set(value)))
+    ):
+        raise ProjectHostHelperError("operation_payload_invalid")
+    return tuple(value)
+
+
+def _apply_receipt(value: Any):
+    if not isinstance(value, dict):
+        raise ProjectHostHelperError("operation_payload_invalid")
+    try:
+        return _receipt_from_response({"receipt": value})
+    except Exception as exc:
+        raise ProjectHostHelperError("operation_payload_invalid") from exc
+
+
+def _commit_receipt(value: Any):
+    if not isinstance(value, dict):
+        raise ProjectHostHelperError("operation_payload_invalid")
+    try:
+        return _commit_receipt_from_response({"receipt": value})
+    except Exception as exc:
+        raise ProjectHostHelperError("operation_payload_invalid") from exc
+
+
+def _followup_operation_id(action: str, operation_id: str) -> str:
+    if action not in {"revert", "undo"} or OPERATION_ID_PATTERN.fullmatch(operation_id) is None:
+        raise ProjectHostHelperError("operation_request_invalid")
+    digest = hashlib.sha256(f"{action}\0{operation_id}".encode("utf-8")).hexdigest()
+    return f"{action}_{digest[:40]}"
 
 
 def _validate_windows_local_path(path: Path) -> None:

--- a/server/coding_project_host/windows_helper.py
+++ b/server/coding_project_host/windows_helper.py
@@ -420,8 +420,13 @@ class ProjectHostRegistry:
                     name=inspected["name"],
                     branch=str(expected_branch or inspected["branch"]),
                     head=str(expected_head or inspected["head"]),
+                    identity_provider=file_identity,
+                    identity_cleanup=_remove_regular_identity,
                 )
-                archive_identity = file_identity(destination)
+                archive_identity = result.archive_identity
+                if _FILE_IDENTITY_PATTERN.fullmatch(str(archive_identity or "")) is None:
+                    raise ProjectHostHelperError("snapshot_failed")
+                assert archive_identity is not None
                 rechecked = (
                     _inspect_git_project_for_recovery_guarded(
                         resolved,

--- a/server/coding_project_host/windows_helper.py
+++ b/server/coding_project_host/windows_helper.py
@@ -27,8 +27,10 @@ from server.coding_runtime.project_host import (
     OBJECT_ID_PATTERN,
     PROJECT_HOST_PLATFORM,
     PROJECT_HOST_PROTOCOL,
+    PROJECT_HOST_V2_CAPABILITIES,
     PROJECT_ID_PATTERN,
 )
+from server.coding_project_host.operation_log import HostOperationJournal
 from server.coding_runtime.host_snapshot import (
     HostSnapshotResult,
     create_host_snapshot_archive,
@@ -41,7 +43,7 @@ from server.coding_runtime.projects import (
 )
 
 
-HELPER_VERSION = "1.0.1"
+HELPER_VERSION = "1.1.0"
 STATE_MAGIC = b"MMCPH1\n"
 MAX_CONTROL_MESSAGE_BYTES = 256 * 1024
 DEFAULT_SERVER_URL = "http://127.0.0.1:8000"
@@ -147,6 +149,10 @@ class ProjectHostRegistry:
         self.protector = protector
         self._lock = threading.RLock()
         self._state = self._load()
+        self.operations = HostOperationJournal(
+            self.path.with_name("operations.bin"),
+            protector,
+        )
 
     @property
     def device_id(self) -> str:
@@ -411,6 +417,7 @@ class ProjectHostTransport:
         self.pairing_code = str(pairing_code or "").strip()
         self.select_folder = select_folder
         self.status_changed = status_changed or (lambda _value: None)
+        self.direct_writeback = False
 
     async def run_forever(self) -> None:
         from websockets.asyncio.client import connect
@@ -484,6 +491,7 @@ class ProjectHostTransport:
                 "device_id": self.registry.device_id,
                 "version": HELPER_VERSION,
                 "platform": PROJECT_HOST_PLATFORM,
+                "capabilities": list(PROJECT_HOST_V2_CAPABILITIES),
             }
         else:
             if len(self.pairing_code) != 8 or not self.pairing_code.isdigit():
@@ -495,13 +503,26 @@ class ProjectHostTransport:
                 "device_id": self.registry.device_id,
                 "version": HELPER_VERSION,
                 "platform": PROJECT_HOST_PLATFORM,
+                "capabilities": list(PROJECT_HOST_V2_CAPABILITIES),
             }
         await websocket.send(json.dumps(first, separators=(",", ":")))
         response = _parse_message(await asyncio.wait_for(websocket.recv(), timeout=15))
         if response.get("type") == "error":
             raise ProjectHostHelperError("project_host_authentication_rejected")
-        if response.get("type") != "welcome" or response.get("protocol") != PROJECT_HOST_PROTOCOL:
+        capabilities = response.get("capabilities")
+        if (
+            response.get("type") != "welcome"
+            or response.get("protocol") != PROJECT_HOST_PROTOCOL
+            or not isinstance(capabilities, list)
+            or "snapshot" not in capabilities
+            or any(item not in PROJECT_HOST_V2_CAPABILITIES for item in capabilities)
+            or not isinstance(response.get("direct_writeback"), bool)
+        ):
             raise ProjectHostHelperError("project_host_handshake_failed")
+        self.direct_writeback = bool(
+            response["direct_writeback"]
+            and {"writeback", "commit", "reconcile"}.issubset(capabilities)
+        )
         if response.get("paired") is True:
             self.registry.save_credentials(
                 str(response.get("host_id") or ""),

--- a/server/coding_project_host/windows_helper.py
+++ b/server/coding_project_host/windows_helper.py
@@ -12,8 +12,10 @@ import json
 import os
 import re
 import secrets
+import stat
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 import unicodedata
@@ -36,8 +38,24 @@ from server.coding_runtime.committer_client import (
     _commit_receipt_to_payload,
 )
 from server.coding_runtime.commit_models import validate_commit_branch
-from server.coding_project_host.host_apply_engine import HostApplyError, HostGitApplyEngine
-from server.coding_project_host.host_commit_engine import HostCommitError, HostGitCommitEngine
+from server.coding_project_host.host_apply_engine import (
+    HostApplyError,
+    HostGitApplyEngine,
+    _guard_directories,
+)
+from server.coding_project_host.host_commit_engine import (
+    HostCommitError,
+    HostGitCommitEngine,
+    _safe_git_namespace,
+)
+from server.coding_project_host.host_file_transaction import (
+    HostFileTransactionError,
+    _windows_close_handle,
+    _windows_handle_identity,
+    _windows_open_existing,
+    _windows_read_all,
+    file_identity,
+)
 from server.coding_project_host.operation_log import (
     HostOperationJournal,
     HostOperationLogError,
@@ -58,11 +76,21 @@ HELPER_VERSION = "1.1.0"
 STATE_MAGIC = b"MMCPH1\n"
 MAX_CONTROL_MESSAGE_BYTES = 256 * 1024
 MAX_OPERATION_PAYLOAD_BYTES = 1200 * 1024
+MAX_GIT_GUARDED_METADATA_BYTES = 64 * 1024 * 1024
+MAX_GIT_CONFIG_BYTES = 2 * 1024 * 1024
+MAX_GIT_INDEX_BYTES = 32 * 1024 * 1024
+MAX_GIT_PACKED_REFS_BYTES = 16 * 1024 * 1024
+MAX_GIT_INFO_LEAF_BYTES = 4 * 1024 * 1024
+MAX_REGISTERED_PROJECTS = 50
 OPERATION_ACTIONS = frozenset({"apply", "revert", "commit", "undo", "reconcile"})
 OPERATION_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]{20,64}$")
 PAYLOAD_ID_PATTERN = re.compile(r"^phop_[a-f0-9]{32}$")
-_LAZY_FETCH_CONFIG_PATTERN = re.compile(
-    r"^(?:extensions\.partialclone|remote\..*\.(?:promisor|partialclonefilter))$",
+_FILE_IDENTITY_PATTERN = re.compile(r"^[a-f0-9]+-[a-f0-9]+$")
+_UNSAFE_LOCAL_CONFIG_PATTERN = re.compile(
+    r"^(?:(?:include(?:if)?|filter|credential|diff|url)(?:\..+)?|"
+    r"core\.(?:worktree|excludesfile)|"
+    r"extensions\.(?:worktreeconfig|partialclone|refstorage)|"
+    r"remote\..*\.(?:promisor|partialclonefilter))$",
     re.IGNORECASE,
 )
 DEFAULT_SERVER_URL = "http://127.0.0.1:8000"
@@ -211,9 +239,45 @@ class ProjectHostRegistry:
 
     def remember_project(self, project: dict[str, str]) -> None:
         project_id = project.get("project_id", "")
-        if PROJECT_ID_PATTERN.fullmatch(project_id) is None or "path" not in project:
+        if (
+            PROJECT_ID_PATTERN.fullmatch(project_id) is None
+            or not isinstance(project.get("path"), str)
+            or _FILE_IDENTITY_PATTERN.fullmatch(str(project.get("root_identity") or ""))
+            is None
+            or _FILE_IDENTITY_PATTERN.fullmatch(str(project.get("git_identity") or ""))
+            is None
+        ):
             raise ProjectHostHelperError("project_registry_invalid")
         with self._lock:
+            if (
+                project_id not in self._state["projects"]
+                and len(self._state["projects"]) >= MAX_REGISTERED_PROJECTS
+            ):
+                # Match the Server catalog bound without first persisting a
+                # 51st entry that would make every subsequent inventory frame
+                # invalid. The user can remove the unavailable old selection
+                # and then explicitly select the replacement repository.
+                raise ProjectHostHelperError("project_limit_exceeded")
+            for key, value in tuple(self._state["projects"].items()):
+                legacy = (
+                    _FILE_IDENTITY_PATTERN.fullmatch(
+                        str(value.get("root_identity") or "")
+                    )
+                    is None
+                    or _FILE_IDENTITY_PATTERN.fullmatch(
+                        str(value.get("git_identity") or "")
+                    )
+                    is None
+                )
+                if legacy or (
+                    key != project_id and value.get("path") == project.get("path")
+                ):
+                    tombstone = dict(value)
+                    tombstone.pop("root_identity", None)
+                    tombstone.pop("git_identity", None)
+                    tombstone["state"] = "unavailable"
+                    tombstone["reason"] = "project_reselection_required"
+                    self._state["projects"][key] = tombstone
             self._state["projects"][project_id] = dict(project)
             self._persist()
 
@@ -274,6 +338,17 @@ class ProjectHostRegistry:
             value = self._state["projects"].get(project_id)
             if value is None:
                 raise ProjectHostHelperError("project_not_found")
+            if (
+                _FILE_IDENTITY_PATTERN.fullmatch(
+                    str(value.get("root_identity") or "")
+                )
+                is None
+                or _FILE_IDENTITY_PATTERN.fullmatch(
+                    str(value.get("git_identity") or "")
+                )
+                is None
+            ):
+                raise ProjectHostHelperError("project_reselection_required")
             return dict(value)
 
     def create_snapshot(
@@ -284,7 +359,7 @@ class ProjectHostRegistry:
         expected_head: str | None = None,
         expected_branch: str | None = None,
         managed_operation_id: str | None = None,
-    ) -> HostSnapshotResult:
+    ) -> tuple[HostSnapshotResult, str]:
         registered = self.project(project_id)
         managed_recovery = bool(
             expected_head
@@ -297,68 +372,89 @@ class ProjectHostRegistry:
                 operation_id=managed_operation_id,
             )
         )
-        inspected = (
-            inspect_git_project_for_recovery(
-                registered["path"],
-                self.device_secret,
-                expected_project_id=project_id,
-                expected_branch=str(expected_branch),
-                expected_head=str(expected_head),
-            )
-            if managed_recovery
-            else inspect_git_project(
-                registered["path"],
-                self.device_secret,
-            )
-        )
-        if inspected["project_id"] != project_id:
-            raise ProjectHostHelperError("project_identity_changed")
-        if managed_operation_id is not None and not managed_recovery:
-            if (
-                expected_head is None
-                or expected_branch is None
-                or inspected.get("head") != expected_head
-                or inspected.get("branch") != expected_branch
-            ):
-                raise ProjectHostHelperError("project_changed")
-        inspected["name"] = registered["name"]
-        if not managed_recovery:
-            self.remember_project(inspected)
+        archive_identity: str | None = None
         try:
-            result = create_host_snapshot_archive(
-                Path(inspected["path"]),
-                destination,
-                project_id=project_id,
-                name=inspected["name"],
-                branch=str(expected_branch or inspected["branch"]),
-                head=str(expected_head or inspected["head"]),
-            )
-            rechecked = (
-                inspect_git_project_for_recovery(
-                    registered["path"],
-                    self.device_secret,
-                    expected_project_id=project_id,
-                    expected_branch=str(expected_branch),
-                    expected_head=str(expected_head),
-                )
-                if managed_recovery
-                else inspect_git_project(
-                    registered["path"],
-                    self.device_secret,
-                )
-            )
-            if any(
-                rechecked[key] != inspected[key]
-                for key in (
-                    ("project_id", "branch")
+            # Keep the selected Git namespace and identity-bearing leaves
+            # protected for the complete inspect -> archive -> reinspect use
+            # interval.  In particular, cat-file must not outlive preflight.
+            with _guard_git_read_session(
+                registered["path"],
+                enforce_windows=True,
+                expected_root_identity=str(registered.get("root_identity") or ""),
+                expected_git_identity=str(registered.get("git_identity") or ""),
+            ) as (resolved, git_path, guarded):
+                inspected = (
+                    _inspect_git_project_for_recovery_guarded(
+                        resolved,
+                        git_path,
+                        self.device_secret,
+                        expected_project_id=project_id,
+                        expected_branch=str(expected_branch),
+                        expected_head=str(expected_head),
+                    )
                     if managed_recovery
-                    else ("project_id", "branch", "head")
+                    else _inspect_git_project_guarded(
+                        resolved,
+                        git_path,
+                        self.device_secret,
+                        guarded_metadata=guarded,
+                    )
                 )
-            ):
-                destination.unlink(missing_ok=True)
-                raise ProjectHostHelperError("project_changed")
-            return result
+                if inspected["project_id"] != project_id:
+                    raise ProjectHostHelperError("project_identity_changed")
+                if managed_operation_id is not None and not managed_recovery:
+                    if (
+                        expected_head is None
+                        or expected_branch is None
+                        or inspected.get("head") != expected_head
+                        or inspected.get("branch") != expected_branch
+                    ):
+                        raise ProjectHostHelperError("project_changed")
+                inspected["name"] = registered["name"]
+                if not managed_recovery:
+                    self.remember_project(inspected)
+                result = create_host_snapshot_archive(
+                    resolved,
+                    destination,
+                    project_id=project_id,
+                    name=inspected["name"],
+                    branch=str(expected_branch or inspected["branch"]),
+                    head=str(expected_head or inspected["head"]),
+                )
+                archive_identity = file_identity(destination)
+                rechecked = (
+                    _inspect_git_project_for_recovery_guarded(
+                        resolved,
+                        git_path,
+                        self.device_secret,
+                        expected_project_id=project_id,
+                        expected_branch=str(expected_branch),
+                        expected_head=str(expected_head),
+                    )
+                    if managed_recovery
+                    else _inspect_git_project_guarded(
+                        resolved,
+                        git_path,
+                        self.device_secret,
+                        guarded_metadata=guarded,
+                    )
+                )
+                if any(
+                    rechecked[key] != inspected[key]
+                    for key in (
+                        ("project_id", "branch")
+                        if managed_recovery
+                        else ("project_id", "branch", "head")
+                    )
+                ):
+                    raise ProjectHostHelperError("project_changed")
+                return result, archive_identity
         except Exception as exc:
+            if archive_identity is not None:
+                try:
+                    _remove_regular_identity(destination, archive_identity)
+                except Exception as cleanup_exc:
+                    raise ProjectHostHelperError("snapshot_cleanup_failed") from cleanup_exc
             raise ProjectHostHelperError(getattr(exc, "code", "snapshot_failed")) from exc
 
     def has_managed_operation(
@@ -406,7 +502,15 @@ class ProjectHostRegistry:
             protected = base64.b64decode(encoded[len(STATE_MAGIC) :], validate=True)
             state = json.loads(self.protector.unprotect(protected).decode("utf-8", errors="strict"))
             if not _valid_registry_state(state):
-                raise ValueError("invalid state")
+                if not _valid_legacy_registry_without_identities(state):
+                    raise ValueError("invalid state")
+                # Preserve legacy entries only as unavailable inventory
+                # tombstones. Operations reject their missing identities and
+                # explicit selection replaces them with a new identity-bound
+                # project id.
+                for project in state["projects"].values():
+                    project["state"] = "unavailable"
+                    project["reason"] = "project_reselection_required"
             return state
         except (OSError, UnicodeError, ValueError, json.JSONDecodeError) as exc:
             raise ProjectHostHelperError("project_host_registry_corrupt") from exc
@@ -434,24 +538,30 @@ def inspect_git_project(
     device_secret: bytes,
     *,
     enforce_windows: bool = True,
+    expected_root_identity: str | None = None,
+    expected_git_identity: str | None = None,
 ) -> dict[str, str]:
-    project_path = Path(path)
-    if not project_path.is_absolute() or not project_path.is_dir():
-        raise ProjectHostHelperError("project_path_invalid")
-    if enforce_windows:
-        _validate_windows_local_path(project_path)
-    elif project_path.is_symlink():
-        raise ProjectHostHelperError("project_reparse_point_not_allowed")
-    resolved = project_path.resolve(strict=True)
-    git_path = resolved / ".git"
-    if git_path.is_symlink() or git_path.is_file():
-        raise ProjectHostHelperError("git_worktree_not_allowed")
-    if not git_path.is_dir():
-        raise ProjectHostHelperError("git_repository_required")
-    if (git_path / "commondir").exists():
-        raise ProjectHostHelperError("git_shared_directory_not_allowed")
-    _assert_no_lazy_fetch_sources(resolved, git_path)
+    with _guard_git_read_session(
+        path,
+        enforce_windows=enforce_windows,
+        expected_root_identity=expected_root_identity,
+        expected_git_identity=expected_git_identity,
+    ) as (resolved, git_path, guarded):
+        return _inspect_git_project_guarded(
+            resolved,
+            git_path,
+            device_secret,
+            guarded_metadata=guarded,
+        )
 
+
+def _inspect_git_project_guarded(
+    resolved: Path,
+    git_path: Path,
+    device_secret: bytes,
+    *,
+    guarded_metadata: frozenset[str],
+) -> dict[str, str]:
     inside = _git_text(
         resolved,
         "rev-parse",
@@ -479,6 +589,11 @@ def inspect_git_project(
     ).lower()
     if OBJECT_ID_PATTERN.fullmatch(head) is None:
         raise ProjectHostHelperError("git_head_invalid")
+    # An unborn repository reaches git_head_required above.  Once HEAD names a
+    # real commit, the initial clean-worktree qualification must use the exact
+    # index object that was guarded before the first Git command.
+    if "index" not in guarded_metadata:
+        raise ProjectHostHelperError("git_metadata_unsafe")
     tree = _run_git(resolved, "ls-tree", "-r", "-z", "--full-tree", "HEAD")
     if tree.returncode != 0:
         raise ProjectHostHelperError("git_tree_unreadable")
@@ -493,7 +608,15 @@ def inspect_git_project(
     if status.stdout:
         raise ProjectHostHelperError("git_repository_dirty")
 
-    canonical = os.path.normcase(str(resolved)).encode("utf-8", errors="strict")
+    root_identity = file_identity(resolved)
+    git_identity = file_identity(git_path)
+    canonical = b"\0".join(
+        (
+            os.path.normcase(str(resolved)).encode("utf-8", errors="strict"),
+            root_identity.encode("ascii"),
+            git_identity.encode("ascii"),
+        )
+    )
     digest = hmac.new(device_secret, canonical, hashlib.sha256).hexdigest()[:32]
     return {
         "project_id": f"hostgit_{digest}",
@@ -503,6 +626,8 @@ def inspect_git_project(
         "state": "available",
         "reason": "",
         "path": str(resolved),
+        "root_identity": root_identity,
+        "git_identity": git_identity,
     }
 
 
@@ -513,6 +638,8 @@ def inspect_git_project_for_recovery(
     expected_project_id: str,
     expected_branch: str,
     expected_head: str,
+    expected_root_identity: str,
+    expected_git_identity: str,
     enforce_windows: bool = True,
 ) -> dict[str, str]:
     """Inspect only immutable identity needed to rebuild a managed baseline.
@@ -521,20 +648,31 @@ def inspect_git_project_for_recovery(
     applied draft is dirty by design and a committed task has advanced HEAD.
     The caller must first prove a matching authenticated operation journal.
     """
-    project_path = Path(path)
-    if not project_path.is_absolute() or not project_path.is_dir():
-        raise ProjectHostHelperError("project_path_invalid")
-    if enforce_windows:
-        _validate_windows_local_path(project_path)
-    elif project_path.is_symlink():
-        raise ProjectHostHelperError("project_reparse_point_not_allowed")
-    resolved = project_path.resolve(strict=True)
-    git_path = resolved / ".git"
-    if git_path.is_symlink() or git_path.is_file():
-        raise ProjectHostHelperError("git_worktree_not_allowed")
-    if not git_path.is_dir() or (git_path / "commondir").exists():
-        raise ProjectHostHelperError("git_shared_directory_not_allowed")
-    _assert_no_lazy_fetch_sources(resolved, git_path)
+    with _guard_git_read_session(
+        path,
+        enforce_windows=enforce_windows,
+        expected_root_identity=expected_root_identity,
+        expected_git_identity=expected_git_identity,
+    ) as (resolved, _git_path, _guarded):
+        return _inspect_git_project_for_recovery_guarded(
+            resolved,
+            _git_path,
+            device_secret,
+            expected_project_id=expected_project_id,
+            expected_branch=expected_branch,
+            expected_head=expected_head,
+        )
+
+
+def _inspect_git_project_for_recovery_guarded(
+    resolved: Path,
+    git_path: Path,
+    device_secret: bytes,
+    *,
+    expected_project_id: str,
+    expected_branch: str,
+    expected_head: str,
+) -> dict[str, str]:
     branch = _git_text(
         resolved,
         "symbolic-ref",
@@ -561,7 +699,15 @@ def inspect_git_project_for_recovery(
         validate_git_tree(tree.stdout)
     except Exception as exc:
         raise ProjectHostHelperError(getattr(exc, "code", "git_tree_invalid")) from exc
-    canonical = os.path.normcase(str(resolved)).encode("utf-8", errors="strict")
+    root_identity = file_identity(resolved)
+    git_identity = file_identity(git_path)
+    canonical = b"\0".join(
+        (
+            os.path.normcase(str(resolved)).encode("utf-8", errors="strict"),
+            root_identity.encode("ascii"),
+            git_identity.encode("ascii"),
+        )
+    )
     digest = hmac.new(device_secret, canonical, hashlib.sha256).hexdigest()[:32]
     project_id = f"hostgit_{digest}"
     if project_id != expected_project_id:
@@ -574,6 +720,8 @@ def inspect_git_project_for_recovery(
         "state": "available",
         "reason": "",
         "path": str(resolved),
+        "root_identity": root_identity,
+        "git_identity": git_identity,
     }
 
 
@@ -739,10 +887,33 @@ class ProjectHostTransport:
     async def _send_inventory(self, websocket: Any) -> None:
         projects: list[dict[str, Any]] = []
         for registered in self.registry.projects():
+            if (
+                _FILE_IDENTITY_PATTERN.fullmatch(
+                    str(registered.get("root_identity") or "")
+                )
+                is None
+                or _FILE_IDENTITY_PATTERN.fullmatch(
+                    str(registered.get("git_identity") or "")
+                )
+                is None
+            ):
+                projects.append(
+                    {
+                        "project_id": registered["project_id"],
+                        "name": registered["name"],
+                        "branch": registered["branch"],
+                        "head": registered["head"],
+                        "state": "unavailable",
+                        "reason": "project_reselection_required",
+                    }
+                )
+                continue
             try:
                 inspected = inspect_git_project(
                     registered["path"],
                     self.registry.device_secret,
+                    expected_root_identity=str(registered.get("root_identity") or ""),
+                    expected_git_identity=str(registered.get("git_identity") or ""),
                 )
                 inspected["name"] = registered["name"]
                 self.registry.remember_project(inspected)
@@ -774,6 +945,9 @@ class ProjectHostTransport:
             try:
                 project = inspect_git_project(selected, self.registry.device_secret)
                 self.registry.remember_project(project)
+                # Publish the old-id tombstone before acknowledging the new
+                # selection so no frame can leave the stale id looking writable.
+                await self._send_inventory(websocket)
                 await websocket.send(
                     json.dumps(
                         {"type": "selection_result", "request_id": request_id, "project": public_project(project)},
@@ -815,7 +989,7 @@ class ProjectHostTransport:
             transfer_root.mkdir(parents=True, exist_ok=True)
             archive = transfer_root / f"{transfer_id}.tar.gz"
             try:
-                result = await asyncio.to_thread(
+                result, archive_identity = await asyncio.to_thread(
                     self.registry.create_snapshot,
                     project_id,
                     archive,
@@ -831,7 +1005,12 @@ class ProjectHostTransport:
                         else None
                     ),
                 )
-                await asyncio.to_thread(self._upload_snapshot, transfer_id, archive)
+                await asyncio.to_thread(
+                    self._upload_snapshot_exact,
+                    transfer_id,
+                    archive,
+                    archive_identity,
+                )
                 await websocket.send(
                     json.dumps(
                         {
@@ -852,8 +1031,6 @@ class ProjectHostTransport:
                 )
             except ProjectHostHelperError as exc:
                 await self._error(websocket, request_id, exc.code)
-            finally:
-                archive.unlink(missing_ok=True)
         elif message_type == "execute_operation":
             try:
                 if not self.direct_writeback:
@@ -1036,6 +1213,32 @@ class ProjectHostTransport:
         return body
 
     def _execute_project_operation(
+        self,
+        registered: dict[str, str],
+        *,
+        operation_id: str,
+        action: str,
+        payload: dict[str, Any],
+        branch: str,
+        baseline_head: str,
+    ) -> dict[str, Any]:
+        with _guard_registered_project_mutation(
+            registered["path"],
+            expected_root_identity=str(registered.get("root_identity") or ""),
+            expected_git_identity=str(registered.get("git_identity") or ""),
+        ) as resolved:
+            bound = dict(registered)
+            bound["path"] = str(resolved)
+            return self._execute_project_operation_guarded(
+                bound,
+                operation_id=operation_id,
+                action=action,
+                payload=payload,
+                branch=branch,
+                baseline_head=baseline_head,
+            )
+
+    def _execute_project_operation_guarded(
         self,
         registered: dict[str, str],
         *,
@@ -1425,6 +1628,18 @@ class ProjectHostTransport:
         finally:
             connection.close()
 
+    def _upload_snapshot_exact(
+        self,
+        transfer_id: str,
+        archive: Path,
+        archive_identity: str,
+    ) -> None:
+        try:
+            with _guard_regular_identity(archive, archive_identity):
+                self._upload_snapshot(transfer_id, archive)
+        finally:
+            _remove_regular_identity(archive, archive_identity)
+
     @staticmethod
     async def _error(websocket: Any, request_id: str, code: str) -> None:
         await websocket.send(
@@ -1618,8 +1833,538 @@ def _validate_windows_local_path(path: Path) -> None:
     drive_type = ctypes.windll.kernel32.GetDriveTypeW(ctypes.c_wchar_p(drive_root))
     if drive_type == DRIVE_REMOTE:
         raise ProjectHostHelperError("network_path_not_allowed")
-    if getattr(path.lstat(), "st_file_attributes", 0) & FILE_ATTRIBUTE_REPARSE_POINT:
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError as exc:
+        raise ProjectHostHelperError("project_path_invalid") from exc
+    except OSError as exc:
+        raise ProjectHostHelperError("project_path_invalid") from exc
+    if getattr(metadata, "st_file_attributes", 0) & FILE_ATTRIBUTE_REPARSE_POINT:
         raise ProjectHostHelperError("project_reparse_point_not_allowed")
+
+
+def _project_directory_chain(path: Path) -> tuple[Path, ...]:
+    parts = path.parts
+    if not parts or not path.anchor or any(part in {"", ".", ".."} for part in parts[1:]):
+        raise ProjectHostHelperError("project_path_invalid")
+    current = Path(parts[0])
+    chain = [current]
+    for part in parts[1:]:
+        current = current / part
+        chain.append(current)
+    return tuple(chain)
+
+
+@contextlib.contextmanager
+def _guard_registered_project_mutation(
+    path: str | Path,
+    *,
+    expected_root_identity: str,
+    expected_git_identity: str,
+):
+    if (
+        _FILE_IDENTITY_PATTERN.fullmatch(expected_root_identity) is None
+        or _FILE_IDENTITY_PATTERN.fullmatch(expected_git_identity) is None
+    ):
+        raise ProjectHostHelperError("project_identity_changed")
+    project_path = Path(path)
+    if not project_path.is_absolute():
+        raise ProjectHostHelperError("project_identity_changed")
+    _validate_windows_local_path(project_path)
+    if not project_path.is_dir():
+        raise ProjectHostHelperError("project_identity_changed")
+    try:
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(_guard_directories(_project_directory_chain(project_path)))
+            root_identity = file_identity(project_path)
+            resolved = project_path.resolve(strict=True)
+            if (
+                root_identity != expected_root_identity
+                or file_identity(resolved) != expected_root_identity
+            ):
+                raise ProjectHostHelperError("project_identity_changed")
+            git_path = resolved / ".git"
+            if _is_link_or_reparse(git_path) or not git_path.is_dir():
+                raise ProjectHostHelperError("project_identity_changed")
+            stack.enter_context(_guard_directories((git_path,)))
+            if file_identity(git_path) != expected_git_identity:
+                raise ProjectHostHelperError("project_identity_changed")
+            yield resolved
+            if (
+                file_identity(resolved) != expected_root_identity
+                or file_identity(git_path) != expected_git_identity
+            ):
+                raise ProjectHostHelperError("project_identity_changed")
+    except ProjectHostHelperError:
+        raise
+    except (HostApplyError, HostFileTransactionError, OSError) as exc:
+        raise ProjectHostHelperError("project_identity_changed") from exc
+
+
+@contextlib.contextmanager
+def _guard_git_read_session(
+    path: str | Path,
+    *,
+    enforce_windows: bool,
+    expected_root_identity: str | None = None,
+    expected_git_identity: str | None = None,
+):
+    """Hold trusted Git metadata across every command that consumes it.
+
+    Static namespace scans reject every Git metadata reparse point, special
+    file, and hard-linked leaf.  Held directory identities plus exact no-follow
+    handles for identity-bearing leaves stay open across inspect, cat-file
+    archive creation, and reinspect.  This does not claim to make arbitrary
+    same-user object-leaf mutations atomic.
+    """
+
+    project_path = Path(path)
+    if (expected_root_identity is None) != (expected_git_identity is None) or (
+        expected_root_identity is not None
+        and (
+            _FILE_IDENTITY_PATTERN.fullmatch(expected_root_identity) is None
+            or _FILE_IDENTITY_PATTERN.fullmatch(str(expected_git_identity)) is None
+        )
+    ):
+        raise ProjectHostHelperError("project_identity_changed")
+    if not project_path.is_absolute():
+        raise ProjectHostHelperError("project_path_invalid")
+    if enforce_windows:
+        _validate_windows_local_path(project_path)
+    elif _is_link_or_reparse(project_path):
+        raise ProjectHostHelperError("project_reparse_point_not_allowed")
+    if not project_path.is_dir():
+        raise ProjectHostHelperError("project_path_invalid")
+    directory_chain = _project_directory_chain(project_path)
+    try:
+        # The selected spelling is guarded before resolve(), so a junction or
+        # rename cannot silently rebind selection to a different directory.
+        with contextlib.ExitStack() as path_stack:
+            path_stack.enter_context(_guard_directories(directory_chain))
+            selected_identity = file_identity(project_path)
+            if (
+                expected_root_identity is not None
+                and selected_identity != expected_root_identity
+            ):
+                raise ProjectHostHelperError("project_identity_changed")
+            resolved = project_path.resolve(strict=True)
+            if file_identity(resolved) != selected_identity:
+                raise ProjectHostHelperError("project_reparse_point_not_allowed")
+            git_path = resolved / ".git"
+            if _is_link_or_reparse(git_path) or git_path.is_file():
+                raise ProjectHostHelperError("git_worktree_not_allowed")
+            if not git_path.is_dir():
+                raise ProjectHostHelperError("git_repository_required")
+            path_stack.enter_context(_guard_directories((git_path,)))
+            git_identity = file_identity(git_path)
+            if expected_git_identity is not None and git_identity != expected_git_identity:
+                raise ProjectHostHelperError("project_identity_changed")
+            directories = _safe_git_namespace(git_path)
+            _assert_git_redirections_absent(git_path)
+            with _guard_directories((resolved, *directories)):
+                if file_identity(resolved) != selected_identity:
+                    raise ProjectHostHelperError("project_reparse_point_not_allowed")
+                if file_identity(git_path) != git_identity:
+                    raise ProjectHostHelperError("git_metadata_unsafe")
+                _safe_git_namespace(git_path)
+                _assert_git_redirections_absent(git_path)
+                guarded: dict[str, tuple[Path, str]] = {}
+                guarded_bytes = 0
+                with contextlib.ExitStack() as stack:
+
+                    def guard_leaf(
+                        name: str,
+                        candidate: Path,
+                        *,
+                        required: bool,
+                        maximum_bytes: int,
+                    ) -> bytes | None:
+                        nonlocal guarded_bytes
+                        if not _path_entry_exists(candidate):
+                            if required:
+                                raise ProjectHostHelperError("git_metadata_unsafe")
+                            return None
+                        content, current_identity = stack.enter_context(
+                            _guard_bounded_regular_object(candidate, maximum_bytes)
+                        )
+                        guarded_bytes += len(content)
+                        if guarded_bytes > MAX_GIT_GUARDED_METADATA_BYTES:
+                            raise ProjectHostHelperError("git_metadata_unsafe")
+                        guarded[name] = (candidate, current_identity)
+                        return content
+
+                    guard_leaf(
+                        "config",
+                        git_path / "config",
+                        required=True,
+                        maximum_bytes=MAX_GIT_CONFIG_BYTES,
+                    )
+                    head = guard_leaf(
+                        "HEAD",
+                        git_path / "HEAD",
+                        required=True,
+                        maximum_bytes=4096,
+                    )
+                    guard_leaf(
+                        "index",
+                        git_path / "index",
+                        required=False,
+                        maximum_bytes=MAX_GIT_INDEX_BYTES,
+                    )
+                    guard_leaf(
+                        "packed-refs",
+                        git_path / "packed-refs",
+                        required=False,
+                        maximum_bytes=MAX_GIT_PACKED_REFS_BYTES,
+                    )
+                    guard_leaf(
+                        "config.worktree",
+                        git_path / "config.worktree",
+                        required=False,
+                        maximum_bytes=MAX_GIT_CONFIG_BYTES,
+                    )
+                    guard_leaf(
+                        "shallow",
+                        git_path / "shallow",
+                        required=False,
+                        maximum_bytes=MAX_GIT_PACKED_REFS_BYTES,
+                    )
+
+                    info_path = git_path / "info"
+                    if _path_entry_exists(info_path):
+                        for candidate in sorted(info_path.rglob("*")):
+                            metadata = candidate.lstat()
+                            if stat.S_ISDIR(metadata.st_mode):
+                                continue
+                            if not stat.S_ISREG(metadata.st_mode):
+                                raise ProjectHostHelperError("git_metadata_unsafe")
+                            guard_leaf(
+                                f"info:{candidate.relative_to(info_path).as_posix()}",
+                                candidate,
+                                required=True,
+                                maximum_bytes=MAX_GIT_INFO_LEAF_BYTES,
+                            )
+
+                    if head is not None:
+                        try:
+                            head_text = head.decode("ascii", errors="strict").strip()
+                        except UnicodeError as exc:
+                            raise ProjectHostHelperError("git_encoding_not_supported") from exc
+                        if head_text.startswith("ref: refs/heads/"):
+                            relative = head_text.removeprefix("ref: ")
+                            if (
+                                not relative
+                                or "\\" in relative
+                                or any(part in {"", ".", ".."} for part in relative.split("/"))
+                            ):
+                                raise ProjectHostHelperError("git_metadata_unsafe")
+                            guard_leaf(
+                                "branch-ref",
+                                git_path.joinpath(*relative.split("/")),
+                                required=False,
+                                maximum_bytes=4096,
+                            )
+
+                    _safe_git_namespace(git_path)
+                    _assert_git_redirections_absent(git_path)
+                    # This is deliberately the first Git command in the session.
+                    _assert_no_unsafe_git_sources(resolved, git_path)
+                    yield resolved, git_path, frozenset(guarded)
+                    if (
+                        file_identity(resolved) != selected_identity
+                        or file_identity(git_path) != git_identity
+                    ):
+                        raise ProjectHostHelperError("git_metadata_unsafe")
+                    _safe_git_namespace(git_path)
+                    _assert_git_redirections_absent(git_path)
+                    for candidate, expected_identity in guarded.values():
+                        metadata = os.stat(candidate, follow_symlinks=False)
+                        if (
+                            not stat.S_ISREG(metadata.st_mode)
+                            or metadata.st_nlink != 1
+                            or file_identity(candidate) != expected_identity
+                        ):
+                            raise ProjectHostHelperError("git_metadata_unsafe")
+    except ProjectHostHelperError:
+        raise
+    except HostApplyError as exc:
+        if exc.code == "project_reparse_point_not_allowed":
+            raise ProjectHostHelperError("project_reparse_point_not_allowed") from exc
+        raise ProjectHostHelperError("git_metadata_unsafe") from exc
+    except (HostCommitError, HostFileTransactionError, OSError) as exc:
+        raise ProjectHostHelperError("git_metadata_unsafe") from exc
+
+
+@contextlib.contextmanager
+def _guard_bounded_regular_object(path: Path, maximum_bytes: int):
+    if maximum_bytes <= 0:
+        raise ProjectHostHelperError("git_metadata_unsafe")
+    if os.name == "nt":
+        handle = _windows_open_existing(
+            path,
+            access=0x80000000 | 0x00000080,  # GENERIC_READ | FILE_READ_ATTRIBUTES
+            share=0x00000001,  # FILE_SHARE_READ; deny write/delete while in use
+            allow_missing=False,
+        )
+        assert handle is not None
+        try:
+            identity = _windows_handle_identity(handle, require_directory=False)
+            metadata = os.stat(path, follow_symlinks=False)
+            if (
+                not stat.S_ISREG(metadata.st_mode)
+                or metadata.st_nlink != 1
+                or metadata.st_size > maximum_bytes
+                or file_identity(path) != identity
+            ):
+                raise ProjectHostHelperError("git_metadata_unsafe")
+            content = _windows_read_all(handle)
+            if len(content) > maximum_bytes:
+                raise ProjectHostHelperError("git_metadata_unsafe")
+            yield content, identity
+            current = os.stat(path, follow_symlinks=False)
+            if (
+                not stat.S_ISREG(current.st_mode)
+                or current.st_nlink != 1
+                or current.st_size > maximum_bytes
+                or file_identity(path) != identity
+                or _windows_handle_identity(handle, require_directory=False) != identity
+                or _windows_read_all(handle) != content
+            ):
+                raise ProjectHostHelperError("git_metadata_unsafe")
+        finally:
+            _windows_close_handle(handle)
+        return
+
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise ProjectHostHelperError("git_metadata_unsafe") from exc
+    try:
+        metadata = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_nlink != 1
+            or metadata.st_size > maximum_bytes
+            or metadata.st_dev <= 0
+            or metadata.st_ino <= 0
+        ):
+            raise ProjectHostHelperError("git_metadata_unsafe")
+        identity = f"{metadata.st_dev:x}-{metadata.st_ino:x}"
+
+        def read_current() -> bytes:
+            os.lseek(descriptor, 0, os.SEEK_SET)
+            chunks: list[bytes] = []
+            remaining = maximum_bytes + 1
+            while remaining:
+                chunk = os.read(descriptor, min(remaining, 64 * 1024))
+                if not chunk:
+                    break
+                chunks.append(chunk)
+                remaining -= len(chunk)
+            value = b"".join(chunks)
+            if len(value) > maximum_bytes:
+                raise ProjectHostHelperError("git_metadata_unsafe")
+            return value
+
+        content = read_current()
+        if file_identity(path) != identity:
+            raise ProjectHostHelperError("git_metadata_unsafe")
+        yield content, identity
+        current = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(current.st_mode)
+            or current.st_nlink != 1
+            or current.st_size > maximum_bytes
+            or f"{current.st_dev:x}-{current.st_ino:x}" != identity
+            or file_identity(path) != identity
+            or read_current() != content
+        ):
+            raise ProjectHostHelperError("git_metadata_unsafe")
+    finally:
+        os.close(descriptor)
+
+
+@contextlib.contextmanager
+def _guard_regular_identity(path: Path, expected_identity: str):
+    if os.name == "nt":
+        handle = _windows_open_existing(
+            path,
+            access=0x80000000 | 0x00000080,
+            share=0x00000001,
+            allow_missing=False,
+        )
+        assert handle is not None
+        try:
+            identity = _windows_handle_identity(handle, require_directory=False)
+            metadata = os.stat(path, follow_symlinks=False)
+            if (
+                identity != expected_identity
+                or not stat.S_ISREG(metadata.st_mode)
+                or metadata.st_nlink != 1
+                or file_identity(path) != identity
+            ):
+                raise ProjectHostHelperError("snapshot_upload_failed")
+            yield
+            current = os.stat(path, follow_symlinks=False)
+            if (
+                _windows_handle_identity(handle, require_directory=False) != identity
+                or not stat.S_ISREG(current.st_mode)
+                or current.st_nlink != 1
+                or file_identity(path) != identity
+            ):
+                raise ProjectHostHelperError("snapshot_upload_failed")
+        finally:
+            _windows_close_handle(handle)
+        return
+
+    try:
+        descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+    except OSError as exc:
+        raise ProjectHostHelperError("snapshot_upload_failed") from exc
+    try:
+        metadata = os.fstat(descriptor)
+        identity = f"{metadata.st_dev:x}-{metadata.st_ino:x}"
+        if (
+            identity != expected_identity
+            or not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_nlink != 1
+            or file_identity(path) != identity
+        ):
+            raise ProjectHostHelperError("snapshot_upload_failed")
+        yield
+        current = os.fstat(descriptor)
+        if (
+            f"{current.st_dev:x}-{current.st_ino:x}" != identity
+            or not stat.S_ISREG(current.st_mode)
+            or current.st_nlink != 1
+            or file_identity(path) != identity
+        ):
+            raise ProjectHostHelperError("snapshot_upload_failed")
+    except OSError as exc:
+        raise ProjectHostHelperError("snapshot_upload_failed") from exc
+    finally:
+        os.close(descriptor)
+
+
+def _remove_regular_identity(path: Path, expected_identity: str) -> None:
+    """Delete only the exact archive object created by this snapshot call."""
+
+    if os.name == "nt":
+        class _FileDispositionInfo(ctypes.Structure):
+            _fields_ = [("delete_file", wintypes.BOOLEAN)]
+
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        kernel32.SetFileInformationByHandle.argtypes = [
+            wintypes.HANDLE,
+            ctypes.c_int,
+            wintypes.LPVOID,
+            wintypes.DWORD,
+        ]
+        kernel32.SetFileInformationByHandle.restype = wintypes.BOOL
+        try:
+            handle = _windows_open_existing(
+                path,
+                access=0x00010000 | 0x00000080,  # DELETE | FILE_READ_ATTRIBUTES
+                share=0x00000001,
+                allow_missing=False,
+            )
+        except HostFileTransactionError as exc:
+            raise ProjectHostHelperError("snapshot_cleanup_failed") from exc
+        assert handle is not None
+        try:
+            identity = _windows_handle_identity(handle, require_directory=False)
+            metadata = os.stat(path, follow_symlinks=False)
+            if (
+                identity != expected_identity
+                or not stat.S_ISREG(metadata.st_mode)
+                or metadata.st_nlink != 1
+                or file_identity(path) != identity
+            ):
+                raise ProjectHostHelperError("snapshot_cleanup_failed")
+            disposition = _FileDispositionInfo(True)
+            if not kernel32.SetFileInformationByHandle(
+                handle,
+                4,  # FileDispositionInfo
+                ctypes.byref(disposition),
+                ctypes.sizeof(disposition),
+            ):
+                raise ProjectHostHelperError("snapshot_cleanup_failed")
+        finally:
+            _windows_close_handle(handle)
+        if _path_entry_exists(path):
+            raise ProjectHostHelperError("snapshot_cleanup_failed")
+        return
+
+    parent_flags = (
+        os.O_RDONLY
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    try:
+        parent = os.open(path.parent, parent_flags)
+    except OSError as exc:
+        raise ProjectHostHelperError("snapshot_cleanup_failed") from exc
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(
+            path.name,
+            os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+            dir_fd=parent,
+        )
+        metadata = os.fstat(descriptor)
+        identity = f"{metadata.st_dev:x}-{metadata.st_ino:x}"
+        named = os.stat(path.name, dir_fd=parent, follow_symlinks=False)
+        if (
+            identity != expected_identity
+            or not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_nlink != 1
+            or not stat.S_ISREG(named.st_mode)
+            or named.st_nlink != 1
+            or (named.st_dev, named.st_ino) != (metadata.st_dev, metadata.st_ino)
+        ):
+            raise ProjectHostHelperError("snapshot_cleanup_failed")
+        os.unlink(path.name, dir_fd=parent)
+        os.fsync(parent)
+    except OSError as exc:
+        raise ProjectHostHelperError("snapshot_cleanup_failed") from exc
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+        os.close(parent)
+
+
+def _is_link_or_reparse(path: Path) -> bool:
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        return False
+    except OSError as exc:
+        raise ProjectHostHelperError("git_metadata_unsafe") from exc
+    return stat.S_ISLNK(metadata.st_mode) or bool(
+        getattr(metadata, "st_file_attributes", 0) & FILE_ATTRIBUTE_REPARSE_POINT
+    )
+
+
+def _path_entry_exists(path: Path) -> bool:
+    try:
+        path.lstat()
+        return True
+    except FileNotFoundError:
+        return False
+    except OSError as exc:
+        raise ProjectHostHelperError("git_metadata_unsafe") from exc
+
+
+def _assert_git_redirections_absent(git_path: Path) -> None:
+    if _path_entry_exists(git_path / "commondir"):
+        raise ProjectHostHelperError("git_shared_directory_not_allowed")
+    for name in ("alternates", "http-alternates"):
+        if _path_entry_exists(git_path / "objects" / "info" / name):
+            raise ProjectHostHelperError("git_alternates_not_allowed")
+    for candidate in (git_path / "refs" / "replace", git_path / "info" / "grafts"):
+        if _path_entry_exists(candidate):
+            raise ProjectHostHelperError("git_metadata_unsafe")
 
 
 def _run_git(path: Path, *arguments: str) -> subprocess.CompletedProcess[bytes]:
@@ -1639,32 +2384,43 @@ def _run_git(path: Path, *arguments: str) -> subprocess.CompletedProcess[bytes]:
         raise ProjectHostHelperError("git_inspection_failed") from exc
 
 
-def _assert_no_lazy_fetch_sources(path: Path, git_path: Path) -> None:
-    for name in ("alternates", "http-alternates"):
-        alternate = git_path / "objects" / "info" / name
-        try:
-            alternate.lstat()
-        except FileNotFoundError:
-            continue
-        except OSError as exc:
-            raise ProjectHostHelperError("git_inspection_failed") from exc
-        raise ProjectHostHelperError("git_alternates_not_allowed")
-
-    configured = _run_git(
-        path,
-        "config",
-        "--local",
-        "--no-includes",
-        "--name-only",
-        "--list",
-    )
+def _assert_no_unsafe_git_sources(path: Path, git_path: Path) -> None:
+    try:
+        # Run outside every repository so even core.worktree/worktreeConfig in
+        # the selected file cannot affect Git startup before we reject it.
+        with tempfile.TemporaryDirectory(prefix="modelmirror-git-config-") as safe_cwd:
+            configured = subprocess.run(
+                build_safe_git_command(
+                    path,
+                    (
+                        "config",
+                        "--file",
+                        str(git_path / "config"),
+                        "--no-includes",
+                        "--name-only",
+                        "--list",
+                    ),
+                ),
+                cwd=safe_cwd,
+                env=build_safe_git_environment(),
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+                timeout=15,
+                creationflags=(
+                    getattr(subprocess, "CREATE_NO_WINDOW", 0) if os.name == "nt" else 0
+                ),
+            )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise ProjectHostHelperError("git_inspection_failed") from exc
     if configured.returncode != 0:
         raise ProjectHostHelperError("git_inspection_failed")
     try:
         names = configured.stdout.decode("utf-8", errors="strict").splitlines()
     except UnicodeError as exc:
         raise ProjectHostHelperError("git_encoding_not_supported") from exc
-    if any(_LAZY_FETCH_CONFIG_PATTERN.fullmatch(name) for name in names):
+    if any(_UNSAFE_LOCAL_CONFIG_PATTERN.fullmatch(name) for name in names):
         raise ProjectHostHelperError("git_config_unsafe")
 
 
@@ -1697,6 +2453,49 @@ def _valid_branch(value: str) -> bool:
 
 
 def _valid_registry_state(value: Any) -> bool:
+    if not _valid_registry_base(value):
+        return False
+    for project_id, project in value["projects"].items():
+        if PROJECT_ID_PATTERN.fullmatch(str(project_id)) is None or not isinstance(project, dict):
+            return False
+        authorized = (
+            _FILE_IDENTITY_PATTERN.fullmatch(str(project.get("root_identity") or ""))
+            is not None
+            and _FILE_IDENTITY_PATTERN.fullmatch(str(project.get("git_identity") or ""))
+            is not None
+        )
+        tombstone = (
+            "root_identity" not in project
+            and "git_identity" not in project
+            and project.get("state") == "unavailable"
+            and project.get("reason") == "project_reselection_required"
+        )
+        if (
+            project.get("project_id") != project_id
+            or not isinstance(project.get("path"), str)
+            or not (authorized or tombstone)
+        ):
+            return False
+    return True
+
+
+def _valid_legacy_registry_without_identities(value: Any) -> bool:
+    if not _valid_registry_base(value):
+        return False
+    for project_id, project in value["projects"].items():
+        if (
+            PROJECT_ID_PATTERN.fullmatch(str(project_id)) is None
+            or not isinstance(project, dict)
+            or project.get("project_id") != project_id
+            or not isinstance(project.get("path"), str)
+            or "root_identity" in project
+            or "git_identity" in project
+        ):
+            return False
+    return True
+
+
+def _valid_registry_base(value: Any) -> bool:
     if not isinstance(value, dict) or value.get("version") != 1:
         return False
     if DEVICE_ID_PATTERN.fullmatch(str(value.get("device_id") or "")) is None:
@@ -1705,14 +2504,7 @@ def _valid_registry_state(value: Any) -> bool:
         secret = base64.b64decode(value.get("device_secret", ""), validate=True)
     except (TypeError, ValueError):
         return False
-    if len(secret) != 32 or not isinstance(value.get("projects"), dict):
-        return False
-    for project_id, project in value["projects"].items():
-        if PROJECT_ID_PATTERN.fullmatch(str(project_id)) is None or not isinstance(project, dict):
-            return False
-        if project.get("project_id") != project_id or not isinstance(project.get("path"), str):
-            return False
-    return True
+    return len(secret) == 32 and isinstance(value.get("projects"), dict)
 
 
 def _parse_message(raw: Any) -> dict[str, Any]:

--- a/server/coding_project_host/windows_helper.py
+++ b/server/coding_project_host/windows_helper.py
@@ -61,6 +61,10 @@ MAX_OPERATION_PAYLOAD_BYTES = 1200 * 1024
 OPERATION_ACTIONS = frozenset({"apply", "revert", "commit", "undo", "reconcile"})
 OPERATION_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]{20,64}$")
 PAYLOAD_ID_PATTERN = re.compile(r"^phop_[a-f0-9]{32}$")
+_LAZY_FETCH_CONFIG_PATTERN = re.compile(
+    r"^(?:extensions\.partialclone|remote\..*\.(?:promisor|partialclonefilter))$",
+    re.IGNORECASE,
+)
 DEFAULT_SERVER_URL = "http://127.0.0.1:8000"
 HEARTBEAT_INTERVAL_SECONDS = 20.0
 FILE_ATTRIBUTE_REPARSE_POINT = 0x0400
@@ -446,9 +450,7 @@ def inspect_git_project(
         raise ProjectHostHelperError("git_repository_required")
     if (git_path / "commondir").exists():
         raise ProjectHostHelperError("git_shared_directory_not_allowed")
-    alternates = git_path / "objects" / "info" / "alternates"
-    if alternates.is_symlink() or (alternates.is_file() and alternates.stat().st_size > 0):
-        raise ProjectHostHelperError("git_alternates_not_allowed")
+    _assert_no_lazy_fetch_sources(resolved, git_path)
 
     inside = _git_text(
         resolved,
@@ -532,12 +534,7 @@ def inspect_git_project_for_recovery(
         raise ProjectHostHelperError("git_worktree_not_allowed")
     if not git_path.is_dir() or (git_path / "commondir").exists():
         raise ProjectHostHelperError("git_shared_directory_not_allowed")
-    for name in ("alternates", "http-alternates"):
-        alternate = git_path / "objects" / "info" / name
-        if alternate.is_symlink() or (
-            alternate.is_file() and alternate.stat().st_size > 0
-        ):
-            raise ProjectHostHelperError("git_alternates_not_allowed")
+    _assert_no_lazy_fetch_sources(resolved, git_path)
     branch = _git_text(
         resolved,
         "symbolic-ref",
@@ -1640,6 +1637,35 @@ def _run_git(path: Path, *arguments: str) -> subprocess.CompletedProcess[bytes]:
         )
     except (OSError, subprocess.TimeoutExpired) as exc:
         raise ProjectHostHelperError("git_inspection_failed") from exc
+
+
+def _assert_no_lazy_fetch_sources(path: Path, git_path: Path) -> None:
+    for name in ("alternates", "http-alternates"):
+        alternate = git_path / "objects" / "info" / name
+        try:
+            alternate.lstat()
+        except FileNotFoundError:
+            continue
+        except OSError as exc:
+            raise ProjectHostHelperError("git_inspection_failed") from exc
+        raise ProjectHostHelperError("git_alternates_not_allowed")
+
+    configured = _run_git(
+        path,
+        "config",
+        "--local",
+        "--no-includes",
+        "--name-only",
+        "--list",
+    )
+    if configured.returncode != 0:
+        raise ProjectHostHelperError("git_inspection_failed")
+    try:
+        names = configured.stdout.decode("utf-8", errors="strict").splitlines()
+    except UnicodeError as exc:
+        raise ProjectHostHelperError("git_encoding_not_supported") from exc
+    if any(_LAZY_FETCH_CONFIG_PATTERN.fullmatch(name) for name in names):
+        raise ProjectHostHelperError("git_config_unsafe")
 
 
 def _git_text(

--- a/server/coding_runtime/api.py
+++ b/server/coding_runtime/api.py
@@ -1065,6 +1065,11 @@ class CodingService:
             return base
         try:
             project = await self._load_recovery_project_context(record)
+            recovery_preview = (
+                self._recovery_operation_preview(record, project)
+                if project.kind is ProjectKind.HOST_GIT
+                else None
+            )
         except HTTPException:
             return {
                 **base,
@@ -1123,12 +1128,26 @@ class CodingService:
                         self.project_host is not None
                         and project.head is not None
                         and project.branch is not None
+                        and recovery_preview is not None
                     )
-                    self.project_host.check_project(
-                        project.project_id,
-                        project.head,
-                        project.branch,
-                    )
+                    if (
+                        recovery_preview.apply_operation_id is None
+                        and not recovery_preview.cycle_history.cycles
+                    ):
+                        self.project_host.check_project(
+                            project.project_id,
+                            project.head,
+                            project.branch,
+                        )
+                    else:
+                        host_health = await self.project_host.health()
+                        if host_health.get("available") is not True:
+                            raise ProjectHostError(
+                                _safe_code(
+                                    host_health.get("reason")
+                                    or "project_host_writeback_unavailable"
+                                )
+                            )
             except ProjectSourceClientError as exc:
                 can_resume = False
                 reason = _safe_code(exc.code)
@@ -1305,6 +1324,7 @@ class CodingService:
         *,
         expected_head: str | None = None,
         expected_branch: str | None = None,
+        managed_operation_id: str | None = None,
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         if self.project_host is None or self.project_source is None:
             raise _http_error(
@@ -1317,6 +1337,7 @@ class CodingService:
                 project_id,
                 expected_head=expected_head,
                 expected_branch=expected_branch,
+                managed_operation_id=managed_operation_id,
             )
             transfer_id = str(transfer["upload_id"])
             project = transfer["project"]
@@ -1340,10 +1361,38 @@ class CodingService:
         finally:
             if transfer_id is not None:
                 self.project_host.finish_transfer(transfer_id)
-        public_project = _project_from_source(source)
+        public_project = self.project_host.public_project(project_id)
+        if managed_operation_id is not None:
+            managed_project = _project_from_source(source)
+            capability = self.project_host.capability()
+            writeback_available = capability.get("direct_writeback") is True
+            features = managed_project.get("features")
+            if isinstance(features, dict):
+                managed_project["features"] = {
+                    **features,
+                    "apply": writeback_available,
+                    "commit": writeback_available,
+                }
+            managed_project["state"] = ProjectState.AVAILABLE.value
+            managed_project["reason"] = None
+            managed_project["writeback_reason"] = (
+                None
+                if writeback_available
+                else _safe_code(
+                    capability.get("writeback_reason")
+                    or "project_host_writeback_unavailable"
+                )
+            )
+            public_project = managed_project
         if (
             source.get("kind") != ProjectKind.HOST_GIT.value
             or public_project.get("id") != project_id
+            or public_project.get("branch") != source.get("branch")
+            or (
+                managed_operation_id is None
+                and public_project.get("head")
+                != str(source.get("head") or "")[:12]
+            )
             or (expected_head is not None and source.get("head") != expected_head)
             or (
                 expected_branch is not None
@@ -1356,6 +1405,121 @@ class CodingService:
                 "invalid_project_source_response",
             )
         return source, public_project
+
+    def _recovery_operation_preview(
+        self,
+        recovery: RecoveryRecord,
+        project: RecoveryProjectContext,
+    ) -> CodingApiSession:
+        source = (
+            {
+                "kind": project.kind.value,
+                "project_id": project.project_id,
+                "name": project.name,
+                "head": project.head,
+                "branch": project.branch,
+                "fingerprint": recovery.snapshot_fingerprint,
+            }
+            if project.kind is not ProjectKind.BUILTIN
+            else None
+        )
+        preview = CodingApiSession(
+            session_id="recovery-preview",
+            worker_session_id="recovery-preview",
+            project=project.to_public(),
+            project_source=source,
+            cycle_number=len(recovery.payload.cycles) + 1,
+            cycle_history=CodingCycleHistory(recovery.payload.cycles),
+        )
+        self._hydrate_recovered_session(preview, recovery)
+        return preview
+
+    def _bind_host_recovery_operations(
+        self,
+        recovery: RecoveryRecord,
+        project: RecoveryProjectContext,
+        preview: CodingApiSession,
+    ) -> str | None:
+        if (
+            self.project_host is None
+            or project.head is None
+            or project.branch is None
+        ):
+            raise _http_error(
+                status.HTTP_503_SERVICE_UNAVAILABLE,
+                "project_host_unavailable",
+            )
+        try:
+            current_parent, lineage = self._host_cycle_lineage(
+                preview,
+                base_head=project.head,
+                branch=project.branch,
+                fingerprint=recovery.snapshot_fingerprint,
+            )
+            anchor_operation_id: str | None = None
+            seen_operations: set[str] = set()
+            for parent, apply_receipt, commit_receipt in lineage:
+                if anchor_operation_id is None:
+                    anchor_operation_id = apply_receipt.apply_id
+                seen_operations.update(
+                    {apply_receipt.apply_id, commit_receipt.commit_id}
+                )
+                self.project_host.bind_recovery_operations(
+                    project_id=project.project_id,
+                    expected_head=parent,
+                    expected_branch=project.branch,
+                    apply_operation_id=apply_receipt.apply_id,
+                    commit_operation_id=commit_receipt.commit_id,
+                    apply_receipt=apply_receipt,
+                    commit_receipt=commit_receipt,
+                )
+
+            active_apply_id = preview.apply_operation_id
+            active_commit_id = preview.commit_operation_id
+            active_apply = preview.apply_receipt
+            active_commit = preview.commit_receipt
+            if active_apply_id is not None:
+                if (
+                    active_apply_id in seen_operations
+                    or active_commit_id in seen_operations
+                    or (
+                        active_apply is not None
+                        and active_apply.snapshot_fingerprint
+                        != recovery.snapshot_fingerprint
+                    )
+                    or (
+                        active_commit is not None
+                        and (
+                            active_apply is None
+                            or active_commit.apply_id != active_apply.apply_id
+                            or active_commit.parent_sha != current_parent
+                            or active_commit.branch != project.branch
+                        )
+                    )
+                ):
+                    raise ValueError("Active host cycle lineage is invalid")
+                self.project_host.bind_recovery_operations(
+                    project_id=project.project_id,
+                    expected_head=current_parent,
+                    expected_branch=project.branch,
+                    apply_operation_id=active_apply_id,
+                    commit_operation_id=active_commit_id,
+                    apply_receipt=active_apply,
+                    commit_receipt=active_commit,
+                )
+                anchor_operation_id = anchor_operation_id or active_apply_id
+            elif active_commit_id is not None:
+                raise ValueError("Host commit has no active application")
+            if lineage and anchor_operation_id is None:
+                raise ValueError("Host recovery has no snapshot anchor")
+            return anchor_operation_id
+        except ProjectHostError as exc:
+            raise _project_host_http_error(exc) from exc
+        except (TypeError, ValueError) as exc:
+            raise _http_error(
+                status.HTTP_503_SERVICE_UNAVAILABLE,
+                "recovery_data_corrupt",
+            ) from exc
 
     async def resume_recovery(self) -> CodingApiSession:
         health = await self._require_available()
@@ -1396,10 +1560,42 @@ class CodingService:
                     status.HTTP_409_CONFLICT,
                     "recovery_data_corrupt",
                 )
-            source, _ = await self._acquire_host_project(
+            if self.project_host is None:
+                raise _http_error(
+                    status.HTTP_503_SERVICE_UNAVAILABLE,
+                    self.project_host_reason or "project_host_unavailable",
+                )
+            recovery_preview = self._recovery_operation_preview(
+                recovery,
+                project_context,
+            )
+            has_managed_operations = bool(
+                recovery_preview.apply_operation_id is not None
+                or recovery_preview.cycle_history.cycles
+            )
+            managed_operation_id: str | None = None
+            if has_managed_operations:
+                try:
+                    host_health = await self.project_host.health()
+                    if host_health.get("available") is not True:
+                        raise ProjectHostError(
+                            _safe_code(
+                                host_health.get("reason")
+                                or "project_host_writeback_unavailable"
+                            )
+                        )
+                except ProjectHostError as exc:
+                    raise _project_host_http_error(exc) from exc
+                managed_operation_id = self._bind_host_recovery_operations(
+                    recovery,
+                    project_context,
+                    recovery_preview,
+                )
+            source, resumed_host_project = await self._acquire_host_project(
                 project_context.project_id,
                 expected_head=project_context.head,
                 expected_branch=project_context.branch,
+                managed_operation_id=managed_operation_id,
             )
         cumulative_changes = _public_changes(recovery.payload.changes)
         active_changes = (
@@ -1501,7 +1697,7 @@ class CodingService:
                 resumed_project["reason"] = None
                 resumed_project["writeback_reason"] = None
         elif project_context.kind is ProjectKind.HOST_GIT and source is not None:
-            resumed_project = _project_from_source(source)
+            resumed_project = resumed_host_project
         record = CodingApiSession(
             session_id=session_id,
             worker_session_id=session_id,
@@ -1658,7 +1854,14 @@ class CodingService:
             "max_cycles": MAX_INCREMENTAL_CYCLES,
             "can_continue": bool(
                 self.incremental_enabled
-                and self._is_builtin_project(record)
+                and (
+                    self._is_builtin_project(record)
+                    or (
+                        self._is_host_project(record)
+                        and isinstance(record.project.get("features"), dict)
+                        and record.project["features"].get("commit") is True
+                    )
+                )
                 and latest_commit is not None
                 and record.cycle_number < MAX_INCREMENTAL_CYCLES
                 and record.recovery_conflict is None
@@ -1675,7 +1878,14 @@ class CodingService:
         commit_id: str,
     ) -> dict[str, Any]:
         record = await self._review_record(session_id)
-        self._require_builtin_project(record)
+        if not (
+            self._is_builtin_project(record)
+            or self._is_host_project(record)
+        ):
+            raise _http_error(
+                status.HTTP_409_CONFLICT,
+                "project_operation_unavailable",
+            )
         async with record.apply_lock:
             if record.publish_manifest is not None:
                 raise _http_error(status.HTTP_409_CONFLICT, "session_published")
@@ -1694,6 +1904,18 @@ class CodingService:
                 or receipt.commit_id != commit_id
             ):
                 raise _http_error(status.HTTP_409_CONFLICT, "commit_mismatch")
+            if self._is_host_project(record):
+                _project_id, expected_parent, _fingerprint, branch = (
+                    self._host_writer_context(record)
+                )
+                if (
+                    receipt.parent_sha != expected_parent
+                    or receipt.branch != branch
+                ):
+                    raise _http_error(
+                        status.HTTP_409_CONFLICT,
+                        "cycle_lineage_invalid",
+                    )
             changes = await self._current_changes(record)
             if changes["revision"] != revision or not changes["files"]:
                 raise _http_error(status.HTTP_409_CONFLICT, "stale_revision")
@@ -1953,8 +2175,21 @@ class CodingService:
                 return self._public_apply(record, revision)
             self._require_mutable(record)
             writer_context: tuple[str, str, str] | None = None
+            host_context: tuple[str, str, str, str] | None = None
+            host_retry_unknown = bool(
+                self._is_host_project(record)
+                and record.apply_state is ApplyState.FAILED
+                and record.apply_operation_id is not None
+                and record.apply_reason == "operation_result_unknown"
+            )
             if self._is_builtin_project(record):
                 expected_fingerprint = await self._require_apply_available()
+            elif self._is_host_project(record):
+                host_context = await self._require_host_writer_available(
+                    record,
+                    require_clean=not host_retry_unknown,
+                )
+                expected_fingerprint = host_context[2]
             else:
                 writer_context = await self._require_project_writer_available(record)
                 expected_fingerprint = writer_context[2]
@@ -2005,7 +2240,68 @@ class CodingService:
                 record.apply_finished_at = time.time()
                 raise
             try:
-                if writer_context is None:
+                if host_context is not None:
+                    assert self.project_host is not None
+                    try:
+                        if host_retry_unknown:
+                            self.project_host.bind_recovery_operations(
+                                project_id=host_context[0],
+                                expected_head=host_context[1],
+                                expected_branch=host_context[3],
+                                apply_operation_id=operation_id,
+                                apply_receipt=record.apply_receipt,
+                                commit_receipt=None,
+                            )
+                        else:
+                            self.project_host.bind_persisted_intent(
+                                project_id=host_context[0],
+                                expected_head=host_context[1],
+                                expected_branch=host_context[3],
+                                operation_id=operation_id,
+                                kind="apply",
+                            )
+                    except ProjectHostError as exc:
+                        raise ProjectWriterClientError(
+                            "Host project intent was rejected.",
+                            code=_safe_code(exc.code),
+                        ) from exc
+                    reconciled_state = "not_applied"
+                    receipt = None
+                    if host_retry_unknown:
+                        reconciled_state, receipt = (
+                            await self.project_host.reconcile_apply(
+                                project_id=host_context[0],
+                                expected_head=host_context[1],
+                                expected_branch=host_context[3],
+                                operation_id=operation_id,
+                                revision=revision,
+                                patch=patch,
+                                paths=paths,
+                                expected_fingerprint=expected_fingerprint,
+                            )
+                        )
+                        if reconciled_state == "conflict":
+                            raise ProjectWriterClientError(
+                                "Host application reconciliation conflicted.",
+                                code="operation_conflict",
+                            )
+                    if reconciled_state == "not_applied":
+                        receipt = await self.project_host.apply(
+                            project_id=host_context[0],
+                            expected_head=host_context[1],
+                            expected_branch=host_context[3],
+                            operation_id=operation_id,
+                            revision=revision,
+                            patch=patch,
+                            paths=paths,
+                            expected_fingerprint=expected_fingerprint,
+                        )
+                    if receipt is None:
+                        raise ProjectWriterClientError(
+                            "Host application reconciliation was incomplete.",
+                            code="operation_result_unknown",
+                        )
+                elif writer_context is None:
                     assert self.applier is not None
                     receipt = await self.applier.apply(
                         operation_id=operation_id,
@@ -2026,10 +2322,16 @@ class CodingService:
                         expected_fingerprint=expected_fingerprint,
                     )
                 if (
-                    receipt.revision != revision
+                    receipt.apply_id != operation_id
+                    or receipt.revision != revision
                     or receipt.snapshot_fingerprint != expected_fingerprint
                     or [item.path for item in receipt.files] != paths
                 ):
+                    if host_context is not None:
+                        raise ProjectWriterClientError(
+                            "Host application result must be reconciled.",
+                            code="operation_result_unknown",
+                        )
                     try:
                         if writer_context is None:
                             assert self.applier is not None
@@ -2122,7 +2424,31 @@ class CodingService:
                 record.commit_state is CommitState.FAILED
                 and record.commit_operation_id is not None
             )
-            if not retrying_unknown_result:
+            host_retry_unknown = bool(
+                self._is_host_project(record)
+                and retrying_unknown_result
+                and record.commit_reason == "operation_result_unknown"
+            )
+            host_context: tuple[str, str, str, str] | None = None
+            host_patch: str | None = None
+            if self._is_host_project(record):
+                host_context = await self._require_host_writer_available(
+                    record,
+                    require_clean=False,
+                )
+                if host_context[2] != apply_receipt.snapshot_fingerprint:
+                    raise _http_error(status.HTTP_409_CONFLICT, "snapshot_mismatch")
+                if host_retry_unknown:
+                    try:
+                        host_patch = _safe_diff(
+                            await self.worker.patch(
+                                record.worker_session_id,
+                                revision,
+                            )
+                        )
+                    except CodingWorkerError as exc:
+                        raise _worker_http_error(exc) from exc
+            elif not retrying_unknown_result:
                 await self._require_commit_available(
                     record,
                     apply_receipt.snapshot_fingerprint
@@ -2151,6 +2477,88 @@ class CodingService:
                         apply_receipt=apply_receipt,
                         message=message,
                     )
+                elif self._is_host_project(record):
+                    assert host_context is not None
+                    project_id, expected_head, _, expected_branch = host_context
+                    assert self.project_host is not None
+                    try:
+                        if host_retry_unknown:
+                            self.project_host.bind_recovery_operations(
+                                project_id=project_id,
+                                expected_head=expected_head,
+                                expected_branch=expected_branch,
+                                apply_operation_id=apply_receipt.apply_id,
+                                commit_operation_id=operation_id,
+                                apply_receipt=apply_receipt,
+                                commit_receipt=record.commit_receipt,
+                            )
+                        else:
+                            self.project_host.bind_persisted_intent(
+                                project_id=project_id,
+                                expected_head=expected_head,
+                                expected_branch=expected_branch,
+                                operation_id=operation_id,
+                                kind="commit",
+                                parent_operation_id=apply_receipt.apply_id,
+                            )
+                    except ProjectHostError as exc:
+                        raise ProjectWriterClientError(
+                            "Host commit intent was rejected.",
+                            code=_safe_code(exc.code),
+                        ) from exc
+                    reconciled_state = "not_committed"
+                    receipt = None
+                    if host_retry_unknown:
+                        assert host_patch is not None
+                        reconciled_state, restored_apply, receipt = (
+                            await self.project_host.reconcile_commit(
+                                project_id=project_id,
+                                expected_head=expected_head,
+                                expected_branch=expected_branch,
+                                operation_id=apply_receipt.apply_id,
+                                revision=revision,
+                                patch=host_patch,
+                                paths=[item.path for item in apply_receipt.files],
+                                expected_fingerprint=(
+                                    apply_receipt.snapshot_fingerprint
+                                ),
+                                apply_receipt=apply_receipt,
+                                commit_operation_id=operation_id,
+                                message=message,
+                            )
+                        )
+                        if restored_apply != apply_receipt:
+                            raise ProjectWriterClientError(
+                                "Host commit reconciliation was not bound.",
+                                code="operation_result_unknown",
+                            )
+                        if reconciled_state == "undone" and receipt is not None:
+                            record.commit_receipt = receipt
+                            record.commit_state = CommitState.UNDONE
+                            record.commit_reason = None
+                            record.commit_finished_at = time.time()
+                            record.updated_at = record.commit_finished_at
+                            await self._persist_recovery(record, required=True)
+                            return self._public_commit(record, revision)
+                    if reconciled_state == "not_committed":
+                        receipt = await self.project_host.commit(
+                            project_id=project_id,
+                            expected_head=expected_head,
+                            expected_branch=expected_branch,
+                            operation_id=operation_id,
+                            apply_receipt=apply_receipt,
+                            message=message,
+                        )
+                    elif reconciled_state != "committed":
+                        raise ProjectWriterClientError(
+                            "Host commit reconciliation conflicted.",
+                            code="operation_conflict",
+                        )
+                    if receipt is None:
+                        raise ProjectWriterClientError(
+                            "Host commit reconciliation was incomplete.",
+                            code="operation_result_unknown",
+                        )
                 else:
                     project_id, expected_head, _ = self._project_writer_context(record)
                     assert self.project_writer is not None
@@ -2168,12 +2576,24 @@ class CodingService:
                     or receipt.apply_id != apply_id
                     or receipt.message != message
                     or receipt.files != expected_files
+                    or (
+                        self._is_host_project(record)
+                        and (
+                            receipt.branch != self._host_writer_context(record)[3]
+                            or receipt.parent_sha != self._host_writer_context(record)[1]
+                        )
+                    )
                 ):
+                    if self._is_host_project(record):
+                        raise ProjectWriterClientError(
+                            "Host commit result must be reconciled.",
+                            code="operation_result_unknown",
+                        )
                     try:
                         if self._is_builtin_project(record):
                             assert self.committer is not None
                             await self.committer.undo(receipt, apply_receipt)
-                        else:
+                        elif not self._is_host_project(record):
                             project_id, expected_head, _ = self._project_writer_context(record)
                             assert self.project_writer is not None
                             await self.project_writer.undo(
@@ -2488,9 +2908,30 @@ class CodingService:
                 return self._public_commit(record, revision)
             if record.commit_state is not CommitState.COMMITTED:
                 raise _http_error(status.HTTP_409_CONFLICT, "commit_not_undoable")
+            host_context: tuple[str, str, str, str] | None = None
+            host_retry_unknown = bool(
+                self._is_host_project(record)
+                and record.commit_reason == "operation_result_unknown"
+            )
+            host_patch: str | None = None
             if self._is_builtin_project(record):
                 if self.committer is None:
                     raise _http_error(status.HTTP_503_SERVICE_UNAVAILABLE, "committer_unavailable")
+            elif self._is_host_project(record):
+                host_context = await self._require_host_writer_available(
+                    record,
+                    require_clean=False,
+                )
+                if host_retry_unknown:
+                    try:
+                        host_patch = _safe_diff(
+                            await self.worker.patch(
+                                record.worker_session_id,
+                                revision,
+                            )
+                        )
+                    except CodingWorkerError as exc:
+                        raise _worker_http_error(exc) from exc
             elif self.project_writer is None:
                 raise _http_error(status.HTTP_503_SERVICE_UNAVAILABLE, "project_writer_unavailable")
             record.commit_state = CommitState.UNDOING
@@ -2506,6 +2947,70 @@ class CodingService:
                 if self._is_builtin_project(record):
                     assert self.committer is not None
                     undone = await self.committer.undo(receipt, apply_receipt)
+                elif host_context is not None:
+                    assert self.project_host is not None
+                    if host_retry_unknown:
+                        try:
+                            self.project_host.bind_recovery_operations(
+                                project_id=host_context[0],
+                                expected_head=host_context[1],
+                                expected_branch=host_context[3],
+                                apply_operation_id=apply_receipt.apply_id,
+                                commit_operation_id=receipt.commit_id,
+                                apply_receipt=apply_receipt,
+                                commit_receipt=receipt,
+                            )
+                        except ProjectHostError as exc:
+                            raise ProjectWriterClientError(
+                                "Host undo intent was rejected.",
+                                code=_safe_code(exc.code),
+                            ) from exc
+                        assert host_patch is not None
+                        state, restored_apply, restored_commit = (
+                            await self.project_host.reconcile_commit(
+                                project_id=host_context[0],
+                                expected_head=host_context[1],
+                                expected_branch=host_context[3],
+                                operation_id=apply_receipt.apply_id,
+                                revision=revision,
+                                patch=host_patch,
+                                paths=[item.path for item in apply_receipt.files],
+                                expected_fingerprint=(
+                                    apply_receipt.snapshot_fingerprint
+                                ),
+                                apply_receipt=apply_receipt,
+                                commit_operation_id=receipt.commit_id,
+                                message=receipt.message,
+                            )
+                        )
+                        if restored_apply != apply_receipt:
+                            raise ProjectWriterClientError(
+                                "Host undo reconciliation was not bound.",
+                                code="operation_result_unknown",
+                            )
+                        if state == "undone" and restored_commit == receipt:
+                            undone = receipt
+                        elif state == "committed" and restored_commit == receipt:
+                            undone = await self.project_host.undo(
+                                project_id=host_context[0],
+                                expected_head=host_context[1],
+                                expected_branch=host_context[3],
+                                apply_receipt=apply_receipt,
+                                commit_receipt=receipt,
+                            )
+                        else:
+                            raise ProjectWriterClientError(
+                                "Host undo reconciliation conflicted.",
+                                code="operation_conflict",
+                            )
+                    else:
+                        undone = await self.project_host.undo(
+                            project_id=host_context[0],
+                            expected_head=host_context[1],
+                            expected_branch=host_context[3],
+                            apply_receipt=apply_receipt,
+                            commit_receipt=receipt,
+                        )
                 else:
                     project_id, expected_head, _ = self._project_writer_context(record)
                     assert self.project_writer is not None
@@ -2564,15 +3069,41 @@ class CodingService:
             if record.apply_state is ApplyState.REVERTED:
                 return self._public_apply(record, revision)
             if record.apply_state is not ApplyState.APPLIED:
-                if record.apply_state is ApplyState.FAILED:
+                if record.apply_state is ApplyState.FAILED and not (
+                    self._is_host_project(record)
+                    and record.apply_reason == "operation_result_unknown"
+                ):
                     return self._public_apply(record, revision)
-                raise _http_error(status.HTTP_409_CONFLICT, "apply_not_revertible")
+                if record.apply_state is not ApplyState.FAILED:
+                    raise _http_error(status.HTTP_409_CONFLICT, "apply_not_revertible")
+            host_context: tuple[str, str, str, str] | None = None
+            host_retry_unknown = bool(
+                self._is_host_project(record)
+                and record.apply_state is ApplyState.FAILED
+                and record.apply_reason == "operation_result_unknown"
+            )
+            host_patch: str | None = None
             if self._is_builtin_project(record):
                 if self.applier is None:
                     raise _http_error(
                         status.HTTP_503_SERVICE_UNAVAILABLE,
                         "applier_unavailable",
                     )
+            elif self._is_host_project(record):
+                host_context = await self._require_host_writer_available(
+                    record,
+                    require_clean=False,
+                )
+                if host_retry_unknown:
+                    try:
+                        host_patch = _safe_diff(
+                            await self.worker.patch(
+                                record.worker_session_id,
+                                revision,
+                            )
+                        )
+                    except CodingWorkerError as exc:
+                        raise _worker_http_error(exc) from exc
             elif self.project_writer is None:
                 raise _http_error(
                     status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -2591,6 +3122,55 @@ class CodingService:
                 if self._is_builtin_project(record):
                     assert self.applier is not None
                     reverted = await self.applier.revert(receipt)
+                elif host_context is not None:
+                    assert self.project_host is not None
+                    if host_retry_unknown:
+                        try:
+                            self.project_host.bind_recovery_operations(
+                                project_id=host_context[0],
+                                expected_head=host_context[1],
+                                expected_branch=host_context[3],
+                                apply_operation_id=receipt.apply_id,
+                                apply_receipt=receipt,
+                                commit_receipt=None,
+                            )
+                        except ProjectHostError as exc:
+                            raise ProjectWriterClientError(
+                                "Host revert intent was rejected.",
+                                code=_safe_code(exc.code),
+                            ) from exc
+                        assert host_patch is not None
+                        state, restored = await self.project_host.reconcile_apply(
+                            project_id=host_context[0],
+                            expected_head=host_context[1],
+                            expected_branch=host_context[3],
+                            operation_id=receipt.apply_id,
+                            revision=revision,
+                            patch=host_patch,
+                            paths=[item.path for item in receipt.files],
+                            expected_fingerprint=receipt.snapshot_fingerprint,
+                        )
+                        if state == "not_applied":
+                            reverted = receipt
+                        elif state == "applied" and restored == receipt:
+                            reverted = await self.project_host.revert(
+                                project_id=host_context[0],
+                                expected_head=host_context[1],
+                                expected_branch=host_context[3],
+                                receipt=receipt,
+                            )
+                        else:
+                            raise ProjectWriterClientError(
+                                "Host revert reconciliation conflicted.",
+                                code="operation_conflict",
+                            )
+                    else:
+                        reverted = await self.project_host.revert(
+                            project_id=host_context[0],
+                            expected_head=host_context[1],
+                            expected_branch=host_context[3],
+                            receipt=receipt,
+                        )
                 else:
                     project_id, expected_head, _ = self._project_writer_context(record)
                     assert self.project_writer is not None
@@ -3095,6 +3675,10 @@ class CodingService:
     def _is_builtin_project(record: CodingApiSession) -> bool:
         return record.project.get("kind") == ProjectKind.BUILTIN.value
 
+    @staticmethod
+    def _is_host_project(record: CodingApiSession) -> bool:
+        return record.project.get("kind") == ProjectKind.HOST_GIT.value
+
     def _require_builtin_project(self, record: CodingApiSession) -> None:
         if not self._is_builtin_project(record):
             raise _http_error(
@@ -3216,6 +3800,14 @@ class CodingService:
         paths: list[str],
         fingerprint: str,
     ) -> None:
+        if self._is_host_project(record):
+            await self._reconcile_recovered_host_writeback(
+                record,
+                patch,
+                paths,
+                fingerprint,
+            )
+            return
         if not self._is_builtin_project(record):
             await self._reconcile_recovered_project_writeback(
                 record,
@@ -3345,6 +3937,177 @@ class CodingService:
         record.publish_reason = None
         record.publish_finished_at = time.time()
         record.state = "published"
+
+    async def _reconcile_recovered_host_writeback(
+        self,
+        record: CodingApiSession,
+        patch: str,
+        paths: list[str],
+        fingerprint: str,
+    ) -> None:
+        if self.project_host is None:
+            self._mark_recovery_conflict(record, "project_host_unavailable")
+            return
+        try:
+            project_id, expected_head, expected_fingerprint, expected_branch = (
+                self._host_writer_context(record)
+            )
+            source = record.project_source
+            if not isinstance(source, dict) or not isinstance(source.get("head"), str):
+                raise ValueError("Host project baseline is missing")
+            _current_parent, lineage = self._host_cycle_lineage(
+                record,
+                base_head=source["head"],
+                branch=expected_branch,
+                fingerprint=fingerprint,
+            )
+        except HTTPException:
+            self._mark_recovery_conflict(record, "project_changed")
+            return
+        except (TypeError, ValueError):
+            self._mark_recovery_conflict(record, "cycle_lineage_invalid")
+            return
+        if expected_fingerprint != fingerprint:
+            self._mark_recovery_conflict(record, "snapshot_mismatch")
+            return
+        apply_operation = record.apply_operation_id
+        apply_receipt = record.apply_receipt
+        if lineage and apply_operation is None:
+            if (
+                record.apply_state is not ApplyState.NOT_APPLIED
+                or record.commit_operation_id is not None
+                or record.commit_state is not CommitState.NOT_COMMITTED
+            ):
+                self._mark_recovery_conflict(record, "cycle_lineage_invalid")
+                return
+            last_cycle = record.cycle_history.cycles[-1]
+            parent, archived_apply, archived_commit = lineage[-1]
+            try:
+                state, restored_apply, restored_commit = (
+                    await self.project_host.reconcile_commit(
+                        project_id=project_id,
+                        expected_head=parent,
+                        expected_branch=expected_branch,
+                        operation_id=archived_apply.apply_id,
+                        revision=last_cycle.revision,
+                        patch=last_cycle.patch,
+                        paths=[item.path for item in archived_apply.files],
+                        expected_fingerprint=fingerprint,
+                        apply_receipt=archived_apply,
+                        commit_operation_id=archived_commit.commit_id,
+                        message=archived_commit.message,
+                    )
+                )
+            except ProjectWriterClientError as exc:
+                self._mark_recovery_conflict(record, _safe_code(exc.code))
+                return
+            if (
+                state != "committed"
+                or restored_apply != archived_apply
+                or restored_commit != archived_commit
+            ):
+                self._mark_recovery_conflict(record, "commit_recovery_conflict")
+            return
+        if (
+            apply_operation is not None
+            and apply_receipt is not None
+            and record.commit_operation_id is not None
+            and record.commit_message is not None
+            and record.commit_state is not CommitState.NOT_COMMITTED
+        ):
+            try:
+                state, restored_apply, commit_receipt = (
+                    await self.project_host.reconcile_commit(
+                        project_id=project_id,
+                        expected_head=expected_head,
+                        expected_branch=expected_branch,
+                        operation_id=apply_operation,
+                        revision=record.apply_revision or 0,
+                        patch=patch,
+                        paths=paths,
+                        expected_fingerprint=fingerprint,
+                        apply_receipt=apply_receipt,
+                        commit_operation_id=record.commit_operation_id,
+                        message=record.commit_message,
+                    )
+                )
+            except ProjectWriterClientError as exc:
+                self._mark_recovery_conflict(record, _safe_code(exc.code))
+                return
+            record.apply_receipt = restored_apply
+            record.apply_state = ApplyState.APPLIED
+            if state == "committed" and commit_receipt is not None:
+                record.commit_receipt = commit_receipt
+                record.commit_state = CommitState.COMMITTED
+                record.apply_reason = None
+                record.commit_reason = None
+                record.commit_finished_at = time.time()
+                record.state = "applied"
+                return
+            if state == "undone" and commit_receipt is not None:
+                record.commit_receipt = commit_receipt
+                record.commit_state = CommitState.UNDONE
+                record.apply_reason = None
+                record.commit_reason = None
+                record.commit_finished_at = time.time()
+                record.state = "applied"
+                return
+            if state == "not_committed" and record.commit_receipt is None:
+                record.commit_state = CommitState.FAILED
+                record.commit_reason = "commit_not_completed"
+                record.state = "applied"
+                return
+            self._mark_recovery_conflict(record, "commit_recovery_conflict")
+            return
+
+        if apply_operation is None or record.apply_state is ApplyState.NOT_APPLIED:
+            return
+        intended_revert = (
+            apply_receipt is not None
+            and record.apply_state in {ApplyState.REVERTING, ApplyState.FAILED}
+        )
+        try:
+            state, receipt = await self.project_host.reconcile_apply(
+                project_id=project_id,
+                expected_head=expected_head,
+                expected_branch=expected_branch,
+                operation_id=apply_operation,
+                revision=record.apply_revision or 0,
+                patch=patch,
+                paths=paths,
+                expected_fingerprint=fingerprint,
+            )
+        except ProjectWriterClientError as exc:
+            self._mark_recovery_conflict(record, _safe_code(exc.code))
+            return
+        if state == "conflict":
+            self._mark_recovery_conflict(record, "apply_recovery_conflict")
+        elif state == "applied" and receipt is not None:
+            record.apply_receipt = receipt
+            record.apply_state = ApplyState.APPLIED
+            record.apply_reason = None
+            record.apply_finished_at = time.time()
+            record.state = "applied"
+        elif state == "not_applied" and intended_revert:
+            record.apply_state = ApplyState.REVERTED
+            record.apply_reason = None
+            record.apply_finished_at = time.time()
+            record.state = "reverted"
+        elif state == "not_applied" and record.apply_state is ApplyState.REVERTED:
+            record.apply_reason = None
+            record.state = "reverted"
+        elif state == "not_applied" and record.apply_state in {
+            ApplyState.APPLYING,
+            ApplyState.FAILED,
+        }:
+            record.apply_state = ApplyState.NOT_APPLIED
+            record.apply_operation_id = None
+            record.apply_receipt = None
+            record.apply_reason = None
+            record.apply_finished_at = time.time()
+            record.state = "ready"
+        else:
+            self._mark_recovery_conflict(record, "apply_recovery_conflict")
 
     async def _reconcile_recovered_project_writeback(
         self,
@@ -3673,6 +4436,14 @@ class CodingService:
         record: CodingApiSession,
         expected_fingerprint: str,
     ) -> None:
+        if self._is_host_project(record):
+            _, _, fingerprint, _ = await self._require_host_writer_available(
+                record,
+                require_clean=False,
+            )
+            if fingerprint != expected_fingerprint:
+                raise _http_error(status.HTTP_409_CONFLICT, "snapshot_mismatch")
+            return
         if not self._is_builtin_project(record):
             _, _, fingerprint = await self._require_project_writer_available(record)
             if fingerprint != expected_fingerprint:
@@ -3700,6 +4471,11 @@ class CodingService:
         self,
         record: CodingApiSession,
     ) -> tuple[str, str, str]:
+        if record.project.get("kind") != ProjectKind.LOCAL_CLONE.value:
+            raise _http_error(
+                status.HTTP_409_CONFLICT,
+                "project_operation_unavailable",
+            )
         features = record.project.get("features")
         if not isinstance(features, dict) or features.get("apply") is not True:
             raise _http_error(
@@ -3711,6 +4487,45 @@ class CodingService:
             reason = str(capability.get("reason") or "project_writer_unavailable")
             raise _http_error(status.HTTP_503_SERVICE_UNAVAILABLE, reason)
         return self._project_writer_context(record)
+
+    async def _require_host_writer_available(
+        self,
+        record: CodingApiSession,
+        *,
+        require_clean: bool,
+    ) -> tuple[str, str, str, str]:
+        if not self._is_host_project(record) or self.project_host is None:
+            raise _http_error(
+                status.HTTP_503_SERVICE_UNAVAILABLE,
+                "project_host_writeback_unavailable",
+            )
+        features = record.project.get("features")
+        if not isinstance(features, dict) or features.get("apply") is not True:
+            raise _http_error(
+                status.HTTP_409_CONFLICT,
+                _safe_code(
+                    record.project.get("writeback_reason")
+                    or "project_operation_unavailable"
+                ),
+            )
+        try:
+            health = await self.project_host.health()
+        except ProjectHostError as exc:
+            raise _project_host_http_error(exc) from exc
+        if health.get("available") is not True:
+            raise _http_error(
+                status.HTTP_503_SERVICE_UNAVAILABLE,
+                _safe_code(
+                    health.get("reason") or "project_host_writeback_unavailable"
+                ),
+            )
+        project_id, head, fingerprint, branch = self._host_writer_context(record)
+        if require_clean:
+            try:
+                self.project_host.check_project(project_id, head, branch)
+            except ProjectHostError as exc:
+                raise _project_host_http_error(exc) from exc
+        return project_id, head, fingerprint, branch
 
     @staticmethod
     def _project_writer_context(
@@ -3732,6 +4547,89 @@ class CodingService:
         ):
             raise _http_error(status.HTTP_409_CONFLICT, "project_changed")
         return project_id, head, fingerprint
+
+    @staticmethod
+    def _host_cycle_lineage(
+        record: CodingApiSession,
+        *,
+        base_head: str,
+        branch: str,
+        fingerprint: str,
+    ) -> tuple[str, tuple[tuple[str, ApplyReceipt, CommitReceipt], ...]]:
+        parent = base_head
+        seen_operations: set[str] = set()
+        lineage: list[tuple[str, ApplyReceipt, CommitReceipt]] = []
+        for cycle in record.cycle_history.cycles:
+            if (
+                cycle.state is not CycleState.COMMITTED
+                or cycle.apply.get("state") != ApplyState.APPLIED.value
+                or cycle.commit.get("state") != CommitState.COMMITTED.value
+            ):
+                raise ValueError("Host cycle is not committed")
+            apply_receipt = _apply_receipt_from_storage(
+                cycle.apply.get("receipt")
+            )
+            commit_receipt = _commit_receipt_from_storage(
+                cycle.commit.get("receipt")
+            )
+            paths = tuple(item.path for item in apply_receipt.files)
+            try:
+                patch_paths = tuple(_diff_paths(cycle.patch))
+            except HTTPException as exc:
+                raise ValueError("Host cycle Patch is invalid") from exc
+            change_files = cycle.changes.get("files")
+            if not isinstance(change_files, list) or any(
+                not isinstance(item, dict) or not isinstance(item.get("path"), str)
+                for item in change_files
+            ):
+                raise ValueError("Host cycle changes are invalid")
+            change_paths = tuple(item["path"] for item in change_files)
+            if (
+                apply_receipt.revision != cycle.revision
+                or apply_receipt.snapshot_fingerprint != fingerprint
+                or patch_paths != paths
+                or change_paths != paths
+                or commit_receipt.revision != cycle.revision
+                or commit_receipt.apply_id != apply_receipt.apply_id
+                or commit_receipt.files != paths
+                or commit_receipt.branch != branch
+                or commit_receipt.parent_sha != parent
+                or commit_receipt.commit_sha == parent
+                or apply_receipt.apply_id in seen_operations
+                or commit_receipt.commit_id in seen_operations
+            ):
+                raise ValueError("Host cycle lineage is invalid")
+            seen_operations.update(
+                {apply_receipt.apply_id, commit_receipt.commit_id}
+            )
+            lineage.append((parent, apply_receipt, commit_receipt))
+            parent = commit_receipt.commit_sha
+        return parent, tuple(lineage)
+
+    @staticmethod
+    def _host_writer_context(
+        record: CodingApiSession,
+    ) -> tuple[str, str, str, str]:
+        if record.project.get("kind") != ProjectKind.HOST_GIT.value:
+            raise _http_error(status.HTTP_409_CONFLICT, "project_changed")
+        project_id, head, fingerprint = CodingService._project_writer_context(record)
+        source = record.project_source
+        branch = source.get("branch") if isinstance(source, dict) else None
+        if not isinstance(branch, str) or not branch:
+            raise _http_error(status.HTTP_409_CONFLICT, "project_changed")
+        try:
+            parent, _lineage = CodingService._host_cycle_lineage(
+                record,
+                base_head=head,
+                branch=branch,
+                fingerprint=fingerprint,
+            )
+        except (TypeError, ValueError) as exc:
+            raise _http_error(
+                status.HTTP_409_CONFLICT,
+                "cycle_lineage_invalid",
+            ) from exc
+        return project_id, parent, fingerprint, branch
 
     async def _publish_capability(self) -> dict[str, Any]:
         capability: dict[str, Any] = {
@@ -5541,8 +6439,12 @@ def _recovery_http_error(exc: CodingRecoveryError) -> HTTPException:
 def _applier_http_error(exc: ApplierClientError) -> HTTPException:
     if exc.code in {
         "already_reverted",
+        "apply_conflict",
+        "branch_changed",
+        "head_changed",
         "operation_conflict",
         "patch_apply_failed",
+        "project_changed",
         "revert_conflict",
         "snapshot_mismatch",
         "target_changed",
@@ -5559,10 +6461,14 @@ def _committer_http_error(exc: CommitterClientError) -> HTTPException:
     if exc.code in {
         "already_undone",
         "baseline_mismatch",
+        "branch_changed",
         "commit_already_exists",
         "commit_conflict",
         "dirty_index",
+        "head_changed",
+        "index_changed",
         "operation_conflict",
+        "project_changed",
         "repository_has_remote",
         "repository_not_independent",
         "shared_git_directory",

--- a/server/coding_runtime/commit_models.py
+++ b/server/coding_runtime/commit_models.py
@@ -19,6 +19,7 @@ COMMIT_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]{20,64}$")
 GIT_OBJECT_ID_PATTERN = re.compile(r"^(?:[a-f0-9]{40}|[a-f0-9]{64})$")
 MAX_COMMIT_MESSAGE_CHARS = 2_000
 MAX_COMMIT_SUBJECT_CHARS = 120
+MAX_COMMIT_BRANCH_CHARS = 200
 
 
 class CommitState(StrEnum):
@@ -56,6 +57,39 @@ def normalize_commit_message(value: str) -> str:
         )
     ):
         raise ValueError("Commit message is outside the allowed scope")
+    return normalized
+
+
+def validate_commit_branch(value: str) -> str:
+    """Validate a branch without invoking repository Git configuration."""
+    if not isinstance(value, str):
+        raise ValueError("Commit branch must be text")
+    normalized = unicodedata.normalize("NFC", value)
+    parts = normalized.split("/")
+    if (
+        not normalized
+        or normalized != value
+        or len(normalized) > MAX_COMMIT_BRANCH_CHARS
+        or normalized in {"@", "HEAD"}
+        or normalized.startswith(("-", "/"))
+        or normalized.endswith((".", "/"))
+        or ".." in normalized
+        or "@{" in normalized
+        or "\\" in normalized
+        or any(
+            not part
+            or part.startswith(".")
+            or part.endswith(".")
+            or part.endswith(".lock")
+            for part in parts
+        )
+        or any(
+            character in " ~^:?*["
+            or unicodedata.category(character).startswith("C")
+            for character in normalized
+        )
+    ):
+        raise ValueError("Commit branch is invalid")
     return normalized
 
 
@@ -105,7 +139,7 @@ class CommitReceipt:
             raise ValueError("Commit object ids are inconsistent")
         if normalize_commit_message(self.message) != self.message:
             raise ValueError("Commit message is not normalized")
-        if self.branch != COMMIT_BRANCH:
+        if validate_commit_branch(self.branch) != self.branch:
             raise ValueError("Commit branch is invalid")
         try:
             safe_files = tuple(
@@ -134,6 +168,7 @@ class CommitReceipt:
         tree_sha: str,
         message: str,
         files: tuple[str, ...],
+        branch: str = COMMIT_BRANCH,
     ) -> CommitReceipt:
         return cls(
             commit_id=secrets.token_urlsafe(18),
@@ -144,6 +179,7 @@ class CommitReceipt:
             tree_sha=tree_sha,
             message=normalize_commit_message(message),
             files=files,
+            branch=validate_commit_branch(branch),
         )
 
     def to_public(self, *, state: CommitState = CommitState.COMMITTED) -> dict[str, object]:
@@ -167,6 +203,7 @@ def not_committed_payload(
     suggested_message: str,
     state: CommitState = CommitState.NOT_COMMITTED,
     reason: str | None = None,
+    branch: str = COMMIT_BRANCH,
 ) -> dict[str, object]:
     if isinstance(revision, bool) or revision < 0:
         raise ValueError("Commit revision is invalid")
@@ -176,7 +213,7 @@ def not_committed_payload(
         "commit_id": None,
         "commit_sha": None,
         "short_sha": None,
-        "branch": COMMIT_BRANCH,
+        "branch": validate_commit_branch(branch),
         "message": None,
         "suggested_message": normalize_commit_message(suggested_message),
         "committed_at": None,

--- a/server/coding_runtime/host_snapshot.py
+++ b/server/coding_runtime/host_snapshot.py
@@ -4,10 +4,12 @@ import contextlib
 import hashlib
 import io
 import json
+import os
 import subprocess
 import tarfile
 import threading
 import unicodedata
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Any
@@ -47,6 +49,7 @@ class HostSnapshotResult:
     file_count: int
     total_bytes: int
     hidden_files: int
+    archive_identity: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -63,7 +66,11 @@ def create_host_snapshot_archive(
     name: str,
     branch: str,
     head: str,
+    identity_provider: Callable[[Path], str] | None = None,
+    identity_cleanup: Callable[[Path, str], None] | None = None,
 ) -> HostSnapshotResult:
+    if identity_cleanup is not None and identity_provider is None:
+        raise ValueError("identity_cleanup requires identity_provider")
     _validate_identity(project_id, name, branch, head)
     project_path = Path(project_path).resolve(strict=True)
     destination = Path(destination)
@@ -89,21 +96,48 @@ def create_host_snapshot_archive(
     fingerprint = hashlib.sha256()
     total_bytes = 0
     temporary = destination.with_name(f".{destination.name}.building")
-    temporary.unlink(missing_ok=True)
-    process = subprocess.Popen(
-        build_safe_git_command(project_path, ("cat-file", "--batch")),
-        cwd=project_path,
-        env=build_safe_git_environment(),
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.DEVNULL,
-    )
+    try:
+        descriptor = os.open(
+            temporary,
+            os.O_WRONLY
+            | os.O_CREAT
+            | os.O_EXCL
+            | getattr(os, "O_NOFOLLOW", 0),
+            0o600,
+        )
+    except OSError as exc:
+        raise HostSnapshotError("snapshot_archive_publish_failed") from exc
+    building_identity: str | None = None
+    try:
+        building_identity = (
+            identity_provider(temporary) if identity_provider is not None else None
+        )
+        process = subprocess.Popen(
+            build_safe_git_command(project_path, ("cat-file", "--batch")),
+            cwd=project_path,
+            env=build_safe_git_environment(),
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+    except BaseException:
+        os.close(descriptor)
+        if building_identity is not None and identity_cleanup is not None:
+            with contextlib.suppress(Exception):
+                identity_cleanup(temporary, building_identity)
+        elif identity_provider is None:
+            temporary.unlink(missing_ok=True)
+        raise
     timeout = threading.Timer(60.0, process.kill)
     timeout.daemon = True
     timeout.start()
     assert process.stdin is not None and process.stdout is not None
     try:
-        with tarfile.open(temporary, mode="w:gz", format=tarfile.PAX_FORMAT) as archive:
+        with os.fdopen(descriptor, "wb") as output, tarfile.open(
+            fileobj=output,
+            mode="w:gz",
+            format=tarfile.PAX_FORMAT,
+        ) as archive:
             for item in visible:
                 process.stdin.write(item.object_id.encode("ascii") + b"\n")
                 process.stdin.flush()
@@ -161,9 +195,18 @@ def create_host_snapshot_archive(
             raise HostSnapshotError("snapshot_git_failed")
         if temporary.stat().st_size > MAX_HOST_ARCHIVE_BYTES:
             raise HostSnapshotError("snapshot_archive_too_large")
-        temporary.replace(destination)
+        archive_identity = _publish_archive_no_replace(
+            temporary,
+            destination,
+            identity_provider=identity_provider,
+            expected_identity=building_identity,
+        )
     except BaseException:
-        temporary.unlink(missing_ok=True)
+        if building_identity is not None and identity_cleanup is not None:
+            with contextlib.suppress(Exception):
+                identity_cleanup(temporary, building_identity)
+        elif identity_provider is None:
+            temporary.unlink(missing_ok=True)
         with contextlib.suppress(Exception):
             process.kill()
         with contextlib.suppress(Exception):
@@ -180,7 +223,33 @@ def create_host_snapshot_archive(
         file_count=len(visible),
         total_bytes=total_bytes,
         hidden_files=hidden_files,
+        archive_identity=archive_identity,
     )
+
+
+def _publish_archive_no_replace(
+    temporary: Path,
+    destination: Path,
+    *,
+    identity_provider: Callable[[Path], str] | None,
+    expected_identity: str | None,
+) -> str | None:
+    """Publish one exact archive object without overwriting another name."""
+
+    identity = expected_identity
+    if identity_provider is not None and identity_provider(temporary) != identity:
+        raise HostSnapshotError("snapshot_archive_publish_failed")
+    try:
+        # Both names are in the same private transfer directory. A hard-link
+        # publication is atomic and fails if an unknown destination exists;
+        # after the building name is removed the archive again has one link.
+        os.link(temporary, destination, follow_symlinks=False)
+    except (FileExistsError, OSError) as exc:
+        raise HostSnapshotError("snapshot_archive_publish_failed") from exc
+    temporary.unlink()
+    if identity_provider is not None and identity_provider(destination) != identity:
+        raise HostSnapshotError("snapshot_archive_publish_failed")
+    return identity
 
 
 def extract_host_snapshot_archive(

--- a/server/coding_runtime/project_host.py
+++ b/server/coding_runtime/project_host.py
@@ -17,7 +17,18 @@ from typing import Any, Callable, Literal
 from .projects import MAX_PROJECT_NAME_CHARS, MAX_PROJECTS, ProjectFeatures, ProjectKind
 
 
-PROJECT_HOST_PROTOCOL = "modelmirror-coding-project-host-v1"
+PROJECT_HOST_PROTOCOL_V1 = "modelmirror-coding-project-host-v1"
+PROJECT_HOST_PROTOCOL_V2 = "modelmirror-coding-project-host-v2"
+PROJECT_HOST_PROTOCOL = PROJECT_HOST_PROTOCOL_V2
+SUPPORTED_PROJECT_HOST_PROTOCOLS = frozenset(
+    {PROJECT_HOST_PROTOCOL_V1, PROJECT_HOST_PROTOCOL_V2}
+)
+PROJECT_HOST_V2_CAPABILITIES = (
+    "snapshot",
+    "writeback",
+    "commit",
+    "reconcile",
+)
 PROJECT_HOST_PLATFORM = "windows"
 PAIRING_TTL_SECONDS = 300
 SELECTION_TTL_SECONDS = 300
@@ -54,11 +65,16 @@ class ProjectHost:
     token_hash: str
     version: str
     platform: str
+    protocol: str = PROJECT_HOST_PROTOCOL_V1
     status: Literal["online", "offline", "revoked"] = "offline"
     connection_id: str | None = None
     created_at: float = field(default_factory=time.time)
     updated_at: float = field(default_factory=time.time)
     last_heartbeat_at: float | None = None
+
+    @property
+    def supports_writeback(self) -> bool:
+        return self.protocol == PROJECT_HOST_PROTOCOL_V2
 
 
 @dataclass(slots=True)
@@ -153,6 +169,7 @@ class ProjectHostStore:
         device_id: str,
         version: str,
         platform: str,
+        protocol: str = PROJECT_HOST_PROTOCOL_V1,
     ) -> tuple[ProjectHost, str]:
         if DEVICE_ID_PATTERN.fullmatch(device_id) is None:
             raise ProjectHostError("project_host_device_invalid")
@@ -160,6 +177,8 @@ class ProjectHostStore:
             raise ProjectHostError("project_host_platform_unsupported")
         if not _valid_version(version):
             raise ProjectHostError("project_host_version_invalid")
+        if protocol not in SUPPORTED_PROJECT_HOST_PROTOCOLS:
+            raise ProjectHostError("project_host_protocol_mismatch")
         now = self._clock()
         code_hash = self._hash_secret(str(code).strip())
         with self._lock:
@@ -193,6 +212,7 @@ class ProjectHostStore:
                     token_hash=self._hash_secret(token),
                     version=version,
                     platform=platform,
+                    protocol=protocol,
                     status="online",
                     last_heartbeat_at=now,
                     created_at=now,
@@ -205,6 +225,7 @@ class ProjectHostStore:
                 host.token_hash = self._hash_secret(token)
                 host.version = version
                 host.platform = platform
+                host.protocol = protocol
                 host.status = "online"
                 host.last_heartbeat_at = now
                 host.updated_at = now
@@ -221,11 +242,23 @@ class ProjectHostStore:
                 raise ProjectHostError("project_host_authentication_failed")
             return host
 
-    def connect(self, host_id: str, token: str, *, connection_id: str, version: str) -> ProjectHost:
+    def connect(
+        self,
+        host_id: str,
+        token: str,
+        *,
+        connection_id: str,
+        version: str,
+        protocol: str = PROJECT_HOST_PROTOCOL_V1,
+    ) -> ProjectHost:
         with self._lock:
             host = self.authenticate(host_id, token)
             if not _valid_version(version):
                 raise ProjectHostError("project_host_version_invalid")
+            if protocol not in SUPPORTED_PROJECT_HOST_PROTOCOLS:
+                raise ProjectHostError("project_host_protocol_mismatch")
+            if protocol != host.protocol:
+                raise ProjectHostError("project_host_protocol_upgrade_requires_pairing")
             now = self._clock()
             host.version = version
             host.connection_id = connection_id
@@ -305,6 +338,8 @@ class ProjectHostStore:
                 "name": active.name if active else None,
                 "version": active.version if active else None,
                 "platform": active.platform if active else PROJECT_HOST_PLATFORM,
+                "protocol": active.protocol if active else None,
+                "direct_writeback": bool(active and active.supports_writeback),
             }
 
     def register_project(self, host_id: str, value: dict[str, Any]) -> HostGitProject:
@@ -451,6 +486,8 @@ class ProjectHostStore:
                 # legacy field while ensuring it is never written again.
                 sanitized.pop("token_prefix", None)
                 host = ProjectHost(**sanitized)
+                if host.protocol not in SUPPORTED_PROJECT_HOST_PROTOCOLS:
+                    raise ValueError("invalid host protocol")
                 if HOST_ID_PATTERN.fullmatch(host.host_id) and DEVICE_ID_PATTERN.fullmatch(host.device_id):
                     host.status = "revoked" if host.status == "revoked" else "offline"
                     host.connection_id = None

--- a/server/coding_runtime/project_host_api.py
+++ b/server/coding_runtime/project_host_api.py
@@ -17,6 +17,13 @@ from typing import Any, AsyncIterator
 from fastapi import APIRouter, Header, HTTPException, Request, Response, WebSocket, WebSocketDisconnect, status
 from pydantic import BaseModel, ConfigDict, Field
 
+from .applier_client import _receipt_from_response, _receipt_to_payload
+from .apply_models import ApplyReceipt
+from .committer_client import (
+    _commit_receipt_from_response,
+    _commit_receipt_to_payload,
+)
+from .commit_models import CommitReceipt
 from .host_snapshot import MAX_HOST_ARCHIVE_BYTES
 from .project_host import (
     PROJECT_HOST_PLATFORM,
@@ -27,12 +34,18 @@ from .project_host import (
     ProjectHostError,
     ProjectHostStore,
 )
+from .project_writer_client import ProjectWriterClientError
 
 
 PROJECT_HOST_REQUEST_TIMEOUT_SECONDS = 150.0
 PROJECT_HOST_MAX_MESSAGE_BYTES = 256 * 1024
 UPLOAD_ROOT_MARKER = ".modelmirror-coding-project-uploads"
 SAFE_TRANSFER_ID = re.compile(r"^[a-f0-9]{32}$")
+SAFE_PAYLOAD_ID = re.compile(r"^phop_[a-f0-9]{32}$")
+SAFE_OPERATION_ID = re.compile(r"^[A-Za-z0-9_-]{20,64}$")
+SAFE_OPERATION_ACTIONS = frozenset({"apply", "revert", "commit", "undo", "reconcile"})
+OPERATION_PAYLOAD_TTL_SECONDS = 90.0
+MAX_OPERATION_PAYLOAD_BYTES = 1200 * 1024
 logger = logging.getLogger(__name__)
 
 
@@ -56,21 +69,73 @@ class _Transfer:
     created_at: float
     size: int = 0
     sha256: str | None = None
+    expected_head: str | None = None
+    expected_branch: str | None = None
+    managed_operation_id: str | None = None
+
+
+@dataclass(slots=True)
+class _OperationPayload:
+    payload_id: str
+    host_id: str
+    project_id: str
+    operation_id: str
+    action: str
+    created_at: float
+    expires_at: float
+    sha256: str
+    size: int
+    body: bytes | None
+    consumed: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class _ManagedOperation:
+    project_id: str
+    operation_id: str
+    kind: str
+    branch: str
+    expected_head: str
 
 
 class ProjectHostRuntime:
-    def __init__(self, store: ProjectHostStore, upload_root: Path) -> None:
+    def __init__(
+        self,
+        store: ProjectHostStore,
+        upload_root: Path,
+        *,
+        writeback_enabled: bool = False,
+    ) -> None:
         self.store = store
         self.upload_root = Path(upload_root)
+        self.writeback_enabled = bool(writeback_enabled)
         self._prepare_upload_root()
         self._connections: dict[str, WebSocket] = {}
         self._pending: dict[str, asyncio.Future[dict[str, Any]]] = {}
         self._pending_hosts: dict[str, str] = {}
+        self._pending_operations: dict[str, tuple[str, str, str]] = {}
         self._transfers: dict[str, _Transfer] = {}
+        self._operation_payloads: dict[str, _OperationPayload] = {}
+        self._uncertain_operations: set[tuple[str, str, str]] = set()
+        self._managed_operations: dict[tuple[str, str], _ManagedOperation] = {}
+        self._request_tombstones: dict[str, float] = {}
         self._lock = asyncio.Lock()
 
     def capability(self, *, enabled: bool = True, reason: str | None = None) -> dict[str, Any]:
         status_payload = self.store.host_status()
+        direct_writeback = bool(
+            enabled
+            and self.writeback_enabled
+            and status_payload["available"]
+            and status_payload.get("direct_writeback") is True
+        )
+        writeback_reason: str | None = None
+        if not self.writeback_enabled:
+            writeback_reason = "project_host_writeback_disabled"
+        elif status_payload.get("direct_writeback") is not True:
+            writeback_reason = "project_host_protocol_readonly"
+        elif not status_payload["available"]:
+            writeback_reason = reason or "project_host_offline"
         return {
             "enabled": enabled,
             "paired": status_payload["paired"],
@@ -78,20 +143,35 @@ class ProjectHostRuntime:
             "platform": PROJECT_HOST_PLATFORM,
             "selection": True,
             "remembers_projects": True,
-            "direct_writeback": False,
+            "direct_writeback": direct_writeback,
+            "writeback_available": direct_writeback,
+            **({"writeback_reason": writeback_reason} if writeback_reason else {}),
             **({"reason": reason or "project_host_offline"} if not status_payload["available"] else {}),
         }
 
     def status(self) -> dict[str, Any]:
-        return self.store.host_status()
+        status_payload = self.store.host_status()
+        capability = self.capability()
+        return {
+            **status_payload,
+            "direct_writeback": capability["direct_writeback"],
+            "writeback_available": capability["writeback_available"],
+            **(
+                {"writeback_reason": capability["writeback_reason"]}
+                if capability.get("writeback_reason") is not None
+                else {}
+            ),
+        }
 
     def list_projects(self) -> list[dict[str, Any]]:
-        return self.store.list_projects()
+        return [self._writeback_project(item) for item in self.store.list_projects()]
 
     def public_project(self, project_id: str) -> dict[str, Any]:
         project = self.store.require_project(project_id)
         host = self.store.require_host(project.host_id)
-        return project.to_public_dict(host_online=host.status == "online")
+        return self._writeback_project(
+            project.to_public_dict(host_online=host.status == "online")
+        )
 
     def check_project(self, project_id: str, head: str, branch: str | None) -> dict[str, Any]:
         project = self.store.require_project(project_id)
@@ -100,7 +180,533 @@ class ProjectHostRuntime:
             raise ProjectHostError("project_host_offline")
         if project.state != "available" or project.head != head or (branch is not None and project.branch != branch):
             raise ProjectHostError("project_changed")
-        return project.to_public_dict(host_online=True)
+        return self._writeback_project(project.to_public_dict(host_online=True))
+
+    async def health(self) -> dict[str, Any]:
+        capability = self.capability()
+        return {
+            "configured": self.writeback_enabled,
+            "available": capability["direct_writeback"],
+            "target": "selected_local_repository",
+            "supports_delete": True,
+            "supports_move": True,
+            "supports_revert": True,
+            "supports_commit": True,
+            "remote_operations": False,
+            **(
+                {"reason": capability["writeback_reason"]}
+                if capability.get("writeback_reason") is not None
+                else {}
+            ),
+        }
+
+    def bind_recovery_operations(
+        self,
+        *,
+        project_id: str,
+        expected_head: str,
+        expected_branch: str,
+        apply_operation_id: str | None = None,
+        commit_operation_id: str | None = None,
+        apply_receipt: ApplyReceipt | None,
+        commit_receipt: CommitReceipt | None,
+    ) -> None:
+        """Rehydrate only receipts already authenticated by encrypted recovery."""
+        if apply_receipt is None and commit_receipt is not None:
+            raise ProjectHostError("recovery_snapshot_invalid")
+        bound_apply_id = apply_operation_id or (
+            apply_receipt.apply_id if apply_receipt is not None else None
+        )
+        if apply_receipt is not None and bound_apply_id != apply_receipt.apply_id:
+            raise ProjectHostError("recovery_snapshot_invalid")
+        if bound_apply_id is not None:
+            self._remember_managed_operation(
+                project_id=project_id,
+                operation_id=bound_apply_id,
+                kind="apply",
+                branch=expected_branch,
+                expected_head=expected_head,
+            )
+        if commit_receipt is not None:
+            if (
+                apply_receipt is None
+                or commit_receipt.apply_id != apply_receipt.apply_id
+                or commit_receipt.revision != apply_receipt.revision
+                or commit_receipt.files
+                != tuple(item.path for item in apply_receipt.files)
+                or commit_receipt.branch != expected_branch
+                or commit_receipt.parent_sha != expected_head
+            ):
+                raise ProjectHostError("recovery_snapshot_invalid")
+            bound_commit_id = commit_operation_id or commit_receipt.commit_id
+            if bound_commit_id != commit_receipt.commit_id:
+                raise ProjectHostError("recovery_snapshot_invalid")
+            self._remember_managed_operation(
+                project_id=project_id,
+                operation_id=bound_commit_id,
+                kind="commit",
+                branch=expected_branch,
+                expected_head=expected_head,
+            )
+        elif commit_operation_id is not None:
+            if bound_apply_id is None:
+                raise ProjectHostError("recovery_snapshot_invalid")
+            self._remember_managed_operation(
+                project_id=project_id,
+                operation_id=commit_operation_id,
+                kind="commit",
+                branch=expected_branch,
+                expected_head=expected_head,
+            )
+
+    def bind_persisted_intent(
+        self,
+        *,
+        project_id: str,
+        expected_head: str,
+        expected_branch: str,
+        operation_id: str,
+        kind: str,
+        parent_operation_id: str | None = None,
+    ) -> None:
+        """Bind an intent only after CodingService durably stored it."""
+        project = self.store.require_project(project_id)
+        host = self.store.require_host(project.host_id)
+        if (
+            not self.writeback_enabled
+            or not host.supports_writeback
+            or host.status != "online"
+            or project.branch != expected_branch
+        ):
+            raise ProjectHostError("project_changed")
+        if kind == "commit":
+            if parent_operation_id is None:
+                raise ProjectHostError("operation_request_invalid")
+            parent = self._require_managed_operation(
+                project_id=project_id,
+                operation_id=parent_operation_id,
+                branch=expected_branch,
+                expected_head=expected_head,
+            )
+            if parent.kind != "apply":
+                raise ProjectHostError("operation_conflict")
+        elif kind == "apply":
+            if (
+                parent_operation_id is not None
+                or project.state != "available"
+                or project.head != expected_head
+            ):
+                raise ProjectHostError("project_changed")
+        else:
+            raise ProjectHostError("operation_request_invalid")
+        self._remember_managed_operation(
+            project_id=project_id,
+            operation_id=operation_id,
+            kind=kind,
+            branch=expected_branch,
+            expected_head=expected_head,
+        )
+
+    async def apply(
+        self,
+        *,
+        project_id: str,
+        expected_head: str,
+        operation_id: str,
+        revision: int,
+        patch: str,
+        paths: list[str],
+        expected_fingerprint: str,
+        expected_branch: str,
+    ) -> ApplyReceipt:
+        intent = self._require_managed_operation(
+            project_id=project_id,
+            operation_id=operation_id,
+            branch=expected_branch,
+            expected_head=expected_head,
+        )
+        if intent.kind != "apply":
+            raise _writer_error("operation_conflict")
+        payload = {
+            "kind": "apply",
+            "revision": revision,
+            "expected_head": expected_head,
+            "snapshot_fingerprint": expected_fingerprint,
+            "patch": patch,
+            "paths": paths,
+        }
+        try:
+            result = await self._execute_operation(
+                project_id=project_id,
+                operation_id=operation_id,
+                action="apply",
+                payload=payload,
+                expected_head=expected_head,
+                expected_branch=expected_branch,
+                managed_operation_id=operation_id,
+            )
+        except ProjectWriterClientError as exc:
+            if exc.code != "operation_result_unknown":
+                self._forget_managed_operation(project_id, operation_id)
+            raise
+        try:
+            receipt = _operation_apply_receipt(result, expected_state="applied")
+            valid_receipt = bool(
+                receipt.apply_id == operation_id
+                and receipt.revision == revision
+                and receipt.snapshot_fingerprint == expected_fingerprint
+                and tuple(item.path for item in receipt.files) == tuple(paths)
+            )
+        except ProjectWriterClientError:
+            valid_receipt = False
+            receipt = None
+        if not valid_receipt or receipt is None:
+            self._uncertain_operations.add((project_id, operation_id, "apply"))
+            raise _writer_error("operation_result_unknown")
+        self._remember_managed_operation(
+            project_id=project_id,
+            operation_id=operation_id,
+            kind="apply",
+            branch=expected_branch,
+            expected_head=expected_head,
+        )
+        self._update_project_catalog(
+            project_id=project_id,
+            expected_branch=expected_branch,
+            allowed_heads={expected_head},
+            head=expected_head,
+            state="unavailable",
+            reason="git_repository_dirty",
+            operation_id=operation_id,
+            action="apply",
+        )
+        return receipt
+
+    async def revert(
+        self,
+        *,
+        project_id: str,
+        expected_head: str,
+        expected_branch: str,
+        receipt: ApplyReceipt,
+    ) -> ApplyReceipt:
+        operation_id = _followup_operation_id("revert", receipt.apply_id)
+        result = await self._execute_operation(
+            project_id=project_id,
+            operation_id=operation_id,
+            action="revert",
+            payload={
+                "kind": "revert",
+                "expected_head": expected_head,
+                "apply_receipt": _receipt_to_payload(receipt),
+            },
+            expected_head=expected_head,
+            expected_branch=expected_branch,
+            managed_operation_id=receipt.apply_id,
+        )
+        try:
+            reverted = _operation_apply_receipt(result, expected_state="reverted")
+        except ProjectWriterClientError:
+            reverted = None
+        if reverted != receipt:
+            self._uncertain_operations.add((project_id, operation_id, "revert"))
+            raise _writer_error("operation_result_unknown")
+        self._update_project_catalog(
+            project_id=project_id,
+            expected_branch=expected_branch,
+            allowed_heads={expected_head},
+            head=expected_head,
+            state="available",
+            reason=None,
+            operation_id=operation_id,
+            action="revert",
+        )
+        return reverted
+
+    async def commit(
+        self,
+        *,
+        project_id: str,
+        expected_head: str,
+        operation_id: str,
+        apply_receipt: ApplyReceipt,
+        message: str,
+        expected_branch: str,
+    ) -> CommitReceipt:
+        intent = self._require_managed_operation(
+            project_id=project_id,
+            operation_id=operation_id,
+            branch=expected_branch,
+            expected_head=expected_head,
+        )
+        if intent.kind != "commit":
+            raise _writer_error("operation_conflict")
+        try:
+            result = await self._execute_operation(
+                project_id=project_id,
+                operation_id=operation_id,
+                action="commit",
+                payload={
+                    "kind": "commit",
+                    "expected_head": expected_head,
+                    "apply_receipt": _receipt_to_payload(apply_receipt),
+                    "message": message,
+                },
+                expected_head=expected_head,
+                expected_branch=expected_branch,
+                managed_operation_id=apply_receipt.apply_id,
+            )
+        except ProjectWriterClientError as exc:
+            if exc.code != "operation_result_unknown":
+                self._forget_managed_operation(project_id, operation_id)
+            raise
+        try:
+            receipt = _operation_commit_receipt(result, expected_state="committed")
+            valid_receipt = _commit_receipt_matches(
+                receipt,
+                operation_id=operation_id,
+                apply_receipt=apply_receipt,
+                expected_head=expected_head,
+                expected_branch=expected_branch,
+                message=message,
+            )
+        except ProjectWriterClientError:
+            valid_receipt = False
+            receipt = None
+        if not valid_receipt or receipt is None:
+            self._uncertain_operations.add((project_id, operation_id, "commit"))
+            raise _writer_error("operation_result_unknown")
+        self._remember_managed_operation(
+            project_id=project_id,
+            operation_id=operation_id,
+            kind="commit",
+            branch=expected_branch,
+            expected_head=expected_head,
+        )
+        self._update_project_catalog(
+            project_id=project_id,
+            expected_branch=expected_branch,
+            allowed_heads={expected_head, receipt.commit_sha},
+            head=receipt.commit_sha,
+            state="available",
+            reason=None,
+            operation_id=operation_id,
+            action="commit",
+        )
+        return receipt
+
+    async def undo(
+        self,
+        *,
+        project_id: str,
+        expected_head: str,
+        apply_receipt: ApplyReceipt,
+        commit_receipt: CommitReceipt,
+        expected_branch: str,
+    ) -> CommitReceipt:
+        operation_id = _followup_operation_id("undo", commit_receipt.commit_id)
+        result = await self._execute_operation(
+            project_id=project_id,
+            operation_id=operation_id,
+            action="undo",
+            payload={
+                "kind": "undo",
+                "expected_head": expected_head,
+                "apply_receipt": _receipt_to_payload(apply_receipt),
+                "commit_receipt": _commit_receipt_to_payload(commit_receipt),
+            },
+            expected_head=expected_head,
+            expected_branch=expected_branch,
+            managed_operation_id=commit_receipt.commit_id,
+        )
+        try:
+            undone = _operation_commit_receipt(result, expected_state="undone")
+        except ProjectWriterClientError:
+            undone = None
+        if undone != commit_receipt:
+            self._uncertain_operations.add((project_id, operation_id, "undo"))
+            raise _writer_error("operation_result_unknown")
+        self._update_project_catalog(
+            project_id=project_id,
+            expected_branch=expected_branch,
+            allowed_heads={expected_head, commit_receipt.commit_sha},
+            head=expected_head,
+            state="unavailable",
+            reason="git_repository_dirty",
+            operation_id=operation_id,
+            action="undo",
+        )
+        return undone
+
+    async def reconcile_apply(
+        self,
+        *,
+        project_id: str,
+        expected_head: str,
+        operation_id: str,
+        revision: int,
+        patch: str,
+        paths: list[str],
+        expected_fingerprint: str,
+        expected_branch: str,
+    ) -> tuple[str, ApplyReceipt | None]:
+        result = await self._execute_operation(
+            project_id=project_id,
+            operation_id=operation_id,
+            action="reconcile",
+            payload={
+                "kind": "apply",
+                "revision": revision,
+                "expected_head": expected_head,
+                "snapshot_fingerprint": expected_fingerprint,
+                "patch_sha256": hashlib.sha256(patch.encode("utf-8")).hexdigest(),
+                "paths": paths,
+            },
+            expected_head=expected_head,
+            expected_branch=expected_branch,
+            managed_operation_id=operation_id,
+        )
+        state = result.get("state")
+        if state not in {"not_applied", "applied", "conflict"}:
+            raise _writer_error("invalid_response")
+        receipt_payload = result.get("receipt")
+        if state == "applied":
+            receipt = _operation_apply_receipt(result, expected_state=state)
+            if (
+                receipt.apply_id != operation_id
+                or receipt.revision != revision
+                or receipt.snapshot_fingerprint != expected_fingerprint
+                or tuple(item.path for item in receipt.files) != tuple(paths)
+            ):
+                raise _writer_error("operation_result_unknown")
+            self._remember_managed_operation(
+                project_id=project_id,
+                operation_id=operation_id,
+                kind="apply",
+                branch=expected_branch,
+                expected_head=expected_head,
+            )
+            self._update_project_catalog(
+                project_id=project_id,
+                expected_branch=expected_branch,
+                allowed_heads={expected_head},
+                head=expected_head,
+                state="unavailable",
+                reason="git_repository_dirty",
+            )
+            self._clear_apply_uncertain(project_id, operation_id)
+            return state, receipt
+        if receipt_payload is not None:
+            raise _writer_error("invalid_response")
+        if state == "not_applied":
+            self._update_project_catalog(
+                project_id=project_id,
+                expected_branch=expected_branch,
+                allowed_heads={expected_head},
+                head=expected_head,
+                state="available",
+                reason=None,
+            )
+            self._clear_apply_uncertain(project_id, operation_id)
+        return state, None
+
+    async def reconcile_commit(
+        self,
+        *,
+        project_id: str,
+        expected_head: str,
+        operation_id: str,
+        revision: int,
+        patch: str,
+        paths: list[str],
+        expected_fingerprint: str,
+        apply_receipt: ApplyReceipt,
+        commit_operation_id: str,
+        message: str,
+        expected_branch: str,
+    ) -> tuple[str, ApplyReceipt, CommitReceipt | None]:
+        result = await self._execute_operation(
+            project_id=project_id,
+            operation_id=commit_operation_id,
+            action="reconcile",
+            payload={
+                "kind": "commit",
+                "apply_operation_id": operation_id,
+                "revision": revision,
+                "expected_head": expected_head,
+                "snapshot_fingerprint": expected_fingerprint,
+                "patch_sha256": hashlib.sha256(patch.encode("utf-8")).hexdigest(),
+                "paths": paths,
+                "apply_receipt": _receipt_to_payload(apply_receipt),
+                "message": message,
+            },
+            expected_head=expected_head,
+            expected_branch=expected_branch,
+            managed_operation_id=apply_receipt.apply_id,
+        )
+        state = result.get("state")
+        if state not in {"not_committed", "committed", "undone"}:
+            raise _writer_error("invalid_response")
+        restored_apply = _operation_apply_receipt(
+            {"state": "applied", "receipt": result.get("apply_receipt")},
+            expected_state="applied",
+        )
+        if restored_apply != apply_receipt:
+            raise _writer_error("operation_result_unknown")
+        commit_payload = result.get("commit_receipt")
+        if state == "not_committed":
+            if commit_payload is not None:
+                raise _writer_error("invalid_response")
+            self._update_project_catalog(
+                project_id=project_id,
+                expected_branch=expected_branch,
+                allowed_heads={expected_head},
+                head=expected_head,
+                state="unavailable",
+                reason="git_repository_dirty",
+            )
+            self._clear_commit_uncertain(project_id, commit_operation_id)
+            return state, restored_apply, None
+        commit_receipt = _operation_commit_receipt(
+            {"state": state, "receipt": commit_payload},
+            expected_state=state,
+        )
+        if not _commit_receipt_matches(
+            commit_receipt,
+            operation_id=commit_operation_id,
+            apply_receipt=apply_receipt,
+            expected_head=expected_head,
+            expected_branch=expected_branch,
+            message=message,
+        ):
+            raise _writer_error("operation_result_unknown")
+        self._remember_managed_operation(
+            project_id=project_id,
+            operation_id=commit_operation_id,
+            kind="commit",
+            branch=expected_branch,
+            expected_head=expected_head,
+        )
+        if state == "committed":
+            self._update_project_catalog(
+                project_id=project_id,
+                expected_branch=expected_branch,
+                allowed_heads={expected_head, commit_receipt.commit_sha},
+                head=commit_receipt.commit_sha,
+                state="available",
+                reason=None,
+            )
+        else:
+            self._update_project_catalog(
+                project_id=project_id,
+                expected_branch=expected_branch,
+                allowed_heads={expected_head, commit_receipt.commit_sha},
+                head=expected_head,
+                state="unavailable",
+                reason="git_repository_dirty",
+            )
+        self._clear_commit_uncertain(project_id, commit_operation_id)
+        return state, restored_apply, commit_receipt
 
     async def create_selection(self) -> dict[str, Any]:
         selection = self.store.create_selection()
@@ -157,15 +763,33 @@ class ProjectHostRuntime:
         *,
         expected_head: str | None = None,
         expected_branch: str | None = None,
+        managed_operation_id: str | None = None,
     ) -> dict[str, Any]:
         project = self.store.require_project(project_id)
         host = self.store.require_host(project.host_id)
-        if host.status != "online" or project.state != "available":
-            raise ProjectHostError(project.reason or "project_host_offline")
-        if expected_head is not None and project.head != expected_head:
-            raise ProjectHostError("project_changed")
-        if expected_branch is not None and project.branch != expected_branch:
-            raise ProjectHostError("project_changed")
+        if (
+            managed_operation_id is not None
+            and SAFE_OPERATION_ID.fullmatch(managed_operation_id) is None
+        ):
+            raise ProjectHostError("operation_request_invalid")
+        if host.status != "online":
+            raise ProjectHostError("project_host_offline")
+        if managed_operation_id is not None:
+            binding = self._require_managed_operation(
+                project_id=project_id,
+                operation_id=managed_operation_id,
+                branch=expected_branch,
+                expected_head=expected_head,
+            )
+            if binding.kind != "apply" or project.branch != expected_branch:
+                raise ProjectHostError("operation_conflict")
+        else:
+            if project.state != "available":
+                raise ProjectHostError(project.reason or "project_changed")
+            if expected_head is not None and project.head != expected_head:
+                raise ProjectHostError("project_changed")
+            if expected_branch is not None and project.branch != expected_branch:
+                raise ProjectHostError("project_changed")
         request_id = f"phreq_{uuid.uuid4().hex}"
         transfer_id = secrets.token_hex(16)
         loop = asyncio.get_running_loop()
@@ -177,6 +801,9 @@ class ProjectHostRuntime:
             project_id=project_id,
             status="awaiting_upload",
             created_at=time.time(),
+            expected_head=expected_head,
+            expected_branch=expected_branch,
+            managed_operation_id=managed_operation_id,
         )
         async with self._lock:
             self._pending[request_id] = future
@@ -191,6 +818,21 @@ class ProjectHostRuntime:
                     "request_id": request_id,
                     "project_id": project_id,
                     "transfer_id": transfer_id,
+                    **(
+                        {"expected_head": expected_head}
+                        if expected_head is not None
+                        else {}
+                    ),
+                    **(
+                        {"expected_branch": expected_branch}
+                        if expected_branch is not None
+                        else {}
+                    ),
+                    **(
+                        {"managed_operation_id": managed_operation_id}
+                        if managed_operation_id is not None
+                        else {}
+                    ),
                 },
             )
             result = await asyncio.wait_for(
@@ -215,6 +857,326 @@ class ProjectHostRuntime:
         if transfer is not None:
             (self.upload_root / f"{transfer_id}.uploading").unlink(missing_ok=True)
             (self.upload_root / f"{transfer_id}.tar.gz").unlink(missing_ok=True)
+
+    async def consume_operation_payload(
+        self,
+        *,
+        payload_id: str,
+        host_id: str,
+        token: str,
+        project_id: str,
+        operation_id: str,
+        action: str,
+    ) -> bytes:
+        self.store.authenticate(host_id, token)
+        if (
+            SAFE_PAYLOAD_ID.fullmatch(payload_id) is None
+            or PROJECT_ID_PATTERN.fullmatch(project_id) is None
+            or SAFE_OPERATION_ID.fullmatch(operation_id) is None
+            or action not in SAFE_OPERATION_ACTIONS
+        ):
+            raise ProjectHostError("operation_payload_invalid")
+        now = time.time()
+        async with self._lock:
+            self._expire_operation_payloads_unlocked(now)
+            payload = self._operation_payloads.get(payload_id)
+            if payload is None:
+                raise ProjectHostError("operation_payload_unavailable")
+            if (
+                payload.host_id != host_id
+                or payload.project_id != project_id
+                or payload.operation_id != operation_id
+                or payload.action != action
+            ):
+                raise ProjectHostError("operation_payload_mismatch")
+            if payload.consumed or payload.body is None:
+                raise ProjectHostError("operation_payload_consumed")
+            body = payload.body
+            payload.body = None
+            payload.consumed = True
+        return body
+
+    async def _execute_operation(
+        self,
+        *,
+        project_id: str,
+        operation_id: str,
+        action: str,
+        payload: dict[str, Any],
+        expected_head: str | None = None,
+        expected_branch: str | None = None,
+        managed_operation_id: str | None = None,
+    ) -> dict[str, Any]:
+        try:
+            if (
+                action != "reconcile"
+                and (project_id, operation_id, action) in self._uncertain_operations
+            ):
+                raise ProjectHostError("operation_result_unknown")
+            project, host = self._operation_context(
+                project_id,
+                operation_id,
+                action,
+                expected_head=expected_head,
+                expected_branch=expected_branch,
+                managed_operation_id=managed_operation_id,
+            )
+            bound_head = expected_head or project.head
+            bound_branch = expected_branch or project.branch
+            body = json.dumps(
+                {
+                    "version": 1,
+                    "host_id": host.host_id,
+                    "project_id": project_id,
+                    "operation_id": operation_id,
+                    "action": action,
+                    "branch": bound_branch,
+                    "head": bound_head,
+                    "payload": payload,
+                },
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+            if not 0 < len(body) <= MAX_OPERATION_PAYLOAD_BYTES:
+                raise ProjectHostError("operation_payload_too_large")
+            payload_id = f"phop_{uuid.uuid4().hex}"
+            digest = hashlib.sha256(body).hexdigest()
+            now = time.time()
+            item = _OperationPayload(
+                payload_id=payload_id,
+                host_id=host.host_id,
+                project_id=project_id,
+                operation_id=operation_id,
+                action=action,
+                created_at=now,
+                expires_at=now + OPERATION_PAYLOAD_TTL_SECONDS,
+                sha256=digest,
+                size=len(body),
+                body=body,
+            )
+            async with self._lock:
+                self._expire_operation_payloads_unlocked(now)
+                self._operation_payloads[payload_id] = item
+            try:
+                result = await self._command(
+                    host.host_id,
+                    {
+                        "type": "execute_operation",
+                        "project_id": project_id,
+                        "operation_id": operation_id,
+                        "action": action,
+                        "payload_id": payload_id,
+                        "payload_sha256": digest,
+                        "payload_size": len(body),
+                        "payload_expires_at": item.expires_at,
+                    },
+                    timeout=PROJECT_HOST_REQUEST_TIMEOUT_SECONDS,
+                )
+            except ProjectHostError as exc:
+                if exc.code in {
+                    "project_host_offline",
+                    "project_host_request_timeout",
+                    "project_host_request_unknown",
+                    "operation_result_unknown",
+                }:
+                    self._uncertain_operations.add((project_id, operation_id, action))
+                    raise ProjectHostError("operation_result_unknown") from exc
+                raise
+            finally:
+                async with self._lock:
+                    self._operation_payloads.pop(payload_id, None)
+            if (
+                result.get("type") != "operation_result"
+                or result.get("project_id") != project_id
+                or result.get("operation_id") != operation_id
+                or result.get("action") != action
+                or not isinstance(result.get("result"), dict)
+            ):
+                self._uncertain_operations.add((project_id, operation_id, action))
+                raise ProjectHostError("operation_result_unknown")
+            self._uncertain_operations.discard((project_id, operation_id, action))
+            return result["result"]
+        except ProjectWriterClientError:
+            raise
+        except ProjectHostError as exc:
+            raise _writer_error(exc.code) from exc
+
+    def _operation_context(
+        self,
+        project_id: str,
+        operation_id: str,
+        action: str,
+        *,
+        expected_head: str | None,
+        expected_branch: str | None,
+        managed_operation_id: str | None = None,
+    ) -> tuple[Any, Any]:
+        if (
+            PROJECT_ID_PATTERN.fullmatch(project_id) is None
+            or SAFE_OPERATION_ID.fullmatch(operation_id) is None
+            or action not in SAFE_OPERATION_ACTIONS
+        ):
+            raise ProjectHostError("operation_request_invalid")
+        project = self.store.require_project(project_id)
+        host = self.store.require_host(project.host_id)
+        if not self.writeback_enabled:
+            raise ProjectHostError("project_host_writeback_disabled")
+        if not host.supports_writeback:
+            raise ProjectHostError("project_host_protocol_readonly")
+        if host.status != "online":
+            raise ProjectHostError("project_host_offline")
+        if expected_branch is not None and project.branch != expected_branch:
+            raise ProjectHostError("project_changed")
+        if action == "apply" and expected_head is not None and project.head != expected_head:
+            raise ProjectHostError("project_changed")
+        if managed_operation_id is not None:
+            self._require_managed_operation(
+                project_id=project_id,
+                operation_id=managed_operation_id,
+                branch=expected_branch,
+                expected_head=expected_head,
+            )
+        elif project.state != "available":
+            raise ProjectHostError(project.reason or "project_changed")
+        return project, host
+
+    def _remember_managed_operation(
+        self,
+        *,
+        project_id: str,
+        operation_id: str,
+        kind: str,
+        branch: str,
+        expected_head: str,
+    ) -> None:
+        if (
+            PROJECT_ID_PATTERN.fullmatch(project_id) is None
+            or SAFE_OPERATION_ID.fullmatch(operation_id) is None
+            or kind not in {"apply", "commit"}
+            or not branch
+            or re.fullmatch(r"(?:[a-f0-9]{40}|[a-f0-9]{64})", expected_head)
+            is None
+        ):
+            raise ProjectHostError("operation_request_invalid")
+        binding = _ManagedOperation(
+            project_id=project_id,
+            operation_id=operation_id,
+            kind=kind,
+            branch=branch,
+            expected_head=expected_head,
+        )
+        key = (project_id, operation_id)
+        existing = self._managed_operations.get(key)
+        if existing is not None and existing != binding:
+            raise ProjectHostError("operation_conflict")
+        self._managed_operations[key] = binding
+
+    def _require_managed_operation(
+        self,
+        *,
+        project_id: str,
+        operation_id: str,
+        branch: str | None,
+        expected_head: str | None,
+    ) -> _ManagedOperation:
+        binding = self._managed_operations.get((project_id, operation_id))
+        if (
+            binding is None
+            or branch is None
+            or expected_head is None
+            or binding.branch != branch
+            or binding.expected_head != expected_head
+        ):
+            raise ProjectHostError("operation_conflict")
+        return binding
+
+    def _clear_apply_uncertain(self, project_id: str, operation_id: str) -> None:
+        self._uncertain_operations.discard((project_id, operation_id, "apply"))
+        self._uncertain_operations.discard(
+            (project_id, _followup_operation_id("revert", operation_id), "revert")
+        )
+
+    def _clear_commit_uncertain(self, project_id: str, operation_id: str) -> None:
+        self._uncertain_operations.discard((project_id, operation_id, "commit"))
+        self._uncertain_operations.discard(
+            (project_id, _followup_operation_id("undo", operation_id), "undo")
+        )
+
+    def _forget_managed_operation(self, project_id: str, operation_id: str) -> None:
+        self._managed_operations.pop((project_id, operation_id), None)
+
+    def _update_project_catalog(
+        self,
+        *,
+        project_id: str,
+        expected_branch: str,
+        allowed_heads: set[str],
+        head: str,
+        state: str,
+        reason: str | None,
+        operation_id: str | None = None,
+        action: str | None = None,
+    ) -> None:
+        """Advance only catalog state proven by an authenticated operation result."""
+        try:
+            project = self.store.require_project(project_id)
+            if project.branch != expected_branch or project.head not in allowed_heads:
+                raise ProjectHostError("project_changed")
+            self.store.register_project(
+                project.host_id,
+                {
+                    "project_id": project.project_id,
+                    "name": project.name,
+                    "branch": expected_branch,
+                    "head": head,
+                    "state": state,
+                    "reason": reason,
+                },
+            )
+        except (OSError, ProjectHostError) as exc:
+            if operation_id is not None and action is not None:
+                self._uncertain_operations.add((project_id, operation_id, action))
+            raise _writer_error("operation_result_unknown") from exc
+
+    def _writeback_project(self, value: dict[str, Any]) -> dict[str, Any]:
+        project_id = value.get("id")
+        available = False
+        reason = "project_host_writeback_not_available"
+        if isinstance(project_id, str):
+            try:
+                project = self.store.require_project(project_id)
+                host = self.store.require_host(project.host_id)
+                available = bool(
+                    self.writeback_enabled
+                    and host.status == "online"
+                    and host.supports_writeback
+                    and project.state == "available"
+                )
+                if not self.writeback_enabled:
+                    reason = "project_host_writeback_disabled"
+                elif not host.supports_writeback:
+                    reason = "project_host_protocol_readonly"
+                elif host.status != "online":
+                    reason = "project_host_offline"
+                elif project.state != "available":
+                    reason = project.reason or "project_changed"
+            except ProjectHostError:
+                pass
+        features = value.get("features")
+        if isinstance(features, dict):
+            value = {**value, "features": {**features, "apply": available, "commit": available}}
+        value["writeback_reason"] = None if available else reason
+        return value
+
+    def _expire_operation_payloads_unlocked(self, now: float) -> None:
+        expired = [
+            payload_id
+            for payload_id, payload in self._operation_payloads.items()
+            if payload.expires_at <= now
+        ]
+        for payload_id in expired:
+            self._operation_payloads.pop(payload_id, None)
 
     async def receive_transfer(
         self,
@@ -300,12 +1262,11 @@ class ProjectHostRuntime:
                     {
                         "type": "welcome",
                         "protocol": protocol,
-                        "capabilities": (
-                            list(PROJECT_HOST_V2_CAPABILITIES)
-                            if protocol == PROJECT_HOST_PROTOCOL_V2
-                            else ["snapshot"]
+                        "capabilities": self._welcome_capabilities(protocol),
+                        "direct_writeback": bool(
+                            protocol == PROJECT_HOST_PROTOCOL_V2
+                            and self.writeback_enabled
                         ),
-                        "direct_writeback": protocol == PROJECT_HOST_PROTOCOL_V2,
                         "paired": True,
                         "host_id": host_id,
                         "host_token": token,
@@ -328,12 +1289,11 @@ class ProjectHostRuntime:
                     {
                         "type": "welcome",
                         "protocol": protocol,
-                        "capabilities": (
-                            list(PROJECT_HOST_V2_CAPABILITIES)
-                            if protocol == PROJECT_HOST_PROTOCOL_V2
-                            else ["snapshot"]
+                        "capabilities": self._welcome_capabilities(protocol),
+                        "direct_writeback": bool(
+                            protocol == PROJECT_HOST_PROTOCOL_V2
+                            and self.writeback_enabled
                         ),
-                        "direct_writeback": protocol == PROJECT_HOST_PROTOCOL_V2,
                         "paired": False,
                         "host_id": host_id,
                         "heartbeat_seconds": 20,
@@ -410,6 +1370,16 @@ class ProjectHostRuntime:
             if not isinstance(projects, list) or len(projects) > 50:
                 raise ProjectHostError("invalid_project_host_response")
             for project in projects:
+                if isinstance(project, dict) and project.get("state") == "unavailable":
+                    project_id = project.get("project_id")
+                    if isinstance(project_id, str):
+                        with contextlib.suppress(ProjectHostError):
+                            known = self.store.require_project(project_id)
+                            if (
+                                known.host_id == host_id
+                                and project.get("branch") == known.branch
+                            ):
+                                project = {**project, "head": known.head}
                 self.store.register_project(host_id, project)
             return
         request_id = str(message.get("request_id") or "")
@@ -433,7 +1403,15 @@ class ProjectHostRuntime:
                 or project_payload.get("project_id") != transfer.project_id
             ):
                 raise ProjectHostError("snapshot_transfer_mismatch")
-            project = self.store.register_project(host_id, project_payload)
+            if transfer.managed_operation_id is not None:
+                if (
+                    project_payload.get("head") != transfer.expected_head
+                    or project_payload.get("branch") != transfer.expected_branch
+                ):
+                    raise ProjectHostError("snapshot_transfer_mismatch")
+                project = self.store.require_project(transfer.project_id)
+            else:
+                project = self.store.register_project(host_id, project_payload)
             if not future.done():
                 future.set_result(
                     {
@@ -441,9 +1419,9 @@ class ProjectHostRuntime:
                         "archive_sha256": transfer.sha256,
                         "project": {
                             "project_id": project.project_id,
-                            "name": project.name,
-                            "branch": project.branch,
-                            "head": project.head,
+                            "name": str(project_payload.get("name") or project.name),
+                            "branch": str(project_payload.get("branch") or project.branch),
+                            "head": str(project_payload.get("head") or project.head),
                         },
                     }
                 )
@@ -456,6 +1434,35 @@ class ProjectHostRuntime:
             if not future.done():
                 future.set_result({"ok": True})
             return
+        if message_type == "operation_result":
+            async with self._lock:
+                self._expire_request_tombstones_unlocked(time.time())
+                future = self._pending.get(request_id)
+                tombstoned = request_id in self._request_tombstones
+                expected_host = self._pending_hosts.get(request_id)
+                expected_operation = self._pending_operations.get(request_id)
+            if future is None:
+                if tombstoned:
+                    return
+                raise ProjectHostError("project_host_request_not_found")
+            if (
+                expected_host != host_id
+                or expected_operation is None
+                or expected_operation
+                != (
+                    str(message.get("project_id") or ""),
+                    str(message.get("operation_id") or ""),
+                    str(message.get("action") or ""),
+                )
+            ):
+                if not future.done():
+                    future.set_exception(
+                        ProjectHostError("invalid_project_host_response")
+                    )
+                return
+            if not future.done():
+                future.set_result(message)
+            return
         if message_type == "request_error":
             error = str(message.get("error") or "project_host_request_failed")
             with contextlib.suppress(ProjectHostError):
@@ -464,29 +1471,65 @@ class ProjectHostRuntime:
                     self.store.complete_selection(host_id, request_id, error=error)
                     return
             async with self._lock:
+                self._expire_request_tombstones_unlocked(time.time())
                 future = self._pending.get(request_id)
+                tombstoned = request_id in self._request_tombstones
+                expected_host = self._pending_hosts.get(request_id)
+            if future is not None and expected_host != host_id:
+                if not future.done():
+                    future.set_exception(
+                        ProjectHostError("invalid_project_host_response")
+                    )
+                return
             if future is not None and not future.done():
                 future.set_exception(ProjectHostError(error))
                 return
+            if tombstoned:
+                return
         raise ProjectHostError("project_host_message_unsupported")
 
-    async def _command(self, host_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+    async def _command(
+        self,
+        host_id: str,
+        payload: dict[str, Any],
+        *,
+        timeout: float = 30.0,
+    ) -> dict[str, Any]:
         request_id = f"phreq_{uuid.uuid4().hex}"
         future: asyncio.Future[dict[str, Any]] = asyncio.get_running_loop().create_future()
         async with self._lock:
             self._pending[request_id] = future
             self._pending_hosts[request_id] = host_id
+            if payload.get("type") == "execute_operation":
+                self._pending_operations[request_id] = (
+                    str(payload.get("project_id") or ""),
+                    str(payload.get("operation_id") or ""),
+                    str(payload.get("action") or ""),
+                )
         try:
             await self._send(host_id, {**payload, "request_id": request_id})
-            return await asyncio.wait_for(asyncio.shield(future), timeout=30)
+            return await asyncio.wait_for(asyncio.shield(future), timeout=timeout)
         except TimeoutError as exc:
+            async with self._lock:
+                self._request_tombstones[request_id] = time.time() + 300.0
             raise ProjectHostError("project_host_request_timeout") from exc
         finally:
             async with self._lock:
                 self._pending.pop(request_id, None)
                 self._pending_hosts.pop(request_id, None)
+                self._pending_operations.pop(request_id, None)
                 if not future.done():
                     future.cancel()
+
+    def _welcome_capabilities(self, protocol: str) -> list[str]:
+        if protocol != PROJECT_HOST_PROTOCOL_V2 or not self.writeback_enabled:
+            return ["snapshot"]
+        return list(PROJECT_HOST_V2_CAPABILITIES)
+
+    def _expire_request_tombstones_unlocked(self, now: float) -> None:
+        for request_id in tuple(self._request_tombstones):
+            if self._request_tombstones[request_id] <= now:
+                self._request_tombstones.pop(request_id, None)
 
     async def _send(self, host_id: str, payload: dict[str, Any]) -> None:
         async with self._lock:
@@ -514,7 +1557,66 @@ class ProjectHostRuntime:
                 child.unlink()
 
 
-def create_project_host_runtime() -> ProjectHostRuntime:
+def _followup_operation_id(action: str, operation_id: str) -> str:
+    digest = hashlib.sha256(f"{action}\0{operation_id}".encode("utf-8")).hexdigest()
+    return f"{action}_{digest[:40]}"
+
+
+def _writer_error(code: str) -> ProjectWriterClientError:
+    safe_code = code if re.fullmatch(r"[a-z][a-z0-9_]{0,63}", code) else "project_writer_error"
+    return ProjectWriterClientError("Project host operation failed.", code=safe_code)
+
+
+def _operation_apply_receipt(
+    result: dict[str, Any],
+    *,
+    expected_state: str,
+) -> ApplyReceipt:
+    if result.get("state") != expected_state or not isinstance(result.get("receipt"), dict):
+        raise _writer_error("invalid_response")
+    try:
+        return _receipt_from_response({"receipt": result["receipt"]})
+    except Exception as exc:
+        raise _writer_error("invalid_response") from exc
+
+
+def _operation_commit_receipt(
+    result: dict[str, Any],
+    *,
+    expected_state: str,
+) -> CommitReceipt:
+    if result.get("state") != expected_state or not isinstance(result.get("receipt"), dict):
+        raise _writer_error("invalid_response")
+    try:
+        return _commit_receipt_from_response({"receipt": result["receipt"]})
+    except Exception as exc:
+        raise _writer_error("invalid_response") from exc
+
+
+def _commit_receipt_matches(
+    receipt: CommitReceipt,
+    *,
+    operation_id: str,
+    apply_receipt: ApplyReceipt,
+    expected_head: str,
+    expected_branch: str,
+    message: str,
+) -> bool:
+    return bool(
+        receipt.commit_id == operation_id
+        and receipt.revision == apply_receipt.revision
+        and receipt.apply_id == apply_receipt.apply_id
+        and receipt.parent_sha == expected_head
+        and receipt.branch == expected_branch
+        and receipt.message == message
+        and receipt.files == tuple(item.path for item in apply_receipt.files)
+    )
+
+
+def create_project_host_runtime(
+    *,
+    writeback_enabled: bool | None = None,
+) -> ProjectHostRuntime:
     state_path = Path(
         os.getenv(
             "CODING_PROJECT_HOST_STATE_PATH",
@@ -524,7 +1626,17 @@ def create_project_host_runtime() -> ProjectHostRuntime:
     upload_root = Path(os.getenv("CODING_PROJECT_UPLOAD_ROOT", "/project-uploads"))
     if not state_path.is_absolute():
         raise ProjectHostError("project_host_state_not_configured")
-    return ProjectHostRuntime(ProjectHostStore(state_path), upload_root)
+    enabled = (
+        os.getenv("CODING_PROJECT_HOST_WRITEBACK_ENABLED", "false").strip().lower()
+        in {"1", "true", "yes", "on"}
+        if writeback_enabled is None
+        else bool(writeback_enabled)
+    )
+    return ProjectHostRuntime(
+        ProjectHostStore(state_path),
+        upload_root,
+        writeback_enabled=enabled,
+    )
 
 
 project_host_router = APIRouter()
@@ -669,3 +1781,44 @@ async def upload_project_snapshot(
         )
     except ProjectHostError as exc:
         _raise(exc)
+
+
+@project_host_router.get("/project-host/operations/{payload_id}")
+async def download_project_operation(
+    payload_id: str,
+    authorization: str | None = Header(default=None),
+    host_id: str | None = Header(default=None, alias="X-ModelMirror-Project-Host-Id"),
+    project_id: str | None = Header(default=None, alias="X-ModelMirror-Project-Id"),
+    operation_id: str | None = Header(default=None, alias="X-ModelMirror-Operation-Id"),
+    action: str | None = Header(default=None, alias="X-ModelMirror-Operation-Action"),
+) -> Response:
+    token = (
+        authorization.removeprefix("Bearer ").strip()
+        if authorization and authorization.startswith("Bearer ")
+        else ""
+    )
+    if not all((token, host_id, project_id, operation_id, action)):
+        raise HTTPException(
+            status_code=401,
+            detail={"code": "project_host_authentication_failed"},
+        )
+    try:
+        body = await _runtime().consume_operation_payload(
+            payload_id=payload_id,
+            host_id=host_id,
+            token=token,
+            project_id=project_id,
+            operation_id=operation_id,
+            action=action,
+        )
+    except ProjectHostError as exc:
+        _raise(exc)
+    return Response(
+        content=body,
+        media_type="application/json",
+        headers={
+            "Cache-Control": "no-store",
+            "Pragma": "no-cache",
+            "Content-Security-Policy": "default-src 'none'",
+        },
+    )

--- a/server/coding_runtime/project_host_api.py
+++ b/server/coding_runtime/project_host_api.py
@@ -20,7 +20,9 @@ from pydantic import BaseModel, ConfigDict, Field
 from .host_snapshot import MAX_HOST_ARCHIVE_BYTES
 from .project_host import (
     PROJECT_HOST_PLATFORM,
-    PROJECT_HOST_PROTOCOL,
+    PROJECT_HOST_PROTOCOL_V2,
+    PROJECT_HOST_V2_CAPABILITIES,
+    SUPPORTED_PROJECT_HOST_PROTOCOLS,
     PROJECT_ID_PATTERN,
     ProjectHostError,
     ProjectHostStore,
@@ -266,8 +268,17 @@ class ProjectHostRuntime:
         host_id = ""
         try:
             first = await asyncio.wait_for(self._receive(websocket), timeout=15)
-            if not isinstance(first, dict) or first.get("protocol") != PROJECT_HOST_PROTOCOL:
+            if not isinstance(first, dict):
                 raise ProjectHostError("project_host_protocol_mismatch")
+            protocol = str(first.get("protocol") or "")
+            if protocol not in SUPPORTED_PROJECT_HOST_PROTOCOLS:
+                raise ProjectHostError("project_host_protocol_mismatch")
+            capabilities = first.get("capabilities")
+            if protocol == PROJECT_HOST_PROTOCOL_V2:
+                if capabilities != list(PROJECT_HOST_V2_CAPABILITIES):
+                    raise ProjectHostError("project_host_capabilities_invalid")
+            elif capabilities is not None:
+                raise ProjectHostError("project_host_capabilities_invalid")
             message_type = first.get("type")
             if message_type == "pair":
                 host, token = self.store.consume_pairing(
@@ -275,13 +286,26 @@ class ProjectHostRuntime:
                     device_id=str(first.get("device_id") or ""),
                     version=str(first.get("version") or ""),
                     platform=str(first.get("platform") or ""),
+                    protocol=protocol,
                 )
                 host_id = host.host_id
-                self.store.connect(host_id, token, connection_id=connection_id, version=host.version)
+                self.store.connect(
+                    host_id,
+                    token,
+                    connection_id=connection_id,
+                    version=host.version,
+                    protocol=protocol,
+                )
                 await websocket.send_json(
                     {
                         "type": "welcome",
-                        "protocol": PROJECT_HOST_PROTOCOL,
+                        "protocol": protocol,
+                        "capabilities": (
+                            list(PROJECT_HOST_V2_CAPABILITIES)
+                            if protocol == PROJECT_HOST_PROTOCOL_V2
+                            else ["snapshot"]
+                        ),
+                        "direct_writeback": protocol == PROJECT_HOST_PROTOCOL_V2,
                         "paired": True,
                         "host_id": host_id,
                         "host_token": token,
@@ -296,13 +320,20 @@ class ProjectHostRuntime:
                     token,
                     connection_id=connection_id,
                     version=str(first.get("version") or ""),
+                    protocol=protocol,
                 )
                 if first.get("device_id") != host.device_id or first.get("platform") != host.platform:
                     raise ProjectHostError("project_host_identity_mismatch")
                 await websocket.send_json(
                     {
                         "type": "welcome",
-                        "protocol": PROJECT_HOST_PROTOCOL,
+                        "protocol": protocol,
+                        "capabilities": (
+                            list(PROJECT_HOST_V2_CAPABILITIES)
+                            if protocol == PROJECT_HOST_PROTOCOL_V2
+                            else ["snapshot"]
+                        ),
+                        "direct_writeback": protocol == PROJECT_HOST_PROTOCOL_V2,
                         "paired": False,
                         "host_id": host_id,
                         "heartbeat_seconds": 20,

--- a/server/coding_runtime/projects.py
+++ b/server/coding_runtime/projects.py
@@ -528,6 +528,7 @@ def build_safe_git_environment() -> dict[str, str]:
         {
             "GIT_CONFIG_NOSYSTEM": "1",
             "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_NO_LAZY_FETCH": "1",
             "GIT_TERMINAL_PROMPT": "0",
             "GIT_OPTIONAL_LOCKS": "0",
         }

--- a/server/coding_runtime/projects.py
+++ b/server/coding_runtime/projects.py
@@ -529,6 +529,7 @@ def build_safe_git_environment() -> dict[str, str]:
             "GIT_CONFIG_NOSYSTEM": "1",
             "GIT_CONFIG_GLOBAL": os.devnull,
             "GIT_NO_LAZY_FETCH": "1",
+            "GIT_NO_REPLACE_OBJECTS": "1",
             "GIT_TERMINAL_PROMPT": "0",
             "GIT_OPTIONAL_LOCKS": "0",
         }
@@ -547,6 +548,8 @@ def build_safe_git_command(project_path: Path, arguments: Sequence[str]) -> tupl
         "credential.helper=",
         "-c",
         f"core.attributesFile={os.devnull}",
+        "-c",
+        f"core.excludesFile={os.devnull}",
         "-c",
         f"safe.directory={project_path}",
         *arguments,

--- a/server/tests/test_coding_project_host.py
+++ b/server/tests/test_coding_project_host.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
 import json
+import hashlib
 
 import pytest
 
-from server.coding_runtime.project_host import ProjectHostError, ProjectHostStore
+from server.coding_project_host.operation_log import HostOperationJournal
+from server.coding_runtime.project_host import (
+    PROJECT_HOST_PROTOCOL_V1,
+    PROJECT_HOST_PROTOCOL_V2,
+    ProjectHostError,
+    ProjectHostStore,
+)
 from server.coding_runtime.project_host_api import ProjectHostRuntime
 
 
@@ -62,6 +69,7 @@ def test_pairing_is_single_use_and_persists_only_hashed_secrets(tmp_path) -> Non
         "token_hash",
         "version",
         "platform",
+        "protocol",
         "status",
         "connection_id",
         "created_at",
@@ -72,6 +80,209 @@ def test_pairing_is_single_use_and_persists_only_hashed_secrets(tmp_path) -> Non
     restored = ProjectHostStore(state)
     assert restored.host_status()["paired"] is True
     assert restored.host_status()["available"] is False
+    assert restored.host_status()["direct_writeback"] is False
+
+
+class _XorProtector:
+    fail_protect = False
+
+    def protect(self, value: bytes) -> bytes:
+        if self.fail_protect:
+            raise OSError("simulated DPAPI failure")
+        return bytes(item ^ 0x6D for item in value)
+
+    def unprotect(self, value: bytes) -> bytes:
+        return bytes(item ^ 0x6D for item in value)
+
+
+def test_v2_protocol_advertises_writeback_while_v1_remains_read_only(tmp_path) -> None:
+    store = ProjectHostStore(tmp_path / "state.json")
+    pairing, code = store.create_pairing("v2 helper")
+    assert pairing.consumed is False
+    host, token = store.consume_pairing(
+        code,
+        device_id="pdev_0123456789abcdef0123456789abcdef",
+        version="1.1.0",
+        platform="windows",
+        protocol=PROJECT_HOST_PROTOCOL_V2,
+    )
+    store.connect(
+        host.host_id,
+        token,
+        connection_id="conn-v2",
+        version="1.1.0",
+        protocol=PROJECT_HOST_PROTOCOL_V2,
+    )
+    assert store.host_status()["direct_writeback"] is True
+
+    restored = ProjectHostStore(tmp_path / "state.json")
+    assert restored.host_status()["protocol"] == PROJECT_HOST_PROTOCOL_V2
+    assert restored.host_status()["direct_writeback"] is True
+
+    with pytest.raises(ProjectHostError) as downgrade:
+        restored.connect(
+            host.host_id,
+            token,
+            connection_id="conn-v1",
+            version="1.0.1",
+            protocol=PROJECT_HOST_PROTOCOL_V1,
+        )
+    assert downgrade.value.code == "project_host_protocol_upgrade_requires_pairing"
+    assert restored.host_status()["direct_writeback"] is True
+
+
+def test_operation_journal_encrypts_patch_and_rejects_conflicting_reuse(tmp_path) -> None:
+    path = tmp_path / "operations.bin"
+    journal = HostOperationJournal(path, _XorProtector(), clock=lambda: 1000.0)
+    patch = "diff --git a/marker.txt b/marker.txt\n+nebula-v13-r7k3\n"
+    record = journal.create(
+        operation_id="operation_v13_0123456789",
+        action="apply",
+        project_id="hostgit_0123456789abcdef0123456789abcdef",
+        revision=7,
+        branch="feature/local-r7k3",
+        expected_head="a" * 40,
+        patch_sha256=hashlib.sha256(patch.encode("utf-8")).hexdigest(),
+        patch=patch,
+    )
+    assert record.state == "prepared"
+    assert patch.encode("utf-8") not in path.read_bytes()
+
+    restored = HostOperationJournal(path, _XorProtector(), clock=lambda: 1001.0)
+    assert restored.get(record.operation_id) == record
+    apply_receipt = {
+        "apply_id": record.operation_id,
+        "revision": 7,
+        "snapshot_fingerprint": "b" * 64,
+        "files": [
+            {
+                "path": "marker.txt",
+                "existed_before": True,
+                "before_sha256": "c" * 64,
+                "after_sha256": "d" * 64,
+            }
+        ],
+        "applied_at": 1001.0,
+    }
+    with pytest.raises(Exception) as missing_receipt:
+        restored.transition(record.operation_id, "applied")
+    assert getattr(missing_receipt.value, "code", None) == "operation_record_invalid"
+    transitioned = restored.transition(
+        record.operation_id,
+        "applied",
+        apply_receipt=apply_receipt,
+    )
+    assert transitioned.state == "applied"
+    assert transitioned.apply_receipt is not None
+    transitioned.apply_receipt["revision"] = 99
+    assert restored.get(record.operation_id).apply_receipt["revision"] == 7
+    with pytest.raises(Exception) as invalid_state:
+        restored.transition(record.operation_id, "committed")
+    assert getattr(invalid_state.value, "code", None) == "operation_state_invalid"
+
+    with pytest.raises(Exception) as conflict:
+        restored.create(
+            operation_id=record.operation_id,
+            action="apply",
+            project_id=record.project_id,
+            revision=8,
+            branch=record.branch,
+            expected_head=record.expected_head,
+            patch_sha256=record.patch_sha256,
+            patch=patch,
+        )
+    assert getattr(conflict.value, "code", None) == "operation_conflict"
+
+    with pytest.raises(Exception) as mismatched_patch:
+        restored.create(
+            operation_id="operation_v13_abcdefghijk",
+            action="apply",
+            project_id=record.project_id,
+            revision=8,
+            branch=record.branch,
+            expected_head=record.expected_head,
+            patch_sha256="e" * 64,
+            patch=patch,
+        )
+    assert getattr(mismatched_patch.value, "code", None) == "operation_record_invalid"
+
+
+def test_operation_journal_does_not_accept_memory_state_when_persist_fails(tmp_path) -> None:
+    protector = _XorProtector()
+    patch = "diff --git a/a.txt b/a.txt\n+stable\n"
+    journal = HostOperationJournal(tmp_path / "operations.bin", protector)
+    record = journal.create(
+        operation_id="operation_v13_persist_01",
+        action="apply",
+        project_id="hostgit_0123456789abcdef0123456789abcdef",
+        revision=3,
+        branch="feature/persist-r8v3",
+        expected_head="a" * 40,
+        patch_sha256=hashlib.sha256(patch.encode("utf-8")).hexdigest(),
+        patch=patch,
+    )
+    protector.fail_protect = True
+    with pytest.raises(OSError):
+        journal.transition(record.operation_id, "applying")
+    protector.fail_protect = False
+    assert journal.get(record.operation_id).state == "prepared"
+
+
+def test_operation_journal_binds_commit_receipt_to_head_and_applied_files(tmp_path) -> None:
+    journal = HostOperationJournal(tmp_path / "operations.bin", _XorProtector())
+    patch = "diff --git a/a.txt b/a.txt\n+stable\n"
+    apply_receipt = {
+        "apply_id": "apply_v13_binding_012345",
+        "revision": 4,
+        "snapshot_fingerprint": "b" * 64,
+        "files": [
+            {
+                "path": "a.txt",
+                "existed_before": True,
+                "before_sha256": "c" * 64,
+                "after_sha256": "d" * 64,
+            }
+        ],
+        "applied_at": 1001.0,
+    }
+    operation_id = "commit_v13_binding_0123"
+    record = journal.create(
+        operation_id=operation_id,
+        action="commit",
+        project_id="hostgit_0123456789abcdef0123456789abcdef",
+        revision=4,
+        branch="feature/binding-r8v3",
+        expected_head="a" * 40,
+        patch_sha256=hashlib.sha256(patch.encode("utf-8")).hexdigest(),
+        patch=patch,
+        apply_receipt=apply_receipt,
+    )
+    commit_receipt = {
+        "commit_id": operation_id,
+        "revision": 4,
+        "apply_id": apply_receipt["apply_id"],
+        "commit_sha": "e" * 40,
+        "parent_sha": "a" * 40,
+        "tree_sha": "f" * 40,
+        "message": "feature: update marker",
+        "files": ["a.txt"],
+        "branch": record.branch,
+        "committed_at": 1002.0,
+    }
+    wrong_parent = {**commit_receipt, "parent_sha": "9" * 40}
+    with pytest.raises(Exception) as parent_conflict:
+        journal.transition(operation_id, "committed", commit_receipt=wrong_parent)
+    assert getattr(parent_conflict.value, "code", None) == "operation_record_invalid"
+    wrong_files = {**commit_receipt, "files": ["other.txt"]}
+    with pytest.raises(Exception) as file_conflict:
+        journal.transition(operation_id, "committed", commit_receipt=wrong_files)
+    assert getattr(file_conflict.value, "code", None) == "operation_record_invalid"
+    committed = journal.transition(
+        operation_id,
+        "committed",
+        commit_receipt=commit_receipt,
+    )
+    assert committed.commit_receipt == commit_receipt
 
 
 def test_authentication_revoke_and_stale_heartbeat_fail_closed(tmp_path) -> None:

--- a/server/tests/test_coding_project_host.py
+++ b/server/tests/test_coding_project_host.py
@@ -171,6 +171,7 @@ def test_operation_journal_encrypts_patch_and_rejects_conflicting_reuse(tmp_path
         record.operation_id,
         "applied",
         apply_receipt=apply_receipt,
+        file_identities=("1-2:marker.txt",),
     )
     assert transitioned.state == "applied"
     assert transitioned.apply_receipt is not None
@@ -179,6 +180,54 @@ def test_operation_journal_encrypts_patch_and_rejects_conflicting_reuse(tmp_path
     with pytest.raises(Exception) as invalid_state:
         restored.transition(record.operation_id, "committed")
     assert getattr(invalid_state.value, "code", None) == "operation_state_invalid"
+
+
+def test_operation_journal_persists_created_directory_identity_once(tmp_path) -> None:
+    path = tmp_path / "operations.bin"
+    journal = HostOperationJournal(path, _XorProtector())
+    patch = "diff --git a/nested/new.txt b/nested/new.txt\n+stable\n"
+    record = journal.create(
+        operation_id="operation_v13_directories",
+        action="apply",
+        project_id="hostgit_0123456789abcdef0123456789abcdef",
+        revision=4,
+        branch="feature/local-k8m2",
+        expected_head="1" * 40,
+        patch_sha256=hashlib.sha256(patch.encode()).hexdigest(),
+        patch=patch,
+    )
+    receipt = {
+        "apply_id": record.operation_id,
+        "revision": 4,
+        "snapshot_fingerprint": "f" * 64,
+        "files": [
+            {
+                "path": "nested/new.txt",
+                "existed_before": False,
+                "before_sha256": None,
+                "after_sha256": "a" * 64,
+            }
+        ],
+        "applied_at": 1.0,
+    }
+    journal.transition(record.operation_id, "applying", apply_receipt=receipt)
+    updated = journal.transition(
+        record.operation_id,
+        "applying",
+        created_directories=("1a-2b@3c-4d:nested",),
+    )
+    assert updated.created_directories == ("1a-2b@3c-4d:nested",)
+    restored = HostOperationJournal(path, _XorProtector())
+    assert restored.get(record.operation_id).created_directories == (
+        "1a-2b@3c-4d:nested",
+    )
+    with pytest.raises(Exception) as conflict:
+        restored.transition(
+            record.operation_id,
+            "applying",
+            created_directories=("1a-2c@3c-4d:nested",),
+        )
+    assert getattr(conflict.value, "code", None) == "operation_conflict"
 
     with pytest.raises(Exception) as conflict:
         restored.create(
@@ -221,9 +270,27 @@ def test_operation_journal_does_not_accept_memory_state_when_persist_fails(tmp_p
         patch_sha256=hashlib.sha256(patch.encode("utf-8")).hexdigest(),
         patch=patch,
     )
+    apply_receipt = {
+        "apply_id": record.operation_id,
+        "revision": 3,
+        "snapshot_fingerprint": "b" * 64,
+        "files": [
+            {
+                "path": "a.txt",
+                "existed_before": False,
+                "before_sha256": None,
+                "after_sha256": "d" * 64,
+            }
+        ],
+        "applied_at": 1001.0,
+    }
     protector.fail_protect = True
     with pytest.raises(OSError):
-        journal.transition(record.operation_id, "applying")
+        journal.transition(
+            record.operation_id,
+            "applying",
+            apply_receipt=apply_receipt,
+        )
     protector.fail_protect = False
     assert journal.get(record.operation_id).state == "prepared"
 

--- a/server/tests/test_coding_project_host.py
+++ b/server/tests/test_coding_project_host.py
@@ -2283,3 +2283,86 @@ def test_host_commit_rejects_replace_refs_and_disables_replace_objects(
         )
 
     assert rejected.value.code == "repository_unsafe"
+
+
+@pytest.mark.parametrize("action", ["commit", "undo", "reconcile"])
+@pytest.mark.parametrize(
+    "unsafe_kind",
+    ["extensions.refStorage", "core.excludesFile", "info-grafts"],
+)
+def test_host_commit_rejects_unsafe_metadata_before_operation_artifacts(
+    tmp_path: Path,
+    action: str,
+    unsafe_kind: str,
+) -> None:
+    root, head, journal, apply_receipt = _host_commit_applied(tmp_path)
+    branch = "feature/local-k8m2"
+    committed: CommitReceipt | None = None
+    if action == "undo":
+        committed = HostGitCommitEngine(
+            root,
+            HOST_COMMIT_PROJECT_ID,
+            journal,
+            enforce_windows=False,
+        ).commit(
+            operation_id="commit_before_unsafe_undo_0123",
+            apply_receipt=apply_receipt,
+            branch=branch,
+            expected_head=head,
+            message="feature: prepare guarded undo",
+        )
+
+    if unsafe_kind == "info-grafts":
+        (root / ".git" / "info" / "grafts").write_text(
+            head + "\n",
+            encoding="ascii",
+        )
+    else:
+        value = "reftable" if unsafe_kind == "extensions.refStorage" else "../outside-ignore"
+        _host_commit_git(root, "config", unsafe_kind, value)
+
+    branch_ref = root / ".git" / "refs" / "heads" / Path(branch)
+    ref_before = branch_ref.read_bytes()
+    transaction_root = root / ".git" / "modelmirror-transactions"
+    artifacts_before = tuple(
+        sorted(path.relative_to(transaction_root).as_posix() for path in transaction_root.rglob("*"))
+    )
+    operation_id = f"{action}_unsafe_metadata_{unsafe_kind.replace('.', '_').replace('-', '_')}_01"
+
+    with pytest.raises(HostCommitError) as rejected:
+        engine = HostGitCommitEngine(
+            root,
+            HOST_COMMIT_PROJECT_ID,
+            journal,
+            enforce_windows=False,
+        )
+        if action == "commit":
+            engine.commit(
+                operation_id=operation_id,
+                apply_receipt=apply_receipt,
+                branch=branch,
+                expected_head=head,
+                message="feature: reject unsafe metadata",
+            )
+        elif action == "undo":
+            assert committed is not None
+            engine.undo(
+                operation_id=operation_id,
+                apply_receipt=apply_receipt,
+                commit_receipt=committed,
+                branch=branch,
+            )
+        else:
+            engine.reconcile(operation_id)
+
+    expected_code = (
+        "repository_unsafe"
+        if unsafe_kind == "info-grafts"
+        else "repository_config_unsafe"
+    )
+    assert rejected.value.code == expected_code
+    assert journal.get(operation_id) is None
+    assert branch_ref.read_bytes() == ref_before
+    assert tuple(
+        sorted(path.relative_to(transaction_root).as_posix() for path in transaction_root.rglob("*"))
+    ) == artifacts_before

--- a/server/tests/test_coding_project_host.py
+++ b/server/tests/test_coding_project_host.py
@@ -692,13 +692,23 @@ def test_host_commit_dynamic_unicode_branch_remote_idempotency_and_undo(
         and "--no-create-reflog" in command
         for command in observed
     )
+    operation_environments = [
+        environment for environment in observed_environments if "GIT_DIR" in environment
+    ]
+    assert operation_environments
     assert all(
         environment["GIT_DIR"] == str(root / ".git")
         and environment["GIT_WORK_TREE"] == str(root)
         and environment["GIT_COMMON_DIR"] == str(root / ".git")
         and environment["GIT_NO_LAZY_FETCH"] == "1"
+        and environment["GIT_NO_REPLACE_OBJECTS"] == "1"
         and "GIT_OBJECT_DIRECTORY" in environment
         and "GIT_ALTERNATE_OBJECT_DIRECTORIES" in environment
+        for environment in operation_environments
+    )
+    assert all(
+        environment["GIT_NO_LAZY_FETCH"] == "1"
+        and environment["GIT_NO_REPLACE_OBJECTS"] == "1"
         for environment in observed_environments
     )
 

--- a/server/tests/test_coding_project_host.py
+++ b/server/tests/test_coding_project_host.py
@@ -2,10 +2,26 @@ from __future__ import annotations
 
 import json
 import hashlib
+import os
+import stat
+import subprocess
+from pathlib import Path
 
 import pytest
 
-from server.coding_project_host.operation_log import HostOperationJournal
+import server.coding_project_host.host_commit_engine as host_commit_engine_module
+from server.coding_project_host.host_apply_engine import HostGitApplyEngine
+from server.coding_project_host.host_commit_engine import (
+    HostCommitError,
+    HostGitCommitEngine,
+)
+from server.coding_project_host.operation_log import (
+    HostOperationJournal,
+    HostOperationLogError,
+)
+from server.coding_runtime.apply_models import ApplyFileReceipt, ApplyReceipt
+from server.coding_runtime.commit_models import validate_commit_branch
+from server.coding_runtime.draft_workspace import DraftWorkspace
 from server.coding_runtime.project_host import (
     PROJECT_HOST_PROTOCOL_V1,
     PROJECT_HOST_PROTOCOL_V2,
@@ -285,12 +301,13 @@ def test_operation_journal_does_not_accept_memory_state_when_persist_fails(tmp_p
         "applied_at": 1001.0,
     }
     protector.fail_protect = True
-    with pytest.raises(OSError):
+    with pytest.raises(HostOperationLogError) as unavailable:
         journal.transition(
             record.operation_id,
             "applying",
             apply_receipt=apply_receipt,
         )
+    assert unavailable.value.code == "operation_log_unavailable"
     protector.fail_protect = False
     assert journal.get(record.operation_id).state == "prepared"
 
@@ -322,7 +339,9 @@ def test_operation_journal_binds_commit_receipt_to_head_and_applied_files(tmp_pa
         expected_head="a" * 40,
         patch_sha256=hashlib.sha256(patch.encode("utf-8")).hexdigest(),
         patch=patch,
+        commit_message="feature: update marker",
         apply_receipt=apply_receipt,
+        file_identities=("1-2:a.txt",),
     )
     commit_receipt = {
         "commit_id": operation_id,
@@ -338,17 +357,27 @@ def test_operation_journal_binds_commit_receipt_to_head_and_applied_files(tmp_pa
     }
     wrong_parent = {**commit_receipt, "parent_sha": "9" * 40}
     with pytest.raises(Exception) as parent_conflict:
-        journal.transition(operation_id, "committed", commit_receipt=wrong_parent)
+        journal.transition(operation_id, "committing", commit_receipt=wrong_parent)
     assert getattr(parent_conflict.value, "code", None) == "operation_record_invalid"
     wrong_files = {**commit_receipt, "files": ["other.txt"]}
     with pytest.raises(Exception) as file_conflict:
-        journal.transition(operation_id, "committed", commit_receipt=wrong_files)
+        journal.transition(operation_id, "committing", commit_receipt=wrong_files)
     assert getattr(file_conflict.value, "code", None) == "operation_record_invalid"
-    committed = journal.transition(
+    committing = journal.transition(
         operation_id,
-        "committed",
+        "committing",
         commit_receipt=commit_receipt,
+        index_sha256="1" * 64,
+        index_before_sha256="6" * 64,
+        index_identity="2-3",
+        index_before_identity="4-5",
+        reflog_metadata=(
+            f"HEAD:{'7' * 64}@6-7",
+            f"branch:{'8' * 64}@8-9",
+        ),
     )
+    assert committing.commit_receipt == commit_receipt
+    committed = journal.transition(operation_id, "committed")
     assert committed.commit_receipt == commit_receipt
 
 
@@ -477,3 +506,1780 @@ def test_project_registration_rejects_malformed_or_path_bearing_payloads(tmp_pat
     with pytest.raises(ProjectHostError) as error:
         store.register_project(host_id, payload)
     assert error.value.code == "invalid_project_host_response"
+
+
+HOST_COMMIT_PROJECT_ID = "hostgit_89abcdef0123456789abcdef01234567"
+HOST_COMMIT_FINGERPRINT = "8" * 64
+
+
+def _host_commit_git(root: Path, *arguments: str, input_bytes: bytes | None = None) -> str:
+    stdin = subprocess.DEVNULL if input_bytes is None else None
+    completed = subprocess.run(
+        ("git", *arguments),
+        cwd=root,
+        stdin=stdin,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        input=input_bytes,
+        check=False,
+        timeout=20,
+    )
+    assert completed.returncode == 0, completed.stderr.decode(errors="replace")
+    return completed.stdout.decode("utf-8", errors="strict").strip()
+
+
+def _host_commit_repository(
+    tmp_path: Path,
+    *,
+    branch: str = "feature/local-k8m2",
+    content: bytes = b"before-r7k3\n",
+    autocrlf: bool = False,
+) -> tuple[Path, str]:
+    root = tmp_path / "host commit project"
+    root.mkdir()
+    _host_commit_git(root, "init", "-b", branch)
+    _host_commit_git(root, "config", "user.name", "Acceptance User")
+    _host_commit_git(root, "config", "user.email", "acceptance@example.invalid")
+    _host_commit_git(root, "config", "core.autocrlf", "true" if autocrlf else "false")
+    (root / "marker.txt").write_bytes(content)
+    _host_commit_git(root, "add", "--", "marker.txt")
+    _host_commit_git(root, "commit", "-m", "baseline")
+    return root, _host_commit_git(root, "rev-parse", "HEAD")
+
+
+def _host_commit_patch(path: str, before: bytes, after: bytes) -> str:
+    return DraftWorkspace._unified_diff(
+        path,
+        before.decode("utf-8"),
+        after.decode("utf-8"),
+        status="modified",
+    )
+
+
+def _host_commit_applied(
+    tmp_path: Path,
+    *,
+    branch: str = "feature/local-k8m2",
+    before: bytes = b"before-r7k3\n",
+    after: bytes = b"after-n4p7\n",
+    autocrlf: bool = False,
+) -> tuple[Path, str, HostOperationJournal, ApplyReceipt]:
+    root, head = _host_commit_repository(
+        tmp_path,
+        branch=branch,
+        content=before,
+        autocrlf=autocrlf,
+    )
+    journal = HostOperationJournal(tmp_path / "host-operations.bin", _XorProtector())
+    receipt = HostGitApplyEngine(
+        root,
+        HOST_COMMIT_PROJECT_ID,
+        journal,
+        enforce_windows=False,
+    ).apply(
+        operation_id="apply_host_commit_0123456789",
+        revision=13,
+        branch=branch,
+        expected_head=head,
+        snapshot_fingerprint=HOST_COMMIT_FINGERPRINT,
+        patch=_host_commit_patch("marker.txt", before, after),
+        paths=("marker.txt",),
+    )
+    return root, head, journal, receipt
+
+
+@pytest.mark.parametrize(
+    "invalid",
+    [
+        "",
+        "@",
+        "HEAD",
+        "-danger",
+        "/danger",
+        "danger/",
+        "danger.",
+        "feature//name",
+        ".hidden/name",
+        "feature/name.lock",
+        "feature/a..b",
+        "feature/a@{b",
+        "feature/a\\b",
+        "feature/a b",
+        "feature/a~b",
+        "feature/a^b",
+        "feature/a:b",
+        "feature/a?b",
+        "feature/a*b",
+        "feature/a[b",
+        "feature/a\nb",
+    ],
+)
+def test_host_commit_branch_validation_rejects_unsafe_refs(invalid: str) -> None:
+    with pytest.raises(ValueError):
+        validate_commit_branch(invalid)
+
+
+def test_host_commit_dynamic_unicode_branch_remote_idempotency_and_undo(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    branch = "feature/本地-k8m2"
+    assert validate_commit_branch(branch) == branch
+    root, head, journal, apply_receipt = _host_commit_applied(
+        tmp_path,
+        branch=branch,
+    )
+    _host_commit_git(
+        root,
+        "remote",
+        "add",
+        "origin",
+        "https://example.invalid/must-not-connect.git",
+    )
+    config_before = (root / ".git" / "config").read_bytes()
+    head_reflog = root / ".git" / "logs" / "HEAD"
+    branch_reflog = root / ".git" / "logs" / "refs" / "heads" / Path(branch)
+    reflogs_before = (head_reflog.read_bytes(), branch_reflog.read_bytes())
+
+    import server.coding_project_host.host_commit_engine as commit_module
+
+    real_run = subprocess.run
+    observed: list[tuple[str, ...]] = []
+    observed_environments: list[dict[str, str]] = []
+
+    def observe_run(arguments, **kwargs):
+        observed.append(tuple(str(item) for item in arguments))
+        if "env" in kwargs:
+            observed_environments.append(dict(kwargs["env"]))
+        return real_run(arguments, **kwargs)
+
+    monkeypatch.setattr(commit_module.subprocess, "run", observe_run)
+    engine = HostGitCommitEngine(
+        root,
+        HOST_COMMIT_PROJECT_ID,
+        journal,
+        enforce_windows=False,
+    )
+    receipt = engine.commit(
+        operation_id="commit_host_basic_01234567",
+        apply_receipt=apply_receipt,
+        branch=branch,
+        expected_head=head,
+        message="feature: 保存中文分支修改",
+    )
+    repeated = engine.commit(
+        operation_id="commit_host_basic_01234567",
+        apply_receipt=apply_receipt,
+        branch=branch,
+        expected_head=head,
+        message="feature: 保存中文分支修改",
+    )
+
+    assert repeated == receipt
+    assert receipt.branch == branch
+    assert _host_commit_git(root, "rev-parse", "HEAD") == receipt.commit_sha
+    assert _host_commit_git(root, "status", "--porcelain=v1", "--untracked-files=all") == ""
+    assert (root / ".git" / "config").read_bytes() == config_before
+    assert (head_reflog.read_bytes(), branch_reflog.read_bytes()) == reflogs_before
+    assert not any(
+        forbidden in command
+        for command in observed
+        for forbidden in ("remote", "fetch", "push", "ls-remote")
+    )
+    assert any(
+        "update-ref" in command
+        and "--no-deref" in command
+        and "--no-create-reflog" in command
+        for command in observed
+    )
+    assert all(
+        environment["GIT_DIR"] == str(root / ".git")
+        and environment["GIT_WORK_TREE"] == str(root)
+        and environment["GIT_COMMON_DIR"] == str(root / ".git")
+        and environment["GIT_NO_LAZY_FETCH"] == "1"
+        and "GIT_OBJECT_DIRECTORY" in environment
+        and "GIT_ALTERNATE_OBJECT_DIRECTORIES" in environment
+        for environment in observed_environments
+    )
+
+    undone = engine.undo(
+        operation_id="undo_host_basic_0123456789",
+        apply_receipt=apply_receipt,
+        commit_receipt=receipt,
+        branch=branch,
+    )
+    assert undone == receipt
+    assert _host_commit_git(root, "rev-parse", "HEAD") == head
+    assert (root / "marker.txt").read_bytes() == b"after-n4p7\n"
+    assert _host_commit_git(root, "status", "--porcelain=v1", "--untracked-files=all") == "M marker.txt"
+    assert engine.undo(
+        operation_id="undo_host_basic_0123456789",
+        apply_receipt=apply_receipt,
+        commit_receipt=receipt,
+        branch=branch,
+    ) == receipt
+    assert (root / ".git" / "config").read_bytes() == config_before
+
+
+def test_host_commit_operation_id_cannot_change_message(tmp_path: Path) -> None:
+    root, head, journal, apply_receipt = _host_commit_applied(tmp_path)
+    engine = HostGitCommitEngine(
+        root,
+        HOST_COMMIT_PROJECT_ID,
+        journal,
+        enforce_windows=False,
+    )
+    engine.commit(
+        operation_id="commit_message_bound_012345",
+        apply_receipt=apply_receipt,
+        branch="feature/local-k8m2",
+        expected_head=head,
+        message="feature: first immutable message",
+    )
+
+    with pytest.raises(HostCommitError) as conflict:
+        engine.commit(
+            operation_id="commit_message_bound_012345",
+            apply_receipt=apply_receipt,
+            branch="feature/local-k8m2",
+            expected_head=head,
+            message="feature: changed message",
+        )
+    assert conflict.value.code == "operation_conflict"
+
+
+@pytest.mark.parametrize(
+    "phase",
+    ["commit_after_receipt", "commit_after_index", "commit_after_ref"],
+)
+def test_host_commit_reconciles_each_metadata_crash_window(
+    tmp_path: Path,
+    phase: str,
+) -> None:
+    root, head, journal, apply_receipt = _host_commit_applied(tmp_path)
+
+    def crash(current: str) -> None:
+        if current == phase:
+            raise RuntimeError(f"crash:{phase}")
+
+    interrupted = HostGitCommitEngine(
+        root,
+        HOST_COMMIT_PROJECT_ID,
+        journal,
+        mutation_hook=crash,
+        enforce_windows=False,
+    )
+    operation_id = "commit_crash_window_012345"
+    with pytest.raises(RuntimeError, match=f"crash:{phase}"):
+        interrupted.commit(
+            operation_id=operation_id,
+            apply_receipt=apply_receipt,
+            branch="feature/local-k8m2",
+            expected_head=head,
+            message="feature: reconcile interrupted commit",
+        )
+
+    restarted = HostGitCommitEngine(
+        root,
+        HOST_COMMIT_PROJECT_ID,
+        HostOperationJournal(tmp_path / "host-operations.bin", _XorProtector()),
+        enforce_windows=False,
+    )
+    state, receipt = restarted.reconcile(operation_id)
+    assert state == "committed"
+    assert receipt is not None
+    assert _host_commit_git(root, "rev-parse", "HEAD") == receipt.commit_sha
+    assert _host_commit_git(root, "rev-list", "--count", f"{head}..HEAD") == "1"
+    assert _host_commit_git(root, "status", "--porcelain=v1", "--untracked-files=all") == ""
+
+
+@pytest.mark.parametrize(
+    "phase",
+    ["undo_after_intent", "undo_after_index", "undo_after_ref"],
+)
+def test_host_commit_reconciles_each_undo_crash_window(
+    tmp_path: Path,
+    phase: str,
+) -> None:
+    root, head, journal, apply_receipt = _host_commit_applied(tmp_path)
+    receipt = HostGitCommitEngine(
+        root,
+        HOST_COMMIT_PROJECT_ID,
+        journal,
+        enforce_windows=False,
+    ).commit(
+        operation_id="commit_before_undo_01234567",
+        apply_receipt=apply_receipt,
+        branch="feature/local-k8m2",
+        expected_head=head,
+        message="feature: prepare undo crash test",
+    )
+
+    def crash(current: str) -> None:
+        if current == phase:
+            raise RuntimeError(f"crash:{phase}")
+
+    interrupted = HostGitCommitEngine(
+        root,
+        HOST_COMMIT_PROJECT_ID,
+        journal,
+        mutation_hook=crash,
+        enforce_windows=False,
+    )
+    operation_id = "undo_crash_window_01234567"
+    with pytest.raises(RuntimeError, match=f"crash:{phase}"):
+        interrupted.undo(
+            operation_id=operation_id,
+            apply_receipt=apply_receipt,
+            commit_receipt=receipt,
+            branch="feature/local-k8m2",
+        )
+
+    restarted = HostGitCommitEngine(
+        root,
+        HOST_COMMIT_PROJECT_ID,
+        HostOperationJournal(tmp_path / "host-operations.bin", _XorProtector()),
+        enforce_windows=False,
+    )
+    state, reconciled = restarted.reconcile(operation_id)
+    assert state == "undone"
+    assert reconciled == receipt
+    assert _host_commit_git(root, "rev-parse", "HEAD") == head
+    assert (root / "marker.txt").read_bytes() == b"after-n4p7\n"
+    assert _host_commit_git(root, "status", "--porcelain=v1", "--untracked-files=all") == "M marker.txt"
+
+
+def test_host_commit_preserves_crlf_worktree_but_writes_normalized_blob(
+    tmp_path: Path,
+) -> None:
+    before = b"before-r7k3\r\n"
+    after = b"after-n4p7\r\n"
+    root, head = _host_commit_repository(
+        tmp_path,
+        content=before,
+        autocrlf=True,
+    )
+    assert _host_commit_git(root, "show", f"{head}:marker.txt") == "before-r7k3"
+    target = root / "marker.txt"
+    target.write_bytes(after)
+    patch = _host_commit_patch("marker.txt", b"before-r7k3\n", b"after-n4p7\n")
+    journal = HostOperationJournal(tmp_path / "host-operations.bin", _XorProtector())
+    apply_receipt = ApplyReceipt(
+        apply_id="apply_host_commit_0123456789",
+        revision=13,
+        snapshot_fingerprint=HOST_COMMIT_FINGERPRINT,
+        files=(
+            ApplyFileReceipt(
+                path="marker.txt",
+                existed_before=True,
+                before_sha256=hashlib.sha256(before).hexdigest(),
+                after_sha256=hashlib.sha256(after).hexdigest(),
+            ),
+        ),
+        applied_at=1_000.0,
+    )
+    receipt_payload = {
+        "apply_id": apply_receipt.apply_id,
+        "revision": apply_receipt.revision,
+        "snapshot_fingerprint": apply_receipt.snapshot_fingerprint,
+        "files": [
+            {
+                "path": "marker.txt",
+                "existed_before": True,
+                "before_sha256": hashlib.sha256(before).hexdigest(),
+                "after_sha256": hashlib.sha256(after).hexdigest(),
+            }
+        ],
+        "applied_at": apply_receipt.applied_at,
+    }
+    journal.create(
+        operation_id=apply_receipt.apply_id,
+        action="apply",
+        project_id=HOST_COMMIT_PROJECT_ID,
+        revision=13,
+        branch="feature/local-k8m2",
+        expected_head=head,
+        patch_sha256=hashlib.sha256(patch.encode("utf-8")).hexdigest(),
+        patch=patch,
+    )
+    journal.transition(
+        apply_receipt.apply_id,
+        "applying",
+        apply_receipt=receipt_payload,
+    )
+    metadata = target.stat(follow_symlinks=False)
+    journal.transition(
+        apply_receipt.apply_id,
+        "applied",
+        file_identities=(f"{metadata.st_dev:x}-{metadata.st_ino:x}:marker.txt",),
+    )
+    assert target.read_bytes() == after
+
+    receipt = HostGitCommitEngine(
+        root,
+        HOST_COMMIT_PROJECT_ID,
+        journal,
+        enforce_windows=False,
+    ).commit(
+        operation_id="commit_crlf_normalized_0123",
+        apply_receipt=apply_receipt,
+        branch="feature/local-k8m2",
+        expected_head=head,
+        message="feature: preserve CRLF checkout",
+    )
+
+    assert (root / "marker.txt").read_bytes() == after
+    blob = subprocess.run(
+        ("git", "show", f"{receipt.commit_sha}:marker.txt"),
+        cwd=root,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+        timeout=20,
+    ).stdout
+    assert blob == b"after-n4p7\n"
+    assert _host_commit_git(root, "status", "--porcelain=v1", "--untracked-files=all") == ""
+
+
+def test_host_commit_rejects_same_content_replacement_identity(tmp_path: Path) -> None:
+    root, head, journal, apply_receipt = _host_commit_applied(tmp_path)
+    target = root / "marker.txt"
+    replacement = root / ".manual-replacement"
+    replacement.write_bytes(target.read_bytes())
+    os.replace(replacement, target)
+
+    with pytest.raises(HostCommitError) as conflict:
+        HostGitCommitEngine(
+            root,
+            HOST_COMMIT_PROJECT_ID,
+            journal,
+            enforce_windows=False,
+        ).commit(
+            operation_id="commit_identity_guard_01234",
+            apply_receipt=apply_receipt,
+            branch="feature/local-k8m2",
+            expected_head=head,
+            message="feature: reject replaced object",
+        )
+    assert conflict.value.code == "target_changed"
+    assert target.read_bytes() == b"after-n4p7\n"
+    assert _host_commit_git(root, "rev-parse", "HEAD") == head
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX fail-closed contract")
+def test_host_commit_production_mode_rejects_posix_before_side_effect(
+    tmp_path: Path,
+) -> None:
+    root, head = _host_commit_repository(tmp_path)
+    status_before = _host_commit_git(root, "status", "--porcelain=v1", "--untracked-files=all")
+
+    with pytest.raises(HostCommitError) as rejected:
+        HostGitCommitEngine(
+            root,
+            HOST_COMMIT_PROJECT_ID,
+            HostOperationJournal(tmp_path / "production-operations.bin", _XorProtector()),
+        )
+
+    assert rejected.value.code == "windows_required"
+    assert _host_commit_git(root, "rev-parse", "HEAD") == head
+    assert _host_commit_git(root, "status", "--porcelain=v1", "--untracked-files=all") == status_before
+
+
+@pytest.mark.parametrize("metadata_leaf", ["ref", "reflog", "loose_object"])
+def test_host_commit_rejects_git_metadata_leaf_symlinks(
+    tmp_path: Path,
+    metadata_leaf: str,
+) -> None:
+    root, head, journal, apply_receipt = _host_commit_applied(tmp_path)
+    branch = "feature/local-k8m2"
+    if metadata_leaf == "ref":
+        target = root / ".git" / "refs" / "heads" / Path(*branch.split("/"))
+    elif metadata_leaf == "reflog":
+        target = root / ".git" / "logs" / "refs" / "heads" / Path(*branch.split("/"))
+    else:
+        object_id = _host_commit_git(root, "rev-parse", f"{head}:marker.txt")
+        target = root / ".git" / "objects" / object_id[:2] / object_id[2:]
+    outside = tmp_path / f"outside-{metadata_leaf}"
+    outside.write_bytes(target.read_bytes())
+    target.unlink()
+    try:
+        target.symlink_to(outside)
+    except OSError:
+        pytest.skip("Symlink creation is not available on this host")
+    outside_before = outside.read_bytes()
+
+    with pytest.raises(HostCommitError) as rejected:
+        HostGitCommitEngine(
+            root,
+            HOST_COMMIT_PROJECT_ID,
+            journal,
+            enforce_windows=False,
+        ).commit(
+            operation_id=f"commit_{metadata_leaf}_link_012345",
+            apply_receipt=apply_receipt,
+            branch=branch,
+            expected_head=head,
+            message="feature: reject Git metadata link",
+        )
+
+    assert rejected.value.code == "repository_unsafe"
+    assert outside.read_bytes() == outside_before
+    assert target.is_symlink()
+    assert _host_commit_git(root, "rev-parse", "HEAD") == head
+
+
+@pytest.mark.parametrize("replaced_path", ["index", "index.lock"])
+def test_host_commit_does_not_overwrite_same_content_index_replacement(
+    tmp_path: Path,
+    replaced_path: str,
+) -> None:
+    root, head, journal, apply_receipt = _host_commit_applied(tmp_path)
+    operation_id = f"commit_replace_{replaced_path.replace('.', '_')}_012345"
+    replacement_identity: str | None = None
+    replacement_content: bytes | None = None
+
+    def replace_metadata(phase: str) -> None:
+        nonlocal replacement_identity, replacement_content
+        if phase != "metadata_before_index":
+            return
+        target = root / ".git" / replaced_path
+        replacement = root / f"manual-{replaced_path.replace('.', '-')}"
+        replacement_content = target.read_bytes()
+        replacement.write_bytes(replacement_content)
+        os.replace(replacement, target)
+        metadata = target.stat(follow_symlinks=False)
+        replacement_identity = f"{metadata.st_dev:x}-{metadata.st_ino:x}"
+
+    with pytest.raises(HostCommitError) as conflict:
+        HostGitCommitEngine(
+            root,
+            HOST_COMMIT_PROJECT_ID,
+            journal,
+            mutation_hook=replace_metadata,
+            enforce_windows=False,
+        ).commit(
+            operation_id=operation_id,
+            apply_receipt=apply_receipt,
+            branch="feature/local-k8m2",
+            expected_head=head,
+            message="feature: reject replaced index metadata",
+        )
+
+    assert conflict.value.code == "index_changed"
+    record = journal.get(operation_id)
+    assert record is not None
+    assert record.state == "conflict"
+    assert record.commit_receipt is not None
+    assert _host_commit_git(root, "rev-parse", "HEAD") == head
+    target = root / ".git" / replaced_path
+    assert target.read_bytes() == replacement_content
+    metadata = target.stat(follow_symlinks=False)
+    assert f"{metadata.st_dev:x}-{metadata.st_ino:x}" == replacement_identity
+    if replaced_path == "index":
+        assert not (root / ".git" / "index.lock").exists()
+        assert (
+            root
+            / ".git"
+            / "modelmirror-transactions"
+            / f"{operation_id}.index-conflict"
+        ).exists()
+    else:
+        assert (root / ".git" / "index").exists()
+
+
+def test_host_commit_quarantines_owned_lock_after_pre_ref_conflict(tmp_path: Path) -> None:
+    root, head, journal, apply_receipt = _host_commit_applied(tmp_path)
+    operation_id = "commit_owned_lock_conflict_0123"
+
+    def introduce_conflict(phase: str) -> None:
+        if phase == "metadata_before_ref":
+            (root / "manual-race.txt").write_text("manual-race-q9t2\n", encoding="utf-8")
+
+    with pytest.raises(HostCommitError) as conflict:
+        HostGitCommitEngine(
+            root,
+            HOST_COMMIT_PROJECT_ID,
+            journal,
+            mutation_hook=introduce_conflict,
+            enforce_windows=False,
+        ).commit(
+            operation_id=operation_id,
+            apply_receipt=apply_receipt,
+            branch="feature/local-k8m2",
+            expected_head=head,
+            message="feature: quarantine owned index lock",
+        )
+
+    assert conflict.value.code == "head_changed"
+    record = journal.get(operation_id)
+    assert record is not None and record.state == "conflict"
+    assert _host_commit_git(root, "rev-parse", "HEAD") == head
+    assert (root / ".git" / "index").is_file()
+    assert not (root / ".git" / "index.lock").exists()
+    artifact = (
+        root
+        / ".git"
+        / "modelmirror-transactions"
+        / f"{operation_id}.index-conflict"
+    )
+    assert artifact.is_file()
+    assert hashlib.sha256(artifact.read_bytes()).hexdigest() == record.index_sha256
+
+
+def test_host_commit_preserves_unknown_lock_while_quarantining_owned_stage(
+    tmp_path: Path,
+) -> None:
+    root, head, journal, apply_receipt = _host_commit_applied(tmp_path)
+    operation_id = "commit_unknown_lock_conflict_012"
+
+    def crash_after_intent(phase: str) -> None:
+        if phase == "commit_after_receipt":
+            raise RuntimeError("simulated restart")
+
+    with pytest.raises(RuntimeError, match="simulated restart"):
+        HostGitCommitEngine(
+            root,
+            HOST_COMMIT_PROJECT_ID,
+            journal,
+            mutation_hook=crash_after_intent,
+            enforce_windows=False,
+        ).commit(
+            operation_id=operation_id,
+            apply_receipt=apply_receipt,
+            branch="feature/local-k8m2",
+            expected_head=head,
+            message="feature: preserve unknown index lock",
+        )
+    unknown_lock = root / ".git" / "index.lock"
+    unknown_content = b"manual-unknown-lock-r8v3"
+    unknown_lock.write_bytes(unknown_content)
+    metadata = unknown_lock.stat(follow_symlinks=False)
+    unknown_identity = f"{metadata.st_dev:x}-{metadata.st_ino:x}"
+
+    state, _receipt = HostGitCommitEngine(
+        root,
+        HOST_COMMIT_PROJECT_ID,
+        HostOperationJournal(tmp_path / "host-operations.bin", _XorProtector()),
+        enforce_windows=False,
+    ).reconcile(operation_id)
+
+    assert state == "conflict"
+    assert unknown_lock.read_bytes() == unknown_content
+    metadata = unknown_lock.stat(follow_symlinks=False)
+    assert f"{metadata.st_dev:x}-{metadata.st_ino:x}" == unknown_identity
+    assert not (
+        root
+        / ".git"
+        / "modelmirror-transactions"
+        / f"{operation_id}.commit-index"
+    ).exists()
+    assert (
+        root
+        / ".git"
+        / "modelmirror-transactions"
+        / f"{operation_id}.index-conflict"
+    ).exists()
+    assert _host_commit_git(root, "rev-parse", "HEAD") == head
+
+
+def test_host_commit_conflict_marker_survives_journal_failure_and_blocks_replay(
+    tmp_path: Path,
+) -> None:
+    root, head, journal, apply_receipt = _host_commit_applied(tmp_path)
+    operation_id = "commit_failed_conflict_log_0123"
+
+    def crash_after_intent(phase: str) -> None:
+        if phase == "commit_after_receipt":
+            raise RuntimeError("simulated restart")
+
+    with pytest.raises(RuntimeError, match="simulated restart"):
+        HostGitCommitEngine(
+            root,
+            HOST_COMMIT_PROJECT_ID,
+            journal,
+            mutation_hook=crash_after_intent,
+            enforce_windows=False,
+        ).commit(
+            operation_id=operation_id,
+            apply_receipt=apply_receipt,
+            branch="feature/local-k8m2",
+            expected_head=head,
+            message="feature: persist fail-closed conflict",
+        )
+    conflict_file = root / "manual-conflict.txt"
+    conflict_file.write_text("conflict-z8k4\n", encoding="utf-8")
+    journal.protector.fail_protect = True
+
+    with pytest.raises(HostCommitError) as unavailable:
+        HostGitCommitEngine(
+            root,
+            HOST_COMMIT_PROJECT_ID,
+            journal,
+            enforce_windows=False,
+        ).reconcile(operation_id)
+    assert unavailable.value.code == "operation_log_unavailable"
+    marker = (
+        root
+        / ".git"
+        / "modelmirror-transactions"
+        / f"{operation_id}.commit-conflict"
+    )
+    assert marker.read_bytes() == f"{operation_id}\n".encode("ascii")
+    assert journal.get(operation_id).state == "committing"
+    assert not (root / ".git" / "index.lock").exists()
+
+    conflict_file.unlink()
+    journal.protector.fail_protect = False
+    restarted = HostGitCommitEngine(
+        root,
+        HOST_COMMIT_PROJECT_ID,
+        HostOperationJournal(tmp_path / "host-operations.bin", _XorProtector()),
+        enforce_windows=False,
+    )
+    state, receipt = restarted.reconcile(operation_id)
+
+    assert state == "conflict"
+    assert receipt is not None
+    assert _host_commit_git(root, "rev-parse", "HEAD") == head
+    assert restarted.journal.get(operation_id).state == "conflict"
+
+
+def test_host_commit_recovers_hard_stop_between_index_backup_and_publish(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root, head, journal, apply_receipt = _host_commit_applied(tmp_path)
+    operation_id = "commit_two_phase_index_012345"
+    import server.coding_project_host.host_commit_engine as commit_module
+
+    real_move = commit_module._move_verified_no_replace
+    crashed = False
+
+    def crash_after_backup(source, destination, *args, **kwargs):
+        nonlocal crashed
+        result = real_move(source, destination, *args, **kwargs)
+        expected_backup = (
+            root
+            / ".git"
+            / "modelmirror-transactions"
+            / f"{operation_id}.index-before"
+        )
+        if not crashed and Path(source) == root / ".git" / "index" and Path(destination) == expected_backup:
+            crashed = True
+            raise SystemExit("simulated hard stop")
+        return result
+
+    monkeypatch.setattr(commit_module, "_move_verified_no_replace", crash_after_backup)
+    with pytest.raises(SystemExit, match="simulated hard stop"):
+        HostGitCommitEngine(
+            root,
+            HOST_COMMIT_PROJECT_ID,
+            journal,
+            enforce_windows=False,
+        ).commit(
+            operation_id=operation_id,
+            apply_receipt=apply_receipt,
+            branch="feature/local-k8m2",
+            expected_head=head,
+            message="feature: recover two phase index publish",
+        )
+    monkeypatch.setattr(commit_module, "_move_verified_no_replace", real_move)
+    backup = (
+        root
+        / ".git"
+        / "modelmirror-transactions"
+        / f"{operation_id}.index-before"
+    )
+    assert not (root / ".git" / "index").exists()
+    assert backup.is_file()
+    assert (root / ".git" / "index.lock").is_file()
+
+    restarted = HostGitCommitEngine(
+        root,
+        HOST_COMMIT_PROJECT_ID,
+        HostOperationJournal(tmp_path / "host-operations.bin", _XorProtector()),
+        enforce_windows=False,
+    )
+    state, receipt = restarted.reconcile(operation_id)
+
+    assert state == "committed"
+    assert receipt is not None
+    assert _host_commit_git(root, "rev-parse", "HEAD") == receipt.commit_sha
+    assert _host_commit_git(root, "rev-list", "--count", f"{head}..HEAD") == "1"
+    assert _host_commit_git(root, "status", "--porcelain=v1", "--untracked-files=all") == ""
+    assert (root / ".git" / "index").is_file()
+    assert not (root / ".git" / "index.lock").exists()
+    assert not backup.exists()
+
+
+def test_host_commit_replay_after_undo_does_not_recreate_commit(tmp_path: Path) -> None:
+    root, head, journal, apply_receipt = _host_commit_applied(tmp_path)
+    engine = HostGitCommitEngine(
+        root,
+        HOST_COMMIT_PROJECT_ID,
+        journal,
+        enforce_windows=False,
+    )
+    operation_id = "commit_then_undo_replay_01234"
+    receipt = engine.commit(
+        operation_id=operation_id,
+        apply_receipt=apply_receipt,
+        branch="feature/local-k8m2",
+        expected_head=head,
+        message="feature: do not replay old commit",
+    )
+    engine.undo(
+        operation_id="undo_then_replay_012345678",
+        apply_receipt=apply_receipt,
+        commit_receipt=receipt,
+        branch="feature/local-k8m2",
+    )
+
+    with pytest.raises(HostCommitError) as stale:
+        engine.commit(
+            operation_id=operation_id,
+            apply_receipt=apply_receipt,
+            branch="feature/local-k8m2",
+            expected_head=head,
+            message="feature: do not replay old commit",
+        )
+    assert stale.value.code == "commit_not_current"
+    assert _host_commit_git(root, "rev-parse", "HEAD") == head
+    assert _host_commit_git(root, "status", "--porcelain=v1", "--untracked-files=all") == "M marker.txt"
+    assert not (root / ".git" / "index.lock").exists()
+
+
+def test_host_commit_only_allows_latest_linear_commit_to_be_undone(tmp_path: Path) -> None:
+    root, head, journal, first_apply = _host_commit_applied(tmp_path)
+    branch = "feature/local-k8m2"
+    engine = HostGitCommitEngine(
+        root,
+        HOST_COMMIT_PROJECT_ID,
+        journal,
+        enforce_windows=False,
+    )
+    first_commit = engine.commit(
+        operation_id="commit_linear_first_0123456",
+        apply_receipt=first_apply,
+        branch=branch,
+        expected_head=head,
+        message="feature: first linear commit",
+    )
+    patch = DraftWorkspace._unified_diff(
+        "second.txt",
+        "",
+        "second-round-q9t2\n",
+        status="added",
+    )
+    second_apply = HostGitApplyEngine(
+        root,
+        HOST_COMMIT_PROJECT_ID,
+        journal,
+        enforce_windows=False,
+    ).apply(
+        operation_id="apply_linear_second_0123456",
+        revision=14,
+        branch=branch,
+        expected_head=first_commit.commit_sha,
+        snapshot_fingerprint=HOST_COMMIT_FINGERPRINT,
+        patch=patch,
+        paths=("second.txt",),
+    )
+    second_commit = engine.commit(
+        operation_id="commit_linear_second_012345",
+        apply_receipt=second_apply,
+        branch=branch,
+        expected_head=first_commit.commit_sha,
+        message="feature: second linear commit",
+    )
+    engine.undo(
+        operation_id="undo_linear_second_01234567",
+        apply_receipt=second_apply,
+        commit_receipt=second_commit,
+        branch=branch,
+    )
+
+    with pytest.raises(HostCommitError) as stale:
+        engine.undo(
+            operation_id="undo_linear_stale_012345678",
+            apply_receipt=first_apply,
+            commit_receipt=first_commit,
+            branch=branch,
+        )
+    assert stale.value.code == "undo_conflict"
+    assert _host_commit_git(root, "rev-parse", "HEAD") == first_commit.commit_sha
+    assert _host_commit_git(root, "status", "--porcelain=v1", "--untracked-files=all") == "?? second.txt"
+    assert journal.get("undo_linear_stale_012345678").state == "conflict"
+    assert not (root / ".git" / "index.lock").exists()
+
+
+def test_host_commit_does_not_restore_tampered_index_backup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root, head, journal, apply_receipt = _host_commit_applied(tmp_path)
+    operation_id = "commit_tampered_backup_012345"
+    import server.coding_project_host.host_commit_engine as commit_module
+
+    real_move = commit_module._move_verified_no_replace
+
+    def stop_after_backup(source, destination, *args, **kwargs):
+        result = real_move(source, destination, *args, **kwargs)
+        if Path(source) == root / ".git" / "index" and Path(destination).name.endswith(
+            ".index-before"
+        ):
+            raise SystemExit("simulated stop after index backup")
+        return result
+
+    monkeypatch.setattr(commit_module, "_move_verified_no_replace", stop_after_backup)
+    with pytest.raises(SystemExit, match="simulated stop"):
+        HostGitCommitEngine(
+            root,
+            HOST_COMMIT_PROJECT_ID,
+            journal,
+            enforce_windows=False,
+        ).commit(
+            operation_id=operation_id,
+            apply_receipt=apply_receipt,
+            branch="feature/local-k8m2",
+            expected_head=head,
+            message="feature: preserve tampered index evidence",
+        )
+    monkeypatch.setattr(commit_module, "_move_verified_no_replace", real_move)
+    backup = (
+        root
+        / ".git"
+        / "modelmirror-transactions"
+        / f"{operation_id}.index-before"
+    )
+    before_identity = backup.stat(follow_symlinks=False)
+    tampered = bytearray(backup.read_bytes())
+    tampered[-1] ^= 1
+    with backup.open("r+b") as handle:
+        handle.seek(0)
+        handle.write(tampered)
+        handle.truncate()
+        handle.flush()
+        os.fsync(handle.fileno())
+    after_identity = backup.stat(follow_symlinks=False)
+    assert (before_identity.st_dev, before_identity.st_ino) == (
+        after_identity.st_dev,
+        after_identity.st_ino,
+    )
+
+    restarted = HostGitCommitEngine(
+        root,
+        HOST_COMMIT_PROJECT_ID,
+        HostOperationJournal(tmp_path / "host-operations.bin", _XorProtector()),
+        enforce_windows=False,
+    )
+    with pytest.raises(HostCommitError) as unavailable:
+        restarted.reconcile(operation_id)
+
+    assert unavailable.value.code == "operation_log_unavailable"
+    assert backup.read_bytes() == bytes(tampered)
+    assert not (root / ".git" / "index").exists()
+    assert restarted.journal.get(operation_id).state == "committing"
+
+
+def test_host_commit_terminal_records_ignore_later_same_tree_index_identity(
+    tmp_path: Path,
+) -> None:
+    root, head, journal, apply_receipt = _host_commit_applied(tmp_path)
+    engine = HostGitCommitEngine(
+        root,
+        HOST_COMMIT_PROJECT_ID,
+        journal,
+        enforce_windows=False,
+    )
+    commit_id = "commit_terminal_index_012345"
+    receipt = engine.commit(
+        operation_id=commit_id,
+        apply_receipt=apply_receipt,
+        branch="feature/local-k8m2",
+        expected_head=head,
+        message="feature: terminal index identity",
+    )
+    index = root / ".git" / "index"
+    replacement = root / "replacement-index"
+    replacement.write_bytes(index.read_bytes())
+    os.replace(replacement, index)
+
+    state, recovered = engine.reconcile(commit_id)
+    assert state == "committed"
+    assert recovered == receipt
+
+    undo_id = "undo_terminal_index_01234567"
+    engine.undo(
+        operation_id=undo_id,
+        apply_receipt=apply_receipt,
+        commit_receipt=receipt,
+        branch="feature/local-k8m2",
+    )
+    replacement.write_bytes(index.read_bytes())
+    os.replace(replacement, index)
+
+    state, recovered = engine.reconcile(undo_id)
+    assert state == "undone"
+    assert recovered == receipt
+
+
+def test_host_commit_terminal_undo_stays_terminal_after_later_head_change(
+    tmp_path: Path,
+) -> None:
+    root, head, journal, apply_receipt = _host_commit_applied(tmp_path)
+    engine = HostGitCommitEngine(
+        root,
+        HOST_COMMIT_PROJECT_ID,
+        journal,
+        enforce_windows=False,
+    )
+    receipt = engine.commit(
+        operation_id="commit_terminal_history_0123",
+        apply_receipt=apply_receipt,
+        branch="feature/local-k8m2",
+        expected_head=head,
+        message="feature: preserve terminal history",
+    )
+    undo_id = "undo_terminal_history_012345"
+    engine.undo(
+        operation_id=undo_id,
+        apply_receipt=apply_receipt,
+        commit_receipt=receipt,
+        branch="feature/local-k8m2",
+    )
+    _host_commit_git(root, "commit", "--allow-empty", "-m", "manual later commit")
+
+    with pytest.raises(HostCommitError) as stale:
+        engine.reconcile(undo_id)
+
+    assert stale.value.code == "undo_not_current"
+    assert journal.get(undo_id).state == "undone"
+
+
+def test_host_commit_persists_conflict_when_marker_cannot_be_created(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root, head, journal, apply_receipt = _host_commit_applied(tmp_path)
+    operation_id = "commit_marker_unavailable_0123"
+    import server.coding_project_host.host_commit_engine as commit_module
+
+    def stop_after_intent(phase: str) -> None:
+        if phase == "commit_after_receipt":
+            raise RuntimeError("simulated restart")
+
+    with pytest.raises(RuntimeError, match="simulated restart"):
+        HostGitCommitEngine(
+            root,
+            HOST_COMMIT_PROJECT_ID,
+            journal,
+            mutation_hook=stop_after_intent,
+            enforce_windows=False,
+        ).commit(
+            operation_id=operation_id,
+            apply_receipt=apply_receipt,
+            branch="feature/local-k8m2",
+            expected_head=head,
+            message="feature: journal conflict fallback",
+        )
+    (root / "manual-conflict.txt").write_text("manual-q7v4\n", encoding="utf-8")
+    real_write = commit_module._write_durable_no_replace
+
+    def reject_conflict_marker(path, *args, **kwargs):
+        if Path(path).name.endswith(".commit-conflict"):
+            raise OSError("simulated marker failure")
+        return real_write(path, *args, **kwargs)
+
+    monkeypatch.setattr(commit_module, "_write_durable_no_replace", reject_conflict_marker)
+    state, recovered = HostGitCommitEngine(
+        root,
+        HOST_COMMIT_PROJECT_ID,
+        journal,
+        enforce_windows=False,
+    ).reconcile(operation_id)
+
+    assert state == "conflict"
+    assert recovered is not None
+    assert journal.get(operation_id).state == "conflict"
+    assert _host_commit_git(root, "rev-parse", "HEAD") == head
+    assert not (root / ".git" / "index.lock").exists()
+
+
+def test_host_commit_rescans_objects_after_commit_tree(
+    tmp_path: Path,
+) -> None:
+    root, head, journal, apply_receipt = _host_commit_applied(tmp_path)
+    object_root = root / ".git" / "objects"
+    existing = {path for path in object_root.rglob("*") if path.is_file()}
+    outside = tmp_path / "outside-new-object"
+    replaced: Path | None = None
+
+    def replace_new_object(phase: str) -> None:
+        nonlocal replaced
+        if phase != "commit_after_tree":
+            return
+        new_objects = [
+            path for path in object_root.rglob("*") if path.is_file() and path not in existing
+        ]
+        assert new_objects
+        replaced = new_objects[0]
+        outside.write_bytes(replaced.read_bytes())
+        try:
+            replaced.unlink()
+            replaced.symlink_to(outside)
+        except OSError as exc:
+            pytest.skip(f"Metadata replacement is blocked on this host: {exc}")
+
+    with pytest.raises(HostCommitError) as rejected:
+        HostGitCommitEngine(
+            root,
+            HOST_COMMIT_PROJECT_ID,
+            journal,
+            mutation_hook=replace_new_object,
+            enforce_windows=False,
+        ).commit(
+            operation_id="commit_post_tree_link_012345",
+            apply_receipt=apply_receipt,
+            branch="feature/local-k8m2",
+            expected_head=head,
+            message="feature: reject replaced new object",
+        )
+
+    assert rejected.value.code == "repository_unsafe"
+    assert replaced is not None and replaced.is_symlink()
+    assert _host_commit_git(root, "rev-parse", "HEAD") == head
+
+
+def test_host_commit_binds_original_index_before_commit_tree(
+    tmp_path: Path,
+) -> None:
+    root, head, journal, apply_receipt = _host_commit_applied(tmp_path)
+    replacement_identity: str | None = None
+
+    def replace_index(phase: str) -> None:
+        nonlocal replacement_identity
+        if phase != "commit_after_tree":
+            return
+        index = root / ".git" / "index"
+        manual = root / "manual-index-before-stage"
+        manual.write_bytes(index.read_bytes())
+        os.replace(manual, index)
+        metadata = index.stat(follow_symlinks=False)
+        replacement_identity = f"{metadata.st_dev:x}-{metadata.st_ino:x}"
+
+    with pytest.raises(HostCommitError) as rejected:
+        HostGitCommitEngine(
+            root,
+            HOST_COMMIT_PROJECT_ID,
+            journal,
+            mutation_hook=replace_index,
+            enforce_windows=False,
+        ).commit(
+            operation_id="commit_pre_stage_index_012345",
+            apply_receipt=apply_receipt,
+            branch="feature/local-k8m2",
+            expected_head=head,
+            message="feature: bind original index",
+        )
+
+    assert rejected.value.code == "index_changed"
+    assert _host_commit_git(root, "rev-parse", "HEAD") == head
+    current = (root / ".git" / "index").stat(follow_symlinks=False)
+    assert f"{current.st_dev:x}-{current.st_ino:x}" == replacement_identity
+
+
+def test_host_commit_preserves_untouched_skip_worktree_index_state(
+    tmp_path: Path,
+) -> None:
+    root, _ = _host_commit_repository(tmp_path)
+    hidden = root / "hidden" / "b.txt"
+    hidden.parent.mkdir()
+    hidden.write_text("hidden-r8v3\n", encoding="utf-8")
+    _host_commit_git(root, "add", "--", "hidden/b.txt")
+    _host_commit_git(root, "commit", "-m", "add hidden baseline")
+    head = _host_commit_git(root, "rev-parse", "HEAD")
+    _host_commit_git(root, "update-index", "--skip-worktree", "--", "hidden/b.txt")
+    hidden.unlink()
+    assert _host_commit_git(root, "status", "--porcelain=v1", "--untracked-files=all") == ""
+    assert _host_commit_git(root, "ls-files", "-t", "--", "hidden/b.txt").startswith("S ")
+
+    before = (root / "marker.txt").read_bytes()
+    after = b"skip-worktree-safe-n4p7\n"
+    journal = HostOperationJournal(tmp_path / "skip-operations.bin", _XorProtector())
+    apply_receipt = HostGitApplyEngine(
+        root,
+        HOST_COMMIT_PROJECT_ID,
+        journal,
+        enforce_windows=False,
+    ).apply(
+        operation_id="apply_skip_worktree_012345",
+        revision=13,
+        branch="feature/local-k8m2",
+        expected_head=head,
+        snapshot_fingerprint=HOST_COMMIT_FINGERPRINT,
+        patch=_host_commit_patch("marker.txt", before, after),
+        paths=("marker.txt",),
+    )
+    engine = HostGitCommitEngine(
+        root,
+        HOST_COMMIT_PROJECT_ID,
+        journal,
+        enforce_windows=False,
+    )
+    receipt = engine.commit(
+        operation_id="commit_skip_worktree_01234",
+        apply_receipt=apply_receipt,
+        branch="feature/local-k8m2",
+        expected_head=head,
+        message="feature: preserve sparse index flags",
+    )
+
+    assert _host_commit_git(root, "ls-files", "-t", "--", "hidden/b.txt").startswith("S ")
+    assert not hidden.exists()
+    assert _host_commit_git(root, "status", "--porcelain=v1", "--untracked-files=all") == ""
+
+    engine.undo(
+        operation_id="undo_skip_worktree_01234567",
+        apply_receipt=apply_receipt,
+        commit_receipt=receipt,
+        branch="feature/local-k8m2",
+    )
+    assert _host_commit_git(root, "ls-files", "-t", "--", "hidden/b.txt").startswith("S ")
+    assert not hidden.exists()
+    assert _host_commit_git(root, "status", "--porcelain=v1", "--untracked-files=all") == "M marker.txt"
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows helper native contract")
+def test_host_commit_windows_native_apply_commit_and_undo(tmp_path: Path) -> None:
+    branch = "feature/windows-native-r7k3"
+    root, head = _host_commit_repository(tmp_path, branch=branch)
+    journal = HostOperationJournal(tmp_path / "windows-operations.bin", _XorProtector())
+    apply_receipt = HostGitApplyEngine(
+        root,
+        HOST_COMMIT_PROJECT_ID,
+        journal,
+    ).apply(
+        operation_id="apply_windows_native_012345",
+        revision=13,
+        branch=branch,
+        expected_head=head,
+        snapshot_fingerprint=HOST_COMMIT_FINGERPRINT,
+        patch=_host_commit_patch(
+            "marker.txt",
+            b"before-r7k3\n",
+            b"windows-after-n4p7\n",
+        ),
+        paths=("marker.txt",),
+    )
+    engine = HostGitCommitEngine(root, HOST_COMMIT_PROJECT_ID, journal)
+    receipt = engine.commit(
+        operation_id="commit_windows_native_0123",
+        apply_receipt=apply_receipt,
+        branch=branch,
+        expected_head=head,
+        message="feature: verify Windows local commit",
+    )
+    assert _host_commit_git(root, "rev-parse", "HEAD") == receipt.commit_sha
+    assert _host_commit_git(root, "status", "--porcelain=v1", "--untracked-files=all") == ""
+
+    engine.undo(
+        operation_id="undo_windows_native_012345",
+        apply_receipt=apply_receipt,
+        commit_receipt=receipt,
+        branch=branch,
+    )
+    assert _host_commit_git(root, "rev-parse", "HEAD") == head
+    assert (root / "marker.txt").read_bytes() == b"windows-after-n4p7\n"
+    assert _host_commit_git(root, "status", "--porcelain=v1", "--untracked-files=all") == "M marker.txt"
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows helper native contract")
+@pytest.mark.parametrize("replacement_kind", ["junction", "same_content"])
+def test_host_commit_windows_private_object_cleanup_rejects_replacement(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    replacement_kind: str,
+) -> None:
+    root, head, journal, apply_receipt = _host_commit_applied(tmp_path)
+    outside_dir = tmp_path / f"outside-private-object-{replacement_kind}"
+    outside_dir.mkdir()
+    sentinel = outside_dir / "sentinel.txt"
+    sentinel.write_bytes(b"outside-private-object-r8v3\n")
+    replaced_path: Path | None = None
+    outside_object: Path | None = None
+    parked_parent: Path | None = None
+    real_remove = host_commit_engine_module._windows_remove_private_loose_object
+
+    def replace_before_handle_open(
+        path: Path,
+        expected: bytes,
+        *,
+        expected_identity: str,
+    ) -> None:
+        nonlocal outside_object, parked_parent, replaced_path
+        if replaced_path is None:
+            replaced_path = path
+            # Simulate a concurrent actor winning the exact interval between
+            # the caller's first read and the private-store delete handle.
+            if replacement_kind == "junction":
+                parked_parent = path.parent.with_name(f"{path.parent.name}-parked")
+                path.parent.rename(parked_parent)
+                outside_object = outside_dir / path.name
+                outside_object.write_bytes(expected)
+                os.chmod(outside_object, stat.S_IREAD)
+                created = subprocess.run(
+                    [
+                        "cmd.exe",
+                        "/d",
+                        "/c",
+                        "mklink",
+                        "/J",
+                        str(path.parent),
+                        str(outside_dir),
+                    ],
+                    stdin=subprocess.DEVNULL,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    check=False,
+                )
+                if created.returncode != 0:
+                    pytest.skip("directory reparse replacement is unavailable")
+            else:
+                os.chmod(path, stat.S_IREAD | stat.S_IWRITE)
+                path.unlink()
+                path.write_bytes(expected)
+        real_remove(
+            path,
+            expected,
+            expected_identity=expected_identity,
+        )
+
+    monkeypatch.setattr(
+        host_commit_engine_module,
+        "_windows_remove_private_loose_object",
+        replace_before_handle_open,
+    )
+    try:
+        with pytest.raises(HostCommitError) as rejected:
+            HostGitCommitEngine(
+                root,
+                HOST_COMMIT_PROJECT_ID,
+                journal,
+            ).commit(
+                operation_id=f"commit_private_cleanup_{replacement_kind}_01",
+                apply_receipt=apply_receipt,
+                branch="feature/local-k8m2",
+                expected_head=head,
+                message="feature: reject private object cleanup replacement",
+            )
+
+        assert rejected.value.code == "repository_unsafe"
+        assert replaced_path is not None
+        assert _host_commit_git(root, "rev-parse", "HEAD") == head
+        assert sentinel.read_bytes() == b"outside-private-object-r8v3\n"
+        if replacement_kind == "junction":
+            assert outside_object is not None
+            assert outside_object.read_bytes() == replaced_path.read_bytes()
+            assert outside_object.stat().st_file_attributes & 0x00000001
+        else:
+            assert replaced_path.is_file()
+            assert not replaced_path.is_symlink()
+    finally:
+        if outside_object is not None:
+            os.chmod(outside_object, stat.S_IREAD | stat.S_IWRITE)
+        if parked_parent is not None and parked_parent.exists():
+            if replaced_path is not None and replaced_path.parent.exists():
+                os.rmdir(replaced_path.parent)
+            parked_parent.rename(replaced_path.parent)
+
+
+@pytest.mark.parametrize("reflog_name", ["HEAD", "branch"])
+@pytest.mark.parametrize("replacement_kind", ["hardlink", "symlink"])
+def test_host_commit_never_writes_reflog_replacement(
+    tmp_path: Path,
+    reflog_name: str,
+    replacement_kind: str,
+) -> None:
+    root, head, journal, apply_receipt = _host_commit_applied(tmp_path)
+    outside = tmp_path / f"outside-{reflog_name}-{replacement_kind}"
+    outside.write_bytes(b"outside-reflog-r8v3\n")
+    outside_before = outside.read_bytes()
+    branch = "feature/local-k8m2"
+
+    def replace_parked_reflog(phase: str) -> None:
+        if phase != "metadata_before_ref":
+            return
+        target = (
+            root / ".git" / "logs" / "HEAD"
+            if reflog_name == "HEAD"
+            else root / ".git" / "logs" / "refs" / "heads" / Path(branch)
+        )
+        assert not target.exists()
+        try:
+            if replacement_kind == "hardlink":
+                os.link(outside, target)
+            else:
+                target.symlink_to(outside)
+        except OSError as exc:
+            pytest.skip(f"reflog replacement is not available on this host: {exc}")
+
+    with pytest.raises(HostCommitError):
+        HostGitCommitEngine(
+            root,
+            HOST_COMMIT_PROJECT_ID,
+            journal,
+            mutation_hook=replace_parked_reflog,
+            enforce_windows=False,
+        ).commit(
+            operation_id=f"commit_reflog_{reflog_name.lower()}_{replacement_kind}_01",
+            apply_receipt=apply_receipt,
+            branch=branch,
+            expected_head=head,
+            message="feature: reject reflog replacement",
+        )
+
+    assert outside.read_bytes() == outside_before
+    assert _host_commit_git(root, "rev-parse", "HEAD") == head
+
+
+@pytest.mark.parametrize(
+    "redirect_name",
+    ["commondir", "alternates", "http-alternates"],
+)
+def test_host_commit_rechecks_git_redirections_before_ref_side_effect(
+    tmp_path: Path,
+    redirect_name: str,
+) -> None:
+    root, head, journal, apply_receipt = _host_commit_applied(tmp_path)
+    outside = tmp_path / "outside-object-store"
+    outside.mkdir()
+    sentinel = outside / "sentinel.txt"
+    sentinel.write_text("outside-q7m4\n", encoding="utf-8")
+    branch_ref = root / ".git" / "refs" / "heads" / "feature" / "local-k8m2"
+    branch_ref_before = branch_ref.read_bytes()
+
+    def inject_redirect(phase: str) -> None:
+        if phase != "metadata_before_ref":
+            return
+        target = (
+            root / ".git" / "commondir"
+            if redirect_name == "commondir"
+            else root / ".git" / "objects" / "info" / redirect_name
+        )
+        target.write_text(str(outside), encoding="utf-8")
+
+    with pytest.raises(HostCommitError) as rejected:
+        HostGitCommitEngine(
+            root,
+            HOST_COMMIT_PROJECT_ID,
+            journal,
+            mutation_hook=inject_redirect,
+            enforce_windows=False,
+        ).commit(
+            operation_id=f"commit_redirect_{redirect_name.replace('-', '_')}_012",
+            apply_receipt=apply_receipt,
+            branch="feature/local-k8m2",
+            expected_head=head,
+            message="feature: reject dynamic Git redirect",
+        )
+
+    assert rejected.value.code == "repository_unsafe"
+    assert sentinel.read_text(encoding="utf-8") == "outside-q7m4\n"
+    assert tuple(outside.iterdir()) == (sentinel,)
+    assert branch_ref.read_bytes() == branch_ref_before == f"{head}\n".encode("ascii")
+
+
+def test_host_commit_rejects_nested_symbolic_branch_ref_before_update(
+    tmp_path: Path,
+) -> None:
+    root, head, journal, apply_receipt = _host_commit_applied(tmp_path)
+    branch = "feature/local-k8m2"
+    other = "refs/heads/manual-target-r8v3"
+    _host_commit_git(root, "update-ref", other, head)
+    branch_ref = root / ".git" / "refs" / "heads" / Path(branch)
+    branch_ref.write_text(f"ref: {other}\n", encoding="ascii")
+
+    with pytest.raises(HostCommitError) as rejected:
+        HostGitCommitEngine(
+            root,
+            HOST_COMMIT_PROJECT_ID,
+            journal,
+            enforce_windows=False,
+        ).commit(
+            operation_id="commit_nested_symbolic_ref_0123",
+            apply_receipt=apply_receipt,
+            branch=branch,
+            expected_head=head,
+            message="feature: reject nested symbolic ref",
+        )
+
+    assert rejected.value.code in {"branch_changed", "head_changed"}
+    assert branch_ref.read_text(encoding="ascii") == f"ref: {other}\n"
+    assert _host_commit_git(root, "rev-parse", other) == head
+
+
+def test_host_commit_reflog_parent_link_cannot_move_external_log(
+    tmp_path: Path,
+) -> None:
+    root, head, journal, apply_receipt = _host_commit_applied(tmp_path)
+    outside_refs = tmp_path / "outside-refs"
+    outside_log = outside_refs / "heads" / "feature" / "local-k8m2"
+    outside_log.parent.mkdir(parents=True)
+    outside_log.write_bytes(b"outside-parent-chain-q7m4\n")
+
+    def replace_parent(phase: str) -> None:
+        if phase != "metadata_before_reflog_bind":
+            return
+        refs = root / ".git" / "logs" / "refs"
+        refs.rename(root / ".git" / "logs" / "refs-real")
+        try:
+            refs.symlink_to(outside_refs, target_is_directory=True)
+        except OSError as exc:
+            pytest.skip(f"parent link is not available on this host: {exc}")
+
+    with pytest.raises(HostCommitError) as rejected:
+        HostGitCommitEngine(
+            root,
+            HOST_COMMIT_PROJECT_ID,
+            journal,
+            mutation_hook=replace_parent,
+            enforce_windows=False,
+        ).commit(
+            operation_id="commit_reflog_parent_link_0123",
+            apply_receipt=apply_receipt,
+            branch="feature/local-k8m2",
+            expected_head=head,
+            message="feature: guard reflog parent chain",
+        )
+
+    assert rejected.value.code == "repository_unsafe"
+    assert outside_log.read_bytes() == b"outside-parent-chain-q7m4\n"
+    assert _host_commit_git(root, "rev-parse", "HEAD") == head
+
+
+def test_host_commit_private_object_publish_rejects_missing_fanout_link(
+    tmp_path: Path,
+) -> None:
+    before = b"before-r7k3\n"
+    root, head = _host_commit_repository(tmp_path, content=before)
+    counter = 0
+    while True:
+        after = f"private-object-{counter}-q9t2\n".encode("ascii")
+        header = f"blob {len(after)}\0".encode("ascii")
+        object_id = hashlib.sha1(header + after).hexdigest()
+        if not (root / ".git" / "objects" / object_id[:2]).exists():
+            break
+        counter += 1
+    journal = HostOperationJournal(tmp_path / "host-operations.bin", _XorProtector())
+    apply_receipt = HostGitApplyEngine(
+        root,
+        HOST_COMMIT_PROJECT_ID,
+        journal,
+        enforce_windows=False,
+    ).apply(
+        operation_id="apply_private_object_0123456",
+        revision=13,
+        branch="feature/local-k8m2",
+        expected_head=head,
+        snapshot_fingerprint=HOST_COMMIT_FINGERPRINT,
+        patch=_host_commit_patch("marker.txt", before, after),
+        paths=("marker.txt",),
+    )
+    outside = tmp_path / "outside-fanout"
+    outside.mkdir()
+    sentinel = outside / "sentinel.txt"
+    sentinel.write_text("outside-k8m2\n", encoding="utf-8")
+
+    def insert_fanout_link(phase: str) -> None:
+        if phase != "commit_before_object_publish":
+            return
+        target = root / ".git" / "objects" / object_id[:2]
+        try:
+            target.symlink_to(outside, target_is_directory=True)
+        except OSError as exc:
+            pytest.skip(f"fanout link is not available on this host: {exc}")
+
+    with pytest.raises(HostCommitError) as rejected:
+        HostGitCommitEngine(
+            root,
+            HOST_COMMIT_PROJECT_ID,
+            journal,
+            mutation_hook=insert_fanout_link,
+            enforce_windows=False,
+        ).commit(
+            operation_id="commit_private_fanout_012345",
+            apply_receipt=apply_receipt,
+            branch="feature/local-k8m2",
+            expected_head=head,
+            message="feature: isolate Git object publication",
+        )
+
+    assert rejected.value.code == "repository_unsafe"
+    assert tuple(outside.iterdir()) == (sentinel,)
+    assert _host_commit_git(root, "rev-parse", "HEAD") == head
+
+
+@pytest.mark.parametrize("ref_advanced", [False, True])
+def test_host_commit_recovers_parked_reflogs_after_restart(
+    tmp_path: Path,
+    ref_advanced: bool,
+) -> None:
+    root, head, journal, apply_receipt = _host_commit_applied(tmp_path)
+    operation_id = f"commit_reflog_restart_{int(ref_advanced)}_012345"
+
+    def stop_after_intent(phase: str) -> None:
+        if phase == "commit_after_receipt":
+            raise RuntimeError("simulated process stop")
+
+    with pytest.raises(RuntimeError, match="simulated process stop"):
+        HostGitCommitEngine(
+            root,
+            HOST_COMMIT_PROJECT_ID,
+            journal,
+            mutation_hook=stop_after_intent,
+            enforce_windows=False,
+        ).commit(
+            operation_id=operation_id,
+            apply_receipt=apply_receipt,
+            branch="feature/local-k8m2",
+            expected_head=head,
+            message="feature: recover exact reflog state",
+        )
+    record = journal.get(operation_id)
+    assert record is not None and record.commit_receipt is not None
+    reflogs = (
+        (
+            root / ".git" / "logs" / "HEAD",
+            root
+            / ".git"
+            / "modelmirror-transactions"
+            / f"{operation_id}.head-reflog-before",
+        ),
+        (
+            root / ".git" / "logs" / "refs" / "heads" / "feature" / "local-k8m2",
+            root
+            / ".git"
+            / "modelmirror-transactions"
+            / f"{operation_id}.branch-reflog-before",
+        ),
+    )
+    reflogs_before = tuple(source.read_bytes() for source, _backup in reflogs)
+    for source, backup in reflogs:
+        os.replace(source, backup)
+    if ref_advanced:
+        _host_commit_git(
+            root,
+            "-c",
+            "core.logAllRefUpdates=false",
+            "update-ref",
+            "--no-deref",
+            "--no-create-reflog",
+            "refs/heads/feature/local-k8m2",
+            str(record.commit_receipt["commit_sha"]),
+            head,
+        )
+
+    state, receipt = HostGitCommitEngine(
+        root,
+        HOST_COMMIT_PROJECT_ID,
+        HostOperationJournal(tmp_path / "host-operations.bin", _XorProtector()),
+        enforce_windows=False,
+    ).reconcile(operation_id)
+
+    assert state == "committed"
+    assert receipt is not None
+    assert _host_commit_git(root, "rev-parse", "HEAD") == receipt.commit_sha
+    assert tuple(source.read_bytes() for source, _backup in reflogs) == reflogs_before
+    assert not any(backup.exists() for _source, backup in reflogs)
+
+
+def test_host_commit_retries_after_objects_were_already_published(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root, head, journal, apply_receipt = _host_commit_applied(tmp_path)
+    operation_id = "commit_objects_published_012345"
+    stopped = False
+
+    def stop_after_publish(phase: str) -> None:
+        nonlocal stopped
+        if phase == "commit_after_tree" and not stopped:
+            stopped = True
+            raise RuntimeError("simulated stop after object publish")
+
+    real_cleanup = HostGitCommitEngine._cleanup_private_object_store
+    monkeypatch.setattr(
+        HostGitCommitEngine,
+        "_cleanup_private_object_store",
+        lambda *_args, **_kwargs: None,
+    )
+
+    with pytest.raises(RuntimeError, match="simulated stop"):
+        HostGitCommitEngine(
+            root,
+            HOST_COMMIT_PROJECT_ID,
+            journal,
+            mutation_hook=stop_after_publish,
+            enforce_windows=False,
+        ).commit(
+            operation_id=operation_id,
+            apply_receipt=apply_receipt,
+            branch="feature/local-k8m2",
+            expected_head=head,
+            message="feature: retry published objects",
+        )
+    private_store = (
+        root
+        / ".git"
+        / "modelmirror-transactions"
+        / f"{operation_id}.private-objects"
+    )
+    assert private_store.is_dir()
+    monkeypatch.setattr(
+        HostGitCommitEngine,
+        "_cleanup_private_object_store",
+        real_cleanup,
+    )
+
+    receipt = HostGitCommitEngine(
+        root,
+        HOST_COMMIT_PROJECT_ID,
+        HostOperationJournal(tmp_path / "host-operations.bin", _XorProtector()),
+        enforce_windows=False,
+    ).commit(
+        operation_id=operation_id,
+        apply_receipt=apply_receipt,
+        branch="feature/local-k8m2",
+        expected_head=head,
+        message="feature: retry published objects",
+    )
+
+    assert _host_commit_git(root, "rev-parse", "HEAD") == receipt.commit_sha
+    assert not private_store.exists()
+
+
+def test_host_commit_rejects_replace_refs_and_disables_replace_objects(
+    tmp_path: Path,
+) -> None:
+    root, head, journal, _apply_receipt = _host_commit_applied(tmp_path)
+    tree = _host_commit_git(root, "rev-parse", f"{head}^{{tree}}")
+    replacement = _host_commit_git(
+        root,
+        "commit-tree",
+        tree,
+        "-p",
+        head,
+        input_bytes=b"replacement must not be observed\n",
+    )
+    _host_commit_git(root, "replace", head, replacement)
+
+    with pytest.raises(HostCommitError) as rejected:
+        HostGitCommitEngine(
+            root,
+            HOST_COMMIT_PROJECT_ID,
+            journal,
+            enforce_windows=False,
+        )
+
+    assert rejected.value.code == "repository_unsafe"

--- a/server/tests/test_coding_project_host_api.py
+++ b/server/tests/test_coding_project_host_api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import time
 from pathlib import Path
@@ -15,9 +16,22 @@ from server.coding_runtime.api import (
     configure_coding_service,
     router,
 )
+from server.coding_runtime.apply_models import ApplyFileReceipt, ApplyReceipt
+from server.coding_runtime.commit_models import CommitReceipt
+from server.coding_runtime.applier_client import _receipt_to_payload
+from server.coding_runtime.committer_client import _commit_receipt_to_payload
 from server.coding_runtime.patch_policy import snapshot_fingerprint
-from server.coding_runtime.project_host import ProjectHostError, ProjectHostStore
-from server.coding_runtime.project_host_api import ProjectHostRuntime, _Transfer
+from server.coding_runtime.project_host import (
+    PROJECT_HOST_PROTOCOL_V2,
+    ProjectHostError,
+    ProjectHostStore,
+)
+from server.coding_runtime.project_host_api import (
+    ProjectHostRuntime,
+    _OperationPayload,
+    _Transfer,
+)
+from server.coding_runtime.project_writer_client import ProjectWriterClientError
 from server.coding_runtime.projects import ProjectFeatures, ProjectKind
 from server.coding_runtime.recovery import CodingRecoveryStore, RecoveryProjectContext
 from server.coding_runtime.worker import CodingWorkerError, CodingWorkerServer
@@ -27,9 +41,47 @@ from server.tests.test_coding_runtime_api import FakeWorker
 PROJECT_ID = "hostgit_0123456789abcdef0123456789abcdef"
 PROJECT_HEAD = "a" * 40
 PROJECT_FINGERPRINT = "b" * 64
+PROJECT_BRANCH = "feature/nebula-k8r3"
 
 
-def _public_project() -> dict[str, Any]:
+def _apply_receipt(operation_id: str = "apply_0123456789abcdef012345") -> ApplyReceipt:
+    return ApplyReceipt(
+        apply_id=operation_id,
+        revision=3,
+        snapshot_fingerprint=PROJECT_FINGERPRINT,
+        files=(
+            ApplyFileReceipt(
+                path="src/nebula.py",
+                existed_before=True,
+                before_sha256="c" * 64,
+                after_sha256="d" * 64,
+            ),
+        ),
+        applied_at=1_785_600_000.0,
+    )
+
+
+def _commit_receipt(
+    apply_receipt: ApplyReceipt,
+    operation_id: str = "commit_0123456789abcdef0123",
+) -> CommitReceipt:
+    return CommitReceipt(
+        commit_id=operation_id,
+        revision=apply_receipt.revision,
+        apply_id=apply_receipt.apply_id,
+        commit_sha="e" * 40,
+        parent_sha=PROJECT_HEAD,
+        tree_sha="f" * 40,
+        message="feature: update nebula",
+        files=tuple(item.path for item in apply_receipt.files),
+        branch=PROJECT_BRANCH,
+        committed_at=1_785_600_001.0,
+    )
+
+
+def _public_project(*, writeback: bool = False) -> dict[str, Any]:
+    features = ProjectFeatures.host_git().to_dict()
+    features.update({"apply": writeback, "commit": writeback})
     return {
         "id": PROJECT_ID,
         "name": "星云 k8r3",
@@ -38,8 +90,8 @@ def _public_project() -> dict[str, Any]:
         "reason": None,
         "branch": "feature/nebula-k8r3",
         "head": PROJECT_HEAD[:12],
-        "features": ProjectFeatures.host_git().to_dict(),
-        "writeback_reason": None,
+        "features": features,
+        "writeback_reason": None if writeback else "project_host_writeback_disabled",
     }
 
 
@@ -59,9 +111,40 @@ def _lease() -> dict[str, Any]:
     }
 
 
+def _registered_runtime(tmp_path: Path) -> ProjectHostRuntime:
+    store = ProjectHostStore(tmp_path / "state.json")
+    _pairing, code = store.create_pairing("local helper")
+    host, _token = store.consume_pairing(
+        code,
+        device_id="pdev_0123456789abcdef0123456789abcdef",
+        version="1.1.0",
+        platform="windows",
+        protocol=PROJECT_HOST_PROTOCOL_V2,
+    )
+    store.register_project(
+        host.host_id,
+        {
+            "project_id": PROJECT_ID,
+            "name": "nebula",
+            "branch": PROJECT_BRANCH,
+            "head": PROJECT_HEAD,
+            "state": "available",
+            "reason": None,
+        },
+    )
+    return ProjectHostRuntime(
+        store,
+        tmp_path / "uploads",
+        writeback_enabled=True,
+    )
+
+
 class FakeHostRuntime:
-    def __init__(self) -> None:
-        self.snapshot_calls: list[tuple[str, str | None, str | None]] = []
+    def __init__(self, *, writeback: bool = False) -> None:
+        self.writeback = writeback
+        self.snapshot_calls: list[
+            tuple[str, str | None, str | None, str | None]
+        ] = []
         self.finished: list[str] = []
 
     def capability(self, **_: Any) -> dict[str, Any]:
@@ -72,11 +155,24 @@ class FakeHostRuntime:
             "platform": "windows",
             "selection": True,
             "remembers_projects": True,
-            "direct_writeback": False,
+            "direct_writeback": self.writeback,
+            "writeback_available": self.writeback,
+        }
+
+    async def health(self) -> dict[str, Any]:
+        return {
+            "configured": self.writeback,
+            "available": self.writeback,
+            **({} if self.writeback else {"reason": "project_host_writeback_disabled"}),
         }
 
     def list_projects(self) -> list[dict[str, Any]]:
-        return [_public_project()]
+        return [_public_project(writeback=self.writeback)]
+
+    def public_project(self, project_id: str) -> dict[str, Any]:
+        if project_id != PROJECT_ID:
+            raise ProjectHostError("project_not_found")
+        return _public_project(writeback=self.writeback)
 
     def check_project(self, project_id: str, head: str, branch: str | None) -> dict[str, Any]:
         if (project_id, head, branch) != (
@@ -93,8 +189,11 @@ class FakeHostRuntime:
         *,
         expected_head: str | None = None,
         expected_branch: str | None = None,
+        managed_operation_id: str | None = None,
     ) -> dict[str, Any]:
-        self.snapshot_calls.append((project_id, expected_head, expected_branch))
+        self.snapshot_calls.append(
+            (project_id, expected_head, expected_branch, managed_operation_id)
+        )
         self.check_project(
             project_id,
             expected_head or PROJECT_HEAD,
@@ -113,6 +212,158 @@ class FakeHostRuntime:
 
     def finish_transfer(self, transfer_id: str) -> None:
         self.finished.append(transfer_id)
+
+
+class WritebackHostRuntime(FakeHostRuntime):
+    def __init__(self) -> None:
+        super().__init__(writeback=True)
+        self.current_head = PROJECT_HEAD
+        self.current_state = "available"
+        self.intent_calls: list[tuple[str, str]] = []
+        self.recovery_bindings: list[tuple[str | None, str | None]] = []
+        self.apply_calls = 0
+        self.commit_calls = 0
+        self.reconcile_commit_calls = 0
+        self.apply_requests: list[dict[str, Any]] = []
+        self.commit_requests: list[dict[str, Any]] = []
+        self.reconcile_commit_requests: list[dict[str, Any]] = []
+        self.commit_receipts: list[CommitReceipt] = []
+        self.fail_commit_after_effect = False
+        self._committed: CommitReceipt | None = None
+        self._committed_by_id: dict[str, CommitReceipt] = {}
+
+    def check_project(
+        self,
+        project_id: str,
+        head: str,
+        branch: str | None,
+    ) -> dict[str, Any]:
+        if (project_id, head, branch) != (
+            PROJECT_ID,
+            self.current_head,
+            PROJECT_BRANCH,
+        ) or self.current_state != "available":
+            raise ProjectHostError("project_changed")
+        return _public_project(writeback=True)
+
+    async def request_snapshot(
+        self,
+        project_id: str,
+        *,
+        expected_head: str | None = None,
+        expected_branch: str | None = None,
+        managed_operation_id: str | None = None,
+    ) -> dict[str, Any]:
+        self.snapshot_calls.append(
+            (project_id, expected_head, expected_branch, managed_operation_id)
+        )
+        if managed_operation_id is None:
+            self.check_project(
+                project_id,
+                expected_head or self.current_head,
+                expected_branch or PROJECT_BRANCH,
+            )
+        elif (project_id, expected_head, expected_branch) != (
+            PROJECT_ID,
+            PROJECT_HEAD,
+            PROJECT_BRANCH,
+        ):
+            raise ProjectHostError("project_changed")
+        return {
+            "upload_id": "1" * 32,
+            "archive_sha256": "2" * 64,
+            "project": {
+                "project_id": PROJECT_ID,
+                "name": "星云 k8r3",
+                "branch": PROJECT_BRANCH,
+                "head": PROJECT_HEAD,
+            },
+        }
+
+    def bind_persisted_intent(
+        self,
+        *,
+        operation_id: str,
+        kind: str,
+        **_: Any,
+    ) -> None:
+        self.intent_calls.append((kind, operation_id))
+
+    def bind_recovery_operations(
+        self,
+        *,
+        apply_operation_id: str | None = None,
+        commit_operation_id: str | None = None,
+        **_: Any,
+    ) -> None:
+        self.recovery_bindings.append(
+            (apply_operation_id, commit_operation_id)
+        )
+
+    async def apply(self, **kwargs: Any) -> ApplyReceipt:
+        self.apply_calls += 1
+        self.apply_requests.append(dict(kwargs))
+        receipt = ApplyReceipt(
+            apply_id=kwargs["operation_id"],
+            revision=kwargs["revision"],
+            snapshot_fingerprint=kwargs["expected_fingerprint"],
+            files=tuple(
+                ApplyFileReceipt(
+                    path=path,
+                    existed_before=True,
+                    before_sha256="c" * 64,
+                    after_sha256="d" * 64,
+                )
+                for path in kwargs["paths"]
+            ),
+            applied_at=1_785_600_000.0,
+        )
+        self.current_state = "dirty"
+        return receipt
+
+    async def commit(self, **kwargs: Any) -> CommitReceipt:
+        self.commit_calls += 1
+        self.commit_requests.append(dict(kwargs))
+        applied = kwargs["apply_receipt"]
+        commit_sha = f"{self.commit_calls:x}" * 40
+        receipt = CommitReceipt(
+            commit_id=kwargs["operation_id"],
+            revision=applied.revision,
+            apply_id=applied.apply_id,
+            commit_sha=commit_sha,
+            parent_sha=kwargs["expected_head"],
+            tree_sha="f" * 40,
+            message=kwargs["message"],
+            files=tuple(item.path for item in applied.files),
+            branch=kwargs["expected_branch"],
+            committed_at=1_785_600_001.0,
+        )
+        self._committed = receipt
+        self._committed_by_id[receipt.commit_id] = receipt
+        self.commit_receipts.append(receipt)
+        self.current_head = receipt.commit_sha
+        self.current_state = "available"
+        if self.fail_commit_after_effect:
+            self.fail_commit_after_effect = False
+            raise ProjectWriterClientError(
+                "result lost",
+                code="operation_result_unknown",
+            )
+        return receipt
+
+    async def reconcile_commit(
+        self,
+        **kwargs: Any,
+    ) -> tuple[str, ApplyReceipt, CommitReceipt | None]:
+        self.reconcile_commit_calls += 1
+        self.reconcile_commit_requests.append(dict(kwargs))
+        applied = kwargs["apply_receipt"]
+        committed = self._committed_by_id.get(kwargs["commit_operation_id"])
+        if committed is None:
+            return "not_committed", applied, None
+        self.current_head = committed.commit_sha
+        self.current_state = "available"
+        return "committed", applied, committed
 
 
 class FakeHostSource:
@@ -160,10 +411,12 @@ class HostWorker(FakeWorker):
 
 def _service(
     store: CodingRecoveryStore | None = None,
+    *,
+    host: FakeHostRuntime | None = None,
 ) -> tuple[CodingService, HostWorker, FakeHostSource, FakeHostRuntime]:
     worker = HostWorker()
     source = FakeHostSource()
-    host = FakeHostRuntime()
+    host = host or FakeHostRuntime()
     service = CodingService(
         enabled=True,
         worker=worker,
@@ -188,6 +441,43 @@ def _client(service: CodingService) -> httpx.AsyncClient:
     )
 
 
+async def _complete_host_cycle(
+    client: httpx.AsyncClient,
+    worker: HostWorker,
+    session_id: str,
+    *,
+    revision: int,
+    path: str,
+    message: str,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    worker.revision = revision
+    worker.change_path = path
+    worker.current_empty = False
+    applied = await client.post(
+        f"/api/coding/sessions/{session_id}/apply",
+        json={"revision": revision, "confirm_quality_risks": True},
+    )
+    assert applied.status_code == 200, applied.text
+    committed = await client.post(
+        f"/api/coding/sessions/{session_id}/commit",
+        json={
+            "revision": revision,
+            "apply_id": applied.json()["apply_id"],
+            "message": message,
+        },
+    )
+    assert committed.status_code == 200, committed.text
+    continued = await client.post(
+        f"/api/coding/sessions/{session_id}/continue",
+        json={
+            "revision": revision,
+            "commit_id": committed.json()["commit_id"],
+        },
+    )
+    assert continued.status_code == 200, continued.text
+    return applied.json(), committed.json()
+
+
 @pytest.mark.asyncio
 async def test_host_project_catalog_and_session_use_one_path_free_snapshot() -> None:
     service, worker, source, host = _service()
@@ -206,7 +496,7 @@ async def test_host_project_catalog_and_session_use_one_path_free_snapshot() -> 
     assert created.status_code == 201
     assert created.json()["project"]["kind"] == "host_git"
     assert worker.source == _lease()
-    assert host.snapshot_calls == [(PROJECT_ID, None, None)]
+    assert host.snapshot_calls == [(PROJECT_ID, None, None, None)]
     assert host.finished == ["1" * 32]
     assert source.imports[0]["project_id"] == PROJECT_ID
     encoded = json.dumps(created.json(), ensure_ascii=False).casefold()
@@ -214,6 +504,227 @@ async def test_host_project_catalog_and_session_use_one_path_free_snapshot() -> 
     assert "remote" not in encoded
     await service.shutdown()
     assert source.released == [(PROJECT_ID, "lease_host_k8r3_202608")]
+    configure_coding_service(None)
+
+
+@pytest.mark.asyncio
+async def test_host_commit_unknown_result_reconciles_before_retry(
+    tmp_path: Path,
+) -> None:
+    host = WritebackHostRuntime()
+    service, _worker, _source, _ = _service(
+        CodingRecoveryStore(tmp_path / "writeback-recovery"),
+        host=host,
+    )
+    async with _client(service) as client:
+        created = await client.post(
+            "/api/coding/sessions",
+            json={"project_id": PROJECT_ID},
+        )
+        assert created.status_code == 201, created.text
+        session_id = created.json()["id"]
+        applied = await client.post(
+            f"/api/coding/sessions/{session_id}/apply",
+            json={"revision": 1, "confirm_quality_risks": True},
+        )
+        apply_id = applied.json()["apply_id"]
+        host.fail_commit_after_effect = True
+        first_commit = await client.post(
+            f"/api/coding/sessions/{session_id}/commit",
+            json={
+                "revision": 1,
+                "apply_id": apply_id,
+                "message": "feature: update host project",
+            },
+        )
+        retried = await client.post(
+            f"/api/coding/sessions/{session_id}/commit",
+            json={
+                "revision": 1,
+                "apply_id": apply_id,
+                "message": "feature: update host project",
+            },
+        )
+
+    assert created.status_code == 201
+    assert applied.status_code == 200
+    assert first_commit.status_code == 503
+    assert first_commit.json()["detail"]["code"] == "operation_result_unknown"
+    assert retried.status_code == 200
+    assert retried.json()["state"] == "committed"
+    assert host.commit_calls == 1
+    assert host.reconcile_commit_calls == 1
+    assert host.recovery_bindings[-1][1] == retried.json()["commit_id"]
+    await service.shutdown()
+    configure_coding_service(None)
+
+
+@pytest.mark.asyncio
+async def test_host_project_two_cycles_advance_parent_but_keep_source_baseline(
+    tmp_path: Path,
+) -> None:
+    store = CodingRecoveryStore(tmp_path / "two-cycle-recovery")
+    host = WritebackHostRuntime()
+    service, worker, _source, _ = _service(store, host=host)
+    service.incremental_enabled = True
+    async with _client(service) as client:
+        created = await client.post(
+            "/api/coding/sessions",
+            json={"project_id": PROJECT_ID},
+        )
+        assert created.status_code == 201, created.text
+        session_id = created.json()["id"]
+        await _complete_host_cycle(
+            client,
+            worker,
+            session_id,
+            revision=1,
+            path="server/round_one.py",
+            message="feature: host round one",
+        )
+        first_head = host.commit_receipts[0].commit_sha
+        await _complete_host_cycle(
+            client,
+            worker,
+            session_id,
+            revision=2,
+            path="server/round_two.py",
+            message="feature: host round two",
+        )
+        history = await client.get(
+            f"/api/coding/sessions/{session_id}/history"
+        )
+
+    assert history.status_code == 200
+    assert history.json()["active_cycle"] == 3
+    assert history.json()["completed_count"] == 2
+    assert [item["expected_head"] for item in host.apply_requests] == [
+        PROJECT_HEAD,
+        first_head,
+    ]
+    assert [item["expected_head"] for item in host.commit_requests] == [
+        PROJECT_HEAD,
+        first_head,
+    ]
+    active = service._sessions[session_id]
+    assert active.project_source is not None
+    assert active.project_source["head"] == PROJECT_HEAD
+    persisted = store.load()
+    assert persisted is not None
+    assert len(persisted.payload.cycles) == 2
+    context = store.load_project_context(persisted.recovery_id)
+    assert context is not None
+    assert context.head == PROJECT_HEAD
+    assert context.branch == PROJECT_BRANCH
+    await service.shutdown()
+    configure_coding_service(None)
+
+
+@pytest.mark.asyncio
+async def test_completed_host_cycles_recover_by_reconciling_exact_last_cycle(
+    tmp_path: Path,
+) -> None:
+    store = CodingRecoveryStore(tmp_path / "completed-cycle-recovery")
+    host = WritebackHostRuntime()
+    first, first_worker, _source, _ = _service(store, host=host)
+    first.incremental_enabled = True
+    async with _client(first) as client:
+        created = await client.post(
+            "/api/coding/sessions",
+            json={"project_id": PROJECT_ID},
+        )
+        assert created.status_code == 201, created.text
+        session_id = created.json()["id"]
+        first_apply, _first_commit = await _complete_host_cycle(
+            client,
+            first_worker,
+            session_id,
+            revision=1,
+            path="server/recovery_round_one.py",
+            message="feature: recovery round one",
+        )
+        second_apply, _second_commit = await _complete_host_cycle(
+            client,
+            first_worker,
+            session_id,
+            revision=2,
+            path="server/recovery_round_two.py",
+            message="feature: recovery round two",
+        )
+    first_head = host.commit_receipts[0].commit_sha
+    last_commit = host.commit_receipts[1]
+    await first.shutdown()
+
+    second, second_worker, _second_source, _ = _service(store, host=host)
+    second.incremental_enabled = True
+    pending = await second.recovery_status()
+    resumed = await second.resume_recovery()
+
+    assert pending["can_resume"] is True
+    assert resumed.recovery_conflict is None
+    assert resumed.apply_operation_id is None
+    assert resumed.commit_operation_id is None
+    reconciled = host.reconcile_commit_requests[-1]
+    assert reconciled["expected_head"] == first_head
+    assert reconciled["operation_id"] == second_apply["apply_id"]
+    assert reconciled["commit_operation_id"] == last_commit.commit_id
+    assert reconciled["revision"] == 2
+    assert reconciled["paths"] == ["server/recovery_round_two.py"]
+    assert "server/recovery_round_two.py" in reconciled["patch"]
+    assert "server/recovery_round_one.py" not in reconciled["patch"]
+    assert host.snapshot_calls[-1] == (
+        PROJECT_ID,
+        PROJECT_HEAD,
+        PROJECT_BRANCH,
+        first_apply["apply_id"],
+    )
+    assert second_worker.restore_calls[0]["source"]["head"] == PROJECT_HEAD
+    await second.shutdown()
+    configure_coding_service(None)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tamper", ["path", "parent"])
+async def test_host_cycle_lineage_tampering_blocks_next_apply(
+    tmp_path: Path,
+    tamper: str,
+) -> None:
+    store = CodingRecoveryStore(tmp_path / f"lineage-{tamper}")
+    host = WritebackHostRuntime()
+    service, worker, _source, _ = _service(store, host=host)
+    service.incremental_enabled = True
+    async with _client(service) as client:
+        created = await client.post(
+            "/api/coding/sessions",
+            json={"project_id": PROJECT_ID},
+        )
+        assert created.status_code == 201, created.text
+        session_id = created.json()["id"]
+        await _complete_host_cycle(
+            client,
+            worker,
+            session_id,
+            revision=1,
+            path="server/lineage_round_one.py",
+            message="feature: lineage round one",
+        )
+        cycle = service._sessions[session_id].cycle_history.cycles[0]
+        if tamper == "path":
+            cycle.changes["files"][0]["path"] = "server/tampered.py"
+        else:
+            cycle.commit["receipt"]["parent_sha"] = "9" * 40
+        worker.revision = 2
+        worker.change_path = "server/lineage_round_two.py"
+        worker.current_empty = False
+        blocked = await client.post(
+            f"/api/coding/sessions/{session_id}/apply",
+            json={"revision": 2, "confirm_quality_risks": True},
+        )
+
+    assert blocked.status_code == 409
+    assert blocked.json()["detail"]["code"] == "cycle_lineage_invalid"
+    assert host.apply_calls == 1
+    await service.shutdown()
     configure_coding_service(None)
 
 
@@ -266,6 +777,7 @@ async def test_host_project_recovery_requests_fresh_matching_snapshot(tmp_path: 
         PROJECT_ID,
         PROJECT_HEAD,
         "feature/nebula-k8r3",
+        None,
     )
     assert second_worker.restore_calls[0]["source"]["kind"] == "host_git"
     await second.shutdown()
@@ -279,7 +791,7 @@ def test_runtime_accepts_host_lease_but_rejects_kind_id_mismatch(tmp_path: Path)
     builtin.mkdir()
     workspace.mkdir(parents=True)
     (builtin / "README.md").write_text("builtin\n", encoding="utf-8")
-    (workspace / "README.md").write_text("nebula-k8r3\n", encoding="utf-8")
+    (workspace / "README.md").write_bytes(b"nebula-k8r3\n")
     source = _lease()
     source["fingerprint"] = snapshot_fingerprint(workspace)
     source["total_bytes"] = len(b"nebula-k8r3\n")
@@ -353,3 +865,442 @@ async def test_transfer_requires_host_token_and_exact_length(tmp_path: Path) -> 
     assert (tmp_path / "uploads" / f"{transfer_id}.tar.gz").read_bytes() == b"random-archive"
     runtime.finish_transfer(transfer_id)
     assert not (tmp_path / "uploads" / f"{transfer_id}.tar.gz").exists()
+
+
+@pytest.mark.asyncio
+async def test_operation_payload_is_bound_single_use_and_supports_large_patch(
+    tmp_path: Path,
+) -> None:
+    store = ProjectHostStore(tmp_path / "state.json")
+    _pairing, code = store.create_pairing("local helper")
+    host, token = store.consume_pairing(
+        code,
+        device_id="pdev_0123456789abcdef0123456789abcdef",
+        version="1.1.0",
+        platform="windows",
+        protocol=PROJECT_HOST_PROTOCOL_V2,
+    )
+    runtime = ProjectHostRuntime(
+        store,
+        tmp_path / "uploads",
+        writeback_enabled=True,
+    )
+    payload_id = "phop_" + "1" * 32
+    operation_id = "apply_0123456789abcdef012345"
+    body = b"x" * (900 * 1024)
+    runtime._operation_payloads[payload_id] = _OperationPayload(
+        payload_id=payload_id,
+        host_id=host.host_id,
+        project_id=PROJECT_ID,
+        operation_id=operation_id,
+        action="apply",
+        created_at=time.time(),
+        expires_at=time.time() + 90,
+        sha256=hashlib.sha256(body).hexdigest(),
+        size=len(body),
+        body=body,
+    )
+
+    for overrides in (
+        {"token": "wrong-token"},
+        {"project_id": "hostgit_" + "f" * 32},
+        {"operation_id": "apply_abcdef0123456789abcdef"},
+        {"action": "commit"},
+    ):
+        arguments = {
+            "payload_id": payload_id,
+            "host_id": host.host_id,
+            "token": token,
+            "project_id": PROJECT_ID,
+            "operation_id": operation_id,
+            "action": "apply",
+            **overrides,
+        }
+        with pytest.raises(ProjectHostError):
+            await runtime.consume_operation_payload(**arguments)
+        assert runtime._operation_payloads[payload_id].body == body
+
+    results = await asyncio.gather(
+        *(
+            runtime.consume_operation_payload(
+                payload_id=payload_id,
+                host_id=host.host_id,
+                token=token,
+                project_id=PROJECT_ID,
+                operation_id=operation_id,
+                action="apply",
+            )
+            for _ in range(2)
+        ),
+        return_exceptions=True,
+    )
+    assert sum(result == body for result in results) == 1
+    errors = [result for result in results if isinstance(result, ProjectHostError)]
+    assert [error.code for error in errors] == ["operation_payload_consumed"]
+
+    expired_id = "phop_" + "2" * 32
+    runtime._operation_payloads[expired_id] = _OperationPayload(
+        payload_id=expired_id,
+        host_id=host.host_id,
+        project_id=PROJECT_ID,
+        operation_id=operation_id,
+        action="apply",
+        created_at=time.time() - 100,
+        expires_at=time.time() - 1,
+        sha256=hashlib.sha256(b"expired").hexdigest(),
+        size=7,
+        body=b"expired",
+    )
+    with pytest.raises(ProjectHostError) as expired:
+        await runtime.consume_operation_payload(
+            payload_id=expired_id,
+            host_id=host.host_id,
+            token=token,
+            project_id=PROJECT_ID,
+            operation_id=operation_id,
+            action="apply",
+        )
+    assert expired.value.code == "operation_payload_unavailable"
+
+    route_id = "phop_" + "3" * 32
+    route_body = b'{"safe":true}'
+    runtime._operation_payloads[route_id] = _OperationPayload(
+        payload_id=route_id,
+        host_id=host.host_id,
+        project_id=PROJECT_ID,
+        operation_id=operation_id,
+        action="apply",
+        created_at=time.time(),
+        expires_at=time.time() + 90,
+        sha256=hashlib.sha256(route_body).hexdigest(),
+        size=len(route_body),
+        body=route_body,
+    )
+    service = CodingService(
+        enabled=False,
+        worker=HostWorker(),
+        project_host=runtime,
+        mode="draft",
+    )
+    async with _client(service) as client:
+        downloaded = await client.get(
+            f"/api/coding/project-host/operations/{route_id}",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "X-ModelMirror-Project-Host-Id": host.host_id,
+                "X-ModelMirror-Project-Id": PROJECT_ID,
+                "X-ModelMirror-Operation-Id": operation_id,
+                "X-ModelMirror-Operation-Action": "apply",
+            },
+        )
+    assert downloaded.status_code == 200
+    assert downloaded.content == route_body
+    assert downloaded.headers["cache-control"] == "no-store"
+    assert downloaded.headers["pragma"] == "no-cache"
+    configure_coding_service(None)
+
+
+@pytest.mark.asyncio
+async def test_late_operation_result_is_ignored_and_malformed_receipt_is_unknown(
+    tmp_path: Path,
+) -> None:
+    runtime = ProjectHostRuntime(
+        ProjectHostStore(tmp_path / "state.json"),
+        tmp_path / "uploads",
+        writeback_enabled=True,
+    )
+    request_id = "phreq_" + "a" * 32
+    runtime._request_tombstones[request_id] = time.time() + 60
+    await runtime._incoming(
+        "phost_" + "b" * 32,
+        "phconn_" + "c" * 32,
+        {
+            "type": "operation_result",
+            "request_id": request_id,
+            "project_id": PROJECT_ID,
+            "operation_id": "apply_0123456789abcdef012345",
+            "action": "apply",
+            "result": {},
+        },
+    )
+
+    operation_id = "apply_0123456789abcdef012345"
+    runtime._remember_managed_operation(
+        project_id=PROJECT_ID,
+        operation_id=operation_id,
+        kind="apply",
+        branch=PROJECT_BRANCH,
+        expected_head=PROJECT_HEAD,
+    )
+
+    async def malformed(**_: Any) -> dict[str, Any]:
+        return {"state": "applied", "receipt": {"apply_id": operation_id}}
+
+    runtime._execute_operation = malformed  # type: ignore[method-assign]
+    with pytest.raises(ProjectWriterClientError) as unknown:
+        await runtime.apply(
+            project_id=PROJECT_ID,
+            expected_head=PROJECT_HEAD,
+            expected_branch=PROJECT_BRANCH,
+            operation_id=operation_id,
+            revision=3,
+            patch="diff --git a/src/nebula.py b/src/nebula.py\n",
+            paths=["src/nebula.py"],
+            expected_fingerprint=PROJECT_FINGERPRINT,
+        )
+    assert unknown.value.code == "operation_result_unknown"
+    assert (PROJECT_ID, operation_id, "apply") in runtime._uncertain_operations
+
+
+@pytest.mark.asyncio
+async def test_host_runtime_binds_direct_commit_receipt(tmp_path: Path) -> None:
+    runtime = _registered_runtime(tmp_path)
+    applied = _apply_receipt()
+    committed = _commit_receipt(applied)
+    runtime._remember_managed_operation(
+        project_id=PROJECT_ID,
+        operation_id=committed.commit_id,
+        kind="commit",
+        branch=PROJECT_BRANCH,
+        expected_head=PROJECT_HEAD,
+    )
+
+    async def execute(**kwargs: Any) -> dict[str, Any]:
+        assert kwargs["expected_head"] == PROJECT_HEAD
+        assert kwargs["expected_branch"] == PROJECT_BRANCH
+        assert kwargs["managed_operation_id"] == applied.apply_id
+        return {"state": "committed", "receipt": _commit_receipt_to_payload(committed)}
+
+    runtime._execute_operation = execute  # type: ignore[method-assign]
+    restored = await runtime.commit(
+        project_id=PROJECT_ID,
+        expected_head=PROJECT_HEAD,
+        expected_branch=PROJECT_BRANCH,
+        operation_id=committed.commit_id,
+        apply_receipt=applied,
+        message=committed.message,
+    )
+
+    assert restored == committed
+    assert runtime._managed_operations[(PROJECT_ID, committed.commit_id)].branch == PROJECT_BRANCH
+    project = runtime.store.require_project(PROJECT_ID)
+    assert (project.head, project.state, project.reason) == (
+        committed.commit_sha,
+        "available",
+        None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_host_runtime_catalog_tracks_apply_commit_undo_revert(
+    tmp_path: Path,
+) -> None:
+    runtime = _registered_runtime(tmp_path)
+    applied = _apply_receipt()
+    committed = _commit_receipt(applied)
+    responses = [
+        {"state": "applied", "receipt": _receipt_to_payload(applied)},
+        {"state": "committed", "receipt": _commit_receipt_to_payload(committed)},
+        {"state": "undone", "receipt": _commit_receipt_to_payload(committed)},
+        {"state": "reverted", "receipt": _receipt_to_payload(applied)},
+    ]
+    actions: list[str] = []
+
+    async def execute(**kwargs: Any) -> dict[str, Any]:
+        actions.append(kwargs["action"])
+        return responses.pop(0)
+
+    runtime._execute_operation = execute  # type: ignore[method-assign]
+    runtime.bind_persisted_intent(
+        project_id=PROJECT_ID,
+        expected_head=PROJECT_HEAD,
+        expected_branch=PROJECT_BRANCH,
+        operation_id=applied.apply_id,
+        kind="apply",
+    )
+    restored_apply = await runtime.apply(
+        project_id=PROJECT_ID,
+        expected_head=PROJECT_HEAD,
+        expected_branch=PROJECT_BRANCH,
+        operation_id=applied.apply_id,
+        revision=applied.revision,
+        patch="diff --git a/src/nebula.py b/src/nebula.py\n",
+        paths=["src/nebula.py"],
+        expected_fingerprint=PROJECT_FINGERPRINT,
+    )
+    dirty_after_apply = runtime.store.require_project(PROJECT_ID)
+    assert (dirty_after_apply.head, dirty_after_apply.state, dirty_after_apply.reason) == (
+        PROJECT_HEAD,
+        "unavailable",
+        "git_repository_dirty",
+    )
+
+    runtime.bind_persisted_intent(
+        project_id=PROJECT_ID,
+        expected_head=PROJECT_HEAD,
+        expected_branch=PROJECT_BRANCH,
+        operation_id=committed.commit_id,
+        kind="commit",
+        parent_operation_id=applied.apply_id,
+    )
+    restored_commit = await runtime.commit(
+        project_id=PROJECT_ID,
+        expected_head=PROJECT_HEAD,
+        expected_branch=PROJECT_BRANCH,
+        operation_id=committed.commit_id,
+        apply_receipt=restored_apply,
+        message=committed.message,
+    )
+    clean_after_commit = runtime.store.require_project(PROJECT_ID)
+    assert (clean_after_commit.head, clean_after_commit.state, clean_after_commit.reason) == (
+        committed.commit_sha,
+        "available",
+        None,
+    )
+
+    await runtime.undo(
+        project_id=PROJECT_ID,
+        expected_head=PROJECT_HEAD,
+        expected_branch=PROJECT_BRANCH,
+        apply_receipt=restored_apply,
+        commit_receipt=restored_commit,
+    )
+    dirty_after_undo = runtime.store.require_project(PROJECT_ID)
+    assert (dirty_after_undo.head, dirty_after_undo.state, dirty_after_undo.reason) == (
+        PROJECT_HEAD,
+        "unavailable",
+        "git_repository_dirty",
+    )
+
+    await runtime.revert(
+        project_id=PROJECT_ID,
+        expected_head=PROJECT_HEAD,
+        expected_branch=PROJECT_BRANCH,
+        receipt=restored_apply,
+    )
+    clean_after_revert = runtime.store.require_project(PROJECT_ID)
+    assert (clean_after_revert.head, clean_after_revert.state, clean_after_revert.reason) == (
+        PROJECT_HEAD,
+        "available",
+        None,
+    )
+    assert actions == ["apply", "commit", "undo", "revert"]
+    assert responses == []
+
+
+@pytest.mark.asyncio
+async def test_host_runtime_binds_apply_and_commit_reconcile_receipts(
+    tmp_path: Path,
+) -> None:
+    runtime = _registered_runtime(tmp_path)
+    applied = _apply_receipt()
+    committed = _commit_receipt(applied)
+    responses = [
+        {"state": "applied", "receipt": _receipt_to_payload(applied)},
+        {
+            "state": "committed",
+            "apply_receipt": _receipt_to_payload(applied),
+            "commit_receipt": _commit_receipt_to_payload(committed),
+        },
+    ]
+
+    async def execute(**kwargs: Any) -> dict[str, Any]:
+        assert kwargs["expected_head"] == PROJECT_HEAD
+        assert kwargs["expected_branch"] == PROJECT_BRANCH
+        return responses.pop(0)
+
+    runtime._execute_operation = execute  # type: ignore[method-assign]
+    apply_state, restored_apply = await runtime.reconcile_apply(
+        project_id=PROJECT_ID,
+        expected_head=PROJECT_HEAD,
+        expected_branch=PROJECT_BRANCH,
+        operation_id=applied.apply_id,
+        revision=applied.revision,
+        patch="diff --git a/src/nebula.py b/src/nebula.py\n",
+        paths=["src/nebula.py"],
+        expected_fingerprint=PROJECT_FINGERPRINT,
+    )
+    applied_project = runtime.store.require_project(PROJECT_ID)
+    assert (applied_project.head, applied_project.state, applied_project.reason) == (
+        PROJECT_HEAD,
+        "unavailable",
+        "git_repository_dirty",
+    )
+    commit_state, reconciled_apply, restored_commit = await runtime.reconcile_commit(
+        project_id=PROJECT_ID,
+        expected_head=PROJECT_HEAD,
+        expected_branch=PROJECT_BRANCH,
+        operation_id=applied.apply_id,
+        revision=applied.revision,
+        patch="diff --git a/src/nebula.py b/src/nebula.py\n",
+        paths=["src/nebula.py"],
+        expected_fingerprint=PROJECT_FINGERPRINT,
+        apply_receipt=applied,
+        commit_operation_id=committed.commit_id,
+        message=committed.message,
+    )
+
+    assert (apply_state, restored_apply) == ("applied", applied)
+    assert (commit_state, reconciled_apply, restored_commit) == (
+        "committed",
+        applied,
+        committed,
+    )
+    committed_project = runtime.store.require_project(PROJECT_ID)
+    assert (committed_project.head, committed_project.state, committed_project.reason) == (
+        committed.commit_sha,
+        "available",
+        None,
+    )
+    assert responses == []
+
+
+def test_host_runtime_binds_commit_intent_after_managed_apply_is_dirty(
+    tmp_path: Path,
+) -> None:
+    store = ProjectHostStore(tmp_path / "state.json")
+    _pairing, code = store.create_pairing("local helper")
+    host, _token = store.consume_pairing(
+        code,
+        device_id="pdev_0123456789abcdef0123456789abcdef",
+        version="1.1.0",
+        platform="windows",
+        protocol=PROJECT_HOST_PROTOCOL_V2,
+    )
+    store.register_project(
+        host.host_id,
+        {
+            "project_id": PROJECT_ID,
+            "name": "nebula",
+            "branch": PROJECT_BRANCH,
+            "head": PROJECT_HEAD,
+            "state": "unavailable",
+            "reason": "git_repository_dirty",
+        },
+    )
+    runtime = ProjectHostRuntime(
+        store,
+        tmp_path / "uploads",
+        writeback_enabled=True,
+    )
+    applied = _apply_receipt()
+    commit_operation_id = "commit_dirty_0123456789abcdef"
+    runtime.bind_recovery_operations(
+        project_id=PROJECT_ID,
+        expected_head=PROJECT_HEAD,
+        expected_branch=PROJECT_BRANCH,
+        apply_operation_id=applied.apply_id,
+        apply_receipt=applied,
+        commit_receipt=None,
+    )
+
+    runtime.bind_persisted_intent(
+        project_id=PROJECT_ID,
+        expected_head=PROJECT_HEAD,
+        expected_branch=PROJECT_BRANCH,
+        operation_id=commit_operation_id,
+        kind="commit",
+        parent_operation_id=applied.apply_id,
+    )
+
+    assert runtime._managed_operations[(PROJECT_ID, commit_operation_id)].kind == "commit"

--- a/server/tests/test_coding_project_host_apply.py
+++ b/server/tests/test_coding_project_host_apply.py
@@ -65,6 +65,38 @@ def _repository(tmp_path: Path, files: dict[str, bytes]) -> tuple[Path, str, str
     return root, "feature/local-k8m2", _git(root, "rev-parse", "HEAD")
 
 
+def _directory_link(link: Path, target: Path) -> None:
+    if os.name == "nt":
+        result = subprocess.run(
+            ("cmd", "/c", "mklink", "/J", str(link), str(target)),
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        if result.returncode != 0:
+            pytest.skip("Directory junctions are unavailable")
+        return
+    link.symlink_to(target, target_is_directory=True)
+
+
+def test_engine_construction_never_runs_git(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root, _branch, _head = _repository(tmp_path, {"safe.txt": b"safe\n"})
+    monkeypatch.setattr(
+        host_apply_engine_module.subprocess,
+        "run",
+        lambda *_args, **_kwargs: pytest.fail("Constructor must not execute Git"),
+    )
+
+    _engine(tmp_path, root)
+
+    assert not (root / ".git" / "modelmirror-transactions").exists()
+    assert not (tmp_path / "operations.bin").exists()
+
+
 def _patch(*changes: tuple[str, bytes | None, bytes | None]) -> tuple[str, tuple[str, ...]]:
     rendered: list[str] = []
     for path, before, after in sorted(changes):
@@ -1295,11 +1327,25 @@ def test_local_include_configuration_is_rejected(tmp_path: Path) -> None:
 @pytest.mark.parametrize(
     ("unsafe_kind", "expected_code"),
     [
+        ("diff.nebula.external", "git_config_unsafe"),
+        ("url.https://example.invalid/.insteadOf", "git_config_unsafe"),
+        ("core.excludesFile", "git_config_unsafe"),
+        ("extensions.refStorage", "git_config_unsafe"),
         ("extensions.partialClone", "git_config_unsafe"),
         ("remote.origin.promisor", "git_config_unsafe"),
         ("remote..promisor", "git_config_unsafe"),
         ("remote.origin.partialCloneFilter", "git_config_unsafe"),
         ("http-alternates", "git_alternates_not_allowed"),
+        ("commondir-broken", "git_shared_directory_not_allowed"),
+        ("replace-refs", "git_metadata_unsafe"),
+        ("grafts", "git_metadata_unsafe"),
+        ("config-hardlink", "git_metadata_unsafe"),
+        ("head-hardlink", "git_metadata_unsafe"),
+        ("index-hardlink", "git_metadata_unsafe"),
+        ("objects-reparse", "git_metadata_unsafe"),
+        ("objects-info-reparse", "git_metadata_unsafe"),
+        ("refs-reparse", "git_metadata_unsafe"),
+        ("info-reparse", "git_metadata_unsafe"),
     ],
 )
 def test_apply_rejects_lazy_fetch_sources_before_object_commands_or_writes(
@@ -1315,8 +1361,43 @@ def test_apply_rejects_lazy_fetch_sources_before_object_commands_or_writes(
             "https://example.invalid/objects\n",
             encoding="utf-8",
         )
+    elif unsafe_kind == "commondir-broken":
+        try:
+            (root / ".git" / "commondir").symlink_to(
+                tmp_path / "missing-common-directory",
+                target_is_directory=False,
+            )
+        except OSError:
+            pytest.skip("File symlinks are unavailable")
+    elif unsafe_kind == "replace-refs":
+        (root / ".git" / "refs" / "replace").mkdir()
+    elif unsafe_kind == "grafts":
+        (root / ".git" / "info" / "grafts").write_text(head + "\n", encoding="ascii")
+    elif unsafe_kind.endswith("-hardlink"):
+        name = unsafe_kind.removesuffix("-hardlink")
+        source = root / ".git" / {"config": "config", "head": "HEAD", "index": "index"}[name]
+        try:
+            os.link(source, tmp_path / f"{name}.outside-link")
+        except OSError:
+            pytest.skip("Hard links are unavailable")
+    elif unsafe_kind.endswith("-reparse"):
+        name = unsafe_kind.removesuffix("-reparse")
+        source = (
+            root / ".git" / "objects" / "info"
+            if name == "objects-info"
+            else root / ".git" / name
+        )
+        target = root / ".git" / f"{name}-real"
+        source.rename(target)
+        _directory_link(source, target)
     else:
-        value = "blob:none" if unsafe_kind.endswith("Filter") else "true"
+        value = {
+            "diff.nebula.external": "outside-diff-driver",
+            "url.https://example.invalid/.insteadOf": "private:",
+            "core.excludesFile": "../outside-excludes",
+            "extensions.refStorage": "reftable",
+            "remote.origin.partialCloneFilter": "blob:none",
+        }.get(unsafe_kind, "true")
         _git(root, "config", unsafe_kind, value)
     patch, paths = _patch(("safe.txt", b"safe\n", b"changed\n"))
     original_run = subprocess.run
@@ -1344,7 +1425,9 @@ def test_apply_rejects_lazy_fetch_sources_before_object_commands_or_writes(
     object_commands = {"rev-parse", "ls-tree", "cat-file", "diff", "status"}
     assert all(object_commands.isdisjoint(command) for command in commands)
     assert all(env["GIT_NO_LAZY_FETCH"] == "1" for env in environments)
+    assert all(env["GIT_NO_REPLACE_OBJECTS"] == "1" for env in environments)
     assert build_safe_git_environment()["GIT_NO_LAZY_FETCH"] == "1"
+    assert build_safe_git_environment()["GIT_NO_REPLACE_OBJECTS"] == "1"
     assert (root / "safe.txt").read_bytes() == b"safe\n"
     assert not (root / ".git" / "modelmirror-transactions").exists()
     assert not (tmp_path / "operations.bin").exists()

--- a/server/tests/test_coding_project_host_apply.py
+++ b/server/tests/test_coding_project_host_apply.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 import pytest
 
+import server.coding_project_host.host_apply_engine as host_apply_engine_module
+
 from server.coding_project_host.host_apply_engine import (
     HostApplyError,
     HostGitApplyEngine,
@@ -18,6 +20,7 @@ from server.coding_project_host.host_file_transaction import (
 )
 from server.coding_project_host.operation_log import HostOperationJournal
 from server.coding_runtime.draft_workspace import DraftWorkspace
+from server.coding_runtime.projects import build_safe_git_environment
 
 
 PROJECT_ID = "hostgit_0123456789abcdef0123456789abcdef"
@@ -1287,6 +1290,64 @@ def test_local_include_configuration_is_rejected(tmp_path: Path) -> None:
         )
     assert unsafe.value.code == "git_config_unsafe"
     assert (root / "safe.txt").read_bytes() == b"safe\n"
+
+
+@pytest.mark.parametrize(
+    ("unsafe_kind", "expected_code"),
+    [
+        ("extensions.partialClone", "git_config_unsafe"),
+        ("remote.origin.promisor", "git_config_unsafe"),
+        ("remote..promisor", "git_config_unsafe"),
+        ("remote.origin.partialCloneFilter", "git_config_unsafe"),
+        ("http-alternates", "git_alternates_not_allowed"),
+    ],
+)
+def test_apply_rejects_lazy_fetch_sources_before_object_commands_or_writes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    unsafe_kind: str,
+    expected_code: str,
+) -> None:
+    root, branch, head = _repository(tmp_path, {"safe.txt": b"safe\n"})
+    engine = _engine(tmp_path, root)
+    if unsafe_kind == "http-alternates":
+        (root / ".git" / "objects" / "info" / "http-alternates").write_text(
+            "https://example.invalid/objects\n",
+            encoding="utf-8",
+        )
+    else:
+        value = "blob:none" if unsafe_kind.endswith("Filter") else "true"
+        _git(root, "config", unsafe_kind, value)
+    patch, paths = _patch(("safe.txt", b"safe\n", b"changed\n"))
+    original_run = subprocess.run
+    commands: list[tuple[str, ...]] = []
+    environments: list[dict[str, str]] = []
+
+    def traced_run(command, **kwargs):
+        commands.append(tuple(command))
+        environments.append(dict(kwargs["env"]))
+        return original_run(command, **kwargs)
+
+    monkeypatch.setattr(host_apply_engine_module.subprocess, "run", traced_run)
+    with pytest.raises(HostApplyError) as rejected:
+        engine.apply(
+            operation_id="apply_v13_lazy_fetch_p8r2",
+            revision=1,
+            branch=branch,
+            expected_head=head,
+            snapshot_fingerprint=FINGERPRINT,
+            patch=patch,
+            paths=paths,
+        )
+
+    assert rejected.value.code == expected_code
+    object_commands = {"rev-parse", "ls-tree", "cat-file", "diff", "status"}
+    assert all(object_commands.isdisjoint(command) for command in commands)
+    assert all(env["GIT_NO_LAZY_FETCH"] == "1" for env in environments)
+    assert build_safe_git_environment()["GIT_NO_LAZY_FETCH"] == "1"
+    assert (root / "safe.txt").read_bytes() == b"safe\n"
+    assert not (root / ".git" / "modelmirror-transactions").exists()
+    assert not (tmp_path / "operations.bin").exists()
 
 
 def test_reconcile_cannot_replace_stored_snapshot_fingerprint(tmp_path: Path) -> None:

--- a/server/tests/test_coding_project_host_apply.py
+++ b/server/tests/test_coding_project_host_apply.py
@@ -49,10 +49,15 @@ def _git(root: Path, *arguments: str) -> str:
     return completed.stdout.decode("utf-8", errors="strict").strip()
 
 
-def _repository(tmp_path: Path, files: dict[str, bytes]) -> tuple[Path, str, str]:
+def _repository(
+    tmp_path: Path,
+    files: dict[str, bytes],
+    *,
+    branch: str = "feature/local-k8m2",
+) -> tuple[Path, str, str]:
     root = tmp_path / "实验项目 aurora_n4p7"
     root.mkdir()
-    _git(root, "init", "-b", "feature/local-k8m2")
+    _git(root, "init", "-b", branch)
     _git(root, "config", "user.name", "Acceptance User")
     _git(root, "config", "user.email", "acceptance@example.invalid")
     _git(root, "config", "core.autocrlf", "false")
@@ -62,7 +67,7 @@ def _repository(tmp_path: Path, files: dict[str, bytes]) -> tuple[Path, str, str
         target.write_bytes(content)
     _git(root, "add", "--all")
     _git(root, "commit", "-m", "baseline")
-    return root, "feature/local-k8m2", _git(root, "rev-parse", "HEAD")
+    return root, branch, _git(root, "rev-parse", "HEAD")
 
 
 def _directory_link(link: Path, target: Path) -> None:
@@ -126,6 +131,29 @@ def _engine(
         mutation_hook=hook,
         enforce_windows=False,
     )
+
+
+def test_apply_accepts_utf8_symbolic_head_branch(tmp_path: Path) -> None:
+    root, branch, head = _repository(
+        tmp_path,
+        {"marker.txt": b"old\n"},
+        branch="feature/中文分支-k8m2",
+    )
+    patch, paths = _patch(("marker.txt", b"old\n", b"new\n"))
+
+    receipt = _engine(tmp_path, root).apply(
+        operation_id="apply_v13_unicode_branch_k8m2",
+        revision=3,
+        branch=branch,
+        expected_head=head,
+        snapshot_fingerprint=FINGERPRINT,
+        patch=patch,
+        paths=paths,
+    )
+
+    assert receipt.apply_id == "apply_v13_unicode_branch_k8m2"
+    assert _git(root, "symbolic-ref", "--short", "HEAD") == branch
+    assert (root / "marker.txt").read_bytes() == b"new\n"
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX fail-closed contract")

--- a/server/tests/test_coding_project_host_apply.py
+++ b/server/tests/test_coding_project_host_apply.py
@@ -1,0 +1,1395 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from server.coding_project_host.host_apply_engine import (
+    HostApplyError,
+    HostGitApplyEngine,
+    _transaction_files,
+)
+from server.coding_project_host.host_file_transaction import (
+    HostFileTransactionError,
+    _move_verified_no_replace,
+)
+from server.coding_project_host.operation_log import HostOperationJournal
+from server.coding_runtime.draft_workspace import DraftWorkspace
+
+
+PROJECT_ID = "hostgit_0123456789abcdef0123456789abcdef"
+FINGERPRINT = "f" * 64
+
+
+class _XorProtector:
+    def protect(self, value: bytes) -> bytes:
+        return bytes(item ^ 0x6D for item in value)
+
+    def unprotect(self, value: bytes) -> bytes:
+        return self.protect(value)
+
+
+def _git(root: Path, *arguments: str) -> str:
+    completed = subprocess.run(
+        ("git", *arguments),
+        cwd=root,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+        timeout=15,
+    )
+    assert completed.returncode == 0, completed.stderr.decode(errors="replace")
+    return completed.stdout.decode("utf-8", errors="strict").strip()
+
+
+def _repository(tmp_path: Path, files: dict[str, bytes]) -> tuple[Path, str, str]:
+    root = tmp_path / "实验项目 aurora_n4p7"
+    root.mkdir()
+    _git(root, "init", "-b", "feature/local-k8m2")
+    _git(root, "config", "user.name", "Acceptance User")
+    _git(root, "config", "user.email", "acceptance@example.invalid")
+    _git(root, "config", "core.autocrlf", "false")
+    for relative, content in files.items():
+        target = root / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(content)
+    _git(root, "add", "--all")
+    _git(root, "commit", "-m", "baseline")
+    return root, "feature/local-k8m2", _git(root, "rev-parse", "HEAD")
+
+
+def _patch(*changes: tuple[str, bytes | None, bytes | None]) -> tuple[str, tuple[str, ...]]:
+    rendered: list[str] = []
+    for path, before, after in sorted(changes):
+        status = "added" if before is None else "deleted" if after is None else "modified"
+        rendered.append(
+            DraftWorkspace._unified_diff(
+                path,
+                "" if before is None else before.decode("utf-8"),
+                "" if after is None else after.decode("utf-8"),
+                status=status,
+            )
+        )
+    return "".join(rendered), tuple(path for path, _before, _after in sorted(changes))
+
+
+def _engine(
+    tmp_path: Path,
+    root: Path,
+    *,
+    hook=None,
+) -> HostGitApplyEngine:
+    journal = HostOperationJournal(tmp_path / "operations.bin", _XorProtector())
+    return HostGitApplyEngine(
+        root,
+        PROJECT_ID,
+        journal,
+        mutation_hook=hook,
+        enforce_windows=False,
+    )
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX fail-closed contract")
+def test_production_engine_rejects_posix_before_any_project_side_effect(
+    tmp_path: Path,
+) -> None:
+    root, _branch, _head = _repository(tmp_path, {"base.txt": b"base\n"})
+    journal_path = tmp_path / "production-operations.bin"
+
+    with pytest.raises(HostApplyError) as rejected:
+        HostGitApplyEngine(
+            root,
+            PROJECT_ID,
+            HostOperationJournal(journal_path, _XorProtector()),
+        )
+
+    assert rejected.value.code == "windows_required"
+    assert (root / "base.txt").read_bytes() == b"base\n"
+    assert _git(root, "status", "--porcelain=v1", "--untracked-files=all") == ""
+    assert not (root / ".git" / "modelmirror-transactions").exists()
+    assert not journal_path.exists()
+
+
+def test_apply_add_modify_delete_and_safe_revert(tmp_path: Path) -> None:
+    root, branch, head = _repository(
+        tmp_path,
+        {"alpha.txt": b"old-alpha\n", "remove.txt": b"remove-me\n"},
+    )
+    _git(root, "remote", "add", "origin", "https://example.invalid/no-network.git")
+    patch, paths = _patch(
+        ("alpha.txt", b"old-alpha\n", b"new-alpha-r7k3\n"),
+        ("nested/new.txt", None, b"nebula-n4p7\n"),
+        ("remove.txt", b"remove-me\n", None),
+    )
+    engine = _engine(tmp_path, root)
+    receipt = engine.apply(
+        operation_id="apply_v13_aurora_n4p7",
+        revision=8,
+        branch=branch,
+        expected_head=head,
+        snapshot_fingerprint=FINGERPRINT,
+        patch=patch,
+        paths=paths,
+    )
+    assert (root / "alpha.txt").read_bytes() == b"new-alpha-r7k3\n"
+    assert (root / "nested/new.txt").read_bytes() == b"nebula-n4p7\n"
+    assert not (root / "remove.txt").exists()
+    assert engine.apply(
+        operation_id="apply_v13_aurora_n4p7",
+        revision=8,
+        branch=branch,
+        expected_head=head,
+        snapshot_fingerprint=FINGERPRINT,
+        patch=patch,
+        paths=paths,
+    ) == receipt
+
+    reverted = engine.revert(
+        operation_id="revert_v13_aurora_n4p7",
+        apply_receipt=receipt,
+        branch=branch,
+        expected_head=head,
+    )
+    assert reverted == receipt
+    assert (root / "alpha.txt").read_bytes() == b"old-alpha\n"
+    assert not (root / "nested/new.txt").exists()
+    assert not (root / "nested").exists()
+    assert (root / "remove.txt").read_bytes() == b"remove-me\n"
+    assert _git(root, "status", "--porcelain=v1", "--untracked-files=all") == ""
+
+
+def test_mid_write_failure_rolls_back_and_same_operation_can_retry(tmp_path: Path) -> None:
+    root, branch, head = _repository(
+        tmp_path,
+        {"a.txt": b"old-a\n", "b.txt": b"old-b\n"},
+    )
+    patch, paths = _patch(
+        ("a.txt", b"old-a\n", b"new-a\n"),
+        ("b.txt", b"old-b\n", b"new-b\n"),
+    )
+
+    def fail_second(_action: str, index: int, _path: str) -> None:
+        if index == 1:
+            raise RuntimeError("simulated interruption")
+
+    first = _engine(tmp_path, root, hook=fail_second)
+    with pytest.raises(RuntimeError, match="simulated interruption"):
+        first.apply(
+            operation_id="apply_v13_failure_r8v3",
+            revision=3,
+            branch=branch,
+            expected_head=head,
+            snapshot_fingerprint=FINGERPRINT,
+            patch=patch,
+            paths=paths,
+        )
+    assert (root / "a.txt").read_bytes() == b"old-a\n"
+    assert (root / "b.txt").read_bytes() == b"old-b\n"
+
+    restarted = _engine(tmp_path, root)
+    receipt = restarted.apply(
+        operation_id="apply_v13_failure_r8v3",
+        revision=3,
+        branch=branch,
+        expected_head=head,
+        snapshot_fingerprint=FINGERPRINT,
+        patch=patch,
+        paths=paths,
+    )
+    assert receipt.apply_id == "apply_v13_failure_r8v3"
+    assert (root / "a.txt").read_bytes() == b"new-a\n"
+    assert (root / "b.txt").read_bytes() == b"new-b\n"
+
+
+def test_apply_rollback_preserves_same_content_manual_replacement(
+    tmp_path: Path,
+) -> None:
+    root, branch, head = _repository(
+        tmp_path,
+        {"a.txt": b"old-a\n", "b.txt": b"old-b\n"},
+    )
+    patch, paths = _patch(
+        ("a.txt", b"old-a\n", b"new-a-r7k3\n"),
+        ("b.txt", b"old-b\n", b"new-b-r7k3\n"),
+    )
+    manual_identity: list[tuple[int, int]] = []
+
+    def replace_first_then_fail(_action: str, index: int, _path: str) -> None:
+        if index != 1:
+            return
+        target = root / "a.txt"
+        replacement = root / ".human-replacement-apply"
+        replacement.write_bytes(b"new-a-r7k3\n")
+        stat_result = replacement.stat(follow_symlinks=False)
+        manual_identity.append((stat_result.st_dev, stat_result.st_ino))
+        os.replace(replacement, target)
+        raise RuntimeError("stop-after-manual-replacement")
+
+    engine = _engine(tmp_path, root, hook=replace_first_then_fail)
+    with pytest.raises(HostApplyError) as conflict:
+        engine.apply(
+            operation_id="apply_v13_same_object_q6m3",
+            revision=19,
+            branch=branch,
+            expected_head=head,
+            snapshot_fingerprint=FINGERPRINT,
+            patch=patch,
+            paths=paths,
+        )
+
+    assert conflict.value.code == "transaction_rollback_failed"
+    assert manual_identity
+    current = (root / "a.txt").stat(follow_symlinks=False)
+    assert (current.st_dev, current.st_ino) == manual_identity[0]
+    assert (root / "a.txt").read_bytes() == b"new-a-r7k3\n"
+    assert (root / "b.txt").read_bytes() == b"old-b\n"
+    stored = engine.journal.get("apply_v13_same_object_q6m3")
+    assert stored is not None and stored.state == "conflict"
+
+
+def test_revert_rollback_preserves_same_content_manual_replacement(
+    tmp_path: Path,
+) -> None:
+    root, branch, head = _repository(
+        tmp_path,
+        {"a.txt": b"old-a\n", "b.txt": b"old-b\n"},
+    )
+    patch, paths = _patch(
+        ("a.txt", b"old-a\n", b"new-a-t8v4\n"),
+        ("b.txt", b"old-b\n", b"new-b-t8v4\n"),
+    )
+    engine = _engine(tmp_path, root)
+    receipt = engine.apply(
+        operation_id="apply_v13_revert_object_t8v4",
+        revision=20,
+        branch=branch,
+        expected_head=head,
+        snapshot_fingerprint=FINGERPRINT,
+        patch=patch,
+        paths=paths,
+    )
+    manual_identity: list[tuple[int, int]] = []
+
+    def replace_first_then_fail(_action: str, index: int, _path: str) -> None:
+        if index != 1:
+            return
+        target = root / "a.txt"
+        replacement = root / ".human-replacement-revert"
+        replacement.write_bytes(b"old-a\n")
+        stat_result = replacement.stat(follow_symlinks=False)
+        manual_identity.append((stat_result.st_dev, stat_result.st_ino))
+        os.replace(replacement, target)
+        raise RuntimeError("stop-after-manual-revert-replacement")
+
+    engine.mutation_hook = replace_first_then_fail
+    with pytest.raises(HostApplyError) as conflict:
+        engine.revert(
+            operation_id="revert_v13_same_object_t8v4",
+            apply_receipt=receipt,
+            branch=branch,
+            expected_head=head,
+        )
+
+    assert conflict.value.code == "transaction_rollback_failed"
+    assert manual_identity
+    current = (root / "a.txt").stat(follow_symlinks=False)
+    assert (current.st_dev, current.st_ino) == manual_identity[0]
+    assert (root / "a.txt").read_bytes() == b"old-a\n"
+    assert (root / "b.txt").read_bytes() == b"new-b-t8v4\n"
+    stored = engine.journal.get("revert_v13_same_object_t8v4")
+    assert stored is not None and stored.state == "conflict"
+
+
+def test_retry_cleans_crash_artifacts_before_writing(tmp_path: Path) -> None:
+    root, branch, head = _repository(tmp_path, {"base.txt": b"base\n"})
+    patch, paths = _patch(("nested/new.txt", None, b"new-r8v3\n"))
+    engine = _engine(tmp_path, root)
+    record = engine.journal.create(
+        operation_id="apply_v13_artifact_r8v3",
+        action="apply",
+        project_id=PROJECT_ID,
+        revision=9,
+        branch=branch,
+        expected_head=head,
+        patch_sha256=hashlib.sha256(patch.encode("utf-8")).hexdigest(),
+        patch=patch,
+    )
+    plan = engine._build_plan(
+        patch=patch,
+        paths=paths,
+        branch=branch,
+        expected_head=head,
+    )
+    receipt = engine._receipt(record.operation_id, 9, FINGERPRINT, plan)
+    engine.journal.transition(
+        record.operation_id,
+        "applying",
+        apply_receipt={
+            "apply_id": receipt.apply_id,
+            "revision": receipt.revision,
+            "snapshot_fingerprint": receipt.snapshot_fingerprint,
+            "files": [
+                {
+                    "path": item.path,
+                    "existed_before": item.existed_before,
+                    "before_sha256": item.before_sha256,
+                    "after_sha256": item.after_sha256,
+                }
+                for item in receipt.files
+            ],
+            "applied_at": receipt.applied_at,
+        },
+    )
+    (root / ".git" / "modelmirror-transactions").mkdir()
+    created = engine._prepare_created_directories(plan, record.operation_id, ())
+    engine.journal.transition(
+        record.operation_id,
+        "applying",
+        created_directories=created,
+    )
+    engine._publish_created_directories(created, record.operation_id)
+    transaction = engine._transaction(
+        plan,
+        action="apply",
+        branch=branch,
+        expected_head=head,
+        operation_id=record.operation_id,
+        created_directories=created,
+    )
+    files = _transaction_files(plan)
+    transaction.prepare(files)
+    item = files[0]
+    _move_verified_no_replace(
+        transaction.tx_dir / f"after-{item.key}",
+        root / item.path,
+        item.after,
+    )
+
+    recovered = _engine(tmp_path, root).apply(
+        operation_id=record.operation_id,
+        revision=9,
+        branch=branch,
+        expected_head=head,
+        snapshot_fingerprint=FINGERPRINT,
+        patch=patch,
+        paths=paths,
+    )
+    assert recovered.apply_id == record.operation_id
+    assert (root / "nested/new.txt").read_bytes() == b"new-r8v3\n"
+    assert not transaction.tx_dir.exists()
+
+
+def test_created_directory_stage_never_deletes_unknown_owner_marker(
+    tmp_path: Path,
+) -> None:
+    root, branch, head = _repository(tmp_path, {"base.txt": b"base\n"})
+    patch, paths = _patch(("nested/new.txt", None, b"stage-recovery-r4m8\n"))
+    engine = _engine(tmp_path, root)
+    plan = engine._build_plan(
+        patch=patch,
+        paths=paths,
+        branch=branch,
+        expected_head=head,
+    )
+    operation_id = "apply_v13_stage_owner_r4m8"
+    suffix = hashlib.sha256(b"nested").hexdigest()[:16]
+    transaction_root = root / ".git" / "modelmirror-transactions"
+    transaction_root.mkdir()
+    stage = transaction_root / f".modelmirror-{operation_id}-{suffix}.dir-stage"
+    stage.mkdir()
+    (stage / f".modelmirror-{operation_id}.dir-owner").write_bytes(b"partial")
+
+    with pytest.raises(HostApplyError) as conflict:
+        engine._prepare_created_directories(plan, operation_id, ())
+
+    assert conflict.value.code == "operation_artifact_conflict"
+    assert stage.is_dir()
+    assert (stage / f".modelmirror-{operation_id}.dir-owner").read_bytes() == b"partial"
+    assert not (root / "nested").exists()
+
+
+def test_rollback_never_deletes_same_content_manual_target(tmp_path: Path) -> None:
+    root, branch, head = _repository(tmp_path, {"base.txt": b"base\n"})
+    patch, paths = _patch(("manual.txt", None, b"same-content-m7q2\n"))
+    engine = _engine(tmp_path, root)
+    plan = engine._build_plan(
+        patch=patch,
+        paths=paths,
+        branch=branch,
+        expected_head=head,
+    )
+    transaction = engine._transaction(
+        plan,
+        action="apply",
+        branch=branch,
+        expected_head=head,
+        operation_id="apply_v13_manual_same_m7q2",
+        created_directories=(),
+    )
+    files = _transaction_files(plan)
+    transaction.prepare(files)
+    (root / "manual.txt").write_bytes(b"same-content-m7q2\n")
+
+    with pytest.raises(HostFileTransactionError) as conflict:
+        transaction.settle(files, commit_callback=lambda: None)
+
+    assert conflict.value.code == "transaction_conflict"
+    assert (root / "manual.txt").read_bytes() == b"same-content-m7q2\n"
+    assert (transaction.tx_dir / f"after-{files[0].key}").exists()
+
+
+def test_reconcile_detects_same_content_replacement_and_persists_conflict(
+    tmp_path: Path,
+) -> None:
+    root, branch, head = _repository(tmp_path, {"marker.txt": b"old\n"})
+    patch, paths = _patch(("marker.txt", b"old\n", b"same-after-r5q8\n"))
+    engine = _engine(tmp_path, root)
+    operation_id = "apply_v13_same_inode_r5q8"
+    record = engine.journal.create(
+        operation_id=operation_id,
+        action="apply",
+        project_id=PROJECT_ID,
+        revision=13,
+        branch=branch,
+        expected_head=head,
+        patch_sha256=hashlib.sha256(patch.encode("utf-8")).hexdigest(),
+        patch=patch,
+    )
+    plan = engine._build_plan(
+        patch=patch,
+        paths=paths,
+        branch=branch,
+        expected_head=head,
+    )
+    receipt = engine._receipt(operation_id, 13, FINGERPRINT, plan)
+    engine.journal.transition(
+        operation_id,
+        "applying",
+        apply_receipt={
+            "apply_id": receipt.apply_id,
+            "revision": receipt.revision,
+            "snapshot_fingerprint": receipt.snapshot_fingerprint,
+            "files": [
+                {
+                    "path": item.path,
+                    "existed_before": item.existed_before,
+                    "before_sha256": item.before_sha256,
+                    "after_sha256": item.after_sha256,
+                }
+                for item in receipt.files
+            ],
+            "applied_at": receipt.applied_at,
+        },
+    )
+    transaction = engine._transaction(
+        plan,
+        action="apply",
+        branch=branch,
+        expected_head=head,
+        operation_id=operation_id,
+        created_directories=(),
+    )
+    files = _transaction_files(plan)
+    transaction.prepare(files)
+    item = files[0]
+    _move_verified_no_replace(
+        root / item.path,
+        transaction.tx_dir / f"before-{item.key}",
+        item.before,
+    )
+    _move_verified_no_replace(
+        transaction.tx_dir / f"after-{item.key}",
+        root / item.path,
+        item.after,
+    )
+    replacement = root / "same-content-replacement.tmp"
+    replacement.write_bytes(item.after)
+    os.replace(replacement, root / item.path)
+
+    state, restored = engine.reconcile_apply(
+        operation_id=record.operation_id,
+        snapshot_fingerprint=FINGERPRINT,
+    )
+
+    assert (state, restored) == ("conflict", None)
+    assert (root / item.path).read_bytes() == item.after
+    assert engine.journal.get(operation_id).state == "conflict"
+
+
+def test_directory_intent_is_durable_before_worktree_publish(tmp_path: Path) -> None:
+    root, branch, head = _repository(tmp_path, {"base.txt": b"base\n"})
+    patch, paths = _patch(("nested/deep/new.txt", None, b"durable-dir-t6p3\n"))
+    operation_id = "apply_v13_dir_intent_t6p3"
+    engine = _engine(tmp_path, root)
+    record = engine.journal.create(
+        operation_id=operation_id,
+        action="apply",
+        project_id=PROJECT_ID,
+        revision=16,
+        branch=branch,
+        expected_head=head,
+        patch_sha256=hashlib.sha256(patch.encode("utf-8")).hexdigest(),
+        patch=patch,
+    )
+    plan = engine._build_plan(
+        patch=patch,
+        paths=paths,
+        branch=branch,
+        expected_head=head,
+    )
+    receipt = engine._receipt(operation_id, 16, FINGERPRINT, plan)
+    engine.journal.transition(
+        operation_id,
+        "applying",
+        apply_receipt={
+            "apply_id": receipt.apply_id,
+            "revision": receipt.revision,
+            "snapshot_fingerprint": receipt.snapshot_fingerprint,
+            "files": [
+                {
+                    "path": item.path,
+                    "existed_before": item.existed_before,
+                    "before_sha256": item.before_sha256,
+                    "after_sha256": item.after_sha256,
+                }
+                for item in receipt.files
+            ],
+            "applied_at": receipt.applied_at,
+        },
+    )
+    transaction_root = root / ".git" / "modelmirror-transactions"
+    transaction_root.mkdir()
+    staged = engine._prepare_created_directories(plan, operation_id, ())
+
+    assert staged
+    assert not (root / "nested").exists()
+    assert all(
+        engine._created_directory_stage(
+            operation_id,
+            value.split(":", 1)[1],
+        ).is_dir()
+        for value in staged
+    )
+
+    state, recovered = _engine(tmp_path, root).reconcile_apply(
+        operation_id=record.operation_id,
+        snapshot_fingerprint=FINGERPRINT,
+    )
+
+    assert (state, recovered) == ("not_applied", None)
+    assert not (root / "nested").exists()
+    assert _git(root, "status", "--porcelain=v1", "--untracked-files=all") == ""
+    assert not any(
+        path.name.endswith(".dir-stage")
+        for path in transaction_root.iterdir()
+    )
+
+
+def test_failed_nested_apply_removes_owned_directories(tmp_path: Path) -> None:
+    root, branch, head = _repository(tmp_path, {"base.txt": b"base\n"})
+    patch, paths = _patch(("nested/deep/new.txt", None, b"never-written-q8m4\n"))
+
+    def stop_before_write(_action: str, _index: int, _path: str) -> None:
+        raise RuntimeError("stop-before-write")
+
+    engine = _engine(tmp_path, root, hook=stop_before_write)
+    with pytest.raises(RuntimeError, match="stop-before-write"):
+        engine.apply(
+            operation_id="apply_v13_nested_cleanup_q8m4",
+            revision=14,
+            branch=branch,
+            expected_head=head,
+            snapshot_fingerprint=FINGERPRINT,
+            patch=patch,
+            paths=paths,
+        )
+
+    assert not (root / "nested").exists()
+    assert _git(root, "status", "--porcelain=v1", "--untracked-files=all") == ""
+    stored = engine.journal.get("apply_v13_nested_cleanup_q8m4")
+    assert stored is not None and stored.created_directories == ()
+
+
+def test_directory_limit_fails_before_touching_project(tmp_path: Path) -> None:
+    root, branch, head = _repository(tmp_path, {"base.txt": b"base\n"})
+    relative = "/".join([f"d{index:02d}" for index in range(65)] + ["new.txt"])
+    patch, paths = _patch((relative, None, b"too-deep-r9k2\n"))
+    engine = _engine(tmp_path, root)
+
+    with pytest.raises(HostApplyError) as rejected:
+        engine.apply(
+            operation_id="apply_v13_too_deep_r9k2",
+            revision=15,
+            branch=branch,
+            expected_head=head,
+            snapshot_fingerprint=FINGERPRINT,
+            patch=patch,
+            paths=paths,
+        )
+
+    assert rejected.value.code == "too_many_created_directories"
+    assert not (root / "d00").exists()
+    assert _git(root, "status", "--porcelain=v1", "--untracked-files=all") == ""
+
+
+def test_project_operation_lock_rejects_hardlink_without_writing_it(
+    tmp_path: Path,
+) -> None:
+    root, branch, head = _repository(tmp_path, {"marker.txt": b"old\n"})
+    patch, paths = _patch(("marker.txt", b"old\n", b"blocked-lock-c8v2\n"))
+    transaction_root = root / ".git" / "modelmirror-transactions"
+    transaction_root.mkdir()
+    outside = tmp_path / "manual-lock-target.bin"
+    outside.write_bytes(b"")
+    os.link(outside, transaction_root / ".project-operation.lock")
+    engine = _engine(tmp_path, root)
+
+    with pytest.raises(HostApplyError) as blocked:
+        engine.apply(
+            operation_id="apply_v13_lock_hardlink_c8v2",
+            revision=18,
+            branch=branch,
+            expected_head=head,
+            snapshot_fingerprint=FINGERPRINT,
+            patch=patch,
+            paths=paths,
+        )
+
+    assert blocked.value.code == "transaction_conflict"
+    assert outside.read_bytes() == b""
+    assert (root / "marker.txt").read_bytes() == b"old\n"
+
+
+def test_commit_marker_recovers_side_effect_before_journal_receipt(tmp_path: Path) -> None:
+    root, branch, head = _repository(tmp_path, {"marker.txt": b"old\n"})
+    patch, paths = _patch(("marker.txt", b"old\n", b"new-k9r4\n"))
+    engine = _engine(tmp_path, root)
+    record = engine.journal.create(
+        operation_id="apply_v13_marker_k9r4",
+        action="apply",
+        project_id=PROJECT_ID,
+        revision=10,
+        branch=branch,
+        expected_head=head,
+        patch_sha256=hashlib.sha256(patch.encode("utf-8")).hexdigest(),
+        patch=patch,
+    )
+    plan = engine._build_plan(
+        patch=patch,
+        paths=paths,
+        branch=branch,
+        expected_head=head,
+    )
+    receipt = engine._receipt(record.operation_id, 10, FINGERPRINT, plan)
+    engine.journal.transition(
+        record.operation_id,
+        "applying",
+        apply_receipt={
+            "apply_id": receipt.apply_id,
+            "revision": receipt.revision,
+            "snapshot_fingerprint": receipt.snapshot_fingerprint,
+            "files": [
+                {
+                    "path": item.path,
+                    "existed_before": item.existed_before,
+                    "before_sha256": item.before_sha256,
+                    "after_sha256": item.after_sha256,
+                }
+                for item in receipt.files
+            ],
+            "applied_at": receipt.applied_at,
+        },
+    )
+    transaction = engine._transaction(
+        plan,
+        action="apply",
+        branch=branch,
+        expected_head=head,
+        operation_id=record.operation_id,
+        created_directories=(),
+    )
+    with pytest.raises(RuntimeError, match="lost acknowledgement"):
+        transaction.apply(
+            _transaction_files(plan),
+            commit_callback=lambda: (_ for _ in ()).throw(
+                RuntimeError("lost acknowledgement")
+            ),
+        )
+
+    state, restored = _engine(tmp_path, root).reconcile_apply(
+        operation_id=record.operation_id,
+        snapshot_fingerprint=FINGERPRINT,
+    )
+    assert state == "applied"
+    assert restored == receipt
+    assert (root / "marker.txt").read_bytes() == b"new-k9r4\n"
+    assert not transaction.tx_dir.exists()
+
+
+def test_reconcile_recovers_after_directory_markers_were_finalized(
+    tmp_path: Path,
+) -> None:
+    root, branch, head = _repository(tmp_path, {"base.txt": b"base\n"})
+    patch, paths = _patch(("nested/deep/new.txt", None, b"new-d7p4\n"))
+    operation_id = "apply_v13_finalized_dirs_d7p4"
+    engine = _engine(tmp_path, root)
+    record = engine.journal.create(
+        operation_id=operation_id,
+        action="apply",
+        project_id=PROJECT_ID,
+        revision=21,
+        branch=branch,
+        expected_head=head,
+        patch_sha256=hashlib.sha256(patch.encode("utf-8")).hexdigest(),
+        patch=patch,
+    )
+    plan = engine._build_plan(
+        patch=patch,
+        paths=paths,
+        branch=branch,
+        expected_head=head,
+    )
+    receipt = engine._receipt(operation_id, 21, FINGERPRINT, plan)
+    engine.journal.transition(
+        operation_id,
+        "applying",
+        apply_receipt={
+            "apply_id": receipt.apply_id,
+            "revision": receipt.revision,
+            "snapshot_fingerprint": receipt.snapshot_fingerprint,
+            "files": [
+                {
+                    "path": item.path,
+                    "existed_before": item.existed_before,
+                    "before_sha256": item.before_sha256,
+                    "after_sha256": item.after_sha256,
+                }
+                for item in receipt.files
+            ],
+            "applied_at": receipt.applied_at,
+        },
+    )
+    (root / ".git" / "modelmirror-transactions").mkdir()
+    created = engine._prepare_created_directories(plan, operation_id, ())
+    engine.journal.transition(
+        operation_id,
+        "applying",
+        created_directories=created,
+    )
+    engine._publish_created_directories(created, operation_id)
+    transaction = engine._transaction(
+        plan,
+        action="apply",
+        branch=branch,
+        expected_head=head,
+        operation_id=operation_id,
+        created_directories=created,
+    )
+
+    def crash_after_marker_cleanup() -> None:
+        engine._finalize_created_directories(created, operation_id)
+        raise RuntimeError("crash-after-directory-marker-cleanup")
+
+    with pytest.raises(RuntimeError, match="crash-after-directory-marker-cleanup"):
+        transaction.apply(
+            _transaction_files(plan),
+            commit_callback=crash_after_marker_cleanup,
+        )
+
+    assert engine.journal.get(operation_id).state == "applying"
+    assert transaction.active_dir.is_dir()
+    assert (root / "nested/deep/new.txt").read_bytes() == b"new-d7p4\n"
+    for directory in (root / "nested", root / "nested/deep"):
+        assert not (directory / f".modelmirror-{operation_id}.dir-owner").exists()
+
+    restarted = _engine(tmp_path, root)
+    state, recovered = restarted.reconcile_apply(
+        operation_id=operation_id,
+        snapshot_fingerprint=FINGERPRINT,
+    )
+
+    assert (state, recovered) == ("applied", receipt)
+    assert restarted.journal.get(operation_id).state == "applied"
+    assert (root / "nested/deep/new.txt").read_bytes() == b"new-d7p4\n"
+    assert not transaction.active_dir.exists()
+    assert not transaction.cleanup_dir.exists()
+
+
+def test_applied_retry_seals_unsealed_transaction_and_is_idempotent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root, branch, head = _repository(tmp_path, {"marker.txt": b"old\n"})
+    patch, paths = _patch(("marker.txt", b"old\n", b"new-s9q2\n"))
+    operation_id = "apply_v13_unsealed_applied_s9q2"
+    engine = _engine(tmp_path, root)
+    record = engine.journal.create(
+        operation_id=operation_id,
+        action="apply",
+        project_id=PROJECT_ID,
+        revision=22,
+        branch=branch,
+        expected_head=head,
+        patch_sha256=hashlib.sha256(patch.encode("utf-8")).hexdigest(),
+        patch=patch,
+    )
+    plan = engine._build_plan(
+        patch=patch,
+        paths=paths,
+        branch=branch,
+        expected_head=head,
+    )
+    receipt = engine._receipt(operation_id, 22, FINGERPRINT, plan)
+    engine.journal.transition(
+        record.operation_id,
+        "applying",
+        apply_receipt={
+            "apply_id": receipt.apply_id,
+            "revision": receipt.revision,
+            "snapshot_fingerprint": receipt.snapshot_fingerprint,
+            "files": [
+                {
+                    "path": item.path,
+                    "existed_before": item.existed_before,
+                    "before_sha256": item.before_sha256,
+                    "after_sha256": item.after_sha256,
+                }
+                for item in receipt.files
+            ],
+            "applied_at": receipt.applied_at,
+        },
+    )
+    transaction = engine._transaction(
+        plan,
+        action="apply",
+        branch=branch,
+        expected_head=head,
+        operation_id=operation_id,
+        created_directories=(),
+    )
+
+    def crash_before_seal(_files: object) -> None:
+        raise RuntimeError("crash-before-transaction-seal")
+
+    monkeypatch.setattr(transaction, "_seal_transaction", crash_before_seal)
+    with pytest.raises(RuntimeError, match="crash-before-transaction-seal"):
+        transaction.apply(
+            _transaction_files(plan),
+            commit_callback=lambda: engine._finish_apply(operation_id, receipt),
+        )
+
+    assert engine.journal.get(operation_id).state == "applied"
+    assert transaction.active_dir.is_dir()
+    assert not transaction.cleanup_dir.exists()
+    assert (root / "marker.txt").read_bytes() == b"new-s9q2\n"
+
+    restarted = _engine(tmp_path, root)
+    recovered = restarted.apply(
+        operation_id=operation_id,
+        revision=22,
+        branch=branch,
+        expected_head=head,
+        snapshot_fingerprint=FINGERPRINT,
+        patch=patch,
+        paths=paths,
+    )
+    repeated = restarted.apply(
+        operation_id=operation_id,
+        revision=22,
+        branch=branch,
+        expected_head=head,
+        snapshot_fingerprint=FINGERPRINT,
+        patch=patch,
+        paths=paths,
+    )
+
+    assert recovered == receipt
+    assert repeated == receipt
+    assert restarted.journal.get(operation_id).state == "applied"
+    assert (root / "marker.txt").read_bytes() == b"new-s9q2\n"
+    assert not transaction.active_dir.exists()
+    assert not transaction.cleanup_dir.exists()
+
+
+def test_concurrent_target_save_is_never_overwritten(tmp_path: Path) -> None:
+    root, branch, head = _repository(tmp_path, {"marker.txt": b"old\n"})
+    patch, paths = _patch(("marker.txt", b"old\n", b"agent-change\n"))
+
+    def human_save(_action: str, index: int, path: str) -> None:
+        if index == 0:
+            (root / path).write_bytes(b"human-save-q4m8\n")
+
+    engine = _engine(tmp_path, root, hook=human_save)
+    with pytest.raises(HostApplyError) as conflict:
+        engine.apply(
+            operation_id="apply_v13_human_q4m8",
+            revision=11,
+            branch=branch,
+            expected_head=head,
+            snapshot_fingerprint=FINGERPRINT,
+            patch=patch,
+            paths=paths,
+        )
+    assert conflict.value.code == "transaction_rollback_failed"
+    assert (root / "marker.txt").read_bytes() == b"human-save-q4m8\n"
+    stored = engine.journal.get("apply_v13_human_q4m8")
+    assert stored is not None and stored.state == "conflict"
+
+
+def test_applying_record_without_transaction_marker_cannot_claim_manual_result(
+    tmp_path: Path,
+) -> None:
+    root, branch, head = _repository(tmp_path, {"marker.txt": b"old\n"})
+    patch, paths = _patch(("marker.txt", b"old\n", b"same-looking\n"))
+    engine = _engine(tmp_path, root)
+    record = engine.journal.create(
+        operation_id="apply_v13_no_evidence_m8q2",
+        action="apply",
+        project_id=PROJECT_ID,
+        revision=12,
+        branch=branch,
+        expected_head=head,
+        patch_sha256=hashlib.sha256(patch.encode("utf-8")).hexdigest(),
+        patch=patch,
+    )
+    plan = engine._build_plan(
+        patch=patch,
+        paths=paths,
+        branch=branch,
+        expected_head=head,
+    )
+    receipt = engine._receipt(record.operation_id, 12, FINGERPRINT, plan)
+    engine.journal.transition(
+        record.operation_id,
+        "applying",
+        apply_receipt={
+            "apply_id": receipt.apply_id,
+            "revision": receipt.revision,
+            "snapshot_fingerprint": receipt.snapshot_fingerprint,
+            "files": [
+                {
+                    "path": item.path,
+                    "existed_before": item.existed_before,
+                    "before_sha256": item.before_sha256,
+                    "after_sha256": item.after_sha256,
+                }
+                for item in receipt.files
+            ],
+            "applied_at": receipt.applied_at,
+        },
+    )
+    (root / "marker.txt").write_bytes(b"same-looking\n")
+
+    with pytest.raises(HostApplyError) as conflict:
+        engine.apply(
+            operation_id=record.operation_id,
+            revision=12,
+            branch=branch,
+            expected_head=head,
+            snapshot_fingerprint=FINGERPRINT,
+            patch=patch,
+            paths=paths,
+        )
+    assert conflict.value.code in {
+        "apply_conflict",
+        "transaction_evidence_missing",
+    }
+    assert (root / "marker.txt").read_bytes() == b"same-looking\n"
+
+
+def test_revert_retry_recovers_mixed_crash_state(tmp_path: Path) -> None:
+    root, branch, head = _repository(
+        tmp_path,
+        {"a.txt": b"old-a\n", "b.txt": b"old-b\n"},
+    )
+    patch, paths = _patch(
+        ("a.txt", b"old-a\n", b"new-a\n"),
+        ("b.txt", b"old-b\n", b"new-b\n"),
+    )
+    engine = _engine(tmp_path, root)
+    receipt = engine.apply(
+        operation_id="apply_v13_mixed_n7m2",
+        revision=7,
+        branch=branch,
+        expected_head=head,
+        snapshot_fingerprint=FINGERPRINT,
+        patch=patch,
+        paths=paths,
+    )
+    revert_id = "revert_v13_mixed_n7m2"
+    applied = engine.journal.get(receipt.apply_id)
+    assert applied is not None
+    receipt_payload = applied.apply_receipt
+    engine.journal.create(
+        operation_id=revert_id,
+        action="revert",
+        project_id=PROJECT_ID,
+        revision=receipt.revision,
+        branch=branch,
+        expected_head=head,
+        patch_sha256=applied.patch_sha256,
+        patch=patch,
+        apply_receipt=receipt_payload,
+        file_identities=applied.file_identities,
+    )
+    engine.journal.transition(revert_id, "reverting")
+    plan = engine._build_plan(
+        patch=patch,
+        paths=paths,
+        branch=branch,
+        expected_head=head,
+        apply_receipt=receipt,
+    )
+    inverse = tuple(
+        type(item)(item.path, item.after, item.before, item.mode) for item in plan
+    )
+    transaction = engine._transaction(
+        inverse,
+        action="revert",
+        branch=branch,
+        expected_head=head,
+        operation_id=revert_id,
+        created_directories=(),
+    )
+    files = _transaction_files(inverse)
+    transaction.prepare(files)
+    item = files[0]
+    _move_verified_no_replace(
+        root / item.path,
+        transaction.tx_dir / f"before-{item.key}",
+        item.before,
+    )
+    _move_verified_no_replace(
+        transaction.tx_dir / f"after-{item.key}",
+        root / item.path,
+        item.after,
+    )
+
+    engine.revert(
+        operation_id=revert_id,
+        apply_receipt=receipt,
+        branch=branch,
+        expected_head=head,
+    )
+    assert (root / "a.txt").read_bytes() == b"old-a\n"
+    assert (root / "b.txt").read_bytes() == b"old-b\n"
+
+
+def test_revert_without_transaction_evidence_rejects_same_content_replacement(
+    tmp_path: Path,
+) -> None:
+    root, branch, head = _repository(tmp_path, {"marker.txt": b"old\n"})
+    patch, paths = _patch(("marker.txt", b"old\n", b"applied-r6n3\n"))
+    engine = _engine(tmp_path, root)
+    receipt = engine.apply(
+        operation_id="apply_v13_revert_identity_r6n3",
+        revision=17,
+        branch=branch,
+        expected_head=head,
+        snapshot_fingerprint=FINGERPRINT,
+        patch=patch,
+        paths=paths,
+    )
+    applied = engine.journal.get(receipt.apply_id)
+    assert applied is not None
+    revert_id = "revert_v13_revert_identity_r6n3"
+    engine.journal.create(
+        operation_id=revert_id,
+        action="revert",
+        project_id=PROJECT_ID,
+        revision=receipt.revision,
+        branch=branch,
+        expected_head=head,
+        patch_sha256=applied.patch_sha256,
+        patch=patch,
+        apply_receipt=applied.apply_receipt,
+        file_identities=applied.file_identities,
+    )
+    engine.journal.transition(revert_id, "reverting")
+    target = root / "marker.txt"
+    target.unlink()
+    target.write_bytes(b"applied-r6n3\n")
+
+    with pytest.raises(HostApplyError) as conflict:
+        engine.revert(
+            operation_id=revert_id,
+            apply_receipt=receipt,
+            branch=branch,
+            expected_head=head,
+        )
+
+    assert conflict.value.code == "revert_conflict"
+    assert target.read_bytes() == b"applied-r6n3\n"
+    assert engine.journal.get(revert_id).state == "conflict"
+
+
+def test_revert_refuses_external_change_without_overwriting_it(tmp_path: Path) -> None:
+    root, branch, head = _repository(tmp_path, {"marker.txt": b"old\n"})
+    patch, paths = _patch(("marker.txt", b"old\n", b"agent-change\n"))
+    engine = _engine(tmp_path, root)
+    receipt = engine.apply(
+        operation_id="apply_v13_conflict_n7m2",
+        revision=2,
+        branch=branch,
+        expected_head=head,
+        snapshot_fingerprint=FINGERPRINT,
+        patch=patch,
+        paths=paths,
+    )
+    (root / "marker.txt").write_text("human-change-q9t2\n", encoding="utf-8")
+    with pytest.raises(HostApplyError) as conflict:
+        engine.revert(
+            operation_id="revert_v13_conflict_n7m2",
+            apply_receipt=receipt,
+            branch=branch,
+            expected_head=head,
+        )
+    assert conflict.value.code == "revert_conflict"
+    assert (root / "marker.txt").read_text(encoding="utf-8") == "human-change-q9t2\n"
+
+
+def test_revert_failure_restores_fully_applied_state(tmp_path: Path) -> None:
+    root, branch, head = _repository(
+        tmp_path,
+        {"a.txt": b"old-a\n", "b.txt": b"old-b\n"},
+    )
+    patch, paths = _patch(
+        ("a.txt", b"old-a\n", b"new-a\n"),
+        ("b.txt", b"old-b\n", b"new-b\n"),
+    )
+    engine = _engine(tmp_path, root)
+    receipt = engine.apply(
+        operation_id="apply_v13_revertfail_p8r2",
+        revision=6,
+        branch=branch,
+        expected_head=head,
+        snapshot_fingerprint=FINGERPRINT,
+        patch=patch,
+        paths=paths,
+    )
+
+    def fail_second(_action: str, index: int, _path: str) -> None:
+        if index == 1:
+            raise RuntimeError("simulated revert interruption")
+
+    engine.mutation_hook = fail_second
+    with pytest.raises(RuntimeError, match="simulated revert interruption"):
+        engine.revert(
+            operation_id="revert_v13_failure_p8r2",
+            apply_receipt=receipt,
+            branch=branch,
+            expected_head=head,
+        )
+    assert (root / "a.txt").read_bytes() == b"new-a\n"
+    assert (root / "b.txt").read_bytes() == b"new-b\n"
+
+
+def test_hard_safety_policy_rejects_secret_symlink_and_branch_change(tmp_path: Path) -> None:
+    root, branch, head = _repository(tmp_path, {"safe.txt": b"safe\n"})
+    engine = _engine(tmp_path, root)
+    simulated_secret = ("s" + "k-" + "abcdefghijklmnopqrstuvwxyz123456").encode()
+    secret_patch, secret_paths = _patch(
+        ("safe.txt", b"safe\n", b"token = '" + simulated_secret + b"'\n")
+    )
+    with pytest.raises(HostApplyError) as secret:
+        engine.apply(
+            operation_id="apply_v13_secret_q7m4",
+            revision=1,
+            branch=branch,
+            expected_head=head,
+            snapshot_fingerprint=FINGERPRINT,
+            patch=secret_patch,
+            paths=secret_paths,
+        )
+    assert secret.value.code == "secret_detected"
+    assert (root / "safe.txt").read_bytes() == b"safe\n"
+
+    if hasattr(os, "symlink"):
+        outside = tmp_path / "outside.txt"
+        outside.write_text("outside\n", encoding="utf-8")
+        link = root / "link.txt"
+        try:
+            link.symlink_to(outside)
+        except OSError:
+            pass
+        else:
+            link_patch, link_paths = _patch(("link.txt", None, b"changed\n"))
+            with pytest.raises(HostApplyError) as linked:
+                engine.apply(
+                    operation_id="apply_v13_symlink_q7m4",
+                    revision=1,
+                    branch=branch,
+                    expected_head=head,
+                    snapshot_fingerprint=FINGERPRINT,
+                    patch=link_patch,
+                    paths=link_paths,
+                )
+            assert linked.value.code in {"symlink_not_allowed", "target_changed"}
+            assert outside.read_text(encoding="utf-8") == "outside\n"
+            link.unlink()
+
+    _git(root, "switch", "-c", "feature/other-r4m8")
+    patch, paths = _patch(("safe.txt", b"safe\n", b"changed\n"))
+    with pytest.raises(HostApplyError) as changed:
+        engine.apply(
+            operation_id="apply_v13_branch_q7m4",
+            revision=1,
+            branch=branch,
+            expected_head=head,
+            snapshot_fingerprint=FINGERPRINT,
+            patch=patch,
+            paths=paths,
+        )
+    assert changed.value.code == "branch_changed"
+
+
+def test_crlf_worktree_style_is_preserved(tmp_path: Path) -> None:
+    root, branch, head = _repository(tmp_path, {"crlf.txt": b"one\ntwo\n"})
+    (root / "crlf.txt").write_bytes(b"one\r\ntwo\r\n")
+    patch, paths = _patch(("crlf.txt", b"one\ntwo\n", b"one\nthree\n"))
+    engine = _engine(tmp_path, root)
+    receipt = engine.apply(
+        operation_id="apply_v13_crlf_k8m2x",
+        revision=5,
+        branch=branch,
+        expected_head=head,
+        snapshot_fingerprint=FINGERPRINT,
+        patch=patch,
+        paths=paths,
+    )
+    assert (root / "crlf.txt").read_bytes() == b"one\r\nthree\r\n"
+    engine.revert(
+        operation_id="revert_v13_crlf_k8m2",
+        apply_receipt=receipt,
+        branch=branch,
+        expected_head=head,
+    )
+    assert (root / "crlf.txt").read_bytes() == b"one\r\ntwo\r\n"
+
+
+def test_local_include_configuration_is_rejected(tmp_path: Path) -> None:
+    root, branch, head = _repository(tmp_path, {"safe.txt": b"safe\n"})
+    _git(root, "config", "include.path", str(tmp_path / "untrusted.gitconfig"))
+    patch, paths = _patch(("safe.txt", b"safe\n", b"changed\n"))
+    with pytest.raises(HostApplyError) as unsafe:
+        _engine(tmp_path, root).apply(
+            operation_id="apply_v13_include_p8r2",
+            revision=1,
+            branch=branch,
+            expected_head=head,
+            snapshot_fingerprint=FINGERPRINT,
+            patch=patch,
+            paths=paths,
+        )
+    assert unsafe.value.code == "git_config_unsafe"
+    assert (root / "safe.txt").read_bytes() == b"safe\n"
+
+
+def test_reconcile_cannot_replace_stored_snapshot_fingerprint(tmp_path: Path) -> None:
+    root, branch, head = _repository(tmp_path, {"safe.txt": b"safe\n"})
+    patch, paths = _patch(("safe.txt", b"safe\n", b"changed\n"))
+
+    def stop_before_write(_action: str, _index: int, _path: str) -> None:
+        raise RuntimeError("stop")
+
+    engine = _engine(tmp_path, root, hook=stop_before_write)
+    with pytest.raises(RuntimeError, match="stop"):
+        engine.apply(
+            operation_id="apply_v13_fingerprint_p8r2",
+            revision=11,
+            branch=branch,
+            expected_head=head,
+            snapshot_fingerprint=FINGERPRINT,
+            patch=patch,
+            paths=paths,
+        )
+    state, receipt = engine.reconcile_apply(
+        operation_id="apply_v13_fingerprint_p8r2",
+        snapshot_fingerprint="e" * 64,
+    )
+    assert state == "conflict"
+    assert receipt is None
+    stored = engine.journal.get("apply_v13_fingerprint_p8r2")
+    assert stored is not None
+    assert stored.apply_receipt["snapshot_fingerprint"] == FINGERPRINT
+
+
+def test_applied_retry_rejects_a_different_snapshot_fingerprint(tmp_path: Path) -> None:
+    root, branch, head = _repository(tmp_path, {"safe.txt": b"safe\n"})
+    patch, paths = _patch(("safe.txt", b"safe\n", b"changed\n"))
+    engine = _engine(tmp_path, root)
+    engine.apply(
+        operation_id="apply_v13_applied_fingerprint",
+        revision=13,
+        branch=branch,
+        expected_head=head,
+        snapshot_fingerprint=FINGERPRINT,
+        patch=patch,
+        paths=paths,
+    )
+    with pytest.raises(HostApplyError) as conflict:
+        engine.apply(
+            operation_id="apply_v13_applied_fingerprint",
+            revision=13,
+            branch=branch,
+            expected_head=head,
+            snapshot_fingerprint="e" * 64,
+            patch=patch,
+            paths=paths,
+        )
+    assert conflict.value.code == "operation_conflict"
+
+
+def test_git_ref_lock_blocks_concurrent_head_change(tmp_path: Path) -> None:
+    root, branch, head = _repository(
+        tmp_path,
+        {"a.txt": b"old-a\n", "b.txt": b"old-b\n"},
+    )
+    patch, paths = _patch(
+        ("a.txt", b"old-a\n", b"new-a\n"),
+        ("b.txt", b"old-b\n", b"new-b\n"),
+    )
+    tree = _git(root, "write-tree")
+    concurrent_head = _git(
+        root,
+        "commit-tree",
+        tree,
+        "-p",
+        head,
+        "-m",
+        "concurrent head",
+    )
+
+    return_codes: list[int] = []
+
+    def advance_head(_action: str, index: int, _path: str) -> None:
+        if index == 1:
+            completed = subprocess.run(
+                ("git", "update-ref", f"refs/heads/{branch}", concurrent_head, head),
+                cwd=root,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+                timeout=15,
+            )
+            return_codes.append(completed.returncode)
+
+    engine = _engine(tmp_path, root, hook=advance_head)
+    engine.apply(
+        operation_id="apply_v13_headrace_n7m2",
+        revision=12,
+        branch=branch,
+        expected_head=head,
+        snapshot_fingerprint=FINGERPRINT,
+        patch=patch,
+        paths=paths,
+    )
+    assert return_codes and all(code != 0 for code in return_codes)
+    assert (root / "a.txt").read_bytes() == b"new-a\n"
+    assert (root / "b.txt").read_bytes() == b"new-b\n"
+    assert _git(root, "rev-parse", "HEAD") == head

--- a/server/tests/test_coding_project_host_windows.py
+++ b/server/tests/test_coding_project_host_windows.py
@@ -23,9 +23,11 @@ from server.coding_project_host.windows_helper import (
     ProjectHostRegistry,
     ProjectHostTransport,
     inspect_git_project,
+    inspect_git_project_for_recovery,
     public_project,
     validate_server_url,
 )
+from server.coding_runtime.projects import build_safe_git_environment
 
 
 class XorProtector:
@@ -151,6 +153,92 @@ def test_git_inspection_accepts_remote_without_reading_or_returning_it(tmp_path:
     assert "path" not in encoded.casefold()
     assert "remote" not in encoded.casefold()
     assert "example.invalid" not in encoded
+
+
+@pytest.mark.parametrize("inspection", ["initial", "recovery"])
+@pytest.mark.parametrize(
+    ("config_name", "config_value"),
+    [
+        ("extensions.partialClone", "origin"),
+        ("remote.origin.promisor", "true"),
+        ("remote..promisor", "true"),
+        ("remote.origin.partialCloneFilter", "blob:none"),
+    ],
+)
+def test_git_inspection_rejects_lazy_fetch_config_before_object_resolution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    inspection: str,
+    config_name: str,
+    config_value: str,
+) -> None:
+    project = _repository(tmp_path)
+    baseline = inspect_git_project(project, b"k" * 32, enforce_windows=False)
+    _git(project, "config", config_name, config_value)
+    original_run = subprocess.run
+    commands: list[tuple[str, ...]] = []
+    environments: list[dict[str, str]] = []
+
+    def traced_run(command, **kwargs):
+        commands.append(tuple(command))
+        environments.append(dict(kwargs["env"]))
+        return original_run(command, **kwargs)
+
+    monkeypatch.setattr(windows_helper_module.subprocess, "run", traced_run)
+    with pytest.raises(ProjectHostHelperError) as rejected:
+        if inspection == "initial":
+            inspect_git_project(project, b"k" * 32, enforce_windows=False)
+        else:
+            inspect_git_project_for_recovery(
+                project,
+                b"k" * 32,
+                expected_project_id=baseline["project_id"],
+                expected_branch=baseline["branch"],
+                expected_head=baseline["head"],
+                enforce_windows=False,
+            )
+
+    assert rejected.value.code == "git_config_unsafe"
+    assert commands
+    assert all("config" in command for command in commands)
+    object_commands = {"rev-parse", "ls-tree", "cat-file", "diff", "status"}
+    assert all(object_commands.isdisjoint(command) for command in commands)
+    assert all(env["GIT_NO_LAZY_FETCH"] == "1" for env in environments)
+    assert build_safe_git_environment()["GIT_NO_LAZY_FETCH"] == "1"
+    assert (project / "README.md").read_bytes() == b"marker: q7m4\n"
+
+
+@pytest.mark.parametrize("inspection", ["initial", "recovery"])
+def test_git_inspection_rejects_http_alternates_without_running_git(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    inspection: str,
+) -> None:
+    project = _repository(tmp_path)
+    baseline = inspect_git_project(project, b"k" * 32, enforce_windows=False)
+    alternate = project / ".git" / "objects" / "info" / "http-alternates"
+    alternate.write_text("https://example.invalid/objects\n", encoding="utf-8")
+    monkeypatch.setattr(
+        windows_helper_module,
+        "_run_git",
+        lambda *_args, **_kwargs: pytest.fail("Git must not run before rejecting http-alternates"),
+    )
+
+    with pytest.raises(ProjectHostHelperError) as rejected:
+        if inspection == "initial":
+            inspect_git_project(project, b"k" * 32, enforce_windows=False)
+        else:
+            inspect_git_project_for_recovery(
+                project,
+                b"k" * 32,
+                expected_project_id=baseline["project_id"],
+                expected_branch=baseline["branch"],
+                expected_head=baseline["head"],
+                enforce_windows=False,
+            )
+
+    assert rejected.value.code == "git_alternates_not_allowed"
+    assert (project / "README.md").read_bytes() == b"marker: q7m4\n"
 
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows helper safety gate")

--- a/server/tests/test_coding_project_host_windows.py
+++ b/server/tests/test_coding_project_host_windows.py
@@ -55,16 +55,21 @@ def _git(path: Path, *arguments: str) -> str:
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         check=False,
-        text=True,
+        encoding="utf-8",
+        errors="strict",
     )
     assert result.returncode == 0, result.stderr
     return result.stdout.strip()
 
 
-def _repository(tmp_path: Path) -> Path:
+def _repository(
+    tmp_path: Path,
+    *,
+    branch: str = "feature/current-q7m4",
+) -> Path:
     project = tmp_path / "随机 项目 nebula-k8r3"
     project.mkdir()
-    _git(project, "init", "-b", "feature/current-q7m4")
+    _git(project, "init", "-b", branch)
     _git(project, "config", "core.autocrlf", "false")
     (project / "README.md").write_bytes(b"marker: q7m4\n")
     _git(project, "add", "README.md")
@@ -299,6 +304,36 @@ def test_git_inspection_accepts_remote_without_reading_or_returning_it(tmp_path:
     assert "path" not in encoded.casefold()
     assert "remote" not in encoded.casefold()
     assert "example.invalid" not in encoded
+
+
+def test_git_inspection_accepts_utf8_symbolic_head_branch(tmp_path: Path) -> None:
+    branch = "feature/中文分支-q7m4"
+    project = _repository(tmp_path, branch=branch)
+
+    inspected = inspect_git_project(project, b"k" * 32, enforce_windows=False)
+
+    assert inspected["branch"] == branch
+    assert inspected["head"] == _git(project, "rev-parse", "HEAD")
+
+
+def test_git_inspection_rejects_invalid_utf8_head_before_git(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = _repository(tmp_path)
+    (project / ".git" / "HEAD").write_bytes(b"ref: refs/heads/feature/\xff\n")
+    monkeypatch.setattr(
+        windows_helper_module,
+        "_run_git",
+        lambda *_args, **_kwargs: pytest.fail(
+            "Invalid HEAD encoding must be rejected before Git"
+        ),
+    )
+
+    with pytest.raises(ProjectHostHelperError) as rejected:
+        inspect_git_project(project, b"k" * 32, enforce_windows=False)
+
+    assert rejected.value.code == "git_encoding_not_supported"
 
 
 @pytest.mark.parametrize("replacement", ["root", "git"])

--- a/server/tests/test_coding_project_host_windows.py
+++ b/server/tests/test_coding_project_host_windows.py
@@ -13,6 +13,7 @@ from types import SimpleNamespace
 import pytest
 
 import server.coding_project_host.windows_helper as windows_helper_module
+import server.coding_runtime.host_snapshot as host_snapshot_module
 
 from server.coding_runtime.applier_client import _receipt_to_payload
 from server.coding_runtime.apply_models import ApplyFileReceipt, ApplyReceipt
@@ -599,8 +600,12 @@ def test_registry_snapshot_holds_config_guard_across_archive(
             blocked_writes.append(True)
         else:
             pytest.fail("Config write must be blocked while snapshot cat-file is running")
-        Path(_args[1]).write_bytes(b"guarded-archive")
-        return SimpleNamespace(project_id=inspected["project_id"])
+        destination = Path(_args[1])
+        destination.write_bytes(b"guarded-archive")
+        return SimpleNamespace(
+            project_id=inspected["project_id"],
+            archive_identity=windows_helper_module.file_identity(destination),
+        )
 
     monkeypatch.setattr(
         windows_helper_module,
@@ -615,6 +620,57 @@ def test_registry_snapshot_holds_config_guard_across_archive(
     assert result.project_id == inspected["project_id"]
     assert archive_identity
     assert blocked_writes == [True]
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows snapshot identity gate")
+def test_snapshot_never_uploads_or_deletes_post_publish_replacement(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = _repository(tmp_path)
+    registry = ProjectHostRegistry(tmp_path / "state.bin", XorProtector())
+    inspected = inspect_git_project(project, registry.device_secret)
+    registry.remember_project(inspected)
+    archive = tmp_path / "snapshot.tar.gz"
+    replacement = b"manual replacement must survive\n"
+    replacement_identity: str | None = None
+    real_publish = host_snapshot_module._publish_archive_no_replace
+
+    def publish_then_replace(*args, **kwargs):
+        nonlocal replacement_identity
+        identity = real_publish(*args, **kwargs)
+        destination = Path(args[1])
+        destination.unlink()
+        destination.write_bytes(replacement)
+        replacement_identity = windows_helper_module.file_identity(destination)
+        return identity
+
+    monkeypatch.setattr(
+        host_snapshot_module,
+        "_publish_archive_no_replace",
+        publish_then_replace,
+    )
+    _result, owned_identity = registry.create_snapshot(
+        inspected["project_id"],
+        archive,
+    )
+    transport = ProjectHostTransport(
+        registry,
+        "http://127.0.0.1:8000",
+        "12345678",
+        select_folder=lambda: None,
+    )
+    monkeypatch.setattr(
+        transport,
+        "_upload_snapshot",
+        lambda *_args, **_kwargs: pytest.fail("Replacement must never be uploaded"),
+    )
+
+    with pytest.raises(ProjectHostHelperError):
+        transport._upload_snapshot_exact("a" * 32, archive, owned_identity)
+
+    assert archive.read_bytes() == replacement
+    assert windows_helper_module.file_identity(archive) == replacement_identity
 
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows helper safety gate")

--- a/server/tests/test_coding_project_host_windows.py
+++ b/server/tests/test_coding_project_host_windows.py
@@ -2,11 +2,21 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import hashlib
 import json
+import os
 import subprocess
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
+
+import server.coding_project_host.windows_helper as windows_helper_module
+
+from server.coding_runtime.applier_client import _receipt_to_payload
+from server.coding_runtime.apply_models import ApplyFileReceipt, ApplyReceipt
+from server.coding_runtime.commit_models import CommitReceipt
+from server.coding_runtime.committer_client import _commit_receipt_to_payload
 
 from server.coding_project_host.windows_helper import (
     ProjectHostHelperError,
@@ -47,7 +57,8 @@ def _repository(tmp_path: Path) -> Path:
     project = tmp_path / "随机 项目 nebula-k8r3"
     project.mkdir()
     _git(project, "init", "-b", "feature/current-q7m4")
-    (project / "README.md").write_text("marker: q7m4\n", encoding="utf-8")
+    _git(project, "config", "core.autocrlf", "false")
+    (project / "README.md").write_bytes(b"marker: q7m4\n")
     _git(project, "add", "README.md")
     _git(project, "-c", "user.name=Test", "-c", "user.email=test@modelmirror.local", "commit", "-m", "initial")
     return project
@@ -80,6 +91,53 @@ def test_registry_encrypts_token_path_and_device_secret(tmp_path: Path) -> None:
     assert restored.projects()[0]["path"] == project_path
 
 
+def test_registry_head_update_is_idempotent_and_rejects_wrong_branch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_id = "hostgit_0123456789abcdef0123456789abcdef"
+    baseline = "a" * 40
+    registry = ProjectHostRegistry(tmp_path / "state.bin", XorProtector())
+    registry.remember_project(
+        {
+            "project_id": project_id,
+            "name": "nebula-k8r3",
+            "branch": "feature/current-q7m4",
+            "head": baseline,
+            "state": "available",
+            "reason": "",
+            "path": "C:\\random\\nebula-k8r3",
+        }
+    )
+    persist_calls = 0
+
+    def count_persist() -> None:
+        nonlocal persist_calls
+        persist_calls += 1
+
+    monkeypatch.setattr(registry, "_persist", count_persist)
+
+    registry.update_project_head(
+        project_id,
+        branch="feature/current-q7m4",
+        expected_heads={baseline},
+        head=baseline,
+    )
+    assert persist_calls == 0
+
+    with pytest.raises(ProjectHostHelperError) as changed:
+        registry.update_project_head(
+            project_id,
+            branch="feature/other-r8v3",
+            expected_heads={baseline},
+            head="b" * 40,
+        )
+
+    assert changed.value.code == "project_changed"
+    assert registry.project(project_id)["head"] == baseline
+    assert persist_calls == 0
+
+
 def test_git_inspection_accepts_remote_without_reading_or_returning_it(tmp_path: Path) -> None:
     project = _repository(tmp_path)
     _git(project, "remote", "add", "origin", "https://example.invalid/private.git")
@@ -93,6 +151,28 @@ def test_git_inspection_accepts_remote_without_reading_or_returning_it(tmp_path:
     assert "path" not in encoded.casefold()
     assert "remote" not in encoded.casefold()
     assert "example.invalid" not in encoded
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows helper safety gate")
+def test_managed_snapshot_without_journal_requires_current_exact_baseline(
+    tmp_path: Path,
+) -> None:
+    project = _repository(tmp_path)
+    registry = ProjectHostRegistry(tmp_path / "state.bin", XorProtector())
+    inspected = inspect_git_project(project, registry.device_secret, enforce_windows=False)
+    registry.remember_project(inspected)
+
+    with pytest.raises(ProjectHostHelperError) as changed:
+        registry.create_snapshot(
+            inspected["project_id"],
+            tmp_path / "snapshot.tar.gz",
+            expected_head="f" * 40,
+            expected_branch=inspected["branch"],
+            managed_operation_id="apply_0123456789abcdef012345",
+        )
+
+    assert changed.value.code == "project_changed"
+    assert not (tmp_path / "snapshot.tar.gz").exists()
 
 
 @pytest.mark.parametrize("dirty", ["tracked", "untracked"])
@@ -270,7 +350,11 @@ async def test_helper_handles_snapshot_request_without_closing_connection(
             "head": "a" * 40,
         },
     )()
-    monkeypatch.setattr(registry, "create_snapshot", lambda *_args: result)
+    monkeypatch.setattr(
+        registry,
+        "create_snapshot",
+        lambda *_args, **_kwargs: result,
+    )
     transport = ProjectHostTransport(
         registry,
         "http://127.0.0.1:8000",
@@ -311,3 +395,435 @@ async def test_helper_handles_snapshot_request_without_closing_connection(
             },
         }
     ]
+
+
+@pytest.mark.parametrize(
+    ("content_length", "expected_sha256"),
+    [
+        (13, "0" * 64),
+        (14, hashlib.sha256(b'{"safe":true}').hexdigest()),
+    ],
+)
+def test_helper_rejects_operation_payload_size_or_digest_tampering(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    content_length: int,
+    expected_sha256: str,
+) -> None:
+    registry = ProjectHostRegistry(tmp_path / "state.bin", XorProtector())
+    registry.save_credentials(
+        "phost_0123456789abcdef0123456789abcdef",
+        "token-" + "x" * 48,
+    )
+    body = b'{"safe":true}'
+    connections: list[object] = []
+
+    class FakeResponse:
+        status = 200
+
+        @staticmethod
+        def getheader(name: str) -> str | None:
+            return {
+                "Content-Length": str(content_length),
+                "Content-Type": "application/json",
+                "Cache-Control": "no-store",
+            }.get(name)
+
+        @staticmethod
+        def read(_limit: int) -> bytes:
+            return body
+
+    class FakeConnection:
+        def __init__(self, host: str, port: int, timeout: int) -> None:
+            assert (host, port, timeout) == ("127.0.0.1", 8000, 30)
+            connections.append(self)
+
+        def request(self, method: str, path: str, *, headers: dict[str, str]) -> None:
+            assert method == "GET"
+            assert path.startswith("/api/coding/project-host/operations/phop_")
+            assert headers["Authorization"].startswith("Bearer ")
+
+        @staticmethod
+        def getresponse() -> FakeResponse:
+            return FakeResponse()
+
+        @staticmethod
+        def close() -> None:
+            return None
+
+    monkeypatch.setattr(
+        windows_helper_module.http.client,
+        "HTTPConnection",
+        FakeConnection,
+    )
+    transport = ProjectHostTransport(
+        registry,
+        "http://127.0.0.1:8000",
+        "12345678",
+        select_folder=lambda: None,
+    )
+
+    with pytest.raises(ProjectHostHelperError) as rejected:
+        transport._download_operation_payload(
+            payload_id="phop_" + "1" * 32,
+            project_id="hostgit_0123456789abcdef0123456789abcdef",
+            operation_id="apply_0123456789abcdef012345",
+            action="apply",
+            expected_size=len(body),
+            expected_sha256=expected_sha256,
+        )
+
+    assert rejected.value.code == "operation_payload_invalid"
+    assert len(connections) == 1
+
+
+def test_helper_reconciles_committed_head_without_replaying_apply_or_crossing_project(
+    tmp_path: Path,
+) -> None:
+    project_id = "hostgit_0123456789abcdef0123456789abcdef"
+    other_project_id = "hostgit_fedcba9876543210fedcba9876543210"
+    branch = "feature/nebula-k8r3"
+    baseline = "a" * 40
+    fingerprint = "b" * 64
+    apply_operation_id = "apply_0123456789abcdef012345"
+    commit_operation_id = "commit_0123456789abcdef0123"
+    patch = "diff --git a/src/nebula.py b/src/nebula.py\n"
+    patch_sha256 = hashlib.sha256(patch.encode("utf-8")).hexdigest()
+    applied = ApplyReceipt(
+        apply_id=apply_operation_id,
+        revision=3,
+        snapshot_fingerprint=fingerprint,
+        files=(
+            ApplyFileReceipt(
+                path="src/nebula.py",
+                existed_before=True,
+                before_sha256="c" * 64,
+                after_sha256="d" * 64,
+            ),
+        ),
+        applied_at=1_785_600_000.0,
+    )
+    committed = CommitReceipt(
+        commit_id=commit_operation_id,
+        revision=applied.revision,
+        apply_id=applied.apply_id,
+        commit_sha="e" * 40,
+        parent_sha=baseline,
+        tree_sha="f" * 40,
+        message="feature: update nebula",
+        files=("src/nebula.py",),
+        branch=branch,
+        committed_at=1_785_600_001.0,
+    )
+    records = {
+        apply_operation_id: SimpleNamespace(
+            action="apply",
+            state="applied",
+            project_id=project_id,
+            branch=branch,
+            expected_head=baseline,
+            patch_sha256=patch_sha256,
+            revision=applied.revision,
+            apply_receipt=_receipt_to_payload(applied),
+        ),
+        commit_operation_id: SimpleNamespace(
+            action="commit",
+            state="committed",
+            project_id=project_id,
+            branch=branch,
+            expected_head=baseline,
+            patch_sha256=patch_sha256,
+            revision=applied.revision,
+            apply_receipt=_receipt_to_payload(applied),
+            commit_receipt=_commit_receipt_to_payload(committed),
+            commit_message=committed.message,
+        ),
+    }
+    registry = ProjectHostRegistry(tmp_path / "state.bin", XorProtector())
+    registry.operations = SimpleNamespace(get=lambda operation_id: records.get(operation_id))  # type: ignore[assignment]
+    transport = ProjectHostTransport(
+        registry,
+        "http://127.0.0.1:8000",
+        "12345678",
+        select_folder=lambda: None,
+    )
+
+    class ApplyEngine:
+        def reconcile_apply(self, **_kwargs: object) -> object:
+            raise AssertionError("committed reconciliation must not replay apply")
+
+    class CommitEngine:
+        def reconcile(self, operation_id: str) -> tuple[str, CommitReceipt]:
+            assert operation_id == commit_operation_id
+            return "committed", committed
+
+    payload = {
+        "kind": "commit",
+        "apply_operation_id": apply_operation_id,
+        "revision": applied.revision,
+        "expected_head": baseline,
+        "snapshot_fingerprint": fingerprint,
+        "patch_sha256": patch_sha256,
+        "paths": ["src/nebula.py"],
+        "apply_receipt": _receipt_to_payload(applied),
+        "message": committed.message,
+    }
+
+    result = transport._reconcile_commit_operation(
+        ApplyEngine(),  # type: ignore[arg-type]
+        CommitEngine(),  # type: ignore[arg-type]
+        project_id=project_id,
+        operation_id=commit_operation_id,
+        branch=branch,
+        baseline_head=baseline,
+        payload=payload,
+    )
+    assert result == {
+        "state": "committed",
+        "apply_receipt": _receipt_to_payload(applied),
+        "commit_receipt": _commit_receipt_to_payload(committed),
+    }
+
+    with pytest.raises(ProjectHostHelperError) as crossed:
+        transport._reconcile_commit_operation(
+            ApplyEngine(),  # type: ignore[arg-type]
+            CommitEngine(),  # type: ignore[arg-type]
+            project_id=other_project_id,
+            operation_id=commit_operation_id,
+            branch=branch,
+            baseline_head=baseline,
+            payload=payload,
+        )
+    assert crossed.value.code == "operation_conflict"
+
+
+def test_helper_registry_tracks_commit_undo_and_revert_heads(tmp_path: Path) -> None:
+    project_id = "hostgit_0123456789abcdef0123456789abcdef"
+    branch = "feature/current-q7m4"
+    baseline = "a" * 40
+    committed_head = "b" * 40
+    registry = ProjectHostRegistry(tmp_path / "state.bin", XorProtector())
+    registry.remember_project(
+        {
+            "project_id": project_id,
+            "name": "nebula-k8r3",
+            "branch": branch,
+            "head": baseline,
+            "state": "available",
+            "reason": "",
+            "path": "C:\\random\\nebula-k8r3",
+        }
+    )
+    transport = ProjectHostTransport(
+        registry,
+        "http://127.0.0.1:8000",
+        "12345678",
+        select_folder=lambda: None,
+    )
+    commit_receipt = CommitReceipt(
+        commit_id="commit_0123456789abcdef0123",
+        revision=1,
+        apply_id="apply_0123456789abcdef012345",
+        commit_sha=committed_head,
+        parent_sha=baseline,
+        tree_sha="c" * 40,
+        message="feature: advance nebula",
+        files=("src/nebula.py",),
+        branch=branch,
+        committed_at=1_785_600_001.0,
+    )
+    registered = registry.project(project_id)
+
+    transport._update_registry_after_operation(
+        registered,
+        branch=branch,
+        baseline_head=baseline,
+        result={
+            "state": "committed",
+            "commit_receipt": _commit_receipt_to_payload(commit_receipt),
+        },
+    )
+    assert registry.project(project_id)["head"] == committed_head
+
+    transport._update_registry_after_operation(
+        registry.project(project_id),
+        branch=branch,
+        baseline_head=baseline,
+        result={
+            "state": "undone",
+            "receipt": _commit_receipt_to_payload(commit_receipt),
+        },
+    )
+    assert registry.project(project_id)["head"] == baseline
+
+    transport._update_registry_after_operation(
+        registry.project(project_id),
+        branch=branch,
+        baseline_head=baseline,
+        result={"state": "reverted"},
+    )
+    assert registry.project(project_id)["head"] == baseline
+
+
+@pytest.mark.asyncio
+async def test_second_cycle_dirty_inventory_uses_committed_head(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_id = "hostgit_0123456789abcdef0123456789abcdef"
+    branch = "feature/current-q7m4"
+    baseline = "a" * 40
+    committed_head = "b" * 40
+    registry = ProjectHostRegistry(tmp_path / "state.bin", XorProtector())
+    registry.remember_project(
+        {
+            "project_id": project_id,
+            "name": "nebula-k8r3",
+            "branch": branch,
+            "head": baseline,
+            "state": "available",
+            "reason": "",
+            "path": "C:\\random\\nebula-k8r3",
+        }
+    )
+    transport = ProjectHostTransport(
+        registry,
+        "http://127.0.0.1:8000",
+        "12345678",
+        select_folder=lambda: None,
+    )
+    receipt = CommitReceipt(
+        commit_id="commit_0123456789abcdef0123",
+        revision=1,
+        apply_id="apply_0123456789abcdef012345",
+        commit_sha=committed_head,
+        parent_sha=baseline,
+        tree_sha="c" * 40,
+        message="feature: advance nebula",
+        files=("src/nebula.py",),
+        branch=branch,
+        committed_at=1_785_600_001.0,
+    )
+    transport._update_registry_after_operation(
+        registry.project(project_id),
+        branch=branch,
+        baseline_head=baseline,
+        result={
+            "state": "committed",
+            "commit_receipt": _commit_receipt_to_payload(receipt),
+        },
+    )
+
+    def dirty_project(*_args: object, **_kwargs: object) -> dict[str, str]:
+        raise ProjectHostHelperError("git_repository_dirty")
+
+    monkeypatch.setattr(windows_helper_module, "inspect_git_project", dirty_project)
+    sent: list[dict[str, object]] = []
+
+    class FakeWebSocket:
+        async def send(self, message: str) -> None:
+            sent.append(json.loads(message))
+
+    await transport._send_inventory(FakeWebSocket())
+
+    assert sent == [
+        {
+            "type": "inventory",
+            "projects": [
+                {
+                    "project_id": project_id,
+                    "name": "nebula-k8r3",
+                    "branch": branch,
+                    "head": committed_head,
+                    "state": "unavailable",
+                    "reason": "git_repository_dirty",
+                }
+            ],
+        }
+    ]
+
+
+def test_registry_persist_failure_turns_operation_result_unknown(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    host_id = "phost_0123456789abcdef0123456789abcdef"
+    project_id = "hostgit_0123456789abcdef0123456789abcdef"
+    operation_id = "commit_0123456789abcdef0123"
+    branch = "feature/current-q7m4"
+    baseline = "a" * 40
+    committed_head = "b" * 40
+    registry = ProjectHostRegistry(tmp_path / "state.bin", XorProtector())
+    registry.save_credentials(host_id, "token-" + "x" * 48)
+    registry.remember_project(
+        {
+            "project_id": project_id,
+            "name": "nebula-k8r3",
+            "branch": branch,
+            "head": baseline,
+            "state": "available",
+            "reason": "",
+            "path": "C:\\random\\nebula-k8r3",
+        }
+    )
+    transport = ProjectHostTransport(
+        registry,
+        "http://127.0.0.1:8000",
+        "12345678",
+        select_folder=lambda: None,
+    )
+    receipt = CommitReceipt(
+        commit_id=operation_id,
+        revision=1,
+        apply_id="apply_0123456789abcdef012345",
+        commit_sha=committed_head,
+        parent_sha=baseline,
+        tree_sha="c" * 40,
+        message="feature: advance nebula",
+        files=("src/nebula.py",),
+        branch=branch,
+        committed_at=1_785_600_001.0,
+    )
+    envelope = json.dumps(
+        {
+            "version": 1,
+            "host_id": host_id,
+            "project_id": project_id,
+            "operation_id": operation_id,
+            "action": "commit",
+            "branch": branch,
+            "head": baseline,
+            "payload": {},
+        },
+        separators=(",", ":"),
+    ).encode("utf-8")
+    monkeypatch.setattr(transport, "_download_operation_payload", lambda **_kwargs: envelope)
+    monkeypatch.setattr(
+        transport,
+        "_execute_project_operation",
+        lambda *_args, **_kwargs: {
+            "state": "committed",
+            "commit_receipt": _commit_receipt_to_payload(receipt),
+        },
+    )
+    monkeypatch.setattr(
+        registry,
+        "update_project_head",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("disk full")),
+    )
+    message = {
+        "type": "execute_operation",
+        "request_id": "phreq_0123456789abcdef0123456789abcdef",
+        "project_id": project_id,
+        "operation_id": operation_id,
+        "action": "commit",
+        "payload_id": "phop_0123456789abcdef0123456789abcdef",
+        "payload_sha256": hashlib.sha256(envelope).hexdigest(),
+        "payload_size": len(envelope),
+        "payload_expires_at": windows_helper_module.time.time() + 30.0,
+    }
+
+    with pytest.raises(ProjectHostHelperError) as unknown:
+        transport._handle_operation_message(message)
+
+    assert unknown.value.code == "operation_result_unknown"

--- a/server/tests/test_coding_project_host_windows.py
+++ b/server/tests/test_coding_project_host_windows.py
@@ -5,6 +5,7 @@ import base64
 import hashlib
 import json
 import os
+import shutil
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
@@ -27,7 +28,11 @@ from server.coding_project_host.windows_helper import (
     public_project,
     validate_server_url,
 )
-from server.coding_runtime.projects import build_safe_git_environment
+from server.coding_runtime.projects import build_safe_git_command, build_safe_git_environment
+
+
+ROOT_IDENTITY = "1-2"
+GIT_IDENTITY = "1-3"
 
 
 class XorProtector:
@@ -66,6 +71,39 @@ def _repository(tmp_path: Path) -> Path:
     return project
 
 
+def _directory_link(link: Path, target: Path) -> None:
+    if os.name == "nt":
+        result = subprocess.run(
+            ("cmd", "/c", "mklink", "/J", str(link), str(target)),
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            text=True,
+        )
+        if result.returncode != 0:
+            pytest.skip(f"Directory junctions are unavailable: {result.stderr}")
+        return
+    try:
+        link.symlink_to(target, target_is_directory=True)
+    except OSError:
+        pytest.skip("Directory symlinks are unavailable on this test host")
+
+
+def _replace_repository_identity(project: Path, tmp_path: Path, target: str) -> None:
+    if target == "root":
+        backup = tmp_path / "original-project"
+        project.rename(backup)
+        shutil.copytree(backup, project)
+        return
+    if target == "git":
+        backup = tmp_path / "original-dot-git"
+        (project / ".git").rename(backup)
+        shutil.copytree(backup, project / ".git")
+        return
+    raise AssertionError(target)
+
+
 def test_registry_encrypts_token_path_and_device_secret(tmp_path: Path) -> None:
     state_path = tmp_path / "state.bin"
     registry = ProjectHostRegistry(state_path, XorProtector())
@@ -81,6 +119,8 @@ def test_registry_encrypts_token_path_and_device_secret(tmp_path: Path) -> None:
             "state": "available",
             "reason": "",
             "path": project_path,
+            "root_identity": ROOT_IDENTITY,
+            "git_identity": GIT_IDENTITY,
         }
     )
 
@@ -91,6 +131,109 @@ def test_registry_encrypts_token_path_and_device_secret(tmp_path: Path) -> None:
     restored = ProjectHostRegistry(state_path, XorProtector())
     assert restored.credentials == ("phost_0123456789abcdef0123456789abcdef", token)
     assert restored.projects()[0]["path"] == project_path
+
+
+def test_registry_never_persists_an_inventory_above_server_limit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = ProjectHostRegistry(tmp_path / "state.bin", XorProtector())
+    monkeypatch.setattr(registry, "_persist", lambda: None)
+    for index in range(50):
+        registry.remember_project(
+            {
+                "project_id": f"hostgit_{index:032x}",
+                "name": f"project-{index}",
+                "branch": "main",
+                "head": "a" * 40,
+                "state": "available",
+                "reason": "",
+                "path": f"C:\\projects\\project-{index}",
+                "root_identity": f"1-{index + 10:x}",
+                "git_identity": f"2-{index + 10:x}",
+            }
+        )
+
+    with pytest.raises(ProjectHostHelperError) as rejected:
+        registry.remember_project(
+            {
+                "project_id": f"hostgit_{50:032x}",
+                "name": "project-50",
+                "branch": "main",
+                "head": "a" * 40,
+                "state": "available",
+                "reason": "",
+                "path": "C:\\projects\\project-50",
+                "root_identity": "1-3c",
+                "git_identity": "2-3c",
+            }
+        )
+
+    assert rejected.value.code == "project_limit_exceeded"
+    assert len(registry.projects()) == 50
+
+
+def test_legacy_registry_project_is_loaded_only_as_reselection_tombstone(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state_path = tmp_path / "state.bin"
+    protector = XorProtector()
+    seed = ProjectHostRegistry(state_path, protector)
+    project_id = "hostgit_0123456789abcdef0123456789abcdef"
+    legacy = dict(seed._state)
+    legacy["projects"] = {
+        project_id: {
+            "project_id": project_id,
+            "name": "legacy-project",
+            "branch": "main",
+            "head": "a" * 40,
+            "state": "available",
+            "reason": "",
+            "path": "C:\\legacy\\project",
+        }
+    }
+    encoded = json.dumps(
+        legacy,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    state_path.write_bytes(
+        windows_helper_module.STATE_MAGIC
+        + base64.b64encode(protector.protect(encoded))
+    )
+
+    restored = ProjectHostRegistry(state_path, protector)
+    [tombstone] = restored.projects()
+    assert tombstone["state"] == "unavailable"
+    assert tombstone["reason"] == "project_reselection_required"
+    assert "root_identity" not in tombstone
+    assert "git_identity" not in tombstone
+    with pytest.raises(ProjectHostHelperError) as rejected:
+        restored.project(project_id)
+    assert rejected.value.code == "project_reselection_required"
+
+    monkeypatch.setattr(
+        windows_helper_module,
+        "inspect_git_project",
+        lambda *_args, **_kwargs: pytest.fail("Legacy inventory must not bind a new identity"),
+    )
+    sent: list[dict[str, object]] = []
+
+    class FakeWebSocket:
+        async def send(self, message: str) -> None:
+            sent.append(json.loads(message))
+
+    transport = ProjectHostTransport(
+        restored,
+        "http://127.0.0.1:8000",
+        "12345678",
+        select_folder=lambda: None,
+    )
+    asyncio.run(transport._send_inventory(FakeWebSocket()))
+    assert sent[0]["projects"][0]["state"] == "unavailable"  # type: ignore[index]
+    assert sent[0]["projects"][0]["reason"] == "project_reselection_required"  # type: ignore[index]
 
 
 def test_registry_head_update_is_idempotent_and_rejects_wrong_branch(
@@ -109,6 +252,8 @@ def test_registry_head_update_is_idempotent_and_rejects_wrong_branch(
             "state": "available",
             "reason": "",
             "path": "C:\\random\\nebula-k8r3",
+            "root_identity": ROOT_IDENTITY,
+            "git_identity": GIT_IDENTITY,
         }
     )
     persist_calls = 0
@@ -155,17 +300,133 @@ def test_git_inspection_accepts_remote_without_reading_or_returning_it(tmp_path:
     assert "example.invalid" not in encoded
 
 
+@pytest.mark.parametrize("replacement", ["root", "git"])
+def test_bound_inspection_rejects_same_repository_content_with_new_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    replacement: str,
+) -> None:
+    project = _repository(tmp_path)
+    secret = b"k" * 32
+    baseline = inspect_git_project(project, secret, enforce_windows=False)
+    _replace_repository_identity(project, tmp_path, replacement)
+    assert _git(project, "symbolic-ref", "--short", "HEAD") == baseline["branch"]
+    assert _git(project, "rev-parse", "HEAD") == baseline["head"]
+
+    original_run_git = windows_helper_module._run_git
+    monkeypatch.setattr(
+        windows_helper_module,
+        "_run_git",
+        lambda *_args, **_kwargs: pytest.fail(
+            "Identity mismatch must be rejected before any repository Git command"
+        ),
+    )
+    with pytest.raises(ProjectHostHelperError) as rejected:
+        inspect_git_project(
+            project,
+            secret,
+            enforce_windows=False,
+            expected_root_identity=baseline["root_identity"],
+            expected_git_identity=baseline["git_identity"],
+        )
+    assert rejected.value.code == "project_identity_changed"
+
+    monkeypatch.setattr(windows_helper_module, "_run_git", original_run_git)
+    reselected = inspect_git_project(project, secret, enforce_windows=False)
+    assert reselected["project_id"] != baseline["project_id"]
+    assert reselected["branch"] == baseline["branch"]
+    assert reselected["head"] == baseline["head"]
+
+
+@pytest.mark.asyncio
+async def test_reselection_publishes_old_identity_tombstone_before_new_result(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = _repository(tmp_path)
+    registry = ProjectHostRegistry(tmp_path / "state.bin", XorProtector())
+    original = inspect_git_project(project, registry.device_secret, enforce_windows=False)
+    registry.remember_project(original)
+    _replace_repository_identity(project, tmp_path, "root")
+    replacement = inspect_git_project(project, registry.device_secret, enforce_windows=False)
+    assert replacement["project_id"] != original["project_id"]
+    assert replacement["branch"] == original["branch"]
+    assert replacement["head"] == original["head"]
+
+    def selected_or_bound(*_args, **kwargs):
+        if kwargs:
+            assert kwargs["expected_root_identity"] == replacement["root_identity"]
+            assert kwargs["expected_git_identity"] == replacement["git_identity"]
+        return dict(replacement)
+
+    monkeypatch.setattr(
+        windows_helper_module,
+        "inspect_git_project",
+        selected_or_bound,
+    )
+    sent: list[dict[str, object]] = []
+
+    class FakeWebSocket:
+        async def send(self, message: str) -> None:
+            sent.append(json.loads(message))
+
+    transport = ProjectHostTransport(
+        registry,
+        "http://127.0.0.1:8000",
+        "12345678",
+        select_folder=lambda: str(project),
+    )
+    await transport._handle_message(
+        FakeWebSocket(),
+        json.dumps(
+            {
+                "type": "select_project",
+                "request_id": "phreq_0123456789abcdef0123456789abcdef",
+            }
+        ),
+    )
+
+    assert [message["type"] for message in sent] == ["inventory", "selection_result"]
+    inventory = {
+        item["project_id"]: item
+        for item in sent[0]["projects"]  # type: ignore[index]
+    }
+    assert inventory[original["project_id"]]["state"] == "unavailable"
+    assert (
+        inventory[original["project_id"]]["reason"]
+        == "project_reselection_required"
+    )
+    assert inventory[replacement["project_id"]]["state"] == "available"
+    with pytest.raises(ProjectHostHelperError) as stale:
+        registry.project(original["project_id"])
+    assert stale.value.code == "project_reselection_required"
+    assert registry.project(replacement["project_id"])["root_identity"] == replacement[
+        "root_identity"
+    ]
+
+
 @pytest.mark.parametrize("inspection", ["initial", "recovery"])
 @pytest.mark.parametrize(
     ("config_name", "config_value"),
     [
+        ("include.path", "../outside-config"),
+        ("includeIf.onbranch:main.path", "../outside-config"),
+        ("filter.nebula.clean", "outside-filter"),
+        ("credential.helper", "outside-credential-helper"),
+        ("diff.nebula.textconv", "outside-textconv"),
+        ("diff.nebula.external", "outside-diff-driver"),
+        ("url.https://example.invalid/.insteadOf", "private:"),
+        ("core.worktree", "../outside-worktree"),
+        ("core.excludesFile", "../outside-excludes"),
+        ("extensions.worktreeConfig", "true"),
+        ("extensions.refStorage", "reftable"),
         ("extensions.partialClone", "origin"),
         ("remote.origin.promisor", "true"),
         ("remote..promisor", "true"),
         ("remote.origin.partialCloneFilter", "blob:none"),
     ],
 )
-def test_git_inspection_rejects_lazy_fetch_config_before_object_resolution(
+def test_git_inspection_rejects_unsafe_config_before_object_resolution(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     inspection: str,
@@ -195,6 +456,8 @@ def test_git_inspection_rejects_lazy_fetch_config_before_object_resolution(
                 expected_project_id=baseline["project_id"],
                 expected_branch=baseline["branch"],
                 expected_head=baseline["head"],
+                expected_root_identity=baseline["root_identity"],
+                expected_git_identity=baseline["git_identity"],
                 enforce_windows=False,
             )
 
@@ -204,7 +467,11 @@ def test_git_inspection_rejects_lazy_fetch_config_before_object_resolution(
     object_commands = {"rev-parse", "ls-tree", "cat-file", "diff", "status"}
     assert all(object_commands.isdisjoint(command) for command in commands)
     assert all(env["GIT_NO_LAZY_FETCH"] == "1" for env in environments)
-    assert build_safe_git_environment()["GIT_NO_LAZY_FETCH"] == "1"
+    safe_environment = build_safe_git_environment()
+    assert safe_environment["GIT_NO_LAZY_FETCH"] == "1"
+    assert safe_environment["GIT_NO_REPLACE_OBJECTS"] == "1"
+    safe_command = build_safe_git_command(project, ("status", "--porcelain=v2"))
+    assert f"core.excludesFile={os.devnull}" in safe_command
     assert (project / "README.md").read_bytes() == b"marker: q7m4\n"
 
 
@@ -234,11 +501,214 @@ def test_git_inspection_rejects_http_alternates_without_running_git(
                 expected_project_id=baseline["project_id"],
                 expected_branch=baseline["branch"],
                 expected_head=baseline["head"],
+                expected_root_identity=baseline["root_identity"],
+                expected_git_identity=baseline["git_identity"],
                 enforce_windows=False,
             )
 
     assert rejected.value.code == "git_alternates_not_allowed"
     assert (project / "README.md").read_bytes() == b"marker: q7m4\n"
+
+
+@pytest.mark.parametrize("inspection", ["initial", "recovery"])
+@pytest.mark.parametrize(
+    "unsafe_metadata",
+    [
+        "config_hardlink",
+        "head_hardlink",
+        "index_hardlink",
+        "objects_reparse",
+        "refs_reparse",
+        "info_reparse",
+        "replace_refs",
+        "grafts",
+    ],
+)
+def test_git_inspection_rejects_unsafe_metadata_before_running_git(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    inspection: str,
+    unsafe_metadata: str,
+) -> None:
+    project = _repository(tmp_path)
+    baseline = inspect_git_project(project, b"k" * 32, enforce_windows=False)
+    git_path = project / ".git"
+    if unsafe_metadata.endswith("_hardlink"):
+        name = unsafe_metadata.removesuffix("_hardlink")
+        source = git_path / {"config": "config", "head": "HEAD", "index": "index"}[name]
+        try:
+            os.link(source, tmp_path / f"{name}.outside-link")
+        except OSError:
+            pytest.skip("Hard links are unavailable on this test host")
+    elif unsafe_metadata.endswith("_reparse"):
+        name = unsafe_metadata.removesuffix("_reparse")
+        source = git_path / name
+        target = git_path / f"{name}-real"
+        source.rename(target)
+        _directory_link(source, target)
+    elif unsafe_metadata == "replace_refs":
+        (git_path / "refs" / "replace").mkdir()
+    else:
+        (git_path / "info" / "grafts").write_text(
+            baseline["head"] + "\n",
+            encoding="ascii",
+        )
+
+    monkeypatch.setattr(
+        windows_helper_module,
+        "_run_git",
+        lambda *_args, **_kwargs: pytest.fail(
+            "Git must not run before rejecting unsafe metadata"
+        ),
+    )
+    with pytest.raises(ProjectHostHelperError) as rejected:
+        if inspection == "initial":
+            inspect_git_project(project, b"k" * 32, enforce_windows=False)
+        else:
+            inspect_git_project_for_recovery(
+                project,
+                b"k" * 32,
+                expected_project_id=baseline["project_id"],
+                expected_branch=baseline["branch"],
+                expected_head=baseline["head"],
+                expected_root_identity=baseline["root_identity"],
+                expected_git_identity=baseline["git_identity"],
+                enforce_windows=False,
+            )
+
+    assert rejected.value.code == "git_metadata_unsafe"
+    assert (project / "README.md").read_bytes() == b"marker: q7m4\n"
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows handle sharing gate")
+def test_registry_snapshot_holds_config_guard_across_archive(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = _repository(tmp_path)
+    registry = ProjectHostRegistry(tmp_path / "state.bin", XorProtector())
+    inspected = inspect_git_project(project, registry.device_secret)
+    registry.remember_project(inspected)
+    blocked_writes: list[bool] = []
+
+    def guarded_archive(*_args, **_kwargs):
+        config = project / ".git" / "config"
+        try:
+            config.write_bytes(config.read_bytes() + b"\n[unsafe]\n")
+        except PermissionError:
+            blocked_writes.append(True)
+        else:
+            pytest.fail("Config write must be blocked while snapshot cat-file is running")
+        Path(_args[1]).write_bytes(b"guarded-archive")
+        return SimpleNamespace(project_id=inspected["project_id"])
+
+    monkeypatch.setattr(
+        windows_helper_module,
+        "create_host_snapshot_archive",
+        guarded_archive,
+    )
+    result, archive_identity = registry.create_snapshot(
+        inspected["project_id"],
+        tmp_path / "snapshot.tar.gz",
+    )
+
+    assert result.project_id == inspected["project_id"]
+    assert archive_identity
+    assert blocked_writes == [True]
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows helper safety gate")
+def test_registry_snapshot_rejects_unsafe_config_before_archive(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = _repository(tmp_path)
+    registry = ProjectHostRegistry(tmp_path / "state.bin", XorProtector())
+    inspected = inspect_git_project(project, registry.device_secret)
+    registry.remember_project(inspected)
+    _git(project, "config", "filter.nebula.clean", "outside-filter")
+    monkeypatch.setattr(
+        windows_helper_module,
+        "create_host_snapshot_archive",
+        lambda *_args, **_kwargs: pytest.fail("Unsafe project must not be archived"),
+    )
+
+    with pytest.raises(ProjectHostHelperError) as rejected:
+        registry.create_snapshot(inspected["project_id"], tmp_path / "snapshot.tar.gz")
+
+    assert rejected.value.code == "git_config_unsafe"
+    assert not (tmp_path / "snapshot.tar.gz").exists()
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows selected-project identity gate")
+@pytest.mark.parametrize("replacement", ["root", "git"])
+def test_snapshot_and_operation_reject_replaced_selected_identity_before_side_effects(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    replacement: str,
+) -> None:
+    project = _repository(tmp_path)
+    registry = ProjectHostRegistry(tmp_path / "state.bin", XorProtector())
+    inspected = inspect_git_project(project, registry.device_secret)
+    registry.remember_project(inspected)
+    registered = registry.project(inspected["project_id"])
+    readme = (project / "README.md").read_bytes()
+    _replace_repository_identity(project, tmp_path, replacement)
+    assert _git(project, "symbolic-ref", "--short", "HEAD") == inspected["branch"]
+    assert _git(project, "rev-parse", "HEAD") == inspected["head"]
+
+    monkeypatch.setattr(
+        windows_helper_module,
+        "_run_git",
+        lambda *_args, **_kwargs: pytest.fail(
+            "Identity mismatch must be rejected before Git"
+        ),
+    )
+    monkeypatch.setattr(
+        windows_helper_module,
+        "create_host_snapshot_archive",
+        lambda *_args, **_kwargs: pytest.fail(
+            "Identity mismatch must be rejected before snapshot creation"
+        ),
+    )
+    monkeypatch.setattr(
+        windows_helper_module,
+        "HostGitApplyEngine",
+        lambda *_args, **_kwargs: pytest.fail(
+            "Identity mismatch must be rejected before engine construction"
+        ),
+    )
+    monkeypatch.setattr(
+        windows_helper_module,
+        "HostGitCommitEngine",
+        lambda *_args, **_kwargs: pytest.fail(
+            "Identity mismatch must be rejected before engine construction"
+        ),
+    )
+    archive = tmp_path / "snapshot.tar.gz"
+    with pytest.raises(ProjectHostHelperError) as snapshot_rejected:
+        registry.create_snapshot(inspected["project_id"], archive)
+    assert snapshot_rejected.value.code == "project_identity_changed"
+
+    transport = ProjectHostTransport(
+        registry,
+        "http://127.0.0.1:8000",
+        "12345678",
+        select_folder=lambda: None,
+    )
+    with pytest.raises(ProjectHostHelperError) as operation_rejected:
+        transport._execute_project_operation(
+            registered,
+            operation_id="apply_0123456789abcdef012345",
+            action="apply",
+            payload={},
+            branch=inspected["branch"],
+            baseline_head=inspected["head"],
+        )
+    assert operation_rejected.value.code == "project_identity_changed"
+    assert not archive.exists()
+    assert not (project / ".git" / "modelmirror-transactions").exists()
+    assert (project / "README.md").read_bytes() == readme
 
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows helper safety gate")
@@ -441,7 +911,7 @@ async def test_helper_handles_snapshot_request_without_closing_connection(
     monkeypatch.setattr(
         registry,
         "create_snapshot",
-        lambda *_args, **_kwargs: result,
+        lambda *_args, **_kwargs: (result, "1-2"),
     )
     transport = ProjectHostTransport(
         registry,
@@ -449,7 +919,7 @@ async def test_helper_handles_snapshot_request_without_closing_connection(
         "12345678",
         select_folder=lambda: None,
     )
-    monkeypatch.setattr(transport, "_upload_snapshot", lambda *_args: None)
+    monkeypatch.setattr(transport, "_upload_snapshot_exact", lambda *_args: None)
     sent: list[dict[str, object]] = []
 
     class FakeWebSocket:
@@ -700,6 +1170,8 @@ def test_helper_registry_tracks_commit_undo_and_revert_heads(tmp_path: Path) -> 
             "state": "available",
             "reason": "",
             "path": "C:\\random\\nebula-k8r3",
+            "root_identity": ROOT_IDENTITY,
+            "git_identity": GIT_IDENTITY,
         }
     )
     transport = ProjectHostTransport(
@@ -772,6 +1244,8 @@ async def test_second_cycle_dirty_inventory_uses_committed_head(
             "state": "available",
             "reason": "",
             "path": "C:\\random\\nebula-k8r3",
+            "root_identity": ROOT_IDENTITY,
+            "git_identity": GIT_IDENTITY,
         }
     )
     transport = ProjectHostTransport(
@@ -852,6 +1326,8 @@ def test_registry_persist_failure_turns_operation_result_unknown(
             "state": "available",
             "reason": "",
             "path": "C:\\random\\nebula-k8r3",
+            "root_identity": ROOT_IDENTITY,
+            "git_identity": GIT_IDENTITY,
         }
     )
     transport = ProjectHostTransport(


### PR DESCRIPTION
## 概要

为 Windows 本地 Git 项目新增 Project Host v2 直接写回闭环，并保持 builtin、manifest local_clone 与 host_git 三条执行面隔离。

## 主要变更

- Windows Helper v2 支持选定仓库的 apply、revert、commit、undo 与原 operation ID reconcile
- Server 通过一次性、绑定 host/project/action/operation 的负载下发操作，不获取宿主物理路径
- DPAPI 操作日志、严格 receipt、文件与 Git 元数据身份校验覆盖崩溃恢复和并发冲突
- H0/Hk 线性谱系支持多轮本地提交与历史恢复
- v1 Helper、离线 Helper或关闭写回开关时严格只读
- 加固 remote/lazy fetch、危险 Git 配置、reparse、replace refs、CRLF、同内容替换等边界
- 前端补充项目与分支确认、活动态轮询、未知结果核对、离线状态保留和 host_git 多轮体验
- 更新架构、部署、集成和 Harness 文档

## 背景与影响

此前自定义项目写回主要依赖 manifest ProjectWriter，Windows 用户选择的现有 Git 仓库只能用于只读会话。该变更将真实宿主写入限制在本机 Helper 内，Server 与容器继续不接触物理路径或 remote 凭据。

## 验证

- 最新 origin/main（PR #116、#117）上 rebase，无文件交叉或冲突
- range-diff：11 个提交补丁逐项一致
- Project Host 专项：239 passed，9 skipped（Windows-only）
- 全部 Coding 后端回归：617 passed，9 skipped（Windows-only）
- 前端：128 passed
- 前端生产构建：通过
- CodingPage gzip：37,221 bytes，低于 +8 KiB 门禁
- Python py_compile：16 个变更文件通过
- git diff --check：通过
- 共享最大 Compose 拓扑、API/UI、Skill Creator、Omniroute、Office：健康
- 用户完成 ASCII 非默认分支测试项目的实际 Helper 流程验收

## 前置收口

- Windows Helper 现以严格 UTF-8 解析 symbolic HEAD，并用统一安全分支校验器接受中文分支、拒绝非法或损坏编码
- Windows 原生 Helper 全文件：83 passed，1 skipped（宿主无目录符号链接权限）
- Windows 原生 Commit/Undo 定向：3 passed
- 无网络 Docker Project Host 两文件：171 passed，9 skipped（Windows-only）
- GitHub Actions：Backend quality、Frontend quality、Windows Project Host 全部通过

PR 暂保持 Draft；共享栈与仍在运行的独立预览器未因本次收口发生变更。