### PR TITLE
feature: 建立 V14 通用 Coding Worker 内核

### DIFF
--- a/docs/tasks/CODING_WORKER_V14.md
+++ b/docs/tasks/CODING_WORKER_V14.md
@@ -26,3 +26,9 @@ V14 不在宿主仓库原地执行，不开放 Git remote/push、自动 PR、任
 ## 回退
 
 关闭 `CODING_WORKER_V14_ENABLED` 后，新任务继续走 legacy；不得删除 Worker Store、Workspace、Coding Recovery 或 Agent Workspace 数据。已有活动 legacy 会话不迁移。
+
+## PR A 当前接口
+
+`/api/coding-worker/v1` 默认关闭。Kernel 阶段提供任务幂等创建、状态、SSE 事件补发、消息、暂停/继续/取消/pin，以及用 opaque `entry_id` 读取的 Workspace tree、文本预览与 Diff。`origin` 始终由 Server 写入；模型路由必须命中 `CODING_WORKER_MODEL_ROUTES`。
+
+PR A 使用 Fake Provider 验证状态机，模型停止后只进入 `testing` 并以 `acceptance_runner_pending` 阻断，绝不伪造完成。OpenCode、Tool Broker、Harness Runner 和 legacy 转发在后续顺序 PR 接入；未配置真实 Provider 时即使误开开关，API 也返回 503，而不会回退到未隔离执行。

--- a/docs/tasks/CODING_WORKER_V14.md
+++ b/docs/tasks/CODING_WORKER_V14.md
@@ -1,0 +1,28 @@
+# V14 通用 Coding Worker 基座
+
+## 目标与边界
+
+V14 将 Agent Workspace 的持久任务语义与 Coding Runtime 的隔离工作区、Diff、验证、恢复及 v13 写回收敛到供应商中立的 `coding_worker` 内核。下游模块只提交不透明来源、目标、上下文和冻结验收合同；不得提交宿主路径、环境变量、供应商名、remote URL、凭据或原始执行端点。
+
+V14 不在宿主仓库原地执行，不开放 Git remote/push、自动 PR、任意 Skill/MCP 注入、长期凭据或领域专属逻辑。宿主写回继续只走 v13 Project Host 确认链。
+
+## 威胁模型
+
+- 任务工作区、进程、事件、审批和 Artifact 必须按 `task_id` 隔离；跨任务 ID、路径穿越、符号链接和硬链接失败关闭。
+- Worker 以固定非 root 身份运行，不挂载 Docker socket、用户目录、SSH、Server 密钥或正式数据根。
+- 网络默认关闭。网络、依赖安装、后台服务和非冻结命令必须持有绑定任务、用途、范围和 TTL 的能力租约。
+- 每个副作用具有稳定 operation ID。未知结果只允许 reconcile，禁止以新 ID 或盲重放继续。
+- Server 只持有不透明来源和 Artifact ID。物理宿主路径只存在于 v13 Windows Helper。
+- 不保存隐藏思维链，只保存公开计划、消息、工具摘要、checkpoint、审批和验收证据；敏感结构字段使用 Coding Recovery 同级 Fernet 持久化。
+
+## 交付门禁
+
+1. `CODING_WORKER_V14_ENABLED` 默认 `false`。
+2. 两个任务可并行，第三个持久排队；取消一个不得终止另一个的进程。
+3. 重启把不确定的执行中任务标记为 `interrupted`，不得恢复旧进程或自动重放。
+4. Agent 停止不代表完成；只有冻结验收合同的全部必需检查及 Artifact 都有绑定当前 Workspace tree hash 的通过证据，状态才可进入 `completed`。
+5. 数据默认保留 604800 秒；pin 后不自动过期，用户可立即删除。
+
+## 回退
+
+关闭 `CODING_WORKER_V14_ENABLED` 后，新任务继续走 legacy；不得删除 Worker Store、Workspace、Coding Recovery 或 Agent Workspace 数据。已有活动 legacy 会话不迁移。

--- a/server/.env.example
+++ b/server/.env.example
@@ -23,6 +23,12 @@ OPENROUTER_VISION_FALLBACK_MODEL=qwen/qwen2.5-vl-72b-instruct
 # storage; override the root when a stable external data directory is desired.
 AGENT_WORKSPACE_ENABLED=true
 AGENT_WORKSPACE_ROOT=./agent_workspace/storage
+CODING_WORKER_V14_ENABLED=false
+CODING_WORKER_STORAGE_DIR=./coding_worker/storage
+CODING_WORKER_MAX_ACTIVE_TASKS=2
+CODING_WORKER_RETENTION_SECONDS=604800
+CODING_WORKER_NETWORK_ENABLED=false
+CODING_WORKER_MODEL_ROUTES=coding/default
 
 # 图片识别与生成使用实时能力目录；关闭后保留静态条目但隐藏交互入口。
 MULTIMODAL_IMAGE_ANALYSIS_ENABLED=true

--- a/server/coding_worker/__init__.py
+++ b/server/coding_worker/__init__.py
@@ -14,11 +14,13 @@ from .contracts import (
     WorkspaceSource,
 )
 from .provider import CodingAgentProvider, FakeCodingAgentProvider
+from .store import CodingWorkerStore
 
 __all__ = [
     "AcceptanceContract",
     "CapabilityLease",
     "CodingAgentProvider",
+    "CodingWorkerStore",
     "ContextReference",
     "FakeCodingAgentProvider",
     "Origin",

--- a/server/coding_worker/__init__.py
+++ b/server/coding_worker/__init__.py
@@ -14,12 +14,15 @@ from .contracts import (
     WorkspaceSource,
 )
 from .provider import CodingAgentProvider, FakeCodingAgentProvider
+from .service import CodingWorkerService
 from .store import CodingWorkerStore
+from .workspace import WorkspaceBroker
 
 __all__ = [
     "AcceptanceContract",
     "CapabilityLease",
     "CodingAgentProvider",
+    "CodingWorkerService",
     "CodingWorkerStore",
     "ContextReference",
     "FakeCodingAgentProvider",
@@ -31,4 +34,5 @@ __all__ = [
     "TaskSpec",
     "TaskState",
     "WorkspaceSource",
+    "WorkspaceBroker",
 ]

--- a/server/coding_worker/__init__.py
+++ b/server/coding_worker/__init__.py
@@ -1,0 +1,32 @@
+"""Provider-neutral task kernel for the ModelMirror Coding Worker."""
+
+from .contracts import (
+    AcceptanceContract,
+    CapabilityLease,
+    ContextReference,
+    Origin,
+    PolicyProfile,
+    TaskBudget,
+    TaskCreateRequest,
+    TaskRecord,
+    TaskSpec,
+    TaskState,
+    WorkspaceSource,
+)
+from .provider import CodingAgentProvider, FakeCodingAgentProvider
+
+__all__ = [
+    "AcceptanceContract",
+    "CapabilityLease",
+    "CodingAgentProvider",
+    "ContextReference",
+    "FakeCodingAgentProvider",
+    "Origin",
+    "PolicyProfile",
+    "TaskBudget",
+    "TaskCreateRequest",
+    "TaskRecord",
+    "TaskSpec",
+    "TaskState",
+    "WorkspaceSource",
+]

--- a/server/coding_worker/api.py
+++ b/server/coding_worker/api.py
@@ -1,0 +1,315 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Query, Request, Response
+from fastapi.responses import StreamingResponse
+from pydantic import Field
+
+from .contracts import Origin, StrictModel, TaskCreateRequest, TaskRecord, TERMINAL_STATES
+from .service import CodingWorkerService
+from .store import WorkerConflictError, WorkerNotFoundError, WorkerStoreError
+from .workspace import WorkspaceError
+
+
+class TaskMessageRequest(StrictModel):
+    message: str = Field(min_length=1, max_length=1_048_576)
+
+
+_service: CodingWorkerService | None = None
+_enabled_override: bool | None = None
+_CONSOLE_ORIGIN = Origin(module="worker-console", object_id="local-user")
+
+
+@asynccontextmanager
+async def _lifespan(_app: object) -> AsyncIterator[None]:
+    yield
+    if _service is not None:
+        await _service.shutdown()
+
+
+router = APIRouter(
+    prefix="/api/coding-worker/v1",
+    tags=["coding-worker"],
+    lifespan=_lifespan,
+)
+
+
+def is_coding_worker_enabled() -> bool:
+    if _enabled_override is not None:
+        return _enabled_override
+    return os.getenv("CODING_WORKER_V14_ENABLED", "false").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def configure_coding_worker_for_tests(
+    service: CodingWorkerService | None, *, enabled: bool | None = None
+) -> None:
+    global _service, _enabled_override
+    _service = service
+    _enabled_override = enabled
+
+
+def get_coding_worker_service() -> CodingWorkerService:
+    _require_enabled()
+    if _service is None:
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "code": "coding_worker_provider_unavailable",
+                "message": "The V14 Worker provider is not configured yet.",
+            },
+        )
+    return _service
+
+
+def _require_enabled() -> None:
+    if not is_coding_worker_enabled():
+        raise HTTPException(status_code=404, detail="Coding Worker V14 is disabled")
+
+
+def _raise_worker_error(exc: Exception) -> None:
+    if isinstance(exc, HTTPException):
+        raise exc
+    if isinstance(exc, WorkerNotFoundError):
+        status = 404
+    elif isinstance(exc, WorkerConflictError):
+        status = 409
+    elif isinstance(exc, WorkspaceError) and exc.code in {
+        "workspace_not_found",
+        "entry_not_found",
+    }:
+        status = 404
+    elif isinstance(exc, (WorkerStoreError, WorkspaceError)):
+        status = 400
+    else:
+        status = 500
+    code = getattr(exc, "code", "coding_worker_failed")
+    raise HTTPException(
+        status_code=status,
+        detail={"code": code, "message": str(exc)},
+    ) from exc
+
+
+@router.get("")
+async def coding_worker_status() -> dict[str, Any]:
+    enabled = is_coding_worker_enabled()
+    return {
+        "enabled": enabled,
+        "available": enabled and _service is not None,
+        "version": "v1",
+        "max_active_tasks": _service.max_active_tasks if _service is not None else 2,
+        "retention_seconds": (
+            _service.store.retention_seconds if _service is not None else 604800
+        ),
+        "network_enabled": False,
+    }
+
+
+@router.post("/tasks", response_model=TaskRecord, status_code=202)
+async def create_task(payload: TaskCreateRequest) -> TaskRecord:
+    _validate_model_route(payload.model_route)
+    try:
+        return await get_coding_worker_service().create_task(_CONSOLE_ORIGIN, payload)
+    except Exception as exc:
+        _raise_worker_error(exc)
+
+
+@router.get("/tasks", response_model=dict[str, list[TaskRecord]])
+async def list_tasks() -> dict[str, list[TaskRecord]]:
+    try:
+        return {"tasks": get_coding_worker_service().store.list_tasks(origin=_CONSOLE_ORIGIN)}
+    except Exception as exc:
+        _raise_worker_error(exc)
+
+
+@router.get("/tasks/{task_id}", response_model=TaskRecord)
+async def get_task(task_id: str) -> TaskRecord:
+    try:
+        return get_coding_worker_service().store.get_task(task_id)
+    except Exception as exc:
+        _raise_worker_error(exc)
+
+
+@router.get("/tasks/{task_id}/events")
+async def task_events(
+    task_id: str,
+    request: Request,
+    after: int = Query(default=0, ge=0),
+) -> StreamingResponse:
+    service = get_coding_worker_service()
+    try:
+        service.store.get_task(task_id)
+    except Exception as exc:
+        _raise_worker_error(exc)
+
+    async def stream() -> AsyncIterator[str]:
+        cursor = after
+        while not await request.is_disconnected():
+            events = service.store.list_events(task_id, after=cursor)
+            for event in events:
+                cursor = event.sequence
+                yield _encode_sse(event.type, event.model_dump(mode="json"), event.sequence)
+            task = service.store.get_task(task_id)
+            if task.state in TERMINAL_STATES and not events:
+                return
+            if not events:
+                yield ": keepalive\n\n"
+            await asyncio.sleep(0.25)
+
+    return StreamingResponse(
+        stream(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-store", "X-Accel-Buffering": "no"},
+    )
+
+
+@router.post("/tasks/{task_id}/messages", response_model=TaskRecord, status_code=202)
+async def append_task_message(task_id: str, payload: TaskMessageRequest) -> TaskRecord:
+    try:
+        return await get_coding_worker_service().append_message(task_id, payload.message)
+    except Exception as exc:
+        _raise_worker_error(exc)
+
+
+@router.post("/tasks/{task_id}/pause", response_model=TaskRecord)
+async def pause_task(task_id: str) -> TaskRecord:
+    try:
+        return await get_coding_worker_service().pause(task_id)
+    except Exception as exc:
+        _raise_worker_error(exc)
+
+
+@router.post("/tasks/{task_id}/resume", response_model=TaskRecord, status_code=202)
+async def resume_task(task_id: str) -> TaskRecord:
+    try:
+        return await get_coding_worker_service().resume(task_id)
+    except Exception as exc:
+        _raise_worker_error(exc)
+
+
+@router.post("/tasks/{task_id}/cancel", response_model=TaskRecord)
+async def cancel_task(task_id: str) -> TaskRecord:
+    try:
+        return await get_coding_worker_service().cancel(task_id)
+    except Exception as exc:
+        _raise_worker_error(exc)
+
+
+@router.post("/tasks/{task_id}/pin", response_model=TaskRecord)
+async def pin_task(task_id: str) -> TaskRecord:
+    try:
+        return get_coding_worker_service().store.set_pinned(task_id, True)
+    except Exception as exc:
+        _raise_worker_error(exc)
+
+
+@router.delete("/tasks/{task_id}/pin", response_model=TaskRecord)
+async def unpin_task(task_id: str) -> TaskRecord:
+    try:
+        return get_coding_worker_service().store.set_pinned(task_id, False)
+    except Exception as exc:
+        _raise_worker_error(exc)
+
+
+@router.delete("/tasks/{task_id}", status_code=204)
+async def delete_task(task_id: str) -> Response:
+    service = get_coding_worker_service()
+    try:
+        task = service.store.get_task(task_id)
+        if service.store.delete_task(task_id) and task.workspace_id is not None:
+            service.workspace_broker.delete(task.workspace_id)
+        return Response(status_code=204)
+    except Exception as exc:
+        _raise_worker_error(exc)
+
+
+@router.get("/tasks/{task_id}/workspace/tree")
+async def workspace_tree(task_id: str) -> dict[str, Any]:
+    service, task = _task_workspace(task_id)
+    try:
+        return {
+            "workspace_id": task.workspace_id,
+            "tree_hash": service.workspace_broker.current_tree_hash(task.workspace_id),
+            "entries": [
+                entry.model_dump(mode="json")
+                for entry in service.workspace_broker.tree(task.workspace_id)
+            ],
+        }
+    except Exception as exc:
+        _raise_worker_error(exc)
+
+
+@router.get("/tasks/{task_id}/workspace/entries/{entry_id}")
+async def workspace_entry(task_id: str, entry_id: str) -> Response:
+    service, task = _task_workspace(task_id)
+    try:
+        content = service.workspace_broker.read_entry(task.workspace_id, entry_id)
+        try:
+            text = content.decode("utf-8", errors="strict")
+        except UnicodeError as exc:
+            raise WorkspaceError(
+                "Binary entries are not available as text previews.",
+                code="preview_unavailable",
+            ) from exc
+        return Response(
+            text,
+            media_type="text/plain; charset=utf-8",
+            headers={"Cache-Control": "no-store"},
+        )
+    except Exception as exc:
+        _raise_worker_error(exc)
+
+
+@router.get("/tasks/{task_id}/workspace/diff")
+async def workspace_diff(task_id: str) -> Response:
+    service, task = _task_workspace(task_id)
+    try:
+        return Response(
+            service.workspace_broker.diff(task.workspace_id),
+            media_type="text/x-diff; charset=utf-8",
+            headers={"Cache-Control": "no-store"},
+        )
+    except Exception as exc:
+        _raise_worker_error(exc)
+
+
+def _task_workspace(task_id: str) -> tuple[CodingWorkerService, TaskRecord]:
+    service = get_coding_worker_service()
+    try:
+        task = service.store.get_task(task_id)
+    except Exception as exc:
+        _raise_worker_error(exc)
+    if task.workspace_id is None:
+        raise HTTPException(
+            status_code=409,
+            detail={"code": "workspace_not_ready", "message": "Workspace is not ready."},
+        )
+    return service, task
+
+
+def _validate_model_route(model_route: str) -> None:
+    configured = {
+        value.strip()
+        for value in os.getenv("CODING_WORKER_MODEL_ROUTES", "coding/default").split(",")
+        if value.strip()
+    }
+    if model_route not in configured:
+        raise HTTPException(
+            status_code=400,
+            detail={"code": "model_route_not_allowed", "message": "Model route is not allowed."},
+        )
+
+
+def _encode_sse(event_type: str, payload: dict[str, Any], sequence: int) -> str:
+    encoded = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+    return f"id: {sequence}\nevent: {event_type}\ndata: {encoded}\n\n"

--- a/server/coding_worker/contracts.py
+++ b/server/coding_worker/contracts.py
@@ -301,3 +301,50 @@ class WorkerEvent(StrictModel):
     type: str = Field(min_length=1, max_length=80)
     payload: dict[str, Any] = Field(default_factory=dict)
     created_at: float
+
+
+class WorkerMessage(StrictModel):
+    message_id: str
+    task_id: str
+    sequence: int = Field(ge=1)
+    role: Literal["user", "assistant", "tool", "system"]
+    content: str
+    created_at: float
+
+
+class ApprovalStatus(StrEnum):
+    PENDING = "pending"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+    CANCELLED = "cancelled"
+    EXPIRED = "expired"
+
+
+class WorkerApproval(StrictModel):
+    approval_id: str
+    task_id: str
+    operation_id: str
+    capability: str
+    status: ApprovalStatus
+    request: dict[str, Any] = Field(default_factory=dict)
+    lease: CapabilityLease | None = None
+    created_at: float
+    decided_at: float | None = None
+
+
+class WorkerCheckpoint(StrictModel):
+    checkpoint_id: str
+    task_id: str
+    workspace_tree_hash: str = Field(pattern=r"^[a-f0-9]{64}$")
+    payload: dict[str, Any] = Field(default_factory=dict)
+    created_at: float
+
+
+class WorkerArtifact(StrictModel):
+    artifact_id: str
+    task_id: str
+    media_type: str
+    sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    size: int = Field(ge=0)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    created_at: float

--- a/server/coding_worker/contracts.py
+++ b/server/coding_worker/contracts.py
@@ -1,0 +1,303 @@
+from __future__ import annotations
+
+import math
+import re
+from enum import StrEnum
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+SAFE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$")
+SAFE_ROUTE = re.compile(r"^[a-z0-9][a-z0-9._/-]{0,127}$")
+TERMINAL_STATES: frozenset["TaskState"]
+
+
+class StrictModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class TaskState(StrEnum):
+    QUEUED = "queued"
+    PREPARING = "preparing"
+    RUNNING = "running"
+    WAITING_APPROVAL = "waiting_approval"
+    PAUSED = "paused"
+    TESTING = "testing"
+    INTERRUPTED = "interrupted"
+    COMPLETED = "completed"
+    BLOCKED = "blocked"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+    BUDGET_LIMITED = "budget_limited"
+    EXPIRED = "expired"
+
+
+TERMINAL_STATES = frozenset(
+    {
+        TaskState.COMPLETED,
+        TaskState.BLOCKED,
+        TaskState.FAILED,
+        TaskState.CANCELLED,
+        TaskState.BUDGET_LIMITED,
+        TaskState.EXPIRED,
+    }
+)
+
+
+_TRANSITIONS: dict[TaskState, frozenset[TaskState]] = {
+    TaskState.QUEUED: frozenset(
+        {TaskState.PREPARING, TaskState.CANCELLED, TaskState.EXPIRED}
+    ),
+    TaskState.PREPARING: frozenset(
+        {
+            TaskState.RUNNING,
+            TaskState.WAITING_APPROVAL,
+            TaskState.INTERRUPTED,
+            TaskState.BLOCKED,
+            TaskState.FAILED,
+            TaskState.CANCELLED,
+        }
+    ),
+    TaskState.RUNNING: frozenset(
+        {
+            TaskState.WAITING_APPROVAL,
+            TaskState.PAUSED,
+            TaskState.TESTING,
+            TaskState.INTERRUPTED,
+            TaskState.BLOCKED,
+            TaskState.FAILED,
+            TaskState.CANCELLED,
+            TaskState.BUDGET_LIMITED,
+        }
+    ),
+    TaskState.WAITING_APPROVAL: frozenset(
+        {
+            TaskState.RUNNING,
+            TaskState.PAUSED,
+            TaskState.INTERRUPTED,
+            TaskState.BLOCKED,
+            TaskState.CANCELLED,
+            TaskState.EXPIRED,
+        }
+    ),
+    TaskState.PAUSED: frozenset(
+        {TaskState.QUEUED, TaskState.CANCELLED, TaskState.EXPIRED}
+    ),
+    TaskState.TESTING: frozenset(
+        {
+            TaskState.RUNNING,
+            TaskState.WAITING_APPROVAL,
+            TaskState.INTERRUPTED,
+            TaskState.COMPLETED,
+            TaskState.BLOCKED,
+            TaskState.FAILED,
+            TaskState.CANCELLED,
+            TaskState.BUDGET_LIMITED,
+        }
+    ),
+    TaskState.INTERRUPTED: frozenset(
+        {TaskState.QUEUED, TaskState.CANCELLED, TaskState.EXPIRED}
+    ),
+    TaskState.COMPLETED: frozenset({TaskState.EXPIRED}),
+    TaskState.BLOCKED: frozenset({TaskState.QUEUED, TaskState.CANCELLED, TaskState.EXPIRED}),
+    TaskState.FAILED: frozenset({TaskState.QUEUED, TaskState.CANCELLED, TaskState.EXPIRED}),
+    TaskState.CANCELLED: frozenset({TaskState.EXPIRED}),
+    TaskState.BUDGET_LIMITED: frozenset({TaskState.QUEUED, TaskState.CANCELLED, TaskState.EXPIRED}),
+    TaskState.EXPIRED: frozenset(),
+}
+
+
+def require_transition(current: TaskState, target: TaskState) -> None:
+    if current == target:
+        return
+    if target not in _TRANSITIONS[current]:
+        raise ValueError(f"invalid task transition: {current.value} -> {target.value}")
+
+
+class PolicyProfile(StrEnum):
+    INSPECT = "inspect"
+    DEVELOP = "develop"
+    DEVELOP_NETWORKED = "develop_networked"
+
+
+class Origin(StrictModel):
+    """Server-owned caller identity. It is never accepted from a public request."""
+
+    module: str = Field(min_length=1, max_length=64)
+    object_id: str = Field(min_length=1, max_length=128)
+
+    @field_validator("module", "object_id")
+    @classmethod
+    def validate_id(cls, value: str) -> str:
+        if SAFE_ID.fullmatch(value) is None:
+            raise ValueError("origin identifiers must be opaque safe ids")
+        return value
+
+
+class WorkspaceSource(StrictModel):
+    kind: Literal["builtin", "manifest", "host_snapshot"]
+    source_id: str = Field(min_length=1, max_length=128)
+    revision: str = Field(min_length=1, max_length=128)
+
+    @field_validator("source_id", "revision")
+    @classmethod
+    def validate_id(cls, value: str) -> str:
+        if SAFE_ID.fullmatch(value) is None:
+            raise ValueError("workspace source values must be opaque safe ids")
+        return value
+
+
+class AcceptanceCheck(StrictModel):
+    check_id: str = Field(min_length=1, max_length=128)
+    label: str = Field(min_length=1, max_length=200)
+    kind: Literal["command", "diff", "artifact", "custom"]
+    required: Literal[True] = True
+
+    @field_validator("check_id")
+    @classmethod
+    def validate_id(cls, value: str) -> str:
+        if SAFE_ID.fullmatch(value) is None:
+            raise ValueError("check id must be opaque")
+        return value
+
+
+class AcceptanceArtifact(StrictModel):
+    artifact_id: str = Field(min_length=1, max_length=128)
+    media_type: str = Field(min_length=1, max_length=120)
+
+    @field_validator("artifact_id")
+    @classmethod
+    def validate_id(cls, value: str) -> str:
+        if SAFE_ID.fullmatch(value) is None:
+            raise ValueError("artifact id must be opaque")
+        return value
+
+
+class AcceptanceContract(StrictModel):
+    contract_id: str = Field(min_length=1, max_length=128)
+    required_checks: tuple[AcceptanceCheck, ...] = Field(min_length=1, max_length=64)
+    required_artifacts: tuple[AcceptanceArtifact, ...] = Field(default=(), max_length=32)
+
+    @model_validator(mode="after")
+    def unique_requirements(self) -> "AcceptanceContract":
+        check_ids = [item.check_id for item in self.required_checks]
+        artifact_ids = [item.artifact_id for item in self.required_artifacts]
+        if len(check_ids) != len(set(check_ids)) or len(artifact_ids) != len(set(artifact_ids)):
+            raise ValueError("acceptance requirement ids must be unique")
+        if SAFE_ID.fullmatch(self.contract_id) is None:
+            raise ValueError("contract id must be opaque")
+        return self
+
+
+class TaskBudget(StrictModel):
+    max_seconds: int = Field(default=3600, ge=30, le=86_400)
+    max_turns: int = Field(default=64, ge=1, le=256)
+    max_tool_calls: int = Field(default=256, ge=1, le=2048)
+    max_output_bytes: int = Field(default=8 * 1024 * 1024, ge=1024, le=64 * 1024 * 1024)
+
+
+class ContextReference(StrictModel):
+    ref_id: str = Field(min_length=1, max_length=128)
+    kind: Literal["artifact", "resource", "file", "image"]
+
+    @field_validator("ref_id")
+    @classmethod
+    def validate_id(cls, value: str) -> str:
+        if SAFE_ID.fullmatch(value) is None:
+            raise ValueError("context reference must be opaque")
+        return value
+
+
+class TaskCreateRequest(StrictModel):
+    client_task_id: str = Field(min_length=1, max_length=128)
+    objective: str = Field(min_length=1, max_length=1_048_576)
+    workspace_source: WorkspaceSource
+    acceptance: AcceptanceContract
+    policy_profile: PolicyProfile = PolicyProfile.INSPECT
+    model_route: str = Field(min_length=1, max_length=128)
+    budget: TaskBudget = Field(default_factory=TaskBudget)
+    context_refs: tuple[ContextReference, ...] = Field(default=(), max_length=128)
+
+    @field_validator("client_task_id")
+    @classmethod
+    def validate_task_id(cls, value: str) -> str:
+        if SAFE_ID.fullmatch(value) is None:
+            raise ValueError("client task id must be opaque")
+        return value
+
+    @field_validator("objective")
+    @classmethod
+    def reject_blank_objective(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("objective cannot be blank")
+        return value
+
+    @field_validator("model_route")
+    @classmethod
+    def validate_model_route(cls, value: str) -> str:
+        if SAFE_ROUTE.fullmatch(value) is None or value.startswith(("http:", "https:")):
+            raise ValueError("model route must be a controlled catalog id")
+        return value
+
+    @model_validator(mode="after")
+    def unique_context_refs(self) -> "TaskCreateRequest":
+        ids = [item.ref_id for item in self.context_refs]
+        if len(ids) != len(set(ids)):
+            raise ValueError("context refs must be unique")
+        return self
+
+
+class TaskSpec(TaskCreateRequest):
+    origin: Origin
+
+
+class CapabilityLease(StrictModel):
+    lease_id: str
+    task_id: str
+    capability: Literal[
+        "workspace_write", "command", "dependency_install", "service", "network"
+    ]
+    scope: dict[str, Any] = Field(default_factory=dict)
+    issued_at: float
+    expires_at: float
+    operation_limit: int = Field(default=1, ge=1, le=1024)
+
+    @model_validator(mode="after")
+    def validate_lease(self) -> "CapabilityLease":
+        if SAFE_ID.fullmatch(self.lease_id) is None or SAFE_ID.fullmatch(self.task_id) is None:
+            raise ValueError("lease identifiers are invalid")
+        if not all(math.isfinite(value) and value >= 0 for value in (self.issued_at, self.expires_at)):
+            raise ValueError("lease timestamps are invalid")
+        if self.expires_at <= self.issued_at:
+            raise ValueError("lease expiry must be after issuance")
+        return self
+
+
+class TaskRecord(StrictModel):
+    task_id: str
+    spec: TaskSpec
+    state: TaskState
+    workspace_id: str | None = None
+    provider_session_id: str | None = None
+    created_at: float
+    updated_at: float
+    expires_at: float
+    pinned: bool = False
+    last_event_sequence: int = 0
+    reason: str | None = None
+
+    @field_validator("task_id", "workspace_id", "provider_session_id")
+    @classmethod
+    def validate_optional_id(cls, value: str | None) -> str | None:
+        if value is not None and SAFE_ID.fullmatch(value) is None:
+            raise ValueError("record identifier is invalid")
+        return value
+
+
+class WorkerEvent(StrictModel):
+    sequence: int = Field(ge=1)
+    task_id: str
+    type: str = Field(min_length=1, max_length=80)
+    payload: dict[str, Any] = Field(default_factory=dict)
+    created_at: float

--- a/server/coding_worker/contracts.py
+++ b/server/coding_worker/contracts.py
@@ -47,7 +47,7 @@ TERMINAL_STATES = frozenset(
 
 _TRANSITIONS: dict[TaskState, frozenset[TaskState]] = {
     TaskState.QUEUED: frozenset(
-        {TaskState.PREPARING, TaskState.CANCELLED, TaskState.EXPIRED}
+        {TaskState.PREPARING, TaskState.PAUSED, TaskState.CANCELLED, TaskState.EXPIRED}
     ),
     TaskState.PREPARING: frozenset(
         {

--- a/server/coding_worker/crypto.py
+++ b/server/coding_worker/crypto.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from cryptography.fernet import Fernet, InvalidToken
+
+
+class WorkerCryptoError(RuntimeError):
+    def __init__(self, message: str, *, code: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+class WorkerEncryptedCodec:
+    """Coding Recovery-compatible authenticated JSON encryption at rest."""
+
+    def __init__(self, storage_root: Path, *, master_key: bytes | str | None = None) -> None:
+        self.storage_root = Path(storage_root)
+        self.database_path = self.storage_root / "coding-worker.sqlite3"
+        self.key_path = self.storage_root / "coding-worker-master.key"
+        self.storage_root.mkdir(parents=True, exist_ok=True)
+        self._fernet = Fernet(self._resolve_key(master_key))
+
+    def encrypt(self, value: Any) -> str:
+        try:
+            encoded = json.dumps(
+                value,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+                allow_nan=False,
+            ).encode("utf-8")
+        except (TypeError, ValueError) as exc:
+            raise WorkerCryptoError(
+                "Worker data is not serializable.", code="worker_data_invalid"
+            ) from exc
+        return self._fernet.encrypt(encoded).decode("ascii")
+
+    def decrypt(self, ciphertext: str) -> Any:
+        try:
+            raw = self._fernet.decrypt(ciphertext.encode("ascii"))
+            return json.loads(raw.decode("utf-8"))
+        except (InvalidToken, UnicodeError, json.JSONDecodeError, AttributeError) as exc:
+            raise WorkerCryptoError(
+                "Worker data could not be authenticated.", code="worker_data_corrupt"
+            ) from exc
+
+    def _resolve_key(self, master_key: bytes | str | None) -> bytes:
+        if master_key is not None:
+            candidate = master_key.encode("ascii") if isinstance(master_key, str) else master_key
+            return self._validate_key(candidate)
+        if self.key_path.exists():
+            try:
+                return self._validate_key(self.key_path.read_bytes().strip())
+            except OSError as exc:
+                raise WorkerCryptoError(
+                    "Worker key could not be read.", code="worker_key_invalid"
+                ) from exc
+        if self.database_path.exists():
+            raise WorkerCryptoError(
+                "Worker key is missing for existing data.", code="worker_key_missing"
+            )
+        candidate = Fernet.generate_key()
+        try:
+            descriptor = os.open(self.key_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+            with os.fdopen(descriptor, "wb") as handle:
+                handle.write(candidate)
+                handle.flush()
+                os.fsync(handle.fileno())
+        except FileExistsError:
+            try:
+                candidate = self.key_path.read_bytes().strip()
+            except OSError as exc:
+                raise WorkerCryptoError(
+                    "Worker key could not be loaded.", code="worker_key_invalid"
+                ) from exc
+        except OSError as exc:
+            raise WorkerCryptoError(
+                "Worker key could not be created.", code="worker_storage_unavailable"
+            ) from exc
+        return self._validate_key(candidate)
+
+    @staticmethod
+    def _validate_key(candidate: bytes) -> bytes:
+        try:
+            Fernet(candidate)
+        except (TypeError, ValueError) as exc:
+            raise WorkerCryptoError(
+                "Worker key is invalid.", code="worker_key_invalid"
+            ) from exc
+        return candidate

--- a/server/coding_worker/provider.py
+++ b/server/coding_worker/provider.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import asyncio
+import uuid
+from collections.abc import AsyncIterator, Sequence
+from enum import StrEnum
+from typing import Any, Protocol, runtime_checkable
+
+from pydantic import Field
+
+from .contracts import PolicyProfile, SAFE_ID, StrictModel, TaskBudget
+
+
+class ProviderEventKind(StrEnum):
+    SESSION_OPENED = "session_opened"
+    MESSAGE = "message"
+    PLAN = "plan"
+    TOOL_REQUEST = "tool_request"
+    TOOL_RESULT = "tool_result"
+    APPROVAL_REQUIRED = "approval_required"
+    CHECKPOINT = "checkpoint"
+    TURN_COMPLETED = "turn_completed"
+    CANCELLED = "cancelled"
+    FAILED = "failed"
+
+
+class ProviderCapabilities(StrictModel):
+    supports_streaming: bool = True
+    supports_cancel: bool = True
+    supports_checkpoint: bool = False
+    supports_restore: bool = False
+    supports_steering: bool = True
+
+
+class ProviderOpenRequest(StrictModel):
+    task_id: str
+    workspace_id: str
+    objective: str = Field(min_length=1, max_length=1_048_576)
+    model_route: str
+    policy_profile: PolicyProfile
+    budget: TaskBudget
+
+
+class ProviderSession(StrictModel):
+    session_id: str
+    task_id: str
+    provider_capabilities: ProviderCapabilities
+
+
+class ProviderEvent(StrictModel):
+    kind: ProviderEventKind
+    data: dict[str, Any] = Field(default_factory=dict)
+
+
+class ProviderCheckpoint(StrictModel):
+    checkpoint_id: str
+    payload: dict[str, Any] = Field(default_factory=dict)
+
+
+@runtime_checkable
+class CodingAgentProvider(Protocol):
+    async def capabilities(self) -> ProviderCapabilities: ...
+
+    async def open(self, request: ProviderOpenRequest) -> ProviderSession: ...
+
+    def message(self, session: ProviderSession, text: str) -> AsyncIterator[ProviderEvent]: ...
+
+    async def cancel(self, session: ProviderSession) -> bool: ...
+
+    async def checkpoint(self, session: ProviderSession) -> ProviderCheckpoint: ...
+
+    async def restore(
+        self, request: ProviderOpenRequest, checkpoint: ProviderCheckpoint
+    ) -> ProviderSession: ...
+
+    async def close(self, session: ProviderSession) -> None: ...
+
+
+class FakeCodingAgentProvider:
+    """Deterministic contract provider; it never touches a workspace or network."""
+
+    def __init__(
+        self,
+        *,
+        script: Sequence[ProviderEvent] | None = None,
+        block: asyncio.Event | None = None,
+    ) -> None:
+        self._script = tuple(
+            script
+            or (
+                ProviderEvent(kind=ProviderEventKind.PLAN, data={"summary": "inspect"}),
+                ProviderEvent(kind=ProviderEventKind.TURN_COMPLETED),
+            )
+        )
+        self._block = block
+        self._cancelled: set[str] = set()
+        self._closed: set[str] = set()
+
+    async def capabilities(self) -> ProviderCapabilities:
+        return ProviderCapabilities(supports_checkpoint=True, supports_restore=True)
+
+    async def open(self, request: ProviderOpenRequest) -> ProviderSession:
+        return ProviderSession(
+            session_id=f"fake_{uuid.uuid4().hex}",
+            task_id=request.task_id,
+            provider_capabilities=await self.capabilities(),
+        )
+
+    async def message(
+        self, session: ProviderSession, text: str
+    ) -> AsyncIterator[ProviderEvent]:
+        if not text.strip():
+            raise ValueError("provider message cannot be blank")
+        if self._block is not None:
+            await self._block.wait()
+        for event in self._script:
+            await asyncio.sleep(0)
+            if session.session_id in self._cancelled:
+                yield ProviderEvent(kind=ProviderEventKind.CANCELLED)
+                return
+            yield event
+
+    async def cancel(self, session: ProviderSession) -> bool:
+        if session.session_id in self._closed:
+            return False
+        self._cancelled.add(session.session_id)
+        return True
+
+    async def checkpoint(self, session: ProviderSession) -> ProviderCheckpoint:
+        return ProviderCheckpoint(
+            checkpoint_id=f"checkpoint_{uuid.uuid4().hex}",
+            payload={"fake_session": session.session_id},
+        )
+
+    async def restore(
+        self, request: ProviderOpenRequest, checkpoint: ProviderCheckpoint
+    ) -> ProviderSession:
+        if SAFE_ID.fullmatch(checkpoint.checkpoint_id) is None:
+            raise ValueError("invalid checkpoint")
+        return await self.open(request)
+
+    async def close(self, session: ProviderSession) -> None:
+        self._closed.add(session.session_id)
+        self._cancelled.discard(session.session_id)

--- a/server/coding_worker/service.py
+++ b/server/coding_worker/service.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from collections.abc import Callable
+
+from .contracts import (
+    Origin,
+    TaskCreateRequest,
+    TaskRecord,
+    TaskSpec,
+    TaskState,
+    TERMINAL_STATES,
+)
+from .provider import (
+    CodingAgentProvider,
+    ProviderEventKind,
+    ProviderOpenRequest,
+    ProviderSession,
+)
+from .store import CodingWorkerStore, WorkerConflictError
+from .workspace import WorkspaceBroker, WorkspaceError
+
+
+class CodingWorkerService:
+    """Persistent two-slot scheduler. Provider processes never survive a restart."""
+
+    def __init__(
+        self,
+        *,
+        store: CodingWorkerStore,
+        workspace_broker: WorkspaceBroker,
+        provider: CodingAgentProvider,
+        max_active_tasks: int = 2,
+    ) -> None:
+        if not 1 <= max_active_tasks <= 16:
+            raise ValueError("active task capacity is outside the allowed range")
+        self.store = store
+        self.workspace_broker = workspace_broker
+        self.provider = provider
+        self.max_active_tasks = max_active_tasks
+        self._active: dict[str, asyncio.Task[None]] = {}
+        self._sessions: dict[str, ProviderSession] = {}
+        self._wake = asyncio.Event()
+        self._scheduler: asyncio.Task[None] | None = None
+        self._started = False
+        self._closing = False
+
+    @property
+    def active_task_ids(self) -> frozenset[str]:
+        return frozenset(self._active)
+
+    async def start(self) -> None:
+        if self._started:
+            return
+        self._started = True
+        self._closing = False
+        self._scheduler = asyncio.create_task(
+            self._scheduler_loop(), name="coding-worker-scheduler"
+        )
+        self._wake.set()
+
+    async def shutdown(self) -> None:
+        if not self._started:
+            return
+        self._closing = True
+        for task_id, session in tuple(self._sessions.items()):
+            with contextlib.suppress(Exception):
+                await self.provider.cancel(session)
+            current = self.store.get_task(task_id)
+            if current.state not in TERMINAL_STATES:
+                with contextlib.suppress(WorkerConflictError):
+                    self.store.transition(task_id, TaskState.INTERRUPTED, reason="service_shutdown")
+        for task in tuple(self._active.values()):
+            task.cancel()
+        if self._active:
+            await asyncio.gather(*tuple(self._active.values()), return_exceptions=True)
+        if self._scheduler is not None:
+            self._scheduler.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._scheduler
+        self._active.clear()
+        self._sessions.clear()
+        self._scheduler = None
+        self._started = False
+
+    async def create_task(self, origin: Origin, request: TaskCreateRequest) -> TaskRecord:
+        await self.start()
+        spec = TaskSpec(**request.model_dump(), origin=origin)
+        task = self.store.create_task(spec)
+        self._wake.set()
+        return task
+
+    async def resume(self, task_id: str) -> TaskRecord:
+        await self.start()
+        task = self.store.get_task(task_id)
+        if task.state not in {
+            TaskState.INTERRUPTED,
+            TaskState.PAUSED,
+            TaskState.BLOCKED,
+            TaskState.FAILED,
+            TaskState.BUDGET_LIMITED,
+        }:
+            raise WorkerConflictError("Task cannot be resumed.", code="task_state_conflict")
+        resumed = self.store.transition(task_id, TaskState.QUEUED)
+        self._wake.set()
+        return resumed
+
+    async def pause(self, task_id: str) -> TaskRecord:
+        task = self.store.get_task(task_id)
+        if task.state is TaskState.QUEUED:
+            return self.store.transition(task_id, TaskState.PAUSED)
+        if task.state not in {
+            TaskState.PREPARING,
+            TaskState.RUNNING,
+            TaskState.WAITING_APPROVAL,
+            TaskState.TESTING,
+        }:
+            raise WorkerConflictError("Task cannot be paused.", code="task_state_conflict")
+        session = self._sessions.get(task_id)
+        if session is not None:
+            await self.provider.cancel(session)
+        active = self._active.get(task_id)
+        if active is not None:
+            active.cancel()
+        paused = self.store.transition(task_id, TaskState.PAUSED, reason="user_paused")
+        self._wake.set()
+        return paused
+
+    async def cancel(self, task_id: str) -> TaskRecord:
+        task = self.store.get_task(task_id)
+        if task.state in TERMINAL_STATES:
+            return task
+        session = self._sessions.get(task_id)
+        if session is not None:
+            await self.provider.cancel(session)
+        active = self._active.get(task_id)
+        if active is not None:
+            active.cancel()
+        cancelled = self.store.transition(task_id, TaskState.CANCELLED, reason="user_cancelled")
+        self._wake.set()
+        return cancelled
+
+    async def append_message(self, task_id: str, text: str) -> TaskRecord:
+        task = self.store.get_task(task_id)
+        if task.state not in {TaskState.RUNNING, TaskState.WAITING_APPROVAL, TaskState.PAUSED}:
+            raise WorkerConflictError("Task is not accepting messages.", code="task_state_conflict")
+        self.store.append_message(task_id, role="user", content=text)
+        self.store.append_event(task_id, "steering_queued", {})
+        return self.store.get_task(task_id)
+
+    async def wait_for(
+        self,
+        task_id: str,
+        predicate: Callable[[TaskRecord], bool],
+        *,
+        timeout: float = 10.0,
+    ) -> TaskRecord:
+        deadline = asyncio.get_running_loop().time() + timeout
+        while True:
+            task = self.store.get_task(task_id)
+            if predicate(task):
+                return task
+            if asyncio.get_running_loop().time() >= deadline:
+                raise TimeoutError(f"Task {task_id} did not reach the expected state")
+            await asyncio.sleep(0.01)
+
+    async def _scheduler_loop(self) -> None:
+        while True:
+            await self._wake.wait()
+            self._wake.clear()
+            while not self._closing and len(self._active) < self.max_active_tasks:
+                queued = self.store.list_queued_tasks(limit=1)
+                if not queued:
+                    break
+                record = queued[0]
+                try:
+                    self.store.transition(
+                        record.task_id,
+                        TaskState.PREPARING,
+                        expected_state=TaskState.QUEUED,
+                    )
+                except WorkerConflictError:
+                    continue
+                runner = asyncio.create_task(
+                    self._run_task(record.task_id), name=f"coding-worker-{record.task_id}"
+                )
+                self._active[record.task_id] = runner
+                runner.add_done_callback(
+                    lambda completed, task_id=record.task_id: self._task_finished(
+                        task_id, completed
+                    )
+                )
+
+    def _task_finished(self, task_id: str, _task: asyncio.Task[None]) -> None:
+        self._active.pop(task_id, None)
+        self._sessions.pop(task_id, None)
+        if not self._closing:
+            self._wake.set()
+
+    async def _run_task(self, task_id: str) -> None:
+        session: ProviderSession | None = None
+        try:
+            task = self.store.get_task(task_id)
+            workspace = (
+                self.workspace_broker.get(task.workspace_id)
+                if task.workspace_id is not None
+                else await self.workspace_broker.prepare(task.spec.workspace_source)
+            )
+            request = ProviderOpenRequest(
+                task_id=task_id,
+                workspace_id=workspace.workspace_id,
+                objective=task.spec.objective,
+                model_route=task.spec.model_route,
+                policy_profile=task.spec.policy_profile,
+                budget=task.spec.budget,
+            )
+            session = await self.provider.open(request)
+            self._sessions[task_id] = session
+            self.store.transition(
+                task_id,
+                TaskState.RUNNING,
+                workspace_id=workspace.workspace_id,
+                provider_session_id=session.session_id,
+                expected_state=TaskState.PREPARING,
+            )
+            if not self.store.list_messages(task_id):
+                self.store.append_message(task_id, role="user", content=task.spec.objective)
+            terminal = False
+            async for event in self.provider.message(session, task.spec.objective):
+                self.store.append_event(
+                    task_id,
+                    "provider_event",
+                    {"kind": event.kind.value, "data": event.data},
+                )
+                if event.kind is ProviderEventKind.TURN_COMPLETED:
+                    self.store.transition(task_id, TaskState.TESTING)
+                    self.store.transition(
+                        task_id,
+                        TaskState.BLOCKED,
+                        reason="acceptance_runner_pending",
+                    )
+                    terminal = True
+                    break
+                if event.kind is ProviderEventKind.CANCELLED:
+                    self.store.transition(task_id, TaskState.CANCELLED, reason="provider_cancelled")
+                    terminal = True
+                    break
+                if event.kind is ProviderEventKind.FAILED:
+                    self.store.transition(task_id, TaskState.FAILED, reason="provider_failed")
+                    terminal = True
+                    break
+            if not terminal:
+                current = self.store.get_task(task_id)
+                if current.state not in TERMINAL_STATES:
+                    self.store.transition(
+                        task_id, TaskState.INTERRUPTED, reason="provider_stream_ended"
+                    )
+        except asyncio.CancelledError:
+            current = self.store.get_task(task_id)
+            if current.state not in TERMINAL_STATES and current.state not in {
+                TaskState.PAUSED,
+                TaskState.INTERRUPTED,
+            }:
+                with contextlib.suppress(WorkerConflictError):
+                    self.store.transition(task_id, TaskState.INTERRUPTED, reason="runner_cancelled")
+            raise
+        except WorkspaceError as exc:
+            current = self.store.get_task(task_id)
+            if current.state not in TERMINAL_STATES:
+                self.store.transition(task_id, TaskState.FAILED, reason=exc.code)
+        except Exception:
+            current = self.store.get_task(task_id)
+            if current.state not in TERMINAL_STATES:
+                with contextlib.suppress(WorkerConflictError):
+                    self.store.transition(task_id, TaskState.FAILED, reason="worker_failed")
+        finally:
+            if session is not None:
+                with contextlib.suppress(Exception):
+                    await self.provider.close(session)

--- a/server/coding_worker/store.py
+++ b/server/coding_worker/store.py
@@ -140,6 +140,19 @@ class CodingWorkerStore:
         with self._connect() as connection:
             return [self._task(row, connection) for row in connection.execute(query, params)]
 
+    def list_queued_tasks(self, *, limit: int = 100) -> list[TaskRecord]:
+        if not 1 <= limit <= 1000:
+            raise ValueError("invalid queued task limit")
+        with self._connect() as connection:
+            rows = connection.execute(
+                """
+                SELECT * FROM worker_tasks WHERE state = ?
+                ORDER BY created_at, task_id LIMIT ?
+                """,
+                (TaskState.QUEUED.value, limit),
+            ).fetchall()
+            return [self._task(row, connection) for row in rows]
+
     def transition(
         self,
         task_id: str,

--- a/server/coding_worker/store.py
+++ b/server/coding_worker/store.py
@@ -1,0 +1,502 @@
+from __future__ import annotations
+
+import math
+import sqlite3
+import threading
+import time
+import uuid
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from .contracts import (
+    TERMINAL_STATES,
+    Origin,
+    TaskRecord,
+    TaskSpec,
+    TaskState,
+    WorkerEvent,
+    WorkerMessage,
+    require_transition,
+)
+from .crypto import WorkerCryptoError, WorkerEncryptedCodec
+
+
+DEFAULT_RETENTION_SECONDS = 7 * 24 * 60 * 60
+MIN_RETENTION_SECONDS = 60
+MAX_RETENTION_SECONDS = 30 * 24 * 60 * 60
+ACTIVE_ON_RESTART = (
+    TaskState.PREPARING,
+    TaskState.RUNNING,
+    TaskState.WAITING_APPROVAL,
+    TaskState.TESTING,
+)
+
+
+class WorkerStoreError(RuntimeError):
+    def __init__(self, message: str, *, code: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+class WorkerNotFoundError(WorkerStoreError):
+    pass
+
+
+class WorkerConflictError(WorkerStoreError):
+    pass
+
+
+class CodingWorkerStore:
+    """Encrypted SQLite task/event store with durable idempotency and replay."""
+
+    def __init__(
+        self,
+        storage_root: Path,
+        *,
+        retention_seconds: int = DEFAULT_RETENTION_SECONDS,
+        clock: Callable[[], float] = time.time,
+        master_key: bytes | str | None = None,
+    ) -> None:
+        if (
+            isinstance(retention_seconds, bool)
+            or not isinstance(retention_seconds, int)
+            or not MIN_RETENTION_SECONDS <= retention_seconds <= MAX_RETENTION_SECONDS
+        ):
+            raise ValueError("Worker retention is outside the allowed range")
+        self.root = Path(storage_root)
+        self.database_path = self.root / "coding-worker.sqlite3"
+        self.workspaces_root = self.root / "workspaces"
+        self.retention_seconds = retention_seconds
+        self._clock = clock
+        self._lock = threading.RLock()
+        self._codec = WorkerEncryptedCodec(self.root, master_key=master_key)
+        self.workspaces_root.mkdir(parents=True, exist_ok=True)
+        self._initialize()
+        self.mark_inflight_interrupted()
+
+    def create_task(self, spec: TaskSpec) -> TaskRecord:
+        now = self._now()
+        expires_at = now + self.retention_seconds
+        task_id = f"task_{uuid.uuid4().hex}"
+        encrypted_spec = self._codec.encrypt(spec.model_dump(mode="json"))
+        with self._lock, self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            existing = connection.execute(
+                """
+                SELECT * FROM worker_tasks
+                WHERE origin_module = ? AND origin_object_id = ? AND client_task_id = ?
+                """,
+                (spec.origin.module, spec.origin.object_id, spec.client_task_id),
+            ).fetchone()
+            if existing is not None:
+                current = self._task(existing, connection)
+                if current.spec != spec:
+                    raise WorkerConflictError(
+                        "The idempotency key is already bound to another task.",
+                        code="task_intent_conflict",
+                    )
+                return current
+            connection.execute(
+                """
+                INSERT INTO worker_tasks (
+                    task_id, origin_module, origin_object_id, client_task_id,
+                    state, spec_ciphertext, created_at, updated_at, expires_at, pinned
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0)
+                """,
+                (
+                    task_id,
+                    spec.origin.module,
+                    spec.origin.object_id,
+                    spec.client_task_id,
+                    TaskState.QUEUED.value,
+                    encrypted_spec,
+                    now,
+                    now,
+                    expires_at,
+                ),
+            )
+            self._append_event_locked(
+                connection,
+                task_id=task_id,
+                event_type="task_created",
+                payload={"state": TaskState.QUEUED.value},
+                created_at=now,
+            )
+        return self.get_task(task_id)
+
+    def get_task(self, task_id: str) -> TaskRecord:
+        with self._connect() as connection:
+            row = self._require_task_row(connection, task_id)
+            return self._task(row, connection)
+
+    def list_tasks(self, *, origin: Origin | None = None) -> list[TaskRecord]:
+        query = "SELECT * FROM worker_tasks"
+        params: tuple[Any, ...] = ()
+        if origin is not None:
+            query += " WHERE origin_module = ? AND origin_object_id = ?"
+            params = (origin.module, origin.object_id)
+        query += " ORDER BY created_at DESC, task_id"
+        with self._connect() as connection:
+            return [self._task(row, connection) for row in connection.execute(query, params)]
+
+    def transition(
+        self,
+        task_id: str,
+        target: TaskState,
+        *,
+        reason: str | None = None,
+        workspace_id: str | None = None,
+        provider_session_id: str | None = None,
+        expected_state: TaskState | None = None,
+    ) -> TaskRecord:
+        now = self._now()
+        with self._lock, self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            row = self._require_task_row(connection, task_id)
+            current = TaskState(row["state"])
+            if expected_state is not None and current is not expected_state:
+                raise WorkerConflictError(
+                    "Task state changed before the requested transition.",
+                    code="task_state_conflict",
+                )
+            try:
+                require_transition(current, target)
+            except ValueError as exc:
+                raise WorkerConflictError(str(exc), code="task_state_conflict") from exc
+            encrypted_reason = self._codec.encrypt(reason) if reason is not None else None
+            encrypted_provider = (
+                self._codec.encrypt(provider_session_id)
+                if provider_session_id is not None
+                else row["provider_session_ciphertext"]
+            )
+            connection.execute(
+                """
+                UPDATE worker_tasks SET state = ?, reason_ciphertext = ?,
+                    workspace_id = COALESCE(?, workspace_id),
+                    provider_session_ciphertext = ?, updated_at = ?
+                WHERE task_id = ?
+                """,
+                (
+                    target.value,
+                    encrypted_reason,
+                    workspace_id,
+                    encrypted_provider,
+                    now,
+                    task_id,
+                ),
+            )
+            self._append_event_locked(
+                connection,
+                task_id=task_id,
+                event_type="task_state",
+                payload={"from": current.value, "to": target.value, "reason": reason},
+                created_at=now,
+            )
+        return self.get_task(task_id)
+
+    def append_event(
+        self, task_id: str, event_type: str, payload: dict[str, Any] | None = None
+    ) -> WorkerEvent:
+        now = self._now()
+        with self._lock, self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            self._require_task_row(connection, task_id)
+            sequence = self._append_event_locked(
+                connection,
+                task_id=task_id,
+                event_type=event_type,
+                payload=payload or {},
+                created_at=now,
+            )
+        return WorkerEvent(
+            sequence=sequence,
+            task_id=task_id,
+            type=event_type,
+            payload=payload or {},
+            created_at=now,
+        )
+
+    def list_events(self, task_id: str, *, after: int = 0, limit: int = 500) -> list[WorkerEvent]:
+        if after < 0 or not 1 <= limit <= 1000:
+            raise ValueError("invalid event replay window")
+        with self._connect() as connection:
+            self._require_task_row(connection, task_id)
+            rows = connection.execute(
+                """
+                SELECT * FROM worker_events
+                WHERE task_id = ? AND sequence > ? ORDER BY sequence LIMIT ?
+                """,
+                (task_id, after, limit),
+            ).fetchall()
+        return [
+            WorkerEvent(
+                sequence=int(row["sequence"]),
+                task_id=task_id,
+                type=str(row["type"]),
+                payload=self._decrypt_dict(row["payload_ciphertext"]),
+                created_at=float(row["created_at"]),
+            )
+            for row in rows
+        ]
+
+    def append_message(self, task_id: str, *, role: str, content: str) -> WorkerMessage:
+        if role not in {"user", "assistant", "tool", "system"} or not content.strip():
+            raise ValueError("invalid worker message")
+        now = self._now()
+        message_id = f"message_{uuid.uuid4().hex}"
+        with self._lock, self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            self._require_task_row(connection, task_id)
+            next_sequence = int(
+                connection.execute(
+                    "SELECT COALESCE(MAX(sequence), 0) + 1 FROM worker_messages WHERE task_id = ?",
+                    (task_id,),
+                ).fetchone()[0]
+            )
+            connection.execute(
+                """
+                INSERT INTO worker_messages (
+                    message_id, task_id, sequence, role, content_ciphertext, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (message_id, task_id, next_sequence, role, self._codec.encrypt(content), now),
+            )
+        return WorkerMessage(
+            message_id=message_id,
+            task_id=task_id,
+            sequence=next_sequence,
+            role=role,  # type: ignore[arg-type]
+            content=content,
+            created_at=now,
+        )
+
+    def list_messages(self, task_id: str) -> list[WorkerMessage]:
+        with self._connect() as connection:
+            self._require_task_row(connection, task_id)
+            rows = connection.execute(
+                "SELECT * FROM worker_messages WHERE task_id = ? ORDER BY sequence",
+                (task_id,),
+            ).fetchall()
+        return [
+            WorkerMessage(
+                message_id=str(row["message_id"]),
+                task_id=task_id,
+                sequence=int(row["sequence"]),
+                role=str(row["role"]),  # type: ignore[arg-type]
+                content=self._decrypt_string(row["content_ciphertext"]),
+                created_at=float(row["created_at"]),
+            )
+            for row in rows
+        ]
+
+    def set_pinned(self, task_id: str, pinned: bool) -> TaskRecord:
+        now = self._now()
+        with self._lock, self._connect() as connection:
+            self._require_task_row(connection, task_id)
+            connection.execute(
+                "UPDATE worker_tasks SET pinned = ?, expires_at = ?, updated_at = ? WHERE task_id = ?",
+                (1 if pinned else 0, now + self.retention_seconds, now, task_id),
+            )
+            self._append_event_locked(
+                connection,
+                task_id=task_id,
+                event_type="task_pinned" if pinned else "task_unpinned",
+                payload={},
+                created_at=now,
+            )
+        return self.get_task(task_id)
+
+    def delete_task(self, task_id: str) -> bool:
+        with self._lock, self._connect() as connection:
+            row = self._require_task_row(connection, task_id)
+            state = TaskState(row["state"])
+            if state not in TERMINAL_STATES and state not in {TaskState.PAUSED, TaskState.INTERRUPTED}:
+                raise WorkerConflictError(
+                    "Active tasks must be cancelled before deletion.", code="task_active"
+                )
+            return connection.execute(
+                "DELETE FROM worker_tasks WHERE task_id = ?", (task_id,)
+            ).rowcount == 1
+
+    def cleanup_expired(self) -> list[str]:
+        now = self._now()
+        with self._lock, self._connect() as connection:
+            rows = connection.execute(
+                "SELECT task_id FROM worker_tasks WHERE pinned = 0 AND expires_at <= ?",
+                (now,),
+            ).fetchall()
+            task_ids = [str(row["task_id"]) for row in rows]
+            if task_ids:
+                connection.executemany(
+                    "DELETE FROM worker_tasks WHERE task_id = ?",
+                    ((task_id,) for task_id in task_ids),
+                )
+        return task_ids
+
+    def mark_inflight_interrupted(self) -> int:
+        now = self._now()
+        count = 0
+        with self._lock, self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            rows = connection.execute(
+                f"SELECT task_id, state FROM worker_tasks WHERE state IN ({','.join('?' for _ in ACTIVE_ON_RESTART)})",
+                tuple(state.value for state in ACTIVE_ON_RESTART),
+            ).fetchall()
+            for row in rows:
+                task_id = str(row["task_id"])
+                connection.execute(
+                    "UPDATE worker_tasks SET state = ?, reason_ciphertext = ?, updated_at = ? WHERE task_id = ?",
+                    (
+                        TaskState.INTERRUPTED.value,
+                        self._codec.encrypt("server_restart"),
+                        now,
+                        task_id,
+                    ),
+                )
+                self._append_event_locked(
+                    connection,
+                    task_id=task_id,
+                    event_type="task_state",
+                    payload={
+                        "from": str(row["state"]),
+                        "to": TaskState.INTERRUPTED.value,
+                        "reason": "server_restart",
+                    },
+                    created_at=now,
+                )
+                count += 1
+        return count
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self.database_path, timeout=15)
+        connection.row_factory = sqlite3.Row
+        connection.execute("PRAGMA foreign_keys = ON")
+        connection.execute("PRAGMA busy_timeout = 15000")
+        return connection
+
+    def _initialize(self) -> None:
+        with self._lock, self._connect() as connection:
+            connection.execute("PRAGMA journal_mode = WAL")
+            connection.execute("PRAGMA synchronous = FULL")
+            connection.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS worker_tasks (
+                    task_id TEXT PRIMARY KEY,
+                    origin_module TEXT NOT NULL,
+                    origin_object_id TEXT NOT NULL,
+                    client_task_id TEXT NOT NULL,
+                    state TEXT NOT NULL,
+                    spec_ciphertext TEXT NOT NULL,
+                    reason_ciphertext TEXT,
+                    workspace_id TEXT,
+                    provider_session_ciphertext TEXT,
+                    created_at REAL NOT NULL,
+                    updated_at REAL NOT NULL,
+                    expires_at REAL NOT NULL,
+                    pinned INTEGER NOT NULL DEFAULT 0 CHECK (pinned IN (0, 1)),
+                    UNIQUE(origin_module, origin_object_id, client_task_id)
+                );
+                CREATE INDEX IF NOT EXISTS idx_worker_tasks_state
+                    ON worker_tasks(state, created_at);
+                CREATE TABLE IF NOT EXISTS worker_events (
+                    sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+                    task_id TEXT NOT NULL,
+                    type TEXT NOT NULL,
+                    payload_ciphertext TEXT NOT NULL,
+                    created_at REAL NOT NULL,
+                    FOREIGN KEY(task_id) REFERENCES worker_tasks(task_id) ON DELETE CASCADE
+                );
+                CREATE INDEX IF NOT EXISTS idx_worker_events_task
+                    ON worker_events(task_id, sequence);
+                CREATE TABLE IF NOT EXISTS worker_messages (
+                    message_id TEXT PRIMARY KEY,
+                    task_id TEXT NOT NULL,
+                    sequence INTEGER NOT NULL,
+                    role TEXT NOT NULL,
+                    content_ciphertext TEXT NOT NULL,
+                    created_at REAL NOT NULL,
+                    UNIQUE(task_id, sequence),
+                    FOREIGN KEY(task_id) REFERENCES worker_tasks(task_id) ON DELETE CASCADE
+                );
+                """
+            )
+
+    def _task(self, row: sqlite3.Row, connection: sqlite3.Connection) -> TaskRecord:
+        try:
+            spec = TaskSpec.model_validate(self._codec.decrypt(str(row["spec_ciphertext"])))
+            reason = (
+                self._decrypt_string(row["reason_ciphertext"])
+                if row["reason_ciphertext"] is not None
+                else None
+            )
+            provider_session_id = (
+                self._decrypt_string(row["provider_session_ciphertext"])
+                if row["provider_session_ciphertext"] is not None
+                else None
+            )
+        except (WorkerCryptoError, ValueError) as exc:
+            raise WorkerStoreError(
+                "Worker task data is corrupt.", code="worker_data_corrupt"
+            ) from exc
+        last_sequence = int(
+            connection.execute(
+                "SELECT COALESCE(MAX(sequence), 0) FROM worker_events WHERE task_id = ?",
+                (row["task_id"],),
+            ).fetchone()[0]
+        )
+        return TaskRecord(
+            task_id=str(row["task_id"]),
+            spec=spec,
+            state=TaskState(row["state"]),
+            workspace_id=row["workspace_id"],
+            provider_session_id=provider_session_id,
+            created_at=float(row["created_at"]),
+            updated_at=float(row["updated_at"]),
+            expires_at=float(row["expires_at"]),
+            pinned=bool(row["pinned"]),
+            last_event_sequence=last_sequence,
+            reason=reason,
+        )
+
+    def _append_event_locked(
+        self,
+        connection: sqlite3.Connection,
+        *,
+        task_id: str,
+        event_type: str,
+        payload: dict[str, Any],
+        created_at: float,
+    ) -> int:
+        cursor = connection.execute(
+            "INSERT INTO worker_events (task_id, type, payload_ciphertext, created_at) VALUES (?, ?, ?, ?)",
+            (task_id, event_type, self._codec.encrypt(payload), created_at),
+        )
+        return int(cursor.lastrowid)
+
+    @staticmethod
+    def _require_task_row(connection: sqlite3.Connection, task_id: str) -> sqlite3.Row:
+        row = connection.execute(
+            "SELECT * FROM worker_tasks WHERE task_id = ?", (task_id,)
+        ).fetchone()
+        if row is None:
+            raise WorkerNotFoundError("Worker task was not found.", code="task_not_found")
+        return row
+
+    def _decrypt_dict(self, ciphertext: str) -> dict[str, Any]:
+        value = self._codec.decrypt(str(ciphertext))
+        if not isinstance(value, dict):
+            raise WorkerStoreError("Worker event is corrupt.", code="worker_data_corrupt")
+        return value
+
+    def _decrypt_string(self, ciphertext: str) -> str:
+        value = self._codec.decrypt(str(ciphertext))
+        if not isinstance(value, str):
+            raise WorkerStoreError("Worker value is corrupt.", code="worker_data_corrupt")
+        return value
+
+    def _now(self) -> float:
+        value = float(self._clock())
+        if not math.isfinite(value) or value < 0:
+            raise WorkerStoreError("Worker clock is invalid.", code="worker_storage_unavailable")
+        return value

--- a/server/coding_worker/workspace.py
+++ b/server/coding_worker/workspace.py
@@ -1,0 +1,396 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import uuid
+from collections.abc import Mapping, Sequence
+from pathlib import Path, PurePosixPath
+from typing import Protocol
+
+from pydantic import Field
+
+from .contracts import StrictModel, WorkspaceSource
+
+
+SAFE_WORKSPACE_ID = re.compile(r"^workspace_[a-f0-9]{32}$")
+MAX_SOURCE_FILES = 20_000
+MAX_SOURCE_FILE_BYTES = 8 * 1024 * 1024
+MAX_SOURCE_BYTES = 192 * 1024 * 1024
+
+
+class WorkspaceError(RuntimeError):
+    def __init__(self, message: str, *, code: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+class SourceFile(StrictModel):
+    path: str = Field(min_length=1, max_length=1024)
+    content: bytes = Field(max_length=MAX_SOURCE_FILE_BYTES)
+    executable: bool = False
+
+
+class SourceSnapshot(StrictModel):
+    source: WorkspaceSource
+    files: tuple[SourceFile, ...] = Field(max_length=MAX_SOURCE_FILES)
+
+
+class WorkspaceRecord(StrictModel):
+    workspace_id: str
+    source: WorkspaceSource
+    baseline_commit: str = Field(pattern=r"^[a-f0-9]{40}$")
+    baseline_tree_hash: str = Field(pattern=r"^[a-f0-9]{64}$")
+    file_count: int = Field(ge=0)
+    total_bytes: int = Field(ge=0)
+
+
+class WorkspaceEntry(StrictModel):
+    entry_id: str
+    name: str
+    display_path: str
+    kind: str
+    size: int = Field(default=0, ge=0)
+    sha256: str | None = None
+
+
+class WorkspaceSourceAdapter(Protocol):
+    async def acquire(self, source: WorkspaceSource) -> SourceSnapshot: ...
+
+
+class InMemoryWorkspaceSourceAdapter:
+    def __init__(self, snapshots: Mapping[tuple[str, str], Mapping[str, bytes]]) -> None:
+        self._snapshots = snapshots
+
+    async def acquire(self, source: WorkspaceSource) -> SourceSnapshot:
+        files = self._snapshots.get((source.source_id, source.revision))
+        if files is None:
+            raise WorkspaceError("Workspace source was not found.", code="source_not_found")
+        return SourceSnapshot(
+            source=source,
+            files=tuple(SourceFile(path=path, content=content) for path, content in files.items()),
+        )
+
+
+class WorkspaceBroker:
+    """Materializes opaque sources into isolated, remote-free synthetic Git workspaces."""
+
+    def __init__(
+        self,
+        root: Path,
+        adapters: Mapping[str, WorkspaceSourceAdapter],
+        *,
+        id_key: bytes,
+    ) -> None:
+        if len(id_key) < 32:
+            raise ValueError("workspace id key is too short")
+        self.root = Path(root).resolve()
+        self.workspaces_root = self.root / "workspaces"
+        self.staging_root = self.root / "workspace-staging"
+        self._adapters = dict(adapters)
+        self._id_key = bytes(id_key)
+        self.workspaces_root.mkdir(parents=True, exist_ok=True)
+        self.staging_root.mkdir(parents=True, exist_ok=True)
+
+    async def prepare(self, source: WorkspaceSource) -> WorkspaceRecord:
+        adapter = self._adapters.get(source.kind)
+        if adapter is None:
+            raise WorkspaceError("Workspace source kind is unavailable.", code="source_unavailable")
+        snapshot = await adapter.acquire(source)
+        if snapshot.source != source:
+            raise WorkspaceError("Workspace source binding changed.", code="source_changed")
+        normalized = self._validate_snapshot(snapshot.files)
+        workspace_id = f"workspace_{uuid.uuid4().hex}"
+        stage = self.staging_root / workspace_id
+        destination = self.workspaces_root / workspace_id
+        if stage.exists() or destination.exists():
+            raise WorkspaceError("Workspace id collision.", code="workspace_unavailable")
+        repository = stage / "repo"
+        try:
+            repository.mkdir(parents=True)
+            for path, file in normalized:
+                target = repository.joinpath(*path.parts)
+                target.parent.mkdir(parents=True, exist_ok=True)
+                self._write_exclusive(target, file.content)
+                if file.executable and os.name != "nt":
+                    target.chmod(0o700)
+            baseline_commit = self._initialize_git(repository)
+            baseline_tree_hash = self._tree_hash(repository)
+            total_bytes = sum(len(file.content) for _, file in normalized)
+            metadata = WorkspaceRecord(
+                workspace_id=workspace_id,
+                source=source,
+                baseline_commit=baseline_commit,
+                baseline_tree_hash=baseline_tree_hash,
+                file_count=len(normalized),
+                total_bytes=total_bytes,
+            )
+            self._write_exclusive(
+                stage / "metadata.json",
+                json.dumps(
+                    metadata.model_dump(mode="json"),
+                    ensure_ascii=False,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ).encode("utf-8"),
+            )
+            os.replace(stage, destination)
+            return self.get(workspace_id)
+        except WorkspaceError:
+            self._remove_tree(stage)
+            raise
+        except (OSError, subprocess.SubprocessError) as exc:
+            self._remove_tree(stage)
+            raise WorkspaceError(
+                "Workspace could not be prepared.", code="workspace_unavailable"
+            ) from exc
+
+    def get(self, workspace_id: str) -> WorkspaceRecord:
+        root = self._workspace_root(workspace_id)
+        try:
+            value = json.loads((root / "metadata.json").read_text(encoding="utf-8"))
+            record = WorkspaceRecord.model_validate(value)
+        except (OSError, json.JSONDecodeError, ValueError) as exc:
+            raise WorkspaceError("Workspace metadata is invalid.", code="workspace_corrupt") from exc
+        if record.workspace_id != workspace_id or not (root / "repo").is_dir():
+            raise WorkspaceError("Workspace metadata is invalid.", code="workspace_corrupt")
+        return record
+
+    def repository_path(self, workspace_id: str) -> Path:
+        root = self._workspace_root(workspace_id)
+        repository = root / "repo"
+        if not repository.is_dir() or repository.is_symlink():
+            raise WorkspaceError("Workspace repository is invalid.", code="workspace_corrupt")
+        return repository
+
+    def tree(self, workspace_id: str) -> tuple[WorkspaceEntry, ...]:
+        repository = self.repository_path(workspace_id)
+        entries: list[WorkspaceEntry] = []
+        for current, directories, files in os.walk(repository, topdown=True, followlinks=False):
+            current_path = Path(current)
+            if current_path == repository:
+                directories[:] = [name for name in directories if name != ".git"]
+            directories.sort()
+            for name in list(directories):
+                candidate = current_path / name
+                if candidate.is_symlink():
+                    raise WorkspaceError("Workspace contains a link.", code="workspace_changed")
+                relative = candidate.relative_to(repository).as_posix()
+                entries.append(
+                    WorkspaceEntry(
+                        entry_id=self._entry_id(workspace_id, relative),
+                        name=name,
+                        display_path=relative,
+                        kind="directory",
+                    )
+                )
+            for name in files:
+                candidate = current_path / name
+                if candidate.is_symlink():
+                    raise WorkspaceError("Workspace contains a link.", code="workspace_changed")
+                relative = candidate.relative_to(repository).as_posix()
+                content = candidate.read_bytes()
+                entries.append(
+                    WorkspaceEntry(
+                        entry_id=self._entry_id(workspace_id, relative),
+                        name=name,
+                        display_path=relative,
+                        kind="file",
+                        size=len(content),
+                        sha256=hashlib.sha256(content).hexdigest(),
+                    )
+                )
+        return tuple(sorted(entries, key=lambda entry: (entry.display_path, entry.kind)))
+
+    def read_entry(self, workspace_id: str, entry_id: str, *, max_bytes: int = 1024 * 1024) -> bytes:
+        for entry in self.tree(workspace_id):
+            if entry.entry_id == entry_id:
+                if entry.kind != "file" or entry.size > max_bytes:
+                    raise WorkspaceError("Workspace entry is not previewable.", code="preview_unavailable")
+                target = self.repository_path(workspace_id).joinpath(
+                    *PurePosixPath(entry.display_path).parts
+                )
+                return target.read_bytes()
+        raise WorkspaceError("Workspace entry was not found.", code="entry_not_found")
+
+    def current_tree_hash(self, workspace_id: str) -> str:
+        return self._tree_hash(self.repository_path(workspace_id))
+
+    def diff(self, workspace_id: str, *, max_bytes: int = 2 * 1024 * 1024) -> bytes:
+        record = self.get(workspace_id)
+        repository = self.repository_path(workspace_id)
+        temporary_index = repository.parent / f"index-{uuid.uuid4().hex}"
+        try:
+            shutil.copy2(repository / ".git" / "index", temporary_index)
+            env = self._git_env(repository)
+            env["GIT_INDEX_FILE"] = str(temporary_index)
+            self._git(repository, "add", "-A", env=env)
+            result = self._git(
+                repository,
+                "diff",
+                "--cached",
+                "--binary",
+                "--no-ext-diff",
+                record.baseline_commit,
+                "--",
+                env=env,
+                text=False,
+            )
+            if len(result) > max_bytes:
+                raise WorkspaceError("Workspace diff is too large.", code="diff_too_large")
+            return result
+        finally:
+            try:
+                temporary_index.unlink(missing_ok=True)
+            except OSError:
+                pass
+
+    def delete(self, workspace_id: str) -> None:
+        self._remove_tree(self._workspace_root(workspace_id))
+
+    def _workspace_root(self, workspace_id: str) -> Path:
+        if SAFE_WORKSPACE_ID.fullmatch(workspace_id) is None:
+            raise WorkspaceError("Workspace id is invalid.", code="workspace_not_found")
+        candidate = self.workspaces_root / workspace_id
+        if not candidate.is_dir() or candidate.is_symlink():
+            raise WorkspaceError("Workspace was not found.", code="workspace_not_found")
+        return candidate
+
+    @staticmethod
+    def _validate_snapshot(files: Sequence[SourceFile]) -> list[tuple[PurePosixPath, SourceFile]]:
+        if len(files) > MAX_SOURCE_FILES:
+            raise WorkspaceError("Workspace source has too many files.", code="source_too_large")
+        seen: set[str] = set()
+        normalized: list[tuple[PurePosixPath, SourceFile]] = []
+        total = 0
+        for file in files:
+            if "\\" in file.path or "\x00" in file.path:
+                raise WorkspaceError("Workspace path is invalid.", code="source_path_invalid")
+            path = PurePosixPath(file.path)
+            if (
+                path.is_absolute()
+                or not path.parts
+                or any(part in {"", ".", "..", ".git"} for part in path.parts)
+            ):
+                raise WorkspaceError("Workspace path is invalid.", code="source_path_invalid")
+            rendered = path.as_posix()
+            collision = rendered.casefold()
+            if collision in seen:
+                raise WorkspaceError("Workspace paths collide.", code="source_path_conflict")
+            seen.add(collision)
+            total += len(file.content)
+            if total > MAX_SOURCE_BYTES:
+                raise WorkspaceError("Workspace source is too large.", code="source_too_large")
+            normalized.append((path, file))
+        return sorted(normalized, key=lambda item: item[0].as_posix())
+
+    @staticmethod
+    def _write_exclusive(path: Path, content: bytes) -> None:
+        descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+
+    def _initialize_git(self, repository: Path) -> str:
+        env = self._git_env(repository)
+        self._git(repository, "init", "--quiet", "--initial-branch=workspace", env=env)
+        self._git(repository, "config", "user.name", "ModelMirror Coding Worker", env=env)
+        self._git(repository, "config", "user.email", "coding-worker@modelmirror.local", env=env)
+        self._git(repository, "add", "-A", env=env)
+        self._git(
+            repository,
+            "commit",
+            "--quiet",
+            "--allow-empty",
+            "-m",
+            "ModelMirror synthetic baseline H0",
+            env=env,
+        )
+        if self._git(repository, "remote", env=env).strip():
+            raise WorkspaceError("Synthetic workspace has a remote.", code="workspace_unsafe")
+        head = self._git(repository, "rev-parse", "HEAD", env=env).strip()
+        if re.fullmatch(r"[a-f0-9]{40}", head) is None:
+            raise WorkspaceError("Synthetic baseline is invalid.", code="workspace_unavailable")
+        return head
+
+    @staticmethod
+    def _git_env(repository: Path) -> dict[str, str]:
+        allowed = {key: os.environ[key] for key in ("PATH", "SYSTEMROOT", "WINDIR") if key in os.environ}
+        home = repository.parent / "git-home"
+        home.mkdir(exist_ok=True)
+        return {
+            **allowed,
+            "HOME": str(home),
+            "XDG_CONFIG_HOME": str(home / "config"),
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_TERMINAL_PROMPT": "0",
+            "GIT_ASKPASS": "",
+            "GIT_SSH_COMMAND": "false",
+            "GIT_NO_LAZY_FETCH": "1",
+            "GIT_NO_REPLACE_OBJECTS": "1",
+            "LC_ALL": "C.UTF-8",
+        }
+
+    @staticmethod
+    def _git(
+        repository: Path,
+        *args: str,
+        env: dict[str, str],
+        text: bool = True,
+    ) -> str | bytes:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=repository,
+            env=env,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=text,
+            check=False,
+            timeout=60,
+        )
+        if result.returncode != 0:
+            raise WorkspaceError("Git workspace operation failed.", code="workspace_unavailable")
+        return result.stdout
+
+    @staticmethod
+    def _tree_hash(repository: Path) -> str:
+        digest = hashlib.sha256()
+        for current, directories, files in os.walk(repository, topdown=True, followlinks=False):
+            current_path = Path(current)
+            if current_path == repository:
+                directories[:] = [name for name in directories if name != ".git"]
+            directories.sort()
+            for name in directories:
+                if (current_path / name).is_symlink():
+                    raise WorkspaceError("Workspace contains a link.", code="workspace_changed")
+            for name in sorted(files):
+                path = current_path / name
+                if path.is_symlink():
+                    raise WorkspaceError("Workspace contains a link.", code="workspace_changed")
+                relative = path.relative_to(repository).as_posix().encode("utf-8")
+                content = path.read_bytes()
+                digest.update(len(relative).to_bytes(4, "big"))
+                digest.update(relative)
+                digest.update(len(content).to_bytes(8, "big"))
+                digest.update(hashlib.sha256(content).digest())
+        return digest.hexdigest()
+
+    def _entry_id(self, workspace_id: str, relative_path: str) -> str:
+        value = hmac.new(
+            self._id_key,
+            f"{workspace_id}\0{relative_path}".encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()
+        return f"entry_{value[:32]}"
+
+    @staticmethod
+    def _remove_tree(path: Path) -> None:
+        if path.exists():
+            shutil.rmtree(path)

--- a/server/main.py
+++ b/server/main.py
@@ -219,6 +219,11 @@ except ModuleNotFoundError:
     from agent_workspace.api import router as agent_workspace_router
 
 try:
+    from server.coding_worker.api import router as coding_worker_router
+except ModuleNotFoundError:
+    from coding_worker.api import router as coding_worker_router
+
+try:
     from server.plugins.api import router as plugins_router
     from server.plugins.registry import get_plugin_store
     from server.prompts import (
@@ -930,6 +935,7 @@ app.include_router(file_assets_router)
 app.include_router(skills_router)
 app.include_router(skill_creator_router)
 app.include_router(agent_workspace_router)
+app.include_router(coding_worker_router)
 app.include_router(xperts_router)
 app.include_router(xpert_apps_router)
 app.include_router(workflow_native_router)

--- a/server/tests/test_coding_worker_api.py
+++ b/server/tests/test_coding_worker_api.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+from cryptography.fernet import Fernet
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from server.coding_worker.api import configure_coding_worker_for_tests, router
+from server.coding_worker.provider import FakeCodingAgentProvider
+from server.coding_worker.service import CodingWorkerService
+from server.coding_worker.store import CodingWorkerStore
+from server.coding_worker.workspace import InMemoryWorkspaceSourceAdapter, WorkspaceBroker
+
+
+def _payload(client_task_id: str = "api-task-01") -> dict[str, object]:
+    return {
+        "client_task_id": client_task_id,
+        "objective": "Inspect the project and report evidence.",
+        "workspace_source": {
+            "kind": "manifest",
+            "source_id": "source-01",
+            "revision": "revision-01",
+        },
+        "acceptance": {
+            "contract_id": "contract-01",
+            "required_checks": [
+                {"check_id": "pytest", "label": "pytest", "kind": "command"}
+            ],
+        },
+        "policy_profile": "inspect",
+        "model_route": "coding/default",
+    }
+
+
+def _client(tmp_path: Path, *, blocked: bool = False) -> tuple[TestClient, CodingWorkerService]:
+    store = CodingWorkerStore(tmp_path / "worker", master_key=Fernet.generate_key())
+    broker = WorkspaceBroker(
+        tmp_path / "worker",
+        {
+            "manifest": InMemoryWorkspaceSourceAdapter(
+                {("source-01", "revision-01"): {"main.py": b"print('ok')\n"}}
+            )
+        },
+        id_key=b"a" * 32,
+    )
+    provider = FakeCodingAgentProvider(block=asyncio.Event() if blocked else None)
+    service = CodingWorkerService(store=store, workspace_broker=broker, provider=provider)
+    configure_coding_worker_for_tests(service, enabled=True)
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app), service
+
+
+def teardown_function() -> None:
+    configure_coding_worker_for_tests(None, enabled=None)
+
+
+def test_feature_flag_is_default_deny(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CODING_WORKER_V14_ENABLED", raising=False)
+    configure_coding_worker_for_tests(None, enabled=None)
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+    assert client.get("/api/coding-worker/v1").json()["enabled"] is False
+    assert client.post("/api/coding-worker/v1/tasks", json=_payload()).status_code == 404
+
+
+def test_create_is_idempotent_and_server_owns_origin(tmp_path: Path) -> None:
+    client, _service = _client(tmp_path)
+    with client:
+        first = client.post("/api/coding-worker/v1/tasks", json=_payload())
+        second = client.post("/api/coding-worker/v1/tasks", json=_payload())
+    assert first.status_code == 202
+    assert second.status_code == 202
+    assert first.json()["task_id"] == second.json()["task_id"]
+    assert first.json()["spec"]["origin"] == {
+        "module": "worker-console",
+        "object_id": "local-user",
+    }
+
+    forged = _payload("forged")
+    forged["origin"] = {"module": "evil", "object_id": "evil"}
+    assert client.post("/api/coding-worker/v1/tasks", json=forged).status_code == 422
+
+
+def test_model_route_is_catalog_controlled(tmp_path: Path) -> None:
+    client, _service = _client(tmp_path)
+    payload = _payload()
+    payload["model_route"] = "vendor/raw-model"
+    response = client.post("/api/coding-worker/v1/tasks", json=payload)
+    assert response.status_code == 400
+    assert response.json()["detail"]["code"] == "model_route_not_allowed"
+
+
+def test_workspace_endpoints_use_task_and_opaque_entry_ids(tmp_path: Path) -> None:
+    client, service = _client(tmp_path)
+    with client:
+        created = client.post("/api/coding-worker/v1/tasks", json=_payload()).json()
+        task_id = created["task_id"]
+        terminal = asyncio.run(
+            service.wait_for(task_id, lambda item: item.state.value == "blocked")
+        )
+        assert terminal.workspace_id
+        tree = client.get(f"/api/coding-worker/v1/tasks/{task_id}/workspace/tree")
+        assert tree.status_code == 200
+        entry = next(item for item in tree.json()["entries"] if item["kind"] == "file")
+        assert entry["entry_id"].startswith("entry_")
+        assert "C:" not in entry["entry_id"] and "/tmp/" not in entry["entry_id"]
+        preview = client.get(
+            f"/api/coding-worker/v1/tasks/{task_id}/workspace/entries/{entry['entry_id']}"
+        )
+        assert preview.text == "print('ok')\n"
+        diff = client.get(f"/api/coding-worker/v1/tasks/{task_id}/workspace/diff")
+        assert diff.status_code == 200 and diff.content == b""
+
+
+def test_pin_unpin_and_delete_keep_active_task_safe(tmp_path: Path) -> None:
+    client, _service = _client(tmp_path, blocked=True)
+    with client:
+        task = client.post("/api/coding-worker/v1/tasks", json=_payload()).json()
+        task_id = task["task_id"]
+        assert client.post(f"/api/coding-worker/v1/tasks/{task_id}/pin").json()["pinned"]
+        assert not client.delete(f"/api/coding-worker/v1/tasks/{task_id}/pin").json()["pinned"]
+        assert client.delete(f"/api/coding-worker/v1/tasks/{task_id}").status_code == 409
+        assert client.post(f"/api/coding-worker/v1/tasks/{task_id}/cancel").status_code == 200
+        assert client.delete(f"/api/coding-worker/v1/tasks/{task_id}").status_code == 204

--- a/server/tests/test_coding_worker_contracts.py
+++ b/server/tests/test_coding_worker_contracts.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from pydantic import ValidationError
+
+from server.coding_worker.contracts import (
+    AcceptanceCheck,
+    AcceptanceContract,
+    Origin,
+    TaskCreateRequest,
+    TaskSpec,
+    TaskState,
+    WorkspaceSource,
+    require_transition,
+)
+from server.coding_worker.provider import (
+    FakeCodingAgentProvider,
+    ProviderEventKind,
+    ProviderOpenRequest,
+)
+
+
+def _request(**overrides: object) -> TaskCreateRequest:
+    values: dict[str, object] = {
+        "client_task_id": "client-task-01",
+        "objective": "Fix the failing tests and provide evidence.",
+        "workspace_source": WorkspaceSource(
+            kind="manifest", source_id="local-abc", revision="rev-01"
+        ),
+        "acceptance": AcceptanceContract(
+            contract_id="python-test-contract",
+            required_checks=(
+                AcceptanceCheck(
+                    check_id="pytest", label="Python tests", kind="command"
+                ),
+            ),
+        ),
+        "model_route": "coding/default",
+    }
+    values.update(overrides)
+    return TaskCreateRequest.model_validate(values)
+
+
+def test_public_task_request_cannot_supply_origin_or_execution_details() -> None:
+    payload = _request().model_dump()
+    payload["origin"] = {"module": "skill", "object_id": "forged"}
+    with pytest.raises(ValidationError, match="origin"):
+        TaskCreateRequest.model_validate(payload)
+
+    for field, value in (
+        ("physical_path", "C:/secret"),
+        ("environment", {"TOKEN": "secret"}),
+        ("provider", "opencode"),
+        ("remote_url", "https://example.invalid/repo.git"),
+    ):
+        candidate = _request().model_dump()
+        candidate[field] = value
+        with pytest.raises(ValidationError, match=field):
+            TaskCreateRequest.model_validate(candidate)
+
+
+def test_acceptance_contract_is_frozen_and_cannot_be_empty() -> None:
+    contract = _request().acceptance
+    with pytest.raises(ValidationError):
+        contract.required_checks = ()  # type: ignore[misc]
+    with pytest.raises(ValidationError):
+        AcceptanceContract(contract_id="empty", required_checks=())
+
+
+def test_task_state_machine_rejects_completion_without_testing() -> None:
+    with pytest.raises(ValueError, match="invalid task transition"):
+        require_transition(TaskState.RUNNING, TaskState.COMPLETED)
+    require_transition(TaskState.RUNNING, TaskState.TESTING)
+    require_transition(TaskState.TESTING, TaskState.COMPLETED)
+
+
+@pytest.mark.asyncio
+async def test_fake_provider_implements_neutral_open_stream_checkpoint_and_cancel() -> None:
+    request = _request()
+    spec = TaskSpec(**request.model_dump(), origin=Origin(module="console", object_id="user"))
+    provider = FakeCodingAgentProvider()
+    session = await provider.open(
+        ProviderOpenRequest(
+            task_id="task-01",
+            workspace_id="workspace-01",
+            objective=spec.objective,
+            model_route=spec.model_route,
+            policy_profile=spec.policy_profile,
+            budget=spec.budget,
+        )
+    )
+    events = [event async for event in provider.message(session, spec.objective)]
+    assert [event.kind for event in events][-1] is ProviderEventKind.TURN_COMPLETED
+    checkpoint = await provider.checkpoint(session)
+    restored = await provider.restore(
+        ProviderOpenRequest(
+            task_id="task-01",
+            workspace_id="workspace-01",
+            objective=spec.objective,
+            model_route=spec.model_route,
+            policy_profile=spec.policy_profile,
+            budget=spec.budget,
+        ),
+        checkpoint,
+    )
+    assert restored.task_id == session.task_id
+
+    blocker = asyncio.Event()
+    blocking = FakeCodingAgentProvider(block=blocker)
+    blocking_session = await blocking.open(
+        ProviderOpenRequest(
+            task_id="task-02",
+            workspace_id="workspace-02",
+            objective="Wait",
+            model_route="coding/default",
+            policy_profile="inspect",
+            budget=spec.budget,
+        )
+    )
+    assert await blocking.cancel(blocking_session) is True
+    blocker.set()
+    cancelled = [event async for event in blocking.message(blocking_session, "Wait")]
+    assert cancelled[-1].kind is ProviderEventKind.CANCELLED

--- a/server/tests/test_coding_worker_service.py
+++ b/server/tests/test_coding_worker_service.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+from cryptography.fernet import Fernet
+
+from server.coding_worker.contracts import (
+    AcceptanceCheck,
+    AcceptanceContract,
+    Origin,
+    TaskCreateRequest,
+    TaskState,
+    WorkspaceSource,
+)
+from server.coding_worker.provider import FakeCodingAgentProvider
+from server.coding_worker.service import CodingWorkerService
+from server.coding_worker.store import CodingWorkerStore
+from server.coding_worker.workspace import InMemoryWorkspaceSourceAdapter, WorkspaceBroker
+
+
+def _request(client_task_id: str) -> TaskCreateRequest:
+    return TaskCreateRequest(
+        client_task_id=client_task_id,
+        objective=f"Complete {client_task_id}",
+        workspace_source=WorkspaceSource(
+            kind="manifest", source_id="source-01", revision="revision-01"
+        ),
+        acceptance=AcceptanceContract(
+            contract_id="contract-01",
+            required_checks=(
+                AcceptanceCheck(check_id="pytest", label="pytest", kind="command"),
+            ),
+        ),
+        model_route="coding/default",
+    )
+
+
+def _service(tmp_path: Path, provider: FakeCodingAgentProvider) -> CodingWorkerService:
+    store = CodingWorkerStore(tmp_path / "worker", master_key=Fernet.generate_key())
+    adapter = InMemoryWorkspaceSourceAdapter(
+        {("source-01", "revision-01"): {"main.py": b"print('ok')\n"}}
+    )
+    broker = WorkspaceBroker(
+        tmp_path / "worker", {"manifest": adapter}, id_key=b"s" * 32
+    )
+    return CodingWorkerService(store=store, workspace_broker=broker, provider=provider)
+
+
+@pytest.mark.asyncio
+async def test_two_tasks_run_and_third_is_durably_queued(tmp_path: Path) -> None:
+    blocker = asyncio.Event()
+    service = _service(tmp_path, FakeCodingAgentProvider(block=blocker))
+    origin = Origin(module="test", object_id="parallel")
+    tasks = [await service.create_task(origin, _request(f"task-{index}")) for index in range(3)]
+
+    for task in tasks[:2]:
+        await service.wait_for(task.task_id, lambda item: item.state is TaskState.RUNNING)
+    third = service.store.get_task(tasks[2].task_id)
+    assert third.state is TaskState.QUEUED
+    assert service.active_task_ids == frozenset(task.task_id for task in tasks[:2])
+
+    await service.cancel(tasks[0].task_id)
+    assert service.store.get_task(tasks[0].task_id).state is TaskState.CANCELLED
+    assert service.store.get_task(tasks[1].task_id).state is TaskState.RUNNING
+    await service.wait_for(tasks[2].task_id, lambda item: item.state is TaskState.RUNNING)
+
+    blocker.set()
+    for task in tasks[1:]:
+        terminal = await service.wait_for(
+            task.task_id, lambda item: item.state is TaskState.BLOCKED
+        )
+        assert terminal.reason == "acceptance_runner_pending"
+    await service.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_model_stop_cannot_complete_without_acceptance_runner(tmp_path: Path) -> None:
+    service = _service(tmp_path, FakeCodingAgentProvider())
+    task = await service.create_task(Origin(module="test", object_id="acceptance"), _request("one"))
+    terminal = await service.wait_for(task.task_id, lambda item: item.state is TaskState.BLOCKED)
+    assert terminal.state is not TaskState.COMPLETED
+    assert [event.type for event in service.store.list_events(task.task_id)].count("task_state") >= 3
+    await service.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_interrupts_without_replaying_and_resume_is_explicit(tmp_path: Path) -> None:
+    blocker = asyncio.Event()
+    service = _service(tmp_path, FakeCodingAgentProvider(block=blocker))
+    task = await service.create_task(Origin(module="test", object_id="restart"), _request("one"))
+    await service.wait_for(task.task_id, lambda item: item.state is TaskState.RUNNING)
+    workspace_id = service.store.get_task(task.task_id).workspace_id
+    await service.shutdown()
+    interrupted = service.store.get_task(task.task_id)
+    assert interrupted.state is TaskState.INTERRUPTED
+    assert interrupted.workspace_id == workspace_id
+
+    resumed = await service.resume(task.task_id)
+    assert resumed.state is TaskState.QUEUED
+    await service.wait_for(task.task_id, lambda item: item.state is TaskState.RUNNING)
+    assert service.store.get_task(task.task_id).workspace_id == workspace_id
+    await service.cancel(task.task_id)
+    await service.shutdown()

--- a/server/tests/test_coding_worker_store.py
+++ b/server/tests/test_coding_worker_store.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+from cryptography.fernet import Fernet
+
+from server.coding_worker.contracts import (
+    AcceptanceCheck,
+    AcceptanceContract,
+    Origin,
+    TaskSpec,
+    TaskState,
+    WorkspaceSource,
+)
+from server.coding_worker.crypto import WorkerCryptoError
+from server.coding_worker.store import CodingWorkerStore, WorkerConflictError
+
+
+def _spec(*, objective: str = "Secret objective", client_task_id: str = "client-01") -> TaskSpec:
+    return TaskSpec(
+        client_task_id=client_task_id,
+        origin=Origin(module="test-module", object_id="object-01"),
+        objective=objective,
+        workspace_source=WorkspaceSource(
+            kind="manifest", source_id="source-01", revision="head-01"
+        ),
+        acceptance=AcceptanceContract(
+            contract_id="contract-01",
+            required_checks=(
+                AcceptanceCheck(check_id="pytest", label="pytest", kind="command"),
+            ),
+        ),
+        model_route="coding/default",
+    )
+
+
+def test_task_intent_events_and_messages_are_encrypted_and_survive_restart(tmp_path: Path) -> None:
+    root = tmp_path / "worker"
+    key = Fernet.generate_key()
+    store = CodingWorkerStore(root, master_key=key)
+    task = store.create_task(_spec())
+    same = store.create_task(_spec())
+    assert same.task_id == task.task_id
+
+    store.append_message(task.task_id, role="user", content="private user message")
+    first = store.append_event(task.task_id, "plan", {"summary": "private plan"})
+    second = store.append_event(task.task_id, "tool_summary", {"tool": "read"})
+
+    restarted = CodingWorkerStore(root, master_key=key)
+    loaded = restarted.get_task(task.task_id)
+    assert loaded.spec.objective == "Secret objective"
+    assert restarted.list_messages(task.task_id)[0].content == "private user message"
+    assert [event.type for event in restarted.list_events(task.task_id, after=first.sequence)] == [
+        second.type
+    ]
+
+    raw = store.database_path.read_bytes()
+    assert b"Secret objective" not in raw
+    assert b"private user message" not in raw
+    assert b"private plan" not in raw
+
+
+def test_idempotency_key_rejects_changed_intent(tmp_path: Path) -> None:
+    store = CodingWorkerStore(tmp_path / "worker", master_key=Fernet.generate_key())
+    store.create_task(_spec())
+    with pytest.raises(WorkerConflictError) as raised:
+        store.create_task(_spec(objective="Different"))
+    assert raised.value.code == "task_intent_conflict"
+
+
+def test_restart_interrupts_inflight_without_replaying_it(tmp_path: Path) -> None:
+    root = tmp_path / "worker"
+    key = Fernet.generate_key()
+    store = CodingWorkerStore(root, master_key=key)
+    task = store.create_task(_spec())
+    store.transition(task.task_id, TaskState.PREPARING)
+    store.transition(task.task_id, TaskState.RUNNING, provider_session_id="provider-01")
+
+    restarted = CodingWorkerStore(root, master_key=key)
+    interrupted = restarted.get_task(task.task_id)
+    assert interrupted.state is TaskState.INTERRUPTED
+    assert interrupted.reason == "server_restart"
+    assert interrupted.provider_session_id == "provider-01"
+    assert [event.payload.get("reason") for event in restarted.list_events(task.task_id)][-1] == (
+        "server_restart"
+    )
+
+
+def test_pin_retention_cleanup_and_immediate_delete(tmp_path: Path) -> None:
+    now = [100.0]
+    store = CodingWorkerStore(
+        tmp_path / "worker",
+        retention_seconds=60,
+        clock=lambda: now[0],
+        master_key=Fernet.generate_key(),
+    )
+    pinned = store.create_task(_spec(client_task_id="pinned"))
+    disposable = store.create_task(_spec(client_task_id="disposable"))
+    store.set_pinned(pinned.task_id, True)
+    store.transition(disposable.task_id, TaskState.CANCELLED)
+    now[0] = 161.0
+    assert store.cleanup_expired() == [disposable.task_id]
+    assert store.get_task(pinned.task_id).pinned is True
+    store.transition(pinned.task_id, TaskState.CANCELLED)
+    assert store.delete_task(pinned.task_id) is True
+
+
+def test_existing_database_without_key_fails_closed(tmp_path: Path) -> None:
+    root = tmp_path / "worker"
+    store = CodingWorkerStore(root, master_key=Fernet.generate_key())
+    store.create_task(_spec())
+    with pytest.raises(WorkerCryptoError) as raised:
+        CodingWorkerStore(root)
+    assert raised.value.code == "worker_key_missing"
+
+
+def test_ciphertext_tampering_is_rejected(tmp_path: Path) -> None:
+    root = tmp_path / "worker"
+    key = Fernet.generate_key()
+    store = CodingWorkerStore(root, master_key=key)
+    task = store.create_task(_spec())
+    with sqlite3.connect(store.database_path) as connection:
+        connection.execute(
+            "UPDATE worker_tasks SET spec_ciphertext = 'invalid' WHERE task_id = ?",
+            (task.task_id,),
+        )
+    with pytest.raises(Exception, match="corrupt"):
+        store.get_task(task.task_id)

--- a/server/tests/test_coding_worker_workspace.py
+++ b/server/tests/test_coding_worker_workspace.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from server.coding_worker.contracts import WorkspaceSource
+from server.coding_worker.workspace import (
+    InMemoryWorkspaceSourceAdapter,
+    SourceFile,
+    SourceSnapshot,
+    WorkspaceBroker,
+    WorkspaceError,
+    WorkspaceSourceAdapter,
+)
+
+
+def _source(kind: str = "manifest") -> WorkspaceSource:
+    return WorkspaceSource(kind=kind, source_id="source-01", revision="revision-01")  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_workspace_builds_remote_free_h0_and_preserves_binary_files(tmp_path: Path) -> None:
+    source = _source()
+    broker = WorkspaceBroker(
+        tmp_path / "worker",
+        {
+            "manifest": InMemoryWorkspaceSourceAdapter(
+                {
+                    (source.source_id, source.revision): {
+                        "src/main.py": b"print('ok')\n",
+                        "assets/pixel.bin": b"\x00\xff\x10",
+                    }
+                }
+            )
+        },
+        id_key=b"w" * 32,
+    )
+    record = await broker.prepare(source)
+    assert record.file_count == 2
+    assert len(record.baseline_commit) == 40
+    assert record.baseline_tree_hash == broker.current_tree_hash(record.workspace_id)
+    repository = broker.repository_path(record.workspace_id)
+    assert not (repository / ".git" / "config").read_text().count("remote ")
+    assert (repository / "assets" / "pixel.bin").read_bytes() == b"\x00\xff\x10"
+
+    files = [entry for entry in broker.tree(record.workspace_id) if entry.kind == "file"]
+    main = next(entry for entry in files if entry.name == "main.py")
+    assert broker.read_entry(record.workspace_id, main.entry_id) == b"print('ok')\n"
+    assert str(repository) not in main.entry_id
+
+
+@pytest.mark.asyncio
+async def test_all_three_opaque_source_kinds_use_the_same_isolation_contract(tmp_path: Path) -> None:
+    adapters: dict[str, WorkspaceSourceAdapter] = {}
+    for kind in ("builtin", "manifest", "host_snapshot"):
+        source = _source(kind)
+        adapters[kind] = InMemoryWorkspaceSourceAdapter(
+            {(source.source_id, source.revision): {f"{kind}.txt": kind.encode()}}
+        )
+    broker = WorkspaceBroker(tmp_path / "worker", adapters, id_key=b"i" * 32)
+    records = [await broker.prepare(_source(kind)) for kind in adapters]
+    assert len({record.workspace_id for record in records}) == 3
+    assert all(not (broker.repository_path(record.workspace_id) / ".git" / "refs" / "remotes").exists() for record in records)
+
+
+class UnsafeAdapter:
+    def __init__(self, source: WorkspaceSource, files: tuple[SourceFile, ...]) -> None:
+        self.source = source
+        self.files = files
+
+    async def acquire(self, source: WorkspaceSource) -> SourceSnapshot:
+        return SourceSnapshot(source=self.source, files=self.files)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", ("../secret", "/absolute", ".git/config", "a\\b"))
+async def test_workspace_rejects_traversal_and_git_metadata(tmp_path: Path, path: str) -> None:
+    source = _source()
+    broker = WorkspaceBroker(
+        tmp_path / "worker",
+        {"manifest": UnsafeAdapter(source, (SourceFile(path=path, content=b"x"),))},
+        id_key=b"p" * 32,
+    )
+    with pytest.raises(WorkspaceError) as raised:
+        await broker.prepare(source)
+    assert raised.value.code == "source_path_invalid"
+    assert not any((tmp_path / "worker" / "workspaces").iterdir())
+
+
+@pytest.mark.asyncio
+async def test_workspace_tree_detects_links_and_diff_uses_private_index(tmp_path: Path) -> None:
+    source = _source()
+    broker = WorkspaceBroker(
+        tmp_path / "worker",
+        {
+            "manifest": InMemoryWorkspaceSourceAdapter(
+                {(source.source_id, source.revision): {"tracked.txt": b"old\n"}}
+            )
+        },
+        id_key=b"d" * 32,
+    )
+    record = await broker.prepare(source)
+    repository = broker.repository_path(record.workspace_id)
+    original_index = (repository / ".git" / "index").read_bytes()
+    (repository / "tracked.txt").write_bytes(b"new\n")
+    (repository / "new.bin").write_bytes(b"\x00\x01")
+    diff = broker.diff(record.workspace_id)
+    assert b"tracked.txt" in diff and b"new.bin" in diff
+    assert (repository / ".git" / "index").read_bytes() == original_index
+
+    if os.name != "nt":
+        (repository / "unsafe-link").symlink_to(repository / "tracked.txt")
+        with pytest.raises(WorkspaceError, match="link"):
+            broker.tree(record.workspace_id)


### PR DESCRIPTION
## What changed

- add provider-neutral V14 task, state, acceptance, lease, event and Provider contracts
- add encrypted SQLite persistence with idempotent task creation, replayable events, messages, retention, pin and restart interruption
- add remote-free synthetic Git H0 workspaces for builtin, manifest and host snapshot source adapters, including binary preservation and opaque entry IDs
- add a persistent two-slot scheduler: two tasks run, the third queues, and cancellation stays task-scoped
- expose the feature-flagged `/api/coding-worker/v1` kernel API for task lifecycle and workspace tree/preview/diff
- document the V14 threat model, completion rule and rollback boundary

## Why

ModelMirror currently has separate Agent Workspace and Coding Runtime state machines. V14 starts the convergence on a platform-level Coding Worker that downstream modules can call through a stable, provider-neutral contract without receiving filesystem paths, credentials, provider identifiers or raw execution endpoints.

This PR is deliberately the Kernel slice. It uses Fake Provider contract tests and refuses to report completion after the model stops; tasks remain blocked until the independent Acceptance Runner lands in the sequential Execution PR.

## Safety and compatibility

- `CODING_WORKER_V14_ENABLED=false` by default
- no existing Agent Workspace or Coding session is migrated
- no host repository runs the agent; v13 remains the only host writeback surface
- no dependency or lockfile changes
- each implementation commit changes at most five files
- if V14 is enabled before a real provider is configured, task execution returns unavailable rather than falling back to Fake execution

## Validation

- V14: `25 passed`
- Agent Workspace: `44 passed`
- Coding: `644 passed, 9 skipped` (Windows-native gates skipped in Linux container)
- backend full suite on this branch: `2057 passed, 21 skipped, 1 failed`
  - the one failure is the pre-existing `test_skill_finder.py::test_python_and_typescript_matcher_keep_the_same_golden_order`
  - reproduced unchanged on detached `origin/main=df4a4b5`; backend image Node 20 reports `ERR_UNKNOWN_FILE_EXTENSION` when importing `skillNeedMatcher.ts`
- frontend: `28 files / 131 tests passed`
- frontend production build: passed
- Python `py_compile`: passed
- Docker Compose base Coding profiles `config --quiet`: passed
- `git diff --check`, dependency-surface, forbidden-artifact and added-secret scans: passed

## Follow-up sequence

PR B will add the real OpenCode provider, Tool Broker, approvals/leases, Acceptance Runner, Evidence Ledger and deterministic recovery. PR C will add module SDK bridges and the shared Worker Console. This PR should remain draft until its stacked follow-ups and final human acceptance are complete.
