### PR TITLE
feature: 增加 Skill Creator 交互式资源规划

### DIFF
--- a/client/src/components/skill-creator/SkillResourcePlanPanel.test.tsx
+++ b/client/src/components/skill-creator/SkillResourcePlanPanel.test.tsx
@@ -1,0 +1,161 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  SkillCreatorSession,
+  SkillCreatorStatus,
+  SkillResourcePlan,
+} from "../../utils/skillCreatorApi";
+import SkillResourcePlanPanel from "./SkillResourcePlanPanel";
+
+function jsonResponse(payload: unknown) {
+  return Promise.resolve(new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  }));
+}
+
+const status: SkillCreatorStatus = {
+  enabled: true,
+  version: "skill-creator-v2",
+  model_available: true,
+  assistant_agent_id: "skill-creator-assistant-v1",
+  supported_sources: ["blank"],
+  resource_authoring_enabled: true,
+  resource_authoring_version: "resource-authoring-v2",
+  resource_planner_available: true,
+};
+
+const plan: SkillResourcePlan = {
+  plan_id: "resourceplan_1",
+  session_id: "creator_1",
+  revision: 2,
+  digest: "b".repeat(64),
+  state: "ready",
+  session_revision: 3,
+  draft_id: "draft_1",
+  draft_revision: 1,
+  draft_digest: "a".repeat(64),
+  skill_name: "review-incidents",
+  skill_description: "Review incidents when users need a factual timeline; do not invent root causes.",
+  workflow_steps: [
+    { step_id: "collect", instruction: "Collect the incident facts." },
+    { step_id: "normalize", instruction: "Normalize the timeline." },
+    { step_id: "review", instruction: "Review unsupported claims." },
+    { step_id: "render", instruction: "Render the final report." },
+  ],
+  output_contract: ["Return a factual incident report."],
+  failure_modes: ["Mark missing facts as unconfirmed."],
+  resources: [{
+    resource_id: "resource_existing",
+    spec_digest: "c".repeat(64),
+    kind: "reference",
+    action: "update",
+    generation_cost: "medium",
+    path: "references/policy.md",
+    purpose: "Keep the evidence policy separate from the main workflow.",
+    source_ids: ["intent"],
+    used_by_steps: ["review"],
+    depends_on: [],
+    acceptance_checks: ["Every claim is traceable."],
+  }],
+  clarifications: [],
+  clarification_answers: {},
+  created_at: 1,
+  updated_at: 2,
+};
+
+const session: SkillCreatorSession = {
+  session_id: "creator_1",
+  session_revision: 3,
+  draft_state_revision: 1,
+  mode: "blank",
+  assistant_agent_id: "skill-creator-assistant-v1",
+  intent: "Create factual incident reviews.",
+  positive_examples: ["Turn this incident log into a review."],
+  near_miss_examples: ["Rewrite this sentence."],
+  expected_output: "A factual report.",
+  success_criteria: ["Do not invent facts."],
+  selected_evidence: [],
+  evidence_confirmed: true,
+  state: "editing_draft",
+  resource_plan: plan,
+  created_at: 1,
+  updated_at: 2,
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("SkillResourcePlanPanel", () => {
+  it("generates a plan without writing resource files", async () => {
+    const emptySession = { ...session, resource_plan: null };
+    const plannedSession = { ...session, resource_plan: { ...plan, resources: [] } };
+    const fetchMock = vi.fn((_input: RequestInfo | URL, _init?: RequestInit) =>
+      jsonResponse({ session: plannedSession, resource_plan: plannedSession.resource_plan }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const onSession = vi.fn();
+
+    render(<SkillResourcePlanPanel onSession={onSession} session={emptySession} status={status} />);
+    await userEvent.click(screen.getByRole("button", { name: "生成资源计划" }));
+
+    await waitFor(() => expect(onSession).toHaveBeenCalledWith(plannedSession));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url).endsWith("/resource-plan/generate")).toBe(true);
+    expect(JSON.parse(String(init?.body))).toEqual({
+      expected_session_revision: 3,
+      expected_plan_revision: null,
+      expected_plan_digest: null,
+    });
+  });
+
+  it("turns removal of an existing resource into an explicit delete action", async () => {
+    const fetchMock = vi.fn((_input: RequestInfo | URL, _init?: RequestInit) =>
+      jsonResponse({ session: { ...session, resource_plan: { ...plan, revision: 3 } } }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<SkillResourcePlanPanel onSession={vi.fn()} session={session} status={status} />);
+    await userEvent.click(screen.getByRole("button", { name: "移除资源" }));
+    await userEvent.click(screen.getByRole("button", { name: "保存计划修改" }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));
+    expect(body.resources).toHaveLength(1);
+    expect(body.resources[0]).toMatchObject({
+      action: "delete",
+      path: "references/policy.md",
+    });
+  });
+
+  it("lets the user add a missing resource and keeps its kind and path aligned", async () => {
+    const zeroResourceSession = {
+      ...session,
+      resource_plan: { ...plan, resources: [] },
+    };
+    const fetchMock = vi.fn((_input: RequestInfo | URL, _init?: RequestInit) =>
+      jsonResponse({ session: { ...zeroResourceSession, resource_plan: { ...plan, revision: 3 } } }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<SkillResourcePlanPanel onSession={vi.fn()} session={zeroResourceSession} status={status} />);
+    await userEvent.click(screen.getByRole("button", { name: "添加必要资源" }));
+    await userEvent.selectOptions(screen.getByRole("combobox", { name: "资源 1 类型" }), "asset");
+    await userEvent.click(screen.getByRole("button", { name: "保存计划修改" }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));
+    expect(body.resources).toHaveLength(1);
+    expect(body.resources[0]).toMatchObject({
+      action: "create",
+      kind: "asset",
+      path: "assets/resource-1.md",
+      source_ids: ["intent"],
+      used_by_steps: ["collect"],
+    });
+  });
+});

--- a/client/src/components/skill-creator/SkillResourcePlanPanel.tsx
+++ b/client/src/components/skill-creator/SkillResourcePlanPanel.tsx
@@ -1,0 +1,380 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  ArrowDown,
+  ArrowUp,
+  CheckCircle2,
+  CircleAlert,
+  FileCode2,
+  FileText,
+  LayoutTemplate,
+  LoaderCircle,
+  Plus,
+  RefreshCw,
+  Sparkles,
+  Trash2,
+} from "lucide-react";
+
+import {
+  answerSkillCreatorResourcePlan,
+  confirmSkillCreatorResourcePlan,
+  generateSkillCreatorResourcePlan,
+  patchSkillCreatorResourcePlan,
+  type SkillCreatorSession,
+  type SkillCreatorStatus,
+  type SkillResourcePlanItem,
+} from "../../utils/skillCreatorApi";
+
+
+const KIND_LABELS = {
+  script: "脚本",
+  reference: "参考资料",
+  asset: "输出模板",
+} as const;
+
+const ACTION_LABELS = {
+  keep: "保留",
+  create: "新增",
+  update: "更新",
+  delete: "删除",
+} as const;
+
+const COST_LABELS = {
+  low: "低",
+  medium: "中",
+  high: "高",
+} as const;
+
+const KIND_ICONS = {
+  script: FileCode2,
+  reference: FileText,
+  asset: LayoutTemplate,
+} as const;
+
+interface Props {
+  session: SkillCreatorSession;
+  status: SkillCreatorStatus;
+  onSession: (session: SkillCreatorSession) => void | Promise<void>;
+}
+
+function errorMessage(value: unknown, fallback: string) {
+  return value instanceof Error && value.message ? value.message : fallback;
+}
+
+export default function SkillResourcePlanPanel({ session, status, onSession }: Props) {
+  const plan = session.resource_plan ?? null;
+  const [busy, setBusy] = useState("");
+  const [error, setError] = useState("");
+  const [notice, setNotice] = useState("");
+  const [answers, setAnswers] = useState<Record<string, string>>({});
+  const [skillName, setSkillName] = useState("");
+  const [skillDescription, setSkillDescription] = useState("");
+  const [resources, setResources] = useState<SkillResourcePlanItem[]>([]);
+
+  useEffect(() => {
+    setSkillName(plan?.skill_name ?? "");
+    setSkillDescription(plan?.skill_description ?? "");
+    setResources(plan?.resources ?? []);
+    setAnswers(plan?.clarification_answers ?? {});
+  }, [plan?.digest]);
+
+  const planDirty = useMemo(() => {
+    if (!plan) return false;
+    return skillName !== plan.skill_name
+      || skillDescription !== plan.skill_description
+      || JSON.stringify(resources) !== JSON.stringify(plan.resources);
+  }, [plan, resources, skillDescription, skillName]);
+  const resourcePathById = useMemo(
+    () => new Map(resources.map((item) => [item.resource_id, item.path])),
+    [resources],
+  );
+
+  async function run(label: string, operation: () => Promise<SkillCreatorSession>, success: string) {
+    setBusy(label);
+    setError("");
+    setNotice("");
+    try {
+      const updated = await operation();
+      await onSession(updated);
+      setNotice(success);
+      return updated;
+    } catch (caught) {
+      setError(errorMessage(caught, "资源计划操作失败。"));
+      return null;
+    } finally {
+      setBusy("");
+    }
+  }
+
+  async function generate() {
+    await run(
+      "generate",
+      () => generateSkillCreatorResourcePlan(session),
+      plan ? "资源计划已按最新定义重新生成。" : "资源计划已生成，请先检查再确认。",
+    );
+  }
+
+  async function saveAnswersAndRegenerate() {
+    if (!plan) return;
+    const missing = plan.clarifications.find((item) => !answers[item.question_id]?.trim());
+    if (missing) {
+      setError(`请先回答：${missing.question}`);
+      return;
+    }
+    setBusy("answers");
+    setError("");
+    setNotice("");
+    try {
+      const answered = await answerSkillCreatorResourcePlan(session, answers);
+      const updated = await generateSkillCreatorResourcePlan(answered);
+      await onSession(updated);
+      setNotice("回答已保存，资源计划已重新生成。请检查新的范围与资源。 ");
+    } catch (caught) {
+      setError(errorMessage(caught, "澄清回答保存失败。"));
+    } finally {
+      setBusy("");
+    }
+  }
+
+  async function savePlan() {
+    if (!plan) return;
+    await run(
+      "save",
+      () => patchSkillCreatorResourcePlan(session, {
+        skill_name: skillName.trim(),
+        skill_description: skillDescription.trim(),
+        resources,
+      }),
+      "资源计划修改已保存为新的不可变版本。",
+    );
+  }
+
+  async function confirmPlan() {
+    if (planDirty) {
+      setError("请先保存当前修改，再确认资源计划。");
+      return;
+    }
+    await run(
+      "confirm",
+      () => confirmSkillCreatorResourcePlan(session),
+      "资源计划已冻结。后续生成只能使用这些已确认路径和来源。",
+    );
+  }
+
+  function updateResource(index: number, changes: Partial<SkillResourcePlanItem>) {
+    setResources((current) => current.map((item, itemIndex) => (
+      itemIndex === index ? { ...item, ...changes } : item
+    )));
+  }
+
+  function changeResourceKind(index: number, kind: SkillResourcePlanItem["kind"]) {
+    const roots = { script: "scripts", reference: "references", asset: "assets" } as const;
+    const current = resources[index];
+    if (!current) return;
+    const basename = current.path.split("/").at(-1)?.replace(/\.(?:py|js|md|txt)$/i, "") || `resource-${index + 1}`;
+    const extension = kind === "script" ? ".py" : ".md";
+    updateResource(index, { kind, path: `${roots[kind]}/${basename}${extension}` });
+  }
+
+  function addResource() {
+    if (!plan || resources.length >= 20) return;
+    const ordinal = resources.length + 1;
+    const firstStep = plan.workflow_steps[0]?.step_id;
+    setResources((current) => [
+      ...current,
+      {
+        resource_id: `draft-resource-${ordinal}`,
+        spec_digest: "",
+        kind: "reference",
+        action: "create",
+        generation_cost: "medium",
+        path: `references/resource-${ordinal}.md`,
+        purpose: "保存主流程不应重复展开、但执行时需要按需读取的规则。",
+        source_ids: ["intent"],
+        used_by_steps: firstStep ? [firstStep] : [],
+        depends_on: [],
+        acceptance_checks: ["资源为 UTF-8 文本，并完整支持计划中绑定的执行步骤。"],
+      },
+    ]);
+  }
+
+  function moveResource(index: number, offset: number) {
+    setResources((current) => {
+      const nextIndex = index + offset;
+      if (nextIndex < 0 || nextIndex >= current.length) return current;
+      const next = [...current];
+      [next[index], next[nextIndex]] = [next[nextIndex], next[index]];
+      return next;
+    });
+  }
+
+  function removeResource(index: number) {
+    setResources((current) => {
+      const target = current[index];
+      if (!target) return current;
+      if (target.action === "create") {
+        return current.filter((_, itemIndex) => itemIndex !== index);
+      }
+      return current.map((item, itemIndex) => (
+        itemIndex === index ? { ...item, action: "delete" } : item
+      ));
+    });
+  }
+
+  const plannerUnavailable = !status.resource_planner_available;
+
+  return (
+    <section className="mt-5 rounded-lg border border-brand-300/20 bg-brand-300/[0.05] p-4 sm:p-5" aria-labelledby="creator-resource-plan-heading">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="flex items-center gap-2 text-brand-100">
+            <Sparkles aria-hidden="true" size={17} />
+            <h3 className="text-base font-semibold" id="creator-resource-plan-heading">资源规划</h3>
+          </div>
+          <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-300">
+            先决定哪些步骤需要脚本、参考资料或输出模板。规划阶段不会写草稿，也不会为了显得完整而强行增加文件。
+          </p>
+        </div>
+        {plan ? (
+          <span className="rounded-full border border-white/10 bg-ink-950/55 px-3 py-1 text-xs text-slate-300">
+            plan r{plan.revision} · {plan.digest.slice(0, 10)}
+          </span>
+        ) : null}
+      </div>
+
+      {error ? <p className="mt-4 rounded-md border border-red-400/25 bg-red-400/10 px-3 py-2 text-sm text-red-100" role="alert">{error}</p> : null}
+      {notice ? <p className="mt-4 rounded-md border border-emerald-400/20 bg-emerald-400/10 px-3 py-2 text-sm text-emerald-100" role="status">{notice}</p> : null}
+
+      {!plan ? (
+        <div className="mt-5 rounded-md border border-white/10 bg-ink-950/45 p-4">
+          <p className="text-sm text-slate-300">素材确认后，让固定 Creator 助手只生成一份可编辑计划，不生成任何文件。</p>
+          <button
+            className="mt-4 inline-flex min-h-11 items-center gap-2 rounded-full bg-hire-300 px-5 py-2.5 text-sm font-semibold text-ink-950 transition hover:bg-hire-200 disabled:cursor-not-allowed disabled:opacity-40"
+            disabled={!session.evidence_confirmed || plannerUnavailable || Boolean(busy)}
+            onClick={() => void generate()}
+            type="button"
+          >
+            {busy === "generate" ? <LoaderCircle className="animate-spin" aria-hidden="true" size={16} /> : <Sparkles aria-hidden="true" size={16} />}
+            {busy === "generate" ? "正在分析需求…" : "生成资源计划"}
+          </button>
+          {plannerUnavailable ? <p className="mt-3 text-xs text-amber-200">模型网关未配置，暂时不能生成资源计划。</p> : null}
+        </div>
+      ) : null}
+
+      {plan?.stale ? (
+        <div className="mt-5 rounded-md border border-amber-300/25 bg-amber-300/10 p-4">
+          <p className="flex items-center gap-2 text-sm font-semibold text-amber-100"><CircleAlert aria-hidden="true" size={16} />用途或草稿已变化，当前计划已过期。</p>
+          <button className="mt-3 inline-flex min-h-11 items-center gap-2 rounded-full border border-amber-200/30 px-4 py-2 text-sm font-semibold text-amber-100 disabled:opacity-40" disabled={plannerUnavailable || Boolean(busy)} onClick={() => void generate()} type="button"><RefreshCw aria-hidden="true" size={15} />按最新内容重新规划</button>
+        </div>
+      ) : null}
+
+      {plan && !plan.stale && plan.state === "needs_input" ? (
+        <div className="mt-5 space-y-4">
+          <div className="rounded-md border border-amber-300/20 bg-amber-300/[0.08] p-4">
+            <p className="font-semibold text-amber-100">需要先补充 {plan.clarifications.length} 项关键信息</p>
+            <p className="mt-1 text-xs leading-5 text-amber-100/75">缺少依据时不会生成虚构的规则文件。回答只作为本次 Creator 会话的可信素材。</p>
+          </div>
+          {plan.clarifications.map((item) => (
+            <label className="block rounded-md border border-white/10 bg-ink-950/45 p-4" key={item.question_id}>
+              <span className="text-sm font-semibold text-white">{item.question}</span>
+              <span className="mt-1 block text-xs leading-5 text-slate-400">原因：{item.reason}</span>
+              <textarea
+                className="mt-3 min-h-28 w-full resize-y rounded-md border border-white/10 bg-ink-950/80 px-3 py-2 text-sm leading-6 text-white focus:border-brand-300/50 focus:outline-none"
+                maxLength={32_000}
+                onChange={(event) => setAnswers((current) => ({ ...current, [item.question_id]: event.target.value }))}
+                value={answers[item.question_id] ?? ""}
+              />
+            </label>
+          ))}
+          <div className="flex justify-end">
+            <button className="inline-flex min-h-11 items-center gap-2 rounded-full bg-hire-300 px-5 py-2.5 text-sm font-semibold text-ink-950 disabled:opacity-40" disabled={Boolean(busy)} onClick={() => void saveAnswersAndRegenerate()} type="button">{busy === "answers" ? <LoaderCircle className="animate-spin" aria-hidden="true" size={16} /> : <RefreshCw aria-hidden="true" size={16} />}{busy === "answers" ? "正在重新规划…" : "保存回答并重新规划"}</button>
+          </div>
+        </div>
+      ) : null}
+
+      {plan && !plan.stale && plan.state === "needs_regeneration" ? (
+        <div className="mt-5 rounded-md border border-white/10 bg-ink-950/45 p-4">
+          <p className="text-sm text-slate-300">澄清回答已保存，需要据此生成新的资源计划。</p>
+          <button className="mt-3 inline-flex min-h-11 items-center gap-2 rounded-full bg-hire-300 px-5 py-2.5 text-sm font-semibold text-ink-950 disabled:opacity-40" disabled={plannerUnavailable || Boolean(busy)} onClick={() => void generate()} type="button"><RefreshCw aria-hidden="true" size={15} />重新规划</button>
+        </div>
+      ) : null}
+
+      {plan && !plan.stale && (plan.state === "ready" || plan.state === "confirmed") ? (
+        <div className="mt-5 space-y-5">
+          <div className="grid gap-4 lg:grid-cols-2">
+            <label className="block">
+              <span className="text-xs font-semibold text-slate-300">Skill ID</span>
+              <input className="mt-2 min-h-11 w-full rounded-md border border-white/10 bg-ink-950/70 px-3 text-sm text-white disabled:opacity-70" disabled={plan.state === "confirmed"} onChange={(event) => setSkillName(event.target.value)} value={skillName} />
+            </label>
+            <label className="block">
+              <span className="text-xs font-semibold text-slate-300">能力、触发场景与边界</span>
+              <textarea className="mt-2 min-h-24 w-full rounded-md border border-white/10 bg-ink-950/70 px-3 py-2 text-sm leading-6 text-white disabled:opacity-70" disabled={plan.state === "confirmed"} maxLength={1024} onChange={(event) => setSkillDescription(event.target.value)} value={skillDescription} />
+            </label>
+          </div>
+
+          <div>
+            <h4 className="text-sm font-semibold text-white">工作流</h4>
+            <ol className="mt-3 space-y-2">
+              {plan.workflow_steps.map((step, index) => <li className="flex gap-3 rounded-md border border-white/8 bg-ink-950/40 px-3 py-2 text-sm text-slate-300" key={step.step_id}><span className="font-semibold text-brand-100">{index + 1}</span><span>{step.instruction}</span></li>)}
+            </ol>
+          </div>
+
+          <div>
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <h4 className="text-sm font-semibold text-white">计划资源（{resources.length}）</h4>
+              <div className="flex flex-wrap items-center gap-2">
+                {resources.length === 0 ? <span className="text-xs text-emerald-200">已判断无需附加资源</span> : null}
+                {plan.state !== "confirmed" ? <button className="inline-flex min-h-11 items-center gap-2 rounded-full border border-white/15 px-4 py-2 text-xs font-semibold text-white disabled:opacity-40" disabled={resources.length >= 20} onClick={addResource} type="button"><Plus aria-hidden="true" size={15} />添加必要资源</button> : null}
+              </div>
+            </div>
+            <div className="mt-3 space-y-3">
+              {resources.map((item, index) => {
+                const Icon = KIND_ICONS[item.kind];
+                return (
+                  <article className="rounded-md border border-white/10 bg-ink-950/45 p-4" key={item.resource_id}>
+                    <div className="flex flex-wrap items-start gap-3">
+                      <span className="rounded-md bg-white/[0.06] p-2 text-brand-100"><Icon aria-hidden="true" size={17} /></span>
+                      <div className="min-w-0 flex-1 space-y-3">
+                        <div className="grid gap-3 sm:grid-cols-[130px_120px_minmax(0,1fr)]">
+                          <select aria-label={`资源 ${index + 1} 类型`} className="min-h-11 rounded-md border border-white/10 bg-ink-950 px-3 text-sm text-white" disabled={plan.state === "confirmed"} onChange={(event) => changeResourceKind(index, event.target.value as SkillResourcePlanItem["kind"])} value={item.kind}>{Object.entries(KIND_LABELS).map(([value, label]) => <option key={value} value={value}>{label}</option>)}</select>
+                          <select aria-label={`资源 ${index + 1} 操作`} className="min-h-11 rounded-md border border-white/10 bg-ink-950 px-3 text-sm text-white" disabled={plan.state === "confirmed"} onChange={(event) => updateResource(index, { action: event.target.value as SkillResourcePlanItem["action"] })} value={item.action}>{Object.entries(ACTION_LABELS).map(([value, label]) => <option key={value} value={value}>{label}</option>)}</select>
+                          <input aria-label={`资源 ${index + 1} 路径`} className="min-h-11 min-w-0 rounded-md border border-white/10 bg-ink-950 px-3 font-mono text-xs text-white" disabled={plan.state === "confirmed"} onChange={(event) => updateResource(index, { path: event.target.value })} value={item.path} />
+                        </div>
+                        <textarea aria-label={`资源 ${index + 1} 用途`} className="min-h-20 w-full rounded-md border border-white/10 bg-ink-950 px-3 py-2 text-sm leading-6 text-white" disabled={plan.state === "confirmed"} onChange={(event) => updateResource(index, { purpose: event.target.value })} value={item.purpose} />
+                        <div className="flex flex-wrap gap-2 text-[11px] text-slate-400">
+                          <span>生成成本：{COST_LABELS[item.generation_cost]}</span>
+                          <span>步骤：{item.used_by_steps.join("、") || "未绑定"}</span>
+                          <span>来源：{item.source_ids.join("、") || "未绑定"}</span>
+                          {item.depends_on.length ? <span>依赖：{item.depends_on.map((value) => resourcePathById.get(value) ?? value).join("、")}</span> : null}
+                        </div>
+                        <p className="text-xs leading-5 text-slate-400">验收：{item.acceptance_checks.join("；")}</p>
+                      </div>
+                      {plan.state !== "confirmed" ? (
+                        <div className="flex gap-1">
+                          <button aria-label="上移资源" className="rounded-md p-2 text-slate-300 hover:bg-white/10 disabled:opacity-30" disabled={index === 0} onClick={() => moveResource(index, -1)} type="button"><ArrowUp aria-hidden="true" size={16} /></button>
+                          <button aria-label="下移资源" className="rounded-md p-2 text-slate-300 hover:bg-white/10 disabled:opacity-30" disabled={index === resources.length - 1} onClick={() => moveResource(index, 1)} type="button"><ArrowDown aria-hidden="true" size={16} /></button>
+                          <button aria-label="移除资源" className="rounded-md p-2 text-red-200 hover:bg-red-400/10" onClick={() => removeResource(index)} type="button"><Trash2 aria-hidden="true" size={16} /></button>
+                        </div>
+                      ) : null}
+                    </div>
+                  </article>
+                );
+              })}
+            </div>
+          </div>
+
+          {plan.state === "confirmed" ? (
+            <div className="rounded-md border border-emerald-300/20 bg-emerald-300/[0.08] p-4">
+              <p className="flex items-center gap-2 text-sm font-semibold text-emerald-100"><CheckCircle2 aria-hidden="true" size={17} />资源计划已确认</p>
+              <p className="mt-1 text-xs leading-5 text-emerald-100/75">路径、来源和生成顺序已经冻结。当前阶段不会提前写入草稿或安装目录。</p>
+            </div>
+          ) : (
+            <div className="flex flex-wrap justify-end gap-3 border-t border-white/10 pt-4">
+              <button className="min-h-11 rounded-full border border-white/15 px-5 py-2 text-sm font-semibold text-white disabled:opacity-40" disabled={!planDirty || Boolean(busy)} onClick={() => void savePlan()} type="button">{busy === "save" ? "正在保存…" : "保存计划修改"}</button>
+              <button className="inline-flex min-h-11 items-center gap-2 rounded-full bg-hire-300 px-5 py-2 text-sm font-semibold text-ink-950 disabled:opacity-40" disabled={planDirty || Boolean(busy)} onClick={() => void confirmPlan()} type="button"><CheckCircle2 aria-hidden="true" size={16} />{busy === "confirm" ? "正在确认…" : "确认并冻结资源计划"}</button>
+            </div>
+          )}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/client/src/pages/SkillCreatorIndexPage.tsx
+++ b/client/src/pages/SkillCreatorIndexPage.tsx
@@ -183,7 +183,9 @@ export default function SkillCreatorIndexPage() {
                   把可复用的做法写成 Skill
                 </h1>
                 <p className="mt-4 max-w-3xl text-sm leading-7 text-slate-300 sm:text-base">
-                  先明确用途和触发条件，再确认素材、审阅文件。模型只能提交类型化提案，批准后仍只是待评测草稿。
+                  {status.resource_authoring_enabled
+                    ? "先明确用途和触发条件，再确认素材、冻结资源计划。规划阶段不会生成文件或提案。"
+                    : "先明确用途和触发条件，再确认素材、审阅文件。模型只能提交类型化提案，批准后仍只是待评测草稿。"}
                 </p>
               </div>
               <div className="rounded-lg border border-white/10 bg-surface-900/80 p-4">
@@ -255,7 +257,9 @@ export default function SkillCreatorIndexPage() {
               <ol className="mt-5 space-y-4 text-sm">
                 {[
                   ["定义用途", "写清触发场景、正向示例和近似反例。"],
-                  ["确认素材", "逐项选择脱敏后的运行证据，也可从零开始。"],
+                  status.resource_authoring_enabled
+                    ? ["素材与资源计划", "确认来源，必要时回答澄清问题，再冻结脚本、参考资料和模板计划。"]
+                    : ["确认素材", "逐项选择脱敏后的运行证据，也可从零开始。"],
                   ["编辑草稿", "检查 SKILL.md 和 UTF-8 文本资源。"],
                   ["设计测试", "为当前摘要准备恰好 3 个真实用例。"],
                   ["对照评审", "隔离比较 Baseline 与使用 Skill 的结果。"],

--- a/client/src/pages/SkillCreatorStudioPage.tsx
+++ b/client/src/pages/SkillCreatorStudioPage.tsx
@@ -21,6 +21,7 @@ import SkillEvaluationDesigner from "../components/skill-creator/SkillEvaluation
 import SkillEvaluationReview from "../components/skill-creator/SkillEvaluationReview";
 import SkillPackageEditor from "../components/skill-creator/SkillPackageEditor";
 import SkillProposalReview from "../components/skill-creator/SkillProposalReview";
+import SkillResourcePlanPanel from "../components/skill-creator/SkillResourcePlanPanel";
 import { useSkillCreatorStatus } from "../hooks/useSkillCreatorStatus";
 import {
   approveSkillCreatorProposal,
@@ -47,7 +48,7 @@ import {
   type SkillPackagePayload,
 } from "../utils/skillCreatorApi";
 
-const STEPS = [
+const LEGACY_STEPS = [
   { title: "定义用途", detail: "触发条件与成功标准", icon: Lightbulb },
   { title: "确认素材", detail: "选择证据并生成草稿", icon: ClipboardCheck },
   { title: "编辑草稿", detail: "文件、规范与安全", icon: FileEdit },
@@ -55,6 +56,18 @@ const STEPS = [
   { title: "评审结果", detail: "Baseline 对照", icon: ShieldCheck },
   { title: "迭代与安装", detail: "反馈、质量门与安装", icon: Sparkles },
 ] as const;
+
+type CreatorStep = {
+  title: string;
+  detail: string;
+  icon: (typeof LEGACY_STEPS)[number]["icon"];
+};
+
+const RESOURCE_STEPS: readonly CreatorStep[] = LEGACY_STEPS.map((step, index) => (
+  index === 1
+    ? { ...step, title: "素材与资源计划", detail: "确认素材并规划可复用资源" }
+    : step
+));
 
 const EVIDENCE_LABELS: Record<SkillCreatorEvidenceCandidate["kind"], string> = {
   intent_summary: "目标摘要",
@@ -129,10 +142,12 @@ function StepRail({
   activeStep,
   availableSteps,
   onSelect,
+  steps,
 }: {
   activeStep: number;
   availableSteps: boolean[];
   onSelect: (index: number) => void;
+  steps: readonly CreatorStep[];
 }) {
   const previous = [...availableSteps.keys()].filter((index) => index < activeStep && availableSteps[index]).at(-1);
   const next = [...availableSteps.keys()].find((index) => index > activeStep && availableSteps[index]);
@@ -143,21 +158,21 @@ function StepRail({
           <button aria-label="上一步" className="rounded-md border border-white/10 p-2 text-slate-200 disabled:opacity-30" disabled={previous == null} onClick={() => previous != null && onSelect(previous)} type="button"><ArrowLeft aria-hidden="true" size={15} /></button>
           <div className="min-w-0 text-center">
             <p className="text-xs text-slate-500">当前步骤 {activeStep + 1}/6</p>
-            <p className="mt-1 truncate text-sm font-semibold text-white">{STEPS[activeStep].title}</p>
+            <p className="mt-1 truncate text-sm font-semibold text-white">{steps[activeStep].title}</p>
           </div>
           <button aria-label="下一步" className="rounded-md border border-white/10 p-2 text-slate-200 disabled:opacity-30" disabled={next == null} onClick={() => next != null && onSelect(next)} type="button"><ArrowRight aria-hidden="true" size={15} /></button>
         </div>
         <details className="mt-3 border-t border-white/10 pt-3">
           <summary className="cursor-pointer text-center text-xs font-semibold text-slate-300">展开全部步骤</summary>
           <ol className="mt-3 grid gap-2">
-            {STEPS.map((step, index) => (
+            {steps.map((step, index) => (
               <li key={step.title}><button aria-current={activeStep === index ? "step" : undefined} className={`flex w-full items-center justify-between rounded-md px-3 py-2 text-left text-xs ${activeStep === index ? "bg-hire-300/10 text-hire-100" : "text-slate-300"}`} disabled={!availableSteps[index]} onClick={() => onSelect(index)} type="button"><span>{index + 1}. {step.title}</span>{!availableSteps[index] ? <LockKeyhole aria-hidden="true" size={12} /> : null}</button></li>
             ))}
           </ol>
         </details>
       </div>
       <ol className="hidden grid-cols-6 gap-2 lg:grid">
-        {STEPS.map((step, index) => {
+        {steps.map((step, index) => {
           const Icon = step.icon;
           const inaccessible = !availableSteps[index];
           const current = activeStep === index;
@@ -253,6 +268,7 @@ export default function SkillCreatorStudioPage() {
     setEvaluationRun(hydratedRun);
     syncSessionForm(value);
     let restoredStep = 0;
+    if (!hydratedDraft && value.evidence_confirmed) restoredStep = 1;
     if (hydratedDraft) restoredStep = 2;
     if (value.state === "designing_tests") restoredStep = 3;
     if (hydratedRun || value.state === "reviewing_results") restoredStep = 4;
@@ -313,7 +329,9 @@ export default function SkillCreatorStudioPage() {
       });
       await hydrate(updated);
       setActiveStep(1);
-      setNotice("用途与示例已保存。下一步确认素材并生成草稿。");
+      setNotice(status?.resource_authoring_enabled
+        ? "用途与示例已保存。下一步确认素材并生成资源计划。"
+        : "用途与示例已保存。下一步确认素材并生成草稿。");
     } catch (caught) {
       handleError(caught, "用途保存失败。");
     } finally {
@@ -549,7 +567,8 @@ export default function SkillCreatorStudioPage() {
     };
   }, [draftDirty]);
 
-  const currentStep = useMemo(() => STEPS[activeStep], [activeStep]);
+  const steps = status?.resource_authoring_enabled ? RESOURCE_STEPS : LEGACY_STEPS;
+  const currentStep = steps[activeStep];
   const qualityStatus = session?.quality_status ?? draft?.quality_status ?? "not_evaluated";
   const installState = session?.install_state ?? draft?.install_state ?? "not_installed";
   const evaluationTerminal = Boolean(evaluationRun && ["completed", "failed", "cancelled", "stale"].includes(evaluationRun.status));
@@ -643,7 +662,7 @@ export default function SkillCreatorStudioPage() {
             </div>
           </header>
 
-          <StepRail activeStep={activeStep} availableSteps={availableSteps} onSelect={selectStep} />
+          <StepRail activeStep={activeStep} availableSteps={availableSteps} onSelect={selectStep} steps={steps} />
 
           {error ? (
             <div className="mt-4 rounded-lg border border-rose-300/25 bg-rose-300/10 px-4 py-3 text-sm text-rose-50" role="alert">{error}</div>
@@ -749,7 +768,11 @@ export default function SkillCreatorStudioPage() {
                 )}
               </section>
 
-              {proposal?.status !== "pending" ? (
+              {status.resource_authoring_enabled ? (
+                <SkillResourcePlanPanel onSession={acceptHydratedSession} session={session} status={status} />
+              ) : null}
+
+              {!status.resource_authoring_enabled && proposal?.status !== "pending" ? (
                 <section className={`grid gap-5 ${draft ? "lg:grid-cols-1" : "lg:grid-cols-2"}`}>
                   <div className="rounded-lg border border-brand-300/20 bg-surface-900/80 p-5">
                     <div className="flex items-center gap-3">
@@ -813,7 +836,7 @@ export default function SkillCreatorStudioPage() {
 
           {activeStep === 2 && draft ? (
             <div className="mt-5">
-              {proposal?.status !== "pending" ? (
+              {!status.resource_authoring_enabled && proposal?.status !== "pending" ? (
                 <section className="mb-4 rounded-lg border border-brand-300/20 bg-brand-300/[0.06] p-4" aria-labelledby="creator-update-proposal-heading">
                   <div className="min-w-0">
                     <h2 className="text-sm font-semibold text-white" id="creator-update-proposal-heading">AI 生成可评测更新初稿</h2>

--- a/client/src/utils/skillCreatorApi.ts
+++ b/client/src/utils/skillCreatorApi.ts
@@ -320,6 +320,60 @@ export interface SkillCreatorProposal {
   updated_at?: number;
 }
 
+export type SkillResourcePlanState =
+  | "needs_input"
+  | "needs_regeneration"
+  | "ready"
+  | "confirmed";
+
+export interface SkillResourcePlanStep {
+  step_id: string;
+  instruction: string;
+}
+
+export interface SkillResourcePlanQuestion {
+  question_id: string;
+  question: string;
+  reason: string;
+}
+
+export interface SkillResourcePlanItem {
+  resource_id: string;
+  spec_digest: string;
+  kind: "script" | "reference" | "asset";
+  action: "keep" | "create" | "update" | "delete";
+  generation_cost: "low" | "medium" | "high";
+  path: string;
+  purpose: string;
+  source_ids: string[];
+  used_by_steps: string[];
+  depends_on: string[];
+  acceptance_checks: string[];
+}
+
+export interface SkillResourcePlan {
+  plan_id: string;
+  session_id: string;
+  revision: number;
+  digest: string;
+  state: SkillResourcePlanState;
+  session_revision: number;
+  draft_id?: string | null;
+  draft_revision?: number | null;
+  draft_digest?: string | null;
+  skill_name: string;
+  skill_description: string;
+  workflow_steps: SkillResourcePlanStep[];
+  output_contract: string[];
+  failure_modes: string[];
+  resources: SkillResourcePlanItem[];
+  clarifications: SkillResourcePlanQuestion[];
+  clarification_answers: Record<string, string>;
+  stale?: boolean;
+  created_at: number;
+  updated_at: number;
+}
+
 export interface SkillCreatorSession {
   session_id: string;
   session_revision: number;
@@ -365,6 +419,7 @@ export interface SkillCreatorSession {
   source_message_id?: string | null;
   proposal?: SkillCreatorProposal | null;
   draft?: SkillCreatorDraft | null;
+  resource_plan?: SkillResourcePlan | null;
   created_at: number;
   updated_at: number;
 }
@@ -377,6 +432,9 @@ export interface SkillCreatorStatus {
   supported_sources: SkillCreatorSourceKind[];
   disabled_reason?: string | null;
   model_unavailable_reason?: string | null;
+  resource_authoring_enabled?: boolean;
+  resource_authoring_version?: string | null;
+  resource_planner_available?: boolean;
 }
 
 export interface SkillCreatorListResponse {
@@ -466,6 +524,7 @@ function unwrapSession(
         cases?: SkillEvaluationCase[];
         cases_revision?: number;
         evaluation_run?: SkillEvaluationRun | null;
+        resource_plan?: SkillResourcePlan | null;
       },
 ): SkillCreatorSession {
   if (!("session" in payload)) return payload;
@@ -476,6 +535,7 @@ function unwrapSession(
     evaluation_cases: payload.cases ?? payload.session.evaluation_cases,
     cases_revision: payload.cases_revision ?? payload.session.cases_revision,
     evaluation_run: payload.evaluation_run ?? payload.session.evaluation_run,
+    resource_plan: payload.resource_plan ?? payload.session.resource_plan,
   };
 }
 
@@ -773,6 +833,84 @@ export async function selectSkillCreatorEvidence(
       preview_fingerprint: preview.preview_fingerprint,
       candidate_ids: candidateIds,
     }),
+  ));
+}
+
+export async function generateSkillCreatorResourcePlan(session: SkillCreatorSession) {
+  const plan = session.resource_plan;
+  return unwrapSession(await request<SkillCreatorSession | {
+    session: SkillCreatorSession;
+    resource_plan?: SkillResourcePlan | null;
+  }>(
+    `/api/skills/creator/sessions/${encodeURIComponent(session.session_id)}/resource-plan/generate`,
+    jsonRequest("POST", {
+      expected_session_revision: session.session_revision,
+      expected_plan_revision: plan?.revision ?? null,
+      expected_plan_digest: plan?.digest ?? null,
+    }),
+  ));
+}
+
+function resourcePlanWritePayload(session: SkillCreatorSession, plan: SkillResourcePlan) {
+  return {
+    plan_id: plan.plan_id,
+    expected_session_revision: session.session_revision,
+    expected_plan_revision: plan.revision,
+    expected_plan_digest: plan.digest,
+  };
+}
+
+export async function answerSkillCreatorResourcePlan(
+  session: SkillCreatorSession,
+  answers: Record<string, string>,
+) {
+  const plan = session.resource_plan;
+  if (!plan) throw new Error("Resource plan is unavailable.");
+  return unwrapSession(await request<SkillCreatorSession | {
+    session: SkillCreatorSession;
+    resource_plan?: SkillResourcePlan | null;
+  }>(
+    `/api/skills/creator/sessions/${encodeURIComponent(session.session_id)}/resource-plan/answers`,
+    jsonRequest("PUT", { ...resourcePlanWritePayload(session, plan), answers }),
+  ));
+}
+
+export async function patchSkillCreatorResourcePlan(
+  session: SkillCreatorSession,
+  changes: Partial<Pick<SkillResourcePlan,
+    "skill_name" | "skill_description" | "workflow_steps" |
+    "output_contract" | "failure_modes" | "resources">>,
+) {
+  const plan = session.resource_plan;
+  if (!plan) throw new Error("Resource plan is unavailable.");
+  const pathById = new Map(plan.resources.map((item) => [item.resource_id, item.path]));
+  const normalized = changes.resources
+    ? {
+        ...changes,
+        resources: changes.resources.map((item) => ({
+          ...item,
+          depends_on: item.depends_on.map((value) => pathById.get(value) ?? value),
+        })),
+      }
+    : changes;
+  return unwrapSession(await request<SkillCreatorSession | {
+    session: SkillCreatorSession;
+    resource_plan?: SkillResourcePlan | null;
+  }>(
+    `/api/skills/creator/sessions/${encodeURIComponent(session.session_id)}/resource-plan`,
+    jsonRequest("PATCH", { ...resourcePlanWritePayload(session, plan), ...normalized }),
+  ));
+}
+
+export async function confirmSkillCreatorResourcePlan(session: SkillCreatorSession) {
+  const plan = session.resource_plan;
+  if (!plan) throw new Error("Resource plan is unavailable.");
+  return unwrapSession(await request<SkillCreatorSession | {
+    session: SkillCreatorSession;
+    resource_plan?: SkillResourcePlan | null;
+  }>(
+    `/api/skills/creator/sessions/${encodeURIComponent(session.session_id)}/resource-plan/confirm`,
+    jsonRequest("POST", resourcePlanWritePayload(session, plan)),
   ));
 }
 

--- a/docs/SKILL_EXPERIENCE_AUDIT.md
+++ b/docs/SKILL_EXPERIENCE_AUDIT.md
@@ -144,6 +144,8 @@ node scripts/audit-skill-experience.mjs
 
 阶段性结论：Creator V1 已能生成“结构完整、可评测的初稿”并建立行为质量证据；下一轮资源化增强再对齐官方 Creator 案例中按需拆分、检索和加载资源的成熟度。
 
+资源化增强 PR 1 已建立 `resource-authoring-v2` 的不可变规划合同：固定 Creator 先提出必要澄清问题，再给出可编辑、可冻结的工作流与资源计划；简单 Skill 可以明确选择零附加资源。该阶段不生成文件，不写 Authoring Proposal，也不改变既有评测和安装门。`SKILL_CREATOR_RESOURCE_AUTHORING_ENABLED` 默认关闭，独立预览验收时才显式开启；PR 2 完成资源构建与脚本实测、PR 3 完成工作台迁移后再成为新 Session 默认流程。
+
 ### 4.4 外部市场
 
 SkillHub 和其他外部市场继续延后。此次来源页读取仅为核验当前索引中的既有条目，不产生新目录、不做市场搜索、不自动同步外部条目。

--- a/server/.env.example
+++ b/server/.env.example
@@ -13,6 +13,8 @@ WORKFLOW_AGENT_STRATEGY_V2_ENABLED=true
 # 私有控制台 Skill Creator V1 默认开启；公共 Xpert App 始终禁用。
 # 设为 false 并重启 Server 可同时关闭 Creator API 与界面入口。
 SKILL_CREATOR_V2_ENABLED=true
+# 资源化 Creator 仍按串行 PR 逐步交付。PR 1 仅开放规划，默认关闭以保持旧流程。
+SKILL_CREATOR_RESOURCE_AUTHORING_ENABLED=false
 # 可选运维覆盖；实时目录和前端默认选择不依赖这两个旧回退值。
 OPENROUTER_TEXT_FALLBACK_MODEL=deepseek/deepseek-chat
 OPENROUTER_VISION_FALLBACK_MODEL=qwen/qwen2.5-vl-72b-instruct

--- a/server/main.py
+++ b/server/main.py
@@ -120,6 +120,7 @@ try:
     from server.skills.creator_api import (
         configure_skill_creator,
         configure_skill_creator_evaluation,
+        configure_skill_creator_resource_planning,
         router as skill_creator_router,
     )
     from server.skills.creator_runtime import (
@@ -127,6 +128,14 @@ try:
         CreatorWorkflowInvocation,
         TrustedCreatorSourceProvider,
         WorkflowCreatorGenerationExecutor,
+    )
+    from server.skills.creator_resource_plan import SkillResourcePlanStore
+    from server.skills.creator_resource_runtime import (
+        ResourcePlannerWorkflowInvocation,
+        WorkflowCreatorResourcePlanner,
+    )
+    from server.skills.creator_resource_service import (
+        SkillCreatorResourcePlanningService,
     )
     from server.skills.creator_evaluation import (
         SkillEvaluationError,
@@ -163,6 +172,7 @@ except ModuleNotFoundError:
     from skills.creator_api import (
         configure_skill_creator,
         configure_skill_creator_evaluation,
+        configure_skill_creator_resource_planning,
         router as skill_creator_router,
     )
     from skills.creator_runtime import (
@@ -171,6 +181,12 @@ except ModuleNotFoundError:
         TrustedCreatorSourceProvider,
         WorkflowCreatorGenerationExecutor,
     )
+    from skills.creator_resource_plan import SkillResourcePlanStore
+    from skills.creator_resource_runtime import (
+        ResourcePlannerWorkflowInvocation,
+        WorkflowCreatorResourcePlanner,
+    )
+    from skills.creator_resource_service import SkillCreatorResourcePlanningService
     from skills.creator_evaluation import (
         SkillEvaluationError,
         SkillEvaluationExecutor,
@@ -797,6 +813,8 @@ WORKFLOW_AGENT_STRATEGY_V2_ENABLED = (
 WORKFLOW_AGENT_MAX_ITERATIONS_DEFAULT = 5
 WORKFLOW_AGENT_MAX_TOKENS = 1024
 SKILL_CREATOR_AGENT_MAX_TOKENS = 12_288
+SKILL_CREATOR_RESOURCE_PLANNER_MAX_TOKENS = 8_192
+SKILL_CREATOR_RESOURCE_PLANNER_TEMPERATURE = 0.1
 SKILL_EVALUATION_AGENT_MAX_TOKENS = 4_096
 AGENT_TASK_STORAGE_DIR = os.getenv("AGENT_TASK_STORAGE_DIR", "").strip()
 
@@ -818,6 +836,9 @@ def workflow_agent_token_budget(runtime_metadata: dict[str, Any] | None) -> int:
     """Return larger budgets only for server-owned Creator workflows."""
 
     if is_trusted_skill_creator_runtime(runtime_metadata):
+        metadata = dict(runtime_metadata or {})
+        if metadata.get("creator_phase") == "resource_plan":
+            return SKILL_CREATOR_RESOURCE_PLANNER_MAX_TOKENS
         return SKILL_CREATOR_AGENT_MAX_TOKENS
     metadata = dict(runtime_metadata or {})
     if is_trusted_skill_evaluation_metadata(metadata):
@@ -1081,6 +1102,13 @@ skill_creator_service = SkillCreatorService(
     authoring_service,
     source_provider=skill_creator_source_provider,
 )
+skill_creator_resource_plan_store = SkillResourcePlanStore(
+    storage_dir=AGENT_TASK_STORAGE_DIR or None
+)
+skill_creator_resource_planning_service = SkillCreatorResourcePlanningService(
+    skill_creator_service,
+    skill_creator_resource_plan_store,
+)
 workflow_xpert_authoring_provider = AuthoringToolsetProvider(
     authoring_service, "xpert"
 )
@@ -1089,6 +1117,7 @@ workflow_skill_creator_provider = AuthoringToolsetProvider(
 )
 configure_runtime_authoring(authoring_service)
 configure_skill_creator(skill_creator_service)
+configure_skill_creator_resource_planning(skill_creator_resource_planning_service)
 runtime_capabilities.register(
     "mcp_tools",
     workflow_mcp_provider,
@@ -10222,9 +10251,16 @@ async def _run_workflow_response(
                         actual_model_successful_responses = 0
                         actual_model_missing_count = 0
                         evaluation_token_usage: dict[str, int] = {}
-                        agent_temperature = skill_evaluation_model_temperature(
-                            run_context,
-                            default=0.7,
+                        agent_temperature = (
+                            SKILL_CREATOR_RESOURCE_PLANNER_TEMPERATURE
+                            if (
+                                is_trusted_skill_creator_runtime(run_context)
+                                and run_context.get("creator_phase") == "resource_plan"
+                            )
+                            else skill_evaluation_model_temperature(
+                                run_context,
+                                default=0.7,
+                            )
                         )
 
                         def observe_actual_model(reported_model_id: str) -> None:
@@ -10569,6 +10605,9 @@ async def _run_workflow_response(
                                     and not skills_enabled
                                     and not browser_enabled
                                 ):
+                                    direct_agent_max_tokens = workflow_agent_token_budget(
+                                        task_state.get("runtime_metadata")
+                                    )
                                     direct_messages = base_agent_messages(
                                         role_prompt,
                                         task_input,
@@ -10577,7 +10616,7 @@ async def _run_workflow_response(
                                         output = await buffered_agent_model_text(
                                             attempt_model_id,
                                             direct_messages,
-                                            WORKFLOW_AGENT_MAX_TOKENS,
+                                            direct_agent_max_tokens,
                                         )
                                     else:
                                         prepared_request = await agent_pipeline.before_model(
@@ -10586,7 +10625,7 @@ async def _run_workflow_response(
                                                 messages=direct_messages,
                                                 params={
                                                     "temperature": agent_temperature,
-                                                    "max_tokens": WORKFLOW_AGENT_MAX_TOKENS,
+                                                    "max_tokens": direct_agent_max_tokens,
                                                     "stream": True,
                                                 },
                                             ),
@@ -10597,6 +10636,16 @@ async def _run_workflow_response(
                                             for message in prepared_request.messages
                                         ]
                                         if (
+                                            direct_agent_max_tokens
+                                            != WORKFLOW_AGENT_MAX_TOKENS
+                                        ):
+                                            model_stream = stream_workflow_llm_messages(
+                                                prepared_request.model_id,
+                                                prepared_messages,
+                                                temperature=agent_temperature,
+                                                max_tokens=direct_agent_max_tokens,
+                                            )
+                                        elif (
                                             len(prepared_messages) == 2
                                             and prepared_messages[0].role == "system"
                                             and prepared_messages[1].role == "user"
@@ -10613,7 +10662,7 @@ async def _run_workflow_response(
                                                 prepared_request.model_id,
                                                 prepared_messages,
                                                 temperature=agent_temperature,
-                                                max_tokens=WORKFLOW_AGENT_MAX_TOKENS,
+                                                max_tokens=direct_agent_max_tokens,
                                             )
                                         async for delta in model_stream:
                                             output += delta
@@ -12751,6 +12800,47 @@ skill_creator_generation_executor = WorkflowCreatorGenerationExecutor(
     runner=run_skill_creator_generation,
 )
 configure_creator_generation_executor(skill_creator_generation_executor)
+
+
+async def run_skill_creator_resource_planning(
+    invocation: ResourcePlannerWorkflowInvocation,
+) -> str:
+    payload = WorkflowRunRequest.model_validate(
+        {
+            "workflow": invocation.workflow,
+            "inputs": invocation.inputs,
+        }
+    )
+    session_id = str(
+        invocation.runtime_metadata.get("creator_session_id") or ""
+    ).strip()
+    response = await _run_workflow_response(
+        payload,
+        None,
+        runtime_run_type="workflow",
+        runtime_source_id=session_id,
+        runtime_metadata=dict(invocation.runtime_metadata),
+    )
+    final_event = await consume_workflow_stream(response)
+    if final_event.get("event") in {
+        "runtime_approval_pending",
+        "client_tool_waiting",
+    }:
+        raise RuntimeError(
+            "The dedicated Skill Creator resource planner cannot pause for tools."
+        )
+    output = str(final_event.get("final_output") or "").strip()
+    if not output:
+        raise RuntimeError("The Skill Creator resource planner returned no plan.")
+    return output
+
+
+skill_creator_resource_planner = WorkflowCreatorResourcePlanner(
+    model_id=TEXT_FALLBACK_MODEL,
+    model_available=lambda: bool(get_llm_gateway_config()[0]),
+    runner=run_skill_creator_resource_planning,
+)
+skill_creator_resource_planning_service.planner = skill_creator_resource_planner
 
 
 async def execute_external_xpert_resource(

--- a/server/skills/creator_api.py
+++ b/server/skills/creator_api.py
@@ -15,6 +15,7 @@ from .creator_evaluation import (
     SkillEvaluationValidationError,
 )
 from .creator_evaluation_service import SkillCreatorEvaluationService
+from .creator_resource_service import SkillCreatorResourcePlanningService
 from .creator_service import SkillCreatorService
 from .creator_store import (
     CREATOR_ASSISTANT_AGENT_ID,
@@ -42,6 +43,7 @@ except ModuleNotFoundError:
 router = APIRouter(prefix="/api/skills/creator", tags=["skill-creator"])
 _service: SkillCreatorService | None = None
 _evaluation_service: SkillCreatorEvaluationService | None = None
+_resource_planning_service: SkillCreatorResourcePlanningService | None = None
 
 
 class CreatorSessionCreateRequest(BaseModel):
@@ -87,6 +89,40 @@ class CreatorGenerateRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     expected_session_revision: int = Field(ge=1)
+
+
+class CreatorResourcePlanGenerateRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    expected_session_revision: int = Field(ge=1)
+    expected_plan_revision: int | None = Field(default=None, ge=1)
+    expected_plan_digest: str | None = Field(
+        default=None, min_length=64, max_length=64, pattern=r"^[0-9a-fA-F]{64}$"
+    )
+
+
+class CreatorResourcePlanWriteRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    plan_id: str = Field(min_length=1, max_length=200)
+    expected_session_revision: int = Field(ge=1)
+    expected_plan_revision: int = Field(ge=1)
+    expected_plan_digest: str = Field(
+        min_length=64, max_length=64, pattern=r"^[0-9a-fA-F]{64}$"
+    )
+
+
+class CreatorResourcePlanAnswersRequest(CreatorResourcePlanWriteRequest):
+    answers: dict[str, str] = Field(max_length=5)
+
+
+class CreatorResourcePlanPatchRequest(CreatorResourcePlanWriteRequest):
+    skill_name: str | None = Field(default=None, min_length=1, max_length=64)
+    skill_description: str | None = Field(default=None, min_length=1, max_length=1_024)
+    workflow_steps: list[dict[str, Any]] | None = Field(default=None, max_length=10)
+    output_contract: list[str] | None = Field(default=None, max_length=20)
+    failure_modes: list[str] | None = Field(default=None, max_length=20)
+    resources: list[dict[str, Any]] | None = Field(default=None, max_length=20)
 
 
 class CreatorBlankDraftRequest(BaseModel):
@@ -188,6 +224,13 @@ def configure_skill_creator_evaluation(
     _evaluation_service = service
 
 
+def configure_skill_creator_resource_planning(
+    service: SkillCreatorResourcePlanningService | None,
+) -> None:
+    global _resource_planning_service
+    _resource_planning_service = service
+
+
 def get_skill_creator_service() -> SkillCreatorService:
     if _service is None:
         raise SkillCreatorValidationError(
@@ -205,6 +248,17 @@ def get_skill_creator_evaluation_service() -> SkillCreatorEvaluationService:
             code="skill_creator_evaluation_unavailable",
         )
     return _evaluation_service
+
+
+def get_skill_creator_resource_planning_service() -> SkillCreatorResourcePlanningService:
+    get_skill_creator_service()
+    if _resource_planning_service is None:
+        raise SkillCreatorValidationError(
+            "Skill Creator resource authoring is unavailable.",
+            code="skill_creator_resource_authoring_disabled",
+        )
+    _resource_planning_service.require_enabled()
+    return _resource_planning_service
 
 
 def _api_error(exc: Exception) -> HTTPException:
@@ -251,7 +305,10 @@ def _api_error(exc: Exception) -> HTTPException:
         code = exc.code
     elif isinstance(exc, SkillCreatorValidationError):
         code = exc.code
-        status = 404 if code == "skill_creator_disabled" else 400
+        status = 404 if code in {
+            "skill_creator_disabled",
+            "skill_creator_resource_authoring_disabled",
+        } else 400
         if code == "model_gateway_unconfigured":
             status = 503
         elif code == "skill_creator_source_unavailable":
@@ -260,6 +317,8 @@ def _api_error(exc: Exception) -> HTTPException:
             "skill_creator_generation_failed",
             "skill_creator_generation_invalid",
             "skill_creator_tool_not_called",
+            "skill_creator_resource_planner_failed",
+            "skill_creator_resource_planner_invalid",
         }:
             status = 502
         elif code == "skill_creator_proposal_binding_invalid":
@@ -308,6 +367,18 @@ def _session_response(
             if _evaluation_service is not None and evaluation_run is not None
             else None
         ),
+        "resource_plan": (
+            _resource_planning_service.serialize_projection(
+                _resource_planning_service.plan_store.current_for_session(
+                    session.session_id
+                ),
+                session=session,
+                draft=draft,
+            )
+            if _resource_planning_service is not None
+            and _resource_planning_service.enabled
+            else None
+        ),
     }
     return response
 
@@ -324,6 +395,9 @@ async def get_creator_status():
             "quality_gate": "not_evaluated",
             "evaluation_available": False,
             "evaluation_version": None,
+            "resource_authoring_enabled": False,
+            "resource_authoring_version": None,
+            "resource_planner_available": False,
         }
     status = _service.status()
     status["evaluation_available"] = _evaluation_service is not None
@@ -332,6 +406,15 @@ async def get_creator_status():
     )
     status["quality_gate"] = (
         "evaluation_required" if _evaluation_service is not None else "not_evaluated"
+    )
+    status.update(
+        _resource_planning_service.status()
+        if _resource_planning_service is not None
+        else {
+            "resource_authoring_enabled": False,
+            "resource_authoring_version": None,
+            "resource_planner_available": False,
+        }
     )
     return status
 
@@ -467,6 +550,134 @@ async def put_creator_evidence(session_id: str, payload: CreatorEvidenceRequest)
             candidate_ids=payload.candidate_ids,
         )
         return _session_response(service, session)
+    except (SkillCreatorError, SkillDraftError) as exc:
+        raise _api_error(exc) from exc
+
+
+@router.post("/sessions/{session_id}/resource-plan/generate")
+async def generate_creator_resource_plan(
+    session_id: str, payload: CreatorResourcePlanGenerateRequest
+):
+    try:
+        if (payload.expected_plan_revision is None) != (
+            payload.expected_plan_digest is None
+        ):
+            raise SkillCreatorValidationError(
+                "Expected resource plan revision and digest must be provided together.",
+                code="skill_creator_resource_plan_invalid",
+            )
+        planning = get_skill_creator_resource_planning_service()
+        plan = await planning.generate(
+            session_id,
+            expected_session_revision=payload.expected_session_revision,
+            expected_plan_revision=payload.expected_plan_revision,
+            expected_plan_digest=(
+                payload.expected_plan_digest.lower()
+                if payload.expected_plan_digest
+                else None
+            ),
+        )
+        service = get_skill_creator_service()
+        session, draft = await asyncio.to_thread(service.get_session, session_id)
+        response = _session_response(service, session, draft)
+        response["resource_plan"] = planning.serialize_projection(
+            plan, session=session, draft=draft
+        )
+        return response
+    except (SkillCreatorError, SkillDraftError) as exc:
+        raise _api_error(exc) from exc
+
+
+@router.put("/sessions/{session_id}/resource-plan/answers")
+async def answer_creator_resource_plan(
+    session_id: str, payload: CreatorResourcePlanAnswersRequest
+):
+    try:
+        planning = get_skill_creator_resource_planning_service()
+        plan = await asyncio.to_thread(
+            planning.save_answers,
+            session_id,
+            plan_id=payload.plan_id,
+            expected_session_revision=payload.expected_session_revision,
+            expected_plan_revision=payload.expected_plan_revision,
+            expected_plan_digest=payload.expected_plan_digest.lower(),
+            answers=payload.answers,
+        )
+        service = get_skill_creator_service()
+        session, draft = await asyncio.to_thread(service.get_session, session_id)
+        response = _session_response(service, session, draft)
+        response["resource_plan"] = planning.serialize_projection(
+            plan, session=session, draft=draft
+        )
+        return response
+    except (SkillCreatorError, SkillDraftError) as exc:
+        raise _api_error(exc) from exc
+
+
+@router.patch("/sessions/{session_id}/resource-plan")
+async def patch_creator_resource_plan(
+    session_id: str, payload: CreatorResourcePlanPatchRequest
+):
+    try:
+        planning = get_skill_creator_resource_planning_service()
+        changes = {
+            name: getattr(payload, name)
+            for name in (
+                "skill_name",
+                "skill_description",
+                "workflow_steps",
+                "output_contract",
+                "failure_modes",
+                "resources",
+            )
+            if name in payload.model_fields_set
+        }
+        if not changes:
+            raise SkillCreatorValidationError(
+                "Resource plan patch contains no changes.",
+                code="skill_creator_resource_plan_invalid",
+            )
+        plan = await asyncio.to_thread(
+            planning.patch,
+            session_id,
+            plan_id=payload.plan_id,
+            expected_session_revision=payload.expected_session_revision,
+            expected_plan_revision=payload.expected_plan_revision,
+            expected_plan_digest=payload.expected_plan_digest.lower(),
+            changes=changes,
+        )
+        service = get_skill_creator_service()
+        session, draft = await asyncio.to_thread(service.get_session, session_id)
+        response = _session_response(service, session, draft)
+        response["resource_plan"] = planning.serialize_projection(
+            plan, session=session, draft=draft
+        )
+        return response
+    except (SkillCreatorError, SkillDraftError) as exc:
+        raise _api_error(exc) from exc
+
+
+@router.post("/sessions/{session_id}/resource-plan/confirm")
+async def confirm_creator_resource_plan(
+    session_id: str, payload: CreatorResourcePlanWriteRequest
+):
+    try:
+        planning = get_skill_creator_resource_planning_service()
+        plan = await asyncio.to_thread(
+            planning.confirm,
+            session_id,
+            plan_id=payload.plan_id,
+            expected_session_revision=payload.expected_session_revision,
+            expected_plan_revision=payload.expected_plan_revision,
+            expected_plan_digest=payload.expected_plan_digest.lower(),
+        )
+        service = get_skill_creator_service()
+        session, draft = await asyncio.to_thread(service.get_session, session_id)
+        response = _session_response(service, session, draft)
+        response["resource_plan"] = planning.serialize_projection(
+            plan, session=session, draft=draft
+        )
+        return response
     except (SkillCreatorError, SkillDraftError) as exc:
         raise _api_error(exc) from exc
 

--- a/server/skills/creator_resource_plan.py
+++ b/server/skills/creator_resource_plan.py
@@ -1,0 +1,946 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import threading
+import time
+import uuid
+from dataclasses import asdict, dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import Any, Literal
+
+from .creator_store import (
+    SkillCreatorConflictError,
+    SkillCreatorNotFoundError,
+    SkillCreatorStorageError,
+    SkillCreatorValidationError,
+)
+from .package_validation import scan_skill_package_credentials
+
+
+RESOURCE_PLAN_VERSION = "skill-resource-plan-v1"
+ResourcePlanState = Literal[
+    "needs_input",
+    "needs_regeneration",
+    "ready",
+    "confirmed",
+]
+ResourceKind = Literal["script", "reference", "asset"]
+ResourceAction = Literal["keep", "create", "update", "delete"]
+ResourceGenerationCost = Literal["low", "medium", "high"]
+
+_IDENTIFIER_RE = re.compile(r"^[a-z][a-z0-9_-]{0,79}$")
+_SOURCE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,199}$")
+_RESOURCE_ROOTS = {
+    "script": "scripts",
+    "reference": "references",
+    "asset": "assets",
+}
+_WINDOWS_RESERVED_NAMES = {
+    "con", "prn", "aux", "nul",
+    *(f"com{index}" for index in range(1, 10)),
+    *(f"lpt{index}" for index in range(1, 10)),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class ResourcePlanStep:
+    step_id: str
+    instruction: str
+
+
+@dataclass(frozen=True, slots=True)
+class ResourcePlanQuestion:
+    question_id: str
+    question: str
+    reason: str
+
+
+@dataclass(frozen=True, slots=True)
+class SkillResourcePlanItem:
+    resource_id: str
+    spec_digest: str
+    kind: ResourceKind
+    action: ResourceAction
+    generation_cost: ResourceGenerationCost
+    path: str
+    purpose: str
+    source_ids: list[str]
+    used_by_steps: list[str]
+    depends_on: list[str]
+    acceptance_checks: list[str]
+
+
+@dataclass(frozen=True, slots=True)
+class SkillResourcePlan:
+    plan_id: str
+    session_id: str
+    revision: int
+    digest: str
+    state: ResourcePlanState
+    session_revision: int
+    draft_id: str | None
+    draft_revision: int | None
+    draft_digest: str | None
+    skill_name: str
+    skill_description: str
+    workflow_steps: list[ResourcePlanStep]
+    output_contract: list[str]
+    failure_modes: list[str]
+    resources: list[SkillResourcePlanItem]
+    clarifications: list[ResourcePlanQuestion] = field(default_factory=list)
+    clarification_answers: dict[str, str] = field(default_factory=dict)
+    created_at: float = field(default_factory=time.time)
+    updated_at: float = field(default_factory=time.time)
+
+
+class SkillResourcePlanStore:
+    """Atomic immutable revisions for Creator resource plans."""
+
+    SCHEMA_VERSION = 1
+    MAX_PLANS = 500
+    MAX_REVISIONS_PER_PLAN = 40
+    MAX_RESOURCES = 20
+    MAX_ANSWER_BYTES = 32 * 1024
+    MAX_ANSWERS_BYTES = 128 * 1024
+
+    def __init__(self, storage_dir: str | Path | None = None) -> None:
+        package_dir = Path(__file__).resolve().parent
+        runtime_dir = os.getenv("AGENT_TASK_STORAGE_DIR", "").strip()
+        self.storage_dir = Path(storage_dir or runtime_dir or package_dir / "storage")
+        self.snapshot_path = self.storage_dir / "skill_creator_resource_plans.json"
+        self._lock = threading.RLock()
+        self._plans: dict[str, list[SkillResourcePlan]] = {}
+        self._session_index: dict[str, str] = {}
+        self._quarantine: list[dict[str, Any]] = []
+        self._load_error: str | None = None
+        self._load()
+
+    @property
+    def load_error(self) -> str | None:
+        return self._load_error
+
+    def current_for_session(self, session_id: str) -> SkillResourcePlan | None:
+        clean = self._required_text(session_id, "session_id", 200)
+        with self._lock:
+            self._ensure_readable_unlocked()
+            plan_id = self._session_index.get(clean)
+            if plan_id is None:
+                return None
+            return self._copy(self._plans[plan_id][-1])
+
+    def require(self, plan_id: str, revision: int | None = None) -> SkillResourcePlan:
+        clean = self._required_text(plan_id, "plan_id", 200)
+        with self._lock:
+            self._ensure_readable_unlocked()
+            revisions = self._plans.get(clean)
+            if not revisions:
+                raise SkillCreatorNotFoundError(f"Resource plan not found: {clean}")
+            if revision is None:
+                return self._copy(revisions[-1])
+            for item in revisions:
+                if item.revision == int(revision):
+                    return self._copy(item)
+        raise SkillCreatorNotFoundError(
+            f"Resource plan revision not found: {clean}@{revision}"
+        )
+
+    def save_generated(
+        self,
+        *,
+        session_id: str,
+        session_revision: int,
+        draft_id: str | None,
+        draft_revision: int | None,
+        draft_digest: str | None,
+        payload: dict[str, Any],
+        allowed_source_ids: set[str],
+        expected_plan_revision: int | None = None,
+        expected_plan_digest: str | None = None,
+    ) -> SkillResourcePlan:
+        clean_session_id = self._required_text(session_id, "session_id", 200)
+        normalized = self._normalize_payload(payload, allowed_source_ids=allowed_source_ids)
+        with self._lock:
+            self._ensure_writable_unlocked()
+            current = self._current_unlocked(clean_session_id)
+            self._require_plan_match(
+                current,
+                expected_revision=expected_plan_revision,
+                expected_digest=expected_plan_digest,
+            )
+            if (
+                current is not None
+                and current.state == "confirmed"
+                and current.session_revision == int(session_revision)
+                and current.draft_id == self._optional_text(draft_id, 200)
+                and current.draft_revision == draft_revision
+                and current.draft_digest == self._optional_digest(draft_digest, "draft_digest")
+            ):
+                raise SkillCreatorConflictError(
+                    "Confirmed resource plans cannot be regenerated. Create a new plan revision first."
+                )
+            if current is None and len(self._plans) >= self.MAX_PLANS:
+                raise SkillCreatorValidationError(
+                    "Skill Creator resource plan limit reached.",
+                    code="skill_creator_resource_plan_limit",
+                )
+            plan_id = current.plan_id if current else f"skillplan_{uuid.uuid4().hex}"
+            revision = (current.revision + 1) if current else 1
+            answers = dict(current.clarification_answers) if current else {}
+            state: ResourcePlanState = (
+                "needs_input" if normalized["clarifications"] else "ready"
+            )
+            now = time.time()
+            item = self._build_plan(
+                plan_id=plan_id,
+                session_id=clean_session_id,
+                revision=revision,
+                state=state,
+                session_revision=self._positive_int(session_revision, "session_revision"),
+                draft_id=self._optional_text(draft_id, 200),
+                draft_revision=(
+                    self._positive_int(draft_revision, "draft_revision")
+                    if draft_revision is not None
+                    else None
+                ),
+                draft_digest=self._optional_digest(draft_digest, "draft_digest"),
+                clarification_answers=answers,
+                created_at=(current.created_at if current else now),
+                updated_at=now,
+                **normalized,
+            )
+            return self._append_unlocked(item)
+
+    def save_answers(
+        self,
+        plan_id: str,
+        *,
+        expected_revision: int,
+        expected_digest: str,
+        answers: dict[str, str],
+    ) -> SkillResourcePlan:
+        with self._lock:
+            current = self._require_current_unlocked(
+                plan_id, expected_revision=expected_revision, expected_digest=expected_digest
+            )
+            if current.state != "needs_input":
+                raise SkillCreatorConflictError(
+                    "This resource plan is not waiting for clarification answers."
+                )
+            question_ids = {item.question_id for item in current.clarifications}
+            if set(answers) != question_ids:
+                raise SkillCreatorValidationError(
+                    "Answer every current clarification question exactly once.",
+                    code="skill_creator_resource_answers_incomplete",
+                )
+            clean_answers = {
+                question_id: self._required_text(value, "answer", self.MAX_ANSWER_BYTES)
+                for question_id, value in answers.items()
+            }
+            if sum(len(value.encode("utf-8")) for value in clean_answers.values()) > self.MAX_ANSWERS_BYTES:
+                raise SkillCreatorValidationError(
+                    "Creator clarification answers are too large.",
+                    code="skill_creator_resource_answers_too_large",
+                )
+            self._reject_credentials(clean_answers)
+            item = self._replace(
+                current,
+                revision=current.revision + 1,
+                state="needs_regeneration",
+                clarification_answers=clean_answers,
+                updated_at=time.time(),
+            )
+            return self._append_unlocked(item)
+
+    def patch(
+        self,
+        plan_id: str,
+        *,
+        expected_revision: int,
+        expected_digest: str,
+        changes: dict[str, Any],
+        allowed_source_ids: set[str],
+    ) -> SkillResourcePlan:
+        allowed = {
+            "skill_name",
+            "skill_description",
+            "workflow_steps",
+            "output_contract",
+            "failure_modes",
+            "resources",
+        }
+        unknown = sorted(set(changes) - allowed)
+        if unknown:
+            raise SkillCreatorValidationError(
+                "Unsupported resource plan fields: " + ", ".join(unknown)
+            )
+        with self._lock:
+            current = self._require_current_unlocked(
+                plan_id, expected_revision=expected_revision, expected_digest=expected_digest
+            )
+            if current.state not in {"ready", "needs_regeneration"}:
+                raise SkillCreatorConflictError(
+                    "Only an unconfirmed ready plan can be edited."
+                )
+            path_by_id = {item.resource_id: item.path for item in current.resources}
+            resource_payload = []
+            for resource in current.resources:
+                raw_resource = asdict(resource)
+                raw_resource["depends_on"] = [
+                    path_by_id[dependency_id]
+                    for dependency_id in resource.depends_on
+                    if dependency_id in path_by_id
+                ]
+                resource_payload.append(raw_resource)
+            payload = {
+                "skill_name": current.skill_name,
+                "skill_description": current.skill_description,
+                "workflow_steps": [asdict(item) for item in current.workflow_steps],
+                "output_contract": list(current.output_contract),
+                "failure_modes": list(current.failure_modes),
+                "resources": resource_payload,
+                "clarifications": [],
+            }
+            payload.update(changes)
+            normalized = self._normalize_payload(payload, allowed_source_ids=allowed_source_ids)
+            item = self._build_plan(
+                plan_id=current.plan_id,
+                session_id=current.session_id,
+                revision=current.revision + 1,
+                state="ready",
+                session_revision=current.session_revision,
+                draft_id=current.draft_id,
+                draft_revision=current.draft_revision,
+                draft_digest=current.draft_digest,
+                clarification_answers=dict(current.clarification_answers),
+                created_at=current.created_at,
+                updated_at=time.time(),
+                **normalized,
+            )
+            return self._append_unlocked(item)
+
+    def confirm(
+        self,
+        plan_id: str,
+        *,
+        expected_revision: int,
+        expected_digest: str,
+        session_revision: int,
+        draft_revision: int | None,
+        draft_digest: str | None,
+    ) -> SkillResourcePlan:
+        with self._lock:
+            current = self._require_current_unlocked(
+                plan_id, expected_revision=expected_revision, expected_digest=expected_digest
+            )
+            if current.state != "ready":
+                raise SkillCreatorConflictError("Only a ready resource plan can be confirmed.")
+            if current.session_revision != int(session_revision):
+                raise SkillCreatorConflictError(
+                    "Creator session changed after this resource plan was generated."
+                )
+            if current.draft_revision != draft_revision or current.draft_digest != self._optional_digest(
+                draft_digest, "draft_digest"
+            ):
+                raise SkillCreatorConflictError(
+                    "Creator draft changed after this resource plan was generated."
+                )
+            item = self._replace(
+                current,
+                revision=current.revision + 1,
+                state="confirmed",
+                updated_at=time.time(),
+            )
+            return self._append_unlocked(item)
+
+    @staticmethod
+    def serialize(item: SkillResourcePlan) -> dict[str, Any]:
+        return asdict(item)
+
+    def _normalize_payload(
+        self, payload: dict[str, Any], *, allowed_source_ids: set[str]
+    ) -> dict[str, Any]:
+        if not isinstance(payload, dict):
+            raise SkillCreatorValidationError(
+                "Resource planner returned an invalid object.",
+                code="skill_creator_resource_plan_invalid",
+            )
+        skill_name = self._required_text(payload.get("skill_name"), "skill_name", 64)
+        if not re.fullmatch(r"[a-z0-9]+(?:-[a-z0-9]+)*", skill_name):
+            raise SkillCreatorValidationError(
+                "Resource plan skill_name must be kebab-case.",
+                code="skill_creator_resource_plan_invalid",
+            )
+        skill_description = self._required_text(
+            payload.get("skill_description"), "skill_description", 1024
+        )
+        workflow_steps = self._steps(payload.get("workflow_steps"))
+        step_ids = {item.step_id for item in workflow_steps}
+        output_contract = self._text_list(
+            payload.get("output_contract"), "output_contract", 20, 2_000
+        )
+        failure_modes = self._text_list(
+            payload.get("failure_modes"), "failure_modes", 20, 2_000
+        )
+        clarifications = self._questions(payload.get("clarifications") or [])
+        resources = self._resources(
+            payload.get("resources") or [],
+            allowed_source_ids=allowed_source_ids,
+            step_ids=step_ids,
+        )
+        if clarifications and resources:
+            raise SkillCreatorValidationError(
+                "A plan waiting for clarification cannot pre-commit resource files.",
+                code="skill_creator_resource_plan_invalid",
+            )
+        self._reject_credentials(payload)
+        return {
+            "skill_name": skill_name,
+            "skill_description": skill_description,
+            "workflow_steps": workflow_steps,
+            "output_contract": output_contract,
+            "failure_modes": failure_modes,
+            "resources": resources,
+            "clarifications": clarifications,
+        }
+
+    def _resources(
+        self,
+        value: Any,
+        *,
+        allowed_source_ids: set[str],
+        step_ids: set[str],
+    ) -> list[SkillResourcePlanItem]:
+        if not isinstance(value, list) or len(value) > self.MAX_RESOURCES:
+            raise SkillCreatorValidationError(
+                "Resource plan contains too many resources.",
+                code="skill_creator_resource_plan_invalid",
+            )
+        prelim: list[dict[str, Any]] = []
+        paths: set[str] = set()
+        for raw in value:
+            if not isinstance(raw, dict):
+                raise SkillCreatorValidationError("Invalid resource plan item.")
+            kind = str(raw.get("kind") or "").strip()
+            action = str(raw.get("action") or "create").strip()
+            generation_cost = str(raw.get("generation_cost") or "").strip()
+            if (
+                kind not in _RESOURCE_ROOTS
+                or action not in {"keep", "create", "update", "delete"}
+                or generation_cost not in {"low", "medium", "high"}
+            ):
+                raise SkillCreatorValidationError("Invalid resource kind or action.")
+            path = self._resource_path(raw.get("path"), expected_root=_RESOURCE_ROOTS[kind])
+            if path.casefold() in {item.casefold() for item in paths}:
+                raise SkillCreatorValidationError("Resource plan paths must be unique.")
+            paths.add(path)
+            prelim.append({
+                **raw,
+                "kind": kind,
+                "action": action,
+                "generation_cost": generation_cost,
+                "path": path,
+            })
+        by_path = {item["path"]: self._resource_id(item["kind"], item["path"]) for item in prelim}
+        result: list[SkillResourcePlanItem] = []
+        for raw in prelim:
+            source_ids = self._source_id_list(raw.get("source_ids"), "source_ids", 30)
+            if any(source_id not in allowed_source_ids for source_id in source_ids):
+                raise SkillCreatorValidationError(
+                    "Resource plan references an unknown source requirement.",
+                    code="skill_creator_resource_source_unknown",
+                )
+            used_by_steps = self._identifier_list(
+                raw.get("used_by_steps"), "used_by_steps", 20
+            )
+            if any(step_id not in step_ids for step_id in used_by_steps):
+                raise SkillCreatorValidationError("Resource plan references an unknown workflow step.")
+            depends_on_paths = self._text_list(
+                raw.get("depends_on") or raw.get("depends_on_paths") or [],
+                "depends_on",
+                20,
+                240,
+                allow_empty=True,
+            )
+            if any(path not in by_path or path == raw["path"] for path in depends_on_paths):
+                raise SkillCreatorValidationError("Resource dependency path is invalid.")
+            purpose = self._required_text(raw.get("purpose"), "purpose", 2_000)
+            dependency_ids = [by_path[path] for path in depends_on_paths]
+            acceptance_checks = self._text_list(
+                raw.get("acceptance_checks"), "acceptance_checks", 10, 1_000
+            )
+            resource_id = by_path[raw["path"]]
+            result.append(
+                SkillResourcePlanItem(
+                    resource_id=resource_id,
+                    spec_digest=self._resource_spec_digest(
+                        resource_id=resource_id,
+                        kind=raw["kind"],
+                        action=raw["action"],
+                        generation_cost=raw["generation_cost"],
+                        path=raw["path"],
+                        purpose=purpose,
+                        source_ids=source_ids,
+                        used_by_steps=used_by_steps,
+                        depends_on=dependency_ids,
+                        acceptance_checks=acceptance_checks,
+                    ),
+                    kind=raw["kind"],
+                    action=raw["action"],
+                    generation_cost=raw["generation_cost"],
+                    path=raw["path"],
+                    purpose=purpose,
+                    source_ids=source_ids,
+                    used_by_steps=used_by_steps,
+                    depends_on=dependency_ids,
+                    acceptance_checks=acceptance_checks,
+                )
+            )
+        self._assert_acyclic(result)
+        return result
+
+    @staticmethod
+    def _assert_acyclic(resources: list[SkillResourcePlanItem]) -> None:
+        dependencies = {item.resource_id: set(item.depends_on) for item in resources}
+        pending = dict(dependencies)
+        while pending:
+            ready = {key for key, values in pending.items() if not values}
+            if not ready:
+                raise SkillCreatorValidationError("Resource plan dependencies contain a cycle.")
+            for key in ready:
+                pending.pop(key)
+            for values in pending.values():
+                values.difference_update(ready)
+
+    @staticmethod
+    def _resource_spec_digest(**values: Any) -> str:
+        return hashlib.sha256(
+            json.dumps(
+                values,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        ).hexdigest()
+
+    def _steps(self, value: Any) -> list[ResourcePlanStep]:
+        if not isinstance(value, list) or not 4 <= len(value) <= 10:
+            raise SkillCreatorValidationError("Resource plan requires four to ten workflow steps.")
+        result: list[ResourcePlanStep] = []
+        seen: set[str] = set()
+        for raw in value:
+            if not isinstance(raw, dict):
+                raise SkillCreatorValidationError("Invalid resource plan workflow step.")
+            step_id = self._identifier(raw.get("step_id") or raw.get("id"), "step_id")
+            if step_id in seen:
+                raise SkillCreatorValidationError("Workflow step IDs must be unique.")
+            seen.add(step_id)
+            result.append(
+                ResourcePlanStep(
+                    step_id=step_id,
+                    instruction=self._required_text(
+                        raw.get("instruction") or raw.get("description"),
+                        "workflow instruction",
+                        2_000,
+                    ),
+                )
+            )
+        return result
+
+    def _questions(self, value: Any) -> list[ResourcePlanQuestion]:
+        if not isinstance(value, list) or len(value) > 5:
+            raise SkillCreatorValidationError("Resource planner may ask at most five questions.")
+        result: list[ResourcePlanQuestion] = []
+        seen: set[str] = set()
+        for raw in value:
+            if not isinstance(raw, dict):
+                raise SkillCreatorValidationError("Invalid resource clarification question.")
+            question_id = self._identifier(raw.get("question_id") or raw.get("id"), "question_id")
+            if question_id in seen:
+                raise SkillCreatorValidationError("Clarification question IDs must be unique.")
+            seen.add(question_id)
+            result.append(
+                ResourcePlanQuestion(
+                    question_id=question_id,
+                    question=self._required_text(raw.get("question"), "question", 2_000),
+                    reason=self._required_text(raw.get("reason"), "reason", 1_000),
+                )
+            )
+        return result
+
+    def _build_plan(self, **values: Any) -> SkillResourcePlan:
+        digest_payload = {
+            key: values[key]
+            for key in (
+                "plan_id",
+                "revision",
+                "state",
+                "session_id",
+                "session_revision",
+                "draft_id",
+                "draft_revision",
+                "draft_digest",
+                "skill_name",
+                "skill_description",
+                "workflow_steps",
+                "output_contract",
+                "failure_modes",
+                "resources",
+                "clarifications",
+                "clarification_answers",
+            )
+        }
+        digest = hashlib.sha256(
+            json.dumps(
+                self._jsonable(digest_payload),
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        ).hexdigest()
+        return SkillResourcePlan(digest=digest, **values)
+
+    def _replace(self, current: SkillResourcePlan, **changes: Any) -> SkillResourcePlan:
+        values = asdict(current)
+        values.pop("digest", None)
+        values.update(changes)
+        values["workflow_steps"] = [ResourcePlanStep(**item) for item in values["workflow_steps"]]
+        values["clarifications"] = [ResourcePlanQuestion(**item) for item in values["clarifications"]]
+        values["resources"] = [SkillResourcePlanItem(**item) for item in values["resources"]]
+        return self._build_plan(**values)
+
+    def _append_unlocked(self, item: SkillResourcePlan) -> SkillResourcePlan:
+        revisions = self._plans.setdefault(item.plan_id, [])
+        if revisions and item.revision != revisions[-1].revision + 1:
+            raise SkillCreatorConflictError("Resource plan revision is not sequential.")
+        if len(revisions) >= self.MAX_REVISIONS_PER_PLAN:
+            raise SkillCreatorValidationError(
+                "Resource plan revision limit reached.",
+                code="skill_creator_resource_plan_revision_limit",
+            )
+        previous_index = self._session_index.get(item.session_id)
+        revisions.append(item)
+        self._session_index[item.session_id] = item.plan_id
+        try:
+            self._save_unlocked()
+        except BaseException:
+            revisions.pop()
+            if not revisions:
+                self._plans.pop(item.plan_id, None)
+            if previous_index is None:
+                self._session_index.pop(item.session_id, None)
+            else:
+                self._session_index[item.session_id] = previous_index
+            raise
+        return self._copy(item)
+
+    def _require_current_unlocked(
+        self, plan_id: str, *, expected_revision: int, expected_digest: str
+    ) -> SkillResourcePlan:
+        self._ensure_writable_unlocked()
+        clean = self._required_text(plan_id, "plan_id", 200)
+        revisions = self._plans.get(clean)
+        if not revisions:
+            raise SkillCreatorNotFoundError(f"Resource plan not found: {clean}")
+        current = revisions[-1]
+        self._require_plan_match(
+            current, expected_revision=expected_revision, expected_digest=expected_digest
+        )
+        return current
+
+    @staticmethod
+    def _require_plan_match(
+        current: SkillResourcePlan | None,
+        *,
+        expected_revision: int | None,
+        expected_digest: str | None,
+    ) -> None:
+        if current is None:
+            if expected_revision is not None or expected_digest is not None:
+                raise SkillCreatorConflictError("Resource plan no longer exists as expected.")
+            return
+        if (
+            expected_revision is None
+            or expected_digest is None
+            or current.revision != int(expected_revision)
+            or current.digest != str(expected_digest).lower()
+        ):
+            raise SkillCreatorConflictError("Resource plan changed. Reload it before continuing.")
+
+    def _current_unlocked(self, session_id: str) -> SkillResourcePlan | None:
+        plan_id = self._session_index.get(session_id)
+        return self._plans[plan_id][-1] if plan_id else None
+
+    def _load(self) -> None:
+        with self._lock:
+            if not self.snapshot_path.exists():
+                return
+            try:
+                raw = json.loads(self.snapshot_path.read_text(encoding="utf-8"))
+            except (OSError, UnicodeDecodeError, ValueError, json.JSONDecodeError) as exc:
+                self._load_error = f"Skill Creator resource plan storage is unreadable: {exc}"
+                return
+            if not isinstance(raw, dict) or raw.get("version") != self.SCHEMA_VERSION or not isinstance(raw.get("items"), list):
+                self._load_error = "Skill Creator resource plan storage has an unsupported structure."
+                return
+            persisted_quarantine = raw.get("quarantine", [])
+            if isinstance(persisted_quarantine, list):
+                self._quarantine = [
+                    dict(item)
+                    for item in persisted_quarantine
+                    if isinstance(item, dict)
+                ][: self.MAX_PLANS]
+            sanitized = False
+            for index, record in enumerate(raw["items"]):
+                try:
+                    item = self._decode(record)
+                    revisions = self._plans.setdefault(item.plan_id, [])
+                    if revisions and item.revision != revisions[-1].revision + 1:
+                        raise ValueError("Non-sequential resource plan revision.")
+                    existing_plan = self._session_index.get(item.session_id)
+                    if existing_plan not in {None, item.plan_id}:
+                        raise ValueError("Multiple resource plans for one Creator session.")
+                    revisions.append(item)
+                    self._session_index[item.session_id] = item.plan_id
+                except (TypeError, ValueError, SkillCreatorValidationError):
+                    self._quarantine.append(self._quarantine_record(record, index=index))
+                    sanitized = True
+            if sanitized:
+                try:
+                    self._save_unlocked()
+                except OSError as exc:
+                    self._load_error = f"Unable to sanitize Creator resource plans: {exc}"
+
+    def _decode(self, record: Any) -> SkillResourcePlan:
+        if not isinstance(record, dict):
+            raise TypeError("Resource plan record must be an object.")
+        values = dict(record)
+        values["workflow_steps"] = [ResourcePlanStep(**item) for item in values.get("workflow_steps", [])]
+        values["clarifications"] = [ResourcePlanQuestion(**item) for item in values.get("clarifications", [])]
+        values["resources"] = [SkillResourcePlanItem(**item) for item in values.get("resources", [])]
+        item = SkillResourcePlan(**values)
+        if item.state not in {"needs_input", "needs_regeneration", "ready", "confirmed"}:
+            raise ValueError("Invalid resource plan state.")
+        for resource in item.resources:
+            expected_spec_digest = self._resource_spec_digest(
+                resource_id=resource.resource_id,
+                kind=resource.kind,
+                action=resource.action,
+                generation_cost=resource.generation_cost,
+                path=resource.path,
+                purpose=resource.purpose,
+                source_ids=resource.source_ids,
+                used_by_steps=resource.used_by_steps,
+                depends_on=resource.depends_on,
+                acceptance_checks=resource.acceptance_checks,
+            )
+            if resource.spec_digest != expected_spec_digest:
+                raise ValueError("Resource plan item digest mismatch.")
+        rebuilt = self._build_plan(
+            **{key: value for key, value in asdict(item).items() if key != "digest"}
+        )
+        if rebuilt.digest != item.digest:
+            raise ValueError("Resource plan digest mismatch.")
+        self._reject_credentials(asdict(item))
+        return item
+
+    def _save_unlocked(self) -> None:
+        self._ensure_writable_unlocked()
+        self.storage_dir.mkdir(parents=True, exist_ok=True)
+        temporary = self.snapshot_path.with_name(
+            f"{self.snapshot_path.name}.tmp.{os.getpid()}.{uuid.uuid4().hex}"
+        )
+        payload = {
+            "version": self.SCHEMA_VERSION,
+            "items": [
+                asdict(item)
+                for plan_id in sorted(self._plans)
+                for item in self._plans[plan_id]
+            ],
+            "quarantine": list(self._quarantine),
+        }
+        encoded = json.dumps(payload, ensure_ascii=False, indent=2).encode("utf-8")
+        try:
+            with temporary.open("xb") as handle:
+                handle.write(encoded)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary, self.snapshot_path)
+        finally:
+            try:
+                temporary.unlink(missing_ok=True)
+            except OSError:
+                pass
+
+    def _ensure_readable_unlocked(self) -> None:
+        if self._load_error:
+            raise SkillCreatorStorageError(self._load_error)
+
+    def _ensure_writable_unlocked(self) -> None:
+        self._ensure_readable_unlocked()
+
+    @staticmethod
+    def _resource_id(kind: str, path: str) -> str:
+        suffix = hashlib.sha256(f"{kind}\0{path}".encode("utf-8")).hexdigest()[:16]
+        return f"skillres_{suffix}"
+
+    @staticmethod
+    def _resource_path(value: Any, *, expected_root: str) -> str:
+        if not isinstance(value, str) or value != value.strip() or "\\" in value:
+            raise SkillCreatorValidationError("Resource paths must use normalized POSIX text.")
+        path = PurePosixPath(value)
+        if (
+            not value
+            or path.is_absolute()
+            or ".." in path.parts
+            or len(path.parts) < 2
+            or path.parts[0] != expected_root
+            or len(value) > 240
+        ):
+            raise SkillCreatorValidationError("Resource path is outside its allowed root.")
+        for segment in path.parts:
+            stem = segment.split(".", 1)[0].casefold()
+            if (
+                not segment
+                or segment.endswith((" ", "."))
+                or len(segment.encode("utf-8")) > 120
+                or stem in _WINDOWS_RESERVED_NAMES
+                or any(ord(character) < 32 for character in segment)
+            ):
+                raise SkillCreatorValidationError("Resource path is not portable.")
+        if expected_root == "scripts" and path.suffix.casefold() not in {".py", ".js"}:
+            raise SkillCreatorValidationError(
+                "Creator scripts must use a .py or .js path."
+            )
+        return path.as_posix()
+
+    @staticmethod
+    def _identifier(value: Any, field_name: str) -> str:
+        clean = str(value or "").strip()
+        if not _IDENTIFIER_RE.fullmatch(clean):
+            raise SkillCreatorValidationError(f"Invalid {field_name}.")
+        return clean
+
+    def _identifier_list(self, value: Any, field_name: str, maximum: int) -> list[str]:
+        if not isinstance(value, list) or len(value) > maximum:
+            raise SkillCreatorValidationError(f"Invalid {field_name}.")
+        result = [self._identifier(item, field_name) for item in value]
+        if len(result) != len(set(result)):
+            raise SkillCreatorValidationError(f"Duplicate {field_name}.")
+        return result
+
+    @staticmethod
+    def _source_id_list(value: Any, field_name: str, maximum: int) -> list[str]:
+        if not isinstance(value, list) or len(value) > maximum:
+            raise SkillCreatorValidationError(f"Invalid {field_name}.")
+        result = [str(item or "").strip() for item in value]
+        if any(not _SOURCE_ID_RE.fullmatch(item) for item in result):
+            raise SkillCreatorValidationError(f"Invalid {field_name}.")
+        if len(result) != len(set(result)):
+            raise SkillCreatorValidationError(f"Duplicate {field_name}.")
+        return result
+
+    @staticmethod
+    def _required_text(value: Any, field_name: str, maximum: int) -> str:
+        if not isinstance(value, str):
+            raise SkillCreatorValidationError(f"Invalid {field_name}.")
+        clean = value.strip()
+        if not clean or len(clean.encode("utf-8")) > maximum:
+            raise SkillCreatorValidationError(f"Invalid {field_name}.")
+        return clean
+
+    @staticmethod
+    def _optional_text(value: Any, maximum: int) -> str | None:
+        if value is None:
+            return None
+        clean = str(value).strip()
+        if not clean or len(clean) > maximum:
+            raise SkillCreatorValidationError("Invalid optional text value.")
+        return clean
+
+    @staticmethod
+    def _positive_int(value: Any, field_name: str) -> int:
+        if isinstance(value, bool):
+            raise SkillCreatorValidationError(f"Invalid {field_name}.")
+        try:
+            result = int(value)
+        except (TypeError, ValueError) as exc:
+            raise SkillCreatorValidationError(f"Invalid {field_name}.") from exc
+        if result < 1:
+            raise SkillCreatorValidationError(f"Invalid {field_name}.")
+        return result
+
+    @staticmethod
+    def _optional_digest(value: Any, field_name: str) -> str | None:
+        if value is None:
+            return None
+        clean = str(value).strip().lower()
+        if not re.fullmatch(r"[0-9a-f]{64}", clean):
+            raise SkillCreatorValidationError(f"Invalid {field_name}.")
+        return clean
+
+    def _text_list(
+        self,
+        value: Any,
+        field_name: str,
+        maximum_items: int,
+        maximum_text: int,
+        *,
+        allow_empty: bool = False,
+    ) -> list[str]:
+        if not isinstance(value, list) or len(value) > maximum_items or (not value and not allow_empty):
+            raise SkillCreatorValidationError(f"Invalid {field_name}.")
+        return [self._required_text(item, field_name, maximum_text) for item in value]
+
+    @staticmethod
+    def _reject_credentials(value: Any) -> None:
+        text = json.dumps(value, ensure_ascii=False, sort_keys=True, default=str)
+        if scan_skill_package_credentials(skill_markdown=text, files={}):
+            raise SkillCreatorValidationError(
+                "Creator resource planning content contains credential-like material.",
+                code="skill_creator_resource_secret_blocked",
+            )
+
+    @staticmethod
+    def _jsonable(value: Any) -> Any:
+        if isinstance(value, dict):
+            return {key: SkillResourcePlanStore._jsonable(item) for key, item in value.items()}
+        if isinstance(value, list):
+            return [SkillResourcePlanStore._jsonable(item) for item in value]
+        if hasattr(value, "__dataclass_fields__"):
+            return SkillResourcePlanStore._jsonable(asdict(value))
+        return value
+
+    @staticmethod
+    def _copy(item: SkillResourcePlan) -> SkillResourcePlan:
+        values = json.loads(json.dumps(asdict(item), ensure_ascii=False))
+        values["workflow_steps"] = [ResourcePlanStep(**entry) for entry in values["workflow_steps"]]
+        values["clarifications"] = [ResourcePlanQuestion(**entry) for entry in values["clarifications"]]
+        values["resources"] = [SkillResourcePlanItem(**entry) for entry in values["resources"]]
+        return SkillResourcePlan(**values)
+
+    @staticmethod
+    def _quarantine_record(record: Any, *, index: int) -> dict[str, Any]:
+        try:
+            encoded = json.dumps(record, ensure_ascii=False, sort_keys=True).encode("utf-8")
+        except (TypeError, UnicodeEncodeError):
+            encoded = type(record).__name__.encode("ascii", errors="replace")
+        return {
+            "index": max(0, int(index)),
+            "reason_code": "blocked_or_invalid_resource_plan",
+            "record_sha256": hashlib.sha256(encoded).hexdigest(),
+            "record_size_bytes": len(encoded),
+            "quarantined_at": time.time(),
+        }
+
+
+__all__ = [
+    "RESOURCE_PLAN_VERSION",
+    "ResourcePlanQuestion",
+    "ResourcePlanStep",
+    "SkillResourcePlan",
+    "SkillResourcePlanItem",
+    "SkillResourcePlanStore",
+]

--- a/server/skills/creator_resource_runtime.py
+++ b/server/skills/creator_resource_runtime.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable
+
+from .creator_quality import load_creator_authoring_playbook
+from .creator_resource_plan import RESOURCE_PLAN_VERSION
+from .creator_resource_service import ResourcePlanningRequest
+from .creator_runtime import CREATOR_WORKFLOW_VERSION
+from .creator_store import (
+    CREATOR_ASSISTANT_AGENT_ID,
+    SkillCreatorValidationError,
+)
+
+
+RESOURCE_PLANNER_WORKFLOW_VERSION = "skill-creator-resource-planner-v1"
+
+
+@dataclass(frozen=True, slots=True)
+class ResourcePlannerWorkflowInvocation:
+    workflow: dict[str, Any]
+    inputs: dict[str, str]
+    runtime_metadata: dict[str, Any]
+
+
+ResourcePlannerWorkflowRunner = Callable[
+    [ResourcePlannerWorkflowInvocation], Awaitable[str]
+]
+
+
+class WorkflowCreatorResourcePlanner:
+    """Run the fixed no-tool Creator planner and parse one strict JSON result."""
+
+    def __init__(
+        self,
+        *,
+        model_id: str,
+        model_available: Callable[[], bool],
+        runner: ResourcePlannerWorkflowRunner,
+    ) -> None:
+        self.model_id = str(model_id or "").strip()
+        self.model_available = model_available
+        self.runner = runner
+
+    def available(self) -> bool:
+        return bool(self.model_id and self.model_available())
+
+    async def plan(self, request: ResourcePlanningRequest) -> dict[str, Any]:
+        invocation = build_resource_planner_invocation(request, model_id=self.model_id)
+        output = await self.runner(invocation)
+        payload = parse_resource_plan_output(output)
+        if payload.pop("resource_plan_version", None) != RESOURCE_PLAN_VERSION:
+            raise SkillCreatorValidationError(
+                "Creator resource planner returned an unsupported contract version.",
+                code="skill_creator_resource_planner_invalid",
+            )
+        return payload
+
+
+def build_resource_planner_invocation(
+    request: ResourcePlanningRequest,
+    *,
+    model_id: str,
+) -> ResourcePlannerWorkflowInvocation:
+    session_id = _required_text(request.session.get("session_id"), "session_id")
+    session_revision = _positive_int(
+        request.session.get("session_revision"), "session_revision"
+    )
+    context = {
+        "resource_plan_version": RESOURCE_PLAN_VERSION,
+        "operation": "update" if request.target_draft is not None else "create",
+        "definition": {
+            "intent": request.session.get("intent") or "",
+            "positive_examples": list(request.session.get("positive_examples") or []),
+            "near_miss_examples": list(request.session.get("near_miss_examples") or []),
+            "expected_output": request.session.get("expected_output") or "",
+            "success_criteria": list(request.session.get("success_criteria") or []),
+        },
+        "selected_evidence": list(request.session.get("selected_evidence") or []),
+        "allowed_source_ids": list(request.allowed_source_ids),
+        "target_draft": request.target_draft,
+        "previous_plan": request.current_plan,
+        "planning_limits": {
+            "clarification_questions_max": 5,
+            "workflow_steps_min": 4,
+            "workflow_steps_max": 10,
+            "resource_count_max": 20,
+            "resource_kinds": ["script", "reference", "asset"],
+            "resource_actions": ["keep", "create", "update", "delete"],
+            "script_languages": ["python", "javascript"],
+            "assets_are_utf8_text_only": True,
+            "forbidden_package_paths": ["README.md", "eval/", "evals/", "user-meta"],
+        },
+    }
+    context_text = json.dumps(
+        context,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    if len(context_text.encode("utf-8")) > 240_000:
+        raise SkillCreatorValidationError(
+            "Creator resource planning context is too large.",
+            code="skill_creator_context_too_large",
+        )
+    workflow = {
+        "id": f"skill-resource-plan-{session_id}",
+        "title": "Skill Creator resource planning",
+        "nodes": [
+            {
+                "id": "planner-input",
+                "type": "input",
+                "data": {"kind": "input", "variableName": "creator_request"},
+            },
+            {
+                "id": "planner-agent",
+                "type": "workflow_agent",
+                "data": {
+                    "kind": "workflow_agent",
+                    "agentName": CREATOR_ASSISTANT_AGENT_ID,
+                    "modelId": str(model_id or "").strip(),
+                    "agentStrategy": "function_calling",
+                    "rolePrompt": _resource_planner_prompt(),
+                    "taskInput": "{{creator_request}}",
+                    "outputVariable": "resource_plan",
+                    "toolMode": "none",
+                    "toolNames": "",
+                    "maxIterations": "1",
+                    "maxToolCalls": "1",
+                    "maxToolConcurrency": "1",
+                    "parallelToolCalls": "false",
+                    "retryOnFailure": "false",
+                    "temperature": "0.1",
+                },
+            },
+            {
+                "id": "planner-output",
+                "type": "output",
+                "data": {"kind": "output", "outputVariable": "resource_plan"},
+            },
+        ],
+        "edges": [
+            {
+                "id": "planner-input-agent",
+                "source": "planner-input",
+                "target": "planner-agent",
+            },
+            {
+                "id": "planner-agent-output",
+                "source": "planner-agent",
+                "target": "planner-output",
+            },
+        ],
+    }
+    return ResourcePlannerWorkflowInvocation(
+        workflow=workflow,
+        inputs={"creator_request": context_text},
+        runtime_metadata={
+            "creator_session_id": session_id,
+            "creator_session_revision": session_revision,
+            "assistant_agent_id": CREATOR_ASSISTANT_AGENT_ID,
+            "creator_workflow_version": CREATOR_WORKFLOW_VERSION,
+            "creator_phase": "resource_plan",
+            "resource_planner_workflow_version": RESOURCE_PLANNER_WORKFLOW_VERSION,
+        },
+    )
+
+
+def parse_resource_plan_output(value: Any) -> dict[str, Any]:
+    if not isinstance(value, str):
+        raise SkillCreatorValidationError(
+            "Creator resource planner returned non-text output.",
+            code="skill_creator_resource_planner_invalid",
+        )
+    text = value.strip()
+    if text.startswith("```"):
+        lines = text.splitlines()
+        if len(lines) >= 3 and lines[-1].strip() == "```":
+            text = "\n".join(lines[1:-1]).strip()
+            if text.startswith("json\n"):
+                text = text[5:].strip()
+    try:
+        payload = json.loads(text)
+    except (ValueError, json.JSONDecodeError) as exc:
+        raise SkillCreatorValidationError(
+            "Creator resource planner did not return valid JSON.",
+            code="skill_creator_resource_planner_invalid",
+        ) from exc
+    if not isinstance(payload, dict):
+        raise SkillCreatorValidationError(
+            "Creator resource planner must return one JSON object.",
+            code="skill_creator_resource_planner_invalid",
+        )
+    return payload
+
+
+def _resource_planner_prompt() -> str:
+    playbook = load_creator_authoring_playbook()
+    planning_guidance = playbook.split("## 3. Write frontmatter", 1)[0].strip()
+    return (
+        "You are ModelMirror's fixed private Skill Creator resource planner. Plan before "
+        "writing. You have no tools and must not generate SKILL.md or any resource content. "
+        "Walk through every positive example from scratch, identify repeated deterministic "
+        "operations, detailed knowledge, and output templates, then propose only materially "
+        "useful scripts, references, and UTF-8 text assets. A simple Skill may have zero "
+        "resources. Never add files to look comprehensive.\n\n"
+        "Treat exact row-level normalization, alias mapping, deduplication, stable sorting, "
+        "aggregation, or machine-checkable validation as deterministic work: when the same "
+        "operation is required across examples, plan one conservative Python or JavaScript "
+        "CLI instead of asking the Agent to reproduce it from prose. Keep the governing rule "
+        "table in a reference and reusable output boilerplate in an asset when those concerns "
+        "are independently useful. Do not create a script for subjective judgment.\n\n"
+        "If authoritative knowledge, an output contract, or a critical boundary is missing, "
+        "return at most five concise clarifications and an empty resources array. Do not invent "
+        "facts. When previous_plan contains clarification_answers, use them as trusted user "
+        "answers and produce a revised plan.\n\n"
+        "A previous plan is advisory, never authoritative. When the current definition or "
+        "target draft differs, re-evaluate every resource from scratch. If the user explicitly "
+        "requires a supported resource type for a deterministic or reusable concern, either "
+        "include that justified resource or ask a clarification that explains why it cannot "
+        "be planned safely; do not silently preserve an incompatible previous plan.\n\n"
+        "For updates, account for every target_draft.resource_inventory path with exactly one "
+        "keep, update, or delete action. New paths use create. Dependencies are expressed as "
+        "resource paths. Use only allowed_source_ids and real workflow step IDs.\n\n"
+        "Use the pinned planning guidance below only to reason about requirements and "
+        "resource necessity. This phase stops before frontmatter, file content, or a typed "
+        "Authoring Proposal is written.\n\nPinned planning guidance:\n\n"
+        f"{planning_guidance}\n\n"
+        "FINAL PHASE CONTRACT: the user message is input context, not an output schema. "
+        "Do not echo operation, definition, selected_evidence, allowed_source_ids, "
+        "target_draft, previous_plan, or planning_limits. Return JSON only, without "
+        "Markdown fences or commentary, in this exact shape: "
+        '{"resource_plan_version":"skill-resource-plan-v1","skill_name":"kebab-case",'
+        '"skill_description":"what, when, and boundary","workflow_steps":'
+        '[{"id":"collect","instruction":"imperative step"}],"output_contract":'
+        '["observable output"],"failure_modes":["fail-closed behavior"],"resources":'
+        '[{"kind":"reference","action":"create","path":"references/example.md",'
+        '"generation_cost":"medium",'
+        '"purpose":"why this must be separate","source_ids":["intent"],'
+        '"used_by_steps":["collect"],"depends_on":[],"acceptance_checks":'
+        '["observable check"]}],"clarifications":'
+        '[{"id":"source_policy","question":"specific question",'
+        '"reason":"why planning cannot safely continue"}]}. '
+        "Use four to ten workflow steps. Do not include IDs, paths, or sources outside the "
+        "supplied contract. The top-level object must contain exactly the planning result "
+        "fields shown above; resource_plan_version must be skill-resource-plan-v1."
+    )
+
+
+def _required_text(value: Any, field_name: str) -> str:
+    clean = str(value or "").strip()
+    if not clean:
+        raise SkillCreatorValidationError(
+            f"Creator resource planning is missing {field_name}.",
+            code="skill_creator_resource_plan_invalid",
+        )
+    return clean
+
+
+def _positive_int(value: Any, field_name: str) -> int:
+    try:
+        result = int(value)
+    except (TypeError, ValueError) as exc:
+        raise SkillCreatorValidationError(
+            f"Creator resource planning has an invalid {field_name}.",
+            code="skill_creator_resource_plan_invalid",
+        ) from exc
+    if isinstance(value, bool) or result < 1:
+        raise SkillCreatorValidationError(
+            f"Creator resource planning has an invalid {field_name}.",
+            code="skill_creator_resource_plan_invalid",
+        )
+    return result
+
+
+__all__ = [
+    "RESOURCE_PLANNER_WORKFLOW_VERSION",
+    "ResourcePlannerWorkflowInvocation",
+    "WorkflowCreatorResourcePlanner",
+    "build_resource_planner_invocation",
+    "parse_resource_plan_output",
+]

--- a/server/skills/creator_resource_service.py
+++ b/server/skills/creator_resource_service.py
@@ -1,0 +1,431 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import os
+import threading
+from dataclasses import asdict, dataclass
+from typing import Any, Protocol
+
+from .creator_quality import build_session_requirements
+from .creator_resource_plan import SkillResourcePlan, SkillResourcePlanStore
+from .creator_service import SkillCreatorService
+from .creator_store import (
+    SkillCreatorConflictError,
+    SkillCreatorSession,
+    SkillCreatorValidationError,
+)
+from .draft_store import WorkspaceSkillDraft, WorkspaceSkillDraftStore
+
+
+RESOURCE_AUTHORING_VERSION = "resource-authoring-v2"
+_RESOURCE_ROOTS = ("scripts/", "references/", "assets/")
+
+
+@dataclass(frozen=True, slots=True)
+class ResourcePlanningRequest:
+    session: dict[str, Any]
+    target_draft: dict[str, Any] | None
+    current_plan: dict[str, Any] | None
+    allowed_source_ids: list[str]
+
+
+class ResourcePlannerExecutor(Protocol):
+    def available(self) -> bool: ...
+
+    async def plan(self, request: ResourcePlanningRequest) -> dict[str, Any]: ...
+
+
+class SkillCreatorResourcePlanningService:
+    VERSION = RESOURCE_AUTHORING_VERSION
+
+    def __init__(
+        self,
+        creator_service: SkillCreatorService,
+        plan_store: SkillResourcePlanStore,
+        *,
+        planner: ResourcePlannerExecutor | None = None,
+        enabled: bool | None = None,
+    ) -> None:
+        self.creator_service = creator_service
+        self.plan_store = plan_store
+        self.planner = planner
+        self.enabled = (
+            os.getenv("SKILL_CREATOR_RESOURCE_AUTHORING_ENABLED", "false")
+            .strip()
+            .lower()
+            in {"1", "true", "yes", "on"}
+            if enabled is None
+            else bool(enabled)
+        )
+        self._locks_guard = threading.RLock()
+        self._locks: dict[str, asyncio.Lock] = {}
+
+    def status(self) -> dict[str, Any]:
+        try:
+            planner_available = bool(self.planner and self.planner.available())
+        except Exception:
+            planner_available = False
+        return {
+            "resource_authoring_version": self.VERSION,
+            "resource_authoring_enabled": self.enabled,
+            "resource_planner_available": self.enabled and planner_available,
+        }
+
+    def require_enabled(self) -> None:
+        self.creator_service.require_enabled()
+        if not self.enabled:
+            raise SkillCreatorValidationError(
+                "Skill Creator resource authoring is disabled.",
+                code="skill_creator_resource_authoring_disabled",
+            )
+
+    def current_projection(self, session_id: str) -> dict[str, Any] | None:
+        self.creator_service.require_enabled()
+        session, draft = self.creator_service.get_session(session_id)
+        current = self.plan_store.current_for_session(session_id)
+        return self._projection(current, session=session, draft=draft)
+
+    async def generate(
+        self,
+        session_id: str,
+        *,
+        expected_session_revision: int,
+        expected_plan_revision: int | None,
+        expected_plan_digest: str | None,
+    ) -> SkillResourcePlan:
+        self.require_enabled()
+        session, _ = self.creator_service.get_session(session_id)
+        self._require_session_revision(session, expected_session_revision)
+        async with self._lock(session.session_id):
+            return await self._generate_locked(
+                session.session_id,
+                expected_session_revision=expected_session_revision,
+                expected_plan_revision=expected_plan_revision,
+                expected_plan_digest=expected_plan_digest,
+            )
+
+    async def _generate_locked(
+        self,
+        session_id: str,
+        *,
+        expected_session_revision: int,
+        expected_plan_revision: int | None,
+        expected_plan_digest: str | None,
+    ) -> SkillResourcePlan:
+        session, draft = self.creator_service.get_session(session_id)
+        self._require_session_revision(session, expected_session_revision)
+        self.creator_service._require_ready_for_generation(session)
+        current = self.plan_store.current_for_session(session_id)
+        self._require_expected_plan(
+            current,
+            expected_revision=expected_plan_revision,
+            expected_digest=expected_plan_digest,
+        )
+        if current is not None and current.state == "needs_input":
+            raise SkillCreatorConflictError(
+                "Answer the current clarification questions before regenerating the plan."
+            )
+        if current is not None and current.state == "confirmed" and not self._projection(
+            current, session=session, draft=draft
+        )["stale"]:
+            raise SkillCreatorConflictError(
+                "The resource plan is already confirmed and cannot be regenerated."
+            )
+        planner = self.planner
+        try:
+            available = bool(planner and planner.available())
+        except Exception as exc:
+            raise SkillCreatorValidationError(
+                "The Skill Creator resource planner status is unavailable.",
+                code="skill_creator_resource_planner_failed",
+            ) from exc
+        if not available or planner is None:
+            raise SkillCreatorValidationError(
+                "The Skill Creator model gateway is not configured.",
+                code="model_gateway_unconfigured",
+            )
+        source_ids = self._source_ids(session)
+        try:
+            payload = await planner.plan(
+                ResourcePlanningRequest(
+                    session=asdict(session),
+                    target_draft=self._draft_context(draft),
+                    current_plan=(
+                        self._planner_plan_context(current) if current else None
+                    ),
+                    allowed_source_ids=sorted(source_ids),
+                )
+            )
+        except (SkillCreatorConflictError, SkillCreatorValidationError):
+            raise
+        except Exception as exc:
+            raise SkillCreatorValidationError(
+                "The dedicated Skill Creator agent could not create a resource plan.",
+                code="skill_creator_resource_planner_failed",
+            ) from exc
+        self._validate_actions(payload, draft=draft)
+        return self.plan_store.save_generated(
+            session_id=session.session_id,
+            session_revision=session.session_revision,
+            draft_id=(draft.draft_id if draft else None),
+            draft_revision=(draft.revision if draft else None),
+            draft_digest=(draft.content_digest if draft else None),
+            payload=payload,
+            allowed_source_ids=source_ids,
+            expected_plan_revision=expected_plan_revision,
+            expected_plan_digest=expected_plan_digest,
+        )
+
+    def save_answers(
+        self,
+        session_id: str,
+        *,
+        plan_id: str,
+        expected_session_revision: int,
+        expected_plan_revision: int,
+        expected_plan_digest: str,
+        answers: dict[str, str],
+    ) -> SkillResourcePlan:
+        self.require_enabled()
+        session, draft = self.creator_service.get_session(session_id)
+        self._require_session_revision(session, expected_session_revision)
+        current = self.plan_store.require(plan_id)
+        self._require_plan_scope(current, session=session, draft=draft)
+        return self.plan_store.save_answers(
+            plan_id,
+            expected_revision=expected_plan_revision,
+            expected_digest=expected_plan_digest,
+            answers=answers,
+        )
+
+    def patch(
+        self,
+        session_id: str,
+        *,
+        plan_id: str,
+        expected_session_revision: int,
+        expected_plan_revision: int,
+        expected_plan_digest: str,
+        changes: dict[str, Any],
+    ) -> SkillResourcePlan:
+        self.require_enabled()
+        session, draft = self.creator_service.get_session(session_id)
+        self._require_session_revision(session, expected_session_revision)
+        current = self.plan_store.require(plan_id)
+        self._require_plan_scope(current, session=session, draft=draft)
+        self._validate_actions({
+            "resources": changes.get(
+                "resources", [asdict(item) for item in current.resources]
+            )
+        }, draft=draft)
+        return self.plan_store.patch(
+            plan_id,
+            expected_revision=expected_plan_revision,
+            expected_digest=expected_plan_digest,
+            changes=changes,
+            allowed_source_ids=self._source_ids(session),
+        )
+
+    def confirm(
+        self,
+        session_id: str,
+        *,
+        plan_id: str,
+        expected_session_revision: int,
+        expected_plan_revision: int,
+        expected_plan_digest: str,
+    ) -> SkillResourcePlan:
+        self.require_enabled()
+        session, draft = self.creator_service.get_session(session_id)
+        self._require_session_revision(session, expected_session_revision)
+        current = self.plan_store.require(plan_id)
+        self._require_plan_scope(current, session=session, draft=draft)
+        return self.plan_store.confirm(
+            plan_id,
+            expected_revision=expected_plan_revision,
+            expected_digest=expected_plan_digest,
+            session_revision=session.session_revision,
+            draft_revision=(draft.revision if draft else None),
+            draft_digest=(draft.content_digest if draft else None),
+        )
+
+    def serialize_projection(
+        self,
+        plan: SkillResourcePlan | None,
+        *,
+        session: SkillCreatorSession,
+        draft: WorkspaceSkillDraft | None,
+    ) -> dict[str, Any] | None:
+        return self._projection(plan, session=session, draft=draft)
+
+    @staticmethod
+    def _projection(
+        plan: SkillResourcePlan | None,
+        *,
+        session: SkillCreatorSession,
+        draft: WorkspaceSkillDraft | None,
+    ) -> dict[str, Any] | None:
+        if plan is None:
+            return None
+        data = SkillResourcePlanStore.serialize(plan)
+        data["stale"] = bool(
+            plan.session_revision != session.session_revision
+            or plan.draft_id != (draft.draft_id if draft else None)
+            or plan.draft_revision != (draft.revision if draft else None)
+            or plan.draft_digest != (draft.content_digest if draft else None)
+        )
+        return data
+
+    @staticmethod
+    def _source_ids(session: SkillCreatorSession) -> set[str]:
+        result = {
+            item.requirement_id
+            for item in build_session_requirements(
+                intent=session.intent,
+                positive_examples=session.positive_examples,
+                near_miss_examples=session.near_miss_examples,
+                expected_output=session.expected_output,
+                success_criteria=session.success_criteria,
+            )
+        }
+        for evidence in session.selected_evidence:
+            candidate_id = str(evidence.get("candidate_id") or "").strip()
+            if candidate_id:
+                result.add(f"evidence:{candidate_id}"[:200])
+        return result
+
+    @staticmethod
+    def _draft_context(draft: WorkspaceSkillDraft | None) -> dict[str, Any] | None:
+        if draft is None:
+            return None
+        files = [
+            {
+                "path": path,
+                "size_bytes": len(content.encode("utf-8")),
+                "sha256": hashlib.sha256(content.encode("utf-8")).hexdigest(),
+            }
+            for path, content in sorted(draft.files.items())
+            if path.startswith(_RESOURCE_ROOTS)
+        ]
+        return {
+            "draft_id": draft.draft_id,
+            "revision": draft.revision,
+            "content_revision": draft.content_revision,
+            "content_digest": draft.content_digest,
+            "name": draft.name,
+            "slug": draft.slug,
+            "description": draft.description,
+            "skill_markdown": draft.skill_markdown[:20_000],
+            "resource_inventory": files,
+        }
+
+    @staticmethod
+    def _planner_plan_context(plan: SkillResourcePlan) -> dict[str, Any]:
+        data = SkillResourcePlanStore.serialize(plan)
+        path_by_id = {item.resource_id: item.path for item in plan.resources}
+        for resource in data["resources"]:
+            resource["depends_on"] = [
+                path_by_id[dependency_id]
+                for dependency_id in resource.get("depends_on", [])
+                if dependency_id in path_by_id
+            ]
+        return data
+
+    @staticmethod
+    def _validate_actions(payload: dict[str, Any], *, draft: WorkspaceSkillDraft | None) -> None:
+        resources = payload.get("resources") or []
+        if not isinstance(resources, list):
+            raise SkillCreatorValidationError("Resource planner returned an invalid resource list.")
+        existing = {
+            path
+            for path in (draft.files if draft else {})
+            if path.startswith(_RESOURCE_ROOTS)
+        }
+        planned_existing: set[str] = set()
+        for raw in resources:
+            if not isinstance(raw, dict):
+                continue
+            path = str(raw.get("path") or "").strip()
+            action = str(raw.get("action") or "create").strip()
+            if action in {"keep", "update", "delete"}:
+                if path not in existing:
+                    raise SkillCreatorValidationError(
+                        "A keep, update, or delete action must target an existing resource.",
+                        code="skill_creator_resource_action_invalid",
+                    )
+                planned_existing.add(path)
+            elif action == "create" and path in existing:
+                raise SkillCreatorValidationError(
+                    "An existing resource must use keep, update, or delete.",
+                    code="skill_creator_resource_action_invalid",
+                )
+        if planned_existing != existing:
+            missing = sorted(existing - planned_existing)
+            raise SkillCreatorValidationError(
+                "The resource plan must explicitly keep, update, or delete every existing resource: "
+                + ", ".join(missing[:10]),
+                code="skill_creator_resource_action_incomplete",
+            )
+
+    @staticmethod
+    def _require_session_revision(
+        session: SkillCreatorSession, expected_session_revision: int
+    ) -> None:
+        if session.session_revision != int(expected_session_revision):
+            raise SkillCreatorConflictError(
+                "Creator session changed. Reload it before continuing."
+            )
+
+    @staticmethod
+    def _require_expected_plan(
+        current: SkillResourcePlan | None,
+        *,
+        expected_revision: int | None,
+        expected_digest: str | None,
+    ) -> None:
+        if current is None:
+            if expected_revision is not None or expected_digest is not None:
+                raise SkillCreatorConflictError("Resource plan changed. Reload it first.")
+            return
+        if (
+            expected_revision is None
+            or expected_digest is None
+            or current.revision != int(expected_revision)
+            or current.digest != str(expected_digest).lower()
+        ):
+            raise SkillCreatorConflictError("Resource plan changed. Reload it first.")
+
+    @staticmethod
+    def _require_plan_scope(
+        plan: SkillResourcePlan,
+        *,
+        session: SkillCreatorSession,
+        draft: WorkspaceSkillDraft | None,
+    ) -> None:
+        if (
+            plan.session_id != session.session_id
+            or plan.session_revision != session.session_revision
+            or plan.draft_id != (draft.draft_id if draft else None)
+            or plan.draft_revision != (draft.revision if draft else None)
+            or plan.draft_digest != (draft.content_digest if draft else None)
+        ):
+            raise SkillCreatorConflictError(
+                "Resource plan no longer matches the current Creator session and draft."
+            )
+
+    def _lock(self, session_id: str) -> asyncio.Lock:
+        with self._locks_guard:
+            lock = self._locks.get(session_id)
+            if lock is None:
+                lock = asyncio.Lock()
+                self._locks[session_id] = lock
+            return lock
+
+
+__all__ = [
+    "RESOURCE_AUTHORING_VERSION",
+    "ResourcePlannerExecutor",
+    "ResourcePlanningRequest",
+    "SkillCreatorResourcePlanningService",
+]

--- a/server/tests/test_skill_creator_resource_plan.py
+++ b/server/tests/test_skill_creator_resource_plan.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from server.skills.creator_resource_plan import SkillResourcePlanStore
+from server.skills.creator_store import (
+    SkillCreatorConflictError,
+    SkillCreatorStorageError,
+    SkillCreatorValidationError,
+)
+
+
+SOURCE_IDS = {
+    "intent",
+    "positive_example:0",
+    "near_miss:0",
+    "expected_output",
+    "success_criterion:0",
+}
+
+
+def _payload(*, resources=None, clarifications=None):
+    return {
+        "skill_name": "review-incidents",
+        "skill_description": (
+            "Create evidence-bound incident reviews when users need a timeline, "
+            "root-cause boundaries, and corrective actions; do not use for generic rewriting."
+        ),
+        "workflow_steps": [
+            {"id": "collect", "instruction": "Collect only explicit incident facts."},
+            {"id": "normalize", "instruction": "Normalize times and missing values."},
+            {"id": "analyze", "instruction": "Separate known causes from unknowns."},
+            {"id": "deliver", "instruction": "Render and verify the final review."},
+        ],
+        "output_contract": ["Return a Chinese Markdown incident report."],
+        "failure_modes": ["Mark unavailable facts as pending confirmation."],
+        "resources": [
+            {"generation_cost": "medium", **item}
+            for item in (resources or [])
+        ],
+        "clarifications": clarifications or [],
+    }
+
+
+def _save(store: SkillResourcePlanStore, payload: dict):
+    return store.save_generated(
+        session_id="skillcreator_test",
+        session_revision=4,
+        draft_id=None,
+        draft_revision=None,
+        draft_digest=None,
+        payload=payload,
+        allowed_source_ids=SOURCE_IDS,
+    )
+
+
+def test_zero_resource_plan_is_ready_and_digest_survives_reload(tmp_path: Path) -> None:
+    store = SkillResourcePlanStore(tmp_path)
+    plan = _save(store, _payload())
+
+    assert plan.state == "ready"
+    assert plan.resources == []
+    assert len(plan.digest) == 64
+    restored = SkillResourcePlanStore(tmp_path).require(plan.plan_id)
+    assert restored == plan
+
+
+def test_failed_atomic_save_does_not_publish_an_in_memory_revision(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = SkillResourcePlanStore(tmp_path)
+    plan = _save(store, _payload())
+
+    def fail_save() -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(store, "_save_unlocked", fail_save)
+    with pytest.raises(OSError, match="disk full"):
+        store.patch(
+            plan.plan_id,
+            expected_revision=plan.revision,
+            expected_digest=plan.digest,
+            allowed_source_ids=SOURCE_IDS,
+            changes={"skill_description": plan.skill_description + " Updated."},
+        )
+    assert store.require(plan.plan_id) == plan
+
+
+def test_complex_plan_assigns_stable_ids_and_dependencies(tmp_path: Path) -> None:
+    store = SkillResourcePlanStore(tmp_path)
+    plan = _save(
+        store,
+        _payload(
+            resources=[
+                {
+                    "kind": "reference",
+                    "action": "create",
+                    "path": "references/evidence-policy.md",
+                    "purpose": "Keep detailed evidence boundaries out of SKILL.md.",
+                    "source_ids": ["intent", "near_miss:0"],
+                    "used_by_steps": ["collect", "analyze"],
+                    "depends_on": [],
+                    "acceptance_checks": ["Contains known, unknown, and unsupported cases."],
+                },
+                {
+                    "kind": "script",
+                    "action": "create",
+                    "path": "scripts/normalize_timeline.py",
+                    "purpose": "Normalize timeline rows deterministically.",
+                    "source_ids": ["positive_example:0", "success_criterion:0"],
+                    "used_by_steps": ["normalize"],
+                    "depends_on": ["references/evidence-policy.md"],
+                    "acceptance_checks": ["Rejects malformed timestamps with a non-zero exit."],
+                },
+                {
+                    "kind": "asset",
+                    "action": "create",
+                    "path": "assets/incident-review-template.md",
+                    "purpose": "Provide the final report skeleton.",
+                    "source_ids": ["expected_output"],
+                    "used_by_steps": ["deliver"],
+                    "depends_on": [],
+                    "acceptance_checks": ["Contains every required output section."],
+                },
+            ]
+        ),
+    )
+
+    assert len({item.resource_id for item in plan.resources}) == 3
+    script = next(item for item in plan.resources if item.kind == "script")
+    reference = next(item for item in plan.resources if item.kind == "reference")
+    assert script.depends_on == [reference.resource_id]
+
+    patched = store.patch(
+        plan.plan_id,
+        expected_revision=plan.revision,
+        expected_digest=plan.digest,
+        allowed_source_ids=SOURCE_IDS,
+        changes={"skill_description": plan.skill_description + " Keep claims conservative."},
+    )
+    assert patched.revision == 2
+    assert [item.resource_id for item in patched.resources] == [
+        item.resource_id for item in plan.resources
+    ]
+    assert [item.spec_digest for item in patched.resources] == [
+        item.spec_digest for item in plan.resources
+    ]
+    assert all(len(item.spec_digest) == 64 for item in plan.resources)
+    assert patched.digest != plan.digest
+
+
+def test_clarification_answers_are_immutable_and_require_regeneration(tmp_path: Path) -> None:
+    store = SkillResourcePlanStore(tmp_path)
+    plan = _save(
+        store,
+        _payload(
+            clarifications=[
+                {
+                    "id": "policy_source",
+                    "question": "Which policy defines incident severity?",
+                    "reason": "The supplied examples do not define authoritative levels.",
+                }
+            ]
+        ),
+    )
+    assert plan.state == "needs_input"
+
+    with pytest.raises(SkillCreatorValidationError):
+        store.save_answers(
+            plan.plan_id,
+            expected_revision=plan.revision,
+            expected_digest=plan.digest,
+            answers={},
+        )
+
+    answered = store.save_answers(
+        plan.plan_id,
+        expected_revision=plan.revision,
+        expected_digest=plan.digest,
+        answers={"policy_source": "No severity policy exists; use explicit missing markers."},
+    )
+    assert answered.state == "needs_regeneration"
+    assert plan.clarification_answers == {}
+    assert answered.clarification_answers["policy_source"].startswith("No severity")
+
+    regenerated = store.save_generated(
+        session_id=answered.session_id,
+        session_revision=answered.session_revision,
+        draft_id=None,
+        draft_revision=None,
+        draft_digest=None,
+        payload=_payload(),
+        allowed_source_ids=SOURCE_IDS,
+        expected_plan_revision=answered.revision,
+        expected_plan_digest=answered.digest,
+    )
+    assert regenerated.state == "ready"
+    assert regenerated.clarification_answers == answered.clarification_answers
+
+
+def test_confirm_is_bound_to_session_and_draft_snapshot(tmp_path: Path) -> None:
+    store = SkillResourcePlanStore(tmp_path)
+    plan = _save(store, _payload())
+
+    with pytest.raises(SkillCreatorConflictError):
+        store.confirm(
+            plan.plan_id,
+            expected_revision=plan.revision,
+            expected_digest=plan.digest,
+            session_revision=5,
+            draft_revision=None,
+            draft_digest=None,
+        )
+    confirmed = store.confirm(
+        plan.plan_id,
+        expected_revision=plan.revision,
+        expected_digest=plan.digest,
+        session_revision=4,
+        draft_revision=None,
+        draft_digest=None,
+    )
+    assert confirmed.state == "confirmed"
+    assert confirmed.revision == plan.revision + 1
+
+    with pytest.raises(SkillCreatorConflictError):
+        store.patch(
+            plan.plan_id,
+            expected_revision=confirmed.revision,
+            expected_digest=confirmed.digest,
+            allowed_source_ids=SOURCE_IDS,
+            changes={"skill_name": "changed-name"},
+        )
+
+
+@pytest.mark.parametrize(
+    "resources",
+    [
+        [
+            {
+                "kind": "script",
+                "path": "references/not-a-script.md",
+                "purpose": "Wrong root.",
+                "source_ids": ["intent"],
+                "used_by_steps": ["collect"],
+                "acceptance_checks": ["Must fail."],
+            }
+        ],
+        [
+            {
+                "kind": "script",
+                "path": "scripts/tool.sh",
+                "purpose": "Unsupported script language.",
+                "source_ids": ["intent"],
+                "used_by_steps": ["collect"],
+                "acceptance_checks": ["Must fail."],
+            }
+        ],
+        [
+            {
+                "kind": "reference",
+                "path": "references/con.md",
+                "purpose": "Windows reserved path.",
+                "source_ids": ["intent"],
+                "used_by_steps": ["collect"],
+                "acceptance_checks": ["Must fail."],
+            }
+        ],
+        [
+            {
+                "kind": "reference",
+                "path": "references/unknown.md",
+                "purpose": "Unknown evidence.",
+                "source_ids": ["invented_source"],
+                "used_by_steps": ["collect"],
+                "acceptance_checks": ["Must fail."],
+            }
+        ],
+    ],
+)
+def test_invalid_resource_mappings_fail_before_persistence(tmp_path: Path, resources) -> None:
+    store = SkillResourcePlanStore(tmp_path)
+    with pytest.raises(SkillCreatorValidationError):
+        _save(store, _payload(resources=resources))
+    assert not store.snapshot_path.exists()
+
+
+def test_resource_dependency_cycle_is_rejected(tmp_path: Path) -> None:
+    store = SkillResourcePlanStore(tmp_path)
+    resources = [
+        {
+            "kind": "reference",
+            "path": "references/one.md",
+            "purpose": "First reference.",
+            "source_ids": ["intent"],
+            "used_by_steps": ["collect"],
+            "depends_on": ["references/two.md"],
+            "acceptance_checks": ["Contains the first rule set."],
+        },
+        {
+            "kind": "reference",
+            "path": "references/two.md",
+            "purpose": "Second reference.",
+            "source_ids": ["intent"],
+            "used_by_steps": ["analyze"],
+            "depends_on": ["references/one.md"],
+            "acceptance_checks": ["Contains the second rule set."],
+        },
+    ]
+    with pytest.raises(SkillCreatorValidationError, match="cycle"):
+        _save(store, _payload(resources=resources))
+
+
+def test_store_quarantines_secret_record_and_fails_closed_on_top_level_damage(
+    tmp_path: Path,
+) -> None:
+    store = SkillResourcePlanStore(tmp_path / "safe")
+    plan = _save(store, _payload())
+    payload = json.loads(store.snapshot_path.read_text(encoding="utf-8"))
+    secret = "sk-" + "x" * 48
+    poisoned = dict(payload["items"][0])
+    poisoned["plan_id"] = "skillplan_poisoned"
+    poisoned["session_id"] = "skillcreator_poisoned"
+    poisoned["skill_description"] = f"OPENROUTER_API_KEY={secret}"
+    payload["items"].append(poisoned)
+    store.snapshot_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    restored = SkillResourcePlanStore(tmp_path / "safe")
+    assert restored.require(plan.plan_id).digest == plan.digest
+    rewritten = restored.snapshot_path.read_text(encoding="utf-8")
+    assert secret not in rewritten
+    assert "record_sha256" in rewritten
+
+    broken_dir = tmp_path / "broken"
+    broken_dir.mkdir()
+    snapshot = broken_dir / "skill_creator_resource_plans.json"
+    snapshot.write_text("{broken", encoding="utf-8")
+    broken = SkillResourcePlanStore(broken_dir)
+    with pytest.raises(SkillCreatorStorageError):
+        broken.current_for_session("skillcreator_test")
+    assert snapshot.read_text(encoding="utf-8") == "{broken"

--- a/server/tests/test_skill_creator_resource_service.py
+++ b/server/tests/test_skill_creator_resource_service.py
@@ -1,0 +1,467 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import httpx
+from fastapi import FastAPI
+
+import server.main as main_module
+from server.skills import creator_api
+from server.skills.creator_resource_plan import (
+    RESOURCE_PLAN_VERSION,
+    SkillResourcePlanStore,
+)
+from server.skills.creator_resource_runtime import (
+    WorkflowCreatorResourcePlanner,
+    build_resource_planner_invocation,
+)
+from server.skills.creator_resource_service import (
+    ResourcePlanningRequest,
+    SkillCreatorResourcePlanningService,
+)
+from server.skills.creator_service import SkillCreatorService
+from server.skills.creator_store import (
+    SkillCreatorConflictError,
+    SkillCreatorSessionStore,
+    SkillCreatorValidationError,
+)
+from server.skills.draft_store import WorkspaceSkillDraftStore
+from server.xpert_runtime.authoring_service import AuthoringService
+from server.xpert_runtime.authoring_store import AuthoringProposalStore
+from server.xpert_runtime import WorkflowExecutionStore
+from server.xpert_runtime.run_registry import RunRegistry
+from server.xperts import XpertStore
+
+
+def _plan_payload(*, clarifications=None, resources=None):
+    return {
+        "skill_name": "review-incidents",
+        "skill_description": (
+            "Create evidence-bound incident reviews when a user needs a timeline and "
+            "corrective actions; do not use for generic rewriting."
+        ),
+        "workflow_steps": [
+            {"id": "collect", "instruction": "Collect explicit incident facts."},
+            {"id": "normalize", "instruction": "Normalize times and missing values."},
+            {"id": "analyze", "instruction": "Separate known causes from unknowns."},
+            {"id": "deliver", "instruction": "Render and verify the final review."},
+        ],
+        "output_contract": ["Return a Chinese Markdown incident report."],
+        "failure_modes": ["Mark unavailable facts as pending confirmation."],
+        "resources": [
+            {"generation_cost": "medium", **item}
+            for item in (resources or [])
+        ],
+        "clarifications": clarifications or [],
+    }
+
+
+class _Planner:
+    def __init__(self, payloads: list[dict]) -> None:
+        self.payloads = list(payloads)
+        self.requests: list[ResourcePlanningRequest] = []
+
+    def available(self) -> bool:
+        return True
+
+    async def plan(self, request: ResourcePlanningRequest):
+        self.requests.append(request)
+        return self.payloads.pop(0)
+
+
+def _services(tmp_path: Path, planner, *, enabled=True):
+    runtime = tmp_path / "runtime"
+    drafts = WorkspaceSkillDraftStore(runtime)
+    authoring = AuthoringService(
+        AuthoringProposalStore(runtime),
+        XpertStore(tmp_path / "xperts"),
+        drafts,
+        local_console_actor_id="console_test",
+    )
+    creator = SkillCreatorService(
+        SkillCreatorSessionStore(runtime),
+        drafts,
+        authoring,
+        enabled=True,
+    )
+    planning = SkillCreatorResourcePlanningService(
+        creator,
+        SkillResourcePlanStore(runtime),
+        planner=planner,
+        enabled=enabled,
+    )
+    session = creator.create_session(
+        mode="blank",
+        intent="Turn incident facts into a repeatable review.",
+        positive_examples=["Review a deployment incident."],
+        near_miss_examples=["Rewrite this paragraph."],
+        expected_output="A Chinese Markdown incident review.",
+        success_criteria=["Never invent a root cause."],
+    )
+    preview = creator.preview_source(session.session_id)
+    session = creator.select_evidence(
+        session.session_id,
+        expected_session_revision=session.session_revision,
+        preview_fingerprint=preview.fingerprint,
+        candidate_ids=[],
+    )
+    return creator, planning, drafts, session
+
+
+@pytest.mark.asyncio
+async def test_planning_service_clarifies_regenerates_and_confirms(tmp_path: Path) -> None:
+    planner = _Planner(
+        [
+            _plan_payload(
+                clarifications=[
+                    {
+                        "id": "severity_source",
+                        "question": "Which source defines severity levels?",
+                        "reason": "No authoritative mapping was supplied.",
+                    }
+                ]
+            ),
+            _plan_payload(),
+        ]
+    )
+    _, planning, _, session = _services(tmp_path, planner)
+
+    first = await planning.generate(
+        session.session_id,
+        expected_session_revision=session.session_revision,
+        expected_plan_revision=None,
+        expected_plan_digest=None,
+    )
+    assert first.state == "needs_input"
+    answered = planning.save_answers(
+        session.session_id,
+        plan_id=first.plan_id,
+        expected_session_revision=session.session_revision,
+        expected_plan_revision=first.revision,
+        expected_plan_digest=first.digest,
+        answers={"severity_source": "No severity policy exists; omit severity."},
+    )
+    second = await planning.generate(
+        session.session_id,
+        expected_session_revision=session.session_revision,
+        expected_plan_revision=answered.revision,
+        expected_plan_digest=answered.digest,
+    )
+    assert second.state == "ready"
+    assert planner.requests[-1].current_plan["clarification_answers"] == {
+        "severity_source": "No severity policy exists; omit severity."
+    }
+    confirmed = planning.confirm(
+        session.session_id,
+        plan_id=second.plan_id,
+        expected_session_revision=session.session_revision,
+        expected_plan_revision=second.revision,
+        expected_plan_digest=second.digest,
+    )
+    assert confirmed.state == "confirmed"
+
+
+@pytest.mark.asyncio
+async def test_definition_change_makes_existing_plan_projection_stale(tmp_path: Path) -> None:
+    planner = _Planner([_plan_payload(), _plan_payload()])
+    creator, planning, _, session = _services(tmp_path, planner)
+    plan = await planning.generate(
+        session.session_id,
+        expected_session_revision=session.session_revision,
+        expected_plan_revision=None,
+        expected_plan_digest=None,
+    )
+    confirmed = planning.confirm(
+        session.session_id,
+        plan_id=plan.plan_id,
+        expected_session_revision=session.session_revision,
+        expected_plan_revision=plan.revision,
+        expected_plan_digest=plan.digest,
+    )
+    updated = creator.update_definition(
+        session.session_id,
+        expected_session_revision=session.session_revision,
+        changes={"intent": "Review incidents and preserve action owners."},
+    )
+    projection = planning.current_projection(updated.session_id)
+    assert projection is not None
+    assert projection["plan_id"] == plan.plan_id
+    assert projection["stale"] is True
+    preview = creator.preview_source(updated.session_id)
+    updated = creator.select_evidence(
+        updated.session_id,
+        expected_session_revision=updated.session_revision,
+        preview_fingerprint=preview.fingerprint,
+        candidate_ids=[],
+    )
+    regenerated = await planning.generate(
+        updated.session_id,
+        expected_session_revision=updated.session_revision,
+        expected_plan_revision=confirmed.revision,
+        expected_plan_digest=confirmed.digest,
+    )
+    assert regenerated.plan_id == confirmed.plan_id
+    assert regenerated.revision == confirmed.revision + 1
+    assert regenerated.state == "ready"
+    assert regenerated.session_revision == updated.session_revision
+
+
+@pytest.mark.asyncio
+async def test_update_plan_accounts_for_every_existing_resource(tmp_path: Path) -> None:
+    planner = _Planner([_plan_payload()])
+    creator, planning, drafts, session = _services(tmp_path, planner)
+    draft = drafts.create(
+        name="review-incidents",
+        slug="review-incidents",
+        description="Review incidents when users need evidence-bound corrective actions.",
+        skill_markdown=(
+            "---\nname: review-incidents\n"
+            "description: Review incidents when users need evidence-bound corrective actions.\n"
+            "---\n\n# Review incidents\n\nUse the evidence policy.\n"
+        ),
+        files={"references/evidence.md": "# Evidence policy\n\nUse explicit facts.\n"},
+        creator_session_id=session.session_id,
+        quality_required=True,
+    )
+    session = creator.session_store.bind_draft(
+        session.session_id,
+        expected_session_revision=session.session_revision,
+        draft_id=draft.draft_id,
+        draft_state_revision=draft.revision,
+        content_revision=draft.content_revision,
+        content_digest=draft.content_digest,
+    )
+    with pytest.raises(SkillCreatorValidationError) as caught:
+        await planning.generate(
+            session.session_id,
+            expected_session_revision=session.session_revision,
+            expected_plan_revision=None,
+            expected_plan_digest=None,
+        )
+    assert caught.value.code == "skill_creator_resource_action_incomplete"
+    assert planning.plan_store.current_for_session(session.session_id) is None
+
+
+def test_resource_planner_workflow_has_no_tools_and_strict_contract() -> None:
+    request = ResourcePlanningRequest(
+        session={
+            "session_id": "skillcreator_test",
+            "session_revision": 3,
+            "intent": "Create incident reviews.",
+            "positive_examples": ["Review this outage."],
+            "near_miss_examples": ["Rewrite this paragraph."],
+            "expected_output": "A Markdown report.",
+            "success_criteria": ["Do not invent causes."],
+            "selected_evidence": [],
+        },
+        target_draft=None,
+        current_plan=None,
+        allowed_source_ids=["intent", "expected_output"],
+    )
+    invocation = build_resource_planner_invocation(
+        request, model_id="gateway/default-text"
+    )
+    agent = next(
+        node for node in invocation.workflow["nodes"] if node["data"]["kind"] == "workflow_agent"
+    )
+    assert agent["data"]["toolMode"] == "none"
+    assert agent["data"]["maxToolCalls"] == "1"
+    assert "plan before writing" in agent["data"]["rolePrompt"].lower()
+    assert "do not echo operation" in agent["data"]["rolePrompt"].lower()
+    assert "return one typed proposal" not in agent["data"]["rolePrompt"].lower()
+    assert "row-level normalization" in agent["data"]["rolePrompt"].lower()
+    assert "do not create a script for subjective judgment" in agent["data"][
+        "rolePrompt"
+    ].lower()
+    assert "## 1. Turn the session into explicit requirements" in agent["data"][
+        "rolePrompt"
+    ]
+    assert invocation.runtime_metadata["creator_phase"] == "resource_plan"
+    assert json.loads(invocation.inputs["creator_request"])["planning_limits"][
+        "resource_count_max"
+    ] == 20
+
+
+@pytest.mark.asyncio
+async def test_workflow_resource_planner_accepts_only_versioned_json() -> None:
+    request = ResourcePlanningRequest(
+        session={"session_id": "skillcreator_test", "session_revision": 3},
+        target_draft=None,
+        current_plan=None,
+        allowed_source_ids=["intent"],
+    )
+
+    async def runner(_invocation):
+        return json.dumps(
+            {"resource_plan_version": RESOURCE_PLAN_VERSION, **_plan_payload()}
+        )
+
+    planner = WorkflowCreatorResourcePlanner(
+        model_id="gateway/default-text",
+        model_available=lambda: True,
+        runner=runner,
+    )
+    assert (await planner.plan(request))["skill_name"] == "review-incidents"
+
+    async def invalid_runner(_invocation):
+        return "Here is the plan"
+
+    invalid = WorkflowCreatorResourcePlanner(
+        model_id="gateway/default-text",
+        model_available=lambda: True,
+        runner=invalid_runner,
+    )
+    with pytest.raises(SkillCreatorValidationError) as caught:
+        await invalid.plan(request)
+    assert caught.value.code == "skill_creator_resource_planner_invalid"
+
+
+@pytest.mark.asyncio
+async def test_resource_planner_direct_runtime_uses_creator_token_budget(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = ResourcePlanningRequest(
+        session={
+            "session_id": "skillcreator_resource_budget",
+            "session_revision": 1,
+            "intent": "Create incident reviews.",
+            "positive_examples": ["Review this outage."],
+            "near_miss_examples": ["Rewrite this paragraph."],
+            "expected_output": "A Markdown report.",
+            "success_criteria": ["Do not invent causes."],
+            "selected_evidence": [],
+        },
+        target_draft=None,
+        current_plan=None,
+        allowed_source_ids=["intent", "expected_output"],
+    )
+    invocation = build_resource_planner_invocation(
+        request, model_id="gateway/default-text"
+    )
+    observed: dict[str, object] = {}
+
+    async def fake_stream_messages(
+        model_id,
+        messages,
+        *,
+        temperature=0.7,
+        max_tokens=2048,
+    ):
+        observed.update(
+            model_id=model_id,
+            message_count=len(messages),
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+        yield json.dumps(
+            {"resource_plan_version": RESOURCE_PLAN_VERSION, **_plan_payload()}
+        )
+
+    async def unexpected_text_stream(*_args, **_kwargs):
+        raise AssertionError("Trusted Creator planning must use the budgeted message stream")
+        yield ""  # pragma: no cover
+
+    monkeypatch.setattr(
+        main_module,
+        "stream_workflow_llm_messages",
+        fake_stream_messages,
+    )
+    monkeypatch.setattr(
+        main_module,
+        "get_llm_gateway_config",
+        lambda: ("http://test-gateway.local/v1/chat/completions", "test-key"),
+    )
+    monkeypatch.setattr(
+        main_module,
+        "stream_workflow_llm_text",
+        unexpected_text_stream,
+    )
+    monkeypatch.setattr(main_module, "run_registry", RunRegistry())
+    monkeypatch.setattr(
+        main_module,
+        "workflow_execution_store",
+        WorkflowExecutionStore(tmp_path / "executions"),
+    )
+    monkeypatch.setattr(main_module, "workflow_task_store", {})
+
+    output = await main_module.run_skill_creator_resource_planning(invocation)
+
+    assert json.loads(output)["resource_plan_version"] == RESOURCE_PLAN_VERSION
+    assert observed["message_count"] == 2
+    assert observed["temperature"] == main_module.SKILL_CREATOR_RESOURCE_PLANNER_TEMPERATURE
+    assert observed["max_tokens"] == main_module.SKILL_CREATOR_RESOURCE_PLANNER_MAX_TOKENS
+    assert (
+        main_module.workflow_agent_token_budget(
+            {
+                **invocation.runtime_metadata,
+                "creator_phase": "draft",
+            }
+        )
+        == main_module.SKILL_CREATOR_AGENT_MAX_TOKENS
+    )
+
+
+def test_resource_authoring_flag_fails_closed(tmp_path: Path) -> None:
+    _, planning, _, session = _services(tmp_path, _Planner([_plan_payload()]), enabled=False)
+    assert planning.status()["resource_authoring_enabled"] is False
+    with pytest.raises(SkillCreatorValidationError) as caught:
+        planning.confirm(
+            session.session_id,
+            plan_id="missing",
+            expected_session_revision=session.session_revision,
+            expected_plan_revision=1,
+            expected_plan_digest="0" * 64,
+        )
+    assert caught.value.code == "skill_creator_resource_authoring_disabled"
+
+
+@pytest.mark.asyncio
+async def test_resource_plan_api_projects_plan_and_confirms(tmp_path: Path) -> None:
+    planner = _Planner([_plan_payload()])
+    creator, planning, _, session = _services(tmp_path, planner)
+    previous_creator = creator_api._service
+    previous_planning = creator_api._resource_planning_service
+    app = FastAPI()
+    app.include_router(creator_api.router)
+    try:
+        creator_api.configure_skill_creator(creator)
+        creator_api.configure_skill_creator_resource_planning(planning)
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            status = await client.get("/api/skills/creator/status")
+            assert status.status_code == 200
+            assert status.json()["resource_authoring_enabled"] is True
+            assert status.json()["resource_planner_available"] is True
+
+            generated = await client.post(
+                f"/api/skills/creator/sessions/{session.session_id}/resource-plan/generate",
+                json={"expected_session_revision": session.session_revision},
+            )
+            assert generated.status_code == 200, generated.text
+            plan = generated.json()["resource_plan"]
+            assert plan["state"] == "ready"
+            assert plan["stale"] is False
+
+            confirmed = await client.post(
+                f"/api/skills/creator/sessions/{session.session_id}/resource-plan/confirm",
+                json={
+                    "plan_id": plan["plan_id"],
+                    "expected_session_revision": session.session_revision,
+                    "expected_plan_revision": plan["revision"],
+                    "expected_plan_digest": plan["digest"],
+                },
+            )
+            assert confirmed.status_code == 200, confirmed.text
+            assert confirmed.json()["resource_plan"]["state"] == "confirmed"
+
+            restored = await client.get(
+                f"/api/skills/creator/sessions/{session.session_id}"
+            )
+            assert restored.status_code == 200
+            assert restored.json()["resource_plan"]["state"] == "confirmed"
+    finally:
+        creator_api.configure_skill_creator(previous_creator)
+        creator_api.configure_skill_creator_resource_planning(previous_planning)


### PR DESCRIPTION
## 本轮内容

这是 Skill Creator 资源化增强三组串行 PR 的第 1 组，仅实现交互式资源规划。

- 新增不可变 SkillResourcePlan、revision/digest 乐观一致性与原子持久化。
- Creator Agent 先提出必要澄清，再生成零资源或必要的 scripts、references、assets 计划。
- 支持计划编辑、资源排序、keep/create/update/delete、依赖关系和确认冻结。
- 工作台 Step 2 调整为“素材与资源计划”，刷新后可恢复当前计划。
- 新增 SKILL_CREATOR_RESOURCE_AUTHORING_ENABLED，默认关闭，原 Creator 流程保持不变。
- 修复可信 Creator 资源规划无工具路径被普通 1024-token 预算截断的问题；普通 Agent 预算不变。

## 设计边界

- 规划阶段不生成文件、不创建 Authoring Proposal、不写全局 Skill 目录。
- 简单 Skill 可以确认零附加资源，不以文件数量作为质量指标。
- 缺少权威来源时必须澄清、缩小范围或明确降级，不编造领域规则。
- PR2 才实现分段资源生成、脚本 Sidecar 实测和资源确认；PR3 才完成工作台闭环与金标验收。
- 不涉及 MCP、/coding、多模态、上传、SkillHub、外部市场、公共 App 或二进制资源。

## 验证

- 后端 Creator/Skill 定向回归：119 passed。
- 前端 Vitest：28 files / 131 tests passed。
- 前端生产构建通过。
- git diff --check origin/main...HEAD 通过。
- 独立预览器完成刷新恢复和冻结计划检查；共享 Docker 栈未重建或重启。
- 真实 Provider 验证：简单事故复盘场景正确选择零附加资源；复杂供应商风险 CSV 场景规划确定性 Python 脚本及其来源、步骤和验收条件。

## 回退

关闭 SKILL_CREATOR_RESOURCE_AUTHORING_ENABLED 即可回到现有 Creator 流程；本 PR 不改变 PR #115 的行为评测和安装质量门。