### PR TITLE
feature: 添加隔离浏览器 MCP 适配器

### DIFF
--- a/client/src/components/McpApprovalDialog.tsx
+++ b/client/src/components/McpApprovalDialog.tsx
@@ -29,6 +29,7 @@ export interface McpCatalogApprovalRequest {
   expires_at: number | string;
   idempotency_key?: string;
   target_preview?: McpApprovalTargetPreview;
+  context_kind?: "workspace" | "remote-resource" | "browser-session" | string;
 }
 
 interface McpApprovalDialogProps {
@@ -78,6 +79,10 @@ export default function McpApprovalDialog({
     : 0;
   const expired = secondsLeft <= 0;
   const preview = approval.target_preview;
+  const isBrowserApproval =
+    approval.context_kind === "browser-session" ||
+    preview?.resource.type === "browser-session" ||
+    preview?.resource.type === "browser-domain";
   const confirmationBlocked = expired || preview?.destructive === true;
 
   useEffect(() => {
@@ -157,7 +162,9 @@ export default function McpApprovalDialog({
       >
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
-            <p className="text-sm font-semibold text-amber-100">一次性写入审批</p>
+            <p className="text-sm font-semibold text-amber-100">
+              {isBrowserApproval ? "一次性浏览器操作审批" : "一次性写入审批"}
+            </p>
             <h2 className="mt-2 text-xl font-semibold text-white" id={titleId}>
               {preview?.action_label ?? "确认本次受控操作"}
             </h2>
@@ -171,7 +178,9 @@ export default function McpApprovalDialog({
           {preview ? (
             <>
               <section className="rounded-lg border border-white/10 bg-white/[0.045] p-4">
-                <p className="text-xs font-semibold text-slate-400">目标资源</p>
+                <p className="text-xs font-semibold text-slate-400">
+                  {isBrowserApproval ? "目标域与会话" : "目标资源"}
+                </p>
                 <p className="mt-2 text-sm font-semibold text-white">{preview.resource.label}</p>
                 <p className="mt-1 text-xs text-slate-400">
                   {preview.resource.type} · 标识尾号 {preview.resource.id_suffix || "未提供"}
@@ -179,7 +188,9 @@ export default function McpApprovalDialog({
               </section>
 
               <section className="rounded-lg border border-white/10 bg-white/[0.045] p-4">
-                <p className="text-xs font-semibold text-slate-400">本次变更摘要</p>
+                <p className="text-xs font-semibold text-slate-400">
+                  {isBrowserApproval ? "本次动作摘要" : "本次变更摘要"}
+                </p>
                 {preview.changes.length > 0 ? (
                   <dl className="mt-2 space-y-2">
                     {preview.changes.map((change, index) => (
@@ -203,7 +214,11 @@ export default function McpApprovalDialog({
                 <p className="text-xs font-semibold text-amber-100">影响范围</p>
                 <p className="mt-2 text-sm leading-6 text-slate-200">{preview.impact}</p>
                 <p className={`mt-2 text-xs font-semibold ${preview.destructive ? "text-rose-200" : "text-emerald-200"}`}>
-                  {preview.destructive ? "终止性操作已被前端阻断" : "非终止性写入 · 仅执行一次"}
+                  {preview.destructive
+                    ? "终止性操作已被前端阻断"
+                    : isBrowserApproval
+                      ? "受控页面操作 · 仅执行一次"
+                      : "非终止性写入 · 仅执行一次"}
                 </p>
               </section>
             </>
@@ -214,8 +229,12 @@ export default function McpApprovalDialog({
           )}
         </div>
 
-        <div className="mt-3 rounded-lg bg-black/15 p-3 text-[11px] leading-5 text-slate-500">
-          <p>确认绑定当前项目、会话、工具和冻结参数，只能使用一次；页面不会展示原始参数或正文。</p>
+        <div className="mt-3 rounded-lg bg-black/15 p-3 text-[11px] leading-5 text-slate-400">
+          <p>
+            {isBrowserApproval
+              ? "确认绑定当前项目、浏览器会话、可访问性快照、目标域、工具和冻结参数，只能使用一次；导航、重连或可检测的快照漂移会使审批失效。元素角色与名称来自目标页，不能证明网站真实性；页面脚本仍可能在摘要不变时改变行为，确认前请核对 Origin 和最新截图，勿在不可信页面执行会产生现实后果的操作。"
+              : "确认绑定当前项目、会话、工具和冻结参数，只能使用一次；页面不会展示原始参数或正文。"}
+          </p>
           {approval.idempotency_key ? (
             <p className="mt-1 font-mono">幂等键：{shorten(approval.idempotency_key)}</p>
           ) : null}
@@ -232,7 +251,7 @@ export default function McpApprovalDialog({
 
         <div className="mt-4 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
           <button
-            className="min-h-11 rounded-full border border-white/10 px-4 py-2 text-sm font-semibold text-slate-200 transition hover:bg-white/[0.06] disabled:opacity-50"
+            className="min-h-11 rounded-full border border-white/10 px-4 py-2 text-sm font-semibold text-slate-200 transition hover:bg-white/[0.06] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-300 disabled:opacity-50"
             disabled={busy}
             onClick={() => void onCancel()}
             ref={cancelButtonRef}
@@ -241,12 +260,17 @@ export default function McpApprovalDialog({
             取消本次操作
           </button>
           <button
-            className="min-h-11 rounded-full bg-amber-300 px-4 py-2 text-sm font-semibold text-ink-950 transition hover:bg-amber-200 disabled:cursor-not-allowed disabled:opacity-45"
+            aria-busy={busy}
+            className="min-h-11 rounded-full bg-amber-300 px-4 py-2 text-sm font-semibold text-ink-950 transition hover:bg-amber-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-100 focus-visible:ring-offset-2 focus-visible:ring-offset-ink-950 disabled:cursor-not-allowed disabled:opacity-45"
             disabled={busy || confirmationBlocked}
             onClick={() => void onConfirm()}
             type="button"
           >
-            {busy ? "正在确认…" : "确认写入一次"}
+            {busy
+              ? "正在确认…"
+              : isBrowserApproval
+                ? "确认执行一次"
+                : "确认写入一次"}
           </button>
         </div>
       </div>

--- a/client/src/components/McpBrowserPanel.tsx
+++ b/client/src/components/McpBrowserPanel.tsx
@@ -1,0 +1,435 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type {
+  McpAvailability,
+  McpBrowserPolicy,
+  McpDatabasePreflightStatus,
+} from "../data/mcpAdaptationPlan";
+
+interface McpBrowserSessionStatus {
+  status: "active" | "tainted" | "disconnected";
+  generation?: string;
+  page_revision?: number;
+  page_digest?: string;
+  current_origin?: string | null;
+  action_count?: number;
+  max_actions?: number;
+  expires_at?: number | string | null;
+  approved_hosts?: string[];
+}
+
+interface McpBrowserArtifact {
+  artifact_id: string;
+  name: string;
+  mime_type: string;
+  size_bytes: number;
+  sha256: string;
+  created_at: number | string;
+  expires_at: number | string;
+  download_url?: string;
+}
+
+interface McpBrowserPanelProps {
+  availability: McpAvailability;
+  connected: boolean;
+  policy: McpBrowserPolicy | null;
+  preflightStatus: McpDatabasePreflightStatus;
+  projectId: string;
+  refreshKey?: number | string;
+}
+
+const preflightCopy: Record<
+  McpDatabasePreflightStatus,
+  { label: string; className: string }
+> = {
+  "not-applicable": { label: "尚未开始", className: "text-slate-300" },
+  blocked: { label: "浏览器预检已阻断", className: "text-rose-100" },
+  "awaiting-workspace": { label: "等待浏览器策略", className: "text-amber-100" },
+  "awaiting-configuration": { label: "等待受控配置", className: "text-amber-100" },
+  unverified: { label: "等待连接预检", className: "text-amber-100" },
+  verifying: { label: "正在校验浏览器与工具契约", className: "text-cyan-100" },
+  verified: { label: "隔离、网络与工具契约通过", className: "text-emerald-100" },
+  failed: { label: "浏览器预检失败", className: "text-rose-100" },
+};
+
+const sessionCopy: Record<
+  McpBrowserSessionStatus["status"],
+  { label: string; className: string }
+> = {
+  active: { label: "临时会话运行中", className: "text-emerald-100" },
+  tainted: { label: "结果未知，会话已隔离", className: "text-rose-100" },
+  disconnected: { label: "尚未连接", className: "text-slate-300" },
+};
+
+function asMilliseconds(value: number | string | null | undefined) {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "number") return value > 10_000_000_000 ? value : value * 1000;
+  const numeric = Number(value);
+  if (Number.isFinite(numeric)) return numeric > 10_000_000_000 ? numeric : numeric * 1000;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function formatDate(value: number | string | null | undefined) {
+  const milliseconds = asMilliseconds(value);
+  if (milliseconds === null) return "未提供";
+  return new Intl.DateTimeFormat("zh-CN", {
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(milliseconds);
+}
+
+function formatDuration(seconds: number) {
+  if (seconds % 86_400 === 0) return `${seconds / 86_400} 天`;
+  if (seconds % 3_600 === 0) return `${seconds / 3_600} 小时`;
+  if (seconds % 60 === 0) return `${seconds / 60} 分钟`;
+  return `${seconds} 秒`;
+}
+
+function formatBytes(bytes: number) {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KiB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)} MiB`;
+}
+
+function safeDownloadUrl(value: string | undefined, projectId: string) {
+  if (!value) return null;
+  try {
+    const parsed = new URL(value, window.location.origin);
+    const prefix = `/api/mcp/catalog/${encodeURIComponent(projectId)}/browser-artifacts/`;
+    if (
+      parsed.origin !== window.location.origin ||
+      !parsed.pathname.startsWith(prefix) ||
+      !parsed.pathname.endsWith("/download")
+    ) return null;
+    return `${parsed.pathname}${parsed.search}`;
+  } catch {
+    return null;
+  }
+}
+
+async function readError(response: Response) {
+  try {
+    const data = (await response.json()) as { detail?: string | { message?: string } };
+    if (typeof data.detail === "string") return data.detail;
+    if (data.detail?.message) return data.detail.message;
+  } catch {
+    // Fall back to the HTTP status below.
+  }
+  return response.statusText || `HTTP ${response.status}`;
+}
+
+export default function McpBrowserPanel({
+  availability,
+  connected,
+  policy,
+  preflightStatus,
+  projectId,
+  refreshKey = 0,
+}: McpBrowserPanelProps) {
+  const [session, setSession] = useState<McpBrowserSessionStatus | null>(null);
+  const [artifacts, setArtifacts] = useState<McpBrowserArtifact[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [deleteCandidate, setDeleteCandidate] = useState<string | null>(null);
+  const [deletingArtifact, setDeletingArtifact] = useState<string | null>(null);
+
+  const loadState = useCallback(async (signal?: AbortSignal) => {
+    if (availability !== "ready" || !policy) return;
+    setLoading(true);
+    try {
+      const [sessionResponse, artifactsResponse] = await Promise.all([
+        fetch(`/api/mcp/catalog/${projectId}/browser-session`, { signal }),
+        fetch(`/api/mcp/catalog/${projectId}/browser-artifacts`, { signal }),
+      ]);
+      if (sessionResponse.ok) {
+        setSession((await sessionResponse.json()) as McpBrowserSessionStatus);
+      } else if (sessionResponse.status === 404 || sessionResponse.status === 409) {
+        setSession({ status: "disconnected" });
+      } else {
+        throw new Error(await readError(sessionResponse));
+      }
+
+      if (artifactsResponse.ok) {
+        const data = (await artifactsResponse.json()) as {
+          items?: McpBrowserArtifact[];
+        };
+        setArtifacts(Array.isArray(data.items) ? data.items : []);
+      } else if (artifactsResponse.status === 404) {
+        setArtifacts([]);
+      } else {
+        throw new Error(await readError(artifactsResponse));
+      }
+      setError("");
+    } catch (exc) {
+      if (exc instanceof DOMException && exc.name === "AbortError") return;
+      setError(exc instanceof Error ? exc.message : "无法读取浏览器会话状态");
+    } finally {
+      if (!signal?.aborted) setLoading(false);
+    }
+  }, [availability, policy, projectId]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void loadState(controller.signal);
+    return () => controller.abort();
+  }, [loadState, refreshKey]);
+
+  useEffect(() => {
+    if (!connected || availability !== "ready" || !policy) return;
+    const timer = window.setInterval(() => void loadState(), 10_000);
+    return () => window.clearInterval(timer);
+  }, [availability, connected, loadState, policy]);
+
+  const status = session?.status ?? (connected ? "active" : "disconnected");
+  const actionCount = session?.action_count ?? 0;
+  const maxActions = session?.max_actions ?? policy?.max_actions ?? 50;
+  const approvedHosts = session?.approved_hosts ?? [];
+  const policyDisabledCapabilities = useMemo(
+    () => [
+      ["账号凭据采集、登录流程与登录态持久化", policy?.login_state],
+      ["上传", policy?.uploads],
+      ["下载", policy?.downloads],
+      ["剪贴板", policy?.clipboard],
+      ["本机文件", policy?.local_files],
+      ["Cookie 导入、导出与持久化", policy?.cookies],
+      ["Storage 导入、导出与持久化", policy?.storage],
+      ["任意脚本求值工具", policy?.evaluate],
+      ["外部 CDP", policy?.cdp],
+    ].filter((entry) => entry[1] === false).map((entry) => entry[0] as string),
+    [policy],
+  );
+
+  async function deleteArtifact(artifactId: string) {
+    setDeletingArtifact(artifactId);
+    setError("");
+    try {
+      const response = await fetch(
+        `/api/mcp/catalog/${projectId}/browser-artifacts/${encodeURIComponent(artifactId)}`,
+        { method: "DELETE" },
+      );
+      if (!response.ok && response.status !== 404) throw new Error(await readError(response));
+      setArtifacts((current) => current.filter((item) => item.artifact_id !== artifactId));
+      setDeleteCandidate(null);
+    } catch (exc) {
+      setError(exc instanceof Error ? exc.message : "截图清理失败");
+    } finally {
+      setDeletingArtifact(null);
+    }
+  }
+
+  if (availability === "blocked") {
+    return (
+      <section
+        aria-label="浏览器适配状态"
+        className="relative mt-3 rounded-lg border border-rose-300/20 bg-rose-300/[0.055] p-3 text-xs"
+      >
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <h3 className="font-semibold text-rose-100">浏览器运行时未启动</h3>
+          <span className="rounded-full border border-rose-300/25 bg-rose-300/[0.08] px-2.5 py-1 font-semibold text-rose-100">
+            连接与安装关闭
+          </span>
+        </div>
+        <p className="mt-2 leading-5 text-slate-300">
+          该条目尚未形成可维护、可审计的固定浏览器契约。页面不会启动浏览器进程，也不会回退到外部 CDP、WebDriver 或归档运行时。
+        </p>
+      </section>
+    );
+  }
+
+  if (!policy) {
+    return (
+      <section
+        aria-label="浏览器适配状态"
+        className="relative mt-3 rounded-lg border border-amber-300/20 bg-amber-300/[0.055] p-3 text-xs text-amber-50"
+      >
+        正在同步服务端浏览器安全策略；策略可用前连接入口保持关闭。
+      </section>
+    );
+  }
+
+  return (
+    <section
+      aria-label="临时浏览器安全与会话状态"
+      className="relative mt-3 rounded-lg border border-cyan-300/20 bg-cyan-300/[0.05] p-3 text-xs"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h3 className="font-semibold text-cyan-100">临时浏览器安全状态</h3>
+        <div className="flex flex-wrap gap-2">
+          <span className="rounded-full border border-cyan-300/25 bg-cyan-300/[0.08] px-2.5 py-1 font-semibold text-cyan-100">
+            匿名临时会话
+          </span>
+          <span className="rounded-full border border-emerald-300/25 bg-emerald-300/[0.08] px-2.5 py-1 font-semibold text-emerald-100">
+            仅截图产物
+          </span>
+        </div>
+      </div>
+
+      <dl className="mt-3 grid gap-2 sm:grid-cols-3">
+        <div className="rounded-lg bg-black/15 p-2.5">
+          <dt className="text-slate-400">会话</dt>
+          <dd aria-live="polite" className={`mt-1 font-semibold ${sessionCopy[status].className}`}>
+            {loading && !session ? "正在读取状态" : sessionCopy[status].label}
+          </dd>
+        </div>
+        <div className="rounded-lg bg-black/15 p-2.5">
+          <dt className="text-slate-400">浏览器预检</dt>
+          <dd aria-live="polite" className={`mt-1 font-semibold ${preflightCopy[preflightStatus].className}`}>
+            {preflightCopy[preflightStatus].label}
+          </dd>
+        </div>
+        <div className="rounded-lg bg-black/15 p-2.5">
+          <dt className="text-slate-400">操作额度</dt>
+          <dd className="mt-1 font-semibold text-white">{actionCount} / {maxActions}</dd>
+          <progress
+            aria-label={`已执行 ${actionCount} 次，最多 ${maxActions} 次`}
+            className="mt-2 h-1.5 w-full accent-cyan-300"
+            max={Math.max(1, maxActions)}
+            value={Math.min(actionCount, maxActions)}
+          />
+        </div>
+      </dl>
+
+      <div className="mt-3 grid gap-2 sm:grid-cols-2">
+        <div className="rounded-lg bg-black/15 p-2.5">
+          <p className="text-slate-400">当前页面来源</p>
+          <p className="mt-1 break-all font-medium text-slate-100">
+            {session?.current_origin || "尚未导航"}
+          </p>
+          <p className="mt-1 text-slate-400">
+            页面版本 {session?.page_revision ?? 0}；跨域后旧审批自动失效。
+          </p>
+        </div>
+        <div className="rounded-lg bg-black/15 p-2.5">
+          <p className="text-slate-400">会话有效期</p>
+          <p className="mt-1 font-medium text-slate-100">
+            {status === "active" ? `最晚 ${formatDate(session?.expires_at)} 结束` : "连接后开始计时"}
+          </p>
+          <p className="mt-1 text-slate-400">
+            最长 {formatDuration(policy.session_ttl_seconds)}；闲置 {formatDuration(policy.idle_ttl_seconds)} 自动清理。
+          </p>
+        </div>
+      </div>
+
+      {approvedHosts.length > 0 ? (
+        <div className="mt-3">
+          <p className="text-slate-400">本次会话已批准目标域</p>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {approvedHosts.map((host) => (
+              <span className="rounded-full border border-white/10 bg-white/[0.055] px-2.5 py-1 text-slate-200" key={host}>
+                {host}
+              </span>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      <div className="mt-3 rounded-lg border border-white/10 bg-white/[0.035] p-3 text-slate-300">
+        <p className="font-semibold text-white">固定边界</p>
+        <p className="mt-1 leading-5">
+          仅允许公网 {policy.allowed_schemes.map((item) => item.toUpperCase()).join("/")} 与端口 {policy.allowed_ports.join("、")}；DNS 固定后连接，跨 origin 请求与重定向直接拒绝。最多 {policy.max_pages} 个页面，全局最多 {policy.max_concurrent_sessions} 个并发会话。
+        </p>
+        <p className="mt-1 leading-5 text-slate-400">
+          导航超时 {policy.navigation_timeout_seconds} 秒，工具调用超时 {policy.call_timeout_seconds} 秒；出口最多 {policy.max_tunnels_per_session} 个并发隧道、累计 {formatBytes(policy.max_egress_bytes_per_session)}，隧道闲置 {policy.egress_tunnel_idle_seconds} 秒或持续 {policy.egress_tunnel_ttl_seconds} 秒即关闭。
+        </p>
+        <p className="mt-1 leading-5 text-slate-400">
+          单次工具结果最多 {formatBytes(policy.max_output_bytes)}。网页自身产生的 Cookie、缓存和站点存储只存在于临时 profile，结束会话时删除。
+        </p>
+        <p className="mt-2 leading-5 text-slate-400">
+          已关闭：{policyDisabledCapabilities.join("、")}。
+        </p>
+        <p className="mt-2 leading-5 text-amber-100">
+          页面仍可能自行呈现登录界面；本批不会把它作为可用能力，也不会采集、继承或保存登录态。请勿输入账号、密码、OTP 或其他认证信息。
+        </p>
+      </div>
+
+      <div className="mt-3 border-t border-white/10 pt-3">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div>
+            <p className="font-semibold text-white">截图产物</p>
+            <p className="mt-1 text-slate-400">
+              单张最多 {formatBytes(policy.max_artifact_bytes)}；每项目最多 {policy.max_artifacts_per_project} 张 / {formatBytes(policy.max_artifact_storage_bytes)}，默认保留 {formatDuration(policy.artifact_ttl_seconds)}。
+            </p>
+          </div>
+          <button
+            className="min-h-11 rounded-full border border-cyan-300/20 px-3 py-2 font-semibold text-cyan-100 transition hover:border-cyan-300/35 hover:bg-cyan-300/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-200 disabled:cursor-not-allowed disabled:opacity-50"
+            disabled={loading}
+            onClick={() => void loadState()}
+            type="button"
+          >
+            {loading ? "正在刷新" : "刷新状态"}
+          </button>
+        </div>
+
+        {artifacts.length === 0 ? (
+          <p className="mt-3 rounded-lg bg-black/15 p-3 leading-5 text-slate-400">
+            暂无截图。执行截图工具后，下载和清理入口会显示在这里。
+          </p>
+        ) : (
+          <ul className="mt-3 space-y-2">
+            {artifacts.map((artifact) => (
+              <li className="rounded-lg bg-black/15 p-3" key={artifact.artifact_id}>
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                  <div className="min-w-0">
+                    <p className="truncate font-semibold text-white">{artifact.name}</p>
+                    <p className="mt-1 text-slate-400">
+                      {formatBytes(artifact.size_bytes)} · {artifact.mime_type} · 到期 {formatDate(artifact.expires_at)}
+                    </p>
+                    <p className="mt-1 truncate font-mono text-[11px] text-slate-400">
+                      SHA-256 {artifact.sha256.slice(0, 16)}…
+                    </p>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {safeDownloadUrl(artifact.download_url, projectId) ? (
+                      <a
+                        className="inline-flex min-h-11 items-center rounded-full bg-cyan-300 px-3 py-2 font-semibold text-ink-950 transition hover:bg-cyan-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-100"
+                        download
+                        href={safeDownloadUrl(artifact.download_url, projectId) ?? undefined}
+                      >
+                        下载截图
+                      </a>
+                    ) : null}
+                    {deleteCandidate === artifact.artifact_id ? (
+                      <>
+                        <button
+                          className="min-h-11 rounded-full border border-white/10 px-3 py-2 font-semibold text-slate-200 transition hover:bg-white/[0.06] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-300"
+                          onClick={() => setDeleteCandidate(null)}
+                          type="button"
+                        >
+                          取消
+                        </button>
+                        <button
+                          className="min-h-11 rounded-full border border-rose-300/30 bg-rose-300/10 px-3 py-2 font-semibold text-rose-100 transition hover:bg-rose-300/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-200 disabled:opacity-50"
+                          disabled={deletingArtifact === artifact.artifact_id}
+                          onClick={() => void deleteArtifact(artifact.artifact_id)}
+                          type="button"
+                        >
+                          {deletingArtifact === artifact.artifact_id ? "正在清理" : "确认清理"}
+                        </button>
+                      </>
+                    ) : (
+                      <button
+                        className="min-h-11 rounded-full border border-rose-300/25 px-3 py-2 font-semibold text-rose-100 transition hover:bg-rose-300/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-200"
+                        onClick={() => setDeleteCandidate(artifact.artifact_id)}
+                        type="button"
+                      >
+                        清理截图
+                      </button>
+                    )}
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {error ? (
+        <p aria-live="polite" className="mt-3 rounded-lg border border-rose-300/25 bg-rose-300/[0.08] p-3 leading-5 text-rose-100" role="status">
+          状态读取失败：{error}
+        </p>
+      ) : null}
+    </section>
+  );
+}

--- a/client/src/components/McpServerCard.tsx
+++ b/client/src/components/McpServerCard.tsx
@@ -8,6 +8,7 @@ import McpCredentialPanel from "./McpCredentialPanel";
 import McpApprovalDialog, {
   type McpCatalogApprovalRequest,
 } from "./McpApprovalDialog";
+import McpBrowserPanel from "./McpBrowserPanel";
 import {
   mcpCatalogSources,
   mcpRequirementLabels,
@@ -33,7 +34,12 @@ interface JsonSchemaProperty {
   default?: unknown;
   items?: JsonSchemaProperty;
   properties?: Record<string, JsonSchemaProperty>;
-  "x-modelmirror-input"?: "workspace-file" | "workspace-directory" | "artifact-name";
+  "x-modelmirror-input"?:
+    | "workspace-file"
+    | "workspace-directory"
+    | "artifact-name"
+    | "browser-url"
+    | "browser-ref";
 }
 
 interface ToolSchema {
@@ -59,6 +65,12 @@ interface ToolCallResult {
   unknown_outcome?: boolean;
 }
 
+interface BrowserElementOption {
+  ref: string;
+  label: string;
+  role: string;
+}
+
 interface CatalogOperationError {
   code: "approval_required" | "provider_rate_limited" | "unknown_outcome" | string;
   message: string;
@@ -69,6 +81,7 @@ interface CatalogOperationError {
   idempotency_key?: string;
   retry_after_seconds?: number;
   target_preview?: McpCatalogApprovalRequest["target_preview"];
+  context_kind?: McpCatalogApprovalRequest["context_kind"];
 }
 
 interface ToolOperationNotice {
@@ -219,6 +232,37 @@ function contentToMarkdown(result: ToolCallResult | null) {
     .join("\n\n");
 }
 
+function browserElementsFromResult(result: ToolCallResult): BrowserElementOption[] | null {
+  const raw = result.raw;
+  const structured =
+    raw.structuredContent && typeof raw.structuredContent === "object"
+      ? raw.structuredContent as Record<string, unknown>
+      : raw.structured_content && typeof raw.structured_content === "object"
+        ? raw.structured_content as Record<string, unknown>
+        : null;
+  const elements = structured?.elements;
+  if (!Array.isArray(elements)) return null;
+  const seen = new Set<string>();
+  const options: BrowserElementOption[] = [];
+  for (const value of elements) {
+    if (!value || typeof value !== "object") continue;
+    const item = value as Record<string, unknown>;
+    const ref = typeof item.ref === "string" ? item.ref : "";
+    if (!/^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$/.test(ref) || seen.has(ref)) continue;
+    seen.add(ref);
+    options.push({
+      ref,
+      label: typeof item.label === "string" && item.label.trim()
+        ? item.label.trim().slice(0, 120)
+        : "未命名元素",
+      role: typeof item.role === "string" && item.role.trim()
+        ? item.role.trim().slice(0, 48)
+        : "元素",
+    });
+  }
+  return options;
+}
+
 function isCatalogOperationError(value: unknown): value is CatalogOperationError {
   return Boolean(
     value &&
@@ -246,6 +290,7 @@ function approvalFromError(
     expires_at: detail.expires_at,
     idempotency_key: detail.idempotency_key,
     target_preview: detail.target_preview,
+    context_kind: detail.context_kind,
   };
 }
 
@@ -253,14 +298,14 @@ function noticeFromError(detail: CatalogOperationError): ToolOperationNotice | n
   if (detail.code === "provider_rate_limited") {
     return {
       kind: "rate-limited",
-      message: detail.message || "上游服务已限流。写入不会自动重试，请稍后重新预览。",
+      message: detail.message || "上游服务已限流。操作不会自动重试，请稍后重新预览。",
       retryAfterSeconds: detail.retry_after_seconds,
     };
   }
   if (detail.code === "unknown_outcome") {
     return {
       kind: "unknown-outcome",
-      message: detail.message || "写入结果未知，禁止自动重试。请先核对上游资源状态。",
+      message: detail.message || "操作结果未知，禁止自动重试。请先核对目标状态。",
       idempotencyKey: detail.idempotency_key,
     };
   }
@@ -271,21 +316,21 @@ function noticeFromResult(result: ToolCallResult): ToolOperationNotice | null {
   if (result.unknown_outcome) {
     return {
       kind: "unknown-outcome",
-      message: "写入结果未知，禁止自动重试。请先核对上游资源状态。",
+      message: "操作结果未知，禁止自动重试。请先核对目标状态。",
       idempotencyKey: result.idempotency_key,
     };
   }
   if (result.idempotent_replay) {
     return {
       kind: "idempotent-replay",
-      message: "检测到重复确认，本次复用了已有结果，没有再次写入。",
+      message: "检测到重复确认，本次复用了已有结果，没有再次执行。",
       idempotencyKey: result.idempotency_key,
     };
   }
   if (result.idempotency_key) {
     return {
       kind: "completed",
-      message: "本次写入已按幂等键完成；重复确认不会再次写入。",
+      message: "本次操作已按幂等键完成；重复确认不会再次执行。",
       idempotencyKey: result.idempotency_key,
     };
   }
@@ -295,6 +340,87 @@ function noticeFromResult(result: ToolCallResult): ToolOperationNotice | null {
 function shortIdempotencyKey(value?: string) {
   if (!value) return "";
   return value.length > 18 ? `${value.slice(0, 10)}…${value.slice(-6)}` : value;
+}
+
+const browserSensitiveQueryKeys = new Set([
+  "accesstoken",
+  "apikey",
+  "authorization",
+  "auth",
+  "bearer",
+  "code",
+  "credential",
+  "idtoken",
+  "jwt",
+  "key",
+  "keypairid",
+  "oauth",
+  "oauthtoken",
+  "password",
+  "passwd",
+  "refreshtoken",
+  "secret",
+  "session",
+  "sessionid",
+  "sig",
+  "signature",
+  "token",
+]);
+
+function browserQueryHasSensitiveKey(query: string) {
+  let decoded = query;
+  for (let index = 0; index < 2; index += 1) {
+    try {
+      decoded = decodeURIComponent(decoded);
+    } catch {
+      return true;
+    }
+  }
+  return decoded.split(/[&;?#]+/).some((component) => {
+    const rawKey = component.split("=", 1)[0] ?? "";
+    const key = rawKey.toLowerCase().replace(/[^a-z0-9]+/g, "");
+    return Boolean(
+      key &&
+        (browserSensitiveQueryKeys.has(key) ||
+          key.startsWith("oauth") ||
+          key.startsWith("xamz") ||
+          key.startsWith("xgoog") ||
+          key.endsWith("secret") ||
+          key.endsWith("signature") ||
+          key.endsWith("token")),
+    );
+  });
+}
+
+function validateBrowserUrl(value: string) {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error("浏览器目标必须是完整的公网 HTTP/HTTPS 地址");
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error("浏览器目标只允许 HTTP 或 HTTPS");
+  }
+  if (parsed.username || parsed.password) {
+    throw new Error("浏览器目标不能包含用户名或密码");
+  }
+  if (parsed.port && parsed.port !== "80" && parsed.port !== "443") {
+    throw new Error("浏览器目标只允许 80 或 443 端口");
+  }
+  if (browserQueryHasSensitiveKey(parsed.search.slice(1))) {
+    throw new Error("浏览器导航 URL 不接受 Token、签名或其他敏感查询参数");
+  }
+  const hostname = parsed.hostname.toLowerCase();
+  if (
+    !hostname.includes(".") ||
+    hostname === "localhost" ||
+    /^\d{1,3}(?:\.\d{1,3}){3}$/.test(hostname) ||
+    hostname.includes(":")
+  ) {
+    throw new Error("浏览器目标必须是完整公网域名；本机名、内部服务名和 IP 地址不可用");
+  }
+  return value;
 }
 
 export default function McpServerCard({
@@ -330,6 +456,8 @@ export default function McpServerCard({
   const [isInstallOpen, setIsInstallOpen] = useState(false);
   const [installState, setInstallState] = useState<InstallState>("checking");
   const [installError, setInstallError] = useState("");
+  const [browserRefreshKey, setBrowserRefreshKey] = useState(0);
+  const [browserRefOptions, setBrowserRefOptions] = useState<BrowserElementOption[]>([]);
   const ignoredRestoredSessionRef = useRef<string | null>(null);
 
   const availability = adapterStatus?.availability ?? project.availability;
@@ -340,6 +468,7 @@ export default function McpServerCard({
     adapterStatus?.required_capabilities ?? project.requiredCapabilities;
   const limitations = adapterStatus?.limitations ?? project.adaptationLimitations;
   const isStatefulSaas = wave === 6;
+  const isBrowserAdapter = wave === 7;
   const statefulSaasGateEnabled =
     !isStatefulSaas || adapterStatus?.stateful_saas_gate_enabled === true;
   const canConnect =
@@ -349,12 +478,14 @@ export default function McpServerCard({
     statefulSaasGateEnabled;
   const workspacePolicy = adapterStatus?.workspace_policy ?? null;
   const databasePolicy = adapterStatus?.database_policy ?? null;
+  const browserPolicy = adapterStatus?.browser_policy ?? null;
   const databasePreflight = adapterStatus?.preflight_status ?? "not-applicable";
   const needsCatalogConfiguration = Boolean(
     adapterStatus?.credential_fields.length || adapterStatus?.setting_fields.length,
   );
   const canStartConnection =
     canConnect &&
+    (!isBrowserAdapter || Boolean(browserPolicy)) &&
     (!workspacePolicy?.required || Boolean(boundWorkspace)) &&
     (!needsCatalogConfiguration || catalogConfigured);
   const canInstall = canConnect && project.installMode === "one-click";
@@ -436,7 +567,7 @@ export default function McpServerCard({
     setSessionId(restoredSession.session_id);
     setState("connected");
     setError("");
-    void fetchTools(restoredSession.session_id).catch((exc) => {
+    void fetchTools().catch((exc) => {
       if (ignoredRestoredSessionRef.current === restoredSession.session_id) return;
       setState("error");
       setError(exc instanceof Error ? exc.message : "无法恢复 MCP 会话");
@@ -468,6 +599,7 @@ export default function McpServerCard({
     setTools([]);
     setToolResults({});
     setToolNotices({});
+    setBrowserRefOptions([]);
     try {
       const response = await fetch(`/api/mcp/catalog/${project.id}/connect`, {
         method: "POST",
@@ -476,8 +608,9 @@ export default function McpServerCard({
       const data = (await response.json()) as { session_id: string };
       setSessionId(data.session_id);
 
-      await fetchTools(data.session_id);
+      await fetchTools();
       setState("connected");
+      setBrowserRefreshKey((current) => current + 1);
       onConnectionChange?.();
     } catch (exc) {
       setState("error");
@@ -485,26 +618,42 @@ export default function McpServerCard({
     }
   }
 
-  async function fetchTools(nextSessionId: string) {
-    const toolsResponse = await fetch(`/api/mcp/${nextSessionId}/tools`);
+  async function fetchTools() {
+    const toolsResponse = await fetch(`/api/mcp/catalog/${project.id}/tools`);
     if (!toolsResponse.ok) throw new Error(await readError(toolsResponse));
     const toolsData = (await toolsResponse.json()) as { tools: McpTool[] };
     setTools(toolsData.tools);
   }
 
   async function disconnect() {
+    setError("");
+    try {
+      const response = await fetch(`/api/mcp/catalog/${project.id}/session`, {
+        method: "DELETE",
+      });
+      if (!response.ok && response.status !== 404) {
+        throw new Error(await readError(response));
+      }
+    } catch (exc) {
+      setState("connected");
+      setError(
+        exc instanceof Error
+          ? `结束会话失败：${exc.message}。临时浏览器可能仍在运行，请再次结束。`
+          : "结束会话失败，临时浏览器可能仍在运行，请再次结束。",
+      );
+      return;
+    }
     ignoredRestoredSessionRef.current =
       sessionId ?? restoredSession?.session_id ?? null;
-    await fetch(`/api/mcp/catalog/${project.id}/session`, {
-      method: "DELETE",
-    }).catch(() => undefined);
     setSessionId(null);
     setTools([]);
     setToolResults({});
     setToolNotices({});
     setFormValues({});
+    setBrowserRefOptions([]);
     setError("");
     setState("idle");
+    setBrowserRefreshKey((current) => current + 1);
     onConnectionChange?.();
   }
 
@@ -547,7 +696,19 @@ export default function McpServerCard({
           ? boundWorkspace?.files[0]?.file_id ?? ""
           : defaultFieldValue(property));
       const coerced = coerceFieldValue(property, rawValue);
-      if (coerced !== undefined) args[key] = coerced;
+      if (property["x-modelmirror-input"] === "browser-url" && typeof coerced === "string") {
+        args[key] = validateBrowserUrl(coerced);
+      } else if (property["x-modelmirror-input"] === "browser-ref" && typeof coerced === "string") {
+        if (
+          !/^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$/.test(coerced) ||
+          !browserRefOptions.some((option) => option.ref === coerced)
+        ) {
+          throw new Error("页面元素引用已失效；请重新执行页面快照并从受控列表选择");
+        }
+        args[key] = coerced;
+      } else if (coerced !== undefined) {
+        args[key] = coerced;
+      }
     }
     return args;
   }
@@ -586,12 +747,18 @@ export default function McpServerCard({
             showApproval(approval, () => {
               setToolResults((current) => ({ ...current }));
               if (boundWorkspace) void refreshBoundWorkspace(boundWorkspace.workspace_id);
+              if (isBrowserAdapter) setBrowserRefreshKey((current) => current + 1);
             });
             return;
           }
           const notice = noticeFromError(detail);
           if (notice) {
             setToolNotices((current) => ({ ...current, [tool.name]: notice }));
+            if (isBrowserAdapter && notice.kind === "unknown-outcome") {
+              markBrowserSessionTainted(
+                "浏览器操作结果未知，临时会话已销毁。请先核对目标状态，再重新连接；不要重试旧操作。",
+              );
+            }
             return;
           }
         }
@@ -599,9 +766,27 @@ export default function McpServerCard({
       }
       const data = (await response.json()) as ToolCallResult;
       setToolResults((current) => ({ ...current, [tool.name]: data }));
+      if (isBrowserAdapter) {
+        const elements = browserElementsFromResult(data);
+        if (
+          adapterStatus?.tool_policies[tool.name]?.effect === "state-write" ||
+          adapterStatus?.tool_policies[tool.name]?.effect === "artifact-create"
+        ) {
+          setBrowserRefOptions([]);
+        } else if (elements !== null) {
+          setBrowserRefOptions(elements);
+        }
+      }
       const notice = noticeFromResult(data);
       if (notice) setToolNotices((current) => ({ ...current, [tool.name]: notice }));
+      if (isBrowserAdapter && notice?.kind === "unknown-outcome") {
+        markBrowserSessionTainted(
+          "浏览器操作结果未知，临时会话已销毁。请先核对目标状态，再重新连接；不要重试旧操作。",
+        );
+        return;
+      }
       if (boundWorkspace) await refreshBoundWorkspace(boundWorkspace.workspace_id);
+      if (isBrowserAdapter) setBrowserRefreshKey((current) => current + 1);
     } catch (exc) {
       setError(exc instanceof Error ? exc.message : "工具执行失败");
     } finally {
@@ -617,9 +802,21 @@ export default function McpServerCard({
     setToolResults({});
     setToolNotices({});
     setFormValues({});
+    setBrowserRefOptions([]);
     setError("");
     setState("idle");
     onConnectionChange?.();
+  }
+
+  function markBrowserSessionTainted(message: string) {
+    ignoredRestoredSessionRef.current = sessionId ?? restoredSession?.session_id ?? null;
+    setSessionId(null);
+    setTools([]);
+    setFormValues({});
+    setBrowserRefOptions([]);
+    setBrowserRefreshKey((current) => current + 1);
+    setState("error");
+    setError(message);
   }
 
   function handleWorkspaceBound(workspace: McpWorkspace | null) {
@@ -656,6 +853,8 @@ export default function McpServerCard({
         if (typeof detail !== "string" && isCatalogOperationError(detail)) {
           const notice = noticeFromError(detail);
           if (notice && approvalToolRef.current) {
+            const unknownBrowserOutcome =
+              isBrowserAdapter && notice.kind === "unknown-outcome";
             setToolNotices((current) => ({
               ...current,
               [approvalToolRef.current as string]: notice,
@@ -663,6 +862,12 @@ export default function McpServerCard({
             setPendingApproval(null);
             approvalCallbackRef.current = null;
             approvalToolRef.current = null;
+            if (unknownBrowserOutcome) {
+              markBrowserSessionTainted(
+                "浏览器操作结果未知，临时会话已销毁。请先核对目标状态，再重新连接；不要重试旧操作。",
+              );
+              onConnectionChange?.();
+            }
             return;
           }
         }
@@ -672,9 +877,23 @@ export default function McpServerCard({
       if (approvalToolRef.current) {
         const toolName = approvalToolRef.current;
         setToolResults((current) => ({ ...current, [toolName]: data }));
+        if (isBrowserAdapter) {
+          setBrowserRefOptions([]);
+        }
         const notice = noticeFromResult(data);
         if (notice) setToolNotices((current) => ({ ...current, [toolName]: notice }));
+        if (isBrowserAdapter && notice?.kind === "unknown-outcome") {
+          markBrowserSessionTainted(
+            "浏览器操作结果未知，临时会话已销毁。请先核对目标状态，再重新连接；不要重试旧操作。",
+          );
+          setPendingApproval(null);
+          approvalCallbackRef.current = null;
+          approvalToolRef.current = null;
+          onConnectionChange?.();
+          return;
+        }
       }
+      if (isBrowserAdapter) setBrowserRefreshKey((current) => current + 1);
       setPendingApproval(null);
       approvalCallbackRef.current?.();
       approvalCallbackRef.current = null;
@@ -795,6 +1014,64 @@ export default function McpServerCard({
             type="text"
             value={value}
           />
+        </label>
+      );
+    }
+
+    if (property["x-modelmirror-input"] === "browser-url") {
+      return (
+        <label className="block rounded-lg border border-cyan-300/15 bg-cyan-300/[0.04] p-3" key={key}>
+          <span className="flex items-center justify-between gap-2 text-xs font-semibold text-slate-200">
+            {label}
+            {required ? <span className="text-hire-100">必填</span> : null}
+          </span>
+          <span className="mt-1 block text-xs leading-5 text-slate-400">
+            仅填写不含 Token、API Key 或签名参数的公网 HTTP/HTTPS 地址；只允许 80/443 端口，DNS 固定后连接，跨 origin 请求与重定向直接拒绝。
+          </span>
+          <input
+            autoCapitalize="none"
+            autoComplete="off"
+            className="mt-2 min-h-11 w-full rounded-lg border border-white/10 bg-ink-950 px-3 py-2 text-sm text-white outline-none transition focus:border-cyan-300/50 focus-visible:ring-2 focus-visible:ring-cyan-300/30"
+            inputMode="url"
+            maxLength={2048}
+            onChange={(event) => updateField(tool.name, key, event.target.value.trim())}
+            placeholder="https://example.com/path"
+            spellCheck={false}
+            type="url"
+            value={value}
+          />
+        </label>
+      );
+    }
+
+    if (property["x-modelmirror-input"] === "browser-ref") {
+      const selectedValue = browserRefOptions.some((option) => option.ref === value)
+        ? value
+        : "";
+      return (
+        <label className="block rounded-lg border border-cyan-300/15 bg-cyan-300/[0.04] p-3" key={key}>
+          <span className="flex items-center justify-between gap-2 text-xs font-semibold text-slate-200">
+            {label}
+            {required ? <span className="text-hire-100">必填</span> : null}
+          </span>
+          <span className="mt-1 block text-xs leading-5 text-slate-400">
+            只能选择当前会话最新页面快照返回的元素；页面操作后需重新执行快照。
+          </span>
+          <select
+            className="mt-2 min-h-11 w-full rounded-lg border border-white/10 bg-ink-950 px-3 py-2 font-mono text-sm text-white outline-none transition focus:border-cyan-300/50 focus-visible:ring-2 focus-visible:ring-cyan-300/30"
+            disabled={browserRefOptions.length === 0}
+            onChange={(event) => updateField(tool.name, key, event.target.value)}
+            value={selectedValue}
+          >
+            <option value="">
+              {browserRefOptions.length === 0 ? "请先执行页面快照" : "选择页面元素"}
+            </option>
+            {browserRefOptions.map((option) => (
+              <option key={option.ref} value={option.ref}>
+                {option.role} · {option.label} · {option.ref}
+              </option>
+            ))}
+          </select>
         </label>
       );
     }
@@ -980,6 +1257,8 @@ export default function McpServerCard({
               ? project.id === "duckdb-mcp"
                 ? "无需 Token 或远程数据库凭据；只读取当前卡片中上传、封存并绑定的本地 DuckDB 文件。"
                 : "数据库连接按只读策略运行；连接字段与加密凭据均在当前卡片独立配置，不接受完整连接串。"
+            : wave === 7
+              ? "无需 Token、OAuth、桌面宿主或本机浏览器；连接会创建匿名临时会话，不支持外站登录流程，也不会继承或保存登录状态。"
             : "不需要 OAuth、Token、额外运行时或桌面宿主，可由当前模镜后端以本地 stdio 启动。"}
         </div>
       )}
@@ -1136,6 +1415,17 @@ export default function McpServerCard({
         </section>
       ) : null}
 
+      {wave === 7 ? (
+        <McpBrowserPanel
+          availability={availability}
+          connected={state === "connected" || adapterStatus?.connected === true}
+          policy={browserPolicy}
+          preflightStatus={databasePreflight}
+          projectId={project.id}
+          refreshKey={browserRefreshKey}
+        />
+      ) : null}
+
       {adapterStatus?.executable && adapterStatus.runtime_image ? (
         <div className="relative mt-3 rounded-lg border border-emerald-300/20 bg-emerald-300/[0.06] p-3 text-xs">
           <div className="flex flex-wrap items-center justify-between gap-2">
@@ -1202,14 +1492,14 @@ export default function McpServerCard({
             type="button"
           >
             {state === "connecting"
-              ? "连接中..."
+              ? isBrowserAdapter ? "正在创建临时会话" : "连接中..."
               : state === "connected"
                 ? "传输已连接"
                 : workspacePolicy?.required && !boundWorkspace
                   ? "先绑定工作区"
                   : needsCatalogConfiguration && !catalogConfigured
                     ? "先保存连接配置"
-                  : "连接 Server"}
+                  : isBrowserAdapter ? "连接临时浏览器" : "连接 Server"}
           </button>
         ) : (
           <button
@@ -1236,7 +1526,7 @@ export default function McpServerCard({
             onClick={() => void disconnect()}
             type="button"
           >
-            断开连接
+            {isBrowserAdapter ? "结束临时会话" : "断开连接"}
           </button>
         ) : null}
         {canInstall ? (
@@ -1328,7 +1618,7 @@ export default function McpServerCard({
               const policyClosed = Boolean(
                 toolPolicy?.sensitive ||
                 toolPolicy?.terminal ||
-                (isStatefulSaas &&
+                ((isStatefulSaas || isBrowserAdapter) &&
                   (!toolPolicy ||
                     (toolPolicy.effect === "state-write" && !toolPolicy.requires_approval))),
               );
@@ -1347,7 +1637,7 @@ export default function McpServerCard({
                         ) : null}
                         {isApprovedWrite ? (
                           <span className="rounded-full border border-amber-300/25 bg-amber-300/[0.08] px-2 py-0.5 text-[11px] font-semibold text-amber-100">
-                            写入 · 需确认
+                            {isBrowserAdapter ? "页面操作 · 需确认" : "写入 · 需确认"}
                           </span>
                         ) : null}
                         {toolPolicy?.effect === "artifact-create" ? (
@@ -1373,7 +1663,7 @@ export default function McpServerCard({
                         : policyClosed
                           ? "工具已关闭"
                           : isApprovedWrite
-                            ? "预览并确认"
+                            ? isBrowserAdapter ? "预览浏览器操作" : "预览并确认"
                             : "执行"}
                     </button>
                   </div>
@@ -1409,12 +1699,12 @@ export default function McpServerCard({
                     >
                       <p className="font-semibold">
                         {notice.kind === "unknown-outcome"
-                          ? "结果未知 · 禁止自动重试"
+                          ? "操作结果未知 · 禁止自动重试"
                           : notice.kind === "rate-limited"
-                            ? "上游限流 · 写入未自动重试"
-                            : notice.kind === "idempotent-replay"
-                              ? "幂等重放 · 未重复写入"
-                              : "写入已完成"}
+                            ? "上游限流 · 操作未自动重试"
+                          : notice.kind === "idempotent-replay"
+                              ? `幂等重放 · ${isBrowserAdapter ? "未重复执行" : "未重复写入"}`
+                              : "操作已完成"}
                       </p>
                       <p className="mt-1 text-slate-300">{notice.message}</p>
                       {notice.retryAfterSeconds !== undefined ? (
@@ -1558,7 +1848,9 @@ export default function McpServerCard({
                   服务端受控适配器
                 </h3>
                 <p className="mt-2 text-sm leading-6 text-slate-300">
-                  安装命令、启动参数和工作目录由后端按项目 ID 固定管理；浏览器不会提交命令、URL、Header 或环境变量。
+                  {isBrowserAdapter
+                    ? "启动命令、浏览器参数、代理、CDP、Header 与环境变量均由后端固定；导航 URL 只作为受控工具参数提交，并经过公网目标、DNS 与单一 Origin 策略校验。"
+                    : "安装命令、启动参数和工作目录由后端按项目 ID 固定管理；浏览器不会提交命令、URL、Header 或环境变量。"}
                 </p>
               </section>
             ) : null}

--- a/client/src/data/mcpAdaptationPlan.ts
+++ b/client/src/data/mcpAdaptationPlan.ts
@@ -28,6 +28,40 @@ export type McpDatabasePreflightStatus =
   | "verified"
   | "failed";
 
+export interface McpBrowserPolicy {
+  engine: string;
+  contract_version: string;
+  tool_schema_sha256: string;
+  session_ttl_seconds: number;
+  idle_ttl_seconds: number;
+  max_pages: number;
+  max_actions: number;
+  max_concurrent_sessions: number;
+  max_tunnels_per_session: number;
+  max_egress_bytes_per_session: number;
+  egress_tunnel_idle_seconds: number;
+  egress_tunnel_ttl_seconds: number;
+  navigation_timeout_seconds: number;
+  call_timeout_seconds: number;
+  max_output_bytes: number;
+  max_artifact_bytes: number;
+  max_artifacts_per_project: number;
+  max_artifact_storage_bytes: number;
+  artifact_ttl_seconds: number;
+  allowed_schemes: string[];
+  allowed_ports: number[];
+  uploads: boolean;
+  downloads: boolean;
+  clipboard: boolean;
+  local_files: boolean;
+  cookies: boolean;
+  storage: boolean;
+  login_state: boolean;
+  evaluate: boolean;
+  cdp: boolean;
+  limitations: string[];
+}
+
 export interface McpDatabasePolicy {
   mode: "remote-read-only" | "local-file-read-only";
   engine: string;
@@ -123,6 +157,7 @@ export interface McpCatalogAdapterStatus {
   workspace_policy: McpWorkspacePolicy | null;
   database_policy: McpDatabasePolicy | null;
   saas_policy?: McpSaasPolicy | null;
+  browser_policy?: McpBrowserPolicy | null;
   stateful_saas_gate_enabled?: boolean;
   account_status?: McpSaasAccountStatus;
   preflight_status: McpDatabasePreflightStatus;
@@ -194,6 +229,8 @@ export const mcpCapabilityLabels: Record<string, string> = {
   "account-unbinding": "账号解绑",
   "ephemeral-browser": "临时浏览器会话",
   "browser-domain-policy": "浏览目标域策略",
+  "browser-session-approval": "浏览器操作逐次审批",
+  "browser-artifact-cleanup": "截图产物下载与清理",
   "ephemeral-code-sandbox": "一次性代码沙箱",
   "process-resource-limits": "进程资源限制",
   "cost-guardrails": "费用与资源护栏",
@@ -232,6 +269,13 @@ export const mcpIsolationLabels: Record<string, string> = {
     "封存数据库输入只读；不允许写入原文件或生成旁路产物",
   "allowlist:api.supabase.com,supabase.com": "仅允许 Supabase 官方 API 域名",
   "blocked:no-production-runtime": "已阻断：没有生产级运行时",
+  "browser-egress:validated-public-http-https":
+    "仅允许 DNS 固定后的公网 HTTP/HTTPS 目标（80/443 端口）；跨 origin 请求与重定向拒绝",
+  "browser-profile:ephemeral-no-login-state":
+    "临时匿名浏览器配置；不保存 Cookie、Storage 或登录状态",
+  "browser-artifacts:screenshot-only": "仅允许生成受控截图产物",
+  "blocked:unmaintained-browser-runtime": "已阻断：上游浏览器运行时已归档",
+  "blocked:license-runtime-contract": "已阻断：许可证与运行时契约尚未厘清",
 };
 
 export function formatMcpCapability(capability: string) {
@@ -366,8 +410,17 @@ const waveMetadata: Record<
   7: {
     connectionKind: "sandboxed-stdio",
     risk: "high",
-    requiredCapabilities: ["临时浏览器", "浏览域策略"],
-    limitations: ["等待临时浏览器、目标域及上传下载边界验证。"],
+    requiredCapabilities: [
+      "ephemeral-browser",
+      "browser-domain-policy",
+      "browser-session-approval",
+      "browser-artifact-cleanup",
+    ],
+    limitations: [
+      "每次连接使用临时匿名浏览器配置，仅允许访问 DNS 固定后的公网 HTTP/HTTPS 目标（80/443 端口）；导航 URL 拒绝 Token、API Key、签名等敏感查询参数，跨 origin 请求与重定向直接拒绝。",
+      "首版不提供账号凭据采集、外站登录流程或登录态保存；页面仍可能自行呈现登录界面，用户不得输入账号、密码、OTP 等认证信息。不提供网页上传/下载、剪贴板、本机文件、Cookie/Storage 导入导出与持久化、任意脚本求值或外部 CDP 工具；只允许生成受控截图产物。",
+      "单 origin 门禁覆盖锁定上游的正常浏览器流量与恶意网页；若浏览器或上游进程本身被完全攻陷，独立出口仍拒绝私网和 metadata 并执行流量上限，但不能保证同一公网 IP 与证书下的虚拟主机隔离。",
+    ],
   },
   8: {
     connectionKind: "sandboxed-stdio",
@@ -497,6 +550,33 @@ const waveSixBlockedDetails: Record<string, string[]> = {
 const waveSixSingleTenantLimitation =
   "当前仅支持部署时固定 tenant/owner 的单租户实例；多租户共享部署保持关闭。";
 
+const waveSevenReadyIds = new Set([
+  "chrome-devtools-mcp",
+  "playwright-mcp",
+]);
+
+const waveSevenReadyDetails: Record<string, string[]> = {
+  "chrome-devtools-mcp": [
+    "固定 Chrome DevTools MCP 1.6.0；只开放会话状态、受控导航、页面快照、点击、填写和截图产物。",
+    "性能分析、Lighthouse、堆快照、文件上传、键盘透传、任意脚本求值工具、扩展和外部 CDP 全部关闭。",
+  ],
+  "playwright-mcp": [
+    "固定 Playwright MCP 0.0.79；只开放会话状态、受控导航、结构化页面快照、点击、填写和截图产物，不接受浏览器启动参数或持久配置目录。",
+    "任意代码、文件上传、网页下载、Cookie/Storage 导入导出与持久化、PDF、视觉定位、网络路由、远程 CDP 和共享会话全部关闭。",
+  ],
+};
+
+const waveSevenBlockedDetails: Record<string, string[]> = {
+  "puppeteer-mcp": [
+    "上游官方参考实现已经归档，包含任意启动参数和页面脚本执行等高风险能力，无法锁定为持续维护的生产契约。",
+    "连接、安装和浏览器进程入口保持关闭；不会回退到归档包、任意 Puppeteer 启动参数或外部 CDP。",
+  ],
+  "selenium-mcp": [
+    "上游仓库与发布包的许可证声明不一致，容器、Node 版本和浏览器驱动契约也存在漂移，当前无法形成可复现镜像。",
+    "连接、安装和 WebDriver 入口保持关闭；待许可证、进程清理和工具白名单形成可审计契约后再评估。",
+  ],
+};
+
 function buildAdaptationPlan() {
   const records: Record<string, McpAdaptationRecord> = {};
   for (const projectId of localStdioIds) {
@@ -525,6 +605,10 @@ function buildAdaptationPlan() {
                 : "blocked"
             : wave === 6
               ? waveSixReadyIds.has(projectId)
+                ? "ready"
+                : "blocked"
+            : wave === 7
+              ? waveSevenReadyIds.has(projectId)
                 ? "ready"
                 : "blocked"
             : wave <= 4
@@ -590,6 +674,13 @@ function buildAdaptationPlan() {
               ? [
                   ...waveSixReadyDetails[projectId],
                   waveSixSingleTenantLimitation,
+                ]
+            : waveSevenBlockedDetails[projectId]
+              ? [...waveSevenBlockedDetails[projectId]]
+            : waveSevenReadyDetails[projectId]
+              ? [
+                  ...waveSevenReadyDetails[projectId],
+                  ...metadata.limitations,
                 ]
             : [...metadata.limitations],
       };

--- a/client/src/data/mcpProjects.ts
+++ b/client/src/data/mcpProjects.ts
@@ -127,17 +127,18 @@ const originalMcpProjectSeeds: McpProjectSeed[] = [
     repoUrl: "https://github.com/microsoft/playwright-mcp",
     category: "浏览器与网页",
     description:
-      "把浏览器自动化、测试和网页数据抽取能力交给 AI，适合前端验证和网页操作。",
+      "在一次性匿名 Chromium 会话中读取页面快照、访问公网网页并执行受控点击与填写，适合前端验收和公开页面检查。",
     readmeSummary:
-      "微软官方实现，使用结构化可访问性快照驱动浏览器，主打快速、轻量和确定性的工具调用。",
+      "固定微软 Playwright MCP 0.0.79，并由模镜裁剪为会话状态、受控导航、结构化快照、点击、填写和截图产物。",
     stars: 33615,
     language: "TypeScript",
-    verifiedAt: "2026-08-02",
+    verifiedAt: "2026-08-07",
     installMode: "one-click",
     installCommand:
       '{\n  "mcpServers": {\n    "playwright": {\n      "command": "npx",\n      "args": ["@playwright/mcp@latest"]\n    }\n  }\n}',
-    installNote: "官方 README 提供的标准 MCP 客户端配置，适合支持 stdio MCP 的宿主。",
-    tags: ["微软官方", "浏览器自动化", "网页测试"],
+    installNote: "模镜使用预装、锁定版本的浏览器 sidecar，不在连接时下载上游代码或浏览器。",
+    tags: ["微软官方", "临时浏览器", "结构化快照"],
+    usageExamples: ["检查公开页面的结构和关键文案", "在逐次确认后完成导航、点击或表单填写并留存截图"],
   },
   {
     id: "chrome-devtools-mcp",
@@ -146,18 +147,19 @@ const originalMcpProjectSeeds: McpProjectSeed[] = [
     repoUrl: "https://github.com/ChromeDevTools/chrome-devtools-mcp",
     category: "浏览器与网页",
     description:
-      "让 AI 直接使用 Chrome DevTools，检查 DOM、网络请求、控制台、性能轨迹和 Lighthouse 结果。",
+      "在一次性匿名 Chrome 会话中检查页面结构，并执行受控导航、点击、填写与截图。",
     readmeSummary:
-      "Google Chrome 官方项目，基于 Puppeteer 驱动 Chrome，兼顾浏览器自动化、调试和性能分析。",
+      "固定 Chrome DevTools MCP 1.6.0；本批仅开放页面读取、受控交互和截图，性能、任意脚本及外部 CDP 均关闭。",
     stars: 42000,
     language: "TypeScript",
-    verifiedAt: "2026-08-02",
+    verifiedAt: "2026-08-07",
     installMode: "one-click",
     installCommand:
       '{\n  "mcpServers": {\n    "chrome-devtools": {\n      "command": "npx",\n      "args": ["-y", "chrome-devtools-mcp@latest", "--headless"]\n    }\n  }\n}',
     installNote:
-      "模镜使用 headless 模式启动。后端运行环境仍需提供兼容版本的 Chrome 或 Chrome for Testing。",
-    tags: ["Google 官方", "Chrome 调试", "性能分析"],
+      "模镜使用预装、锁定版本的 Chrome for Testing 和独立 sidecar，不连接宿主浏览器或复用登录状态。",
+    tags: ["Chrome 官方", "临时浏览器", "页面结构"],
+    usageExamples: ["核对公开页面结构和关键文案", "在逐次确认后导航并生成可下载截图"],
   },
   {
     id: "opentabs",
@@ -713,12 +715,12 @@ const expandedMcpProjectSeeds: McpProjectSeed[] = [
     repoName: "modelcontextprotocol/servers-archived",
     repoUrl: "https://github.com/modelcontextprotocol/servers-archived/tree/main/src/puppeteer",
     category: "浏览器与网页",
-    description: "通过 Puppeteer 控制浏览器页面、截图和执行网页脚本。",
-    readmeSummary: "MCP 早期官方参考实现，现归档保留，适合了解浏览器工具的基础形态。",
+    description: "归档的 Puppeteer MCP 参考实现，包含浏览器控制、截图和页面脚本执行能力。",
+    readmeSummary: "上游已经归档且包含任意启动参数与脚本执行入口，本批不启动运行时、不提供连接或替代入口。",
     language: "TypeScript",
     tags: ["官方归档", "Puppeteer", "浏览器控制"],
     requirements: ["external-runtime", "system-permission"],
-    usageExamples: ["截取页面关键区域", "验证网页交互是否正常"],
+    usageExamples: ["仅查看归档项目资料", "等待有持续维护的固定工具契约后重新评估"],
     sources: ["awesome-mcp-zh", "awesome-mcp-servers"],
   }),
   plannedMcp({
@@ -727,12 +729,12 @@ const expandedMcpProjectSeeds: McpProjectSeed[] = [
     repoName: "angiejones/mcp-selenium",
     repoUrl: "https://github.com/angiejones/mcp-selenium",
     category: "浏览器与网页",
-    description: "使用 Selenium 驱动浏览器完成页面操作和自动化测试。",
-    readmeSummary: "社区 Selenium MCP 实现，适合已有 WebDriver 测试资产的团队。",
+    description: "社区 Selenium MCP 实现，可通过 WebDriver 执行页面操作和自动化测试。",
+    readmeSummary: "许可证、容器和驱动契约尚未形成一致的可复现版本，本批不启动 WebDriver 或提供连接入口。",
     language: "Python",
     tags: ["Selenium", "WebDriver", "自动化测试"],
     requirements: ["external-runtime", "system-permission"],
-    usageExamples: ["复用 Selenium 场景执行验收", "跨浏览器检查表单流程"],
+    usageExamples: ["仅查看社区项目资料", "等待许可证与运行时契约厘清后重新评估"],
     sources: ["awesome-mcp-zh", "awesome-mcp-servers"],
   }),
   plannedMcp({
@@ -1723,6 +1725,7 @@ function normalizeMcpProject(seed: McpProjectSeed): McpProject {
   const isDatabaseSandbox = isBundledSandbox && adaptation.wave === 5;
   const isDatabaseFileSandbox = isDatabaseSandbox && seed.id === "duckdb-mcp";
   const isStatefulSaas = isReady && adaptation.wave === 6;
+  const isBrowserSandbox = isBundledSandbox && adaptation.wave === 7;
   const requirements: McpRequirement[] = isCredentialSandbox
     ? ["token"]
     : isDatabaseSandbox
@@ -1751,6 +1754,8 @@ function normalizeMcpProject(seed: McpProjectSeed): McpProject {
         ? "内置数据库适配器由服务端固定部署，不接受 DSN、URI、命令或宿主路径。"
         : isStatefulSaas
           ? "内置有状态 SaaS 适配器由服务端固定部署，不接受任意 URL、Header、命令或环境变量。"
+        : isBrowserSandbox
+          ? "内置浏览器适配器由服务端固定部署，不接受浏览器命令、启动参数、代理、CDP 地址或宿主路径。"
         : isBundledSandbox
           ? "内置隔离适配器由服务端固定部署，无需安装命令。"
         : "当前版本仅收录资料，不提供本地 stdio 安装或外站认证入口。",
@@ -1771,7 +1776,9 @@ function normalizeMcpProject(seed: McpProjectSeed): McpProject {
           ? "在当前卡片加密保存 Personal Access Token 并填写项目 ID；首批主机固定为 gitlab.com，写入先预览目标再逐次确认。"
           : seed.id === "notion-mcp-server"
             ? "在当前卡片加密保存 Integration Token，并填写已显式共享给该 Integration 的 Data Source ID；写入仅限该范围内的新建页面与页面属性更新。"
-          : "在当前卡片加密保存账号凭据并填写服务端声明的资源 ID；连接预检通过后，写入先预览目标再逐次确认。"
+           : "在当前卡片加密保存账号凭据并填写服务端声明的资源 ID；连接预检通过后，写入先预览目标再逐次确认。"
+      : isBrowserSandbox
+        ? "连接会创建临时匿名 Chromium 配置；只允许 DNS 固定后的公网 HTTP/HTTPS 目标（80/443 端口），跨 origin 请求与重定向拒绝，首版仅生成截图产物。"
       : isBundledSandbox
         ? "适配器随断网 Python 沙箱镜像固定部署；浏览器不会提交命令、目录或环境变量。"
       : seed.installNote,
@@ -1812,6 +1819,13 @@ function normalizeMcpProject(seed: McpProjectSeed): McpProject {
               : "填写服务端提供的账号与资源 ID 字段；当前没有资源发现接口，因此只显示受控 ID 输入，不虚构选择器。",
             "确认单租户边界并保存配置，然后连接并等待账号预检通过。只读工具可直接执行，写入工具必须查看目标与影响摘要后一次性确认。",
             "出现限流或结果未知时不要重复点击；先核对上游状态。解绑可只断开账号，也可同时撤销模镜内的加密凭据。",
+          ]
+      : isBrowserSandbox
+        ? [
+            "点击“连接 Server”创建一次性匿名浏览器会话；会话最多 15 分钟，闲置 5 分钟自动结束，单页最多执行 50 次操作。",
+            "导航只接受公网 HTTP/HTTPS 地址和 80/443 端口；URL 查询参数不得携带 Token、API Key、签名或其他凭据，DNS 固定后连接，跨 origin 请求与重定向直接拒绝。",
+            "页面状态修改必须查看目标域和动作影响摘要后确认执行一次；本批不采集账号凭据、不提供外站登录流程或保存登录态。页面仍可能自行呈现登录界面，请勿输入账号、密码、OTP 等认证信息；同时不提供网页上传/下载、剪贴板、本机文件、Cookie/Storage 导入导出与持久化、任意脚本求值或 CDP 工具。",
+            "截图进入卡片内的临时产物列表，可下载或清理；断开连接会终止浏览器进程并删除临时配置。",
           ]
       : seed.configGuide ??
         (isLocalStdio

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -243,6 +243,95 @@ services:
       retries: 8
       start_period: 30s
 
+  mcp-browser-egress:
+    build:
+      context: ./server/sandbox_sidecar
+      dockerfile: Dockerfile.browser
+    image: modelmirror-mcp-browser:wave7-v1
+    container_name: modelmirror-mcp-browser-egress
+    command: ["python", "-m", "sandbox_sidecar.browser_server", "egress"]
+    networks:
+      - mcp_browser_egress
+    environment:
+      MCP_BROWSER_EGRESS_SOCKET_PATH: /run/modelmirror-browser-egress/browser-egress.sock
+      MCP_BROWSER_ALLOW_SYNTHETIC_DNS: "false"
+    user: "65532:65532"
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    pids_limit: 64
+    mem_limit: 256m
+    cpus: 0.5
+    tmpfs:
+      - /tmp:rw,nosuid,nodev,noexec,size=32m,uid=65532,gid=65532,mode=0700
+    volumes:
+      - mcp_browser_egress_socket:/run/modelmirror-browser-egress
+    restart: unless-stopped
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import json,socket; s=socket.socket(socket.AF_UNIX); s.connect('/run/modelmirror-browser-egress/browser-egress.sock'); s.sendall(b'{\"action\":\"health\"}\\n'); assert json.loads(s.recv(4096))['ok']",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 8
+      start_period: 30s
+
+  mcp-browser:
+    build:
+      context: ./server/sandbox_sidecar
+      dockerfile: Dockerfile.browser
+    image: modelmirror-mcp-browser:wave7-v1
+    container_name: modelmirror-mcp-browser
+    command: ["python", "-m", "sandbox_sidecar.browser_server"]
+    network_mode: none
+    depends_on:
+      mcp-browser-egress:
+        condition: service_healthy
+    environment:
+      MCP_BROWSER_SOCKET_PATH: /run/modelmirror-browser-mcp/browser-mcp.sock
+      MCP_BROWSER_EGRESS_SOCKET_PATH: /run/modelmirror-browser-egress/browser-egress.sock
+      MCP_BROWSER_PROFILE_ROOT: /profiles
+      MCP_BROWSER_ARTIFACT_ROOT: /artifacts
+      MCP_BROWSER_MAX_SESSIONS: "1"
+      MCP_BROWSER_TRUSTED_CLIENT_UID: "0"
+    user: "65532:65532"
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+      - seccomp=./server/sandbox_sidecar/seccomp_profile.browser.json
+    pids_limit: 256
+    mem_limit: 1g
+    cpus: 1.5
+    tmpfs:
+      - /tmp:rw,nosuid,nodev,noexec,size=128m,uid=65532,gid=65532,mode=0700
+      - /profiles:rw,nosuid,nodev,noexec,size=256m,uid=65532,gid=65532,mode=0700
+      - /dev/shm:rw,nosuid,nodev,noexec,size=256m,uid=65532,gid=65532,mode=0700
+    volumes:
+      - mcp_browser_socket:/run/modelmirror-browser-mcp
+      - mcp_browser_egress_socket:/run/modelmirror-browser-egress
+      - mcp_browser_artifact_staging:/artifacts
+    restart: unless-stopped
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import json,socket; s=socket.socket(socket.AF_UNIX); s.connect('/run/modelmirror-browser-mcp/browser-mcp.sock'); s.sendall(b'{\"action\":\"health\"}\\n'); assert json.loads(s.recv(4096))['ok']",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 8
+      start_period: 60s
+
   mcp-database:
     build:
       context: ./server/sandbox_sidecar
@@ -405,6 +494,8 @@ services:
         condition: service_healthy
       mcp-saas:
         condition: service_healthy
+      mcp-browser:
+        condition: service_healthy
       mcp-database:
         condition: service_healthy
       mcp-database-local:
@@ -457,6 +548,11 @@ services:
       MCP_FILES_SOCKET_PATH: /run/modelmirror-files-mcp/files-mcp.sock
       MCP_TOKEN_SOCKET_PATH: /run/modelmirror-token-mcp/token-mcp.sock
       MCP_SAAS_SOCKET_PATH: /run/modelmirror-saas-mcp/saas-mcp.sock
+      MCP_BROWSER_SOCKET_PATH: /run/modelmirror-browser-mcp/browser-mcp.sock
+      MCP_BROWSER_ARTIFACT_STAGING_ROOT: /app/mcp-browser-staging
+      MCP_BROWSER_TRUSTED_ARTIFACT_ROOT: /app/mcp/storage/browser-artifacts
+      MCP_CATALOG_ENABLE_CHROME_DEVTOOLS_MCP: ${MCP_CATALOG_ENABLE_CHROME_DEVTOOLS_MCP:-false}
+      MCP_CATALOG_ENABLE_PLAYWRIGHT_MCP: ${MCP_CATALOG_ENABLE_PLAYWRIGHT_MCP:-false}
       MCP_CATALOG_STATEFUL_SAAS_SINGLE_USER_ACK: ${MCP_CATALOG_STATEFUL_SAAS_SINGLE_USER_ACK:-false}
       MCP_CATALOG_ENABLE_AIRTABLE_MCP: ${MCP_CATALOG_ENABLE_AIRTABLE_MCP:-false}
       MCP_CATALOG_ENABLE_ASANA_MCP: ${MCP_CATALOG_ENABLE_ASANA_MCP:-false}
@@ -496,6 +592,8 @@ services:
       - mcp_files_socket:/run/modelmirror-files-mcp
       - mcp_token_socket:/run/modelmirror-token-mcp
       - mcp_saas_socket:/run/modelmirror-saas-mcp
+      - mcp_browser_socket:/run/modelmirror-browser-mcp
+      - mcp_browser_artifact_staging:/app/mcp-browser-staging
       - mcp_database_socket:/run/modelmirror-database-mcp
       - mcp_database_local_socket:/run/modelmirror-database-local-mcp
       - mcp_file_inputs:/app/mcp-file-inputs
@@ -659,6 +757,14 @@ volumes:
   mcp_files_socket:
   mcp_token_socket:
   mcp_saas_socket:
+  mcp_browser_socket:
+  mcp_browser_egress_socket:
+  mcp_browser_artifact_staging:
+    driver: local
+    driver_opts:
+      type: tmpfs
+      device: tmpfs
+      o: size=67108864,uid=65532,gid=65532,mode=0700,nosuid,nodev,noexec
   mcp_database_socket:
   mcp_database_local_socket:
   mcp_file_inputs:
@@ -679,4 +785,6 @@ networks:
   mcp_database_egress:
     driver: bridge
   mcp_saas_egress:
+    driver: bridge
+  mcp_browser_egress:
     driver: bridge

--- a/docs/MCP_CATALOG_ROADMAP.md
+++ b/docs/MCP_CATALOG_ROADMAP.md
@@ -15,11 +15,11 @@
 - [Awesome-MCP-ZH](https://github.com/yzfly/Awesome-MCP-ZH)
 - [awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers)
 
-截至 2026-08-07，目录仍冻结为 100 个 MCP 条目、18 个分类。批次 0—5 已验收的 38 项保持不变；批次 6 的 Airtable、Asana、GitLab.com 与 Notion 已完成固定适配。中国电商经营 MCP 因八个平台的 OAuth/商家授权、短期 Token 与敏感订单数据边界尚未逐平台验收，Mem0 因本地上游归档并迁移到未锁定版本的托管远程 MCP，二者标记为 `blocked`。当前状态精确为 **42 ready / 47 planned / 11 blocked**。
+截至 2026-08-07，目录仍冻结为 100 个 MCP 条目、18 个分类。批次 0—6 已验收的 42 项保持不变；批次 7 的 Chrome DevTools MCP 与 Playwright MCP 已完成固定浏览器适配，Puppeteer MCP 与 Selenium MCP 因上游维护、安全和许可证门槛标记为 `blocked`。当前状态精确为 **44 ready / 43 planned / 13 blocked**。
 
 ## 2. 当前边界与明确不实现
 
-批次 1–6 只增加固定适配器：批次 1 使用完全断网计算 sidecar，批次 2 使用独立公网 sidecar，批次 3 使用受控上传工作区和完全断网的文件处理 sidecar，批次 4 使用固定 Token 槽和只读出口 sidecar，批次 5 使用结构化数据库配置及相互隔离的远程/本地数据库 sidecar，批次 6 使用固定 SaaS 服务、账号作用域和资源级一次性审批 sidecar。六批都不扩大任意连接或任意执行能力：
+批次 1–7 只增加固定适配器：批次 1 使用完全断网计算 sidecar，批次 2 使用独立公网 sidecar，批次 3 使用受控上传工作区和完全断网的文件处理 sidecar，批次 4 使用固定 Token 槽和只读出口 sidecar，批次 5 使用结构化数据库配置及相互隔离的远程/本地数据库 sidecar，批次 6 使用固定 SaaS 服务、账号作用域和资源级一次性审批 sidecar，批次 7 使用真实锁定上游、临时 Chromium 和强制出口代理。七批都不扩大任意连接或任意执行能力：
 
 - 不接受用户指定的 Python 包、解释器、命令、工作目录或其他额外运行时。
 - 不实现 OAuth 回调、刷新或外站登录；批次 4—5 的卡片可把明文 Secret 单次提交到服务端加密库，但连接配置只接受不透明 `credential_id`，保存后不再返回或显示明文。
@@ -30,6 +30,7 @@
 - 批次 5 客户端只能提交清单声明的数据库类型、主机名、端口、库名、用户名、严格 TLS 模式或 Supabase `project_ref`；DBHub 首批仅支持 PostgreSQL、MySQL 与 MariaDB，SQL Server 保持关闭；不接受 DSN、数据库 URI、SSH 隧道、Header、环境变量名或任意连接参数。
 - 批次 6 只接受清单声明的 Personal Access Token / Internal Integration Token 与固定资源 ID；不接受服务 URL、任意 Host、Header、环境变量、OAuth 回调或外站登录。GitLab 首批只连接 `gitlab.com`，自建 GitLab 保持未开放。
 - 批次 6 的真实账号执行还需部署者显式设置单用户本地实例确认门禁；当前 API 没有逐请求认证主体传播，多用户共享部署不得开启。
+- 批次 7 不接受浏览器启动参数、CDP/远程端点、profile、代理、Header、Cookie、storage、上传/下载路径或本机文件。用户只提交待审批且不含 Token、API Key、签名等敏感查询参数的公网 URL，以及网关签发的不透明元素 ref；首版不采集账号凭据、不提供外站登录流程，也不继承或保存登录态。页面仍可能自行呈现无法由透明 HTTPS 出口可靠识别的登录界面，用户不得输入账号、密码、OTP 或其他认证信息。
 - 不接管 Blender、Zotero、Obsidian、JetBrains、Xcode、Ghidra 等桌面宿主。
 - 不提供用户自定义 MCP 连接。
 - 不提供 MCP Builder、可视化生成器或发布市场流程。
@@ -49,7 +50,7 @@
 数据层必须满足以下约束：
 
 1. 前端条目不得包含可执行 `command`、MCP URL、Header 或环境变量配置。
-2. `ready` 后端适配器必须有固定命令或端点、独立功能开关和显式工具策略；现有 7 项以兼容策略保持行为不变，批次 1—6 的 35 项使用完整的逐工具策略。
+2. `ready` 后端适配器必须有固定命令或端点、独立功能开关和显式工具策略；现有 7 项以兼容策略保持行为不变，批次 1—7 的 37 项使用完整的逐工具策略。
 3. `planned` 后端适配器不得包含可执行命令或端点，环境开关不能绕过状态门禁。
 4. 前端不得保存真实 Secret，也不得在仓库内出现真实凭证。
 5. 上游清单只用于发现项目；能否连接必须按模镜运行边界重新核验。
@@ -84,7 +85,7 @@
 | 4 | AgentQL、Brave、Exa、Firecrawl、Perplexity、Tavily、Axiom、Figma Context、Google Maps、Grafana、Graphlit、Kagi、Pinecone、Shodan、Snyk、VirusTotal | 16 | **已完成门槛判定**：15 项通过加密凭据槽、固定出口域、只读工具和 Secret 泄漏测试；Snyk 因本地构建执行依赖第 8 批隔离而阻断 |
 | 5 | DBHub、PostgreSQL、MongoDB、ClickHouse、Cognee、Graphiti、Hindsight、Redis、SQLite、DuckDB、Supabase | 11 | **已完成门槛判定**：DBHub、MongoDB、ClickHouse、Redis、DuckDB、Supabase 通过结构化配置、租户凭据、协议级只读、预检与查询限制；PostgreSQL、SQLite 因归档实现受阻，三项状态化记忆转入第 5B 计划 |
 | 6 | Airtable、Asana、GitLab、中国电商经营、Notion、Mem0 | 6 | **已完成门槛判定**：Airtable、Asana、GitLab.com、Notion 通过固定作用域、真实预检、资源级审批、限流与解绑；中国电商与 Mem0 因授权/托管契约受阻 |
-| 7 | Chrome DevTools、Playwright、Puppeteer、Selenium | 4 | 临时浏览器、目标域、上传下载与会话清理边界 |
+| 7 | Chrome DevTools、Playwright、Puppeteer、Selenium | 4 | **已完成门槛判定**：Chrome DevTools 与 Playwright 通过真实上游 Schema、临时浏览器、固定出口、页面状态审批与清理测试；Puppeteer、Selenium 因归档安全风险与许可证/运行时边界受阻 |
 | 8 | MCP Run Python、MCP Python Interpreter | 2 | 一次性断网容器、无宿主挂载、无 Docker socket、进程资源限制 |
 | 9 | Apify、Bright Data、Browserbase、E2B、Stripe、Terraform、Aiven、Alpaca、AWS KB、ElevenLabs、MiniMax、S3、Kubernetes、Semgrep | 14 | 费用/资源上限、目标预览、终止性操作强制审批 |
 | 10 | Gmail、Atlassian、Google Calendar、Google Drive、Microsoft 365、OneDrive、Sentry、Azure、Box、Cloudflare、GitHub、Linear、Neon、Slack | 14 | PKCE、state、最小 scope、刷新、撤销与解绑 |
@@ -143,10 +144,21 @@
 - 当前目录服务仍是部署时固定 `tenant/owner` 的单例，因此真实 SaaS 能力除项目开关外还要求 `MCP_CATALOG_STATEFUL_SAAS_SINGLE_USER_ACK=true`；默认关闭，多用户部署继续视为发布阻断。
 - `mcp-cn-commerce` v0.1.5 覆盖八个平台和 114 个工具，各平台授权、域名、短期 Token 与订单/售后敏感数据无法作为单一契约验收，保持 `blocked`。Mem0 本地 v0.2.1 已归档，官方迁移到无固定版本的托管远程 MCP；在 OAuth、Schema 锁定和租户记忆作用域完成前保持 `blocked`。
 
+批次 7 的执行结论：
+
+- 独立 `modelmirror-mcp-browser:wave7-v1` 锁定 `chrome-devtools-mcp` 1.6.0 + Chrome for Testing 150.0.7871.24，以及 `@playwright/mcp` 0.0.79 + Chromium 1237 / Chrome for Testing 152.0.7977.8；两个适配器使用彼此独立的固定浏览器路径。每个目录连接启动真实上游 stdio MCP 与独立临时 profile；安全网关核对 `initialize`、工具名和规范化 `inputSchema`，每个适配器只公开五项经过审核的上游能力和一个网关状态工具，运行时不安装或更新依赖。
+- `mcp-browser` 执行容器使用 `network_mode: none`、非 root、只读根文件系统、移除 capabilities、`no-new-privileges`、1 GiB/1.5 CPU/256 PIDs，且无 Docker socket 或宿主目录；256 PID 配额只用于该浏览器执行容器。独立 `mcp-browser-egress` 仅持有公网网络和出口 Unix socket，不挂载 MCP socket、profile 或截图产物；上游 Chromium 无法直接访问它。两者均与既有 Runtime Browser 完全分离。每会话一页、最多 50 次动作、15 分钟总时长/5 分钟闲置，首版目录实例只运行一个浏览器会话；控制密钥和 MCP socket 只在 Docker 重启策略的 10 秒保护窗口之后（实现使用 11 秒裕量）开放，任何会话结束或异常都会终止两个 PID1、清除 profile，并由 `unless-stopped` 成对重建。
+- Landlock 只允许上游进程读取锁定运行时并写当前 profile/截图暂存目录，继续拒绝 `/run` 与兄弟路径。Chromium 创建自身 user namespace 时所需的 procfs 映射写入仅恢复 `WRITE_FILE`；不开放 procfs 创建、删除、截断、目录写或 socket 权限，容器仍无 capabilities，Docker 对敏感 procfs 的掩蔽与只读挂载保持不变。
+- Chromium 强制通过执行容器内的 loopback HTTP/CONNECT 代理，再以不传给上游的一次性会话能力访问出口 sidecar。只允许公网 HTTP/HTTPS 80/443；生产出口不使用宿主 DNS，而是通过固定数值地址的 Cloudflare JSON DoH（TLS 1.2+、SNI/证书名 `cloudflare-dns.com`）重新解析完整 A/AAAA 集合，再执行 SSRF 门禁，连接固定到已验证地址并保留目标 hostname/SNI。Synthetic DNS 只在随机隔离 fixture smoke 中显式开启，生产 Compose 固定为 false。IP 字面量、单标签主机、userinfo、私网/回环/链路本地/保留/metadata、混合 DNS 答案、跨 origin 请求与重定向均拒绝；每会话最多 12 个并发隧道和累计 64 MiB 流量，并限制隧道闲置与绝对时长。
+- 出口进程生成的一次性配对密钥只由两个 sidecar 父进程持有，不传给上游。任一 sidecar 单独重启后旧配对与旧会话均 fail-closed；运维恢复必须成对重启执行端与出口端，不恢复旧页面或元素 ref。
+- 单 origin 门禁覆盖锁定上游的正常 Chromium 流量与恶意网页。若锁定的上游或浏览器进程本身被完全攻陷，独立出口仍只连接经过校验的公网 IP，并继续执行端口、流量与时限门禁，但没有 TLS 终止能力，不能保证同一公网 IP 与证书下的其他虚拟主机绝对隔离；本批不把该边界描述为浏览器 RCE 防护。
+- 导航、点击和填写必须经过 `browser-session` 一次性审批。审批冻结目录会话、浏览器 generation、页面 revision/digest、origin、工具/Schema、参数和配置版本；确认时状态漂移即失效。交互调用不重试，歧义超时会标记 `unknown_outcome`、污染并关闭会话；sidecar 明确返回 `-32011` 且原因属于调用前 DNS/目标 URL 拒绝时，旧审批终止但会话保留，修正目标后必须重新审批，调用后风险原因仍不得降级为明确拒绝。截图先进入 64 MiB 临时共享卷，经后端单文件描述符校验后复制到仅服务端挂载的可信目录并持久登记 24 小时索引；可通过项目专属接口下载或清理。异常临时项仅按固定深度与已知命名清扫，畸形条目告警并 fail-closed。网页上传、网页下载、登录态保存、Cookie/Storage 导入导出与持久化、剪贴板、任意脚本求值工具、CDP、扩展与本机文件不进入本批。网页自身的 Cookie、缓存和站点存储只存在于临时 profile，断开时删除。
+- Chrome DevTools MCP 1.6.0 与 Playwright MCP 0.0.79 为 `ready`。官方 Puppeteer MCP 已归档且保留危险启动/脚本入口，Selenium MCP 0.2.3 存在 MIT/ISC 许可证元数据冲突、root/漂移镜像和任意参数/路径/脚本/Cookie 面，二者保持 `blocked`，不得通过功能开关绕过。
+
 ## 6. 验收、发布和回退
 
-- 每个项目必须通过初始化、工具发现、代表性调用、超时、重连、断开与清理测试；Schema 漂移视为阻断。
-- 安全测试按批次覆盖 Secret 泄漏、SSRF、重定向、路径越界、ZIP Slip、链接与压缩炸弹、跨项目/产物/租户越权、沙箱逃逸、TLS 降级、SQL 多语句及写入旁路、查询超时/行数、权限撤销、审批绕过、参数/配置/凭据漂移、限流、重试、幂等重放、未知写入结果、账号解绑和高风险操作默认关闭。
+- 每个项目必须通过初始化、工具发现、代表性调用、超时、重连、断开与清理测试；Schema 漂移视为阻断。浏览器条目还必须在双 sidecar 容器中走完 UDS 握手、受控导航、快照、元素交互、真实截图登记、断开与进程/profile/临时文件清理，单独的上游 `tools/list` 或容器健康检查不能作为 ready 证据。
+- 安全测试按批次覆盖 Secret 泄漏、SSRF、DNS 重绑定、跨域重定向、路径越界、ZIP Slip、链接与压缩炸弹、跨项目/产物/租户越权、浏览器 profile/进程清理、元素 ref 与页面 digest 漂移、沙箱逃逸、TLS 降级、SQL 多语句及写入旁路、查询超时/行数、权限撤销、审批绕过、参数/配置/凭据漂移、限流、重试、幂等重放、未知写入结果、账号解绑和高风险操作默认关闭。
 - 前端必须显示中文批次、状态、连接方式、风险、限制和门槛；后端未返回 `executable=true` 时按钮不可连接。
 - 每个项目有独立服务端开关。回退只关闭开关、断开会话并清理沙箱，不删除目录条目或凭据。
 - 运行日志只记录项目 ID、状态、耗时、错误类别和策略事件，不记录 Secret、完整参数或工具返回正文。
@@ -162,7 +174,7 @@
 
 主要风险是上游项目快速变化、条目说明过期，以及把“已收录”误解为“当前可安全运行”。前端必须持续使用明确的状态标签和禁用按钮表达边界。
 
-批次 0–4 不引入数据库迁移；批次 5 只把旧凭据 JSON 元数据显式迁移到 `local/local` 作用域，不接触外部数据库 schema 或数据。批次 2 回退时关闭对应公网项目开关并停止 `mcp-public`；批次 3 回退时关闭四个文件项目开关、撤销审批并停止 `mcp-files`；批次 4 回退时关闭 15 个 Token 项目的独立功能开关、断开目录会话并停止 `mcp-token`；批次 5 回退时关闭六个数据库项目开关、断开会话、停止远程和本地数据库 sidecar，并清理临时 DuckDB 工作区；批次 6 回退时关闭四个 SaaS 项目开关和全局单用户确认门禁、执行项目解绑并停止 `mcp-saas`。回退不自动删除外部 SaaS 数据，也不声称撤销服务商 Token；卡片专属加密凭据仅在用户选择撤销时删除。Airbnb、BibiGPT、Manim、Snyk、PostgreSQL、SQLite、Cognee、Graphiti、Hindsight、中国电商经营 MCP 与 Mem0 本来就不可执行。旧版 `/api/mcp/*` 接口保持兼容，但目录会话不能使用无项目策略的直接调用端点：
+批次 0–4 不引入数据库迁移；批次 5 只把旧凭据 JSON 元数据显式迁移到 `local/local` 作用域，不接触外部数据库 schema 或数据。批次 2 回退时关闭对应公网项目开关并停止 `mcp-public`；批次 3 回退时关闭四个文件项目开关、撤销审批并停止 `mcp-files`；批次 4 回退时关闭 15 个 Token 项目的独立功能开关、断开目录会话并停止 `mcp-token`；批次 5 回退时关闭六个数据库项目开关、断开会话、停止远程和本地数据库 sidecar，并清理临时 DuckDB 工作区；批次 6 回退时关闭四个 SaaS 项目开关和全局单用户确认门禁、执行项目解绑并停止 `mcp-saas`；批次 7 回退时关闭两个浏览器项目开关、作废待确认操作、断开会话并停止 `mcp-browser` 与 `mcp-browser-egress`，随后清理临时 profile 与截图产物。回退不自动删除外部 SaaS 数据，也不声称撤销服务商 Token；卡片专属加密凭据仅在用户选择撤销时删除。Airbnb、BibiGPT、Manim、Snyk、PostgreSQL、SQLite、Cognee、Graphiti、Hindsight、中国电商经营 MCP、Mem0、Puppeteer MCP 与 Selenium MCP 本来就不可执行。旧版 `/api/mcp/*` 接口保持兼容，但目录会话不能使用无项目策略的直接调用端点：
 
 - `server/mcp/catalog.py`
 - `server/mcp/sandbox_proxy.py`

--- a/docs/MCP_INTEGRATION.md
+++ b/docs/MCP_INTEGRATION.md
@@ -83,7 +83,7 @@ Agent 画布使用 `toolset_resource -> workflow_agent` 的 `toolset` 绑定边�
 目录适配器安全默认值：
 
 - 前端不能提交 `server_command`、MCP URL、Header、环境变量名或工作目录。
-- 当前目录状态为 **42 ready / 47 planned / 11 blocked**；planned 与 blocked 项没有可执行命令或端点，设置环境功能开关也不能绕过状态门槛。
+- 当前目录状态为 **44 ready / 43 planned / 13 blocked**；planned 与 blocked 项没有可执行命令或端点，设置环境功能开关也不能绕过状态门槛。
 - 新适配器若没有显式工具读写与审批策略，工具调用会 fail-closed。
 - 日志只记录项目 ID、工具名、状态和耗时，不记录参数、返回正文或 Secret。
 
@@ -146,6 +146,19 @@ Agent 画布使用 `toolset_resource -> workflow_agent` 的 `toolset` 绑定边�
 - 卡片内“解绑账号”会先阻止新调用并等待活动读取结束，再断开会话、撤销待审批并清除配置、预检与本地执行账本；可选择撤销该卡片的本地加密凭据。它不等于在 Airtable、Asana、GitLab 或 Notion 后台撤销 Token，用户仍需在服务商后台完成上游撤销。
 - `mcp-cn-commerce` 保持 `blocked`：八个平台、114 个工具、OAuth/商家授权、短期 Token 和订单/售后敏感数据尚未逐平台验收。`mem0-mcp` 保持 `blocked`：本地上游已归档，官方迁移到无固定版本的托管远程 MCP；OAuth、Schema 锁定和租户记忆作用域尚未完成。两项都不显示凭据、登录或连接入口。
 
+批次 7 的两个可用浏览器适配器通过固定 `browser_proxy.py` 接入彼此隔离的 `mcp-browser` 执行 sidecar 与 `mcp-browser-egress` 出口 sidecar：
+
+- `chrome-devtools-mcp` 锁定上游 1.6.0 与 Chrome for Testing 150.0.7871.24，`playwright-mcp` 锁定上游 0.0.79 与 Chromium 1237 / Chrome for Testing 152.0.7977.8。两个适配器使用各自固定的浏览器路径；sidecar 每次连接启动对应的真实上游 stdio MCP 与独立 Chromium/profile，先核对 `initialize`、完整工具名和规范化 `inputSchema` 摘要；外层网关只转发经过审核的导航、快照、元素交互与截图子集，运行时不下载包或浏览器。
+- 浏览器会话匿名且临时：每项最多一个页面、50 次动作、总时长 15 分钟、闲置 5 分钟；首版目录实例只运行一个浏览器会话。断开、超时、上游 EOF 或状态不确定时都会终止浏览器进程并删除 profile、Cookie、缓存和站点存储，不保存登录态。
+- 本批不采集账号凭据、不提供外站登录流程，也不继承或保存登录态。导航 URL 双层拒绝 Token、API Key、签名等敏感查询参数；URL 与动作后的页面检查还会拒绝常见登录、授权和回调路径，但 HTTPS 页面仍可能自行呈现无法由透明出口可靠识别的登录界面；用户不得在临时浏览器中输入账号、密码、OTP 或其他认证信息。
+- `mcp-browser` 使用 `network_mode: none`、1 GiB 内存、1.5 CPU 与 256 PIDs；该 PID 配额仅适用于浏览器执行 sidecar，其他 MCP sidecar 不随之放宽。Chromium 只能访问同容器的 loopback HTTP/CONNECT 代理；代理携带不传给上游进程的一次性会话能力，通过私有 Unix socket 请求独立联网的 `mcp-browser-egress`。执行端和出口端都会校验目标。生产出口不信任宿主机或 Docker Desktop 的 DNS 答案，而是只向固定数值地址 `1.1.1.1` / `1.0.0.1` 建立 TLS 1.2+ 连接，以 `cloudflare-dns.com` 做 SNI/证书校验并通过 JSON DoH 查询完整 A/AAAA 集合；随后再次执行公网地址门禁并固定连接到已验证地址。显式 synthetic DNS 只供随机隔离 fixture smoke 使用，生产 Compose 固定关闭。两端均拒绝 userinfo、IP 字面量、单标签主机、非 80/443 端口及私网、回环、链路本地、保留地址和 metadata，TLS 仍使用原 hostname。首版每个会话只允许一个已审批 origin，跨域请求与重定向 fail-closed；出口最多 12 个并发隧道、累计 64 MiB，并限制闲置与绝对时长，因此依赖第三方 CDN 的页面可能显示不完整。
+- 上游进程及 Chromium 后代继续受 Landlock 约束，只能读取锁定运行时并写当前 profile/截图暂存目录；`/run` 和兄弟路径不可见。为让 Chromium 自身的 user namespace sandbox 写入 `uid_map`、`gid_map` 与 `setgroups`，`/proc` 只额外开放 `WRITE_FILE`，不开放创建、删除、截断、目录写或 socket 权限；容器仍无 capabilities，敏感 procfs 路径继续由 Docker 掩蔽或只读挂载。
+- 执行 sidecar 与出口 sidecar 使用由出口进程生成的一次性配对密钥，每个容器生命周期只接纳一次目录会话。两端在 Docker 重启策略生效的 10 秒窗口之后（实现使用 11 秒裕量）才发布控制密钥或 MCP socket；会话结束或任一异常都会让两个 PID1 退出并由 `unless-stopped` 成对重建，不会复用旧配对、旧页面状态、旧元素 ref 或逃逸后代。
+- 单 origin 门禁覆盖锁定上游的正常 Chromium 流量与恶意网页。若锁定的上游或浏览器进程本身被完全攻陷，独立出口仍只连接经过校验的公网 IP，并继续执行端口、流量和时限门禁，但没有 TLS 终止能力，不能保证同一公网 IP 与证书下的其他虚拟主机绝对隔离；本批不把这一边界描述为浏览器 RCE 防护。
+- 导航、点击和填写属于 `state-write + requires_approval`。一次性审批绑定租户、所有者、项目、目录会话、浏览器 generation、页面 revision/digest、当前 origin、工具/Schema、冻结参数和配置版本；确认前页面或会话漂移即失效。此类调用永不自动重试，发送后超时或连接中断标记为 `unknown_outcome` 并污染、关闭当前会话。若 sidecar 以 `-32011` 明确证明 DNS 或目标 URL 在调用前被策略拒绝，则旧审批进入 `rejected` 终态但临时会话保留，用户修正目标后必须发起全新的审批；跨域跳转等可能发生在调用后的策略错误仍按未知结果 fail-closed。
+- 快照只产生网关签发的不透明元素 ref；点击与填写不接受 CSS、XPath 或任意文本定位器，并拒绝密码、OTP、支付和验证码字段。截图先写入上限 64 MiB 的临时共享区，后端以单一文件描述符校验 PNG、大小、链接数与摘要，再复制到仅服务端可见的可信产物目录并登记 24 小时索引；产物接口只返回不透明 ID，并允许用户下载或清理。异常临时项只按固定目录和命名规则清扫，畸形条目告警并 fail-closed，不做宽泛递归删除。网页上传、网页下载、剪贴板、Cookie/Storage 导入导出与持久化、任意脚本求值工具、CDP、扩展和本机文件全部关闭。网页自身在会话内产生的 Cookie、缓存和站点存储只存在于临时 profile，断开时一并删除。
+- `puppeteer-mcp` 因官方仓库归档、危险启动参数/脚本执行面及未修复安全报告保持 `blocked`。`selenium-mcp` 因发行物许可证元数据冲突、未锁定的 root 浏览器镜像及任意参数/路径/脚本/Cookie 能力保持 `blocked`。两项都不显示安装或连接入口。
+
 兼容层仍保留以下默认值：
 
 - 后端只接受 `list[str]` 形式的命令，不使用 shell。
@@ -197,7 +210,12 @@ npm view @example/mcp-server version
 | POST | `/api/mcp/catalog/{project_id}/connect` | 按项目 ID 建立受控会话；数据库项目须先通过目标、TLS、认证与只读预检 |
 | DELETE | `/api/mcp/catalog/{project_id}/session` | 断开该目录项目的会话 |
 | POST | `/api/mcp/catalog/{project_id}/unbind` | 解绑当前 SaaS 账号：断开会话、作废审批并清除作用域；可选择撤销本地卡片凭据，但不声称撤销上游 Token |
+| GET | `/api/mcp/catalog/{project_id}/tools` | 通过目录所有者隔离读取已审核工具；通用 session 工具接口不能读取目录会话 |
 | POST | `/api/mcp/catalog/{project_id}/tools/{tool_name}/call` | 经项目工具策略调用已连接工具 |
+| GET | `/api/mcp/catalog/{project_id}/browser-session` | 查看当前临时浏览器 generation、页面摘要、origin、动作额度、到期和污染状态 |
+| GET | `/api/mcp/catalog/{project_id}/browser-artifacts` | 列出当前项目的不透明浏览器截图产物，不返回容器或宿主路径 |
+| GET | `/api/mcp/catalog/{project_id}/browser-artifacts/{artifact_id}/download` | 下载绑定当前租户、所有者、项目与浏览器会话的截图产物 |
+| DELETE | `/api/mcp/catalog/{project_id}/browser-artifacts/{artifact_id}` | 清理绑定当前租户、所有者、项目与浏览器会话的截图产物 |
 | GET/POST | `/api/mcp/catalog/{project_id}/workspaces` | 列出或创建当前项目的受控工作区 |
 | POST | `/api/mcp/catalog/{project_id}/workspaces/{workspace_id}/files` | 上传多文件、目录相对路径或安全 ZIP |
 | POST | `/api/mcp/catalog/{project_id}/workspaces/{workspace_id}/seal` | 封存输入并生成不可变 manifest 摘要 |
@@ -415,6 +433,16 @@ python -m pytest server/tests/test_mcp_integration.py -q
 python -m pytest server/tests/test_mcp_catalog.py server/tests/test_mcp_compute_adapters.py server/tests/test_mcp_file_workspaces.py server/tests/test_mcp_multisession.py -q
 ```
 
+批次 7 浏览器适配器还必须在实际 Compose 等价隔离边界中完成双 sidecar 验收。构建后先记录本地镜像 ID/摘要，再运行真实 UDS、浏览器与超时 smoke：
+
+```bash
+docker build -f server/sandbox_sidecar/Dockerfile.browser -t modelmirror-mcp-browser:wave7-v1 server/sandbox_sidecar
+docker image inspect modelmirror-mcp-browser:wave7-v1 --format '{{json .RepoDigests}} {{.Id}}'
+python server/sandbox_sidecar/smoke_browser_runtime.py --image modelmirror-mcp-browser:wave7-v1 --seccomp server/sandbox_sidecar/seccomp_profile.browser.json
+```
+
+成功结果必须包含 Chrome DevTools 与 Playwright 各两次导航、快照、元素交互和 PNG 登记，以及各一次真实 20 秒导航超时（`-32008 / unknown_outcome / retryable=false`）、browser/egress PID1 精确单次重启、运行目录/进程清理和最终 `cleanup=verified`。该 harness 只创建随机 `mm-wave7-runtime-smoke-*` 资源；任何失败或残留都返回非零，不能用容器健康检查代替。
+
 测试覆盖：
 
 - 成功启动本地 mock MCP Server。
@@ -444,6 +472,7 @@ python server/mcp/test_manager.py
 | `server/mcp/token_proxy.py` | 移除短期凭据环境并把批次 4 固定项目 ID 与配置单次传给私有 sidecar。 |
 | `server/mcp/database_proxy.py` | 移除短期数据库配置环境，按固定项目路由到批次 5 的远程或断网本地 Unix socket。 |
 | `server/mcp/saas_proxy.py` | 移除短期 SaaS 配置环境，把批次 6 固定项目与账号作用域单次传给私有 sidecar。 |
+| `server/mcp/browser_proxy.py` | 把批次 7 固定项目和服务端浏览器策略单次传给私有 sidecar，不接受客户端命令、CDP 地址、启动参数或路径。 |
 | `server/mcp/workspace.py` | 工作区、上传/ZIP 校验、封存 manifest、产物与保留期管理。 |
 | `server/sandbox_sidecar/compute_mcp.py` | 批次 1 的三个内置 Python MCP 工具契约。 |
 | `server/sandbox_sidecar/public_mcp.py` | 批次 2 的内置公网 MCP 兼容契约。 |
@@ -462,6 +491,9 @@ python server/mcp/test_manager.py
 | `server/sandbox_sidecar/saas_contracts.py` | 批次 6 的固定服务、作用域、凭据槽、工具 Schema、读写与幂等契约。 |
 | `server/sandbox_sidecar/saas_server.py` | 批次 6 的预检、限流、有界只读重试、写入未知结果与会话清理网关。 |
 | `server/sandbox_sidecar/Dockerfile.saas` | `modelmirror-mcp-saas:wave6-v1` 独立固定契约镜像。 |
+| `server/sandbox_sidecar/browser_contracts.py` | 批次 7 的上游版本、固定工具 Schema、会话额度、网络与浏览器能力契约。 |
+| `server/sandbox_sidecar/browser_server.py` | 批次 7 的真实上游进程、HTTP/CONNECT 出口代理、临时 profile、状态与产物清理网关。 |
+| `server/sandbox_sidecar/Dockerfile.browser` | `modelmirror-mcp-browser:wave7-v1` 锁定上游 MCP 与 Chromium 的独立镜像。 |
 | `server/toolsets/` | Toolset/凭据 Store、版本发布、Schema 漂移与固定版本 Provider。 |
 | `client/src/pages/ToolsetsPage.tsx` | MCP Toolset 创建、连接、工具配置、测试和发布管理页。 |
 | `server/tests/test_toolset_*.py` | Toolset Store、API、连接、固定版本与安全回归。 |
@@ -477,6 +509,9 @@ python server/mcp/test_manager.py
 | `server/tests/test_mcp_token_sidecar.py` | 批次 4 清单一致性、配置契约、Secret 传递、工具过滤和 URL 预检测试。 |
 | `server/tests/test_mcp_database_sidecar.py` | 批次 5 配置、租户凭据、TLS/只读预检、协议旁路、行数与超时测试。 |
 | `server/tests/test_mcp_saas_sidecar.py` | 批次 6 固定 Host、Schema、预检、审批、限流、幂等、未知写入结果与解绑测试。 |
+| `server/tests/test_mcp_browser_sidecar.py` | 批次 7 上游 Schema、DNS/SSRF、重定向、临时会话、ref 漂移、审批、未知结果和清理测试。 |
+| `server/tests/test_mcp_browser_runtime_smoke.py` | 批次 7 双 sidecar 编排、资源登记/精确清理、重启、真实超时和固定安全探针的 harness 单测。 |
+| `server/sandbox_sidecar/smoke_browser_runtime.py` | 在随机隔离 Docker 资源中执行两个浏览器适配器的真实交互、截图、超时、PID1 轮换与残留清理终端门禁。 |
 | `server/mcp/smoke_file_adapters.py` | 四个文件适配器初始化、发现、代表调用、重连、源文件不变和清理 smoke。 |
 | `client/src/components/McpServerCard.tsx` | 前端连接、工具表单、执行结果组件。 |
 | `client/src/components/McpWorkspacePanel.tsx` | 中文工作区上传、封存、绑定、容量/到期、产物下载和清理面板。 |

--- a/server/mcp/browser_proxy.py
+++ b/server/mcp/browser_proxy.py
@@ -1,0 +1,162 @@
+"""One-shot stdio proxy for the fixed Wave 7 browser MCP sidecar."""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import socket
+import sys
+import threading
+from pathlib import Path
+
+
+ALLOWED_ADAPTERS = frozenset({"chrome-devtools-mcp", "playwright-mcp"})
+CONTRACT_VERSION = "modelmirror-browser-wave7-v1"
+SOCKET_PATH = Path(
+    os.getenv(
+        "MCP_BROWSER_SOCKET_PATH",
+        "/run/modelmirror-browser-mcp/browser-mcp.sock",
+    )
+)
+HANDSHAKE_LIMIT = 64 * 1024
+RESPONSE_LIMIT = 4096
+EXPECTED_LIMITS = {
+    "max_actions": 50,
+    "max_artifact_bytes": 32 * 1024 * 1024,
+    "max_output_bytes": 256 * 1024,
+    "max_pages": 1,
+    "navigation_timeout_seconds": 20,
+    "session_ttl_seconds": 15 * 60,
+    "idle_ttl_seconds": 5 * 60,
+    "tool_call_timeout_seconds": 30,
+    "max_sessions": 1,
+    "max_tunnels_per_session": 12,
+    "max_egress_bytes_per_session": 64 * 1024 * 1024,
+    "egress_tunnel_idle_seconds": 30,
+    "egress_tunnel_ttl_seconds": 120,
+}
+
+# Kept in sync with sandbox_sidecar.browser_contracts.  The server image does
+# not contain sidecar implementation modules, so the public contract digests
+# are deliberately duplicated here and checked on both sides of the socket.
+BROWSER_SCHEMA_SHA256 = {
+    "chrome-devtools-mcp": "74e74ee147c7293035b969af687248b05934052973d7798ecdc651208a7739c3",
+    "playwright-mcp": "efafd6dabf2e78173423ed2172092eb9865d82b8571fe5f687b9658ce9caaadc",
+}
+
+
+def _copy_stdin(sock: socket.socket) -> None:
+    try:
+        while True:
+            chunk = os.read(sys.stdin.fileno(), 64 * 1024)
+            if not chunk:
+                break
+            sock.sendall(chunk)
+    except (BrokenPipeError, ConnectionError, OSError):
+        pass
+    finally:
+        try:
+            sock.shutdown(socket.SHUT_WR)
+        except OSError:
+            pass
+
+
+def _load_handshake(adapter_id: str) -> dict[str, object]:
+    encoded = os.environ.pop("MCP_BROWSER_HANDSHAKE_B64", "")
+    if not encoded or len(encoded) > HANDSHAKE_LIMIT * 2:
+        raise ValueError("missing_browser_handshake")
+    try:
+        raw = base64.urlsafe_b64decode(encoded.encode("ascii"))
+    except (ValueError, UnicodeError) as exc:
+        raise ValueError("invalid_browser_handshake") from exc
+    if len(raw) > HANDSHAKE_LIMIT:
+        raise ValueError("browser_handshake_too_large")
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeError, json.JSONDecodeError) as exc:
+        raise ValueError("invalid_browser_handshake") from exc
+    if not isinstance(payload, dict) or set(payload) != {
+        "project_id",
+        "contract_version",
+        "tool_schema_sha256",
+        "limits",
+    }:
+        raise ValueError("browser_handshake_contract_mismatch")
+    if payload.get("project_id") != adapter_id:
+        raise ValueError("browser_handshake_project_mismatch")
+    if payload.get("contract_version") != CONTRACT_VERSION:
+        raise ValueError("browser_handshake_version_mismatch")
+    if payload.get("tool_schema_sha256") != BROWSER_SCHEMA_SHA256.get(adapter_id):
+        raise ValueError("browser_handshake_schema_mismatch")
+    if payload.get("limits") != EXPECTED_LIMITS:
+        raise ValueError("browser_handshake_limits_mismatch")
+    return payload
+
+
+def run(adapter_id: str) -> int:
+    if adapter_id not in ALLOWED_ADAPTERS:
+        print("MCP browser adapter is not allowed.", file=sys.stderr)
+        return 64
+    if not SOCKET_PATH.is_absolute():
+        print("MCP browser socket path must be absolute.", file=sys.stderr)
+        return 78
+    try:
+        configuration = _load_handshake(adapter_id)
+    except ValueError:
+        print("MCP browser handshake is missing or invalid.", file=sys.stderr)
+        return 78
+
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        # The sidecar verifies the real upstream package, starts one sandboxed
+        # Chromium process and performs a representative blank-page snapshot
+        # before accepting the session.
+        sock.settimeout(60)
+        sock.connect(str(SOCKET_PATH))
+        request = json.dumps(
+            {
+                "action": "mcp_stdio",
+                "adapter_id": adapter_id,
+                "configuration": configuration,
+            },
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        configuration = {}
+        sock.sendall(request + b"\n")
+        raw = sock.makefile("rb", buffering=0).readline(RESPONSE_LIMIT + 1)
+        if not raw or len(raw) > RESPONSE_LIMIT:
+            print("MCP browser sidecar handshake failed.", file=sys.stderr)
+            return 69
+        response = json.loads(raw.decode("utf-8"))
+        if not isinstance(response, dict) or response.get("ok") is not True:
+            code = str(response.get("code") or "browser_sidecar_unavailable")
+            print(f"MCP browser sidecar rejected the session: {code}", file=sys.stderr)
+            return 69
+        sock.settimeout(None)
+        input_thread = threading.Thread(target=_copy_stdin, args=(sock,), daemon=True)
+        input_thread.start()
+        while True:
+            chunk = sock.recv(64 * 1024)
+            if not chunk:
+                break
+            sys.stdout.buffer.write(chunk)
+            sys.stdout.buffer.flush()
+        return 0
+    except (ConnectionError, OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"MCP browser proxy unavailable: {type(exc).__name__}", file=sys.stderr)
+        return 69
+    finally:
+        sock.close()
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: browser_proxy.py ADAPTER_ID", file=sys.stderr)
+        return 64
+    return run(sys.argv[1].strip())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/server/mcp/catalog.py
+++ b/server/mcp/catalog.py
@@ -25,6 +25,7 @@ import uuid
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Literal, Protocol
+from urllib.parse import unquote, urlsplit
 
 from fastapi import APIRouter, File, Form, HTTPException, UploadFile
 from fastapi.responses import FileResponse
@@ -36,6 +37,7 @@ from mcp.types import CallToolResult, Tool
 try:
     from server.mcp.manager import (
         MCPClientManager,
+        MCPClientError,
         MCPInstaller,
         MCPSessionNotFoundError,
     )
@@ -52,7 +54,12 @@ try:
         MCPCatalogWorkspaceStore,
     )
 except ModuleNotFoundError:
-    from mcp.manager import MCPClientManager, MCPInstaller, MCPSessionNotFoundError
+    from mcp.manager import (
+        MCPClientError,
+        MCPClientManager,
+        MCPInstaller,
+        MCPSessionNotFoundError,
+    )
     from registry.tool_registry import ToolRegistry
     from mcp.workspace import (
         FILE_PROJECTS,
@@ -66,8 +73,120 @@ except ModuleNotFoundError:
         MCPCatalogWorkspaceStore,
     )
 
+try:
+    from server.mcp.browser_proxy import (
+        BROWSER_SCHEMA_SHA256,
+        CONTRACT_VERSION as BROWSER_CONTRACT_VERSION,
+        EXPECTED_LIMITS as BROWSER_LIMITS,
+    )
+except ModuleNotFoundError:
+    from mcp.browser_proxy import (
+        BROWSER_SCHEMA_SHA256,
+        CONTRACT_VERSION as BROWSER_CONTRACT_VERSION,
+        EXPECTED_LIMITS as BROWSER_LIMITS,
+    )
+
 
 AdapterAvailability = Literal["planned", "adapting", "ready", "blocked"]
+
+BROWSER_LOGIN_TOKENS = frozenset(
+    {
+        "auth",
+        "account",
+        "accounts",
+        "authorize",
+        "callback",
+        "consent",
+        "login",
+        "log-in",
+        "oauth",
+        "oauth2",
+        "oidc",
+        "saml",
+        "session",
+        "signin",
+        "sign-in",
+        "sso",
+    }
+)
+BROWSER_LOGIN_COMPONENT_BOUNDARIES = re.compile(r"[/&=?#]+")
+BROWSER_HOST_COMPONENT_BOUNDARIES = re.compile(r"[.]+")
+BROWSER_QUERY_COMPONENT_BOUNDARIES = re.compile(r"[&;?#]+")
+BROWSER_SENSITIVE_QUERY_KEYS = frozenset(
+    {
+        "accesstoken",
+        "apikey",
+        "authorization",
+        "auth",
+        "bearer",
+        "code",
+        "credential",
+        "idtoken",
+        "jwt",
+        "key",
+        "keypairid",
+        "oauth",
+        "oauthtoken",
+        "password",
+        "passwd",
+        "refreshtoken",
+        "secret",
+        "session",
+        "sessionid",
+        "sig",
+        "signature",
+        "token",
+    }
+)
+BROWSER_SENSITIVE_QUERY_PREFIXES = ("oauth", "xamz", "xgoog")
+
+
+def canonical_browser_login_tokens(
+    value: str, *, host: bool = False
+) -> frozenset[str]:
+    """Mirror the browser sidecar's ordinary and punctuation-folded tokens."""
+
+    boundaries = (
+        BROWSER_HOST_COMPONENT_BOUNDARIES
+        if host
+        else BROWSER_LOGIN_COMPONENT_BOUNDARIES
+    )
+    tokens: set[str] = set()
+    ordinary_sequence: list[str] = []
+    for component in boundaries.split(value.lower()):
+        ordinary = re.findall(r"[a-z0-9]+", component)
+        tokens.update(ordinary)
+        ordinary_sequence.extend(ordinary)
+        compact = "".join(ordinary)
+        if compact:
+            tokens.add(compact)
+    tokens.update(
+        left + right
+        for left, right in zip(ordinary_sequence, ordinary_sequence[1:])
+    )
+    return frozenset(tokens)
+
+
+def browser_query_has_sensitive_key(query: str) -> bool:
+    """Mirror the sidecar's bearer/signing query-key rejection."""
+
+    decoded = query
+    for _ in range(2):
+        decoded = unquote(decoded)
+    for component in BROWSER_QUERY_COMPONENT_BOUNDARIES.split(decoded):
+        raw_key = component.partition("=")[0]
+        key = "".join(re.findall(r"[a-z0-9]+", raw_key.lower()))
+        if not key:
+            continue
+        if (
+            key in BROWSER_SENSITIVE_QUERY_KEYS
+            or key.startswith(BROWSER_SENSITIVE_QUERY_PREFIXES)
+            or key.endswith(("secret", "signature", "token"))
+        ):
+            return True
+    return False
+
+
 AdapterConnectionKind = Literal[
     "local-stdio",
     "sandboxed-stdio",
@@ -79,7 +198,11 @@ AdapterPreparationKind = Literal["installer", "bundled"]
 CatalogToolEffect = Literal["read", "artifact-create", "state-write", "terminal"]
 CatalogSettingKind = Literal["text", "integer", "enum", "slug", "hostname"]
 CatalogDatabaseMode = Literal["remote-read-only", "local-file-read-only"]
-CatalogApprovalContextKind = Literal["workspace", "remote-resource"]
+CatalogApprovalContextKind = Literal[
+    "workspace",
+    "remote-resource",
+    "browser-session",
+]
 
 logger = logging.getLogger("modelmirror.mcp.catalog")
 
@@ -131,6 +254,72 @@ class CatalogProviderRejectedError(CatalogAdapterPolicyError):
         super().__init__(message)
         self.reason = normalized_reason
         self.idempotency_key = idempotency_key
+
+
+class CatalogBrowserPolicyRejectedError(CatalogAdapterPolicyError):
+    """Raised when the browser proves that no reviewed action was dispatched."""
+
+    def __init__(self, reason: str, idempotency_key: str) -> None:
+        normalized_reason = (
+            reason
+            if reason
+            in {
+                "dns_policy_rejected",
+                "target_policy_rejected",
+            }
+            else "browser_policy_rejected"
+        )
+        messages = {
+            "dns_policy_rejected": (
+                "目标域名未通过浏览器公网 DNS 安全校验，本次操作未执行；会话仍可继续。"
+            ),
+            "target_policy_rejected": (
+                "目标地址未通过浏览器安全策略，本次操作未执行；会话仍可继续。"
+            ),
+            "browser_policy_rejected": (
+                "浏览器安全策略已明确拒绝本次操作；会话仍可继续。"
+            ),
+        }
+        super().__init__(messages[normalized_reason])
+        self.reason = normalized_reason
+        self.idempotency_key = idempotency_key
+
+
+def _browser_policy_rejection_reason(exc: BaseException) -> str | None:
+    """Classify only reviewed, non-retryable browser JSON-RPC rejections."""
+
+    if not isinstance(exc, McpError):
+        return None
+    rpc_error = exc.error
+    rpc_data = rpc_error.data if isinstance(rpc_error.data, dict) else {}
+    if rpc_error.code != -32011 or rpc_data.get("retryable") is not False:
+        return None
+    raw_reason = str(rpc_data.get("reason") or "")
+    if raw_reason.startswith("browser_dns_") or raw_reason == "browser_private_dns_denied":
+        return "dns_policy_rejected"
+    if raw_reason in {
+        "browser_external_login_denied",
+        "browser_sensitive_query_denied",
+        "browser_url_scheme_denied",
+        "browser_url_host_denied",
+        "browser_url_port_denied",
+        "browser_url_credentials_denied",
+        "browser_url_fragment_denied",
+        "browser_literal_address_denied",
+    }:
+        return "target_policy_rejected"
+    # Other -32011 reasons can be emitted after an upstream action (for
+    # example a cross-origin redirect observed after navigation). They remain
+    # fail-closed and ambiguous rather than being mislabeled pre-dispatch.
+    return None
+
+
+class CatalogBrowserStateDriftError(CatalogAdapterPolicyError):
+    """Raised before dispatch when a frozen browser page is no longer current."""
+
+
+class CatalogBrowserSessionExpiredError(CatalogAdapterPolicyError):
+    """Raised when the ephemeral browser TTL has elapsed."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -262,6 +451,51 @@ class CatalogSaaSPolicy:
 
 
 @dataclass(frozen=True, slots=True)
+class CatalogBrowserPolicy:
+    """Public, non-secret guardrails for an ephemeral browser adapter."""
+
+    engine: str
+    contract_version: str
+    tool_schema_sha256: str
+    session_ttl_seconds: int = 15 * 60
+    idle_ttl_seconds: int = 5 * 60
+    max_pages: int = 1
+    max_actions: int = 50
+    max_concurrent_sessions: int = 1
+    max_tunnels_per_session: int = 12
+    max_egress_bytes_per_session: int = 64 * 1024 * 1024
+    egress_tunnel_idle_seconds: int = 30
+    egress_tunnel_ttl_seconds: int = 120
+    navigation_timeout_seconds: int = 20
+    call_timeout_seconds: int = 30
+    max_output_bytes: int = 256 * 1024
+    max_artifact_bytes: int = 32 * 1024 * 1024
+    max_artifacts_per_project: int = 50
+    max_artifact_storage_bytes: int = 256 * 1024 * 1024
+    artifact_ttl_seconds: int = 24 * 60 * 60
+    allowed_schemes: tuple[str, ...] = ("http", "https")
+    allowed_ports: tuple[int, ...] = (80, 443)
+    uploads: bool = False
+    downloads: bool = False
+    clipboard: bool = False
+    local_files: bool = False
+    cookies: bool = False
+    storage: bool = False
+    login_state: bool = False
+    evaluate: bool = False
+    cdp: bool = False
+    limitations: tuple[str, ...] = (
+        "仅允许经一次性确认的公网 HTTP/HTTPS 导航；每次 DNS 解析和重定向都重新校验。",
+        "浏览器会话临时化且仅允许单页；不保留 Cookie、存储、登录态或本机文件。",
+        "不采集账号凭据或提供外站登录流程；页面仍可能呈现登录界面，用户不得输入账号、密码或 OTP。",
+        "上传、下载、剪贴板、任意脚本求值和外部 CDP 均关闭。",
+    )
+
+    def to_public(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
 class CatalogAdapterManifest:
     project_id: str
     wave: int
@@ -288,6 +522,7 @@ class CatalogAdapterManifest:
     workspace_policy: CatalogWorkspacePolicy | None = None
     database_policy: CatalogDatabasePolicy | None = None
     saas_policy: CatalogSaaSPolicy | None = None
+    browser_policy: CatalogBrowserPolicy | None = None
     legacy_unrestricted_calls: bool = False
     enabled_by_default: bool = False
     operation_timeout: float = 30.0
@@ -387,6 +622,11 @@ class CatalogAdapterManifest:
                 if self.saas_policy is not None
                 else None
             ),
+            "browser_policy": (
+                self.browser_policy.to_public()
+                if self.browser_policy is not None
+                else None
+            ),
             "stateful_saas_gate_enabled": self.stateful_saas_gate_enabled,
         }
 
@@ -441,6 +681,10 @@ SAAS_SANDBOX_PROXY = (
     sys.executable,
     "-m",
     "mcp.saas_proxy",
+)
+BROWSER_SANDBOX_PROXY = (
+    sys.executable,
+    str(Path(__file__).resolve().with_name("browser_proxy.py")),
 )
 WAVE_ONE_ADAPTERS: dict[str, tuple[str, tuple[str, ...]]] = {
     "calculator-mcp": (
@@ -1039,6 +1283,36 @@ WAVE_SIX_ADAPTERS: dict[str, WaveSixAdapterSpec] = {
             ),
         ),
         ("仅开放固定 Data Source；归档、删除、Schema 修改、任意搜索和跨作用域写入均关闭。",),
+    ),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class WaveSevenAdapterSpec:
+    adapter_version: str
+    engine: str
+    tool_schema_sha256: str
+    read_tools: tuple[str, ...]
+    artifact_tools: tuple[str, ...]
+    state_write_tools: tuple[str, ...]
+
+
+WAVE_SEVEN_ADAPTERS: dict[str, WaveSevenAdapterSpec] = {
+    "chrome-devtools-mcp": WaveSevenAdapterSpec(
+        "1.6.0-wave7-v1",
+        "chrome-devtools",
+        BROWSER_SCHEMA_SHA256["chrome-devtools-mcp"],
+        ("browser_session_status", "take_snapshot"),
+        ("take_screenshot",),
+        ("navigate_page", "click", "fill"),
+    ),
+    "playwright-mcp": WaveSevenAdapterSpec(
+        "0.0.79-wave7-v1",
+        "playwright",
+        BROWSER_SCHEMA_SHA256["playwright-mcp"],
+        ("browser_session_status", "browser_snapshot"),
+        ("browser_take_screenshot",),
+        ("browser_navigate", "browser_click", "browser_fill_form"),
     ),
 }
 
@@ -1729,6 +2003,124 @@ def build_catalog_manifests() -> dict[str, CatalogAdapterManifest]:
         filesystem_policy="blocked:no-runtime",
     )
 
+    for project_id, spec in WAVE_SEVEN_ADAPTERS.items():
+        browser_policy = CatalogBrowserPolicy(
+            engine=spec.engine,
+            contract_version=BROWSER_CONTRACT_VERSION,
+            tool_schema_sha256=spec.tool_schema_sha256,
+        )
+        manifests[project_id] = CatalogAdapterManifest(
+            project_id=project_id,
+            wave=7,
+            availability="ready",
+            connection_kind="sandboxed-stdio",
+            risk="high",
+            required_capabilities=(
+                "ephemeral-browser",
+                "browser-domain-policy",
+                "browser-session-approval",
+                "browser-artifact-cleanup",
+            ),
+            limitations=(
+                *browser_policy.limitations,
+                "所有页面状态修改都冻结参数并一次性确认；超时或连接中断按结果未知处理并销毁会话。",
+                "单 Origin 锁定覆盖可信上游的正常 Chromium 与恶意网页流量；若浏览器或上游进程本身完全 RCE，独立出口仍拒绝私网与 metadata 并限流，但不保证同公网 IP/证书下的虚拟主机精确隔离；本批不做 TLS MITM 或每会话容器。",
+                "浏览器与出口使用一次性配对密钥；任一服务单独重启后不复用旧会话并保持失败关闭，需成对重启恢复；共享 staging 临时卷硬限制为 64 MiB。",
+                "Landlock 对 /proc 恢复 WRITE_FILE 类别供 Chromium user namespace 映射；这不是路径白名单，实际写入仍受非 root、无 capabilities、Docker procfs 掩蔽/只读挂载与 seccomp 约束。",
+            ),
+            adapter_version=spec.adapter_version,
+            runtime_image="modelmirror-mcp-browser:wave7-v1",
+            network_policy=(
+                "public-http-https-only,dns-pinning,redirect-revalidation,"
+                "private-metadata-blocked"
+            ),
+            filesystem_policy=(
+                "read-only-root,ephemeral-profile,server-generated-artifacts-only,"
+                "landlock-proc-write-file-with-docker-procfs-guards"
+            ),
+            resource_limits=(
+                ("browser_cpu", "1.5 cores"),
+                ("browser_memory", "1 GiB"),
+                ("browser_processes", "maximum 1 session / 256 PIDs"),
+                ("egress_cpu", "0.5 cores"),
+                ("egress_memory", "256 MiB"),
+                ("egress_processes", "64 PIDs"),
+                ("pages", "1 page per session"),
+                ("session_ttl", "15 minutes / 5 minutes idle"),
+                ("actions", "50 per session"),
+                ("navigation_timeout", "20 seconds"),
+                ("operation_timeout", "30 seconds"),
+                ("tool_output", "256 KiB"),
+                ("screenshot", "32 MiB"),
+            ),
+            server_command=(*BROWSER_SANDBOX_PROXY, project_id),
+            preparation_kind="bundled",
+            tool_policies={
+                **{
+                    name: CatalogToolPolicy(read_only=True, effect="read")
+                    for name in spec.read_tools
+                },
+                **{
+                    name: CatalogToolPolicy(
+                        read_only=False,
+                        effect="artifact-create",
+                    )
+                    for name in spec.artifact_tools
+                },
+                **{
+                    name: CatalogToolPolicy(
+                        read_only=False,
+                        requires_approval=True,
+                        effect="state-write",
+                    )
+                    for name in spec.state_write_tools
+                },
+            },
+            browser_policy=browser_policy,
+            enabled_by_default=False,
+            operation_timeout=30.0,
+            max_output_bytes=256 * 1024,
+        )
+
+    manifests["puppeteer-mcp"] = CatalogAdapterManifest(
+        project_id="puppeteer-mcp",
+        wave=7,
+        availability="blocked",
+        connection_kind="sandboxed-stdio",
+        risk="critical",
+        required_capabilities=(
+            "maintained-upstream-contract",
+            "ephemeral-browser",
+            "browser-domain-policy",
+        ),
+        limitations=(
+            "官方仓库已经归档，现有实现允许危险启动参数、任意脚本求值和宽泛浏览器控制，无法满足持续安全维护门槛。",
+            "本条目保留目录与第 7 批编号，但不显示安装、连接、上传、登录或外部 CDP 入口。",
+        ),
+        adapter_version="blocked:archived-dangerous-runtime",
+        network_policy="blocked:unmaintained-browser-runtime",
+        filesystem_policy="blocked:no-runtime",
+    )
+    manifests["selenium-mcp"] = CatalogAdapterManifest(
+        project_id="selenium-mcp",
+        wave=7,
+        availability="blocked",
+        connection_kind="sandboxed-stdio",
+        risk="critical",
+        required_capabilities=(
+            "license-contract-resolution",
+            "maintained-upstream-contract",
+            "ephemeral-browser",
+        ),
+        limitations=(
+            "上游 v0.2.3 的仓库与包许可证声明冲突，并暴露任意 Chrome 参数、脚本执行、Cookie 和宿主路径能力。",
+            "完成许可证核验、受控驱动封装和进程清理契约前，连接、Grid、VNC 和本机桥接入口全部关闭。",
+        ),
+        adapter_version="0.2.3-blocked:license-and-runtime-contract",
+        network_policy="blocked:no-production-runtime",
+        filesystem_policy="blocked:no-runtime",
+    )
+
     manifests["snyk-mcp"] = CatalogAdapterManifest(
         project_id="snyk-mcp",
         wave=4,
@@ -1831,6 +2223,29 @@ class CatalogAccountSnapshot:
     verified_at: float
 
 
+@dataclass(frozen=True, slots=True)
+class CatalogBrowserSnapshot:
+    status: Literal["active", "tainted", "disconnected"]
+    generation: str
+    page_revision: int
+    page_digest: str
+    current_origin: str
+    action_count: int
+    max_actions: int
+    expires_at: float
+    approved_hosts: tuple[str, ...] = ()
+
+    @property
+    def digest(self) -> str:
+        encoded = json.dumps(
+            asdict(self),
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+
 @dataclass(slots=True)
 class CatalogExecutionLedgerEntry:
     approval_id: str
@@ -1840,6 +2255,23 @@ class CatalogExecutionLedgerEntry:
     idempotency_key: str
     state: Literal["started", "completed", "unknown", "rejected"]
     result: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class CatalogBrowserArtifact:
+    artifact_id: str
+    tenant_id: str
+    owner_id: str
+    project_id: str
+    session_id: str
+    browser_generation: str
+    relative_path: str
+    name: str
+    mime_type: str
+    size_bytes: int
+    sha256: str
+    created_at: float
+    expires_at: float
 
 
 @dataclass(slots=True)
@@ -1861,6 +2293,7 @@ class CatalogApproval:
     configuration_digest: str = ""
     credential_snapshot_digest: str = ""
     account_snapshot_digest: str = ""
+    browser_snapshot_digest: str = ""
     tool_schema_sha256: str = ""
     tool_policy_digest: str = ""
     idempotency_key: str = ""
@@ -1904,6 +2337,9 @@ class MCPCatalogService:
         credential_creator: Callable[..., tuple[Any, str]] | None = None,
         credential_revoker: Callable[[str], Any] | None = None,
         workspace_store: MCPCatalogWorkspaceStore | None = None,
+        browser_artifact_root: Path | None = None,
+        browser_artifact_staging_root: Path | None = None,
+        browser_artifact_index_path: Path | None = None,
         tenant_id: str = "local",
         owner_id: str = "local",
     ) -> None:
@@ -1917,6 +2353,36 @@ class MCPCatalogService:
         self.credential_creator = credential_creator
         self.credential_revoker = credential_revoker
         self.workspace_store = workspace_store
+        catalog_storage_root = Path(
+            os.getenv(
+                "MCP_CATALOG_STORAGE_DIR",
+                str(Path(__file__).resolve().parent / "storage"),
+            )
+        )
+        configured_browser_artifact_root = browser_artifact_root or Path(
+            os.getenv(
+                "MCP_BROWSER_TRUSTED_ARTIFACT_ROOT",
+                str(catalog_storage_root / "browser-artifacts"),
+            )
+        )
+        self.browser_artifact_root = configured_browser_artifact_root.resolve(
+            strict=False
+        )
+        configured_browser_staging_root = browser_artifact_staging_root or Path(
+            os.getenv(
+                "MCP_BROWSER_ARTIFACT_STAGING_ROOT",
+                str(Path(__file__).resolve().parent / "browser-artifact-staging"),
+            )
+        )
+        self.browser_artifact_staging_root = (
+            configured_browser_staging_root.resolve(strict=False)
+        )
+        configured_browser_index = browser_artifact_index_path or (
+            self.browser_artifact_root / "index.json"
+        )
+        self.browser_artifact_index_path = configured_browser_index.resolve(
+            strict=False
+        )
         self.tenant_id = str(tenant_id or "local")
         self.owner_id = str(owner_id or "local")
         self._sessions: dict[tuple[str, str, str], str] = {}
@@ -1932,6 +2398,19 @@ class MCPCatalogService:
         self._account_snapshots: dict[
             tuple[str, str, str], CatalogAccountSnapshot
         ] = {}
+        self._browser_snapshots: dict[
+            tuple[str, str, str], CatalogBrowserSnapshot
+        ] = {}
+        self._browser_elements: dict[
+            tuple[str, str, str], dict[str, dict[str, str]]
+        ] = {}
+        self._browser_disconnect_reasons: dict[
+            tuple[str, str, str], str
+        ] = {}
+        self._browser_artifacts: dict[
+            tuple[str, str, str], CatalogBrowserArtifact
+        ] = {}
+        self._load_browser_artifact_index()
         self._credential_verification: dict[tuple[str, str, str], str] = {}
         self._preflight_status: dict[tuple[str, str, str], str] = {}
         self._approvals: dict[tuple[str, str, str], CatalogApproval] = {}
@@ -1960,6 +2439,13 @@ class MCPCatalogService:
             self.tenant_id,
             self.owner_id,
             str(approval_id or "").strip(),
+        )
+
+    def _artifact_key(self, artifact_id: str) -> tuple[str, str, str]:
+        return (
+            self.tenant_id,
+            self.owner_id,
+            str(artifact_id or "").strip(),
         )
 
     def _session_owner(self, project_id: str) -> str:
@@ -2047,10 +2533,29 @@ class MCPCatalogService:
                     scope_key,
                     "unverified",
                 )
-            if manifest.database_policy is None and manifest.saas_policy is None:
+            browser_snapshot = self._browser_snapshots.get(scope_key)
+            item["browser_session_status"] = (
+                browser_snapshot.status
+                if manifest.browser_policy is not None and browser_snapshot is not None
+                else (
+                    "disconnected"
+                    if manifest.browser_policy is not None
+                    else "not-applicable"
+                )
+            )
+            if (
+                manifest.database_policy is None
+                and manifest.saas_policy is None
+                and manifest.browser_policy is None
+            ):
                 item["preflight_status"] = "not-applicable"
             elif manifest.availability == "blocked":
                 item["preflight_status"] = "blocked"
+            elif manifest.browser_policy is not None:
+                item["preflight_status"] = self._preflight_status.get(
+                    scope_key,
+                    "unverified",
+                )
             elif configuration is None:
                 item["preflight_status"] = (
                     "awaiting-workspace"
@@ -2234,9 +2739,14 @@ class MCPCatalogService:
         )
         self._credential_snapshots.pop(scope_key, None)
         self._account_snapshots.pop(scope_key, None)
+        self._browser_snapshots.pop(scope_key, None)
         if manifest.credential_policies:
             self._credential_verification[scope_key] = "unverified"
-        if manifest.database_policy is not None or manifest.saas_policy is not None:
+        if (
+            manifest.database_policy is not None
+            or manifest.saas_policy is not None
+            or manifest.browser_policy is not None
+        ):
             self._preflight_status[scope_key] = "unverified"
         self._revoke_approvals(manifest.project_id)
         return {
@@ -2278,9 +2788,42 @@ class MCPCatalogService:
                         existing,
                         session_owner=session_owner,
                     )
+                    if manifest.browser_policy is not None:
+                        schema_digest = self._tool_schema_digest(tools)
+                        if (
+                            {tool.name for tool in tools}
+                            != set(manifest.tool_policies)
+                            or schema_digest
+                            != manifest.browser_policy.tool_schema_sha256
+                        ):
+                            await self._taint_browser_session(manifest)
+                            raise CatalogAdapterPolicyError(
+                                "浏览器工具清单或输入 Schema 发生漂移，连接已阻断。"
+                            )
+                        snapshot = await self._refresh_browser_snapshot(
+                            manifest,
+                            session_id=existing,
+                        )
+                        if snapshot.status != "active":
+                            await self._taint_browser_session(manifest)
+                            raise CatalogAdapterPolicyError(
+                                "浏览器会话已经污染，请重新连接。"
+                            )
                     return self._connection_payload(manifest, existing, tools)
-                except MCPSessionNotFoundError:
-                    self._sessions.pop(scope_key, None)
+                except (
+                    MCPClientError,
+                    CatalogBrowserSessionExpiredError,
+                    EOFError,
+                    BrokenPipeError,
+                    OSError,
+                ):
+                    if manifest.browser_policy is not None:
+                        await self._forget_browser_session(
+                            manifest,
+                            reason="expired",
+                        )
+                    else:
+                        self._sessions.pop(scope_key, None)
 
             if manifest.transport != "stdio" or not manifest.server_command:
                 raise CatalogAdapterUnavailableError(
@@ -2371,6 +2914,27 @@ class MCPCatalogService:
                     environment[handshake_name] = base64.urlsafe_b64encode(
                         handshake_payload
                     ).decode("ascii")
+                if manifest.browser_policy is not None:
+                    browser_handshake = json.dumps(
+                        {
+                            "project_id": manifest.project_id,
+                            "contract_version": manifest.browser_policy.contract_version,
+                            "tool_schema_sha256": (
+                                manifest.browser_policy.tool_schema_sha256
+                            ),
+                            "limits": BROWSER_LIMITS,
+                        },
+                        ensure_ascii=False,
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    ).encode("utf-8")
+                    if len(browser_handshake) > 64 * 1024:
+                        raise CatalogAdapterPolicyError(
+                            "浏览器内部握手超过安全上限。"
+                        )
+                    environment["MCP_BROWSER_HANDSHAKE_B64"] = (
+                        base64.urlsafe_b64encode(browser_handshake).decode("ascii")
+                    )
                 profile: dict[str, Any] = {
                     "transport": "stdio",
                     "server_command": list(manifest.server_command),
@@ -2379,6 +2943,7 @@ class MCPCatalogService:
                         0
                         if manifest.credential_policies
                         or manifest.database_policy is not None
+                        or manifest.browser_policy is not None
                         else 1
                     ),
                     "operation_timeout": manifest.operation_timeout,
@@ -2387,7 +2952,11 @@ class MCPCatalogService:
                 if environment:
                     profile["environment"] = environment
                 session_id = await self.manager.connect_profile(**profile)
-                if manifest.credential_policies or manifest.database_policy is not None:
+                if (
+                    manifest.credential_policies
+                    or manifest.database_policy is not None
+                    or manifest.browser_policy is not None
+                ):
                     await self.manager.scrub_session_environment(
                         session_id,
                         session_owner=session_owner,
@@ -2398,7 +2967,11 @@ class MCPCatalogService:
                     session_owner=session_owner,
                 )
             try:
-                if manifest.database_policy is not None or manifest.saas_policy is not None:
+                if (
+                    manifest.database_policy is not None
+                    or manifest.saas_policy is not None
+                    or manifest.browser_policy is not None
+                ):
                     self._preflight_status[scope_key] = "verifying"
                 tools = await self.manager.list_tools(
                     session_id,
@@ -2411,7 +2984,11 @@ class MCPCatalogService:
                         tools=tools,
                     )
             except Exception:
-                if manifest.database_policy is not None or manifest.saas_policy is not None:
+                if (
+                    manifest.database_policy is not None
+                    or manifest.saas_policy is not None
+                    or manifest.browser_policy is not None
+                ):
                     self._preflight_status[scope_key] = "failed"
                 await self.manager.disconnect(
                     session_id,
@@ -2454,6 +3031,44 @@ class MCPCatalogService:
                     tool_schema_sha256=schema_digest,
                     verified_at=time.time(),
                 )
+            browser_snapshot: CatalogBrowserSnapshot | None = None
+            if manifest.browser_policy is not None:
+                schema_digest = self._tool_schema_digest(tools)
+                expected_tools = set(manifest.tool_policies)
+                if (
+                    {tool.name for tool in tools} != expected_tools
+                    or schema_digest
+                    != manifest.browser_policy.tool_schema_sha256
+                ):
+                    await self.manager.disconnect(
+                        session_id,
+                        session_owner=session_owner,
+                    )
+                    self._preflight_status[scope_key] = "failed"
+                    raise CatalogAdapterPolicyError(
+                        "浏览器工具清单或输入 Schema 发生漂移，连接已阻断。"
+                    )
+                try:
+                    browser_snapshot = await self._refresh_browser_snapshot(
+                        manifest,
+                        session_id=session_id,
+                    )
+                except Exception:
+                    await self.manager.disconnect(
+                        session_id,
+                        session_owner=session_owner,
+                    )
+                    self._preflight_status[scope_key] = "failed"
+                    raise
+                if browser_snapshot.status != "active":
+                    await self.manager.disconnect(
+                        session_id,
+                        session_owner=session_owner,
+                    )
+                    self._preflight_status[scope_key] = "failed"
+                    raise CatalogAdapterPolicyError(
+                        "浏览器会话初始化后即处于污染状态，连接已阻断。"
+                    )
             if scope_key in self._unbinding_scopes:
                 await self.manager.disconnect(
                     session_id,
@@ -2466,11 +3081,17 @@ class MCPCatalogService:
             # Publish catalog ownership only after all provider preflight and
             # fixed tools/inputSchema checks have succeeded.
             self._sessions[scope_key] = session_id
+            if manifest.browser_policy is not None:
+                self._browser_disconnect_reasons.pop(scope_key, None)
             if manifest.credential_policies:
                 self._credential_snapshots[scope_key] = snapshots
             if account_snapshot is not None:
                 self._account_snapshots[scope_key] = account_snapshot
-            if manifest.database_policy is not None or manifest.saas_policy is not None:
+            if (
+                manifest.database_policy is not None
+                or manifest.saas_policy is not None
+                or manifest.browser_policy is not None
+            ):
                 self._preflight_status[scope_key] = "verified"
                 if manifest.credential_policies:
                     # Database and stateful SaaS children complete an
@@ -2496,26 +3117,110 @@ class MCPCatalogService:
             raise MCPSessionNotFoundError(
                 f"MCP catalog session not found: {manifest.project_id}"
             )
+        disconnected = False
         try:
             await self.manager.disconnect(
                 session_id,
                 session_owner=self._session_owner(manifest.project_id),
             )
+            disconnected = True
+        except Exception:
+            if manifest.browser_policy is not None:
+                self._preflight_status[scope_key] = "failed"
+                self._browser_disconnect_reasons[scope_key] = "disconnect-failed"
+                self._browser_elements.pop(scope_key, None)
+                self._revoke_approvals(manifest.project_id)
+            raise
         finally:
-            await self.registry.unregister_session(session_id)
-            async with self._lock:
-                if self._sessions.get(scope_key) == session_id:
-                    self._sessions.pop(scope_key, None)
-                    self._credential_snapshots.pop(scope_key, None)
-                    self._account_snapshots.pop(scope_key, None)
-                    if (
-                        manifest.database_policy is not None
-                        or manifest.saas_policy is not None
-                    ):
-                        self._preflight_status[scope_key] = "unverified"
+            if disconnected or manifest.browser_policy is None:
+                await self.registry.unregister_session(session_id)
+                async with self._lock:
+                    if self._sessions.get(scope_key) == session_id:
+                        self._sessions.pop(scope_key, None)
+                        self._credential_snapshots.pop(scope_key, None)
+                        self._account_snapshots.pop(scope_key, None)
+                        browser_snapshot = self._browser_snapshots.get(scope_key)
+                        if browser_snapshot is not None:
+                            self._browser_snapshots[scope_key] = CatalogBrowserSnapshot(
+                                **{**asdict(browser_snapshot), "status": "disconnected"}
+                            )
+                            self._browser_disconnect_reasons[scope_key] = (
+                                "user-disconnected"
+                            )
+                        self._browser_elements.pop(scope_key, None)
+                        if (
+                            manifest.database_policy is not None
+                            or manifest.saas_policy is not None
+                            or manifest.browser_policy is not None
+                        ):
+                            self._preflight_status[scope_key] = "unverified"
         self._revoke_approvals(manifest.project_id)
         logger.info("MCP catalog disconnect project=%s", manifest.project_id)
         return {"ok": True, "project_id": manifest.project_id}
+
+    async def _taint_browser_session(
+        self,
+        manifest: CatalogAdapterManifest,
+    ) -> None:
+        """Fail closed after an ambiguous browser state change."""
+
+        if manifest.browser_policy is None:
+            return
+        scope_key = self._scope_key(manifest.project_id)
+        snapshot = self._browser_snapshots.get(scope_key)
+        if snapshot is not None and snapshot.status != "tainted":
+            self._browser_snapshots[scope_key] = CatalogBrowserSnapshot(
+                **{**asdict(snapshot), "status": "tainted"}
+            )
+        self._preflight_status[scope_key] = "failed"
+        self._browser_disconnect_reasons[scope_key] = "tainted"
+        self._browser_elements.pop(scope_key, None)
+        self._revoke_approvals(manifest.project_id)
+        session_id = self._sessions.pop(scope_key, None)
+        if session_id is None:
+            return
+        try:
+            await self.manager.disconnect(
+                session_id,
+                session_owner=self._session_owner(manifest.project_id),
+            )
+        except Exception as exc:
+            logger.warning(
+                "MCP catalog browser teardown failed project=%s",
+                manifest.project_id,
+            )
+        finally:
+            await self.registry.unregister_session(session_id)
+
+    async def _forget_browser_session(
+        self,
+        manifest: CatalogAdapterManifest,
+        *,
+        reason: str,
+    ) -> None:
+        if manifest.browser_policy is None:
+            return
+        scope_key = self._scope_key(manifest.project_id)
+        session_id = self._sessions.pop(scope_key, None)
+        snapshot = self._browser_snapshots.get(scope_key)
+        if snapshot is not None:
+            self._browser_snapshots[scope_key] = CatalogBrowserSnapshot(
+                **{**asdict(snapshot), "status": "disconnected"}
+            )
+        self._browser_disconnect_reasons[scope_key] = reason
+        self._browser_elements.pop(scope_key, None)
+        self._preflight_status[scope_key] = "unverified"
+        self._revoke_approvals(manifest.project_id)
+        if session_id is None:
+            return
+        try:
+            await self.manager.disconnect(
+                session_id,
+                session_owner=self._session_owner(manifest.project_id),
+            )
+        except Exception:
+            pass
+        await self.registry.unregister_session(session_id)
 
     async def disconnect(self, project_id: str) -> dict[str, Any]:
         manifest = self.get_manifest(project_id)
@@ -2549,6 +3254,13 @@ class MCPCatalogService:
         session_id = self._sessions.get(scope_key)
         if session_id is None:
             raise CatalogAdapterUnavailableError("请先连接该 MCP 适配器。")
+        if (
+            manifest.browser_policy is not None
+            and self._preflight_status.get(scope_key) != "verified"
+        ):
+            raise CatalogAdapterPolicyError(
+                "浏览器会话状态尚未验证；请刷新会话状态或重新连接。"
+            )
         await self._ensure_credentials_fresh(manifest.project_id)
 
         if not manifest.legacy_unrestricted_calls:
@@ -2561,11 +3273,44 @@ class MCPCatalogService:
                 raise CatalogAdapterPolicyError(
                     "第 5 批数据库适配器仅允许已审计的只读工具。"
                 )
+            if manifest.browser_policy is not None and {
+                "generation",
+                "page_revision",
+                "page_digest",
+            } & set(arguments):
+                raise CatalogAdapterPolicyError(
+                    "浏览器会话代次与页面摘要由服务端绑定，客户端不能提交。"
+                )
             if policy.sensitive or policy.terminal or policy.effect == "terminal":
                 raise CatalogAdapterPolicyError(
                     "该工具属于敏感或终止性操作，当前批次不允许执行。"
                 )
             if policy.requires_approval:
+                if manifest.browser_policy is not None:
+                    try:
+                        browser_snapshot = await self._refresh_browser_snapshot(
+                            manifest,
+                            session_id=session_id,
+                        )
+                    except (
+                        MCPClientError,
+                        CatalogBrowserSessionExpiredError,
+                        EOFError,
+                        BrokenPipeError,
+                        OSError,
+                    ) as exc:
+                        await self._forget_browser_session(
+                            manifest,
+                            reason="expired",
+                        )
+                        raise CatalogAdapterPolicyError(
+                            "浏览器临时会话已经过期，请重新连接。"
+                        ) from exc
+                    if browser_snapshot.status != "active":
+                        await self._taint_browser_session(manifest)
+                        raise CatalogAdapterPolicyError(
+                            "浏览器会话已经污染，请重新连接后再操作。"
+                        )
                 raise CatalogApprovalRequiredError(
                     self._create_approval(
                         manifest,
@@ -2598,6 +3343,12 @@ class MCPCatalogService:
                 )
             approval = self._approvals.get(approval_key)
             ledger = self._execution_ledger.get(approval_key)
+            if ledger is not None and (
+                ledger.tenant_id != self.tenant_id
+                or ledger.owner_id != self.owner_id
+                or ledger.project_id != manifest.project_id
+            ):
+                ledger = None
             if approval is None and ledger is not None:
                 if ledger.state == "completed" and ledger.result is not None:
                     replay = json.loads(json.dumps(ledger.result, ensure_ascii=False))
@@ -2627,7 +3378,7 @@ class MCPCatalogService:
                 )
                 if workspace.manifest_sha256 != approval.workspace_manifest_sha256:
                     raise CatalogAdapterPolicyError("工作区内容已经变化，请重新发起操作。")
-            else:
+            elif approval.context_kind == "remote-resource":
                 await self._ensure_credentials_fresh(manifest.project_id)
                 configuration_snapshot = self._configuration_snapshots.get(scope_key)
                 account_snapshot = self._account_snapshots.get(scope_key)
@@ -2650,6 +3401,39 @@ class MCPCatalogService:
                     raise CatalogAdapterPolicyError(
                         "账号、配置、凭据或工具策略已经变化，请重新发起操作。"
                     )
+            elif approval.context_kind == "browser-session":
+                current_session_id = self._sessions.get(scope_key)
+                if not current_session_id or current_session_id != approval.session_id:
+                    self._approvals.pop(approval_key, None)
+                    raise CatalogAdapterPolicyError(
+                        "浏览器会话已经变化，请重新发起操作。"
+                    )
+                try:
+                    browser_snapshot = await self._refresh_browser_snapshot(
+                        manifest,
+                        session_id=current_session_id,
+                    )
+                except Exception:
+                    self._approvals.pop(approval_key, None)
+                    await self._taint_browser_session(manifest)
+                    raise
+                policy = manifest.tool_policies.get(approval.tool_name)
+                if (
+                    browser_snapshot.status != "active"
+                    or browser_snapshot.digest != approval.browser_snapshot_digest
+                    or manifest.browser_policy is None
+                    or manifest.browser_policy.tool_schema_sha256
+                    != approval.tool_schema_sha256
+                    or policy is None
+                    or self._tool_policy_digest(policy) != approval.tool_policy_digest
+                ):
+                    self._approvals.pop(approval_key, None)
+                    raise CatalogAdapterPolicyError(
+                        "浏览器页面、会话或工具策略已经变化，请重新发起操作。"
+                    )
+            else:
+                self._approvals.pop(approval_key, None)
+                raise CatalogAdapterPolicyError("一次性确认上下文无效。")
             session_id = self._sessions.get(scope_key)
             if (
                 approval.tool_name != "__delete_workspace__"
@@ -2658,7 +3442,7 @@ class MCPCatalogService:
                 raise CatalogAdapterPolicyError("MCP 会话已经变化，请重新发起操作。")
             approval.used = True
             self._approvals.pop(approval_key, None)
-            if approval.context_kind == "remote-resource":
+            if approval.context_kind in {"remote-resource", "browser-session"}:
                 ledger = CatalogExecutionLedgerEntry(
                     approval_id=approval.approval_id,
                     tenant_id=self.tenant_id,
@@ -2686,7 +3470,7 @@ class MCPCatalogService:
                 "workspace_id": approval.workspace_id,
             }
         assert session_id is not None
-        if approval.context_kind != "remote-resource":
+        if approval.context_kind == "workspace":
             return await self._execute_tool(
                 manifest,
                 session_id=session_id,
@@ -2694,6 +3478,41 @@ class MCPCatalogService:
                 arguments=approval.arguments,
             )
         assert ledger is not None
+        if approval.context_kind == "browser-session":
+            try:
+                result = await self._execute_tool(
+                    manifest,
+                    session_id=session_id,
+                    tool_name=approval.tool_name,
+                    arguments=approval.arguments,
+                    expected_browser_snapshot_digest=(
+                        approval.browser_snapshot_digest
+                    ),
+                )
+            except CatalogBrowserStateDriftError:
+                ledger.state = "rejected"
+                raise
+            except Exception as exc:
+                rejection_reason = _browser_policy_rejection_reason(exc)
+                if rejection_reason is not None:
+                    ledger.state = "rejected"
+                    raise CatalogBrowserPolicyRejectedError(
+                        rejection_reason,
+                        approval.idempotency_key,
+                    ) from exc
+                ledger.state = "unknown"
+                await self._taint_browser_session(manifest)
+                raise CatalogUnknownOutcomeError(approval.idempotency_key) from exc
+            if result.get("is_error"):
+                ledger.state = "unknown"
+                await self._taint_browser_session(manifest)
+                raise CatalogUnknownOutcomeError(approval.idempotency_key)
+            result["idempotency_key"] = approval.idempotency_key
+            result["idempotent_replay"] = False
+            result["unknown_outcome"] = False
+            ledger.state = "completed"
+            ledger.result = json.loads(json.dumps(result, ensure_ascii=False))
+            return result
         execution_arguments = dict(approval.arguments)
         execution_arguments["__modelmirror_idempotency_key"] = approval.idempotency_key
         try:
@@ -2773,16 +3592,20 @@ class MCPCatalogService:
         session_id: str,
         tool_name: str,
         arguments: dict[str, Any],
+        expected_browser_snapshot_digest: str = "",
     ) -> dict[str, Any]:
 
         scope_key = self._scope_key(manifest.project_id)
         started_at = time.monotonic()
         tool_policy = manifest.tool_policies.get(tool_name)
         retry_on_failure = not (
-            manifest.saas_policy is not None
-            and tool_policy is not None
-            and tool_policy.effect == "state-write"
+            manifest.browser_policy is not None
+            or (
+                tool_policy is not None
+                and tool_policy.effect in {"state-write", "terminal"}
+            )
         )
+
         try:
             call_lock = self._call_locks.setdefault(scope_key, asyncio.Lock())
             async with call_lock:
@@ -2790,6 +3613,23 @@ class MCPCatalogService:
                     raise CatalogAdapterPolicyError(
                         "账号解绑或凭据撤销正在进行，当前不能调用工具。"
                     )
+                if expected_browser_snapshot_digest:
+                    if manifest.browser_policy is None:
+                        raise CatalogBrowserStateDriftError(
+                            "浏览器审批上下文不存在。"
+                        )
+                    current_snapshot = await self._refresh_browser_snapshot(
+                        manifest,
+                        session_id=session_id,
+                    )
+                    if (
+                        current_snapshot.status != "active"
+                        or current_snapshot.digest
+                        != expected_browser_snapshot_digest
+                    ):
+                        raise CatalogBrowserStateDriftError(
+                            "浏览器页面状态已经变化，请重新发起操作。"
+                        )
                 if retry_on_failure:
                     result = await self.manager.call_tool(
                         session_id,
@@ -2805,11 +3645,27 @@ class MCPCatalogService:
                         retry_on_failure=False,
                         session_owner=self._session_owner(manifest.project_id),
                     )
-        except Exception:
+        except Exception as exc:
+            browser_rejection = _browser_policy_rejection_reason(exc)
             if manifest.credential_policies and manifest.saas_policy is None:
                 self._credential_verification[scope_key] = "verification-failed"
             if manifest.database_policy is not None:
                 self._preflight_status[scope_key] = "failed"
+            if manifest.browser_policy is not None:
+                if browser_rejection is None:
+                    self._preflight_status[scope_key] = "failed"
+                    if (
+                        tool_policy is not None
+                        and tool_policy.effect != "read"
+                        and not isinstance(exc, CatalogBrowserStateDriftError)
+                    ):
+                        await self._taint_browser_session(manifest)
+                else:
+                    # JSON-RPC -32011 + retryable=false is a definitive
+                    # pre-dispatch policy rejection. Preserve the one-shot
+                    # browser session so the user can correct the target and
+                    # request a fresh approval; never replay the old approval.
+                    self._preflight_status[scope_key] = "verified"
             raise
         logger.info(
             "MCP catalog call project=%s tool=%s duration_ms=%d",
@@ -2821,6 +3677,64 @@ class MCPCatalogService:
             result,
             max_output_bytes=manifest.max_output_bytes,
         )
+        if manifest.browser_policy is not None:
+            if (
+                payload["is_error"]
+                and tool_policy is not None
+                and tool_policy.effect != "read"
+            ):
+                await self._taint_browser_session(manifest)
+            else:
+                try:
+                    snapshot = await self._refresh_browser_snapshot(
+                        manifest,
+                        session_id=session_id,
+                    )
+                except Exception:
+                    self._preflight_status[scope_key] = "failed"
+                    if (
+                        tool_policy is not None
+                        and tool_policy.effect != "read"
+                    ):
+                        await self._taint_browser_session(manifest)
+                    raise
+                if snapshot.status == "tainted":
+                    await self._taint_browser_session(manifest)
+                    if (
+                        tool_policy is not None
+                        and tool_policy.effect != "read"
+                    ):
+                        raise CatalogAdapterPolicyError(
+                            "浏览器操作后会话状态未知，已销毁临时浏览器。"
+                        )
+                else:
+                    if tool_policy is not None and tool_policy.effect != "read":
+                        self._browser_elements.pop(scope_key, None)
+                    if tool_name in {"take_snapshot", "browser_snapshot"}:
+                        self._store_browser_elements(
+                            manifest,
+                            payload,
+                            snapshot,
+                        )
+                    if (
+                        tool_policy is not None
+                        and tool_policy.effect == "artifact-create"
+                        and not payload["is_error"]
+                    ):
+                        try:
+                            payload["artifacts"] = [
+                                self._register_browser_artifact(
+                                    manifest,
+                                    session_id=session_id,
+                                    payload=payload,
+                                    snapshot=snapshot,
+                                )
+                            ]
+                        except Exception:
+                            self._preflight_status[scope_key] = "failed"
+                            await self._taint_browser_session(manifest)
+                            raise
+                    self._preflight_status[scope_key] = "verified"
         if manifest.credential_policies and manifest.saas_policy is None:
             self._credential_verification[scope_key] = (
                 "verification-failed" if payload["is_error"] else "verified"
@@ -2852,6 +3766,579 @@ class MCPCatalogService:
             ]
         return payload
 
+    def _store_browser_elements(
+        self,
+        manifest: CatalogAdapterManifest,
+        payload: dict[str, Any],
+        snapshot: CatalogBrowserSnapshot,
+    ) -> None:
+        raw = payload.get("raw")
+        structured = None
+        if isinstance(raw, dict):
+            structured = raw.get("structuredContent") or raw.get(
+                "structured_content"
+            )
+        if not isinstance(structured, dict):
+            raise CatalogAdapterPolicyError(
+                "浏览器快照缺少受控元素预览，工具契约已阻断。"
+            )
+        elements = structured.get("elements")
+        if not isinstance(elements, list) or len(elements) > 100:
+            raise CatalogAdapterPolicyError(
+                "浏览器快照元素列表不符合固定契约。"
+            )
+        safe: dict[str, dict[str, str]] = {}
+        sensitive = re.compile(
+            r"password|passcode|secret|token|api[ _-]?key|credit|cvv|cvc|"
+            r"otp|login|sign[ -]?in|oauth|密码|口令|令牌|密钥|验证码|信用卡|登录",
+            re.IGNORECASE,
+        )
+        for item in elements:
+            if not isinstance(item, dict):
+                raise CatalogAdapterPolicyError("浏览器快照元素项无效。")
+            ref = str(item.get("ref") or "").strip()
+            role = " ".join(str(item.get("role") or "element").split())
+            label = " ".join(str(item.get("label") or "").split())
+            page_digest = str(item.get("page_digest") or "").strip().lower()
+            if (
+                re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}", ref)
+                is None
+                or not role
+                or not label
+                or len(role) > 48
+                or len(label) > 120
+                or page_digest != snapshot.page_digest
+                or any(ord(character) < 32 for character in role + label)
+                or ref in safe
+            ):
+                raise CatalogAdapterPolicyError("浏览器快照元素项违反固定契约。")
+            if sensitive.search(f"{role} {label}"):
+                continue
+            safe[ref] = {
+                "role": role,
+                "label": label,
+                "page_digest": page_digest,
+            }
+        if len(
+            json.dumps(
+                safe,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        ) > 32 * 1024:
+            raise CatalogAdapterPolicyError(
+                "浏览器快照元素摘要超过固定大小上限。"
+            )
+        self._browser_elements[self._scope_key(manifest.project_id)] = safe
+
+    def _register_browser_artifact(
+        self,
+        manifest: CatalogAdapterManifest,
+        *,
+        session_id: str,
+        payload: dict[str, Any],
+        snapshot: CatalogBrowserSnapshot,
+    ) -> dict[str, Any]:
+        policy = manifest.browser_policy
+        if policy is None:
+            raise CatalogAdapterPolicyError("浏览器产物策略不存在。")
+        raw = payload.get("raw")
+        structured = None
+        structured_key = ""
+        if isinstance(raw, dict):
+            if isinstance(raw.get("structuredContent"), dict):
+                structured = raw["structuredContent"]
+                structured_key = "structuredContent"
+            elif isinstance(raw.get("structured_content"), dict):
+                structured = raw["structured_content"]
+                structured_key = "structured_content"
+        if not isinstance(structured, dict):
+            raise CatalogAdapterPolicyError("浏览器截图缺少结构化产物信息。")
+        internal_id = str(structured.get("artifact_id") or "").strip()
+        relative_path = str(structured.get("relative_path") or "").strip()
+        sha256 = str(structured.get("sha256") or "").strip().lower()
+        mime_type = str(structured.get("mime") or "").strip().lower()
+        try:
+            size_bytes = int(structured.get("size"))
+        except (TypeError, ValueError) as exc:
+            raise CatalogAdapterPolicyError("浏览器截图大小无效。") from exc
+        if (
+            re.fullmatch(r"browser_[0-9a-f]{32}", internal_id) is None
+            or re.fullmatch(
+                r"[0-9a-f]{32}/registered/browser_[0-9a-f]{32}\.png",
+                relative_path,
+            )
+            is None
+            or not relative_path.endswith(f"/{internal_id}.png")
+            or re.fullmatch(r"[0-9a-f]{64}", sha256) is None
+            or mime_type != "image/png"
+            or size_bytes < 1
+            or size_bytes > policy.max_artifact_bytes
+        ):
+            raise CatalogAdapterPolicyError("浏览器截图产物违反固定契约。")
+        staging_root = self.browser_artifact_staging_root.resolve(strict=False)
+        candidate = staging_root.joinpath(*relative_path.split("/"))
+        cursor = staging_root
+        for component in relative_path.split("/"):
+            cursor = cursor / component
+            if cursor.is_symlink():
+                raise CatalogAdapterPolicyError(
+                    "浏览器截图产物路径包含符号链接。"
+                )
+        try:
+            resolved = candidate.resolve(strict=True)
+            resolved.relative_to(staging_root)
+        except (FileNotFoundError, OSError, RuntimeError, ValueError) as exc:
+            raise CatalogAdapterPolicyError("浏览器截图产物不存在或越界。") from exc
+        if (
+            candidate.is_symlink()
+            or candidate.parent.is_symlink()
+            or not resolved.is_file()
+        ):
+            raise CatalogAdapterPolicyError("浏览器截图产物类型不安全。")
+        stat = resolved.stat()
+        if stat.st_size != size_bytes or stat.st_nlink != 1:
+            raise CatalogAdapterPolicyError("浏览器截图产物大小校验失败。")
+        self._cleanup_expired_browser_artifacts()
+        existing = [
+            item
+            for key, item in self._browser_artifacts.items()
+            if key[:2] == (self.tenant_id, self.owner_id)
+            and item.project_id == manifest.project_id
+        ]
+        if (
+            len(existing) >= policy.max_artifacts_per_project
+            or sum(item.size_bytes for item in existing) + size_bytes
+            > policy.max_artifact_storage_bytes
+        ):
+            try:
+                resolved.unlink()
+            except OSError:
+                pass
+            raise CatalogAdapterPolicyError(
+                "浏览器截图产物已达到每项目 50 张或 256 MiB 配额。"
+            )
+        now = time.time()
+        public_id = f"mcpbart_{uuid.uuid4().hex}"
+        trusted_relative_path = f"files/{public_id}.png"
+        trusted_root = self.browser_artifact_root.resolve(strict=False)
+        trusted_files = trusted_root / "files"
+        trusted_files.mkdir(parents=True, exist_ok=True, mode=0o700)
+        try:
+            trusted_files.chmod(0o700)
+        except OSError:
+            pass
+        trusted_path = trusted_files / f"{public_id}.png"
+        temporary_path = trusted_files / f".{public_id}.{uuid.uuid4().hex}.tmp"
+        target_descriptor = os.open(
+            temporary_path,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            0o600,
+        )
+        source_descriptor = -1
+        try:
+            source_descriptor = os.open(
+                resolved,
+                os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+            )
+            digest = hashlib.sha256()
+            copied = 0
+            magic = b""
+            with os.fdopen(target_descriptor, "wb") as target, os.fdopen(
+                source_descriptor,
+                "rb",
+            ) as source:
+                target_descriptor = -1
+                source_descriptor = -1
+                for chunk in iter(lambda: source.read(1024 * 1024), b""):
+                    if not magic:
+                        magic = chunk[:8]
+                    copied += len(chunk)
+                    digest.update(chunk)
+                    target.write(chunk)
+                source_stat = os.fstat(source.fileno())
+                target.flush()
+                os.fsync(target.fileno())
+            if (
+                magic != b"\x89PNG\r\n\x1a\n"
+                or copied != size_bytes
+                or source_stat.st_size != size_bytes
+                or source_stat.st_nlink != 1
+                or digest.hexdigest() != sha256
+            ):
+                raise CatalogAdapterPolicyError(
+                    "浏览器截图在隔离复制期间发生变化或校验失败。"
+                )
+            os.replace(temporary_path, trusted_path)
+            trusted_path.chmod(0o600)
+            trusted_stat = trusted_path.stat()
+            trusted_digest = hashlib.sha256()
+            with trusted_path.open("rb") as trusted:
+                trusted_magic = trusted.read(8)
+                trusted.seek(0)
+                for chunk in iter(lambda: trusted.read(1024 * 1024), b""):
+                    trusted_digest.update(chunk)
+            if (
+                trusted_magic != b"\x89PNG\r\n\x1a\n"
+                or trusted_stat.st_size != size_bytes
+                or trusted_stat.st_nlink != 1
+                or trusted_digest.hexdigest() != sha256
+            ):
+                raise CatalogAdapterPolicyError(
+                    "浏览器截图可信副本复核失败。"
+                )
+        except Exception as exc:
+            if target_descriptor >= 0:
+                try:
+                    os.close(target_descriptor)
+                except OSError:
+                    pass
+            if source_descriptor >= 0:
+                try:
+                    os.close(source_descriptor)
+                except OSError:
+                    pass
+            try:
+                temporary_path.unlink(missing_ok=True)
+                trusted_path.unlink(missing_ok=True)
+                resolved.unlink(missing_ok=True)
+            except OSError:
+                pass
+            if isinstance(exc, CatalogAdapterPolicyError):
+                raise
+            raise CatalogAdapterPolicyError(
+                "浏览器截图无法导入服务端可信存储。"
+            ) from exc
+        try:
+            resolved.unlink()
+        except OSError:
+            pass
+        artifact = CatalogBrowserArtifact(
+            artifact_id=public_id,
+            tenant_id=self.tenant_id,
+            owner_id=self.owner_id,
+            project_id=manifest.project_id,
+            session_id=session_id,
+            browser_generation=snapshot.generation,
+            relative_path=trusted_relative_path,
+            name=f"browser-screenshot-{public_id[-8:]}.png",
+            mime_type=mime_type,
+            size_bytes=size_bytes,
+            sha256=sha256,
+            created_at=now,
+            expires_at=now + policy.artifact_ttl_seconds,
+        )
+        self._browser_artifacts[self._artifact_key(public_id)] = artifact
+        try:
+            self._persist_browser_artifact_index()
+        except Exception:
+            self._browser_artifacts.pop(self._artifact_key(public_id), None)
+            trusted_path.unlink(missing_ok=True)
+            raise
+        public = self._public_browser_artifact(artifact)
+        assert isinstance(raw, dict)
+        raw[structured_key] = {
+            key: public[key]
+            for key in (
+                "artifact_id",
+                "name",
+                "mime_type",
+                "size_bytes",
+                "sha256",
+                "created_at",
+                "expires_at",
+                "download_url",
+            )
+        }
+        return public
+
+    def list_browser_artifacts(self, project_id: str) -> dict[str, Any]:
+        manifest = self.get_manifest(project_id)
+        if manifest.browser_policy is None:
+            raise CatalogAdapterPolicyError("该目录条目不支持浏览器产物。")
+        self._cleanup_expired_browser_artifacts()
+        items = [
+            self._public_browser_artifact(item)
+            for key, item in self._browser_artifacts.items()
+            if key[:2] == (self.tenant_id, self.owner_id)
+            and item.project_id == manifest.project_id
+        ]
+        items.sort(key=lambda item: item["created_at"], reverse=True)
+        return {
+            "project_id": manifest.project_id,
+            "items": items,
+            "total": len(items),
+        }
+
+    def browser_artifact_download(
+        self,
+        project_id: str,
+        artifact_id: str,
+    ) -> tuple[CatalogBrowserArtifact, Path]:
+        manifest = self.get_manifest(project_id)
+        if manifest.browser_policy is None:
+            raise CatalogAdapterPolicyError("该目录条目不支持浏览器产物。")
+        self._cleanup_expired_browser_artifacts()
+        artifact = self._browser_artifacts.get(self._artifact_key(artifact_id))
+        if artifact is None or artifact.project_id != manifest.project_id:
+            raise CatalogAdapterNotFoundError("浏览器产物不存在或已经过期。")
+        return artifact, self._browser_artifact_path(artifact)
+
+    def delete_browser_artifact(
+        self,
+        project_id: str,
+        artifact_id: str,
+    ) -> dict[str, Any]:
+        manifest = self.get_manifest(project_id)
+        if manifest.browser_policy is None:
+            raise CatalogAdapterPolicyError("该目录条目不支持浏览器产物。")
+        key = self._artifact_key(artifact_id)
+        artifact = self._browser_artifacts.get(key)
+        if artifact is None or artifact.project_id != manifest.project_id:
+            raise CatalogAdapterNotFoundError("浏览器产物不存在或已经过期。")
+        self._delete_browser_artifact_file(artifact)
+        self._browser_artifacts.pop(key, None)
+        self._persist_browser_artifact_index()
+        return {
+            "ok": True,
+            "project_id": manifest.project_id,
+            "artifact_id": artifact.artifact_id,
+        }
+
+    def _cleanup_expired_browser_artifacts(self) -> None:
+        now = time.time()
+        changed = False
+        for key, artifact in list(self._browser_artifacts.items()):
+            if key[:2] != (self.tenant_id, self.owner_id):
+                continue
+            if artifact.expires_at <= now:
+                self._delete_browser_artifact_file(artifact)
+                self._browser_artifacts.pop(key, None)
+                changed = True
+        if changed:
+            self._persist_browser_artifact_index()
+
+    def _browser_artifact_path(self, artifact: CatalogBrowserArtifact) -> Path:
+        root = self.browser_artifact_root.resolve(strict=False)
+        candidate = root.joinpath(*artifact.relative_path.split("/"))
+        try:
+            resolved = candidate.resolve(strict=True)
+            resolved.relative_to(root)
+        except (FileNotFoundError, OSError, RuntimeError, ValueError) as exc:
+            raise CatalogAdapterNotFoundError(
+                "浏览器产物不存在或已经过期。"
+            ) from exc
+        stat = resolved.stat()
+        if (
+            candidate.is_symlink()
+            or candidate.parent.is_symlink()
+            or not resolved.is_file()
+            or stat.st_nlink != 1
+        ):
+            raise CatalogAdapterPolicyError("浏览器产物路径不安全。")
+        if stat.st_size != artifact.size_bytes:
+            raise CatalogAdapterPolicyError("浏览器产物已经变化，下载已阻断。")
+        digest = hashlib.sha256()
+        with resolved.open("rb") as handle:
+            if handle.read(8) != b"\x89PNG\r\n\x1a\n":
+                raise CatalogAdapterPolicyError("浏览器产物 PNG 签名无效。")
+            handle.seek(0)
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+        if digest.hexdigest() != artifact.sha256:
+            raise CatalogAdapterPolicyError("浏览器产物摘要已经变化，下载已阻断。")
+        return resolved
+
+    def _delete_browser_artifact_file(
+        self,
+        artifact: CatalogBrowserArtifact,
+    ) -> None:
+        try:
+            path = self._browser_artifact_path(artifact)
+        except (CatalogAdapterNotFoundError, CatalogAdapterPolicyError):
+            return
+        try:
+            path.unlink(missing_ok=True)
+            path.parent.rmdir()
+        except OSError:
+            pass
+
+    @staticmethod
+    def _public_browser_artifact(
+        artifact: CatalogBrowserArtifact,
+    ) -> dict[str, Any]:
+        return {
+            "artifact_id": artifact.artifact_id,
+            "name": artifact.name,
+            "mime_type": artifact.mime_type,
+            "size_bytes": artifact.size_bytes,
+            "sha256": artifact.sha256,
+            "created_at": artifact.created_at,
+            "expires_at": artifact.expires_at,
+            "download_url": (
+                f"/api/mcp/catalog/{artifact.project_id}/browser-artifacts/"
+                f"{artifact.artifact_id}/download"
+            ),
+        }
+
+    def _load_browser_artifact_index(self) -> None:
+        path = self.browser_artifact_index_path
+        if not path.exists():
+            self._scavenge_browser_artifact_orphans()
+            return
+        if path.is_symlink() or not path.is_file():
+            raise CatalogAdapterPolicyError("浏览器产物索引路径不安全。")
+        stat = path.stat()
+        if stat.st_nlink != 1 or stat.st_size > 1024 * 1024:
+            raise CatalogAdapterPolicyError("浏览器产物索引违反固定上限。")
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+            raise CatalogAdapterPolicyError("浏览器产物索引损坏。") from exc
+        if (
+            not isinstance(payload, dict)
+            or set(payload) != {"version", "items"}
+            or payload.get("version") != 1
+            or not isinstance(payload.get("items"), list)
+            or len(payload["items"]) > 2_000
+        ):
+            raise CatalogAdapterPolicyError("浏览器产物索引 Schema 无效。")
+        loaded: dict[tuple[str, str, str], CatalogBrowserArtifact] = {}
+        expected_keys = set(CatalogBrowserArtifact.__dataclass_fields__)
+        now = time.time()
+        changed = False
+        for raw in payload["items"]:
+            if not isinstance(raw, dict) or set(raw) != expected_keys:
+                raise CatalogAdapterPolicyError("浏览器产物索引记录无效。")
+            try:
+                artifact = CatalogBrowserArtifact(**raw)
+            except TypeError as exc:
+                raise CatalogAdapterPolicyError("浏览器产物索引记录无效。") from exc
+            if (
+                re.fullmatch(r"mcpbart_[0-9a-f]{32}", artifact.artifact_id)
+                is None
+                or not artifact.tenant_id
+                or len(artifact.tenant_id) > 120
+                or not artifact.owner_id
+                or len(artifact.owner_id) > 120
+                or artifact.project_id not in self.manifests
+                or self.manifests[artifact.project_id].browser_policy is None
+                or re.fullmatch(
+                    r"files/mcpbart_[0-9a-f]{32}\.png",
+                    artifact.relative_path,
+                )
+                is None
+                or artifact.relative_path
+                != f"files/{artifact.artifact_id}.png"
+                or artifact.mime_type != "image/png"
+                or artifact.size_bytes < 1
+                or artifact.size_bytes > 32 * 1024 * 1024
+                or re.fullmatch(r"[0-9a-f]{64}", artifact.sha256) is None
+                or not math.isfinite(artifact.created_at)
+                or not math.isfinite(artifact.expires_at)
+                or artifact.expires_at <= artifact.created_at
+            ):
+                raise CatalogAdapterPolicyError("浏览器产物索引记录违反安全契约。")
+            key = (artifact.tenant_id, artifact.owner_id, artifact.artifact_id)
+            if key in loaded:
+                raise CatalogAdapterPolicyError("浏览器产物索引包含重复记录。")
+            if artifact.expires_at <= now:
+                self._delete_browser_artifact_file(artifact)
+                changed = True
+                continue
+            self._browser_artifact_path(artifact)
+            loaded[key] = artifact
+        self._browser_artifacts = loaded
+        if self._scavenge_browser_artifact_orphans():
+            changed = True
+        if changed:
+            self._persist_browser_artifact_index()
+
+    def _persist_browser_artifact_index(self) -> None:
+        path = self.browser_artifact_index_path
+        path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        try:
+            path.parent.chmod(0o700)
+        except OSError:
+            pass
+        payload = json.dumps(
+            {
+                "version": 1,
+                "items": [
+                    asdict(item)
+                    for _, item in sorted(
+                        self._browser_artifacts.items(),
+                        key=lambda pair: pair[0],
+                    )
+                ],
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        if len(payload) > 1024 * 1024:
+            raise CatalogAdapterPolicyError("浏览器产物索引超过固定上限。")
+        temporary = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+        descriptor = os.open(
+            temporary,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            0o600,
+        )
+        try:
+            with os.fdopen(descriptor, "wb") as handle:
+                handle.write(payload)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary, path)
+            path.chmod(0o600)
+        except Exception:
+            try:
+                temporary.unlink(missing_ok=True)
+            except OSError:
+                pass
+            raise
+
+    def _scavenge_browser_artifact_orphans(self) -> bool:
+        changed = False
+        referenced = {
+            item.relative_path for item in self._browser_artifacts.values()
+        }
+        trusted_files = self.browser_artifact_root / "files"
+        if trusted_files.is_dir() and not trusted_files.is_symlink():
+            for candidate in trusted_files.iterdir():
+                if candidate.name.startswith(".") and candidate.name.endswith(".tmp"):
+                    try:
+                        candidate.unlink()
+                        changed = True
+                    except OSError:
+                        pass
+                    continue
+                relative = f"files/{candidate.name}"
+                if (
+                    re.fullmatch(r"mcpbart_[0-9a-f]{32}\.png", candidate.name)
+                    and relative not in referenced
+                ):
+                    try:
+                        candidate.unlink()
+                        changed = True
+                    except OSError:
+                        pass
+        staging = self.browser_artifact_staging_root
+        if staging.is_dir() and not staging.is_symlink():
+            for candidate in staging.glob("*/registered/browser_*.png"):
+                relative = candidate.relative_to(staging).as_posix()
+                if re.fullmatch(
+                    r"[0-9a-f]{32}/registered/browser_[0-9a-f]{32}\.png",
+                    relative,
+                ):
+                    try:
+                        candidate.unlink()
+                        changed = True
+                    except OSError:
+                        pass
+        return changed
+
     def _create_approval(
         self,
         manifest: CatalogAdapterManifest,
@@ -2874,6 +4361,7 @@ class MCPCatalogService:
         configuration_digest = ""
         credential_snapshot_digest = ""
         account_snapshot_digest = ""
+        browser_snapshot_digest = ""
         tool_schema_sha256 = ""
         target_preview: dict[str, Any] = {}
         if bound_workspace_id:
@@ -2910,6 +4398,22 @@ class MCPCatalogService:
                 frozen_arguments,
             )
             summary = str(target_preview["impact"])
+        elif manifest.browser_policy is not None:
+            browser_snapshot = self._browser_snapshots.get(scope_key)
+            if browser_snapshot is None or browser_snapshot.status != "active":
+                raise CatalogAdapterPolicyError(
+                    "浏览器会话尚未完成预检或已经污染，请重新连接。"
+                )
+            context_kind = "browser-session"
+            browser_snapshot_digest = browser_snapshot.digest
+            tool_schema_sha256 = manifest.browser_policy.tool_schema_sha256
+            target_preview = self._browser_target_preview(
+                manifest,
+                tool_name,
+                frozen_arguments,
+                browser_snapshot,
+            )
+            summary = str(target_preview["impact"])
         else:
             raise CatalogAdapterPolicyError("该操作缺少有效的受控审批上下文。")
         policy = manifest.tool_policies.get(tool_name)
@@ -2933,6 +4437,7 @@ class MCPCatalogService:
             configuration_digest=configuration_digest,
             credential_snapshot_digest=credential_snapshot_digest,
             account_snapshot_digest=account_snapshot_digest,
+            browser_snapshot_digest=browser_snapshot_digest,
             tool_schema_sha256=tool_schema_sha256,
             tool_policy_digest=self._tool_policy_digest(policy),
             idempotency_key=f"mcpidem_{uuid.uuid4().hex}",
@@ -2941,13 +4446,159 @@ class MCPCatalogService:
         self._approvals[self._approval_key(approval.approval_id)] = approval
         return {
             "code": "approval_required",
-            "message": "该操作会修改持久状态；参数和账号上下文已由服务端冻结，请确认后执行。",
+            "message": (
+                "该浏览器操作会修改临时页面状态；参数和页面版本已由服务端冻结，请确认后执行一次。"
+                if context_kind == "browser-session"
+                else "该操作会修改持久状态；参数和账号上下文已由服务端冻结，请确认后执行。"
+            ),
             "approval_id": approval.approval_id,
+            "context_kind": approval.context_kind,
             "summary": approval.summary,
             "argument_digest": approval.argument_digest,
             "idempotency_key": approval.idempotency_key,
             "target_preview": approval.target_preview or None,
             "expires_at": approval.expires_at,
+        }
+
+    def _browser_target_preview(
+        self,
+        manifest: CatalogAdapterManifest,
+        tool_name: str,
+        arguments: dict[str, Any],
+        snapshot: CatalogBrowserSnapshot,
+    ) -> dict[str, Any]:
+        action_labels = {
+            "navigate_page": "导航 Chrome DevTools 页面",
+            "click": "点击 Chrome DevTools 页面元素",
+            "fill": "填写 Chrome DevTools 页面字段",
+            "browser_navigate": "导航 Playwright 页面",
+            "browser_click": "点击 Playwright 页面元素",
+            "browser_fill_form": "填写 Playwright 页面字段",
+        }
+        target_origin = snapshot.current_origin
+        target_path = ""
+        raw_url = arguments.get("url")
+        if isinstance(raw_url, str) and raw_url:
+            parsed = urlsplit(raw_url)
+            if (
+                len(raw_url) > 16_384
+                or parsed.scheme not in {"http", "https"}
+                or not parsed.hostname
+                or parsed.username is not None
+                or parsed.password is not None
+                or parsed.fragment
+            ):
+                raise CatalogAdapterPolicyError(
+                    "浏览器导航 URL 不符合受控公网策略。"
+                )
+            host = parsed.hostname.encode("idna").decode("ascii").lower()
+            try:
+                ipaddress.ip_address(host)
+            except ValueError:
+                pass
+            else:
+                raise CatalogAdapterPolicyError(
+                    "浏览器导航 URL 不能使用 IP 字面量。"
+                )
+            if "." not in host or host.endswith(
+                (".internal", ".local", ".localhost", ".home.arpa")
+            ):
+                raise CatalogAdapterPolicyError(
+                    "浏览器导航目标不是允许的公网主机名。"
+                )
+            try:
+                port = parsed.port
+            except ValueError as exc:
+                raise CatalogAdapterPolicyError(
+                    "浏览器导航 URL 端口无效。"
+                ) from exc
+            effective_port = port or (80 if parsed.scheme == "http" else 443)
+            if (parsed.scheme, effective_port) not in {
+                ("http", 80),
+                ("https", 443),
+            }:
+                raise CatalogAdapterPolicyError(
+                    "浏览器导航端口必须与 HTTP/HTTPS 默认端口严格匹配。"
+                )
+            if browser_query_has_sensitive_key(parsed.query):
+                raise CatalogAdapterPolicyError(
+                    "浏览器导航 URL 不接受 Token、签名或其他敏感查询参数。"
+                )
+            decoded_target = f"{parsed.path}?{parsed.query}"
+            for _ in range(2):
+                decoded_target = unquote(decoded_target)
+            target_tokens = canonical_browser_login_tokens(decoded_target)
+            host_tokens = canonical_browser_login_tokens(host, host=True)
+            if (
+                target_tokens & BROWSER_LOGIN_TOKENS
+                or host_tokens & BROWSER_LOGIN_TOKENS
+            ):
+                raise CatalogAdapterPolicyError(
+                    "浏览器登录或外站认证路径不在本批开放范围。"
+                )
+            target_origin = f"{parsed.scheme}://{host}"
+            segments = [
+                re.sub(r"[^A-Za-z0-9._~-]", "·", segment)[:32]
+                for segment in parsed.path.split("/")
+                if segment
+            ][:3]
+            if segments:
+                target_path = "/" + "/".join(segments)
+        target_label = (
+            f"{target_origin}{target_path}"
+            if target_origin
+            else "尚未导航的临时页面"
+        )
+        changes: list[dict[str, str]] = []
+        if isinstance(raw_url, str) and raw_url:
+            changes.append({"field": "目标 Origin", "summary": target_label})
+        element_refs: list[str] = []
+        if isinstance(arguments.get("ref"), str):
+            element_refs.append(str(arguments["ref"]))
+        fields = arguments.get("fields")
+        if isinstance(fields, list):
+            element_refs.extend(
+                str(item.get("ref") or "")
+                for item in fields
+                if isinstance(item, dict)
+            )
+        elements = self._browser_elements.get(
+            self._scope_key(manifest.project_id),
+            {},
+        )
+        for ref in element_refs:
+            element = elements.get(ref)
+            if (
+                element is None
+                or element.get("page_digest") != snapshot.page_digest
+            ):
+                raise CatalogAdapterPolicyError(
+                    "页面元素引用不属于当前受控快照，请重新获取快照。"
+                )
+            changes.append(
+                {
+                    "field": element["role"],
+                    "summary": element["label"],
+                }
+            )
+        if tool_name in {"fill", "browser_fill_form"}:
+            count = len(fields) if isinstance(fields, list) else 1
+            changes.append({"field": "填写内容", "summary": f"{count} 个受控字段（内容不展示）"})
+        action_label = action_labels.get(tool_name, f"执行 {tool_name}")
+        return {
+            "action_label": action_label,
+            "resource": {
+                "type": "临时浏览器页面",
+                "label": target_label,
+                "id_suffix": snapshot.page_digest[-8:],
+            },
+            "changes": changes,
+            "content": None,
+            "impact": (
+                f"将在“{target_label}”执行{action_label}；页面状态可能变化，"
+                "仅执行一次且不会自动重试。"
+            ),
+            "destructive": False,
         }
 
     @staticmethod
@@ -3319,6 +4970,8 @@ class MCPCatalogService:
             for key in tenant_keys:
                 self._credential_snapshots.pop(key, None)
                 self._account_snapshots.pop(key, None)
+                self._browser_snapshots.pop(key, None)
+                self._browser_elements.pop(key, None)
                 self._preflight_status.pop(key, None)
         for project_id, session_id in sessions:
             try:
@@ -3557,6 +5210,8 @@ class MCPCatalogService:
                     self._sessions.pop(scope_key, None)
                     self._credential_snapshots.pop(scope_key, None)
                     self._account_snapshots.pop(scope_key, None)
+                    self._browser_snapshots.pop(scope_key, None)
+                    self._browser_elements.pop(scope_key, None)
                     self._preflight_status[scope_key] = "unverified"
 
     @staticmethod
@@ -3691,6 +5346,245 @@ class MCPCatalogService:
                 return scope_key[2]
         return None
 
+    async def list_tools(self, project_id: str) -> dict[str, Any]:
+        """List tools through the catalog owner boundary, never the generic route."""
+
+        manifest = self._require_executable(project_id)
+        scope_key = self._scope_key(manifest.project_id)
+        session_id = self._sessions.get(scope_key)
+        if session_id is None:
+            raise MCPSessionNotFoundError(manifest.project_id)
+        tools = await self.manager.list_tools(
+            session_id,
+            session_owner=self._session_owner(manifest.project_id),
+        )
+        names_match = {tool.name for tool in tools} == set(manifest.tool_policies)
+        browser_schema_matches = (
+            manifest.browser_policy is None
+            or self._tool_schema_digest(tools)
+            == manifest.browser_policy.tool_schema_sha256
+        )
+        if (
+            not manifest.legacy_unrestricted_calls
+            and (not names_match or not browser_schema_matches)
+        ):
+            if manifest.browser_policy is not None:
+                await self._taint_browser_session(manifest)
+            raise CatalogAdapterPolicyError(
+                "目录工具清单与固定适配器策略不一致，工具发现已阻断。"
+            )
+        return {
+            "project_id": manifest.project_id,
+            "tools": [
+                tool.model_dump(mode="json", by_alias=True, exclude_none=True)
+                for tool in tools
+            ],
+        }
+
+    async def browser_session_status(self, project_id: str) -> dict[str, Any]:
+        manifest = self.get_manifest(project_id)
+        if manifest.browser_policy is None:
+            raise CatalogAdapterPolicyError("该目录条目不是受控浏览器适配器。")
+        scope_key = self._scope_key(manifest.project_id)
+        session_id = self._sessions.get(scope_key)
+        if session_id is None:
+            snapshot = self._browser_snapshots.get(scope_key)
+            if snapshot is None or snapshot.status != "tainted":
+                payload = self._browser_session_payload(None)
+            else:
+                payload = self._browser_session_payload(snapshot)
+            payload["reason"] = self._browser_disconnect_reasons.get(scope_key)
+            return payload
+        try:
+            snapshot = await self._refresh_browser_snapshot(
+                manifest,
+                session_id=session_id,
+            )
+        except (MCPClientError, EOFError, BrokenPipeError, OSError) as exc:
+            await self._forget_browser_session(manifest, reason="expired")
+            payload = self._browser_session_payload(None)
+            payload["reason"] = "expired"
+            return payload
+        except CatalogBrowserSessionExpiredError:
+            await self._forget_browser_session(manifest, reason="expired")
+            payload = self._browser_session_payload(None)
+            payload["reason"] = "expired"
+            return payload
+        except CatalogAdapterPolicyError:
+            await self._taint_browser_session(manifest)
+            raise
+        if snapshot.status == "active":
+            self._preflight_status[scope_key] = "verified"
+            self._browser_disconnect_reasons.pop(scope_key, None)
+        payload = self._browser_session_payload(snapshot)
+        payload["reason"] = None
+        return payload
+
+    async def _refresh_browser_snapshot(
+        self,
+        manifest: CatalogAdapterManifest,
+        *,
+        session_id: str,
+    ) -> CatalogBrowserSnapshot:
+        policy = manifest.browser_policy
+        if policy is None:
+            raise CatalogAdapterPolicyError("浏览器会话策略不存在。")
+        result = await self.manager.call_tool(
+            session_id,
+            "browser_session_status",
+            {},
+            retry_on_failure=False,
+            session_owner=self._session_owner(manifest.project_id),
+        )
+        payload = result.model_dump(mode="json", by_alias=True, exclude_none=True)
+        if bool(payload.get("isError") or payload.get("is_error")):
+            raise CatalogAdapterPolicyError("浏览器会话状态预检失败。")
+        structured = payload.get("structuredContent") or payload.get(
+            "structured_content"
+        )
+        if not isinstance(structured, dict):
+            for item in payload.get("content") or []:
+                if not isinstance(item, dict) or item.get("type") != "text":
+                    continue
+                try:
+                    candidate = json.loads(str(item.get("text") or ""))
+                except (TypeError, ValueError, json.JSONDecodeError):
+                    continue
+                if isinstance(candidate, dict):
+                    structured = candidate
+                    break
+        if not isinstance(structured, dict):
+            raise CatalogAdapterPolicyError("浏览器会话状态缺少结构化结果。")
+        try:
+            generation = str(structured["generation"]).strip().lower()
+            page_revision = int(structured["page_revision"])
+            page_digest = str(structured["page_digest"])
+            current_origin = self._normalize_browser_origin(
+                str(structured.get("current_origin") or "")
+            )
+            action_count = int(structured["action_count"])
+            max_actions = int(structured["max_actions"])
+            expires_at = float(structured["expires_at"])
+            tainted = structured.get("tainted")
+        except (KeyError, TypeError, ValueError) as exc:
+            raise CatalogAdapterPolicyError("浏览器会话状态 Schema 无效。") from exc
+        if (
+            isinstance(tainted, bool) is False
+            or re.fullmatch(
+                r"[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-"
+                r"[89ab][0-9a-f]{3}-[0-9a-f]{12}",
+                generation,
+            )
+            is None
+            or page_revision < 0
+            or re.fullmatch(r"[0-9a-f]{64}", page_digest) is None
+            or action_count < 0
+            or max_actions != policy.max_actions
+            or action_count > max_actions
+            or not math.isfinite(expires_at)
+        ):
+            raise CatalogAdapterPolicyError("浏览器会话状态违反固定安全契约。")
+        if expires_at <= time.time():
+            raise CatalogBrowserSessionExpiredError(
+                "浏览器临时会话已经过期，请重新连接。"
+            )
+        previous = self._browser_snapshots.get(
+            self._scope_key(manifest.project_id)
+        )
+        approved_hosts = set(
+            previous.approved_hosts
+            if previous is not None and previous.generation == generation
+            else ()
+        )
+        if current_origin:
+            host = str(urlsplit(current_origin).hostname or "").lower()
+            if host:
+                approved_hosts.add(host)
+        snapshot = CatalogBrowserSnapshot(
+            status="tainted" if tainted else "active",
+            generation=generation,
+            page_revision=page_revision,
+            page_digest=page_digest,
+            current_origin=current_origin,
+            action_count=action_count,
+            max_actions=max_actions,
+            expires_at=expires_at,
+            approved_hosts=tuple(sorted(approved_hosts)),
+        )
+        scope_key = self._scope_key(manifest.project_id)
+        if previous is not None and (
+            previous.generation != snapshot.generation
+            or previous.page_revision != snapshot.page_revision
+            or previous.page_digest != snapshot.page_digest
+        ):
+            self._browser_elements.pop(scope_key, None)
+        self._browser_snapshots[scope_key] = snapshot
+        if snapshot.status == "tainted":
+            self._browser_elements.pop(scope_key, None)
+            self._preflight_status[scope_key] = "failed"
+        return snapshot
+
+    @staticmethod
+    def _normalize_browser_origin(value: str) -> str:
+        if not value:
+            return ""
+        parsed = urlsplit(value)
+        if (
+            parsed.scheme not in {"http", "https"}
+            or not parsed.hostname
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.path not in {"", "/"}
+            or parsed.query
+            or parsed.fragment
+        ):
+            raise CatalogAdapterPolicyError("浏览器会话返回了无效 Origin。")
+        try:
+            port = parsed.port
+        except ValueError as exc:
+            raise CatalogAdapterPolicyError("浏览器会话返回了无效 Origin 端口。") from exc
+        if port is not None and port not in {80, 443}:
+            raise CatalogAdapterPolicyError("浏览器会话 Origin 端口不在允许范围。")
+        host = parsed.hostname.encode("idna").decode("ascii").lower()
+        try:
+            ipaddress.ip_address(host)
+        except ValueError:
+            pass
+        else:
+            raise CatalogAdapterPolicyError(
+                "浏览器会话 Origin 不能使用 IP 字面量。"
+            )
+        if "." not in host or host.endswith(
+            (".internal", ".local", ".localhost", ".home.arpa")
+        ):
+            raise CatalogAdapterPolicyError(
+                "浏览器会话 Origin 不是允许的公网主机名。"
+            )
+        default_port = 80 if parsed.scheme == "http" else 443
+        suffix = f":{port}" if port is not None and port != default_port else ""
+        return f"{parsed.scheme}://{host}{suffix}"
+
+    @staticmethod
+    def _browser_session_payload(
+        snapshot: CatalogBrowserSnapshot | None,
+    ) -> dict[str, Any]:
+        if snapshot is None:
+            return {
+                "status": "disconnected",
+                "generation": "",
+                "page_revision": 0,
+                "page_digest": "",
+                "current_origin": "",
+                "action_count": 0,
+                "max_actions": 50,
+                "expires_at": 0.0,
+                "approved_hosts": [],
+            }
+        return {
+            **asdict(snapshot),
+            "approved_hosts": list(snapshot.approved_hosts),
+        }
+
     def _connection_payload(
         self,
         manifest: CatalogAdapterManifest,
@@ -3714,8 +5608,21 @@ class MCPCatalogService:
                     self._scope_key(manifest.project_id),
                     "unverified",
                 )
-                if manifest.database_policy is not None or manifest.saas_policy is not None
+                if (
+                    manifest.database_policy is not None
+                    or manifest.saas_policy is not None
+                    or manifest.browser_policy is not None
+                )
                 else "not-applicable"
+            ),
+            "browser_session": (
+                self._browser_session_payload(
+                    self._browser_snapshots.get(
+                        self._scope_key(manifest.project_id)
+                    )
+                )
+                if manifest.browser_policy is not None
+                else None
             ),
         }
 
@@ -3811,6 +5718,16 @@ def _raise_http_error(exc: Exception) -> None:
                     if exc.reason == "rate_limited"
                     else "provider_rejected"
                 ),
+                "message": str(exc),
+                "idempotency_key": exc.idempotency_key,
+            },
+        ) from exc
+    if isinstance(exc, CatalogBrowserPolicyRejectedError):
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": "browser_policy_rejected",
+                "reason": exc.reason,
                 "message": str(exc),
                 "idempotency_key": exc.idempotency_key,
             },
@@ -3924,6 +5841,75 @@ async def connect_catalog_adapter(project_id: str) -> dict[str, Any]:
 async def disconnect_catalog_adapter(project_id: str) -> dict[str, Any]:
     try:
         return await get_mcp_catalog_service().disconnect(project_id)
+    except Exception as exc:
+        _raise_http_error(exc)
+        raise
+
+
+@router.get("/api/mcp/catalog/{project_id}/tools")
+async def list_catalog_tools(project_id: str) -> dict[str, Any]:
+    try:
+        return await get_mcp_catalog_service().list_tools(project_id)
+    except Exception as exc:
+        _raise_http_error(exc)
+        raise
+
+
+@router.get("/api/mcp/catalog/{project_id}/browser-session")
+async def get_catalog_browser_session(project_id: str) -> dict[str, Any]:
+    try:
+        return await get_mcp_catalog_service().browser_session_status(project_id)
+    except Exception as exc:
+        _raise_http_error(exc)
+        raise
+
+
+@router.get("/api/mcp/catalog/{project_id}/browser-artifacts")
+async def list_catalog_browser_artifacts(project_id: str) -> dict[str, Any]:
+    try:
+        return get_mcp_catalog_service().list_browser_artifacts(project_id)
+    except Exception as exc:
+        _raise_http_error(exc)
+        raise
+
+
+@router.get(
+    "/api/mcp/catalog/{project_id}/browser-artifacts/{artifact_id}/download"
+)
+async def download_catalog_browser_artifact(
+    project_id: str,
+    artifact_id: str,
+) -> FileResponse:
+    try:
+        artifact, path = get_mcp_catalog_service().browser_artifact_download(
+            project_id,
+            artifact_id,
+        )
+        return FileResponse(
+            path,
+            media_type=artifact.mime_type,
+            filename=artifact.name,
+            headers={
+                "Cache-Control": "no-store",
+                "Content-Security-Policy": "default-src 'none'; sandbox",
+                "X-Content-Type-Options": "nosniff",
+            },
+        )
+    except Exception as exc:
+        _raise_http_error(exc)
+        raise
+
+
+@router.delete("/api/mcp/catalog/{project_id}/browser-artifacts/{artifact_id}")
+async def delete_catalog_browser_artifact(
+    project_id: str,
+    artifact_id: str,
+) -> dict[str, Any]:
+    try:
+        return get_mcp_catalog_service().delete_browser_artifact(
+            project_id,
+            artifact_id,
+        )
     except Exception as exc:
         _raise_http_error(exc)
         raise

--- a/server/sandbox_sidecar/Dockerfile.browser
+++ b/server/sandbox_sidecar/Dockerfile.browser
@@ -1,0 +1,77 @@
+FROM mcr.microsoft.com/playwright:v1.58.2-noble@sha256:6446946a1d9fd62d9ae501312a2d76a43ee688542b21622056a372959b65d63d AS browser-runtime
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 \
+    PUPPETEER_SKIP_DOWNLOAD=1 \
+    MCP_BROWSER_SOCKET_PATH=/run/modelmirror-browser-mcp/browser-mcp.sock \
+    MCP_BROWSER_EGRESS_SOCKET_PATH=/run/modelmirror-browser-egress/browser-egress.sock \
+    MCP_BROWSER_PROFILE_ROOT=/profiles \
+    MCP_BROWSER_ARTIFACT_ROOT=/artifacts \
+    MCP_BROWSER_UPSTREAM_ROOT=/opt/browser-upstream \
+    MCP_BROWSER_CDP_CHROMIUM_PATH=/opt/modelmirror-browsers/cdp/chrome/linux-150.0.7871.24/chrome-linux64/chrome \
+    MCP_BROWSER_PLAYWRIGHT_CHROMIUM_PATH=/opt/modelmirror-browsers/playwright/chromium-1237/chrome-linux64/chrome \
+    MCP_BROWSER_MAX_SESSIONS=1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends python3-minimal ca-certificates unzip \
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -sf /usr/bin/python3 /usr/local/bin/python \
+    && groupadd --gid 65532 sandbox \
+    && useradd --uid 65532 --gid 65532 --home-dir /profiles --no-create-home sandbox \
+    && mkdir -p /opt/modelmirror/sandbox_sidecar /opt/browser-upstream \
+        /opt/modelmirror-browsers/cdp /opt/modelmirror-browsers/playwright \
+        /profiles /artifacts /run/modelmirror-browser-mcp \
+        /run/modelmirror-browser-egress /etc/chromium/policies/managed \
+        /etc/opt/chrome/policies/managed \
+    && chown -R sandbox:sandbox /profiles /artifacts \
+        /run/modelmirror-browser-mcp /run/modelmirror-browser-egress
+
+WORKDIR /opt/browser-upstream
+COPY browser_requirements.lock ./package-lock.json
+RUN node -e "const fs=require('fs');const lock=JSON.parse(fs.readFileSync('package-lock.json','utf8'));fs.writeFileSync('package.json',JSON.stringify(lock.packages[''],null,2)+'\n')" \
+    && npm ci --include=dev --ignore-scripts --no-audit --no-fund \
+    && node -e "const c=require('./node_modules/chrome-devtools-mcp/package.json').version;const p=require('./node_modules/@playwright/mcp/package.json').version;const b=require('./node_modules/@puppeteer/browsers/package.json').version;if(c!=='1.6.0'||p!=='0.0.79'||b!=='3.0.6'){throw new Error('locked browser package version mismatch')}"
+
+RUN ./node_modules/.bin/browsers install \
+        chrome@150.0.7871.24 --path /opt/modelmirror-browsers/cdp \
+    && env -u PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD \
+        PLAYWRIGHT_BROWSERS_PATH=/opt/modelmirror-browsers/playwright \
+        ./node_modules/.bin/playwright install chromium \
+    && npm prune --omit=dev --ignore-scripts --no-audit --no-fund \
+    && test ! -e ./node_modules/@puppeteer/browsers \
+    && test ! -e ./node_modules/.bin/browsers \
+    && npm cache clean --force
+
+RUN cdp_version="$("$MCP_BROWSER_CDP_CHROMIUM_PATH" --version | sed 's/[[:space:]]*$//')" \
+    && playwright_version="$("$MCP_BROWSER_PLAYWRIGHT_CHROMIUM_PATH" --version | sed 's/[[:space:]]*$//')" \
+    && printf '%s\n' "$cdp_version" "$playwright_version" \
+    && test -x "$MCP_BROWSER_CDP_CHROMIUM_PATH" \
+    && test -x "$MCP_BROWSER_PLAYWRIGHT_CHROMIUM_PATH" \
+    && test "$cdp_version" = \
+        "Google Chrome for Testing 150.0.7871.24" \
+    && test "$playwright_version" = \
+        "Google Chrome for Testing 152.0.7977.8" \
+    && rm -rf /opt/modelmirror-browsers/playwright/ffmpeg-1011 \
+        /opt/modelmirror-browsers/playwright/chromium_headless_shell-1237
+
+# Browser policy is defense in depth for capabilities that are not exposed by
+# the gateway.  The network-less execution container and separated egress
+# socket remain the actual SSRF boundary.
+RUN node -e "const fs=require('fs');const p={BrowserNetworkTimeQueriesEnabled:false,EncryptedClientHelloEnabled:false,DownloadRestrictions:3,DefaultNotificationsSetting:2,DefaultGeolocationSetting:2,DefaultWebUsbGuardSetting:2,DefaultSerialGuardSetting:2,DefaultBluetoothGuardSetting:2,URLBlocklist:['ws://*/*','wss://*/*','file://*/*','ftp://*/*','data:*','blob:*','chrome-extension://*/*']};for(const d of ['/etc/chromium/policies/managed','/etc/opt/chrome/policies/managed'])fs.writeFileSync(d+'/modelmirror-browser.json',JSON.stringify(p))"
+
+WORKDIR /opt/modelmirror
+COPY __init__.py engine.py browser_contracts.py browser_mcp.py browser_server.py smoke_browser_adapters.py ./sandbox_sidecar/
+COPY THIRD_PARTY_NOTICES.md /usr/share/doc/modelmirror-mcp-browser/THIRD_PARTY_NOTICES.md
+
+USER 65532:65532
+
+FROM browser-runtime AS browser-release
+# BuildKit cannot inherit the service's locked custom seccomp profile.  Keep
+# package identity, initialize/tools/list, schema and argv checks here.  Each
+# claimed adapter session runs its real upstream preflight, and the release
+# gate runs a fresh-pair full smoke under the actual runtime seccomp boundary.
+RUN python -m sandbox_sidecar.smoke_browser_adapters --contract-only
+
+CMD ["python", "-m", "sandbox_sidecar.browser_server"]

--- a/server/sandbox_sidecar/THIRD_PARTY_NOTICES.md
+++ b/server/sandbox_sidecar/THIRD_PARTY_NOTICES.md
@@ -120,3 +120,42 @@ The Chinese commerce bundle and archived Mem0 local MCP server are not present
 in the image.  Their OAuth/account-lifecycle and remotely versioned contract
 requirements remain blocked.  The SaaS image's only direct Python runtime
 dependency beyond CPython is the pinned MCP Python SDK 1.27.2 (MIT).
+
+The `modelmirror-mcp-browser:wave7-v1` image runs the following real, pinned
+upstream MCP packages behind ModelMirror's fixed Unix-socket policy gateway.
+Neither package is downloaded or updated at runtime:
+
+- Chrome DevTools MCP 1.6.0
+  (`https://github.com/ChromeDevTools/chrome-devtools-mcp`): Apache-2.0.
+- Playwright MCP 0.0.79
+  (`https://github.com/microsoft/playwright-mcp`): Apache-2.0.
+
+Playwright MCP 0.0.79 pins Playwright and Playwright Core
+1.63.0-alpha-2026-08-05 (Apache-2.0). Its locked Chromium revision 1237
+(Chrome for Testing 152.0.7977.8) is installed only while the image is built.
+Chrome DevTools MCP 1.6.0 bundles Puppeteer Core 25.3.0 and is paired with its
+locked Chrome for Testing 150.0.7871.24. The two adapters use separate fixed
+browser paths; neither can select the other adapter's browser or download a
+replacement at runtime. Chromium and Chrome for Testing retain their upstream
+BSD-style and component-specific license notices. The build-only downloader is
+`@puppeteer/browsers` 3.0.6 (Apache-2.0). The npm integrity values and complete
+direct dependency graph used by `npm ci` are recorded in
+`browser_requirements.lock`; installed package license/source metadata remains
+under `/opt/browser-upstream/node_modules`.
+
+The browser service also vendors the Moby seccomp default profile from
+`moby/profiles` tag `seccomp/v0.2.3` (Apache-2.0). The vendored profile
+retains the upstream default-deny policy and adds only `clone`, `setns`,
+`unshare`, and `chroot`. The first three syscalls are required by the non-root
+Chromium user-namespace sandbox; `chroot` is used only after Chromium has
+entered its self-created user namespace to contract the process into an empty
+root. The outer container has no `CAP_SYS_CHROOT` or any other capability, and
+no other seccomp rule is relaxed. The browser-specific copy also removes the
+modern-kernel legacy unconditional allow for `ptrace`, `process_vm_readv`, and
+`process_vm_writev` so same-UID processes cannot inspect one another; only the
+upstream `CAP_SYS_PTRACE`-conditioned rule remains, and `cap_drop: ALL` keeps it
+inactive. The original source is `seccomp/default.json` in that tagged release.
+
+Puppeteer MCP and Selenium MCP are not installed or executed in Wave 7. Their
+catalog entries remain blocked until an independently verified sandbox and
+upstream schema contract are available.

--- a/server/sandbox_sidecar/browser_contracts.py
+++ b/server/sandbox_sidecar/browser_contracts.py
@@ -1,0 +1,523 @@
+"""Fixed public contracts and security policy for Wave 7 browser adapters.
+
+The two public adapter IDs are backed by the real, version-locked upstream
+MCP packages.  This module describes the smaller reviewed surface that the
+ModelMirror Unix-socket gateway is allowed to expose.  Upstream tool schemas
+are verified independently before this reviewed schema is returned to a
+client.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import ipaddress
+import json
+import os
+import re
+import socket
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Final
+from urllib.parse import SplitResult, unquote, urlsplit, urlunsplit
+
+
+CONTRACT_VERSION: Final = "modelmirror-browser-wave7-v1"
+MAX_ARGUMENT_BYTES: Final = 256 * 1024
+MAX_OUTPUT_BYTES: Final = 256 * 1024
+MAX_ARTIFACT_BYTES: Final = 32 * 1024 * 1024
+MAX_ACTIONS: Final = 50
+MAX_PAGES: Final = 1
+# A single execution session is the fail-closed first release.  Same-UID
+# Chromium processes cannot keep a loopback proxy capability secret from a
+# concurrently compromised sibling through /proc.  The first release is
+# therefore explicitly single-session.
+MAX_SESSIONS: Final = 1
+SESSION_TTL_SECONDS: Final = 15 * 60
+IDLE_TTL_SECONDS: Final = 5 * 60
+NAVIGATION_TIMEOUT_SECONDS: Final = 20
+TOOL_CALL_TIMEOUT_SECONDS: Final = 30
+SYNTHETIC_DNS_NETWORK: Final = ipaddress.ip_network("198.18.0.0/15")
+
+BROWSER_LIMITS: Final[dict[str, int]] = {
+    "max_actions": MAX_ACTIONS,
+    "max_artifact_bytes": MAX_ARTIFACT_BYTES,
+    "max_output_bytes": MAX_OUTPUT_BYTES,
+    "max_pages": MAX_PAGES,
+    "navigation_timeout_seconds": NAVIGATION_TIMEOUT_SECONDS,
+    "session_ttl_seconds": SESSION_TTL_SECONDS,
+    "idle_ttl_seconds": IDLE_TTL_SECONDS,
+    "tool_call_timeout_seconds": TOOL_CALL_TIMEOUT_SECONDS,
+    "max_sessions": MAX_SESSIONS,
+    "max_tunnels_per_session": 12,
+    "max_egress_bytes_per_session": 64 * 1024 * 1024,
+    "egress_tunnel_idle_seconds": 30,
+    "egress_tunnel_ttl_seconds": 120,
+}
+
+METADATA_HOSTS: Final = frozenset(
+    {
+        "metadata.google.internal",
+        "metadata.google",
+        "metadata.azure.internal",
+        "instance-data",
+        "instance-data.ec2.internal",
+    }
+)
+BLOCKED_HOST_SUFFIXES: Final = (
+    ".internal",
+    ".local",
+    ".localhost",
+    ".home.arpa",
+)
+LOGIN_PATH_SEGMENTS: Final = frozenset(
+    {
+        "auth",
+        "account",
+        "accounts",
+        "authorize",
+        "callback",
+        "consent",
+        "login",
+        "log-in",
+        "oauth",
+        "oauth2",
+        "oidc",
+        "saml",
+        "session",
+        "signin",
+        "sign-in",
+        "sso",
+    }
+)
+LOGIN_COMPONENT_BOUNDARIES: Final = re.compile(r"[/&=?#]+")
+HOST_COMPONENT_BOUNDARIES: Final = re.compile(r"[.]+")
+QUERY_COMPONENT_BOUNDARIES: Final = re.compile(r"[&;?#]+")
+SENSITIVE_QUERY_KEYS: Final = frozenset(
+    {
+        "accesstoken",
+        "apikey",
+        "authorization",
+        "auth",
+        "bearer",
+        "code",
+        "credential",
+        "idtoken",
+        "jwt",
+        "key",
+        "keypairid",
+        "oauth",
+        "oauthtoken",
+        "password",
+        "passwd",
+        "refreshtoken",
+        "secret",
+        "session",
+        "sessionid",
+        "sig",
+        "signature",
+        "token",
+    }
+)
+SENSITIVE_QUERY_PREFIXES: Final = ("oauth", "xamz", "xgoog")
+REF_PATTERN: Final = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$")
+DIGEST_PATTERN: Final = re.compile(r"^[0-9a-f]{64}$")
+GENERATION_PATTERN: Final = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+)
+SENSITIVE_ELEMENT_PATTERN: Final = re.compile(
+    r"(?:password|passcode|passwd|secret|api[ _-]?key|access[ _-]?token|"
+    r"authorization|cookie|credit[ _-]?card|card[ _-]?number|cvv|cvc|"
+    r"social[ _-]?security|one[ _-]?time[ _-]?(?:code|password)|otp|"
+    r"log[ -]?in|sign[ -]?in|oauth|授权|认证|登录|登陆|密码|口令|令牌|密钥|"
+    r"验证码|信用卡|银行卡)",
+    re.IGNORECASE,
+)
+SENSITIVE_VALUE_PATTERNS: Final = (
+    re.compile(r"\bBearer\s+[A-Za-z0-9._~+/=-]{8,}", re.IGNORECASE),
+    re.compile(r"\b(?:gh[pousr]|github_pat)_[A-Za-z0-9_]{16,}\b"),
+    re.compile(r"\bsk-[A-Za-z0-9_-]{16,}\b"),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+    re.compile(r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b"),
+)
+
+
+def _object_schema(properties: dict[str, object], required: tuple[str, ...] = ()) -> dict[str, object]:
+    schema: dict[str, object] = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": properties,
+        "additionalProperties": False,
+    }
+    if required:
+        schema["required"] = list(required)
+    return schema
+
+
+PROOF_PROPERTIES: Final[dict[str, object]] = {
+    "generation": {
+        "type": "string",
+        "pattern": GENERATION_PATTERN.pattern,
+        "description": "来自最近一次受控快照的会话代次。",
+    },
+    "page_revision": {
+        "type": "integer",
+        "minimum": 0,
+        "description": "来自最近一次受控快照的页面修订号。",
+    },
+    "page_digest": {
+        "type": "string",
+        "pattern": DIGEST_PATTERN.pattern,
+        "description": "来自最近一次受控快照的页面摘要。",
+    },
+}
+PROOF_REQUIRED: Final = ("generation", "page_revision", "page_digest")
+REF_PROPERTY: Final[dict[str, object]] = {
+    "type": "string",
+    "pattern": REF_PATTERN.pattern,
+    "x-modelmirror-input": "browser-ref",
+    "description": "只能选择最近一次受控快照返回的不透明元素引用。",
+}
+
+STATUS_SCHEMA: Final = _object_schema({})
+NAVIGATE_SCHEMA: Final = _object_schema(
+    {
+        "url": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 16_384,
+            "format": "uri",
+            "x-modelmirror-input": "browser-url",
+            "description": "仅允许公网 HTTP/HTTPS 80/443，且会话锁定单一 origin。",
+        }
+    },
+    ("url",),
+)
+SNAPSHOT_SCHEMA: Final = _object_schema({})
+CLICK_SCHEMA: Final = {
+    **_object_schema({"ref": REF_PROPERTY}, ("ref",)),
+    # The proof is deliberately not client supplied.  browser_server binds the
+    # ref to its private generation/revision/digest tuple and re-snapshots the
+    # page immediately before forwarding the action upstream.
+    "x-modelmirror-ref-proof": "sidecar-bound",
+}
+FILL_SCHEMA: Final = {
+    **_object_schema(
+        {
+            "ref": REF_PROPERTY,
+            "value": {"type": "string", "maxLength": 4096},
+        },
+        ("ref", "value"),
+    ),
+    "x-modelmirror-ref-proof": "sidecar-bound",
+}
+FILL_FORM_SCHEMA: Final = {
+    **_object_schema(
+        {
+            "ref": REF_PROPERTY,
+            "value": {"type": "string", "maxLength": 4096},
+        },
+        ("ref", "value"),
+    ),
+    "x-modelmirror-ref-proof": "sidecar-bound",
+}
+SCREENSHOT_SCHEMA: Final = _object_schema(
+    {
+        "full_page": {
+            "type": "boolean",
+            "default": False,
+            "description": "是否截取完整滚动页面；文件名和存储位置由服务端生成。",
+        }
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class BrowserToolContract:
+    upstream_name: str | None
+    effect: str
+    description: str
+    input_schema: dict[str, object]
+
+
+@dataclass(frozen=True, slots=True)
+class BrowserAdapterContract:
+    package_name: str
+    package_version: str
+    upstream_server_name: str
+    upstream_server_version: str
+    tools: dict[str, BrowserToolContract]
+
+
+def _tool(
+    upstream_name: str | None,
+    effect: str,
+    description: str,
+    schema: dict[str, object],
+) -> BrowserToolContract:
+    return BrowserToolContract(upstream_name, effect, description, schema)
+
+
+BROWSER_ADAPTERS: Final[dict[str, BrowserAdapterContract]] = {
+    "chrome-devtools-mcp": BrowserAdapterContract(
+        package_name="chrome-devtools-mcp",
+        package_version="1.6.0",
+        upstream_server_name="chrome_devtools",
+        upstream_server_version="1.6.0",
+        tools={
+            "browser_session_status": _tool(None, "read", "查看受控浏览器会话状态。", STATUS_SCHEMA),
+            "navigate_page": _tool("navigate_page", "state-write", "导航到受策略保护的公网页面。", NAVIGATE_SCHEMA),
+            "take_snapshot": _tool("take_snapshot", "read", "获取带不透明元素引用的受控页面快照。", SNAPSHOT_SCHEMA),
+            "click": _tool("click", "state-write", "点击最近快照中的非敏感元素。", CLICK_SCHEMA),
+            "fill": _tool("fill", "state-write", "填写最近快照中的非敏感字段。", FILL_SCHEMA),
+            "take_screenshot": _tool("take_screenshot", "artifact-create", "生成服务端 PNG 截图产物。", SCREENSHOT_SCHEMA),
+        },
+    ),
+    "playwright-mcp": BrowserAdapterContract(
+        package_name="@playwright/mcp",
+        package_version="0.0.79",
+        upstream_server_name="Playwright",
+        upstream_server_version="1.63.0-alpha-2026-08-05",
+        tools={
+            "browser_session_status": _tool(None, "read", "查看受控浏览器会话状态。", STATUS_SCHEMA),
+            "browser_navigate": _tool("browser_navigate", "state-write", "导航到受策略保护的公网页面。", NAVIGATE_SCHEMA),
+            "browser_snapshot": _tool("browser_snapshot", "read", "获取带不透明元素引用的受控页面快照。", SNAPSHOT_SCHEMA),
+            "browser_click": _tool("browser_click", "state-write", "点击最近快照中的非敏感元素。", CLICK_SCHEMA),
+            "browser_fill_form": _tool("browser_fill_form", "state-write", "填写最近快照中的非敏感字段。", FILL_FORM_SCHEMA),
+            "browser_take_screenshot": _tool("browser_take_screenshot", "artifact-create", "生成服务端 PNG 截图产物。", SCREENSHOT_SCHEMA),
+        },
+    ),
+}
+
+
+def _schema_digest(contract: BrowserAdapterContract) -> str:
+    reviewed = [
+        {"name": name, "inputSchema": tool.input_schema}
+        for name, tool in sorted(contract.tools.items())
+    ]
+    encoded = json.dumps(
+        reviewed, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+# Literal release snapshots.  smoke_browser_adapters.py recomputes and checks
+# these values, so an accidental public schema change blocks the image build.
+BROWSER_SCHEMA_SHA256: Final[dict[str, str]] = {
+    "chrome-devtools-mcp": "74e74ee147c7293035b969af687248b05934052973d7798ecdc651208a7739c3",
+    "playwright-mcp": "efafd6dabf2e78173423ed2172092eb9865d82b8571fe5f687b9658ce9caaadc",
+}
+
+# Filled after real upstream tools/list capture.  This digest covers the exact
+# upstream schemas for the five forwarded tools (the status tool is local).
+UPSTREAM_SCHEMA_SHA256: Final[dict[str, str]] = {
+    "chrome-devtools-mcp": "a1e53699ad871492ab71a34b8f6aefced24317a6d4851cf1e0e7f6951a1d4c1d",
+    "playwright-mcp": "68b833cff0a90f00d3b94bd9979855f83888dbd46ba539d968521949d5268b02",
+}
+
+
+def assert_schema_snapshots() -> None:
+    for adapter_id, contract in BROWSER_ADAPTERS.items():
+        if BROWSER_SCHEMA_SHA256.get(adapter_id) != _schema_digest(contract):
+            raise RuntimeError(f"{adapter_id} reviewed browser schema drifted")
+
+
+class BrowserPolicyError(ValueError):
+    """Stable fail-closed browser policy error."""
+
+
+def _normalized_host(hostname: str | None) -> str:
+    raw = str(hostname or "").strip().rstrip(".").lower()
+    if not raw or len(raw) > 253:
+        raise BrowserPolicyError("browser_host_invalid")
+    try:
+        host = raw.encode("idna").decode("ascii")
+    except UnicodeError as exc:
+        raise BrowserPolicyError("browser_host_invalid") from exc
+    try:
+        ipaddress.ip_address(host)
+    except ValueError:
+        pass
+    else:
+        raise BrowserPolicyError("browser_ip_literal_denied")
+    if "." not in host:
+        raise BrowserPolicyError("browser_single_label_host_denied")
+    if host in METADATA_HOSTS or host.endswith(BLOCKED_HOST_SUFFIXES):
+        raise BrowserPolicyError("browser_internal_host_denied")
+    return host
+
+
+def canonical_browser_login_tokens(
+    value: str, *, host: bool = False
+) -> frozenset[str]:
+    """Return ordinary and punctuation-folded tokens for login-route checks."""
+
+    boundaries = HOST_COMPONENT_BOUNDARIES if host else LOGIN_COMPONENT_BOUNDARIES
+    tokens: set[str] = set()
+    ordinary_sequence: list[str] = []
+    for component in boundaries.split(value.lower()):
+        ordinary = re.findall(r"[a-z0-9]+", component)
+        tokens.update(ordinary)
+        ordinary_sequence.extend(ordinary)
+        compact = "".join(ordinary)
+        if compact:
+            tokens.add(compact)
+    tokens.update(
+        left + right
+        for left, right in zip(ordinary_sequence, ordinary_sequence[1:])
+    )
+    return frozenset(tokens)
+
+
+def browser_query_has_sensitive_key(query: str) -> bool:
+    """Reject bearer/signing query parameters, including nested encoded URLs."""
+
+    decoded = query
+    for _ in range(2):
+        decoded = unquote(decoded)
+    for component in QUERY_COMPONENT_BOUNDARIES.split(decoded):
+        raw_key = component.partition("=")[0]
+        key = "".join(re.findall(r"[a-z0-9]+", raw_key.lower()))
+        if not key:
+            continue
+        if (
+            key in SENSITIVE_QUERY_KEYS
+            or key.startswith(SENSITIVE_QUERY_PREFIXES)
+            or key.endswith(("secret", "signature", "token"))
+        ):
+            return True
+    return False
+
+
+def validate_browser_url(value: object, *, allow_login_path: bool = False) -> tuple[str, str, str, int]:
+    clean = str(value or "").strip()
+    if not clean or len(clean) > 16_384:
+        raise BrowserPolicyError("browser_url_invalid")
+    parsed = urlsplit(clean)
+    scheme = parsed.scheme.lower()
+    if scheme not in {"http", "https"}:
+        raise BrowserPolicyError("browser_scheme_denied")
+    if parsed.username is not None or parsed.password is not None:
+        raise BrowserPolicyError("browser_userinfo_denied")
+    host = _normalized_host(parsed.hostname)
+    try:
+        port = parsed.port or (443 if scheme == "https" else 80)
+    except ValueError as exc:
+        raise BrowserPolicyError("browser_port_denied") from exc
+    if (scheme, port) not in {("http", 80), ("https", 443)}:
+        raise BrowserPolicyError("browser_port_denied")
+    if browser_query_has_sensitive_key(parsed.query):
+        raise BrowserPolicyError("browser_sensitive_query_denied")
+    decoded_target = f"{parsed.path}?{parsed.query}"
+    # Decode twice so `%256cogin` cannot become a login route after a second
+    # server-side decoding pass.  Tokenization treats punctuation as a boundary
+    # (`login.html`, `action=login`) without matching benign words like author.
+    for _ in range(2):
+        decoded_target = unquote(decoded_target)
+    target_tokens = canonical_browser_login_tokens(decoded_target)
+    host_tokens = canonical_browser_login_tokens(host, host=True)
+    if not allow_login_path and (
+        target_tokens & LOGIN_PATH_SEGMENTS or host_tokens & LOGIN_PATH_SEGMENTS
+    ):
+        raise BrowserPolicyError("browser_external_login_denied")
+    normalized_parts = SplitResult(
+        scheme,
+        host if port in {80, 443} else f"{host}:{port}",
+        parsed.path or "/",
+        parsed.query,
+        "",
+    )
+    normalized = urlunsplit(normalized_parts)
+    origin = f"{scheme}://{host}"
+    return normalized, origin, host, port
+
+
+def validate_pinned_addresses(addresses: object) -> tuple[str, ...]:
+    if not isinstance(addresses, (list, tuple)):
+        raise BrowserPolicyError("browser_dns_failed")
+    if not all(isinstance(address, str) and address for address in addresses):
+        raise BrowserPolicyError("browser_dns_answer_invalid")
+    addresses = tuple(dict.fromkeys(addresses))
+    if not addresses:
+        raise BrowserPolicyError("browser_dns_failed")
+    parsed: list[ipaddress.IPv4Address | ipaddress.IPv6Address] = []
+    for raw in addresses:
+        try:
+            parsed.append(ipaddress.ip_address(raw))
+        except ValueError as exc:
+            raise BrowserPolicyError("browser_dns_answer_invalid") from exc
+    synthetic = [address in SYNTHETIC_DNS_NETWORK for address in parsed]
+    allow_synthetic = os.getenv("MCP_BROWSER_ALLOW_SYNTHETIC_DNS", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+    if any(synthetic):
+        # Synthetic DNS can only be enabled for an all-synthetic answer set.
+        # Literal URLs and mixed public/synthetic answers are never accepted.
+        if not allow_synthetic or not all(synthetic):
+            raise BrowserPolicyError("browser_dns_mixed_or_synthetic_denied")
+    elif not all(address.is_global for address in parsed):
+        raise BrowserPolicyError("browser_private_dns_denied")
+    return tuple(str(address) for address in parsed)
+
+
+def validate_pinned_records(records: object) -> tuple[str, ...]:
+    if not isinstance(records, (list, tuple)):
+        raise BrowserPolicyError("browser_dns_failed")
+    try:
+        addresses = tuple(str(record[4][0]) for record in records)
+    except (IndexError, TypeError) as exc:
+        raise BrowserPolicyError("browser_dns_answer_invalid") from exc
+    return validate_pinned_addresses(addresses)
+
+
+def resolve_pinned_addresses(host: str, port: int) -> tuple[str, ...]:
+    try:
+        records = socket.getaddrinfo(
+            host,
+            port,
+            type=socket.SOCK_STREAM,
+            proto=socket.IPPROTO_TCP,
+        )
+    except socket.gaierror as exc:
+        raise BrowserPolicyError("browser_dns_failed") from exc
+    return validate_pinned_records(records)
+
+
+def validate_snapshot_proof(arguments: dict[str, object]) -> tuple[str, int, str]:
+    generation = str(arguments.get("generation") or "").strip().lower()
+    revision = arguments.get("page_revision")
+    digest = str(arguments.get("page_digest") or "").strip().lower()
+    if not GENERATION_PATTERN.fullmatch(generation):
+        raise BrowserPolicyError("browser_generation_invalid")
+    if not isinstance(revision, int) or isinstance(revision, bool) or revision < 0:
+        raise BrowserPolicyError("browser_revision_invalid")
+    if not DIGEST_PATTERN.fullmatch(digest):
+        raise BrowserPolicyError("browser_digest_invalid")
+    return generation, revision, digest
+
+
+def validate_ref(value: object) -> str:
+    ref = str(value or "").strip()
+    if not REF_PATTERN.fullmatch(ref):
+        raise BrowserPolicyError("browser_ref_invalid")
+    return ref
+
+
+def assert_non_sensitive_interaction(context: str, value: object | None = None) -> None:
+    if SENSITIVE_ELEMENT_PATTERN.search(str(context or "")):
+        raise BrowserPolicyError("browser_sensitive_field_denied")
+    if value is None:
+        return
+    text = str(value)
+    if len(text) > 4096:
+        raise BrowserPolicyError("browser_value_too_large")
+    if any(pattern.search(text) for pattern in SENSITIVE_VALUE_PATTERNS):
+        raise BrowserPolicyError("browser_sensitive_value_denied")
+
+
+def session_expiry(started_at: datetime) -> float:
+    """Return a finite UTC epoch timestamp for the catalog status contract."""
+
+    return (started_at + timedelta(seconds=SESSION_TTL_SECONDS)).astimezone(UTC).timestamp()

--- a/server/sandbox_sidecar/browser_mcp.py
+++ b/server/sandbox_sidecar/browser_mcp.py
@@ -1,0 +1,675 @@
+"""Security gateway helpers for the real, locked Wave 7 upstream MCPs.
+
+This module is intentionally not an MCP facade.  ``browser_server`` launches
+the actual npm package for the selected adapter and uses these helpers only to
+verify its identity/schema and translate the reviewed public arguments to the
+upstream package's fixed arguments.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import ctypes
+import json
+import os
+import platform
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .browser_contracts import (
+    BROWSER_ADAPTERS,
+    MAX_ARTIFACT_BYTES,
+    NAVIGATION_TIMEOUT_SECONDS,
+    TOOL_CALL_TIMEOUT_SECONDS,
+)
+
+
+LANDLOCK_CREATE_RULESET_VERSION = 1
+LANDLOCK_RULE_PATH_BENEATH = 1
+PR_SET_NO_NEW_PRIVS = 38
+ACCESS_FS_EXECUTE = 1 << 0
+ACCESS_FS_WRITE_FILE = 1 << 1
+ACCESS_FS_READ_FILE = 1 << 2
+ACCESS_FS_READ_DIR = 1 << 3
+ACCESS_FS_REMOVE_DIR = 1 << 4
+ACCESS_FS_REMOVE_FILE = 1 << 5
+ACCESS_FS_MAKE_CHAR = 1 << 6
+ACCESS_FS_MAKE_DIR = 1 << 7
+ACCESS_FS_MAKE_REG = 1 << 8
+ACCESS_FS_MAKE_SOCK = 1 << 9
+ACCESS_FS_MAKE_FIFO = 1 << 10
+ACCESS_FS_MAKE_BLOCK = 1 << 11
+ACCESS_FS_MAKE_SYM = 1 << 12
+ACCESS_FS_REFER = 1 << 13
+ACCESS_FS_TRUNCATE = 1 << 14
+READ_EXECUTE = ACCESS_FS_EXECUTE | ACCESS_FS_READ_FILE | ACCESS_FS_READ_DIR
+PROC_USERNS_ACCESS = READ_EXECUTE | ACCESS_FS_WRITE_FILE
+WRITABLE = (
+    READ_EXECUTE
+    | ACCESS_FS_WRITE_FILE
+    | ACCESS_FS_REMOVE_DIR
+    | ACCESS_FS_REMOVE_FILE
+    | ACCESS_FS_MAKE_DIR
+    | ACCESS_FS_MAKE_REG
+    | ACCESS_FS_MAKE_SOCK
+    | ACCESS_FS_MAKE_FIFO
+    | ACCESS_FS_MAKE_SYM
+    | ACCESS_FS_REFER
+    | ACCESS_FS_TRUNCATE
+)
+HANDLED = WRITABLE | ACCESS_FS_MAKE_CHAR | ACCESS_FS_MAKE_BLOCK
+DEVICE_FILE_ACCESS = ACCESS_FS_READ_FILE | ACCESS_FS_WRITE_FILE
+
+
+class _RulesetAttr(ctypes.Structure):
+    _fields_ = [("handled_access_fs", ctypes.c_uint64)]
+
+
+class _PathBeneathAttr(ctypes.Structure):
+    _fields_ = [
+        ("allowed_access", ctypes.c_uint64),
+        ("parent_fd", ctypes.c_int32),
+        ("reserved", ctypes.c_uint32),
+    ]
+
+
+def _landlock_syscalls() -> tuple[int, int, int]:
+    if platform.machine().lower() in {"x86_64", "amd64", "aarch64", "arm64"}:
+        return 444, 445, 446
+    raise RuntimeError("browser_landlock_architecture_unsupported")
+
+
+def apply_browser_landlock(profile_dir: Path, staging_dir: Path) -> None:
+    """Restrict one upstream and all Chromium descendants to its own dirs."""
+
+    create_nr, add_nr, restrict_nr = _landlock_syscalls()
+    libc = ctypes.CDLL(None, use_errno=True)
+    abi = libc.syscall(create_nr, 0, 0, LANDLOCK_CREATE_RULESET_VERSION)
+    if abi < 1:
+        raise RuntimeError("browser_landlock_unavailable")
+    supported = HANDLED
+    if abi < 2:
+        supported &= ~ACCESS_FS_REFER
+    if abi < 3:
+        supported &= ~ACCESS_FS_TRUNCATE
+    attr = _RulesetAttr(supported)
+    ruleset_fd = libc.syscall(create_nr, ctypes.byref(attr), ctypes.sizeof(attr), 0)
+    if ruleset_fd < 0:
+        raise RuntimeError("browser_landlock_create_failed")
+
+    def add(path: Path, access: int) -> None:
+        if not path.exists():
+            return
+        descriptor = os.open(path, os.O_PATH | os.O_CLOEXEC)
+        try:
+            rule = _PathBeneathAttr(access & supported, descriptor, 0)
+            if libc.syscall(
+                add_nr,
+                ruleset_fd,
+                LANDLOCK_RULE_PATH_BENEATH,
+                ctypes.byref(rule),
+                0,
+            ) < 0:
+                raise RuntimeError("browser_landlock_rule_failed")
+        finally:
+            os.close(descriptor)
+
+    try:
+        for path in (
+            Path("/usr"),
+            Path("/bin"),
+            Path("/lib"),
+            Path("/lib64"),
+            Path("/etc"),
+            Path("/opt/browser-upstream"),
+            Path("/opt/modelmirror-browsers"),
+            Path("/opt/modelmirror"),
+            Path("/sys/devices/system"),
+        ):
+            add(path, READ_EXECUTE)
+        # Chromium's namespace sandbox writes uid_map/gid_map/setgroups through
+        # procfs after clone(CLONE_NEWUSER). Restore only WRITE_FILE here: the
+        # container still masks or mounts sensitive procfs trees read-only,
+        # carries no capabilities, and Landlock continues to deny create,
+        # remove, truncate, refer, or socket operations below /proc.
+        add(Path("/proc"), PROC_USERNS_ACCESS)
+        for path in (Path("/dev/null"), Path("/dev/urandom"), Path("/dev/random")):
+            add(path, DEVICE_FILE_ACCESS)
+        add(profile_dir.resolve(strict=True), WRITABLE)
+        add(staging_dir.resolve(strict=True), WRITABLE)
+        if libc.prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0:
+            raise RuntimeError("browser_no_new_privs_failed")
+        if libc.syscall(restrict_nr, ruleset_fd, 0) != 0:
+            raise RuntimeError("browser_landlock_restrict_failed")
+    finally:
+        os.close(ruleset_fd)
+
+
+def landlock_exec(profile_dir: Path, staging_dir: Path, command: list[str]) -> int:
+    if not command:
+        return 64
+    apply_browser_landlock(profile_dir, staging_dir)
+    os.chdir(profile_dir)
+    os.execvpe(command[0], command, os.environ)
+    return 127
+
+
+REF_VALUE = r"[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}"
+JSON_STRING = r'"(?:\\["\\/bfnrt]|\\u[0-9A-Fa-f]{4}|[^"\\\x00-\x1f])*"'
+SNAPSHOT_REF_TOKEN = re.compile(rf"(?<![A-Za-z0-9_])(?:uid|ref)=({REF_VALUE})\b")
+CHROME_SNAPSHOT_LINE = re.compile(
+    rf"^(?P<indent>(?:  )*)uid=(?P<ref>{REF_VALUE}) "
+    r"(?P<role>ignored|[A-Za-z][A-Za-z0-9_-]{0,63})"
+    rf"(?P<name> {JSON_STRING})?"
+    rf"(?P<attrs>(?: [A-Za-z][A-Za-z0-9_-]{{0,63}}(?:={JSON_STRING})?)*)"
+    r"(?: \[selected in the DevTools Elements panel\])?$"
+)
+PLAYWRIGHT_SNAPSHOT_KEY = re.compile(
+    rf"^(?P<role>[a-z][a-z0-9]{{0,63}})"
+    rf"(?P<name> {JSON_STRING})?"
+    rf"(?P<attrs>(?: \[[a-z][a-z0-9_-]{{0,31}}(?:=[^\]\s]+)?\])*)"
+    rf"(?P<suffix>:(?: .*)?)?$"
+)
+INTERACTIVE_SNAPSHOT_ROLES = frozenset(
+    {
+        "button",
+        "checkbox",
+        "combobox",
+        "link",
+        "menuitem",
+        "option",
+        "radio",
+        "searchbox",
+        "slider",
+        "spinbutton",
+        "switch",
+        "tab",
+        "textbox",
+        "treeitem",
+    }
+)
+PLAYWRIGHT_PAGE_URL = re.compile(
+    r"^- Page URL:[ \t]*(?P<url>\S(?:[^\r\n]*\S)?)[ \t]*$", re.MULTILINE
+)
+PLAYWRIGHT_PAGE_TITLE = re.compile(
+    r"^- Page Title:[ \t]*(?P<title>[^\r\n]*?)[ \t]*$", re.MULTILINE
+)
+
+
+class SnapshotStructureError(ValueError):
+    """The locked upstream emitted an ambiguous or spoofable ref structure."""
+
+
+@dataclass(frozen=True, slots=True)
+class SnapshotElement:
+    """A ref whose role, name and attributes came from structural positions."""
+
+    role: str
+    name: str
+    attributes: str
+
+    @property
+    def context(self) -> str:
+        return " ".join(
+            part for part in (self.role, self.name, self.attributes) if part
+        )
+
+
+def _snapshot_name(raw_name: str | None) -> str:
+    if not raw_name:
+        return ""
+    try:
+        value = json.loads(raw_name.strip())
+    except (TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise SnapshotStructureError("browser_snapshot_ref_structure_invalid") from exc
+    if not isinstance(value, str):
+        raise SnapshotStructureError("browser_snapshot_ref_structure_invalid")
+    return value
+
+
+def _playwright_snapshot_key(line: str) -> str | None:
+    match = re.fullmatch(r"(?P<indent>(?:  )*)- (?P<body>.*)", line)
+    if match is None:
+        return None
+    body = match.group("body")
+    if not body.startswith("'"):
+        return body
+    # Playwright's YAML key escaper uses single-quoted scalars and doubles a
+    # literal apostrophe.  Parse the wrapper before applying the fixed key
+    # grammar so a page label cannot manufacture a structural ref line.
+    output: list[str] = []
+    index = 1
+    while index < len(body):
+        if body[index] != "'":
+            output.append(body[index])
+            index += 1
+            continue
+        if index + 1 < len(body) and body[index + 1] == "'":
+            output.append("'")
+            index += 2
+            continue
+        remainder = body[index + 1 :]
+        if remainder and not remainder.startswith(":"):
+            raise SnapshotStructureError("browser_snapshot_ref_structure_invalid")
+        return "".join(output) + remainder
+    raise SnapshotStructureError("browser_snapshot_ref_structure_invalid")
+
+
+def upstream_command(
+    adapter_id: str,
+    *,
+    profile_dir: Path,
+    artifact_dir: Path,
+    proxy_url: str,
+) -> list[str]:
+    """Return the complete, fixed argv for one real upstream MCP process."""
+
+    if adapter_id not in BROWSER_ADAPTERS:
+        raise ValueError("mcp_adapter_denied")
+    chromium_env = (
+        "MCP_BROWSER_CDP_CHROMIUM_PATH"
+        if adapter_id == "chrome-devtools-mcp"
+        else "MCP_BROWSER_PLAYWRIGHT_CHROMIUM_PATH"
+    )
+    chromium_default = (
+        "/opt/modelmirror-browsers/cdp/chrome/linux-150.0.7871.24/"
+        "chrome-linux64/chrome"
+        if adapter_id == "chrome-devtools-mcp"
+        else "/opt/modelmirror-browsers/playwright/chromium-1237/"
+        "chrome-linux64/chrome"
+    )
+    chromium = os.getenv(chromium_env, chromium_default)
+    upstream_root = Path(os.getenv("MCP_BROWSER_UPSTREAM_ROOT", "/opt/browser-upstream"))
+    local_state_path = profile_dir / "Local State"
+    local_state_path.write_text(
+        json.dumps({"ssl": {"ech_enabled": False}}, separators=(",", ":")),
+        encoding="utf-8",
+    )
+    local_state_path.chmod(0o600)
+    if adapter_id == "chrome-devtools-mcp":
+        executable = upstream_root / "node_modules" / ".bin" / "chrome-devtools-mcp"
+        return [
+            str(executable),
+            "--headless",
+            f"--executablePath={chromium}",
+            f"--userDataDir={profile_dir}",
+            f"--proxyServer={proxy_url}",
+            "--viewport=1280x720",
+            "--no-usage-statistics",
+            "--no-performance-crux",
+            "--no-category-emulation",
+            "--no-category-performance",
+            "--no-category-network",
+            "--screenshotFormat=png",
+            "--screenshotMaxWidth=4096",
+            "--screenshotMaxHeight=16384",
+            "--ignoreDefaultChromeArg=--disable-popup-blocking",
+            "--blockedUrlPattern=ws://*/*",
+            "--blockedUrlPattern=wss://*/*",
+            "--blockedUrlPattern=file://*/*",
+            "--blockedUrlPattern=ftp://*/*",
+            "--blockedUrlPattern=data:*",
+            "--blockedUrlPattern=blob:*",
+            "--chromeArg=--disable-dev-shm-usage",
+            "--chromeArg=--disable-quic",
+            "--chromeArg=--disable-sync",
+            "--chromeArg=--disable-background-networking",
+            "--chromeArg=--disable-component-update",
+            "--chromeArg=--disable-domain-reliability",
+            "--chromeArg=--disable-blink-features=PushMessaging,PushMessagingSubscriptionChange",
+            "--chromeArg=--disable-preconnect",
+            "--chromeArg=--incognito",
+            "--chromeArg=--disable-features=kAutofillServerCommunication,EncryptedClientHello,MediaRouter,NetworkTimeServiceQuerying,OptimizationHints,PreconnectToSearch,WebOTP,WebRtcHideLocalIpsWithMdns",
+            "--chromeArg=--enable-features=NoSearchDomainCheck",
+            "--chromeArg=--force-webrtc-ip-handling-policy=disable_non_proxied_udp",
+            "--chromeArg=--proxy-bypass-list=<-loopback>",
+        ]
+    executable = upstream_root / "node_modules" / ".bin" / "playwright-mcp"
+    config_path = profile_dir / "modelmirror-playwright-config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "browser": {
+                    "launchOptions": {
+                        "args": [
+                            "--disable-dev-shm-usage",
+                            "--disable-quic",
+                            "--disable-sync",
+                            "--disable-background-networking",
+                            "--disable-component-update",
+                            "--disable-domain-reliability",
+                            "--disable-blink-features=PushMessaging,PushMessagingSubscriptionChange",
+                            "--disable-preconnect",
+                            "--incognito",
+                            "--disable-features=kAutofillServerCommunication,EncryptedClientHello,MediaRouter,NetworkTimeServiceQuerying,OptimizationHints,PreconnectToSearch,WebOTP,WebRtcHideLocalIpsWithMdns",
+                            "--enable-features=NoSearchDomainCheck",
+                            "--force-webrtc-ip-handling-policy=disable_non_proxied_udp",
+                            "--proxy-bypass-list=<-loopback>",
+                        ]
+                    },
+                    "contextOptions": {
+                        "acceptDownloads": False,
+                        "serviceWorkers": "block",
+                    },
+                },
+                "snapshot": {"mode": "none"},
+            },
+            separators=(",", ":"),
+        ),
+        encoding="utf-8",
+    )
+    config_path.chmod(0o400)
+    return [
+        str(executable),
+        f"--config={config_path}",
+        "--headless",
+        "--sandbox",
+        f"--executable-path={chromium}",
+        f"--user-data-dir={profile_dir}",
+        "--block-service-workers",
+        "--image-responses=omit",
+        "--snapshot-mode=none",
+        "--codegen=none",
+        f"--timeout-action={TOOL_CALL_TIMEOUT_SECONDS * 1000}",
+        f"--timeout-navigation={NAVIGATION_TIMEOUT_SECONDS * 1000}",
+        "--timeout-settle=500",
+        "--viewport-size=1280x720",
+        f"--output-dir={artifact_dir}",
+        f"--output-max-size={MAX_ARTIFACT_BYTES}",
+        f"--proxy-server={proxy_url}",
+        "--proxy-bypass=<-loopback>",
+    ]
+
+
+def result_text(payload: object) -> str:
+    if not isinstance(payload, dict):
+        return ""
+    result = payload.get("result")
+    if not isinstance(result, dict):
+        return ""
+    content = result.get("content")
+    if not isinstance(content, list):
+        return ""
+    parts: list[str] = []
+    for item in content:
+        if isinstance(item, dict) and item.get("type") == "text":
+            text = item.get("text")
+            if isinstance(text, str):
+                parts.append(text)
+    return "\n".join(parts)
+
+
+def result_failed(payload: object) -> bool:
+    if not isinstance(payload, dict):
+        return True
+    if "error" in payload:
+        return True
+    result = payload.get("result")
+    return not isinstance(result, dict) or result.get("isError") is True or result.get("is_error") is True
+
+
+def extract_snapshot(
+    adapter_id: str, payload: object
+) -> tuple[str, dict[str, SnapshotElement], str, str]:
+    """Return text, ref-to-context mapping, observed URL and title."""
+
+    text = result_text(payload)
+    refs: dict[str, SnapshotElement] = {}
+    seen_refs: set[str] = set()
+    observed_url = ""
+    title = ""
+    chrome_root_seen = False
+    for line in text.splitlines():
+        tokens = SNAPSHOT_REF_TOKEN.findall(line)
+        if not tokens:
+            continue
+        if len(tokens) != 1:
+            raise SnapshotStructureError("browser_snapshot_ref_structure_invalid")
+        if adapter_id == "chrome-devtools-mcp":
+            match = CHROME_SNAPSHOT_LINE.fullmatch(line)
+            if match is None:
+                raise SnapshotStructureError("browser_snapshot_ref_structure_invalid")
+            ref = match.group("ref")
+            role = match.group("role").lower()
+            name = _snapshot_name(match.group("name"))
+            attributes = (match.group("attrs") or "").strip()
+            if role == "rootwebarea" and not match.group("indent"):
+                if chrome_root_seen:
+                    raise SnapshotStructureError(
+                        "browser_snapshot_ref_structure_invalid"
+                    )
+                chrome_root_seen = True
+                url_values = re.findall(
+                    rf"(?:^| )url=({JSON_STRING})(?= |$)", attributes
+                )
+                if len(url_values) != 1:
+                    raise SnapshotStructureError(
+                        "browser_snapshot_ref_structure_invalid"
+                    )
+                observed_url = _snapshot_name(url_values[0])
+                if not observed_url:
+                    raise SnapshotStructureError(
+                        "browser_snapshot_ref_structure_invalid"
+                    )
+                title = name
+        elif adapter_id == "playwright-mcp":
+            key = _playwright_snapshot_key(line)
+            if key is None:
+                raise SnapshotStructureError("browser_snapshot_ref_structure_invalid")
+            match = PLAYWRIGHT_SNAPSHOT_KEY.fullmatch(key)
+            if match is None:
+                raise SnapshotStructureError("browser_snapshot_ref_structure_invalid")
+            attrs = match.group("attrs") or ""
+            ref_attributes = re.findall(rf" \[ref=({REF_VALUE})\]", attrs)
+            if ref_attributes != tokens:
+                raise SnapshotStructureError("browser_snapshot_ref_structure_invalid")
+            ref = tokens[0]
+            role = match.group("role").lower()
+            name = _snapshot_name(match.group("name"))
+            attributes = re.sub(
+                rf"(?:^| )\[ref={re.escape(ref)}\](?= |$)",
+                "",
+                attrs.strip(),
+                count=1,
+            ).strip()
+        else:
+            raise SnapshotStructureError("browser_snapshot_adapter_invalid")
+        if ref != tokens[0] or ref in seen_refs:
+            raise SnapshotStructureError("browser_snapshot_ref_structure_invalid")
+        seen_refs.add(ref)
+        if role in INTERACTIVE_SNAPSHOT_ROLES:
+            refs[ref] = SnapshotElement(role, name, attributes)
+    if adapter_id == "chrome-devtools-mcp":
+        if not chrome_root_seen:
+            raise SnapshotStructureError("browser_snapshot_ref_structure_invalid")
+    else:
+        url_matches = PLAYWRIGHT_PAGE_URL.findall(text)
+        title_matches = PLAYWRIGHT_PAGE_TITLE.findall(text)
+        if len(url_matches) != 1 or len(title_matches) > 1:
+            raise SnapshotStructureError("browser_snapshot_ref_structure_invalid")
+        observed_url = url_matches[0].strip()
+        if not observed_url:
+            raise SnapshotStructureError("browser_snapshot_ref_structure_invalid")
+        if title_matches:
+            title = title_matches[0].strip()
+        elif observed_url == "about:blank":
+            # Locked Playwright MCP 0.0.79 omits the Page Title metadata line
+            # for its initial about:blank page when snapshot-mode is none.
+            # Keep every navigated page fail-closed: only this non-networked
+            # bootstrap state may use the unambiguous empty-title fallback.
+            title = ""
+        else:
+            raise SnapshotStructureError("browser_snapshot_ref_structure_invalid")
+    return text, refs, observed_url, title
+
+
+def page_digest(origin: str, observed_url: str, title: str, snapshot_text: str) -> str:
+    encoded = json.dumps(
+        {
+            "origin": origin,
+            "url": observed_url[:16_384],
+            "title": title[:512],
+            "snapshot": snapshot_text,
+        },
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def upstream_schema_digest(adapter_id: str, tools: object) -> str:
+    contract = BROWSER_ADAPTERS[adapter_id]
+    wanted = {
+        tool.upstream_name
+        for tool in contract.tools.values()
+        if tool.upstream_name is not None
+    }
+    if not isinstance(tools, list):
+        raise ValueError("browser_upstream_tools_invalid")
+    selected: list[dict[str, object]] = []
+    for item in tools:
+        if not isinstance(item, dict) or item.get("name") not in wanted:
+            continue
+        schema = item.get("inputSchema")
+        if not isinstance(schema, dict):
+            raise ValueError("browser_upstream_schema_invalid")
+        selected.append({"name": item["name"], "inputSchema": schema})
+    if {item["name"] for item in selected} != wanted:
+        raise ValueError("browser_upstream_tool_missing")
+    encoded = json.dumps(
+        sorted(selected, key=lambda item: str(item["name"])),
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def public_tools(adapter_id: str) -> list[dict[str, object]]:
+    contract = BROWSER_ADAPTERS[adapter_id]
+    output: list[dict[str, object]] = []
+    for name, tool in contract.tools.items():
+        read_only = tool.effect == "read"
+        output.append(
+            {
+                "name": name,
+                "description": tool.description,
+                "inputSchema": tool.input_schema,
+                "annotations": {
+                    "title": tool.description,
+                    "readOnlyHint": read_only,
+                    "destructiveHint": False,
+                    "idempotentHint": read_only,
+                    "openWorldHint": True,
+                },
+            }
+        )
+    return output
+
+
+CHROME_FILL_ROLES = frozenset({"textbox", "searchbox", "spinbutton", "combobox"})
+PLAYWRIGHT_FILL_ROLE_TYPES = {
+    "textbox": "textbox",
+    "searchbox": "textbox",
+    "spinbutton": "textbox",
+    "checkbox": "checkbox",
+    "switch": "checkbox",
+    "radio": "radio",
+    "combobox": "combobox",
+    "slider": "slider",
+}
+
+
+def playwright_field_type(role: str) -> str:
+    try:
+        return PLAYWRIGHT_FILL_ROLE_TYPES[role]
+    except KeyError as exc:
+        raise ValueError("browser_fill_role_denied") from exc
+
+
+def to_upstream_arguments(
+    adapter_id: str,
+    tool_name: str,
+    arguments: dict[str, Any],
+    *,
+    ref_roles: dict[str, str],
+    artifact_path: Path | None = None,
+) -> dict[str, object]:
+    """Translate the reviewed schema without forwarding proof/private fields."""
+
+    if tool_name in {"navigate_page", "browser_navigate"}:
+        if adapter_id == "chrome-devtools-mcp":
+            return {
+                "type": "url",
+                "url": arguments["url"],
+                "timeout": NAVIGATION_TIMEOUT_SECONDS * 1000,
+            }
+        return {"url": arguments["url"]}
+    if tool_name in {"take_snapshot", "browser_snapshot"}:
+        return {}
+    if tool_name in {"click", "browser_click"}:
+        ref = str(arguments["ref"])
+        if adapter_id == "chrome-devtools-mcp":
+            return {"uid": ref, "includeSnapshot": False}
+        return {"target": ref, "element": "受控快照元素"}
+    if tool_name == "fill":
+        return {
+            "uid": str(arguments["ref"]),
+            "value": str(arguments["value"]),
+            "includeSnapshot": False,
+        }
+    if tool_name == "browser_fill_form":
+        ref = str(arguments["ref"])
+        role = ref_roles[ref]
+        return {
+            "fields": [
+                {
+                    "target": ref,
+                    "name": "受控字段",
+                    "type": playwright_field_type(role),
+                    "value": str(arguments["value"]),
+                }
+            ]
+        }
+    if tool_name in {"take_screenshot", "browser_take_screenshot"}:
+        if artifact_path is None:
+            raise ValueError("browser_artifact_path_missing")
+        full_page = bool(arguments.get("full_page", False))
+        if adapter_id == "chrome-devtools-mcp":
+            return {
+                "format": "png",
+                "fullPage": full_page,
+                "filePath": str(artifact_path),
+            }
+        return {
+            "type": "png",
+            "filename": artifact_path.name,
+            "fullPage": full_page,
+            "scale": "css",
+        }
+    raise ValueError("browser_tool_denied")
+
+
+def main() -> int:
+    if len(sys.argv) < 5 or sys.argv[1] != "landlock" or "--" not in sys.argv[4:]:
+        print(
+            "usage: browser_mcp.py landlock PROFILE_DIR STAGING_DIR -- COMMAND [ARGS...]",
+            file=sys.stderr,
+        )
+        return 64
+    separator = sys.argv.index("--", 4)
+    if separator != 4:
+        return 64
+    return landlock_exec(
+        Path(sys.argv[2]).resolve(strict=True),
+        Path(sys.argv[3]).resolve(strict=True),
+        sys.argv[separator + 1 :],
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/server/sandbox_sidecar/browser_requirements.lock
+++ b/server/sandbox_sidecar/browser_requirements.lock
@@ -1,0 +1,343 @@
+{
+  "name": "modelmirror-mcp-browser-upstream",
+  "version": "7.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "modelmirror-mcp-browser-upstream",
+      "version": "7.1.0",
+      "dependencies": {
+        "@playwright/mcp": "0.0.79",
+        "chrome-devtools-mcp": "1.6.0"
+      },
+      "devDependencies": {
+        "@puppeteer/browsers": "3.0.6"
+      }
+    },
+    "node_modules/@playwright/mcp": {
+      "version": "0.0.79",
+      "resolved": "https://registry.npmjs.org/@playwright/mcp/-/mcp-0.0.79.tgz",
+      "integrity": "sha512-VpqD4a3vFyGQMY9sh3UJiO6wjcurggkljKfAyCHL0QWGY5m6Ehr3MNsAAHPDHO//n13g0PCjpHatAOiulrqdZQ==",
+      "dependencies": {
+        "playwright": "1.63.0-alpha-2026-08-05",
+        "playwright-core": "1.63.0-alpha-2026-08-05"
+      },
+      "bin": {
+        "playwright-mcp": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@puppeteer/browsers": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.0.6.tgz",
+      "integrity": "sha512-B/gKoqlFkzhvzsI6jo9K1cZz9o5ypviVv/xu8CwA4grZzyVwN+XfkT+tu8T1zrauuEXv6VhS2oGX+6NL95WcKA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "modern-tar": "^0.7.6",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "browsers": "lib/main-cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "peerDependencies": {
+        "proxy-agent": ">=8.0.1",
+        "yauzl": "^2.10.0 || ^3.4.0"
+      },
+      "peerDependenciesMeta": {
+        "proxy-agent": {
+          "optional": true
+        },
+        "yauzl": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/chrome-devtools-mcp": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/chrome-devtools-mcp/-/chrome-devtools-mcp-1.6.0.tgz",
+      "integrity": "sha512-VZX6f/OjQSYhy2BGGRs+y3LsrsAQAz/HwZCWKBLVyST/4r/3zjVEjjVW7gMCVbRDuspnVdcp5hQDPrQ5UFrdZw==",
+      "bin": {
+        "chrome-devtools": "build/src/bin/chrome-devtools.js",
+        "chrome-devtools-mcp": "build/src/bin/chrome-devtools-mcp.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      },
+      "peerDependencies": {
+        "@blackwell-systems/gcf": "^2.2.2",
+        "@toon-format/toon": "^2.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@blackwell-systems/gcf": {
+          "optional": true
+        },
+        "@toon-format/toon": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/modern-tar": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.7.tgz",
+      "integrity": "sha512-t9VmxaqrmANnEOBhpSDI6HD192Ge48k8vmWqQQL7hSFEqHEYwZbbsu49+aKLWZeRvFs3j1pMhXOqqF4kPlvjkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.63.0-alpha-2026-08-05",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.63.0-alpha-2026-08-05.tgz",
+      "integrity": "sha512-zbGZUK+JYkoDV3cUgfvh2czTBJL34Gmz5gHVI25xiIpvYSR17Q1M7TS8hnwECUe+IkKaeXbKrSyJTyogm2DVWw==",
+      "dependencies": {
+        "playwright-core": "1.63.0-alpha-2026-08-05"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.63.0-alpha-2026-08-05",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0-alpha-2026-08-05.tgz",
+      "integrity": "sha512-YussvUybTfBtyYbGXWh43f+5kNP03wg98M6mu4DphYET7PSbNVajsdLGjWE1xrsjqOw32i2wFlRP7U5mcOpMZg==",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.1.0.tgz",
+      "integrity": "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^8.2.1",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    }
+  }
+}

--- a/server/sandbox_sidecar/browser_server.py
+++ b/server/sandbox_sidecar/browser_server.py
@@ -1,0 +1,3057 @@
+"""Unix-socket gateway and separated egress for Wave 7 browser MCPs.
+
+``python -m sandbox_sidecar.browser_server`` runs in the network-less browser
+execution container.  ``python -m sandbox_sidecar.browser_server egress`` runs
+in a distinct, Internet-connected container and owns DNS resolution plus the
+pinned outbound socket.  The two processes share only a private Unix socket.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import ctypes
+import hashlib
+import ipaddress
+import json
+import os
+import re
+import secrets
+import signal
+import shutil
+import socket
+import ssl
+import stat
+import struct
+import sys
+import tempfile
+import time
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+from .browser_contracts import (
+    BROWSER_ADAPTERS,
+    BROWSER_LIMITS,
+    BROWSER_SCHEMA_SHA256,
+    CONTRACT_VERSION,
+    IDLE_TTL_SECONDS,
+    MAX_ACTIONS,
+    MAX_ARGUMENT_BYTES,
+    MAX_ARTIFACT_BYTES,
+    MAX_OUTPUT_BYTES,
+    MAX_SESSIONS,
+    NAVIGATION_TIMEOUT_SECONDS,
+    SESSION_TTL_SECONDS,
+    TOOL_CALL_TIMEOUT_SECONDS,
+    UPSTREAM_SCHEMA_SHA256,
+    BrowserPolicyError,
+    assert_non_sensitive_interaction,
+    session_expiry,
+    validate_pinned_addresses,
+    validate_pinned_records,
+    validate_browser_url,
+    validate_ref,
+)
+from .browser_mcp import (
+    CHROME_FILL_ROLES,
+    PLAYWRIGHT_FILL_ROLE_TYPES,
+    SnapshotElement,
+    SnapshotStructureError,
+    extract_snapshot,
+    page_digest,
+    public_tools,
+    result_failed,
+    result_text,
+    to_upstream_arguments,
+    upstream_command,
+    upstream_schema_digest,
+)
+from .engine import SandboxEngineError
+
+
+SOCKET_PATH = Path(
+    os.getenv("MCP_BROWSER_SOCKET_PATH", "/run/modelmirror-browser-mcp/browser-mcp.sock")
+)
+EGRESS_SOCKET_PATH = Path(
+    os.getenv(
+        "MCP_BROWSER_EGRESS_SOCKET_PATH",
+        "/run/modelmirror-browser-egress/browser-egress.sock",
+    )
+)
+EGRESS_CONTROL_PATH = EGRESS_SOCKET_PATH.with_name("browser-egress.control")
+PROFILE_ROOT = Path(os.getenv("MCP_BROWSER_PROFILE_ROOT", "/profiles"))
+ARTIFACT_ROOT = Path(os.getenv("MCP_BROWSER_ARTIFACT_ROOT", "/artifacts"))
+TRUSTED_CLIENT_UID = int(os.getenv("MCP_BROWSER_TRUSTED_CLIENT_UID", "0"))
+MAX_REQUEST_BYTES = 64 * 1024
+MAX_MCP_MESSAGE_BYTES = MAX_OUTPUT_BYTES + 16 * 1024
+MAX_PROXY_HEADER_BYTES = 64 * 1024
+MAX_EGRESS_TUNNELS_PER_SESSION = 12
+MAX_EGRESS_BYTES_PER_SESSION = 64 * 1024 * 1024
+EGRESS_TUNNEL_IDLE_SECONDS = 30
+EGRESS_TUNNEL_TTL_SECONDS = 120
+DNS_TIMEOUT_SECONDS = 5
+DOH_MAX_HEADER_BYTES = 16 * 1024
+DOH_MAX_BODY_BYTES = 64 * 1024
+DOH_MAX_ANSWERS = 64
+DOH_RESOLVERS = (
+    ("1.1.1.1", "cloudflare-dns.com"),
+    ("1.0.0.1", "cloudflare-dns.com"),
+)
+REQUEST_PREAMBLE_TIMEOUT_SECONDS = 2
+EGRESS_WATCH_BOOTSTRAP_SECONDS = 15
+# Docker only activates a container restart policy after ten seconds of
+# successful runtime.  Keep the control key and catalog socket private until
+# that window has passed so even a very short first session can tear down and
+# reliably restart the one-shot pair.
+DOCKER_RESTART_ARM_SECONDS = 11.0
+ALLOWED_ADAPTERS = frozenset(BROWSER_ADAPTERS)
+PR_SET_DUMPABLE = 4
+PR_GET_DUMPABLE = 3
+PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+AUTHORITY = re.compile(r"^(?P<host>[^:@/]+):(?P<port>[0-9]{1,5})$")
+SESSION_DIRECTORY = re.compile(r"^[0-9a-f]{32}$")
+ARTIFACT_SESSION_CHILDREN = frozenset({"staging", "registered"})
+BROWSER_UPSTREAM_FAILURE_PATTERNS = (
+    ("no usable sandbox", "chromium_sandbox"),
+    ("sandbox", "chromium_sandbox"),
+    ("failed to launch", "browser_launch"),
+    ("browser process", "browser_process"),
+    ("target closed", "target_closed"),
+    ("session closed", "session_closed"),
+    ("connection closed", "connection_closed"),
+    ("not connected", "browser_not_connected"),
+    ("response must have a page", "page_missing"),
+    ("no page", "page_missing"),
+    ("accessibility", "accessibility_failed"),
+    ("protocol error", "protocol_error"),
+    ("permission denied", "permission_denied"),
+    ("enoent", "path_missing"),
+    ("timed out", "upstream_timeout"),
+)
+BROWSER_UPSTREAM_FAILURE_CATEGORIES = frozenset(
+    {category for _, category in BROWSER_UPSTREAM_FAILURE_PATTERNS}
+    | {"unclassified"}
+)
+BROWSER_STDERR_PATTERNS = (
+    (b"no usable sandbox", "no_usable_sandbox"),
+    (b"sys_chroot", "chroot_failed"),
+    (b"failed to move to new namespace", "namespace_denied"),
+    (b"operation not permitted", "namespace_denied"),
+    (b"bad system call", "seccomp_denied"),
+    (b"sigsys", "seccomp_denied"),
+    (b"seccomp", "seccomp_denied"),
+    (b"zygote", "zygote_failed"),
+    (b"devtoolsactiveport", "devtools_failed"),
+    (b"permission denied", "permission_denied"),
+    (b"target closed", "target_closed"),
+    (b"out of memory", "out_of_memory"),
+    (b"fatal", "generic_fatal"),
+)
+BROWSER_STDERR_CATEGORY_PRIORITY = (
+    "no_usable_sandbox",
+    "chroot_failed",
+    "namespace_denied",
+    "seccomp_denied",
+    "zygote_failed",
+    "devtools_failed",
+    "permission_denied",
+    "target_closed",
+    "out_of_memory",
+    "generic_fatal",
+)
+BROWSER_STDERR_CATEGORIES = frozenset(
+    {*BROWSER_STDERR_CATEGORY_PRIORITY, "none"}
+)
+BROWSER_PREFLIGHT_ERROR_CODES = frozenset(
+    {
+        "browser_upstream_identity_drift",
+        "browser_upstream_schema_drift",
+        "browser_upstream_representative_call_failed",
+        "browser_upstream_page_contract_failed",
+        "browser_upstream_output_invalid",
+        "browser_upstream_stdio_unavailable",
+    }
+    | {
+        f"browser_upstream_representative_{category}"
+        for category in BROWSER_UPSTREAM_FAILURE_CATEGORIES
+    }
+    | {
+        f"browser_upstream_representative_target_closed_{category}"
+        for category in BROWSER_STDERR_CATEGORIES
+    }
+)
+
+BROWSER_RUNTIME_EVENT_CODES = frozenset(
+    {
+        "rpc_timeout",
+        "rpc_transport_failure",
+        "proxy_policy_violation",
+        "proxy_policy_cross_origin",
+        "proxy_policy_origin_unset",
+        "proxy_policy_request_invalid",
+        "proxy_policy_headers_too_large",
+        "proxy_policy_websocket_or_auth",
+        "proxy_policy_authority_invalid",
+        "proxy_policy_method_denied",
+        "proxy_policy_host_invalid",
+        "proxy_policy_host_mismatch",
+        "proxy_policy_egress_unavailable",
+        "proxy_policy_egress_tunnel_limit",
+        "proxy_policy_egress_byte_budget",
+        "proxy_policy_dns_failed",
+        "proxy_policy_dns_timeout",
+        "proxy_policy_dns_answer_invalid",
+        "proxy_policy_dns_private",
+        "proxy_policy_dns_synthetic",
+        "proxy_policy_tls_clienthello_invalid",
+        "proxy_policy_tls_sni_denied",
+        "proxy_policy_tls_ech_denied",
+        "proxy_policy_egress_tunnel_deadline",
+        "proxy_policy_egress_tunnel_idle",
+        "proxy_policy_egress_capability_denied",
+        "egress_revoked",
+        "unregistered_artifact",
+        "unregistered_artifact_console_log",
+        "unregistered_artifact_download",
+        "unregistered_artifact_trace",
+        "unregistered_artifact_other",
+        "unregistered_artifact_mixed",
+        "proxy_policy_android_client_background_blocked_no_taint",
+        "browser_policy_page_count",
+        "browser_policy_snapshot_failed",
+        "browser_policy_snapshot_structure",
+        "browser_policy_output_too_large",
+        "browser_policy_cross_origin",
+        "browser_policy_unregistered_artifact",
+    }
+    | {
+        f"proxy_policy_cross_origin_{relation}_{phase}"
+        for relation in (
+            "network_time", "connectivity", "component_update", "safe_browsing",
+            "account", "optimization", "translate", "autofill", "push",
+            "search_domain", "search_suggest", "google_home_connect", "google_home_root", "google_home_other",
+            "google_chrome_service", "google_favicon", "static_service", "font_service",
+            "google_api", "usercontent_service", "vendor_other", "external_host",
+            "google_subdomain",
+            "google_client", "clients1", "android_client",
+            "scheme", "port", "unknown",
+        )
+        for phase in ("before_forward", "after_forward")
+    }
+    | {
+        f"upstream_result_{category}"
+        for category in BROWSER_UPSTREAM_FAILURE_CATEGORIES
+    }
+)
+
+BROWSER_BACKGROUND_HOST_CATEGORIES = {
+    "clients1.google.com": "clients1",
+    "clients2.google.com": "network_time",
+    "clients3.google.com": "connectivity",
+    "connectivitycheck.gstatic.com": "connectivity",
+    "clients4.google.com": "component_update",
+    "update.googleapis.com": "component_update",
+    "redirector.gvt1.com": "component_update",
+    "edgedl.me.gvt1.com": "component_update",
+    "safebrowsing.googleapis.com": "safe_browsing",
+    "safebrowsing.google.com": "safe_browsing",
+    "accounts.google.com": "account",
+    "optimizationguide-pa.googleapis.com": "optimization",
+    "chromemodelexecution-pa.googleapis.com": "optimization",
+    "chromemodelquality-pa.googleapis.com": "optimization",
+    "translate.googleapis.com": "translate",
+    "content-autofill.googleapis.com": "autofill",
+    "mtalk.google.com": "push",
+    "www.google.com": "google_home",
+    "google.com": "google_home",
+    "ssl.gstatic.com": "static_service",
+    "www.gstatic.com": "static_service",
+    "gstatic.com": "static_service",
+    "fonts.googleapis.com": "font_service",
+    "fonts.gstatic.com": "font_service",
+    "apis.google.com": "google_api",
+    "googleapis.com": "google_api",
+    "clients2.googleusercontent.com": "component_update",
+    "googleusercontent.com": "usercontent_service",
+    "tools.google.com": "component_update",
+    "android.clients.google.com": "android_client",
+    "chrome.google.com": "google_chrome_service",
+    "dl.google.com": "component_update",
+}
+BROWSER_VENDOR_HOST_SUFFIXES = (
+    "google.com", "googleapis.com", "gstatic.com", "googleusercontent.com", "gvt1.com"
+)
+BROWSER_VENDOR_SUFFIX_CATEGORIES = {
+    "google.com": "google_subdomain",
+    "googleapis.com": "google_api",
+    "gstatic.com": "static_service",
+    "googleusercontent.com": "usercontent_service",
+    "gvt1.com": "component_update",
+}
+
+BROWSER_PROXY_RUNTIME_EVENTS = {
+    "browser_cross_origin_denied": "proxy_policy_cross_origin",
+    "browser_origin_not_set": "proxy_policy_origin_unset",
+    "browser_proxy_request_invalid": "proxy_policy_request_invalid",
+    "browser_proxy_headers_too_large": "proxy_policy_headers_too_large",
+    "browser_websocket_or_proxy_auth_denied": "proxy_policy_websocket_or_auth",
+    "browser_proxy_authority_invalid": "proxy_policy_authority_invalid",
+    "browser_http_method_denied": "proxy_policy_method_denied",
+    "browser_http_host_invalid": "proxy_policy_host_invalid",
+    "browser_http_host_mismatch": "proxy_policy_host_mismatch",
+    "browser_egress_unavailable": "proxy_policy_egress_unavailable",
+    "browser_egress_tunnel_limit": "proxy_policy_egress_tunnel_limit",
+    "browser_egress_byte_budget": "proxy_policy_egress_byte_budget",
+    "browser_dns_failed": "proxy_policy_dns_failed",
+    "browser_dns_timeout": "proxy_policy_dns_timeout",
+    "browser_dns_answer_invalid": "proxy_policy_dns_answer_invalid",
+    "browser_private_dns_denied": "proxy_policy_dns_private",
+    "browser_dns_mixed_or_synthetic_denied": "proxy_policy_dns_synthetic",
+    "browser_tls_client_hello_invalid": "proxy_policy_tls_clienthello_invalid",
+    "browser_tls_sni_denied": "proxy_policy_tls_sni_denied",
+    "browser_tls_ech_denied": "proxy_policy_tls_ech_denied",
+    "browser_egress_tunnel_deadline": "proxy_policy_egress_tunnel_deadline",
+    "browser_egress_tunnel_idle": "proxy_policy_egress_tunnel_idle",
+    "browser_egress_capability_denied": "proxy_policy_egress_capability_denied",
+}
+
+BROWSER_POLICY_RUNTIME_EVENTS = {
+    "browser_page_count_violation": "browser_policy_page_count",
+    "browser_snapshot_verification_failed": "browser_policy_snapshot_failed",
+    "browser_snapshot_ref_structure_invalid": "browser_policy_snapshot_structure",
+    "browser_output_too_large": "browser_policy_output_too_large",
+    "browser_cross_origin_denied": "browser_policy_cross_origin",
+    "browser_unregistered_artifact": "browser_policy_unregistered_artifact",
+}
+
+
+def _emit_browser_runtime_event(code: str) -> None:
+    safe_code = code if code in BROWSER_RUNTIME_EVENT_CODES else "rpc_transport_failure"
+    print(
+        json.dumps({"browser_runtime_event": safe_code}, separators=(",", ":")),
+        file=sys.stderr,
+        flush=True,
+    )
+
+
+def _proxy_runtime_event(reason: str) -> str:
+    """Map an internal proxy denial to a fixed, content-free diagnostic."""
+
+    return BROWSER_PROXY_RUNTIME_EVENTS.get(reason, "proxy_policy_violation")
+
+
+def _disable_process_dumping() -> None:
+    if os.name != "posix":
+        raise RuntimeError("browser_prctl_unavailable")
+    libc = ctypes.CDLL(None, use_errno=True)
+    if libc.prctl(PR_SET_DUMPABLE, 0, 0, 0, 0) != 0:
+        raise RuntimeError("browser_pr_set_dumpable_failed")
+    if libc.prctl(PR_GET_DUMPABLE, 0, 0, 0, 0) != 0:
+        raise RuntimeError("browser_pr_get_dumpable_failed")
+
+
+def _trusted_peer_uid(writer: asyncio.StreamWriter) -> int:
+    """Return the kernel-authenticated peer UID for the catalog UDS client."""
+
+    if not sys.platform.startswith("linux") or not hasattr(socket, "SO_PEERCRED"):
+        raise SandboxEngineError("Browser peer credentials unavailable.", code="browser_peer_unavailable")
+    transport_socket = writer.get_extra_info("socket")
+    if transport_socket is None:
+        raise SandboxEngineError("Browser peer credentials unavailable.", code="browser_peer_unavailable")
+    try:
+        credentials = transport_socket.getsockopt(
+            socket.SOL_SOCKET,
+            socket.SO_PEERCRED,
+            struct.calcsize("3i"),
+        )
+        _pid, uid, _gid = struct.unpack("3i", credentials)
+    except (OSError, struct.error) as exc:
+        raise SandboxEngineError(
+            "Browser peer credentials unavailable.", code="browser_peer_unavailable"
+        ) from exc
+    return int(uid)
+
+
+def _require_supervisor_pid1() -> None:
+    """Fail closed unless the Python supervisor owns the container PID namespace."""
+
+    if not sys.platform.startswith("linux") or os.getpid() != 1:
+        raise RuntimeError("browser_supervisor_must_be_pid1")
+
+
+def _safe_preflight_error_code(exc: BaseException) -> str | None:
+    """Expose only reviewed machine codes, never upstream text or arguments."""
+
+    if isinstance(exc, asyncio.TimeoutError):
+        return "browser_upstream_preflight_timeout"
+    reason = str(exc)
+    return reason if reason in BROWSER_PREFLIGHT_ERROR_CODES else None
+
+
+def _classify_upstream_failure(payload: object) -> str:
+    """Reduce an untrusted upstream error body to a reviewed fixed category."""
+
+    lowered = result_text(payload).lower()
+    for token, category in BROWSER_UPSTREAM_FAILURE_PATTERNS:
+        if token in lowered:
+            return category
+    return "unclassified"
+
+
+class SafeStderrClassifier:
+    """Classify a stream without retaining or exposing its untrusted text."""
+
+    def __init__(self) -> None:
+        self.categories: set[str] = set()
+        self.changed = asyncio.Event()
+        self._overlap = b""
+        self._overlap_bytes = max(len(token) for token, _ in BROWSER_STDERR_PATTERNS) - 1
+
+    def feed(self, chunk: bytes) -> None:
+        if not chunk:
+            return
+        combined = self._overlap + chunk.lower()
+        before = len(self.categories)
+        for token, category in BROWSER_STDERR_PATTERNS:
+            if token in combined:
+                self.categories.add(category)
+        if len(self.categories) != before:
+            self.changed.set()
+        self._overlap = combined[-self._overlap_bytes :]
+
+    def primary(self) -> str:
+        return next(
+            (
+                category
+                for category in BROWSER_STDERR_CATEGORY_PRIORITY
+                if category in self.categories
+            ),
+            "none",
+        )
+
+
+class BrowserOneShotLifecycle:
+    """Atomically admit one trusted catalog session without queueing successors."""
+
+    def __init__(self) -> None:
+        self._claimed = False
+        self.finished = asyncio.Event()
+
+    @property
+    def claimed(self) -> bool:
+        return self._claimed
+
+    def claim(self) -> None:
+        # This method intentionally contains no await.  All handlers run on the
+        # same event loop, so check-and-set is atomic with respect to peers.
+        if self._claimed:
+            raise SandboxEngineError(
+                "Browser container session already consumed.",
+                code="browser_container_session_consumed",
+            )
+        self._claimed = True
+
+    def finish(self) -> None:
+        if self._claimed:
+            self.finished.set()
+
+
+class RestartPolicyReadinessGate:
+    """Delay readiness (or an early failed exit) until Docker can restart PID1."""
+
+    def __init__(self, started_at: float) -> None:
+        self.started_at = started_at
+        self.armed = False
+
+    def remaining(self) -> float:
+        return max(
+            0.0,
+            self.started_at + DOCKER_RESTART_ARM_SECONDS - time.monotonic(),
+        )
+
+    async def wait_before_arm(self) -> None:
+        remaining = self.remaining()
+        if remaining > 0:
+            await asyncio.sleep(remaining)
+
+    def arm(self) -> None:
+        self.armed = True
+
+    async def hold_early_exit(self) -> None:
+        """Finish the bounded activation wait even when the main task is cancelled."""
+
+        if self.armed:
+            return
+        remaining = self.remaining()
+        if remaining <= 0:
+            return
+        delay = asyncio.create_task(asyncio.sleep(remaining))
+        try:
+            while not delay.done():
+                try:
+                    await asyncio.shield(delay)
+                except asyncio.CancelledError:
+                    continue
+        finally:
+            if not delay.done():
+                delay.cancel()
+            await asyncio.gather(delay, return_exceptions=True)
+
+
+def _is_symlink_or_non_directory(path: Path) -> bool:
+    metadata = path.lstat()
+    return stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(metadata.st_mode)
+
+
+def _validate_artifact_tree(path: Path) -> None:
+    """Validate a stale artifact tree without following attacker-created links."""
+
+    for child in path.iterdir():
+        metadata = child.lstat()
+        if stat.S_ISLNK(metadata.st_mode) or os.path.ismount(child):
+            raise RuntimeError("browser_runtime_cleanup_unsafe_entry")
+        if stat.S_ISDIR(metadata.st_mode):
+            _validate_artifact_tree(child)
+        elif not stat.S_ISREG(metadata.st_mode):
+            raise RuntimeError("browser_runtime_cleanup_unsafe_entry")
+
+
+def _cleanup_stale_runtime_root(root: Path, *, artifacts: bool) -> None:
+    """Remove only strict session directories from a dedicated runtime root.
+
+    The roots are container-owned tmpfs/volumes.  Unexpected direct children,
+    session symlinks, nested mounts, and special files fail closed so a restart
+    can never turn cleanup into traversal of an administrator-provided path.
+    """
+
+    try:
+        metadata = root.lstat()
+    except FileNotFoundError as exc:
+        raise RuntimeError("browser_runtime_root_missing") from exc
+    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(metadata.st_mode):
+        raise RuntimeError("browser_runtime_root_unsafe")
+    for session_dir in root.iterdir():
+        if not SESSION_DIRECTORY.fullmatch(session_dir.name):
+            raise RuntimeError("browser_runtime_cleanup_unexpected_entry")
+        if _is_symlink_or_non_directory(session_dir) or os.path.ismount(session_dir):
+            raise RuntimeError("browser_runtime_cleanup_unsafe_entry")
+        if artifacts:
+            children = {child.name: child for child in session_dir.iterdir()}
+            if not set(children).issubset(ARTIFACT_SESSION_CHILDREN):
+                raise RuntimeError("browser_runtime_cleanup_unexpected_entry")
+            for child in children.values():
+                if _is_symlink_or_non_directory(child) or os.path.ismount(child):
+                    raise RuntimeError("browser_runtime_cleanup_unsafe_entry")
+                _validate_artifact_tree(child)
+        shutil.rmtree(session_dir)
+
+
+def _cleanup_stale_runtime_roots() -> None:
+    _cleanup_stale_runtime_root(PROFILE_ROOT, artifacts=False)
+    _cleanup_stale_runtime_root(ARTIFACT_ROOT, artifacts=True)
+
+
+def _register_png_artifact(
+    artifact_path: Path,
+    registered_dir: Path,
+) -> tuple[Path, str, int]:
+    """Copy a validated PNG into a new trusted inode, then unlink its source."""
+
+    source_descriptor = -1
+    registered_directory_descriptor = -1
+    registered_descriptor = -1
+    registered_created = False
+    registered_name = artifact_path.name.removeprefix(".modelmirror-")
+    if re.fullmatch(r"browser_[0-9a-f]{32}\.png", registered_name) is None:
+        raise BrowserPolicyError("browser_artifact_name_denied")
+    registered_path = registered_dir / registered_name
+    try:
+        before = artifact_path.lstat()
+        if (
+            not stat.S_ISREG(before.st_mode)
+            or before.st_nlink != 1
+            or before.st_size <= 0
+            or before.st_size > MAX_ARTIFACT_BYTES
+        ):
+            raise BrowserPolicyError("browser_artifact_metadata_denied")
+        source_descriptor = os.open(
+            artifact_path,
+            os.O_RDONLY | os.O_CLOEXEC | getattr(os, "O_NOFOLLOW", 0),
+        )
+        opened = os.fstat(source_descriptor)
+        identity = (opened.st_dev, opened.st_ino)
+        if (
+            identity != (before.st_dev, before.st_ino)
+            or not stat.S_ISREG(opened.st_mode)
+            or opened.st_nlink != 1
+            or opened.st_size != before.st_size
+        ):
+            raise BrowserPolicyError("browser_artifact_race_denied")
+        registered_directory_descriptor = os.open(
+            registered_dir,
+            os.O_RDONLY
+            | os.O_CLOEXEC
+            | getattr(os, "O_DIRECTORY", 0)
+            | getattr(os, "O_NOFOLLOW", 0),
+        )
+        registered_directory = os.fstat(registered_directory_descriptor)
+        if not stat.S_ISDIR(registered_directory.st_mode):
+            raise BrowserPolicyError("browser_artifact_directory_denied")
+        try:
+            registered_descriptor = os.open(
+                registered_name,
+                os.O_RDWR
+                | os.O_CREAT
+                | os.O_EXCL
+                | os.O_CLOEXEC
+                | getattr(os, "O_NOFOLLOW", 0),
+                0o600,
+                dir_fd=registered_directory_descriptor,
+            )
+        except FileExistsError as exc:
+            raise BrowserPolicyError("browser_artifact_collision") from exc
+        registered_created = True
+        created = os.fstat(registered_descriptor)
+        if not stat.S_ISREG(created.st_mode) or created.st_nlink != 1:
+            raise BrowserPolicyError("browser_artifact_metadata_denied")
+        registered_identity = (created.st_dev, created.st_ino)
+
+        hasher = hashlib.sha256()
+        prefix = bytearray()
+        copied_size = 0
+        while True:
+            chunk = os.read(source_descriptor, 64 * 1024)
+            if not chunk:
+                break
+            if len(prefix) < len(PNG_MAGIC):
+                prefix.extend(chunk[: len(PNG_MAGIC) - len(prefix)])
+            hasher.update(chunk)
+            copied_size += len(chunk)
+            remaining = memoryview(chunk)
+            while remaining:
+                written = os.write(registered_descriptor, remaining)
+                if written <= 0:
+                    raise OSError("browser_artifact_copy_failed")
+                remaining = remaining[written:]
+        if bytes(prefix) != PNG_MAGIC:
+            raise BrowserPolicyError("browser_artifact_type_denied")
+        after_read = os.fstat(source_descriptor)
+        if (
+            (after_read.st_dev, after_read.st_ino) != identity
+            or after_read.st_nlink != 1
+            or after_read.st_size != opened.st_size
+            or after_read.st_mtime_ns != opened.st_mtime_ns
+            or after_read.st_ctime_ns != opened.st_ctime_ns
+            or copied_size != opened.st_size
+        ):
+            raise BrowserPolicyError("browser_artifact_race_denied")
+        os.fsync(registered_descriptor)
+        os.fchmod(registered_descriptor, 0o440)
+        os.fsync(registered_descriptor)
+        final = os.fstat(registered_descriptor)
+        if (
+            (final.st_dev, final.st_ino) != registered_identity
+            or not stat.S_ISREG(final.st_mode)
+            or final.st_nlink != 1
+            or final.st_size != opened.st_size
+        ):
+            raise BrowserPolicyError("browser_artifact_race_denied")
+        if (final.st_mode & 0o777) != 0o440:
+            raise BrowserPolicyError("browser_artifact_permissions_denied")
+
+        os.lseek(registered_descriptor, 0, os.SEEK_SET)
+        registered_hasher = hashlib.sha256()
+        registered_size = 0
+        while True:
+            chunk = os.read(registered_descriptor, 64 * 1024)
+            if not chunk:
+                break
+            registered_hasher.update(chunk)
+            registered_size += len(chunk)
+        digest = hasher.hexdigest()
+        if registered_size != copied_size or registered_hasher.hexdigest() != digest:
+            raise BrowserPolicyError("browser_artifact_copy_mismatch")
+
+        before_unlink = artifact_path.lstat()
+        if (
+            (before_unlink.st_dev, before_unlink.st_ino) != identity
+            or before_unlink.st_nlink != 1
+        ):
+            raise BrowserPolicyError("browser_artifact_race_denied")
+        artifact_path.unlink()
+        if os.fstat(source_descriptor).st_nlink != 0:
+            raise BrowserPolicyError("browser_artifact_race_denied")
+        return registered_path, digest, registered_size
+    except Exception:
+        if registered_created and registered_directory_descriptor >= 0:
+            try:
+                os.unlink(
+                    registered_name,
+                    dir_fd=registered_directory_descriptor,
+                )
+            except FileNotFoundError:
+                pass
+        raise
+    finally:
+        if source_descriptor >= 0:
+            os.close(source_descriptor)
+        if registered_descriptor >= 0:
+            os.close(registered_descriptor)
+        if registered_directory_descriptor >= 0:
+            os.close(registered_directory_descriptor)
+
+
+def _rpc_result(request_id: object, result: object) -> bytes:
+    return (
+        json.dumps(
+            {"jsonrpc": "2.0", "id": request_id, "result": result},
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        + b"\n"
+    )
+
+
+def _rpc_error(
+    request_id: object,
+    code: int,
+    message: str,
+    *,
+    reason: str,
+    retryable: bool = False,
+) -> bytes:
+    return (
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "error": {
+                    "code": code,
+                    "message": message,
+                    "data": {"reason": reason, "retryable": retryable},
+                },
+            },
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        + b"\n"
+    )
+
+
+def _validate_handshake(adapter_id: str, value: object) -> None:
+    if not isinstance(value, dict) or set(value) != {
+        "project_id",
+        "contract_version",
+        "tool_schema_sha256",
+        "limits",
+    }:
+        raise SandboxEngineError("Browser handshake denied.", code="browser_handshake_contract_mismatch")
+    if value.get("project_id") != adapter_id:
+        raise SandboxEngineError("Browser handshake denied.", code="browser_handshake_project_mismatch")
+    if value.get("contract_version") != CONTRACT_VERSION:
+        raise SandboxEngineError("Browser handshake denied.", code="browser_handshake_version_mismatch")
+    if value.get("tool_schema_sha256") != BROWSER_SCHEMA_SHA256.get(adapter_id):
+        raise SandboxEngineError("Browser handshake denied.", code="browser_handshake_schema_mismatch")
+    if value.get("limits") != BROWSER_LIMITS:
+        raise SandboxEngineError("Browser handshake denied.", code="browser_handshake_limits_mismatch")
+
+
+async def _read_json_line(
+    reader: asyncio.StreamReader,
+    *,
+    limit: int = MAX_REQUEST_BYTES,
+) -> dict[str, Any]:
+    raw = await reader.readline()
+    if not raw or len(raw) > limit:
+        raise SandboxEngineError("Request is empty or too large.", code="invalid_request")
+    try:
+        value = json.loads(raw.decode("utf-8"))
+    except (UnicodeError, json.JSONDecodeError) as exc:
+        raise SandboxEngineError("Request JSON is invalid.", code="invalid_request") from exc
+    if not isinstance(value, dict):
+        raise SandboxEngineError("Request must be an object.", code="invalid_request")
+    return value
+
+
+async def _relay(source: asyncio.StreamReader, destination: asyncio.StreamWriter) -> None:
+    try:
+        while True:
+            chunk = await source.read(64 * 1024)
+            if not chunk:
+                break
+            destination.write(chunk)
+            await destination.drain()
+    except (ConnectionError, OSError):
+        pass
+    finally:
+        try:
+            destination.write_eof()
+        except (AttributeError, ConnectionError, OSError):
+            pass
+
+
+async def _close_writer(writer: asyncio.StreamWriter) -> None:
+    writer.close()
+    try:
+        await asyncio.wait_for(writer.wait_closed(), timeout=1)
+    except (asyncio.TimeoutError, ConnectionError, OSError):
+        pass
+
+
+def _synthetic_dns_enabled() -> bool:
+    return os.getenv("MCP_BROWSER_ALLOW_SYNTHETIC_DNS", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _parse_doh_answers(payload: object, record_type: str) -> tuple[str, ...]:
+    expected_type = {"A": 1, "AAAA": 28}.get(record_type)
+    if expected_type is None or not isinstance(payload, dict):
+        raise BrowserPolicyError("browser_dns_answer_invalid")
+    status = payload.get("Status")
+    if not isinstance(status, int) or isinstance(status, bool):
+        raise BrowserPolicyError("browser_dns_answer_invalid")
+    if status != 0:
+        raise BrowserPolicyError("browser_dns_failed")
+    answers = payload.get("Answer", [])
+    if not isinstance(answers, list) or len(answers) > DOH_MAX_ANSWERS:
+        raise BrowserPolicyError("browser_dns_answer_invalid")
+    addresses: list[str] = []
+    for answer in answers:
+        if not isinstance(answer, dict):
+            raise BrowserPolicyError("browser_dns_answer_invalid")
+        answer_type = answer.get("type")
+        if not isinstance(answer_type, int) or isinstance(answer_type, bool):
+            raise BrowserPolicyError("browser_dns_answer_invalid")
+        if answer_type != expected_type:
+            continue
+        raw_address = answer.get("data")
+        if not isinstance(raw_address, str) or not raw_address:
+            raise BrowserPolicyError("browser_dns_answer_invalid")
+        try:
+            address = ipaddress.ip_address(raw_address)
+        except ValueError as exc:
+            raise BrowserPolicyError("browser_dns_answer_invalid") from exc
+        if (record_type == "A") != isinstance(address, ipaddress.IPv4Address):
+            raise BrowserPolicyError("browser_dns_answer_invalid")
+        addresses.append(str(address))
+    return tuple(dict.fromkeys(addresses))
+
+
+async def _read_doh_http_body(reader: asyncio.StreamReader) -> bytes:
+    try:
+        header_block = await reader.readuntil(b"\r\n\r\n")
+    except (asyncio.IncompleteReadError, asyncio.LimitOverrunError) as exc:
+        raise BrowserPolicyError("browser_dns_failed") from exc
+    if len(header_block) > DOH_MAX_HEADER_BYTES:
+        raise BrowserPolicyError("browser_dns_answer_invalid")
+    lines = header_block[:-4].split(b"\r\n")
+    if not lines or lines[0] not in {b"HTTP/1.1 200 OK", b"HTTP/1.0 200 OK"}:
+        raise BrowserPolicyError("browser_dns_failed")
+    selected_headers: dict[bytes, bytes] = {}
+    selected_names = {
+        b"content-length",
+        b"content-type",
+        b"content-encoding",
+        b"transfer-encoding",
+    }
+    for line in lines[1:]:
+        if b":" not in line:
+            raise BrowserPolicyError("browser_dns_answer_invalid")
+        name, value = line.split(b":", 1)
+        name = name.strip().lower()
+        value = value.strip().lower()
+        if not name or any(byte < 33 or byte > 126 for byte in name):
+            raise BrowserPolicyError("browser_dns_answer_invalid")
+        if name in selected_names:
+            if name in selected_headers:
+                raise BrowserPolicyError("browser_dns_answer_invalid")
+            selected_headers[name] = value
+    content_type = selected_headers.get(b"content-type", b"")
+    if not content_type.startswith(b"application/dns-json"):
+        raise BrowserPolicyError("browser_dns_answer_invalid")
+    if selected_headers.get(b"content-encoding"):
+        raise BrowserPolicyError("browser_dns_answer_invalid")
+    transfer_encoding = selected_headers.get(b"transfer-encoding", b"")
+    content_length = selected_headers.get(b"content-length")
+    if transfer_encoding:
+        if transfer_encoding != b"chunked" or content_length is not None:
+            raise BrowserPolicyError("browser_dns_answer_invalid")
+        body = bytearray()
+        while True:
+            try:
+                size_line = await reader.readuntil(b"\r\n")
+            except (asyncio.IncompleteReadError, asyncio.LimitOverrunError) as exc:
+                raise BrowserPolicyError("browser_dns_failed") from exc
+            if len(size_line) > 128:
+                raise BrowserPolicyError("browser_dns_answer_invalid")
+            size_token = size_line[:-2].split(b";", 1)[0]
+            try:
+                chunk_size = int(size_token, 16)
+            except ValueError as exc:
+                raise BrowserPolicyError("browser_dns_answer_invalid") from exc
+            if chunk_size < 0 or len(body) + chunk_size > DOH_MAX_BODY_BYTES:
+                raise BrowserPolicyError("browser_dns_answer_invalid")
+            if chunk_size == 0:
+                trailer_size = 0
+                while True:
+                    try:
+                        trailer_line = await reader.readuntil(b"\r\n")
+                    except (
+                        asyncio.IncompleteReadError,
+                        asyncio.LimitOverrunError,
+                    ) as exc:
+                        raise BrowserPolicyError("browser_dns_failed") from exc
+                    trailer_size += len(trailer_line)
+                    if trailer_size > DOH_MAX_HEADER_BYTES:
+                        raise BrowserPolicyError("browser_dns_answer_invalid")
+                    if trailer_line == b"\r\n":
+                        break
+                break
+            try:
+                body.extend(await reader.readexactly(chunk_size))
+                if await reader.readexactly(2) != b"\r\n":
+                    raise BrowserPolicyError("browser_dns_answer_invalid")
+            except asyncio.IncompleteReadError as exc:
+                raise BrowserPolicyError("browser_dns_failed") from exc
+        return bytes(body)
+    if content_length is not None:
+        try:
+            length = int(content_length)
+        except ValueError as exc:
+            raise BrowserPolicyError("browser_dns_answer_invalid") from exc
+        if length < 0 or length > DOH_MAX_BODY_BYTES:
+            raise BrowserPolicyError("browser_dns_answer_invalid")
+        try:
+            return await reader.readexactly(length)
+        except asyncio.IncompleteReadError as exc:
+            raise BrowserPolicyError("browser_dns_failed") from exc
+    body = await reader.read(DOH_MAX_BODY_BYTES + 1)
+    if len(body) > DOH_MAX_BODY_BYTES:
+        raise BrowserPolicyError("browser_dns_answer_invalid")
+    return body
+
+
+async def _query_doh_once(
+    resolver_address: str,
+    resolver_name: str,
+    host: str,
+    record_type: str,
+) -> tuple[str, ...]:
+    writer: asyncio.StreamWriter | None = None
+
+    async def query() -> tuple[str, ...]:
+        nonlocal writer
+        context = ssl.create_default_context()
+        context.minimum_version = ssl.TLSVersion.TLSv1_2
+        reader, writer = await asyncio.open_connection(
+            resolver_address,
+            443,
+            ssl=context,
+            server_hostname=resolver_name,
+        )
+        target = f"/dns-query?name={quote(host, safe='')}&type={record_type}"
+        request = (
+            f"GET {target} HTTP/1.1\r\n"
+            f"Host: {resolver_name}\r\n"
+            "Accept: application/dns-json\r\n"
+            "Connection: close\r\n\r\n"
+        ).encode("ascii")
+        writer.write(request)
+        await writer.drain()
+        body = await _read_doh_http_body(reader)
+        try:
+            payload = json.loads(body.decode("utf-8"))
+        except (UnicodeError, json.JSONDecodeError) as exc:
+            raise BrowserPolicyError("browser_dns_answer_invalid") from exc
+        return _parse_doh_answers(payload, record_type)
+
+    try:
+        return await asyncio.wait_for(query(), timeout=DNS_TIMEOUT_SECONDS)
+    except asyncio.TimeoutError as exc:
+        raise BrowserPolicyError("browser_dns_timeout") from exc
+    except BrowserPolicyError:
+        raise
+    except (ConnectionError, OSError, ssl.SSLError) as exc:
+        raise BrowserPolicyError("browser_dns_failed") from exc
+    finally:
+        if writer is not None:
+            await _close_writer(writer)
+
+
+async def _resolve_fixed_doh(host: str) -> tuple[str, ...]:
+    failures: list[str] = []
+    for resolver_address, resolver_name in DOH_RESOLVERS:
+        try:
+            ipv4 = await _query_doh_once(
+                resolver_address, resolver_name, host, "A"
+            )
+            ipv6 = await _query_doh_once(
+                resolver_address, resolver_name, host, "AAAA"
+            )
+            return validate_pinned_addresses((*ipv4, *ipv6))
+        except BrowserPolicyError as exc:
+            reason = str(exc)
+            if reason in {
+                "browser_private_dns_denied",
+                "browser_dns_mixed_or_synthetic_denied",
+            }:
+                raise
+            failures.append(reason)
+    if failures and all(reason == "browser_dns_timeout" for reason in failures):
+        raise BrowserPolicyError("browser_dns_timeout")
+    raise BrowserPolicyError("browser_dns_failed")
+
+
+async def _terminate_process_group(process: asyncio.subprocess.Process) -> None:
+    """Terminate the upstream process group, including Chromium descendants."""
+
+    if process.returncode is not None:
+        return
+    try:
+        if os.name == "posix":
+            os.killpg(process.pid, signal.SIGTERM)
+        else:
+            process.terminate()
+    except ProcessLookupError:
+        pass
+    try:
+        await asyncio.wait_for(process.wait(), timeout=3)
+        return
+    except asyncio.TimeoutError:
+        pass
+    try:
+        if os.name == "posix":
+            os.killpg(process.pid, signal.SIGKILL)
+        else:
+            process.kill()
+    except ProcessLookupError:
+        pass
+    try:
+        await asyncio.wait_for(process.wait(), timeout=2)
+    except asyncio.TimeoutError:
+        # The supervisor is PID1 in production; returning lets container exit
+        # destroy any descendant that escaped the original process group.
+        return
+
+
+@dataclass(slots=True)
+class EgressGrant:
+    origin: str = ""
+    host: str = ""
+    port: int = 0
+    expires_at: float = 0.0
+    active_tunnels: int = 0
+    transferred_bytes: int = 0
+
+
+async def _relay_limited(
+    source: asyncio.StreamReader,
+    destination: asyncio.StreamWriter,
+    service: "BrowserEgressService",
+    capability: str,
+    deadline: float,
+    expected_sni: str | None = None,
+) -> None:
+    if expected_sni is not None:
+        records = bytearray()
+        handshake = bytearray()
+        try:
+            for _ in range(4):
+                remaining = deadline - time.monotonic()
+                header = await asyncio.wait_for(
+                    source.readexactly(5),
+                    timeout=min(EGRESS_TUNNEL_IDLE_SECONDS, remaining),
+                )
+                record_length = int.from_bytes(header[3:5], "big")
+                if header[0] != 22 or record_length <= 0 or record_length > 18 * 1024:
+                    raise BrowserPolicyError("browser_tls_client_hello_invalid")
+                body = await asyncio.wait_for(
+                    source.readexactly(record_length),
+                    timeout=min(EGRESS_TUNNEL_IDLE_SECONDS, remaining),
+                )
+                records.extend(header)
+                records.extend(body)
+                handshake.extend(body)
+                if len(records) > 64 * 1024:
+                    raise BrowserPolicyError("browser_tls_client_hello_invalid")
+                if len(handshake) >= 4:
+                    expected_length = 4 + int.from_bytes(handshake[1:4], "big")
+                    if expected_length <= len(handshake):
+                        break
+            else:
+                raise BrowserPolicyError("browser_tls_client_hello_invalid")
+        except (asyncio.IncompleteReadError, asyncio.TimeoutError) as exc:
+            await service.revoke(capability, "browser_tls_client_hello_invalid")
+            raise BrowserPolicyError("browser_tls_client_hello_invalid") from exc
+        try:
+            sni = _client_hello_sni(bytes(handshake[:expected_length]))
+        except BrowserPolicyError as exc:
+            await service.revoke(capability, str(exc))
+            raise
+        if sni != expected_sni:
+            await service.revoke(capability, "browser_tls_sni_denied")
+            raise BrowserPolicyError("browser_tls_sni_denied")
+        await service.consume(capability, len(records))
+        destination.write(records)
+        await destination.drain()
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            await service.revoke(capability, "browser_egress_tunnel_deadline")
+            raise BrowserPolicyError("browser_egress_tunnel_deadline")
+        try:
+            chunk = await asyncio.wait_for(
+                source.read(64 * 1024),
+                timeout=min(EGRESS_TUNNEL_IDLE_SECONDS, remaining),
+            )
+        except asyncio.TimeoutError as exc:
+            raise BrowserPolicyError("browser_egress_tunnel_idle") from exc
+        if not chunk:
+            break
+        await service.consume(capability, len(chunk))
+        destination.write(chunk)
+        await destination.drain()
+
+
+def _client_hello_sni(data: bytes) -> str:
+    """Parse a bounded reassembled TLS ClientHello handshake."""
+
+    hello = memoryview(data)
+    if len(hello) < 42 or hello[0] != 1:
+        raise BrowserPolicyError("browser_tls_client_hello_invalid")
+    handshake_length = int.from_bytes(hello[1:4], "big")
+    if handshake_length + 4 > len(hello):
+        raise BrowserPolicyError("browser_tls_client_hello_invalid")
+    offset = 4 + 2 + 32
+    session_length = int(hello[offset])
+    offset += 1 + session_length
+    if offset + 2 > len(hello):
+        raise BrowserPolicyError("browser_tls_client_hello_invalid")
+    cipher_length = int.from_bytes(hello[offset : offset + 2], "big")
+    offset += 2 + cipher_length
+    if offset >= len(hello):
+        raise BrowserPolicyError("browser_tls_client_hello_invalid")
+    compression_length = int(hello[offset])
+    offset += 1 + compression_length
+    if offset + 2 > len(hello):
+        raise BrowserPolicyError("browser_tls_client_hello_invalid")
+    extensions_length = int.from_bytes(hello[offset : offset + 2], "big")
+    offset += 2
+    end = offset + extensions_length
+    if end > len(hello):
+        raise BrowserPolicyError("browser_tls_client_hello_invalid")
+    found_sni: str | None = None
+    seen_sni_extension = False
+    while offset + 4 <= end:
+        extension_type = int.from_bytes(hello[offset : offset + 2], "big")
+        extension_length = int.from_bytes(hello[offset + 2 : offset + 4], "big")
+        offset += 4
+        extension_end = offset + extension_length
+        if extension_end > end:
+            raise BrowserPolicyError("browser_tls_client_hello_invalid")
+        if extension_type == 0xFE0D:
+            raise BrowserPolicyError("browser_tls_ech_denied")
+        if extension_type == 0:
+            if seen_sni_extension:
+                raise BrowserPolicyError("browser_tls_sni_denied")
+            seen_sni_extension = True
+            if extension_length < 5:
+                raise BrowserPolicyError("browser_tls_sni_denied")
+            names_length = int.from_bytes(hello[offset : offset + 2], "big")
+            cursor = offset + 2
+            names_end = cursor + names_length
+            if names_end != extension_end:
+                raise BrowserPolicyError("browser_tls_sni_denied")
+            while cursor + 3 <= names_end:
+                name_type = int(hello[cursor])
+                name_length = int.from_bytes(hello[cursor + 1 : cursor + 3], "big")
+                cursor += 3
+                raw_name = bytes(hello[cursor : cursor + name_length])
+                cursor += name_length
+                if name_type == 0:
+                    if found_sni is not None:
+                        raise BrowserPolicyError("browser_tls_sni_denied")
+                    try:
+                        found_sni = raw_name.decode("ascii").lower().rstrip(".")
+                    except UnicodeError as exc:
+                        raise BrowserPolicyError("browser_tls_sni_denied") from exc
+            if cursor != names_end:
+                raise BrowserPolicyError("browser_tls_sni_denied")
+        offset = extension_end
+    if offset != end or found_sni is None:
+        raise BrowserPolicyError("browser_tls_sni_denied")
+    return found_sni
+
+
+class BrowserEgressService:
+    """Internet-connected half of the fail-closed browser proxy."""
+
+    def __init__(self, control_key: str) -> None:
+        self.control_key = control_key
+        self.grants: dict[str, EgressGrant] = {}
+        self.lock = asyncio.Lock()
+        self.watchers: set[asyncio.StreamWriter] = set()
+        self.tunnel_writers: set[asyncio.StreamWriter] = set()
+        self.shutdown_event = asyncio.Event()
+        self.watcher_ready = asyncio.Event()
+        self._watcher_claimed = False
+        self._shutting_down = False
+
+    async def shutdown(self) -> None:
+        """Revoke every grant, close active tunnels, and stop the egress PID1."""
+
+        async with self.lock:
+            if self._shutting_down:
+                return
+            self._shutting_down = True
+            self.grants.clear()
+            writers = tuple(self.tunnel_writers)
+            self.tunnel_writers.clear()
+        for tunnel_writer in writers:
+            tunnel_writer.close()
+        if writers:
+            await asyncio.gather(
+                *(_close_writer(tunnel_writer) for tunnel_writer in writers),
+                return_exceptions=True,
+            )
+        self.shutdown_event.set()
+
+    async def resolve(self, host: str, port: int) -> tuple[str, ...]:
+        # Synthetic fixture DNS is an explicit acceptance-only mode. Production
+        # resolution bypasses host DNS entirely because Docker Desktop may
+        # return synthetic 198.18/15 answers even when a public resolver is set.
+        if not _synthetic_dns_enabled():
+            return await _resolve_fixed_doh(host)
+        try:
+            records = await asyncio.wait_for(
+                asyncio.get_running_loop().getaddrinfo(
+                    host,
+                    port,
+                    type=socket.SOCK_STREAM,
+                    proto=socket.IPPROTO_TCP,
+                ),
+                timeout=DNS_TIMEOUT_SECONDS,
+            )
+        except asyncio.TimeoutError as exc:
+            raise BrowserPolicyError("browser_dns_timeout") from exc
+        except socket.gaierror as exc:
+            raise BrowserPolicyError("browser_dns_failed") from exc
+        return validate_pinned_records(records)
+
+    async def _notify(self, capability: str, reason: str) -> None:
+        payload = json.dumps(
+            {"event": "revoked", "capability": capability, "reason": reason},
+            separators=(",", ":"),
+        ).encode("utf-8") + b"\n"
+        stale: list[asyncio.StreamWriter] = []
+        for watcher in tuple(self.watchers):
+            try:
+                watcher.write(payload)
+                await asyncio.wait_for(watcher.drain(), timeout=1)
+            except (asyncio.TimeoutError, ConnectionError, OSError):
+                stale.append(watcher)
+        for watcher in stale:
+            self.watchers.discard(watcher)
+        if stale:
+            await asyncio.gather(
+                *(_close_writer(watcher) for watcher in stale),
+                return_exceptions=True,
+            )
+            await self.shutdown()
+
+    async def revoke(self, capability: str, reason: str) -> None:
+        async with self.lock:
+            existed = self.grants.pop(capability, None) is not None
+        if existed:
+            await self._notify(capability, reason)
+
+    async def consume(self, capability: str, amount: int) -> None:
+        exceeded = False
+        async with self.lock:
+            grant = self._grant(capability)
+            if amount < 0 or grant.transferred_bytes + amount > MAX_EGRESS_BYTES_PER_SESSION:
+                self.grants.pop(capability, None)
+                exceeded = True
+            else:
+                grant.transferred_bytes += amount
+        if exceeded:
+            await self._notify(capability, "browser_egress_byte_budget")
+            raise BrowserPolicyError("browser_egress_byte_budget")
+
+    async def _authenticate_control(self, request: dict[str, Any]) -> None:
+        if not secrets.compare_digest(str(request.get("control_key") or ""), self.control_key):
+            raise SandboxEngineError("Egress control denied.", code="browser_egress_control_denied")
+
+    async def handle(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        tunnel = False
+        shutdown_after_response = False
+        try:
+            request = await _read_json_line(reader)
+            action = str(request.get("action") or "")
+            if action == "health":
+                response = {
+                    "ok": True,
+                    "protocol": "modelmirror-browser-egress-v1",
+                    "active_grants": len(self.grants),
+                    "max_tunnels_per_session": MAX_EGRESS_TUNNELS_PER_SESSION,
+                    "max_bytes_per_session": MAX_EGRESS_BYTES_PER_SESSION,
+                }
+            elif action == "watch":
+                await self._authenticate_control(request)
+                async with self.lock:
+                    if self._watcher_claimed or self._shutting_down:
+                        raise SandboxEngineError(
+                            "Egress watcher already consumed.",
+                            code="browser_egress_watcher_consumed",
+                        )
+                    self._watcher_claimed = True
+                    self.watchers.add(writer)
+                try:
+                    writer.write(b'{"ok":true,"protocol":"modelmirror-browser-egress-v1"}\n')
+                    await asyncio.wait_for(writer.drain(), timeout=2)
+                    self.watcher_ready.set()
+                    await reader.read()
+                finally:
+                    self.watchers.discard(writer)
+                    await _close_writer(writer)
+                    await self.shutdown()
+                return
+            elif action == "register":
+                await self._authenticate_control(request)
+                capability = str(request.get("capability") or "")
+                if len(capability) != 64:
+                    raise SandboxEngineError("Egress capability invalid.", code="browser_egress_capability_invalid")
+                async with self.lock:
+                    if self._shutting_down:
+                        raise SandboxEngineError(
+                            "Egress is shutting down.", code="browser_egress_unavailable"
+                        )
+                    self._purge()
+                    if capability not in self.grants and len(self.grants) >= MAX_SESSIONS:
+                        raise SandboxEngineError("Egress session limit reached.", code="browser_session_limit")
+                    self.grants[capability] = EgressGrant(
+                        expires_at=time.monotonic() + SESSION_TTL_SECONDS
+                    )
+                response = {"ok": True, "protocol": "modelmirror-browser-egress-v1"}
+            elif action == "authorize":
+                await self._authenticate_control(request)
+                capability = str(request.get("capability") or "")
+                normalized, origin, host, port = validate_browser_url(request.get("url"))
+                del normalized
+                # Validate every DNS answer at authorization time and again at
+                # connection time to close DNS rebinding races.
+                await self.resolve(host, port)
+                async with self.lock:
+                    grant = self._grant(capability)
+                    if grant.origin and (origin, host, port) != (
+                        grant.origin,
+                        grant.host,
+                        grant.port,
+                    ):
+                        raise SandboxEngineError(
+                            "Cross-origin authorization denied.",
+                            code="browser_cross_origin_denied",
+                        )
+                    grant.origin = origin
+                    grant.host = host
+                    grant.port = port
+                response = {"ok": True, "protocol": "modelmirror-browser-egress-v1"}
+            elif action == "revoke":
+                await self._authenticate_control(request)
+                await self.revoke(str(request.get("capability") or ""), "browser_session_closed")
+                response = {"ok": True, "protocol": "modelmirror-browser-egress-v1"}
+            elif action == "shutdown":
+                await self._authenticate_control(request)
+                response = {"ok": True, "protocol": "modelmirror-browser-egress-v1"}
+                shutdown_after_response = True
+            elif action == "connect":
+                capability = str(request.get("capability") or "")
+                normalized, origin, host, port = validate_browser_url(request.get("url"), allow_login_path=True)
+                del normalized
+                async with self.lock:
+                    grant = self._grant(capability)
+                    if (origin, host, port) != (grant.origin, grant.host, grant.port):
+                        raise SandboxEngineError("Cross-origin egress denied.", code="browser_cross_origin_denied")
+                    if grant.active_tunnels >= MAX_EGRESS_TUNNELS_PER_SESSION:
+                        raise SandboxEngineError("Egress tunnel limit reached.", code="browser_egress_tunnel_limit")
+                    grant.active_tunnels += 1
+                    self.tunnel_writers.add(writer)
+                remote_writer: asyncio.StreamWriter | None = None
+                try:
+                    addresses = await self.resolve(host, port)
+                    remote_reader, remote_writer = await asyncio.wait_for(
+                        asyncio.open_connection(addresses[0], port), timeout=10
+                    )
+                    self.tunnel_writers.add(remote_writer)
+                    # Re-check after DNS and connect, before acknowledging the
+                    # tunnel.  A concurrent revoke/expiry must close the newly
+                    # opened remote socket without forwarding a byte.
+                    async with self.lock:
+                        current = self._grant(capability)
+                        if (origin, host, port) != (
+                            current.origin,
+                            current.host,
+                            current.port,
+                        ):
+                            raise SandboxEngineError(
+                                "Cross-origin egress denied.",
+                                code="browser_cross_origin_denied",
+                            )
+                    writer.write(b'{"ok":true,"protocol":"modelmirror-browser-egress-v1"}\n')
+                    await writer.drain()
+                    tunnel = True
+                    deadline = time.monotonic() + EGRESS_TUNNEL_TTL_SECONDS
+                    tasks = [
+                        asyncio.create_task(
+                            _relay_limited(
+                                reader,
+                                remote_writer,
+                                self,
+                                capability,
+                                deadline,
+                                expected_sni=host if origin.startswith("https://") else None,
+                            )
+                        ),
+                        asyncio.create_task(
+                            _relay_limited(remote_reader, writer, self, capability, deadline)
+                        ),
+                    ]
+                    done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+                    for task in pending:
+                        task.cancel()
+                    results = await asyncio.gather(*done, *pending, return_exceptions=True)
+                    for result in results:
+                        if isinstance(result, BrowserPolicyError):
+                            raise result
+                    return
+                finally:
+                    async with self.lock:
+                        grant = self.grants.get(capability)
+                        if grant is not None:
+                            grant.active_tunnels = max(0, grant.active_tunnels - 1)
+                        self.tunnel_writers.discard(writer)
+                        if remote_writer is not None:
+                            self.tunnel_writers.discard(remote_writer)
+                    if remote_writer is not None:
+                        await _close_writer(remote_writer)
+                    if tunnel:
+                        await _close_writer(writer)
+            else:
+                raise SandboxEngineError("Egress action denied.", code="action_denied")
+        except BrowserPolicyError as exc:
+            response = {"ok": False, "code": str(exc), "error": "browser_egress_denied"}
+        except SandboxEngineError as exc:
+            response = {"ok": False, "code": exc.code, "error": "browser_egress_denied"}
+        except (asyncio.TimeoutError, ConnectionError, OSError):
+            response = {"ok": False, "code": "browser_egress_unavailable", "error": "browser_egress_denied"}
+        if not tunnel:
+            try:
+                writer.write(json.dumps(response, separators=(",", ":")).encode("utf-8") + b"\n")
+                await asyncio.wait_for(writer.drain(), timeout=2)
+            except (asyncio.TimeoutError, ConnectionError, OSError):
+                pass
+            finally:
+                await _close_writer(writer)
+                if shutdown_after_response:
+                    await self.shutdown()
+
+    def _purge(self) -> None:
+        now = time.monotonic()
+        for capability in [key for key, grant in self.grants.items() if grant.expires_at <= now]:
+            self.grants.pop(capability, None)
+
+    def _grant(self, capability: str) -> EgressGrant:
+        if self._shutting_down:
+            raise SandboxEngineError("Egress is shutting down.", code="browser_egress_unavailable")
+        self._purge()
+        grant = self.grants.get(capability)
+        if grant is None:
+            raise SandboxEngineError("Egress capability denied.", code="browser_egress_capability_denied")
+        return grant
+
+
+class BrowserEgressClient:
+    def __init__(self, control_key: str) -> None:
+        self.control_key = control_key
+        self.capability = secrets.token_hex(32)
+        self.revocation_reason = ""
+
+    async def _control(self, action: str, **values: object) -> None:
+        writer: asyncio.StreamWriter | None = None
+        try:
+            reader, writer = await asyncio.wait_for(
+                asyncio.open_unix_connection(str(EGRESS_SOCKET_PATH)), timeout=2
+            )
+            request = {
+                "action": action,
+                "control_key": self.control_key,
+                "capability": self.capability,
+                **values,
+            }
+            writer.write(json.dumps(request, separators=(",", ":")).encode("utf-8") + b"\n")
+            await asyncio.wait_for(writer.drain(), timeout=2)
+            response = await asyncio.wait_for(
+                _read_json_line(reader, limit=4096), timeout=2
+            )
+        finally:
+            if writer is not None:
+                await _close_writer(writer)
+        if response.get("ok") is not True:
+            raise BrowserPolicyError(str(response.get("code") or "browser_egress_unavailable"))
+
+    async def register(self) -> None:
+        await self._control("register")
+        EGRESS_CLIENTS[self.capability] = self
+
+    async def authorize(self, url: str) -> None:
+        await self._control("authorize", url=url)
+
+    async def revoke(self) -> None:
+        try:
+            await self._control("revoke")
+        except (asyncio.TimeoutError, BrowserPolicyError, ConnectionError, OSError):
+            pass
+        finally:
+            EGRESS_CLIENTS.pop(self.capability, None)
+
+    async def open_tunnel(self, url: str) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+        writer: asyncio.StreamWriter | None = None
+        try:
+            reader, writer = await asyncio.wait_for(
+                asyncio.open_unix_connection(str(EGRESS_SOCKET_PATH)), timeout=2
+            )
+            writer.write(
+                json.dumps(
+                    {"action": "connect", "capability": self.capability, "url": url},
+                    separators=(",", ":"),
+                ).encode("utf-8")
+                + b"\n"
+            )
+            await asyncio.wait_for(writer.drain(), timeout=2)
+            response = await asyncio.wait_for(
+                _read_json_line(reader, limit=4096), timeout=10
+            )
+            if response.get("ok") is not True:
+                raise BrowserPolicyError(
+                    str(response.get("code") or "browser_egress_unavailable")
+                )
+            return reader, writer
+        except BaseException:
+            if writer is not None:
+                await _close_writer(writer)
+            raise
+
+
+EGRESS_CLIENTS: dict[str, BrowserEgressClient] = {}
+
+
+async def _watch_egress(control_key: str, ready: asyncio.Event) -> None:
+    """Exit the browser supervisor when egress restarts or becomes unavailable."""
+
+    reader, writer = await asyncio.wait_for(
+        asyncio.open_unix_connection(str(EGRESS_SOCKET_PATH)), timeout=2
+    )
+    writer.write(
+        json.dumps(
+            {"action": "watch", "control_key": control_key}, separators=(",", ":")
+        ).encode("utf-8")
+        + b"\n"
+    )
+    await asyncio.wait_for(writer.drain(), timeout=2)
+    response = await asyncio.wait_for(_read_json_line(reader, limit=4096), timeout=2)
+    if response.get("ok") is not True:
+        await _close_writer(writer)
+        raise RuntimeError("browser_egress_watch_denied")
+    ready.set()
+    try:
+        while True:
+            raw = await reader.readline()
+            if not raw:
+                raise RuntimeError("browser_egress_restarted")
+            event = json.loads(raw.decode("utf-8"))
+            if not isinstance(event, dict) or event.get("event") != "revoked":
+                continue
+            client = EGRESS_CLIENTS.get(str(event.get("capability") or ""))
+            if client is not None:
+                client.revocation_reason = str(
+                    event.get("reason") or "browser_egress_revoked"
+                )
+                fixed_event = BROWSER_PROXY_RUNTIME_EVENTS.get(
+                    client.revocation_reason
+                )
+                if fixed_event:
+                    _emit_browser_runtime_event(fixed_event)
+    finally:
+        await _close_writer(writer)
+
+
+async def _request_egress_shutdown(control_key: str) -> None:
+    """Best-effort authenticated pair shutdown after the browser PID1 stops."""
+
+    writer: asyncio.StreamWriter | None = None
+    try:
+        reader, writer = await asyncio.wait_for(
+            asyncio.open_unix_connection(str(EGRESS_SOCKET_PATH)), timeout=2
+        )
+        writer.write(
+            json.dumps(
+                {"action": "shutdown", "control_key": control_key},
+                separators=(",", ":"),
+            ).encode("utf-8")
+            + b"\n"
+        )
+        await asyncio.wait_for(writer.drain(), timeout=2)
+        await asyncio.wait_for(_read_json_line(reader, limit=4096), timeout=2)
+    except (asyncio.TimeoutError, ConnectionError, OSError, SandboxEngineError):
+        # Egress may already have exited or rotated its one-shot key.  Either
+        # case is fail-closed, and Docker will restart the pair.
+        return
+    finally:
+        if writer is not None:
+            await _close_writer(writer)
+
+
+async def _enforce_egress_watch_bootstrap(service: BrowserEgressService) -> None:
+    """Rotate the pair if the browser dies after consuming the control key."""
+
+    try:
+        await asyncio.wait_for(
+            service.watcher_ready.wait(), timeout=EGRESS_WATCH_BOOTSTRAP_SECONDS
+        )
+    except asyncio.TimeoutError:
+        await service.shutdown()
+
+
+class LoopbackBrowserProxy:
+    """Browser-facing proxy; it has no Internet route of its own."""
+
+    def __init__(self, egress: BrowserEgressClient) -> None:
+        self.egress = egress
+        self.server: asyncio.AbstractServer | None = None
+        self.origin = ""
+        self.host = ""
+        self.port = 0
+        self.last_violation = ""
+        self.last_violation_event = ""
+        self.forwarded_requests = 0
+        self.authorized_at = 0.0
+        self.suppressed_android_client_probes = 0
+
+    async def start(self) -> str:
+        self.server = await asyncio.start_server(self.handle, host="127.0.0.1", port=0)
+        socket_info = self.server.sockets[0].getsockname()
+        return f"http://127.0.0.1:{int(socket_info[1])}"
+
+    async def authorize(self, url: str) -> str:
+        normalized, origin, host, port = validate_browser_url(url)
+        if self.origin and (origin, host, port) != (self.origin, self.host, self.port):
+            raise BrowserPolicyError("browser_cross_origin_denied")
+        await self.egress.authorize(normalized)
+        self.origin, self.host, self.port = origin, host, port
+        self.last_violation = ""
+        self.last_violation_event = ""
+        self.forwarded_requests = 0
+        self.authorized_at = time.monotonic()
+        self.suppressed_android_client_probes = 0
+        return normalized
+
+    def _suppress_blocked_android_client_probe(
+        self, method: str, target: str, event: str, remote_writer: object | None
+    ) -> bool:
+        """Keep a small bounded set of Chrome GCM retries blocked without taint.
+
+        The request has already failed the exact-origin check, so this never
+        reaches DNS or the egress service.  A fifth attempt, another method,
+        another authority, or an attempt outside the bounded bootstrap window
+        retains the normal fail-closed taint behavior.
+        """
+
+        age = time.monotonic() - self.authorized_at
+        if not (
+            remote_writer is None
+            and method.upper() == "CONNECT"
+            and target.lower() == "android.clients.google.com:443"
+            and event == "proxy_policy_cross_origin_android_client_after_forward"
+            and self.forwarded_requests > 0
+            and self.suppressed_android_client_probes < 4
+            and 0 <= age <= 180
+        ):
+            return False
+        self.suppressed_android_client_probes += 1
+        _emit_browser_runtime_event(
+            "proxy_policy_android_client_background_blocked_no_taint"
+        )
+        return True
+
+    def _cross_origin_event(self, method: str, target: str) -> str:
+        """Classify only the mismatch shape; never retain or emit the target."""
+
+        from urllib.parse import urlsplit
+
+        relation = "unknown"
+        try:
+            candidate = f"https://{target}/" if method.upper() == "CONNECT" else target
+            split = urlsplit(candidate)
+            scheme = split.scheme.lower()
+            host = (split.hostname or "").lower().rstrip(".")
+            port = split.port or (443 if scheme == "https" else 80)
+            expected_scheme = self.origin.split(":", 1)[0]
+            if host != self.host:
+                relation = BROWSER_BACKGROUND_HOST_CATEGORIES.get(host, "")
+                if relation == "google_home":
+                    if method.upper() == "CONNECT":
+                        relation = "google_home_connect"
+                    elif split.path.startswith("/searchdomaincheck"):
+                        relation = "search_domain"
+                    elif split.path.endswith(("/generate_204", "/gen_204")):
+                        relation = "connectivity"
+                    elif split.path.startswith("/complete/"):
+                        relation = "search_suggest"
+                    elif split.path.startswith(("/chrome/", "/_/Chrome")):
+                        relation = "google_chrome_service"
+                    elif split.path.endswith("/favicon.ico"):
+                        relation = "google_favicon"
+                    elif split.path in {"", "/"}:
+                        relation = "google_home_root"
+                    else:
+                        relation = "google_home_other"
+                if not relation:
+                    relation = next(
+                        (
+                            category
+                            for suffix, category in BROWSER_VENDOR_SUFFIX_CATEGORIES.items()
+                            if host == suffix or host.endswith(f".{suffix}")
+                        ),
+                        "external_host",
+                    )
+            elif scheme != expected_scheme:
+                relation = "scheme"
+            elif port != self.port:
+                relation = "port"
+        except (TypeError, ValueError):
+            relation = "unknown"
+        phase = "after_forward" if self.forwarded_requests else "before_forward"
+        return f"proxy_policy_cross_origin_{relation}_{phase}"
+
+    def _target(self, url: str, *, allow_login_path: bool = False) -> tuple[str, str, str, int]:
+        normalized, origin, host, port = validate_browser_url(url, allow_login_path=allow_login_path)
+        if not self.origin:
+            raise BrowserPolicyError("browser_origin_not_set")
+        if (origin, host, port) != (self.origin, self.host, self.port):
+            raise BrowserPolicyError("browser_cross_origin_denied")
+        return normalized, origin, host, port
+
+    async def handle(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        remote_writer: asyncio.StreamWriter | None = None
+        method = ""
+        target = ""
+        try:
+            request_line = await asyncio.wait_for(reader.readline(), timeout=10)
+            if not request_line or len(request_line) > 8192:
+                raise BrowserPolicyError("browser_proxy_request_invalid")
+            header_bytes = bytearray()
+            while True:
+                line = await asyncio.wait_for(reader.readline(), timeout=10)
+                if not line:
+                    raise BrowserPolicyError("browser_proxy_request_invalid")
+                header_bytes.extend(line)
+                if len(header_bytes) > MAX_PROXY_HEADER_BYTES:
+                    raise BrowserPolicyError("browser_proxy_headers_too_large")
+                if line in {b"\r\n", b"\n"}:
+                    break
+            first = request_line.decode("latin-1").strip().split(" ")
+            if len(first) != 3:
+                raise BrowserPolicyError("browser_proxy_request_invalid")
+            method, target, version = first
+            headers_text = bytes(header_bytes).decode("latin-1")
+            parsed_headers: list[tuple[str, str, str]] = []
+            for line in headers_text.splitlines():
+                if not line or ":" not in line:
+                    if line:
+                        raise BrowserPolicyError("browser_proxy_request_invalid")
+                    continue
+                raw_name, raw_value = line.split(":", 1)
+                name = raw_name.strip().lower()
+                value = raw_value.strip()
+                if not name:
+                    raise BrowserPolicyError("browser_proxy_request_invalid")
+                connection_tokens = {
+                    token.strip().lower() for token in value.split(",") if token.strip()
+                }
+                if name in {"proxy-authorization", "upgrade"} or (
+                    name == "connection" and "upgrade" in connection_tokens
+                ):
+                    raise BrowserPolicyError("browser_websocket_or_proxy_auth_denied")
+                parsed_headers.append((name, value, line))
+            if method.upper() == "CONNECT":
+                match = AUTHORITY.fullmatch(target)
+                if not match:
+                    raise BrowserPolicyError("browser_proxy_authority_invalid")
+                host = match.group("host")
+                port = int(match.group("port"))
+                normalized, _, _, _ = self._target(
+                    f"https://{host}:{port}/", allow_login_path=True
+                )
+                remote_reader, remote_writer = await self.egress.open_tunnel(normalized)
+                self.forwarded_requests += 1
+                writer.write(b"HTTP/1.1 200 Connection Established\r\nConnection: close\r\n\r\n")
+                await writer.drain()
+                tasks = [
+                    asyncio.create_task(_relay(reader, remote_writer)),
+                    asyncio.create_task(_relay(remote_reader, writer)),
+                ]
+            else:
+                if method.upper() not in {"GET", "HEAD", "POST"}:
+                    raise BrowserPolicyError("browser_http_method_denied")
+                normalized, _, _, _ = self._target(target)
+                parsed = validate_browser_url(normalized)[0]
+                from urllib.parse import urlsplit
+
+                split = urlsplit(parsed)
+                path = split.path or "/"
+                if split.query:
+                    path = f"{path}?{split.query}"
+                filtered = []
+                host_values: list[str] = []
+                for name, value, line in parsed_headers:
+                    if name == "host":
+                        host_values.append(value.lower())
+                        continue
+                    if name in {"proxy-connection", "proxy-authorization", "connection"}:
+                        continue
+                    filtered.append(line)
+                expected_host = self.host if self.port in {80, 443} else f"{self.host}:{self.port}"
+                if len(host_values) != 1 or host_values[0].rstrip(".") != expected_host:
+                    raise BrowserPolicyError("browser_http_host_mismatch")
+                filtered.append(f"Host: {expected_host}")
+                filtered.append("Connection: close")
+                remote_reader, remote_writer = await self.egress.open_tunnel(normalized)
+                self.forwarded_requests += 1
+                remote_writer.write(
+                    f"{method.upper()} {path} {version}\r\n".encode("latin-1")
+                    + "\r\n".join(filtered).encode("latin-1")
+                    + b"\r\n\r\n"
+                )
+                await remote_writer.drain()
+                tasks = [
+                    asyncio.create_task(_relay(reader, remote_writer)),
+                    asyncio.create_task(_relay(remote_reader, writer)),
+                ]
+            done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+            for task in pending:
+                task.cancel()
+            await asyncio.gather(*done, *pending, return_exceptions=True)
+        except BrowserPolicyError as exc:
+            violation = str(exc)
+            violation_event = (
+                self._cross_origin_event(method, target)
+                if violation == "browser_cross_origin_denied"
+                else _proxy_runtime_event(violation)
+            )
+            if not self._suppress_blocked_android_client_probe(
+                method, target, violation_event, remote_writer
+            ):
+                self.last_violation = violation
+                self.last_violation_event = violation_event
+            writer.write(b"HTTP/1.1 403 Forbidden\r\nConnection: close\r\nContent-Length: 0\r\n\r\n")
+            try:
+                await writer.drain()
+            except (ConnectionError, OSError):
+                pass
+        except (asyncio.TimeoutError, ConnectionError, OSError):
+            self.last_violation = "browser_egress_unavailable"
+            self.last_violation_event = "proxy_policy_egress_unavailable"
+        finally:
+            if remote_writer is not None:
+                await _close_writer(remote_writer)
+            await _close_writer(writer)
+
+    async def close(self) -> None:
+        if self.server is not None:
+            self.server.close()
+            try:
+                await asyncio.wait_for(self.server.wait_closed(), timeout=2)
+            except asyncio.TimeoutError:
+                pass
+
+
+class UpstreamRpc:
+    def __init__(
+        self,
+        process: asyncio.subprocess.Process,
+        artifact_dir: Path,
+    ) -> None:
+        if process.stdin is None or process.stdout is None:
+            raise RuntimeError("browser_upstream_stdio_unavailable")
+        self.process = process
+        self.stdin = process.stdin
+        self.stdout = process.stdout
+        self.artifact_dir = artifact_dir
+        self.counter = 0
+
+    async def notify(self, method: str, params: object | None = None) -> None:
+        payload: dict[str, object] = {"jsonrpc": "2.0", "method": method}
+        if params is not None:
+            payload["params"] = params
+        self.stdin.write(json.dumps(payload, separators=(",", ":")).encode("utf-8") + b"\n")
+        await self.stdin.drain()
+
+    async def request(
+        self,
+        method: str,
+        params: object,
+        *,
+        timeout: float = TOOL_CALL_TIMEOUT_SECONDS,
+    ) -> dict[str, Any]:
+        self.counter += 1
+        request_id = f"modelmirror-internal-{self.counter}"
+        payload = {"jsonrpc": "2.0", "id": request_id, "method": method, "params": params}
+        self.stdin.write(json.dumps(payload, separators=(",", ":")).encode("utf-8") + b"\n")
+        await self.stdin.drain()
+        deadline = asyncio.get_running_loop().time() + timeout
+        while True:
+            remaining = deadline - asyncio.get_running_loop().time()
+            if remaining <= 0:
+                raise asyncio.TimeoutError
+            raw = await asyncio.wait_for(self.stdout.readline(), timeout=remaining)
+            if not raw or len(raw) > MAX_MCP_MESSAGE_BYTES:
+                raise RuntimeError("browser_upstream_output_invalid")
+            try:
+                response = json.loads(raw.decode("utf-8"))
+            except (UnicodeError, json.JSONDecodeError):
+                continue
+            if not isinstance(response, dict):
+                continue
+            if response.get("method") == "roots/list" and response.get("id") is not None:
+                root_uri = self.artifact_dir.resolve().as_uri()
+                self.stdin.write(
+                    _rpc_result(
+                        response["id"],
+                        {"roots": [{"uri": root_uri, "name": "browser-artifacts"}]},
+                    )
+                )
+                await self.stdin.drain()
+                continue
+            if response.get("id") == request_id:
+                return response
+
+
+@dataclass(frozen=True, slots=True)
+class RefBinding:
+    generation: str
+    revision: int
+    digest: str
+    context: str
+    role: str
+    label: str
+
+
+@dataclass(slots=True)
+class BrowserSessionState:
+    adapter_id: str
+    session_id: str
+    generation: str = field(default_factory=lambda: str(uuid.uuid4()))
+    started_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    last_activity: float = field(default_factory=time.monotonic)
+    page_revision: int = 0
+    page_digest: str = field(default_factory=lambda: hashlib.sha256(b"about:blank").hexdigest())
+    current_origin: str = ""
+    action_count: int = 0
+    tainted: bool = False
+    taint_reason: str = ""
+    refs: dict[str, RefBinding] = field(default_factory=dict)
+
+    def bump(self) -> None:
+        self.page_revision += 1
+        self.refs.clear()
+        self.last_activity = time.monotonic()
+
+    def taint(self, reason: str) -> None:
+        self.tainted = True
+        self.taint_reason = reason
+        self.refs.clear()
+        self.page_revision += 1
+        self.last_activity = time.monotonic()
+
+    def status(self) -> dict[str, object]:
+        return {
+            "status": "tainted" if self.tainted else "active",
+            "generation": self.generation,
+            "page_revision": self.page_revision,
+            "page_digest": self.page_digest,
+            "current_origin": self.current_origin,
+            "action_count": self.action_count,
+            "max_actions": MAX_ACTIONS,
+            "tainted": self.tainted,
+            "expires_at": session_expiry(self.started_at),
+        }
+
+
+def _safe_element(
+    ref: str, element: SnapshotElement, digest: str
+) -> dict[str, str] | None:
+    try:
+        assert_non_sensitive_interaction(element.context)
+    except BrowserPolicyError:
+        return None
+    role = element.role
+    label = re.sub(r"\s+", " ", element.name).strip(" -\t")[:120]
+    if not label:
+        label = role
+    return {"ref": ref, "role": role, "label": label, "page_digest": digest}
+
+
+def _page_count(adapter_id: str, payload: object) -> int:
+    text = result_text(payload)
+    if adapter_id == "chrome-devtools-mcp":
+        return len(re.findall(r"(?m)^\s*[0-9]+:\s", text))
+    return len(re.findall(r"(?m)^\s*-\s*[0-9]+:\s", text))
+
+
+async def _drain_stderr(
+    stream: asyncio.StreamReader | None,
+    classifier: SafeStderrClassifier | None = None,
+) -> None:
+    if stream is None:
+        return
+    while chunk := await stream.read(4096):
+        if classifier is not None:
+            classifier.feed(chunk)
+
+
+class BrowserGatewaySession:
+    def __init__(
+        self,
+        adapter_id: str,
+        state: BrowserSessionState,
+        process: asyncio.subprocess.Process,
+        rpc: UpstreamRpc,
+        proxy: LoopbackBrowserProxy,
+        artifact_dir: Path,
+        staging_dir: Path,
+        registered_dir: Path,
+    ) -> None:
+        self.adapter_id = adapter_id
+        self.contract = BROWSER_ADAPTERS[adapter_id]
+        self.state = state
+        self.process = process
+        self.rpc = rpc
+        self.proxy = proxy
+        self.artifact_dir = artifact_dir
+        self.staging_dir = staging_dir
+        self.registered_dir = registered_dir
+        self.registered_artifacts: set[Path] = set()
+        self.unregistered_artifact_event = "unregistered_artifact"
+        self.initialize_result: dict[str, object] = {}
+
+    async def preflight(self) -> None:
+        init = await self.rpc.request(
+            "initialize",
+            {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {"roots": {"listChanged": False}},
+                "clientInfo": {"name": "ModelMirror browser gateway", "version": CONTRACT_VERSION},
+            },
+        )
+        result = init.get("result")
+        info = result.get("serverInfo") if isinstance(result, dict) else None
+        if not isinstance(info, dict) or (
+            info.get("name"), info.get("version")
+        ) != (self.contract.upstream_server_name, self.contract.upstream_server_version):
+            raise RuntimeError("browser_upstream_identity_drift")
+        self.initialize_result = dict(result)
+        await self.rpc.notify("notifications/initialized", {})
+        listing = await self.rpc.request("tools/list", {})
+        list_result = listing.get("result")
+        tools = list_result.get("tools") if isinstance(list_result, dict) else None
+        digest = upstream_schema_digest(self.adapter_id, tools)
+        if digest != UPSTREAM_SCHEMA_SHA256.get(self.adapter_id):
+            raise RuntimeError("browser_upstream_schema_drift")
+        # This representative call starts the single browser process and proves
+        # that the locked package can talk to the pinned Chromium build.
+        snapshot = await self._internal_snapshot()
+        if result_failed(snapshot):
+            category = _classify_upstream_failure(snapshot)
+            raise RuntimeError(f"browser_upstream_representative_{category}")
+        pages = await self._internal_pages()
+        if result_failed(pages) or _page_count(self.adapter_id, pages) != 1:
+            raise RuntimeError("browser_upstream_page_contract_failed")
+
+    async def _internal_snapshot(self) -> dict[str, Any]:
+        name = "take_snapshot" if self.adapter_id == "chrome-devtools-mcp" else "browser_snapshot"
+        return await self.rpc.request("tools/call", {"name": name, "arguments": {}})
+
+    async def _internal_pages(self) -> dict[str, Any]:
+        if self.adapter_id == "chrome-devtools-mcp":
+            return await self.rpc.request("tools/call", {"name": "list_pages", "arguments": {}})
+        return await self.rpc.request(
+            "tools/call", {"name": "browser_tabs", "arguments": {"action": "list"}}
+        )
+
+    async def _observe(
+        self,
+    ) -> tuple[str, dict[str, SnapshotElement], str, str, str]:
+        pages = await self._internal_pages()
+        if result_failed(pages) or _page_count(self.adapter_id, pages) != 1:
+            raise BrowserPolicyError("browser_page_count_violation")
+        snapshot = await self._internal_snapshot()
+        if result_failed(snapshot):
+            raise BrowserPolicyError("browser_snapshot_verification_failed")
+        try:
+            text, refs, observed_url, title = extract_snapshot(self.adapter_id, snapshot)
+        except SnapshotStructureError as exc:
+            await self._taint("browser_snapshot_ref_structure_invalid")
+            raise BrowserPolicyError("browser_snapshot_ref_structure_invalid") from exc
+        if len(text.encode("utf-8")) > MAX_OUTPUT_BYTES:
+            raise BrowserPolicyError("browser_output_too_large")
+        if observed_url and observed_url != "about:blank":
+            _, observed_origin, _, _ = validate_browser_url(observed_url)
+            if self.state.current_origin and observed_origin != self.state.current_origin:
+                raise BrowserPolicyError("browser_cross_origin_denied")
+        digest = page_digest(self.state.current_origin, observed_url, title, text)
+        return text, refs, observed_url, title, digest
+
+    async def _verify_bound_refs(self, refs: list[str]) -> None:
+        if not refs:
+            raise BrowserPolicyError("browser_ref_invalid")
+        for ref in refs:
+            binding = self.state.refs.get(ref)
+            if binding is None or (
+                binding.generation,
+                binding.revision,
+                binding.digest,
+            ) != (
+                self.state.generation,
+                self.state.page_revision,
+                self.state.page_digest,
+            ):
+                raise BrowserPolicyError("browser_ref_stale")
+        _, observed_refs, _, _, digest = await self._observe()
+        if digest != self.state.page_digest or any(ref not in observed_refs for ref in refs):
+            self.state.bump()
+            self.state.page_digest = digest
+            raise BrowserPolicyError("browser_state_drift")
+
+    async def _terminate_upstream(self) -> None:
+        await _terminate_process_group(self.process)
+
+    async def _taint(self, reason: str) -> None:
+        self.state.taint(reason)
+        await self._terminate_upstream()
+
+    def _purge_unregistered_artifacts(self, *, allowed_pending: Path | None = None) -> bool:
+        """Reject and best-effort remove every unregistered artifact entry.
+
+        Playwright writes downloads into its output directory.  Keeping a
+        before/after inventory around every tool call makes a click-triggered
+        download an immediate taint instead of a durable artifact escape.  The
+        inventory deliberately uses ``lstat``-style metadata and never follows
+        browser-created links.  Nested directories and special files are
+        policy violations too; they must not disappear from the inventory just
+        because ``Path.is_file()`` returns false.
+        """
+
+        unexpected = False
+        categories: set[str] = set()
+        lexical = lambda value: Path(os.path.abspath(os.fspath(value)))
+        allowed = {lexical(path) for path in self.registered_artifacts}
+        if allowed_pending is not None:
+            allowed.add(lexical(allowed_pending))
+
+        expected_directories = {
+            lexical(self.staging_dir),
+            lexical(self.registered_dir),
+        }
+        seen_directories: set[Path] = set()
+
+        def record_unexpected(path: Path, metadata: os.stat_result | None) -> None:
+            nonlocal unexpected
+            unexpected = True
+            mode = metadata.st_mode if metadata is not None else 0
+            if metadata is not None and stat.S_ISREG(mode):
+                name = path.name
+                if re.fullmatch(
+                    r"console-[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9-]+Z\.log",
+                    name,
+                ):
+                    categories.add("console_log")
+                elif (
+                    name.startswith("download-")
+                    or name.endswith(".download")
+                    or path.suffix == ".bin"
+                ):
+                    categories.add("download")
+                elif path.suffix in {".trace", ".network", ".stacks", ".crtrace"}:
+                    categories.add("trace")
+                else:
+                    categories.add("other")
+            else:
+                categories.add("other")
+
+            # Removing an entry never follows its final symlink.  Unexpected
+            # non-empty directories remain for the session-level teardown,
+            # after the caller has tainted and killed the upstream process.
+            try:
+                if metadata is not None and stat.S_ISDIR(mode):
+                    path.rmdir()
+                else:
+                    path.unlink()
+            except OSError:
+                pass
+
+        try:
+            root_metadata = os.lstat(self.artifact_dir)
+            root_entries = list(os.scandir(self.artifact_dir))
+        except OSError:
+            self.unregistered_artifact_event = "unregistered_artifact_other"
+            return True
+        if not stat.S_ISDIR(root_metadata.st_mode):
+            self.unregistered_artifact_event = "unregistered_artifact_other"
+            return True
+
+        for root_entry in root_entries:
+            path = lexical(Path(root_entry.path))
+            try:
+                metadata = root_entry.stat(follow_symlinks=False)
+            except OSError:
+                record_unexpected(path, None)
+                continue
+            if path not in expected_directories or not stat.S_ISDIR(metadata.st_mode):
+                record_unexpected(path, metadata)
+                continue
+            seen_directories.add(path)
+            try:
+                children = list(os.scandir(path))
+            except OSError:
+                record_unexpected(path, metadata)
+                continue
+            for child in children:
+                child_path = lexical(Path(child.path))
+                try:
+                    child_metadata = child.stat(follow_symlinks=False)
+                except OSError:
+                    record_unexpected(child_path, None)
+                    continue
+                if (
+                    stat.S_ISREG(child_metadata.st_mode)
+                    and child_metadata.st_nlink == 1
+                    and child_path in allowed
+                ):
+                    continue
+                record_unexpected(child_path, child_metadata)
+
+        if seen_directories != expected_directories:
+            unexpected = True
+            categories.add("other")
+        if unexpected:
+            category = next(iter(categories)) if len(categories) == 1 else "mixed"
+            self.unregistered_artifact_event = f"unregistered_artifact_{category}"
+        else:
+            self.unregistered_artifact_event = "unregistered_artifact"
+        return unexpected
+
+    def _check_lifetime(self) -> None:
+        now = time.monotonic()
+        age = (datetime.now(UTC) - self.state.started_at).total_seconds()
+        if age >= SESSION_TTL_SECONDS:
+            raise BrowserPolicyError("browser_session_expired")
+        if now - self.state.last_activity >= IDLE_TTL_SECONDS:
+            raise BrowserPolicyError("browser_session_idle_expired")
+
+    async def status(self) -> dict[str, object]:
+        self._check_lifetime()
+        if self.proxy.egress.revocation_reason and not self.state.tainted:
+            await self._taint(self.proxy.egress.revocation_reason)
+        if not self.state.tainted and self.process.returncode is None:
+            try:
+                _, _, _, _, digest = await self._observe()
+                if digest != self.state.page_digest:
+                    self.state.bump()
+                    self.state.page_digest = digest
+            except BrowserPolicyError as exc:
+                await self._taint(str(exc))
+        return self.state.status()
+
+    def _validate_public_arguments(self, tool_name: str, value: object) -> dict[str, Any]:
+        if not isinstance(value, dict):
+            raise BrowserPolicyError("browser_arguments_invalid")
+        arguments = dict(value)
+        if len(json.dumps(arguments, ensure_ascii=False, separators=(",", ":")).encode("utf-8")) > MAX_ARGUMENT_BYTES:
+            raise BrowserPolicyError("browser_arguments_too_large")
+        if tool_name in {"navigate_page", "browser_navigate"}:
+            if set(arguments) != {"url"}:
+                raise BrowserPolicyError("browser_arguments_invalid")
+        elif tool_name in {"take_snapshot", "browser_snapshot", "browser_session_status"}:
+            if arguments:
+                raise BrowserPolicyError("browser_arguments_invalid")
+        elif tool_name in {"click", "browser_click"}:
+            if set(arguments) != {"ref"}:
+                raise BrowserPolicyError("browser_arguments_invalid")
+            arguments["ref"] = validate_ref(arguments["ref"])
+        elif tool_name in {"fill", "browser_fill_form"}:
+            if set(arguments) != {"ref", "value"}:
+                raise BrowserPolicyError("browser_arguments_invalid")
+            arguments["ref"] = validate_ref(arguments["ref"])
+            if not isinstance(arguments["value"], str):
+                raise BrowserPolicyError("browser_value_invalid")
+        elif tool_name in {"take_screenshot", "browser_take_screenshot"}:
+            if not set(arguments) <= {"full_page"} or (
+                "full_page" in arguments and not isinstance(arguments["full_page"], bool)
+            ):
+                raise BrowserPolicyError("browser_arguments_invalid")
+        else:
+            raise BrowserPolicyError("browser_tool_denied")
+        return arguments
+
+    async def call(self, tool_name: str, raw_arguments: object) -> dict[str, Any]:
+        self._check_lifetime()
+        if self.proxy.egress.revocation_reason and not self.state.tainted:
+            await self._taint(self.proxy.egress.revocation_reason)
+        if self.state.tainted or self.process.returncode is not None:
+            raise BrowserPolicyError(self.state.taint_reason or "browser_session_tainted")
+        if tool_name not in self.contract.tools:
+            raise BrowserPolicyError("browser_tool_denied")
+        arguments = self._validate_public_arguments(tool_name, raw_arguments)
+        if tool_name == "browser_session_status":
+            if self._purge_unregistered_artifacts():
+                await self._taint("browser_unregistered_artifact")
+                raise BrowserPolicyError("browser_unregistered_artifact")
+            return {"result": {"content": [{"type": "text", "text": "浏览器会话状态已更新。"}], "structuredContent": await self.status()}}
+        if self.state.action_count >= MAX_ACTIONS:
+            raise BrowserPolicyError("browser_action_limit")
+        if self._purge_unregistered_artifacts():
+            await self._taint("browser_unregistered_artifact")
+            raise BrowserPolicyError("browser_unregistered_artifact")
+        self.state.action_count += 1
+        self.state.last_activity = time.monotonic()
+
+        artifact_path: Path | None = None
+        forwarded_ref_roles: dict[str, str] = {}
+        if tool_name in {"navigate_page", "browser_navigate"}:
+            normalized = await self.proxy.authorize(str(arguments["url"]))
+            arguments["url"] = normalized
+            self.state.current_origin = validate_browser_url(normalized)[1]
+        elif tool_name in {"click", "browser_click", "fill", "browser_fill_form"}:
+            ref = str(arguments["ref"])
+            await self._verify_bound_refs([ref])
+            binding = self.state.refs[ref]
+            if tool_name == "fill" and binding.role not in CHROME_FILL_ROLES:
+                raise BrowserPolicyError("browser_fill_role_denied")
+            if (
+                tool_name == "browser_fill_form"
+                and binding.role not in PLAYWRIGHT_FILL_ROLE_TYPES
+            ):
+                raise BrowserPolicyError("browser_fill_role_denied")
+            forwarded_ref_roles[ref] = binding.role
+            assert_non_sensitive_interaction(
+                binding.context,
+                arguments.get("value") if tool_name in {"fill", "browser_fill_form"} else None,
+            )
+        elif tool_name in {"take_screenshot", "browser_take_screenshot"}:
+            artifact_id = f"browser_{uuid.uuid4().hex}"
+            artifact_path = self.staging_dir / f".modelmirror-{artifact_id}.png"
+
+        self.state.bump()
+        upstream_name = self.contract.tools[tool_name].upstream_name
+        assert upstream_name is not None
+        upstream_arguments = to_upstream_arguments(
+            self.adapter_id,
+            tool_name,
+            arguments,
+            ref_roles=forwarded_ref_roles,
+            artifact_path=artifact_path,
+        )
+        timeout = NAVIGATION_TIMEOUT_SECONDS if tool_name in {"navigate_page", "browser_navigate"} else TOOL_CALL_TIMEOUT_SECONDS
+        effect = self.contract.tools[tool_name].effect
+        try:
+            response = await self.rpc.request(
+                "tools/call",
+                {"name": upstream_name, "arguments": upstream_arguments},
+                timeout=timeout,
+            )
+        except asyncio.TimeoutError:
+            _emit_browser_runtime_event("rpc_timeout")
+            if artifact_path is not None:
+                artifact_path.unlink(missing_ok=True)
+            if effect == "state-write":
+                await self._taint("unknown_outcome")
+                raise BrowserPolicyError("unknown_outcome")
+            if effect == "artifact-create":
+                await self._taint("browser_artifact_outcome_unknown")
+                raise BrowserPolicyError("browser_artifact_outcome_unknown")
+            raise BrowserPolicyError("browser_upstream_unavailable")
+        except (ConnectionError, OSError, RuntimeError):
+            _emit_browser_runtime_event("rpc_transport_failure")
+            if artifact_path is not None:
+                artifact_path.unlink(missing_ok=True)
+            if effect == "state-write":
+                await self._taint("unknown_outcome")
+                raise BrowserPolicyError("unknown_outcome")
+            if effect == "artifact-create":
+                await self._taint("browser_artifact_outcome_unknown")
+                raise BrowserPolicyError("browser_artifact_outcome_unknown")
+            raise BrowserPolicyError("browser_upstream_unavailable")
+
+        if self.proxy.last_violation:
+            reason = self.proxy.last_violation
+            _emit_browser_runtime_event(
+                getattr(self.proxy, "last_violation_event", "")
+                or _proxy_runtime_event(reason)
+            )
+            await self._taint(reason)
+            if effect == "state-write":
+                raise BrowserPolicyError("unknown_outcome")
+            if effect == "artifact-create":
+                raise BrowserPolicyError("browser_artifact_outcome_unknown")
+            raise BrowserPolicyError(reason)
+        if self.proxy.egress.revocation_reason:
+            _emit_browser_runtime_event("egress_revoked")
+            reason = self.proxy.egress.revocation_reason
+            await self._taint(reason)
+            if effect == "state-write":
+                raise BrowserPolicyError("unknown_outcome")
+            if effect == "artifact-create":
+                raise BrowserPolicyError("browser_artifact_outcome_unknown")
+            raise BrowserPolicyError(reason)
+        if self._purge_unregistered_artifacts(allowed_pending=artifact_path):
+            _emit_browser_runtime_event(self.unregistered_artifact_event)
+            await self._taint("browser_unregistered_artifact")
+            if effect == "state-write":
+                raise BrowserPolicyError("unknown_outcome")
+            if effect == "artifact-create":
+                raise BrowserPolicyError("browser_artifact_outcome_unknown")
+            raise BrowserPolicyError("browser_unregistered_artifact")
+        if result_failed(response):
+            _emit_browser_runtime_event(
+                f"upstream_result_{_classify_upstream_failure(response)}"
+            )
+            if effect == "state-write":
+                await self._taint("unknown_outcome")
+                raise BrowserPolicyError("unknown_outcome")
+            if effect == "artifact-create":
+                if artifact_path is not None:
+                    artifact_path.unlink(missing_ok=True)
+                await self._taint("browser_artifact_outcome_unknown")
+                raise BrowserPolicyError("browser_artifact_outcome_unknown")
+            raise BrowserPolicyError("browser_upstream_call_failed")
+
+        if tool_name in {"take_snapshot", "browser_snapshot"}:
+            try:
+                text, refs, observed_url, title = extract_snapshot(
+                    self.adapter_id, response
+                )
+            except SnapshotStructureError as exc:
+                await self._taint("browser_snapshot_ref_structure_invalid")
+                raise BrowserPolicyError(
+                    "browser_snapshot_ref_structure_invalid"
+                ) from exc
+            if len(text.encode("utf-8")) > MAX_OUTPUT_BYTES:
+                raise BrowserPolicyError("browser_output_too_large")
+            if observed_url and observed_url != "about:blank":
+                try:
+                    _, origin, _, _ = validate_browser_url(observed_url)
+                except BrowserPolicyError as exc:
+                    await self._taint(str(exc))
+                    raise
+                if self.state.current_origin and origin != self.state.current_origin:
+                    await self._taint("browser_cross_origin_denied")
+                    raise BrowserPolicyError("browser_cross_origin_denied")
+            digest = page_digest(self.state.current_origin, observed_url, title, text)
+            self.state.page_digest = digest
+            elements: list[dict[str, str]] = []
+            for ref, element in refs.items():
+                item = _safe_element(ref, element, digest)
+                if item is None:
+                    continue
+                binding = RefBinding(
+                    self.state.generation,
+                    self.state.page_revision,
+                    digest,
+                    element.context,
+                    item["role"],
+                    item["label"],
+                )
+                self.state.refs[ref] = binding
+                elements.append(item)
+                if len(elements) >= 100:
+                    break
+            result = response.get("result")
+            assert isinstance(result, dict)
+            result["structuredContent"] = {
+                "generation": self.state.generation,
+                "page_revision": self.state.page_revision,
+                "page_digest": digest,
+                "elements": elements,
+            }
+            return response
+
+        if artifact_path is not None:
+            try:
+                registered_path, digest, artifact_size = _register_png_artifact(
+                    artifact_path, self.registered_dir
+                )
+                self.registered_artifacts.add(registered_path.resolve())
+            except (OSError, BrowserPolicyError):
+                artifact_path.unlink(missing_ok=True)
+                await self._taint("browser_artifact_invalid")
+                raise BrowserPolicyError("browser_artifact_invalid")
+            relative_path = f"{self.state.session_id}/registered/{registered_path.name}"
+            return {
+                "result": {
+                    "content": [{"type": "text", "text": "PNG 截图已生成并登记为受控产物。"}],
+                    "structuredContent": {
+                        "artifact_id": registered_path.stem,
+                        "relative_path": relative_path,
+                        "sha256": digest,
+                        "size": artifact_size,
+                        "mime": "image/png",
+                    },
+                }
+            }
+
+        # A successful state-changing action must still leave exactly one page
+        # at the authorized origin.  Failure is ambiguous, so the session is
+        # tainted and never retried.
+        if effect == "state-write":
+            try:
+                _, _, _, _, digest = await self._observe()
+                self.state.page_digest = digest
+            except BrowserPolicyError as exc:
+                await self._taint(str(exc))
+                raise BrowserPolicyError("unknown_outcome") from exc
+        return response
+
+
+async def _send_client_response(writer: asyncio.StreamWriter, payload: bytes) -> None:
+    if len(payload) > MAX_MCP_MESSAGE_BYTES:
+        payload = _rpc_error(None, -32013, "浏览器输出超过限制。", reason="browser_output_too_large")
+    writer.write(payload)
+    await asyncio.wait_for(writer.drain(), timeout=2)
+
+
+async def _serve_mcp_client(
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+    gateway: BrowserGatewaySession,
+) -> None:
+    while True:
+        age = (datetime.now(UTC) - gateway.state.started_at).total_seconds()
+        remaining = min(
+            max(SESSION_TTL_SECONDS - age, 0.0),
+            max(IDLE_TTL_SECONDS - (time.monotonic() - gateway.state.last_activity), 0.0),
+        )
+        if remaining <= 0:
+            break
+        try:
+            raw = await asyncio.wait_for(reader.readline(), timeout=remaining)
+        except asyncio.TimeoutError:
+            break
+        if not raw:
+            break
+        if len(raw) > MAX_MCP_MESSAGE_BYTES:
+            await _send_client_response(
+                writer,
+                _rpc_error(None, -32600, "MCP 请求超过限制。", reason="mcp_message_too_large"),
+            )
+            continue
+        try:
+            request = json.loads(raw.decode("utf-8"))
+        except (UnicodeError, json.JSONDecodeError):
+            continue
+        if not isinstance(request, dict):
+            continue
+        request_id = request.get("id")
+        method = request.get("method")
+        if request_id is None:
+            continue
+        if not isinstance(request_id, (str, int)) or isinstance(request_id, bool):
+            await _send_client_response(
+                writer,
+                _rpc_error(None, -32600, "MCP 请求 ID 无效。", reason="invalid_request_id"),
+            )
+            continue
+        try:
+            if method == "initialize":
+                result = dict(gateway.initialize_result)
+                response = _rpc_result(request_id, result)
+            elif method == "ping":
+                response = _rpc_result(request_id, {})
+            elif method == "tools/list":
+                response = _rpc_result(request_id, {"tools": public_tools(gateway.adapter_id)})
+            elif method == "tools/call":
+                params = request.get("params")
+                if not isinstance(params, dict):
+                    raise BrowserPolicyError("browser_arguments_invalid")
+                name = params.get("name")
+                if not isinstance(name, str):
+                    raise BrowserPolicyError("browser_tool_denied")
+                outcome = await gateway.call(name, params.get("arguments", {}))
+                result = outcome.get("result")
+                response = _rpc_result(request_id, result)
+            else:
+                response = _rpc_error(request_id, -32601, "MCP 方法未开放。", reason="method_denied")
+        except BrowserPolicyError as exc:
+            reason = str(exc)
+            _emit_browser_runtime_event(
+                BROWSER_POLICY_RUNTIME_EVENTS.get(reason, "proxy_policy_violation")
+            )
+            if reason == "unknown_outcome":
+                response = _rpc_error(
+                    request_id,
+                    -32008,
+                    "浏览器状态写入结果未知，会话已终止且不得自动重试。",
+                    reason="unknown_outcome",
+                )
+            else:
+                response = _rpc_error(
+                    request_id,
+                    -32011,
+                    "浏览器操作被安全策略拒绝。",
+                    reason=reason,
+                )
+        await _send_client_response(writer, response)
+
+
+async def _browser_stdio(
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+    request: dict[str, Any],
+    control_key: str,
+    lifecycle: BrowserOneShotLifecycle,
+) -> None:
+    adapter_id = str(request.get("adapter_id") or "")
+    if adapter_id not in ALLOWED_ADAPTERS:
+        raise SandboxEngineError("Browser adapter denied.", code="mcp_adapter_denied")
+    _validate_handshake(adapter_id, request.get("configuration"))
+    request["configuration"] = None
+
+    if not lifecycle.claimed:
+        raise SandboxEngineError(
+            "Browser session was not claimed.", code="browser_session_not_claimed"
+        )
+    if lifecycle.claimed:
+        session_id = uuid.uuid4().hex
+        profile_dir = (PROFILE_ROOT / session_id).resolve()
+        artifact_dir = (ARTIFACT_ROOT / session_id).resolve()
+        if profile_dir.parent != PROFILE_ROOT.resolve() or artifact_dir.parent != ARTIFACT_ROOT.resolve():
+            raise SandboxEngineError("Browser session path denied.", code="unsafe_workspace")
+        profile_dir.mkdir(mode=0o700, parents=True, exist_ok=False)
+        artifact_dir.mkdir(mode=0o700, parents=True, exist_ok=False)
+        runtime_tmp_dir = profile_dir / "tmp"
+        staging_dir = artifact_dir / "staging"
+        registered_dir = artifact_dir / "registered"
+        runtime_tmp_dir.mkdir(mode=0o700)
+        staging_dir.mkdir(mode=0o700)
+        registered_dir.mkdir(mode=0o700)
+        egress = BrowserEgressClient(control_key)
+        proxy = LoopbackBrowserProxy(egress)
+        process: asyncio.subprocess.Process | None = None
+        stderr_classifier = SafeStderrClassifier()
+        stderr_task: asyncio.Task[None] | None = None
+        handshake_sent = False
+        try:
+            await egress.register()
+            proxy_url = await proxy.start()
+            env = {
+                "PATH": "/opt/browser-upstream/node_modules/.bin:/usr/local/bin:/usr/bin:/bin",
+                "PYTHONPATH": "/opt/modelmirror",
+                "HOME": str(profile_dir),
+                "TMPDIR": str(runtime_tmp_dir),
+                "LANG": "C.UTF-8",
+                "LC_ALL": "C.UTF-8",
+                "TZ": "UTC",
+                "CI": "1",
+                "CHROME_DEVTOOLS_MCP_NO_USAGE_STATISTICS": "1",
+                "NODE_DISABLE_COMPILE_CACHE": "1",
+                "DO_NOT_TRACK": "1",
+                "NO_PROXY": "",
+                "no_proxy": "",
+                "HTTP_PROXY": proxy_url,
+                "HTTPS_PROXY": proxy_url,
+                "http_proxy": proxy_url,
+                "https_proxy": proxy_url,
+            }
+            command = upstream_command(
+                adapter_id,
+                profile_dir=profile_dir,
+                artifact_dir=staging_dir,
+                proxy_url=proxy_url,
+            )
+            if any(
+                forbidden in argument
+                for argument in command
+                for forbidden in ("--no-sandbox", "--disable-web-security", "--remote-debugging-address=0.0.0.0")
+            ):
+                raise SandboxEngineError("Unsafe Chromium argv denied.", code="browser_unsafe_argv")
+            command = [
+                sys.executable,
+                "-m",
+                "sandbox_sidecar.browser_mcp",
+                "landlock",
+                str(profile_dir),
+                str(staging_dir),
+                "--",
+                *command,
+            ]
+            process = await asyncio.create_subprocess_exec(
+                *command,
+                cwd=str(profile_dir),
+                env=env,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                start_new_session=True,
+                limit=MAX_MCP_MESSAGE_BYTES + 1,
+            )
+            env.clear()
+            stderr_task = asyncio.create_task(
+                _drain_stderr(process.stderr, stderr_classifier)
+            )
+            try:
+                rpc = UpstreamRpc(process, staging_dir)
+                state = BrowserSessionState(adapter_id, session_id)
+                gateway = BrowserGatewaySession(
+                    adapter_id,
+                    state,
+                    process,
+                    rpc,
+                    proxy,
+                    artifact_dir,
+                    staging_dir,
+                    registered_dir,
+                )
+                await asyncio.wait_for(gateway.preflight(), timeout=45)
+            except (asyncio.TimeoutError, RuntimeError) as exc:
+                safe_code = _safe_preflight_error_code(exc)
+                if safe_code is None:
+                    raise
+                if safe_code == "browser_upstream_representative_target_closed":
+                    if stderr_classifier.primary() == "none":
+                        try:
+                            await asyncio.wait_for(
+                                stderr_classifier.changed.wait(), timeout=0.25
+                            )
+                        except asyncio.TimeoutError:
+                            pass
+                    candidate = (
+                        "browser_upstream_representative_target_closed_"
+                        f"{stderr_classifier.primary()}"
+                    )
+                    if candidate in BROWSER_PREFLIGHT_ERROR_CODES:
+                        safe_code = candidate
+                raise SandboxEngineError(
+                    "Browser upstream preflight failed.", code=safe_code
+                ) from exc
+            writer.write(
+                json.dumps(
+                    {
+                        "ok": True,
+                        "adapter_id": adapter_id,
+                        "protocol": "modelmirror-browser-mcp-stdio-v1",
+                        "contract_version": CONTRACT_VERSION,
+                        "tool_schema_sha256": BROWSER_SCHEMA_SHA256[adapter_id],
+                        "upstream": {
+                            "package": gateway.contract.package_name,
+                            "version": gateway.contract.package_version,
+                            "verified": True,
+                        },
+                        "limits": BROWSER_LIMITS,
+                    },
+                    ensure_ascii=False,
+                    separators=(",", ":"),
+                ).encode("utf-8")
+                + b"\n"
+            )
+            await asyncio.wait_for(writer.drain(), timeout=2)
+            handshake_sent = True
+            await _serve_mcp_client(reader, writer, gateway)
+        finally:
+            if process is not None:
+                await _terminate_process_group(process)
+            if stderr_task is not None:
+                stderr_task.cancel()
+                await asyncio.gather(stderr_task, return_exceptions=True)
+            await proxy.close()
+            await egress.revoke()
+            shutil.rmtree(profile_dir, ignore_errors=True)
+            if "gateway" in locals():
+                gateway._purge_unregistered_artifacts()
+            shutil.rmtree(artifact_dir, ignore_errors=True)
+            if handshake_sent:
+                await _close_writer(writer)
+
+
+async def handle_browser_client(
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+    control_key: str,
+    lifecycle: BrowserOneShotLifecycle,
+) -> None:
+    response: dict[str, Any] | None = None
+    session_claimed = False
+    try:
+        peer_uid = _trusted_peer_uid(writer)
+        service_uid = os.getuid() if hasattr(os, "getuid") else -1
+        if peer_uid not in {TRUSTED_CLIENT_UID, service_uid}:
+            raise SandboxEngineError(
+                "Browser sidecar peer denied.", code="browser_peer_denied"
+            )
+        request = await asyncio.wait_for(
+            _read_json_line(reader), timeout=REQUEST_PREAMBLE_TIMEOUT_SECONDS
+        )
+        action = str(request.get("action") or "")
+        if action == "mcp_stdio":
+            if peer_uid != TRUSTED_CLIENT_UID:
+                raise SandboxEngineError(
+                    "Browser catalog peer denied.", code="browser_peer_denied"
+                )
+            lifecycle.claim()
+            session_claimed = True
+            await _browser_stdio(reader, writer, request, control_key, lifecycle)
+            return
+        if action != "health":
+            raise SandboxEngineError("Browser sidecar action denied.", code="action_denied")
+        response = {
+            "ok": True,
+            "protocol": "modelmirror-browser-mcp-stdio-v1",
+            "mcp_browser_adapters": sorted(ALLOWED_ADAPTERS),
+            "mcp_browser_max_sessions": MAX_SESSIONS,
+            "mcp_message_limit_bytes": MAX_OUTPUT_BYTES,
+            "network_mode": "egress-unix-socket-only",
+        }
+    except asyncio.TimeoutError:
+        response = {
+            "ok": False,
+            "error": "browser_sidecar_rejected",
+            "code": "browser_request_timeout",
+        }
+    except SandboxEngineError as exc:
+        response = {"ok": False, "error": "browser_sidecar_rejected", "code": exc.code}
+    except Exception:
+        response = {
+            "ok": False,
+            "error": "browser_sidecar_internal_error",
+            "code": "browser_sidecar_internal_error",
+        }
+    finally:
+        if response is not None:
+            try:
+                writer.write(json.dumps(response, separators=(",", ":")).encode("utf-8") + b"\n")
+                await writer.drain()
+            except (ConnectionError, OSError):
+                pass
+        await _close_writer(writer)
+        if session_claimed:
+            lifecycle.finish()
+
+
+async def _wait_for_control_key() -> str:
+    for _ in range(300):
+        try:
+            value = EGRESS_CONTROL_PATH.read_text(encoding="ascii").strip()
+            if len(value) == 64:
+                EGRESS_CONTROL_PATH.unlink(missing_ok=True)
+                return value
+        except OSError:
+            pass
+        await asyncio.sleep(0.1)
+    raise RuntimeError("browser_egress_control_unavailable")
+
+
+def _publish_control_key(control_key: str) -> None:
+    """Atomically publish a new one-shot key only after egress is listening."""
+
+    encoded = control_key.encode("ascii")
+    temporary = EGRESS_CONTROL_PATH.with_name(
+        f".{EGRESS_CONTROL_PATH.name}.{secrets.token_hex(8)}.tmp"
+    )
+    descriptor = -1
+    directory_descriptor = -1
+    try:
+        descriptor = os.open(
+            temporary,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0),
+            0o600,
+        )
+        written = os.write(descriptor, encoded)
+        if written != len(encoded):
+            raise RuntimeError("browser_egress_control_write_failed")
+        os.fsync(descriptor)
+        os.close(descriptor)
+        descriptor = -1
+        os.replace(temporary, EGRESS_CONTROL_PATH)
+        directory_descriptor = os.open(
+            EGRESS_CONTROL_PATH.parent,
+            os.O_RDONLY | getattr(os, "O_DIRECTORY", 0),
+        )
+        os.fsync(directory_descriptor)
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        if directory_descriptor >= 0:
+            os.close(directory_descriptor)
+        temporary.unlink(missing_ok=True)
+
+
+async def browser_main() -> None:
+    readiness = RestartPolicyReadinessGate(time.monotonic())
+    lifecycle = BrowserOneShotLifecycle()
+    watch_ready = asyncio.Event()
+    control_key: str | None = None
+    watch_task: asyncio.Task[None] | None = None
+    ready_task: asyncio.Task[bool] | None = None
+    server: asyncio.AbstractServer | None = None
+    serve_task: asyncio.Task[None] | None = None
+    session_task: asyncio.Task[bool] | None = None
+    try:
+        _require_supervisor_pid1()
+        _disable_process_dumping()
+        _cleanup_stale_runtime_roots()
+        control_key = await _wait_for_control_key()
+        watch_task = asyncio.create_task(_watch_egress(control_key, watch_ready))
+        ready_task = asyncio.create_task(watch_ready.wait())
+        done, _ = await asyncio.wait(
+            {watch_task, ready_task}, return_when=asyncio.FIRST_COMPLETED
+        )
+        if watch_task in done:
+            watch_task.result()
+        ready_task.result()
+        if not watch_ready.is_set():
+            raise RuntimeError("browser_egress_watch_not_ready")
+
+        # Do not expose the catalog socket until the authenticated egress watch
+        # has acknowledged this exact key and Docker's restart policy is armed.
+        await readiness.wait_before_arm()
+        readiness.arm()
+        SOCKET_PATH.parent.mkdir(parents=True, exist_ok=True)
+        SOCKET_PATH.unlink(missing_ok=True)
+        server = await asyncio.start_unix_server(
+            lambda reader, writer: handle_browser_client(
+                reader, writer, control_key, lifecycle
+            ),
+            path=str(SOCKET_PATH),
+            limit=MAX_MCP_MESSAGE_BYTES + 1,
+        )
+        os.chmod(SOCKET_PATH, 0o660)
+        serve_task = asyncio.create_task(server.serve_forever())
+        session_task = asyncio.create_task(lifecycle.finished.wait())
+        done, pending = await asyncio.wait(
+            {watch_task, serve_task, session_task}, return_when=asyncio.FIRST_COMPLETED
+        )
+        for task in done:
+            task.result()
+        for task in pending:
+            task.cancel()
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+    finally:
+        try:
+            if server is not None:
+                server.close()
+                try:
+                    await asyncio.wait_for(server.wait_closed(), timeout=2)
+                except asyncio.TimeoutError:
+                    pass
+            tasks = [
+                task
+                for task in (watch_task, ready_task, serve_task, session_task)
+                if task is not None
+            ]
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+            if control_key is not None:
+                await _request_egress_shutdown(control_key)
+            SOCKET_PATH.unlink(missing_ok=True)
+        finally:
+            # Early failures remain unavailable while waiting: the listener is
+            # closed and no upstream browser has been admitted.
+            await readiness.hold_early_exit()
+
+
+async def egress_main() -> None:
+    readiness = RestartPolicyReadinessGate(time.monotonic())
+    service: BrowserEgressService | None = None
+    server: asyncio.AbstractServer | None = None
+    serve_task: asyncio.Task[None] | None = None
+    shutdown_task: asyncio.Task[bool] | None = None
+    bootstrap_task: asyncio.Task[None] | None = None
+    try:
+        _require_supervisor_pid1()
+        EGRESS_SOCKET_PATH.parent.mkdir(parents=True, exist_ok=True)
+        EGRESS_SOCKET_PATH.unlink(missing_ok=True)
+        EGRESS_CONTROL_PATH.unlink(missing_ok=True)
+        control_key = secrets.token_hex(32)
+        service = BrowserEgressService(control_key)
+        server = await asyncio.start_unix_server(
+            service.handle,
+            path=str(EGRESS_SOCKET_PATH),
+            limit=MAX_PROXY_HEADER_BYTES + 1,
+            start_serving=False,
+        )
+        os.chmod(EGRESS_SOCKET_PATH, 0o660)
+        await readiness.wait_before_arm()
+        await server.start_serving()
+        readiness.arm()
+        _publish_control_key(control_key)
+        # Bootstrap starts only after the one-shot key is published; the 11s
+        # Docker activation wait is not charged against the watcher timeout.
+        serve_task = asyncio.create_task(server.serve_forever())
+        shutdown_task = asyncio.create_task(service.shutdown_event.wait())
+        bootstrap_task = asyncio.create_task(_enforce_egress_watch_bootstrap(service))
+        done, pending = await asyncio.wait(
+            {serve_task, shutdown_task}, return_when=asyncio.FIRST_COMPLETED
+        )
+        for task in done:
+            task.result()
+        for task in pending:
+            task.cancel()
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+    finally:
+        try:
+            if service is not None:
+                await service.shutdown()
+            if server is not None:
+                server.close()
+                try:
+                    await asyncio.wait_for(server.wait_closed(), timeout=2)
+                except asyncio.TimeoutError:
+                    pass
+            tasks = [
+                task
+                for task in (serve_task, shutdown_task, bootstrap_task)
+                if task is not None
+            ]
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            if tasks:
+                await asyncio.gather(*tasks, return_exceptions=True)
+            EGRESS_SOCKET_PATH.unlink(missing_ok=True)
+            EGRESS_CONTROL_PATH.unlink(missing_ok=True)
+        finally:
+            # No key is published and no listener is serving while an early
+            # failure waits out Docker's bounded restart activation window.
+            await readiness.hold_early_exit()
+
+
+def main() -> None:
+    if len(sys.argv) == 2 and sys.argv[1] == "egress":
+        asyncio.run(egress_main())
+        return
+    if len(sys.argv) != 1:
+        raise SystemExit("usage: browser_server.py [egress]")
+    asyncio.run(browser_main())
+
+
+if __name__ == "__main__":
+    main()

--- a/server/sandbox_sidecar/seccomp_profile.browser.json
+++ b/server/sandbox_sidecar/seccomp_profile.browser.json
@@ -1,0 +1,877 @@
+{
+  "defaultAction": "SCMP_ACT_ERRNO",
+  "defaultErrnoRet": 1,
+  "archMap": [
+    {
+      "architecture": "SCMP_ARCH_X86_64",
+      "subArchitectures": [
+        "SCMP_ARCH_X86",
+        "SCMP_ARCH_X32"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_AARCH64",
+      "subArchitectures": [
+        "SCMP_ARCH_ARM"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_MIPS64",
+      "subArchitectures": [
+        "SCMP_ARCH_MIPS",
+        "SCMP_ARCH_MIPS64N32"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_MIPS64N32",
+      "subArchitectures": [
+        "SCMP_ARCH_MIPS",
+        "SCMP_ARCH_MIPS64"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_MIPSEL64",
+      "subArchitectures": [
+        "SCMP_ARCH_MIPSEL",
+        "SCMP_ARCH_MIPSEL64N32"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_MIPSEL64N32",
+      "subArchitectures": [
+        "SCMP_ARCH_MIPSEL",
+        "SCMP_ARCH_MIPSEL64"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_S390X",
+      "subArchitectures": [
+        "SCMP_ARCH_S390"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_RISCV64",
+      "subArchitectures": null
+    },
+    {
+      "architecture": "SCMP_ARCH_LOONGARCH64",
+      "subArchitectures": null
+    }
+  ],
+  "syscalls": [
+    {
+      "comment": "ModelMirror: allow Chromium user-namespace creation and its post-namespace empty-root chroot sandbox.",
+      "names": [
+        "chroot",
+        "clone",
+        "setns",
+        "unshare"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "includes": {},
+      "excludes": {}
+    },
+    {
+      "names": [
+        "accept",
+        "accept4",
+        "access",
+        "adjtimex",
+        "alarm",
+        "bind",
+        "brk",
+        "cachestat",
+        "capget",
+        "capset",
+        "chdir",
+        "chmod",
+        "chown",
+        "chown32",
+        "clock_adjtime",
+        "clock_adjtime64",
+        "clock_getres",
+        "clock_getres_time64",
+        "clock_gettime",
+        "clock_gettime64",
+        "clock_nanosleep",
+        "clock_nanosleep_time64",
+        "close",
+        "close_range",
+        "connect",
+        "copy_file_range",
+        "creat",
+        "dup",
+        "dup2",
+        "dup3",
+        "epoll_create",
+        "epoll_create1",
+        "epoll_ctl",
+        "epoll_ctl_old",
+        "epoll_pwait",
+        "epoll_pwait2",
+        "epoll_wait",
+        "epoll_wait_old",
+        "eventfd",
+        "eventfd2",
+        "execve",
+        "execveat",
+        "exit",
+        "exit_group",
+        "faccessat",
+        "faccessat2",
+        "fadvise64",
+        "fadvise64_64",
+        "fallocate",
+        "fanotify_mark",
+        "fchdir",
+        "fchmod",
+        "fchmodat",
+        "fchmodat2",
+        "fchown",
+        "fchown32",
+        "fchownat",
+        "fcntl",
+        "fcntl64",
+        "fdatasync",
+        "fgetxattr",
+        "flistxattr",
+        "flock",
+        "fork",
+        "fremovexattr",
+        "fsetxattr",
+        "fstat",
+        "fstat64",
+        "fstatat64",
+        "fstatfs",
+        "fstatfs64",
+        "fsync",
+        "ftruncate",
+        "ftruncate64",
+        "futex",
+        "futex_requeue",
+        "futex_time64",
+        "futex_wait",
+        "futex_waitv",
+        "futex_wake",
+        "futimesat",
+        "getcpu",
+        "getcwd",
+        "getdents",
+        "getdents64",
+        "getegid",
+        "getegid32",
+        "geteuid",
+        "geteuid32",
+        "getgid",
+        "getgid32",
+        "getgroups",
+        "getgroups32",
+        "getitimer",
+        "getpeername",
+        "getpgid",
+        "getpgrp",
+        "getpid",
+        "getppid",
+        "getpriority",
+        "getrandom",
+        "getresgid",
+        "getresgid32",
+        "getresuid",
+        "getresuid32",
+        "getrlimit",
+        "get_robust_list",
+        "getrusage",
+        "getsid",
+        "getsockname",
+        "getsockopt",
+        "get_thread_area",
+        "gettid",
+        "gettimeofday",
+        "getuid",
+        "getuid32",
+        "getxattr",
+        "getxattrat",
+        "inotify_add_watch",
+        "inotify_init",
+        "inotify_init1",
+        "inotify_rm_watch",
+        "io_cancel",
+        "ioctl",
+        "io_destroy",
+        "io_getevents",
+        "io_pgetevents",
+        "io_pgetevents_time64",
+        "ioprio_get",
+        "ioprio_set",
+        "io_setup",
+        "io_submit",
+        "ipc",
+        "kill",
+        "landlock_add_rule",
+        "landlock_create_ruleset",
+        "landlock_restrict_self",
+        "lchown",
+        "lchown32",
+        "lgetxattr",
+        "link",
+        "linkat",
+        "listen",
+        "listmount",
+        "listxattr",
+        "listxattrat",
+        "llistxattr",
+        "_llseek",
+        "lremovexattr",
+        "lseek",
+        "lsetxattr",
+        "lstat",
+        "lstat64",
+        "madvise",
+        "map_shadow_stack",
+        "membarrier",
+        "memfd_create",
+        "memfd_secret",
+        "mincore",
+        "mkdir",
+        "mkdirat",
+        "mknod",
+        "mknodat",
+        "mlock",
+        "mlock2",
+        "mlockall",
+        "mmap",
+        "mmap2",
+        "mprotect",
+        "mq_getsetattr",
+        "mq_notify",
+        "mq_open",
+        "mq_timedreceive",
+        "mq_timedreceive_time64",
+        "mq_timedsend",
+        "mq_timedsend_time64",
+        "mq_unlink",
+        "mremap",
+        "mseal",
+        "msgctl",
+        "msgget",
+        "msgrcv",
+        "msgsnd",
+        "msync",
+        "munlock",
+        "munlockall",
+        "munmap",
+        "name_to_handle_at",
+        "nanosleep",
+        "newfstatat",
+        "_newselect",
+        "open",
+        "openat",
+        "openat2",
+        "pause",
+        "pidfd_open",
+        "pidfd_send_signal",
+        "pipe",
+        "pipe2",
+        "pkey_alloc",
+        "pkey_free",
+        "pkey_mprotect",
+        "poll",
+        "ppoll",
+        "ppoll_time64",
+        "prctl",
+        "pread64",
+        "preadv",
+        "preadv2",
+        "prlimit64",
+        "process_mrelease",
+        "pselect6",
+        "pselect6_time64",
+        "pwrite64",
+        "pwritev",
+        "pwritev2",
+        "read",
+        "readahead",
+        "readlink",
+        "readlinkat",
+        "readv",
+        "recv",
+        "recvfrom",
+        "recvmmsg",
+        "recvmmsg_time64",
+        "recvmsg",
+        "remap_file_pages",
+        "removexattr",
+        "removexattrat",
+        "rename",
+        "renameat",
+        "renameat2",
+        "restart_syscall",
+        "riscv_hwprobe",
+        "rmdir",
+        "rseq",
+        "rt_sigaction",
+        "rt_sigpending",
+        "rt_sigprocmask",
+        "rt_sigqueueinfo",
+        "rt_sigreturn",
+        "rt_sigsuspend",
+        "rt_sigtimedwait",
+        "rt_sigtimedwait_time64",
+        "rt_tgsigqueueinfo",
+        "sched_getaffinity",
+        "sched_getattr",
+        "sched_getparam",
+        "sched_get_priority_max",
+        "sched_get_priority_min",
+        "sched_getscheduler",
+        "sched_rr_get_interval",
+        "sched_rr_get_interval_time64",
+        "sched_setaffinity",
+        "sched_setattr",
+        "sched_setparam",
+        "sched_setscheduler",
+        "sched_yield",
+        "seccomp",
+        "select",
+        "semctl",
+        "semget",
+        "semop",
+        "semtimedop",
+        "semtimedop_time64",
+        "send",
+        "sendfile",
+        "sendfile64",
+        "sendmmsg",
+        "sendmsg",
+        "sendto",
+        "setfsgid",
+        "setfsgid32",
+        "setfsuid",
+        "setfsuid32",
+        "setgid",
+        "setgid32",
+        "setgroups",
+        "setgroups32",
+        "setitimer",
+        "setpgid",
+        "setpriority",
+        "setregid",
+        "setregid32",
+        "setresgid",
+        "setresgid32",
+        "setresuid",
+        "setresuid32",
+        "setreuid",
+        "setreuid32",
+        "setrlimit",
+        "set_robust_list",
+        "setsid",
+        "setsockopt",
+        "set_thread_area",
+        "set_tid_address",
+        "setuid",
+        "setuid32",
+        "setxattr",
+        "setxattrat",
+        "shmat",
+        "shmctl",
+        "shmdt",
+        "shmget",
+        "shutdown",
+        "sigaltstack",
+        "signalfd",
+        "signalfd4",
+        "sigprocmask",
+        "sigreturn",
+        "socketcall",
+        "socketpair",
+        "splice",
+        "stat",
+        "stat64",
+        "statfs",
+        "statfs64",
+        "statmount",
+        "statx",
+        "symlink",
+        "symlinkat",
+        "sync",
+        "sync_file_range",
+        "syncfs",
+        "sysinfo",
+        "tee",
+        "tgkill",
+        "time",
+        "timer_create",
+        "timer_delete",
+        "timer_getoverrun",
+        "timer_gettime",
+        "timer_gettime64",
+        "timer_settime",
+        "timer_settime64",
+        "timerfd_create",
+        "timerfd_gettime",
+        "timerfd_gettime64",
+        "timerfd_settime",
+        "timerfd_settime64",
+        "times",
+        "tkill",
+        "truncate",
+        "truncate64",
+        "ugetrlimit",
+        "umask",
+        "uname",
+        "unlink",
+        "unlinkat",
+        "uretprobe",
+        "utime",
+        "utimensat",
+        "utimensat_time64",
+        "utimes",
+        "vfork",
+        "vmsplice",
+        "wait4",
+        "waitid",
+        "waitpid",
+        "write",
+        "writev"
+      ],
+      "action": "SCMP_ACT_ALLOW"
+    },
+    {
+      "names": [
+        "socket"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "value": 38,
+          "op": "SCMP_CMP_LT"
+        }
+      ]
+    },
+    {
+      "names": [
+        "socket"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "value": 39,
+          "op": "SCMP_CMP_EQ"
+        }
+      ]
+    },
+    {
+      "names": [
+        "socket"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "value": 40,
+          "op": "SCMP_CMP_GT"
+        }
+      ]
+    },
+    {
+      "names": [
+        "personality"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "value": 0,
+          "op": "SCMP_CMP_EQ"
+        }
+      ]
+    },
+    {
+      "names": [
+        "personality"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "value": 8,
+          "op": "SCMP_CMP_EQ"
+        }
+      ]
+    },
+    {
+      "names": [
+        "personality"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "value": 131072,
+          "op": "SCMP_CMP_EQ"
+        }
+      ]
+    },
+    {
+      "names": [
+        "personality"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "value": 131080,
+          "op": "SCMP_CMP_EQ"
+        }
+      ]
+    },
+    {
+      "names": [
+        "personality"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "value": 4294967295,
+          "op": "SCMP_CMP_EQ"
+        }
+      ]
+    },
+    {
+      "names": [
+        "sync_file_range2",
+        "swapcontext"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "arches": [
+          "ppc64le"
+        ]
+      }
+    },
+    {
+      "names": [
+        "arm_fadvise64_64",
+        "arm_sync_file_range",
+        "sync_file_range2",
+        "breakpoint",
+        "cacheflush",
+        "set_tls"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "arches": [
+          "arm",
+          "arm64"
+        ]
+      }
+    },
+    {
+      "names": [
+        "arch_prctl"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "arches": [
+          "amd64",
+          "x32"
+        ]
+      }
+    },
+    {
+      "names": [
+        "modify_ldt"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "arches": [
+          "amd64",
+          "x32",
+          "x86"
+        ]
+      }
+    },
+    {
+      "names": [
+        "s390_pci_mmio_read",
+        "s390_pci_mmio_write",
+        "s390_runtime_instr"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "arches": [
+          "s390",
+          "s390x"
+        ]
+      }
+    },
+    {
+      "names": [
+        "riscv_flush_icache"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "arches": [
+          "riscv64"
+        ]
+      }
+    },
+    {
+      "names": [
+        "open_by_handle_at"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "caps": [
+          "CAP_DAC_READ_SEARCH"
+        ]
+      }
+    },
+    {
+      "names": [
+        "bpf",
+        "clone",
+        "clone3",
+        "fanotify_init",
+        "fsconfig",
+        "fsmount",
+        "fsopen",
+        "fspick",
+        "lookup_dcookie",
+        "lsm_get_self_attr",
+        "lsm_list_modules",
+        "lsm_set_self_attr",
+        "mount",
+        "mount_setattr",
+        "move_mount",
+        "open_tree",
+        "perf_event_open",
+        "quotactl",
+        "quotactl_fd",
+        "setdomainname",
+        "sethostname",
+        "setns",
+        "syslog",
+        "umount",
+        "umount2",
+        "unshare"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "caps": [
+          "CAP_SYS_ADMIN"
+        ]
+      }
+    },
+    {
+      "names": [
+        "clone"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "value": 2114060288,
+          "op": "SCMP_CMP_MASKED_EQ"
+        }
+      ],
+      "excludes": {
+        "caps": [
+          "CAP_SYS_ADMIN"
+        ],
+        "arches": [
+          "s390",
+          "s390x"
+        ]
+      }
+    },
+    {
+      "names": [
+        "clone"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 1,
+          "value": 2114060288,
+          "op": "SCMP_CMP_MASKED_EQ"
+        }
+      ],
+      "comment": "s390 parameter ordering for clone is different",
+      "includes": {
+        "arches": [
+          "s390",
+          "s390x"
+        ]
+      },
+      "excludes": {
+        "caps": [
+          "CAP_SYS_ADMIN"
+        ]
+      }
+    },
+    {
+      "names": [
+        "clone3"
+      ],
+      "action": "SCMP_ACT_ERRNO",
+      "errnoRet": 38,
+      "excludes": {
+        "caps": [
+          "CAP_SYS_ADMIN"
+        ]
+      }
+    },
+    {
+      "names": [
+        "reboot"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "caps": [
+          "CAP_SYS_BOOT"
+        ]
+      }
+    },
+    {
+      "names": [
+        "chroot"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "caps": [
+          "CAP_SYS_CHROOT"
+        ]
+      }
+    },
+    {
+      "names": [
+        "delete_module",
+        "init_module",
+        "finit_module"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "caps": [
+          "CAP_SYS_MODULE"
+        ]
+      }
+    },
+    {
+      "names": [
+        "acct"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "caps": [
+          "CAP_SYS_PACCT"
+        ]
+      }
+    },
+    {
+      "names": [
+        "kcmp",
+        "pidfd_getfd",
+        "process_madvise",
+        "process_vm_readv",
+        "process_vm_writev",
+        "ptrace"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "caps": [
+          "CAP_SYS_PTRACE"
+        ]
+      }
+    },
+    {
+      "names": [
+        "iopl",
+        "ioperm"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "caps": [
+          "CAP_SYS_RAWIO"
+        ]
+      }
+    },
+    {
+      "names": [
+        "settimeofday",
+        "stime",
+        "clock_settime",
+        "clock_settime64"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "caps": [
+          "CAP_SYS_TIME"
+        ]
+      }
+    },
+    {
+      "names": [
+        "vhangup"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "caps": [
+          "CAP_SYS_TTY_CONFIG"
+        ]
+      }
+    },
+    {
+      "names": [
+        "get_mempolicy",
+        "mbind",
+        "set_mempolicy",
+        "set_mempolicy_home_node"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "caps": [
+          "CAP_SYS_NICE"
+        ]
+      }
+    },
+    {
+      "names": [
+        "syslog"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "caps": [
+          "CAP_SYSLOG"
+        ]
+      }
+    },
+    {
+      "names": [
+        "bpf"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "caps": [
+          "CAP_BPF"
+        ]
+      }
+    },
+    {
+      "names": [
+        "perf_event_open"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "caps": [
+          "CAP_PERFMON"
+        ]
+      }
+    }
+  ]
+}

--- a/server/sandbox_sidecar/smoke_browser_adapters.py
+++ b/server/sandbox_sidecar/smoke_browser_adapters.py
@@ -1,0 +1,623 @@
+"""Real upstream initialization/schema/representative smoke for Wave 7."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from .browser_contracts import (
+    BROWSER_ADAPTERS,
+    BROWSER_LIMITS,
+    BROWSER_SCHEMA_SHA256,
+    CONTRACT_VERSION,
+    UPSTREAM_SCHEMA_SHA256,
+    _schema_digest,
+    assert_schema_snapshots,
+)
+from .browser_mcp import (
+    extract_snapshot,
+    result_failed,
+    result_text,
+    upstream_command,
+    upstream_schema_digest,
+)
+from .browser_server import (
+    ARTIFACT_ROOT,
+    PROFILE_ROOT,
+    SOCKET_PATH,
+    UpstreamRpc,
+    _page_count,
+    _terminate_process_group,
+)
+
+
+FORBIDDEN_CHROMIUM_ARGUMENTS = (
+    "--no-sandbox",
+    "--disable-web-security",
+    "--remote-debugging-address=0.0.0.0",
+)
+
+
+def _safe_failure_diagnostic(payload: object) -> str:
+    text = result_text(payload)
+    lowered = text.lower()
+    category = "upstream_error"
+    for token, label in (
+        ("sandbox", "chromium_sandbox"),
+        ("failed to launch", "browser_launch"),
+        ("browser process", "browser_process"),
+        ("target closed", "target_closed"),
+        ("not connected", "browser_not_connected"),
+        ("permission denied", "permission_denied"),
+        ("enoent", "path_missing"),
+    ):
+        if token in lowered:
+            category = label
+            break
+    digest = __import__("hashlib").sha256(text.encode("utf-8")).hexdigest()
+    return f"category={category},text_bytes={len(text.encode('utf-8'))},sha256={digest}"
+
+
+async def _deny_proxy(
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+) -> None:
+    try:
+        await asyncio.wait_for(reader.read(64 * 1024), timeout=2)
+    except (asyncio.TimeoutError, ConnectionError, OSError):
+        pass
+    writer.write(b"HTTP/1.1 403 Forbidden\r\nConnection: close\r\nContent-Length: 0\r\n\r\n")
+    try:
+        await writer.drain()
+    except (ConnectionError, OSError):
+        pass
+    writer.close()
+    try:
+        await writer.wait_closed()
+    except (ConnectionError, OSError):
+        pass
+
+
+def _package_version(root: Path, package_name: str) -> str:
+    path = root / "node_modules"
+    for segment in package_name.split("/"):
+        path /= segment
+    payload = json.loads((path / "package.json").read_text(encoding="utf-8"))
+    return str(payload.get("version") or "")
+
+
+def _chromium_version(adapter_id: str) -> str:
+    if adapter_id == "chrome-devtools-mcp":
+        executable = os.getenv(
+            "MCP_BROWSER_CDP_CHROMIUM_PATH",
+            "/opt/modelmirror-browsers/cdp/chrome/linux-150.0.7871.24/"
+            "chrome-linux64/chrome",
+        )
+    elif adapter_id == "playwright-mcp":
+        executable = os.getenv(
+            "MCP_BROWSER_PLAYWRIGHT_CHROMIUM_PATH",
+            "/opt/modelmirror-browsers/playwright/chromium-1237/"
+            "chrome-linux64/chrome",
+        )
+    else:
+        raise RuntimeError("browser adapter denied")
+    completed = subprocess.run(
+        [executable, "--version"],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    output = completed.stdout.strip()
+    if not output:
+        raise RuntimeError("locked Chromium executable did not report a version")
+    return output
+
+
+async def discover(
+    adapter_id: str,
+    *,
+    representative: bool = True,
+) -> tuple[set[str], str, str]:
+    contract = BROWSER_ADAPTERS[adapter_id]
+    with tempfile.TemporaryDirectory(prefix=f"browser-smoke-{adapter_id[:10]}-") as root:
+        session = Path(root)
+        profile = session / "profile"
+        artifacts = session / "artifacts"
+        runtime_tmp = profile / "tmp"
+        profile.mkdir(mode=0o700)
+        artifacts.mkdir(mode=0o700)
+        runtime_tmp.mkdir(mode=0o700)
+        proxy = await asyncio.start_server(_deny_proxy, "127.0.0.1", 0)
+        proxy_port = int(proxy.sockets[0].getsockname()[1])
+        proxy_url = f"http://127.0.0.1:{proxy_port}"
+        command = upstream_command(
+            adapter_id,
+            profile_dir=profile,
+            artifact_dir=artifacts,
+            proxy_url=proxy_url,
+        )
+        if any(forbidden in argument for argument in command for forbidden in FORBIDDEN_CHROMIUM_ARGUMENTS):
+            raise RuntimeError(f"{adapter_id} contains forbidden Chromium argv")
+        command = [
+            sys.executable,
+            "-m",
+            "sandbox_sidecar.browser_mcp",
+            "landlock",
+            str(profile),
+            str(artifacts),
+            "--",
+            *command,
+        ]
+        env = {
+            "PATH": "/opt/browser-upstream/node_modules/.bin:/usr/local/bin:/usr/bin:/bin",
+            "PYTHONPATH": "/opt/modelmirror",
+            "HOME": str(profile),
+            "TMPDIR": str(runtime_tmp),
+            "LANG": "C.UTF-8",
+            "LC_ALL": "C.UTF-8",
+            "TZ": "UTC",
+            "CI": "1",
+            "CHROME_DEVTOOLS_MCP_NO_USAGE_STATISTICS": "1",
+            "NODE_DISABLE_COMPILE_CACHE": "1",
+            "DO_NOT_TRACK": "1",
+            "NO_PROXY": "",
+            "no_proxy": "",
+            "HTTP_PROXY": proxy_url,
+            "HTTPS_PROXY": proxy_url,
+        }
+        process = await asyncio.create_subprocess_exec(
+            *command,
+            cwd=str(profile),
+            env=env,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            start_new_session=True,
+        )
+        try:
+            rpc = UpstreamRpc(process, artifacts)
+            initialized = await rpc.request(
+                "initialize",
+                {
+                    "protocolVersion": "2025-06-18",
+                    "capabilities": {"roots": {"listChanged": False}},
+                    "clientInfo": {"name": "ModelMirror build smoke", "version": "wave7-v1"},
+                },
+            )
+            info = initialized.get("result", {}).get("serverInfo", {})
+            if (info.get("name"), info.get("version")) != (
+                contract.upstream_server_name,
+                contract.upstream_server_version,
+            ):
+                raise RuntimeError(f"{adapter_id} upstream identity drifted: {info}")
+            await rpc.notify("notifications/initialized", {})
+            listing = await rpc.request("tools/list", {})
+            tools = listing.get("result", {}).get("tools")
+            digest = upstream_schema_digest(adapter_id, tools)
+            if digest != UPSTREAM_SCHEMA_SHA256[adapter_id]:
+                raise RuntimeError(f"{adapter_id} upstream schema drifted: {digest}")
+            upstream_names = {
+                item["name"] for item in tools if isinstance(item, dict) and isinstance(item.get("name"), str)
+            }
+            if representative:
+                snapshot_name = (
+                    "take_snapshot"
+                    if adapter_id == "chrome-devtools-mcp"
+                    else "browser_snapshot"
+                )
+                snapshot = await rpc.request(
+                    "tools/call",
+                    {"name": snapshot_name, "arguments": {}},
+                    timeout=30,
+                )
+                if result_failed(snapshot):
+                    raise RuntimeError(
+                        f"{adapter_id} representative snapshot failed: "
+                        f"{_safe_failure_diagnostic(snapshot)}"
+                    )
+                _, _, observed_url, _ = extract_snapshot(adapter_id, snapshot)
+                if observed_url != "about:blank":
+                    raise RuntimeError(
+                        f"{adapter_id} representative snapshot origin drifted"
+                    )
+                if adapter_id == "chrome-devtools-mcp":
+                    pages = await rpc.request(
+                        "tools/call", {"name": "list_pages", "arguments": {}}
+                    )
+                else:
+                    pages = await rpc.request(
+                        "tools/call",
+                        {"name": "browser_tabs", "arguments": {"action": "list"}},
+                    )
+                if result_failed(pages) or _page_count(adapter_id, pages) != 1:
+                    raise RuntimeError(f"{adapter_id} did not keep exactly one page")
+            return upstream_names, digest, str(info.get("version") or "")
+        except Exception as exc:
+            await _terminate_process_group(process)
+            diagnostics = b""
+            if process.stderr is not None:
+                diagnostics = await process.stderr.read(16 * 1024)
+            safe_diagnostics = diagnostics.decode("utf-8", errors="replace")[-4096:]
+            raise RuntimeError(
+                f"{adapter_id} upstream smoke failed: {safe_diagnostics}"
+            ) from exc
+        finally:
+            await _terminate_process_group(process)
+            proxy.close()
+            await proxy.wait_closed()
+
+
+async def upstream_smoke(*, representative: bool = True) -> None:
+    assert_schema_snapshots()
+    upstream_root = Path(os.getenv("MCP_BROWSER_UPSTREAM_ROOT", "/opt/browser-upstream"))
+    for adapter_id, contract in BROWSER_ADAPTERS.items():
+        chromium = _chromium_version(adapter_id)
+        print(f"{adapter_id}: chromium_runtime={chromium}", flush=True)
+        installed = _package_version(upstream_root, contract.package_name)
+        if installed != contract.package_version:
+            raise RuntimeError(
+                f"{adapter_id} package drift: expected={contract.package_version} installed={installed}"
+            )
+        names, upstream_digest, server_version = await asyncio.wait_for(
+            discover(adapter_id, representative=representative), timeout=60
+        )
+        public_digest = _schema_digest(contract)
+        if public_digest != BROWSER_SCHEMA_SHA256[adapter_id]:
+            raise RuntimeError(f"{adapter_id} public schema drifted")
+        print(
+            f"{adapter_id}: package={contract.package_name}@{installed}, "
+            f"server={server_version}, upstream_tools={len(names)}, "
+            f"forwarded_tools={len(contract.tools) - 1}, "
+            f"upstream_schema_sha256={upstream_digest}, "
+            f"public_schema_sha256={public_digest}, "
+            f"representative={'snapshot' if representative else 'runtime-gated'}",
+            flush=True,
+        )
+
+
+async def _gateway_request(
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+    request_id: int,
+    method: str,
+    params: dict[str, object],
+    *,
+    allow_error: bool = False,
+) -> dict[str, object]:
+    writer.write(
+        json.dumps(
+            {"jsonrpc": "2.0", "id": request_id, "method": method, "params": params},
+            separators=(",", ":"),
+        ).encode("utf-8")
+        + b"\n"
+    )
+    await writer.drain()
+    raw = await asyncio.wait_for(reader.readline(), timeout=60)
+    response = json.loads(raw.decode("utf-8"))
+    if not isinstance(response, dict) or response.get("id") != request_id:
+        raise RuntimeError(f"gateway response invalid for {method}")
+    if "error" in response and not allow_error:
+        raise RuntimeError(f"gateway {method} failed: {response['error']}")
+    return response
+
+
+def _assert_timeout_outcome(
+    response: dict[str, object], elapsed_seconds: float,
+) -> None:
+    error = response.get("error")
+    if not isinstance(error, dict):
+        raise RuntimeError("gateway timeout response did not contain an error")
+    if error.get("code") != -32008:
+        raise RuntimeError("gateway timeout error code drifted")
+    data = error.get("data")
+    if not isinstance(data, dict):
+        raise RuntimeError("gateway timeout error data missing")
+    if data.get("reason") != "unknown_outcome":
+        raise RuntimeError("gateway timeout reason was not unknown_outcome")
+    if data.get("retryable") is not False:
+        raise RuntimeError("gateway timeout unexpectedly became retryable")
+
+    reviewed_timeout = float(BROWSER_LIMITS["navigation_timeout_seconds"])
+    if not reviewed_timeout - 2 <= elapsed_seconds <= reviewed_timeout + 8:
+        raise RuntimeError("gateway navigation timeout elapsed window drifted")
+
+
+def _tool_result(response: dict[str, object]) -> dict[str, object]:
+    result = response.get("result")
+    if not isinstance(result, dict):
+        raise RuntimeError("gateway tool result missing")
+    return result
+
+
+def _element_ref(result: dict[str, object], role: str) -> str:
+    structured = result.get("structuredContent")
+    if not isinstance(structured, dict):
+        raise RuntimeError("gateway snapshot structuredContent missing")
+    elements = structured.get("elements")
+    if not isinstance(elements, list):
+        raise RuntimeError("gateway snapshot elements missing")
+    for element in elements:
+        if (
+            isinstance(element, dict)
+            and element.get("role") == role
+            and isinstance(element.get("ref"), str)
+        ):
+            return str(element["ref"])
+    raise RuntimeError(f"gateway snapshot did not expose a safe {role} ref")
+
+
+async def _wait_for_session_cleanup(session_id: str) -> None:
+    for _ in range(100):
+        profile = PROFILE_ROOT / session_id
+        artifacts = ARTIFACT_ROOT / session_id
+        residual_process = False
+        proc = Path("/proc")
+        if proc.exists():
+            for entry in proc.iterdir():
+                if not entry.name.isdigit():
+                    continue
+                try:
+                    command = (entry / "cmdline").read_bytes()
+                except OSError:
+                    continue
+                if session_id.encode("ascii") in command:
+                    residual_process = True
+                    break
+        if not profile.exists() and not artifacts.exists() and not residual_process:
+            return
+        await asyncio.sleep(0.1)
+    raise RuntimeError(f"gateway session cleanup incomplete: {session_id}")
+
+
+async def gateway_smoke(
+    adapter_id: str, url: str, *, expect_timeout: bool = False,
+) -> None:
+    contract = BROWSER_ADAPTERS[adapter_id]
+    reader, writer = await asyncio.open_unix_connection(str(SOCKET_PATH))
+    session_id = ""
+    try:
+        writer.write(
+            json.dumps(
+                {
+                    "action": "mcp_stdio",
+                    "adapter_id": adapter_id,
+                    "configuration": {
+                        "project_id": adapter_id,
+                        "contract_version": CONTRACT_VERSION,
+                        "tool_schema_sha256": BROWSER_SCHEMA_SHA256[adapter_id],
+                        "limits": BROWSER_LIMITS,
+                    },
+                },
+                separators=(",", ":"),
+            ).encode("utf-8")
+            + b"\n"
+        )
+        await writer.drain()
+        handshake = json.loads((await asyncio.wait_for(reader.readline(), timeout=60)).decode("utf-8"))
+        if not isinstance(handshake, dict) or handshake.get("ok") is not True:
+            raise RuntimeError(f"gateway handshake failed: {handshake}")
+        upstream = handshake.get("upstream")
+        if not isinstance(upstream, dict) or (
+            upstream.get("package"), upstream.get("version"), upstream.get("verified")
+        ) != (contract.package_name, contract.package_version, True):
+            raise RuntimeError(f"gateway upstream identity invalid: {upstream}")
+
+        request_id = 1
+        await _gateway_request(
+            reader,
+            writer,
+            request_id,
+            "initialize",
+            {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "ModelMirror gateway smoke", "version": "wave7-v1"},
+            },
+        )
+        request_id += 1
+        listed = _tool_result(
+            await _gateway_request(reader, writer, request_id, "tools/list", {})
+        )
+        names = {
+            item.get("name")
+            for item in listed.get("tools", [])
+            if isinstance(item, dict)
+        }
+        if names != set(contract.tools):
+            raise RuntimeError(f"gateway public tools drifted: {names}")
+
+        request_id += 1
+        initial_status = _tool_result(
+            await _gateway_request(
+                reader,
+                writer,
+                request_id,
+                "tools/call",
+                {"name": "browser_session_status", "arguments": {}},
+            )
+        ).get("structuredContent")
+        if not isinstance(initial_status, dict) or (
+            initial_status.get("status") != "active"
+            or initial_status.get("tainted") is not False
+            or initial_status.get("current_origin") != ""
+            or initial_status.get("action_count") != 0
+        ):
+            raise RuntimeError(
+                f"gateway initial browser status invalid: {initial_status}"
+            )
+
+        navigate = "navigate_page" if adapter_id == "chrome-devtools-mcp" else "browser_navigate"
+        snapshot = "take_snapshot" if adapter_id == "chrome-devtools-mcp" else "browser_snapshot"
+        fill = "fill" if adapter_id == "chrome-devtools-mcp" else "browser_fill_form"
+        click = "click" if adapter_id == "chrome-devtools-mcp" else "browser_click"
+        screenshot = "take_screenshot" if adapter_id == "chrome-devtools-mcp" else "browser_take_screenshot"
+
+        request_id += 1
+        if expect_timeout:
+            started = asyncio.get_running_loop().time()
+            timeout_response = await _gateway_request(
+                reader,
+                writer,
+                request_id,
+                "tools/call",
+                {"name": navigate, "arguments": {"url": url}},
+                allow_error=True,
+            )
+            elapsed_seconds = asyncio.get_running_loop().time() - started
+            _assert_timeout_outcome(timeout_response, elapsed_seconds)
+            print(
+                f"{adapter_id}: timeout=unknown_outcome navigation_timeout=20s "
+                "elapsed_window=ok retryable=false",
+                flush=True,
+            )
+            return
+
+        await _gateway_request(
+            reader,
+            writer,
+            request_id,
+            "tools/call",
+            {"name": navigate, "arguments": {"url": url}},
+        )
+        request_id += 1
+        first_snapshot = _tool_result(
+            await _gateway_request(
+                reader, writer, request_id, "tools/call", {"name": snapshot, "arguments": {}}
+            )
+        )
+        textbox_ref = _element_ref(first_snapshot, "textbox")
+        request_id += 1
+        await _gateway_request(
+            reader,
+            writer,
+            request_id,
+            "tools/call",
+            {"name": fill, "arguments": {"ref": textbox_ref, "value": "wave7-safe"}},
+        )
+        request_id += 1
+        second_snapshot = _tool_result(
+            await _gateway_request(
+                reader, writer, request_id, "tools/call", {"name": snapshot, "arguments": {}}
+            )
+        )
+        button_ref = _element_ref(second_snapshot, "button")
+        request_id += 1
+        await _gateway_request(
+            reader,
+            writer,
+            request_id,
+            "tools/call",
+            {"name": click, "arguments": {"ref": button_ref}},
+        )
+        request_id += 1
+        outcome_snapshot = _tool_result(
+            await _gateway_request(
+                reader,
+                writer,
+                request_id,
+                "tools/call",
+                {"name": snapshot, "arguments": {}},
+            )
+        )
+        outcome_text = "\n".join(
+            str(item.get("text") or "")
+            for item in outcome_snapshot.get("content", [])
+            if isinstance(item, dict) and item.get("type") == "text"
+        )
+        if "clicked:wave7-safe" not in outcome_text:
+            raise RuntimeError("gateway click/fill outcome was not observed")
+        request_id += 1
+        screenshot_result = _tool_result(
+            await _gateway_request(
+                reader,
+                writer,
+                request_id,
+                "tools/call",
+                {"name": screenshot, "arguments": {"full_page": False}},
+            )
+        )
+        artifact = screenshot_result.get("structuredContent")
+        if not isinstance(artifact, dict):
+            raise RuntimeError("gateway screenshot metadata missing")
+        relative_path = str(artifact.get("relative_path") or "")
+        segments = Path(relative_path).parts
+        if len(segments) != 3 or segments[1] != "registered":
+            raise RuntimeError(f"gateway artifact locator invalid: {relative_path}")
+        session_id = segments[0]
+        artifact_path = ARTIFACT_ROOT / relative_path
+        payload = artifact_path.read_bytes()
+        if not payload.startswith(b"\x89PNG\r\n\x1a\n"):
+            raise RuntimeError("gateway screenshot is not PNG")
+        if int(artifact.get("size") or 0) != len(payload):
+            raise RuntimeError("gateway screenshot size mismatch")
+        request_id += 1
+        status = _tool_result(
+            await _gateway_request(
+                reader,
+                writer,
+                request_id,
+                "tools/call",
+                {"name": "browser_session_status", "arguments": {}},
+            )
+        ).get("structuredContent")
+        if not isinstance(status, dict) or status.get("tainted") is not False:
+            raise RuntimeError(f"gateway session unexpectedly tainted: {status}")
+        print(
+            f"{adapter_id}: gateway=ok navigate=ok snapshot=ok fill=ok click=ok "
+            f"outcome=ok screenshot=png artifact={relative_path}",
+            flush=True,
+        )
+    finally:
+        writer.close()
+        try:
+            await writer.wait_closed()
+        except (ConnectionError, OSError):
+            pass
+    if session_id:
+        await _wait_for_session_cleanup(session_id)
+        # The trusted helper shares the artifact volume, but not the browser
+        # container's private /profiles tmpfs or PID namespace.  Full process
+        # and profile cleanup is therefore asserted by smoke_browser_runtime
+        # after Docker automatically restarts the one-shot pair.
+        print(
+            f"{adapter_id}: artifact_cleanup=ok session={session_id}",
+            flush=True,
+        )
+
+
+async def main() -> None:
+    if sys.argv[1:] == ["--contract-only"]:
+        await upstream_smoke(representative=False)
+        return
+    if (
+        len(sys.argv) in {5, 6}
+        and sys.argv[1] == "--gateway-url"
+        and sys.argv[3] == "--adapter"
+        and sys.argv[4] in BROWSER_ADAPTERS
+        and (len(sys.argv) == 5 or sys.argv[5] == "--expect-timeout")
+    ):
+        # Run from the trusted UID 0 helper/container.  The orchestrator starts
+        # a fresh browser+egress container pair for each adapter so no session
+        # or Chromium descendant can cross adapter lifecycles.
+        await gateway_smoke(
+            sys.argv[4], sys.argv[2], expect_timeout=len(sys.argv) == 6,
+        )
+        return
+    if len(sys.argv) != 1:
+        raise SystemExit(
+            "usage: smoke_browser_adapters.py "
+            "[--contract-only | --gateway-url URL --adapter ADAPTER_ID "
+            "[--expect-timeout]]"
+        )
+    await upstream_smoke(representative=True)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/server/sandbox_sidecar/smoke_browser_runtime.py
+++ b/server/sandbox_sidecar/smoke_browser_runtime.py
@@ -1,0 +1,1720 @@
+"""Isolated real-container acceptance smoke for Wave 7 browser adapters.
+
+This host-side harness never calls Compose and never addresses a shared-stack
+resource. Every Docker object uses a random name below the fixed
+``mm-wave7-runtime-smoke-`` prefix and is removed explicitly in ``finally``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import secrets
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Final
+
+
+PREFIX: Final = "mm-wave7-runtime-smoke"
+ADAPTERS: Final = ("chrome-devtools-mcp", "playwright-mcp")
+ADAPTER_TOKENS: Final = {
+    "chrome-devtools-mcp": "cdp",
+    "playwright-mcp": "pw",
+}
+FIXTURE_HOST: Final = "fixture.wave7.test"
+TIMEOUT_FIXTURE_PATH: Final = "/__modelmirror_timeout"
+TIMEOUT_FIXTURE_DELAY_SECONDS: Final = 25
+TIMEOUT_RUNTIME_EVENTS: Final = (
+    '"browser_runtime_event":"rpc_timeout"',
+    '"browser_runtime_event":"upstream_result_upstream_timeout"',
+)
+RESOURCE_NAME = re.compile(r"^mm-wave7-runtime-smoke-[0-9a-f]{8}(?:-[a-z0-9-]+)?$")
+
+
+FIXTURE_CODE = r'''
+import http.server
+import os
+import time
+
+TIMEOUT_PATH = os.environ["MM_WAVE7_TIMEOUT_PATH"]
+TIMEOUT_DELAY_SECONDS = int(os.environ["MM_WAVE7_TIMEOUT_DELAY_SECONDS"])
+
+HTML = b"""<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>Wave 7 Fixture</title></head>
+<body>
+  <label for="wave7-input">Wave 7 text</label>
+  <input id="wave7-input" aria-label="Wave 7 text" autocomplete="off">
+  <button id="wave7-button" type="button"
+    onclick="document.getElementById('wave7-result').textContent='clicked:'+document.getElementById('wave7-input').value">
+    Apply
+  </button>
+  <output id="wave7-result" aria-live="polite">idle</output>
+</body></html>"""
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        path = self.path.partition("?")[0]
+        time.sleep(TIMEOUT_DELAY_SECONDS if path == TIMEOUT_PATH else 3)
+        try:
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(HTML)))
+            self.send_header("Cache-Control", "no-store")
+            self.end_headers()
+            self.wfile.write(HTML)
+        except (BrokenPipeError, ConnectionResetError):
+            pass
+
+    def log_message(self, *_args):
+        return
+
+http.server.ThreadingHTTPServer(("0.0.0.0", 80), Handler).serve_forever()
+'''
+
+
+CAPABILITY_RESTART_PROBE_CODE = r'''
+import asyncio
+import json
+import secrets
+from pathlib import Path
+
+SOCKET = Path("/run/modelmirror-browser-egress/browser-egress.sock")
+CONTROL = SOCKET.with_name("browser-egress.control")
+URL = "http://fixture.wave7.test/"
+
+async def request(payload, timeout=10):
+    reader, writer = await asyncio.wait_for(
+        asyncio.open_unix_connection(str(SOCKET)), timeout=timeout
+    )
+    writer.write(json.dumps(payload, separators=(",", ":")).encode() + b"\n")
+    await writer.drain()
+    raw = await asyncio.wait_for(reader.readline(), timeout=timeout)
+    writer.close()
+    try:
+        await writer.wait_closed()
+    except (ConnectionError, OSError):
+        pass
+    if not raw:
+        raise RuntimeError("egress probe received EOF")
+    return json.loads(raw.decode())
+
+async def wait_generation(old_key=None):
+    for _ in range(300):
+        try:
+            key = CONTROL.read_text(encoding="ascii").strip()
+            if len(key) == 64 and key != old_key:
+                health = await request({"action": "health"}, timeout=2)
+                if health.get("ok") is True:
+                    return key
+        except (OSError, asyncio.TimeoutError, ConnectionError, ValueError):
+            pass
+        await asyncio.sleep(0.1)
+    raise RuntimeError("egress generation did not become ready")
+
+async def main():
+    old_key = await wait_generation()
+    capability = secrets.token_hex(32)
+    registered = await request({
+        "action": "register", "control_key": old_key, "capability": capability,
+    })
+    if registered.get("ok") is not True:
+        raise RuntimeError("old capability registration failed")
+    authorized = await request({
+        "action": "authorize", "control_key": old_key,
+        "capability": capability, "url": URL,
+    })
+    if authorized.get("ok") is not True:
+        raise RuntimeError("old capability authorization failed")
+    stopped = await request({"action": "shutdown", "control_key": old_key})
+    if stopped.get("ok") is not True:
+        raise RuntimeError("authenticated egress shutdown failed")
+    await wait_generation(old_key)
+    old_control = await request({"action": "watch", "control_key": old_key})
+    if old_control.get("code") != "browser_egress_control_denied":
+        raise RuntimeError("old egress control key was accepted")
+    old_capability = await request({
+        "action": "connect", "capability": capability, "url": URL,
+    })
+    if old_capability.get("code") != "browser_egress_capability_denied":
+        raise RuntimeError("old egress capability was accepted")
+    print("egress_generation=rotated old_control=denied old_capability=denied", flush=True)
+
+asyncio.run(main())
+'''
+
+
+def _bounded_container_args(
+    *, name: str, user: str, network: str, label: str,
+    pids: int, memory: str, cpus: str,
+) -> list[str]:
+    return [
+        "--name", name,
+        "--label", f"com.modelmirror.wave7-runtime-smoke={label}",
+        "--network", network,
+        "--user", user,
+        "--read-only",
+        "--cap-drop", "ALL",
+        "--security-opt", "no-new-privileges:true",
+        "--pids-limit", str(pids),
+        "--memory", memory,
+        "--cpus", cpus,
+        "--tmpfs", "/tmp:rw,nosuid,nodev,noexec,size=33554432,uid=65532,gid=65532,mode=0700",
+    ]
+
+
+def _create_network(
+    runner: DockerRunner, ledger: ResourceLedger, base: str, seed: int,
+) -> tuple[str, str]:
+    name = _resource(base, "net")
+    _reserve_resource(runner, ledger, "network", name)
+    for offset in range(256):
+        octet = (seed + offset) % 256
+        subnet = f"198.18.{octet}.0/24"
+        result = runner.run(
+            "network", "create", "--driver", "bridge", "--subnet", subnet,
+            name, check=False,
+        )
+        if result.returncode == 0:
+            return name, f"198.18.{octet}.10"
+        diagnostic = (result.stderr or result.stdout).lower()
+        if "overlap" not in diagnostic and "pool" not in diagnostic:
+            raise SmokeFailure(f"isolated network creation failed: {diagnostic[-2048:]}")
+    raise SmokeFailure("no isolated synthetic DNS subnet was available")
+
+
+def _create_volume(
+    runner: DockerRunner,
+    ledger: ResourceLedger,
+    name: str,
+    *,
+    tmpfs: bool = False,
+) -> None:
+    _reserve_resource(runner, ledger, "volume", name)
+    arguments = ["volume", "create"]
+    if tmpfs:
+        arguments.extend(
+            [
+                "--driver", "local", "--opt", "type=tmpfs",
+                "--opt", "device=tmpfs",
+                "--opt", "o=size=67108864,uid=65532,gid=65532,mode=0700,nosuid,nodev,noexec",
+            ]
+        )
+    runner.run(*arguments, name)
+
+
+def _start_fixture(
+    runner: DockerRunner,
+    ledger: ResourceLedger,
+    *,
+    base: str,
+    image: str,
+    network: str,
+    address: str,
+) -> str:
+    name = _resource(base, "fixture")
+    _reserve_resource(runner, ledger, "container", name)
+    runner.run(
+        "run", "-d",
+        *_bounded_container_args(
+            name=name, user="65532:65532", network=network, label=base,
+            pids=32, memory="128m", cpus="0.25",
+        ),
+        "--ip", address,
+        "--network-alias", FIXTURE_HOST,
+        "--env", f"MM_WAVE7_TIMEOUT_PATH={TIMEOUT_FIXTURE_PATH}",
+        "--env", f"MM_WAVE7_TIMEOUT_DELAY_SECONDS={TIMEOUT_FIXTURE_DELAY_SECONDS}",
+        image, "python", "-c", FIXTURE_CODE,
+    )
+    _assert_common_security(
+        _inspect(runner, name), user="65532:65532", network_mode=network
+    )
+    deadline = time.monotonic() + 15
+    while time.monotonic() < deadline:
+        ready = runner.run(
+            "exec", name, "python", "-c",
+            "import socket; s=socket.create_connection(('127.0.0.1',80),2); s.close()",
+            check=False, timeout=5,
+        )
+        if ready.returncode == 0:
+            return name
+        time.sleep(0.2)
+    logs = runner.run("logs", name, check=False).stdout[-2048:]
+    raise SmokeFailure(f"synthetic fixture did not bind port 80: {logs}")
+
+
+def _wait_log(
+    runner: DockerRunner, name: str, marker: str, *, timeout: int = 90,
+) -> str:
+    deadline = time.monotonic() + timeout
+    last = ""
+    while time.monotonic() < deadline:
+        result = runner.run("logs", name, check=False, timeout=10)
+        last = f"{result.stdout}\n{result.stderr}"
+        if marker in last:
+            return last
+        inspect = runner.run("inspect", name, check=False, timeout=10)
+        if inspect.returncode != 0:
+            break
+        state = json.loads(inspect.stdout)[0]["State"]
+        if state.get("Status") == "exited":
+            # Docker can report the exit before the json-file log driver has
+            # exposed the final buffered lines. Wait for the final status,
+            # then read once more so a successful cleanup marker is not lost.
+            runner.run("wait", name, check=False, timeout=10)
+            final_logs = runner.run("logs", name, check=False, timeout=10)
+            last = f"{final_logs.stdout}\n{final_logs.stderr}"
+            if marker in last:
+                return last
+            break
+        time.sleep(0.2)
+    raise SmokeFailure(
+        f"{name} did not emit {marker}: "
+        f"state={json.dumps(_safe_container_state(runner, name), separators=(',', ':'))} "
+        f"logs={_safe_log_tail(last)}"
+    )
+
+
+def _wait_exit(runner: DockerRunner, name: str, *, timeout: int = 90) -> None:
+    result = runner.run("wait", name, timeout=timeout)
+    try:
+        code = int(result.stdout.strip())
+    except ValueError as exc:
+        raise SmokeFailure(f"invalid docker wait status for {name}") from exc
+    if code != 0:
+        logs = runner.run("logs", name, check=False).stdout[-4096:]
+        raise SmokeFailure(f"{name} exited with {code}: {logs}")
+
+
+def _run_seccomp_calibration(
+    runner: DockerRunner, ledger: ResourceLedger, *, base: str, image: str,
+) -> None:
+    name = _resource(base, "seccomp-control")
+    _reserve_resource(runner, ledger, "container", name)
+    runner.run(
+        "run", "-d",
+        *_bounded_container_args(
+            name=name, user="65532:65532", network="none", label=base,
+            pids=16, memory="96m", cpus="0.25",
+        ),
+        "--security-opt", "seccomp=unconfined",
+        image, "python", "-c", SECCOMP_PROBE_CODE, "allow",
+    )
+    payload = _inspect(runner, name)
+    _assert_common_security(payload, user="65532:65532", network_mode="none")
+    host = payload["HostConfig"]
+    security = set(host.get("SecurityOpt") or [])
+    if "seccomp=unconfined" not in security or not any(
+        item.startswith("no-new-privileges") for item in security
+    ):
+        raise SmokeFailure("calibration container security options drifted")
+    if payload.get("Mounts") or host.get("Binds") or host.get("Devices"):
+        raise SmokeFailure("calibration container unexpectedly has host access")
+    logs = _wait_log(runner, name, '"mode":"allow"', timeout=30)
+    print(next(line for line in logs.splitlines() if '"mode":"allow"' in line))
+    _wait_exit(runner, name, timeout=30)
+
+
+def _wait_path(
+    runner: DockerRunner, container: str, path: str, *, timeout: int = 30,
+) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        result = runner.run(
+            "exec", container, "python", "-c",
+            f"from pathlib import Path; assert Path({path!r}).exists()",
+            check=False, timeout=5,
+        )
+        if result.returncode == 0:
+            return
+        time.sleep(0.2)
+    raise SmokeFailure(f"{container} did not publish {path}")
+
+
+class SmokeFailure(RuntimeError):
+    """A fail-closed runtime acceptance failure."""
+
+
+@dataclass
+class DockerRunner:
+    timeout: int = 120
+
+    def run(
+        self,
+        *arguments: str,
+        check: bool = True,
+        timeout: int | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        completed = subprocess.run(
+            ["docker", *arguments],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout or self.timeout,
+        )
+        if check and completed.returncode != 0:
+            diagnostic = (completed.stderr or completed.stdout)[-4096:]
+            raise SmokeFailure(
+                f"docker {arguments[0]} failed with {completed.returncode}: {diagnostic}"
+            )
+        return completed
+
+
+@dataclass
+class ResourceLedger:
+    runner: DockerRunner
+    containers: list[str] = field(default_factory=list)
+    volumes: list[str] = field(default_factory=list)
+    networks: list[str] = field(default_factory=list)
+
+    def cleanup(self) -> None:
+        failures: list[str] = []
+        for name in reversed(self.containers):
+            self.runner.run("rm", "-f", name, check=False, timeout=30)
+            if _object_present(self.runner, "container", name):
+                failures.append(f"container:{name}")
+        for name in reversed(self.volumes):
+            self.runner.run("volume", "rm", "-f", name, check=False, timeout=30)
+            if _object_present(self.runner, "volume", name):
+                failures.append(f"volume:{name}")
+        for name in reversed(self.networks):
+            self.runner.run("network", "rm", name, check=False, timeout=30)
+            if _object_present(self.runner, "network", name):
+                failures.append(f"network:{name}")
+        if failures:
+            raise SmokeFailure(
+                "runtime smoke cleanup left exact resources: " + ",".join(failures)
+            )
+
+
+def _resource(base: str, suffix: str) -> str:
+    name = f"{base}-{suffix}"
+    if not RESOURCE_NAME.fullmatch(name):
+        raise SmokeFailure(f"unsafe smoke resource name: {name}")
+    return name
+
+
+def _object_present(runner: DockerRunner, kind: str, name: str) -> bool:
+    result = runner.run(kind, "inspect", name, check=False, timeout=10)
+    if result.returncode == 0:
+        return True
+    diagnostic = f"{result.stdout}\n{result.stderr}".lower()
+    if "no such" in diagnostic or "not found" in diagnostic:
+        return False
+    raise SmokeFailure(f"could not verify {kind} {name} absence: {diagnostic[-2048:]}")
+
+
+def _reserve_resource(
+    runner: DockerRunner,
+    ledger: ResourceLedger,
+    kind: str,
+    name: str,
+) -> None:
+    if _object_present(runner, kind, name):
+        raise SmokeFailure(f"runtime smoke {kind} already exists: {name}")
+    targets = {
+        "container": ledger.containers,
+        "volume": ledger.volumes,
+        "network": ledger.networks,
+    }
+    if kind not in targets:
+        raise SmokeFailure(f"unsupported runtime smoke resource kind: {kind}")
+    targets[kind].append(name)
+
+
+def _inspect(runner: DockerRunner, name: str) -> dict[str, Any]:
+    payload = json.loads(runner.run("inspect", name).stdout)
+    if not isinstance(payload, list) or len(payload) != 1:
+        raise SmokeFailure(f"unexpected inspect payload for {name}")
+    return payload[0]
+
+
+def _assert_common_security(
+    payload: dict[str, Any], *, user: str, network_mode: str,
+    cap_add: frozenset[str] = frozenset(),
+) -> None:
+    host = payload["HostConfig"]
+    config = payload["Config"]
+    if config.get("User") != user:
+        raise SmokeFailure(f"unexpected container user: {config.get('User')}")
+    if host.get("NetworkMode") != network_mode:
+        raise SmokeFailure(f"unexpected network mode: {host.get('NetworkMode')}")
+    if host.get("ReadonlyRootfs") is not True or host.get("Privileged") is not False:
+        raise SmokeFailure("container root or privilege boundary is unsafe")
+    actual_cap_add = {
+        str(value).removeprefix("CAP_") for value in (host.get("CapAdd") or [])
+    }
+    if set(host.get("CapDrop") or []) != {"ALL"} or actual_cap_add != set(cap_add):
+        raise SmokeFailure("container capability boundary is unsafe")
+    security = set(host.get("SecurityOpt") or [])
+    if not any(item.startswith("no-new-privileges") for item in security):
+        raise SmokeFailure("no-new-privileges is missing")
+    if int(host.get("PidsLimit") or 0) <= 0 or int(host.get("Memory") or 0) <= 0:
+        raise SmokeFailure("container process or memory limit is missing")
+    if int(host.get("NanoCpus") or 0) <= 0:
+        raise SmokeFailure("container CPU limit is missing")
+    forbidden_targets = {"/var/run/docker.sock", "/run/docker.sock"}
+    if any(mount.get("Destination") in forbidden_targets for mount in payload.get("Mounts", [])):
+        raise SmokeFailure("Docker socket mount is forbidden")
+    if any(mount.get("Type") == "bind" for mount in payload.get("Mounts", [])):
+        raise SmokeFailure("host bind mounts are forbidden")
+    if host.get("Devices"):
+        raise SmokeFailure("device access is forbidden")
+
+
+def _assert_browser_procfs_boundary(payload: dict[str, Any]) -> None:
+    host = payload["HostConfig"]
+    readonly = set(host.get("ReadonlyPaths") or [])
+    masked = set(host.get("MaskedPaths") or [])
+    required_readonly = {
+        "/proc/bus", "/proc/fs", "/proc/irq", "/proc/sys",
+        "/proc/sysrq-trigger",
+    }
+    required_masked = {
+        "/proc/kcore", "/proc/keys", "/proc/timer_list",
+    }
+    if not required_readonly.issubset(readonly):
+        raise SmokeFailure("browser procfs read-only paths are incomplete")
+    if not required_masked.issubset(masked):
+        raise SmokeFailure("browser procfs masked paths are incomplete")
+    security = set(host.get("SecurityOpt") or [])
+    if any("systempaths=unconfined" in item for item in security):
+        raise SmokeFailure("browser procfs system paths are unconfined")
+
+
+def _state(payload: dict[str, Any]) -> tuple[int, str, int, str]:
+    state = payload["State"]
+    return (
+        int(payload.get("RestartCount") or 0),
+        str(state.get("StartedAt") or ""),
+        int(state.get("Pid") or 0),
+        str(payload.get("Id") or ""),
+    )
+
+
+SECCOMP_PROBE_CODE = r'''
+import ctypes
+import errno
+import json
+import os
+import subprocess
+import sys
+import time
+
+EXPECT = sys.argv[1]
+if EXPECT == "allow":
+    time.sleep(2)
+
+child_code = r"""
+import ctypes, os, time
+libc = ctypes.CDLL(None, use_errno=True)
+if libc.prctl(4, 1, 0, 0, 0) != 0 or libc.prctl(3, 0, 0, 0, 0) != 1:
+    raise SystemExit(21)
+buffer = ctypes.create_string_buffer(b'wave7-seccomp-buffer')
+print(f'{os.getpid()} {ctypes.addressof(buffer)} {len(buffer.raw)}', flush=True)
+time.sleep(30)
+"""
+
+class IOVec(ctypes.Structure):
+    _fields_ = [("iov_base", ctypes.c_void_p), ("iov_len", ctypes.c_size_t)]
+
+child = subprocess.Popen(
+    [sys.executable, "-c", child_code], stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE, text=True,
+)
+try:
+    line = child.stdout.readline().strip()
+    child_pid, remote_address, size = map(int, line.split())
+    os.kill(child_pid, 0)
+    libc = ctypes.CDLL(None, use_errno=True)
+    local_read = ctypes.create_string_buffer(size)
+    local_write = ctypes.create_string_buffer(b"wave7-seccomp-write".ljust(size, b"!"))
+    read_local = IOVec(ctypes.cast(local_read, ctypes.c_void_p), size)
+    read_remote = IOVec(ctypes.c_void_p(remote_address), size)
+    write_local = IOVec(ctypes.cast(local_write, ctypes.c_void_p), size)
+    write_remote = IOVec(ctypes.c_void_p(remote_address), size)
+
+    ctypes.set_errno(0)
+    read_result = libc.process_vm_readv(
+        child_pid, ctypes.byref(read_local), 1, ctypes.byref(read_remote), 1, 0
+    )
+    read_errno = ctypes.get_errno()
+    ctypes.set_errno(0)
+    write_result = libc.process_vm_writev(
+        child_pid, ctypes.byref(write_local), 1, ctypes.byref(write_remote), 1, 0
+    )
+    write_errno = ctypes.get_errno()
+    ctypes.set_errno(0)
+    ptrace_result = libc.ptrace(16, child_pid, None, None)
+    ptrace_errno = ctypes.get_errno()
+    if ptrace_result == 0:
+        os.waitpid(child_pid, 0)
+        libc.ptrace(17, child_pid, None, None)
+
+    if EXPECT == "allow":
+        if not (read_result == size and write_result == size and ptrace_result == 0):
+            raise RuntimeError(
+                f"calibration failed: read={read_result}/{read_errno} "
+                f"write={write_result}/{write_errno} ptrace={ptrace_result}/{ptrace_errno}"
+            )
+    elif EXPECT == "deny":
+        denied = (
+            (read_result, read_errno), (write_result, write_errno),
+            (ptrace_result, ptrace_errno),
+        )
+        if not all(result == -1 and error == errno.EPERM for result, error in denied):
+            raise RuntimeError(f"seccomp denial mismatch: {denied}")
+        syscall_numbers = {
+            "x86_64": {
+                "mount": 165, "pivot_root": 155, "open_by_handle_at": 304,
+                "pidfd_getfd": 438, "bpf": 321, "keyctl": 250,
+                "userfaultfd": 323, "io_uring_setup": 425,
+            },
+            "aarch64": {
+                "mount": 40, "pivot_root": 41, "open_by_handle_at": 265,
+                "pidfd_getfd": 438, "bpf": 280, "keyctl": 219,
+                "userfaultfd": 282, "io_uring_setup": 425,
+            },
+        }.get(os.uname().machine)
+        if syscall_numbers is None:
+            raise RuntimeError("unsupported seccomp probe architecture")
+        dangerous = {}
+        for name, number in syscall_numbers.items():
+            ctypes.set_errno(0)
+            result = libc.syscall(number, -1, 0, 0, 0, 0, 0)
+            error = ctypes.get_errno()
+            if result != -1 or error not in {errno.EPERM, errno.EACCES, errno.ENOSYS}:
+                raise RuntimeError(
+                    f"dangerous syscall was not denied: {name}={result}/{error}"
+                )
+            dangerous[name] = "denied"
+    else:
+        raise RuntimeError("unknown seccomp probe expectation")
+    ptrace_scope = open("/proc/sys/kernel/yama/ptrace_scope", encoding="ascii").read().strip()
+    print(json.dumps({
+        "seccomp_probe": "ok", "mode": EXPECT, "dumpable_child": True,
+        "valid_remote_buffer": True, "ptrace_scope": ptrace_scope,
+        "dangerous_syscalls": dangerous if EXPECT == "deny" else {},
+    }, separators=(",", ":")), flush=True)
+    if EXPECT == "allow":
+        time.sleep(2)
+finally:
+    child.terminate()
+    try:
+        child.wait(timeout=3)
+    except subprocess.TimeoutExpired:
+        child.kill()
+        child.wait(timeout=3)
+'''
+
+
+CHROMIUM_PROBE_CODE = r'''
+import json
+import os
+from pathlib import Path
+
+rows = []
+for entry in Path("/proc").iterdir():
+    if not entry.name.isdigit():
+        continue
+    try:
+        command = (entry / "cmdline").read_bytes().replace(b"\0", b" ").decode(errors="replace")
+    except OSError:
+        continue
+    executable = ""
+    try:
+        executable = os.readlink(entry / "exe")
+    except OSError:
+        pass
+    argv0 = command.split(" ", 1)[0]
+    if (
+        "chrome-linux64/chrome" in executable
+        or executable.endswith("modelmirror-chromium")
+        or argv0.endswith("modelmirror-chromium")
+        or os.path.basename(argv0) == "chrome"
+    ):
+        rows.append((entry, command))
+if not rows:
+    raise RuntimeError("no real Chromium process was observed")
+forbidden = ("--no-sandbox", "--disable-web-security", "--remote-debugging-address=0.0.0.0")
+if any(token in command for _, command in rows for token in forbidden):
+    raise RuntimeError("forbidden Chromium argument observed")
+required_features = (
+    "AutofillServerCommunication",
+    "NetworkTimeServiceQuerying",
+    "PreconnectToSearch",
+    "NoSearchDomainCheck",
+)
+if any(not any(token in command for _, command in rows) for token in required_features):
+    raise RuntimeError("required Chromium network guard was not observed")
+# docker exec joins the container's initial user namespace.  PID 1 is
+# deliberately non-dumpable, so reading its proc namespace can be denied even
+# to the same UID; the probe's own namespace is the equivalent safe baseline.
+container_user = os.readlink("/proc/self/ns/user")
+userns_children = 0
+for entry, _ in rows:
+    try:
+        if os.readlink(entry / "ns/user") != container_user:
+            userns_children += 1
+    except OSError:
+        pass
+if userns_children < 1:
+    raise RuntimeError("Chromium user namespace sandbox was not observed")
+print(json.dumps({
+    "chromium_processes": len(rows), "userns_sandboxed": userns_children,
+    "no_sandbox": False, "disable_web_security": False,
+    "remote_debug_all": False,
+    "autofill_server_disabled": True, "network_time_disabled": True,
+    "search_preconnect_disabled": True, "search_domain_check_disabled": True,
+}, separators=(",", ":")), flush=True)
+'''
+
+
+PROCESS_SNAPSHOT_CODE = r'''
+import json
+import os
+from pathlib import Path
+
+safe_flags = (
+    "--headless", "--no-sandbox", "--disable-web-security",
+    "--remote-debugging-address", "--remote-debugging-port", "--user-data-dir",
+)
+rows = []
+for entry in Path("/proc").iterdir():
+    if not entry.name.isdigit():
+        continue
+    try:
+        comm = (entry / "comm").read_text(encoding="utf-8", errors="replace").strip()
+        argv = [
+            value.decode("utf-8", errors="replace")
+            for value in (entry / "cmdline").read_bytes().split(b"\0")
+            if value
+        ]
+    except OSError:
+        continue
+    executable = ""
+    executable_errno = None
+    try:
+        executable = os.path.basename(os.readlink(entry / "exe"))
+    except OSError as exc:
+        executable_errno = exc.errno
+    argv0 = os.path.basename(argv[0]) if argv else ""
+    identity = f"{comm} {executable} {argv0}".lower()
+    if not any(token in identity for token in ("chrome", "node", "python", "sleep")):
+        continue
+    rows.append({
+        "pid": int(entry.name),
+        "comm": comm[:64],
+        "exe": executable[:128],
+        "exe_errno": executable_errno,
+        "argv0": argv0[:128],
+        "flags": {
+            flag: any(value == flag or value.startswith(flag + "=") for value in argv[1:])
+            for flag in safe_flags
+        },
+    })
+print(json.dumps(rows, separators=(",", ":")), flush=True)
+'''
+
+
+CGROUP_DIAGNOSTIC_FIELDS: Final = (
+    "probe_ok",
+    "pids_events_max",
+    "pids_current",
+    "memory_events_low",
+    "memory_events_high",
+    "memory_events_max",
+    "memory_events_oom",
+    "memory_events_oom_kill",
+    "memory_events_oom_group_kill",
+    "memory_current",
+    "memory_peak",
+)
+CGROUP_CUMULATIVE_FIELDS: Final = frozenset(
+    {
+        "pids_events_max",
+        "memory_events_low",
+        "memory_events_high",
+        "memory_events_max",
+        "memory_events_oom",
+        "memory_events_oom_kill",
+        "memory_events_oom_group_kill",
+        "memory_peak",
+    }
+)
+
+
+CGROUP_DIAGNOSTIC_CODE = r'''
+import json
+from pathlib import Path
+
+values = {
+    "probe_ok": 1,
+    "pids_events_max": -1,
+    "pids_current": -1,
+    "memory_events_low": -1,
+    "memory_events_high": -1,
+    "memory_events_max": -1,
+    "memory_events_oom": -1,
+    "memory_events_oom_kill": -1,
+    "memory_events_oom_group_kill": -1,
+    "memory_current": -1,
+    "memory_peak": -1,
+}
+
+def read_scalar(name):
+    try:
+        return int(Path("/sys/fs/cgroup", name).read_text(encoding="ascii").strip())
+    except (OSError, ValueError):
+        return -1
+
+def read_events(name):
+    result = {}
+    try:
+        lines = Path("/sys/fs/cgroup", name).read_text(encoding="ascii").splitlines()
+    except OSError:
+        return result
+    for line in lines:
+        parts = line.split()
+        if len(parts) != 2:
+            continue
+        try:
+            result[parts[0]] = int(parts[1])
+        except ValueError:
+            continue
+    return result
+
+pids_events = read_events("pids.events")
+memory_events = read_events("memory.events")
+values["pids_events_max"] = pids_events.get("max", -1)
+values["pids_current"] = read_scalar("pids.current")
+for event in ("low", "high", "max", "oom", "oom_kill", "oom_group_kill"):
+    values["memory_events_" + event] = memory_events.get(event, -1)
+values["memory_current"] = read_scalar("memory.current")
+values["memory_peak"] = read_scalar("memory.peak")
+print(json.dumps(values, separators=(",", ":")), flush=True)
+'''
+
+
+PID1_PROBE_CODE = r'''
+import json
+from pathlib import Path
+
+command = Path("/proc/1/cmdline").read_bytes().replace(b"\0", b" ").decode().strip()
+status = {}
+for line in Path("/proc/1/status").read_text().splitlines():
+    if ":" in line:
+        key, value = line.split(":", 1)
+        status[key] = value.strip()
+if not command.startswith("python -m sandbox_sidecar.browser_server"):
+    raise RuntimeError(f"unexpected PID1: {command}")
+if status.get("CapEff") != "0000000000000000":
+    raise RuntimeError("PID1 retained an effective capability")
+if status.get("NoNewPrivs") != "1" or status.get("Seccomp") != "2":
+    raise RuntimeError("PID1 hardening is inactive")
+print(json.dumps({
+    "pid1": command, "cap_eff": status["CapEff"],
+    "no_new_privs": status["NoNewPrivs"], "seccomp": status["Seccomp"],
+}, separators=(",", ":")), flush=True)
+'''
+
+
+PROCFS_LANDLOCK_PROBE_CODE = r'''
+import errno
+import os
+from pathlib import Path
+
+DENIED = {errno.EACCES, errno.EPERM, errno.EROFS, errno.ENOENT}
+
+def expect_open_denied(path, flags):
+    try:
+        descriptor = os.open(path, flags, 0o600)
+    except OSError as exc:
+        if exc.errno not in DENIED:
+            raise
+        return
+    os.close(descriptor)
+    raise RuntimeError(f"procfs access unexpectedly succeeded: {path}")
+
+for sensitive in ("/proc/1/mem", "/proc/1/environ", "/proc/1/fd/0"):
+    expect_open_denied(sensitive, os.O_RDONLY)
+for protected in ("/proc/sys/kernel/core_pattern", "/proc/sysrq-trigger"):
+    expect_open_denied(protected, os.O_WRONLY)
+expect_open_denied("/proc/modelmirror-wave7-probe", os.O_WRONLY | os.O_CREAT)
+expect_open_denied("/proc/self/comm", os.O_WRONLY | os.O_TRUNC)
+
+# WRITE_FILE is deliberately available for Chromium's user-namespace map
+# setup. Prove the category without altering persistent state or another PID.
+descriptor = os.open("/proc/self/comm", os.O_WRONLY)
+try:
+    os.write(descriptor, b"mm-wave7-probe\n")
+finally:
+    os.close(descriptor)
+if Path("/proc/self/comm").read_text(encoding="ascii").strip() != "mm-wave7-probe":
+    raise RuntimeError("procfs self-write category was not available")
+print(
+    "procfs_guard=ok pid1_sensitive=denied sysctl=readonly "
+    "create=denied truncate=denied self_comm_write=allowed",
+    flush=True,
+)
+'''
+
+
+POST_RESTART_PROBE_CODE = r'''
+import os
+from pathlib import Path
+
+for root in (Path("/profiles"), Path("/artifacts")):
+    if any(root.iterdir()):
+        raise RuntimeError(f"runtime residue remains under {root}")
+for entry in Path("/proc").iterdir():
+    if not entry.name.isdigit():
+        continue
+    if int(entry.name) == os.getpid():
+        continue
+    try:
+        command = (entry / "cmdline").read_bytes().replace(b"\0", b" ")
+    except OSError:
+        continue
+    if b"modelmirror-chromium" in command or b"chrome-linux64/chrome" in command:
+        raise RuntimeError("Chromium residue survived PID1 restart")
+    if b"sleep 300" in command:
+        raise RuntimeError("independent setsid residue survived PID1 restart")
+print("runtime_roots=empty chromium_residue=none setsid_residue=none", flush=True)
+'''
+
+
+UNTRUSTED_PEER_CODE = r'''
+import asyncio
+import json
+import sys
+
+async def main():
+    reader, writer = await asyncio.open_unix_connection(
+        "/run/modelmirror-browser-mcp/browser-mcp.sock"
+    )
+    writer.write(json.dumps({
+        "action": "mcp_stdio", "adapter_id": sys.argv[1], "configuration": {},
+    }, separators=(",", ":")).encode() + b"\n")
+    await writer.drain()
+    response = json.loads((await asyncio.wait_for(reader.readline(), 5)).decode())
+    writer.close()
+    try:
+        await writer.wait_closed()
+    except (ConnectionError, OSError):
+        pass
+    if response.get("code") != "browser_peer_denied":
+        raise RuntimeError("sandbox UID unexpectedly passed SO_PEERCRED gate")
+    print("peer_uid=65532 mcp_stdio=denied", flush=True)
+
+asyncio.run(main())
+'''
+
+
+def _start_egress(
+    runner: DockerRunner,
+    ledger: ResourceLedger,
+    *,
+    base: str,
+    token: str,
+    image: str,
+    network: str,
+    socket_volume: str,
+) -> str:
+    name = _resource(base, f"{token}-egress")
+    _reserve_resource(runner, ledger, "container", name)
+    runner.run(
+        "run", "-d", "--restart", "unless-stopped",
+        *_bounded_container_args(
+            name=name, user="65532:65532", network=network, label=base,
+            pids=64, memory="256m", cpus="0.5",
+        ),
+        "-e", "MCP_BROWSER_EGRESS_SOCKET_PATH=/run/modelmirror-browser-egress/browser-egress.sock",
+        "-e", "MCP_BROWSER_ALLOW_SYNTHETIC_DNS=true",
+        "--mount", f"type=volume,src={socket_volume},dst=/run/modelmirror-browser-egress",
+        image, "python", "-m", "sandbox_sidecar.browser_server", "egress",
+    )
+    payload = _inspect(runner, name)
+    _assert_common_security(payload, user="65532:65532", network_mode=network)
+    if payload["HostConfig"]["RestartPolicy"]["Name"] != "unless-stopped":
+        raise SmokeFailure("egress automatic restart policy is missing")
+    _wait_path(
+        runner, name, "/run/modelmirror-browser-egress/browser-egress.control"
+    )
+    print(runner.run("exec", name, "python", "-c", PID1_PROBE_CODE).stdout.strip())
+    return name
+
+
+def _probe_egress_rotation(
+    runner: DockerRunner,
+    ledger: ResourceLedger,
+    *,
+    base: str,
+    token: str,
+    image: str,
+    socket_volume: str,
+    egress: str,
+) -> None:
+    before = _state(_inspect(runner, egress))
+    name = _resource(base, f"{token}-cap-probe")
+    _reserve_resource(runner, ledger, "container", name)
+    runner.run(
+        "run", "-d",
+        *_bounded_container_args(
+            name=name, user="65532:65532", network="none", label=base,
+            pids=16, memory="96m", cpus="0.25",
+        ),
+        "--mount", f"type=volume,src={socket_volume},dst=/run/modelmirror-browser-egress",
+        image, "python", "-c", CAPABILITY_RESTART_PROBE_CODE,
+    )
+    helper = _inspect(runner, name)
+    _assert_common_security(helper, user="65532:65532", network_mode="none")
+    allowed = {"/run/modelmirror-browser-egress"}
+    if {item["Destination"] for item in helper.get("Mounts", [])} != allowed:
+        raise SmokeFailure("capability probe mount surface drifted")
+    logs = _wait_log(runner, name, "old_capability=denied", timeout=60)
+    print(next(line for line in logs.splitlines() if "old_capability=denied" in line))
+    _wait_exit(runner, name, timeout=30)
+    after = _wait_restart(runner, egress, before, timeout=30)
+    print(
+        f"{token}: egress_preflight_restart={before[0]}->{after[0]} "
+        f"started_at_changed={after[1] != before[1]}"
+    )
+
+
+def _start_browser(
+    runner: DockerRunner,
+    ledger: ResourceLedger,
+    *,
+    base: str,
+    token: str,
+    image: str,
+    seccomp: Path,
+    browser_socket: str,
+    egress_socket: str,
+    artifact_volume: str,
+) -> str:
+    name = _resource(base, f"{token}-browser")
+    _reserve_resource(runner, ledger, "container", name)
+    runner.run(
+        "run", "-d", "--restart", "unless-stopped",
+        *_bounded_container_args(
+            name=name, user="65532:65532", network="none", label=base,
+            pids=256, memory="1g", cpus="1.5",
+        ),
+        "--security-opt", f"seccomp={seccomp}",
+        "--tmpfs", "/profiles:rw,nosuid,nodev,noexec,size=268435456,uid=65532,gid=65532,mode=0700",
+        "--tmpfs", "/dev/shm:rw,nosuid,nodev,noexec,size=268435456,uid=65532,gid=65532,mode=0700",
+        "-e", "MCP_BROWSER_SOCKET_PATH=/run/modelmirror-browser-mcp/browser-mcp.sock",
+        "-e", "MCP_BROWSER_EGRESS_SOCKET_PATH=/run/modelmirror-browser-egress/browser-egress.sock",
+        "-e", "MCP_BROWSER_PROFILE_ROOT=/profiles",
+        "-e", "MCP_BROWSER_ARTIFACT_ROOT=/artifacts",
+        "-e", "MCP_BROWSER_MAX_SESSIONS=1",
+        "-e", "MCP_BROWSER_TRUSTED_CLIENT_UID=0",
+        "--mount", f"type=volume,src={browser_socket},dst=/run/modelmirror-browser-mcp",
+        "--mount", f"type=volume,src={egress_socket},dst=/run/modelmirror-browser-egress",
+        "--mount", f"type=volume,src={artifact_volume},dst=/artifacts",
+        image, "python", "-m", "sandbox_sidecar.browser_server",
+    )
+    payload = _inspect(runner, name)
+    _assert_common_security(payload, user="65532:65532", network_mode="none")
+    _assert_browser_procfs_boundary(payload)
+    security = set(payload["HostConfig"].get("SecurityOpt") or [])
+    if "seccomp=unconfined" in security or not any(
+        item.startswith("seccomp=") for item in security
+    ):
+        raise SmokeFailure("browser custom seccomp is not active")
+    if payload["HostConfig"]["RestartPolicy"]["Name"] != "unless-stopped":
+        raise SmokeFailure("browser automatic restart policy is missing")
+    allowed = {
+        "/run/modelmirror-browser-mcp",
+        "/run/modelmirror-browser-egress",
+        "/artifacts",
+    }
+    if {item["Destination"] for item in payload.get("Mounts", [])} != allowed:
+        raise SmokeFailure("browser mount surface drifted")
+    _wait_path(runner, name, "/run/modelmirror-browser-mcp/browser-mcp.sock")
+    print(runner.run("exec", name, "python", "-c", PID1_PROBE_CODE).stdout.strip())
+    _run_landlock_procfs_probe(runner, name)
+    return name
+
+
+def _wait_restart(
+    runner: DockerRunner,
+    name: str,
+    before: tuple[int, str, int, str],
+    *,
+    timeout: int = 45,
+) -> tuple[int, str, int, str]:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        payload = _inspect(runner, name)
+        current = _state(payload)
+        if (
+            current[0] > before[0]
+            and current[1] != before[1]
+            and current[2] > 0
+            and current[2] != before[2]
+            and current[3] == before[3]
+            and payload["State"].get("Running") is True
+        ):
+            time.sleep(1)
+            stable = _state(_inspect(runner, name))
+            if stable[0] != current[0]:
+                raise SmokeFailure(f"{name} entered a restart loop")
+            return stable
+        time.sleep(0.2)
+    raise SmokeFailure(f"{name} did not automatically restart")
+
+
+def _run_untrusted_peer_probe(
+    runner: DockerRunner,
+    ledger: ResourceLedger,
+    *,
+    base: str,
+    token: str,
+    image: str,
+    browser_socket: str,
+    adapter: str,
+) -> None:
+    name = _resource(base, f"{token}-peer-deny")
+    _reserve_resource(runner, ledger, "container", name)
+    result = runner.run(
+        "run",
+        *_bounded_container_args(
+            name=name, user="65532:65532", network="none", label=base,
+            pids=16, memory="96m", cpus="0.25",
+        ),
+        "--mount", f"type=volume,src={browser_socket},dst=/run/modelmirror-browser-mcp",
+        image, "python", "-c", UNTRUSTED_PEER_CODE, adapter,
+        timeout=30,
+    )
+    print(result.stdout.strip())
+
+
+def _run_production_seccomp_probe(runner: DockerRunner, browser: str) -> None:
+    result = runner.run(
+        "exec", browser, "python", "-c", SECCOMP_PROBE_CODE, "deny", timeout=30
+    )
+    print(result.stdout.strip())
+
+
+def _run_landlock_procfs_probe(runner: DockerRunner, browser: str) -> None:
+    profile = "/profiles/modelmirror-procfs-probe"
+    artifacts = "/artifacts/modelmirror-procfs-probe"
+    runner.run(
+        "exec", browser, "python", "-c",
+        (
+            "from pathlib import Path; "
+            f"Path('{profile}').mkdir(mode=0o700); "
+            f"Path('{artifacts}').mkdir(mode=0o700)"
+        ),
+        timeout=15,
+    )
+    try:
+        result = runner.run(
+            "exec", browser,
+            "python", "-m", "sandbox_sidecar.browser_mcp", "landlock",
+            profile, artifacts, "--", "python", "-c",
+            PROCFS_LANDLOCK_PROBE_CODE,
+            timeout=30,
+        )
+        print(result.stdout.strip())
+    finally:
+        runner.run(
+            "exec", browser, "python", "-c",
+            (
+                "from pathlib import Path; "
+                f"Path('{profile}').rmdir(); "
+                f"Path('{artifacts}').rmdir()"
+            ),
+            check=False,
+            timeout=15,
+        )
+
+
+def _start_setsid_residue(runner: DockerRunner, browser: str) -> None:
+    runner.run("exec", "-d", browser, "setsid", "sleep", "300")
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        listing = runner.run("top", browser, check=False, timeout=5).stdout
+        if "sleep 300" in listing:
+            print("setsid_descendant=running_before_pid1_exit")
+            return
+        time.sleep(0.2)
+    raise SmokeFailure("independent setsid descendant did not start")
+
+
+def _start_gateway_helper(
+    runner: DockerRunner,
+    ledger: ResourceLedger,
+    *,
+    base: str,
+    token: str,
+    attempt: int,
+    image: str,
+    browser_socket: str,
+    artifact_volume: str,
+    adapter: str,
+    url: str,
+    expect_timeout: bool = False,
+) -> str:
+    name = _resource(base, f"{token}-gateway-{attempt}")
+    _reserve_resource(runner, ledger, "container", name)
+    helper_command = [
+        "python", "-m", "sandbox_sidecar.smoke_browser_adapters",
+        "--gateway-url", url, "--adapter", adapter,
+    ]
+    if expect_timeout:
+        helper_command.append("--expect-timeout")
+    runner.run(
+        "run", "-d",
+        *_bounded_container_args(
+            name=name, user="0:65532", network="none", label=base,
+            pids=64, memory="256m", cpus="0.5",
+        ),
+        "--cap-add", "DAC_READ_SEARCH",
+        "--mount", f"type=volume,src={browser_socket},dst=/run/modelmirror-browser-mcp",
+        "--mount", f"type=volume,src={artifact_volume},dst=/artifacts,readonly",
+        image, *helper_command,
+    )
+    payload = _inspect(runner, name)
+    _assert_common_security(
+        payload,
+        user="0:65532",
+        network_mode="none",
+        cap_add=frozenset({"DAC_READ_SEARCH"}),
+    )
+    allowed = {"/run/modelmirror-browser-mcp", "/artifacts"}
+    if {item["Destination"] for item in payload.get("Mounts", [])} != allowed:
+        raise SmokeFailure("gateway helper mount surface drifted")
+    mount_modes = {
+        item["Destination"]: bool(item.get("RW")) for item in payload.get("Mounts", [])
+    }
+    if mount_modes != {"/run/modelmirror-browser-mcp": True, "/artifacts": False}:
+        raise SmokeFailure("gateway helper volume access mode drifted")
+    print(
+        "acceptance_helper=uid0_gid65532 cap_add=DAC_READ_SEARCH artifact_mount=readonly "
+        "browser_socket=readwrite network=none"
+    )
+    return name
+
+
+_LOG_SECRET = re.compile(
+    r"(?i)\b(control[_-]?key|capability|authorization|token)\b\s*[:=]\s*[^\s,}\]]+"
+)
+_LOG_URL = re.compile(r"(?i)\b(?:https?|data|file)://[^\s\"']+")
+_LOG_PAYLOAD = re.compile(
+    r"(?i)([\"']?(?:content|structuredContent|arguments|params|result|text)[\"']?\s*[:=]\s*).*$"
+)
+
+
+def _safe_log_tail(value: str, *, limit: int = 2048) -> str:
+    """Keep bounded failure context without credentials, URLs, or tool payloads."""
+
+    lines: list[str] = []
+    for raw_line in value.splitlines()[-40:]:
+        line = re.sub(r"\b[0-9a-fA-F]{64}\b", "<redacted-64hex>", raw_line)
+        line = _LOG_SECRET.sub(r"\1=<redacted>", line)
+        line = _LOG_URL.sub("<redacted-url>", line)
+        line = _LOG_PAYLOAD.sub(r"\1<redacted-payload>", line)
+        line = re.sub(r"\b[A-Za-z0-9+/]{128,}={0,2}\b", "<redacted-blob>", line)
+        lines.append(line[:512])
+    safe = "\n".join(lines)
+    return safe[-limit:] if safe else "<empty>"
+
+
+def _safe_container_state(runner: DockerRunner, name: str) -> dict[str, object]:
+    result = runner.run("inspect", name, check=False, timeout=5)
+    if result.returncode != 0:
+        return {"inspect": "unavailable", "returncode": result.returncode}
+    try:
+        payload = json.loads(result.stdout)[0]
+        state = payload["State"]
+        return {
+            "Status": str(state.get("Status") or ""),
+            "ExitCode": int(state.get("ExitCode") or 0),
+            "OOMKilled": bool(state.get("OOMKilled")),
+            "Restarting": bool(state.get("Restarting")),
+            "RestartCount": int(payload.get("RestartCount") or 0),
+        }
+    except (KeyError, TypeError, ValueError, IndexError):
+        return {"inspect": "invalid"}
+
+
+def _safe_process_snapshot(runner: DockerRunner, browser: str) -> list[dict[str, object]]:
+    result = runner.run(
+        "exec", browser, "python", "-c", PROCESS_SNAPSHOT_CODE,
+        check=False, timeout=10,
+    )
+    if result.returncode != 0:
+        return [{"probe": "unavailable", "returncode": result.returncode}]
+    try:
+        payload = json.loads(result.stdout)
+    except ValueError:
+        return [{"probe": "invalid"}]
+    if not isinstance(payload, list):
+        return [{"probe": "invalid"}]
+    # The in-container probe emits only bounded process metadata and boolean flags.
+    return payload[-32:]
+
+
+def _empty_cgroup_snapshot() -> dict[str, int]:
+    return {
+        field: 0 if field == "probe_ok" else -1
+        for field in CGROUP_DIAGNOSTIC_FIELDS
+    }
+
+
+def _safe_cgroup_snapshot(runner: DockerRunner, browser: str) -> dict[str, int]:
+    """Return only the fixed numeric cgroup fields; never forward probe output."""
+
+    result = runner.run(
+        "exec", browser, "python", "-c", CGROUP_DIAGNOSTIC_CODE,
+        check=False, timeout=10,
+    )
+    if result.returncode != 0:
+        return _empty_cgroup_snapshot()
+    try:
+        payload = json.loads(result.stdout)
+    except ValueError:
+        return _empty_cgroup_snapshot()
+    if not isinstance(payload, dict) or set(payload) != set(CGROUP_DIAGNOSTIC_FIELDS):
+        return _empty_cgroup_snapshot()
+    normalized: dict[str, int] = {}
+    for field in CGROUP_DIAGNOSTIC_FIELDS:
+        value = payload[field]
+        if isinstance(value, bool) or not isinstance(value, int) or value < -1:
+            return _empty_cgroup_snapshot()
+        normalized[field] = value
+    if normalized["probe_ok"] != 1:
+        return _empty_cgroup_snapshot()
+    return normalized
+
+
+def _merge_cgroup_diagnostics(
+    observed: dict[str, int],
+    current: dict[str, int],
+) -> dict[str, int]:
+    """Preserve lifetime counters/peak while currents remain the latest sample."""
+
+    if current["probe_ok"] != 1:
+        return observed
+    if observed["probe_ok"] != 1:
+        return current
+    merged = dict(current)
+    for field in CGROUP_CUMULATIVE_FIELDS:
+        merged[field] = max(observed[field], current[field])
+    return merged
+
+
+def _chromium_failure_evidence(
+    runner: DockerRunner,
+    browser: str,
+    helper: str,
+    snapshots: list[dict[str, object]],
+    last_probe: str,
+    cgroup_before: dict[str, int],
+    cgroup_observed: dict[str, int],
+    cgroup_final: dict[str, int],
+) -> str:
+    helper_logs = runner.run(
+        "logs", "--tail", "80", helper, check=False, timeout=10,
+    )
+    browser_logs = runner.run(
+        "logs", "--tail", "80", browser, check=False, timeout=10,
+    )
+    return (
+        "real Chromium security probe failed: "
+        f"helper_state={json.dumps(_safe_container_state(runner, helper), separators=(',', ':'))} "
+        f"browser_state={json.dumps(_safe_container_state(runner, browser), separators=(',', ':'))} "
+        f"cgroup_before={json.dumps(cgroup_before, separators=(',', ':'))} "
+        f"cgroup_observed={json.dumps(cgroup_observed, separators=(',', ':'))} "
+        f"cgroup_final={json.dumps(cgroup_final, separators=(',', ':'))} "
+        f"process_snapshots={json.dumps(snapshots[-8:], separators=(',', ':'))} "
+        f"probe={_safe_log_tail(last_probe, limit=1024)!r} "
+        f"helper_logs={_safe_log_tail(helper_logs.stdout + helper_logs.stderr)!r} "
+        f"browser_logs={_safe_log_tail(browser_logs.stdout + browser_logs.stderr)!r}"
+    )
+
+
+def _wait_chromium_probe(
+    runner: DockerRunner,
+    browser: str,
+    helper: str,
+    *,
+    cgroup_before: dict[str, int],
+    timeout: int = 45,
+) -> None:
+    deadline = time.monotonic() + timeout
+    started = time.monotonic()
+    next_snapshot = started
+    snapshots: list[dict[str, object]] = []
+    cgroup_observed = cgroup_before
+    last = ""
+    while time.monotonic() < deadline:
+        result = runner.run(
+            "exec", browser, "python", "-c", CHROMIUM_PROBE_CODE,
+            check=False, timeout=10,
+        )
+        last = f"{result.stdout}\n{result.stderr}"
+        if result.returncode == 0:
+            print(result.stdout.strip())
+            return
+        now = time.monotonic()
+        if now >= next_snapshot:
+            current_cgroup = _safe_cgroup_snapshot(runner, browser)
+            cgroup_observed = _merge_cgroup_diagnostics(
+                cgroup_observed, current_cgroup,
+            )
+            snapshots.append({
+                "t": round(now - started, 3),
+                "processes": _safe_process_snapshot(runner, browser),
+            })
+            snapshots = snapshots[-8:]
+            next_snapshot = now + 0.5
+        helper_state = runner.run("inspect", helper, check=False, timeout=5)
+        if helper_state.returncode == 0:
+            state = json.loads(helper_state.stdout)[0]["State"]
+            if state.get("Status") == "exited":
+                cgroup_final = _safe_cgroup_snapshot(runner, browser)
+                cgroup_observed = _merge_cgroup_diagnostics(
+                    cgroup_observed, cgroup_final,
+                )
+                raise SmokeFailure(
+                    _chromium_failure_evidence(
+                        runner, browser, helper, snapshots, last,
+                        cgroup_before, cgroup_observed, cgroup_final,
+                    )
+                )
+        time.sleep(0.1)
+    cgroup_final = _safe_cgroup_snapshot(runner, browser)
+    cgroup_observed = _merge_cgroup_diagnostics(
+        cgroup_observed, cgroup_final,
+    )
+    raise SmokeFailure(
+        _chromium_failure_evidence(
+            runner, browser, helper, snapshots, last,
+            cgroup_before, cgroup_observed, cgroup_final,
+        )
+    )
+
+
+def _run_gateway_attempt(
+    runner: DockerRunner,
+    ledger: ResourceLedger,
+    *,
+    base: str,
+    token: str,
+    attempt: int,
+    image: str,
+    browser: str,
+    egress: str,
+    browser_socket: str,
+    artifact_volume: str,
+    adapter: str,
+    url: str,
+    inspect_chromium: bool,
+) -> tuple[tuple[int, str, int, str], tuple[int, str, int, str]]:
+    _wait_path(runner, browser, "/run/modelmirror-browser-mcp/browser-mcp.sock")
+    browser_before = _state(_inspect(runner, browser))
+    egress_before = _state(_inspect(runner, egress))
+    cgroup_before = _safe_cgroup_snapshot(runner, browser)
+    helper = _start_gateway_helper(
+        runner, ledger, base=base, token=token, attempt=attempt,
+        image=image, browser_socket=browser_socket,
+        artifact_volume=artifact_volume, adapter=adapter, url=url,
+    )
+    if inspect_chromium:
+        _wait_chromium_probe(
+            runner, browser, helper, cgroup_before=cgroup_before,
+        )
+    try:
+        logs = _wait_log(runner, helper, "cleanup=ok", timeout=120)
+    except SmokeFailure as exc:
+        browser_logs = runner.run(
+            "logs", "--tail", "80", browser, check=False, timeout=10,
+        )
+        raise SmokeFailure(
+            f"{exc} browser_events="
+            f"{_safe_log_tail(browser_logs.stdout + browser_logs.stderr)}"
+        ) from exc
+    required = (
+        "gateway=ok", "navigate=ok", "snapshot=ok", "fill=ok",
+        "click=ok", "outcome=ok", "screenshot=png", "cleanup=ok",
+    )
+    if any(marker not in logs for marker in required):
+        raise SmokeFailure(f"gateway smoke evidence incomplete: {logs[-4096:]}")
+    for line in logs.splitlines():
+        if "gateway=ok" in line or "cleanup=ok" in line:
+            print(line)
+    _wait_exit(runner, helper, timeout=30)
+    browser_after = _wait_restart(runner, browser, browser_before)
+    egress_after = _wait_restart(runner, egress, egress_before)
+    if browser_after[0] != browser_before[0] + 1:
+        raise SmokeFailure("browser restarted more than once for one session")
+    if egress_after[0] != egress_before[0] + 1:
+        raise SmokeFailure("egress restarted more than once for one session")
+    print(
+        f"{adapter} attempt={attempt}: peer_uid=0 handshake=ok "
+        f"browser_restart={browser_before[0]}->{browser_after[0]} "
+        f"egress_restart={egress_before[0]}->{egress_after[0]} "
+        "started_at_changed=true pid1_changed=true"
+    )
+    return browser_after, egress_after
+
+
+def _run_gateway_timeout_attempt(
+    runner: DockerRunner,
+    ledger: ResourceLedger,
+    *,
+    base: str,
+    token: str,
+    attempt: int,
+    image: str,
+    browser: str,
+    egress: str,
+    browser_socket: str,
+    artifact_volume: str,
+    adapter: str,
+    url: str,
+) -> tuple[tuple[int, str, int, str], tuple[int, str, int, str]]:
+    _wait_path(runner, browser, "/run/modelmirror-browser-mcp/browser-mcp.sock")
+    browser_before = _state(_inspect(runner, browser))
+    egress_before = _state(_inspect(runner, egress))
+    helper = _start_gateway_helper(
+        runner, ledger, base=base, token=token, attempt=attempt,
+        image=image, browser_socket=browser_socket,
+        artifact_volume=artifact_volume, adapter=adapter, url=url,
+        expect_timeout=True,
+    )
+    try:
+        logs = _wait_log(
+            runner, helper, "timeout=unknown_outcome", timeout=120,
+        )
+    except SmokeFailure as exc:
+        browser_logs = runner.run(
+            "logs", "--tail", "120", browser, check=False, timeout=10,
+        )
+        raise SmokeFailure(
+            f"{exc} browser_events="
+            f"{_safe_log_tail(browser_logs.stdout + browser_logs.stderr)}"
+        ) from exc
+    required = (
+        "timeout=unknown_outcome",
+        "navigation_timeout=20s",
+        "elapsed_window=ok",
+        "retryable=false",
+    )
+    if any(marker not in logs for marker in required):
+        raise SmokeFailure(
+            f"gateway timeout evidence incomplete: {_safe_log_tail(logs)}"
+        )
+
+    browser_logs = runner.run(
+        "logs", "--tail", "120", browser, check=False, timeout=10,
+    )
+    browser_events = browser_logs.stdout + browser_logs.stderr
+    matched_event = next(
+        (marker for marker in TIMEOUT_RUNTIME_EVENTS if marker in browser_events),
+        None,
+    )
+    if matched_event is None:
+        raise SmokeFailure(
+            "browser did not emit a reviewed timeout runtime event: "
+            f"{_safe_log_tail(browser_events)}"
+        )
+    for line in logs.splitlines():
+        if "timeout=unknown_outcome" in line:
+            print(line)
+    print(f"browser_timeout_event={matched_event.split(':', 1)[1].strip(chr(34))}")
+
+    _wait_exit(runner, helper, timeout=30)
+    browser_after = _wait_restart(runner, browser, browser_before)
+    egress_after = _wait_restart(runner, egress, egress_before)
+    if browser_after[0] != browser_before[0] + 1:
+        raise SmokeFailure("browser restarted more than once for timeout session")
+    if egress_after[0] != egress_before[0] + 1:
+        raise SmokeFailure("egress restarted more than once for timeout session")
+    print(
+        f"{adapter} attempt={attempt}: timeout=unknown_outcome "
+        f"browser_restart={browser_before[0]}->{browser_after[0]} "
+        f"egress_restart={egress_before[0]}->{egress_after[0]} "
+        "started_at_changed=true pid1_changed=true"
+    )
+    return browser_after, egress_after
+
+
+def _post_restart_cleanup(runner: DockerRunner, browser: str) -> None:
+    print(
+        runner.run(
+            "exec", browser, "python", "-c", POST_RESTART_PROBE_CODE,
+            timeout=15,
+        ).stdout.strip()
+    )
+
+
+def _run_adapter_pair(
+    runner: DockerRunner,
+    ledger: ResourceLedger,
+    *,
+    base: str,
+    image: str,
+    seccomp: Path,
+    network: str,
+    adapter: str,
+    previous_ids: set[str],
+) -> set[str]:
+    token = ADAPTER_TOKENS[adapter]
+    egress_socket = _resource(base, f"{token}-egress-sock")
+    browser_socket = _resource(base, f"{token}-browser-sock")
+    artifact_volume = _resource(base, f"{token}-artifacts")
+    _create_volume(runner, ledger, egress_socket)
+    _create_volume(runner, ledger, browser_socket)
+    _create_volume(runner, ledger, artifact_volume, tmpfs=True)
+    egress = _start_egress(
+        runner, ledger, base=base, token=token, image=image,
+        network=network, socket_volume=egress_socket,
+    )
+    _probe_egress_rotation(
+        runner, ledger, base=base, token=token, image=image,
+        socket_volume=egress_socket, egress=egress,
+    )
+    browser = _start_browser(
+        runner, ledger, base=base, token=token, image=image, seccomp=seccomp,
+        browser_socket=browser_socket, egress_socket=egress_socket,
+        artifact_volume=artifact_volume,
+    )
+    ids = {_state(_inspect(runner, browser))[3], _state(_inspect(runner, egress))[3]}
+    if ids & previous_ids:
+        raise SmokeFailure("adapter did not receive a fresh browser+egress pair")
+    _run_untrusted_peer_probe(
+        runner, ledger, base=base, token=token, image=image,
+        browser_socket=browser_socket, adapter=adapter,
+    )
+    _run_production_seccomp_probe(runner, browser)
+    _start_setsid_residue(runner, browser)
+    url = f"http://{FIXTURE_HOST}/"
+    _run_gateway_attempt(
+        runner, ledger, base=base, token=token, attempt=1, image=image,
+        browser=browser, egress=egress, browser_socket=browser_socket,
+        artifact_volume=artifact_volume, adapter=adapter, url=url,
+        inspect_chromium=True,
+    )
+    _post_restart_cleanup(runner, browser)
+    _run_gateway_attempt(
+        runner, ledger, base=base, token=token, attempt=2, image=image,
+        browser=browser, egress=egress, browser_socket=browser_socket,
+        artifact_volume=artifact_volume, adapter=adapter, url=url,
+        inspect_chromium=False,
+    )
+    _post_restart_cleanup(runner, browser)
+    timeout_url = f"http://{FIXTURE_HOST}{TIMEOUT_FIXTURE_PATH}"
+    _run_gateway_timeout_attempt(
+        runner, ledger, base=base, token=token, attempt=3, image=image,
+        browser=browser, egress=egress, browser_socket=browser_socket,
+        artifact_volume=artifact_volume, adapter=adapter, url=timeout_url,
+    )
+    _post_restart_cleanup(runner, browser)
+    return previous_ids | ids
+
+
+def _validate_seccomp_file(path: Path) -> None:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if payload.get("defaultAction") != "SCMP_ACT_ERRNO":
+        raise SmokeFailure("browser seccomp default action is not deny")
+    rules = payload.get("syscalls")
+    if not isinstance(rules, list) or not rules:
+        raise SmokeFailure("browser seccomp rules are missing")
+    first = rules[0]
+    if first.get("action") != "SCMP_ACT_ALLOW" or first.get("names") != [
+        "chroot", "clone", "setns", "unshare"
+    ]:
+        raise SmokeFailure("Chromium namespace exception drifted")
+    sensitive = {"ptrace", "process_vm_readv", "process_vm_writev"}
+    for rule in rules:
+        if sensitive.intersection(rule.get("names") or []):
+            caps = set((rule.get("includes") or {}).get("caps") or [])
+            if rule.get("action") == "SCMP_ACT_ALLOW" and caps != {"CAP_SYS_PTRACE"}:
+                raise SmokeFailure("ptrace syscall became unconditionally available")
+
+
+def _selected_adapters(adapter: str | None) -> tuple[str, ...]:
+    if adapter is None:
+        return ADAPTERS
+    if adapter not in ADAPTERS:
+        raise SmokeFailure("unsupported fixed browser adapter selection")
+    return (adapter,)
+
+
+def run(
+    image: str,
+    seccomp: Path,
+    *,
+    run_id: str | None = None,
+    adapter: str | None = None,
+) -> None:
+    if not seccomp.is_file():
+        raise SmokeFailure(f"seccomp profile not found: {seccomp}")
+    _validate_seccomp_file(seccomp)
+    runner = DockerRunner()
+    runner.run("image", "inspect", image)
+    identifier = run_id or secrets.token_hex(4)
+    if not re.fullmatch(r"[0-9a-f]{8}", identifier):
+        raise SmokeFailure("run id must be exactly eight lowercase hex characters")
+    base = f"{PREFIX}-{identifier}"
+    selected_adapters = _selected_adapters(adapter)
+    ledger = ResourceLedger(runner)
+    succeeded = False
+    try:
+        network, address = _create_network(
+            runner, ledger, base, seed=int(identifier[:2], 16)
+        )
+        _start_fixture(
+            runner, ledger, base=base, image=image,
+            network=network, address=address,
+        )
+        _run_seccomp_calibration(runner, ledger, base=base, image=image)
+        pair_ids: set[str] = set()
+        for selected_adapter in selected_adapters:
+            pair_ids = _run_adapter_pair(
+                runner, ledger, base=base, image=image, seccomp=seccomp,
+                network=network, adapter=selected_adapter, previous_ids=pair_ids,
+            )
+        succeeded = True
+    finally:
+        ledger.cleanup()
+    if succeeded:
+        print(
+            f"wave7_runtime_smoke=ok adapters={','.join(selected_adapters)} "
+            "shared_stack_touched=false cleanup=verified",
+            flush=True,
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--image", required=True)
+    parser.add_argument("--seccomp", required=True, type=Path)
+    parser.add_argument("--adapter", choices=ADAPTERS)
+    parser.add_argument("--run-id", help="optional eight-character lowercase hex suffix")
+    arguments = parser.parse_args(argv)
+    try:
+        run(
+            arguments.image,
+            arguments.seccomp.resolve(),
+            run_id=arguments.run_id,
+            adapter=arguments.adapter,
+        )
+    except (SmokeFailure, subprocess.TimeoutExpired, OSError, ValueError) as exc:
+        print(f"wave7_runtime_smoke=failed reason={exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/server/tests/test_mcp_browser_runtime_smoke.py
+++ b/server/tests/test_mcp_browser_runtime_smoke.py
@@ -1,0 +1,475 @@
+from __future__ import annotations
+
+import inspect
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from server.sandbox_sidecar import smoke_browser_adapters as adapter_smoke
+from server.sandbox_sidecar import smoke_browser_runtime as runtime_smoke
+
+
+def _secure_inspect(*, user: str = "65532:65532", network: str = "none") -> dict:
+    return {
+        "Config": {"User": user},
+        "HostConfig": {
+            "NetworkMode": network,
+            "ReadonlyRootfs": True,
+            "Privileged": False,
+            "CapDrop": ["ALL"],
+            "CapAdd": None,
+            "SecurityOpt": ["no-new-privileges", "seccomp=test.json"],
+            "ReadonlyPaths": [
+                "/proc/bus", "/proc/fs", "/proc/irq", "/proc/sys",
+                "/proc/sysrq-trigger",
+            ],
+            "MaskedPaths": ["/proc/kcore", "/proc/keys", "/proc/timer_list"],
+            "PidsLimit": 16,
+            "Memory": 64 * 1024 * 1024,
+            "NanoCpus": 250_000_000,
+            "Devices": [],
+        },
+        "Mounts": [],
+    }
+
+
+def test_runtime_helper_snippets_compile() -> None:
+    snippets = (
+        runtime_smoke.FIXTURE_CODE,
+        runtime_smoke.CAPABILITY_RESTART_PROBE_CODE,
+        runtime_smoke.UNTRUSTED_PEER_CODE,
+        runtime_smoke.SECCOMP_PROBE_CODE,
+        runtime_smoke.CHROMIUM_PROBE_CODE,
+        runtime_smoke.PROCESS_SNAPSHOT_CODE,
+        runtime_smoke.CGROUP_DIAGNOSTIC_CODE,
+        runtime_smoke.PID1_PROBE_CODE,
+        runtime_smoke.PROCFS_LANDLOCK_PROBE_CODE,
+        runtime_smoke.POST_RESTART_PROBE_CODE,
+    )
+    for index, source in enumerate(snippets):
+        compile(source, f"<wave7-runtime-smoke-{index}>", "exec")
+
+
+def test_post_restart_probe_does_not_match_its_own_python_command() -> None:
+    source = runtime_smoke.POST_RESTART_PROBE_CODE
+    assert "import os" in source
+    assert "int(entry.name) == os.getpid()" in source
+
+
+def test_chromium_probe_uses_its_own_container_userns_baseline() -> None:
+    source = runtime_smoke.CHROMIUM_PROBE_CODE
+    assert 'os.readlink("/proc/self/ns/user")' in source
+    assert 'os.readlink("/proc/1/ns/user")' not in source
+    assert 'argv0.endswith("modelmirror-chromium")' in source
+    assert "AutofillServerCommunication" in source
+    assert "NetworkTimeServiceQuerying" in source
+    assert "PreconnectToSearch" in source
+    assert "NoSearchDomainCheck" in source
+
+
+def test_runtime_resources_are_isolated_and_bounded() -> None:
+    base = f"{runtime_smoke.PREFIX}-1234abcd"
+    assert runtime_smoke._resource(base, "cdp-browser") == (
+        "mm-wave7-runtime-smoke-1234abcd-cdp-browser"
+    )
+    with pytest.raises(runtime_smoke.SmokeFailure, match="unsafe smoke resource"):
+        runtime_smoke._resource("modelmirror", "server")
+    with pytest.raises(runtime_smoke.SmokeFailure, match="unsafe smoke resource"):
+        runtime_smoke._resource(base, "../shared")
+
+
+def test_runtime_cleanup_only_addresses_recorded_exact_resources() -> None:
+    class Runner:
+        calls: list[tuple[str, ...]] = []
+
+        def run(self, *arguments: str, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            self.calls.append(arguments)
+            is_inspect = len(arguments) > 1 and arguments[1] == "inspect"
+            return subprocess.CompletedProcess(
+                arguments,
+                1 if is_inspect else 0,
+                "",
+                "No such object" if is_inspect else "",
+            )
+
+    runner = Runner()
+    ledger = runtime_smoke.ResourceLedger(
+        runner,  # type: ignore[arg-type]
+        containers=["mm-wave7-runtime-smoke-1234abcd-c"],
+        volumes=["mm-wave7-runtime-smoke-1234abcd-v"],
+        networks=["mm-wave7-runtime-smoke-1234abcd-n"],
+    )
+    ledger.cleanup()
+    assert runner.calls == [
+        ("rm", "-f", "mm-wave7-runtime-smoke-1234abcd-c"),
+        ("container", "inspect", "mm-wave7-runtime-smoke-1234abcd-c"),
+        ("volume", "rm", "-f", "mm-wave7-runtime-smoke-1234abcd-v"),
+        ("volume", "inspect", "mm-wave7-runtime-smoke-1234abcd-v"),
+        ("network", "rm", "mm-wave7-runtime-smoke-1234abcd-n"),
+        ("network", "inspect", "mm-wave7-runtime-smoke-1234abcd-n"),
+    ]
+    assert not any(
+        token in {"compose", "down", "prune", "system"}
+        for call in runner.calls
+        for token in call
+    )
+
+
+def test_timeout_after_daemon_create_is_still_exactly_cleaned() -> None:
+    class Runner:
+        exists = False
+        calls: list[tuple[str, ...]] = []
+
+        def run(self, *arguments: str, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            self.calls.append(arguments)
+            if arguments[:2] == ("container", "inspect"):
+                if self.exists:
+                    return subprocess.CompletedProcess(arguments, 0, "[]", "")
+                return subprocess.CompletedProcess(arguments, 1, "", "No such object")
+            if arguments[0] == "run":
+                self.exists = True
+                raise subprocess.TimeoutExpired(arguments, 1)
+            if arguments[:2] == ("rm", "-f"):
+                self.exists = False
+            return subprocess.CompletedProcess(arguments, 0, "", "")
+
+    runner = Runner()
+    ledger = runtime_smoke.ResourceLedger(runner)  # type: ignore[arg-type]
+    base = f"{runtime_smoke.PREFIX}-1234abcd"
+    with pytest.raises(subprocess.TimeoutExpired):
+        runtime_smoke._start_fixture(
+            runner,  # type: ignore[arg-type]
+            ledger,
+            base=base,
+            image="audit-image",
+            network="audit-network",
+            address="198.18.1.10",
+        )
+    assert runner.exists is True
+    assert ledger.containers == [f"{base}-fixture"]
+    ledger.cleanup()
+    assert runner.exists is False
+    assert ("rm", "-f", f"{base}-fixture") in runner.calls
+
+
+def test_runtime_security_inspection_is_fail_closed() -> None:
+    payload = _secure_inspect()
+    runtime_smoke._assert_common_security(
+        payload, user="65532:65532", network_mode="none"
+    )
+    payload["HostConfig"]["CapDrop"] = []
+    with pytest.raises(runtime_smoke.SmokeFailure, match="capability"):
+        runtime_smoke._assert_common_security(
+            payload, user="65532:65532", network_mode="none"
+        )
+
+
+def test_browser_procfs_inspection_requires_docker_system_path_guards() -> None:
+    payload = _secure_inspect()
+    runtime_smoke._assert_browser_procfs_boundary(payload)
+
+    payload["HostConfig"]["ReadonlyPaths"].remove("/proc/sys")
+    with pytest.raises(runtime_smoke.SmokeFailure, match="read-only"):
+        runtime_smoke._assert_browser_procfs_boundary(payload)
+
+    payload = _secure_inspect()
+    payload["HostConfig"]["MaskedPaths"].remove("/proc/kcore")
+    with pytest.raises(runtime_smoke.SmokeFailure, match="masked"):
+        runtime_smoke._assert_browser_procfs_boundary(payload)
+
+    payload = _secure_inspect()
+    payload["HostConfig"]["SecurityOpt"].append("systempaths=unconfined")
+    with pytest.raises(runtime_smoke.SmokeFailure, match="unconfined"):
+        runtime_smoke._assert_browser_procfs_boundary(payload)
+
+
+def test_landlock_procfs_probe_covers_sensitive_and_category_boundaries() -> None:
+    source = runtime_smoke.PROCFS_LANDLOCK_PROBE_CODE
+    for path in (
+        "/proc/1/mem", "/proc/1/environ", "/proc/1/fd/0",
+        "/proc/sys/kernel/core_pattern", "/proc/sysrq-trigger",
+    ):
+        assert path in source
+    assert "os.O_WRONLY | os.O_CREAT" in source
+    assert "os.O_WRONLY | os.O_TRUNC" in source
+    assert 'os.open("/proc/self/comm", os.O_WRONLY)' in source
+    assert "_run_landlock_procfs_probe(runner, name)" in inspect.getsource(
+        runtime_smoke._start_browser
+    )
+
+
+def test_runtime_seccomp_contract_requires_only_reviewed_namespace_exceptions() -> None:
+    profile = Path(runtime_smoke.__file__).with_name("seccomp_profile.browser.json")
+    runtime_smoke._validate_seccomp_file(profile)
+    probe = runtime_smoke.SECCOMP_PROBE_CODE
+    for syscall in (
+        "mount", "pivot_root", "open_by_handle_at", "pidfd_getfd",
+        "bpf", "keyctl", "userfaultfd", "io_uring_setup",
+    ):
+        assert f'"{syscall}"' in probe
+
+
+def test_runtime_adapter_pairs_are_fixed() -> None:
+    assert runtime_smoke.ADAPTERS == (
+        "chrome-devtools-mcp",
+        "playwright-mcp",
+    )
+    assert set(runtime_smoke.ADAPTER_TOKENS) == set(runtime_smoke.ADAPTERS)
+    assert runtime_smoke._selected_adapters(None) == runtime_smoke.ADAPTERS
+    assert runtime_smoke._selected_adapters("chrome-devtools-mcp") == (
+        "chrome-devtools-mcp",
+    )
+    with pytest.raises(runtime_smoke.SmokeFailure, match="unsupported fixed"):
+        runtime_smoke._selected_adapters("user-controlled-adapter")
+    assert "choices=ADAPTERS" in inspect.getsource(runtime_smoke.main)
+
+
+def test_runtime_timeout_session_is_fixed_and_cleans_after_one_restart() -> None:
+    assert runtime_smoke.TIMEOUT_FIXTURE_PATH == "/__modelmirror_timeout"
+    assert runtime_smoke.TIMEOUT_FIXTURE_DELAY_SECONDS == 25
+    assert adapter_smoke.BROWSER_LIMITS["navigation_timeout_seconds"] == 20
+    assert (
+        adapter_smoke.BROWSER_LIMITS["navigation_timeout_seconds"]
+        < runtime_smoke.TIMEOUT_FIXTURE_DELAY_SECONDS
+        < adapter_smoke.BROWSER_LIMITS["egress_tunnel_idle_seconds"]
+    )
+    assert 'os.environ["MM_WAVE7_TIMEOUT_PATH"]' in runtime_smoke.FIXTURE_CODE
+    assert (
+        'os.environ["MM_WAVE7_TIMEOUT_DELAY_SECONDS"]'
+        in runtime_smoke.FIXTURE_CODE
+    )
+
+    helper_source = inspect.getsource(runtime_smoke._start_gateway_helper)
+    assert 'helper_command.append("--expect-timeout")' in helper_source
+    pair_source = inspect.getsource(runtime_smoke._run_adapter_pair)
+    assert "attempt=3" in pair_source
+    assert "TIMEOUT_FIXTURE_PATH" in pair_source
+    assert pair_source.count("_post_restart_cleanup(runner, browser)") == 3
+
+    timeout_source = inspect.getsource(runtime_smoke._run_gateway_timeout_attempt)
+    assert 'expect_timeout=True' in timeout_source
+    assert timeout_source.count("[0] !=") == 2
+    assert timeout_source.count("[0] + 1") == 2
+    assert "TIMEOUT_RUNTIME_EVENTS" in timeout_source
+
+
+def test_gateway_timeout_outcome_requires_non_retryable_20_second_contract() -> None:
+    response = {
+        "jsonrpc": "2.0",
+        "id": 3,
+        "error": {
+            "code": -32008,
+            "message": "redacted",
+            "data": {"reason": "unknown_outcome", "retryable": False},
+        },
+    }
+    adapter_smoke._assert_timeout_outcome(response, 20.0)
+
+    for invalid in (
+        {"error": {"code": -32011, "data": {"reason": "unknown_outcome", "retryable": False}}},
+        {"error": {"code": -32008, "data": {"reason": "browser_upstream_unavailable", "retryable": False}}},
+        {"error": {"code": -32008, "data": {"reason": "unknown_outcome", "retryable": True}}},
+    ):
+        with pytest.raises(RuntimeError):
+            adapter_smoke._assert_timeout_outcome(invalid, 20.0)
+    with pytest.raises(RuntimeError, match="elapsed window"):
+        adapter_smoke._assert_timeout_outcome(response, 17.9)
+    with pytest.raises(RuntimeError, match="elapsed window"):
+        adapter_smoke._assert_timeout_outcome(response, 28.1)
+
+
+def test_gateway_timeout_cli_has_no_user_selected_duration() -> None:
+    main_source = inspect.getsource(adapter_smoke.main)
+    gateway_source = inspect.getsource(adapter_smoke.gateway_smoke)
+    assert 'sys.argv[5] == "--expect-timeout"' in main_source
+    assert "expect_timeout=len(sys.argv) == 6" in main_source
+    assert "--timeout-seconds" not in main_source
+    assert "allow_error=True" in gateway_source
+    assert "_assert_timeout_outcome" in gateway_source
+
+
+def test_capability_rotation_probe_uses_the_control_key_owner_without_caps() -> None:
+    source = inspect.getsource(runtime_smoke._probe_egress_rotation)
+    assert source.count('user="65532:65532"') == 2
+    assert 'user="0:0"' not in source
+    assert "cap_add=" not in source
+
+
+def test_runtime_failure_logs_are_bounded_and_redacted() -> None:
+    secret = "a" * 64
+    page_text = "private page body"
+    diagnostic = runtime_smoke._safe_log_tail(
+        f"control_key={secret}\nurl=https://secret.example/path\n"
+        f'content: {page_text}\nblob={'b' * 256}'
+    )
+    assert secret not in diagnostic
+    assert "secret.example" not in diagnostic
+    assert page_text not in diagnostic
+    assert "b" * 128 not in diagnostic
+    assert len(diagnostic) <= 2048
+
+
+def test_cgroup_diagnostic_accepts_only_fixed_numeric_fields() -> None:
+    expected = {
+        field: 1 if field == "probe_ok" else index
+        for index, field in enumerate(runtime_smoke.CGROUP_DIAGNOSTIC_FIELDS)
+    }
+
+    class Runner:
+        def run(self, *arguments: str, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            assert arguments[-1] == runtime_smoke.CGROUP_DIAGNOSTIC_CODE
+            return subprocess.CompletedProcess(arguments, 0, json.dumps(expected), "")
+
+    assert runtime_smoke._safe_cgroup_snapshot(  # type: ignore[arg-type]
+        Runner(), "browser"
+    ) == expected
+    assert all(
+        isinstance(value, int) and not isinstance(value, bool)
+        for value in expected.values()
+    )
+
+
+def test_cgroup_diagnostic_discards_invalid_or_sensitive_probe_output() -> None:
+    secret = "d" * 64
+
+    class Runner:
+        def run(self, *arguments: str, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess(
+                arguments, 0, json.dumps({"probe_ok": 1, "secret": secret}), ""
+            )
+
+    snapshot = runtime_smoke._safe_cgroup_snapshot(  # type: ignore[arg-type]
+        Runner(), "browser"
+    )
+    assert tuple(snapshot) == runtime_smoke.CGROUP_DIAGNOSTIC_FIELDS
+    assert snapshot["probe_ok"] == 0
+    assert all(isinstance(value, int) for value in snapshot.values())
+    assert secret not in json.dumps(snapshot)
+
+
+def test_cgroup_merge_preserves_events_and_peak_but_uses_final_currents() -> None:
+    observed = {
+        field: 1 if field == "probe_ok" else 0
+        for field in runtime_smoke.CGROUP_DIAGNOSTIC_FIELDS
+    }
+    observed.update({
+        "pids_events_max": 3,
+        "pids_current": 17,
+        "memory_events_oom": 2,
+        "memory_current": 40_000_000,
+        "memory_peak": 50_000_000,
+    })
+    final = dict(observed)
+    final.update({
+        "pids_events_max": 0,
+        "pids_current": 2,
+        "memory_events_oom": 0,
+        "memory_current": 20_000_000,
+        "memory_peak": 22_000_000,
+    })
+
+    merged = runtime_smoke._merge_cgroup_diagnostics(observed, final)
+    assert tuple(merged) == runtime_smoke.CGROUP_DIAGNOSTIC_FIELDS
+    assert merged["pids_events_max"] == 3
+    assert merged["memory_events_oom"] == 2
+    assert merged["memory_peak"] == 50_000_000
+    assert merged["pids_current"] == 2
+    assert merged["memory_current"] == 20_000_000
+
+
+def test_chromium_probe_failure_reports_safe_state_and_process_snapshot() -> None:
+    secret = "c" * 64
+
+    class Runner:
+        cgroup_calls = 0
+
+        def run(self, *arguments: str, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            if arguments[0] == "exec" and arguments[-1] == runtime_smoke.CHROMIUM_PROBE_CODE:
+                return subprocess.CompletedProcess(arguments, 1, "", "no Chromium")
+            if arguments[0] == "exec" and arguments[-1] == runtime_smoke.PROCESS_SNAPSHOT_CODE:
+                return subprocess.CompletedProcess(
+                    arguments, 0,
+                    '[{"pid":7,"comm":"node","exe":"node","argv0":"node","flags":{}}]',
+                    "",
+                )
+            if arguments[0] == "exec" and arguments[-1] == runtime_smoke.CGROUP_DIAGNOSTIC_CODE:
+                self.cgroup_calls += 1
+                cgroup = {
+                    field: 1 if field == "probe_ok" else 0
+                    for field in runtime_smoke.CGROUP_DIAGNOSTIC_FIELDS
+                }
+                if self.cgroup_calls == 1:
+                    cgroup.update({
+                        "pids_events_max": 3,
+                        "pids_current": 11,
+                        "memory_current": 33_000_000,
+                        "memory_peak": 44_000_000,
+                    })
+                else:
+                    cgroup.update({
+                        "pids_events_max": 0,
+                        "pids_current": 2,
+                        "memory_current": 22_000_000,
+                        "memory_peak": 23_000_000,
+                    })
+                return subprocess.CompletedProcess(arguments, 0, json.dumps(cgroup), "")
+            if arguments[0] == "inspect":
+                return subprocess.CompletedProcess(
+                    arguments, 0,
+                    '[{"State":{"Status":"exited","ExitCode":7,"OOMKilled":false,'
+                    '"Restarting":false},"RestartCount":0}]',
+                    "",
+                )
+            if arguments[0] == "logs":
+                return subprocess.CompletedProcess(
+                    arguments, 0,
+                    f"RuntimeError: failed control_key={secret} content: private body",
+                    "",
+                )
+            raise AssertionError(arguments)
+
+    with pytest.raises(runtime_smoke.SmokeFailure) as captured:
+        runtime_smoke._wait_chromium_probe(
+            Runner(),  # type: ignore[arg-type]
+            "browser", "helper",
+            cgroup_before=runtime_smoke._empty_cgroup_snapshot(),
+            timeout=1,
+        )
+    message = str(captured.value)
+    assert '"ExitCode":7' in message
+    assert '"comm":"node"' in message
+    assert 'cgroup_observed={"probe_ok":1,"pids_events_max":3,"pids_current":2' in message
+    assert '"memory_current":22000000,"memory_peak":44000000}' in message
+    assert 'cgroup_final={"probe_ok":1,"pids_events_max":0,"pids_current":2' in message
+    assert '"memory_current":22000000,"memory_peak":23000000}' in message
+    assert '"OOMKilled":false' in message
+    assert secret not in message
+    assert "private body" not in message
+
+
+def test_every_runtime_creator_reserves_before_cli_and_calibration_is_not_auto_removed() -> None:
+    creators = (
+        runtime_smoke._create_network,
+        runtime_smoke._create_volume,
+        runtime_smoke._start_fixture,
+        runtime_smoke._run_seccomp_calibration,
+        runtime_smoke._start_egress,
+        runtime_smoke._probe_egress_rotation,
+        runtime_smoke._start_browser,
+        runtime_smoke._run_untrusted_peer_probe,
+        runtime_smoke._start_gateway_helper,
+    )
+    for creator in creators:
+        source = inspect.getsource(creator)
+        assert "_reserve_resource(" in source, creator.__name__
+        assert source.index("_reserve_resource(") < source.index("runner.run("), creator.__name__
+    assert '"--rm"' not in inspect.getsource(runtime_smoke._run_seccomp_calibration)
+
+
+def test_browser_runtime_uses_the_reviewed_process_budget() -> None:
+    source = inspect.getsource(runtime_smoke._start_browser)
+
+    assert 'pids=256, memory="1g", cpus="1.5"' in source
+    assert "pids=128" not in source

--- a/server/tests/test_mcp_browser_sidecar.py
+++ b/server/tests/test_mcp_browser_sidecar.py
@@ -1,0 +1,2157 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import inspect
+import json
+import os
+import socket
+import time
+from pathlib import Path
+from types import MethodType
+from typing import Any
+
+import pytest
+
+from server.mcp import browser_proxy
+from server.sandbox_sidecar import browser_mcp, browser_server, smoke_browser_adapters
+from server.sandbox_sidecar.browser_contracts import (
+    BROWSER_ADAPTERS,
+    BROWSER_LIMITS,
+    BROWSER_SCHEMA_SHA256,
+    CONTRACT_VERSION,
+    MAX_OUTPUT_BYTES,
+    UPSTREAM_SCHEMA_SHA256,
+    BrowserPolicyError,
+    _schema_digest,
+    assert_schema_snapshots,
+    resolve_pinned_addresses,
+    validate_browser_url,
+)
+
+
+EXPECTED_TOOLS = {
+    "chrome-devtools-mcp": {
+        "browser_session_status",
+        "navigate_page",
+        "take_snapshot",
+        "click",
+        "fill",
+        "take_screenshot",
+    },
+    "playwright-mcp": {
+        "browser_session_status",
+        "browser_navigate",
+        "browser_snapshot",
+        "browser_click",
+        "browser_fill_form",
+        "browser_take_screenshot",
+    },
+}
+
+
+class MemoryWriter:
+    def __init__(self) -> None:
+        self.data = bytearray()
+        self.closed = False
+
+    def write(self, value: bytes | bytearray) -> None:
+        self.data.extend(value)
+
+    async def drain(self) -> None:
+        return None
+
+    def write_eof(self) -> None:
+        return None
+
+    def close(self) -> None:
+        self.closed = True
+
+    async def wait_closed(self) -> None:
+        return None
+
+
+class FakeEgress:
+    def __init__(self) -> None:
+        self.authorized: list[str] = []
+        self.revocation_reason = ""
+
+    async def authorize(self, url: str) -> None:
+        self.authorized.append(url)
+
+    async def open_tunnel(self, url: str) -> tuple[asyncio.StreamReader, MemoryWriter]:
+        raise AssertionError(f"unexpected tunnel: {url}")
+
+
+def _handshake(adapter_id: str) -> dict[str, object]:
+    return {
+        "project_id": adapter_id,
+        "contract_version": CONTRACT_VERSION,
+        "tool_schema_sha256": BROWSER_SCHEMA_SHA256[adapter_id],
+        "limits": BROWSER_LIMITS,
+    }
+
+
+def _snapshot_payload(text: str) -> dict[str, object]:
+    return {
+        "jsonrpc": "2.0",
+        "id": "snapshot",
+        "result": {"content": [{"type": "text", "text": text}]},
+    }
+
+
+def test_fixed_public_tools_and_schema_snapshots() -> None:
+    assert_schema_snapshots()
+    assert set(BROWSER_ADAPTERS) == set(EXPECTED_TOOLS)
+    assert set(BROWSER_SCHEMA_SHA256) == set(BROWSER_ADAPTERS)
+    assert set(UPSTREAM_SCHEMA_SHA256) == set(BROWSER_ADAPTERS)
+    forbidden = {
+        "evaluate",
+        "evaluate_script",
+        "browser_evaluate",
+        "upload_file",
+        "browser_file_upload",
+        "press_key",
+        "browser_press_key",
+        "browser_tabs",
+        "list_pages",
+    }
+    for adapter_id, contract in BROWSER_ADAPTERS.items():
+        assert set(contract.tools) == EXPECTED_TOOLS[adapter_id]
+        assert _schema_digest(contract) == BROWSER_SCHEMA_SHA256[adapter_id]
+        assert not set(contract.tools) & forbidden
+        for name in set(contract.tools) & {
+            "click",
+            "fill",
+            "browser_click",
+            "browser_fill_form",
+        }:
+            schema = contract.tools[name].input_schema
+            properties = schema["properties"]
+            assert properties["ref"]["x-modelmirror-input"] == "browser-ref"
+            assert not {"generation", "page_revision", "page_digest"} & set(properties)
+            assert schema["x-modelmirror-ref-proof"] == "sidecar-bound"
+        screenshot = next(
+            tool for name, tool in contract.tools.items() if "screenshot" in name
+        )
+        assert set(screenshot.input_schema["properties"]) == {"full_page"}
+
+
+def test_browser_seccomp_profile_preserves_default_deny_and_capability_gates() -> None:
+    profile_path = Path(browser_server.__file__).with_name(
+        "seccomp_profile.browser.json"
+    )
+    profile = json.loads(profile_path.read_text(encoding="utf-8"))
+    assert profile["defaultAction"] == "SCMP_ACT_ERRNO"
+    rules = profile["syscalls"]
+    assert rules[0]["action"] == "SCMP_ACT_ALLOW"
+    assert rules[0]["names"] == ["chroot", "clone", "setns", "unshare"]
+    assert rules[0].get("includes") == {}
+
+    ptrace_syscalls = {"ptrace", "process_vm_readv", "process_vm_writev"}
+    ptrace_rules = [
+        rule
+        for rule in rules
+        if rule.get("action") == "SCMP_ACT_ALLOW"
+        and ptrace_syscalls.intersection(rule.get("names", []))
+    ]
+    assert ptrace_rules
+    for rule in ptrace_rules:
+        includes = rule.get("includes") or {}
+        assert "CAP_SYS_PTRACE" in set(includes.get("caps") or [])
+        assert "minKernel" not in includes
+
+    capability_only = {
+        "mount",
+        "mount_setattr",
+        "open_by_handle_at",
+        "pidfd_getfd",
+        "pivot_root",
+        "bpf",
+        "keyctl",
+        "userfaultfd",
+        "io_uring_setup",
+        "io_uring_enter",
+        "io_uring_register",
+    }
+    for rule in rules:
+        if rule.get("action") != "SCMP_ACT_ALLOW":
+            continue
+        covered = capability_only.intersection(rule.get("names", []))
+        if not covered:
+            continue
+        includes = rule.get("includes") or {}
+        assert includes.get("caps"), f"unconditional allow for {sorted(covered)}"
+        assert "minKernel" not in includes
+
+
+def test_browser_downloader_is_integrity_locked_and_pruned_from_release() -> None:
+    sidecar_dir = Path(browser_server.__file__).parent
+    lock = json.loads(
+        (sidecar_dir / "browser_requirements.lock").read_text(encoding="utf-8")
+    )
+    root = lock["packages"][""]
+    assert root["devDependencies"] == {"@puppeteer/browsers": "3.0.6"}
+    downloader = lock["packages"]["node_modules/@puppeteer/browsers"]
+    assert downloader["version"] == "3.0.6"
+    assert downloader["resolved"] == (
+        "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.0.6.tgz"
+    )
+    assert downloader["integrity"] == (
+        "sha512-B/gKoqlFkzhvzsI6jo9K1cZz9o5ypviVv/xu8CwA4grZzyVwN+"
+        "XfkT+tu8T1zrauuEXv6VhS2oGX+6NL95WcKA=="
+    )
+    assert downloader["dev"] is True
+
+    dockerfile = (sidecar_dir / "Dockerfile.browser").read_text(encoding="utf-8")
+    assert "npm ci --include=dev --ignore-scripts --no-audit --no-fund" in dockerfile
+    assert "./node_modules/.bin/browsers install" in dockerfile
+    assert "npx --yes" not in dockerfile
+    assert "npm prune --omit=dev --ignore-scripts --no-audit --no-fund" in dockerfile
+    assert "test ! -e ./node_modules/@puppeteer/browsers" in dockerfile
+    assert "test ! -e ./node_modules/.bin/browsers" in dockerfile
+    assert "EncryptedClientHelloEnabled:false" in dockerfile
+
+def test_proxy_handshake_is_exact_and_size_bounded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter_id = "chrome-devtools-mcp"
+    encoded = base64.urlsafe_b64encode(
+        json.dumps(_handshake(adapter_id), separators=(",", ":")).encode()
+    ).decode()
+    monkeypatch.setenv("MCP_BROWSER_HANDSHAKE_B64", encoded)
+    assert browser_proxy._load_handshake(adapter_id) == _handshake(adapter_id)
+    assert "MCP_BROWSER_HANDSHAKE_B64" not in __import__("os").environ
+
+    wrong = _handshake(adapter_id)
+    wrong["limits"] = {**BROWSER_LIMITS, "max_actions": 51}
+    monkeypatch.setenv(
+        "MCP_BROWSER_HANDSHAKE_B64",
+        base64.urlsafe_b64encode(json.dumps(wrong).encode()).decode(),
+    )
+    with pytest.raises(ValueError, match="limits_mismatch"):
+        browser_proxy._load_handshake(adapter_id)
+
+
+@pytest.mark.parametrize(
+    ("url", "reason"),
+    [
+        ("file:///etc/passwd", "browser_scheme_denied"),
+        ("https://user@example.com/", "browser_userinfo_denied"),
+        ("https://127.0.0.1/", "browser_ip_literal_denied"),
+        ("https://localhost/", "browser_single_label_host_denied"),
+        ("https://metadata.google.internal/", "browser_internal_host_denied"),
+        ("https://example.com:8443/", "browser_port_denied"),
+        ("https://login.example.com/", "browser_external_login_denied"),
+        ("https://example.com/login.html", "browser_external_login_denied"),
+        ("https://example.com/%6cogin", "browser_external_login_denied"),
+        ("https://example.com/%256cogin", "browser_external_login_denied"),
+        ("https://example.com/sign-in", "browser_external_login_denied"),
+        ("https://example.com/sign_in", "browser_external_login_denied"),
+        ("https://example.com/log-in", "browser_external_login_denied"),
+        ("https://example.com/log_in", "browser_external_login_denied"),
+        ("https://example.com/sign/in", "browser_external_login_denied"),
+        ("https://example.com/user-sign-in", "browser_external_login_denied"),
+        ("https://example.com/%73ign%2Din", "browser_external_login_denied"),
+        ("https://example.com/%2573ign%252Din", "browser_external_login_denied"),
+        ("https://example.com/log%255Fin", "browser_external_login_denied"),
+        ("https://sign-in.example.com/", "browser_external_login_denied"),
+        ("https://sign.in.example.com/", "browser_external_login_denied"),
+        ("https://example.com/?action=login", "browser_external_login_denied"),
+        ("https://accounts.example.com/", "browser_external_login_denied"),
+        ("https://example.com/session/new", "browser_external_login_denied"),
+        ("https://example.com/consent", "browser_external_login_denied"),
+        ("https://example.com/saml/callback", "browser_external_login_denied"),
+        ("https://example.com/oidc", "browser_external_login_denied"),
+    ],
+)
+def test_url_policy_blocks_ssrf_and_login_bypasses(url: str, reason: str) -> None:
+    with pytest.raises(BrowserPolicyError, match=reason):
+        validate_browser_url(url)
+
+
+def test_url_policy_does_not_confuse_author_with_auth() -> None:
+    normalized, origin, host, port = validate_browser_url(
+        "https://authors.example.com/author/profile"
+    )
+    assert normalized == "https://authors.example.com/author/profile"
+    assert (origin, host, port) == (
+        "https://authors.example.com",
+        "authors.example.com",
+        443,
+    )
+    validate_browser_url("https://example.com/design/inspiration")
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://example.com/report?token=opaque",
+        "https://example.com/report?access_token=opaque",
+        "https://example.com/report?%2561pi%255Fkey=opaque",
+        "https://example.com/report?X-Amz-Signature=opaque",
+        "https://example.com/report?x-goog-credential=opaque",
+        "https://example.com/report?sig=opaque",
+        (
+            "https://example.com/report?redirect="
+            "https%253A%252F%252Fother.example%252Fcallback"
+            "%253Foauth_token%253Dopaque"
+        ),
+    ],
+)
+def test_url_policy_rejects_sensitive_query_keys_after_nested_decoding(
+    url: str,
+) -> None:
+    with pytest.raises(BrowserPolicyError, match="browser_sensitive_query_denied"):
+        validate_browser_url(url)
+
+
+def test_url_policy_allows_ordinary_pagination_and_sort_query() -> None:
+    normalized, origin, host, port = validate_browser_url(
+        "https://example.com/report?page=2&sort=recent"
+    )
+    assert normalized == "https://example.com/report?page=2&sort=recent"
+    assert (origin, host, port) == (
+        "https://example.com",
+        "example.com",
+        443,
+    )
+
+
+def _dns_record(address: str) -> tuple[Any, ...]:
+    family = socket.AF_INET6 if ":" in address else socket.AF_INET
+    sockaddr: tuple[Any, ...] = (address, 443, 0, 0) if family == socket.AF_INET6 else (address, 443)
+    return (family, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", sockaddr)
+
+
+def _doh_response(payload: dict[str, object]) -> bytes:
+    body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    return (
+        b"HTTP/1.1 200 OK\r\n"
+        b"Content-Type: application/dns-json\r\n"
+        + f"Content-Length: {len(body)}\r\n".encode("ascii")
+        + b"Connection: close\r\n\r\n"
+        + body
+    )
+
+
+def _memory_reader(payload: bytes) -> asyncio.StreamReader:
+    reader = asyncio.StreamReader()
+    reader.feed_data(payload)
+    reader.feed_eof()
+    return reader
+
+
+def test_dns_policy_rejects_private_mixed_and_rebinding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda *args, **kwargs: [_dns_record("93.184.216.34"), _dns_record("10.0.0.1")],
+    )
+    with pytest.raises(BrowserPolicyError, match="private_dns_denied"):
+        resolve_pinned_addresses("example.com", 443)
+
+    monkeypatch.setenv("MCP_BROWSER_ALLOW_SYNTHETIC_DNS", "true")
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda *args, **kwargs: [_dns_record("93.184.216.34"), _dns_record("198.18.0.9")],
+    )
+    with pytest.raises(BrowserPolicyError, match="mixed_or_synthetic_denied"):
+        resolve_pinned_addresses("example.com", 443)
+
+    answers = iter(
+        [
+            [_dns_record("93.184.216.34")],
+            [_dns_record("169.254.169.254")],
+        ]
+    )
+    monkeypatch.delenv("MCP_BROWSER_ALLOW_SYNTHETIC_DNS", raising=False)
+    monkeypatch.setattr(socket, "getaddrinfo", lambda *args, **kwargs: next(answers))
+    assert resolve_pinned_addresses("example.com", 443) == ("93.184.216.34",)
+    with pytest.raises(BrowserPolicyError, match="private_dns_denied"):
+        resolve_pinned_addresses("example.com", 443)
+
+
+@pytest.mark.asyncio
+async def test_production_egress_uses_fixed_tls_doh_and_pins_all_answers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("MCP_BROWSER_ALLOW_SYNTHETIC_DNS", raising=False)
+    responses = iter(
+        [
+            _doh_response(
+                {
+                    "Status": 0,
+                    "Answer": [
+                        {"name": "example.com.", "type": 1, "data": "93.184.216.34"},
+                    ],
+                }
+            ),
+            _doh_response(
+                {
+                    "Status": 0,
+                    "Answer": [
+                        {"name": "example.com.", "type": 28, "data": "2606:2800:220:1:248:1893:25c8:1946"},
+                    ],
+                }
+            ),
+        ]
+    )
+    writers: list[MemoryWriter] = []
+
+    async def fixed_open_connection(
+        address: str,
+        port: int,
+        **kwargs: object,
+    ) -> tuple[asyncio.StreamReader, MemoryWriter]:
+        assert (address, port) == ("1.1.1.1", 443)
+        assert kwargs.get("server_hostname") == "cloudflare-dns.com"
+        assert kwargs.get("ssl") is not None
+        writer = MemoryWriter()
+        writers.append(writer)
+        return _memory_reader(next(responses)), writer
+
+    async def forbidden_system_dns(*args: object, **kwargs: object) -> object:
+        raise AssertionError("production browser egress must not use host DNS")
+
+    loop = asyncio.get_running_loop()
+    monkeypatch.setattr(loop, "getaddrinfo", forbidden_system_dns)
+    monkeypatch.setattr(asyncio, "open_connection", fixed_open_connection)
+
+    service = browser_server.BrowserEgressService("k" * 64)
+    assert await service.resolve("example.com", 443) == (
+        "93.184.216.34",
+        "2606:2800:220:1:248:1893:25c8:1946",
+    )
+    assert len(writers) == 2
+    assert b"GET /dns-query?name=example.com&type=A HTTP/1.1" in writers[0].data
+    assert b"GET /dns-query?name=example.com&type=AAAA HTTP/1.1" in writers[1].data
+    assert all(b"Accept: application/dns-json" in writer.data for writer in writers)
+
+
+@pytest.mark.asyncio
+async def test_synthetic_fixture_mode_keeps_system_dns_isolated_from_doh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MCP_BROWSER_ALLOW_SYNTHETIC_DNS", "true")
+    loop = asyncio.get_running_loop()
+
+    async def fixture_dns(*args: object, **kwargs: object) -> object:
+        return [_dns_record("198.18.0.8")]
+
+    async def forbidden_doh(host: str) -> tuple[str, ...]:
+        raise AssertionError(f"fixture DNS unexpectedly used DoH for {host}")
+
+    monkeypatch.setattr(loop, "getaddrinfo", fixture_dns)
+    monkeypatch.setattr(browser_server, "_resolve_fixed_doh", forbidden_doh)
+    service = browser_server.BrowserEgressService("k" * 64)
+    assert await service.resolve("fixture.wave7", 80) == ("198.18.0.8",)
+
+
+@pytest.mark.asyncio
+async def test_doh_rejects_private_or_malformed_answer_sets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("MCP_BROWSER_ALLOW_SYNTHETIC_DNS", raising=False)
+    responses = iter(
+        [
+            _doh_response(
+                {
+                    "Status": 0,
+                    "Answer": [
+                        {"name": "example.com.", "type": 1, "data": "169.254.169.254"},
+                    ],
+                }
+            ),
+            _doh_response({"Status": 0, "Answer": []}),
+        ]
+    )
+
+    async def fixed_open_connection(
+        *args: object, **kwargs: object
+    ) -> tuple[asyncio.StreamReader, MemoryWriter]:
+        return _memory_reader(next(responses)), MemoryWriter()
+
+    monkeypatch.setattr(asyncio, "open_connection", fixed_open_connection)
+    with pytest.raises(BrowserPolicyError, match="browser_private_dns_denied"):
+        await browser_server.BrowserEgressService("k" * 64).resolve(
+            "example.com", 443
+        )
+
+
+@pytest.mark.asyncio
+async def test_single_origin_is_immutable_after_first_navigation() -> None:
+    egress = FakeEgress()
+    proxy = browser_server.LoopbackBrowserProxy(egress)  # type: ignore[arg-type]
+    assert await proxy.authorize("https://example.com/a") == "https://example.com/a"
+    assert await proxy.authorize("https://example.com/b") == "https://example.com/b"
+    with pytest.raises(BrowserPolicyError, match="browser_cross_origin_denied"):
+        await proxy.authorize("https://other.example/b")
+    assert len(egress.authorized) == 2
+
+
+@pytest.mark.asyncio
+async def test_http_proxy_rejects_mismatched_or_duplicate_host() -> None:
+    for headers in (
+        b"Host: evil.example\r\n\r\n",
+        b"Host: example.com\r\nHost: example.com\r\n\r\n",
+    ):
+        reader = asyncio.StreamReader()
+        reader.feed_data(b"GET http://example.com/ HTTP/1.1\r\n" + headers)
+        reader.feed_eof()
+        writer = MemoryWriter()
+        proxy = browser_server.LoopbackBrowserProxy(FakeEgress())  # type: ignore[arg-type]
+        proxy.origin, proxy.host, proxy.port = (
+            "http://example.com",
+            "example.com",
+            80,
+        )
+        await proxy.handle(reader, writer)  # type: ignore[arg-type]
+        assert bytes(writer.data).startswith(b"HTTP/1.1 403")
+        assert proxy.last_violation == "browser_http_host_mismatch"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "headers",
+    [
+        b"Upgrade: websocket\r\nHost: example.com\r\n\r\n",
+        b"uPgRaDe: websocket\r\nHost: example.com\r\nUpgrade: websocket\r\n\r\n",
+        b"Connection: keep-alive, Upgrade\r\nHost: example.com\r\n\r\n",
+        b"Proxy-Authorization: Basic opaque\r\nHost: example.com\r\n\r\n",
+    ],
+)
+async def test_http_proxy_rejects_upgrade_and_proxy_auth_in_any_header_position(
+    headers: bytes,
+) -> None:
+    reader = asyncio.StreamReader()
+    reader.feed_data(b"GET http://example.com/ HTTP/1.1\r\n" + headers)
+    reader.feed_eof()
+    writer = MemoryWriter()
+    proxy = browser_server.LoopbackBrowserProxy(FakeEgress())  # type: ignore[arg-type]
+    proxy.origin, proxy.host, proxy.port = (
+        "http://example.com",
+        "example.com",
+        80,
+    )
+    await proxy.handle(reader, writer)  # type: ignore[arg-type]
+    assert bytes(writer.data).startswith(b"HTTP/1.1 403")
+    assert proxy.last_violation == "browser_websocket_or_proxy_auth_denied"
+
+
+@pytest.mark.asyncio
+async def test_bounded_android_gcm_probes_are_blocked_without_taint_or_egress() -> None:
+    proxy = browser_server.LoopbackBrowserProxy(FakeEgress())  # type: ignore[arg-type]
+    proxy.origin, proxy.host, proxy.port = "https://example.com", "example.com", 443
+    proxy.forwarded_requests = 1
+    proxy.authorized_at = time.monotonic()
+
+    def request() -> asyncio.StreamReader:
+        reader = asyncio.StreamReader()
+        reader.feed_data(
+            b"CONNECT android.clients.google.com:443 HTTP/1.1\r\n"
+            b"Host: android.clients.google.com:443\r\n\r\n"
+        )
+        reader.feed_eof()
+        return reader
+
+    for expected_count in range(1, 5):
+        blocked_writer = MemoryWriter()
+        await proxy.handle(request(), blocked_writer)  # type: ignore[arg-type]
+        assert bytes(blocked_writer.data).startswith(b"HTTP/1.1 403")
+        assert proxy.last_violation == ""
+        assert proxy.suppressed_android_client_probes == expected_count
+
+    fifth_writer = MemoryWriter()
+    await proxy.handle(request(), fifth_writer)  # type: ignore[arg-type]
+    assert bytes(fifth_writer.data).startswith(b"HTTP/1.1 403")
+    assert proxy.last_violation == "browser_cross_origin_denied"
+    assert (
+        proxy.last_violation_event
+        == "proxy_policy_cross_origin_android_client_after_forward"
+    )
+
+
+def _client_hello(host: str, *, ech_after_sni: bool = False, duplicate_sni: bool = False) -> bytes:
+    raw_host = host.encode("ascii")
+    name = b"\x00" + len(raw_host).to_bytes(2, "big") + raw_host
+    sni_body = len(name).to_bytes(2, "big") + name
+    sni = b"\x00\x00" + len(sni_body).to_bytes(2, "big") + sni_body
+    extensions = sni + (sni if duplicate_sni else b"")
+    if ech_after_sni:
+        extensions += b"\xfe\x0d\x00\x01\x00"
+    body = (
+        b"\x03\x03"
+        + b"\x00" * 32
+        + b"\x00"
+        + b"\x00\x02\x13\x01"
+        + b"\x01\x00"
+        + len(extensions).to_bytes(2, "big")
+        + extensions
+    )
+    return b"\x01" + len(body).to_bytes(3, "big") + body
+
+
+def _tls_record(payload: bytes) -> bytes:
+    return b"\x16\x03\x03" + len(payload).to_bytes(2, "big") + payload
+
+
+def test_sni_parser_rejects_ech_after_sni_and_duplicate_sni() -> None:
+    assert browser_server._client_hello_sni(_client_hello("example.com")) == "example.com"
+    with pytest.raises(BrowserPolicyError, match="browser_tls_ech_denied"):
+        browser_server._client_hello_sni(
+            _client_hello("example.com", ech_after_sni=True)
+        )
+    with pytest.raises(BrowserPolicyError, match="browser_tls_sni_denied"):
+        browser_server._client_hello_sni(
+            _client_hello("example.com", duplicate_sni=True)
+        )
+
+
+@pytest.mark.asyncio
+async def test_fragmented_client_hello_is_reassembled_and_sni_checked() -> None:
+    hello = _client_hello("example.com")
+    midpoint = len(hello) // 2
+    wire = _tls_record(hello[:midpoint]) + _tls_record(hello[midpoint:])
+    reader = asyncio.StreamReader()
+    for index in range(0, len(wire), 3):
+        reader.feed_data(wire[index : index + 3])
+    reader.feed_eof()
+    writer = MemoryWriter()
+
+    class Service:
+        consumed = 0
+        revoked = ""
+
+        async def consume(self, capability: str, amount: int) -> None:
+            self.consumed += amount
+
+        async def revoke(self, capability: str, reason: str) -> None:
+            self.revoked = reason
+
+    service = Service()
+    await browser_server._relay_limited(  # type: ignore[arg-type]
+        reader,
+        writer,
+        service,
+        "c" * 64,
+        asyncio.get_running_loop().time() + 5,
+        expected_sni="example.com",
+    )
+    assert bytes(writer.data) == wire
+    assert service.consumed == len(wire)
+    assert not service.revoked
+
+
+@pytest.mark.asyncio
+async def test_sni_mismatch_revokes_tunnel() -> None:
+    wire = _tls_record(_client_hello("evil.example"))
+    reader = asyncio.StreamReader()
+    reader.feed_data(wire)
+    reader.feed_eof()
+    writer = MemoryWriter()
+
+    class Service:
+        revoked = ""
+
+        async def consume(self, capability: str, amount: int) -> None:
+            raise AssertionError("mismatched SNI must not be forwarded")
+
+        async def revoke(self, capability: str, reason: str) -> None:
+            self.revoked = reason
+
+    service = Service()
+    with pytest.raises(BrowserPolicyError, match="browser_tls_sni_denied"):
+        await browser_server._relay_limited(  # type: ignore[arg-type]
+            reader,
+            writer,
+            service,
+            "c" * 64,
+            asyncio.get_running_loop().time() + 5,
+            expected_sni="example.com",
+        )
+    assert service.revoked == "browser_tls_sni_denied"
+    assert not writer.data
+
+
+@pytest.mark.asyncio
+async def test_ref_binding_rejects_dom_drift(tmp_path: Path) -> None:
+    state = browser_server.BrowserSessionState("chrome-devtools-mcp", "a" * 32)
+    state.page_revision = 4
+    state.page_digest = "1" * 64
+    state.refs["1_2"] = browser_server.RefBinding(
+        state.generation,
+        4,
+        "1" * 64,
+        'button "Continue" uid=1_2',
+        "button",
+        "Continue",
+    )
+    gateway = browser_server.BrowserGatewaySession(
+        "chrome-devtools-mcp",
+        state,
+        object(),  # type: ignore[arg-type]
+        object(),  # type: ignore[arg-type]
+        object(),  # type: ignore[arg-type]
+        tmp_path,
+        tmp_path,
+        tmp_path,
+    )
+
+    async def observe(self: Any) -> tuple[str, dict[str, str], str, str, str]:
+        return "changed", {"1_2": "button"}, "", "", "2" * 64
+
+    gateway._observe = MethodType(observe, gateway)  # type: ignore[method-assign]
+    with pytest.raises(BrowserPolicyError, match="browser_state_drift"):
+        await gateway._verify_bound_refs(["1_2"])
+    assert state.page_revision == 5
+    assert not state.refs
+
+
+def test_unregistered_download_is_deleted_before_it_can_persist(tmp_path: Path) -> None:
+    staging = tmp_path / "staging"
+    registered = tmp_path / "registered"
+    staging.mkdir()
+    registered.mkdir()
+    download = staging / "page-triggered-download.bin"
+    download.write_bytes(b"untrusted")
+    gateway = browser_server.BrowserGatewaySession(
+        "playwright-mcp",
+        browser_server.BrowserSessionState("playwright-mcp", "b" * 32),
+        object(),  # type: ignore[arg-type]
+        object(),  # type: ignore[arg-type]
+        object(),  # type: ignore[arg-type]
+        tmp_path,
+        staging,
+        registered,
+    )
+    assert gateway._purge_unregistered_artifacts() is True
+    assert gateway.unregistered_artifact_event == "unregistered_artifact_download"
+    assert not download.exists()
+
+
+def test_unregistered_artifact_diagnostics_are_fixed_and_content_free(
+    tmp_path: Path,
+) -> None:
+    profile = tmp_path / "profile"
+    staging = tmp_path / "artifacts" / "staging"
+    registered = tmp_path / "artifacts" / "registered"
+    for path in (profile, staging, registered):
+        path.mkdir(parents=True, exist_ok=True)
+    gateway = browser_server.BrowserGatewaySession(
+        "playwright-mcp",
+        browser_server.BrowserSessionState("playwright-mcp", "d" * 32),
+        object(),  # type: ignore[arg-type]
+        object(),  # type: ignore[arg-type]
+        object(),  # type: ignore[arg-type]
+        staging.parent,
+        staging,
+        registered,
+    )
+    console_log = staging / "console-2026-08-08T12-34-56-000Z.log"
+    console_log.write_text("https://secret.invalid/?token=hidden", encoding="utf-8")
+    assert gateway._purge_unregistered_artifacts() is True
+    assert gateway.unregistered_artifact_event == "unregistered_artifact_console_log"
+    assert "secret" not in gateway.unregistered_artifact_event
+    assert not console_log.exists()
+
+
+def _artifact_gateway(tmp_path: Path) -> tuple[browser_server.BrowserGatewaySession, Path]:
+    staging = tmp_path / "artifacts" / "staging"
+    registered = tmp_path / "artifacts" / "registered"
+    staging.mkdir(parents=True)
+    registered.mkdir()
+    return (
+        browser_server.BrowserGatewaySession(
+            "playwright-mcp",
+            browser_server.BrowserSessionState("playwright-mcp", "e" * 32),
+            object(),  # type: ignore[arg-type]
+            object(),  # type: ignore[arg-type]
+            object(),  # type: ignore[arg-type]
+            staging.parent,
+            staging,
+            registered,
+        ),
+        staging,
+    )
+
+
+def test_unregistered_nested_directory_is_not_silently_ignored(tmp_path: Path) -> None:
+    gateway, staging = _artifact_gateway(tmp_path)
+    nested = staging / "nested"
+    nested.mkdir()
+    (nested / "payload.bin").write_bytes(b"untrusted")
+
+    assert gateway._purge_unregistered_artifacts() is True
+    assert gateway.unregistered_artifact_event == "unregistered_artifact_other"
+
+
+def test_unregistered_symlink_is_unlinked_without_touching_target(tmp_path: Path) -> None:
+    gateway, staging = _artifact_gateway(tmp_path)
+    target = tmp_path / "outside.txt"
+    target.write_text("keep", encoding="utf-8")
+    link = staging / "download.bin"
+    link.symlink_to(target)
+
+    assert gateway._purge_unregistered_artifacts() is True
+    assert gateway.unregistered_artifact_event == "unregistered_artifact_other"
+    assert not link.exists()
+    assert target.read_text(encoding="utf-8") == "keep"
+
+
+def test_unregistered_hardlink_is_rejected_and_source_survives(tmp_path: Path) -> None:
+    gateway, staging = _artifact_gateway(tmp_path)
+    source = tmp_path / "outside.bin"
+    source.write_bytes(b"keep")
+    linked = staging / "download.bin"
+    os.link(source, linked)
+
+    assert gateway._purge_unregistered_artifacts() is True
+    assert gateway.unregistered_artifact_event == "unregistered_artifact_download"
+    assert not linked.exists()
+    assert source.read_bytes() == b"keep"
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="FIFO requires POSIX")
+def test_unregistered_fifo_is_rejected_and_removed(tmp_path: Path) -> None:
+    gateway, staging = _artifact_gateway(tmp_path)
+    fifo = staging / "browser.pipe"
+    os.mkfifo(fifo)
+
+    assert gateway._purge_unregistered_artifacts() is True
+    assert gateway.unregistered_artifact_event == "unregistered_artifact_other"
+    assert not fifo.exists()
+
+
+@pytest.mark.asyncio
+async def test_egress_byte_budget_revokes_capability() -> None:
+    service = browser_server.BrowserEgressService("k" * 64)
+    capability = "c" * 64
+    service.grants[capability] = browser_server.EgressGrant(
+        origin="https://example.com",
+        host="example.com",
+        port=443,
+        expires_at=asyncio.get_running_loop().time() + 60,
+        transferred_bytes=browser_server.MAX_EGRESS_BYTES_PER_SESSION - 1,
+    )
+    with pytest.raises(BrowserPolicyError, match="browser_egress_byte_budget"):
+        await service.consume(capability, 2)
+    assert capability not in service.grants
+
+
+@pytest.mark.asyncio
+async def test_async_dns_timeout_does_not_block_revocation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MCP_BROWSER_ALLOW_SYNTHETIC_DNS", "true")
+    loop = asyncio.get_running_loop()
+
+    async def stalled_getaddrinfo(*args: object, **kwargs: object) -> object:
+        await asyncio.Future()
+
+    monkeypatch.setattr(loop, "getaddrinfo", stalled_getaddrinfo)
+    monkeypatch.setattr(browser_server, "DNS_TIMEOUT_SECONDS", 0.01)
+    service = browser_server.BrowserEgressService("k" * 64)
+    capability = "7" * 64
+    service.grants[capability] = browser_server.EgressGrant(
+        expires_at=loop.time() + 60
+    )
+    resolving = asyncio.create_task(service.resolve("example.com", 443))
+    await asyncio.wait_for(service.revoke(capability, "test_revoke"), timeout=0.1)
+    assert capability not in service.grants
+    with pytest.raises(BrowserPolicyError, match="browser_dns_timeout"):
+        await resolving
+
+
+def test_commands_are_real_locked_upstreams_with_no_sandbox_bypass(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MCP_BROWSER_CDP_CHROMIUM_PATH", "/locked/chrome-150")
+    monkeypatch.setenv(
+        "MCP_BROWSER_PLAYWRIGHT_CHROMIUM_PATH", "/locked/chromium-152"
+    )
+    for adapter_id, contract in BROWSER_ADAPTERS.items():
+        profile = tmp_path / adapter_id
+        artifacts = profile / "artifacts"
+        artifacts.mkdir(parents=True)
+        command = browser_mcp.upstream_command(
+            adapter_id,
+            profile_dir=profile,
+            artifact_dir=artifacts,
+            proxy_url="http://127.0.0.1:54321",
+        )
+        joined = " ".join(command)
+        assert contract.package_name.split("/")[-1] in joined
+        expected_browser = (
+            "/locked/chrome-150"
+            if adapter_id == "chrome-devtools-mcp"
+            else "/locked/chromium-152"
+        )
+        assert expected_browser in joined
+        assert (
+            "/locked/chromium-152"
+            if adapter_id == "chrome-devtools-mcp"
+            else "/locked/chrome-150"
+        ) not in joined
+        assert "--no-sandbox" not in joined
+        assert "--disable-web-security" not in joined
+        assert "--remote-debugging-address=0.0.0.0" not in joined
+        assert "--disable-dev-shm-usage" in joined or adapter_id == "playwright-mcp"
+        if adapter_id == "playwright-mcp":
+            assert "--sandbox" in command
+            assert "--no-sandbox" not in command
+            assert "--snapshot-mode=none" in command
+            assert "--snapshot-mode=full" not in command
+            config = json.loads((profile / "modelmirror-playwright-config.json").read_text())
+            launch_args = config["browser"]["launchOptions"]["args"]
+            assert "--disable-dev-shm-usage" in launch_args
+            assert config["browser"]["contextOptions"]["acceptDownloads"] is False
+            assert config["snapshot"] == {"mode": "none"}
+            feature_surface = " ".join(launch_args)
+        else:
+            feature_surface = joined
+        local_state = json.loads((profile / "Local State").read_text())
+        assert local_state == {"ssl": {"ech_enabled": False}}
+        assert "kAutofillServerCommunication" in feature_surface
+        assert "PushMessaging,PushMessagingSubscriptionChange" in feature_surface
+        assert "--incognito" in feature_surface
+        assert "NetworkTimeServiceQuerying" in feature_surface
+        assert "PreconnectToSearch" in feature_surface
+        assert "--disable-preconnect" in feature_surface
+        assert "NoSearchDomainCheck" in feature_surface
+
+
+def test_landlock_does_not_grant_egress_socket_or_shared_dev_shm() -> None:
+    source = Path(browser_mcp.__file__).read_text(encoding="utf-8")
+    assert 'Path("/run")' not in source
+    assert 'Path("/run/modelmirror-browser-egress")' not in source
+    assert 'add(Path("/dev/shm")' not in source
+    assert 'Path("/opt/modelmirror-browsers")' in source
+    assert 'Path("/ms-playwright")' not in source
+    assert "apply_browser_landlock(profile_dir, staging_dir)" in source
+
+
+def test_landlock_proc_access_restores_only_the_write_file_category() -> None:
+    assert browser_mcp.PROC_USERNS_ACCESS == (
+        browser_mcp.READ_EXECUTE | browser_mcp.ACCESS_FS_WRITE_FILE
+    )
+    assert browser_mcp.PROC_USERNS_ACCESS & browser_mcp.ACCESS_FS_WRITE_FILE
+    assert not browser_mcp.PROC_USERNS_ACCESS & browser_mcp.ACCESS_FS_MAKE_REG
+    assert not browser_mcp.PROC_USERNS_ACCESS & browser_mcp.ACCESS_FS_REMOVE_FILE
+    assert not browser_mcp.PROC_USERNS_ACCESS & browser_mcp.ACCESS_FS_TRUNCATE
+    source = Path(browser_mcp.__file__).read_text(encoding="utf-8")
+    assert 'add(Path("/proc"), PROC_USERNS_ACCESS)' in source
+    assert 'Path("/run/modelmirror-browser-egress")' not in source
+
+
+def test_browser_runtime_diagnostics_are_fixed_enums_without_payloads() -> None:
+    assert "rpc_timeout" in browser_server.BROWSER_RUNTIME_EVENT_CODES
+    assert "proxy_policy_violation" in browser_server.BROWSER_RUNTIME_EVENT_CODES
+    assert (
+        browser_server._proxy_runtime_event("browser_cross_origin_denied")
+        == "proxy_policy_cross_origin"
+    )
+    assert (
+        browser_server._proxy_runtime_event("browser_dns_failed")
+        == "proxy_policy_dns_failed"
+    )
+    assert (
+        browser_server._proxy_runtime_event("browser_tls_sni_denied")
+        == "proxy_policy_tls_sni_denied"
+    )
+    assert (
+        browser_server._proxy_runtime_event("https://secret.invalid/?token=hidden")
+        == "proxy_policy_violation"
+    )
+    assert "egress_revoked" in browser_server.BROWSER_RUNTIME_EVENT_CODES
+    assert "browser_policy_snapshot_structure" in browser_server.BROWSER_RUNTIME_EVENT_CODES
+    assert all("http" not in item for item in browser_server.BROWSER_RUNTIME_EVENT_CODES)
+    source = inspect.getsource(browser_server._emit_browser_runtime_event)
+    assert "browser_runtime_event" in source
+    assert "arguments" not in source
+    assert "result_text" not in source
+
+
+def test_cross_origin_runtime_diagnostic_only_reports_relation_and_phase() -> None:
+    proxy = browser_server.LoopbackBrowserProxy(FakeEgress())  # type: ignore[arg-type]
+    proxy.origin, proxy.host, proxy.port = "http://example.com", "example.com", 80
+    assert (
+        proxy._cross_origin_event("GET", "http://other.example/path?secret=value")
+        == "proxy_policy_cross_origin_external_host_before_forward"
+    )
+    assert (
+        proxy._cross_origin_event("GET", "http://clients2.google.com/private")
+        == "proxy_policy_cross_origin_network_time_before_forward"
+    )
+    assert (
+        proxy._cross_origin_event("CONNECT", "clients1.google.com:443")
+        == "proxy_policy_cross_origin_clients1_before_forward"
+    )
+    assert (
+        proxy._cross_origin_event("GET", "https://www.google.com/searchdomaincheck")
+        == "proxy_policy_cross_origin_search_domain_before_forward"
+    )
+    assert (
+        proxy._cross_origin_event("GET", "https://www.google.com/opaque/path")
+        == "proxy_policy_cross_origin_google_home_other_before_forward"
+    )
+    assert (
+        proxy._cross_origin_event("CONNECT", "www.google.com:443")
+        == "proxy_policy_cross_origin_google_home_connect_before_forward"
+    )
+    assert (
+        proxy._cross_origin_event("CONNECT", "unknown.googleapis.com:443")
+        == "proxy_policy_cross_origin_google_api_before_forward"
+    )
+    assert (
+        proxy._cross_origin_event("CONNECT", "unknown.google.com:443")
+        == "proxy_policy_cross_origin_google_subdomain_before_forward"
+    )
+    proxy.forwarded_requests = 1
+    assert (
+        proxy._cross_origin_event("CONNECT", "example.com:443")
+        == "proxy_policy_cross_origin_scheme_after_forward"
+    )
+
+
+def test_browser_tmpdir_is_inside_writable_profile_not_artifact_parent() -> None:
+    source = Path(browser_server.__file__).read_text(encoding="utf-8")
+    assert 'runtime_tmp_dir = profile_dir / "tmp"' in source
+    assert '"TMPDIR": str(runtime_tmp_dir)' in source
+    assert '"TMPDIR": str(artifact_dir)' not in source
+    assert '"NODE_DISABLE_COMPILE_CACHE": "1"' in source
+    smoke_source = Path(smoke_browser_adapters.__file__).read_text(encoding="utf-8")
+    assert '"NODE_DISABLE_COMPILE_CACHE": "1"' in smoke_source
+
+
+def test_status_contract_uses_finite_epoch_and_internal_ref_metadata() -> None:
+    state = browser_server.BrowserSessionState("chrome-devtools-mcp", "c" * 32)
+    status = state.status()
+    assert status["status"] == "active"
+    assert status["tainted"] is False
+    assert isinstance(status["expires_at"], float)
+    assert status["expires_at"] > 0
+    safe = browser_server._safe_element(
+        "1_2",
+        browser_mcp.SnapshotElement("button", "Continue", ""),
+        state.page_digest,
+    )
+    assert safe == {
+        "ref": "1_2",
+        "role": "button",
+        "label": "Continue",
+        "page_digest": state.page_digest,
+    }
+    assert browser_server._safe_element(
+        "1_3",
+        browser_mcp.SnapshotElement("textbox", "Password", ""),
+        state.page_digest,
+    ) is None
+
+
+@pytest.mark.parametrize(
+    ("adapter_id", "snapshot", "expected"),
+    [
+        (
+            "chrome-devtools-mcp",
+            "\n".join(
+                [
+                    'uid=1_0 RootWebArea "Example Domain" url="https://example.com/"',
+                    '  uid=1_1 heading "Example Domain" level="1"',
+                    '  uid=1_2 textbox "Search \\"docs\\"" value=""',
+                    '  uid=1_3 switch "Enable"',
+                    '  uid=1_4 spinbutton "Count" valuemin="0"',
+                    '  uid=1_5 treeitem "Node"',
+                ]
+            ),
+            {
+                "1_2": ("textbox", 'Search "docs"'),
+                "1_3": ("switch", "Enable"),
+                "1_4": ("spinbutton", "Count"),
+                "1_5": ("treeitem", "Node"),
+            },
+        ),
+        (
+            "playwright-mcp",
+            "\n".join(
+                [
+                    "- Page URL: https://example.com/",
+                    "- Page Title: Example Domain",
+                    "- Page Snapshot:",
+                    "```yaml",
+                    "- generic [ref=e1]:",
+                    '  - textbox "Search \\"docs\\"" [ref=e2]',
+                    '  - button "Continue" [ref=e3] [cursor=pointer]',
+                    '  - switch "Enable" [ref=e4]',
+                    "```",
+                ]
+            ),
+            {
+                "e2": ("textbox", 'Search "docs"'),
+                "e3": ("button", "Continue"),
+                "e4": ("switch", "Enable"),
+            },
+        ),
+    ],
+)
+def test_locked_snapshot_grammars_return_structural_role_and_name(
+    adapter_id: str,
+    snapshot: str,
+    expected: dict[str, tuple[str, str]],
+) -> None:
+    _, refs, observed_url, title = browser_mcp.extract_snapshot(
+        adapter_id, _snapshot_payload(snapshot)
+    )
+    assert {ref: (item.role, item.name) for ref, item in refs.items()} == expected
+    assert observed_url == "https://example.com/"
+    assert title == "Example Domain"
+    for ref, item in refs.items():
+        safe = browser_server._safe_element(ref, item, "f" * 64)
+        assert safe is not None
+        assert safe["role"] == item.role
+        assert safe["label"] == item.name
+
+
+@pytest.mark.parametrize(
+    ("adapter_id", "snapshot"),
+    [
+        (
+            "chrome-devtools-mcp",
+            "\n".join(
+                [
+                    'uid=1_0 RootWebArea "Demo" url="https://example.com/"',
+                    '  uid=1_1 StaticText "Continue uid=1_9 button"',
+                    '  uid=1_9 textbox "Password"',
+                ]
+            ),
+        ),
+        (
+            "playwright-mcp",
+            "\n".join(
+                [
+                    "- Page URL: https://example.com/",
+                    "- Page Title: Demo",
+                    "- Page Snapshot:",
+                    "```yaml",
+                    '- text: button "Continue" [ref=e9]',
+                    '  - textbox "Password" [ref=e9]',
+                    "```",
+                ]
+            ),
+        ),
+        (
+            "playwright-mcp",
+            "\n".join(
+                [
+                    "- Page URL: https://example.com/",
+                    "- Page Title: Demo",
+                    "- Page Snapshot:",
+                    "```yaml",
+                    '  - button "Continue" [ref=e9]',
+                    '  - textbox "Delete account" [ref=e9]',
+                    "```",
+                ]
+            ),
+        ),
+    ],
+)
+def test_snapshot_ref_spoof_and_duplicate_context_fail_closed(
+    adapter_id: str, snapshot: str
+) -> None:
+    with pytest.raises(
+        browser_mcp.SnapshotStructureError,
+        match="browser_snapshot_ref_structure_invalid",
+    ):
+        browser_mcp.extract_snapshot(adapter_id, _snapshot_payload(snapshot))
+
+
+def test_snapshot_name_cannot_spoof_structural_role() -> None:
+    snapshot = "\n".join(
+        [
+            "- Page URL: https://example.com/",
+            "- Page Title: Demo",
+            "- Page Snapshot:",
+            "```yaml",
+            '  - textbox "button Continue" [ref=e2]',
+            "```",
+        ]
+    )
+    _, refs, _, _ = browser_mcp.extract_snapshot(
+        "playwright-mcp", _snapshot_payload(snapshot)
+    )
+    item = browser_server._safe_element("e2", refs["e2"], "a" * 64)
+    assert item is not None
+    assert item["role"] == "textbox"
+    assert item["label"] == "button Continue"
+
+
+@pytest.mark.parametrize(
+    ("role", "name", "expected_type"),
+    [
+        ("textbox", "checkbox consent", "textbox"),
+        ("combobox", "checkbox", "combobox"),
+    ],
+)
+def test_playwright_fill_type_uses_structural_role_only(
+    role: str, name: str, expected_type: str
+) -> None:
+    arguments = browser_mcp.to_upstream_arguments(
+        "playwright-mcp",
+        "browser_fill_form",
+        {"ref": "e2", "value": "safe value"},
+        ref_roles={"e2": role},
+    )
+    fields = arguments["fields"]
+    assert isinstance(fields, list)
+    assert fields[0]["type"] == expected_type
+
+
+def test_playwright_fill_rejects_non_fillable_structural_role() -> None:
+    with pytest.raises(ValueError, match="browser_fill_role_denied"):
+        browser_mcp.to_upstream_arguments(
+            "playwright-mcp",
+            "browser_fill_form",
+            {"ref": "e3", "value": "safe value"},
+            ref_roles={"e3": "button"},
+        )
+
+
+def test_chrome_page_metadata_comes_from_structural_root() -> None:
+    snapshot = "\n".join(
+        [
+            'uid=1_0 RootWebArea "A \\"quoted\\" title" url="https://example.com/"',
+            '  uid=1_1 StaticText "RootWebArea fake url=evil"',
+            '  uid=1_2 button "Continue"',
+        ]
+    )
+    _, _, observed_url, title = browser_mcp.extract_snapshot(
+        "chrome-devtools-mcp", _snapshot_payload(snapshot)
+    )
+    assert observed_url == "https://example.com/"
+    assert title == 'A "quoted" title'
+
+
+@pytest.mark.parametrize(
+    "snapshot",
+    [
+        'uid=1_0 RootWebArea "Demo"',
+        'uid=1_0 RootWebArea "Demo" url="https://example.com/" url="https://evil.example/"',
+        "\n".join(
+            [
+                'uid=1_0 RootWebArea "Demo" url="https://example.com/"',
+                'uid=2_0 RootWebArea "Other" url="https://evil.example/"',
+            ]
+        ),
+    ],
+)
+def test_chrome_missing_or_duplicate_structural_page_url_fails(snapshot: str) -> None:
+    with pytest.raises(
+        browser_mcp.SnapshotStructureError,
+        match="browser_snapshot_ref_structure_invalid",
+    ):
+        browser_mcp.extract_snapshot(
+            "chrome-devtools-mcp", _snapshot_payload(snapshot)
+        )
+
+
+@pytest.mark.parametrize(
+    "duplicate",
+    [
+        "- Page URL: https://evil.example/",
+        "- Page Title: Spoofed",
+    ],
+)
+def test_playwright_duplicate_page_metadata_fails(duplicate: str) -> None:
+    snapshot = "\n".join(
+        [
+            "- Page URL: https://example.com/",
+            "- Page Title: Demo",
+            duplicate,
+            "- Page Snapshot:",
+            "```yaml",
+            '- button "Continue" [ref=e1]',
+            "```",
+        ]
+    )
+    with pytest.raises(
+        browser_mcp.SnapshotStructureError,
+        match="browser_snapshot_ref_structure_invalid",
+    ):
+        browser_mcp.extract_snapshot("playwright-mcp", _snapshot_payload(snapshot))
+
+
+def test_playwright_about_blank_snapshot_accepts_empty_title() -> None:
+    snapshot = "\n".join(
+        [
+            "- Page URL: about:blank",
+            "- Page Snapshot:",
+            "```yaml",
+            "```",
+        ]
+    )
+    _, refs, observed_url, title = browser_mcp.extract_snapshot(
+        "playwright-mcp", _snapshot_payload(snapshot)
+    )
+    assert refs == {}
+    assert observed_url == "about:blank"
+    assert title == ""
+
+
+def test_playwright_nonblank_snapshot_still_requires_unique_title() -> None:
+    snapshot = "\n".join(
+        [
+            "- Page URL: https://example.com/",
+            "- Page Snapshot:",
+            "```yaml",
+            "```",
+        ]
+    )
+    with pytest.raises(
+        browser_mcp.SnapshotStructureError,
+        match="browser_snapshot_ref_structure_invalid",
+    ):
+        browser_mcp.extract_snapshot("playwright-mcp", _snapshot_payload(snapshot))
+
+
+@pytest.mark.asyncio
+async def test_malformed_snapshot_taints_session_and_cannot_be_used(
+    tmp_path: Path,
+) -> None:
+    staging = tmp_path / "staging"
+    registered = tmp_path / "registered"
+    staging.mkdir()
+    registered.mkdir()
+    adversarial = _snapshot_payload(
+        "\n".join(
+            [
+                'uid=1_0 RootWebArea "Demo" url="https://example.com/"',
+                '  uid=1_1 StaticText "Continue uid=1_9 button"',
+                '  uid=1_9 textbox "Password"',
+            ]
+        )
+    )
+
+    class Process:
+        returncode = None
+
+    class Rpc:
+        calls = 0
+
+        async def request(self, *args: object, **kwargs: object) -> dict[str, object]:
+            self.calls += 1
+            return adversarial
+
+    class Egress:
+        revocation_reason = ""
+
+    class Proxy:
+        egress = Egress()
+        last_violation = ""
+
+    rpc = Rpc()
+    state = browser_server.BrowserSessionState("chrome-devtools-mcp", "7" * 32)
+    gateway = browser_server.BrowserGatewaySession(
+        "chrome-devtools-mcp",
+        state,
+        Process(),  # type: ignore[arg-type]
+        rpc,  # type: ignore[arg-type]
+        Proxy(),  # type: ignore[arg-type]
+        tmp_path,
+        staging,
+        registered,
+    )
+
+    async def taint_without_process(self: Any, reason: str) -> None:
+        self.state.taint(reason)
+
+    gateway._taint = MethodType(taint_without_process, gateway)  # type: ignore[method-assign]
+    with pytest.raises(BrowserPolicyError, match="browser_snapshot_ref_structure_invalid"):
+        await gateway.call("take_snapshot", {})
+    assert state.tainted is True
+    assert state.refs == {}
+    assert rpc.calls == 1
+    with pytest.raises(BrowserPolicyError, match="browser_snapshot_ref_structure_invalid"):
+        await gateway.call("click", {"ref": "1_9"})
+    assert rpc.calls == 1
+
+
+def test_supervisor_startup_removes_strict_crash_residue(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    profiles = tmp_path / "profiles"
+    artifacts = tmp_path / "artifacts"
+    profiles.mkdir()
+    artifacts.mkdir()
+    session_id = "d" * 32
+    profile = profiles / session_id
+    staging = artifacts / session_id / "staging"
+    registered = artifacts / session_id / "registered"
+    profile.mkdir()
+    (profile / "Preferences").write_text("stale", encoding="utf-8")
+    staging.mkdir(parents=True)
+    registered.mkdir()
+    (staging / "download.tmp").write_bytes(b"stale")
+    (registered / f"browser_{'e' * 32}.png").write_bytes(b"stale")
+    monkeypatch.setattr(browser_server, "PROFILE_ROOT", profiles)
+    monkeypatch.setattr(browser_server, "ARTIFACT_ROOT", artifacts)
+
+    browser_server._cleanup_stale_runtime_roots()
+
+    assert list(profiles.iterdir()) == []
+    assert list(artifacts.iterdir()) == []
+
+
+def test_supervisor_cleanup_fails_closed_on_malformed_or_linked_entry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    profiles = tmp_path / "profiles"
+    artifacts = tmp_path / "artifacts"
+    profiles.mkdir()
+    artifacts.mkdir()
+    monkeypatch.setattr(browser_server, "PROFILE_ROOT", profiles)
+    monkeypatch.setattr(browser_server, "ARTIFACT_ROOT", artifacts)
+    (profiles / "not-a-session").mkdir()
+    with pytest.raises(RuntimeError, match="unexpected_entry"):
+        browser_server._cleanup_stale_runtime_roots()
+    (profiles / "not-a-session").rmdir()
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "canary").write_text("do-not-follow", encoding="utf-8")
+    try:
+        os.symlink(outside, profiles / ("a" * 32), target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("directory symlink creation is unavailable")
+    with pytest.raises(RuntimeError, match="unsafe_entry"):
+        browser_server._cleanup_stale_runtime_roots()
+    assert (outside / "canary").read_text(encoding="utf-8") == "do-not-follow"
+
+
+@pytest.mark.asyncio
+async def test_restart_readiness_waits_before_arm_and_armed_exit_is_immediate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = [100.0]
+    sleeps: list[float] = []
+
+    async def advance(delay: float) -> None:
+        sleeps.append(delay)
+        now[0] += delay
+
+    monkeypatch.setattr(browser_server.time, "monotonic", lambda: now[0])
+    monkeypatch.setattr(browser_server.asyncio, "sleep", advance)
+    gate = browser_server.RestartPolicyReadinessGate(now[0])
+
+    await gate.wait_before_arm()
+    assert sleeps == [browser_server.DOCKER_RESTART_ARM_SECONDS]
+    assert gate.remaining() == 0
+    gate.arm()
+    await gate.hold_early_exit()
+    assert sleeps == [browser_server.DOCKER_RESTART_ARM_SECONDS]
+
+
+@pytest.mark.asyncio
+async def test_restart_readiness_early_exit_survives_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(browser_server, "DOCKER_RESTART_ARM_SECONDS", 0.05)
+    gate = browser_server.RestartPolicyReadinessGate(time.monotonic())
+    hold = asyncio.create_task(gate.hold_early_exit())
+    await asyncio.sleep(0)
+    hold.cancel()
+
+    await hold
+
+    assert gate.remaining() == 0
+    assert gate.armed is False
+
+
+def test_restart_readiness_precedes_browser_socket_and_egress_control_key() -> None:
+    source = Path(browser_server.__file__).read_text(encoding="utf-8")
+    browser_source = source[source.index("async def browser_main()") : source.index("async def egress_main()")]
+    egress_source = source[source.index("async def egress_main()") : source.index("def main()")]
+
+    assert browser_source.index("await readiness.wait_before_arm()") < browser_source.index(
+        "await asyncio.start_unix_server("
+    )
+    assert browser_source.index("readiness.arm()") < browser_source.index(
+        "await asyncio.start_unix_server("
+    )
+    assert egress_source.index("await readiness.wait_before_arm()") < egress_source.index(
+        "_publish_control_key(control_key)"
+    )
+    assert egress_source.index("await server.start_serving()") < egress_source.index(
+        "_publish_control_key(control_key)"
+    )
+    assert egress_source.index("_publish_control_key(control_key)") < egress_source.index(
+        "_enforce_egress_watch_bootstrap(service)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_one_shot_control_key_requires_paired_restart(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    control = tmp_path / "browser-egress.control"
+    monkeypatch.setattr(browser_server, "EGRESS_CONTROL_PATH", control)
+    key = "1" * 64
+    control.write_text(key, encoding="ascii")
+    assert await browser_server._wait_for_control_key() == key
+    assert not control.exists()
+
+    async def no_wait(_: float) -> None:
+        return None
+
+    monkeypatch.setattr(browser_server.asyncio, "sleep", no_wait)
+    with pytest.raises(RuntimeError, match="browser_egress_control_unavailable"):
+        await browser_server._wait_for_control_key()
+
+    replacement = "2" * 64
+    control.write_text(replacement, encoding="ascii")
+    assert await browser_server._wait_for_control_key() == replacement
+    old_service = browser_server.BrowserEgressService(key)
+    new_service = browser_server.BrowserEgressService(replacement)
+    await old_service._authenticate_control({"control_key": key})
+    with pytest.raises(browser_server.SandboxEngineError, match="Egress control denied"):
+        await new_service._authenticate_control({"control_key": key})
+
+
+@pytest.mark.asyncio
+async def test_egress_restart_closes_watcher_rejects_old_capability_and_pair_recovers(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    if not hasattr(socket, "AF_UNIX"):
+        pytest.skip("AF_UNIX is unavailable")
+    uds = tmp_path / "egress.sock"
+    monkeypatch.setattr(browser_server, "EGRESS_SOCKET_PATH", uds)
+
+    async def wait_for_watcher(service: browser_server.BrowserEgressService) -> None:
+        for _ in range(100):
+            if service.watchers:
+                return
+            await asyncio.sleep(0.01)
+        raise AssertionError("watcher did not connect")
+
+    old_key = "3" * 64
+    old_service = browser_server.BrowserEgressService(old_key)
+    old_server = await asyncio.start_unix_server(old_service.handle, path=str(uds))
+    old_client = browser_server.BrowserEgressClient(old_key)
+    await old_client.register()
+    old_capability = old_client.capability
+    assert old_service._grant(old_capability)
+    old_ready = asyncio.Event()
+    old_watch = asyncio.create_task(browser_server._watch_egress(old_key, old_ready))
+    await wait_for_watcher(old_service)
+    await asyncio.wait_for(old_ready.wait(), timeout=1)
+
+    for watcher in tuple(old_service.watchers):
+        await browser_server._close_writer(watcher)
+    with pytest.raises(RuntimeError, match="browser_egress_restarted"):
+        await asyncio.wait_for(old_watch, timeout=1)
+    old_server.close()
+    await old_server.wait_closed()
+    uds.unlink(missing_ok=True)
+
+    new_key = "4" * 64
+    new_service = browser_server.BrowserEgressService(new_key)
+    with pytest.raises(browser_server.SandboxEngineError, match="capability denied"):
+        new_service._grant(old_capability)
+    new_server = await asyncio.start_unix_server(new_service.handle, path=str(uds))
+    new_client = browser_server.BrowserEgressClient(new_key)
+    await new_client.register()
+    assert new_service._grant(new_client.capability)
+    new_ready = asyncio.Event()
+    new_watch = asyncio.create_task(browser_server._watch_egress(new_key, new_ready))
+    await wait_for_watcher(new_service)
+    await asyncio.wait_for(new_ready.wait(), timeout=1)
+    assert not new_watch.done()
+
+    await new_client.revoke()
+    for watcher in tuple(new_service.watchers):
+        await browser_server._close_writer(watcher)
+    with pytest.raises(RuntimeError, match="browser_egress_restarted"):
+        await asyncio.wait_for(new_watch, timeout=1)
+    new_server.close()
+    await new_server.wait_closed()
+    browser_server.EGRESS_CLIENTS.pop(old_capability, None)
+
+
+def test_dumpability_guard_fails_closed_on_set_or_get_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeLibc:
+        def __init__(self, values: list[int]) -> None:
+            self.values = iter(values)
+
+        def prctl(self, *_: object) -> int:
+            return next(self.values)
+
+    monkeypatch.setattr(browser_server.os, "name", "posix")
+    monkeypatch.setattr(browser_server.ctypes, "CDLL", lambda *a, **k: FakeLibc([1]))
+    with pytest.raises(RuntimeError, match="browser_pr_set_dumpable_failed"):
+        browser_server._disable_process_dumping()
+    monkeypatch.setattr(
+        browser_server.ctypes, "CDLL", lambda *a, **k: FakeLibc([0, 1])
+    )
+    with pytest.raises(RuntimeError, match="browser_pr_get_dumpable_failed"):
+        browser_server._disable_process_dumping()
+
+
+def test_preflight_diagnostics_expose_only_reviewed_machine_codes() -> None:
+    for code in browser_server.BROWSER_PREFLIGHT_ERROR_CODES:
+        assert browser_server._safe_preflight_error_code(RuntimeError(code)) == code
+    assert (
+        browser_server._safe_preflight_error_code(asyncio.TimeoutError())
+        == "browser_upstream_preflight_timeout"
+    )
+    assert browser_server._safe_preflight_error_code(
+        RuntimeError("secret upstream stderr https://private.example/token")
+    ) is None
+
+    target_closed = {
+        "result": {
+            "isError": True,
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Target closed https://private.example/?token=secret",
+                }
+            ],
+        }
+    }
+    category = browser_server._classify_upstream_failure(target_closed)
+    assert category == "target_closed"
+    code = f"browser_upstream_representative_{category}"
+    assert code in browser_server.BROWSER_PREFLIGHT_ERROR_CODES
+    assert "private" not in code and "token" not in code
+    assert browser_server._classify_upstream_failure(
+        {"result": {"isError": True, "content": [{"type": "text", "text": "opaque secret"}]}}
+    ) == "unclassified"
+
+
+@pytest.mark.asyncio
+async def test_stderr_classifier_streams_fixed_enum_without_retaining_text() -> None:
+    classifier = browser_server.SafeStderrClassifier()
+    stream = asyncio.StreamReader()
+    stream.feed_data(
+        b"x" * 20_000
+        + b" https://private.example/?token=secret BAD SYS"
+    )
+    stream.feed_data(b"TEM CALL bearer-value")
+    stream.feed_eof()
+
+    await browser_server._drain_stderr(stream, classifier)
+
+    assert classifier.primary() == "seccomp_denied"
+    assert classifier.categories == {"seccomp_denied"}
+    assert len(classifier._overlap) <= classifier._overlap_bytes
+    assert b"private.example" not in classifier._overlap
+    code = (
+        "browser_upstream_representative_target_closed_"
+        f"{classifier.primary()}"
+    )
+    assert code in browser_server.BROWSER_PREFLIGHT_ERROR_CODES
+    assert "token" not in code and "bearer" not in code
+
+
+def test_kernel_peer_credentials_distinguish_catalog_and_sandbox_uid() -> None:
+    class CredSocket:
+        def __init__(self, uid: int) -> None:
+            self.uid = uid
+
+        def getsockopt(self, level: int, option: int, size: int) -> bytes:
+            assert (level, option, size) == (
+                socket.SOL_SOCKET,
+                socket.SO_PEERCRED,
+                browser_server.struct.calcsize("3i"),
+            )
+            return browser_server.struct.pack("3i", 123, self.uid, self.uid)
+
+    class PeerWriter:
+        def __init__(self, uid: int) -> None:
+            self.peer = CredSocket(uid)
+
+        def get_extra_info(self, name: str) -> object:
+            assert name == "socket"
+            return self.peer
+
+    assert browser_server._trusted_peer_uid(PeerWriter(0)) == 0  # type: ignore[arg-type]
+    assert browser_server._trusted_peer_uid(PeerWriter(65532)) == 65532  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_one_shot_lifecycle_rejects_successor_without_queueing() -> None:
+    lifecycle = browser_server.BrowserOneShotLifecycle()
+    lifecycle.claim()
+    assert lifecycle.claimed is True
+    with pytest.raises(browser_server.SandboxEngineError) as exc_info:
+        lifecycle.claim()
+    assert exc_info.value.code == "browser_container_session_consumed"
+    assert lifecycle.finished.is_set() is False
+    lifecycle.finish()
+    await asyncio.wait_for(lifecycle.finished.wait(), timeout=0.1)
+
+
+@pytest.mark.asyncio
+async def test_untrusted_peer_is_rejected_before_request_read(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def unexpected_read(*_: object, **__: object) -> dict[str, Any]:
+        raise AssertionError("untrusted peer must be rejected before reading")
+
+    monkeypatch.setattr(browser_server, "TRUSTED_CLIENT_UID", 0)
+    monkeypatch.setattr(browser_server, "_trusted_peer_uid", lambda writer: 12345)
+    monkeypatch.setattr(browser_server, "_read_json_line", unexpected_read)
+    lifecycle = browser_server.BrowserOneShotLifecycle()
+    writer = MemoryWriter()
+    await browser_server.handle_browser_client(  # type: ignore[arg-type]
+        asyncio.StreamReader(), writer, "4" * 64, lifecycle
+    )
+    assert json.loads(bytes(writer.data))["code"] == "browser_peer_denied"
+    assert lifecycle.claimed is False
+
+
+@pytest.mark.asyncio
+async def test_second_trusted_session_is_rejected_while_first_is_active(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def held_session(*_: object) -> None:
+        started.set()
+        await release.wait()
+
+    monkeypatch.setattr(browser_server, "TRUSTED_CLIENT_UID", 0)
+    monkeypatch.setattr(browser_server, "_trusted_peer_uid", lambda writer: 0)
+    monkeypatch.setattr(browser_server, "_browser_stdio", held_session)
+    lifecycle = browser_server.BrowserOneShotLifecycle()
+
+    def request_reader() -> asyncio.StreamReader:
+        reader = asyncio.StreamReader()
+        reader.feed_data(b'{"action":"mcp_stdio","adapter_id":"test","configuration":{}}\n')
+        reader.feed_eof()
+        return reader
+
+    first_writer = MemoryWriter()
+    first = asyncio.create_task(
+        browser_server.handle_browser_client(  # type: ignore[arg-type]
+            request_reader(), first_writer, "5" * 64, lifecycle
+        )
+    )
+    await asyncio.wait_for(started.wait(), timeout=0.2)
+    second_writer = MemoryWriter()
+    await asyncio.wait_for(
+        browser_server.handle_browser_client(  # type: ignore[arg-type]
+            request_reader(), second_writer, "5" * 64, lifecycle
+        ),
+        timeout=0.2,
+    )
+    assert json.loads(bytes(second_writer.data))["code"] == "browser_container_session_consumed"
+    assert lifecycle.finished.is_set() is False
+    release.set()
+    await asyncio.wait_for(first, timeout=0.2)
+    assert lifecycle.finished.is_set() is True
+
+
+@pytest.mark.asyncio
+async def test_claimed_session_exception_still_finishes_lifecycle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def failed_session(*_: object) -> None:
+        raise RuntimeError("simulated cleanup failure")
+
+    monkeypatch.setattr(browser_server, "TRUSTED_CLIENT_UID", 0)
+    monkeypatch.setattr(browser_server, "_trusted_peer_uid", lambda writer: 0)
+    monkeypatch.setattr(browser_server, "_browser_stdio", failed_session)
+    lifecycle = browser_server.BrowserOneShotLifecycle()
+    reader = asyncio.StreamReader()
+    reader.feed_data(b'{"action":"mcp_stdio","adapter_id":"test","configuration":{}}\n')
+    reader.feed_eof()
+    writer = MemoryWriter()
+    await browser_server.handle_browser_client(  # type: ignore[arg-type]
+        reader, writer, "5" * 64, lifecycle
+    )
+    assert json.loads(bytes(writer.data))["code"] == "browser_sidecar_internal_error"
+    assert lifecycle.finished.is_set() is True
+
+
+def test_browser_supervisor_requires_pid1(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(browser_server.sys, "platform", "linux")
+    monkeypatch.setattr(browser_server.os, "getpid", lambda: 2)
+    with pytest.raises(RuntimeError, match="browser_supervisor_must_be_pid1"):
+        browser_server._require_supervisor_pid1()
+    monkeypatch.setattr(browser_server.os, "getpid", lambda: 1)
+    browser_server._require_supervisor_pid1()
+
+
+@pytest.mark.asyncio
+async def test_egress_watch_bootstrap_timeout_shuts_down(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = browser_server.BrowserEgressService("7" * 64)
+    monkeypatch.setattr(browser_server, "EGRESS_WATCH_BOOTSTRAP_SECONDS", 0.01)
+    await browser_server._enforce_egress_watch_bootstrap(service)
+    assert service.shutdown_event.is_set() is True
+    assert service._shutting_down is True
+
+
+@pytest.mark.asyncio
+async def test_mcp_stdio_rejects_sandbox_peer_before_handshake(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(browser_server, "TRUSTED_CLIENT_UID", 0)
+    for uid, expected in ((65532, "browser_peer_denied"), (0, "mcp_adapter_denied")):
+        monkeypatch.setattr(browser_server, "_trusted_peer_uid", lambda writer, value=uid: value)
+        reader = asyncio.StreamReader()
+        reader.feed_data(
+            b'{"action":"mcp_stdio","adapter_id":"not-allowed","configuration":{}}\n'
+        )
+        reader.feed_eof()
+        writer = MemoryWriter()
+        await browser_server.handle_browser_client(  # type: ignore[arg-type]
+            reader,
+            writer,
+            "5" * 64,
+            browser_server.BrowserOneShotLifecycle(),
+        )
+        response = json.loads(bytes(writer.data).decode("utf-8"))
+        assert response["code"] == expected
+
+
+@pytest.mark.asyncio
+async def test_tunnel_deadline_revokes_capability() -> None:
+    reader = asyncio.StreamReader()
+    writer = MemoryWriter()
+
+    class Service:
+        revoked = ""
+
+        async def consume(self, capability: str, amount: int) -> None:
+            raise AssertionError("expired tunnel must not transfer bytes")
+
+        async def revoke(self, capability: str, reason: str) -> None:
+            self.revoked = reason
+
+    service = Service()
+    with pytest.raises(BrowserPolicyError, match="browser_egress_tunnel_deadline"):
+        await browser_server._relay_limited(  # type: ignore[arg-type]
+            reader,
+            writer,
+            service,
+            "f" * 64,
+            asyncio.get_running_loop().time() - 1,
+        )
+    assert service.revoked == "browser_egress_tunnel_deadline"
+
+
+@pytest.mark.asyncio
+async def test_idle_tunnel_closes_without_revoking_session_capability(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(browser_server, "EGRESS_TUNNEL_IDLE_SECONDS", 0.01)
+    reader = asyncio.StreamReader()
+    writer = MemoryWriter()
+
+    class Service:
+        revoked = ""
+
+        async def consume(self, capability: str, amount: int) -> None:
+            raise AssertionError("idle tunnel must not transfer bytes")
+
+        async def revoke(self, capability: str, reason: str) -> None:
+            self.revoked = reason
+
+    service = Service()
+    with pytest.raises(BrowserPolicyError, match="browser_egress_tunnel_idle"):
+        await browser_server._relay_limited(  # type: ignore[arg-type]
+            reader,
+            writer,
+            service,
+            "f" * 64,
+            asyncio.get_running_loop().time() + 1,
+        )
+    assert service.revoked == ""
+
+
+@pytest.mark.asyncio
+async def test_process_group_cleanup_uses_term_then_kill(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    signals: list[int] = []
+
+    class Process:
+        pid = 4242
+        returncode = None
+
+        def __init__(self) -> None:
+            self.exited = asyncio.Event()
+
+        async def wait(self) -> int:
+            await self.exited.wait()
+            return int(self.returncode or 0)
+
+    process = Process()
+    monkeypatch.setattr(browser_server.os, "name", "posix")
+    def killpg(pid: int, sig: int) -> None:
+        signals.append(sig)
+        if sig == browser_server.signal.SIGKILL:
+            process.returncode = -int(sig)
+            process.exited.set()
+
+    monkeypatch.setattr(browser_server.os, "killpg", killpg)
+    original_wait_for = browser_server.asyncio.wait_for
+
+    async def quick_wait_for(awaitable: Any, timeout: float) -> Any:
+        if timeout == 3:
+            awaitable.close()
+            raise asyncio.TimeoutError
+        return await original_wait_for(awaitable, timeout)
+
+    monkeypatch.setattr(browser_server.asyncio, "wait_for", quick_wait_for)
+    await browser_server._terminate_process_group(process)  # type: ignore[arg-type]
+    assert signals == [browser_server.signal.SIGTERM, browser_server.signal.SIGKILL]
+
+
+@pytest.mark.asyncio
+async def test_status_polling_does_not_extend_idle_deadline(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class Process:
+        returncode = 0
+
+    class Egress:
+        revocation_reason = ""
+
+    class Proxy:
+        egress = Egress()
+
+    state = browser_server.BrowserSessionState("chrome-devtools-mcp", "9" * 32)
+    state.last_activity = 100.0
+    gateway = browser_server.BrowserGatewaySession(
+        "chrome-devtools-mcp",
+        state,
+        Process(),  # type: ignore[arg-type]
+        object(),  # type: ignore[arg-type]
+        Proxy(),  # type: ignore[arg-type]
+        tmp_path,
+        tmp_path,
+        tmp_path,
+    )
+    monkeypatch.setattr(browser_server.time, "monotonic", lambda: 120.0)
+    await gateway.status()
+    await gateway.status()
+    assert state.last_activity == 100.0
+    monkeypatch.setattr(
+        browser_server.time,
+        "monotonic",
+        lambda: 100.0 + browser_server.IDLE_TTL_SECONDS,
+    )
+    with pytest.raises(BrowserPolicyError, match="browser_session_idle_expired"):
+        await gateway.status()
+
+
+def test_png_registration_rejects_hardlink_and_symlink(
+    tmp_path: Path,
+) -> None:
+    staging = tmp_path / "staging"
+    registered = tmp_path / "registered"
+    staging.mkdir()
+    registered.mkdir()
+    artifact = staging / f".modelmirror-browser_{'a' * 32}.png"
+    artifact.write_bytes(browser_server.PNG_MAGIC + b"payload")
+    hardlink = tmp_path / "hardlink.png"
+    os.link(artifact, hardlink)
+    with pytest.raises(BrowserPolicyError, match="browser_artifact_metadata_denied"):
+        browser_server._register_png_artifact(artifact, registered)
+    hardlink.unlink()
+    artifact.unlink()
+
+    target = tmp_path / "target.png"
+    target.write_bytes(browser_server.PNG_MAGIC + b"outside")
+    try:
+        os.symlink(target, artifact)
+    except (OSError, NotImplementedError):
+        pytest.skip("file symlink creation is unavailable")
+    with pytest.raises(BrowserPolicyError, match="browser_artifact_metadata_denied"):
+        browser_server._register_png_artifact(artifact, registered)
+    assert target.read_bytes().endswith(b"outside")
+
+
+def test_png_registration_rejects_path_swap(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    staging = tmp_path / "staging"
+    registered = tmp_path / "registered"
+    staging.mkdir()
+    registered.mkdir()
+    artifact = staging / f".modelmirror-browser_{'b' * 32}.png"
+    displaced = staging / "displaced.png"
+    artifact.write_bytes(browser_server.PNG_MAGIC + b"first")
+    original_read = browser_server.os.read
+    swapped = False
+
+    def swapping_read(descriptor: int, amount: int) -> bytes:
+        nonlocal swapped
+        chunk = original_read(descriptor, amount)
+        if not swapped:
+            swapped = True
+            artifact.replace(displaced)
+            artifact.write_bytes(browser_server.PNG_MAGIC + b"replacement")
+        return chunk
+
+    monkeypatch.setattr(browser_server.os, "read", swapping_read)
+    with pytest.raises(BrowserPolicyError, match="browser_artifact_race_denied"):
+        browser_server._register_png_artifact(artifact, registered)
+    assert not list(registered.iterdir())
+
+
+def test_png_registration_copies_away_from_retained_source_write_fd(
+    tmp_path: Path,
+) -> None:
+    staging = tmp_path / "staging"
+    registered = tmp_path / "registered"
+    staging.mkdir()
+    registered.mkdir()
+    artifact = staging / f".modelmirror-browser_{'c' * 32}.png"
+    original = browser_server.PNG_MAGIC + b"trusted-payload"
+    artifact.write_bytes(original)
+    attacker_descriptor = os.open(
+        artifact,
+        os.O_WRONLY | os.O_CLOEXEC | getattr(os, "O_NOFOLLOW", 0),
+    )
+    source_inode = os.fstat(attacker_descriptor).st_ino
+    try:
+        registered_path, digest, size = browser_server._register_png_artifact(
+            artifact, registered
+        )
+        assert not artifact.exists()
+        assert registered_path.stat().st_ino != source_inode
+        assert registered_path.read_bytes() == original
+        assert digest == hashlib.sha256(original).hexdigest()
+        assert size == len(original)
+
+        os.lseek(attacker_descriptor, 0, os.SEEK_SET)
+        os.write(attacker_descriptor, b"attacker-controlled")
+        os.ftruncate(attacker_descriptor, 3)
+        os.fsync(attacker_descriptor)
+
+        assert registered_path.read_bytes() == original
+        assert hashlib.sha256(registered_path.read_bytes()).hexdigest() == digest
+        assert registered_path.stat().st_size == size
+    finally:
+        os.close(attacker_descriptor)
+
+
+@pytest.mark.asyncio
+async def test_artifact_timeout_taints_session_and_late_file_cannot_recover(
+    tmp_path: Path,
+) -> None:
+    staging = tmp_path / "staging"
+    registered = tmp_path / "registered"
+    staging.mkdir()
+    registered.mkdir()
+
+    class Process:
+        returncode = None
+
+    class Rpc:
+        async def request(self, *args: object, **kwargs: object) -> dict[str, object]:
+            raise asyncio.TimeoutError
+
+    class Egress:
+        revocation_reason = ""
+
+    class Proxy:
+        egress = Egress()
+        last_violation = ""
+
+    state = browser_server.BrowserSessionState("chrome-devtools-mcp", "8" * 32)
+    gateway = browser_server.BrowserGatewaySession(
+        "chrome-devtools-mcp",
+        state,
+        Process(),  # type: ignore[arg-type]
+        Rpc(),  # type: ignore[arg-type]
+        Proxy(),  # type: ignore[arg-type]
+        tmp_path,
+        staging,
+        registered,
+    )
+
+    async def taint_without_process(self: Any, reason: str) -> None:
+        self.state.taint(reason)
+
+    gateway._taint = MethodType(taint_without_process, gateway)  # type: ignore[method-assign]
+    with pytest.raises(BrowserPolicyError, match="browser_artifact_outcome_unknown"):
+        await gateway.call("take_screenshot", {})
+    assert state.tainted is True
+    assert state.taint_reason == "browser_artifact_outcome_unknown"
+
+    # A late browser write cannot make a tainted session look healthy again.
+    (staging / "late.png").write_bytes(browser_server.PNG_MAGIC + b"late")
+    with pytest.raises(BrowserPolicyError, match="browser_artifact_outcome_unknown"):
+        await gateway.call("browser_session_status", {})
+    assert state.tainted is True
+    assert gateway._purge_unregistered_artifacts() is True
+    assert not (staging / "late.png").exists()
+
+
+@pytest.mark.asyncio
+async def test_snapshot_login_redirect_immediately_taints_and_stops_session(
+    tmp_path: Path,
+) -> None:
+    staging = tmp_path / "staging"
+    registered = tmp_path / "registered"
+    staging.mkdir()
+    registered.mkdir()
+
+    class Process:
+        returncode = None
+
+    class Rpc:
+        async def request(self, *args: object, **kwargs: object) -> dict[str, object]:
+            return {
+                "jsonrpc": "2.0",
+                "id": "internal",
+                "result": {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": 'uid=1_0 RootWebArea "Account" url="https://example.com/accounts"',
+                        }
+                    ]
+                },
+            }
+
+    class Egress:
+        revocation_reason = ""
+
+    class Proxy:
+        egress = Egress()
+        last_violation = ""
+
+    state = browser_server.BrowserSessionState("chrome-devtools-mcp", "6" * 32)
+    state.current_origin = "https://example.com"
+    gateway = browser_server.BrowserGatewaySession(
+        "chrome-devtools-mcp",
+        state,
+        Process(),  # type: ignore[arg-type]
+        Rpc(),  # type: ignore[arg-type]
+        Proxy(),  # type: ignore[arg-type]
+        tmp_path,
+        staging,
+        registered,
+    )
+
+    async def taint_without_process(self: Any, reason: str) -> None:
+        self.state.taint(reason)
+
+    gateway._taint = MethodType(taint_without_process, gateway)  # type: ignore[method-assign]
+    with pytest.raises(BrowserPolicyError, match="browser_external_login_denied"):
+        await gateway.call("take_snapshot", {})
+    assert state.tainted is True
+    assert state.taint_reason == "browser_external_login_denied"

--- a/server/tests/test_mcp_catalog.py
+++ b/server/tests/test_mcp_catalog.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import hashlib
 import json
+import os
 import re
 from dataclasses import replace
 from pathlib import Path
@@ -26,6 +28,7 @@ from server.mcp.catalog import (
     WAVE_FOUR_ADAPTERS,
     WAVE_FIVE_ADAPTERS,
     WAVE_SIX_ADAPTERS,
+    WAVE_SEVEN_ADAPTERS,
     WAVE_PROJECTS,
     CatalogAdapterManifest,
     CatalogConfigurationRequest,
@@ -36,6 +39,14 @@ from server.mcp.catalog import (
     MCPCatalogService,
 )
 from server.sandbox_sidecar.saas_contracts import SAAS_SCHEMA_SHA256
+from server.sandbox_sidecar.browser_contracts import (
+    BROWSER_ADAPTERS,
+    BROWSER_SCHEMA_SHA256,
+    CONTRACT_VERSION as BROWSER_CONTRACT_VERSION,
+    LOGIN_PATH_SEGMENTS,
+    canonical_browser_login_tokens as sidecar_browser_login_tokens,
+    browser_query_has_sensitive_key as sidecar_browser_query_has_sensitive_key,
+)
 from server.toolsets.credentials import CredentialStore
 
 
@@ -54,10 +65,14 @@ class FakeManager:
         self.scrubbed: list[str] = []
         self.call_is_error = False
         self.call_error: Exception | None = None
+        self.tool_errors: dict[str, Exception] = {}
+        self.tool_results: dict[str, Any] = {}
         self.call_gate: asyncio.Event | None = None
+        self.call_gates: dict[str, asyncio.Event] = {}
         self.connect_gate: asyncio.Event | None = None
         self.connect_started = asyncio.Event()
         self.disconnect_gate: asyncio.Event | None = None
+        self.disconnect_error: Exception | None = None
         self.disconnect_started = asyncio.Event()
         self.tools: list[Tool] = [Tool(name="echo", description="Echo", inputSchema={})]
 
@@ -119,10 +134,17 @@ class FakeManager:
             raise catalog.MCPSessionNotFoundError(session_id)
         self.calls.append((session_id, tool_name, dict(arguments)))
         self.retry_on_failure.append(retry_on_failure)
-        if self.call_gate is not None:
+        tool_gate = self.call_gates.get(tool_name)
+        if tool_gate is not None:
+            await tool_gate.wait()
+        elif self.call_gate is not None:
             await self.call_gate.wait()
+        if tool_name in self.tool_errors:
+            raise self.tool_errors[tool_name]
         if self.call_error is not None:
             raise self.call_error
+        if tool_name in self.tool_results:
+            return self.tool_results[tool_name]
         return CallToolResult(
             content=[TextContent(type="text", text=str(arguments.get("value", "ok")))],
             isError=self.call_is_error,
@@ -142,6 +164,8 @@ class FakeManager:
         self.disconnect_started.set()
         if self.disconnect_gate is not None:
             await self.disconnect_gate.wait()
+        if self.disconnect_error is not None:
+            raise self.disconnect_error
         self.sessions.remove(session_id)
         self.session_owners.pop(session_id, None)
         self.disconnected.append(session_id)
@@ -193,8 +217,56 @@ class FakeRegistry:
         self.unregistered.append(session_id)
 
 
+class FakeToolResult:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.payload = payload
+
+    def model_dump(self, **_: Any) -> dict[str, Any]:
+        return json.loads(json.dumps(self.payload, ensure_ascii=False))
+
+
+def browser_tools(project_id: str) -> list[Tool]:
+    contract = BROWSER_ADAPTERS[project_id]
+    return [
+        Tool(
+            name=name,
+            description=tool.description,
+            inputSchema=tool.input_schema,
+        )
+        for name, tool in contract.tools.items()
+    ]
+
+
+def browser_status_result(
+    *,
+    generation: str = "12345678-1234-4234-9234-123456789abc",
+    page_revision: int = 1,
+    page_digest: str = "a" * 64,
+    current_origin: str = "https://example.com",
+    action_count: int = 1,
+    tainted: bool = False,
+) -> FakeToolResult:
+    return FakeToolResult(
+        {
+            "content": [],
+            "isError": False,
+            "structuredContent": {
+                "generation": generation,
+                "page_revision": page_revision,
+                "page_digest": page_digest,
+                "current_origin": current_origin,
+                "action_count": action_count,
+                "max_actions": 50,
+                "tainted": tainted,
+                "expires_at": 4_102_444_800.0,
+            },
+        }
+    )
+
+
 def make_service(
     manifests: dict[str, CatalogAdapterManifest] | None = None,
+    **service_kwargs: Any,
 ) -> tuple[MCPCatalogService, FakeManager, FakeInstaller, FakeRegistry]:
     manager = FakeManager()
     installer = FakeInstaller()
@@ -232,6 +304,7 @@ def make_service(
         manifests=manifests,
         credential_validator=credential_validator,
         credential_resolver=lambda credential_id: f"secret-for-{credential_id}",
+        **service_kwargs,
     )
     return service, manager, installer, registry
 
@@ -260,18 +333,22 @@ def test_catalog_freezes_100_projects_and_maps_all_waves_once() -> None:
         "duckdb-mcp",
         "supabase-mcp",
     }
+    assert set(WAVE_SEVEN_ADAPTERS) == {
+        "chrome-devtools-mcp",
+        "playwright-mcp",
+    }
     assert sum(
         manifest.availability == "ready"
         for manifest in CATALOG_ADAPTERS.values()
-    ) == 42
+    ) == 44
     assert sum(
         manifest.availability == "planned"
         for manifest in CATALOG_ADAPTERS.values()
-    ) == 47
+    ) == 43
     assert sum(
         manifest.availability == "blocked"
         for manifest in CATALOG_ADAPTERS.values()
-    ) == 11
+    ) == 13
     assert {manifest.availability for manifest in CATALOG_ADAPTERS.values()} == {
         "ready",
         "planned",
@@ -315,13 +392,988 @@ def test_frontend_catalog_ids_match_backend_registry_and_never_submit_commands()
 def test_planned_adapter_cannot_be_enabled_by_environment(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    manifest = CATALOG_ADAPTERS["chrome-devtools-mcp"]
+    manifest = CATALOG_ADAPTERS["mcp-run-python"]
     monkeypatch.setenv(manifest.feature_flag, "true")
 
     assert manifest.feature_enabled is True
     assert manifest.executable is False
     assert not manifest.server_command
     assert not manifest.endpoint
+
+
+def test_wave_seven_manifest_freezes_ready_blocked_and_public_policy() -> None:
+    for project_id, engine in {
+        "chrome-devtools-mcp": "chrome-devtools",
+        "playwright-mcp": "playwright",
+    }.items():
+        manifest = CATALOG_ADAPTERS[project_id]
+        assert manifest.availability == "ready"
+        assert manifest.enabled_by_default is False
+        assert manifest.runtime_image == "modelmirror-mcp-browser:wave7-v1"
+        assert manifest.server_command[-1] == project_id
+        assert manifest.browser_policy is not None
+        assert manifest.browser_policy.engine == engine
+        assert manifest.browser_policy.contract_version == BROWSER_CONTRACT_VERSION
+        assert (
+            manifest.browser_policy.tool_schema_sha256
+            == BROWSER_SCHEMA_SHA256[project_id]
+        )
+        assert manifest.browser_policy.max_pages == 1
+        assert manifest.browser_policy.max_actions == 50
+        assert manifest.browser_policy.max_concurrent_sessions == 1
+        resource_limits = dict(manifest.resource_limits)
+        assert resource_limits["browser_cpu"] == "1.5 cores"
+        assert resource_limits["browser_memory"] == "1 GiB"
+        assert resource_limits["browser_processes"] == "maximum 1 session / 256 PIDs"
+        assert resource_limits["egress_cpu"] == "0.5 cores"
+        assert resource_limits["egress_memory"] == "256 MiB"
+        assert resource_limits["egress_processes"] == "64 PIDs"
+        assert manifest.browser_policy.max_tunnels_per_session == 12
+        assert manifest.browser_policy.max_egress_bytes_per_session == 64 * 1024 * 1024
+        assert manifest.browser_policy.max_artifacts_per_project == 50
+        assert manifest.browser_policy.max_artifact_storage_bytes == 256 * 1024 * 1024
+        assert manifest.browser_policy.uploads is False
+        assert manifest.browser_policy.downloads is False
+        assert manifest.browser_policy.cookies is False
+        assert manifest.browser_policy.evaluate is False
+        assert manifest.workspace_policy is None
+        assert "landlock-proc-write-file-with-docker-procfs-guards" in (
+            manifest.filesystem_policy
+        )
+        assert any("/proc" in item and "WRITE_FILE" in item for item in manifest.limitations)
+        assert manifest.required_capabilities == (
+            "ephemeral-browser",
+            "browser-domain-policy",
+            "browser-session-approval",
+            "browser-artifact-cleanup",
+        )
+        public = manifest.to_public()
+        assert public["browser_policy"]["allowed_schemes"] == ("http", "https")
+        assert public["browser_policy"]["allowed_ports"] == (80, 443)
+        assert "server_command" not in public
+
+    assert CATALOG_ADAPTERS["puppeteer-mcp"].availability == "blocked"
+    assert CATALOG_ADAPTERS["selenium-mcp"].availability == "blocked"
+    assert CATALOG_ADAPTERS["puppeteer-mcp"].server_command == ()
+    assert CATALOG_ADAPTERS["selenium-mcp"].server_command == ()
+
+
+def test_wave_seven_compose_isolates_browser_and_egress_services() -> None:
+    source = (PROJECT_ROOT / "docker-compose.yml").read_text(encoding="utf-8")
+    browser_block = source[
+        source.index("  mcp-browser:\n") : source.index("  mcp-database:\n")
+    ]
+    egress_block = source[
+        source.index("  mcp-browser-egress:\n") : source.index("  mcp-browser:\n")
+    ]
+    assert "network_mode: none" in browser_block
+    assert "pids_limit: 256" in browser_block
+    assert "mem_limit: 1g" in browser_block
+    assert "cpus: 1.5" in browser_block
+    assert "cap_drop:\n      - ALL" in browser_block
+    assert "no-new-privileges:true" in browser_block
+    assert "seccomp=./server/sandbox_sidecar/seccomp_profile.browser.json" in browser_block
+    assert 'user: "65532:65532"' in browser_block
+    assert (
+        "/tmp:rw,nosuid,nodev,noexec,size=128m,uid=65532,gid=65532,mode=0700"
+        in browser_block
+    )
+    assert (
+        "/profiles:rw,nosuid,nodev,noexec,size=256m,uid=65532,gid=65532,mode=0700"
+        in browser_block
+    )
+    assert (
+        "/dev/shm:rw,nosuid,nodev,noexec,size=256m,uid=65532,gid=65532,mode=0700"
+        in browser_block
+    )
+    assert "mcp_browser_egress_socket" in browser_block
+    assert "mcp_browser_artifact_staging:/artifacts" in browser_block
+    assert "mcp_browser_socket" not in egress_block
+    assert "mcp_browser_artifact_staging" not in egress_block
+    assert "mcp_browser_egress" in egress_block
+    assert "pids_limit: 64" in egress_block
+    assert "mem_limit: 256m" in egress_block
+    assert "cpus: 0.5" in egress_block
+    assert "cap_drop:\n      - ALL" in egress_block
+    assert "no-new-privileges:true" in egress_block
+    assert (
+        "/tmp:rw,nosuid,nodev,noexec,size=32m,uid=65532,gid=65532,mode=0700"
+        in egress_block
+    )
+    assert 'MCP_BROWSER_ALLOW_SYNTHETIC_DNS: "false"' in egress_block
+    assert "${MCP_BROWSER_ALLOW_SYNTHETIC_DNS" not in egress_block
+    assert "MCP_CATALOG_ENABLE_CHROME_DEVTOOLS_MCP:-false" in source
+    assert "MCP_CATALOG_ENABLE_PLAYWRIGHT_MCP:-false" in source
+    assert "o: size=67108864" in source
+
+
+@pytest.mark.asyncio
+async def test_wave_seven_connect_uses_exact_handshake_preflight_and_catalog_tools(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_id = "chrome-devtools-mcp"
+    manifest = CATALOG_ADAPTERS[project_id]
+    monkeypatch.setenv(manifest.feature_flag, "true")
+    service, manager, _, _ = make_service()
+    manager.tools = browser_tools(project_id)
+    manager.tool_results["browser_session_status"] = browser_status_result()
+
+    connected = await service.connect(project_id)
+
+    assert connected["preflight_status"] == "verified"
+    assert connected["browser_session"]["status"] == "active"
+    profile = manager.profiles[-1]
+    assert profile["reconnect_attempts"] == 0
+    assert profile["session_owner"] == "catalog:local:local:chrome-devtools-mcp"
+    assert manager.scrubbed == [connected["session_id"]]
+    encoded = profile["environment"]["MCP_BROWSER_HANDSHAKE_B64"]
+    handshake = json.loads(base64.urlsafe_b64decode(encoded).decode("utf-8"))
+    assert set(handshake) == {
+        "project_id",
+        "contract_version",
+        "tool_schema_sha256",
+        "limits",
+    }
+    assert handshake["project_id"] == project_id
+    assert handshake["contract_version"] == BROWSER_CONTRACT_VERSION
+    assert handshake["tool_schema_sha256"] == BROWSER_SCHEMA_SHA256[project_id]
+    assert handshake["limits"]["max_actions"] == 50
+    assert handshake["limits"]["max_sessions"] == 1
+    assert handshake["limits"]["max_tunnels_per_session"] == 12
+
+    discovered = await service.list_tools(project_id)
+    assert {item["name"] for item in discovered["tools"]} == set(
+        manifest.tool_policies
+    )
+    with pytest.raises(catalog.MCPSessionNotFoundError):
+        await manager.list_tools(connected["session_id"])
+
+    previous = catalog._catalog_service
+    catalog.configure_mcp_catalog(service)
+    app = FastAPI()
+    app.include_router(catalog.router)
+    try:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://testserver",
+        ) as client:
+            response = await client.get(
+                f"/api/mcp/catalog/{project_id}/tools"
+            )
+            assert response.status_code == 200
+            assert len(response.json()["tools"]) == 6
+            status = await client.get(
+                f"/api/mcp/catalog/{project_id}/browser-session"
+            )
+            assert status.status_code == 200
+            assert status.json()["current_origin"] == "https://example.com"
+    finally:
+        catalog._catalog_service = previous
+
+    drifted_tools = browser_tools(project_id)
+    first = drifted_tools[0]
+    drifted_tools[0] = Tool(
+        name=first.name,
+        description=first.description,
+        inputSchema={"type": "object", "properties": {"drift": {"type": "string"}}},
+    )
+    manager.tools = drifted_tools
+    with pytest.raises(catalog.CatalogAdapterPolicyError, match="策略不一致"):
+        await service.list_tools(project_id)
+    assert service._scope_key(project_id) not in service._sessions
+    assert (await service.browser_session_status(project_id))["status"] == "tainted"
+
+
+@pytest.mark.asyncio
+async def test_wave_seven_approval_freezes_snapshot_and_element_preview(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_id = "playwright-mcp"
+    manifest = CATALOG_ADAPTERS[project_id]
+    monkeypatch.setenv(manifest.feature_flag, "true")
+    service, manager, _, _ = make_service()
+    manager.tools = browser_tools(project_id)
+    manager.tool_results["browser_session_status"] = browser_status_result()
+    manager.tool_results["browser_snapshot"] = FakeToolResult(
+        {
+            "content": [{"type": "text", "text": "受控快照"}],
+            "isError": False,
+            "structuredContent": {
+                "elements": [
+                    {
+                        "ref": "button.submit",
+                        "role": "button",
+                        "label": "提交表单",
+                        "page_digest": "a" * 64,
+                    }
+                ]
+            },
+        }
+    )
+    await service.connect(project_id)
+    await service.call_tool(project_id, "browser_snapshot", {})
+    snapshot_index = next(
+        index
+        for index, call in enumerate(manager.calls)
+        if call[1] == "browser_snapshot"
+    )
+    assert manager.retry_on_failure[snapshot_index] is False
+
+    with pytest.raises(catalog.CatalogApprovalRequiredError) as captured:
+        await service.call_tool(
+            project_id,
+            "browser_click",
+            {"ref": "button.submit"},
+        )
+    approval = captured.value.payload
+    assert approval["context_kind"] == "browser-session"
+    assert approval["target_preview"]["resource"]["label"] == "https://example.com"
+    assert approval["target_preview"]["changes"] == [
+        {"field": "button", "summary": "提交表单"}
+    ]
+
+    result = await service.confirm_approval(project_id, approval["approval_id"])
+    assert result["unknown_outcome"] is False
+    click_calls = [call for call in manager.calls if call[1] == "browser_click"]
+    assert click_calls == [
+        (service._sessions[service._scope_key(project_id)], "browser_click", {"ref": "button.submit"})
+    ]
+    assert manager.retry_on_failure[manager.calls.index(click_calls[0])] is False
+
+
+@pytest.mark.asyncio
+async def test_wave_seven_navigation_preflight_rejects_private_and_login_targets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    assert catalog.BROWSER_LOGIN_TOKENS == LOGIN_PATH_SEGMENTS
+    project_id = "chrome-devtools-mcp"
+    manifest = CATALOG_ADAPTERS[project_id]
+    monkeypatch.setenv(manifest.feature_flag, "true")
+    service, manager, _, _ = make_service()
+    manager.tools = browser_tools(project_id)
+    manager.tool_results["browser_session_status"] = browser_status_result()
+    await service.connect(project_id)
+
+    for target in (
+        "http://127.0.0.1/private",
+        "https://example.com/login",
+        "https://example.com/%6cogin",
+        "https://example.com/%256cogin",
+        "https://example.com/sign-in",
+        "https://example.com/sign_in",
+        "https://example.com/log-in",
+        "https://example.com/log_in",
+        "https://example.com/sign/in",
+        "https://example.com/user-sign-in",
+        "https://example.com/%73ign%2Din",
+        "https://example.com/%2573ign%252Din",
+        "https://example.com/log%255Fin",
+        "https://sign-in.example.com/",
+        "https://sign.in.example.com/",
+        "https://example.com/?action=login",
+        "https://accounts.example.com/",
+        "https://example.com/session/new",
+        "https://example.com/consent",
+        "https://example.com/saml/callback",
+        "https://example.com/oidc",
+        "http://example.com:443/public",
+        "https://example.com:80/public",
+        "https://user:password@example.com/",
+        "https://example.com/path#secret",
+        "https://example.com/public?token=secret",
+        "https://example.com/public?access_token=secret",
+        "https://example.com/public?api%255fkey=secret",
+        "https://example.com/public?X-Amz-Signature=secret",
+        "https://example.com/public?x-goog-credential=secret",
+        "https://example.com/public?sig=secret",
+        (
+            "https://example.com/public?redirect="
+            "https%253A%252F%252Fa.example%252F%253Foauth_token%253Dsecret"
+        ),
+    ):
+        with pytest.raises(catalog.CatalogAdapterPolicyError, match="浏览器"):
+            await service.call_tool(project_id, "navigate_page", {"url": target})
+
+    with pytest.raises(catalog.CatalogApprovalRequiredError) as captured:
+        await service.call_tool(
+            project_id,
+            "navigate_page",
+            {"url": "https://example.com/public/report?page=2&sort=recent"},
+        )
+    preview = captured.value.payload["target_preview"]
+    serialized = json.dumps(preview, ensure_ascii=False)
+    assert preview["resource"]["label"] == "https://example.com/public/report"
+    assert "page" not in serialized
+    assert "sort" not in serialized
+    assert not [call for call in manager.calls if call[1] == "navigate_page"]
+
+
+@pytest.mark.asyncio
+async def test_wave_seven_definite_dns_policy_rejection_keeps_session_reusable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_id = "playwright-mcp"
+    manifest = CATALOG_ADAPTERS[project_id]
+    monkeypatch.setenv(manifest.feature_flag, "true")
+    service, manager, _, _ = make_service()
+    manager.tools = browser_tools(project_id)
+    manager.tool_results["browser_session_status"] = browser_status_result()
+    connected = await service.connect(project_id)
+
+    with pytest.raises(catalog.CatalogApprovalRequiredError) as captured:
+        await service.call_tool(
+            project_id,
+            "browser_navigate",
+            {"url": "https://example.com/"},
+        )
+    approval = captured.value.payload
+    manager.tool_errors["browser_navigate"] = McpError(
+        ErrorData(
+            code=-32011,
+            message="Browser policy denied",
+            data={
+                "reason": "browser_dns_mixed_or_synthetic_denied",
+                "retryable": False,
+            },
+        )
+    )
+
+    with pytest.raises(catalog.CatalogBrowserPolicyRejectedError) as rejected:
+        await service.confirm_approval(project_id, approval["approval_id"])
+
+    assert rejected.value.reason == "dns_policy_rejected"
+    ledger = service._execution_ledger[
+        service._approval_key(approval["approval_id"])
+    ]
+    assert ledger.state == "rejected"
+    scope_key = service._scope_key(project_id)
+    assert service._sessions[scope_key] == connected["session_id"]
+    assert service._preflight_status[scope_key] == "verified"
+    assert manager.disconnected == []
+    with pytest.raises(HTTPException) as response:
+        catalog._raise_http_error(rejected.value)
+    assert response.value.status_code == 409
+    assert response.value.detail == {
+        "code": "browser_policy_rejected",
+        "reason": "dns_policy_rejected",
+        "message": str(rejected.value),
+        "idempotency_key": approval["idempotency_key"],
+    }
+
+    manager.tool_errors.pop("browser_navigate")
+    with pytest.raises(catalog.CatalogApprovalRequiredError) as retry_request:
+        await service.call_tool(
+            project_id,
+            "browser_navigate",
+            {"url": "https://example.com/"},
+        )
+    result = await service.confirm_approval(
+        project_id,
+        retry_request.value.payload["approval_id"],
+    )
+    assert result["unknown_outcome"] is False
+    assert service._sessions[scope_key] == connected["session_id"]
+
+
+@pytest.mark.asyncio
+async def test_wave_seven_post_dispatch_policy_error_remains_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_id = "playwright-mcp"
+    manifest = CATALOG_ADAPTERS[project_id]
+    monkeypatch.setenv(manifest.feature_flag, "true")
+    service, manager, _, _ = make_service()
+    manager.tools = browser_tools(project_id)
+    manager.tool_results["browser_session_status"] = browser_status_result()
+    await service.connect(project_id)
+    with pytest.raises(catalog.CatalogApprovalRequiredError) as captured:
+        await service.call_tool(
+            project_id,
+            "browser_navigate",
+            {"url": "https://example.com/"},
+        )
+    manager.tool_errors["browser_navigate"] = McpError(
+        ErrorData(
+            code=-32011,
+            message="Browser policy denied",
+            data={"reason": "browser_cross_origin_denied", "retryable": False},
+        )
+    )
+
+    with pytest.raises(CatalogUnknownOutcomeError):
+        await service.confirm_approval(
+            project_id,
+            captured.value.payload["approval_id"],
+        )
+    assert service._scope_key(project_id) not in service._sessions
+
+
+def test_wave_seven_login_token_canonicalization_matches_sidecar() -> None:
+    samples = (
+        ("/sign-in", False),
+        ("/sign_in", False),
+        ("/log-in", False),
+        ("/log_in", False),
+        ("/sign/in", False),
+        ("/user-sign-in", False),
+        ("/?action=sign-in", False),
+        ("sign-in.example.com", True),
+        ("sign.in.example.com", True),
+        ("authors.example.com", True),
+    )
+    for value, host in samples:
+        assert catalog.canonical_browser_login_tokens(
+            value, host=host
+        ) == sidecar_browser_login_tokens(value, host=host)
+
+
+def test_wave_seven_sensitive_query_canonicalization_matches_sidecar() -> None:
+    samples = (
+        "page=2&sort=recent",
+        "token=secret",
+        "access_token=secret",
+        "%2561pi%255Fkey=secret",
+        "X-Amz-Signature=secret",
+        "x-goog-credential=secret",
+        "sig=secret",
+        (
+            "redirect=https%253A%252F%252Fa.example%252Fcallback"
+            "%253Foauth_token%253Dsecret"
+        ),
+    )
+    for query in samples:
+        assert catalog.browser_query_has_sensitive_key(
+            query
+        ) == sidecar_browser_query_has_sensitive_key(query)
+
+
+@pytest.mark.asyncio
+async def test_wave_seven_screenshot_timeout_taints_and_disconnects_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_id = "chrome-devtools-mcp"
+    manifest = CATALOG_ADAPTERS[project_id]
+    monkeypatch.setenv(manifest.feature_flag, "true")
+    service, manager, _, registry = make_service()
+    manager.tools = browser_tools(project_id)
+    manager.tool_results["browser_session_status"] = browser_status_result()
+    connected = await service.connect(project_id)
+    manager.tool_errors["take_screenshot"] = catalog.MCPClientError(
+        "screenshot timeout"
+    )
+
+    with pytest.raises(catalog.MCPClientError, match="screenshot timeout"):
+        await service.call_tool(project_id, "take_screenshot", {})
+
+    scope_key = service._scope_key(project_id)
+    screenshot_index = next(
+        index
+        for index, call in enumerate(manager.calls)
+        if call[1] == "take_screenshot"
+    )
+    assert manager.retry_on_failure[screenshot_index] is False
+    assert scope_key not in service._sessions
+    assert connected["session_id"] in manager.disconnected
+    assert connected["session_id"] in registry.unregistered
+    assert service._preflight_status[scope_key] == "failed"
+    assert (await service.browser_session_status(project_id))["status"] == "tainted"
+
+
+@pytest.mark.asyncio
+async def test_wave_seven_screenshot_registry_download_and_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    project_id = "chrome-devtools-mcp"
+    manifest = CATALOG_ADAPTERS[project_id]
+    monkeypatch.setenv(manifest.feature_flag, "true")
+    staging_root = (tmp_path / "staging").resolve()
+    trusted_root = (tmp_path / "trusted").resolve()
+    index_path = trusted_root / "index.json"
+    service, manager, _, _ = make_service(
+        browser_artifact_staging_root=staging_root,
+        browser_artifact_root=trusted_root,
+        browser_artifact_index_path=index_path,
+    )
+    manager.tools = browser_tools(project_id)
+    manager.tool_results["browser_session_status"] = browser_status_result()
+    content = b"\x89PNG\r\n\x1a\ncontrolled-screenshot"
+    session_dir = "1" * 32
+    internal_id = "browser_" + "2" * 32
+    artifact_dir = staging_root / session_dir / "registered"
+    artifact_dir.mkdir(parents=True)
+    artifact_path = artifact_dir / f"{internal_id}.png"
+    artifact_path.write_bytes(content)
+    manager.tool_results["take_screenshot"] = FakeToolResult(
+        {
+            "content": [{"type": "text", "text": "截图已生成"}],
+            "isError": False,
+            "structuredContent": {
+                "artifact_id": internal_id,
+                "relative_path": f"{session_dir}/registered/{internal_id}.png",
+                "sha256": hashlib.sha256(content).hexdigest(),
+                "size": len(content),
+                "mime": "image/png",
+            },
+        }
+    )
+    await service.connect(project_id)
+    service._browser_elements[service._scope_key(project_id)] = {
+        "old-ref": {
+            "role": "button",
+            "label": "旧按钮",
+            "page_digest": "a" * 64,
+        }
+    }
+
+    result = await service.call_tool(project_id, "take_screenshot", {})
+
+    assert artifact_path.exists() is False
+    assert artifact_dir.is_dir()
+    assert artifact_dir.parent.is_dir()
+    assert manager.retry_on_failure[
+        next(index for index, call in enumerate(manager.calls) if call[1] == "take_screenshot")
+    ] is False
+    serialized = json.dumps(result, ensure_ascii=False)
+    assert f"{session_dir}/registered/{internal_id}.png" not in serialized
+    assert internal_id not in serialized
+    public = result["artifacts"][0]
+    assert public["artifact_id"].startswith("mcpbart_")
+    assert public["download_url"].endswith(
+        f"/{public['artifact_id']}/download"
+    )
+    with pytest.raises(catalog.CatalogAdapterPolicyError, match="不属于当前受控快照"):
+        await service.call_tool(project_id, "click", {"ref": "old-ref"})
+    await service.disconnect(project_id)
+    reloaded, _, _, _ = make_service(
+        browser_artifact_staging_root=staging_root,
+        browser_artifact_root=trusted_root,
+        browser_artifact_index_path=index_path,
+    )
+    listed = reloaded.list_browser_artifacts(project_id)
+    assert listed["total"] == 1
+    _, trusted_path = reloaded.browser_artifact_download(
+        project_id,
+        public["artifact_id"],
+    )
+    trusted_path.write_bytes(content[:-1] + b"X")
+    with pytest.raises(catalog.CatalogAdapterPolicyError, match="摘要已经变化"):
+        reloaded.browser_artifact_download(project_id, public["artifact_id"])
+    trusted_path.write_bytes(content)
+
+    previous = catalog._catalog_service
+    catalog.configure_mcp_catalog(reloaded)
+    app = FastAPI()
+    app.include_router(catalog.router)
+    try:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://testserver",
+        ) as client:
+            download = await client.get(public["download_url"])
+            assert download.status_code == 200
+            assert download.content == content
+            assert download.headers["cache-control"] == "no-store"
+            assert download.headers["x-content-type-options"] == "nosniff"
+            deleted = await client.delete(
+                f"/api/mcp/catalog/{project_id}/browser-artifacts/"
+                f"{public['artifact_id']}"
+            )
+            assert deleted.status_code == 200
+    finally:
+        catalog._catalog_service = previous
+    assert not artifact_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_wave_seven_concurrent_approvals_recheck_inside_call_lock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_id = "chrome-devtools-mcp"
+    manifest = CATALOG_ADAPTERS[project_id]
+    monkeypatch.setenv(manifest.feature_flag, "true")
+    service, manager, _, _ = make_service()
+    manager.tools = browser_tools(project_id)
+    manager.tool_results["browser_session_status"] = browser_status_result()
+    await service.connect(project_id)
+    service._browser_elements[service._scope_key(project_id)] = {
+        "submit": {
+            "role": "button",
+            "label": "提交",
+            "page_digest": "a" * 64,
+        }
+    }
+
+    approvals: list[dict[str, Any]] = []
+    for _ in range(2):
+        with pytest.raises(catalog.CatalogApprovalRequiredError) as captured:
+            await service.call_tool(project_id, "click", {"ref": "submit"})
+        approvals.append(captured.value.payload)
+
+    click_gate = asyncio.Event()
+    manager.call_gates["click"] = click_gate
+    first = asyncio.create_task(
+        service.confirm_approval(project_id, approvals[0]["approval_id"])
+    )
+    for _ in range(100):
+        if any(call[1] == "click" for call in manager.calls):
+            break
+        await asyncio.sleep(0)
+    second = asyncio.create_task(
+        service.confirm_approval(project_id, approvals[1]["approval_id"])
+    )
+    await asyncio.sleep(0)
+    manager.tool_results["browser_session_status"] = browser_status_result(
+        page_revision=2,
+        page_digest="b" * 64,
+        action_count=2,
+    )
+    click_gate.set()
+
+    assert (await first)["unknown_outcome"] is False
+    with pytest.raises(catalog.CatalogBrowserStateDriftError, match="已经变化"):
+        await second
+    assert len([call for call in manager.calls if call[1] == "click"]) == 1
+    assert (await service.browser_session_status(project_id))["status"] == "active"
+
+
+@pytest.mark.asyncio
+async def test_wave_seven_rejects_hardlinked_screenshot(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    project_id = "playwright-mcp"
+    manifest = CATALOG_ADAPTERS[project_id]
+    monkeypatch.setenv(manifest.feature_flag, "true")
+    staging_root = tmp_path / "staging"
+    trusted_root = tmp_path / "trusted"
+    service, manager, _, _ = make_service(
+        browser_artifact_staging_root=staging_root,
+        browser_artifact_root=trusted_root,
+        browser_artifact_index_path=trusted_root / "index.json",
+    )
+    manager.tools = browser_tools(project_id)
+    manager.tool_results["browser_session_status"] = browser_status_result()
+    content = b"\x89PNG\r\n\x1a\nhardlink"
+    session_dir = "5" * 32
+    internal_id = "browser_" + "6" * 32
+    registered = staging_root / session_dir / "registered"
+    registered.mkdir(parents=True)
+    source = registered / f"{internal_id}.png"
+    source.write_bytes(content)
+    os.link(source, registered / "second-link.png")
+    manager.tool_results["browser_take_screenshot"] = FakeToolResult(
+        {
+            "content": [],
+            "isError": False,
+            "structuredContent": {
+                "artifact_id": internal_id,
+                "relative_path": f"{session_dir}/registered/{internal_id}.png",
+                "sha256": hashlib.sha256(content).hexdigest(),
+                "size": len(content),
+                "mime": "image/png",
+            },
+        }
+    )
+    await service.connect(project_id)
+
+    with pytest.raises(catalog.CatalogAdapterPolicyError, match="大小校验失败"):
+        await service.call_tool(project_id, "browser_take_screenshot", {})
+    assert not (trusted_root / "files").exists()
+
+
+@pytest.mark.asyncio
+async def test_wave_seven_browser_artifact_quota_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    project_id = "chrome-devtools-mcp"
+    original = CATALOG_ADAPTERS[project_id]
+    assert original.browser_policy is not None
+    limited = replace(
+        original,
+        browser_policy=replace(
+            original.browser_policy,
+            max_artifacts_per_project=0,
+        ),
+    )
+    manifests = dict(CATALOG_ADAPTERS)
+    manifests[project_id] = limited
+    monkeypatch.setenv(limited.feature_flag, "true")
+    staging_root = tmp_path / "staging"
+    trusted_root = tmp_path / "trusted"
+    service, manager, _, _ = make_service(
+        manifests,
+        browser_artifact_staging_root=staging_root,
+        browser_artifact_root=trusted_root,
+        browser_artifact_index_path=trusted_root / "index.json",
+    )
+    manager.tools = browser_tools(project_id)
+    manager.tool_results["browser_session_status"] = browser_status_result()
+    content = b"\x89PNG\r\n\x1a\nquota"
+    session_dir = "7" * 32
+    internal_id = "browser_" + "8" * 32
+    source = staging_root / session_dir / "registered" / f"{internal_id}.png"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(content)
+    manager.tool_results["take_screenshot"] = FakeToolResult(
+        {
+            "content": [],
+            "isError": False,
+            "structuredContent": {
+                "artifact_id": internal_id,
+                "relative_path": f"{session_dir}/registered/{internal_id}.png",
+                "sha256": hashlib.sha256(content).hexdigest(),
+                "size": len(content),
+                "mime": "image/png",
+            },
+        }
+    )
+    await service.connect(project_id)
+
+    with pytest.raises(catalog.CatalogAdapterPolicyError, match="配额"):
+        await service.call_tool(project_id, "take_screenshot", {})
+    assert not source.exists()
+    assert service.list_browser_artifacts(project_id)["total"] == 0
+
+
+def test_wave_seven_artifact_restart_prunes_expired_and_strict_orphans(
+    tmp_path: Path,
+) -> None:
+    trusted_root = tmp_path / "trusted"
+    trusted_files = trusted_root / "files"
+    staging_root = tmp_path / "staging"
+    trusted_files.mkdir(parents=True)
+    content = b"\x89PNG\r\n\x1a\nexpired"
+    expired_id = "mcpbart_" + "a" * 32
+    expired_path = trusted_files / f"{expired_id}.png"
+    expired_path.write_bytes(content)
+    orphan_id = "mcpbart_" + "b" * 32
+    orphan_path = trusted_files / f"{orphan_id}.png"
+    orphan_path.write_bytes(content)
+    staging_id = "browser_" + "c" * 32
+    staging_path = (
+        staging_root
+        / ("d" * 32)
+        / "registered"
+        / f"{staging_id}.png"
+    )
+    staging_path.parent.mkdir(parents=True)
+    staging_path.write_bytes(content)
+    index_path = trusted_root / "index.json"
+    now = 1_700_000_000.0
+    index_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "items": [
+                    {
+                        "artifact_id": expired_id,
+                        "tenant_id": "local",
+                        "owner_id": "local",
+                        "project_id": "chrome-devtools-mcp",
+                        "session_id": "session-old",
+                        "browser_generation": "12345678-1234-4234-9234-123456789abc",
+                        "relative_path": f"files/{expired_id}.png",
+                        "name": "browser-screenshot-expired.png",
+                        "mime_type": "image/png",
+                        "size_bytes": len(content),
+                        "sha256": hashlib.sha256(content).hexdigest(),
+                        "created_at": now - 100,
+                        "expires_at": now - 1,
+                    }
+                ],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    service, _, _, _ = make_service(
+        browser_artifact_staging_root=staging_root,
+        browser_artifact_root=trusted_root,
+        browser_artifact_index_path=index_path,
+    )
+
+    assert service.list_browser_artifacts("chrome-devtools-mcp")["total"] == 0
+    assert not expired_path.exists()
+    assert not orphan_path.exists()
+    assert not staging_path.exists()
+    assert json.loads(index_path.read_text(encoding="utf-8"))["items"] == []
+
+
+@pytest.mark.asyncio
+async def test_wave_seven_rejects_snapshot_drift_and_taints_ambiguous_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_id = "chrome-devtools-mcp"
+    manifest = CATALOG_ADAPTERS[project_id]
+    monkeypatch.setenv(manifest.feature_flag, "true")
+    service, manager, _, _ = make_service()
+    manager.tools = browser_tools(project_id)
+    manager.tool_results["browser_session_status"] = browser_status_result()
+    await service.connect(project_id)
+    service._browser_elements[service._scope_key(project_id)] = {
+        "submit": {
+            "role": "button",
+            "label": "提交",
+            "page_digest": "a" * 64,
+        }
+    }
+
+    with pytest.raises(catalog.CatalogApprovalRequiredError) as drifted_error:
+        await service.call_tool(project_id, "click", {"ref": "submit"})
+    manager.tool_results["browser_session_status"] = browser_status_result(
+        page_revision=2,
+        page_digest="b" * 64,
+        action_count=2,
+    )
+    with pytest.raises(catalog.CatalogAdapterPolicyError, match="已经变化"):
+        await service.confirm_approval(
+            project_id,
+            drifted_error.value.payload["approval_id"],
+        )
+    assert not [call for call in manager.calls if call[1] == "click"]
+
+    manager.tool_results["browser_session_status"] = browser_status_result()
+    await service.browser_session_status(project_id)
+    service._browser_elements[service._scope_key(project_id)] = {
+        "submit": {
+            "role": "button",
+            "label": "提交",
+            "page_digest": "a" * 64,
+        }
+    }
+    with pytest.raises(catalog.CatalogApprovalRequiredError) as unknown_error:
+        await service.call_tool(project_id, "click", {"ref": "submit"})
+    manager.tool_errors["click"] = TimeoutError("ambiguous")
+    with pytest.raises(CatalogUnknownOutcomeError):
+        await service.confirm_approval(
+            project_id,
+            unknown_error.value.payload["approval_id"],
+        )
+    status = await service.browser_session_status(project_id)
+    assert status["status"] == "tainted"
+    assert service._scope_key(project_id) not in service._sessions
+
+
+@pytest.mark.asyncio
+async def test_wave_seven_expired_sidecar_session_is_forgotten_and_reconnects(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_id = "playwright-mcp"
+    manifest = CATALOG_ADAPTERS[project_id]
+    monkeypatch.setenv(manifest.feature_flag, "true")
+    service, manager, _, registry = make_service()
+    manager.tools = browser_tools(project_id)
+    manager.tool_results["browser_session_status"] = browser_status_result()
+    first = await service.connect(project_id)
+    manager.tool_errors["browser_session_status"] = catalog.MCPClientError(
+        "MCP session is not running."
+    )
+
+    expired = await service.browser_session_status(project_id)
+
+    assert expired["status"] == "disconnected"
+    assert expired["reason"] == "expired"
+    assert service._scope_key(project_id) not in service._sessions
+    assert first["session_id"] in registry.unregistered
+    manager.tool_errors.pop("browser_session_status")
+    manager.tool_results["browser_session_status"] = browser_status_result(
+        generation="87654321-4321-4321-8321-cba987654321",
+        current_origin="https://next.example.com",
+    )
+    second = await service.connect(project_id)
+    assert second["session_id"] != first["session_id"]
+    assert second["preflight_status"] == "verified"
+    assert second["browser_session"]["approved_hosts"] == ["next.example.com"]
+
+
+@pytest.mark.asyncio
+async def test_wave_seven_malformed_status_taints_and_forgets_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_id = "playwright-mcp"
+    manifest = CATALOG_ADAPTERS[project_id]
+    monkeypatch.setenv(manifest.feature_flag, "true")
+    service, manager, _, registry = make_service()
+    manager.tools = browser_tools(project_id)
+    manager.tool_results["browser_session_status"] = browser_status_result()
+    connected = await service.connect(project_id)
+    manager.tool_results["browser_session_status"] = browser_status_result(
+        generation="not-a-uuid",
+    )
+
+    with pytest.raises(catalog.CatalogAdapterPolicyError, match="安全契约"):
+        await service.browser_session_status(project_id)
+
+    scope_key = service._scope_key(project_id)
+    assert scope_key not in service._sessions
+    assert service._preflight_status[scope_key] == "failed"
+    assert connected["session_id"] in manager.disconnected
+    assert connected["session_id"] in registry.unregistered
+
+
+@pytest.mark.asyncio
+async def test_wave_seven_disconnect_failure_keeps_session_but_blocks_calls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_id = "chrome-devtools-mcp"
+    manifest = CATALOG_ADAPTERS[project_id]
+    monkeypatch.setenv(manifest.feature_flag, "true")
+    service, manager, _, _ = make_service()
+    manager.tools = browser_tools(project_id)
+    manager.tool_results["browser_session_status"] = browser_status_result()
+    connected = await service.connect(project_id)
+    manager.disconnect_error = catalog.MCPClientError("disconnect failed")
+
+    with pytest.raises(catalog.MCPClientError, match="disconnect failed"):
+        await service.disconnect(project_id)
+
+    scope_key = service._scope_key(project_id)
+    assert service._sessions[scope_key] == connected["session_id"]
+    status_item = next(
+        item
+        for item in service.list_adapters()["adapters"]
+        if item["project_id"] == project_id
+    )
+    assert status_item["connected"] is True
+    assert status_item["preflight_status"] == "failed"
+    with pytest.raises(catalog.CatalogAdapterPolicyError, match="尚未验证"):
+        await service.call_tool(project_id, "take_snapshot", {})
+
+    manager.disconnect_error = None
+    assert (await service.browser_session_status(project_id))["status"] == "active"
+    assert (await service.disconnect(project_id))["ok"] is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("ledger_state", ["completed", "unknown"])
+async def test_approval_ledger_replay_is_project_scoped(
+    monkeypatch: pytest.MonkeyPatch,
+    ledger_state: str,
+) -> None:
+    source_project = "chrome-devtools-mcp"
+    target_project = "playwright-mcp"
+    monkeypatch.setenv(CATALOG_ADAPTERS[target_project].feature_flag, "true")
+    service, _, _, _ = make_service()
+    approval_id = "mcpauth_" + "9" * 32
+    service._execution_ledger[service._approval_key(approval_id)] = (
+        catalog.CatalogExecutionLedgerEntry(
+            approval_id=approval_id,
+            tenant_id=service.tenant_id,
+            owner_id=service.owner_id,
+            project_id=source_project,
+            idempotency_key="mcpidem_" + "a" * 32,
+            state=ledger_state,
+            result={"content": [], "is_error": False}
+            if ledger_state == "completed"
+            else None,
+        )
+    )
+
+    with pytest.raises(catalog.CatalogAdapterPolicyError, match="不存在"):
+        await service.confirm_approval(target_project, approval_id)
 
 
 @pytest.mark.asyncio
@@ -340,9 +1392,9 @@ async def test_catalog_api_hides_execution_details_and_rejects_planned_connect()
             assert response.status_code == 200
             payload = response.json()
             assert payload["total"] == 100
-            assert payload["ready"] == 42
-            assert payload["planned"] == 47
-            assert payload["blocked"] == 11
+            assert payload["ready"] == 44
+            assert payload["planned"] == 43
+            assert payload["blocked"] == 13
             serialized = response.text.lower()
             assert "server_command" not in serialized
             assert "install_command" not in serialized


### PR DESCRIPTION
## 概要

- 新增 Chrome DevTools MCP 1.6.0 与 Playwright MCP 0.0.79 的隔离浏览器适配器；Puppeteer 与 Selenium 保持 blocked。
- 引入独立 browser/egress 双 sidecar、一次性会话、固定工具与 schema digest、逐次审批、可信截图导入和项目级配额。
- 浏览器容器保持 `network_mode: none`，出口层执行公网 DNS 全答案复验、IP pin、单 Origin、Host/SNI/ECH 校验、字节/隧道/时限预算。
- 新增目录专用 tools/status/artifact/unbind API，以及浏览器状态、审批、截图下载与清理 UI。

## 根因与修复

本轮实测中的“浏览器操作结果未知”由三类假阳性叠加触发：

1. Chromium 内部 GCM 探测被代理正确 403 后污染当前工具结果。
2. 服务端导入截图后误删 sidecar 固定 `registered/` 目录，后续状态检查被判为未登记产物。
3. Playwright 初始 `about:blank` 快照省略空标题，严格解析器将首次状态检查错误标记为污染。

修复后，后台探测仍在本地 403、不会进入 DNS/出口；仅对精确且有界的 Chromium 内部探测不污染会话。截图导入只删除源 PNG，保留固定目录结构；初始空白页只允许唯一 URL 且缺失空标题，其他页面继续 fail closed。

## 安全边界

- 非 root、cap-drop ALL、只读根、NNP、定制 seccomp、Landlock 和 procfs 动态负向探针。
- 禁止任意命令、启动参数、Header、代理/CDP、脚本求值、上传、下载、剪贴板和登录流程。
- 写操作冻结参数并一次性审批；超时或歧义结果销毁会话且不自动重试。
- ECH 由 Chromium policy、profile 状态和启动参数多层关闭；egress 仍拒绝实际 ECH。
- 会话结束后 browser/egress 成对轮换，清除 Chromium、Node、profile 与 staging artifact。

## 验证

- `client/npm.cmd run build`：通过（3063 modules）
- Python `py_compile`：通过
- `test_mcp_browser_sidecar.py + test_mcp_catalog.py`：**168 passed**
- Fresh isolated runtime：双适配器正常会话、真实 timeout/unknown-outcome、精确重启和清理均通过
- UI 真实输入 `https://example.com/`：
  - 导航结果 `Example Domain`
  - 闲置 35 秒后快照仍返回 `Learn more`
  - PNG 截图 15,909 bytes，SHA-256 `6cc928b05a53a95e6adfc303397a58a426b32b638810d93edbf1fb9dc2a833c0`
  - 结束会话后 browser/egress healthy，仅剩 supervisor PID1，`/profiles` 与 `/artifacts` 为空
- 已变基到最新 `main`；`git diff --check` 通过

## 发布说明

功能仍由全局单用户确认与项目级开关双门禁控制，默认失败关闭。隔离 preview override 未纳入提交。