### PR TITLE
feature: 完成第八九批 MCP 适配与 Registry 隔离运行时

### DIFF
--- a/client/src/data/mcpAdaptationPlan.ts
+++ b/client/src/data/mcpAdaptationPlan.ts
@@ -268,6 +268,7 @@ export const mcpIsolationLabels: Record<string, string> = {
   "sealed-database-input-read-only,no-artifact-write":
     "封存数据库输入只读；不允许写入原文件或生成旁路产物",
   "allowlist:api.supabase.com,supabase.com": "仅允许 Supabase 官方 API 域名",
+  "allowlist:registry.terraform.io": "仅允许匿名访问 registry.terraform.io",
   "blocked:no-production-runtime": "已阻断：没有生产级运行时",
   "browser-egress:validated-public-http-https":
     "仅允许 DNS 固定后的公网 HTTP/HTTPS 目标（80/443 端口）；跨 origin 请求与重定向拒绝",
@@ -276,6 +277,8 @@ export const mcpIsolationLabels: Record<string, string> = {
   "browser-artifacts:screenshot-only": "仅允许生成受控截图产物",
   "blocked:unmaintained-browser-runtime": "已阻断：上游浏览器运行时已归档",
   "blocked:license-runtime-contract": "已阻断：许可证与运行时契约尚未厘清",
+  "blocked:credential-egress-not-approved": "已阻断：未批准账号凭据出站",
+  "blocked:unreconciled-provider-cost": "已阻断：供应商费用尚无逐项目对账与硬上限",
 };
 
 export function formatMcpCapability(capability: string) {
@@ -426,7 +429,7 @@ const waveMetadata: Record<
     connectionKind: "sandboxed-stdio",
     risk: "critical",
     requiredCapabilities: ["一次性代码沙箱", "进程资源上限"],
-    limitations: ["等待断网、无宿主挂载的一次性代码执行沙箱验证。"],
+    limitations: ["两个上游均未通过安全与发布物门槛，当前不提供代码执行运行时。"],
   },
   9: {
     connectionKind: "sandboxed-stdio",
@@ -577,6 +580,81 @@ const waveSevenBlockedDetails: Record<string, string[]> = {
   ],
 };
 
+const waveEightBlockedDetails: Record<string, string[]> = {
+  "mcp-run-python": [
+    "固定核验上游 0.0.22。维护方已归档项目，并明确说明 Pyodide 代码可执行任意 JavaScript、污染后续调用、访问运行时文件且无法可靠限制内存。",
+    "连接、依赖安装、Deno/Pyodide 和代码提交入口全部关闭；不会以实验性的 Monty 或自研执行器冒充该上游。",
+  ],
+  "python-interpreter": [
+    "固定核验 PyPI 1.2.3。默认 inline 模式会在 MCP Server 进程内执行代码并保留会话，同时开放 pip 安装、文件读写、环境选择和最长 300 秒的子进程执行。",
+    "发布 wheel 声明 MIT classifier，但携带的 LICENSE 文件为空；许可证正文、一次性容器和固定 subprocess-only 契约完成前不开放任何执行或文件入口。",
+  ],
+};
+
+const waveNineReadyIds = new Set(["terraform-mcp"]);
+
+const waveNineReadyDetails: Record<string, string[]> = {
+  "terraform-mcp": [
+    "固定为 Terraform MCP 1.2.0 公共 Registry 只读兼容契约，仅开放 Provider 版本、能力、文档与 Module 搜索、详情、最新版本六项工具。",
+    "独立 mcp-registry sidecar 仅连接 registry.terraform.io；不接收 Token，不读取 Terraform 工作区、状态文件、变量或本机配置。HCP/TFE、私有 Registry、plan、apply、destroy 与资源变更工具全部关闭。",
+  ],
+};
+
+const waveNineBlockedDetails: Record<string, string[]> = {
+  "apify-mcp": [
+    "固定上游仍要求 Apify Token，Actor 运行与动态工具会产生外部费用；本批未批准向 Apify 发送账号凭据。",
+    "Token、OAuth、Actor 运行、数据集与动态工具全部关闭；需单独批准凭据出站并建立逐项目费用上限后再评估。",
+  ],
+  "aiven-mcp": [
+    "上游可收窄为只读 scope，但仍需向 Aiven 发送项目账号 Token，并可读取项目、服务、VPC 与套餐元数据。",
+    "本批未批准账号凭据出站，配置、连接和工具入口全部关闭。",
+  ],
+  "bright-data-mcp": [
+    "基础抓取和 Pro 工具均消耗供应商额度，当前没有可与账单对账的逐项目硬预算。",
+    "Token、连接与抓取入口全部关闭；免费额度不替代费用护栏。",
+  ],
+  "browserbase-mcp": [
+    "官方仓库已归档，托管浏览器会话还会持续消耗外部资源，无法锁定维护中的生产契约。",
+    "连接、项目密钥与云浏览器入口全部关闭；浏览器能力使用第七批一次性本地适配器。",
+  ],
+  "e2b-mcp": [
+    "官方 MCP 仓库已归档；云沙箱默认允许联网、任意安装与命令执行，并在存活期间计费。",
+    "API Key、代码、依赖安装和云沙箱创建入口全部关闭。",
+  ],
+  "stripe-mcp": [
+    "当前官方 MCP 已迁移到 mcp.stripe.com 的 OAuth 远程服务，支付、退款与订阅写入具有真实资金影响。",
+    "转入第十批处理 OAuth scope、解绑和终止性金融操作审批；本批不开放登录或 API Key。",
+  ],
+  "alpaca-mcp": [
+    "官方 v2 同时暴露真实交易、平仓与期权能力，市场数据订阅也可能产生费用；paper 默认值不能证明凭据属于模拟账户。",
+    "API Key、行情、账户和订单工具全部关闭，等待账户类型证明、费用上限与金融终止操作审批。",
+  ],
+  "aws-kb-mcp": [
+    "Bedrock Knowledge Bases 检索依赖 AWS 身份、区域与知识库范围，可能产生查询费用并返回企业敏感内容。",
+    "AWS 凭据、Knowledge Base ID 与检索入口全部关闭，等待 SigV4 代理、资源白名单与 usage 对账。",
+  ],
+  "elevenlabs-mcp": [
+    "语音与音效生成会消耗外部额度并产生媒体产物，部分工具还管理持久 Voice 资源。",
+    "API Key、生成、克隆、播放、下载和删除入口全部关闭，等待费用与产物隔离。",
+  ],
+  "minimax-mcp": [
+    "官方工具会发起付费语音、图像、视频、音乐与 Voice Clone 任务，并接受本地文件或 URL。",
+    "API Key、生成、轮询、文件与产物入口全部关闭，等待价格锁定、异步账本与媒体隔离。",
+  ],
+  "s3-mcp": [
+    "S3 Tables Server 包含 Namespace 与 Table 的创建、更新和删除能力，并依赖 AWS 凭据与资源级 IAM。",
+    "AWS 凭据、资源 ARN 与工具入口全部关闭，等待固定只读工具集和 SigV4 资源白名单。",
+  ],
+  "kubernetes-mcp": [
+    "即使禁用 destructive，仍需 kubeconfig/ServiceAccount、集群网络和 namespace 级 RBAC；日志与资源可能包含敏感数据。",
+    "Kubeconfig、集群连接、exec、日志与资源入口全部关闭，等待只读 RBAC 实测与固定 namespace 绑定。",
+  ],
+  "semgrep-mcp": [
+    "官方仓库已归档，扫描需要读取项目源码并启动本地 Semgrep 运行时，不能形成维护中的文件与执行契约。",
+    "源码目录、Token、CLI 与扫描入口全部关闭。",
+  ],
+};
+
 function buildAdaptationPlan() {
   const records: Record<string, McpAdaptationRecord> = {};
   for (const projectId of localStdioIds) {
@@ -611,6 +689,12 @@ function buildAdaptationPlan() {
               ? waveSevenReadyIds.has(projectId)
                 ? "ready"
                 : "blocked"
+            : wave === 8
+              ? "blocked"
+            : wave === 9
+              ? waveNineReadyIds.has(projectId)
+                ? "ready"
+                : "blocked"
             : wave <= 4
               ? "ready"
               : "planned",
@@ -625,7 +709,9 @@ function buildAdaptationPlan() {
           projectId === "graphiti-mcp" ||
           projectId === "hindsight-mcp"
             ? "critical"
-            : metadata.risk,
+            : projectId === "terraform-mcp"
+              ? "medium"
+              : metadata.risk,
         requiredCapabilities:
           projectId === "bibigpt-mcp"
             ? ["OAuth PKCE", "授权撤销与解绑", "最小 Scope 审核"]
@@ -639,6 +725,8 @@ function buildAdaptationPlan() {
               ? ["维护中的固定上游契约", "数据库只读策略", "查询超时与结果限制"]
             : projectId === "cognee-mcp" || projectId === "graphiti-mcp" || projectId === "hindsight-mcp"
               ? ["状态化记忆运行时", "模型与向量服务隔离", "持久写入审批与数据保留"]
+            : projectId === "terraform-mcp"
+              ? ["固定服务出口域名", "只读工具策略", "Schema 漂移恢复", "进程资源限制"]
             : [...metadata.requiredCapabilities],
         limitations:
           projectId === "bibigpt-mcp"
@@ -682,6 +770,12 @@ function buildAdaptationPlan() {
                   ...waveSevenReadyDetails[projectId],
                   ...metadata.limitations,
                 ]
+            : waveEightBlockedDetails[projectId]
+              ? [...waveEightBlockedDetails[projectId]]
+            : waveNineBlockedDetails[projectId]
+              ? [...waveNineBlockedDetails[projectId]]
+            : waveNineReadyDetails[projectId]
+              ? [...waveNineReadyDetails[projectId]]
             : [...metadata.limitations],
       };
     }

--- a/client/src/data/mcpProjects.ts
+++ b/client/src/data/mcpProjects.ts
@@ -225,9 +225,9 @@ const originalMcpProjectSeeds: McpProjectSeed[] = [
     repoUrl: "https://github.com/yzfly/mcp-python-interpreter",
     category: "开发与代码",
     description:
-      "在指定工作目录和 Python 环境中执行代码、管理包并读写文件，适合数据分析和开发任务。",
+      "上游提供 Python 执行、包管理、文件读写和持久会话；这些能力尚未形成可安全部署的固定沙箱契约。",
     readmeSummary:
-      "项目要求显式指定工作目录，并提供文件大小限制和路径隔离；同时具备代码执行能力，使用前应审查权限。",
+      "PyPI 1.2.3 默认在 MCP Server 进程内执行代码，并开放 pip、文件和环境选择；发布 wheel 的 LICENSE 文件为空，因此保持阻断。",
     stars: 0,
     language: "Python",
     verifiedAt: "2026-08-02",
@@ -235,8 +235,8 @@ const originalMcpProjectSeeds: McpProjectSeed[] = [
     installCommand:
       "pip install mcp-python-interpreter\nuvx mcp-python-interpreter --dir <sandbox> --python-path <python>",
     installNote:
-      "需要 uv/uvx 和显式 Python 路径。模镜后端尚未提供该安装链路，因此不开放一键连接。",
-    tags: ["代码执行", "Python 环境", "目录隔离"],
+      "不会安装或运行该发布物；待许可证正文、一次性容器和固定 subprocess-only 契约全部通过后再评估。",
+    tags: ["代码执行", "高风险", "许可证待核验"],
   },
   {
     id: "github-mcp-server",
@@ -754,8 +754,8 @@ const expandedMcpProjectSeeds: McpProjectSeed[] = [
   plannedMcp({
     id: "apify-mcp",
     name: "Apify Actors MCP",
-    repoName: "apify/actors-mcp-server",
-    repoUrl: "https://github.com/apify/actors-mcp-server",
+    repoName: "apify/apify-mcp-server",
+    repoUrl: "https://github.com/apify/apify-mcp-server",
     category: "浏览器与网页",
     description: "把 Apify Actors 的网页抓取、数据处理和自动化能力提供给 AI。",
     readmeSummary: "Apify 官方集成，可发现并运行 Actors，再读取其数据集结果。",
@@ -910,10 +910,10 @@ const expandedMcpProjectSeeds: McpProjectSeed[] = [
     repoName: "pydantic/mcp-run-python",
     repoUrl: "https://github.com/pydantic/mcp-run-python",
     category: "开发与代码",
-    description: "在隔离环境中执行 Python 代码，适合计算、转换和小型数据任务。",
-    readmeSummary: "Pydantic 团队项目，强调通过 Pyodide/Deno 等运行时隔离 Python 执行。",
+    description: "曾通过 Pyodide/Deno 执行 Python；维护方已因无法安全隔离不可信代码而归档项目。",
+    readmeSummary: "Pydantic 已退休该实现，并明确警告任意 JavaScript、运行时污染、文件访问和内存耗尽风险。",
     language: "Python",
-    tags: ["Pydantic", "Python", "隔离执行"],
+    tags: ["Pydantic", "Python", "已归档"],
     requirements: ["external-runtime", "system-permission"],
     usageExamples: ["执行可复现的数据计算", "把输入文本批量转换为结构化结果"],
     sources: ["awesome-mcp-zh", "awesome-mcp-servers"],
@@ -1051,10 +1051,10 @@ const expandedMcpProjectSeeds: McpProjectSeed[] = [
     repoUrl: "https://github.com/hashicorp/terraform-mcp-server",
     category: "云平台与运维",
     description: "查询 Terraform Registry、Provider、Module 和基础设施开发信息。",
-    readmeSummary: "HashiCorp 官方 MCP Server，为 Terraform 与 HCP Terraform 工作流提供工具。",
+    readmeSummary: "HashiCorp 官方契约的公共 Terraform Registry 只读子集；HCP/TFE 与资源变更能力不进入本批运行时。",
     language: "Go",
     tags: ["HashiCorp 官方", "Terraform", "基础设施即代码"],
-    requirements: ["external-runtime", "token", "account-binding"],
+    requirements: ["external-runtime", "remote-transport"],
     usageExamples: ["查找合适的 Terraform 模块", "读取 Provider 资源文档"],
     sources: ["awesome-mcp-zh", "awesome-mcp-servers"],
   }),
@@ -1635,8 +1635,8 @@ const expandedMcpProjectSeeds: McpProjectSeed[] = [
   plannedMcp({
     id: "stripe-mcp",
     name: "Stripe MCP",
-    repoName: "stripe/agent-toolkit",
-    repoUrl: "https://github.com/stripe/agent-toolkit",
+    repoName: "stripe/ai",
+    repoUrl: "https://github.com/stripe/ai",
     category: "金融与市场",
     description: "查询和管理 Stripe 客户、支付、订阅、退款与账单对象。",
     readmeSummary: "Stripe 官方 Agent Toolkit 包含 MCP 支持，为支付业务提供结构化工具。",
@@ -1745,6 +1745,7 @@ function normalizeMcpProject(seed: McpProjectSeed): McpProject {
 
   return {
     ...seed,
+    verifiedAt: adaptation.wave === 8 ? "2026-08-09" : seed.verifiedAt,
     installMode: isLocalStdio ? "one-click" : "manual",
     installCommand: isLocalStdio
       ? seed.installCommand

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -170,6 +170,7 @@ services:
       - mcp_public_egress
     environment:
       MCP_TOKEN_MAX_SESSIONS: "6"
+      MCP_TOKEN_ALLOWED_ADAPTERS: agentql-mcp,brave-search-mcp,exa-mcp,firecrawl-mcp,perplexity-mcp,tavily-mcp,axiom-mcp,figma-context-mcp,google-maps-mcp,grafana-mcp,graphlit-mcp,kagi-mcp,pinecone-assistant-mcp,shodan-mcp,virustotal-mcp
       MCP_TOKEN_SOCKET_PATH: /run/modelmirror-token-mcp/token-mcp.sock
       MCP_TOKEN_WORKSPACE_ROOT: /workspaces
       MCP_PUBLIC_ALLOW_SYNTHETIC_DNS: "true"
@@ -195,6 +196,50 @@ services:
           "python",
           "-c",
           "import json,socket; s=socket.socket(socket.AF_UNIX); s.connect('/run/modelmirror-token-mcp/token-mcp.sock'); s.sendall(b'{\"action\":\"health\"}\\n'); assert json.loads(s.recv(4096))['ok']",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 8
+      start_period: 30s
+
+  mcp-registry:
+    build:
+      context: ./server/sandbox_sidecar
+      dockerfile: Dockerfile.registry
+    image: modelmirror-mcp-registry:wave9-v1
+    container_name: modelmirror-mcp-registry
+    networks:
+      - mcp_public_egress
+    environment:
+      MCP_TOKEN_MAX_SESSIONS: "4"
+      MCP_TOKEN_ALLOWED_ADAPTERS: terraform-mcp
+      MCP_TOKEN_SOCKET_PATH: /run/modelmirror-registry-mcp/registry-mcp.sock
+      MCP_TOKEN_WORKSPACE_ROOT: /workspaces
+      # Docker Desktop maps public DNS through 198.18/15; the adapter still
+      # pins registry.terraform.io and verifies its TLS hostname/certificate.
+      MCP_PUBLIC_ALLOW_SYNTHETIC_DNS: "true"
+    user: "65532:65532"
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    pids_limit: 64
+    mem_limit: 512m
+    cpus: 1.0
+    tmpfs:
+      - /tmp:rw,nosuid,nodev,noexec,size=32m,uid=65532,gid=65532,mode=0700
+      - /workspaces:rw,nosuid,nodev,noexec,size=64m,uid=65532,gid=65532,mode=0700
+    volumes:
+      - mcp_registry_socket:/run/modelmirror-registry-mcp
+    restart: unless-stopped
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import json,socket; s=socket.socket(socket.AF_UNIX); s.connect('/run/modelmirror-registry-mcp/registry-mcp.sock'); s.sendall(b'{\"action\":\"health\"}\\n'); assert json.loads(s.recv(4096))['ok']",
         ]
       interval: 10s
       timeout: 5s
@@ -492,6 +537,8 @@ services:
         condition: service_healthy
       mcp-token:
         condition: service_healthy
+      mcp-registry:
+        condition: service_healthy
       mcp-saas:
         condition: service_healthy
       mcp-browser:
@@ -547,6 +594,7 @@ services:
       MCP_PUBLIC_SOCKET_PATH: /run/modelmirror-public-mcp/public-mcp.sock
       MCP_FILES_SOCKET_PATH: /run/modelmirror-files-mcp/files-mcp.sock
       MCP_TOKEN_SOCKET_PATH: /run/modelmirror-token-mcp/token-mcp.sock
+      MCP_REGISTRY_SOCKET_PATH: /run/modelmirror-registry-mcp/registry-mcp.sock
       MCP_SAAS_SOCKET_PATH: /run/modelmirror-saas-mcp/saas-mcp.sock
       MCP_BROWSER_SOCKET_PATH: /run/modelmirror-browser-mcp/browser-mcp.sock
       MCP_BROWSER_ARTIFACT_STAGING_ROOT: /app/mcp-browser-staging
@@ -591,6 +639,7 @@ services:
       - mcp_public_socket:/run/modelmirror-public-mcp
       - mcp_files_socket:/run/modelmirror-files-mcp
       - mcp_token_socket:/run/modelmirror-token-mcp
+      - mcp_registry_socket:/run/modelmirror-registry-mcp
       - mcp_saas_socket:/run/modelmirror-saas-mcp
       - mcp_browser_socket:/run/modelmirror-browser-mcp
       - mcp_browser_artifact_staging:/app/mcp-browser-staging
@@ -756,6 +805,7 @@ volumes:
   mcp_public_socket:
   mcp_files_socket:
   mcp_token_socket:
+  mcp_registry_socket:
   mcp_saas_socket:
   mcp_browser_socket:
   mcp_browser_egress_socket:

--- a/docs/MCP_CATALOG_ROADMAP.md
+++ b/docs/MCP_CATALOG_ROADMAP.md
@@ -15,11 +15,11 @@
 - [Awesome-MCP-ZH](https://github.com/yzfly/Awesome-MCP-ZH)
 - [awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers)
 
-截至 2026-08-07，目录仍冻结为 100 个 MCP 条目、18 个分类。批次 0—6 已验收的 42 项保持不变；批次 7 的 Chrome DevTools MCP 与 Playwright MCP 已完成固定浏览器适配，Puppeteer MCP 与 Selenium MCP 因上游维护、安全和许可证门槛标记为 `blocked`。当前状态精确为 **44 ready / 43 planned / 13 blocked**。
+截至 2026-08-09，目录仍冻结为 100 个 MCP 条目、18 个分类。批次 8 的两个 Python 执行上游均未通过门槛；批次 9 仅 Terraform 公共 Registry 只读子集通过，另外 13 项因凭据、费用、归档、资源写入或本机/集群范围受阻。当前状态精确为 **45 ready / 27 planned / 28 blocked**。
 
 ## 2. 当前边界与明确不实现
 
-批次 1–7 只增加固定适配器：批次 1 使用完全断网计算 sidecar，批次 2 使用独立公网 sidecar，批次 3 使用受控上传工作区和完全断网的文件处理 sidecar，批次 4 使用固定 Token 槽和只读出口 sidecar，批次 5 使用结构化数据库配置及相互隔离的远程/本地数据库 sidecar，批次 6 使用固定 SaaS 服务、账号作用域和资源级一次性审批 sidecar，批次 7 使用真实锁定上游、临时 Chromium 和强制出口代理。七批都不扩大任意连接或任意执行能力：
+批次 1–9 只允许固定且完成验收的适配器：批次 1 使用完全断网计算 sidecar，批次 2 使用独立公网 sidecar，批次 3 使用受控上传工作区和完全断网的文件处理 sidecar，批次 4 使用固定 Token 槽和只读出口 sidecar，批次 5 使用结构化数据库配置及相互隔离的远程/本地数据库 sidecar，批次 6 使用固定 SaaS 服务、账号作用域和资源级一次性审批 sidecar，批次 7 使用真实锁定上游、临时 Chromium 和强制出口代理；批次 8 因两个上游均未通过门槛，不新增运行时；批次 9 仅新增无凭据、固定公共 Registry 出口的 Terraform sidecar。这些批次都不扩大任意连接或任意执行能力：
 
 - 不接受用户指定的 Python 包、解释器、命令、工作目录或其他额外运行时。
 - 不实现 OAuth 回调、刷新或外站登录；批次 4—5 的卡片可把明文 Secret 单次提交到服务端加密库，但连接配置只接受不透明 `credential_id`，保存后不再返回或显示明文。
@@ -31,6 +31,8 @@
 - 批次 6 只接受清单声明的 Personal Access Token / Internal Integration Token 与固定资源 ID；不接受服务 URL、任意 Host、Header、环境变量、OAuth 回调或外站登录。GitLab 首批只连接 `gitlab.com`，自建 GitLab 保持未开放。
 - 批次 6 的真实账号执行还需部署者显式设置单用户本地实例确认门禁；当前 API 没有逐请求认证主体传播，多用户共享部署不得开启。
 - 批次 7 不接受浏览器启动参数、CDP/远程端点、profile、代理、Header、Cookie、storage、上传/下载路径或本机文件。用户只提交待审批且不含 Token、API Key、签名等敏感查询参数的公网 URL，以及网关签发的不透明元素 ref；首版不采集账号凭据、不提供外站登录流程，也不继承或保存登录态。页面仍可能自行呈现无法由透明 HTTPS 出口可靠识别的登录界面，用户不得输入账号、密码、OTP 或其他认证信息。
+- 批次 8 不接受 Python 代码、包名、解释器、环境、文件、会话 ID、命令、工作目录或执行超时。两个条目均无镜像、命令、端点或工具策略；功能开关不能把 `blocked` 改为可执行。
+- 批次 9 的 Terraform 适配器不接收 Token、组织、工作区、状态文件、变量、Terraform CLI 路径或任意 Registry URL；仅匿名访问固定 `registry.terraform.io`。HCP Terraform、Terraform Enterprise、私有 Registry、plan、apply、destroy、run 与资源变更能力全部不可发现、不可调用。
 - 不接管 Blender、Zotero、Obsidian、JetBrains、Xcode、Ghidra 等桌面宿主。
 - 不提供用户自定义 MCP 连接。
 - 不提供 MCP Builder、可视化生成器或发布市场流程。
@@ -86,8 +88,8 @@
 | 5 | DBHub、PostgreSQL、MongoDB、ClickHouse、Cognee、Graphiti、Hindsight、Redis、SQLite、DuckDB、Supabase | 11 | **已完成门槛判定**：DBHub、MongoDB、ClickHouse、Redis、DuckDB、Supabase 通过结构化配置、租户凭据、协议级只读、预检与查询限制；PostgreSQL、SQLite 因归档实现受阻，三项状态化记忆转入第 5B 计划 |
 | 6 | Airtable、Asana、GitLab、中国电商经营、Notion、Mem0 | 6 | **已完成门槛判定**：Airtable、Asana、GitLab.com、Notion 通过固定作用域、真实预检、资源级审批、限流与解绑；中国电商与 Mem0 因授权/托管契约受阻 |
 | 7 | Chrome DevTools、Playwright、Puppeteer、Selenium | 4 | **已完成门槛判定**：Chrome DevTools 与 Playwright 通过真实上游 Schema、临时浏览器、固定出口、页面状态审批与清理测试；Puppeteer、Selenium 因归档安全风险与许可证/运行时边界受阻 |
-| 8 | MCP Run Python、MCP Python Interpreter | 2 | 一次性断网容器、无宿主挂载、无 Docker socket、进程资源限制 |
-| 9 | Apify、Bright Data、Browserbase、E2B、Stripe、Terraform、Aiven、Alpaca、AWS KB、ElevenLabs、MiniMax、S3、Kubernetes、Semgrep | 14 | 费用/资源上限、目标预览、终止性操作强制审批 |
+| 8 | MCP Run Python、MCP Python Interpreter | 2 | **已完成门槛判定**：MCP Run Python 因维护方明确否定 Pyodide 不可信代码沙箱并归档而受阻；MCP Python Interpreter 因进程内执行、包/文件/会话能力及空 LICENSE 发布物受阻 |
+| 9 | Apify、Bright Data、Browserbase、E2B、Stripe、Terraform、Aiven、Alpaca、AWS KB、ElevenLabs、MiniMax、S3、Kubernetes、Semgrep | 14 | **已完成门槛判定**：Terraform 公共 Registry 六项只读工具可用；其余 13 项因凭据出站未批准、费用无法对账、归档运行时、真实金融/云资源写入或本机/集群范围受阻 |
 | 10 | Gmail、Atlassian、Google Calendar、Google Drive、Microsoft 365、OneDrive、Sentry、Azure、Box、Cloudflare、GitHub、Linear、Neon、Slack | 14 | PKCE、state、最小 scope、刷新、撤销与解绑 |
 | 11 | 小红书、Ableton、Binary Ninja、Blender、Ghidra、JetBrains、ChatCrystal、Obsidian、OpenTabs、Zotero、Docker、Mobile、XcodeBuild | 13 | 版本化本机桥接、宿主校验、逐应用与目录授权 |
 
@@ -155,6 +157,19 @@
 - 导航、点击和填写必须经过 `browser-session` 一次性审批。审批冻结目录会话、浏览器 generation、页面 revision/digest、origin、工具/Schema、参数和配置版本；确认时状态漂移即失效。交互调用不重试，歧义超时会标记 `unknown_outcome`、污染并关闭会话；sidecar 明确返回 `-32011` 且原因属于调用前 DNS/目标 URL 拒绝时，旧审批终止但会话保留，修正目标后必须重新审批，调用后风险原因仍不得降级为明确拒绝。截图先进入 64 MiB 临时共享卷，经后端单文件描述符校验后复制到仅服务端挂载的可信目录并持久登记 24 小时索引；可通过项目专属接口下载或清理。异常临时项仅按固定深度与已知命名清扫，畸形条目告警并 fail-closed。网页上传、网页下载、登录态保存、Cookie/Storage 导入导出与持久化、剪贴板、任意脚本求值工具、CDP、扩展与本机文件不进入本批。网页自身的 Cookie、缓存和站点存储只存在于临时 profile，断开时删除。
 - Chrome DevTools MCP 1.6.0 与 Playwright MCP 0.0.79 为 `ready`。官方 Puppeteer MCP 已归档且保留危险启动/脚本入口，Selenium MCP 0.2.3 存在 MIT/ISC 许可证元数据冲突、root/漂移镜像和任意参数/路径/脚本/Cookie 面，二者保持 `blocked`，不得通过功能开关绕过。
 
+批次 8 的执行结论：
+
+- `mcp-run-python` 0.0.22 的官方仓库已归档。维护方明确说明 Pyodide 中的 Python 可执行任意 JavaScript、污染后续调用、读写运行时可见文件，并且 Deno 无法提供可靠内存限制；因此不构建 Deno/Pyodide sidecar，也不把实验性的 Monty 替换成同名适配器。
+- `mcp-python-interpreter` 的最新已发布版本固定核验为 PyPI 1.2.3。其 `run_python_code` 默认使用 `inline`，在 MCP Server 进程内维护全局 REPL 会话；同时公开任意 pip 安装、文件读写、环境选择和最长 300 秒子进程执行。发布 wheel 的 metadata 使用 MIT classifier，但携带的 `LICENSE` 文件为空，无法形成完整可再分发来源证明。
+- 两项均为 `blocked`，没有 Docker 镜像、Unix socket、宿主挂载、Docker socket、运行命令、端点或代码输入入口。第 8 批没有交付可复用的一次性代码执行边界，因此 Manim 与 Snyk 的既有阻断也不自动解除；若未来引入新的维护中执行引擎，应作为新威胁模型和新适配器重新验收，不复用这两个项目 ID 冒充上游兼容。
+
+批次 9 的执行结论：
+
+- `terraform-mcp` 固定为 [HashiCorp Terraform MCP Server v1.2.0](https://github.com/hashicorp/terraform-mcp-server/tree/v1.2.0) 的公共 Registry 只读兼容契约。独立 `modelmirror-mcp-registry:wave9-v1` 只开放 `get_latest_provider_version`、`get_provider_capabilities`、`get_provider_details`、`search_modules`、`get_module_details` 与 `get_latest_module_version`，工具 Schema 摘要冻结为 `73a2b116bcaa257dbf158d1ab8a778d067dac2d969db7dff160372d1617e3445`。
+- `mcp-registry` 使用独立 Unix socket、非 root UID/GID 65532、只读根文件系统、移除全部 capabilities、`no-new-privileges`、512 MiB/1 CPU/64 PIDs 与空白 tmpfs 工作区；最多四个会话，调用不重连。Docker Desktop 把公网 DNS 映射到 `198.18.0.0/15` 时只允许该传输兼容地址，应用层仍把主机编译固定为 `registry.terraform.io`，保留 TLS hostname/证书校验，不接收用户 URL。
+- 真实隔离验收通过六项工具：`hashicorp/random` 最新版本 `3.9.0`、3 类能力、1935 字节公开文档；`vpc` 搜索首项 `terraform-aws-modules/vpc/aws/6.6.1`，详情裁剪为 50 个输入并确认最新版本 `6.6.1`。`apply` 在真实网关调用中返回拒绝；HCP/TFE、私有 Registry、plan、destroy 与资源写入工具均不在工具清单。
+- Apify 与 Aiven 因未批准账号凭据出站保持 `blocked`；Bright Data 因缺少供应商账单对账与逐项目硬预算受阻；Browserbase、E2B、Semgrep 因归档/不维护运行时受阻；Stripe 转入第十批 OAuth 与金融终止操作审批；Alpaca、AWS KB、ElevenLabs、MiniMax、S3 Tables、Kubernetes 因真实交易、云资源、付费媒体、AWS/集群作用域或写入面保持关闭。
+
 ## 6. 验收、发布和回退
 
 - 每个项目必须通过初始化、工具发现、代表性调用、超时、重连、断开与清理测试；Schema 漂移视为阻断。浏览器条目还必须在双 sidecar 容器中走完 UDS 握手、受控导航、快照、元素交互、真实截图登记、断开与进程/profile/临时文件清理，单独的上游 `tools/list` 或容器健康检查不能作为 ready 证据。
@@ -174,7 +189,7 @@
 
 主要风险是上游项目快速变化、条目说明过期，以及把“已收录”误解为“当前可安全运行”。前端必须持续使用明确的状态标签和禁用按钮表达边界。
 
-批次 0–4 不引入数据库迁移；批次 5 只把旧凭据 JSON 元数据显式迁移到 `local/local` 作用域，不接触外部数据库 schema 或数据。批次 2 回退时关闭对应公网项目开关并停止 `mcp-public`；批次 3 回退时关闭四个文件项目开关、撤销审批并停止 `mcp-files`；批次 4 回退时关闭 15 个 Token 项目的独立功能开关、断开目录会话并停止 `mcp-token`；批次 5 回退时关闭六个数据库项目开关、断开会话、停止远程和本地数据库 sidecar，并清理临时 DuckDB 工作区；批次 6 回退时关闭四个 SaaS 项目开关和全局单用户确认门禁、执行项目解绑并停止 `mcp-saas`；批次 7 回退时关闭两个浏览器项目开关、作废待确认操作、断开会话并停止 `mcp-browser` 与 `mcp-browser-egress`，随后清理临时 profile 与截图产物。回退不自动删除外部 SaaS 数据，也不声称撤销服务商 Token；卡片专属加密凭据仅在用户选择撤销时删除。Airbnb、BibiGPT、Manim、Snyk、PostgreSQL、SQLite、Cognee、Graphiti、Hindsight、中国电商经营 MCP、Mem0、Puppeteer MCP 与 Selenium MCP 本来就不可执行。旧版 `/api/mcp/*` 接口保持兼容，但目录会话不能使用无项目策略的直接调用端点：
+批次 0–4 不引入数据库迁移；批次 5 只把旧凭据 JSON 元数据显式迁移到 `local/local` 作用域，不接触外部数据库 schema 或数据。批次 2 回退时关闭对应公网项目开关并停止 `mcp-public`；批次 3 回退时关闭四个文件项目开关、撤销审批并停止 `mcp-files`；批次 4 回退时关闭 15 个 Token 项目的独立功能开关、断开目录会话并停止 `mcp-token`；批次 5 回退时关闭六个数据库项目开关、断开会话、停止远程和本地数据库 sidecar，并清理临时 DuckDB 工作区；批次 6 回退时关闭四个 SaaS 项目开关和全局单用户确认门禁、执行项目解绑并停止 `mcp-saas`；批次 7 回退时关闭两个浏览器项目开关、作废待确认操作、断开会话并停止 `mcp-browser` 与 `mcp-browser-egress`，随后清理临时 profile 与截图产物。批次 8 没有新增运行时，回退只需恢复目录状态与说明；批次 9 回退时先断开 Terraform 目录会话，再停止 `mcp-registry`，无需删除凭据、工作区或外部资源。回退不自动删除外部 SaaS 数据，也不声称撤销服务商 Token；卡片专属加密凭据仅在用户选择撤销时删除。Airbnb、BibiGPT、Manim、Snyk、PostgreSQL、SQLite、Cognee、Graphiti、Hindsight、中国电商经营 MCP、Mem0、Puppeteer MCP、Selenium MCP、MCP Run Python 与 MCP Python Interpreter 本来就不可执行。旧版 `/api/mcp/*` 接口保持兼容，但目录会话不能使用无项目策略的直接调用端点：
 
 - `server/mcp/catalog.py`
 - `server/mcp/sandbox_proxy.py`

--- a/docs/MCP_INTEGRATION.md
+++ b/docs/MCP_INTEGRATION.md
@@ -83,7 +83,7 @@ Agent 画布使用 `toolset_resource -> workflow_agent` 的 `toolset` 绑定边�
 目录适配器安全默认值：
 
 - 前端不能提交 `server_command`、MCP URL、Header、环境变量名或工作目录。
-- 当前目录状态为 **44 ready / 43 planned / 13 blocked**；planned 与 blocked 项没有可执行命令或端点，设置环境功能开关也不能绕过状态门槛。
+- 当前目录状态为 **45 ready / 27 planned / 28 blocked**；planned 与 blocked 项没有可执行命令或端点，设置环境功能开关也不能绕过状态门槛。
 - 新适配器若没有显式工具读写与审批策略，工具调用会 fail-closed。
 - 日志只记录项目 ID、工具名、状态和耗时，不记录参数、返回正文或 Secret。
 
@@ -158,6 +158,20 @@ Agent 画布使用 `toolset_resource -> workflow_agent` 的 `toolset` 绑定边�
 - 导航、点击和填写属于 `state-write + requires_approval`。一次性审批绑定租户、所有者、项目、目录会话、浏览器 generation、页面 revision/digest、当前 origin、工具/Schema、冻结参数和配置版本；确认前页面或会话漂移即失效。此类调用永不自动重试，发送后超时或连接中断标记为 `unknown_outcome` 并污染、关闭当前会话。若 sidecar 以 `-32011` 明确证明 DNS 或目标 URL 在调用前被策略拒绝，则旧审批进入 `rejected` 终态但临时会话保留，用户修正目标后必须发起全新的审批；跨域跳转等可能发生在调用后的策略错误仍按未知结果 fail-closed。
 - 快照只产生网关签发的不透明元素 ref；点击与填写不接受 CSS、XPath 或任意文本定位器，并拒绝密码、OTP、支付和验证码字段。截图先写入上限 64 MiB 的临时共享区，后端以单一文件描述符校验 PNG、大小、链接数与摘要，再复制到仅服务端可见的可信产物目录并登记 24 小时索引；产物接口只返回不透明 ID，并允许用户下载或清理。异常临时项只按固定目录和命名规则清扫，畸形条目告警并 fail-closed，不做宽泛递归删除。网页上传、网页下载、剪贴板、Cookie/Storage 导入导出与持久化、任意脚本求值工具、CDP、扩展和本机文件全部关闭。网页自身在会话内产生的 Cookie、缓存和站点存储只存在于临时 profile，断开时一并删除。
 - `puppeteer-mcp` 因官方仓库归档、危险启动参数/脚本执行面及未修复安全报告保持 `blocked`。`selenium-mcp` 因发行物许可证元数据冲突、未锁定的 root 浏览器镜像及任意参数/路径/脚本/Cookie 能力保持 `blocked`。两项都不显示安装或连接入口。
+
+批次 8 的两个 Python 执行条目均保持 `blocked`，本批不新增代码执行 sidecar：
+
+- `mcp-run-python` 固定核验 0.0.22。官方仓库已归档，维护方明确说明 Pyodide 代码能够执行任意 JavaScript、污染后续调用、访问运行时文件并耗尽宿主内存，因此不把该实现部署为不可信代码沙箱。
+- `mcp-python-interpreter` 固定核验 PyPI 1.2.3。默认 `run_python_code` 是进程内 `inline` 执行并保留全局会话，同时公开 pip 安装、文件读写、环境选择和最长 300 秒子进程调用；发布 wheel 虽声明 MIT classifier，但携带的 `LICENSE` 文件为空。
+- 两个后端 manifest 都没有镜像、命令、端点、工具策略或 enabled-by-default 路径，功能开关不能使其可执行。前端不提交代码、包名、Python 路径、工作目录、环境、文件或会话 ID，也不显示安装/连接按钮。Manim 与 Snyk 仍等待一个独立立项、可复现且维护中的代码执行边界，不能因完成目录裁决而自动解锁。
+
+批次 9 仅把 Terraform 公共 Registry 适配为可执行项，并使用独立 `mcp-registry` sidecar：
+
+- 固定兼容 HashiCorp Terraform MCP Server v1.2.0，只开放 Provider 最新版本/能力/文档和 Module 搜索/详情/最新版本六个只读工具；Schema 摘要为 `73a2b116bcaa257dbf158d1ab8a778d067dac2d969db7dff160372d1617e3445`。
+- `mcp-registry` 不复用 `mcp-token` socket：服务端通过 `/run/modelmirror-registry-mcp/registry-mcp.sock` 发送固定项目 ID 与空 `{settings, credentials}` 握手。sidecar 只允许 `terraform-mcp`，而 Wave4 `mcp-token` 只允许原 15 项 Token 适配器。
+- 运行时不接收 Token、账号或配置字段，不挂载宿主目录和 Docker socket；容器为 UID/GID 65532、只读根文件系统、`cap_drop: ALL`、`no-new-privileges`、512 MiB/1 CPU/64 PIDs，tmpfs 工作区不持久化。固定主机为 `registry.terraform.io`、禁止重定向、DNS 后固定连接地址并校验 TLS hostname；Docker Desktop 合成 DNS 仅作为固定主机的传输兼容，不形成任意 URL 输入。
+- HCP Terraform、Terraform Enterprise、私有 Registry、plan、apply、destroy、run、workspace、本地状态/变量/配置和资源变更工具均不在清单；目录连接零重试且连接后立即擦除内部握手环境。
+- Apify、Aiven、Bright Data、Browserbase、E2B、Stripe、Alpaca、AWS KB、ElevenLabs、MiniMax、S3 Tables、Kubernetes 与 Semgrep 均为 `blocked`，没有凭据、命令、端点或工具入口。
 
 兼容层仍保留以下默认值：
 
@@ -442,6 +456,8 @@ python server/sandbox_sidecar/smoke_browser_runtime.py --image modelmirror-mcp-b
 ```
 
 成功结果必须包含 Chrome DevTools 与 Playwright 各两次导航、快照、元素交互和 PNG 登记，以及各一次真实 20 秒导航超时（`-32008 / unknown_outcome / retryable=false`）、browser/egress PID1 精确单次重启、运行目录/进程清理和最终 `cleanup=verified`。该 harness 只创建随机 `mm-wave7-runtime-smoke-*` 资源；任何失败或残留都返回非零，不能用容器健康检查代替。
+
+批次 8 没有可执行运行时，因此验收不得以 mock 或自研 Python 执行器替代上游 smoke。聚焦测试必须断言两个项目始终为 `blocked`，公开 `executable=false`，且不存在 `runtime_image`、`server_command`、`endpoint` 和工具策略；同时保持 Manim 与 Snyk 的既有阻断。
 
 测试覆盖：
 

--- a/server/mcp/catalog.py
+++ b/server/mcp/catalog.py
@@ -1317,6 +1317,132 @@ WAVE_SEVEN_ADAPTERS: dict[str, WaveSevenAdapterSpec] = {
 }
 
 
+@dataclass(frozen=True, slots=True)
+class WaveNineAdapterSpec:
+    adapter_version: str
+    tools: tuple[str, ...]
+    credential_policies: tuple[CatalogCredentialSlotPolicy, ...]
+    network_policy: str
+    limitations: tuple[str, ...]
+    sensitive: bool = False
+
+
+WAVE_NINE_READY_ADAPTERS: dict[str, WaveNineAdapterSpec] = {
+    "terraform-mcp": WaveNineAdapterSpec(
+        "1.2.0-registry-read-only-compatible-v1",
+        (
+            "get_latest_provider_version",
+            "get_provider_capabilities",
+            "get_provider_details",
+            "search_modules",
+            "get_module_details",
+            "get_latest_module_version",
+        ),
+        (),
+        "allowlist:registry.terraform.io",
+        (
+            "仅访问匿名公共 Terraform Registry；不接收 Token，不读取工作区、状态文件、变量或本机 Terraform 配置。",
+            "HCP Terraform、Terraform Enterprise、私有 Registry、plan、apply、destroy、run、workspace 与任何资源变更工具全部不可发现、不可调用。",
+        ),
+    ),
+}
+
+
+WAVE_NINE_BLOCKED_ADAPTERS: dict[str, tuple[str, tuple[str, ...]]] = {
+    "apify-mcp": (
+        "0.14.2-blocked:credential-and-cost-boundary",
+        (
+            "Actor 搜索与详情虽免费，但固定 stdio 上游仍要求 Apify Token；Actor 运行和动态工具会产生外部费用。",
+            "本批不向 Apify 发送账号 Token，也不开放 OAuth、AGI、x402、MPP、Skyfire、Actor 运行、数据集或动态工具；需单独批准凭据出站后再评估只读发现子集。",
+        ),
+    ),
+    "aiven-mcp": (
+        "1.15.2-blocked:credential-egress-not-approved",
+        (
+            "上游 1.15.2 支持 read-only/core scope，但仍需向 Aiven API 发送项目账号 Token，并可读取项目、服务、VPC 与套餐元数据。",
+            "本批未获向 Aiven 发送具体凭据的授权，因此 Token、配置、连接和工具入口全部关闭；后续需单独批准账号范围与凭据出站。",
+        ),
+    ),
+    "bright-data-mcp": (
+        "2.11.1-blocked:unreconciled-provider-cost",
+        (
+            "上游基础抓取与 Pro 工具均消耗 Bright Data 请求额度，且 Pro 模式默认不限制调用频率；当前目录没有可与供应商账单对账的逐项目硬预算。",
+            "Token、连接和抓取工具全部关闭；完成供应商 usage 对账、硬预算、并发与停止开关前不以免费额度替代费用护栏。",
+        ),
+    ),
+    "browserbase-mcp": (
+        "3.0.0-blocked:archived-cloud-browser-runtime",
+        (
+            "官方仓库已归档，托管浏览器会话又会持续消耗外部资源，无法锁定维护中的生产契约与费用停止语义。",
+            "连接、项目密钥、云浏览器和任意页面操作全部关闭；需要浏览器能力时使用第七批的一次性本地浏览器适配器。",
+        ),
+    ),
+    "e2b-mcp": (
+        "0.1.1-blocked:archived-billed-code-runtime",
+        (
+            "官方 MCP 仓库已归档；上游沙箱默认允许联网、支持任意安装和运行命令，并在存活期间计费。",
+            "连接、API Key、代码、依赖安装和云沙箱创建入口全部关闭；不会以当前归档包承载不可信代码。",
+        ),
+    ),
+    "stripe-mcp": (
+        "remote-oauth-blocked:wave10",
+        (
+            "Stripe 当前官方 MCP 是 mcp.stripe.com 的 OAuth 远程服务，而非旧 agent-toolkit 本地包；支付、退款和订阅写入具有真实资金影响。",
+            "本批不打开外站登录、API Key 或支付对象入口；转入第十批完成 OAuth scope、账号解绑与终止性金融操作审批。",
+        ),
+    ),
+    "alpaca-mcp": (
+        "v2-blocked:trading-and-market-data-cost",
+        (
+            "官方 v2 同时暴露真实交易、平仓、期权行权和账户能力，市场数据订阅也可能产生套餐费用；paper 默认值不能证明凭据属于模拟账户。",
+            "API Key、行情、账户和订单工具全部关闭；完成 paper/live 身份证明、行情费用上限与金融终止操作审批前不开放。",
+        ),
+    ),
+    "aws-kb-mcp": (
+        "2026.08.20260805092707-blocked:aws-scope-and-query-cost",
+        (
+            "Bedrock Knowledge Bases 检索依赖 AWS 身份、区域和知识库范围，并可能产生检索或模型费用；结果还可能包含企业敏感内容。",
+            "AWS 凭据、Knowledge Base ID 和检索入口全部关闭；等待 SigV4 凭据代理、资源白名单、usage 对账与数据范围预检。",
+        ),
+    ),
+    "elevenlabs-mcp": (
+        "0.12.2-blocked:paid-media-and-artifacts",
+        (
+            "语音、音效与相关生成工具会消耗外部额度并产生音频产物，部分工具还管理 Voice 等持久资源。",
+            "API Key、生成、克隆、播放、下载和删除入口全部关闭；等待字符/时长预算、价格快照、产物隔离和逐次费用确认。",
+        ),
+    ),
+    "minimax-mcp": (
+        "main-blocked:paid-multimodal-and-local-files",
+        (
+            "官方工具会发起语音、图像、视频、音乐和 Voice Clone 付费任务，并接受本地文件或 URL、写入媒体产物。",
+            "API Key、地区主机、生成、轮询、文件和产物入口全部关闭；等待模型价格锁定、异步任务账本与媒体输入输出隔离。",
+        ),
+    ),
+    "s3-mcp": (
+        "2026.08.20260805092707-blocked:aws-resource-scope",
+        (
+            "S3 Tables Server 同时包含 Namespace 与 Table 的创建、更新和删除能力，依赖 AWS 凭据、区域和资源级 IAM。",
+            "AWS 凭据、Bucket/Table ARN 和工具入口全部关闭；等待 SigV4 代理、固定资源白名单、只读工具集与终止性删除审批。",
+        ),
+    ),
+    "kubernetes-mcp": (
+        "0.0.66-blocked:cluster-credential-and-namespace-scope",
+        (
+            "上游虽提供 disable-destructive，但仍需 kubeconfig/ServiceAccount、集群网络和命名空间级 RBAC；日志与资源内容可能包含敏感数据。",
+            "Kubeconfig、集群连接、exec、日志和资源工具全部关闭；等待固定集群/namespace 绑定、只读 RBAC 实测与连接后权限预检。",
+        ),
+    ),
+    "semgrep-mcp": (
+        "0.4.0-blocked:archived-local-scan-runtime",
+        (
+            "官方仓库已归档，扫描需要读取项目源码并启动本地 Semgrep 运行时，无法满足维护中的代码执行与文件范围契约。",
+            "源码目录、Token、CLI 和扫描入口全部关闭；不会回退到归档包或未固定的社区替代品。",
+        ),
+    ),
+}
+
+
 WAVE_PROJECTS: dict[int, tuple[str, ...]] = {
     1: ("calculator-mcp", "time-mcp", "vegalite-mcp"),
     2: (
@@ -1479,7 +1605,7 @@ WAVE_METADATA: dict[
         "sandboxed-stdio",
         "critical",
         ("ephemeral-code-sandbox", "process-resource-limits"),
-        ("等待断网、无宿主挂载的一次性代码执行沙箱验证。",),
+        ("两个上游均未通过安全与发布物门槛，当前不提供代码执行运行时。",),
     ),
     9: (
         "sandboxed-stdio",
@@ -2120,6 +2246,103 @@ def build_catalog_manifests() -> dict[str, CatalogAdapterManifest]:
         network_policy="blocked:no-production-runtime",
         filesystem_policy="blocked:no-runtime",
     )
+
+    manifests["mcp-run-python"] = CatalogAdapterManifest(
+        project_id="mcp-run-python",
+        wave=8,
+        availability="blocked",
+        connection_kind="sandboxed-stdio",
+        risk="critical",
+        required_capabilities=(
+            "maintained-safe-execution-runtime",
+            "ephemeral-code-sandbox",
+            "process-resource-limits",
+        ),
+        limitations=(
+            "上游 0.0.22 已由维护方归档；维护方明确说明 Pyodide 中的代码可执行任意 JavaScript、污染后续调用、访问运行时文件并耗尽宿主内存，因此不再把该实现视为不可信代码沙箱。",
+            "连接、依赖安装、Deno/Pyodide 运行时和代码提交入口全部关闭；不会用实验性的 Monty 或模镜自研执行器冒充该上游适配器。",
+        ),
+        adapter_version="0.0.22-blocked:retired-unsafe-runtime",
+        network_policy="blocked:no-production-runtime",
+        filesystem_policy="blocked:no-runtime",
+    )
+    manifests["python-interpreter"] = CatalogAdapterManifest(
+        project_id="python-interpreter",
+        wave=8,
+        availability="blocked",
+        connection_kind="sandboxed-stdio",
+        risk="critical",
+        required_capabilities=(
+            "complete-license-provenance",
+            "ephemeral-code-sandbox",
+            "fixed-subprocess-only-contract",
+            "process-resource-limits",
+        ),
+        limitations=(
+            "PyPI 1.2.3 默认以 inline 模式在 MCP Server 进程内执行代码并保留全局会话，同时开放任意 pip 安装、文件读写、环境选择和最长 300 秒子进程执行，不能作为受控代码沙箱直接部署。",
+            "发布 wheel 虽声明 MIT classifier，但所携 LICENSE 文件为空；在许可证正文、固定 subprocess-only 契约与一次性容器边界全部核验前，不提供安装、连接、文件或执行入口。",
+        ),
+        adapter_version="1.2.3-blocked:unsafe-contract-and-empty-license",
+        network_policy="blocked:no-production-runtime",
+        filesystem_policy="blocked:no-runtime",
+    )
+
+    for project_id, spec in WAVE_NINE_READY_ADAPTERS.items():
+        manifests[project_id] = CatalogAdapterManifest(
+            project_id=project_id,
+            wave=9,
+            availability="ready",
+            connection_kind="sandboxed-stdio",
+            risk="medium",
+            required_capabilities=(
+                "fixed-egress-policy",
+                "read-only-tool-policy",
+                "schema-drift-recovery",
+                "cost-guardrails",
+                "process-resource-limits",
+            ),
+            limitations=spec.limitations,
+            adapter_version=spec.adapter_version,
+            runtime_image="modelmirror-mcp-registry:wave9-v1",
+            network_policy=spec.network_policy,
+            filesystem_policy="read-only-empty-workspace",
+            resource_limits=(
+                ("cpu", "1 core / 60 CPU seconds per call"),
+                ("memory", "512 MiB sidecar"),
+                ("processes", "maximum 4 sessions / 64 sidecar PIDs"),
+                ("operation_timeout", "60 seconds"),
+                ("tool_output", "256 KiB"),
+                ("provider_cost", "anonymous public Registry reads only"),
+            ),
+            server_command=(*TOKEN_SANDBOX_PROXY, project_id),
+            preparation_kind="bundled",
+            tool_policies={
+                name: CatalogToolPolicy(read_only=True, effect="read")
+                for name in spec.tools
+            },
+            enabled_by_default=True,
+            operation_timeout=60.0,
+            max_output_bytes=256 * 1024,
+        )
+
+    for project_id, (version, limitations) in WAVE_NINE_BLOCKED_ADAPTERS.items():
+        manifests[project_id] = CatalogAdapterManifest(
+            project_id=project_id,
+            wave=9,
+            availability="blocked",
+            connection_kind="sandboxed-stdio",
+            risk="critical",
+            required_capabilities=(
+                "cost-guardrails",
+                "resource-preview",
+                "terminal-action-approval",
+                "maintained-upstream-contract",
+            ),
+            limitations=limitations,
+            adapter_version=version,
+            network_policy="blocked:no-production-runtime",
+            filesystem_policy="blocked:no-runtime",
+        )
 
     manifests["snyk-mcp"] = CatalogAdapterManifest(
         project_id="snyk-mcp",
@@ -2832,6 +3055,15 @@ class MCPCatalogService:
             if manifest.connection_kind == "sandboxed-stdio":
                 environment: dict[str, str] = {}
                 configuration = self._configurations.get(scope_key)
+                uses_token_sidecar = (
+                    tuple(manifest.server_command[: len(TOKEN_SANDBOX_PROXY)])
+                    == TOKEN_SANDBOX_PROXY
+                )
+                if uses_token_sidecar and manifest.project_id == "terraform-mcp":
+                    environment["MCP_TOKEN_SOCKET_PATH"] = os.getenv(
+                        "MCP_REGISTRY_SOCKET_PATH",
+                        "/run/modelmirror-registry-mcp/registry-mcp.sock",
+                    )
                 workspace_id = ""
                 if manifest.workspace_policy is not None:
                     workspace_id = str(
@@ -2887,10 +3119,15 @@ class MCPCatalogService:
                             credential_id,
                             float(getattr(public, "updated_at", 0.0)),
                         )
-                if manifest.credential_policies or manifest.database_policy is not None:
-                    assert configuration is not None
+                if (
+                    uses_token_sidecar
+                    or manifest.credential_policies
+                    or manifest.database_policy is not None
+                ):
                     handshake_configuration: dict[str, Any] = {
-                        "settings": configuration.settings,
+                        "settings": (
+                            configuration.settings if configuration is not None else {}
+                        ),
                         "credentials": secrets,
                     }
                     if manifest.database_policy is not None:
@@ -2941,7 +3178,8 @@ class MCPCatalogService:
                     "network_policy": manifest.network_policy,
                     "reconnect_attempts": (
                         0
-                        if manifest.credential_policies
+                        if uses_token_sidecar
+                        or manifest.credential_policies
                         or manifest.database_policy is not None
                         or manifest.browser_policy is not None
                         else 1
@@ -2953,7 +3191,8 @@ class MCPCatalogService:
                     profile["environment"] = environment
                 session_id = await self.manager.connect_profile(**profile)
                 if (
-                    manifest.credential_policies
+                    uses_token_sidecar
+                    or manifest.credential_policies
                     or manifest.database_policy is not None
                     or manifest.browser_policy is not None
                 ):

--- a/server/mcp/token_proxy.py
+++ b/server/mcp/token_proxy.py
@@ -1,4 +1,4 @@
-"""Credential-aware stdio proxy for fixed Wave 4 catalog adapters.
+"""Configuration-aware stdio proxy for fixed catalog adapters.
 
 The server process supplies one short-lived, base64-encoded configuration via
 the child environment.  This proxy removes it immediately and transfers it to
@@ -22,6 +22,7 @@ ALLOWED_ADAPTERS = {
     "perplexity-mcp", "tavily-mcp", "axiom-mcp", "figma-context-mcp",
     "google-maps-mcp", "grafana-mcp", "graphlit-mcp", "kagi-mcp",
     "pinecone-assistant-mcp", "shodan-mcp", "virustotal-mcp",
+    "terraform-mcp",
 }
 SOCKET_PATH = Path(
     os.getenv(

--- a/server/sandbox_sidecar/Dockerfile.registry
+++ b/server/sandbox_sidecar/Dockerfile.registry
@@ -1,0 +1,25 @@
+FROM python:3.12-slim@sha256:401f6e1a67dad31a1bd78e9ad22d0ee0a3b52154e6bd30e90be696bb6a3d7461
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    MCP_TOKEN_ALLOWED_ADAPTERS=terraform-mcp \
+    MCP_TOKEN_SOCKET_PATH=/run/modelmirror-registry-mcp/registry-mcp.sock \
+    MCP_TOKEN_WORKSPACE_ROOT=/workspaces
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd --gid 65532 sandbox \
+    && useradd --uid 65532 --gid 65532 --home-dir /workspaces --no-create-home sandbox \
+    && mkdir -p /opt/modelmirror/sandbox_sidecar /workspaces /run/modelmirror-registry-mcp \
+    && chown -R sandbox:sandbox /workspaces /run/modelmirror-registry-mcp
+
+WORKDIR /opt/modelmirror
+COPY requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir --retries 5 --timeout 120 -r requirements.txt
+COPY __init__.py engine.py landlock_exec.py safe_http.py smoke_token_adapters.py token_builtin.py token_contracts.py token_server.py ./sandbox_sidecar/
+COPY THIRD_PARTY_NOTICES.md /usr/share/doc/modelmirror-mcp-registry/THIRD_PARTY_NOTICES.md
+RUN MCP_SMOKE_ADAPTERS=terraform-mcp python -m sandbox_sidecar.smoke_token_adapters
+
+USER 65532:65532
+CMD ["python", "-m", "sandbox_sidecar.token_server"]

--- a/server/sandbox_sidecar/THIRD_PARTY_NOTICES.md
+++ b/server/sandbox_sidecar/THIRD_PARTY_NOTICES.md
@@ -159,3 +159,13 @@ inactive. The original source is `seccomp/default.json` in that tagged release.
 Puppeteer MCP and Selenium MCP are not installed or executed in Wave 7. Their
 catalog entries remain blocked until an independently verified sandbox and
 upstream schema contract are available.
+
+The `modelmirror-mcp-registry:wave9-v1` image implements an independent,
+credential-free, read-only compatibility subset after reviewing HashiCorp
+Terraform MCP Server v1.2.0 (`hashicorp/terraform-mcp-server`), licensed under
+MPL-2.0. No HashiCorp server source or binary is copied into the image. The
+runtime exposes six public Terraform Registry discovery/documentation tools
+and cannot access HCP Terraform, Terraform Enterprise, private registries,
+local Terraform files, or infrastructure mutation tools. Its pinned direct
+Python runtime dependencies are MCP Python SDK 1.27.2 (MIT) and tzdata 2026.3
+(public-domain/IANA database notices retained in installed package metadata).

--- a/server/sandbox_sidecar/smoke_registry_runtime.py
+++ b/server/sandbox_sidecar/smoke_registry_runtime.py
@@ -1,0 +1,203 @@
+"""Isolated real-call acceptance for the public Terraform Registry adapter."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+from mcp.shared.exceptions import McpError
+from mcp.types import CallToolResult
+
+
+EXPECTED_TOOLS = {
+    "get_latest_provider_version",
+    "get_provider_capabilities",
+    "get_provider_details",
+    "search_modules",
+    "get_module_details",
+    "get_latest_module_version",
+}
+BLOCKED_TOOL_NAMES = {
+    "apply",
+    "destroy",
+    "plan",
+    "run",
+    "create_workspace",
+    "create_run",
+    "private_registry",
+}
+
+
+def _decode_result(result: CallToolResult) -> Any:
+    if result.isError:
+        raise RuntimeError("terraform_registry_tool_failed")
+    structured = result.structuredContent
+    if isinstance(structured, dict) and "result" in structured:
+        return structured["result"]
+    texts = [
+        str(item.text)
+        for item in result.content
+        if getattr(item, "type", "") == "text"
+    ]
+    if not texts:
+        raise RuntimeError("terraform_registry_tool_result_missing")
+    text = "\n".join(texts)
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return text
+
+
+async def _call(session: ClientSession, name: str, arguments: dict[str, Any]) -> Any:
+    result = await session.call_tool(name, arguments)
+    return _decode_result(result)
+
+
+async def run(socket_path: Path, proxy_path: Path) -> None:
+    if not socket_path.is_absolute() or not proxy_path.is_absolute():
+        raise RuntimeError("runtime_smoke_paths_must_be_absolute")
+    handshake = base64.urlsafe_b64encode(
+        json.dumps(
+            {"settings": {}, "credentials": {}},
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).decode("ascii")
+    env = {
+        "PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"),
+        "PYTHONDONTWRITEBYTECODE": "1",
+        "PYTHONUNBUFFERED": "1",
+        "MCP_TOKEN_SOCKET_PATH": str(socket_path),
+        "MCP_TOKEN_HANDSHAKE_B64": handshake,
+    }
+    params = StdioServerParameters(
+        command=sys.executable,
+        args=[str(proxy_path), "terraform-mcp"],
+        env=env,
+        cwd=Path("/tmp"),
+    )
+    async with stdio_client(params) as (read_stream, write_stream):
+        async with ClientSession(read_stream, write_stream) as session:
+            await session.initialize()
+            listed = await session.list_tools()
+            names = {tool.name for tool in listed.tools}
+            if names != EXPECTED_TOOLS or names & BLOCKED_TOOL_NAMES:
+                raise RuntimeError("terraform_registry_tool_contract_drift")
+            try:
+                await session.call_tool("apply", {})
+            except McpError:
+                pass
+            else:
+                raise RuntimeError("terraform_registry_blocked_tool_was_callable")
+
+            provider_input = {"namespace": "hashicorp", "name": "random"}
+            provider_version = str(
+                await _call(session, "get_latest_provider_version", provider_input)
+            ).strip()
+            if re.fullmatch(r"[0-9A-Za-z][0-9A-Za-z.+-]{0,79}", provider_version) is None:
+                raise RuntimeError("terraform_registry_provider_version_invalid")
+
+            capabilities = await _call(
+                session,
+                "get_provider_capabilities",
+                {**provider_input, "version": "latest"},
+            )
+            if not isinstance(capabilities, dict):
+                raise RuntimeError("terraform_registry_capabilities_invalid")
+            categories = capabilities.get("capabilities")
+            if not isinstance(categories, list) or not categories:
+                raise RuntimeError("terraform_registry_capabilities_empty")
+            provider_doc_id = ""
+            for category in categories:
+                examples = category.get("examples") if isinstance(category, dict) else None
+                if not isinstance(examples, list):
+                    continue
+                for example in examples:
+                    candidate = str(
+                        example.get("provider_doc_id")
+                        if isinstance(example, dict)
+                        else ""
+                    )
+                    if candidate.isdigit():
+                        provider_doc_id = candidate
+                        break
+                if provider_doc_id:
+                    break
+            if not provider_doc_id:
+                raise RuntimeError("terraform_registry_provider_doc_id_missing")
+            provider_doc = str(
+                await _call(
+                    session,
+                    "get_provider_details",
+                    {"provider_doc_id": provider_doc_id},
+                )
+            )
+            if not provider_doc.strip() or len(provider_doc.encode("utf-8")) > 128 * 1024:
+                raise RuntimeError("terraform_registry_provider_doc_invalid")
+
+            modules = await _call(
+                session,
+                "search_modules",
+                {"module_query": "vpc", "current_offset": 0},
+            )
+            module_items = modules.get("modules") if isinstance(modules, dict) else None
+            if not isinstance(module_items, list) or not module_items:
+                raise RuntimeError("terraform_registry_module_search_empty")
+            module_id = str(module_items[0].get("module_id") or "")
+            if len(module_id.split("/")) != 4:
+                raise RuntimeError("terraform_registry_module_id_invalid")
+            module = await _call(
+                session,
+                "get_module_details",
+                {"module_id": module_id},
+            )
+            if not isinstance(module, dict) or module.get("module_id") != module_id.lower():
+                raise RuntimeError("terraform_registry_module_details_invalid")
+            module_version = str(
+                await _call(
+                    session,
+                    "get_latest_module_version",
+                    {
+                        "module_publisher": "terraform-aws-modules",
+                        "module_name": "vpc",
+                        "module_provider": "aws",
+                    },
+                )
+            ).strip()
+            if not module_version:
+                raise RuntimeError("terraform_registry_module_version_invalid")
+
+    print("adapter=terraform-mcp")
+    print("input.provider=hashicorp/random")
+    print(f"result.provider_version={provider_version}")
+    print(f"result.capability_categories={len(categories)}")
+    print(f"result.provider_doc_bytes={len(provider_doc.encode('utf-8'))}")
+    print("input.module_query=vpc")
+    print(f"result.first_module_id={module_id}")
+    print(f"result.module_inputs={len(module.get('inputs') or [])}")
+    print(f"result.latest_module_version={module_version}")
+    print("blocked_tools=apply,destroy,plan,hcp,tfe,private_registry")
+    print("blocked_call.apply=denied")
+    print("terraform_registry_runtime_smoke=ok")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--socket", required=True)
+    parser.add_argument("--proxy", required=True)
+    args = parser.parse_args()
+    import asyncio
+
+    asyncio.run(run(Path(args.socket), Path(args.proxy)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/server/sandbox_sidecar/smoke_token_adapters.py
+++ b/server/sandbox_sidecar/smoke_token_adapters.py
@@ -1,4 +1,4 @@
-"""Offline initialization and tool-discovery smoke for Wave 4 runtime pins."""
+"""Offline initialization and tool-discovery smoke for fixed token runtimes."""
 
 from __future__ import annotations
 
@@ -86,7 +86,15 @@ async def discover(adapter_id: str) -> tuple[str, set[str], str]:
 
 
 async def main() -> None:
-    for adapter_id in sorted(TOKEN_ADAPTERS):
+    requested = {
+        item.strip()
+        for item in os.getenv("MCP_SMOKE_ADAPTERS", "").split(",")
+        if item.strip()
+    }
+    adapter_ids = requested or set(TOKEN_ADAPTERS)
+    if not adapter_ids.issubset(TOKEN_ADAPTERS):
+        raise RuntimeError("unknown adapter requested for runtime smoke")
+    for adapter_id in sorted(adapter_ids):
         name, discovered, digest = await asyncio.wait_for(discover(adapter_id), timeout=20)
         allowed = discovered & TOKEN_ADAPTERS[name].tools
         print(

--- a/server/sandbox_sidecar/token_builtin.py
+++ b/server/sandbox_sidecar/token_builtin.py
@@ -1,4 +1,4 @@
-"""Small reviewed compatibility adapters for four Wave 4 providers."""
+"""Small reviewed compatibility adapters for fixed read-only providers."""
 
 from __future__ import annotations
 
@@ -216,11 +216,243 @@ def build_pinecone() -> FastMCP:
     return mcp
 
 
+_TERRAFORM_SEGMENT = re.compile(
+    r"[a-z0-9](?:[a-z0-9_.-]{0,118}[a-z0-9])?",
+)
+
+
+def _terraform_segment(value: object, name: str) -> str:
+    clean = str(value or "").strip().lower()
+    if _TERRAFORM_SEGMENT.fullmatch(clean) is None:
+        raise ValueError(f"{name} must be a Terraform Registry identifier.")
+    return clean
+
+
+def _terraform_bounded_text(value: object, name: str, maximum: int = 128 * 1024) -> str:
+    text = str(value or "")
+    if len(text.encode("utf-8")) > maximum:
+        raise ValueError(f"{name} exceeds the fixed output limit.")
+    return text
+
+
+def build_terraform() -> FastMCP:
+    """Expose a credential-free subset compatible with Terraform MCP v1.2.0."""
+
+    host = "registry.terraform.io"
+    internal_module_response_limit = 2 * 1024 * 1024
+    client = SafeHttpClient(
+        allowed_hosts=frozenset({host}),
+        timeout=10.0,
+        max_redirects=0,
+        max_response_bytes=internal_module_response_limit,
+        minimum_intervals={host: 0.2},
+    )
+    mcp = FastMCP("ModelMirror Terraform Registry Read Only")
+
+    def get(path: str, *, response_limit: int = MAX_RESULT_BYTES) -> Any:
+        response = client.request(
+            f"https://{host}{path}",
+            max_response_bytes=response_limit,
+        )
+        if response_limit <= MAX_RESULT_BYTES:
+            return _json(response, "Terraform Registry")
+        if not 200 <= response.status < 300:
+            raise ValueError(f"Terraform Registry returned HTTP {response.status}.")
+        try:
+            return json.loads(response.body.decode("utf-8"))
+        except (UnicodeError, json.JSONDecodeError) as exc:
+            raise ValueError("Terraform Registry returned invalid JSON.") from exc
+
+    def latest_provider_version(namespace: str, name: str) -> str:
+        payload = get(f"/v1/providers/{namespace}/{name}")
+        version = str(payload.get("version") if isinstance(payload, dict) else "").strip()
+        if not version or len(version) > 80:
+            raise ValueError("Terraform Registry did not return a valid provider version.")
+        return version
+
+    @mcp.tool(annotations=READ_ONLY)
+    def get_latest_provider_version(namespace: str, name: str) -> str:
+        """Fetch the latest public Terraform provider version."""
+        return latest_provider_version(
+            _terraform_segment(namespace, "namespace"),
+            _terraform_segment(name, "name"),
+        )
+
+    @mcp.tool(annotations=READ_ONLY)
+    def get_provider_capabilities(
+        namespace: str,
+        name: str,
+        version: str = "latest",
+    ) -> dict[str, object]:
+        """List public provider documentation categories and bounded examples."""
+        clean_namespace = _terraform_segment(namespace, "namespace")
+        clean_name = _terraform_segment(name, "name")
+        clean_version = str(version or "latest").strip().lower()
+        if clean_version == "latest":
+            clean_version = latest_provider_version(clean_namespace, clean_name)
+        elif re.fullmatch(r"[0-9A-Za-z](?:[0-9A-Za-z.+-]{0,78}[0-9A-Za-z])?", clean_version) is None:
+            raise ValueError("version must be a Terraform provider version or latest.")
+        payload = get(
+            f"/v1/providers/{clean_namespace}/{clean_name}/{quote(clean_version, safe='')}"
+        )
+        docs = payload.get("docs") if isinstance(payload, dict) else None
+        if not isinstance(docs, list):
+            raise ValueError("Terraform Registry provider documentation is unavailable.")
+        grouped: dict[str, list[dict[str, str]]] = {}
+        counts: dict[str, int] = {}
+        for item in docs:
+            if not isinstance(item, dict) or str(item.get("language") or "").lower() != "hcl":
+                continue
+            category = str(item.get("category") or "other").strip().lower()[:80]
+            counts[category] = counts.get(category, 0) + 1
+            examples = grouped.setdefault(category, [])
+            if len(examples) < 10:
+                examples.append(
+                    {
+                        "title": str(item.get("title") or "")[:240],
+                        "provider_doc_id": str(item.get("id") or "")[:40],
+                    }
+                )
+        return {
+            "provider": f"{clean_namespace}/{clean_name}",
+            "version": clean_version,
+            "capabilities": [
+                {"category": category, "count": counts[category], "examples": grouped[category]}
+                for category in sorted(grouped)
+            ],
+        }
+
+    @mcp.tool(annotations=READ_ONLY)
+    def get_provider_details(provider_doc_id: str) -> str:
+        """Fetch one public provider documentation page by numeric document ID."""
+        clean_id = str(provider_doc_id or "").strip()
+        if re.fullmatch(r"[1-9][0-9]{0,19}", clean_id) is None:
+            raise ValueError("provider_doc_id must be a positive numeric Registry document ID.")
+        payload = get(f"/v2/provider-docs/{clean_id}")
+        data = payload.get("data") if isinstance(payload, dict) else None
+        attributes = data.get("attributes") if isinstance(data, dict) else None
+        if not isinstance(attributes, dict):
+            raise ValueError("Terraform Registry provider documentation is unavailable.")
+        return _terraform_bounded_text(attributes.get("content"), "provider documentation")
+
+    @mcp.tool(annotations=READ_ONLY)
+    def search_modules(module_query: str, current_offset: int = 0) -> dict[str, object]:
+        """Search public Terraform modules and return at most twenty compact matches."""
+        query = _text(module_query, "module_query", 240).lower()
+        offset = int(current_offset)
+        if offset < 0 or offset > 10_000:
+            raise ValueError("current_offset must be between 0 and 10000.")
+        payload = get(f"/v1/modules/search?{urlencode({'q': query, 'offset': offset})}")
+        modules = payload.get("modules") if isinstance(payload, dict) else None
+        if not isinstance(modules, list):
+            raise ValueError("Terraform Registry module search is unavailable.")
+        compact: list[dict[str, object]] = []
+        for item in modules[:20]:
+            if not isinstance(item, dict):
+                continue
+            compact.append(
+                {
+                    "module_id": str(item.get("id") or "")[:500],
+                    "name": str(item.get("name") or "")[:240],
+                    "description": str(item.get("description") or "")[:1_000],
+                    "downloads": max(0, int(item.get("downloads") or 0)),
+                    "verified": bool(item.get("verified")),
+                    "published_at": str(item.get("published_at") or "")[:80],
+                }
+            )
+        return {"query": query, "offset": offset, "modules": compact}
+
+    @mcp.tool(annotations=READ_ONLY)
+    def get_module_details(module_id: str) -> dict[str, object]:
+        """Fetch bounded public module metadata using a four-part Registry module ID."""
+        raw_parts = str(module_id or "").strip().split("/")
+        if len(raw_parts) != 4:
+            raise ValueError("module_id must use namespace/name/provider/version format.")
+        parts = [_terraform_segment(part, "module_id segment") for part in raw_parts]
+        payload = get(
+            f"/v1/modules/{'/'.join(parts)}?offset=0",
+            response_limit=internal_module_response_limit,
+        )
+        if not isinstance(payload, dict):
+            raise ValueError("Terraform Registry module details are unavailable.")
+        root = payload.get("root")
+        if not isinstance(root, dict):
+            root = {}
+
+        def bounded_items(name: str, limit: int = 50) -> list[dict[str, object]]:
+            value = root.get(name)
+            if not isinstance(value, list):
+                return []
+            output: list[dict[str, object]] = []
+            for item in value[:limit]:
+                if not isinstance(item, dict):
+                    continue
+                output.append(
+                    {
+                        key: (
+                            (raw if isinstance(raw, bool) else False)
+                            if key == "required"
+                            else str(raw if raw is not None else "")[:500]
+                        )
+                        for key, raw in item.items()
+                        if key
+                        in {
+                            "name",
+                            "type",
+                            "description",
+                            "default",
+                            "required",
+                            "namespace",
+                            "source",
+                            "version",
+                        }
+                    }
+                )
+            return output
+
+        return {
+            "module_id": "/".join(parts),
+            "namespace": str(payload.get("namespace") or "")[:240],
+            "name": str(payload.get("name") or "")[:240],
+            "provider": str(payload.get("provider") or "")[:240],
+            "version": str(payload.get("version") or "")[:80],
+            "source": str(payload.get("source") or "")[:500],
+            "description": str(payload.get("description") or "")[:2_000],
+            "inputs": bounded_items("inputs"),
+            "outputs": bounded_items("outputs"),
+            "provider_dependencies": bounded_items("provider_dependencies"),
+        }
+
+    @mcp.tool(annotations=READ_ONLY)
+    def get_latest_module_version(
+        module_publisher: str,
+        module_name: str,
+        module_provider: str,
+    ) -> str:
+        """Fetch the latest public Terraform module version."""
+        parts = [
+            _terraform_segment(module_publisher, "module_publisher"),
+            _terraform_segment(module_name, "module_name"),
+            _terraform_segment(module_provider, "module_provider"),
+        ]
+        payload = get(
+            f"/v1/modules/{'/'.join(parts)}",
+            response_limit=internal_module_response_limit,
+        )
+        version = str(payload.get("version") if isinstance(payload, dict) else "").strip()
+        if not version or len(version) > 80:
+            raise ValueError("Terraform Registry did not return a valid module version.")
+        return version
+
+    return mcp
+
+
 BUILDERS = {
     "axiom-mcp": build_axiom,
     "grafana-mcp": build_grafana,
     "kagi-mcp": build_kagi,
     "pinecone-assistant-mcp": build_pinecone,
+    "terraform-mcp": build_terraform,
 }
 
 

--- a/server/sandbox_sidecar/token_contracts.py
+++ b/server/sandbox_sidecar/token_contracts.py
@@ -117,6 +117,22 @@ TOKEN_ADAPTERS: dict[str, TokenAdapterContract] = {
         (("api_key", "VIRUSTOTAL_API_KEY"),),
         allowed_hosts=frozenset({"www.virustotal.com"}),
     ),
+    "terraform-mcp": TokenAdapterContract(
+        ("python", "-m", "sandbox_sidecar.token_builtin", "terraform-mcp"),
+        frozenset(
+            {
+                "get_latest_provider_version",
+                "get_provider_capabilities",
+                "get_provider_details",
+                "search_modules",
+                "get_module_details",
+                "get_latest_module_version",
+            }
+        ),
+        (),
+        allowed_hosts=frozenset({"registry.terraform.io"}),
+        builtin=True,
+    ),
 }
 
 
@@ -136,6 +152,7 @@ TOKEN_SCHEMA_SHA256: dict[str, str] = {
     "shodan-mcp": "5fefb2af3c61d61dc3c5679db0bbdaf095de5fd2fbbee5d1ffc5401bb6cd001e",
     "tavily-mcp": "01ca28e4482a06c12ef88bf26e1ddb96e2aae83ec65c5234365a8555854d7710",
     "virustotal-mcp": "c66291ebfcfb5ccf9cd23608cbfca9760031f3215271448249959927f843c234",
+    "terraform-mcp": "73a2b116bcaa257dbf158d1ab8a778d067dac2d969db7dff160372d1617e3445",
 }
 
 

--- a/server/sandbox_sidecar/token_server.py
+++ b/server/sandbox_sidecar/token_server.py
@@ -20,6 +20,14 @@ SOCKET_PATH = Path(os.getenv("MCP_TOKEN_SOCKET_PATH", "/run/modelmirror-token-mc
 WORKSPACE_ROOT = Path(os.getenv("MCP_TOKEN_WORKSPACE_ROOT", "/workspaces"))
 MAX_MCP_MESSAGE_BYTES = 256 * 1024
 MAX_TOKEN_SESSIONS = max(1, min(int(os.getenv("MCP_TOKEN_MAX_SESSIONS", "6")), 12))
+_raw_allowed_adapters = os.getenv("MCP_TOKEN_ALLOWED_ADAPTERS", "").strip()
+ALLOWED_ADAPTERS = (
+    frozenset(item.strip() for item in _raw_allowed_adapters.split(",") if item.strip())
+    if _raw_allowed_adapters
+    else frozenset(TOKEN_ADAPTERS)
+)
+if not ALLOWED_ADAPTERS or not ALLOWED_ADAPTERS.issubset(TOKEN_ADAPTERS):
+    raise RuntimeError("invalid_token_adapter_allowlist")
 TOKEN_SEMAPHORE = asyncio.Semaphore(MAX_TOKEN_SESSIONS)
 
 
@@ -170,6 +178,12 @@ def _child_environment(
         "DISABLE_TELEMETRY": "true",
         "NO_PROXY": "*",
         "no_proxy": "*",
+        "MCP_PUBLIC_ALLOW_SYNTHETIC_DNS": (
+            "true"
+            if os.getenv("MCP_PUBLIC_ALLOW_SYNTHETIC_DNS", "").strip().lower()
+            in {"1", "true", "yes", "on"}
+            else "false"
+        ),
         "MCP_ALLOWED_HOSTS": ",".join(sorted(hosts)),
         "NODE_OPTIONS": "--require=/opt/modelmirror/sandbox_sidecar/network_guard.cjs",
     }
@@ -186,6 +200,8 @@ async def _handle_mcp_stdio(
     request: dict[str, Any],
 ) -> None:
     adapter_id = str(request.get("adapter_id") or "").strip()
+    if adapter_id not in ALLOWED_ADAPTERS:
+        raise SandboxEngineError("Token adapter denied.", code="mcp_adapter_denied")
     try:
         contract, credentials, settings = validate_configuration(
             adapter_id, request.get("configuration")

--- a/server/tests/test_mcp_catalog.py
+++ b/server/tests/test_mcp_catalog.py
@@ -29,6 +29,8 @@ from server.mcp.catalog import (
     WAVE_FIVE_ADAPTERS,
     WAVE_SIX_ADAPTERS,
     WAVE_SEVEN_ADAPTERS,
+    WAVE_NINE_BLOCKED_ADAPTERS,
+    WAVE_NINE_READY_ADAPTERS,
     WAVE_PROJECTS,
     CatalogAdapterManifest,
     CatalogConfigurationRequest,
@@ -340,15 +342,15 @@ def test_catalog_freezes_100_projects_and_maps_all_waves_once() -> None:
     assert sum(
         manifest.availability == "ready"
         for manifest in CATALOG_ADAPTERS.values()
-    ) == 44
+    ) == 45
     assert sum(
         manifest.availability == "planned"
         for manifest in CATALOG_ADAPTERS.values()
-    ) == 43
+    ) == 27
     assert sum(
         manifest.availability == "blocked"
         for manifest in CATALOG_ADAPTERS.values()
-    ) == 13
+    ) == 28
     assert {manifest.availability for manifest in CATALOG_ADAPTERS.values()} == {
         "ready",
         "planned",
@@ -392,7 +394,7 @@ def test_frontend_catalog_ids_match_backend_registry_and_never_submit_commands()
 def test_planned_adapter_cannot_be_enabled_by_environment(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    manifest = CATALOG_ADAPTERS["mcp-run-python"]
+    manifest = CATALOG_ADAPTERS["apify-mcp"]
     monkeypatch.setenv(manifest.feature_flag, "true")
 
     assert manifest.feature_enabled is True
@@ -456,6 +458,130 @@ def test_wave_seven_manifest_freezes_ready_blocked_and_public_policy() -> None:
     assert CATALOG_ADAPTERS["selenium-mcp"].availability == "blocked"
     assert CATALOG_ADAPTERS["puppeteer-mcp"].server_command == ()
     assert CATALOG_ADAPTERS["selenium-mcp"].server_command == ()
+
+
+def test_wave_eight_manifest_blocks_unsafe_python_runtimes() -> None:
+    expected = {
+        "mcp-run-python": (
+            "0.0.22-blocked:retired-unsafe-runtime",
+            "maintained-safe-execution-runtime",
+            "Pyodide",
+        ),
+        "python-interpreter": (
+            "1.2.3-blocked:unsafe-contract-and-empty-license",
+            "complete-license-provenance",
+            "LICENSE",
+        ),
+    }
+    for project_id, (version, capability, evidence) in expected.items():
+        manifest = CATALOG_ADAPTERS[project_id]
+        assert manifest.wave == 8
+        assert manifest.availability == "blocked"
+        assert manifest.risk == "critical"
+        assert manifest.adapter_version == version
+        assert capability in manifest.required_capabilities
+        assert any(evidence in item for item in manifest.limitations)
+        assert manifest.runtime_image == ""
+        assert manifest.server_command == ()
+        assert manifest.endpoint == ""
+        assert manifest.tool_policies == {}
+        assert manifest.network_policy == "blocked:no-production-runtime"
+        assert manifest.filesystem_policy == "blocked:no-runtime"
+
+
+def test_wave_eight_feature_flags_cannot_enable_blocked_adapters(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for project_id in ("mcp-run-python", "python-interpreter"):
+        manifest = CATALOG_ADAPTERS[project_id]
+        monkeypatch.setenv(manifest.feature_flag, "true")
+        assert manifest.feature_enabled is True
+        assert manifest.executable is False
+        assert manifest.to_public()["executable"] is False
+
+
+def test_wave_nine_freezes_one_public_registry_adapter_and_thirteen_blocked() -> None:
+    assert set(WAVE_NINE_READY_ADAPTERS) == {"terraform-mcp"}
+    assert len(WAVE_NINE_BLOCKED_ADAPTERS) == 13
+    terraform = CATALOG_ADAPTERS["terraform-mcp"]
+    assert terraform.wave == 9
+    assert terraform.availability == "ready"
+    assert terraform.risk == "medium"
+    assert terraform.enabled_by_default is True
+    assert terraform.executable is True
+    assert terraform.runtime_image == "modelmirror-mcp-registry:wave9-v1"
+    assert terraform.network_policy == "allowlist:registry.terraform.io"
+    assert terraform.filesystem_policy == "read-only-empty-workspace"
+    assert terraform.credential_policies == ()
+    assert terraform.allowed_settings == ()
+    assert set(terraform.tool_policies) == set(
+        WAVE_NINE_READY_ADAPTERS["terraform-mcp"].tools
+    )
+    assert all(policy.effect == "read" for policy in terraform.tool_policies.values())
+    assert all(policy.read_only for policy in terraform.tool_policies.values())
+
+    for project_id in WAVE_NINE_BLOCKED_ADAPTERS:
+        manifest = CATALOG_ADAPTERS[project_id]
+        assert manifest.wave == 9
+        assert manifest.availability == "blocked"
+        assert manifest.server_command == ()
+        assert manifest.runtime_image == ""
+        assert manifest.tool_policies == {}
+        assert manifest.network_policy == "blocked:no-production-runtime"
+
+
+def test_wave_nine_compose_isolates_registry_from_wave_four_token_sidecar() -> None:
+    source = (PROJECT_ROOT / "docker-compose.yml").read_text(encoding="utf-8")
+    registry_block = source[
+        source.index("  mcp-registry:\n") : source.index("  mcp-saas:\n")
+    ]
+    token_block = source[source.index("  mcp-token:\n") : source.index("  mcp-registry:\n")]
+    assert "image: modelmirror-mcp-registry:wave9-v1" in registry_block
+    assert "MCP_TOKEN_ALLOWED_ADAPTERS: terraform-mcp" in registry_block
+    assert 'MCP_PUBLIC_ALLOW_SYNTHETIC_DNS: "true"' in registry_block
+    assert "read_only: true" in registry_block
+    assert "cap_drop:\n      - ALL" in registry_block
+    assert "pids_limit: 64" in registry_block
+    assert "mcp_registry_socket:/run/modelmirror-registry-mcp" in registry_block
+    assert "terraform-mcp" not in token_block
+    assert "mcp-registry:\n        condition: service_healthy" in source
+    assert "MCP_REGISTRY_SOCKET_PATH: /run/modelmirror-registry-mcp/registry-mcp.sock" in source
+
+
+@pytest.mark.asyncio
+async def test_wave_nine_terraform_connect_uses_empty_handshake_and_registry_socket(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, manager, installer, registry = make_service()
+    manager.tools = [
+        Tool(name=name, description=name, inputSchema={})
+        for name in sorted(WAVE_NINE_READY_ADAPTERS["terraform-mcp"].tools)
+    ]
+    monkeypatch.setenv(
+        "MCP_REGISTRY_SOCKET_PATH",
+        "/run/modelmirror-registry-mcp/registry-mcp.sock",
+    )
+
+    connected = await service.connect("terraform-mcp")
+
+    assert connected["tools_count"] == 6
+    assert installer.calls == []
+    assert registry.registered == []
+    profile = manager.profiles[0]
+    assert profile["server_command"] == list(
+        CATALOG_ADAPTERS["terraform-mcp"].server_command
+    )
+    assert profile["reconnect_attempts"] == 0
+    assert profile["environment"]["MCP_TOKEN_SOCKET_PATH"] == (
+        "/run/modelmirror-registry-mcp/registry-mcp.sock"
+    )
+    payload = json.loads(
+        base64.urlsafe_b64decode(
+            profile["environment"]["MCP_TOKEN_HANDSHAKE_B64"]
+        ).decode("utf-8")
+    )
+    assert payload == {"settings": {}, "credentials": {}}
+    assert manager.scrubbed == [connected["session_id"]]
 
 
 def test_wave_seven_compose_isolates_browser_and_egress_services() -> None:
@@ -1392,9 +1518,9 @@ async def test_catalog_api_hides_execution_details_and_rejects_planned_connect()
             assert response.status_code == 200
             payload = response.json()
             assert payload["total"] == 100
-            assert payload["ready"] == 44
-            assert payload["planned"] == 43
-            assert payload["blocked"] == 13
+            assert payload["ready"] == 45
+            assert payload["planned"] == 27
+            assert payload["blocked"] == 28
             serialized = response.text.lower()
             assert "server_command" not in serialized
             assert "install_command" not in serialized

--- a/server/tests/test_mcp_token_sidecar.py
+++ b/server/tests/test_mcp_token_sidecar.py
@@ -7,7 +7,11 @@ import json
 import pytest
 
 from server.mcp import token_proxy
-from server.mcp.catalog import CATALOG_ADAPTERS, WAVE_FOUR_ADAPTERS
+from server.mcp.catalog import (
+    CATALOG_ADAPTERS,
+    WAVE_FOUR_ADAPTERS,
+    WAVE_NINE_READY_ADAPTERS,
+)
 from server.sandbox_sidecar import token_server
 from server.sandbox_sidecar.safe_http import NetworkPolicyError
 from server.sandbox_sidecar.token_contracts import (
@@ -37,9 +41,10 @@ def reader_for(*messages: dict[str, object]) -> asyncio.StreamReader:
 
 
 def test_runtime_contracts_match_catalog_and_never_include_snyk() -> None:
-    assert set(TOKEN_ADAPTERS) == set(WAVE_FOUR_ADAPTERS)
+    expected = set(WAVE_FOUR_ADAPTERS) | set(WAVE_NINE_READY_ADAPTERS)
+    assert set(TOKEN_ADAPTERS) == expected
     assert set(TOKEN_SCHEMA_SHA256) == set(TOKEN_ADAPTERS)
-    assert set(token_proxy.ALLOWED_ADAPTERS) == set(WAVE_FOUR_ADAPTERS)
+    assert set(token_proxy.ALLOWED_ADAPTERS) == expected
     assert "snyk-mcp" not in TOKEN_ADAPTERS
     for project_id, contract in TOKEN_ADAPTERS.items():
         assert contract.tools == frozenset(CATALOG_ADAPTERS[project_id].tool_policies)
@@ -58,6 +63,15 @@ def test_configuration_contract_rejects_missing_and_extra_fields() -> None:
     assert contract.builtin is True
     assert credentials == {"service_token": "secret"}
     assert settings == {"stack_slug": "my-stack"}
+
+    terraform, credentials, settings = validate_configuration(
+        "terraform-mcp",
+        {"credentials": {}, "settings": {}},
+    )
+    assert terraform.builtin is True
+    assert terraform.allowed_hosts == frozenset({"registry.terraform.io"})
+    assert credentials == {}
+    assert settings == {}
 
     with pytest.raises(ValueError, match="configuration_contract_mismatch"):
         validate_configuration(
@@ -85,6 +99,20 @@ def test_proxy_configuration_is_removed_from_environment(monkeypatch: pytest.Mon
     )
     assert token_proxy._load_configuration() == payload
     assert "MCP_TOKEN_HANDSHAKE_B64" not in token_proxy.os.environ
+
+
+def test_synthetic_dns_flag_is_normalized_for_child(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    contract = TOKEN_ADAPTERS["terraform-mcp"]
+    monkeypatch.setenv("MCP_PUBLIC_ALLOW_SYNTHETIC_DNS", "YES")
+    enabled = token_server._child_environment(contract, {}, {}, tmp_path)
+    assert enabled["MCP_PUBLIC_ALLOW_SYNTHETIC_DNS"] == "true"
+
+    monkeypatch.setenv("MCP_PUBLIC_ALLOW_SYNTHETIC_DNS", "unexpected")
+    disabled = token_server._child_environment(contract, {}, {}, tmp_path)
+    assert disabled["MCP_PUBLIC_ALLOW_SYNTHETIC_DNS"] == "false"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 改动内容

- 完成第八批边界收口：MCP Run Python 与 MCP Python Interpreter 保持 blocked，不引入未验证执行面。
- 完成第九批目录审计：Terraform 公共 Registry 只读子集 ready，其余 13 项按凭据、费用、归档或资源写入风险保持 blocked。
- 新增独立 `mcp-registry` sidecar，固定 `registry.terraform.io`，仅开放 6 个 Provider/Module 查询工具。
- 冻结工具 Schema 摘要，隔离 Wave4 Token socket，补齐非 root、只读根、cap-drop、NNP 与资源限制。
- 同步前端目录状态、适配说明、路线图、集成文档、第三方声明与回退策略。

## 原因与影响

第八批上游未满足安全执行门槛；第九批仅 Terraform 公共 Registry 能在无凭据、无工作区、无资源写入的边界内提供确定性价值。本 PR 将目录更新为 45 ready / 27 planned / 28 blocked，并提供可独立回退的 Registry 运行时。

## 验证

- `server/tests/test_mcp_catalog.py`: 58 passed
- `server/tests/test_mcp_token_sidecar.py`: 7 passed
- `npm.cmd run build`: passed
- `docker compose config --quiet`: passed
- Python 内存语法编译：9 files passed
- 隔离真实 Registry smoke：6 个只读工具通过；`apply` 明确拒绝
- 一次性验收容器、卷、网络：精确清理为 0/0/0

## 风险与回退

Docker Desktop 的公网 DNS 可能映射到 `198.18.0.0/15`；兼容仅作用于编译固定的 `registry.terraform.io`，仍执行 TLS hostname/证书校验，不接收用户 URL。回退只需断开 Terraform 目录会话并停止 `mcp-registry`，不涉及凭据、Terraform 状态或外部资源删除。
