### PR TITLE
feature: 添加针对性 Xpert 评测集生成与校准

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Do not use for: refactoring, writing scripts from scratch, debugging business lo
 
 本文件是模镜仓库内 AI Agent、人类开发者和自动化任务的项目级操作说明。任何代码生成、重构、测试、提交和发布都必须优先遵守本文档。
 
-最后更新日期：2026-08-07
+最后更新日期：2026-08-08
 维护人：模镜团队
 
 ## 1. 项目边界
@@ -375,8 +375,45 @@ npm.cmd run build
 - 旧 Dataset 缺少元数据时必须按 `origin=manual` 兼容读取，不得要求破坏性离线迁移。
 - 后续定向生成必须固定目标 revision/version、能力摘要、模型、资源版本和 Dataset revision；
   生成结果只能进入待审核草稿，不得批准 Proposal、修改线上 Xpert 或自动发布。
+- 定向生成只允许一次生成和一次 JSON 修复。生成任务必须保存安全 Job 状态；重启后应
+  复用相同 generation job 已落盘的数据集，不能重复创建草稿。
+- 固定目标必须编译为安全 `target_anchors` 和有限专业 `focus_terms`。每条模型生成用例必须
+  引用真实锚点、声明 1–3 项能力矩阵，并由服务端证明输入包含精确专业词或至少两个锚点专业
+  标记，同时说明针对性理由、压力点
+  与通用底模区分证据，并标记 `basic / edge / adversarial`。不得接受无法关联目标 Prompt、
+  契约或资源的通用常识题，也不得允许模型发明锚点外专业词。
+- Benchmark 解析器只能确定性规范化 targeting 派生元数据，并必须写入可见的
+  `normalization_notes`；严禁在规范化中改写题目、历史、Gold、JSON Schema、工具期望或难度。
+  找不到真实 anchor、合法能力或足够题面专业证据时必须 fail-closed。工具名、知识文档名和
+  Prompt Command 别名必须保持精确匹配，不能被语义近似放宽。
+- 定向生成必须先由服务端生成逐题 Blueprint，固定能力矩阵、难度、真实资源锚点和压力类型；
+  模型不得决定或扩大授权范围。结构输出、多轮、工具、知识引用和 Prompt Command 必须分别
+  具有可机器验证的 Schema、历史、固定工具名、固定文档名和 `/alias` 证据。
+- Blueprint 固定的 locale、coverage、target refs、工具必选/禁用集合、知识文档和 JSON Schema
+  必须由服务端注入；不要要求模型重复回传这些字段。模型输出只承担题面、历史、解释字段及
+  不依赖固定资源的文本 Gold。
+- Toolset、Knowledge 和 Prompt Command 能力只有在固定版本可解析出安全工具名、文档名或命令
+  别名时才可进入生成覆盖；缺少可验证 Gold 来源时不得让模型猜测 ID 或名称。
+- 用例数不少于 6 时，edge 与 adversarial 各不得少于 25%，basic 不得超过 30%，且每个
+  用户选择的覆盖项至少出现一次。选择两个以上能力时，至少 60% 用例必须组合多个能力，
+  每项能力须出现在组合题中，并在可行时形成至少三种组合。针对性证据和固定基线逐例分数
+  必须在管理 UI 可检查。
+- 会话样例只能由用户显式选择；传给生成器的能力快照不得包含附件正文、长期记忆、
+  私有工具输出、凭据或物理路径。`tool_call_match` 只能保存工具名和稳定顺序，禁止保存
+  参数或结果。
 - 校准只能验证评分契约、重复、泄漏、难度和基线表现，不得使用当前回答或 Top-K 结果
-  改写预先固定的 Gold。
+  改写预先固定的 Gold。针对性校准必须同时执行同模型通用对照：保留工作流骨架与输出契约，
+  移除领域 Prompt、命令和资源绑定；默认专业目标至少领先 `0.10`，否则产生 warning。
+- JSON 生成器兼容推理模型时，只能从 provider-specific reasoning 字段提取一个可解析 JSON
+  对象，不得返回、持久化或记录外围推理文本；普通聊天不得启用该兼容路径。
+- 生成失败必须先依据安全诊断区分空响应、契约缺失和截断：仅允许持久化 `finish_reason`、
+  content/reasoning 字符数、契约存在性、候选顶层键名和标准 token usage。不得保存 reasoning
+  正文，也不得以增加重试次数或无依据提高 token 上限代替根因修复；可恢复错误只消费既有的
+  一次 JSON 修复机会。
+- Benchmark 生成与修复调用使用低 reasoning effort，为结构化正文保留 completion 预算；
+  不得把该设置扩散到普通聊天、Evaluator 或其他模型调用路径。
+- 生成 Dataset 仅在同 revision 校准为 `calibrated` 后可发布；`warning` 必须由用户显式
+  确认，`pending / failed / stale` 必须阻断。编辑用例或目标 checksum 漂移后必须重新校准。
 - Benchmark API、报告和 checkpoint 不得保存完整 Prompt、知识正文、工具参数/结果、隐藏
   推理、路径、凭据或未选择的会话内容。
 - `server/Dockerfile` 必须复制 `benchmarks/`。每轮在完成非 Docker 验证后停止，等待用户
@@ -384,7 +421,7 @@ npm.cmd run build
 - 修改 Benchmark Catalog 或 Dataset 元数据时至少运行：
 
 ```bash
-python -m pytest server/tests/test_benchmark_catalog.py server/tests/test_xpert_evaluations.py -q
+python -m pytest server/tests/test_benchmark_catalog.py server/tests/test_benchmark_generator.py server/tests/test_xpert_evaluations.py -q
 cd client
 npm.cmd run build
 ```

--- a/client/src/components/evaluations/BenchmarkGeneratorPanel.tsx
+++ b/client/src/components/evaluations/BenchmarkGeneratorPanel.tsx
@@ -1,0 +1,788 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  LoaderCircle,
+  Play,
+  RefreshCw,
+  Sparkles,
+  Square,
+} from "lucide-react";
+import { models } from "../../data/models";
+import { listXpertVersions, listXperts } from "../../utils/xpertApi";
+import { type XpertSummary } from "../../types/xpert";
+
+type TargetKind = "xpert_draft" | "xpert_version" | "proposal" | "prompt_profile";
+
+interface PromptProfileSummary {
+  id: string;
+  name: string;
+  draft_revision: number;
+  status: string;
+}
+
+interface ProposalSummary {
+  proposal_id: string;
+  revision: number;
+  title: string;
+  kind: string;
+  status: string;
+}
+
+interface VersionOption {
+  key: string;
+  xpert_id: string;
+  version: number;
+  label: string;
+}
+
+interface GenerationJob {
+  job_id: string;
+  status: string;
+  dataset_id?: string | null;
+  dataset_revision?: number | null;
+  evaluation_run_id?: string | null;
+  target?: { label?: string };
+  generation?: {
+    case_count?: number;
+    repair_used?: boolean;
+    assumptions?: string[];
+    targeting?: TargetingSummary;
+  };
+  calibration?: {
+    status?: string;
+    baseline_score?: number;
+    generic_counterfactual_score?: number | null;
+    targeting_advantage?: number | null;
+    easy_count?: number;
+    hard_count?: number;
+    warnings?: string[];
+  };
+  error?: string | null;
+  created_at: number;
+}
+
+interface TargetAnchor {
+  id: string;
+  kind: string;
+  axis?: string;
+  label: string;
+  summary: string;
+  focus_terms?: string[];
+  coverage: string[];
+}
+
+interface TargetingSummary {
+  difficulty_counts?: Record<string, number>;
+  target_ref_counts?: Record<string, number>;
+  coverage_counts?: Record<string, number>;
+  capability_matrix_counts?: Record<string, number>;
+  combined_case_count?: number;
+  combined_capabilities?: string[];
+  focus_term_counts?: Record<string, number>;
+  cases_with_focus?: number;
+  pressure_type_counts?: Record<string, number>;
+  discriminator_count?: number;
+  blueprint_case_count?: number;
+  normalized_case_count?: number;
+  normalization_note_counts?: Record<string, number>;
+  target_anchor_count?: number;
+  missing_count?: number;
+}
+
+interface GeneratedCase {
+  case_id: string;
+  name: string;
+  messages: Array<{ role: string; content: string }>;
+  message: string;
+  tags: string[];
+  expected: Record<string, unknown>;
+  targeting?: {
+    blueprint_id?: string;
+    difficulty: "basic" | "edge" | "adversarial";
+    target_refs: string[];
+    capability_matrix?: string[];
+    focus_terms?: string[];
+    pressure_types?: string[];
+    rationale: string;
+    challenge?: string;
+    discriminator?: string;
+    normalization_notes?: string[];
+  };
+}
+
+interface GeneratedDatasetDetail {
+  dataset_id: string;
+  cases: GeneratedCase[];
+  coverage?: {
+    target_anchors?: TargetAnchor[];
+  };
+}
+
+interface EvaluationRunDetail {
+  targets?: Array<{ target_id: string; benchmark_counterfactual?: boolean }>;
+  items?: Array<{
+    target_id: string;
+    case_id: string;
+    status: string;
+    score?: number;
+    metrics?: Array<{ kind: string; score?: number; passed?: boolean }>;
+    error?: string | null;
+  }>;
+}
+
+interface PreflightResult {
+  valid: boolean;
+  target?: { label?: string; checksum?: string } | null;
+  coverage: {
+    available: string[];
+    recommended: string[];
+    reasons?: Record<string, string>;
+  };
+  target_anchors?: TargetAnchor[];
+  targeting?: {
+    focus_term_count?: number;
+    focus_terms?: string[];
+    domain_anchor_count?: number;
+    resource_anchor_count?: number;
+  };
+  conversation_seed_count: number;
+  warnings: string[];
+  issues: Array<{ message: string }>;
+}
+
+interface Props {
+  onDatasetReady: (datasetId: string) => Promise<void> | void;
+}
+
+const coverageLabels: Record<string, string> = {
+  instruction_following: "指令遵循",
+  structured_output: "结构输出",
+  multi_turn: "多轮上下文",
+  tool_routing: "工具路由",
+  knowledge_citation: "知识引用",
+  prompt_command: "Prompt Command",
+};
+
+async function requestJson<T>(url: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(url, init);
+  const payload = await response.json().catch(() => null);
+  if (!response.ok) {
+    const detail = payload?.detail;
+    throw new Error(
+      typeof detail === "string"
+        ? detail
+        : detail?.issues?.map((item: { message: string }) => item.message).join("；")
+          || `请求失败：${response.status}`,
+    );
+  }
+  return payload as T;
+}
+
+function postJson(body: unknown): RequestInit {
+  return {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  };
+}
+
+function statusTone(status: string) {
+  if (["completed", "calibrated"].includes(status)) return "border-emerald-300/30 bg-emerald-300/10 text-emerald-100";
+  if (["failed", "stale"].includes(status)) return "border-rose-300/30 bg-rose-300/10 text-rose-100";
+  if (status === "cancelled") return "border-slate-400/20 bg-slate-400/10 text-slate-300";
+  return "border-amber-300/30 bg-amber-300/10 text-amber-100";
+}
+
+function difficultyTone(difficulty?: string) {
+  if (difficulty === "adversarial") return "border-rose-300/30 bg-rose-300/10 text-rose-100";
+  if (difficulty === "edge") return "border-amber-300/30 bg-amber-300/10 text-amber-100";
+  return "border-cyan-300/25 bg-cyan-300/10 text-cyan-100";
+}
+
+function expectationSummary(expected: Record<string, unknown>) {
+  if (typeof expected.exact_answer === "string" && expected.exact_answer) {
+    return `精确答案：${expected.exact_answer}`;
+  }
+  if (Array.isArray(expected.contains) && expected.contains.length) {
+    return `必须包含：${expected.contains.join(" / ")}`;
+  }
+  if (expected.json_schema && typeof expected.json_schema === "object") {
+    return `JSON Schema：${JSON.stringify(expected.json_schema)}`;
+  }
+  if (Array.isArray(expected.required_tools) && expected.required_tools.length) {
+    return `必需工具：${expected.required_tools.join(" → ")}`;
+  }
+  if (Array.isArray(expected.forbidden_tools) && expected.forbidden_tools.length) {
+    return `禁用工具：${expected.forbidden_tools.join("、")}`;
+  }
+  if (Array.isArray(expected.citation_ids) && expected.citation_ids.length) {
+    return `预期引用：${expected.citation_ids.join("、")}`;
+  }
+  return "已配置确定性评分契约";
+}
+
+function calibrationWarningText(warning: string) {
+  if (warning.includes("easy and the fixed target does not outperform")) {
+    return "至少 80% 的样例对专业目标过易，且相对同模型通用对照的优势不足 10 个百分点；当前数据不能证明针对性。";
+  }
+  if (warning.includes("Target-specific advantage")) {
+    return "专业目标相对同模型通用对照的优势不足 10 个百分点，请提高领域约束和判别难度。";
+  }
+  if (warning === "At least 80% of cases are very hard for the fixed baseline.") {
+    return "固定基线在至少 80% 的样例上得分不高于 20%，这些样例实测过难，请核对 Gold 与评分契约。";
+  }
+  return warning;
+}
+
+export default function BenchmarkGeneratorPanel({ onDatasetReady }: Props) {
+  const search = useMemo(() => new URLSearchParams(window.location.search), []);
+  const [targetKind, setTargetKind] = useState<TargetKind>(
+    (search.get("target_kind") as TargetKind) || "xpert_draft",
+  );
+  const [xperts, setXperts] = useState<XpertSummary[]>([]);
+  const [versions, setVersions] = useState<VersionOption[]>([]);
+  const [proposals, setProposals] = useState<ProposalSummary[]>([]);
+  const [profiles, setProfiles] = useState<PromptProfileSummary[]>([]);
+  const [selectedId, setSelectedId] = useState(
+    search.get("target_id") || search.get("xpert_id") || "",
+  );
+  const [hostVersionKey, setHostVersionKey] = useState("");
+  const [generatorModelId, setGeneratorModelId] = useState(models[0]?.id ?? "");
+  const [caseCount, setCaseCount] = useState(12);
+  const [coverage, setCoverage] = useState<string[]>([]);
+  const [preflight, setPreflight] = useState<PreflightResult | null>(null);
+  const [jobs, setJobs] = useState<GenerationJob[]>([]);
+  const [activeJob, setActiveJob] = useState<GenerationJob | null>(null);
+  const [datasetPreview, setDatasetPreview] = useState<GeneratedDatasetDetail | null>(null);
+  const [calibrationRun, setCalibrationRun] = useState<EvaluationRunDetail | null>(null);
+  const [previewError, setPreviewError] = useState("");
+  const [busy, setBusy] = useState("");
+  const [error, setError] = useState("");
+
+  const targetChoices = useMemo(() => {
+    if (targetKind === "xpert_draft") {
+      return xperts
+        .filter((item) => item.status !== "archived")
+        .map((item) => ({ value: item.id, label: `${item.name} · r${item.draft_revision}` }));
+    }
+    if (targetKind === "xpert_version") {
+      return versions.map((item) => ({ value: item.key, label: item.label }));
+    }
+    if (targetKind === "proposal") {
+      return proposals.map((item) => ({
+        value: item.proposal_id,
+        label: `${item.title} · r${item.revision}`,
+      }));
+    }
+    return profiles.map((item) => ({
+      value: item.id,
+      label: `${item.name} · r${item.draft_revision}`,
+    }));
+  }, [profiles, proposals, targetKind, versions, xperts]);
+
+  const targetAnchors = useMemo(
+    () => datasetPreview?.coverage?.target_anchors ?? [],
+    [datasetPreview],
+  );
+  const anchorsById = useMemo(
+    () => new Map(targetAnchors.map((anchor) => [anchor.id, anchor])),
+    [targetAnchors],
+  );
+  const calibrationByCase = useMemo(() => {
+    const genericTargetId = calibrationRun?.targets?.find((item) => item.benchmark_counterfactual)?.target_id;
+    const grouped = new Map<string, { specialist: Array<{ score: number; status: string; error?: string | null }>; generic: Array<{ score: number; status: string; error?: string | null }> }>();
+    for (const item of calibrationRun?.items ?? []) {
+      const values = grouped.get(item.case_id) ?? { specialist: [], generic: [] };
+      const bucket = item.target_id === genericTargetId ? values.generic : values.specialist;
+      bucket.push({ score: Number(item.score ?? 0), status: item.status, error: item.error });
+      grouped.set(item.case_id, values);
+    }
+    return new Map(
+      [...grouped.entries()].map(([caseId, values]) => [
+        caseId,
+        {
+          score: values.specialist.length ? values.specialist.reduce((total, item) => total + item.score, 0) / values.specialist.length : 0,
+          genericScore: values.generic.length ? values.generic.reduce((total, item) => total + item.score, 0) / values.generic.length : null,
+          status: values.specialist.every((item) => item.status === "completed") ? "completed" : values.specialist[0]?.status,
+          error: values.specialist.find((item) => item.error)?.error,
+        },
+      ]),
+    );
+  }, [calibrationRun]);
+
+  useEffect(() => {
+    void loadOptions();
+    void loadJobs();
+  }, []);
+
+  useEffect(() => {
+    if (!activeJob || ["completed", "failed", "cancelled"].includes(activeJob.status)) return;
+    const timer = window.setInterval(() => void refreshJob(activeJob.job_id), 1500);
+    return () => window.clearInterval(timer);
+  }, [activeJob?.job_id, activeJob?.status]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setDatasetPreview(null);
+    setCalibrationRun(null);
+    setPreviewError("");
+    if (!activeJob?.dataset_id) return () => { cancelled = true; };
+    const loadPreview = async () => {
+      try {
+        const [dataset, run] = await Promise.all([
+          requestJson<GeneratedDatasetDetail>(
+            `/api/xpert-evaluations/datasets/${activeJob.dataset_id}`,
+          ),
+          activeJob.evaluation_run_id
+            ? requestJson<EvaluationRunDetail>(
+              `/api/xpert-evaluations/runs/${activeJob.evaluation_run_id}`,
+            )
+            : Promise.resolve(null),
+        ]);
+        if (!cancelled) {
+          setDatasetPreview(dataset);
+          setCalibrationRun(run);
+        }
+      } catch (caught) {
+        if (!cancelled) {
+          setPreviewError(caught instanceof Error ? caught.message : "样例证据加载失败。");
+        }
+      }
+    };
+    void loadPreview();
+    return () => { cancelled = true; };
+  }, [activeJob?.dataset_id, activeJob?.evaluation_run_id, activeJob?.status]);
+
+  useEffect(() => {
+    setPreflight(null);
+    setCoverage([]);
+    if (!selectedId && targetChoices[0]) setSelectedId(targetChoices[0].value);
+  }, [targetKind, targetChoices, selectedId]);
+
+  async function loadOptions() {
+    setError("");
+    try {
+      const [xpertPayload, proposalPayload, profilePayload] = await Promise.all([
+        listXperts({ status: "all", limit: 200 }),
+        requestJson<{ items: ProposalSummary[] }>(
+          "/api/runtime/authoring-proposals?status=pending&limit=200",
+        ),
+        requestJson<{ items: PromptProfileSummary[] }>("/api/prompt-profiles?limit=200"),
+      ]);
+      setXperts(xpertPayload.items);
+      setProposals(
+        proposalPayload.items.filter((item) =>
+          ["xpert_create", "xpert_update"].includes(item.kind),
+        ),
+      );
+      setProfiles(profilePayload.items.filter((item) => item.status !== "archived"));
+      const groups = await Promise.all(
+        xpertPayload.items
+          .filter((item) => item.published_version)
+          .map(async (xpert) => ({ xpert, versions: await listXpertVersions(xpert.id) })),
+      );
+      const nextVersions = groups.flatMap(({ xpert, versions: items }) =>
+        items.map((version) => ({
+          key: `${xpert.id}:${version.version}`,
+          xpert_id: xpert.id,
+          version: version.version,
+          label: `${xpert.name} v${version.version}`,
+        })),
+      );
+      setVersions(nextVersions);
+      setHostVersionKey((current) => current || nextVersions[0]?.key || "");
+      if (!selectedId) {
+        const preferred =
+          search.get("prompt_profile_id")
+          || search.get("proposal_id")
+          || search.get("xpert_id");
+        setSelectedId(preferred || xpertPayload.items[0]?.id || "");
+      }
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "生成目标加载失败。");
+    }
+  }
+
+  async function loadJobs() {
+    const payload = await requestJson<{ items: GenerationJob[] }>(
+      "/api/benchmarks/generations?limit=30",
+    );
+    setJobs(payload.items);
+    setActiveJob((current) => current ?? payload.items[0] ?? null);
+  }
+
+  function targetPayload() {
+    if (targetKind === "xpert_draft") {
+      const target = xperts.find((item) => item.id === selectedId);
+      if (!target) throw new Error("请选择 Xpert 草稿。");
+      return {
+        kind: targetKind,
+        xpert_id: target.id,
+        draft_revision: target.draft_revision,
+        label: `${target.name} draft`,
+      };
+    }
+    if (targetKind === "xpert_version") {
+      const target = versions.find((item) => item.key === selectedId);
+      if (!target) throw new Error("请选择已发布 Xpert 版本。");
+      return {
+        kind: targetKind,
+        xpert_id: target.xpert_id,
+        version: target.version,
+        label: target.label,
+      };
+    }
+    if (targetKind === "proposal") {
+      const target = proposals.find((item) => item.proposal_id === selectedId);
+      if (!target) throw new Error("请选择 Authoring Proposal。");
+      return {
+        kind: targetKind,
+        proposal_id: target.proposal_id,
+        proposal_revision: target.revision,
+        label: target.title,
+      };
+    }
+    const profile = profiles.find((item) => item.id === selectedId);
+    const host = versions.find((item) => item.key === hostVersionKey);
+    if (!profile || !host) throw new Error("请选择 Prompt Profile 与固定宿主版本。");
+    return {
+      kind: targetKind,
+      prompt_profile_id: profile.id,
+      prompt_profile_revision: profile.draft_revision,
+      host_xpert_id: host.xpert_id,
+      host_xpert_version: host.version,
+      label: `${profile.name} via ${host.label}`,
+    };
+  }
+
+  async function analyze() {
+    setBusy("preflight");
+    setError("");
+    try {
+      const result = await requestJson<PreflightResult>(
+        "/api/benchmarks/generations/preflight",
+        postJson({ target: targetPayload(), coverage, conversation_selections: [] }),
+      );
+      setPreflight(result);
+      if (!result.valid) throw new Error(result.issues.map((item) => item.message).join("；"));
+      setCoverage((current) => current.length ? current : result.coverage.recommended);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "目标分析失败。");
+    } finally {
+      setBusy("");
+    }
+  }
+
+  async function createGeneration() {
+    setBusy("generate");
+    setError("");
+    try {
+      const created = await requestJson<GenerationJob>(
+        "/api/benchmarks/generations",
+        postJson({
+          target: targetPayload(),
+          generator_model_id: generatorModelId,
+          case_count: caseCount,
+          locales: ["zh-CN", "en-US"],
+          coverage,
+          conversation_selections: [],
+          seed: 0,
+        }),
+      );
+      setActiveJob(created);
+      setJobs((current) => [created, ...current]);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "生成任务创建失败。");
+    } finally {
+      setBusy("");
+    }
+  }
+
+  async function refreshJob(jobId: string) {
+    try {
+      const item = await requestJson<GenerationJob>(`/api/benchmarks/generations/${jobId}`);
+      setActiveJob(item);
+      setJobs((current) => [item, ...current.filter((job) => job.job_id !== item.job_id)]);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "生成进度加载失败。");
+    }
+  }
+
+  async function cancelJob() {
+    if (!activeJob) return;
+    const item = await requestJson<GenerationJob>(
+      `/api/benchmarks/generations/${activeJob.job_id}/cancel`,
+      { method: "POST" },
+    );
+    setActiveJob(item);
+  }
+
+  return (
+    <div className="grid min-w-0 gap-5 xl:grid-cols-[minmax(0,1fr)_380px]">
+      <section className="min-w-0 space-y-5">
+        <div className="border-b border-white/10 pb-4">
+          <div className="flex items-center gap-2 text-sm font-semibold text-white">
+            <Sparkles className="h-4 w-4 text-cyan-200" />针对目标生成评测集
+          </div>
+          <p className="mt-2 text-xs leading-5 text-slate-400">
+            生成结果先进入草稿，并自动以固定目标运行一次校准。校准不会用当前回答改写 Gold。
+          </p>
+        </div>
+
+        {error ? (
+          <p className="rounded-md border border-rose-300/25 bg-rose-300/10 px-3 py-2 text-xs text-rose-100">{error}</p>
+        ) : null}
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="text-xs font-semibold text-slate-300">
+            目标类型
+            <select className="mt-1 h-10 w-full rounded-md border border-white/10 bg-ink-950 px-3 text-sm text-white" onChange={(event) => { setTargetKind(event.target.value as TargetKind); setSelectedId(""); }} value={targetKind}>
+              <option value="xpert_draft">Xpert 草稿</option>
+              <option value="xpert_version">已发布 Xpert 版本</option>
+              <option value="proposal">Authoring Proposal</option>
+              <option value="prompt_profile">Prompt Profile</option>
+            </select>
+          </label>
+          <label className="text-xs font-semibold text-slate-300">
+            评测对象
+            <select className="mt-1 h-10 w-full rounded-md border border-white/10 bg-ink-950 px-3 text-sm text-white" onChange={(event) => { setSelectedId(event.target.value); setPreflight(null); setCoverage([]); }} value={selectedId}>
+              <option value="">请选择</option>
+              {targetChoices.map((item) => <option key={item.value} value={item.value}>{item.label}</option>)}
+            </select>
+          </label>
+        </div>
+
+        {targetKind === "prompt_profile" ? (
+          <label className="block text-xs font-semibold text-slate-300">
+            固定评测宿主 XpertVersion
+            <select className="mt-1 h-10 w-full rounded-md border border-white/10 bg-ink-950 px-3 text-sm text-white" onChange={(event) => setHostVersionKey(event.target.value)} value={hostVersionKey}>
+              {versions.map((item) => <option key={item.key} value={item.key}>{item.label}</option>)}
+            </select>
+          </label>
+        ) : null}
+
+        <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_180px]">
+          <label className="text-xs font-semibold text-slate-300">
+            生成模型
+            <select className="mt-1 h-10 w-full rounded-md border border-white/10 bg-ink-950 px-3 text-sm text-white" onChange={(event) => setGeneratorModelId(event.target.value)} value={generatorModelId}>
+              {models.map((model) => <option key={model.id} value={model.id}>{model.name}</option>)}
+            </select>
+          </label>
+          <label className="text-xs font-semibold text-slate-300">
+            用例数量
+            <input className="mt-1 h-10 w-full rounded-md border border-white/10 bg-ink-950 px-3 text-sm text-white" max={30} min={6} onChange={(event) => setCaseCount(Number(event.target.value))} type="number" value={caseCount} />
+          </label>
+        </div>
+
+        <div>
+          <div className="flex items-center justify-between gap-3">
+            <span className="text-xs font-semibold text-slate-300">覆盖矩阵</span>
+            <button className="inline-flex items-center gap-2 rounded-md border border-white/10 px-3 py-2 text-xs text-slate-200" disabled={!selectedId || busy === "preflight"} onClick={() => void analyze()} type="button">
+              {busy === "preflight" ? <LoaderCircle className="h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="h-3.5 w-3.5" />}分析目标
+            </button>
+          </div>
+          <div className="mt-3 grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+            {(preflight?.coverage.available ?? Object.keys(coverageLabels)).map((item) => {
+              const available = !preflight || preflight.coverage.available.includes(item);
+              return (
+                <label className={`flex items-center gap-2 rounded-md border px-3 py-2 text-xs ${available ? "border-white/10 bg-white/[0.03] text-slate-200" : "border-white/5 text-slate-600"}`} key={item}>
+                  <input checked={coverage.includes(item)} disabled={!available} onChange={(event) => setCoverage((current) => event.target.checked ? [...current, item] : current.filter((value) => value !== item))} type="checkbox" />
+                  {coverageLabels[item] ?? item}
+                </label>
+              );
+            })}
+          </div>
+          {preflight?.target_anchors?.length ? (
+            <div className="mt-4 border-t border-white/10 pt-4">
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-xs font-semibold text-slate-300">固定目标锚点</span>
+                <span className="text-[11px] text-slate-500">生成样例必须逐条引用</span>
+              </div>
+              <div className="mt-2 grid gap-2 md:grid-cols-2">
+                {preflight.target_anchors.map((anchor) => (
+                  <div className="min-w-0 border-l-2 border-cyan-300/35 pl-3" key={anchor.id}>
+                    <div className="flex min-w-0 items-center gap-2">
+                      <span className="truncate text-xs font-semibold text-slate-200">{anchor.label}</span>
+                      <span className="shrink-0 font-mono text-[9px] text-slate-500">{anchor.kind}</span>
+                      {anchor.axis ? <span className="shrink-0 rounded border border-white/10 px-1.5 py-0.5 text-[9px] text-slate-500">{anchor.axis}</span> : null}
+                    </div>
+                    <p className="mt-1 line-clamp-2 text-[11px] leading-4 text-slate-500">{anchor.summary}</p>
+                    {anchor.focus_terms?.length ? (
+                      <div className="mt-2 flex flex-wrap gap-1">
+                        {anchor.focus_terms.slice(0, 6).map((term) => (
+                          <span className="rounded bg-cyan-300/10 px-1.5 py-0.5 text-[9px] text-cyan-100" key={`${anchor.id}-${term}`}>{term}</span>
+                        ))}
+                      </div>
+                    ) : null}
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : null}
+        </div>
+
+        <button className="inline-flex w-full items-center justify-center gap-2 rounded-md bg-cyan-300 px-4 py-3 text-sm font-semibold text-ink-950 disabled:cursor-not-allowed disabled:opacity-50" disabled={!selectedId || !generatorModelId || coverage.length === 0 || Boolean(busy)} onClick={() => void createGeneration()} type="button">
+          {busy === "generate" ? <LoaderCircle className="h-4 w-4 animate-spin" /> : <Play className="h-4 w-4" />}生成并自动校准
+        </button>
+
+        {activeJob ? (
+          <article className="border-t border-white/10 pt-5">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <p className="text-sm font-semibold text-white">{activeJob.target?.label || "生成任务"}</p>
+                <p className="mt-1 font-mono text-[10px] text-slate-500">{activeJob.job_id}</p>
+              </div>
+              <span className={`rounded border px-2 py-1 text-[11px] ${statusTone(activeJob.status)}`}>{activeJob.status}</span>
+            </div>
+            <div className="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+              <div className="rounded-md border border-white/10 bg-white/[0.025] p-3 text-xs text-slate-400">生成用例<br /><strong className="text-slate-100">{activeJob.generation?.case_count ?? "-"}</strong></div>
+              <div className="rounded-md border border-white/10 bg-white/[0.025] p-3 text-xs text-slate-400">专业目标<br /><strong className="text-slate-100">{activeJob.calibration?.baseline_score == null ? "-" : `${(activeJob.calibration.baseline_score * 100).toFixed(1)}%`}</strong></div>
+              <div className="rounded-md border border-white/10 bg-white/[0.025] p-3 text-xs text-slate-400">通用对照<br /><strong className="text-slate-100">{activeJob.calibration?.generic_counterfactual_score == null ? "-" : `${(activeJob.calibration.generic_counterfactual_score * 100).toFixed(1)}%`}</strong></div>
+              <div className="rounded-md border border-white/10 bg-white/[0.025] p-3 text-xs text-slate-400">针对性优势<br /><strong className="text-slate-100">{activeJob.calibration?.targeting_advantage == null ? "-" : `${(activeJob.calibration.targeting_advantage * 100).toFixed(1)} pp`}</strong></div>
+            </div>
+            {activeJob.calibration?.warnings?.length ? (
+              <div className="mt-3 flex items-start gap-2 rounded-md border border-amber-300/25 bg-amber-300/10 p-3 text-xs text-amber-100"><AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" /><span>{activeJob.calibration.warnings.map(calibrationWarningText).join("；")}</span></div>
+            ) : null}
+            {previewError ? (
+              <p className="mt-3 rounded-md border border-rose-300/25 bg-rose-300/10 px-3 py-2 text-xs text-rose-100">{previewError}</p>
+            ) : null}
+            {datasetPreview?.cases?.length ? (
+              <section className="mt-5 border-t border-white/10 pt-5">
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <p className="text-sm font-semibold text-white">逐例针对性证据</p>
+                    <p className="mt-1 text-xs leading-5 text-slate-400">
+                      目标锚点来自生成时固定的 Prompt、输出契约或资源配置；校准分数来自同一固定基线的实际执行。
+                    </p>
+                  </div>
+                  <div className="flex flex-wrap gap-2 text-[10px]">
+                    {Object.entries(activeJob.generation?.targeting?.difficulty_counts ?? {}).map(([difficulty, count]) => (
+                      <span className={`rounded border px-2 py-1 ${difficultyTone(difficulty)}`} key={difficulty}>{difficulty} {count}</span>
+                    ))}
+                    <span className="rounded border border-cyan-300/25 px-2 py-1 text-cyan-100">
+                      复合能力 {activeJob.generation?.targeting?.combined_case_count ?? 0}
+                    </span>
+                    <span className="rounded border border-emerald-300/25 px-2 py-1 text-emerald-100">
+                      专业锚定 {activeJob.generation?.targeting?.cases_with_focus ?? 0}
+                    </span>
+                    <span className="rounded border border-violet-300/25 px-2 py-1 text-violet-100">
+                      服务端蓝图 {activeJob.generation?.targeting?.blueprint_case_count ?? 0}
+                    </span>
+                  </div>
+                </div>
+
+                {datasetPreview.cases.some((item) => !item.targeting) ? (
+                  <div className="mt-3 flex items-start gap-2 rounded-md border border-amber-300/25 bg-amber-300/10 p-3 text-xs text-amber-100">
+                    <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                    <span>这是旧契约生成的任务，部分样例没有可验证的目标锚点。请重新生成后再判断针对性。</span>
+                  </div>
+                ) : null}
+
+                <div className="mt-4 divide-y divide-white/10 border-y border-white/10">
+                  {datasetPreview.cases.map((item, index) => {
+                    const targeting = item.targeting;
+                    const result = calibrationByCase.get(item.case_id);
+                    const caseCoverage = targeting?.capability_matrix?.length
+                      ? targeting.capability_matrix
+                      : item.tags.filter((tag) => Boolean(coverageLabels[tag])).slice(0, 1);
+                    return (
+                      <div className="py-4" key={item.case_id}>
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span className="font-mono text-[10px] text-slate-600">#{index + 1}</span>
+                          {targeting?.blueprint_id ? <span className="font-mono text-[9px] text-violet-200/80">{targeting.blueprint_id}</span> : null}
+                          <span className="text-xs font-semibold text-slate-100">{item.name}</span>
+                          {targeting ? <span className={`rounded border px-2 py-0.5 text-[10px] ${difficultyTone(targeting.difficulty)}`}>{targeting.difficulty}</span> : null}
+                          {caseCoverage?.map((capability) => (
+                            <span className="rounded border border-white/10 px-2 py-0.5 text-[10px] text-slate-400" key={`${item.case_id}-${capability}`}>{coverageLabels[capability] ?? capability}</span>
+                          ))}
+                          <span className={`ml-auto rounded border px-2 py-0.5 text-[10px] ${result?.score != null && result.score < 0.95 ? "border-cyan-300/25 text-cyan-100" : "border-amber-300/25 text-amber-100"}`}>
+                            专业 {result?.status === "completed" ? `${(result.score * 100).toFixed(0)}%` : result?.status ?? "待校准"}{result?.genericScore == null ? "" : ` · 通用 ${(result.genericScore * 100).toFixed(0)}%`}
+                          </span>
+                        </div>
+                        {item.messages?.length ? (
+                          <div className="mt-3 border-l-2 border-white/10 pl-3">
+                            <p className="text-[10px] font-semibold uppercase text-slate-500">输入上下文</p>
+                            <div className="mt-1 space-y-1">
+                              {item.messages.map((message, messageIndex) => (
+                                <p className="text-[11px] leading-4 text-slate-500" key={`${item.case_id}-history-${messageIndex}`}>
+                                  <span className="mr-2 font-mono text-slate-600">{message.role}</span>{message.content}
+                                </p>
+                              ))}
+                            </div>
+                          </div>
+                        ) : null}
+                        <p className="mt-2 whitespace-pre-wrap text-xs leading-5 text-slate-300">{item.message}</p>
+                        {targeting ? (
+                          <div className="mt-3 grid gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+                            <div className="border-l-2 border-cyan-300/35 pl-3">
+                              <p className="text-[10px] font-semibold uppercase text-cyan-100">验证目标</p>
+                              <p className="mt-1 text-xs leading-5 text-slate-300">{targeting.rationale}</p>
+                              {targeting.challenge ? <p className="mt-1 text-[11px] leading-4 text-slate-500">压力点：{targeting.challenge}</p> : null}
+                              {targeting.discriminator ? <p className="mt-1 text-[11px] leading-4 text-cyan-100/75">区分证据：{targeting.discriminator}</p> : null}
+                              {targeting.pressure_types?.length ? (
+                                <div className="mt-2 flex flex-wrap gap-1">
+                                  {targeting.pressure_types.map((pressure) => <span className="rounded border border-amber-300/20 px-1.5 py-0.5 text-[9px] text-amber-100" key={`${item.case_id}-${pressure}`}>{pressure}</span>)}
+                                </div>
+                              ) : null}
+                              {targeting.focus_terms?.length ? (
+                                <div className="mt-2 flex flex-wrap gap-1">
+                                  {targeting.focus_terms.map((term) => <span className="rounded bg-emerald-300/10 px-1.5 py-0.5 text-[9px] text-emerald-100" key={`${item.case_id}-${term}`}>{term}</span>)}
+                                </div>
+                              ) : null}
+                              {targeting.normalization_notes?.length ? (
+                                <div className="mt-2 border-l-2 border-amber-300/30 pl-2 text-[10px] leading-4 text-amber-100/80">
+                                  {targeting.normalization_notes.join("; ")}
+                                </div>
+                              ) : null}
+                            </div>
+                            <div className="space-y-2">
+                              {targeting.target_refs.map((ref) => {
+                                const anchor = anchorsById.get(ref);
+                                return (
+                                  <div className="min-w-0" key={ref}>
+                                    <p className="truncate font-mono text-[10px] text-cyan-200">{anchor?.label ?? ref}</p>
+                                    {anchor?.summary ? <p className="mt-0.5 line-clamp-2 text-[11px] leading-4 text-slate-500">{anchor.summary}</p> : null}
+                                  </div>
+                                );
+                              })}
+                            </div>
+                          </div>
+                        ) : null}
+                        <p className="mt-3 text-[11px] leading-4 text-slate-500">Gold：{expectationSummary(item.expected)}</p>
+                        {result?.error ? <p className="mt-1 text-[11px] text-rose-200">{result.error}</p> : null}
+                      </div>
+                    );
+                  })}
+                </div>
+              </section>
+            ) : null}
+            {activeJob.status === "completed" && activeJob.dataset_id ? (
+              <button className="mt-4 inline-flex items-center gap-2 rounded-md border border-emerald-300/25 bg-emerald-300/10 px-3 py-2 text-xs font-semibold text-emerald-100" onClick={() => void onDatasetReady(activeJob.dataset_id!)} type="button"><CheckCircle2 className="h-3.5 w-3.5" />打开评测集草稿</button>
+            ) : null}
+            {!(["completed", "failed", "cancelled"].includes(activeJob.status)) ? (
+              <button className="mt-4 inline-flex items-center gap-2 rounded-md border border-rose-300/25 px-3 py-2 text-xs text-rose-100" onClick={() => void cancelJob()} type="button"><Square className="h-3.5 w-3.5" />取消任务</button>
+            ) : null}
+          </article>
+        ) : null}
+      </section>
+
+      <aside className="min-w-0 border-l border-white/10 pl-5">
+        <div className="flex items-center justify-between gap-3">
+          <span className="text-sm font-semibold text-white">最近生成</span>
+          <button aria-label="刷新生成任务" className="grid h-8 w-8 place-items-center rounded-md border border-white/10 text-slate-300" onClick={() => void loadJobs()} title="刷新" type="button"><RefreshCw className="h-3.5 w-3.5" /></button>
+        </div>
+        <div className="mt-3 space-y-2">
+          {jobs.map((job) => (
+            <button className={`w-full rounded-md border p-3 text-left ${activeJob?.job_id === job.job_id ? "border-cyan-300/35 bg-cyan-300/10" : "border-white/10 bg-white/[0.025]"}`} key={job.job_id} onClick={() => { setActiveJob(job); if (!(["completed", "failed", "cancelled"].includes(job.status))) void refreshJob(job.job_id); }} type="button">
+              <div className="flex items-center justify-between gap-2"><span className="truncate text-xs font-semibold text-slate-200">{job.target?.label || "待处理目标"}</span><span className={`rounded border px-1.5 py-0.5 text-[10px] ${statusTone(job.status)}`}>{job.status}</span></div>
+              <p className="mt-2 text-[10px] text-slate-500">{new Date(job.created_at * 1000).toLocaleString("zh-CN", { hour12: false })}</p>
+              {job.error ? <p className="mt-2 line-clamp-2 text-[11px] text-rose-200">{job.error}</p> : null}
+            </button>
+          ))}
+          {!jobs.length ? <p className="rounded-md border border-dashed border-white/10 p-5 text-center text-xs text-slate-500">暂无生成任务</p> : null}
+        </div>
+      </aside>
+    </div>
+  );
+}

--- a/client/src/components/meta/MetaPlannerV2.tsx
+++ b/client/src/components/meta/MetaPlannerV2.tsx
@@ -780,6 +780,17 @@ export default function MetaPlannerV2() {
                   </label>
                   <div className="mt-3 flex flex-wrap gap-2">
                     <button
+                      className="rounded-md border border-amber-300/30 bg-amber-300/10 px-3 py-2 text-xs font-semibold text-amber-100 hover:bg-amber-300/15"
+                      onClick={() =>
+                        navigate(
+                          `/agents/evaluations?target_kind=proposal&proposal_id=${proposal.proposal_id}`,
+                        )
+                      }
+                      type="button"
+                    >
+                      生成评测集
+                    </button>
+                    <button
                       className="rounded-md border border-violet-300/30 bg-violet-300/10 px-3 py-2 text-xs font-semibold text-violet-100 hover:bg-violet-300/15"
                       onClick={() =>
                         navigate(

--- a/client/src/pages/PromptProfilesPage.tsx
+++ b/client/src/pages/PromptProfilesPage.tsx
@@ -220,6 +220,7 @@ export default function PromptProfilesPage() {
               ) : <p className="text-xs text-slate-500">发布后会在这里保留固定模板与命令别名。</p>}
             </div>
             <div className="flex flex-wrap items-center gap-2 border-t border-white/10 pt-4">
+              <Link className="rounded-md border border-amber-300/25 bg-amber-300/10 px-3 py-2 text-xs font-semibold text-amber-100" to={`/agents/evaluations?target_kind=prompt_profile&prompt_profile_id=${draft.id}`}>生成评测集</Link>
               <Link className="rounded-md border border-violet-300/25 bg-violet-300/10 px-3 py-2 text-xs font-semibold text-violet-100" to={`/agents/evolution?prompt_profile_id=${draft.id}`}>优化模板</Link>
               <button className="rounded-md border border-white/10 px-3 py-2 text-xs font-semibold text-white" disabled={Boolean(busy)} onClick={() => void saveProfile()} type="button">保存草稿</button>
               <button className="rounded-md border border-white/10 px-3 py-2 text-xs font-semibold text-white" disabled={Boolean(busy)} onClick={() => void action("validate")} type="button">校验</button>

--- a/client/src/pages/XpertEvaluationsPage.tsx
+++ b/client/src/pages/XpertEvaluationsPage.tsx
@@ -15,10 +15,12 @@ import {
   Plus,
   RefreshCw,
   Save,
+  Sparkles,
   Square,
   XCircle,
 } from "lucide-react";
 import BenchmarkCatalogPanel from "../components/evaluations/BenchmarkCatalogPanel";
+import BenchmarkGeneratorPanel from "../components/evaluations/BenchmarkGeneratorPanel";
 import PageContainer from "../components/PageContainer";
 import { models } from "../data/models";
 import { listXpertVersions, listXperts } from "../utils/xpertApi";
@@ -39,6 +41,9 @@ interface EvaluationCase {
     chunk_ids?: string[];
     document_names?: string[];
     rubric?: string;
+    required_tools?: string[];
+    forbidden_tools?: string[];
+    tool_order?: string[];
   };
   weights?: Record<string, number>;
 }
@@ -57,6 +62,17 @@ interface DatasetSummary {
     pack_id?: string;
     version?: number;
     checksum?: string;
+  };
+  provenance?: Record<string, unknown>;
+  coverage?: Record<string, unknown>;
+  calibration?: {
+    status?: "pending" | "calibrated" | "warning" | "failed" | "stale" | string;
+    dataset_revision?: number;
+    baseline_score?: number;
+    generic_counterfactual_score?: number | null;
+    targeting_advantage?: number | null;
+    warnings?: string[];
+    job_id?: string;
   };
   updated_at: number;
 }
@@ -167,7 +183,7 @@ interface AuthoringProposalSummary {
   status: string;
 }
 
-type EvaluationWorkspaceView = "catalog" | "datasets" | "reports";
+type EvaluationWorkspaceView = "catalog" | "generator" | "datasets" | "reports";
 
 const defaultCases: EvaluationCase[] = [
   {
@@ -250,8 +266,9 @@ export default function XpertEvaluationsPage() {
   const [busy, setBusy] = useState("");
   const [error, setError] = useState("");
   const [notice, setNotice] = useState("");
+  const [calibrationJobId, setCalibrationJobId] = useState("");
   const [workspaceView, setWorkspaceView] = useState<EvaluationWorkspaceView>(
-    runId ? "reports" : "catalog",
+    runId ? "reports" : searchParams.get("target_kind") ? "generator" : "catalog",
   );
 
   const selectedItem = useMemo(
@@ -364,6 +381,13 @@ export default function XpertEvaluationsPage() {
     setNotice(`${item.name} 已加入工作区，并固定发布为 v${item.published_version}。`);
   }
 
+  async function openGeneratedDataset(datasetId: string) {
+    await loadWorkspace();
+    await selectDataset(datasetId);
+    setWorkspaceView("datasets");
+    setNotice("生成的评测集草稿已打开。请先审阅用例和校准结果，再决定是否发布。");
+  }
+
   async function loadRun(id: string, silent = false) {
     if (!silent) setBusy("run");
     try {
@@ -428,15 +452,47 @@ export default function XpertEvaluationsPage() {
     setBusy("dataset-publish");
     setError("");
     try {
+      let acknowledgeCalibrationWarnings = false;
+      if (dataset.origin === "generated" && dataset.calibration?.status === "warning") {
+        acknowledgeCalibrationWarnings = window.confirm(
+          "该生成数据集的校准包含警告。确认已人工审阅这些警告并继续发布吗？",
+        );
+        if (!acknowledgeCalibrationWarnings) return;
+      }
       const published = await requestJson<DatasetVersion>(
         `/api/xpert-evaluations/datasets/${dataset.dataset_id}/publish`,
-        jsonInit("POST", { revision: dataset.revision, release_notes: "Evaluation dataset snapshot" }),
+        jsonInit("POST", {
+          revision: dataset.revision,
+          release_notes: "Evaluation dataset snapshot",
+          acknowledge_calibration_warnings: acknowledgeCalibrationWarnings,
+        }),
       );
       await selectDataset(dataset.dataset_id);
       setDatasetVersion(published.version);
       setNotice(`数据集 v${published.version} 已发布，后续草稿修改不会影响该版本。`);
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : "数据集发布失败。");
+    } finally {
+      setBusy("");
+    }
+  }
+
+  async function recalibrateDataset() {
+    if (!dataset) return;
+    setBusy("dataset-calibrate");
+    setError("");
+    try {
+      const job = await requestJson<{ job_id: string }>(
+        "/api/benchmarks/calibrations",
+        jsonInit("POST", {
+          dataset_id: dataset.dataset_id,
+          dataset_revision: dataset.revision,
+        }),
+      );
+      setCalibrationJobId(job.job_id);
+      setNotice("校准任务已创建；完成后刷新评测集即可查看结果。");
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "校准任务创建失败。");
     } finally {
       setBusy("");
     }
@@ -590,6 +646,7 @@ export default function XpertEvaluationsPage() {
       <nav aria-label="评测工作台视图" className="mb-5 flex flex-wrap gap-1 border-b border-white/10" role="tablist">
         {([
           ["catalog", "标准基准", BookOpenCheck],
+          ["generator", "针对性生成", Sparkles],
           ["datasets", "我的评测集", Database],
           ["reports", "运行报告", BarChart3],
         ] as const).map(([view, label, Icon]) => (
@@ -613,6 +670,8 @@ export default function XpertEvaluationsPage() {
 
       {workspaceView === "catalog" ? (
         <BenchmarkCatalogPanel onInstantiated={openInstantiatedDataset} />
+      ) : workspaceView === "generator" ? (
+        <BenchmarkGeneratorPanel onDatasetReady={openGeneratedDataset} />
       ) : workspaceView === "reports" ? (
         <section className="grid min-w-0 gap-5 lg:grid-cols-[340px_minmax(0,1fr)]">
           <aside className="min-w-0 border-r border-white/10 pr-5">
@@ -677,6 +736,7 @@ export default function XpertEvaluationsPage() {
                   <span className="truncate text-sm font-semibold text-slate-100">{item.name}</span>
                   <span className="flex shrink-0 items-center gap-1.5 text-[10px] text-slate-500">
                     {item.origin === "catalog" ? <span className="text-cyan-200">标准</span> : null}
+                    {item.origin === "generated" ? <span className="text-violet-200">生成</span> : null}
                     r{item.revision}
                   </span>
                 </div>
@@ -711,6 +771,20 @@ export default function XpertEvaluationsPage() {
               <div>
                 <h2 className="text-base font-semibold text-white">{dataset?.name ?? "选择评测集"}</h2>
                 <p className="mt-1 text-xs text-slate-500">草稿 revision 与发布版本相互隔离。</p>
+                {dataset?.origin === "generated" ? (
+                  <p className="mt-2 text-[11px] text-slate-400">
+                    校准：<span className="font-semibold text-slate-200">{dataset.calibration?.status ?? "pending"}</span>
+                    {dataset.calibration?.baseline_score == null
+                      ? ""
+                      : ` · 专业 ${(dataset.calibration.baseline_score * 100).toFixed(1)}%`}
+                    {dataset.calibration?.generic_counterfactual_score == null
+                      ? ""
+                      : ` · 通用 ${(dataset.calibration.generic_counterfactual_score * 100).toFixed(1)}%`}
+                    {dataset.calibration?.targeting_advantage == null
+                      ? ""
+                      : ` · 优势 ${(dataset.calibration.targeting_advantage * 100).toFixed(1)} pp`}
+                  </p>
+                ) : null}
               </div>
               {dataset ? (
                 <div className="flex gap-2">
@@ -724,6 +798,11 @@ export default function XpertEvaluationsPage() {
                   <button className="inline-flex items-center gap-2 rounded-md border border-white/10 bg-white/[0.04] px-3 py-2 text-xs text-slate-200" disabled={Boolean(busy)} onClick={() => void saveCases()} type="button">
                     <Save className="h-3.5 w-3.5" />保存草稿
                   </button>
+                  {dataset.origin === "generated" ? (
+                    <button className="inline-flex items-center gap-2 rounded-md border border-white/10 bg-white/[0.04] px-3 py-2 text-xs text-slate-200 disabled:opacity-50" disabled={Boolean(busy)} onClick={() => void recalibrateDataset()} type="button">
+                      <Beaker className="h-3.5 w-3.5" />重新校准
+                    </button>
+                  ) : null}
                   <button className="inline-flex items-center gap-2 rounded-md bg-cyan-300 px-3 py-2 text-xs font-semibold text-ink-950 disabled:opacity-50" disabled={!dataset.case_count || Boolean(busy)} onClick={() => void publishDataset()} type="button">
                     <CheckCircle2 className="h-3.5 w-3.5" />发布版本
                   </button>
@@ -734,6 +813,17 @@ export default function XpertEvaluationsPage() {
 
           {dataset ? (
             <>
+              {dataset.origin === "generated" && dataset.calibration?.warnings?.length ? (
+                <div className="flex items-start gap-2 rounded-md border border-amber-300/25 bg-amber-300/10 p-3 text-xs leading-5 text-amber-100">
+                  <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                  <span>{dataset.calibration.warnings.join("；")}</span>
+                </div>
+              ) : null}
+              {calibrationJobId ? (
+                <p className="rounded-md border border-cyan-300/20 bg-cyan-300/10 px-3 py-2 font-mono text-[11px] text-cyan-100">
+                  calibration job: {calibrationJobId}
+                </p>
+              ) : null}
               <textarea className="min-h-[380px] w-full resize-y rounded-md border border-white/10 bg-ink-950/70 p-4 font-mono text-xs leading-6 text-slate-200 outline-none focus:border-cyan-300/40" onChange={(event) => setCasesText(event.target.value)} spellCheck={false} value={casesText} />
               <div className="grid gap-3 sm:grid-cols-2">
                 <label className="text-xs font-semibold text-slate-300">

--- a/client/src/pages/XpertEvolutionPage.tsx
+++ b/client/src/pages/XpertEvolutionPage.tsx
@@ -970,16 +970,23 @@ function RunDetail({
                 <h3 className="text-sm font-semibold text-white">待审批 Proposal 已创建</h3>
                 <p className="mt-1 text-xs text-slate-400">{run.proposal_id} · 审批后只更新草稿，不自动发布。</p>
               </div>
-              <Link
-                className="rounded-md bg-cyan-300 px-3 py-2 text-xs font-semibold text-slate-950"
-                to={
-                  run.target.kind === "xpert"
-                    ? `/agents/meta-agent?proposal_id=${run.proposal_id}`
-                    : `/prompts?profile_id=${run.target.target_id}&proposal_id=${run.proposal_id}`
-                }
-              >
-                进入审批
-              </Link>
+              <div className="flex flex-wrap gap-2">
+                {run.target.kind === "xpert" ? (
+                  <Link className="rounded-md border border-amber-300/25 bg-amber-300/10 px-3 py-2 text-xs font-semibold text-amber-100" to={`/agents/evaluations?target_kind=proposal&proposal_id=${run.proposal_id}`}>
+                    生成评测集
+                  </Link>
+                ) : null}
+                <Link
+                  className="rounded-md bg-cyan-300 px-3 py-2 text-xs font-semibold text-slate-950"
+                  to={
+                    run.target.kind === "xpert"
+                      ? `/agents/meta-agent?proposal_id=${run.proposal_id}`
+                      : `/prompts?profile_id=${run.target.target_id}&proposal_id=${run.proposal_id}`
+                  }
+                >
+                  进入审批
+                </Link>
+              </div>
             </section>
           ) : null}
           {run.error ? <div className="border border-rose-300/25 bg-rose-300/10 p-3 text-xs text-rose-100">{run.error}</div> : null}

--- a/client/src/pages/XpertStudioPage.tsx
+++ b/client/src/pages/XpertStudioPage.tsx
@@ -286,6 +286,9 @@ export default function XpertStudioPage() {
             </div>
           </div>
           <div className="flex shrink-0 flex-wrap gap-2">
+            <Link className="rounded-full border border-amber-300/25 bg-amber-300/10 px-3 py-2 text-xs font-semibold text-amber-100 transition hover:bg-amber-300/20" to={`/agents/evaluations?target_kind=xpert_draft&xpert_id=${xpert.id}`}>
+              生成评测集
+            </Link>
             <Link className="rounded-full border border-violet-300/25 bg-violet-300/10 px-3 py-2 text-xs font-semibold text-violet-100 transition hover:bg-violet-300/20" to={`/agents/evolution?xpert_id=${xpert.id}`}>
               优化 Prompt
             </Link>

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,6 +1,6 @@
 # ModelMirror Benchmark
 
-最后更新日期：2026-08-07
+最后更新日期：2026-08-08
 
 ## 1. 定位
 
@@ -11,8 +11,9 @@ Benchmark 产品层为 Xpert Evaluator、Knowledge Evaluation 和后续 Agent Wo
 - RAG 数据集继续由 `KnowledgeEvaluationStore` 保存。
 - 后续生成与校准任务只在 `BenchmarkJobStore` 保存任务状态，不复制正式数据集。
 
-当前已交付 `EVOAGENTX-BENCHMARK-CATALOG-01`。定向生成、RAG 标准 Pack、RAG
-定向生成和 Agent Workspace 适配仍为后续独立轮次。
+当前已交付 `EVOAGENTX-BENCHMARK-CATALOG-01` 与
+`EVOAGENTX-BENCHMARK-GENERATOR-02`。RAG 标准 Pack、RAG 定向生成和 Agent
+Workspace 适配仍为后续独立轮次。
 
 ## 2. 统一 Manifest
 
@@ -64,30 +65,138 @@ Dataset 兼容新增：
 
 这些字段也固定到 DatasetVersion。旧 JSON Store 无需离线迁移，读取时自动补安全默认值。
 
-## 5. API
+## 5. 针对性生成与校准
+
+`EVOAGENTX-BENCHMARK-GENERATOR-02` 可以为以下固定目标生成待审核评测集：
+
+- Xpert 草稿 revision。
+- 已发布 XpertVersion。
+- 固定 revision 的 Xpert Authoring Proposal。
+- Prompt Profile 草稿 revision，并固定一个已发布 XpertVersion 作为宿主。
+
+服务端只向生成模型提供受限 Agent Prompt、输出契约和安全能力摘要。会话样例必须由
+用户显式选择；附件、长期记忆、私有工具输出、凭据和物理路径不会进入能力快照。
+默认生成中英双语 12 条用例，允许 6–30 条；一次任务最多一次生成和一次 JSON 修复。
+正式生成调用会向兼容网关请求 `response_format=json_object`；不支持该约束的模型应明确失败，
+而不是把不可解析输出写入评测集。一次修复仍是上限，不会进行无界重试。
+
+生成前会把固定目标编译为一组安全 `target_anchors`，例如 Agent `rolePrompt`、会话输入
+契约、输出 Schema、允许工具、知识资源或 Prompt Command。每条生成用例必须保存：
+
+- 服务端先确定性生成逐题 `case_blueprints`，固定 locale、主覆盖项、1–3 项能力矩阵、
+  难度、真实锚点、专业焦点、压力类型和可观察要求；模型只负责专业题面、历史、解释字段和
+  不依赖固定资源的文本 Gold。工具必选/禁用集合、知识文档名及 JSON Schema 由服务端注入。
+- Toolset 覆盖只能使用固定 ToolsetVersion 中已启用的真实工具名；知识引用只能使用固定活动
+  知识版本中的安全文档名；Prompt Command 样例必须真实以固定 `/alias` 发起。缺少这些
+  可验证资源时，对应能力不会进入可选覆盖。
+- 工具、知识与命令题还会在逐题蓝图中固定 `required_tool_name`、
+  `forbidden_tool_names`、`required_document_name` 和 `required_prompt_alias`；结构输出题固定
+  `required_json_schema`。模型不能以同类但错误的资源替代，也不需要回传这些服务端字段。
+
+- `targeting.target_refs`：引用一个或多个真实锚点 ID，且锚点必须支持该用例覆盖项。
+- `targeting.capability_matrix`：组合 1–3 个真实能力轴，主覆盖项必须在矩阵中。
+- `targeting.focus_terms`：只能取自锚点抽取的专业术语，并必须直接出现在题目或历史消息中。
+- `targeting.pressure_types`：记录冲突上下文、缺失证据、工具诱饵、Schema 边界等压力类型。
+- `targeting.rationale`：说明该用例具体验证目标的哪项行为。
+- `targeting.challenge`：说明边界或对抗压力点。
+- `targeting.discriminator`：说明该目标与未配置的通用底模应产生何种可观察差异。
+- `targeting.difficulty`：`basic / edge / adversarial`。
+- `targeting.blueprint_id`：对应服务端逐题蓝图，用于核对模型没有自行改写覆盖设计。
+- 服务端只允许规范化派生元数据：移除未授权的额外 matrix 值、从合法 matrix 恢复主覆盖项、补齐真实 anchor 引用，以及移除未在题面出现的多余 focus 声明。规范化不得改写题目、历史、Gold、Schema、工具期望或难度；所有动作写入 `targeting.normalization_notes` 并在管理 UI 展示。规范化后仍缺少专业焦点或合法覆盖时继续拒绝。
+
+用例数不少于 6 时，边界和对抗样例各不少于 25%，基础样例不超过 30%，并必须覆盖每个
+用户选择的能力项。选择两个以上能力时，至少 60% 用例必须组合多个能力，每个能力必须
+出现在组合题中，并在可行时形成至少三种不同组合。通用常识、算术、翻译或任意格式题若
+无法指向目标锚点，将被生成校验拒绝。管理 UI 逐例展示能力组合、专业词、压力类型、
+区分证据、锚点安全摘要、Gold 契约和固定基线校准分数；不会展示完整 Prompt。
+
+专业性不是依赖模型自述：服务端从固定 Prompt 和资源摘要中提取有限 `focus_terms`，模型
+不得发明域外术语，且所声明术语必须可在实际输入中定位。若目标本身只有“通用助手”式
+描述而没有专业焦点，预检会明确警告；此时生成器只能证明通用契约，不能宣称领域针对性。
+
+蓝图还要求能力在题面和 Gold 中可观察：`structured_output` 必须提供 JSON Schema，
+`multi_turn` 必须含至少两条历史且包含 assistant turn，`tool_routing` 必须提供工具调用
+期望，`knowledge_citation` 必须引用固定文档名，`prompt_command` 必须使用固定命令别名。
+边界题至少暴露一个结构化挑战信号，对抗题至少暴露两个；只在 metadata 中自报难度不会通过。
+单一工具能力的对抗题会固定一个必选工具和一个题面可见的禁用诱饵工具，使两项压力都能由
+`tool_call_match` 验证，而不是按能力类别数量推断难度。
+
+覆盖矩阵根据目标真实能力选择：指令遵循、结构化输出、多轮上下文、工具路由、知识引用
+和 Prompt Command。工具路由增加确定性 `tool_call_match` 指标，只比较工具名、必需/
+禁止集合与稳定调用顺序，不保存参数或工具结果。
+
+生成后自动用固定目标执行一次受限校准。校准只报告评分契约可执行性、基线分数、过易、
+过难、重复和 Gold 泄漏，不会根据当前回答修改 Gold：
+
+- `calibrated`：可发布。
+- `warning`：人工确认警告后才可发布。
+- `pending / failed / stale`：禁止发布。
+- 用例编辑或目标 checksum 漂移后必须重新校准。
+
+“至少 80% 用例过易”是有效质量警告，不会被隐藏或自动改写 Gold。用户应根据逐例目标
+证据和分数编辑或重新生成样例；旧生成任务缺少 `targeting` 时会明确标记为不可验证针对性。
+即使校准基线高分，复合能力比例、专业词命中和区分证据仍作为独立的生成门禁与人工证据，
+不会被单一平均分替代。
+
+`BenchmarkJobStore` 只保存生成与校准任务状态，正式用例仍写入
+`XpertEvaluationStore`。任务重启恢复时复用相同 generation job 已创建的数据集，避免
+重复草稿；已完成 Evaluator work item 继续遵循原有不重复执行规则。
+
+## 6. API
 
 ```text
 GET  /api/benchmarks/capabilities
 GET  /api/benchmarks/catalog?kind=agent_response
 GET  /api/benchmarks/catalog/{pack_id}
 POST /api/benchmarks/catalog/{pack_id}/instantiate
+POST /api/benchmarks/generations/preflight
+GET  /api/benchmarks/generations
+POST /api/benchmarks/generations
+GET  /api/benchmarks/generations/{job_id}
+POST /api/benchmarks/generations/{job_id}/cancel
+POST /api/benchmarks/calibrations
+GET  /api/benchmarks/calibrations/{job_id}
 ```
+
+生成器 V5 的校准同时执行固定专业目标与同模型通用对照。通用对照保留原工作流
+骨架、模型和输出契约，但移除领域 Prompt、Prompt Command、资源绑定及持久读写能力。
+校准报告同时返回 `baseline_score`、`generic_counterfactual_score` 和
+`targeting_advantage`。默认要求专业目标至少领先通用对照 `0.10`，否则产生针对性
+warning。高分本身不再等同于过易：只有当大量样例高分且专业目标未显著领先通用对照
+时，才报告“容易且缺少区分度”。
+
+专业针对性门禁由服务端计算 `professional_evidence`。工具名、知识文档名和 Prompt
+Command 别名继续精确匹配；领域 Prompt 则允许“精确 focus term”或“至少两个来自引用
+锚点的专业标记”，避免因抽取短语的表面差异误杀真实专业场景。该证据摘要只保存匹配
+术语、分数和锚点 ID，不保存完整 Prompt。
+
+对 OpenAI 兼容推理模型，Benchmark JSON 模式可在 `message.content` 为空时，从
+provider-specific reasoning 字段中仅提取一个包含 `dataset` 契约的 JSON 对象。外围推理
+文本不会返回、持久化或进入日志；普通聊天不启用该兼容路径。每次生成仅保存安全诊断：
+`finish_reason`、content/reasoning 字符数、是否找到契约、候选顶层键名及标准 token usage。
+空内容、契约缺失或截断后的解析失败都只进入既有的一次修复机会，不增加重试次数或盲目提高
+token 上限。Benchmark 生成与修复请求固定使用 `reasoning.effort=low`，避免复杂能力矩阵把
+completion 预算主要消耗在推理通道；该配置不影响普通聊天或 Evaluator 调用。
 
 目录列表返回 Manifest 摘要；详情返回固定用例。接口不返回完整 Xpert Prompt、工具结果、
 知识正文、凭据、物理路径或 Runtime Store 数据。
 
-## 6. 前端
+## 7. 前端
 
 `/agents/evaluations` 按以下视图组织：
 
 - 标准基准：浏览 Pack 并添加到工作区。
+- 针对性生成：选择固定目标、覆盖矩阵、模型和用例数，查看生成与校准进度。
 - 我的评测集：编辑、导入、发布及配置基线/候选。
 - 运行报告：查看运行记录、总体指标和逐样例结果。
 
 实例化完成后自动进入新 Dataset 草稿。v1 已发布，可立即选择固定版本运行；继续编辑不会
 改写 v1。
 
-## 7. 安全与后续边界
+Xpert Studio、Meta Planner Proposal、Prompt Profile 与 Evolution Proposal 均提供
+“生成评测集”入口。生成草稿仍须在“我的评测集”中人工审阅；校准不会自动发布。
+
+## 8. 安全与后续边界
 
 - Pack 内容与 checksum 随仓库版本发布，不在运行时联网更新。
 - 标准核心 Benchmark 不执行真实副作用、HITL、Browser、Sandbox 写入或外部实时数据。
@@ -96,10 +205,10 @@ POST /api/benchmarks/catalog/{pack_id}/instantiate
 - RAG Benchmark 使用 `KnowledgeEvaluationStore`，不会复制到 Xpert Dataset Store。
 - General Agent Workspace 最终只接目录和运行摘要，不替换 Penguin Benchmark Runtime。
 
-## 8. 回归
+## 9. 回归
 
 ```bash
-python -m pytest server/tests/test_benchmark_catalog.py -q
+python -m pytest server/tests/test_benchmark_catalog.py server/tests/test_benchmark_generator.py -q
 python -m pytest server/tests/test_xpert_evaluations.py -q
 cd client
 npm.cmd run build

--- a/docs/EVOAGENTX_ALIGNMENT.md
+++ b/docs/EVOAGENTX_ALIGNMENT.md
@@ -189,14 +189,24 @@ Evaluator 不批准 Proposal、不写 Xpert 草稿、不发布版本。完整契
 - Dataset 已兼容 origin、catalog provenance、coverage 和 calibration 状态。
 - `/agents/evaluations` 已增加标准基准、我的评测集和运行报告视图。
 
+### `EVOAGENTX-BENCHMARK-GENERATOR-02`：已实现
+
+- 已支持 Xpert 草稿、发布版本、固定 Proposal 与 Prompt Profile + 固定宿主版本。
+- 已按真实目标能力生成指令、结构输出、多轮、工具路由、知识引用与命令覆盖矩阵。
+- 已实现一次生成、一次 JSON 修复、显式会话样例、重复/泄漏和未知资源校验。
+- 已增加确定性 `tool_call_match`，只捕获工具名和稳定顺序。
+- 已复用 Evaluator 固定快照完成自动校准；校准不会修改 Gold。
+- 已实现生成 Job 重启恢复，以及 pending/warning/failed/stale 发布门禁。
+- Studio、Meta Planner、Prompt 与 Evolution 已提供一键生成入口。
+
 ### 当前路线：Benchmark 闭环
 
 Meta Planner、Evaluator、Prompt Evolution 和 Structure Evolution 已形成第一阶段闭环，
-但缺少可重复标准数据与针对性生成。当前按以下独立轮次补齐后再做收益审计：
+Xpert 标准数据与针对性生成也已补齐。当前按以下独立轮次完成 RAG 和兼容性收口：
 
 1. 已完成标准 Xpert Benchmark 目录。
-2. 下一轮实现 Xpert/Prompt/Profile/结构目标的一键生成与受限校准。
-3. 随后实现标准 RAG Pack 与版本化 Gold 引用。
+2. 已完成 Xpert/Prompt/Profile/结构目标的一键生成与受限校准。
+3. 下一轮实现标准 RAG Pack 与版本化 Gold 引用。
 4. 再实现知识库定向 Benchmark 生成。
 5. 最后只对 General Agent Workspace 做目录和运行摘要适配，不替换 Penguin Runtime。
 

--- a/docs/EVOAGENTX_EVALUATOR.md
+++ b/docs/EVOAGENTX_EVALUATOR.md
@@ -1,6 +1,6 @@
 # EvoAgentX Xpert Evaluator
 
-最后更新日期：2026-08-07
+最后更新日期：2026-08-08
 
 ## 1. 定位
 
@@ -42,6 +42,7 @@ Evaluator 只评价固定快照。它不会批准 Authoring Proposal、修改 Xp
 - 必须包含的文本。
 - JSON Schema。
 - Citation ID、chunk ID 或文档名。
+- 必需工具、禁止工具和稳定工具调用顺序。
 - LLM Judge rubric。
 - 指标权重。
 
@@ -58,6 +59,34 @@ Evaluator 只评价固定快照。它不会批准 Authoring Proposal、修改 Xp
 Dataset，并自动发布与 Pack 完全一致的 v1。Dataset 的 `origin`、`catalog_ref`、
 `provenance`、`coverage` 和 `calibration` 会固定到不可变版本；旧数据读取时默认为
 `origin=manual`。完整契约见 [BENCHMARKS.md](./BENCHMARKS.md)。
+
+### 2.2 针对性 Benchmark 生成
+
+`EVOAGENTX-BENCHMARK-GENERATOR-02` 为 Xpert 草稿、发布版本、固定 Proposal 和
+Prompt Profile + 固定宿主版本生成待审核 Dataset 草稿。生成任务固定目标 checksum、
+模型、覆盖矩阵、seed 和显式选择的用户会话样例；最多执行一次生成和一次 JSON 修复。
+服务端持有 locale、覆盖、难度、资源 ID、工具必选/禁用集合与 JSON Schema，模型只补专业
+题面、历史和必要文本 Gold，避免回显大段服务端契约造成截断或授权漂移。
+目标 Prompt、会话契约、Schema 和安全资源会被编译为可校验 `target_anchors`，并从中
+提取有限专业 `focus_terms`。每条用例必须记录锚点引用、1–3 项能力矩阵、专业词、压力
+类型、针对性理由、区分证据和难度；服务端要求输入包含精确 focus term，或至少两个来自
+引用锚点的专业标记。工具、文档和命令别名仍须精确匹配。管理页逐例展示这些证据与校准
+分数，因此“针对目标”不再只依赖数据集名称或模型自述。
+
+多能力目标至少 60% 用例必须形成复合矩阵，并在可行时覆盖至少三种不同组合；edge 和
+adversarial 还必须分别携带一个和两个可验证压力类型。目标 Prompt 若没有专业内容会在
+预检中收到警告，避免把基础通用题包装成专业评测。
+
+生成后自动复用 Evaluator 内部固定快照入口执行一次受限校准。校准同时运行专业目标与
+同模型通用对照：通用对照保留工作流骨架和输出契约，但移除领域 Prompt、Prompt Command
+与资源绑定。报告包含两者分数及针对性优势，默认优势低于 `0.10` 时产生 warning。校准
+不会重写 Gold，只报告评分契约可执行性、重复、泄漏、难度和反事实区分度。生成数据集只有在相同 revision
+达到 `calibrated`，或用户显式确认 `warning` 后才能发布；目标或用例漂移会转为
+`stale`。完整契约见 [BENCHMARKS.md](./BENCHMARKS.md)。
+
+生成失败诊断仅保留结束原因、响应字符数、契约存在性、候选顶层键名和 token 统计；不保存
+reasoning 正文。可恢复的空内容、契约缺失和截断解析错误复用同一个单次修复预算。Benchmark
+生成和修复固定使用低 reasoning effort，为最终 JSON 保留 completion 预算。
 
 ## 3. 固定快照
 
@@ -156,6 +185,12 @@ GET       /api/benchmarks/capabilities
 GET       /api/benchmarks/catalog
 GET       /api/benchmarks/catalog/{pack_id}
 POST      /api/benchmarks/catalog/{pack_id}/instantiate
+POST      /api/benchmarks/generations/preflight
+GET/POST  /api/benchmarks/generations
+GET       /api/benchmarks/generations/{job_id}
+POST      /api/benchmarks/generations/{job_id}/cancel
+POST      /api/benchmarks/calibrations
+GET       /api/benchmarks/calibrations/{job_id}
 ```
 
 列表只返回摘要。可信管理面的 detail 会移除 workflow、Prompt、完整 Tool 配置和
@@ -167,9 +202,9 @@ POST      /api/benchmarks/catalog/{pack_id}/instantiate
 - `/agents/evaluations/:runId`
 
 Meta Planner V2 候选提供“评测候选”入口，并固定当前 Proposal revision。
-Xpert Studio 的已发布版本提供“版本回归评测”入口。工作台按“标准基准 / 我的评测集 /
-运行报告”组织，支持目录实例化、数据集编辑/导入、发布、基线与候选选择、模型策略、
-预算、预检、运行、取消和报告查看。
+Xpert Studio 的已发布版本提供“版本回归评测”入口。工作台按“标准基准 / 针对性生成 /
+我的评测集 / 运行报告”组织，支持目录实例化、目标分析、生成与校准、数据集编辑/导入、
+发布、基线与候选选择、模型策略、预算、预检、运行、取消和报告查看。
 
 ## 9. 安全边界
 
@@ -185,7 +220,7 @@ Xpert Studio 的已发布版本提供“版本回归评测”入口。工作台�
 
 ```bash
 python -m pytest server/tests/test_xpert_evaluations.py -q
-python -m pytest server/tests/test_benchmark_catalog.py -q
+python -m pytest server/tests/test_benchmark_catalog.py server/tests/test_benchmark_generator.py -q
 python -m pytest server/tests/test_meta_agent.py server/tests/test_xpert_publish.py -q
 cd client
 npm.cmd run build

--- a/server/benchmarks/__init__.py
+++ b/server/benchmarks/__init__.py
@@ -1,5 +1,13 @@
-from .api import configure_benchmarks, get_benchmark_catalog, router
+from .api import (
+    configure_benchmarks,
+    get_benchmark_catalog,
+    get_benchmark_generation_service,
+    get_benchmark_job_executor,
+    get_benchmark_job_store,
+    router,
+)
 from .catalog import BenchmarkCatalog, BenchmarkCatalogError, BenchmarkPackNotFoundError
+from .executor import BenchmarkGeneratorOutput
 from .models import BenchmarkManifest, BenchmarkPack
 
 __all__ = [
@@ -8,7 +16,11 @@ __all__ = [
     "BenchmarkManifest",
     "BenchmarkPack",
     "BenchmarkPackNotFoundError",
+    "BenchmarkGeneratorOutput",
     "configure_benchmarks",
     "get_benchmark_catalog",
+    "get_benchmark_generation_service",
+    "get_benchmark_job_executor",
+    "get_benchmark_job_store",
     "router",
 ]

--- a/server/benchmarks/api.py
+++ b/server/benchmarks/api.py
@@ -10,18 +10,76 @@ except ModuleNotFoundError:
     from evaluations.store import EvaluationStateError, XpertEvaluationStore
 
 from .catalog import BenchmarkCatalog, BenchmarkCatalogError, BenchmarkPackNotFoundError
-from .models import InstantiateBenchmarkRequest
+from .executor import BenchmarkJobExecutor, GeneratorRunner
+from .models import (
+    BenchmarkCalibrationRequest,
+    BenchmarkGenerationPreflightRequest,
+    BenchmarkGenerationRequest,
+    InstantiateBenchmarkRequest,
+)
+from .service import BenchmarkGenerationError, BenchmarkGenerationService
+from .store import BenchmarkJobNotFoundError, BenchmarkJobStore
 
 
 router = APIRouter(prefix="/api/benchmarks", tags=["benchmarks"])
 _catalog: BenchmarkCatalog | None = None
 _evaluation_store: XpertEvaluationStore | None = None
+_job_store: BenchmarkJobStore | None = None
+_service: BenchmarkGenerationService | None = None
+_executor: BenchmarkJobExecutor | None = None
 
 
-def configure_benchmarks(evaluation_store: XpertEvaluationStore) -> BenchmarkCatalog:
-    global _catalog, _evaluation_store
+def configure_benchmarks(
+    evaluation_store: XpertEvaluationStore,
+    *,
+    storage_dir: str | None = None,
+    evaluation_service: Any | None = None,
+    evaluation_executor: Any | None = None,
+    xpert_store: Any | None = None,
+    proposal_store: Any | None = None,
+    prompt_store: Any | None = None,
+    context_store: Any | None = None,
+    rag_service: Any | None = None,
+    toolset_store: Any | None = None,
+    generator_runner: GeneratorRunner | None = None,
+) -> BenchmarkCatalog:
+    global _catalog, _evaluation_store, _job_store, _service, _executor
     _catalog = BenchmarkCatalog()
     _evaluation_store = evaluation_store
+    _job_store = None
+    _service = None
+    _executor = None
+    if all(
+        value is not None
+        for value in (
+            evaluation_service,
+            evaluation_executor,
+            xpert_store,
+            proposal_store,
+            prompt_store,
+            context_store,
+            generator_runner,
+        )
+    ):
+        _job_store = BenchmarkJobStore(storage_dir)
+        _service = BenchmarkGenerationService(
+            evaluation_store=evaluation_store,
+            evaluation_service=evaluation_service,
+            xpert_store=xpert_store,
+            proposal_store=proposal_store,
+            prompt_store=prompt_store,
+            context_store=context_store,
+            rag_service=rag_service,
+            toolset_store=toolset_store,
+        )
+        _executor = BenchmarkJobExecutor(
+            _job_store,
+            service=_service,
+            generator_runner=generator_runner,
+            evaluation_store=evaluation_store,
+            evaluation_service=evaluation_service,
+            evaluation_executor=evaluation_executor,
+        )
     return _catalog
 
 
@@ -37,9 +95,30 @@ def _require_evaluation_store() -> XpertEvaluationStore:
     return _evaluation_store
 
 
+def get_benchmark_job_store() -> BenchmarkJobStore:
+    if _job_store is None:
+        raise RuntimeError("Benchmark generator is not configured.")
+    return _job_store
+
+
+def get_benchmark_generation_service() -> BenchmarkGenerationService:
+    if _service is None:
+        raise RuntimeError("Benchmark generator is not configured.")
+    return _service
+
+
+def get_benchmark_job_executor() -> BenchmarkJobExecutor:
+    if _executor is None:
+        raise RuntimeError("Benchmark generator is not configured.")
+    return _executor
+
+
 @router.get("/capabilities")
 async def get_capabilities() -> dict[str, Any]:
-    return get_benchmark_catalog().capabilities()
+    payload = get_benchmark_catalog().capabilities()
+    if _service is not None:
+        payload["generator"] = _service.capabilities()
+    return payload
 
 
 @router.get("/catalog")
@@ -74,3 +153,149 @@ async def instantiate_catalog_pack(
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except (BenchmarkCatalogError, EvaluationStateError) as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.post("/generations/preflight")
+async def preflight_generation(
+    payload: BenchmarkGenerationPreflightRequest,
+) -> dict[str, Any]:
+    try:
+        return await _to_thread(
+            get_benchmark_generation_service().preflight,
+            target_reference=payload.target.model_dump(mode="json"),
+            requested_coverage=payload.coverage,
+            conversation_selections=[
+                item.model_dump(mode="json")
+                for item in payload.conversation_selections
+            ],
+        )
+    except Exception as exc:
+        return {
+            "valid": False,
+            "target": None,
+            "coverage": {"available": [], "recommended": []},
+            "conversation_seed_count": 0,
+            "warnings": [],
+            "issues": [{"code": "benchmark_preflight", "message": str(exc)[:500]}],
+        }
+
+
+@router.get("/generations")
+async def list_generations(
+    status: str | None = None,
+    limit: int = 100,
+) -> dict[str, Any]:
+    items = await _to_thread(
+        get_benchmark_job_store().list_jobs,
+        kind="generation",
+        status=status,
+        limit=limit,
+    )
+    return {"items": [_sanitize_job(item) for item in items], "total": len(items)}
+
+
+@router.post("/generations")
+async def create_generation(payload: BenchmarkGenerationRequest) -> dict[str, Any]:
+    preflight = await preflight_generation(
+        BenchmarkGenerationPreflightRequest(
+            target=payload.target,
+            coverage=payload.coverage,
+            conversation_selections=payload.conversation_selections,
+        )
+    )
+    if not preflight.get("valid"):
+        raise HTTPException(status_code=400, detail=preflight)
+    item = await _to_thread(
+        get_benchmark_job_store().create_job,
+        kind="generation",
+        request=payload.model_dump(mode="json"),
+    )
+    get_benchmark_job_executor().wake()
+    return _sanitize_job(item)
+
+
+@router.get("/generations/{job_id}")
+async def get_generation(job_id: str) -> dict[str, Any]:
+    try:
+        item = await _to_thread(get_benchmark_job_store().require_job, job_id)
+    except BenchmarkJobNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    if item.get("kind") != "generation":
+        raise HTTPException(status_code=404, detail="Benchmark generation not found.")
+    return _sanitize_job(item)
+
+
+@router.post("/generations/{job_id}/cancel")
+async def cancel_generation(job_id: str) -> dict[str, Any]:
+    try:
+        item = await _to_thread(get_benchmark_job_store().require_job, job_id)
+        if item.get("kind") != "generation":
+            raise BenchmarkJobNotFoundError("Benchmark generation not found.")
+        result = await _to_thread(get_benchmark_job_store().cancel_job, job_id)
+        get_benchmark_job_executor().wake()
+        return _sanitize_job(result)
+    except BenchmarkJobNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.post("/calibrations")
+async def create_calibration(payload: BenchmarkCalibrationRequest) -> dict[str, Any]:
+    try:
+        dataset = await _to_thread(
+            _require_evaluation_store().require_dataset, payload.dataset_id
+        )
+        if int(dataset.get("revision") or 0) != payload.dataset_revision:
+            raise EvaluationStateError("Dataset changed. Reload before calibration.")
+        target = (
+            payload.target.model_dump(mode="json")
+            if payload.target is not None
+            else dict((dataset.get("provenance") or {}).get("target_reference") or {})
+        )
+        if not target:
+            raise EvaluationStateError("Calibration target is required.")
+        preflight = await _to_thread(
+            get_benchmark_generation_service().preflight,
+            target_reference=target,
+            requested_coverage=[],
+            conversation_selections=[],
+        )
+        if not preflight.get("valid"):
+            raise EvaluationStateError("Calibration target failed preflight.")
+        item = await _to_thread(
+            get_benchmark_job_store().create_job,
+            kind="calibration",
+            request={
+                "dataset_id": payload.dataset_id,
+                "dataset_revision": payload.dataset_revision,
+                "target": target,
+            },
+        )
+        get_benchmark_job_executor().wake()
+        return _sanitize_job(item)
+    except (EvaluationStateError, BenchmarkGenerationError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.get("/calibrations/{job_id}")
+async def get_calibration(job_id: str) -> dict[str, Any]:
+    try:
+        item = await _to_thread(get_benchmark_job_store().require_job, job_id)
+    except BenchmarkJobNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    if item.get("kind") != "calibration":
+        raise HTTPException(status_code=404, detail="Benchmark calibration not found.")
+    return _sanitize_job(item)
+
+
+async def _to_thread(function: Any, *args: Any, **kwargs: Any) -> Any:
+    import asyncio
+
+    return await asyncio.to_thread(function, *args, **kwargs)
+
+
+def _sanitize_job(item: dict[str, Any]) -> dict[str, Any]:
+    payload = dict(item)
+    request = dict(payload.get("request") or {})
+    request.pop("conversation_selections", None)
+    payload["request"] = request
+    return payload

--- a/server/benchmarks/executor.py
+++ b/server/benchmarks/executor.py
@@ -1,0 +1,554 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import copy
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from .service import BenchmarkGenerationError, BenchmarkGenerationService
+from .store import BenchmarkJobStore
+
+
+@dataclass(frozen=True)
+class BenchmarkGeneratorOutput:
+    text: str = ""
+    diagnostics: dict[str, Any] = field(default_factory=dict)
+    error_code: str | None = None
+    error_message: str | None = None
+
+
+GeneratorRunner = Callable[
+    [str, str, str, float, int],
+    Awaitable[str | BenchmarkGeneratorOutput],
+]
+
+
+def _normalize_generator_output(
+    value: str | BenchmarkGeneratorOutput,
+) -> BenchmarkGeneratorOutput:
+    if isinstance(value, BenchmarkGeneratorOutput):
+        return value
+    return BenchmarkGeneratorOutput(text=str(value or ""))
+
+
+def _safe_generator_diagnostics(value: dict[str, Any]) -> dict[str, Any]:
+    diagnostics: dict[str, Any] = {}
+    finish_reason = value.get("finish_reason")
+    if isinstance(finish_reason, str):
+        diagnostics["finish_reason"] = finish_reason[:80]
+    for key in ("content_chars", "reasoning_chars"):
+        item = value.get(key)
+        if isinstance(item, int) and not isinstance(item, bool):
+            diagnostics[key] = max(0, item)
+    for key in ("reasoning_present", "contract_found"):
+        item = value.get(key)
+        if isinstance(item, bool):
+            diagnostics[key] = item
+    selected_source = value.get("selected_source")
+    if selected_source in {"none", "content", "reasoning"}:
+        diagnostics["selected_source"] = selected_source
+    candidate_keys = value.get("candidate_top_level_keys")
+    if isinstance(candidate_keys, list):
+        diagnostics["candidate_top_level_keys"] = [
+            str(item)[:80] for item in candidate_keys[:20]
+        ]
+    usage = value.get("usage")
+    if isinstance(usage, dict):
+        diagnostics["usage"] = {
+            key: max(0, int(usage[key]))
+            for key in ("prompt_tokens", "completion_tokens", "total_tokens")
+            if isinstance(usage.get(key), int)
+            and not isinstance(usage.get(key), bool)
+        }
+    return diagnostics
+
+
+class BenchmarkJobExecutor:
+    """Restart-safe generator and calibration coordinator."""
+
+    def __init__(
+        self,
+        store: BenchmarkJobStore,
+        *,
+        service: BenchmarkGenerationService,
+        generator_runner: GeneratorRunner,
+        evaluation_store: Any,
+        evaluation_service: Any,
+        evaluation_executor: Any,
+        poll_seconds: float = 0.5,
+    ) -> None:
+        self.store = store
+        self.service = service
+        self.generator_runner = generator_runner
+        self.evaluation_store = evaluation_store
+        self.evaluation_service = evaluation_service
+        self.evaluation_executor = evaluation_executor
+        self.poll_seconds = max(0.1, float(poll_seconds))
+        self._task: asyncio.Task[None] | None = None
+        self._wake = asyncio.Event()
+        self._stopping = False
+
+    def start(self) -> None:
+        if self._task is not None and not self._task.done():
+            return
+        self.store.recover_jobs()
+        self._stopping = False
+        self._task = asyncio.create_task(self._loop())
+
+    async def stop(self) -> None:
+        self._stopping = True
+        self._wake.set()
+        if self._task is not None:
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
+        self._task = None
+
+    def wake(self) -> None:
+        self._wake.set()
+
+    async def _loop(self) -> None:
+        while not self._stopping:
+            progressed = await self._poll_calibrations()
+            job = await asyncio.to_thread(self.store.claim_next_job)
+            if job is not None:
+                progressed = True
+                try:
+                    if job.get("kind") == "generation":
+                        await self._run_generation(job)
+                    else:
+                        await self._run_calibration(job)
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    await self._fail_job(job, exc)
+            if progressed:
+                continue
+            self._wake.clear()
+            try:
+                await asyncio.wait_for(self._wake.wait(), timeout=self.poll_seconds)
+            except TimeoutError:
+                pass
+
+    async def _run_generation(self, job: dict[str, Any]) -> None:
+        request = dict(job.get("request") or {})
+        reference = dict(request.get("target") or {})
+        snapshot, target_warnings = await asyncio.to_thread(
+            self.service.snapshot_target, reference
+        )
+        existing = await asyncio.to_thread(
+            self._find_generation_dataset, job["job_id"]
+        )
+        if existing is not None:
+            await asyncio.to_thread(
+                self.store.update_job,
+                job["job_id"],
+                status="validating",
+                target=self.service.public_target(snapshot),
+                dataset_id=existing["dataset_id"],
+                dataset_revision=existing["revision"],
+                warnings=target_warnings,
+            )
+            await self._start_evaluation(
+                job_id=job["job_id"],
+                dataset=existing,
+                snapshot=snapshot,
+                reference=reference,
+            )
+            return
+        coverage = await asyncio.to_thread(self.service.detect_coverage, snapshot)
+        requested_coverage = [
+            str(item) for item in list(request.get("coverage") or []) if str(item)
+        ]
+        selected_coverage = requested_coverage or list(coverage["recommended"])
+        unavailable = sorted(set(selected_coverage) - set(coverage["available"]))
+        if unavailable:
+            raise BenchmarkGenerationError(
+                "Requested coverage is unavailable: " + ", ".join(unavailable)
+            )
+        seeds = await asyncio.to_thread(
+            self.service.conversation_seeds,
+            list(request.get("conversation_selections") or []),
+        )
+        system, user, coverage = await asyncio.to_thread(
+            self.service.generation_prompt,
+            snapshot=snapshot,
+            case_count=int(request.get("case_count") or 12),
+            locales=list(request.get("locales") or ["zh-CN", "en-US"]),
+            requested_coverage=selected_coverage,
+            conversation_seeds=seeds,
+            seed=int(request.get("seed") or 0),
+        )
+        await asyncio.to_thread(
+            self.store.update_job,
+            job["job_id"],
+            status="generating",
+            target=self.service.public_target(snapshot),
+            coverage=coverage,
+            warnings=target_warnings,
+        )
+        initial_output = _normalize_generator_output(await self.generator_runner(
+            str(request.get("generator_model_id") or ""),
+            system,
+            user,
+            0.2,
+            12_000,
+        ))
+        raw = initial_output.text
+        generation_attempts = [
+            {
+                "attempt": "initial",
+                "error_code": initial_output.error_code,
+                "diagnostics": _safe_generator_diagnostics(
+                    initial_output.diagnostics
+                ),
+            }
+        ]
+        await asyncio.to_thread(
+            self.store.update_job,
+            job["job_id"],
+            generation_attempts=generation_attempts,
+        )
+        repair_used = False
+        try:
+            if initial_output.error_code:
+                raise BenchmarkGenerationError(
+                    initial_output.error_message
+                    or f"Generator response failed: {initial_output.error_code}."
+                )
+            generated = self.service.parse_generated_cases(
+                raw,
+                expected_count=int(request.get("case_count") or 12),
+                allowed_coverage=list(coverage["selected"]),
+                allowed_tool_names=list(coverage.get("tool_names") or []),
+                allowed_target_anchors=list(coverage.get("target_anchors") or []),
+                case_blueprints=list(coverage.get("case_blueprints") or []),
+                allowed_document_names=list(
+                    coverage.get("knowledge_document_names") or []
+                ),
+                allowed_prompt_aliases=list(
+                    coverage.get("prompt_command_aliases") or []
+                ),
+            )
+        except BenchmarkGenerationError as exc:
+            repair_used = True
+            repair_system, repair_user = self.service.repair_prompt(
+                raw,
+                str(exc),
+                expected_count=int(request.get("case_count") or 12),
+                allowed_coverage=list(coverage["selected"]),
+                target_anchors=list(coverage.get("target_anchors") or []),
+                case_blueprints=list(coverage.get("case_blueprints") or []),
+                allowed_document_names=list(
+                    coverage.get("knowledge_document_names") or []
+                ),
+                allowed_prompt_aliases=list(
+                    coverage.get("prompt_command_aliases") or []
+                ),
+            )
+            repaired_output = _normalize_generator_output(await self.generator_runner(
+                str(request.get("generator_model_id") or ""),
+                repair_system,
+                repair_user,
+                0.0,
+                12_000,
+            ))
+            generation_attempts.append(
+                {
+                    "attempt": "repair",
+                    "error_code": repaired_output.error_code,
+                    "diagnostics": _safe_generator_diagnostics(
+                        repaired_output.diagnostics
+                    ),
+                }
+            )
+            await asyncio.to_thread(
+                self.store.update_job,
+                job["job_id"],
+                generation_attempts=generation_attempts,
+            )
+            if repaired_output.error_code:
+                raise BenchmarkGenerationError(
+                    repaired_output.error_message
+                    or f"Generator repair failed: {repaired_output.error_code}."
+                )
+            repaired = repaired_output.text
+            generated = self.service.parse_generated_cases(
+                repaired,
+                expected_count=int(request.get("case_count") or 12),
+                allowed_coverage=list(coverage["selected"]),
+                allowed_tool_names=list(coverage.get("tool_names") or []),
+                allowed_target_anchors=list(coverage.get("target_anchors") or []),
+                case_blueprints=list(coverage.get("case_blueprints") or []),
+                allowed_document_names=list(
+                    coverage.get("knowledge_document_names") or []
+                ),
+                allowed_prompt_aliases=list(
+                    coverage.get("prompt_command_aliases") or []
+                ),
+            )
+        if (await asyncio.to_thread(self.store.require_job, job["job_id"])).get(
+            "cancel_requested"
+        ):
+            await asyncio.to_thread(
+                self.store.update_job, job["job_id"], status="cancelled"
+            )
+            return
+        dataset = await asyncio.to_thread(
+            self.service.evaluation_store.create_generated_dataset,
+            name=generated["name"],
+            description=generated["description"],
+            cases=generated["cases"],
+            provenance={
+                "generator": "modelmirror-targeted-benchmark-v2",
+                "generation_job_id": job["job_id"],
+                "generator_model_id": str(request.get("generator_model_id") or "")[:300],
+                "target_reference": copy.deepcopy(reference),
+                "target_checksum": snapshot["checksum"],
+                "seed": int(request.get("seed") or 0),
+                "repair_used": repair_used,
+                "attempt_diagnostics": copy.deepcopy(generation_attempts),
+                "conversation_seed_count": len(seeds),
+                "targeting_contract_version": 5,
+                "target_anchor_hash": str(coverage.get("target_anchor_hash") or ""),
+                "target_anchor_count": len(coverage.get("target_anchors") or []),
+                "case_blueprint_hash": str(coverage.get("case_blueprint_hash") or ""),
+                "case_blueprint_count": len(coverage.get("case_blueprints") or []),
+            },
+            coverage={
+                "selected": list(coverage["selected"]),
+                "available": list(coverage["available"]),
+                "locales": list(request.get("locales") or ["zh-CN", "en-US"]),
+                "target_anchors": copy.deepcopy(coverage.get("target_anchors") or []),
+                "target_anchor_hash": str(coverage.get("target_anchor_hash") or ""),
+                "difficulty_policy": {
+                    "basic_max_ratio": 0.30,
+                    "edge_min_ratio": 0.25,
+                    "adversarial_min_ratio": 0.25,
+                },
+                "matrix_policy": {
+                    "combined_case_min_ratio": 0.60,
+                    "professional_focus_required_when_available": True,
+                },
+                "case_blueprint_hash": str(coverage.get("case_blueprint_hash") or ""),
+                "case_blueprint_count": len(coverage.get("case_blueprints") or []),
+            },
+            calibration={
+                "status": "pending",
+                "dataset_revision": 1,
+                "target_reference": copy.deepcopy(reference),
+                "target_checksum": snapshot["checksum"],
+            },
+        )
+        await asyncio.to_thread(
+            self.store.update_job,
+            job["job_id"],
+            status="validating",
+            generation={
+                "case_count": len(generated["cases"]),
+                "repair_used": repair_used,
+                "attempt_diagnostics": copy.deepcopy(generation_attempts),
+                "assumptions": generated["assumptions"],
+                "targeting": copy.deepcopy(generated.get("targeting") or {}),
+            },
+            dataset_id=dataset["dataset_id"],
+            dataset_revision=dataset["revision"],
+        )
+        await self._start_evaluation(
+            job_id=job["job_id"],
+            dataset=dataset,
+            snapshot=snapshot,
+            reference=reference,
+        )
+
+    async def _run_calibration(self, job: dict[str, Any]) -> None:
+        request = dict(job.get("request") or {})
+        dataset = await asyncio.to_thread(
+            self.service.evaluation_store.require_dataset,
+            str(request.get("dataset_id") or ""),
+        )
+        expected_revision = int(request.get("dataset_revision") or 0)
+        if int(dataset.get("revision") or 0) != expected_revision:
+            raise BenchmarkGenerationError(
+                "Dataset changed before calibration started."
+            )
+        reference = dict(request.get("target") or {})
+        if not reference:
+            reference = dict((dataset.get("provenance") or {}).get("target_reference") or {})
+        if not reference:
+            raise BenchmarkGenerationError("Calibration target is required.")
+        snapshot, warnings = await asyncio.to_thread(
+            self.service.snapshot_target, reference
+        )
+        await asyncio.to_thread(
+            self.store.update_job,
+            job["job_id"],
+            target=self.service.public_target(snapshot),
+            warnings=warnings,
+        )
+        await self._start_evaluation(
+            job_id=job["job_id"],
+            dataset=dataset,
+            snapshot=snapshot,
+            reference=reference,
+        )
+
+    async def _start_evaluation(
+        self,
+        *,
+        job_id: str,
+        dataset: dict[str, Any],
+        snapshot: dict[str, Any],
+        reference: dict[str, Any],
+    ) -> None:
+        revision = int(dataset["revision"])
+        evaluation_dataset = {
+            "dataset_id": dataset["dataset_id"],
+            "version": 0,
+            "draft_revision": revision,
+            "name": dataset["name"],
+            "description": dataset.get("description") or "",
+            "cases": copy.deepcopy(dataset.get("cases") or []),
+            "case_count": len(dataset.get("cases") or []),
+            "origin": dataset.get("origin") or "generated",
+            "provenance": copy.deepcopy(dataset.get("provenance") or {}),
+            "coverage": copy.deepcopy(dataset.get("coverage") or {}),
+            "calibration": copy.deepcopy(dataset.get("calibration") or {}),
+        }
+        generic_counterfactual = (
+            self.service.generic_counterfactual_snapshot(snapshot)
+            if hasattr(self.service, "generic_counterfactual_snapshot")
+            else None
+        )
+        run = await asyncio.to_thread(
+            self.evaluation_service.create_run_from_snapshots,
+            dataset_version=evaluation_dataset,
+            cases=list(evaluation_dataset["cases"]),
+            baseline=generic_counterfactual,
+            candidates=[snapshot],
+            config={
+                "model_policy": "snapshot",
+                "override_model_id": None,
+                "judge_model_id": None,
+                "seed": int((dataset.get("provenance") or {}).get("seed") or 0),
+                "budget": {
+                    "repetitions": 1,
+                    "max_concurrency": 2,
+                    "case_timeout_seconds": 120,
+                    "max_model_calls": 16,
+                    "max_tool_calls": 24,
+                    "max_estimated_tokens": 64_000,
+                    "max_output_chars": 20_000,
+                },
+            },
+            warnings=[
+                "Calibration verifies scoring executability and never rewrites Gold.",
+                "Target specificity is measured against a same-model generic counterfactual.",
+            ],
+        )
+        await asyncio.to_thread(
+            self.service.evaluation_store.set_dataset_calibration,
+            dataset["dataset_id"],
+            revision=revision,
+            calibration={
+                "status": "pending",
+                "dataset_revision": revision,
+                "target_reference": copy.deepcopy(reference),
+                "target_checksum": snapshot["checksum"],
+                "evaluation_run_id": run["run_id"],
+            },
+        )
+        await asyncio.to_thread(
+            self.store.update_job,
+            job_id,
+            status="calibrating",
+            dataset_id=dataset["dataset_id"],
+            dataset_revision=revision,
+            evaluation_run_id=run["run_id"],
+        )
+        self.evaluation_executor.wake()
+
+    async def _poll_calibrations(self) -> bool:
+        progressed = False
+        jobs = await asyncio.to_thread(
+            self.store.list_jobs, status="calibrating", limit=200
+        )
+        for job in jobs:
+            run_id = str(job.get("evaluation_run_id") or "")
+            if not run_id:
+                await self._fail_job(job, BenchmarkGenerationError("Calibration run missing."))
+                progressed = True
+                continue
+            current_job = await asyncio.to_thread(self.store.require_job, job["job_id"])
+            if current_job.get("cancel_requested"):
+                await asyncio.to_thread(self.evaluation_store.cancel_run, run_id)
+                await asyncio.to_thread(
+                    self.store.update_job, job["job_id"], status="cancelled"
+                )
+                progressed = True
+                continue
+            run = await asyncio.to_thread(self.evaluation_service.run_detail, run_id)
+            if run.get("status") not in {"completed", "failed", "cancelled"}:
+                continue
+            dataset = await asyncio.to_thread(
+                self.service.evaluation_store.require_dataset,
+                str(job.get("dataset_id") or ""),
+            )
+            target = dict(job.get("target") or {})
+            reference = dict((target.get("source") or {}))
+            request_reference = dict((job.get("request") or {}).get("target") or {})
+            if request_reference:
+                reference = request_reference
+            result = await asyncio.to_thread(
+                self.service.calibration_result,
+                dataset=dataset,
+                evaluation_run=run,
+                target_reference=reference,
+                target_checksum=str(target.get("checksum") or ""),
+            )
+            await asyncio.to_thread(
+                self.service.evaluation_store.set_dataset_calibration,
+                dataset["dataset_id"],
+                revision=int(job.get("dataset_revision") or 0),
+                calibration=result,
+            )
+            await asyncio.to_thread(
+                self.store.update_job,
+                job["job_id"],
+                status="completed",
+                calibration=result,
+            )
+            progressed = True
+        return progressed
+
+    async def _fail_job(self, job: dict[str, Any], exc: Exception) -> None:
+        error = str(exc)[:1_000]
+        dataset_id = str(job.get("dataset_id") or "")
+        revision = int(job.get("dataset_revision") or 0)
+        if dataset_id and revision:
+            with contextlib.suppress(Exception):
+                await asyncio.to_thread(
+                    self.service.evaluation_store.set_dataset_calibration,
+                    dataset_id,
+                    revision=revision,
+                    calibration={"status": "failed", "reason": error},
+                )
+        await asyncio.to_thread(
+            self.store.update_job,
+            job["job_id"],
+            status="failed",
+            error=error,
+        )
+
+    def _find_generation_dataset(self, job_id: str) -> dict[str, Any] | None:
+        for item in self.service.evaluation_store.list_datasets():
+            if str(item.get("origin") or "") != "generated":
+                continue
+            provenance = dict(item.get("provenance") or {})
+            if str(provenance.get("generation_job_id") or "") == job_id:
+                return self.service.evaluation_store.require_dataset(
+                    str(item["dataset_id"])
+                )
+        return None

--- a/server/benchmarks/models.py
+++ b/server/benchmarks/models.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
+
+try:
+    from server.evaluations.models import ConversationImportSelection
+except ModuleNotFoundError:
+    from evaluations.models import ConversationImportSelection
 
 
 BenchmarkKind = Literal["agent_response", "knowledge_retrieval"]
@@ -33,4 +38,84 @@ class BenchmarkPack(BaseModel):
 class InstantiateBenchmarkRequest(BaseModel):
     name: str | None = Field(default=None, min_length=1, max_length=160)
     description: str | None = Field(default=None, max_length=2_000)
+
+
+BenchmarkTargetKind = Literal[
+    "xpert_draft",
+    "xpert_version",
+    "proposal",
+    "prompt_profile",
+]
+
+
+class BenchmarkTargetRequest(BaseModel):
+    kind: BenchmarkTargetKind
+    xpert_id: str | None = Field(default=None, max_length=200)
+    draft_revision: int | None = Field(default=None, ge=1)
+    version: int | None = Field(default=None, ge=1)
+    proposal_id: str | None = Field(default=None, max_length=200)
+    proposal_revision: int | None = Field(default=None, ge=1)
+    prompt_profile_id: str | None = Field(default=None, max_length=200)
+    prompt_profile_revision: int | None = Field(default=None, ge=1)
+    host_xpert_id: str | None = Field(default=None, max_length=200)
+    host_xpert_version: int | None = Field(default=None, ge=1)
+    label: str = Field(default="", max_length=160)
+
+    @model_validator(mode="after")
+    def validate_reference(self) -> "BenchmarkTargetRequest":
+        if self.kind == "xpert_draft" and (
+            not self.xpert_id or self.draft_revision is None
+        ):
+            raise ValueError("xpert_id and draft_revision are required.")
+        if self.kind == "xpert_version" and (
+            not self.xpert_id or self.version is None
+        ):
+            raise ValueError("xpert_id and version are required.")
+        if self.kind == "proposal" and (
+            not self.proposal_id or self.proposal_revision is None
+        ):
+            raise ValueError("proposal_id and proposal_revision are required.")
+        if self.kind == "prompt_profile" and (
+            not self.prompt_profile_id
+            or self.prompt_profile_revision is None
+            or not self.host_xpert_id
+            or self.host_xpert_version is None
+        ):
+            raise ValueError(
+                "prompt_profile_id, prompt_profile_revision, host_xpert_id, and "
+                "host_xpert_version are required."
+            )
+        return self
+
+
+class BenchmarkGenerationRequest(BaseModel):
+    target: BenchmarkTargetRequest
+    generator_model_id: str = Field(min_length=1, max_length=300)
+    case_count: int = Field(default=12, ge=6, le=30)
+    locales: list[Literal["zh-CN", "en-US"]] = Field(
+        default_factory=lambda: ["zh-CN", "en-US"],
+        min_length=1,
+        max_length=2,
+    )
+    coverage: list[str] = Field(default_factory=list, max_length=10)
+    conversation_selections: list[ConversationImportSelection] = Field(
+        default_factory=list,
+        max_length=20,
+    )
+    seed: int = Field(default=0, ge=0, le=2_147_483_647)
+
+
+class BenchmarkGenerationPreflightRequest(BaseModel):
+    target: BenchmarkTargetRequest
+    coverage: list[str] = Field(default_factory=list, max_length=10)
+    conversation_selections: list[ConversationImportSelection] = Field(
+        default_factory=list,
+        max_length=20,
+    )
+
+
+class BenchmarkCalibrationRequest(BaseModel):
+    dataset_id: str = Field(min_length=1, max_length=200)
+    dataset_revision: int = Field(ge=1)
+    target: BenchmarkTargetRequest | None = None
 

--- a/server/benchmarks/service.py
+++ b/server/benchmarks/service.py
@@ -1,0 +1,2467 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import math
+import re
+from typing import Any
+
+from pydantic import ValidationError
+
+try:
+    from server.evaluations.models import EvaluationCaseInput
+    from server.evaluations.service import XpertEvaluationService
+    from server.evaluations.store import (
+        EvaluationConflictError,
+        EvaluationStateError,
+        XpertEvaluationStore,
+    )
+except ModuleNotFoundError:
+    from evaluations.models import EvaluationCaseInput
+    from evaluations.service import XpertEvaluationService
+    from evaluations.store import (
+        EvaluationConflictError,
+        EvaluationStateError,
+        XpertEvaluationStore,
+    )
+
+
+SUPPORTED_COVERAGE = {
+    "instruction_following",
+    "structured_output",
+    "multi_turn",
+    "tool_routing",
+    "knowledge_citation",
+    "prompt_command",
+}
+
+PRESSURE_TYPES_BY_COVERAGE: dict[str, tuple[str, ...]] = {
+    "instruction_following": ("competing_constraints", "domain_exception", "ambiguity"),
+    "structured_output": ("schema_boundary", "competing_constraints"),
+    "multi_turn": ("conflicting_context", "cross_turn_override"),
+    "tool_routing": ("tool_decoy", "competing_constraints"),
+    "knowledge_citation": ("missing_evidence", "conflicting_context"),
+    "prompt_command": ("ambiguity", "competing_constraints"),
+}
+
+GENERIC_FOCUS_TERMS = {
+    "agent",
+    "answer",
+    "assistant",
+    "complete",
+    "context",
+    "current",
+    "directly",
+    "execute",
+    "final",
+    "follow",
+    "model",
+    "output",
+    "request",
+    "response",
+    "result",
+    "task",
+    "user",
+    "workflow",
+    "and",
+    "are",
+    "evaluate",
+    "for",
+    "from",
+    "must",
+    "review",
+    "should",
+    "the",
+    "with",
+    "you",
+    "\u4e00\u4e2a",
+    "\u4e0a\u4e0b\u6587",
+    "\u4efb\u52a1",
+    "\u4f7f\u7528",
+    "\u52a9\u624b",
+    "\u56de\u7b54",
+    "\u5b8c\u6210",
+    "\u5f53\u524d",
+    "\u6267\u884c",
+    "\u667a\u80fd\u4f53",
+    "\u6a21\u578b",
+    "\u7528\u6237",
+    "\u76f4\u63a5",
+    "\u7ed3\u679c",
+    "\u7ed3\u5408",
+    "\u8bf7\u6c42",
+    "\u8f93\u51fa",
+    "\u4f60\u662f",
+    "\u4f5c\u4e3a",
+    "\u4e13\u5bb6",
+    "\u8bc4\u4f30",
+    "\u6838\u5bf9",
+    "\u8d1f\u8d23",
+    "\u5fc5\u987b",
+}
+
+GENERIC_EVIDENCE_TERMS = GENERIC_FOCUS_TERMS | {
+    "analysis",
+    "assess",
+    "case",
+    "decision",
+    "describe",
+    "determine",
+    "evidence",
+    "explain",
+    "professional",
+    "provide",
+    "recommend",
+    "scenario",
+    "specialist",
+    "verify",
+}
+
+
+class BenchmarkGenerationError(RuntimeError):
+    pass
+
+
+class BenchmarkGenerationService:
+    """Builds safe target snapshots and validates generated benchmark drafts."""
+
+    def __init__(
+        self,
+        *,
+        evaluation_store: XpertEvaluationStore,
+        evaluation_service: XpertEvaluationService,
+        xpert_store: Any,
+        proposal_store: Any,
+        prompt_store: Any,
+        context_store: Any,
+        rag_service: Any | None = None,
+        toolset_store: Any | None = None,
+    ) -> None:
+        self.evaluation_store = evaluation_store
+        self.evaluation_service = evaluation_service
+        self.xpert_store = xpert_store
+        self.proposal_store = proposal_store
+        self.prompt_store = prompt_store
+        self.context_store = context_store
+        self.rag_service = rag_service
+        self.toolset_store = toolset_store
+
+    def capabilities(self) -> dict[str, Any]:
+        return {
+            "version": "evoagentx-benchmark-generator-v6",
+            "target_kinds": [
+                "xpert_draft",
+                "xpert_version",
+                "proposal",
+                "prompt_profile",
+            ],
+            "coverage": sorted(SUPPORTED_COVERAGE),
+            "case_count": {"default": 12, "min": 6, "max": 30},
+            "locales": ["zh-CN", "en-US"],
+            "generator_model_required": True,
+            "generation_model_calls": {"generate": 1, "repair": 1},
+            "calibration": {
+                "repetitions": 1,
+                "max_concurrency": 2,
+                "case_timeout_seconds": 120,
+                "rewrites_gold": False,
+                "generic_counterfactual": True,
+                "targeting_advantage_threshold": 0.10,
+            },
+            "targeting": {
+                "required": True,
+                "difficulties": ["basic", "edge", "adversarial"],
+                "target_refs_required_per_case": True,
+                "rationale_required_per_case": True,
+                "capability_matrix_size": {"min": 1, "max": 3},
+                "combined_case_min_ratio": 0.60,
+                "professional_focus_required_when_available": True,
+                "pressure_types_required_for": ["edge", "adversarial"],
+            },
+        }
+
+    def preflight(
+        self,
+        *,
+        target_reference: dict[str, Any],
+        requested_coverage: list[str] | None = None,
+        conversation_selections: list[dict[str, Any]] | None = None,
+    ) -> dict[str, Any]:
+        snapshot, warnings = self.snapshot_target(target_reference)
+        coverage = self.detect_coverage(snapshot)
+        selected = [str(item) for item in list(requested_coverage or []) if str(item)]
+        unknown = sorted(set(selected) - SUPPORTED_COVERAGE)
+        unavailable = sorted(set(selected) - set(coverage["available"]))
+        seeds = self.conversation_seeds(conversation_selections or [])
+        target_anchors = self.target_anchors(snapshot)
+        focus_terms = list(
+            dict.fromkeys(
+                str(term)
+                for anchor in target_anchors
+                for term in list(anchor.get("focus_terms") or [])
+                if str(term).strip()
+            )
+        )
+        if not focus_terms:
+            warnings.append(
+                "Target exposes no professional focus terms; generated cases can only "
+                "prove generic execution contracts until the target prompt is specialized."
+            )
+        issues: list[dict[str, Any]] = []
+        if unknown:
+            issues.append(
+                {
+                    "code": "benchmark_coverage_unknown",
+                    "message": f"Unsupported coverage: {', '.join(unknown)}",
+                }
+            )
+        if unavailable:
+            issues.append(
+                {
+                    "code": "benchmark_coverage_unavailable",
+                    "message": (
+                        "Target does not expose the requested capability: "
+                        + ", ".join(unavailable)
+                    ),
+                }
+            )
+        return {
+            "valid": not issues,
+            "target": self.public_target(snapshot),
+            "coverage": coverage,
+            "target_anchors": target_anchors,
+            "targeting": {
+                "focus_term_count": len(focus_terms),
+                "focus_terms": focus_terms[:20],
+                "domain_anchor_count": sum(
+                    1 for anchor in target_anchors if anchor.get("axis") == "domain"
+                ),
+                "resource_anchor_count": sum(
+                    1 for anchor in target_anchors if anchor.get("axis") == "resource"
+                ),
+            },
+            "conversation_seed_count": len(seeds),
+            "warnings": list(dict.fromkeys(warnings)),
+            "issues": issues,
+        }
+
+    def snapshot_target(
+        self, reference: dict[str, Any]
+    ) -> tuple[dict[str, Any], list[str]]:
+        kind = str(reference.get("kind") or "")
+        if kind in {"xpert_version", "proposal"}:
+            snapshot, warnings = self.evaluation_service.snapshot_target(
+                reference,
+                model_policy="snapshot",
+                override_model_id=None,
+            )
+            return snapshot, warnings
+        if kind == "xpert_draft":
+            xpert_id = str(reference.get("xpert_id") or "")
+            revision = int(reference.get("draft_revision") or 0)
+            xpert = self.xpert_store.get_xpert(xpert_id)
+            if xpert.draft_revision != revision:
+                raise EvaluationConflictError(
+                    "Xpert draft changed before the Benchmark snapshot was created."
+                )
+            return self.evaluation_service.snapshot_xpert_draft(
+                xpert,
+                source={
+                    "kind": "xpert_draft",
+                    "xpert_id": xpert.id,
+                    "draft_revision": revision,
+                },
+                label=str(reference.get("label") or f"{xpert.name} draft r{revision}"),
+                model_policy="snapshot",
+                override_model_id=None,
+                target_id=f"xpert-draft:{xpert.id}:r{revision}",
+            )
+        if kind == "prompt_profile":
+            profile_id = str(reference.get("prompt_profile_id") or "")
+            profile_revision = int(reference.get("prompt_profile_revision") or 0)
+            profile = self.prompt_store.get_profile(profile_id)
+            if profile.draft_revision != profile_revision:
+                raise EvaluationConflictError(
+                    "Prompt Profile changed before the Benchmark snapshot was created."
+                )
+            host_reference = {
+                "kind": "xpert_version",
+                "xpert_id": str(reference.get("host_xpert_id") or ""),
+                "version": int(reference.get("host_xpert_version") or 0),
+                "label": str(reference.get("label") or profile.name),
+            }
+            snapshot, warnings = self.evaluation_service.snapshot_target(
+                host_reference,
+                model_policy="snapshot",
+                override_model_id=None,
+            )
+            snapshot["target_id"] = (
+                f"prompt-profile:{profile.id}:r{profile_revision}:host:"
+                f"{host_reference['xpert_id']}:v{host_reference['version']}"
+            )
+            snapshot["label"] = str(
+                reference.get("label") or f"{profile.name} r{profile_revision}"
+            )[:160]
+            snapshot["source"] = {
+                "kind": "prompt_profile",
+                "prompt_profile_id": profile.id,
+                "prompt_profile_revision": profile_revision,
+                "host_xpert_id": host_reference["xpert_id"],
+                "host_xpert_version": host_reference["version"],
+            }
+            snapshot["input_template"] = profile.template
+            snapshot["prompt_profile"] = {
+                "id": profile.id,
+                "name": profile.name,
+                "aliases": list(profile.aliases),
+                "argument_hint": profile.argument_hint,
+                "template": profile.template,
+            }
+            snapshot["checksum"] = self._checksum(
+                {
+                    "host_checksum": snapshot.get("checksum"),
+                    "profile_id": profile.id,
+                    "profile_revision": profile_revision,
+                    "template": profile.template,
+                }
+            )
+            return snapshot, warnings
+        raise EvaluationStateError("Unsupported Benchmark generation target kind.")
+
+    def target_is_fresh(self, reference: dict[str, Any], checksum: str) -> bool:
+        try:
+            snapshot, _ = self.snapshot_target(reference)
+        except Exception:
+            return False
+        return str(snapshot.get("checksum") or "") == str(checksum or "")
+
+    def detect_coverage(self, snapshot: dict[str, Any]) -> dict[str, Any]:
+        workflow = dict(snapshot.get("workflow") or {})
+        nodes = list(workflow.get("nodes") or [])
+        available = {"instruction_following", "multi_turn"}
+        reasons: dict[str, str] = {
+            "instruction_following": "The target contains an executable Agent prompt.",
+            "multi_turn": "The Xpert execution contract accepts bounded conversation history.",
+        }
+        tool_names: list[str] = self._resolved_tool_names(snapshot)
+        knowledge_ids: list[str] = []
+        for node in nodes:
+            data = dict(node.get("data") or {}) if isinstance(node, dict) else {}
+            kind = str(data.get("kind") or node.get("type") or "")
+            if kind == "workflow_agent":
+                if str(data.get("outputSchemaMode") or "none") not in {"", "none"}:
+                    available.add("structured_output")
+                    reasons["structured_output"] = "The Agent declares a structured output contract."
+            elif kind in {"mcp_tool", "toolset_resource", "external_xpert"}:
+                pass
+            elif kind in {"knowledge_base", "knowledge_retrieval", "knowledge_citation"}:
+                available.add("knowledge_citation")
+                reasons["knowledge_citation"] = "The workflow includes knowledge retrieval or citation."
+                kb_id = str(data.get("knowledgeBaseId") or data.get("kbId") or "")
+                if kb_id:
+                    knowledge_ids.append(kb_id)
+            elif kind == "runtime_middleware" and str(
+                data.get("middlewareId") or data.get("middleware_id") or ""
+            ) == "structured_output":
+                available.add("structured_output")
+                reasons["structured_output"] = "Structured output middleware is bound."
+        prompt_profile = dict(snapshot.get("prompt_profile") or {})
+        prompt_profiles = list(snapshot.get("prompt_profiles") or [])
+        if prompt_profile or prompt_profiles:
+            available.add("prompt_command")
+            reasons["prompt_command"] = "The target exposes fixed Prompt Profile commands."
+        if tool_names:
+            available.add("tool_routing")
+            reasons["tool_routing"] = "The target exposes fixed callable tool names."
+        knowledge_documents = self._knowledge_document_names(snapshot)
+        if knowledge_ids and knowledge_documents:
+            available.add("knowledge_citation")
+            reasons["knowledge_citation"] = (
+                "The fixed active knowledge version exposes safe document references."
+            )
+        elif "knowledge_citation" in available:
+            available.remove("knowledge_citation")
+            reasons.pop("knowledge_citation", None)
+        return {
+            "available": sorted(available),
+            "recommended": sorted(available),
+            "reasons": reasons,
+            "tool_names": sorted(set(tool_names))[:100],
+            "knowledge_base_ids": sorted(set(knowledge_ids))[:20],
+        }
+
+    def target_anchors(self, snapshot: dict[str, Any]) -> list[dict[str, Any]]:
+        """Return bounded, safe evidence that generated cases must explicitly cite."""
+
+        anchors: list[dict[str, Any]] = []
+        seen: set[str] = set()
+
+        def add(
+            anchor_id: str,
+            *,
+            kind: str,
+            axis: str,
+            label: str,
+            summary: str,
+            coverage: list[str],
+        ) -> None:
+            normalized_id = str(anchor_id or "")[:160]
+            if not normalized_id or normalized_id in seen:
+                return
+            seen.add(normalized_id)
+            anchors.append(
+                {
+                    "id": normalized_id,
+                    "kind": kind[:80],
+                    "axis": axis[:40],
+                    "label": str(label or kind)[:160],
+                    "summary": self._safe_excerpt(summary, 280),
+                    "focus_terms": self._focus_terms(summary),
+                    "coverage": [
+                        item for item in coverage if item in SUPPORTED_COVERAGE
+                    ],
+                }
+            )
+
+        xpert = dict(snapshot.get("xpert") or {})
+        description = str(xpert.get("description") or "").strip()
+        if description:
+            add(
+                "xpert:purpose",
+                kind="xpert_purpose",
+                axis="domain",
+                label="Xpert purpose",
+                summary=description,
+                coverage=["instruction_following"],
+            )
+
+        workflow = dict(snapshot.get("workflow") or {})
+        knowledge_document_names = self._knowledge_document_names(snapshot)
+        for index, node in enumerate(list(workflow.get("nodes") or [])):
+            if not isinstance(node, dict):
+                continue
+            data = dict(node.get("data") or {})
+            node_kind = str(data.get("kind") or node.get("type") or "")
+            node_key = self._anchor_key(node.get("id") or f"node-{index + 1}")
+            title = str(data.get("title") or node_kind or f"Node {index + 1}")[:160]
+            if node_kind == "workflow_agent":
+                role_prompt = str(data.get("rolePrompt") or "").strip()
+                prompt_suffix = str(data.get("promptSuffix") or "").strip()
+                task_input = str(data.get("taskInput") or "").strip()
+                output_schema = str(data.get("outputSchemaJson") or "").strip()
+                if role_prompt:
+                    add(
+                        f"agent:{node_key}:role_prompt",
+                        kind="agent_prompt",
+                        axis="domain",
+                        label=f"{title} rolePrompt",
+                        summary=role_prompt,
+                        coverage=["instruction_following"],
+                    )
+                else:
+                    add(
+                        f"agent:{node_key}:execution_contract",
+                        kind="agent_contract",
+                        axis="contract",
+                        label=f"{title} execution contract",
+                        summary=f"Agent {title} must directly complete its assigned task.",
+                        coverage=["instruction_following"],
+                    )
+                if prompt_suffix:
+                    add(
+                        f"agent:{node_key}:prompt_suffix",
+                        kind="agent_prompt",
+                        axis="domain",
+                        label=f"{title} promptSuffix",
+                        summary=prompt_suffix,
+                        coverage=["instruction_following"],
+                    )
+                if "conversation_history" in task_input:
+                    add(
+                        f"agent:{node_key}:conversation_contract",
+                        kind="conversation_contract",
+                        axis="contract",
+                        label=f"{title} conversation history",
+                        summary="The Agent receives bounded conversation_history and must resolve recent context and conflicts.",
+                        coverage=["multi_turn"],
+                    )
+                if str(data.get("outputSchemaMode") or "none") not in {"", "none"}:
+                    add(
+                        f"agent:{node_key}:output_schema",
+                        kind="output_schema",
+                        axis="contract",
+                        label=f"{title} structured output",
+                        summary=output_schema or "The Agent final output must satisfy its configured JSON Schema.",
+                        coverage=["structured_output"],
+                    )
+                for tool_name in self._string_list(data.get("toolNames"))[:20]:
+                    add(
+                        f"tool:{self._anchor_key(tool_name)}",
+                        kind="tool",
+                        axis="resource",
+                        label=f"Tool {tool_name}",
+                        summary=f"The Agent may route an eligible request to {tool_name}.",
+                        coverage=["tool_routing"],
+                    )
+            elif node_kind in {"mcp_tool", "toolset_resource", "external_xpert"}:
+                add(
+                    f"resource:{node_key}",
+                    kind=node_kind,
+                    axis="resource",
+                    label=title,
+                    summary=str(data.get("description") or f"Callable {node_kind} resource {title}."),
+                    coverage=["tool_routing"],
+                )
+            elif node_kind in {"knowledge_base", "knowledge_retrieval", "knowledge_citation"}:
+                kb_id = str(data.get("knowledgeBaseId") or data.get("kbId") or node_key)
+                add(
+                    f"knowledge:{self._anchor_key(kb_id)}",
+                    kind="knowledge",
+                    axis="resource",
+                    label=title,
+                    summary=(
+                        str(
+                            data.get("description")
+                            or f"Knowledge source {title} must ground retrievable claims."
+                        )
+                        + (
+                            " Fixed document names: "
+                            + ", ".join(knowledge_document_names[:20])
+                            if knowledge_document_names
+                            else ""
+                        )
+                    ),
+                    coverage=["knowledge_citation"],
+                )
+            elif node_kind == "runtime_middleware" and str(
+                data.get("middlewareId") or data.get("middleware_id") or ""
+            ) == "structured_output":
+                add(
+                    f"middleware:{node_key}:structured_output",
+                    kind="output_schema",
+                    axis="contract",
+                    label=f"{title} structured output",
+                    summary=str(data.get("outputSchemaJson") or "The final answer must satisfy the bound structured-output contract."),
+                    coverage=["structured_output"],
+                )
+
+        if not any("multi_turn" in anchor["coverage"] for anchor in anchors):
+            add(
+                "runtime:conversation_history",
+                kind="conversation_contract",
+                axis="contract",
+                label="Bounded conversation contract",
+                summary="The Xpert runtime supplies up to 20 history messages; the current user message remains authoritative.",
+                coverage=["multi_turn"],
+            )
+
+        prompt_profiles = [dict(item) for item in list(snapshot.get("prompt_profiles") or []) if isinstance(item, dict)]
+        direct_profile = dict(snapshot.get("prompt_profile") or {})
+        if direct_profile:
+            prompt_profiles.insert(0, direct_profile)
+        for index, profile in enumerate(prompt_profiles[:10]):
+            profile_key = self._anchor_key(profile.get("id") or profile.get("name") or index)
+            aliases = ", ".join(str(item) for item in list(profile.get("aliases") or [])[:5])
+            add(
+                f"prompt_profile:{profile_key}",
+                kind="prompt_command",
+                axis="resource",
+                label=str(profile.get("name") or aliases or "Prompt command"),
+                summary=(
+                    (f"Command aliases: {aliases}. " if aliases else "")
+                    + str(profile.get("template") or profile.get("description") or "")
+                ),
+                coverage=["prompt_command"],
+            )
+
+        for tool_name in self._resolved_tool_names(snapshot)[:40]:
+            add(
+                f"tool:{self._anchor_key(tool_name)}",
+                kind="tool",
+                axis="resource",
+                label=f"Tool {tool_name}",
+                summary=f"The fixed target may route eligible requests to {tool_name}.",
+                coverage=["tool_routing"],
+            )
+
+        if not any("instruction_following" in anchor["coverage"] for anchor in anchors):
+            add(
+                "xpert:execution_contract",
+                kind="agent_contract",
+                axis="contract",
+                label="Xpert execution contract",
+                summary="The fixed Xpert must directly fulfill the current user task through its published workflow.",
+                coverage=["instruction_following"],
+            )
+        return anchors[:40]
+
+    def conversation_seeds(
+        self, selections: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        seeds: list[dict[str, Any]] = []
+        for selection in selections[:20]:
+            conversation = self.context_store.get_conversation(
+                str(selection.get("xpert_id") or ""),
+                str(selection.get("conversation_id") or ""),
+            )
+            selected_ids = {
+                str(item) for item in list(selection.get("message_ids") or []) if str(item)
+            }
+            history: list[dict[str, str]] = []
+            for message in conversation.messages:
+                if message.role == "user" and message.message_id in selected_ids:
+                    seeds.append(
+                        {
+                            "message_id": message.message_id,
+                            "message": str(message.content)[:8_000],
+                            "messages": copy.deepcopy(history[-6:]),
+                        }
+                    )
+                history.append(
+                    {
+                        "role": message.role,
+                        "content": str(message.content)[:4_000],
+                    }
+                )
+        return seeds[:30]
+
+    def generation_prompt(
+        self,
+        *,
+        snapshot: dict[str, Any],
+        case_count: int,
+        locales: list[str],
+        requested_coverage: list[str],
+        conversation_seeds: list[dict[str, Any]],
+        seed: int,
+    ) -> tuple[str, str, dict[str, Any]]:
+        coverage = self.detect_coverage(snapshot)
+        selected = requested_coverage or list(coverage["recommended"])
+        selected = [item for item in selected if item in coverage["available"]]
+        context = self._safe_generation_context(snapshot)
+        target_anchors = list(context.get("target_anchors") or [])
+        case_blueprints = self.case_blueprints(
+            case_count=case_count,
+            locales=locales,
+            selected_coverage=selected,
+            target_anchors=target_anchors,
+            seed=seed,
+            tool_names=list(context.get("allowed_tool_names") or []),
+            document_names=list(context.get("knowledge_document_names") or []),
+            prompt_aliases=list(context.get("prompt_command_aliases") or []),
+            structured_output_schemas=self._structured_output_schemas(snapshot),
+        )
+        contract = {
+            "dataset": {
+                "name": "short descriptive name",
+                "description": "what this generated set validates",
+                "cases": [
+                    {
+                        "name": "short name",
+                        "targeting": {
+                            "blueprint_id": "copy the matching server blueprint ID",
+                            "rationale": "which exact target behavior this case verifies",
+                            "challenge": "the concrete failure mode or pressure applied",
+                            "discriminator": "observable behavior that a generic assistant would likely miss",
+                        },
+                        "message": "current user message",
+                        "messages": [{"role": "user|assistant", "content": "bounded history"}],
+                        "expected": {
+                            "exact_answer": "optional deterministic answer",
+                            "contains": ["optional required fragments"],
+                        },
+                        "weights": {"contains": 1.0},
+                    }
+                ],
+                "assumptions": ["short public assumption"],
+            }
+        }
+        system = (
+            "You design deterministic, repeatable benchmark cases for one fixed AI "
+            "target. Every case must test an explicit prompt, contract, tool, knowledge, "
+            "or command anchor supplied by the target snapshot. Return JSON only. Never "
+            "include hidden reasoning, credentials, "
+            "file paths, attachment content, memories, or private tool output. Do not "
+            "derive expected answers from assistant messages. Gold expectations must "
+            "be independently stated and machine-checkable. Generic trivia, arithmetic, "
+            "translation, or arbitrary formatting are invalid unless an explicit target "
+            "anchor requires them. A benchmark case is invalid if it could be reused for "
+            "an unrelated general-purpose assistant by only changing its title. The server "
+            "has already designed each case's capability, evidence, pressure, locale, and "
+            "difficulty blueprint. Return only blueprint_id plus rationale, challenge, and "
+            "discriminator in targeting; the server injects all other targeting and fixed "
+            "Gold metadata. Do not repeat full JSON Schemas or resource identifiers. "
+            "Concentrate on a realistic "
+            "professional scenario and deterministic Gold that make the blueprint observable."
+        )
+        user = (
+            f"Create exactly {case_count} cases. Seed={seed}. Locales={locales}. "
+            f"Coverage={selected}. Balance both locales when both are selected. Each "
+            "case whose blueprint has no fixed resource or schema expectation must define "
+            "at least one deterministic exact_answer or contains expectation. Never invent citation "
+            "IDs. Conversation samples are input inspiration only, never Gold. Produce cases "
+            "in the exact order of case_blueprints and copy each blueprint_id. The server "
+            "will enforce the blueprint's locale, coverage, target_refs, capability_matrix, "
+            "focus_terms, pressure_types, difficulty, and exact resource requirements. "
+            "When a blueprint contains required_prompt_alias, the message must begin exactly "
+            "with /<required_prompt_alias>. The server inserts required/forbidden tools, "
+            "knowledge documents, and structured output schemas from the blueprint. The professional "
+            "case input must visibly exercise either a required focus term or multiple "
+            "domain markers from its cited anchors. The rationale must "
+            "explain the exact target-specific "
+            "behavior and the challenge must name the likely failure mode; write both in "
+            "the same language as the case. discriminator must state a concrete observable "
+            "difference from an unconfigured general-purpose model. Meet every item in each "
+            "blueprint's observable_requirements. Edge cases must contain the specified "
+            "concrete pressure rather than merely naming it. Adversarial cases must combine "
+            "all specified pressures and include enough contradictory, incomplete, boundary, "
+            "or decoy evidence for the deterministic Gold to discriminate the configured "
+            "target. Do not make adversarial cases into direct fully specified questions.\n\n"
+            f"Server-authored case blueprints:\n{json.dumps(case_blueprints, ensure_ascii=False)}\n\n"
+            f"Target context:\n{json.dumps(context, ensure_ascii=False)}\n\n"
+            f"Explicit user seeds:\n{json.dumps(conversation_seeds, ensure_ascii=False)}\n\n"
+            f"JSON contract:\n{json.dumps(contract, ensure_ascii=False)}"
+        )
+        return system, user, {
+            "selected": selected,
+            **coverage,
+            "target_anchors": target_anchors,
+            "target_anchor_hash": self._checksum(target_anchors),
+            "case_blueprints": case_blueprints,
+            "case_blueprint_hash": self._checksum(case_blueprints),
+            "knowledge_document_names": list(
+                context.get("knowledge_document_names") or []
+            ),
+            "prompt_command_aliases": list(
+                context.get("prompt_command_aliases") or []
+            ),
+        }
+
+    def case_blueprints(
+        self,
+        *,
+        case_count: int,
+        locales: list[str],
+        selected_coverage: list[str],
+        target_anchors: list[dict[str, Any]],
+        seed: int,
+        tool_names: list[str] | None = None,
+        document_names: list[str] | None = None,
+        prompt_aliases: list[str] | None = None,
+        structured_output_schemas: dict[str, dict[str, Any]] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Build the evaluation design before asking a model to write case content."""
+
+        selected = [item for item in selected_coverage if item in SUPPORTED_COVERAGE]
+        if not selected:
+            raise BenchmarkGenerationError("At least one supported capability is required.")
+        locale_values = [item for item in locales if item in {"zh-CN", "en-US"}]
+        if not locale_values:
+            locale_values = ["zh-CN", "en-US"]
+        anchors = [
+            dict(item)
+            for item in target_anchors
+            if isinstance(item, dict) and str(item.get("id") or "")
+        ]
+        if not anchors:
+            raise BenchmarkGenerationError("Target snapshot exposes no benchmark anchors.")
+        fixed_tools = [str(item) for item in list(tool_names or []) if str(item)]
+        fixed_documents = [
+            str(item) for item in list(document_names or []) if str(item)
+        ]
+        fixed_aliases = [
+            str(item).lstrip("/").casefold()
+            for item in list(prompt_aliases or [])
+            if str(item).strip()
+        ]
+
+        rotation = int(seed) % len(selected)
+        wheel = selected[rotation:] + selected[:rotation]
+        combined_count = (
+            min(case_count - 1, math.ceil(case_count * 0.60))
+            if len(wheel) >= 2
+            else 0
+        )
+        basic_count = max(1, math.floor(case_count * 0.20))
+        remaining = case_count - basic_count
+        edge_count = max(math.ceil(case_count * 0.25), remaining // 2)
+        edge_count = min(edge_count, remaining - math.ceil(case_count * 0.25))
+        difficulties = [
+            *(["basic"] * basic_count),
+            *(["edge"] * edge_count),
+            *(["adversarial"] * (case_count - basic_count - edge_count)),
+        ]
+        difficulty_rotation = int(seed) % len(difficulties)
+        difficulties = difficulties[difficulty_rotation:] + difficulties[:difficulty_rotation]
+
+        professional_anchors = [
+            item
+            for item in anchors
+            if item.get("axis") in {"domain", "resource"}
+            and list(item.get("focus_terms") or [])
+        ]
+
+        def anchor_for(capability: str) -> dict[str, Any]:
+            candidates = [
+                item
+                for item in anchors
+                if capability in set(item.get("coverage") or [])
+            ]
+            if not candidates:
+                raise BenchmarkGenerationError(
+                    f"Target snapshot has no anchor for capability: {capability}."
+                )
+            axis_priority = {
+                "instruction_following": {"domain": 0, "contract": 1, "resource": 2},
+                "structured_output": {"contract": 0, "domain": 1, "resource": 2},
+                "multi_turn": {"contract": 0, "domain": 1, "resource": 2},
+                "tool_routing": {"resource": 0, "domain": 1, "contract": 2},
+                "knowledge_citation": {"resource": 0, "domain": 1, "contract": 2},
+                "prompt_command": {"resource": 0, "domain": 1, "contract": 2},
+            }.get(capability, {})
+            return sorted(
+                candidates,
+                key=lambda item: (
+                    axis_priority.get(str(item.get("axis") or ""), 3),
+                    0 if list(item.get("focus_terms") or []) else 1,
+                    str(item.get("id") or ""),
+                ),
+            )[0]
+
+        output: list[dict[str, Any]] = []
+        for index in range(case_count):
+            primary = wheel[index % len(wheel)]
+            difficulty = difficulties[index]
+            if index < combined_count:
+                matrix_size = 3 if len(wheel) >= 3 and index % 2 else 2
+                matrix = [
+                    wheel[(index + offset) % len(wheel)]
+                    for offset in range(matrix_size)
+                ]
+                matrix = list(dict.fromkeys(matrix))
+            else:
+                matrix = [primary]
+            if difficulty == "adversarial" and len(matrix) == 1 and len(wheel) > 1:
+                matrix.append(wheel[(index + 1) % len(wheel)])
+                matrix = list(dict.fromkeys(matrix))
+
+            selected_anchors: list[dict[str, Any]] = []
+            for capability in matrix:
+                candidate = anchor_for(capability)
+                if candidate not in selected_anchors:
+                    selected_anchors.append(candidate)
+            if professional_anchors and not any(
+                item.get("axis") in {"domain", "resource"}
+                for item in selected_anchors
+            ):
+                selected_anchors.insert(0, professional_anchors[index % len(professional_anchors)])
+            selected_anchors = selected_anchors[:5]
+
+            focus_terms: list[str] = []
+            for anchor in selected_anchors:
+                for term in list(anchor.get("focus_terms") or []):
+                    if str(term).strip() and str(term) not in focus_terms:
+                        focus_terms.append(str(term))
+                        break
+                if len(focus_terms) >= 3:
+                    break
+            pressure_pool: list[str] = []
+            for capability in matrix:
+                pressure_pool.extend(PRESSURE_TYPES_BY_COVERAGE.get(capability, ()))
+            pressure_pool = list(dict.fromkeys(pressure_pool))
+            minimum_pressure = 2 if difficulty == "adversarial" else 1 if difficulty == "edge" else 0
+            if pressure_pool:
+                pressure_offset = (int(seed) + index) % len(pressure_pool)
+                pressure_pool = pressure_pool[pressure_offset:] + pressure_pool[:pressure_offset]
+            pressure_types = pressure_pool[:minimum_pressure]
+            required_tool_name = (
+                fixed_tools[index % len(fixed_tools)]
+                if "tool_routing" in matrix and fixed_tools
+                else None
+            )
+            forbidden_tool_names: list[str] = []
+            if required_tool_name and "tool_decoy" in pressure_types:
+                anchored_tools = [
+                    str(item.get("id") or "").removeprefix("tool:")
+                    for item in selected_anchors
+                    if str(item.get("id") or "").startswith("tool:")
+                ]
+                decoys = [
+                    item
+                    for item in [*anchored_tools, *fixed_tools]
+                    if item and item != required_tool_name
+                ]
+                if decoys:
+                    forbidden_tool_names = [decoys[0]]
+                    decoy_anchor_id = f"tool:{decoys[0]}"
+                    decoy_anchor = next(
+                        (
+                            item
+                            for item in anchors
+                            if str(item.get("id") or "") == decoy_anchor_id
+                        ),
+                        None,
+                    )
+                    if decoy_anchor is not None and decoy_anchor not in selected_anchors:
+                        selected_anchors.append(decoy_anchor)
+                        selected_anchors = selected_anchors[:5]
+            required_document_name = (
+                fixed_documents[index % len(fixed_documents)]
+                if "knowledge_citation" in matrix and fixed_documents
+                else None
+            )
+            required_prompt_alias = (
+                fixed_aliases[index % len(fixed_aliases)]
+                if "prompt_command" in matrix and fixed_aliases
+                else None
+            )
+            required_json_schema: dict[str, Any] | None = None
+            if "structured_output" in matrix:
+                schemas = structured_output_schemas or {}
+                for anchor in selected_anchors:
+                    candidate = schemas.get(str(anchor.get("id") or ""))
+                    if isinstance(candidate, dict):
+                        required_json_schema = copy.deepcopy(candidate)
+                        break
+                if required_json_schema is None and schemas:
+                    required_json_schema = copy.deepcopy(next(iter(schemas.values())))
+
+            observable_requirements: list[str] = [
+                "State deterministic Gold that is not copied into the input.",
+            ]
+            if focus_terms:
+                observable_requirements.insert(
+                    0, "Use every required_focus_term verbatim in message or history."
+                )
+            if "structured_output" in matrix:
+                observable_requirements.append(
+                    "The server will inject the fixed structured response schema."
+                )
+            if "multi_turn" in matrix:
+                observable_requirements.append(
+                    "Provide at least two history messages, including an earlier assistant response."
+                )
+            if "tool_routing" in matrix:
+                observable_requirements.append(
+                    "The server will inject required_tool_name into deterministic Gold."
+                )
+                if forbidden_tool_names:
+                    observable_requirements.append(
+                        "Mention the forbidden decoy tool in the input while making clear it must not be selected."
+                    )
+            if "knowledge_citation" in matrix:
+                observable_requirements.append(
+                    "The server will inject required_document_name; do not invent citation or chunk IDs."
+                )
+            if "prompt_command" in matrix:
+                observable_requirements.append(
+                    "Begin message exactly with /<required_prompt_alias> followed by one space and the professional task."
+                )
+            if difficulty == "adversarial":
+                observable_requirements.append(
+                    "Expose at least two independent challenge signals in the actual input and Gold."
+                )
+            elif difficulty == "edge":
+                observable_requirements.append(
+                    "Expose at least one non-routine boundary or conflict in the actual input and Gold."
+                )
+
+            output.append(
+                {
+                    "blueprint_id": f"case-{index + 1:02d}",
+                    "locale": locale_values[index % len(locale_values)],
+                    "primary_coverage": primary,
+                    "capability_matrix": matrix,
+                    "difficulty": difficulty,
+                    "target_refs": [str(item["id"]) for item in selected_anchors],
+                    "required_focus_terms": focus_terms,
+                    "pressure_types": pressure_types,
+                    "required_tool_name": required_tool_name,
+                    "forbidden_tool_names": forbidden_tool_names,
+                    "required_document_name": required_document_name,
+                    "required_prompt_alias": required_prompt_alias,
+                    "required_json_schema": required_json_schema,
+                    "anchor_evidence": [
+                        {
+                            "id": str(item["id"]),
+                            "label": str(item.get("label") or "")[:160],
+                            "summary": str(item.get("summary") or "")[:280],
+                        }
+                        for item in selected_anchors
+                    ],
+                    "observable_requirements": observable_requirements,
+                }
+            )
+        return output
+
+    def parse_generated_cases(
+        self,
+        raw: str,
+        *,
+        expected_count: int,
+        allowed_coverage: list[str],
+        allowed_tool_names: list[str],
+        allowed_target_anchors: list[dict[str, Any]] | None = None,
+        case_blueprints: list[dict[str, Any]] | None = None,
+        allowed_document_names: list[str] | None = None,
+        allowed_prompt_aliases: list[str] | None = None,
+    ) -> dict[str, Any]:
+        payload = self._extract_json(raw)
+        dataset = payload.get("dataset") if isinstance(payload, dict) else None
+        if not isinstance(dataset, dict):
+            raise BenchmarkGenerationError("Generator output is missing dataset.")
+        raw_cases = dataset.get("cases")
+        if not isinstance(raw_cases, list) or len(raw_cases) != expected_count:
+            raise BenchmarkGenerationError(
+                f"Generator must return exactly {expected_count} cases."
+            )
+        allowed_tools = set(allowed_tool_names)
+        anchors = {
+            str(item.get("id") or ""): item
+            for item in list(allowed_target_anchors or [])
+            if isinstance(item, dict) and str(item.get("id") or "")
+        }
+        if not anchors:
+            raise BenchmarkGenerationError("Target snapshot exposes no benchmark anchors.")
+        blueprints = [dict(item) for item in list(case_blueprints or []) if isinstance(item, dict)]
+        if blueprints and len(blueprints) != expected_count:
+            raise BenchmarkGenerationError(
+                f"Server blueprint must contain exactly {expected_count} cases."
+            )
+        normalized: list[dict[str, Any]] = []
+        seen: set[str] = set()
+        seen_coverage: set[str] = set()
+        referenced_anchor_ids: set[str] = set()
+        for index, raw_case in enumerate(raw_cases, start=1):
+            if not isinstance(raw_case, dict):
+                raise BenchmarkGenerationError(f"Case {index} is not an object.")
+            case = copy.deepcopy(raw_case)
+            blueprint = blueprints[index - 1] if blueprints else None
+            removed_server_owned_contains: list[str] = []
+            if blueprint:
+                case["case_id"] = str(blueprint.get("blueprint_id") or f"case-{index:02d}")
+                case["locale"] = str(blueprint.get("locale") or "zh-CN")
+                case["coverage"] = str(
+                    blueprint.get("primary_coverage") or "instruction_following"
+                )
+                generated_targeting = dict(case.get("targeting") or {})
+                generated_targeting.update(
+                    {
+                        "blueprint_id": str(blueprint.get("blueprint_id") or ""),
+                        "difficulty": str(blueprint.get("difficulty") or "basic"),
+                        "target_refs": list(blueprint.get("target_refs") or []),
+                        "capability_matrix": list(
+                            blueprint.get("capability_matrix") or []
+                        ),
+                        "focus_terms": list(
+                            blueprint.get("required_focus_terms") or []
+                        ),
+                        "pressure_types": list(
+                            blueprint.get("pressure_types") or []
+                        ),
+                    }
+                )
+                case["targeting"] = generated_targeting
+                expectation = dict(case.get("expected") or {})
+                required_tool_name = str(blueprint.get("required_tool_name") or "")
+                if required_tool_name:
+                    expectation["required_tools"] = list(
+                        dict.fromkeys(
+                            [
+                                *list(expectation.get("required_tools") or []),
+                                required_tool_name,
+                            ]
+                        )
+                    )
+                forbidden_tool_names = [
+                    str(item)
+                    for item in list(blueprint.get("forbidden_tool_names") or [])
+                    if str(item)
+                ]
+                if forbidden_tool_names:
+                    expectation["forbidden_tools"] = list(
+                        dict.fromkeys(
+                            [
+                                *list(expectation.get("forbidden_tools") or []),
+                                *forbidden_tool_names,
+                            ]
+                        )
+                    )
+                required_document_name = str(
+                    blueprint.get("required_document_name") or ""
+                )
+                if required_document_name:
+                    expectation["document_names"] = list(
+                        dict.fromkeys(
+                            [
+                                *list(expectation.get("document_names") or []),
+                                required_document_name,
+                            ]
+                        )
+                    )
+                required_json_schema = blueprint.get("required_json_schema")
+                if isinstance(required_json_schema, dict):
+                    expectation["json_schema"] = copy.deepcopy(required_json_schema)
+                removed_server_owned_contains = self._strip_server_owned_contains(
+                    expectation,
+                    blueprint,
+                )
+                case["expected"] = expectation
+            coverage = str(case.pop("coverage", "instruction_following"))
+            locale = str(case.pop("locale", ""))
+            if locale not in {"zh-CN", "en-US"}:
+                raise BenchmarkGenerationError(f"Case {index} has an invalid locale.")
+            targeting = case.get("targeting")
+            if not isinstance(targeting, dict):
+                raise BenchmarkGenerationError(
+                    f"Case {index} is missing target-specific evidence."
+                )
+            normalization_notes: list[str] = []
+            if removed_server_owned_contains:
+                normalization_notes.append(
+                    "moved server-owned resource identifiers out of expected.contains: "
+                    + ", ".join(removed_server_owned_contains)
+                )
+            target_refs = list(
+                dict.fromkeys(
+                    str(item) for item in list(targeting.get("target_refs") or []) if str(item)
+                )
+            )
+            unknown_refs = sorted(set(target_refs) - set(anchors))
+            if unknown_refs:
+                raise BenchmarkGenerationError(
+                    f"Case {index} references unknown target anchors: {', '.join(unknown_refs)}"
+                )
+            if not target_refs:
+                raise BenchmarkGenerationError(
+                    f"Case {index} must reference at least one target anchor."
+                )
+            target_has_professional_anchors = any(
+                anchor.get("axis") in {"domain", "resource"}
+                for anchor in anchors.values()
+            )
+            capability_matrix = list(
+                dict.fromkeys(
+                    str(item)
+                    for item in list(targeting.get("capability_matrix") or [])
+                    if str(item)
+                )
+            )
+            if not 1 <= len(capability_matrix) <= 3:
+                raise BenchmarkGenerationError(
+                    f"Case {index} must define one to three capability_matrix values."
+                )
+            unknown_matrix = sorted(set(capability_matrix) - set(allowed_coverage))
+            if unknown_matrix:
+                capability_matrix = [
+                    item for item in capability_matrix if item in allowed_coverage
+                ]
+                normalization_notes.append(
+                    "removed unavailable matrix capabilities: "
+                    + ", ".join(unknown_matrix)
+                )
+            if coverage not in allowed_coverage:
+                if not capability_matrix:
+                    raise BenchmarkGenerationError(
+                        f"Case {index} uses unavailable coverage: {coverage}."
+                    )
+                previous_coverage = coverage
+                coverage = capability_matrix[0]
+                normalization_notes.append(
+                    f"replaced unavailable primary coverage {previous_coverage} with {coverage}"
+                )
+            if coverage not in capability_matrix:
+                capability_matrix = list(
+                    dict.fromkeys([coverage, *capability_matrix])
+                )[:3]
+                normalization_notes.append("restored primary coverage in capability_matrix")
+            for capability in capability_matrix:
+                if not any(
+                    capability in set(anchors[ref].get("coverage") or [])
+                    for ref in target_refs
+                ):
+                    supporting_refs = sorted(
+                        ref
+                        for ref, anchor in anchors.items()
+                        if capability in set(anchor.get("coverage") or [])
+                    )
+                    if not supporting_refs:
+                        raise BenchmarkGenerationError(
+                            f"Case {index} has no target anchor for matrix capability "
+                            f"{capability}."
+                        )
+                    target_refs.append(supporting_refs[0])
+                    target_refs = list(dict.fromkeys(target_refs))
+                    normalization_notes.append(
+                        f"added supporting target anchor for {capability}"
+                    )
+
+            professional_refs = [
+                ref
+                for ref in target_refs
+                if anchors[ref].get("axis") in {"domain", "resource"}
+            ]
+            if target_has_professional_anchors and not professional_refs:
+                candidates = sorted(
+                    ref
+                    for ref, anchor in anchors.items()
+                    if anchor.get("axis") in {"domain", "resource"}
+                )
+                if not candidates or len(target_refs) >= 5:
+                    raise BenchmarkGenerationError(
+                        f"Case {index} must cite a professional domain or resource anchor."
+                    )
+                target_refs.append(candidates[0])
+                professional_refs = [candidates[0]]
+                normalization_notes.append("added professional target anchor")
+
+            allowed_focus_terms = {
+                self._normalize_text(term): str(term)
+                for ref in target_refs
+                for term in list(anchors[ref].get("focus_terms") or [])
+                if str(term).strip()
+            }
+            target_anchor_summaries = [
+                self._normalize_text(anchors[ref].get("summary") or "")
+                for ref in target_refs
+            ]
+
+            def focus_is_grounded(term: str, *, summaries: list[str]) -> bool:
+                normalized = self._normalize_text(term)
+                return bool(normalized) and (
+                    normalized in allowed_focus_terms
+                    or any(normalized in summary for summary in summaries)
+                )
+
+            focus_terms = list(
+                dict.fromkeys(
+                    str(item).strip()
+                    for item in list(targeting.get("focus_terms") or [])
+                    if str(item).strip()
+                )
+            )
+            if allowed_focus_terms and not focus_terms:
+                raise BenchmarkGenerationError(
+                    f"Case {index} must use professional focus_terms from its target anchors."
+                )
+            unknown_focus = sorted(
+                term
+                for term in focus_terms
+                if not focus_is_grounded(term, summaries=target_anchor_summaries)
+            )
+            unresolved_focus: list[str] = []
+            for term in unknown_focus:
+                normalized_term = self._normalize_text(term)
+                supporting_refs = sorted(
+                    ref
+                    for ref, anchor in anchors.items()
+                    if normalized_term
+                    and normalized_term
+                    in self._normalize_text(anchor.get("summary") or "")
+                )
+                if supporting_refs and len(target_refs) < 5:
+                    target_refs.append(supporting_refs[0])
+                    target_refs = list(dict.fromkeys(target_refs))
+                    normalization_notes.append(
+                        f"added target anchor for declared focus term: {term}"
+                    )
+                else:
+                    unresolved_focus.append(term)
+            if unresolved_focus:
+                raise BenchmarkGenerationError(
+                    f"Case {index} invents focus terms outside its target anchors: "
+                    + ", ".join(unresolved_focus)
+                )
+            if unknown_focus and not unresolved_focus:
+                professional_refs = [
+                    ref
+                    for ref in target_refs
+                    if anchors[ref].get("axis") in {"domain", "resource"}
+                ]
+                allowed_focus_terms = {
+                    self._normalize_text(term): str(term)
+                    for ref in target_refs
+                    for term in list(anchors[ref].get("focus_terms") or [])
+                    if str(term).strip()
+                }
+                target_anchor_summaries = [
+                    self._normalize_text(anchors[ref].get("summary") or "")
+                    for ref in target_refs
+                ]
+            professional_focus_terms = {
+                self._normalize_text(term)
+                for ref in professional_refs
+                for term in list(anchors[ref].get("focus_terms") or [])
+                if str(term).strip()
+            }
+            professional_summaries = [
+                self._normalize_text(anchors[ref].get("summary") or "")
+                for ref in professional_refs
+            ]
+            if professional_focus_terms and not any(
+                self._normalize_text(term) in professional_focus_terms
+                or any(
+                    self._normalize_text(term) in summary
+                    for summary in professional_summaries
+                )
+                for term in focus_terms
+            ):
+                raise BenchmarkGenerationError(
+                    f"Case {index} must use a focus term from its professional anchor."
+                )
+            professional_evidence = self._professional_evidence(
+                case=case,
+                anchors=[anchors[ref] for ref in professional_refs],
+            )
+            if professional_refs and not professional_evidence["sufficient"]:
+                raise BenchmarkGenerationError(
+                    f"Case {index} lacks observable professional evidence from its "
+                    "cited target anchors."
+                )
+
+            difficulty = str(targeting.get("difficulty") or "")
+            pressure_types = list(
+                dict.fromkeys(
+                    str(item)
+                    for item in list(targeting.get("pressure_types") or [])
+                    if str(item)
+                )
+            )
+            minimum_pressure = 2 if difficulty == "adversarial" else 1 if difficulty == "edge" else 0
+            if len(pressure_types) < minimum_pressure:
+                raise BenchmarkGenerationError(
+                    f"Case {index} {difficulty} difficulty needs at least "
+                    f"{minimum_pressure} pressure_types."
+                )
+            if len(str(targeting.get("challenge") or "").strip()) < 8:
+                raise BenchmarkGenerationError(
+                    f"Case {index} must describe its concrete challenge."
+                )
+            if len(str(targeting.get("discriminator") or "").strip()) < 20:
+                raise BenchmarkGenerationError(
+                    f"Case {index} must explain how it discriminates this target "
+                    "from a generic model."
+                )
+            targeting["target_refs"] = target_refs
+            targeting["capability_matrix"] = capability_matrix
+            targeting["focus_terms"] = focus_terms
+            targeting["pressure_types"] = pressure_types
+            targeting["professional_evidence"] = professional_evidence
+            targeting["normalization_notes"] = normalization_notes[:8]
+            case["targeting"] = targeting
+            case.setdefault("tags", [])
+            case["tags"] = list(
+                dict.fromkeys(
+                    [*case["tags"], "generated", *capability_matrix, locale]
+                )
+            )[:20]
+            expectation = dict(case.get("expected") or {})
+            if blueprint:
+                self._validate_blueprint_observability(
+                    index=index,
+                    case=case,
+                    capability_matrix=capability_matrix,
+                    difficulty=difficulty,
+                    expectation=expectation,
+                    allowed_document_names=list(allowed_document_names or []),
+                    allowed_prompt_aliases=list(allowed_prompt_aliases or []),
+                    blueprint=blueprint,
+                )
+            referenced_tools = {
+                str(item)
+                for field in ("required_tools", "forbidden_tools", "tool_order")
+                for item in list(expectation.get(field) or [])
+                if str(item)
+            }
+            unknown_tools = sorted(referenced_tools - allowed_tools)
+            if unknown_tools:
+                raise BenchmarkGenerationError(
+                    f"Case {index} references unavailable tools: {', '.join(unknown_tools)}"
+                )
+            if not self._has_deterministic_expectation(expectation):
+                raise BenchmarkGenerationError(
+                    f"Case {index} has no deterministic expectation."
+                )
+            try:
+                validated = EvaluationCaseInput.model_validate(case).model_dump(mode="json")
+            except ValidationError as exc:
+                raise BenchmarkGenerationError(
+                    f"Case {index} failed schema validation: {str(exc)[:500]}"
+                ) from exc
+            signature = self._normalize_text(validated["message"])
+            if signature in seen:
+                raise BenchmarkGenerationError(f"Case {index} duplicates another message.")
+            seen.add(signature)
+            if self._gold_leaks_into_input(validated):
+                raise BenchmarkGenerationError(
+                    f"Case {index} copies its deterministic Gold into the input."
+                )
+            normalized.append(validated)
+            seen_coverage.add(coverage)
+            referenced_anchor_ids.update(target_refs)
+        if expected_count >= 6:
+            missing_coverage = sorted(set(allowed_coverage) - seen_coverage)
+            if missing_coverage:
+                raise BenchmarkGenerationError(
+                    "Generated cases do not cover all selected capabilities: "
+                    + ", ".join(missing_coverage)
+                )
+            difficulty_counts = self.targeting_summary(normalized)["difficulty_counts"]
+            minimum_challenging = max(1, math.ceil(expected_count * 0.25))
+            maximum_basic = max(1, math.ceil(expected_count * 0.30))
+            if int(difficulty_counts.get("basic") or 0) < 1:
+                raise BenchmarkGenerationError("Generated cases need at least one basic case.")
+            if int(difficulty_counts.get("basic") or 0) > maximum_basic:
+                raise BenchmarkGenerationError(
+                    f"At most {maximum_basic} of {expected_count} cases may be basic."
+                )
+            for difficulty in ("edge", "adversarial"):
+                if int(difficulty_counts.get(difficulty) or 0) < minimum_challenging:
+                    raise BenchmarkGenerationError(
+                        f"At least {minimum_challenging} cases must be {difficulty}."
+                    )
+            required_anchor_diversity = min(2, len(anchors))
+            if len(referenced_anchor_ids) < required_anchor_diversity:
+                raise BenchmarkGenerationError(
+                    "Generated cases do not exercise enough distinct target anchors."
+                )
+            if len(allowed_coverage) >= 2:
+                summary = self.targeting_summary(normalized)
+                minimum_combined = math.ceil(expected_count * 0.60)
+                if int(summary.get("combined_case_count") or 0) < minimum_combined:
+                    raise BenchmarkGenerationError(
+                        f"At least {minimum_combined} of {expected_count} cases must "
+                        "combine multiple capabilities."
+                    )
+                combined_capabilities = set(summary.get("combined_capabilities") or [])
+                missing_combined = sorted(set(allowed_coverage) - combined_capabilities)
+                if missing_combined:
+                    raise BenchmarkGenerationError(
+                        "Selected capabilities missing from combined cases: "
+                        + ", ".join(missing_combined)
+                    )
+                possible_signatures = sum(
+                    math.comb(len(allowed_coverage), size)
+                    for size in range(2, min(3, len(allowed_coverage)) + 1)
+                )
+                required_signatures = min(3, possible_signatures)
+                if len(summary.get("capability_matrix_counts") or {}) < required_signatures:
+                    raise BenchmarkGenerationError(
+                        f"Generated cases need at least {required_signatures} distinct "
+                        "multi-capability combinations."
+                    )
+        targeting_summary = self.targeting_summary(normalized)
+        return {
+            "name": str(dataset.get("name") or "Generated target benchmark")[:160],
+            "description": str(dataset.get("description") or "")[:2_000],
+            "cases": normalized,
+            "assumptions": [
+                str(item)[:500]
+                for item in list(dataset.get("assumptions") or [])[:20]
+                if str(item).strip()
+            ],
+            "targeting": targeting_summary,
+        }
+
+    def repair_prompt(
+        self,
+        raw: str,
+        error: str,
+        *,
+        expected_count: int,
+        allowed_coverage: list[str] | None = None,
+        target_anchors: list[dict[str, Any]] | None = None,
+        case_blueprints: list[dict[str, Any]] | None = None,
+        allowed_document_names: list[str] | None = None,
+        allowed_prompt_aliases: list[str] | None = None,
+    ) -> tuple[str, str]:
+        repair_context = {
+            "allowed_coverage": list(allowed_coverage or []),
+            "target_anchors": list(target_anchors or []),
+            "case_blueprints": list(case_blueprints or []),
+            "allowed_document_names": list(allowed_document_names or []),
+            "allowed_prompt_aliases": list(allowed_prompt_aliases or []),
+            "difficulty_policy": {
+                "basic_max_ratio": 0.30,
+                "edge_min_ratio": 0.25,
+                "adversarial_min_ratio": 0.25,
+            },
+            "matrix_policy": {
+                "combined_case_min_ratio": 0.60,
+                "distinct_combinations_min": 3,
+                "professional_focus_required_when_available": True,
+            },
+            "case_contract": {
+                "exact_case_count": expected_count,
+                "primary_coverage_must_be_in_capability_matrix": True,
+                "each_matrix_capability_needs_a_supporting_target_ref": True,
+                "focus_terms_must_be_verbatim_in_cited_anchor_summary": True,
+                "professional_evidence_must_be_observable_in_input": True,
+                "edge_min_pressure_types": 1,
+                "adversarial_min_pressure_types": 2,
+                "discriminator_required": True,
+                "deterministic_expectation_required": True,
+            },
+        }
+        return (
+            "Repair a benchmark JSON document. Return JSON only and do not add commentary.",
+            (
+                f"The document must contain exactly {expected_count} cases and obey the "
+                "original contract. Return one object shaped as "
+                "{\"dataset\": {\"name\": str, \"description\": str, "
+                "\"cases\": [...], \"assumptions\": [...]}}. Do not omit, duplicate, "
+                "or add cases. For every case, keep primary coverage inside "
+                "capability_matrix; cite enough target_refs so each matrix capability is "
+                "supported by a cited anchor. Every declared focus_term must be grounded "
+                "in a cited anchor. The case input must visibly exercise either an exact "
+                "focus term or at least two professional markers from those anchors. "
+                "Follow the server case_blueprints in exact order; "
+                "their metadata is authoritative. Preserve deterministic expectations, "
+                "difficulty distribution, pressure counts, discriminator, and exact "
+                "required_tool_name, required_document_name, and required_prompt_alias. "
+                "A prompt-command case message must start with the slash alias. Fix only the listed "
+                "validation problems. Never add "
+                "credentials, paths, hidden reasoning, or private content.\n\n"
+                f"Allowed targeting contract:\n{json.dumps(repair_context, ensure_ascii=False)}\n\n"
+                f"Validation error: {error[:1_000]}\n\n"
+                f"Invalid JSON/output:\n{raw[:40_000]}"
+            ),
+        )
+
+    @staticmethod
+    def _validate_blueprint_observability(
+        *,
+        index: int,
+        case: dict[str, Any],
+        capability_matrix: list[str],
+        difficulty: str,
+        expectation: dict[str, Any],
+        allowed_document_names: list[str],
+        allowed_prompt_aliases: list[str],
+        blueprint: dict[str, Any],
+    ) -> None:
+        messages = [
+            dict(item) for item in list(case.get("messages") or []) if isinstance(item, dict)
+        ]
+        if "structured_output" in capability_matrix and not isinstance(
+            expectation.get("json_schema"), dict
+        ):
+            raise BenchmarkGenerationError(
+                f"Case {index} must provide expected.json_schema for structured_output."
+            )
+        if "multi_turn" in capability_matrix and (
+            len(messages) < 2
+            or not any(str(item.get("role") or "") == "assistant" for item in messages)
+        ):
+            raise BenchmarkGenerationError(
+                f"Case {index} must include two history messages and an assistant turn for multi_turn."
+            )
+        if "tool_routing" in capability_matrix and not any(
+            bool(expectation.get(field))
+            for field in ("required_tools", "forbidden_tools", "tool_order")
+        ):
+            raise BenchmarkGenerationError(
+                f"Case {index} must define deterministic tool expectations for tool_routing."
+            )
+        required_tool_name = str(blueprint.get("required_tool_name") or "")
+        if required_tool_name and required_tool_name not in {
+            str(item)
+            for field in ("required_tools", "tool_order")
+            for item in list(expectation.get(field) or [])
+        }:
+            raise BenchmarkGenerationError(
+                f"Case {index} must require blueprint tool {required_tool_name}."
+            )
+        required_forbidden_tools = {
+            str(item)
+            for item in list(blueprint.get("forbidden_tool_names") or [])
+            if str(item)
+        }
+        actual_forbidden_tools = {
+            str(item)
+            for item in list(expectation.get("forbidden_tools") or [])
+            if str(item)
+        }
+        missing_forbidden_tools = sorted(
+            required_forbidden_tools - actual_forbidden_tools
+        )
+        if missing_forbidden_tools:
+            raise BenchmarkGenerationError(
+                f"Case {index} must forbid blueprint decoy tools: "
+                + ", ".join(missing_forbidden_tools)
+            )
+        if required_forbidden_tools:
+            visible_input = BenchmarkGenerationService._normalize_text(
+                " ".join(
+                    [
+                        str(case.get("message") or ""),
+                        *[
+                            str(item.get("content") or "")
+                            for item in messages
+                            if isinstance(item, dict)
+                        ],
+                    ]
+                )
+            )
+            hidden_decoys = sorted(
+                item
+                for item in required_forbidden_tools
+                if BenchmarkGenerationService._normalize_text(item) not in visible_input
+            )
+            if hidden_decoys:
+                raise BenchmarkGenerationError(
+                    f"Case {index} must expose blueprint decoy tools in its input: "
+                    + ", ".join(hidden_decoys)
+                )
+        if "knowledge_citation" in capability_matrix and not any(
+            bool(expectation.get(field))
+            for field in ("citation_ids", "chunk_ids", "document_names")
+        ):
+            raise BenchmarkGenerationError(
+                f"Case {index} must define fixed citation expectations for knowledge_citation."
+            )
+        if "knowledge_citation" in capability_matrix:
+            expected_documents = {
+                str(item)
+                for item in list(expectation.get("document_names") or [])
+                if str(item)
+            }
+            unknown_documents = sorted(
+                expected_documents - set(allowed_document_names)
+            )
+            if not expected_documents or unknown_documents:
+                detail = ", ".join(unknown_documents) if unknown_documents else "none provided"
+                raise BenchmarkGenerationError(
+                    f"Case {index} must use fixed knowledge document_names; invalid: {detail}."
+                )
+            if expectation.get("citation_ids") or expectation.get("chunk_ids"):
+                raise BenchmarkGenerationError(
+                    f"Case {index} may not invent citation_ids or chunk_ids during Xpert generation."
+                )
+            required_document_name = str(
+                blueprint.get("required_document_name") or ""
+            )
+            if required_document_name and required_document_name not in expected_documents:
+                raise BenchmarkGenerationError(
+                    f"Case {index} must cite blueprint document {required_document_name}."
+                )
+        if "prompt_command" in capability_matrix:
+            message = str(case.get("message") or "").lstrip().casefold()
+            required_alias = str(blueprint.get("required_prompt_alias") or "").lstrip(
+                "/"
+            ).casefold()
+            prefixes = (
+                [f"/{required_alias}"]
+                if required_alias
+                else [
+                    f"/{str(alias).lstrip('/').casefold()}"
+                    for alias in allowed_prompt_aliases
+                    if str(alias).strip()
+                ]
+            )
+            if not prefixes or not any(
+                message == prefix or message.startswith(prefix + " ")
+                for prefix in prefixes
+            ):
+                raise BenchmarkGenerationError(
+                    f"Case {index} must invoke one fixed Prompt Command alias."
+                )
+
+        observable_signals = 0
+        if len(capability_matrix) > 1:
+            observable_signals += 1
+        if len(messages) >= 2:
+            observable_signals += 1
+        if isinstance(expectation.get("json_schema"), dict):
+            observable_signals += 1
+        if expectation.get("required_tools"):
+            observable_signals += 1
+        if expectation.get("forbidden_tools"):
+            observable_signals += 1
+        if len(list(expectation.get("tool_order") or [])) >= 2:
+            observable_signals += 1
+        if any(
+            bool(expectation.get(field))
+            for field in ("citation_ids", "chunk_ids", "document_names")
+        ):
+            observable_signals += 1
+        if len(list(expectation.get("contains") or [])) >= 2:
+            observable_signals += 1
+        if "prompt_command" in capability_matrix:
+            observable_signals += 1
+        minimum = 2 if difficulty == "adversarial" else 1 if difficulty == "edge" else 0
+        if observable_signals < minimum:
+            raise BenchmarkGenerationError(
+                f"Case {index} {difficulty} difficulty exposes only {observable_signals} "
+                f"observable challenge signals; at least {minimum} are required."
+            )
+
+    def calibration_result(
+        self,
+        *,
+        dataset: dict[str, Any],
+        evaluation_run: dict[str, Any],
+        target_reference: dict[str, Any],
+        target_checksum: str,
+    ) -> dict[str, Any]:
+        if int(dataset.get("revision") or 0) != int(
+            (evaluation_run.get("dataset") or {}).get("draft_revision")
+            or dataset.get("revision")
+        ):
+            return {"status": "stale", "reason": "dataset_revision_changed"}
+        if not self.target_is_fresh(target_reference, target_checksum):
+            return {"status": "stale", "reason": "target_changed"}
+        if evaluation_run.get("status") in {"failed", "cancelled"}:
+            return {
+                "status": "failed",
+                "reason": str(evaluation_run.get("error") or evaluation_run.get("status"))[:500],
+            }
+        targets = list(evaluation_run.get("targets") or [])
+        specialist_target = next(
+            (
+                item
+                for item in targets
+                if str(item.get("checksum") or "") == str(target_checksum)
+                and not bool(item.get("benchmark_counterfactual"))
+            ),
+            targets[-1] if targets else {},
+        )
+        specialist_target_id = str(specialist_target.get("target_id") or "")
+        generic_target = next(
+            (item for item in targets if bool(item.get("benchmark_counterfactual"))),
+            None,
+        )
+        generic_target_id = str((generic_target or {}).get("target_id") or "")
+        all_items = list(evaluation_run.get("items") or [])
+        items = [
+            item
+            for item in all_items
+            if not specialist_target_id
+            or str(item.get("target_id") or "") == specialist_target_id
+        ]
+        completed = [item for item in items if item.get("status") == "completed"]
+        if not completed:
+            return {"status": "failed", "reason": "no_cases_completed"}
+        warnings: list[str] = []
+        failed_count = len(items) - len(completed)
+        if failed_count:
+            warnings.append(f"{failed_count} calibration cases failed to execute.")
+        scores = [float(item.get("score") or 0.0) for item in completed]
+        easy_count = sum(score >= 0.95 for score in scores)
+        hard_count = sum(score <= 0.20 for score in scores)
+        report_targets = {
+            str(item.get("target_id") or ""): item
+            for item in list((evaluation_run.get("report") or {}).get("targets") or [])
+        }
+        specialist_score = float(
+            (report_targets.get(specialist_target_id) or {}).get("score") or 0.0
+        )
+        generic_score = (
+            float((report_targets.get(generic_target_id) or {}).get("score") or 0.0)
+            if generic_target_id
+            else None
+        )
+        targeting_advantage = (
+            specialist_score - generic_score if generic_score is not None else None
+        )
+        if easy_count / len(scores) >= 0.80 and (
+            targeting_advantage is None or targeting_advantage < 0.10
+        ):
+            warnings.append(
+                "At least 80% of cases are easy and the fixed target does not "
+                "outperform the generic counterfactual by 0.10."
+            )
+        if hard_count / len(scores) >= 0.80:
+            warnings.append("At least 80% of cases are very hard for the fixed baseline.")
+        duplicate_count = self._near_duplicate_count(list(dataset.get("cases") or []))
+        if duplicate_count:
+            warnings.append(f"Detected {duplicate_count} near-duplicate case pairs.")
+        leak_count = sum(
+            1 for case in list(dataset.get("cases") or []) if self._gold_leaks_into_input(case)
+        )
+        if leak_count:
+            warnings.append(f"Detected possible Gold leakage in {leak_count} cases.")
+        targeting = self.targeting_summary(list(dataset.get("cases") or []))
+        if str(dataset.get("origin") or "manual") == "generated" and targeting[
+            "missing_count"
+        ]:
+            warnings.append(
+                f"{targeting['missing_count']} generated cases lack target-specific evidence."
+            )
+        if targeting_advantage is not None and targeting_advantage < 0.10:
+            warnings.append(
+                "Target-specific advantage over the generic counterfactual is below 0.10."
+            )
+        return {
+            "status": "warning" if warnings else "calibrated",
+            "evaluation_run_id": evaluation_run.get("run_id"),
+            "target_checksum": target_checksum,
+            "target_reference": copy.deepcopy(target_reference),
+            "case_count": len(items),
+            "completed_count": len(completed),
+            "failed_count": failed_count,
+            "baseline_score": round(specialist_score, 6),
+            "generic_counterfactual_score": (
+                round(generic_score, 6) if generic_score is not None else None
+            ),
+            "targeting_advantage": (
+                round(targeting_advantage, 6)
+                if targeting_advantage is not None
+                else None
+            ),
+            "targeting_advantage_threshold": 0.10,
+            "easy_count": easy_count,
+            "hard_count": hard_count,
+            "duplicate_count": duplicate_count,
+            "leak_count": leak_count,
+            "warnings": warnings,
+            "targeting": targeting,
+        }
+
+    def generic_counterfactual_snapshot(
+        self, snapshot: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Build a same-model target with specialization and bound resources removed."""
+
+        generic = copy.deepcopy(snapshot)
+        workflow = dict(generic.get("workflow") or {})
+        nodes = [dict(item) for item in list(workflow.get("nodes") or [])]
+        edges = [dict(item) for item in list(workflow.get("edges") or [])]
+        binding_handles = {"expert", "knowledge", "toolset", "plugin", "middleware"}
+        binding_sources = {
+            str(edge.get("source") or "")
+            for edge in edges
+            if str(edge.get("targetHandle") or "") in binding_handles
+        }
+        resource_kinds = {
+            "external_xpert",
+            "knowledge_base",
+            "toolset_resource",
+            "plugin_resource",
+            "runtime_middleware",
+        }
+        retained_nodes: list[dict[str, Any]] = []
+        removed_node_ids: set[str] = set()
+        for node in nodes:
+            data = dict(node.get("data") or {})
+            kind = str(data.get("kind") or node.get("type") or "")
+            node_id = str(node.get("id") or "")
+            if kind in resource_kinds and node_id in binding_sources:
+                removed_node_ids.add(node_id)
+                continue
+            if kind == "workflow_agent":
+                data.update(
+                    {
+                        "rolePrompt": (
+                            "You are a general-purpose assistant. Answer the current "
+                            "request accurately without relying on private domain instructions."
+                        ),
+                        "promptSuffix": "",
+                        "toolMode": "none",
+                        "toolNames": "",
+                        "memoryReadEnabled": False,
+                        "memoryWriteEnabled": False,
+                        "knowledgeReadEnabled": False,
+                        "knowledgeWriteEnabled": False,
+                        "knowledgeBaseIds": [],
+                        "enableFileUnderstanding": False,
+                    }
+                )
+                node["data"] = data
+            retained_nodes.append(node)
+        workflow["nodes"] = retained_nodes
+        workflow["edges"] = [
+            edge
+            for edge in edges
+            if str(edge.get("source") or "") not in removed_node_ids
+            and str(edge.get("target") or "") not in removed_node_ids
+            and str(edge.get("targetHandle") or "") not in binding_handles
+        ]
+        generic["workflow"] = workflow
+        generic["prompt_profiles"] = []
+        generic["input_template"] = None
+        generic["resources"] = {
+            "toolsets": [],
+            "plugins": [],
+            "knowledge_versions": [],
+            "external_xperts": [],
+        }
+        generic["target_id"] = f"{snapshot.get('target_id')}:generic-counterfactual"
+        generic["label"] = f"{snapshot.get('label')} generic counterfactual"[:160]
+        generic["source"] = {
+            "kind": "benchmark_generic_counterfactual",
+            "based_on_target_id": snapshot.get("target_id"),
+        }
+        generic["benchmark_counterfactual"] = True
+        generic["checksum"] = self._checksum(
+            {
+                "workflow": workflow,
+                "input_template": None,
+                "based_on": snapshot.get("checksum"),
+            }
+        )
+        return generic
+
+    def assert_dataset_target_fresh(self, dataset: dict[str, Any]) -> None:
+        if str(dataset.get("origin") or "manual") != "generated":
+            return
+        calibration = dict(dataset.get("calibration") or {})
+        reference = dict(calibration.get("target_reference") or {})
+        checksum = str(calibration.get("target_checksum") or "")
+        if not reference or not checksum or not self.target_is_fresh(reference, checksum):
+            self.evaluation_store.set_dataset_calibration(
+                str(dataset["dataset_id"]),
+                revision=int(dataset["revision"]),
+                calibration={
+                    **calibration,
+                    "status": "stale",
+                    "reason": "target_changed",
+                },
+            )
+            raise EvaluationStateError(
+                "Generated dataset calibration is stale because its target changed."
+            )
+
+    def _safe_generation_context(self, snapshot: dict[str, Any]) -> dict[str, Any]:
+        workflow = dict(snapshot.get("workflow") or {})
+        agents: list[dict[str, Any]] = []
+        for node in list(workflow.get("nodes") or []):
+            data = dict(node.get("data") or {}) if isinstance(node, dict) else {}
+            if str(data.get("kind") or node.get("type") or "") != "workflow_agent":
+                continue
+            agents.append(
+                {
+                    "node_id": str(node.get("id") or "")[:120],
+                    "title": str(data.get("title") or "Agent")[:160],
+                    "role_prompt": str(data.get("rolePrompt") or "")[:6_000],
+                    "prompt_suffix": str(data.get("promptSuffix") or "")[:2_000],
+                    "task_input": str(data.get("taskInput") or "")[:2_000],
+                    "output_schema_mode": str(data.get("outputSchemaMode") or "none"),
+                    "output_schema": str(data.get("outputSchemaJson") or "")[:4_000],
+                }
+            )
+        profile = dict(snapshot.get("prompt_profile") or {})
+        prompt_command_aliases = self._prompt_aliases(snapshot)
+        return {
+            "target": {
+                "name": str((snapshot.get("xpert") or {}).get("name") or snapshot.get("label") or ""),
+                "description": str((snapshot.get("xpert") or {}).get("description") or "")[:2_000],
+                "kind": str((snapshot.get("source") or {}).get("kind") or ""),
+            },
+            "agents": agents[:10],
+            "input_variable": snapshot.get("input_variable"),
+            "output_variable": snapshot.get("output_variable"),
+            "allowed_tool_names": self.detect_coverage(snapshot)["tool_names"],
+            "knowledge_base_ids": self.detect_coverage(snapshot)["knowledge_base_ids"],
+            "knowledge_document_names": self._knowledge_document_names(snapshot),
+            "prompt_command_aliases": prompt_command_aliases,
+            "target_anchors": self.target_anchors(snapshot),
+            "prompt_command": {
+                "aliases": list(profile.get("aliases") or [])[:5],
+                "template": str(profile.get("template") or "")[:8_000],
+                "argument_hint": str(profile.get("argument_hint") or "")[:500],
+            }
+            if profile
+            else None,
+        }
+
+    @staticmethod
+    def _prompt_aliases(snapshot: dict[str, Any]) -> list[str]:
+        profiles = [
+            dict(item)
+            for item in list(snapshot.get("prompt_profiles") or [])
+            if isinstance(item, dict)
+        ]
+        direct = dict(snapshot.get("prompt_profile") or {})
+        if direct:
+            profiles.insert(0, direct)
+        aliases = [
+            str(alias).lstrip("/").strip().casefold()
+            for profile in profiles
+            for alias in list(profile.get("aliases") or [])
+            if str(alias).strip()
+        ]
+        return list(dict.fromkeys(aliases))[:50]
+
+    def _structured_output_schemas(
+        self,
+        snapshot: dict[str, Any],
+    ) -> dict[str, dict[str, Any]]:
+        schemas: dict[str, dict[str, Any]] = {}
+        workflow = dict(snapshot.get("workflow") or {})
+        for index, node in enumerate(list(workflow.get("nodes") or [])):
+            if not isinstance(node, dict):
+                continue
+            data = dict(node.get("data") or {})
+            node_kind = str(data.get("kind") or node.get("type") or "")
+            node_key = self._anchor_key(node.get("id") or f"node-{index + 1}")
+            anchor_id = ""
+            if node_kind == "workflow_agent" and str(
+                data.get("outputSchemaMode") or "none"
+            ) not in {"", "none"}:
+                anchor_id = f"agent:{node_key}:output_schema"
+            elif node_kind == "runtime_middleware" and str(
+                data.get("middlewareId") or data.get("middleware_id") or ""
+            ) == "structured_output":
+                anchor_id = f"middleware:{node_key}:structured_output"
+            if not anchor_id:
+                continue
+            raw_schema = str(data.get("outputSchemaJson") or "").strip()
+            try:
+                parsed = json.loads(raw_schema)
+            except (TypeError, ValueError, json.JSONDecodeError):
+                continue
+            if isinstance(parsed, dict):
+                schemas[anchor_id] = parsed
+        return schemas
+
+    def _resolved_tool_names(self, snapshot: dict[str, Any]) -> list[str]:
+        names: list[str] = []
+        workflow = dict(snapshot.get("workflow") or {})
+        for node in list(workflow.get("nodes") or []):
+            data = dict(node.get("data") or {}) if isinstance(node, dict) else {}
+            kind = str(data.get("kind") or node.get("type") or "")
+            if kind == "workflow_agent":
+                names.extend(self._string_list(data.get("toolNames")))
+                if self._truthy(data.get("memoryReadEnabled")):
+                    names.extend(["memory_search", "memory_get"])
+                if self._truthy(data.get("knowledgeReadEnabled")):
+                    names.extend(["knowledge_search", "knowledge_get", "knowledge_cite"])
+            elif kind in {"mcp_tool", "external_xpert"}:
+                names.extend(
+                    self._string_list(
+                        data.get("toolName")
+                        or data.get("mcpToolName")
+                        or data.get("title")
+                    )
+                )
+            elif kind == "toolset_resource" and self.toolset_store is not None:
+                try:
+                    version = self.toolset_store.get_version(
+                        str(data.get("toolsetId") or ""),
+                        int(data.get("pinnedVersion") or 0),
+                    )
+                    for tool in list(getattr(version, "tools", []) or []):
+                        if bool(getattr(tool, "enabled", False)):
+                            names.append(
+                                str(
+                                    getattr(tool, "exposed_name", None)
+                                    or getattr(tool, "alias", None)
+                                    or getattr(tool, "name", "")
+                                )
+                            )
+                except Exception:
+                    continue
+        return sorted({name.strip() for name in names if str(name).strip()})[:100]
+
+    def _knowledge_document_names(self, snapshot: dict[str, Any]) -> list[str]:
+        if self.rag_service is None:
+            return []
+        names: list[str] = []
+        resources = dict(snapshot.get("resources") or {})
+        for item in list(resources.get("knowledge_versions") or []):
+            if not isinstance(item, dict) or not str(item.get("version_id") or ""):
+                continue
+            try:
+                version = self.rag_service.get_pipeline_version(str(item["version_id"]))
+            except Exception:
+                continue
+            for source in list(version.get("source_summary") or []):
+                if not isinstance(source, dict):
+                    continue
+                name = str(
+                    source.get("filename") or source.get("document_name") or ""
+                ).strip()
+                if name:
+                    names.append(name[:240])
+        return list(dict.fromkeys(names))[:100]
+
+    @staticmethod
+    def _truthy(value: Any) -> bool:
+        if isinstance(value, bool):
+            return value
+        return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+    @staticmethod
+    def public_target(snapshot: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "target_id": snapshot.get("target_id"),
+            "label": snapshot.get("label"),
+            "source": copy.deepcopy(snapshot.get("source") or {}),
+            "xpert": copy.deepcopy(snapshot.get("xpert") or {}),
+            "checksum": snapshot.get("checksum"),
+            "warnings": list(snapshot.get("warnings") or []),
+        }
+
+    @staticmethod
+    def _extract_json(raw: str) -> dict[str, Any]:
+        text = str(raw or "").strip()
+        if text.startswith("```"):
+            text = re.sub(r"^```(?:json)?\s*", "", text, flags=re.IGNORECASE)
+            text = re.sub(r"\s*```$", "", text)
+        start = text.find("{")
+        end = text.rfind("}")
+        if start < 0 or end <= start:
+            raise BenchmarkGenerationError("Generator did not return a JSON object.")
+        try:
+            value = json.loads(text[start : end + 1])
+        except json.JSONDecodeError as exc:
+            raise BenchmarkGenerationError(f"Generator returned invalid JSON: {exc}") from exc
+        if not isinstance(value, dict):
+            raise BenchmarkGenerationError("Generator output must be a JSON object.")
+        return value
+
+    @staticmethod
+    def _string_list(value: Any) -> list[str]:
+        if isinstance(value, str):
+            return [item.strip() for item in value.split(",") if item.strip()]
+        return [str(item).strip() for item in list(value or []) if str(item).strip()]
+
+    @staticmethod
+    def _has_deterministic_expectation(expected: dict[str, Any]) -> bool:
+        return any(
+            [
+                isinstance(expected.get("exact_answer"), str),
+                bool(expected.get("contains")),
+                isinstance(expected.get("json_schema"), dict),
+                bool(expected.get("citation_ids")),
+                bool(expected.get("chunk_ids")),
+                bool(expected.get("document_names")),
+                bool(expected.get("required_tools")),
+                bool(expected.get("forbidden_tools")),
+                bool(expected.get("tool_order")),
+            ]
+        )
+
+    @classmethod
+    def _strip_server_owned_contains(
+        cls,
+        expectation: dict[str, Any],
+        blueprint: dict[str, Any],
+    ) -> list[str]:
+        prompt_alias = str(blueprint.get("required_prompt_alias") or "").lstrip("/")
+        reserved_values = {
+            str(blueprint.get("required_tool_name") or ""),
+            str(blueprint.get("required_document_name") or ""),
+            *(
+                str(item)
+                for item in list(blueprint.get("forbidden_tool_names") or [])
+            ),
+            prompt_alias,
+            f"/{prompt_alias}" if prompt_alias else "",
+        }
+        normalized_reserved = {
+            cls._normalize_text(item) for item in reserved_values if item
+        }
+        original = [
+            str(item)
+            for item in list(expectation.get("contains") or [])
+            if str(item)
+        ]
+        kept = [
+            item
+            for item in original
+            if cls._normalize_text(item) not in normalized_reserved
+        ]
+        removed = [item for item in original if item not in kept]
+        if removed:
+            expectation["contains"] = kept
+        return removed
+
+    @classmethod
+    def _gold_leaks_into_input(cls, case: dict[str, Any]) -> bool:
+        message = cls._normalize_text(case.get("message") or "")
+        expected = dict(case.get("expected") or {})
+        values = []
+        exact = expected.get("exact_answer")
+        if isinstance(exact, str):
+            values.append(exact)
+        values.extend(list(expected.get("contains") or []))
+        return any(
+            len(cls._normalize_text(item)) >= 24
+            and cls._normalize_text(item) in message
+            for item in values
+        )
+
+    @classmethod
+    def _near_duplicate_count(cls, cases: list[dict[str, Any]]) -> int:
+        signatures = [set(cls._normalize_text(case.get("message") or "").split()) for case in cases]
+        count = 0
+        for index, left in enumerate(signatures):
+            for right in signatures[index + 1 :]:
+                union = left | right
+                if union and len(left & right) / len(union) >= 0.85:
+                    count += 1
+        return count
+
+    @staticmethod
+    def targeting_summary(cases: list[dict[str, Any]]) -> dict[str, Any]:
+        difficulty_counts = {"basic": 0, "edge": 0, "adversarial": 0}
+        target_ref_counts: dict[str, int] = {}
+        coverage_counts: dict[str, int] = {}
+        capability_matrix_counts: dict[str, int] = {}
+        focus_term_counts: dict[str, int] = {}
+        pressure_type_counts: dict[str, int] = {}
+        combined_capabilities: set[str] = set()
+        combined_case_count = 0
+        cases_with_focus = 0
+        discriminator_count = 0
+        blueprint_case_count = 0
+        normalized_case_count = 0
+        normalization_note_counts: dict[str, int] = {}
+        professional_evidence_case_count = 0
+        professional_evidence_scores: list[float] = []
+        missing_count = 0
+        for case in cases:
+            targeting = case.get("targeting") if isinstance(case, dict) else None
+            if not isinstance(targeting, dict):
+                missing_count += 1
+                continue
+            difficulty = str(targeting.get("difficulty") or "")
+            if difficulty in difficulty_counts:
+                difficulty_counts[difficulty] += 1
+            else:
+                missing_count += 1
+            for ref in list(targeting.get("target_refs") or []):
+                key = str(ref)
+                if key:
+                    target_ref_counts[key] = target_ref_counts.get(key, 0) + 1
+            matrix = sorted(
+                {
+                    str(item)
+                    for item in list(targeting.get("capability_matrix") or [])
+                    if str(item) in SUPPORTED_COVERAGE
+                }
+            )
+            if len(matrix) > 1:
+                combined_case_count += 1
+                combined_capabilities.update(matrix)
+                signature = " + ".join(matrix)
+                capability_matrix_counts[signature] = (
+                    capability_matrix_counts.get(signature, 0) + 1
+                )
+            focus_terms = [
+                str(item)
+                for item in list(targeting.get("focus_terms") or [])
+                if str(item).strip()
+            ]
+            if focus_terms:
+                cases_with_focus += 1
+            for term in focus_terms:
+                focus_term_counts[term] = focus_term_counts.get(term, 0) + 1
+            for pressure_type in list(targeting.get("pressure_types") or []):
+                key = str(pressure_type)
+                if key:
+                    pressure_type_counts[key] = pressure_type_counts.get(key, 0) + 1
+            if str(targeting.get("discriminator") or "").strip():
+                discriminator_count += 1
+            if str(targeting.get("blueprint_id") or "").strip():
+                blueprint_case_count += 1
+            professional_evidence = targeting.get("professional_evidence")
+            if isinstance(professional_evidence, dict) and bool(
+                professional_evidence.get("sufficient")
+            ):
+                professional_evidence_case_count += 1
+                professional_evidence_scores.append(
+                    float(professional_evidence.get("score") or 0.0)
+                )
+            notes = [
+                str(item)
+                for item in list(targeting.get("normalization_notes") or [])
+                if str(item).strip()
+            ]
+            if notes:
+                normalized_case_count += 1
+            for note in notes:
+                normalization_note_counts[note] = (
+                    normalization_note_counts.get(note, 0) + 1
+                )
+            for tag in list(case.get("tags") or []):
+                key = str(tag)
+                if key in SUPPORTED_COVERAGE:
+                    coverage_counts[key] = coverage_counts.get(key, 0) + 1
+        return {
+            "difficulty_counts": difficulty_counts,
+            "target_ref_counts": dict(sorted(target_ref_counts.items())),
+            "coverage_counts": dict(sorted(coverage_counts.items())),
+            "capability_matrix_counts": dict(sorted(capability_matrix_counts.items())),
+            "combined_case_count": combined_case_count,
+            "combined_capabilities": sorted(combined_capabilities),
+            "focus_term_counts": dict(sorted(focus_term_counts.items())),
+            "cases_with_focus": cases_with_focus,
+            "pressure_type_counts": dict(sorted(pressure_type_counts.items())),
+            "discriminator_count": discriminator_count,
+            "blueprint_case_count": blueprint_case_count,
+            "normalized_case_count": normalized_case_count,
+            "normalization_note_counts": dict(
+                sorted(normalization_note_counts.items())
+            ),
+            "professional_evidence_case_count": professional_evidence_case_count,
+            "professional_evidence_score_average": round(
+                sum(professional_evidence_scores)
+                / max(1, len(professional_evidence_scores)),
+                4,
+            ),
+            "target_anchor_count": len(target_ref_counts),
+            "missing_count": missing_count,
+        }
+
+    @classmethod
+    def _professional_evidence(
+        cls,
+        *,
+        case: dict[str, Any],
+        anchors: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        input_text = cls._normalize_text(
+            " ".join(
+                [
+                    str(case.get("message") or ""),
+                    *[
+                        str(item.get("content") or "")
+                        for item in list(case.get("messages") or [])
+                        if isinstance(item, dict)
+                    ],
+                ]
+            )
+        )
+        support_text = cls._normalize_text(
+            " ".join(
+                [
+                    json.dumps(case.get("expected") or {}, ensure_ascii=False),
+                    *[
+                        str((case.get("targeting") or {}).get(field) or "")
+                        for field in ("rationale", "challenge", "discriminator")
+                    ],
+                ]
+            )
+        )
+        focus_terms = list(
+            dict.fromkeys(
+                str(term).strip()
+                for anchor in anchors
+                for term in list(anchor.get("focus_terms") or [])
+                if str(term).strip()
+            )
+        )
+        marker_terms = list(focus_terms)
+        for anchor in anchors:
+            summary = str(anchor.get("summary") or "")
+            for token in re.findall(r"[A-Za-z][A-Za-z0-9_.+:/-]{2,}", summary):
+                normalized = cls._normalize_text(token.strip(".,;:()[]{}"))
+                if normalized and normalized not in GENERIC_EVIDENCE_TERMS:
+                    marker_terms.append(token.strip(".,;:()[]{}"))
+            marker_terms.extend(cls._focus_terms(summary, limit=24))
+        marker_terms = list(
+            dict.fromkeys(
+                term
+                for term in marker_terms
+                if cls._normalize_text(term)
+                and cls._normalize_text(term) not in GENERIC_EVIDENCE_TERMS
+            )
+        )
+        exact_input = [
+            term for term in focus_terms if cls._normalize_text(term) in input_text
+        ]
+        matched_input = [
+            term for term in marker_terms if cls._normalize_text(term) in input_text
+        ]
+        matched_support = [
+            term for term in marker_terms if cls._normalize_text(term) in support_text
+        ]
+        distinct_input = list(dict.fromkeys(matched_input))
+        distinct_support = list(dict.fromkeys(matched_support))
+        sufficient = bool(exact_input) or len(distinct_input) >= 2 or (
+            len(distinct_input) >= 1 and len(distinct_support) >= 2
+        )
+        raw_score = min(
+            1.0,
+            (2 * len(set(exact_input)) + len(distinct_input) + 0.5 * len(distinct_support))
+            / 4.0,
+        )
+        return {
+            "sufficient": sufficient,
+            "score": round(raw_score, 4),
+            "exact_focus_matches": exact_input[:8],
+            "input_markers": distinct_input[:12],
+            "support_markers": distinct_support[:12],
+            "anchor_ids": [str(anchor.get("id") or "") for anchor in anchors][:8],
+        }
+
+    @staticmethod
+    def _anchor_key(value: Any) -> str:
+        normalized = re.sub(r"[^a-zA-Z0-9_.-]+", "-", str(value or "").strip())
+        return normalized.strip("-")[:96] or "resource"
+
+    @staticmethod
+    def _safe_excerpt(value: Any, limit: int) -> str:
+        text = " ".join(str(value or "").split())
+        text = re.sub(
+            r"(?i)\b(api[_ -]?key|token|secret|password)\b\s*[:=]\s*[^\s,;]+",
+            r"\1=[redacted]",
+            text,
+        )
+        text = re.sub(r"(?i)\bsk-[a-z0-9_-]{8,}\b", "[redacted]", text)
+        return text[:limit]
+
+    @classmethod
+    def _focus_terms(cls, value: Any, limit: int = 16) -> list[str]:
+        """Extract stable domain terms without exposing more prompt text."""
+
+        text = cls._safe_excerpt(value, 2_000)
+        candidates: list[str] = []
+        words = re.findall(r"[A-Za-z][A-Za-z0-9_.+:/-]{1,}", text)
+        meaningful_words = [
+            word.strip(".,;:()[]{}")
+            for word in words
+            if len(word.casefold().strip("._+:/-")) >= 3
+            and word.casefold().strip("._+:/-") not in GENERIC_FOCUS_TERMS
+            and not word.isdigit()
+        ]
+        candidates.extend(
+            word
+            for word in meaningful_words
+            if word.isupper() or "-" in word or "_" in word
+        )
+        candidates.extend(
+            f"{left} {right}"
+            for left, right in zip(meaningful_words, meaningful_words[1:])
+            if len(left) + len(right) >= 8
+        )
+        candidates.extend(meaningful_words)
+
+        cjk_chunks = re.findall(r"[\u3400-\u9fff]{2,18}", text)
+        for chunk in cjk_chunks:
+            cleaned = chunk
+            for prefix in ("\u4f60\u662f", "\u4f5c\u4e3a", "\u8bf7", "\u8d1f\u8d23"):
+                if cleaned.startswith(prefix):
+                    cleaned = cleaned[len(prefix) :]
+            for suffix in ("\u667a\u80fd\u4f53", "\u52a9\u624b", "\u4e13\u5bb6"):
+                if cleaned.endswith(suffix):
+                    cleaned = cleaned[: -len(suffix)]
+            for part in re.split(r"[\u4e0e\u53ca\u548c\u6216]", cleaned):
+                term = part.strip()
+                if 2 <= len(term) <= 14 and term not in GENERIC_FOCUS_TERMS:
+                    candidates.append(term)
+
+        output: list[str] = []
+        seen: set[str] = set()
+        for candidate in candidates:
+            normalized = cls._normalize_text(candidate)
+            if not normalized or normalized in seen or normalized in GENERIC_FOCUS_TERMS:
+                continue
+            seen.add(normalized)
+            output.append(candidate[:80])
+            if len(output) >= limit:
+                break
+        return output
+
+    @staticmethod
+    def _normalize_text(value: Any) -> str:
+        return " ".join(str(value or "").casefold().split())
+
+    @staticmethod
+    def _checksum(value: Any) -> str:
+        payload = json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()

--- a/server/benchmarks/store.py
+++ b/server/benchmarks/store.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import copy
+import json
+import os
+import threading
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+
+class BenchmarkJobError(RuntimeError):
+    pass
+
+
+class BenchmarkJobNotFoundError(BenchmarkJobError):
+    pass
+
+
+class BenchmarkJobStateError(BenchmarkJobError):
+    pass
+
+
+class BenchmarkJobStore:
+    """Atomic task index for generated benchmarks and calibration runs."""
+
+    TERMINAL_STATUSES = {"completed", "failed", "cancelled"}
+    ACTIVE_STATUSES = {
+        "queued",
+        "generating",
+        "validating",
+        "calibrating",
+    }
+
+    def __init__(self, storage_dir: str | Path | None = None) -> None:
+        root = Path(
+            storage_dir
+            or os.getenv("BENCHMARK_STORAGE_DIR", "").strip()
+            or os.getenv("AGENT_TASK_STORAGE_DIR", "").strip()
+            or Path(__file__).resolve().parent / "storage"
+        )
+        self.storage_dir = root
+        self.path = root / "benchmark_jobs.json"
+        self._lock = threading.RLock()
+        self._data = self._load()
+
+    def create_job(self, *, kind: str, request: dict[str, Any]) -> dict[str, Any]:
+        if kind not in {"generation", "calibration"}:
+            raise BenchmarkJobStateError("Unsupported Benchmark job kind.")
+        now = time.time()
+        job = {
+            "job_id": f"benchmark_job_{uuid.uuid4().hex}",
+            "kind": kind,
+            "status": "queued",
+            "request": copy.deepcopy(request),
+            "target": {},
+            "coverage": {},
+            "generation": {},
+            "generation_attempts": [],
+            "dataset_id": None,
+            "dataset_revision": None,
+            "evaluation_run_id": None,
+            "calibration": {},
+            "warnings": [],
+            "error": None,
+            "cancel_requested": False,
+            "attempts": 0,
+            "created_at": now,
+            "updated_at": now,
+            "completed_at": None,
+        }
+        with self._lock:
+            self._data["jobs"][job["job_id"]] = job
+            self._save_unlocked()
+        return copy.deepcopy(job)
+
+    def list_jobs(
+        self,
+        *,
+        kind: str | None = None,
+        status: str | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        with self._lock:
+            items = list(self._data["jobs"].values())
+        if kind:
+            items = [item for item in items if item.get("kind") == kind]
+        if status:
+            items = [item for item in items if item.get("status") == status]
+        items.sort(key=lambda item: float(item.get("created_at") or 0), reverse=True)
+        return [copy.deepcopy(item) for item in items[: max(1, min(limit, 200))]]
+
+    def require_job(self, job_id: str) -> dict[str, Any]:
+        with self._lock:
+            return copy.deepcopy(self._require_unlocked(job_id))
+
+    def claim_next_job(self) -> dict[str, Any] | None:
+        with self._lock:
+            queued = [
+                item
+                for item in self._data["jobs"].values()
+                if item.get("status") == "queued"
+                and not item.get("cancel_requested")
+            ]
+            if not queued:
+                return None
+            item = min(queued, key=lambda value: float(value.get("created_at") or 0))
+            item["status"] = (
+                "generating" if item.get("kind") == "generation" else "validating"
+            )
+            item["attempts"] = int(item.get("attempts") or 0) + 1
+            item["updated_at"] = time.time()
+            self._save_unlocked()
+            return copy.deepcopy(item)
+
+    def update_job(self, job_id: str, **patch: Any) -> dict[str, Any]:
+        allowed = {
+            "status",
+            "target",
+            "coverage",
+            "generation",
+            "generation_attempts",
+            "dataset_id",
+            "dataset_revision",
+            "evaluation_run_id",
+            "calibration",
+            "warnings",
+            "error",
+        }
+        unknown = set(patch) - allowed
+        if unknown:
+            raise BenchmarkJobStateError(
+                f"Unsupported Benchmark job fields: {', '.join(sorted(unknown))}"
+            )
+        with self._lock:
+            item = self._require_unlocked(job_id)
+            for key, value in patch.items():
+                item[key] = copy.deepcopy(value)
+            item["updated_at"] = time.time()
+            if item.get("status") in self.TERMINAL_STATUSES:
+                item["completed_at"] = item["updated_at"]
+            self._save_unlocked()
+            return copy.deepcopy(item)
+
+    def cancel_job(self, job_id: str) -> dict[str, Any]:
+        with self._lock:
+            item = self._require_unlocked(job_id)
+            if item.get("status") in self.TERMINAL_STATUSES:
+                return copy.deepcopy(item)
+            item["cancel_requested"] = True
+            if item.get("status") == "queued":
+                item["status"] = "cancelled"
+                item["completed_at"] = time.time()
+            item["updated_at"] = time.time()
+            self._save_unlocked()
+            return copy.deepcopy(item)
+
+    def recover_jobs(self) -> int:
+        recovered = 0
+        with self._lock:
+            for item in self._data["jobs"].values():
+                if item.get("status") in {"generating", "validating"}:
+                    item["status"] = "queued"
+                    item["updated_at"] = time.time()
+                    recovered += 1
+            if recovered:
+                self._save_unlocked()
+        return recovered
+
+    def _load(self) -> dict[str, Any]:
+        if not self.path.exists():
+            return {"schema_version": 1, "jobs": {}}
+        try:
+            raw = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return {"schema_version": 1, "jobs": {}}
+        return {"schema_version": 1, "jobs": dict(raw.get("jobs") or {})}
+
+    def _save_unlocked(self) -> None:
+        self.storage_dir.mkdir(parents=True, exist_ok=True)
+        temp = self.path.with_suffix(".tmp")
+        temp.write_text(
+            json.dumps(self._data, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+        os.replace(temp, self.path)
+
+    def _require_unlocked(self, job_id: str) -> dict[str, Any]:
+        item = self._data["jobs"].get(job_id)
+        if not isinstance(item, dict):
+            raise BenchmarkJobNotFoundError("Benchmark job not found.")
+        return item

--- a/server/evaluations/api.py
+++ b/server/evaluations/api.py
@@ -103,6 +103,7 @@ async def get_capabilities() -> dict[str, Any]:
             "contains",
             "json_schema",
             "citation_hit",
+            "tool_call_match",
             "rubric_judge",
         ],
         "dataset_limits": {"max_cases": 500, "max_cases_per_run": 100},
@@ -230,11 +231,25 @@ async def publish_dataset(
     payload: DatasetPublishRequest,
 ) -> dict[str, Any]:
     try:
+        dataset = await _to_thread(_require_store().require_dataset, dataset_id)
+        if str(dataset.get("origin") or "manual") == "generated":
+            try:
+                from server.benchmarks import get_benchmark_generation_service
+            except ModuleNotFoundError:
+                from benchmarks import get_benchmark_generation_service
+
+            await _to_thread(
+                get_benchmark_generation_service().assert_dataset_target_fresh,
+                dataset,
+            )
         return await _to_thread(
             _require_store().publish_dataset,
             dataset_id,
             revision=payload.revision,
             release_notes=payload.release_notes,
+            acknowledge_calibration_warnings=(
+                payload.acknowledge_calibration_warnings
+            ),
         )
     except EvaluationConflictError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc

--- a/server/evaluations/executor.py
+++ b/server/evaluations/executor.py
@@ -158,6 +158,11 @@ class XpertEvaluationExecutor:
                         case=case,
                         output=output,
                         citations=dict(result.get("citations") or {}),
+                        tool_calls=[
+                            str(item)
+                            for item in list(result.get("tool_calls") or [])
+                            if str(item)
+                        ],
                         judge=self.judge_runner,
                         judge_model_id=run.get("config", {}).get("judge_model_id"),
                     )
@@ -165,6 +170,11 @@ class XpertEvaluationExecutor:
                         "status": "completed",
                         "output": output,
                         "citations": dict(result.get("citations") or {}),
+                        "tool_calls": [
+                            str(item)
+                            for item in list(result.get("tool_calls") or [])[:100]
+                            if str(item)
+                        ],
                         "usage": dict(result.get("usage") or {}),
                         "latency_ms": round(
                             (time.perf_counter() - started) * 1000, 3

--- a/server/evaluations/metrics.py
+++ b/server/evaluations/metrics.py
@@ -16,6 +16,7 @@ async def evaluate_case_metrics(
     case: dict[str, Any],
     output: str,
     citations: dict[str, list[str]],
+    tool_calls: list[str] | None = None,
     judge: JudgeCallback | None = None,
     judge_model_id: str | None = None,
 ) -> dict[str, Any]:
@@ -96,6 +97,32 @@ async def evaluate_case_metrics(
             )
         )
 
+    required_tools = _string_list(expected.get("required_tools"))
+    forbidden_tools = _string_list(expected.get("forbidden_tools"))
+    expected_order = _string_list(expected.get("tool_order"))
+    if required_tools or forbidden_tools or expected_order:
+        actual_tools = [str(item) for item in list(tool_calls or []) if str(item)]
+        required_hits = sum(item in actual_tools for item in required_tools)
+        forbidden_hits = sum(item in actual_tools for item in forbidden_tools)
+        order_ok = _is_subsequence(expected_order, actual_tools)
+        checks = len(required_tools) + len(forbidden_tools) + (1 if expected_order else 0)
+        passed_checks = (
+            required_hits
+            + (len(forbidden_tools) - forbidden_hits)
+            + (1 if expected_order and order_ok else 0)
+        )
+        metrics.append(
+            _metric(
+                "tool_call_match",
+                passed_checks / checks if checks else 0.0,
+                (
+                    f"required={required_hits}/{len(required_tools)}, "
+                    f"forbidden_hits={forbidden_hits}, "
+                    f"order={'matched' if order_ok else 'mismatched'}"
+                ),
+                weights,
+            )
+        )
     rubric = expected.get("rubric")
     if isinstance(rubric, str) and rubric.strip():
         if judge is None or not judge_model_id:
@@ -246,6 +273,22 @@ def _normalize(value: str) -> str:
 
 def _string_set(value: Any) -> set[str]:
     return {str(item).strip() for item in list(value or []) if str(item).strip()}
+
+
+def _string_list(value: Any) -> list[str]:
+    return [str(item).strip() for item in list(value or []) if str(item).strip()]
+
+
+def _is_subsequence(expected: list[str], actual: list[str]) -> bool:
+    if not expected:
+        return True
+    position = 0
+    for item in actual:
+        if item == expected[position]:
+            position += 1
+            if position == len(expected):
+                return True
+    return False
 
 
 def _percentile(values: list[float], quantile: float) -> float:

--- a/server/evaluations/models.py
+++ b/server/evaluations/models.py
@@ -10,6 +10,7 @@ MetricKind = Literal[
     "contains",
     "json_schema",
     "citation_hit",
+    "tool_call_match",
     "rubric_judge",
 ]
 
@@ -26,7 +27,44 @@ class EvaluationExpectation(BaseModel):
     citation_ids: list[str] = Field(default_factory=list, max_length=50)
     chunk_ids: list[str] = Field(default_factory=list, max_length=50)
     document_names: list[str] = Field(default_factory=list, max_length=50)
+    required_tools: list[str] = Field(default_factory=list, max_length=30)
+    forbidden_tools: list[str] = Field(default_factory=list, max_length=30)
+    tool_order: list[str] = Field(default_factory=list, max_length=30)
     rubric: str | None = Field(default=None, max_length=4_000)
+
+
+class EvaluationProfessionalEvidence(BaseModel):
+    sufficient: bool = False
+    score: float = Field(default=0.0, ge=0.0, le=1.0)
+    exact_focus_matches: list[str] = Field(default_factory=list, max_length=8)
+    input_markers: list[str] = Field(default_factory=list, max_length=12)
+    support_markers: list[str] = Field(default_factory=list, max_length=12)
+    anchor_ids: list[str] = Field(default_factory=list, max_length=8)
+
+
+class EvaluationCaseTargeting(BaseModel):
+    blueprint_id: str = Field(default="", max_length=120)
+    difficulty: Literal["basic", "edge", "adversarial"]
+    target_refs: list[str] = Field(min_length=1, max_length=5)
+    capability_matrix: list[str] = Field(default_factory=list, max_length=3)
+    focus_terms: list[str] = Field(default_factory=list, max_length=8)
+    pressure_types: list[
+        Literal[
+            "ambiguity",
+            "conflicting_context",
+            "missing_evidence",
+            "competing_constraints",
+            "schema_boundary",
+            "tool_decoy",
+            "cross_turn_override",
+            "domain_exception",
+        ]
+    ] = Field(default_factory=list, max_length=4)
+    rationale: str = Field(min_length=8, max_length=1_000)
+    challenge: str = Field(default="", max_length=500)
+    discriminator: str = Field(default="", max_length=500)
+    professional_evidence: EvaluationProfessionalEvidence | None = None
+    normalization_notes: list[str] = Field(default_factory=list, max_length=8)
 
 
 class EvaluationCaseInput(BaseModel):
@@ -37,6 +75,7 @@ class EvaluationCaseInput(BaseModel):
     tags: list[str] = Field(default_factory=list, max_length=20)
     expected: EvaluationExpectation = Field(default_factory=EvaluationExpectation)
     weights: dict[MetricKind, float] = Field(default_factory=dict)
+    targeting: EvaluationCaseTargeting | None = None
 
     @model_validator(mode="after")
     def normalize_weights(self) -> "EvaluationCaseInput":
@@ -67,6 +106,7 @@ class DatasetCasesRequest(BaseModel):
 class DatasetPublishRequest(BaseModel):
     revision: int = Field(ge=1)
     release_notes: str = Field(default="", max_length=2_000)
+    acknowledge_calibration_warnings: bool = False
 
 
 class ConversationImportSelection(BaseModel):

--- a/server/evaluations/service.py
+++ b/server/evaluations/service.py
@@ -8,16 +8,16 @@ from typing import Any, Callable
 
 try:
     from server.workflow_native.schemas import NativeWorkflowDefinition
-    from server.workflow_native.validate import validate_workflow_graph
     from server.xperts.models import (
         XpertDefinition,
         XpertDraft,
         XpertVersion,
     )
+    from server.xperts.validation import validate_xpert_workflow_graph
 except ModuleNotFoundError:
     from workflow_native.schemas import NativeWorkflowDefinition
-    from workflow_native.validate import validate_workflow_graph
     from xperts.models import XpertDefinition, XpertDraft, XpertVersion
+    from xperts.validation import validate_xpert_workflow_graph
 
 from .store import (
     EvaluationConflictError,
@@ -166,7 +166,10 @@ class XpertEvaluationService:
             workflow,
             recursion_path=(*recursion_path, xpert.id),
         )
-        validation = validate_workflow_graph(workflow)
+        validation = validate_xpert_workflow_graph(
+            workflow,
+            history_variable=version.history_variable,
+        )
         issues.extend(
             {
                 "code": issue.code,
@@ -305,7 +308,10 @@ class XpertEvaluationService:
             workflow,
             recursion_path=(xpert.id,),
         )
-        graph_validation = validate_workflow_graph(workflow)
+        graph_validation = validate_xpert_workflow_graph(
+            workflow,
+            history_variable=xpert.draft.history_variable,
+        )
         issues.extend(
             {
                 "code": issue.code,

--- a/server/evaluations/store.py
+++ b/server/evaluations/store.py
@@ -145,6 +145,54 @@ class XpertEvaluationStore:
             self._save_unlocked()
         return self.dataset_payload(dataset, include_cases=True)
 
+    def create_generated_dataset(
+        self,
+        *,
+        name: str,
+        description: str,
+        cases: list[dict[str, Any]],
+        provenance: dict[str, Any],
+        coverage: dict[str, Any],
+        calibration: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        normalized = [self.normalize_case(item) for item in cases]
+        if not normalized:
+            raise EvaluationStateError("Generated dataset must contain at least one case.")
+        if len(normalized) > self.MAX_DATASET_CASES:
+            raise EvaluationStateError("A dataset may contain at most 500 cases.")
+        case_ids = [str(item["case_id"]) for item in normalized]
+        if len(case_ids) != len(set(case_ids)):
+            raise EvaluationStateError("Generated case ids must be unique.")
+        now = time.time()
+        dataset = {
+            "dataset_id": f"xeval_dataset_{uuid.uuid4().hex}",
+            "name": self._required(name, "name", 160),
+            "description": str(description or "").strip()[:2_000],
+            "status": "draft",
+            "revision": 1,
+            "published_version": None,
+            "cases": copy.deepcopy(normalized),
+            "versions": [],
+            "origin": "generated",
+            "catalog_ref": {},
+            "provenance": copy.deepcopy(provenance),
+            "coverage": copy.deepcopy(coverage),
+            "calibration": copy.deepcopy(
+                calibration
+                or {
+                    "status": "pending",
+                    "dataset_revision": 1,
+                    "updated_at": now,
+                }
+            ),
+            "created_at": now,
+            "updated_at": now,
+        }
+        with self._lock:
+            self._data["datasets"][dataset["dataset_id"]] = dataset
+            self._save_unlocked()
+        return self.dataset_payload(dataset, include_cases=True)
+
     def list_datasets(self, *, status: str | None = None) -> list[dict[str, Any]]:
         with self._lock:
             items = list(self._data["datasets"].values())
@@ -206,7 +254,12 @@ class XpertEvaluationStore:
                 raise EvaluationStateError("A dataset may contain at most 500 cases.")
             item["cases"] = list(by_id.values())
             calibration = dict(item.get("calibration") or {})
-            if calibration.get("status") == "calibrated":
+            if calibration.get("status") in {
+                "pending",
+                "calibrated",
+                "warning",
+                "failed",
+            }:
                 calibration.update(
                     {
                         "status": "stale",
@@ -219,18 +272,57 @@ class XpertEvaluationStore:
             self._save_unlocked()
             return copy.deepcopy(item)
 
+    def set_dataset_calibration(
+        self,
+        dataset_id: str,
+        *,
+        revision: int,
+        calibration: dict[str, Any],
+    ) -> dict[str, Any]:
+        status = str(calibration.get("status") or "")
+        if status not in {"pending", "calibrated", "warning", "failed", "stale"}:
+            raise EvaluationStateError("Invalid calibration status.")
+        with self._lock:
+            item = self._dataset_unlocked(dataset_id)
+            self._check_revision(item, revision)
+            payload = copy.deepcopy(calibration)
+            payload["status"] = status
+            payload["dataset_revision"] = revision
+            payload["updated_at"] = time.time()
+            item["calibration"] = payload
+            item["updated_at"] = payload["updated_at"]
+            self._save_unlocked()
+            return self.dataset_payload(item, include_cases=True)
+
     def publish_dataset(
         self,
         dataset_id: str,
         *,
         revision: int,
         release_notes: str = "",
+        acknowledge_calibration_warnings: bool = False,
     ) -> dict[str, Any]:
         with self._lock:
             item = self._dataset_unlocked(dataset_id)
             self._check_revision(item, revision)
             if not item.get("cases"):
                 raise EvaluationStateError("Dataset must contain at least one case.")
+            if str(item.get("origin") or "manual") == "generated":
+                calibration = dict(item.get("calibration") or {})
+                calibration_status = str(calibration.get("status") or "pending")
+                if int(calibration.get("dataset_revision") or 0) != int(revision):
+                    raise EvaluationStateError(
+                        "Generated dataset calibration is stale for this revision."
+                    )
+                if calibration_status == "warning":
+                    if not acknowledge_calibration_warnings:
+                        raise EvaluationStateError(
+                            "Calibration warnings must be acknowledged before publishing."
+                        )
+                elif calibration_status != "calibrated":
+                    raise EvaluationStateError(
+                        "Generated dataset must complete calibration before publishing."
+                    )
             version_number = len(item.get("versions") or []) + 1
             cases = copy.deepcopy(item["cases"])
             version = {
@@ -510,7 +602,7 @@ class XpertEvaluationStore:
             content = content[:remaining]
             total_history += len(content)
             messages.append({"role": role, "content": content})
-        return {
+        normalized = {
             "case_id": case_id[:120],
             "name": str(case.get("name") or message[:80]).strip()[:160],
             "message": message[:20_000],
@@ -523,6 +615,9 @@ class XpertEvaluationStore:
             "expected": copy.deepcopy(case.get("expected") or {}),
             "weights": copy.deepcopy(case.get("weights") or {}),
         }
+        if isinstance(case.get("targeting"), dict):
+            normalized["targeting"] = copy.deepcopy(case["targeting"])
+        return normalized
 
     def _load(self) -> dict[str, Any]:
         if not self.path.exists():

--- a/server/main.py
+++ b/server/main.py
@@ -92,11 +92,18 @@ except ModuleNotFoundError:
 
 try:
     from server.benchmarks import (
+        BenchmarkGeneratorOutput,
         configure_benchmarks,
+        get_benchmark_job_executor,
         router as benchmarks_router,
     )
 except ModuleNotFoundError:
-    from benchmarks import configure_benchmarks, router as benchmarks_router
+    from benchmarks import (
+        BenchmarkGeneratorOutput,
+        configure_benchmarks,
+        get_benchmark_job_executor,
+        router as benchmarks_router,
+    )
 
 try:
     from server.evolutions import (
@@ -2575,6 +2582,126 @@ def completion_text_from_payload(payload: dict[str, Any]) -> str:
     return ""
 
 
+def completion_json_text_from_payload(
+    payload: dict[str, Any],
+    *,
+    required_top_level_key: str | None = None,
+) -> str:
+    """Recover only a JSON object from provider-specific reasoning fields.
+
+    Some OpenAI-compatible reasoning models return an empty ``content`` while
+    placing the requested JSON object in a reasoning field. This adapter is
+    intentionally opt-in and returns only the parsed JSON slice, never the
+    surrounding reasoning text.
+    """
+
+    text, _ = completion_json_result_from_payload(
+        payload,
+        required_top_level_key=required_top_level_key,
+    )
+    return text
+
+
+def completion_json_result_from_payload(
+    payload: dict[str, Any],
+    *,
+    required_top_level_key: str | None = None,
+) -> tuple[str, dict[str, Any]]:
+    """Return JSON text plus safe provider diagnostics without reasoning text."""
+
+    diagnostics: dict[str, Any] = {
+        "finish_reason": None,
+        "content_chars": 0,
+        "reasoning_chars": 0,
+        "reasoning_present": False,
+        "selected_source": "none",
+        "contract_found": False,
+        "candidate_top_level_keys": [],
+        "usage": {},
+    }
+    text = completion_text_from_payload(payload)
+    choices = payload.get("choices")
+    if not isinstance(choices, list) or not choices:
+        return "", diagnostics
+    first_choice = choices[0]
+    if not isinstance(first_choice, dict):
+        return "", diagnostics
+    finish_reason = first_choice.get("finish_reason")
+    if isinstance(finish_reason, str) and finish_reason.strip():
+        diagnostics["finish_reason"] = finish_reason[:80]
+    message = first_choice.get("message")
+    if not isinstance(message, dict):
+        return "", diagnostics
+
+    diagnostics["content_chars"] = len(text)
+    usage = payload.get("usage")
+    if isinstance(usage, dict):
+        diagnostics["usage"] = {
+            key: int(usage[key])
+            for key in ("prompt_tokens", "completion_tokens", "total_tokens")
+            if isinstance(usage.get(key), int)
+        }
+
+    candidates: list[tuple[str, str]] = []
+    for field in ("reasoning_content", "reasoning"):
+        value = message.get(field)
+        if isinstance(value, str) and value.strip():
+            candidates.append(("reasoning", value))
+    details = message.get("reasoning_details")
+    if isinstance(details, list):
+        for detail in details:
+            if not isinstance(detail, dict):
+                continue
+            for field in ("text", "content", "reasoning"):
+                value = detail.get(field)
+                if isinstance(value, str) and value.strip():
+                    candidates.append(("reasoning", value))
+
+    diagnostics["reasoning_chars"] = sum(len(value) for _, value in candidates)
+    diagnostics["reasoning_present"] = bool(candidates)
+
+    decoder = json.JSONDecoder()
+    detected_keys: set[str] = set()
+    selected_reasoning = ""
+    for source, candidate in [*candidates, ("content", text)]:
+        for match in re.finditer(r"\{", candidate):
+            try:
+                value, end = decoder.raw_decode(candidate[match.start() :])
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(value, dict):
+                continue
+            detected_keys.update(str(key)[:80] for key in value.keys())
+            if not required_top_level_key or required_top_level_key in value:
+                diagnostics["contract_found"] = True
+                if source == "reasoning" and not selected_reasoning:
+                    selected_reasoning = candidate[match.start() : match.start() + end]
+                break
+    diagnostics["candidate_top_level_keys"] = sorted(detected_keys)[:20]
+    if selected_reasoning:
+        diagnostics["selected_source"] = "reasoning"
+        return selected_reasoning, diagnostics
+    # Preserve ordinary content for the caller's normal validation/repair path.
+    # Provider-specific reasoning remains hidden unless it contains the exact
+    # requested top-level contract.
+    if text.strip():
+        diagnostics["selected_source"] = "content"
+        return text, diagnostics
+    return "", diagnostics
+
+
+class ChatCompletionContentError(RuntimeError):
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        diagnostics: dict[str, Any],
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.diagnostics = diagnostics
+
+
 def chat_sse_delta(text: str) -> bytes:
     payload = json.dumps(
         {"choices": [{"delta": {"content": text}}]},
@@ -2664,6 +2791,11 @@ async def collect_chat_completion_text(
     gateway_key: str | None = None,
     actual_model_observer: Callable[[str], None] | None = None,
     usage_observer: Callable[[dict[str, int]], None] | None = None,
+    response_format: dict[str, Any] | None = None,
+    reasoning: dict[str, Any] | None = None,
+    allow_json_reasoning_fallback: bool = False,
+    json_required_top_level_key: str | None = None,
+    completion_diagnostics: dict[str, Any] | None = None,
 ) -> str:
     if gateway_url is not None:
         url = gateway_url
@@ -2692,12 +2824,18 @@ async def collect_chat_completion_text(
         ChatMessage.model_validate(message)
         for message in optimization.messages
     ]
+    extra: dict[str, Any] = {}
+    if response_format:
+        extra["response_format"] = response_format
+    if reasoning:
+        extra["reasoning"] = reasoning
     request_payload = build_chat_payload_from_messages(
         model_id,
         prepared_messages,
         stream=False,
         temperature=temperature,
         max_tokens=max_tokens,
+        extra=extra or None,
     )
 
     async with execution_operation("model_call"), httpx.AsyncClient(
@@ -2720,8 +2858,32 @@ async def collect_chat_completion_text(
             if isinstance(raw_reported_model, str)
             else ""
         )
-        text = completion_text_from_payload(data)
+        if allow_json_reasoning_fallback:
+            text, diagnostics = completion_json_result_from_payload(
+                data,
+                required_top_level_key=json_required_top_level_key,
+            )
+            if completion_diagnostics is not None:
+                completion_diagnostics.update(diagnostics)
+        else:
+            text = completion_text_from_payload(data)
         if not text.strip():
+            if allow_json_reasoning_fallback:
+                error_code = (
+                    "empty_content"
+                    if not diagnostics["content_chars"]
+                    and not diagnostics["reasoning_chars"]
+                    else "contract_missing"
+                )
+                raise ChatCompletionContentError(
+                    error_code,
+                    (
+                        "Generator returned no content."
+                        if error_code == "empty_content"
+                        else "Generator response did not contain the required JSON contract."
+                    ),
+                    diagnostics,
+                )
             raise RuntimeError("模型没有返回可用内容。")
         if actual_model_observer is not None:
             actual_model_observer(reported_model)
@@ -14852,6 +15014,34 @@ def evaluation_citation_summary(value: Any) -> dict[str, list[str]]:
     }
 
 
+async def evaluation_tool_call_summary(runtime_run_id: str) -> list[str]:
+    """Return only dispatched tool names in stable checkpoint order."""
+    if not runtime_run_id:
+        return []
+    pending = [runtime_run_id]
+    visited: set[str] = set()
+    checkpoints: list[Any] = []
+    while pending and len(visited) < 200:
+        current = pending.pop(0)
+        if current in visited:
+            continue
+        visited.add(current)
+        try:
+            checkpoints.extend(await run_registry.list_checkpoints(current, limit=500))
+        except KeyError:
+            pass
+        children = await run_registry.list_runs(parent_run_id=current, limit=200)
+        pending.extend(child.run_id for child in children if child.run_id not in visited)
+    checkpoints.sort(key=lambda item: (float(item.created_at), str(item.checkpoint_id)))
+    return [
+        str(item.metadata.get("tool_name"))[:300]
+        for item in checkpoints
+        if item.event_type
+        in {"workflow_agent.tool_call", "workflow_agent.tool_call_failed"}
+        and str(item.metadata.get("tool_name") or "").strip()
+    ][:100]
+
+
 async def run_xpert_evaluation_target(
     target: dict[str, Any],
     case: dict[str, Any],
@@ -14975,6 +15165,7 @@ async def run_xpert_evaluation_target(
     return {
         "output": output,
         "citations": evaluation_citation_summary(citation_value),
+        "tool_calls": await evaluation_tool_call_summary(runtime_run_id),
         "usage": usage,
         "runtime_run_id": runtime_run_id or None,
     }
@@ -15212,7 +15403,53 @@ configure_xpert_evaluations(
     judge_runner=run_xpert_evaluation_judge,
     run_registry=run_registry,
 )
-configure_benchmarks(get_xpert_evaluation_store())
+
+
+async def run_benchmark_generator_model(
+    model_id: str,
+    system_prompt: str,
+    user_prompt: str,
+    temperature: float,
+    max_tokens: int,
+) -> BenchmarkGeneratorOutput:
+    diagnostics: dict[str, Any] = {}
+    try:
+        text = await collect_chat_completion_text(
+            model_id,
+            [
+                ChatMessage(role="system", content=system_prompt),
+                ChatMessage(role="user", content=user_prompt),
+            ],
+            temperature=temperature,
+            max_tokens=max_tokens,
+            response_format={"type": "json_object"},
+            reasoning={"effort": "low"},
+            allow_json_reasoning_fallback=True,
+            json_required_top_level_key="dataset",
+            completion_diagnostics=diagnostics,
+        )
+    except ChatCompletionContentError as exc:
+        return BenchmarkGeneratorOutput(
+            diagnostics=exc.diagnostics,
+            error_code=exc.code,
+            error_message=str(exc),
+        )
+    return BenchmarkGeneratorOutput(text=text, diagnostics=diagnostics)
+
+
+configure_benchmarks(
+    get_xpert_evaluation_store(),
+    storage_dir=AGENT_TASK_STORAGE_DIR or None,
+    evaluation_service=get_xpert_evaluation_service(),
+    evaluation_executor=get_xpert_evaluation_executor(),
+    xpert_store=get_xpert_store(),
+    proposal_store=authoring_proposal_store,
+    prompt_store=get_prompt_profile_store(),
+    context_store=xpert_context_store,
+    rag_service=get_rag_service(),
+    toolset_store=toolset_store,
+    generator_runner=run_benchmark_generator_model,
+)
 
 
 async def run_xpert_evolution_optimizer(
@@ -15261,6 +15498,7 @@ async def start_mcp_ttl_cleanup() -> None:
     get_evaluation_executor().start()
     get_xpert_evaluation_executor().start()
     start_skill_creator_evaluation_runtime()
+    get_benchmark_job_executor().start()
     get_xpert_evolution_executor().start()
     get_handoff_executor().start()
     get_goal_coordinator().start()
@@ -15273,6 +15511,7 @@ async def start_mcp_ttl_cleanup() -> None:
 async def shutdown_mcp_sessions() -> None:
     await get_pipeline_executor().stop()
     await get_evaluation_executor().stop()
+    await get_benchmark_job_executor().stop()
     await get_xpert_evolution_executor().stop()
     await get_xpert_evaluation_executor().stop()
     await skill_evaluation_executor.stop()

--- a/server/tests/test_benchmark_generator.py
+++ b/server/tests/test_benchmark_generator.py
@@ -1,0 +1,1569 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from server.benchmarks import api as benchmark_api
+from server.benchmarks.catalog import BenchmarkCatalog
+from server.benchmarks.executor import BenchmarkGeneratorOutput, BenchmarkJobExecutor
+from server.benchmarks.service import (
+    BenchmarkGenerationError,
+    BenchmarkGenerationService,
+)
+from server.benchmarks.store import BenchmarkJobStore
+from server.evaluations.metrics import evaluate_case_metrics
+from server.evaluations.service import XpertEvaluationService
+from server.evaluations.store import EvaluationStateError, XpertEvaluationStore
+from server.xperts import XpertStore
+from server.xperts.validation import validate_xpert_definition
+
+
+class _MissingResourceStore:
+    def get_version(self, *_args: Any, **_kwargs: Any) -> Any:
+        raise KeyError("resource not found")
+
+
+class _NoKnowledgeService:
+    def get_active_pipeline_version(self, _kb_id: str) -> None:
+        return None
+
+
+def _generated_case(case_id: str = "generated-one") -> dict[str, Any]:
+    return {
+        "case_id": case_id,
+        "name": "Generated case",
+        "message": "Give a concise plan for the supplied task.",
+        "tags": ["generated", "instruction_following", "en-US"],
+        "expected": {"contains": ["plan"]},
+        "weights": {"contains": 1.0},
+        "targeting": {
+            "difficulty": "edge",
+            "target_refs": ["agent:primary:role_prompt"],
+            "capability_matrix": ["instruction_following"],
+            "pressure_types": ["ambiguity"],
+            "rationale": "Exercises the target Agent's explicit planning instruction.",
+            "challenge": "The request is underspecified and requires a concise plan.",
+            "discriminator": (
+                "The configured target must return its explicit planning contract, "
+                "rather than a generic prose answer."
+            ),
+        },
+    }
+
+
+def test_benchmark_job_store_persists_recovers_and_cancels(tmp_path: Path) -> None:
+    store = BenchmarkJobStore(tmp_path)
+    created = store.create_job(kind="generation", request={"target": {"kind": "xpert_draft"}})
+    claimed = store.claim_next_job()
+
+    assert claimed is not None
+    assert claimed["job_id"] == created["job_id"]
+    assert claimed["status"] == "generating"
+    assert claimed["attempts"] == 1
+
+    restored = BenchmarkJobStore(tmp_path)
+    assert restored.recover_jobs() == 1
+    retried = restored.claim_next_job()
+    assert retried is not None
+    assert retried["attempts"] == 2
+
+    queued = restored.create_job(kind="calibration", request={"dataset_id": "dataset"})
+    cancelled = restored.cancel_job(queued["job_id"])
+    assert cancelled["status"] == "cancelled"
+    assert BenchmarkJobStore(tmp_path).require_job(queued["job_id"])["status"] == "cancelled"
+
+
+def test_generated_dataset_requires_current_calibration_and_warning_ack(
+    tmp_path: Path,
+) -> None:
+    store = XpertEvaluationStore(tmp_path)
+    dataset = store.create_generated_dataset(
+        name="Generated benchmark",
+        description="",
+        cases=[_generated_case()],
+        provenance={
+            "target_reference": {
+                "kind": "xpert_draft",
+                "xpert_id": "xpert-one",
+                "draft_revision": 1,
+            },
+            "target_checksum": "fixed",
+        },
+        coverage={"selected": ["instruction_following"]},
+    )
+
+    with pytest.raises(EvaluationStateError, match="complete calibration"):
+        store.publish_dataset(dataset["dataset_id"], revision=dataset["revision"])
+
+    warned = store.set_dataset_calibration(
+        dataset["dataset_id"],
+        revision=dataset["revision"],
+        calibration={
+            "status": "warning",
+            "target_reference": dataset["provenance"]["target_reference"],
+            "target_checksum": "fixed",
+            "warnings": ["Baseline is very easy."],
+        },
+    )
+    with pytest.raises(EvaluationStateError, match="acknowledged"):
+        store.publish_dataset(warned["dataset_id"], revision=warned["revision"])
+
+    version = store.publish_dataset(
+        warned["dataset_id"],
+        revision=warned["revision"],
+        acknowledge_calibration_warnings=True,
+    )
+    assert version["version"] == 1
+    assert version["calibration"]["status"] == "warning"
+
+    edited = store.put_cases(
+        warned["dataset_id"],
+        revision=warned["revision"] + 1,
+        cases=[_generated_case("generated-two")],
+    )
+    assert edited["calibration"]["status"] == "stale"
+    with pytest.raises(EvaluationStateError, match="calibration is stale"):
+        store.publish_dataset(edited["dataset_id"], revision=edited["revision"])
+
+
+def test_default_xpert_draft_preflight_accepts_runtime_history_variable(
+    tmp_path: Path,
+) -> None:
+    xpert_store = XpertStore(tmp_path / "xperts")
+    xpert = xpert_store.create_xpert(name="Benchmark preview")
+    evaluation_store = XpertEvaluationStore(tmp_path / "evaluations")
+
+    def prompt_preflight(candidate: Any) -> tuple[Any, Any, list[Any]]:
+        return (
+            validate_xpert_definition(candidate),
+            candidate.draft.workflow.model_copy(deep=True),
+            [],
+        )
+
+    evaluation_service = XpertEvaluationService(
+        evaluation_store,
+        xpert_store=xpert_store,
+        proposal_store=_MissingResourceStore(),
+        prompt_preflight=prompt_preflight,
+        toolset_store=_MissingResourceStore(),
+        plugin_store=_MissingResourceStore(),
+        rag_service=_NoKnowledgeService(),
+        context_store=_MissingResourceStore(),
+    )
+    service = BenchmarkGenerationService(
+        evaluation_store=evaluation_store,
+        evaluation_service=evaluation_service,
+        xpert_store=xpert_store,
+        proposal_store=_MissingResourceStore(),
+        prompt_store=_MissingResourceStore(),
+        context_store=_MissingResourceStore(),
+    )
+
+    result = service.preflight(
+        target_reference={
+            "kind": "xpert_draft",
+            "xpert_id": xpert.id,
+            "draft_revision": xpert.draft_revision,
+        },
+        requested_coverage=["instruction_following", "multi_turn"],
+    )
+
+    assert result["valid"] is True
+    assert result["issues"] == []
+    assert result["target"]["source"]["draft_revision"] == 1
+    assert any(
+        anchor["kind"] == "agent_prompt" for anchor in result["target_anchors"]
+    )
+    assert any(
+        anchor["kind"] == "conversation_contract"
+        for anchor in result["target_anchors"]
+    )
+
+
+def test_generator_validation_rejects_unknown_tools_duplicates_and_gold_leak(
+    tmp_path: Path,
+) -> None:
+    service = BenchmarkGenerationService(
+        evaluation_store=XpertEvaluationStore(tmp_path),
+        evaluation_service=object(),
+        xpert_store=object(),
+        proposal_store=object(),
+        prompt_store=object(),
+        context_store=object(),
+    )
+    payload = {
+        "dataset": {
+            "name": "Tool routing",
+            "description": "",
+            "cases": [
+                {
+                    "case_id": "tool-one",
+                    "name": "Use search",
+                    "message": "Find current release notes.",
+                    "locale": "en-US",
+                    "coverage": "tool_routing",
+                    "targeting": {
+                        "difficulty": "edge",
+                        "target_refs": ["tool:search"],
+                        "capability_matrix": ["tool_routing"],
+                        "pressure_types": ["tool_decoy"],
+                        "rationale": "Verifies routing to the explicitly available search tool.",
+                        "challenge": "The request requires current release information.",
+                        "discriminator": (
+                            "The configured target must invoke search instead of "
+                            "answering from unsupported general knowledge."
+                        ),
+                    },
+                    "expected": {
+                        "required_tools": ["search"],
+                        "forbidden_tools": ["write"],
+                        "tool_order": ["search"],
+                    },
+                    "weights": {"tool_call_match": 1.0},
+                }
+            ],
+        }
+    }
+    parsed = service.parse_generated_cases(
+        json.dumps(payload),
+        expected_count=1,
+        allowed_coverage=["tool_routing"],
+        allowed_tool_names=["search", "write"],
+        allowed_target_anchors=[
+            {
+                "id": "tool:search",
+                "kind": "tool",
+                "label": "Search",
+                "summary": "Search tool",
+                "coverage": ["tool_routing"],
+            }
+        ],
+    )
+    assert parsed["cases"][0]["expected"]["required_tools"] == ["search"]
+
+    unknown = copy.deepcopy(payload)
+    unknown["dataset"]["cases"][0]["expected"]["required_tools"] = ["unknown"]
+    with pytest.raises(BenchmarkGenerationError, match="unavailable tools"):
+        service.parse_generated_cases(
+            json.dumps(unknown),
+            expected_count=1,
+            allowed_coverage=["tool_routing"],
+            allowed_tool_names=["search"],
+            allowed_target_anchors=[
+                {"id": "tool:search", "coverage": ["tool_routing"]}
+            ],
+        )
+
+    duplicate = copy.deepcopy(payload)
+    duplicate["dataset"]["cases"] = [
+        copy.deepcopy(payload["dataset"]["cases"][0]),
+        {**copy.deepcopy(payload["dataset"]["cases"][0]), "case_id": "tool-two"},
+    ]
+    with pytest.raises(BenchmarkGenerationError, match="duplicates"):
+        service.parse_generated_cases(
+            json.dumps(duplicate),
+            expected_count=2,
+            allowed_coverage=["tool_routing"],
+            allowed_tool_names=["search", "write"],
+            allowed_target_anchors=[
+                {"id": "tool:search", "coverage": ["tool_routing"]}
+            ],
+        )
+
+    leaked = copy.deepcopy(payload)
+    long_gold = "This exact deterministic answer is deliberately copied into the prompt."
+    leaked["dataset"]["cases"][0]["message"] = f"Repeat: {long_gold}"
+    leaked["dataset"]["cases"][0]["expected"] = {"exact_answer": long_gold}
+    with pytest.raises(BenchmarkGenerationError, match="Gold"):
+        service.parse_generated_cases(
+            json.dumps(leaked),
+            expected_count=1,
+            allowed_coverage=["tool_routing"],
+            allowed_tool_names=[],
+            allowed_target_anchors=[
+                {"id": "tool:search", "coverage": ["tool_routing"]}
+            ],
+        )
+
+
+def test_generator_requires_target_evidence_and_balanced_difficulty(
+    tmp_path: Path,
+) -> None:
+    service = BenchmarkGenerationService(
+        evaluation_store=XpertEvaluationStore(tmp_path),
+        evaluation_service=object(),
+        xpert_store=object(),
+        proposal_store=object(),
+        prompt_store=object(),
+        context_store=object(),
+    )
+    anchors = [
+        {
+            "id": "agent:primary:role_prompt",
+            "kind": "agent_prompt",
+            "axis": "domain",
+            "label": "Primary rolePrompt",
+            "summary": "Review supply chain escalation constraints.",
+            "focus_terms": ["supply chain"],
+            "coverage": ["instruction_following"],
+        },
+        {
+            "id": "agent:primary:conversation_contract",
+            "kind": "conversation_contract",
+            "axis": "contract",
+            "label": "Conversation history",
+            "summary": "Resolve conflicts in recent context.",
+            "focus_terms": ["escalation"],
+            "coverage": ["multi_turn"],
+        },
+    ]
+    difficulties = ["basic"] * 4 + ["edge"] * 4 + ["adversarial"] * 4
+    cases = []
+    for index, difficulty in enumerate(difficulties):
+        coverage = "instruction_following" if index % 2 == 0 else "multi_turn"
+        combined = index < 8
+        matrix = (
+            ["instruction_following", "multi_turn"] if combined else [coverage]
+        )
+        target_refs = (
+            [anchors[0]["id"], anchors[1]["id"]]
+            if combined or coverage == "multi_turn"
+            else [anchors[0]["id"] if coverage == "instruction_following" else anchors[1]["id"]]
+        )
+        focus_terms = ["supply chain", "escalation"] if combined or coverage == "multi_turn" else (
+            ["supply chain"] if coverage == "instruction_following" else ["escalation"]
+        )
+        pressure_types = (
+            ["conflicting_context", "competing_constraints"]
+            if difficulty == "adversarial"
+            else ["ambiguity"] if difficulty == "edge" else []
+        )
+        cases.append(
+            {
+                "case_id": f"targeted-{index}",
+                "name": f"Targeted {index}",
+                "message": f"Handle {', '.join(focus_terms)} scenario number {index}.",
+                "locale": "en-US" if index % 2 == 0 else "zh-CN",
+                "coverage": coverage,
+                "targeting": {
+                    "difficulty": difficulty,
+                    "target_refs": target_refs,
+                    "capability_matrix": matrix,
+                    "focus_terms": focus_terms,
+                    "pressure_types": pressure_types,
+                    "rationale": f"Verifies the fixed {coverage} contract for scenario {index}.",
+                    "challenge": f"Applies {difficulty} pressure without changing the Gold.",
+                    "discriminator": (
+                        "The configured supply-chain reviewer must preserve its "
+                        "escalation contract instead of giving generic advice."
+                    ),
+                },
+                "expected": {"exact_answer": f"result-{index}"},
+                "weights": {"exact_match": 1.0},
+            }
+        )
+    payload = {"dataset": {"name": "Targeted", "cases": cases}}
+
+    parsed = service.parse_generated_cases(
+        json.dumps(payload),
+        expected_count=12,
+        allowed_coverage=["instruction_following", "multi_turn"],
+        allowed_tool_names=[],
+        allowed_target_anchors=anchors,
+    )
+
+    assert parsed["targeting"]["difficulty_counts"] == {
+        "basic": 4,
+        "edge": 4,
+        "adversarial": 4,
+    }
+    assert parsed["targeting"]["target_anchor_count"] == 2
+    assert parsed["targeting"]["combined_case_count"] == 8
+    assert parsed["targeting"]["cases_with_focus"] == 12
+
+    unknown = copy.deepcopy(payload)
+    unknown["dataset"]["cases"][0]["targeting"]["target_refs"] = ["unknown"]
+    with pytest.raises(BenchmarkGenerationError, match="unknown target anchors"):
+        service.parse_generated_cases(
+            json.dumps(unknown),
+            expected_count=12,
+            allowed_coverage=["instruction_following", "multi_turn"],
+            allowed_tool_names=[],
+            allowed_target_anchors=anchors,
+        )
+
+    unbalanced = copy.deepcopy(payload)
+    for case in unbalanced["dataset"]["cases"]:
+        case["targeting"]["difficulty"] = "basic"
+    with pytest.raises(BenchmarkGenerationError, match="may be basic"):
+        service.parse_generated_cases(
+            json.dumps(unbalanced),
+            expected_count=12,
+            allowed_coverage=["instruction_following", "multi_turn"],
+            allowed_tool_names=[],
+            allowed_target_anchors=anchors,
+        )
+
+
+def test_generator_enforces_professional_focus_and_three_axis_matrices(
+    tmp_path: Path,
+) -> None:
+    service = BenchmarkGenerationService(
+        evaluation_store=XpertEvaluationStore(tmp_path),
+        evaluation_service=object(),
+        xpert_store=object(),
+        proposal_store=object(),
+        prompt_store=object(),
+        context_store=object(),
+    )
+    anchors = [
+        {
+            "id": "agent:supplier:role_prompt",
+            "kind": "agent_prompt",
+            "axis": "domain",
+            "label": "Supplier quality role",
+            "summary": "Assess PPAP evidence and supplier risk.",
+            "focus_terms": ["PPAP"],
+            "coverage": ["instruction_following"],
+        },
+        {
+            "id": "agent:supplier:output_schema",
+            "kind": "output_schema",
+            "axis": "contract",
+            "label": "Risk schema",
+            "summary": "Return a numeric risk_score in strict JSON.",
+            "focus_terms": ["risk_score"],
+            "coverage": ["structured_output"],
+        },
+        {
+            "id": "agent:supplier:conversation_contract",
+            "kind": "conversation_contract",
+            "axis": "contract",
+            "label": "Escalation history",
+            "summary": "Resolve supplier escalation conflicts across turns.",
+            "focus_terms": ["supplier escalation"],
+            "coverage": ["multi_turn"],
+        },
+    ]
+    matrices = [
+        ["instruction_following"],
+        ["structured_output"],
+        ["instruction_following", "structured_output"],
+        ["multi_turn", "instruction_following"],
+        ["multi_turn", "structured_output"],
+        ["instruction_following", "structured_output", "multi_turn"],
+    ]
+    difficulties = ["basic", "basic", "edge", "edge", "adversarial", "adversarial"]
+    anchor_by_capability = {
+        "instruction_following": anchors[0],
+        "structured_output": anchors[1],
+        "multi_turn": anchors[2],
+    }
+    cases: list[dict[str, Any]] = []
+    for index, (matrix, difficulty) in enumerate(zip(matrices, difficulties)):
+        selected_anchors = list(
+            {
+                anchor["id"]: anchor
+                for anchor in [anchors[0], *[anchor_by_capability[item] for item in matrix]]
+            }.values()
+        )
+        focus_terms = [anchor["focus_terms"][0] for anchor in selected_anchors]
+        pressure_types = (
+            ["conflicting_context", "schema_boundary"]
+            if difficulty == "adversarial"
+            else ["competing_constraints"] if difficulty == "edge" else []
+        )
+        cases.append(
+            {
+                "case_id": f"supplier-{index}",
+                "name": f"Supplier audit {index}",
+                "message": (
+                    "Review the professional supplier case using "
+                    + ", ".join(focus_terms)
+                    + f"; scenario {index}."
+                ),
+                "locale": "en-US",
+                "coverage": matrix[0],
+                "targeting": {
+                    "difficulty": difficulty,
+                    "target_refs": [anchor["id"] for anchor in selected_anchors],
+                    "capability_matrix": matrix,
+                    "focus_terms": focus_terms,
+                    "pressure_types": pressure_types,
+                    "rationale": "Tests the supplier-quality contract and its bound output behavior.",
+                    "challenge": "Requires evidence-aware handling of a specialized supplier exception.",
+                    "discriminator": (
+                        "A generic assistant is unlikely to preserve PPAP evidence, "
+                        "risk_score schema, and escalation precedence together."
+                    ),
+                },
+                "expected": {"contains": [f"supplier-result-{index}"]},
+                "weights": {"contains": 1.0},
+            }
+        )
+    payload = {"dataset": {"name": "Professional supplier benchmark", "cases": cases}}
+
+    parsed = service.parse_generated_cases(
+        json.dumps(payload),
+        expected_count=6,
+        allowed_coverage=[
+            "instruction_following",
+            "structured_output",
+            "multi_turn",
+        ],
+        allowed_tool_names=[],
+        allowed_target_anchors=anchors,
+    )
+
+    assert parsed["targeting"]["combined_case_count"] == 4
+    assert len(parsed["targeting"]["capability_matrix_counts"]) == 4
+    assert parsed["targeting"]["combined_capabilities"] == [
+        "instruction_following",
+        "multi_turn",
+        "structured_output",
+    ]
+    assert parsed["targeting"]["cases_with_focus"] == 6
+    assert parsed["targeting"]["discriminator_count"] == 6
+
+    normalized_metadata = copy.deepcopy(payload)
+    normalized_case = normalized_metadata["dataset"]["cases"][2]
+    normalized_case["targeting"]["capability_matrix"].append("tool_routing")
+    normalized_case["targeting"]["target_refs"] = [anchors[0]["id"]]
+    normalized_case["targeting"]["focus_terms"].append("supplier risk")
+    coverage_case = normalized_metadata["dataset"]["cases"][0]
+    coverage_case["coverage"] = "tool_routing"
+    coverage_case["targeting"]["focus_terms"].append("risk_score")
+    coverage_case["message"] += " risk_score"
+    normalized = service.parse_generated_cases(
+        json.dumps(normalized_metadata),
+        expected_count=6,
+        allowed_coverage=[
+            "instruction_following",
+            "structured_output",
+            "multi_turn",
+        ],
+        allowed_tool_names=[],
+        allowed_target_anchors=anchors,
+    )
+    normalized_targeting = normalized["cases"][2]["targeting"]
+    assert "tool_routing" not in normalized_targeting["capability_matrix"]
+    assert anchors[1]["id"] in normalized_targeting["target_refs"]
+    assert "supplier risk" in normalized_targeting["focus_terms"]
+    assert len(normalized_targeting["normalization_notes"]) == 2
+    normalized_coverage = normalized["cases"][0]["targeting"]
+    assert anchors[1]["id"] in normalized_coverage["target_refs"]
+    assert "risk_score" in normalized_coverage["focus_terms"]
+    assert any(
+        note.startswith("replaced unavailable primary coverage")
+        for note in normalized_coverage["normalization_notes"]
+    )
+    assert any(
+        note.startswith("added target anchor for declared focus term")
+        for note in normalized_coverage["normalization_notes"]
+    )
+    assert normalized["targeting"]["normalized_case_count"] == 2
+
+    grounded_phrase = copy.deepcopy(payload)
+    grounded_phrase["dataset"]["cases"][0]["targeting"]["focus_terms"] = [
+        "supplier risk"
+    ]
+    grounded_phrase["dataset"]["cases"][0]["message"] += " supplier risk"
+    service.parse_generated_cases(
+        json.dumps(grounded_phrase),
+        expected_count=6,
+        allowed_coverage=[
+            "instruction_following",
+            "structured_output",
+            "multi_turn",
+        ],
+        allowed_tool_names=[],
+        allowed_target_anchors=anchors,
+    )
+
+    professional_markers = copy.deepcopy(payload)
+    marker_case = professional_markers["dataset"]["cases"][0]
+    marker_case["message"] = (
+        "Review supplier risk using production-part approval evidence and return "
+        "a disposition for the launch decision."
+    )
+    parsed_markers = service.parse_generated_cases(
+        json.dumps(professional_markers),
+        expected_count=6,
+        allowed_coverage=[
+            "instruction_following",
+            "structured_output",
+            "multi_turn",
+        ],
+        allowed_tool_names=[],
+        allowed_target_anchors=anchors,
+    )
+    assert parsed_markers["cases"][0]["targeting"]["professional_evidence"][
+        "sufficient"
+    ] is True
+
+    generic_input = copy.deepcopy(payload)
+    generic_case = generic_input["dataset"]["cases"][0]
+    generic_case["message"] = "Review this case and provide a useful recommendation."
+    with pytest.raises(BenchmarkGenerationError, match="professional evidence"):
+        service.parse_generated_cases(
+            json.dumps(generic_input),
+            expected_count=6,
+            allowed_coverage=[
+                "instruction_following",
+                "structured_output",
+                "multi_turn",
+            ],
+            allowed_tool_names=[],
+            allowed_target_anchors=anchors,
+        )
+
+    invented_focus = copy.deepcopy(payload)
+    invented_focus["dataset"]["cases"][0]["targeting"]["focus_terms"] = ["Basel III"]
+    with pytest.raises(BenchmarkGenerationError, match="invents focus terms"):
+        service.parse_generated_cases(
+            json.dumps(invented_focus),
+            expected_count=6,
+            allowed_coverage=[
+                "instruction_following",
+                "structured_output",
+                "multi_turn",
+            ],
+            allowed_tool_names=[],
+            allowed_target_anchors=anchors,
+        )
+
+    weak_adversarial = copy.deepcopy(payload)
+    weak_adversarial["dataset"]["cases"][4]["targeting"]["pressure_types"] = [
+        "schema_boundary"
+    ]
+    with pytest.raises(BenchmarkGenerationError, match="needs at least 2 pressure_types"):
+        service.parse_generated_cases(
+            json.dumps(weak_adversarial),
+            expected_count=6,
+            allowed_coverage=[
+                "instruction_following",
+                "structured_output",
+                "multi_turn",
+            ],
+            allowed_tool_names=[],
+            allowed_target_anchors=anchors,
+        )
+
+    repair_system, repair_user = service.repair_prompt(
+        "{invalid}",
+        "Case 1 does not visibly use its declared focus terms",
+        expected_count=6,
+        allowed_coverage=[
+            "instruction_following",
+            "structured_output",
+            "multi_turn",
+        ],
+        target_anchors=anchors,
+    )
+    assert "Return JSON only" in repair_system
+    assert '"exact_case_count": 6' in repair_user
+    assert "must visibly exercise either an exact" in repair_user
+    assert "each matrix capability is supported by a cited anchor" in repair_user
+
+
+def test_server_blueprints_generalize_across_all_supported_capabilities(
+    tmp_path: Path,
+) -> None:
+    service = BenchmarkGenerationService(
+        evaluation_store=XpertEvaluationStore(tmp_path),
+        evaluation_service=object(),
+        xpert_store=object(),
+        proposal_store=object(),
+        prompt_store=object(),
+        context_store=object(),
+    )
+    anchors = [
+        {
+            "id": "agent:supplier:role",
+            "kind": "agent_prompt",
+            "axis": "domain",
+            "label": "Supplier quality specialist",
+            "summary": "Assess PPAP evidence for automotive supplier quality decisions.",
+            "focus_terms": ["PPAP"],
+            "coverage": ["instruction_following"],
+        },
+        {
+            "id": "agent:supplier:schema",
+            "kind": "output_schema",
+            "axis": "contract",
+            "label": "Risk result schema",
+            "summary": "Return risk_score and disposition in strict JSON.",
+            "focus_terms": ["risk_score"],
+            "coverage": ["structured_output"],
+        },
+        {
+            "id": "agent:supplier:history",
+            "kind": "conversation_contract",
+            "axis": "contract",
+            "label": "Supplier escalation history",
+            "summary": "Resolve supplier escalation conflicts across turns.",
+            "focus_terms": ["supplier escalation"],
+            "coverage": ["multi_turn"],
+        },
+        {
+            "id": "tool:supplier_search",
+            "kind": "tool",
+            "axis": "resource",
+            "label": "supplier_search",
+            "summary": "Route evidence lookup through supplier_search.",
+            "focus_terms": ["supplier_search"],
+            "coverage": ["tool_routing"],
+        },
+        {
+            "id": "knowledge:quality",
+            "kind": "knowledge",
+            "axis": "resource",
+            "label": "Quality manual",
+            "summary": "Ground claims in quality_manual.md.",
+            "focus_terms": ["quality_manual.md"],
+            "coverage": ["knowledge_citation"],
+        },
+        {
+            "id": "prompt_profile:audit",
+            "kind": "prompt_command",
+            "axis": "resource",
+            "label": "Audit command",
+            "summary": "Command alias /audit runs the supplier audit profile.",
+            "focus_terms": ["audit"],
+            "coverage": ["prompt_command"],
+        },
+    ]
+    coverage = [
+        "instruction_following",
+        "structured_output",
+        "multi_turn",
+        "tool_routing",
+        "knowledge_citation",
+        "prompt_command",
+    ]
+    fixed_output_schema = {
+        "type": "object",
+        "required": ["risk_score", "disposition"],
+        "properties": {
+            "risk_score": {"type": "number"},
+            "disposition": {"type": "string"},
+        },
+    }
+    blueprints = service.case_blueprints(
+        case_count=12,
+        locales=["zh-CN", "en-US"],
+        selected_coverage=coverage,
+        target_anchors=anchors,
+        seed=3,
+        tool_names=["supplier_search"],
+        document_names=["quality_manual.md"],
+        prompt_aliases=["audit"],
+        structured_output_schemas={
+            "agent:supplier:schema": fixed_output_schema,
+        },
+    )
+
+    assert len(blueprints) == 12
+    assert {item["primary_coverage"] for item in blueprints} == set(coverage)
+    assert sum(len(item["capability_matrix"]) > 1 for item in blueprints) >= 8
+    assert {
+        capability
+        for item in blueprints
+        if len(item["capability_matrix"]) > 1
+        for capability in item["capability_matrix"]
+    } == set(coverage)
+    assert {item["locale"] for item in blueprints} == {"zh-CN", "en-US"}
+    assert {item["difficulty"] for item in blueprints} == {
+        "basic",
+        "edge",
+        "adversarial",
+    }
+    assert all(
+        item["required_tool_name"] == "supplier_search"
+        for item in blueprints
+        if "tool_routing" in item["capability_matrix"]
+    )
+    assert all(
+        item["required_document_name"] == "quality_manual.md"
+        for item in blueprints
+        if "knowledge_citation" in item["capability_matrix"]
+    )
+    assert all(
+        item["required_prompt_alias"] == "audit"
+        for item in blueprints
+        if "prompt_command" in item["capability_matrix"]
+    )
+
+    cases: list[dict[str, Any]] = []
+    for blueprint in blueprints:
+        matrix = list(blueprint["capability_matrix"])
+        focus = " ".join(blueprint["required_focus_terms"])
+        message = (
+            f"Assess the professional exception for {focus}; "
+            f"scenario {blueprint['blueprint_id']}."
+        )
+        if "prompt_command" in matrix:
+            message = f"/audit {message}"
+        messages = []
+        if "multi_turn" in matrix or blueprint["difficulty"] == "adversarial":
+            messages = [
+                {"role": "user", "content": "Earlier evidence was incomplete."},
+                {"role": "assistant", "content": "I requested a corrected evidence packet."},
+            ]
+        expected: dict[str, Any] = {
+            "contains": ["approved-state", "evidence-logged"],
+        }
+        weights: dict[str, float] = {"contains": 1.0}
+        if "structured_output" in matrix:
+            weights["json_schema"] = 1.0
+        if "tool_routing" in matrix:
+            expected["required_tools"] = ["supplier_search"]
+            expected["forbidden_tools"] = []
+            expected["tool_order"] = ["supplier_search"]
+            weights["tool_call_match"] = 1.0
+        if "knowledge_citation" in matrix:
+            expected["document_names"] = ["quality_manual.md"]
+            weights["citation_hit"] = 1.0
+        cases.append(
+            {
+                "case_id": "model-controlled-id",
+                "name": f"Professional case {blueprint['blueprint_id']}",
+                "locale": "en-US",
+                "coverage": "instruction_following",
+                "message": message,
+                "messages": messages,
+                "targeting": {
+                    "difficulty": "basic",
+                    "target_refs": [anchors[0]["id"]],
+                    "capability_matrix": ["instruction_following"],
+                    "focus_terms": ["PPAP"],
+                    "pressure_types": [],
+                    "rationale": "Checks the fixed supplier-quality behavior and contract.",
+                    "challenge": "Uses a realistic evidence exception with a bounded answer.",
+                    "discriminator": (
+                        "The configured specialist must preserve the exact supplier evidence, "
+                        "routing, citation, and response contracts represented by this blueprint."
+                    ),
+                },
+                "expected": expected,
+                "weights": weights,
+            }
+        )
+
+    parsed = service.parse_generated_cases(
+        json.dumps({"dataset": {"name": "Six-axis benchmark", "cases": cases}}),
+        expected_count=12,
+        allowed_coverage=coverage,
+        allowed_tool_names=["supplier_search"],
+        allowed_target_anchors=anchors,
+        case_blueprints=blueprints,
+        allowed_document_names=["quality_manual.md"],
+        allowed_prompt_aliases=["audit"],
+    )
+
+    assert [item["case_id"] for item in parsed["cases"]] == [
+        item["blueprint_id"] for item in blueprints
+    ]
+    assert parsed["targeting"]["blueprint_case_count"] == 12
+    assert parsed["targeting"]["normalized_case_count"] == 0
+    for case, blueprint in zip(parsed["cases"], blueprints):
+        assert case["targeting"]["difficulty"] == blueprint["difficulty"]
+        assert case["targeting"]["capability_matrix"] == blueprint["capability_matrix"]
+        assert case["targeting"]["target_refs"] == blueprint["target_refs"]
+        if "structured_output" in blueprint["capability_matrix"]:
+            assert case["expected"]["json_schema"] == fixed_output_schema
+
+    missing_schema = copy.deepcopy(cases)
+    blueprints_without_schema = copy.deepcopy(blueprints)
+    schema_index = next(
+        index
+        for index, item in enumerate(blueprints)
+        if "structured_output" in item["capability_matrix"]
+    )
+    blueprints_without_schema[schema_index]["required_json_schema"] = None
+    with pytest.raises(BenchmarkGenerationError, match="expected.json_schema"):
+        service.parse_generated_cases(
+            json.dumps({"dataset": {"name": "Invalid", "cases": missing_schema}}),
+            expected_count=12,
+            allowed_coverage=coverage,
+            allowed_tool_names=["supplier_search"],
+            allowed_target_anchors=anchors,
+            case_blueprints=blueprints_without_schema,
+            allowed_document_names=["quality_manual.md"],
+            allowed_prompt_aliases=["audit"],
+        )
+
+
+def test_single_capability_adversarial_tool_blueprints_use_fixed_decoy_gold(
+    tmp_path: Path,
+) -> None:
+    service = BenchmarkGenerationService(
+        evaluation_store=XpertEvaluationStore(tmp_path),
+        evaluation_service=object(),
+        xpert_store=object(),
+        proposal_store=object(),
+        prompt_store=object(),
+        context_store=object(),
+    )
+    anchors = [
+        {
+            "id": "tool:case_narrative_lookup",
+            "kind": "tool",
+            "axis": "resource",
+            "label": "case_narrative_lookup",
+            "summary": "Retrieve the complete pharmacovigilance case narrative.",
+            "focus_terms": ["case_narrative_lookup"],
+            "coverage": ["tool_routing"],
+        },
+        {
+            "id": "tool:signal_history_lookup",
+            "kind": "tool",
+            "axis": "resource",
+            "label": "signal_history_lookup",
+            "summary": "Retrieve the validated pharmacovigilance signal history.",
+            "focus_terms": ["signal_history_lookup"],
+            "coverage": ["tool_routing"],
+        },
+    ]
+    blueprints = service.case_blueprints(
+        case_count=6,
+        locales=["zh-CN", "en-US"],
+        selected_coverage=["tool_routing"],
+        target_anchors=anchors,
+        seed=95002,
+        tool_names=["case_narrative_lookup", "signal_history_lookup"],
+    )
+
+    adversarial = [
+        item for item in blueprints if item["difficulty"] == "adversarial"
+    ]
+    assert adversarial
+    assert all(item["forbidden_tool_names"] for item in adversarial)
+
+    cases = []
+    for blueprint in blueprints:
+        visible_terms = [
+            *blueprint["required_focus_terms"],
+            *blueprint["forbidden_tool_names"],
+        ]
+        cases.append(
+            {
+                "name": f"PV routing {blueprint['blueprint_id']}",
+                "targeting": {
+                    "blueprint_id": blueprint["blueprint_id"],
+                    "rationale": "Checks the fixed pharmacovigilance routing contract.",
+                    "challenge": "A decoy lookup competes with the required signal lookup.",
+                    "discriminator": (
+                        "The configured reviewer must select the required signal tool and "
+                        "must not dispatch the visible narrative decoy."
+                    ),
+                },
+                "message": (
+                    f"Case {blueprint['blueprint_id']}: use the required signal workflow; "
+                    + " ".join(visible_terms)
+                ),
+                "messages": [],
+                "expected": {},
+                "weights": {"tool_call_match": 1.0},
+            }
+        )
+
+    parsed = service.parse_generated_cases(
+        json.dumps({"dataset": {"name": "PV routing", "cases": cases}}),
+        expected_count=6,
+        allowed_coverage=["tool_routing"],
+        allowed_tool_names=["case_narrative_lookup", "signal_history_lookup"],
+        allowed_target_anchors=anchors,
+        case_blueprints=blueprints,
+    )
+
+    for case, blueprint in zip(parsed["cases"], blueprints):
+        assert case["expected"]["required_tools"] == [
+            blueprint["required_tool_name"]
+        ]
+        assert case["expected"].get("forbidden_tools", []) == blueprint[
+            "forbidden_tool_names"
+        ]
+
+
+def test_server_owned_resource_gold_is_removed_from_generated_contains() -> None:
+    expectation = {
+        "contains": [
+            "SPC_Western_Electric_Rules.md",
+            "metrology_msa_lookup",
+            "lot_genealogy_lookup",
+            "/excursion-review",
+            "keep the lot on hold until MSA is verified",
+        ]
+    }
+    removed = BenchmarkGenerationService._strip_server_owned_contains(
+        expectation,
+        {
+            "required_tool_name": "metrology_msa_lookup",
+            "forbidden_tool_names": ["lot_genealogy_lookup"],
+            "required_document_name": "SPC_Western_Electric_Rules.md",
+            "required_prompt_alias": "excursion-review",
+        },
+    )
+
+    assert removed == [
+        "SPC_Western_Electric_Rules.md",
+        "metrology_msa_lookup",
+        "lot_genealogy_lookup",
+        "/excursion-review",
+    ]
+    assert expectation["contains"] == [
+        "keep the lot on hold until MSA is verified"
+    ]
+
+
+def test_fixed_resource_names_drive_tool_and_knowledge_coverage(tmp_path: Path) -> None:
+    class _ToolsetStore:
+        @staticmethod
+        def get_version(_toolset_id: str, _version: int) -> Any:
+            return SimpleNamespace(
+                tools=[
+                    SimpleNamespace(enabled=True, exposed_name="supplier_search"),
+                    SimpleNamespace(enabled=False, exposed_name="supplier_write"),
+                ]
+            )
+
+    class _RagService:
+        @staticmethod
+        def get_pipeline_version(_version_id: str) -> dict[str, Any]:
+            return {
+                "source_summary": [
+                    {"filename": "quality_manual.md"},
+                    {"filename": "supplier_controls.xlsx"},
+                ]
+            }
+
+    service = BenchmarkGenerationService(
+        evaluation_store=XpertEvaluationStore(tmp_path),
+        evaluation_service=object(),
+        xpert_store=object(),
+        proposal_store=object(),
+        prompt_store=object(),
+        context_store=object(),
+        toolset_store=_ToolsetStore(),
+        rag_service=_RagService(),
+    )
+    snapshot = {
+        "workflow": {
+            "nodes": [
+                {
+                    "id": "toolset",
+                    "type": "toolset_resource",
+                    "data": {
+                        "kind": "toolset_resource",
+                        "toolsetId": "supplier-tools",
+                        "pinnedVersion": 2,
+                        "title": "Supplier tools",
+                    },
+                },
+                {
+                    "id": "knowledge",
+                    "type": "knowledge_base",
+                    "data": {
+                        "kind": "knowledge_base",
+                        "knowledgeBaseId": "supplier-kb",
+                        "title": "Supplier knowledge",
+                    },
+                },
+            ]
+        },
+        "resources": {
+            "knowledge_versions": [
+                {"knowledge_base_id": "supplier-kb", "version_id": "version-7"}
+            ]
+        },
+        "prompt_profiles": [
+            {
+                "id": "audit-profile",
+                "name": "Audit",
+                "aliases": ["audit"],
+                "template": "Audit {{args}} against supplier controls.",
+            }
+        ],
+    }
+
+    coverage = service.detect_coverage(snapshot)
+    assert "tool_routing" in coverage["available"]
+    assert "knowledge_citation" in coverage["available"]
+    assert "prompt_command" in coverage["available"]
+    assert coverage["tool_names"] == ["supplier_search"]
+    context = service._safe_generation_context(snapshot)
+    assert context["knowledge_document_names"] == [
+        "quality_manual.md",
+        "supplier_controls.xlsx",
+    ]
+    assert context["prompt_command_aliases"] == ["audit"]
+    assert any(
+        "quality_manual.md" in anchor["summary"]
+        for anchor in context["target_anchors"]
+        if anchor["kind"] == "knowledge"
+    )
+
+
+def test_generic_counterfactual_removes_specialization_and_bound_resources(
+    tmp_path: Path,
+) -> None:
+    service = BenchmarkGenerationService(
+        evaluation_store=XpertEvaluationStore(tmp_path),
+        evaluation_service=object(),
+        xpert_store=object(),
+        proposal_store=object(),
+        prompt_store=object(),
+        context_store=object(),
+    )
+    snapshot = {
+        "target_id": "xpert:supplier:v2",
+        "label": "Supplier specialist",
+        "checksum": "specialist-checksum",
+        "source": {"kind": "xpert_version", "xpert_id": "supplier", "version": 2},
+        "workflow": {
+            "nodes": [
+                {
+                    "id": "agent",
+                    "type": "workflow_agent",
+                    "data": {
+                        "kind": "workflow_agent",
+                        "rolePrompt": "Apply PPAP and APQP escalation rules.",
+                        "promptSuffix": "Cite supplier evidence.",
+                        "modelId": "same-model",
+                        "toolMode": "mcp_tools",
+                        "toolNames": "supplier_search",
+                        "outputSchemaMode": "json_schema",
+                    },
+                },
+                {
+                    "id": "knowledge",
+                    "type": "knowledge_base",
+                    "data": {"kind": "knowledge_base", "knowledgeBaseId": "supplier-kb"},
+                },
+            ],
+            "edges": [
+                {
+                    "id": "knowledge-agent",
+                    "source": "knowledge",
+                    "target": "agent",
+                    "targetHandle": "knowledge",
+                }
+            ],
+        },
+        "prompt_profiles": [{"name": "Supplier audit"}],
+        "input_template": "/audit {{args}}",
+        "resources": {"knowledge_versions": [{"knowledge_base_id": "supplier-kb"}]},
+    }
+
+    generic = service.generic_counterfactual_snapshot(snapshot)
+
+    agent = generic["workflow"]["nodes"][0]["data"]
+    assert agent["modelId"] == "same-model"
+    assert agent["outputSchemaMode"] == "json_schema"
+    assert agent["toolMode"] == "none"
+    assert "PPAP" not in agent["rolePrompt"]
+    assert generic["workflow"]["edges"] == []
+    assert len(generic["workflow"]["nodes"]) == 1
+    assert generic["prompt_profiles"] == []
+    assert generic["input_template"] is None
+    assert generic["benchmark_counterfactual"] is True
+
+
+def test_calibration_reports_target_advantage_over_generic_counterfactual(
+    tmp_path: Path,
+) -> None:
+    service = BenchmarkGenerationService(
+        evaluation_store=XpertEvaluationStore(tmp_path),
+        evaluation_service=object(),
+        xpert_store=object(),
+        proposal_store=object(),
+        prompt_store=object(),
+        context_store=object(),
+    )
+    service.target_is_fresh = lambda _reference, _checksum: True  # type: ignore[method-assign]
+    dataset = {
+        "revision": 1,
+        "origin": "generated",
+        "cases": [_generated_case("case-one")],
+    }
+    run = {
+        "status": "completed",
+        "dataset": {"draft_revision": 1},
+        "targets": [
+            {
+                "target_id": "generic",
+                "checksum": "generic-checksum",
+                "benchmark_counterfactual": True,
+            },
+            {"target_id": "specialist", "checksum": "specialist-checksum"},
+        ],
+        "items": [
+            {"target_id": "generic", "case_id": "case-one", "status": "completed", "score": 0.4},
+            {"target_id": "specialist", "case_id": "case-one", "status": "completed", "score": 1.0},
+        ],
+        "report": {
+            "targets": [
+                {"target_id": "specialist", "score": 1.0},
+                {"target_id": "generic", "score": 0.4},
+            ]
+        },
+        "run_id": "run-one",
+    }
+
+    result = service.calibration_result(
+        dataset=dataset,
+        evaluation_run=run,
+        target_reference={"kind": "xpert_draft"},
+        target_checksum="specialist-checksum",
+    )
+
+    assert result["baseline_score"] == 1.0
+    assert result["generic_counterfactual_score"] == 0.4
+    assert result["targeting_advantage"] == 0.6
+    assert not any("easy and" in warning for warning in result["warnings"])
+
+
+@pytest.mark.asyncio
+async def test_tool_call_match_uses_names_and_stable_order() -> None:
+    result = await evaluate_case_metrics(
+        case={
+            "message": "Research and summarize",
+            "expected": {
+                "required_tools": ["search", "read"],
+                "forbidden_tools": ["write"],
+                "tool_order": ["search", "read"],
+            },
+            "weights": {"tool_call_match": 1.0},
+        },
+        output="done",
+        citations={},
+        tool_calls=["search", "read"],
+    )
+    assert result["score"] == 1.0
+    assert result["metrics"][0]["kind"] == "tool_call_match"
+
+    failed = await evaluate_case_metrics(
+        case={
+            "message": "Research and summarize",
+            "expected": {
+                "required_tools": ["search", "read"],
+                "forbidden_tools": ["write"],
+                "tool_order": ["search", "read"],
+            },
+        },
+        output="done",
+        citations={},
+        tool_calls=["read", "write", "search"],
+    )
+    assert failed["score"] == pytest.approx(0.5)
+
+
+class _FakeGeneratorService:
+    def __init__(self, evaluation_store: XpertEvaluationStore) -> None:
+        self.evaluation_store = evaluation_store
+        self.parse_calls = 0
+
+    def snapshot_target(self, reference: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
+        return {
+            "target_id": "target-one",
+            "label": "Target One",
+            "source": copy.deepcopy(reference),
+            "xpert": {"id": "xpert-one", "name": "Xpert One"},
+            "workflow": {"nodes": [], "edges": []},
+            "checksum": "fixed-checksum",
+        }, []
+
+    @staticmethod
+    def detect_coverage(_snapshot: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "available": ["instruction_following"],
+            "recommended": ["instruction_following"],
+            "tool_names": [],
+        }
+
+    @staticmethod
+    def conversation_seeds(_selections: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        return []
+
+    @staticmethod
+    def generation_prompt(**_kwargs: Any) -> tuple[str, str, dict[str, Any]]:
+        return "system", "user", {
+            "selected": ["instruction_following"],
+            "available": ["instruction_following"],
+            "recommended": ["instruction_following"],
+            "tool_names": [],
+        }
+
+    def parse_generated_cases(self, raw: str, **_kwargs: Any) -> dict[str, Any]:
+        self.parse_calls += 1
+        if raw == "invalid":
+            raise BenchmarkGenerationError("invalid generated JSON")
+        return {
+            "name": "Generated",
+            "description": "",
+            "cases": [_generated_case()],
+            "assumptions": [],
+        }
+
+    @staticmethod
+    def repair_prompt(_raw: str, _error: str, **_kwargs: Any) -> tuple[str, str]:
+        return "repair-system", "repair-user"
+
+    @staticmethod
+    def public_target(snapshot: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "target_id": snapshot["target_id"],
+            "label": snapshot["label"],
+            "source": snapshot["source"],
+            "checksum": snapshot["checksum"],
+        }
+
+
+class _FakeEvaluationService:
+    def __init__(self, store: XpertEvaluationStore) -> None:
+        self.store = store
+
+    def create_run_from_snapshots(self, **payload: Any) -> dict[str, Any]:
+        return self.store.create_run(
+            dataset_version=payload["dataset_version"],
+            cases=payload["cases"],
+            baseline=payload["baseline"],
+            candidates=payload["candidates"],
+            config=payload["config"],
+            warnings=payload["warnings"],
+        )
+
+
+class _WakeOnlyExecutor:
+    def __init__(self) -> None:
+        self.wake_count = 0
+
+    def wake(self) -> None:
+        self.wake_count += 1
+
+
+class _ApiGenerationService:
+    @staticmethod
+    def capabilities() -> dict[str, Any]:
+        return {"version": "test-generator"}
+
+    @staticmethod
+    def preflight(**_kwargs: Any) -> dict[str, Any]:
+        return {
+            "valid": True,
+            "target": {"target_id": "fixed"},
+            "coverage": {
+                "available": ["instruction_following"],
+                "recommended": ["instruction_following"],
+            },
+            "conversation_seed_count": 1,
+            "warnings": [],
+            "issues": [],
+        }
+
+
+@pytest.mark.asyncio
+async def test_generation_repairs_once_and_reuses_persisted_dataset(
+    tmp_path: Path,
+) -> None:
+    evaluation_store = XpertEvaluationStore(tmp_path / "evaluations")
+    job_store = BenchmarkJobStore(tmp_path / "jobs")
+    service = _FakeGeneratorService(evaluation_store)
+    evaluation_executor = _WakeOnlyExecutor()
+    responses = iter(["invalid", "valid"])
+    calls: list[tuple[str, float]] = []
+
+    async def generator(
+        model_id: str,
+        _system: str,
+        _user: str,
+        temperature: float,
+        _max_tokens: int,
+    ) -> str:
+        calls.append((model_id, temperature))
+        return next(responses)
+
+    executor = BenchmarkJobExecutor(
+        job_store,
+        service=service,  # type: ignore[arg-type]
+        generator_runner=generator,
+        evaluation_store=evaluation_store,
+        evaluation_service=_FakeEvaluationService(evaluation_store),
+        evaluation_executor=evaluation_executor,
+    )
+    created = job_store.create_job(
+        kind="generation",
+        request={
+            "target": {
+                "kind": "xpert_draft",
+                "xpert_id": "xpert-one",
+                "draft_revision": 1,
+            },
+            "generator_model_id": "planner",
+            "case_count": 1,
+            "coverage": ["instruction_following"],
+            "locales": ["zh-CN", "en-US"],
+        },
+    )
+    claimed = job_store.claim_next_job()
+    assert claimed is not None
+    await executor._run_generation(claimed)
+
+    current = job_store.require_job(created["job_id"])
+    assert current["status"] == "calibrating"
+    assert current["generation"]["repair_used"] is True
+    assert calls == [("planner", 0.2), ("planner", 0.0)]
+    assert service.parse_calls == 2
+    assert len(evaluation_store.list_datasets()) == 1
+
+    job_store.update_job(created["job_id"], status="generating")
+    await executor._run_generation(job_store.require_job(created["job_id"]))
+    assert len(evaluation_store.list_datasets()) == 1
+    assert len(calls) == 2
+    assert evaluation_executor.wake_count == 2
+
+
+@pytest.mark.asyncio
+async def test_generation_repairs_recoverable_contract_failure_and_keeps_diagnostics(
+    tmp_path: Path,
+) -> None:
+    evaluation_store = XpertEvaluationStore(tmp_path / "evaluations")
+    job_store = BenchmarkJobStore(tmp_path / "jobs")
+    service = _FakeGeneratorService(evaluation_store)
+    evaluation_executor = _WakeOnlyExecutor()
+    responses: Any = iter(
+        [
+            BenchmarkGeneratorOutput(
+                diagnostics={
+                    "finish_reason": "stop",
+                    "content_chars": 0,
+                    "reasoning_chars": 900,
+                    "candidate_top_level_keys": ["type"],
+                    "private_detail": "must never be persisted",
+                },
+                error_code="contract_missing",
+                error_message="Generator response did not contain the required JSON contract.",
+            ),
+            BenchmarkGeneratorOutput(
+                text="valid",
+                diagnostics={
+                    "finish_reason": "stop",
+                    "content_chars": 120,
+                    "reasoning_chars": 0,
+                    "candidate_top_level_keys": ["dataset"],
+                },
+            ),
+        ]
+    )
+
+    async def generator(
+        _model_id: str,
+        _system: str,
+        _user: str,
+        _temperature: float,
+        _max_tokens: int,
+    ) -> BenchmarkGeneratorOutput:
+        return next(responses)
+
+    executor = BenchmarkJobExecutor(
+        job_store,
+        service=service,  # type: ignore[arg-type]
+        generator_runner=generator,
+        evaluation_store=evaluation_store,
+        evaluation_service=_FakeEvaluationService(evaluation_store),
+        evaluation_executor=evaluation_executor,
+    )
+    created = job_store.create_job(
+        kind="generation",
+        request={
+            "target": {
+                "kind": "xpert_draft",
+                "xpert_id": "xpert-one",
+                "draft_revision": 1,
+            },
+            "generator_model_id": "planner",
+            "case_count": 1,
+            "coverage": ["instruction_following"],
+            "locales": ["en-US"],
+        },
+    )
+
+    claimed = job_store.claim_next_job()
+    assert claimed is not None
+    await executor._run_generation(claimed)
+
+    current = job_store.require_job(created["job_id"])
+    assert current["status"] == "calibrating"
+    assert current["generation"]["repair_used"] is True
+    assert service.parse_calls == 1
+    assert [item["attempt"] for item in current["generation_attempts"]] == [
+        "initial",
+        "repair",
+    ]
+    assert current["generation_attempts"][0]["error_code"] == "contract_missing"
+    assert current["generation_attempts"][0]["diagnostics"][
+        "candidate_top_level_keys"
+    ] == ["type"]
+    assert "private_detail" not in current["generation_attempts"][0]["diagnostics"]
+
+
+@pytest.mark.asyncio
+async def test_generation_api_creates_safe_job_and_hides_conversation_selections(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = FastAPI()
+    app.include_router(benchmark_api.router)
+    job_store = BenchmarkJobStore(tmp_path / "jobs")
+    executor = _WakeOnlyExecutor()
+    monkeypatch.setattr(benchmark_api, "_catalog", BenchmarkCatalog())
+    monkeypatch.setattr(
+        benchmark_api,
+        "_evaluation_store",
+        XpertEvaluationStore(tmp_path / "evaluations"),
+    )
+    monkeypatch.setattr(benchmark_api, "_job_store", job_store)
+    monkeypatch.setattr(benchmark_api, "_service", _ApiGenerationService())
+    monkeypatch.setattr(benchmark_api, "_executor", executor)
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/api/benchmarks/generations",
+            json={
+                "target": {
+                    "kind": "xpert_draft",
+                    "xpert_id": "xpert-one",
+                    "draft_revision": 1,
+                },
+                "generator_model_id": "planner-model",
+                "case_count": 6,
+                "coverage": ["instruction_following"],
+                "conversation_selections": [
+                    {
+                        "xpert_id": "xpert-one",
+                        "conversation_id": "private-conversation",
+                        "message_ids": ["message-one"],
+                    }
+                ],
+            },
+        )
+        assert response.status_code == 200
+        created = response.json()
+        assert created["status"] == "queued"
+        assert "conversation_selections" not in created["request"]
+
+        listed = await client.get("/api/benchmarks/generations")
+        assert listed.status_code == 200
+        assert listed.json()["total"] == 1
+        assert "conversation_selections" not in listed.json()["items"][0]["request"]
+
+    assert executor.wake_count == 1

--- a/server/tests/test_xpert_runtime_chat.py
+++ b/server/tests/test_xpert_runtime_chat.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 import pytest
 import httpx
 import pytest_asyncio
@@ -8,6 +10,9 @@ import server.main as main_module
 from server.main import (
     ChatMessage,
     app,
+    collect_chat_completion_text,
+    completion_json_result_from_payload,
+    completion_json_text_from_payload,
     parse_upstream_error,
     sse_delta_text,
     stream_chat_text,
@@ -135,6 +140,181 @@ async def test_sse_text_stream_passthrough(monkeypatch: pytest.MonkeyPatch) -> N
     ]
 
     assert "".join(chunks) == "hello world"
+
+
+@pytest.mark.asyncio
+async def test_collected_completion_forwards_json_response_format(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeResponse:
+        status_code = 200
+        content = b""
+
+        def json(self):
+            return {"choices": [{"message": {"content": '{"ok":true}'}}]}
+
+    class FakeClient:
+        def __init__(self, **_kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, _exc_type, _exc, _tb) -> None:
+            return None
+
+        async def post(self, _url, *, headers, json):
+            captured["headers"] = headers
+            captured["payload"] = json
+            return FakeResponse()
+
+    monkeypatch.setattr(
+        main_module, "get_llm_gateway_config", lambda: ("http://mock", "key")
+    )
+    monkeypatch.setattr(main_module.httpx, "AsyncClient", FakeClient)
+
+    result = await collect_chat_completion_text(
+        "mock-model",
+        [ChatMessage(role="user", content="return JSON")],
+        response_format={"type": "json_object"},
+        reasoning={"effort": "low"},
+    )
+
+    assert result == '{"ok":true}'
+    assert captured["payload"]["response_format"] == {"type": "json_object"}
+    assert captured["payload"]["reasoning"] == {"effort": "low"}
+
+
+def test_json_completion_recovers_object_without_exposing_reasoning() -> None:
+    payload = {
+        "choices": [
+            {
+                "message": {
+                    "content": "",
+                    "reasoning_content": (
+                        "private analysis that must never be returned\n"
+                        '{"dataset":{"name":"safe","cases":[]}}\n'
+                        "more private analysis"
+                    ),
+                }
+            }
+        ]
+    }
+
+    recovered = completion_json_text_from_payload(payload)
+
+    assert json.loads(recovered) == {"dataset": {"name": "safe", "cases": []}}
+    assert "private analysis" not in recovered
+
+
+def test_json_completion_does_not_return_unstructured_reasoning() -> None:
+    payload = {
+        "choices": [
+            {
+                "message": {
+                    "content": "",
+                    "reasoning": "private analysis without a JSON object",
+                }
+            }
+        ]
+    }
+
+    assert completion_json_text_from_payload(payload) == ""
+
+
+def test_json_completion_selects_required_dataset_after_schema_example() -> None:
+    payload = {
+        "choices": [
+            {
+                "message": {
+                    "content": "",
+                    "reasoning_content": (
+                        '{"type":"object","properties":{"answer":{"type":"string"}}}\n'
+                        "then the final contract follows\n"
+                        '{"dataset":{"name":"professional","cases":[]}}'
+                    ),
+                }
+            }
+        ]
+    }
+
+    recovered = completion_json_text_from_payload(
+        payload,
+        required_top_level_key="dataset",
+    )
+
+    assert json.loads(recovered) == {
+        "dataset": {"name": "professional", "cases": []}
+    }
+
+
+def test_json_completion_rejects_reasoning_schema_without_required_dataset() -> None:
+    payload = {
+        "choices": [
+            {
+                "message": {
+                    "content": "",
+                    "reasoning_content": '{"type":"object","properties":{}}',
+                }
+            }
+        ]
+    }
+
+    assert (
+        completion_json_text_from_payload(
+            payload,
+            required_top_level_key="dataset",
+        )
+        == ""
+    )
+
+
+def test_json_completion_reports_safe_finish_usage_and_contract_diagnostics() -> None:
+    payload = {
+        "choices": [
+            {
+                "finish_reason": "length",
+                "message": {
+                    "content": "",
+                    "reasoning_content": (
+                        "private analysis\n"
+                        '{"type":"object"}\n'
+                        '{"dataset":{"name":"safe","cases":[]}}'
+                    ),
+                },
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 120,
+            "completion_tokens": 80,
+            "total_tokens": 200,
+            "cost": 99,
+        },
+    }
+
+    recovered, diagnostics = completion_json_result_from_payload(
+        payload,
+        required_top_level_key="dataset",
+    )
+
+    assert json.loads(recovered)["dataset"]["name"] == "safe"
+    assert diagnostics == {
+        "finish_reason": "length",
+        "content_chars": 0,
+        "reasoning_chars": len(payload["choices"][0]["message"]["reasoning_content"]),
+        "reasoning_present": True,
+        "selected_source": "reasoning",
+        "contract_found": True,
+        "candidate_top_level_keys": ["dataset", "type"],
+        "usage": {
+            "prompt_tokens": 120,
+            "completion_tokens": 80,
+            "total_tokens": 200,
+        },
+    }
+    assert "private analysis" not in json.dumps(diagnostics)
 
 
 @pytest.mark.asyncio

--- a/server/xperts/validation.py
+++ b/server/xperts/validation.py
@@ -3,10 +3,18 @@ from __future__ import annotations
 from .models import XpertDefinition, XpertValidationResult
 
 try:
-    from server.workflow_native.schemas import ValidationIssue
+    from server.workflow_native.schemas import (
+        NativeWorkflowDefinition,
+        ValidateWorkflowResponse,
+        ValidationIssue,
+    )
     from server.workflow_native.validate import validate_workflow_graph
 except ModuleNotFoundError:
-    from workflow_native.schemas import ValidationIssue
+    from workflow_native.schemas import (
+        NativeWorkflowDefinition,
+        ValidateWorkflowResponse,
+        ValidationIssue,
+    )
     from workflow_native.validate import validate_workflow_graph
 
 
@@ -15,9 +23,14 @@ def _node_kind(node) -> str:
     return str(value or node.type or "")
 
 
-def validate_xpert_definition(xpert: XpertDefinition) -> XpertValidationResult:
-    base = validate_workflow_graph(xpert.draft.workflow)
-    history_variable = xpert.draft.history_variable
+def validate_xpert_workflow_graph(
+    workflow: NativeWorkflowDefinition,
+    *,
+    history_variable: str,
+) -> ValidateWorkflowResponse:
+    """Validate a workflow while honoring Xpert's injected history variable."""
+
+    base = validate_workflow_graph(workflow)
     history_reference = f"variable '{history_variable}'"
     issues = [
         issue
@@ -27,6 +40,20 @@ def validate_xpert_definition(xpert: XpertDefinition) -> XpertValidationResult:
             and history_reference in issue.message
         )
     ]
+    return base.model_copy(
+        update={
+            "valid": not any(issue.severity == "error" for issue in issues),
+            "issues": issues,
+        }
+    )
+
+
+def validate_xpert_definition(xpert: XpertDefinition) -> XpertValidationResult:
+    base = validate_xpert_workflow_graph(
+        xpert.draft.workflow,
+        history_variable=xpert.draft.history_variable,
+    )
+    issues = list(base.issues)
     nodes = xpert.draft.workflow.nodes
     input_nodes = [node for node in nodes if _node_kind(node) == "input"]
     output_nodes = [node for node in nodes if _node_kind(node) == "output"]


### PR DESCRIPTION
## 概要
- 新增 Xpert / Prompt Profile / Proposal 定向评测集生成、持久任务、一次修复与受限校准闭环。
- 使用服务端能力蓝图固定中英语言、能力矩阵、难度、资源锚点以及工具/知识 Gold，生成结果保持待审核草稿。
- 新增 `tool_call_match`、目标 revision/checksum 固定、漂移 stale、校准 warning 确认及发布门禁。
- 在 Evaluations、Studio、Prompt、Evolution 与 Meta Planner 入口接入生成面板和报告。

## C 组根因与验证
- 原失败由推理模型耗尽 12,000 completion token 导致，`finish_reason=length`，最终 JSON 被截断。
- 仅 Benchmark 生成/修复调用设置 `reasoning.effort=low`；普通 Chat 与 Evaluator 未改变。
- C 单独实模复跑使用 `deepseek/deepseek-v4-flash-0731`，HTTP 200，`finish_reason=stop`，`contract_found=true`，响应 SHA-256 为 `cb9f6ac861fee05ddb669c448df776c890403343f55345f12763dbf12b7a0c26`。
- 严格解析进一步发现服务端专用资源 Gold 与 `expected.contains` 的误重叠：输入按蓝图必须出现文档/诱饵工具名，却被通用泄漏检查误判。修复只移除 `contains` 中与服务端固定资源标识完全相等的值，专用 `required_tools`、`forbidden_tools`、`document_names` 以及语义答案 Gold 均保留。
- 对同一份实模响应本地重放后 6/6 通过；覆盖五类能力组合，难度为 basic 1 / edge 2 / adversarial 3，专业证据均分 1.0。未追加模型调用。

## 验证
- `python -m pytest server/tests/test_benchmark_catalog.py server/tests/test_benchmark_generator.py server/tests/test_xpert_evaluations.py server/tests/test_xpert_runtime_chat.py -q`：45 passed。
- 相关 Benchmark/Evaluator/Main 模块 `py_compile`：通过。
- `cd client && npm.cmd run build`：通过；仅保留既有大 chunk warning。
- `git diff --check origin/main...HEAD`：通过。
- PR 路径与敏感值扫描：通过；未包含 `.env`、API key、预览数据、虚拟环境、`dist` 或临时 Vite 配置。

## 已知边界
- 本轮使用独立预览器验收，不占用共享栈容器。
- 全量后端 suite 未作为绿色门禁；此前运行结果为 1357 passed / 94 failed / 10 skipped，存在本轮范围外的仓库基线失败，本 PR 不宣称全量测试已全绿。