### PR TITLE
feature: V14 Coding Worker execution foundation

### DIFF
--- a/docker-compose.coding-worker-v14.yml
+++ b/docker-compose.coding-worker-v14.yml
@@ -13,6 +13,9 @@ services:
       CODING_WORKER_MAX_ACTIVE_TASKS: ${CODING_WORKER_MAX_ACTIVE_TASKS:-2}
       CODING_WORKER_RETENTION_SECONDS: ${CODING_WORKER_RETENTION_SECONDS:-604800}
       CODING_WORKER_NETWORK_ENABLED: ${CODING_WORKER_NETWORK_ENABLED:-false}
+      CODING_WORKER_NETWORK_DOMAINS: ${CODING_WORKER_NETWORK_DOMAINS:-registry.npmjs.org}
+      CODING_WORKER_EGRESS_PROXY_URL: http://coding-worker-egress:8080
+      CODING_WORKER_EGRESS_GRANT_KEY: ${CODING_WORKER_EGRESS_GRANT_KEY:-}
     volumes:
       - coding_worker_state:/var/lib/modelmirror/coding-worker
       - coding_worker_slot_a:/worker-slots/slot-a
@@ -81,6 +84,34 @@ services:
       - coding_worker_provider_b:/run/modelmirror-coding
       - coding_worker_broker:/run/modelmirror-coding-broker:ro
 
+  coding-worker-egress:
+    profiles:
+      - coding-worker-network
+    image: modelmirror-coding-worker-v14:local
+    build:
+      context: .
+      dockerfile: server/coding_worker/Dockerfile.v14
+    container_name: modelmirror-coding-worker-egress
+    command: ["python", "-m", "coding_worker.egress_proxy"]
+    networks:
+      - coding_internal
+      - coding_worker_egress
+    user: "65532:65532"
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    pids_limit: 64
+    mem_limit: 128m
+    cpus: 0.5
+    tmpfs:
+      - /tmp:rw,nosuid,noexec,size=8m,uid=65532,gid=65532,mode=0700
+    environment:
+      CODING_WORKER_EGRESS_GRANT_KEY: ${CODING_WORKER_EGRESS_GRANT_KEY:-}
+      CODING_WORKER_NETWORK_DOMAINS: ${CODING_WORKER_NETWORK_DOMAINS:-registry.npmjs.org}
+    restart: unless-stopped
+
 volumes:
   coding_worker_state:
   coding_worker_slot_a:
@@ -88,3 +119,7 @@ volumes:
   coding_worker_provider_a:
   coding_worker_provider_b:
   coding_worker_broker:
+
+networks:
+  coding_worker_egress:
+    driver: bridge

--- a/docker-compose.coding-worker-v14.yml
+++ b/docker-compose.coding-worker-v14.yml
@@ -1,0 +1,90 @@
+services:
+  server:
+    environment:
+      CODING_WORKER_V14_ENABLED: ${CODING_WORKER_V14_ENABLED:-false}
+      CODING_WORKER_STATE_ROOT: /var/lib/modelmirror/coding-worker
+      CODING_WORKER_SLOT_A_ROOT: /worker-slots/slot-a
+      CODING_WORKER_SLOT_B_ROOT: /worker-slots/slot-b
+      CODING_WORKER_SLOT_A_ENDPOINT: unix:/run/modelmirror-coding-slot-a/provider.sock
+      CODING_WORKER_SLOT_B_ENDPOINT: unix:/run/modelmirror-coding-slot-b/provider.sock
+      CODING_WORKER_SLOT_A_TOKEN: ${CODING_WORKER_SLOT_A_TOKEN:?set a random V14 slot A token}
+      CODING_WORKER_SLOT_B_TOKEN: ${CODING_WORKER_SLOT_B_TOKEN:?set a random V14 slot B token}
+      CODING_WORKER_BROKER_SOCKET: /run/modelmirror-coding-broker/broker.sock
+      CODING_WORKER_MAX_ACTIVE_TASKS: ${CODING_WORKER_MAX_ACTIVE_TASKS:-2}
+      CODING_WORKER_RETENTION_SECONDS: ${CODING_WORKER_RETENTION_SECONDS:-604800}
+      CODING_WORKER_NETWORK_ENABLED: ${CODING_WORKER_NETWORK_ENABLED:-false}
+    volumes:
+      - coding_worker_state:/var/lib/modelmirror/coding-worker
+      - coding_worker_slot_a:/worker-slots/slot-a
+      - coding_worker_slot_b:/worker-slots/slot-b
+      - coding_worker_provider_a:/run/modelmirror-coding-slot-a
+      - coding_worker_provider_b:/run/modelmirror-coding-slot-b
+      - coding_worker_broker:/run/modelmirror-coding-broker
+
+  coding-worker-slot-a:
+    image: modelmirror-coding-worker-v14:local
+    build:
+      context: .
+      dockerfile: server/coding_worker/Dockerfile.v14
+    container_name: modelmirror-coding-worker-slot-a
+    depends_on:
+      new-api:
+        condition: service_healthy
+    networks:
+      - coding_internal
+    user: "65532:65532"
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    pids_limit: 192
+    mem_limit: 2g
+    cpus: 2.0
+    tmpfs:
+      - /tmp:rw,nosuid,size=256m,uid=65532,gid=65532,mode=0700
+      - /home/coding:rw,nosuid,size=128m,uid=65532,gid=65532,mode=0700
+      - /worker-runtime:rw,nosuid,size=512m,uid=65532,gid=65532,mode=0700
+    environment:
+      CODING_WORKER_PROVIDER_SOCKET: /run/modelmirror-coding/provider.sock
+      CODING_WORKER_SIDECAR_TOKEN: ${CODING_WORKER_SLOT_A_TOKEN:?set a random V14 slot A token}
+      CODING_WORKER_ROUTE_ID: coding/default
+      CODING_WORKER_MODEL_ID: ${CODING_WORKER_MODEL_ID:?set the controlled V14 model id}
+      CODING_WORKER_MODEL_BASE_URL: ${CODING_WORKER_MODEL_BASE_URL:-http://new-api:3000/v1}
+      CODING_WORKER_ROUTE_KEY: ${CODING_WORKER_ROUTE_KEY:?set a dedicated V14 route key}
+    volumes:
+      - coding_worker_slot_a:/worker-data
+      - coding_worker_provider_a:/run/modelmirror-coding
+      - coding_worker_broker:/run/modelmirror-coding-broker:ro
+    restart: unless-stopped
+    stop_grace_period: 10s
+    healthcheck:
+      test: ["CMD", "python", "-c", "import json,os,socket; s=socket.socket(socket.AF_UNIX); s.connect('/run/modelmirror-coding/provider.sock'); s.sendall((json.dumps({'token':os.environ['CODING_WORKER_SIDECAR_TOKEN'],'action':'capabilities','payload':{}})+'\\n').encode()); assert json.loads(s.recv(65536))['ok']"]
+      interval: 10s
+      timeout: 5s
+      retries: 8
+      start_period: 30s
+
+  coding-worker-slot-b:
+    extends:
+      service: coding-worker-slot-a
+    container_name: modelmirror-coding-worker-slot-b
+    environment:
+      CODING_WORKER_PROVIDER_SOCKET: /run/modelmirror-coding/provider.sock
+      CODING_WORKER_SIDECAR_TOKEN: ${CODING_WORKER_SLOT_B_TOKEN:?set a random V14 slot B token}
+      CODING_WORKER_ROUTE_ID: coding/default
+      CODING_WORKER_MODEL_ID: ${CODING_WORKER_MODEL_ID:?set the controlled V14 model id}
+      CODING_WORKER_MODEL_BASE_URL: ${CODING_WORKER_MODEL_BASE_URL:-http://new-api:3000/v1}
+      CODING_WORKER_ROUTE_KEY: ${CODING_WORKER_ROUTE_KEY:?set a dedicated V14 route key}
+    volumes:
+      - coding_worker_slot_b:/worker-data
+      - coding_worker_provider_b:/run/modelmirror-coding
+      - coding_worker_broker:/run/modelmirror-coding-broker:ro
+
+volumes:
+  coding_worker_state:
+  coding_worker_slot_a:
+  coding_worker_slot_b:
+  coding_worker_provider_a:
+  coding_worker_provider_b:
+  coding_worker_broker:

--- a/docker-compose.coding-worker-v14.yml
+++ b/docker-compose.coding-worker-v14.yml
@@ -9,6 +9,10 @@ services:
       CODING_WORKER_SLOT_B_ENDPOINT: unix:/run/modelmirror-coding-slot-b/provider.sock
       CODING_WORKER_SLOT_A_TOKEN: ${CODING_WORKER_SLOT_A_TOKEN:?set a random V14 slot A token}
       CODING_WORKER_SLOT_B_TOKEN: ${CODING_WORKER_SLOT_B_TOKEN:?set a random V14 slot B token}
+      CODING_WORKER_EXECUTOR_A_ENDPOINT: unix:/run/modelmirror-coding-executor-a/executor.sock
+      CODING_WORKER_EXECUTOR_B_ENDPOINT: unix:/run/modelmirror-coding-executor-b/executor.sock
+      CODING_WORKER_EXECUTOR_A_TOKEN: ${CODING_WORKER_EXECUTOR_A_TOKEN:?set a random V14 executor A token}
+      CODING_WORKER_EXECUTOR_B_TOKEN: ${CODING_WORKER_EXECUTOR_B_TOKEN:?set a random V14 executor B token}
       CODING_WORKER_BROKER_SOCKET: /run/modelmirror-coding-broker/broker.sock
       CODING_WORKER_MAX_ACTIVE_TASKS: ${CODING_WORKER_MAX_ACTIVE_TASKS:-2}
       CODING_WORKER_RETENTION_SECONDS: ${CODING_WORKER_RETENTION_SECONDS:-604800}
@@ -22,14 +26,16 @@ services:
       - coding_worker_slot_b:/worker-slots/slot-b
       - coding_worker_provider_a:/run/modelmirror-coding-slot-a
       - coding_worker_provider_b:/run/modelmirror-coding-slot-b
+      - coding_worker_executor_a:/run/modelmirror-coding-executor-a
+      - coding_worker_executor_b:/run/modelmirror-coding-executor-b
       - coding_worker_broker:/run/modelmirror-coding-broker
 
-  coding-worker-slot-a:
+  coding-worker-provider-a:
     image: modelmirror-coding-worker-v14:local
     build:
       context: .
       dockerfile: server/coding_worker/Dockerfile.v14
-    container_name: modelmirror-coding-worker-slot-a
+    container_name: modelmirror-coding-worker-provider-a
     depends_on:
       new-api:
         condition: service_healthy
@@ -56,7 +62,7 @@ services:
       CODING_WORKER_MODEL_BASE_URL: ${CODING_WORKER_MODEL_BASE_URL:-http://new-api:3000/v1}
       CODING_WORKER_ROUTE_KEY: ${CODING_WORKER_ROUTE_KEY:?set a dedicated V14 route key}
     volumes:
-      - coding_worker_slot_a:/worker-data
+      - coding_worker_slot_a:/worker-data:ro
       - coding_worker_provider_a:/run/modelmirror-coding
       - coding_worker_broker:/run/modelmirror-coding-broker:ro
     restart: unless-stopped
@@ -68,10 +74,10 @@ services:
       retries: 8
       start_period: 30s
 
-  coding-worker-slot-b:
+  coding-worker-provider-b:
     extends:
-      service: coding-worker-slot-a
-    container_name: modelmirror-coding-worker-slot-b
+      service: coding-worker-provider-a
+    container_name: modelmirror-coding-worker-provider-b
     environment:
       CODING_WORKER_PROVIDER_SOCKET: /run/modelmirror-coding/provider.sock
       CODING_WORKER_SIDECAR_TOKEN: ${CODING_WORKER_SLOT_B_TOKEN:?set a random V14 slot B token}
@@ -80,9 +86,57 @@ services:
       CODING_WORKER_MODEL_BASE_URL: ${CODING_WORKER_MODEL_BASE_URL:-http://new-api:3000/v1}
       CODING_WORKER_ROUTE_KEY: ${CODING_WORKER_ROUTE_KEY:?set a dedicated V14 route key}
     volumes:
-      - coding_worker_slot_b:/worker-data
+      - coding_worker_slot_b:/worker-data:ro
       - coding_worker_provider_b:/run/modelmirror-coding
       - coding_worker_broker:/run/modelmirror-coding-broker:ro
+
+  coding-worker-slot-a:
+    image: modelmirror-coding-worker-v14:local
+    build:
+      context: .
+      dockerfile: server/coding_worker/Dockerfile.v14
+    container_name: modelmirror-coding-worker-slot-a
+    networks:
+      - coding_internal
+    user: "65532:65532"
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    pids_limit: 192
+    mem_limit: 2g
+    cpus: 2.0
+    tmpfs:
+      - /tmp:rw,nosuid,size=256m,uid=65532,gid=65532,mode=0700
+      - /worker-runtime:rw,nosuid,size=512m,uid=65532,gid=65532,mode=0700
+    environment:
+      CODING_WORKER_MODE: executor
+      CODING_WORKER_PROVIDER_SOCKET: /run/modelmirror-coding/executor.sock
+      CODING_WORKER_EXECUTOR_TOKEN: ${CODING_WORKER_EXECUTOR_A_TOKEN:?set a random V14 executor A token}
+    volumes:
+      - coding_worker_slot_a:/worker-data
+      - coding_worker_executor_a:/run/modelmirror-coding
+    restart: unless-stopped
+    stop_grace_period: 10s
+    healthcheck:
+      test: ["CMD", "python", "-c", "import json,os,socket; s=socket.socket(socket.AF_UNIX); s.connect('/run/modelmirror-coding/executor.sock'); s.sendall((json.dumps({'token':os.environ['CODING_WORKER_EXECUTOR_TOKEN'],'action':'bind_task','payload':{'task_id':'healthcheck','workspace_id':'healthcheck'}})+'\\n').encode()); assert json.loads(s.recv(65536))['error']['code']=='executor_failed'"]
+      interval: 10s
+      timeout: 5s
+      retries: 8
+      start_period: 20s
+
+  coding-worker-slot-b:
+    extends:
+      service: coding-worker-slot-a
+    container_name: modelmirror-coding-worker-slot-b
+    environment:
+      CODING_WORKER_MODE: executor
+      CODING_WORKER_PROVIDER_SOCKET: /run/modelmirror-coding/executor.sock
+      CODING_WORKER_EXECUTOR_TOKEN: ${CODING_WORKER_EXECUTOR_B_TOKEN:?set a random V14 executor B token}
+    volumes:
+      - coding_worker_slot_b:/worker-data
+      - coding_worker_executor_b:/run/modelmirror-coding
 
   coding-worker-egress:
     profiles:
@@ -118,6 +172,8 @@ volumes:
   coding_worker_slot_b:
   coding_worker_provider_a:
   coding_worker_provider_b:
+  coding_worker_executor_a:
+  coding_worker_executor_b:
   coding_worker_broker:
 
 networks:

--- a/server/coding_worker/Dockerfile.v14
+++ b/server/coding_worker/Dockerfile.v14
@@ -1,0 +1,41 @@
+FROM node:22-bookworm-slim AS opencode_runtime
+
+ARG OPENCODE_VERSION=1.18.9
+ARG OPENCODE_INTEGRITY=sha512-tqvu/hJ26c2dBj/V/uTHaQI3bMSpLck0hIgGXO2z7b11s5mYfnaq+K1CBjsg8Pp6EirfzwUYGzi85K/SvOgkKg==
+
+RUN npm pack "opencode-ai@${OPENCODE_VERSION}" --pack-destination /tmp \
+    && node -e "const fs=require('fs');const crypto=require('crypto');const p='/tmp/opencode-ai-${OPENCODE_VERSION}.tgz';const actual='sha512-'+crypto.createHash('sha512').update(fs.readFileSync(p)).digest('base64');if(actual!=='${OPENCODE_INTEGRITY}'){throw new Error('OpenCode package integrity mismatch')}" \
+    && npm install --global "/tmp/opencode-ai-${OPENCODE_VERSION}.tgz" \
+    && test "$(opencode --version)" = "${OPENCODE_VERSION}"
+
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    CODING_WORKER_SLOT_ROOT=/worker-data \
+    CODING_WORKER_RUNTIME_ROOT=/worker-runtime
+
+COPY --from=opencode_runtime /usr/local/bin/node /usr/local/bin/node
+COPY --from=opencode_runtime /usr/local/lib/node_modules /usr/local/lib/node_modules
+
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends ca-certificates git ripgrep \
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+    && ln -s ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx \
+    && ln -s ../lib/node_modules/opencode-ai/bin/opencode.exe /usr/local/bin/opencode \
+    && groupadd --gid 65532 coding \
+    && useradd --uid 65532 --gid 65532 --home-dir /home/coding --no-create-home coding \
+    && mkdir -p /opt/modelmirror /home/coding /worker-data /worker-runtime /run/modelmirror-coding \
+    && chown -R 65532:65532 /home/coding /worker-data /worker-runtime /run/modelmirror-coding
+
+WORKDIR /opt/modelmirror
+COPY server/requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir --retries 5 --timeout 120 -r /tmp/requirements.txt
+
+COPY server/coding_worker ./coding_worker
+COPY server/THIRD_PARTY_NOTICES.md /usr/share/doc/modelmirror-coding/THIRD_PARTY_NOTICES.md
+
+USER 65532:65532
+
+CMD ["python", "-m", "coding_worker.sidecar"]

--- a/server/coding_worker/__init__.py
+++ b/server/coding_worker/__init__.py
@@ -14,6 +14,7 @@ from .contracts import (
     WorkspaceSource,
 )
 from .provider import CodingAgentProvider, FakeCodingAgentProvider
+from .evidence import HarnessRunner
 from .opencode_provider import OpenCodeProvider
 from .service import CodingWorkerService
 from .store import CodingWorkerStore
@@ -27,6 +28,7 @@ __all__ = [
     "CodingWorkerService",
     "CodingWorkerStore",
     "FrozenCheck",
+    "HarnessRunner",
     "ToolBroker",
     "ToolBrokerError",
     "ToolResult",

--- a/server/coding_worker/__init__.py
+++ b/server/coding_worker/__init__.py
@@ -15,6 +15,7 @@ from .contracts import (
 )
 from .provider import CodingAgentProvider, FakeCodingAgentProvider
 from .evidence import HarnessRunner
+from .network_policy import EgressPolicy, NetworkPolicyError
 from .opencode_provider import OpenCodeProvider
 from .service import CodingWorkerService
 from .store import CodingWorkerStore
@@ -29,6 +30,8 @@ __all__ = [
     "CodingWorkerStore",
     "FrozenCheck",
     "HarnessRunner",
+    "EgressPolicy",
+    "NetworkPolicyError",
     "ToolBroker",
     "ToolBrokerError",
     "ToolResult",

--- a/server/coding_worker/__init__.py
+++ b/server/coding_worker/__init__.py
@@ -16,6 +16,7 @@ from .contracts import (
 from .provider import CodingAgentProvider, FakeCodingAgentProvider
 from .evidence import HarnessRunner
 from .network_policy import EgressPolicy, NetworkPolicyError
+from .process_manager import BackgroundProcessManager, ManagedProcess, ProcessManagerError
 from .opencode_provider import OpenCodeProvider
 from .service import CodingWorkerService
 from .store import CodingWorkerStore
@@ -32,6 +33,9 @@ __all__ = [
     "HarnessRunner",
     "EgressPolicy",
     "NetworkPolicyError",
+    "BackgroundProcessManager",
+    "ManagedProcess",
+    "ProcessManagerError",
     "ToolBroker",
     "ToolBrokerError",
     "ToolResult",

--- a/server/coding_worker/__init__.py
+++ b/server/coding_worker/__init__.py
@@ -17,6 +17,7 @@ from .provider import CodingAgentProvider, FakeCodingAgentProvider
 from .opencode_provider import OpenCodeProvider
 from .service import CodingWorkerService
 from .store import CodingWorkerStore
+from .tool_broker import FrozenCheck, ToolBroker, ToolBrokerError, ToolResult
 from .workspace import WorkspaceBroker
 
 __all__ = [
@@ -25,6 +26,10 @@ __all__ = [
     "CodingAgentProvider",
     "CodingWorkerService",
     "CodingWorkerStore",
+    "FrozenCheck",
+    "ToolBroker",
+    "ToolBrokerError",
+    "ToolResult",
     "ContextReference",
     "FakeCodingAgentProvider",
     "OpenCodeProvider",

--- a/server/coding_worker/__init__.py
+++ b/server/coding_worker/__init__.py
@@ -14,6 +14,7 @@ from .contracts import (
     WorkspaceSource,
 )
 from .provider import CodingAgentProvider, FakeCodingAgentProvider
+from .opencode_provider import OpenCodeProvider
 from .service import CodingWorkerService
 from .store import CodingWorkerStore
 from .workspace import WorkspaceBroker
@@ -26,6 +27,7 @@ __all__ = [
     "CodingWorkerStore",
     "ContextReference",
     "FakeCodingAgentProvider",
+    "OpenCodeProvider",
     "Origin",
     "PolicyProfile",
     "TaskBudget",

--- a/server/coding_worker/__init__.py
+++ b/server/coding_worker/__init__.py
@@ -17,6 +17,7 @@ from .provider import CodingAgentProvider, FakeCodingAgentProvider
 from .evidence import HarnessRunner
 from .network_policy import EgressPolicy, NetworkPolicyError
 from .process_manager import BackgroundProcessManager, ManagedProcess, ProcessManagerError
+from .broker_rpc import BrokerRPCClient, BrokerRPCError, BrokerRPCServer
 from .opencode_provider import OpenCodeProvider
 from .service import CodingWorkerService
 from .store import CodingWorkerStore
@@ -36,6 +37,9 @@ __all__ = [
     "BackgroundProcessManager",
     "ManagedProcess",
     "ProcessManagerError",
+    "BrokerRPCClient",
+    "BrokerRPCError",
+    "BrokerRPCServer",
     "ToolBroker",
     "ToolBrokerError",
     "ToolResult",

--- a/server/coding_worker/api.py
+++ b/server/coding_worker/api.py
@@ -5,13 +5,21 @@ import json
 import os
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from typing import Any
+from typing import Any, Literal
 
 from fastapi import APIRouter, HTTPException, Query, Request, Response
 from fastapi.responses import StreamingResponse
 from pydantic import Field
 
-from .contracts import Origin, StrictModel, TaskCreateRequest, TaskRecord, TERMINAL_STATES
+from .contracts import (
+    Origin,
+    StrictModel,
+    TaskCreateRequest,
+    TaskRecord,
+    TaskState,
+    TERMINAL_STATES,
+    WorkerApproval,
+)
 from .service import CodingWorkerService
 from .store import WorkerConflictError, WorkerNotFoundError, WorkerStoreError
 from .workspace import WorkspaceError
@@ -19,6 +27,12 @@ from .workspace import WorkspaceError
 
 class TaskMessageRequest(StrictModel):
     message: str = Field(min_length=1, max_length=1_048_576)
+
+
+class ApprovalDecisionRequest(StrictModel):
+    approval_id: str = Field(pattern=r"^approval_[a-f0-9]{32}$")
+    decision: Literal["approve_once", "approve_task", "reject"]
+    ttl_seconds: int = Field(default=900, ge=30, le=3600)
 
 
 _service: CodingWorkerService | None = None
@@ -177,6 +191,41 @@ async def task_events(
 async def append_task_message(task_id: str, payload: TaskMessageRequest) -> TaskRecord:
     try:
         return await get_coding_worker_service().append_message(task_id, payload.message)
+    except Exception as exc:
+        _raise_worker_error(exc)
+
+
+@router.get("/tasks/{task_id}/approvals", response_model=dict[str, list[WorkerApproval]])
+async def task_approvals(task_id: str) -> dict[str, list[WorkerApproval]]:
+    try:
+        return {"approvals": get_coding_worker_service().store.list_approvals(task_id)}
+    except Exception as exc:
+        _raise_worker_error(exc)
+
+
+@router.post("/tasks/{task_id}/approvals", response_model=WorkerApproval)
+async def decide_task_approval(
+    task_id: str, payload: ApprovalDecisionRequest
+) -> WorkerApproval:
+    service = get_coding_worker_service()
+    try:
+        approval = service.store.get_approval(payload.approval_id)
+        if approval.task_id != task_id:
+            raise WorkerNotFoundError("Approval was not found.", code="approval_not_found")
+        decided = service.store.decide_approval(
+            payload.approval_id,
+            approved=payload.decision != "reject",
+            task_scope=payload.decision == "approve_task",
+            ttl_seconds=payload.ttl_seconds,
+        )
+        task = service.store.get_task(task_id)
+        if task.state is TaskState.WAITING_APPROVAL:
+            service.store.transition(
+                task_id,
+                TaskState.RUNNING,
+                expected_state=TaskState.WAITING_APPROVAL,
+            )
+        return decided
     except Exception as exc:
         _raise_worker_error(exc)
 

--- a/server/coding_worker/api.py
+++ b/server/coding_worker/api.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+from pathlib import PurePosixPath
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Any, Literal
 
 from fastapi import APIRouter, HTTPException, Query, Request, Response
 from fastapi.responses import StreamingResponse
+import httpx
 from pydantic import Field
 
 from .contracts import (
@@ -412,6 +414,89 @@ async def workspace_diff(task_id: str) -> Response:
         )
     except Exception as exc:
         _raise_worker_error(exc)
+
+
+@router.get("/tasks/{task_id}/services/{service_id}/preview/{preview_path:path}")
+async def service_preview(
+    task_id: str,
+    service_id: str,
+    preview_path: str,
+    request: Request,
+) -> Response:
+    service, task = _task_workspace(task_id)
+    try:
+        if service.tool_broker is None or service.tool_broker.executor is None:
+            raise WorkerConflictError(
+                "Preview service is unavailable.", code="preview_unavailable"
+            )
+        path = PurePosixPath(preview_path or ".")
+        if "\\" in preview_path or any(part == ".." for part in path.parts):
+            raise WorkerConflictError(
+                "Preview path is invalid.", code="preview_path_invalid"
+            )
+        result = await service.tool_broker.executor.service_status(
+            task_id=task_id,
+            workspace_id=task.workspace_id,
+            service_id=service_id,
+        )
+        port = result.get("preview_port")
+        if result.get("state") != "running" or isinstance(port, bool) or not isinstance(port, int):
+            raise WorkerConflictError(
+                "Preview service is not running.", code="preview_unavailable"
+            )
+        slot_id = service.workspace_broker.workspace_slot(task.workspace_id)
+        host = os.getenv(
+            f"CODING_WORKER_{slot_id.replace('-', '_').upper()}_PREVIEW_HOST",
+            f"coding-worker-{slot_id}",
+        )
+        query = request.url.query
+        upstream = await _fetch_preview(
+            f"http://{host}:{port}/{preview_path}" + (f"?{query}" if query else "")
+        )
+        if 300 <= upstream.status_code < 400:
+            raise WorkerConflictError(
+                "Preview redirects are not allowed.", code="preview_redirect_denied"
+            )
+        return Response(
+            upstream.content,
+            status_code=upstream.status_code,
+            media_type=upstream.headers.get("content-type", "application/octet-stream"),
+            headers={
+                "Cache-Control": "no-store",
+                "Content-Security-Policy": "sandbox allow-scripts allow-forms; default-src 'self' data: blob:; connect-src 'self'; frame-ancestors 'self'",
+                "X-Content-Type-Options": "nosniff",
+            },
+        )
+    except Exception as exc:
+        _raise_worker_error(exc)
+
+
+async def _fetch_preview(url: str) -> httpx.Response:
+    async with httpx.AsyncClient(
+        timeout=httpx.Timeout(15.0, connect=3.0),
+        follow_redirects=False,
+        trust_env=False,
+    ) as client:
+        request = client.build_request("GET", url)
+        response = await client.send(request, stream=True)
+        try:
+            chunks: list[bytes] = []
+            size = 0
+            async for chunk in response.aiter_bytes(64 * 1024):
+                size += len(chunk)
+                if size > 4 * 1024 * 1024:
+                    raise WorkerConflictError(
+                        "Preview response is too large.",
+                        code="preview_response_too_large",
+                    )
+                chunks.append(chunk)
+            return httpx.Response(
+                response.status_code,
+                headers=response.headers,
+                content=b"".join(chunks),
+            )
+        finally:
+            await response.aclose()
 
 
 def _task_workspace(task_id: str) -> tuple[CodingWorkerService, TaskRecord]:

--- a/server/coding_worker/api.py
+++ b/server/coding_worker/api.py
@@ -148,7 +148,7 @@ async def coding_worker_status() -> dict[str, Any]:
         "retention_seconds": (
             _service.store.retention_seconds if _service is not None else 604800
         ),
-        "network_enabled": False,
+        "network_enabled": _runtime.network_enabled if _runtime is not None else False,
         "reason": _startup_error,
     }
 

--- a/server/coding_worker/api.py
+++ b/server/coding_worker/api.py
@@ -23,6 +23,7 @@ from .contracts import (
     WorkerEvidence,
 )
 from .service import CodingWorkerService
+from .runtime import CodingWorkerRuntime, build_runtime_from_environment
 from .store import WorkerConflictError, WorkerNotFoundError, WorkerStoreError
 from .workspace import WorkspaceError
 
@@ -39,14 +40,32 @@ class ApprovalDecisionRequest(StrictModel):
 
 _service: CodingWorkerService | None = None
 _enabled_override: bool | None = None
+_runtime: CodingWorkerRuntime | None = None
+_startup_error: str | None = None
 _CONSOLE_ORIGIN = Origin(module="worker-console", object_id="local-user")
 
 
 @asynccontextmanager
 async def _lifespan(_app: object) -> AsyncIterator[None]:
-    yield
-    if _service is not None:
-        await _service.shutdown()
+    global _service, _runtime, _startup_error
+    if is_coding_worker_enabled() and _service is None:
+        try:
+            _runtime = build_runtime_from_environment()
+            _service = await _runtime.start()
+            _startup_error = None
+        except Exception as exc:
+            _startup_error = getattr(
+                exc, "code", "coding_worker_provider_unavailable"
+            )
+    try:
+        yield
+    finally:
+        if _runtime is not None:
+            await _runtime.close()
+            _runtime = None
+            _service = None
+        elif _service is not None:
+            await _service.shutdown()
 
 
 router = APIRouter(
@@ -70,9 +89,10 @@ def is_coding_worker_enabled() -> bool:
 def configure_coding_worker_for_tests(
     service: CodingWorkerService | None, *, enabled: bool | None = None
 ) -> None:
-    global _service, _enabled_override
+    global _service, _enabled_override, _startup_error
     _service = service
     _enabled_override = enabled
+    _startup_error = None
 
 
 def get_coding_worker_service() -> CodingWorkerService:
@@ -82,7 +102,8 @@ def get_coding_worker_service() -> CodingWorkerService:
             status_code=503,
             detail={
                 "code": "coding_worker_provider_unavailable",
-                "message": "The V14 Worker provider is not configured yet.",
+                "message": "The V14 Worker provider is unavailable.",
+                "reason": _startup_error,
             },
         )
     return _service
@@ -128,6 +149,7 @@ async def coding_worker_status() -> dict[str, Any]:
             _service.store.retention_seconds if _service is not None else 604800
         ),
         "network_enabled": False,
+        "reason": _startup_error,
     }
 
 

--- a/server/coding_worker/api.py
+++ b/server/coding_worker/api.py
@@ -19,6 +19,8 @@ from .contracts import (
     TaskState,
     TERMINAL_STATES,
     WorkerApproval,
+    WorkerArtifact,
+    WorkerEvidence,
 )
 from .service import CodingWorkerService
 from .store import WorkerConflictError, WorkerNotFoundError, WorkerStoreError
@@ -226,6 +228,64 @@ async def decide_task_approval(
                 expected_state=TaskState.WAITING_APPROVAL,
             )
         return decided
+    except Exception as exc:
+        _raise_worker_error(exc)
+
+
+@router.get(
+    "/tasks/{task_id}/evidence", response_model=dict[str, list[WorkerEvidence]]
+)
+async def task_evidence(task_id: str) -> dict[str, list[WorkerEvidence]]:
+    service = get_coding_worker_service()
+    try:
+        task = service.store.get_task(task_id)
+        tree_hash = (
+            service.workspace_broker.current_tree_hash(task.workspace_id)
+            if task.workspace_id is not None
+            else None
+        )
+        return {
+            "evidence": service.store.list_evidence(
+                task_id, current_tree_hash=tree_hash
+            )
+        }
+    except Exception as exc:
+        _raise_worker_error(exc)
+
+
+@router.get(
+    "/tasks/{task_id}/artifacts", response_model=dict[str, list[WorkerArtifact]]
+)
+async def task_artifacts(task_id: str) -> dict[str, list[WorkerArtifact]]:
+    try:
+        return {"artifacts": get_coding_worker_service().store.list_artifacts(task_id)}
+    except Exception as exc:
+        _raise_worker_error(exc)
+
+
+@router.get("/tasks/{task_id}/artifacts/{artifact_id}")
+async def task_artifact(task_id: str, artifact_id: str) -> Response:
+    service = get_coding_worker_service()
+    try:
+        artifact = next(
+            (
+                item
+                for item in service.store.list_artifacts(task_id)
+                if item.artifact_id == artifact_id
+            ),
+            None,
+        )
+        if artifact is None:
+            raise WorkerNotFoundError("Artifact was not found.", code="artifact_not_found")
+        content = service.store.read_artifact(artifact_id, task_id=task_id)
+        return Response(
+            content,
+            media_type=artifact.media_type,
+            headers={
+                "Cache-Control": "no-store",
+                "Content-Disposition": f'attachment; filename="{artifact_id}.bin"',
+            },
+        )
     except Exception as exc:
         _raise_worker_error(exc)
 

--- a/server/coding_worker/broker_mcp.py
+++ b/server/coding_worker/broker_mcp.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import os
+import uuid
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from .broker_rpc import BrokerRPCClient
+
+
+def build_server(client: BrokerRPCClient) -> FastMCP:
+    mcp = FastMCP("ModelMirror Coding Worker Tools")
+
+    async def call(
+        tool_name: str,
+        arguments: dict[str, Any],
+        *,
+        operation_id: str | None = None,
+        lease_id: str | None = None,
+        network_lease_id: str | None = None,
+    ) -> dict[str, Any]:
+        return await client.call(
+            operation_id=operation_id or f"inspect_{uuid.uuid4().hex}",
+            tool_name=tool_name,
+            arguments=arguments,
+            lease_id=lease_id,
+            network_lease_id=network_lease_id,
+        )
+
+    @mcp.tool()
+    async def list_files() -> dict[str, Any]:
+        """List task workspace entries using opaque, workspace-relative identities."""
+        return await call("list_files", {})
+
+    @mcp.tool()
+    async def read_file(path: str) -> dict[str, Any]:
+        """Read one workspace-relative text file or return binary metadata."""
+        return await call("read_file", {"path": path})
+
+    @mcp.tool()
+    async def search_text(query: str) -> dict[str, Any]:
+        """Search text inside the current task workspace."""
+        return await call("search_text", {"query": query})
+
+    @mcp.tool()
+    async def workspace_diff() -> dict[str, Any]:
+        """Return the current synthetic-H0 Git diff."""
+        return await call("diff", {})
+
+    @mcp.tool()
+    async def write_file(
+        operation_id: str, path: str, content: str, content_sha256: str
+    ) -> dict[str, Any]:
+        """Atomically write UTF-8 text using a stable operation id and content digest."""
+        return await call(
+            "write_file",
+            {"path": path, "content": content, "content_sha256": content_sha256},
+            operation_id=operation_id,
+        )
+
+    @mcp.tool()
+    async def delete_file(
+        operation_id: str, path: str, expected_sha256: str
+    ) -> dict[str, Any]:
+        """Delete an unchanged workspace file using a stable operation id."""
+        return await call(
+            "delete_file",
+            {"path": path, "expected_sha256": expected_sha256},
+            operation_id=operation_id,
+        )
+
+    @mcp.tool()
+    async def run_check(check_id: str) -> dict[str, Any]:
+        """Run one immutable server-defined acceptance check."""
+        return await call("run_check", {"check_id": check_id})
+
+    @mcp.tool()
+    async def run_command(
+        operation_id: str,
+        argv: list[str],
+        lease_id: str,
+        timeout_seconds: int = 300,
+    ) -> dict[str, Any]:
+        """Run an argv-only command after an exact command lease is approved."""
+        return await call(
+            "run_command",
+            {"argv": argv, "timeout_seconds": timeout_seconds},
+            operation_id=operation_id,
+            lease_id=lease_id,
+        )
+
+    @mcp.tool()
+    async def install_dependencies(
+        operation_id: str, lease_id: str, network_lease_id: str
+    ) -> dict[str, Any]:
+        """Run frozen npm-ci through the approved egress lease and proxy."""
+        return await call(
+            "install_dependencies",
+            {"manager": "npm", "action": "ci"},
+            operation_id=operation_id,
+            lease_id=lease_id,
+            network_lease_id=network_lease_id,
+        )
+
+    @mcp.tool()
+    async def start_service(
+        operation_id: str,
+        argv: list[str],
+        lease_id: str,
+        ttl_seconds: int = 900,
+    ) -> dict[str, Any]:
+        """Start one approved task-owned background service."""
+        return await call(
+            "start_service",
+            {"argv": argv, "ttl_seconds": ttl_seconds},
+            operation_id=operation_id,
+            lease_id=lease_id,
+        )
+
+    @mcp.tool()
+    async def service_status(service_id: str) -> dict[str, Any]:
+        """Read task-owned service state without exposing its process id."""
+        return await call("service_status", {"service_id": service_id})
+
+    @mcp.tool()
+    async def service_input(
+        operation_id: str, service_id: str, data: str
+    ) -> dict[str, Any]:
+        """Send bounded input to a task-owned service."""
+        return await call(
+            "service_input",
+            {"service_id": service_id, "data": data},
+            operation_id=operation_id,
+        )
+
+    @mcp.tool()
+    async def stop_service(operation_id: str, service_id: str) -> dict[str, Any]:
+        """Send Ctrl-C to a task-owned service and archive its output."""
+        return await call(
+            "stop_service",
+            {"service_id": service_id},
+            operation_id=operation_id,
+        )
+
+    return mcp
+
+
+def main() -> None:
+    endpoint = os.environ.get("CODING_WORKER_BROKER_ENDPOINT", "")
+    token = os.environ.get("CODING_WORKER_BROKER_TOKEN", "")
+    task_id = os.environ.get("CODING_WORKER_TASK_ID", "")
+    if not endpoint or not token or not task_id:
+        raise SystemExit("Coding Worker broker binding is unavailable")
+    build_server(BrokerRPCClient(endpoint, token=token, task_id=task_id)).run()
+
+
+if __name__ == "__main__":
+    main()

--- a/server/coding_worker/broker_mcp.py
+++ b/server/coding_worker/broker_mcp.py
@@ -109,11 +109,16 @@ def build_server(client: BrokerRPCClient) -> FastMCP:
         argv: list[str],
         lease_id: str,
         ttl_seconds: int = 900,
+        preview_port: int | None = None,
     ) -> dict[str, Any]:
         """Start one approved task-owned background service."""
         return await call(
             "start_service",
-            {"argv": argv, "ttl_seconds": ttl_seconds},
+            {
+                "argv": argv,
+                "ttl_seconds": ttl_seconds,
+                "preview_port": preview_port,
+            },
             operation_id=operation_id,
             lease_id=lease_id,
         )

--- a/server/coding_worker/broker_rpc.py
+++ b/server/coding_worker/broker_rpc.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import secrets
+from pathlib import Path
+from typing import Any
+
+from pydantic import Field
+
+from .contracts import StrictModel
+from .tool_broker import ToolBroker, ToolBrokerError
+
+
+MAX_RPC_BYTES = 1024 * 1024
+
+
+class BrokerRPCError(RuntimeError):
+    def __init__(self, message: str, *, code: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+class BrokerRPCRequest(StrictModel):
+    token: str = Field(min_length=32, max_length=256)
+    task_id: str
+    operation_id: str
+    tool_name: str
+    arguments: dict[str, Any] = Field(default_factory=dict)
+    lease_id: str | None = None
+    network_lease_id: str | None = None
+
+
+class BrokerRPCServer:
+    """Authenticated internal RPC boundary used by the task-local MCP process."""
+
+    def __init__(self, broker: ToolBroker) -> None:
+        self.broker = broker
+        self._tokens: dict[str, str] = {}
+        self._server: asyncio.AbstractServer | None = None
+        self.endpoint: str | None = None
+
+    def register_task(self, task_id: str) -> str:
+        self.broker.store.get_task(task_id)
+        token = secrets.token_urlsafe(48)
+        self._tokens[task_id] = token
+        return token
+
+    def revoke_task(self, task_id: str) -> None:
+        self._tokens.pop(task_id, None)
+
+    async def start_unix(self, socket_path: Path) -> str:
+        if self._server is not None:
+            raise RuntimeError("broker RPC server is already running")
+        socket_path = Path(socket_path)
+        socket_path.parent.mkdir(parents=True, exist_ok=True)
+        socket_path.unlink(missing_ok=True)
+        self._server = await asyncio.start_unix_server(
+            self._handle, path=str(socket_path), limit=MAX_RPC_BYTES
+        )
+        socket_path.chmod(0o600)
+        self.endpoint = f"unix:{socket_path}"
+        return self.endpoint
+
+    async def start_tcp_for_tests(self) -> str:
+        if self._server is not None:
+            raise RuntimeError("broker RPC server is already running")
+        self._server = await asyncio.start_server(
+            self._handle, "127.0.0.1", 0, limit=MAX_RPC_BYTES
+        )
+        address = self._server.sockets[0].getsockname()
+        self.endpoint = f"tcp:127.0.0.1:{address[1]}"
+        return self.endpoint
+
+    async def close(self) -> None:
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+        self._server = None
+        self.endpoint = None
+        self._tokens.clear()
+
+    async def _handle(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        response: dict[str, Any]
+        try:
+            raw = await reader.readline()
+            if not raw or len(raw) > MAX_RPC_BYTES or not raw.endswith(b"\n"):
+                raise BrokerRPCError("Broker request is invalid.", code="broker_request_invalid")
+            request = BrokerRPCRequest.model_validate_json(raw)
+            expected = self._tokens.get(request.task_id)
+            if expected is None or not secrets.compare_digest(expected, request.token):
+                raise BrokerRPCError("Broker authentication failed.", code="broker_unauthorized")
+            result = await self.broker.execute(
+                task_id=request.task_id,
+                operation_id=request.operation_id,
+                tool_name=request.tool_name,
+                arguments=request.arguments,
+                lease_id=request.lease_id,
+                network_lease_id=request.network_lease_id,
+            )
+            response = {"ok": True, "result": result.model_dump(mode="json")}
+        except Exception as exc:
+            response = {
+                "ok": False,
+                "error": {
+                    "code": getattr(exc, "code", "broker_failed"),
+                    "message": str(exc)
+                    if isinstance(exc, (BrokerRPCError, ToolBrokerError))
+                    else "Broker request failed.",
+                },
+            }
+        encoded = json.dumps(response, separators=(",", ":")).encode("utf-8") + b"\n"
+        if len(encoded) > MAX_RPC_BYTES:
+            encoded = b'{"ok":false,"error":{"code":"broker_response_too_large","message":"Broker response is too large."}}\n'
+        writer.write(encoded)
+        await writer.drain()
+        writer.close()
+        await writer.wait_closed()
+
+
+class BrokerRPCClient:
+    def __init__(self, endpoint: str, *, token: str, task_id: str) -> None:
+        self.endpoint = endpoint
+        self.token = token
+        self.task_id = task_id
+
+    async def call(
+        self,
+        *,
+        operation_id: str,
+        tool_name: str,
+        arguments: dict[str, Any],
+        lease_id: str | None = None,
+        network_lease_id: str | None = None,
+    ) -> dict[str, Any]:
+        reader, writer = await self._connect()
+        request = BrokerRPCRequest(
+            token=self.token,
+            task_id=self.task_id,
+            operation_id=operation_id,
+            tool_name=tool_name,
+            arguments=arguments,
+            lease_id=lease_id,
+            network_lease_id=network_lease_id,
+        )
+        writer.write(request.model_dump_json().encode("utf-8") + b"\n")
+        await writer.drain()
+        raw = await reader.readline()
+        writer.close()
+        await writer.wait_closed()
+        if not raw or len(raw) > MAX_RPC_BYTES:
+            raise BrokerRPCError("Broker response is invalid.", code="broker_invalid_response")
+        value = json.loads(raw)
+        if not isinstance(value, dict) or not isinstance(value.get("ok"), bool):
+            raise BrokerRPCError("Broker response is invalid.", code="broker_invalid_response")
+        if not value["ok"]:
+            error = value.get("error")
+            code = error.get("code") if isinstance(error, dict) else "broker_failed"
+            message = error.get("message") if isinstance(error, dict) else "Broker request failed."
+            raise BrokerRPCError(str(message), code=str(code))
+        result = value.get("result")
+        if not isinstance(result, dict):
+            raise BrokerRPCError("Broker response is invalid.", code="broker_invalid_response")
+        return result
+
+    async def _connect(self) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+        if self.endpoint.startswith("unix:"):
+            return await asyncio.open_unix_connection(
+                self.endpoint.removeprefix("unix:"), limit=MAX_RPC_BYTES
+            )
+        if self.endpoint.startswith("tcp:127.0.0.1:"):
+            port = int(self.endpoint.rsplit(":", 1)[1])
+            return await asyncio.open_connection("127.0.0.1", port, limit=MAX_RPC_BYTES)
+        raise BrokerRPCError("Broker endpoint is invalid.", code="broker_endpoint_invalid")

--- a/server/coding_worker/broker_rpc.py
+++ b/server/coding_worker/broker_rpc.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import secrets
 from pathlib import Path
 from typing import Any
@@ -49,7 +50,7 @@ class BrokerRPCServer:
     def revoke_task(self, task_id: str) -> None:
         self._tokens.pop(task_id, None)
 
-    async def start_unix(self, socket_path: Path) -> str:
+    async def start_unix(self, socket_path: Path, *, group_id: int | None = None) -> str:
         if self._server is not None:
             raise RuntimeError("broker RPC server is already running")
         socket_path = Path(socket_path)
@@ -59,6 +60,9 @@ class BrokerRPCServer:
             self._handle, path=str(socket_path), limit=MAX_RPC_BYTES
         )
         socket_path.chmod(0o600)
+        if group_id is not None and hasattr(os, "chown"):
+            os.chown(socket_path, -1, group_id)
+            socket_path.chmod(0o660)
         self.endpoint = f"unix:{socket_path}"
         return self.endpoint
 

--- a/server/coding_worker/contracts.py
+++ b/server/coding_worker/contracts.py
@@ -351,6 +351,24 @@ class WorkerArtifact(StrictModel):
     created_at: float
 
 
+class EvidenceStatus(StrEnum):
+    PASSED = "passed"
+    FAILED = "failed"
+    INVALIDATED = "invalidated"
+
+
+class WorkerEvidence(StrictModel):
+    evidence_id: str
+    task_id: str
+    check_id: str
+    operation_id: str
+    workspace_tree_hash: str = Field(pattern=r"^[a-f0-9]{64}$")
+    status: EvidenceStatus
+    exit_code: int
+    artifact_id: str
+    created_at: float
+
+
 class OperationState(StrEnum):
     PREPARED = "prepared"
     RUNNING = "running"

--- a/server/coding_worker/contracts.py
+++ b/server/coding_worker/contracts.py
@@ -91,6 +91,7 @@ _TRANSITIONS: dict[TaskState, frozenset[TaskState]] = {
         {
             TaskState.RUNNING,
             TaskState.WAITING_APPROVAL,
+            TaskState.PAUSED,
             TaskState.INTERRUPTED,
             TaskState.COMPLETED,
             TaskState.BLOCKED,

--- a/server/coding_worker/contracts.py
+++ b/server/coding_worker/contracts.py
@@ -279,7 +279,7 @@ class TaskRecord(StrictModel):
     spec: TaskSpec
     state: TaskState
     workspace_id: str | None = None
-    provider_session_id: str | None = None
+    provider_session_id: str | None = Field(default=None, exclude=True, repr=False)
     created_at: float
     updated_at: float
     expires_at: float

--- a/server/coding_worker/contracts.py
+++ b/server/coding_worker/contracts.py
@@ -11,6 +11,9 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 SAFE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$")
 SAFE_ROUTE = re.compile(r"^[a-z0-9][a-z0-9._/-]{0,127}$")
 TERMINAL_STATES: frozenset["TaskState"]
+CapabilityName = Literal[
+    "workspace_write", "command", "dependency_install", "service", "network"
+]
 
 
 class StrictModel(BaseModel):
@@ -255,9 +258,7 @@ class TaskSpec(TaskCreateRequest):
 class CapabilityLease(StrictModel):
     lease_id: str
     task_id: str
-    capability: Literal[
-        "workspace_write", "command", "dependency_install", "service", "network"
-    ]
+    capability: CapabilityName
     scope: dict[str, Any] = Field(default_factory=dict)
     issued_at: float
     expires_at: float
@@ -324,7 +325,7 @@ class WorkerApproval(StrictModel):
     approval_id: str
     task_id: str
     operation_id: str
-    capability: str
+    capability: CapabilityName
     status: ApprovalStatus
     request: dict[str, Any] = Field(default_factory=dict)
     lease: CapabilityLease | None = None
@@ -348,3 +349,23 @@ class WorkerArtifact(StrictModel):
     size: int = Field(ge=0)
     metadata: dict[str, Any] = Field(default_factory=dict)
     created_at: float
+
+
+class OperationState(StrEnum):
+    PREPARED = "prepared"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    UNKNOWN = "unknown"
+
+
+class WorkerOperation(StrictModel):
+    operation_id: str
+    task_id: str
+    tool_name: str
+    intent_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    state: OperationState
+    request: dict[str, Any]
+    result: dict[str, Any] | None = None
+    created_at: float
+    updated_at: float

--- a/server/coding_worker/egress_proxy.py
+++ b/server/coding_worker/egress_proxy.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import contextlib
+import ipaddress
+import os
+import socket
+
+from .network_policy import EgressPolicy, NetworkPolicyError
+
+
+MAX_HEADER_BYTES = 16 * 1024
+
+
+class EgressProxy:
+    def __init__(self, policy: EgressPolicy) -> None:
+        self.policy = policy
+
+    async def handle(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        upstream_writer: asyncio.StreamWriter | None = None
+        try:
+            header = await asyncio.wait_for(reader.readuntil(b"\r\n\r\n"), timeout=5)
+            if len(header) > MAX_HEADER_BYTES:
+                raise NetworkPolicyError("Proxy header is too large.", code="network_request_invalid")
+            lines = header.decode("iso-8859-1").split("\r\n")
+            method, authority, version = lines[0].split(" ", 2)
+            if method != "CONNECT" or version != "HTTP/1.1" or authority.count(":") != 1:
+                raise NetworkPolicyError("Only HTTPS CONNECT is allowed.", code="network_request_invalid")
+            domain, port = authority.rsplit(":", 1)
+            if port != "443":
+                raise NetworkPolicyError("Only HTTPS port 443 is allowed.", code="network_request_invalid")
+            authorization = next(
+                (line.split(":", 1)[1].strip() for line in lines[1:] if line.lower().startswith("proxy-authorization:")),
+                "",
+            )
+            if not authorization.startswith("Basic "):
+                raise NetworkPolicyError("Proxy authorization is required.", code="network_grant_invalid")
+            username, token = base64.b64decode(authorization[6:]).decode("utf-8").split(":", 1)
+            if username != "grant":
+                raise NetworkPolicyError("Proxy authorization is invalid.", code="network_grant_invalid")
+            self.policy.validate_grant(token, domain=domain)
+            addresses = await asyncio.get_running_loop().getaddrinfo(
+                domain, 443, type=socket.SOCK_STREAM
+            )
+            selected: str | None = None
+            for _family, _type, _protocol, _name, address in addresses:
+                candidate = str(address[0])
+                if not ipaddress.ip_address(candidate).is_global:
+                    raise NetworkPolicyError("Private destination is denied.", code="network_private_address_denied")
+                selected = selected or candidate
+            if selected is None:
+                raise NetworkPolicyError("Destination could not be resolved.", code="network_resolution_required")
+            upstream_reader, upstream_writer = await asyncio.open_connection(selected, 443)
+            writer.write(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+            await writer.drain()
+            await asyncio.gather(
+                self._relay(reader, upstream_writer),
+                self._relay(upstream_reader, writer),
+            )
+        except Exception:
+            if not writer.is_closing():
+                writer.write(b"HTTP/1.1 403 Forbidden\r\nConnection: close\r\n\r\n")
+                with contextlib.suppress(Exception):
+                    await writer.drain()
+        finally:
+            if upstream_writer is not None:
+                upstream_writer.close()
+                with contextlib.suppress(Exception):
+                    await upstream_writer.wait_closed()
+            writer.close()
+            with contextlib.suppress(Exception):
+                await writer.wait_closed()
+
+    @staticmethod
+    async def _relay(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        while data := await reader.read(64 * 1024):
+            writer.write(data)
+            await writer.drain()
+        with contextlib.suppress(Exception):
+            writer.write_eof()
+
+
+async def run() -> None:
+    key = os.environ.get("CODING_WORKER_EGRESS_GRANT_KEY", "")
+    domains = tuple(
+        item.strip().lower()
+        for item in os.environ.get("CODING_WORKER_NETWORK_DOMAINS", "").split(",")
+        if item.strip()
+    )
+    policy = EgressPolicy(enabled=True, allowed_domains=domains, grant_key=key)
+    proxy = EgressProxy(policy)
+    server = await asyncio.start_server(proxy.handle, "0.0.0.0", 8080, limit=MAX_HEADER_BYTES)
+    async with server:
+        await server.serve_forever()
+
+
+if __name__ == "__main__":
+    asyncio.run(run())

--- a/server/coding_worker/evidence.py
+++ b/server/coding_worker/evidence.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import hashlib
+
+from .contracts import EvidenceStatus, WorkerEvidence
+from .store import CodingWorkerStore
+from .tool_broker import ToolBroker, ToolBrokerError
+from .workspace import WorkspaceBroker
+
+
+class HarnessRunner:
+    """Runs the immutable server-side acceptance contract and records evidence."""
+
+    def __init__(
+        self,
+        *,
+        store: CodingWorkerStore,
+        workspace_broker: WorkspaceBroker,
+        tool_broker: ToolBroker,
+    ) -> None:
+        self.store = store
+        self.workspace_broker = workspace_broker
+        self.tool_broker = tool_broker
+
+    async def run_required_checks(self, task_id: str) -> tuple[WorkerEvidence, ...]:
+        task = self.store.get_task(task_id)
+        if task.workspace_id is None:
+            raise ToolBrokerError("Task workspace is unavailable.", code="workspace_unavailable")
+        results: list[WorkerEvidence] = []
+        for check in task.spec.acceptance.required_checks:
+            before = self.workspace_broker.current_tree_hash(task.workspace_id)
+            operation_id = self._operation_id(task_id, check.check_id, before)
+            if check.kind == "command":
+                result = await self.tool_broker.execute(
+                    task_id=task_id,
+                    operation_id=operation_id,
+                    tool_name="run_check",
+                    arguments={"check_id": check.check_id},
+                )
+                exit_code = int(result.data["exit_code"])
+                output = str(result.data.get("output", "")).encode("utf-8")
+            elif check.kind == "diff":
+                output = self.workspace_broker.diff(task.workspace_id)
+                exit_code = 0 if output else 1
+            else:
+                output = f"Unsupported acceptance check kind: {check.kind}\n".encode()
+                exit_code = 2
+            after = self.workspace_broker.current_tree_hash(task.workspace_id)
+            if after != before:
+                raise ToolBrokerError(
+                    "Workspace changed while acceptance was running.",
+                    code="acceptance_workspace_changed",
+                )
+            artifact = self.store.create_artifact(
+                task_id=task_id,
+                media_type="text/plain; charset=utf-8",
+                content=output,
+                metadata={"check_id": check.check_id, "workspace_tree_hash": before},
+            )
+            results.append(
+                self.store.record_evidence(
+                    task_id=task_id,
+                    check_id=check.check_id,
+                    operation_id=operation_id,
+                    workspace_tree_hash=before,
+                    exit_code=exit_code,
+                    artifact_id=artifact.artifact_id,
+                )
+            )
+        return tuple(results)
+
+    def acceptance_satisfied(self, task_id: str) -> bool:
+        task = self.store.get_task(task_id)
+        if task.workspace_id is None:
+            return False
+        tree_hash = self.workspace_broker.current_tree_hash(task.workspace_id)
+        evidence = self.store.list_evidence(task_id, current_tree_hash=tree_hash)
+        latest: dict[str, WorkerEvidence] = {}
+        for item in evidence:
+            latest[item.check_id] = item
+        if any(
+            latest.get(check.check_id) is None
+            or latest[check.check_id].status is not EvidenceStatus.PASSED
+            for check in task.spec.acceptance.required_checks
+        ):
+            return False
+        artifacts = self.store.list_artifacts(task_id)
+        requirement_ids = {
+            str(item.metadata.get("requirement_id"))
+            for item in artifacts
+            if item.metadata.get("workspace_tree_hash") == tree_hash
+        }
+        return all(
+            requirement.artifact_id in requirement_ids
+            for requirement in task.spec.acceptance.required_artifacts
+        )
+
+    @staticmethod
+    def _operation_id(task_id: str, check_id: str, tree_hash: str) -> str:
+        digest = hashlib.sha256(f"{task_id}\0{check_id}\0{tree_hash}".encode()).hexdigest()
+        return f"acceptance_{digest[:32]}"

--- a/server/coding_worker/executor.py
+++ b/server/coding_worker/executor.py
@@ -127,7 +127,14 @@ class SidecarExecutor:
             process = await asyncio.create_subprocess_exec(
                 *argv,
                 cwd=self._workspace_resolver(workspace_id),
-                env=self._environment(self._workspace_resolver(workspace_id)),
+                env=self._environment(
+                    self._workspace_resolver(workspace_id),
+                    (
+                        {"HOST": "0.0.0.0", "PORT": str(preview_port)}
+                        if preview_port is not None
+                        else None
+                    ),
+                ),
                 stdin=asyncio.subprocess.PIPE,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,

--- a/server/coding_worker/executor.py
+++ b/server/coding_worker/executor.py
@@ -26,6 +26,7 @@ class _Service:
     started_at: float
     expires_at: float
     output: bytearray
+    preview_port: int | None = None
     state: str = "running"
     exit_code: int | None = None
     reason: str | None = None
@@ -105,9 +106,14 @@ class SidecarExecutor:
         workspace_id: str,
         argv: Sequence[str],
         ttl_seconds: int,
+        preview_port: int | None = None,
     ) -> dict[str, object]:
         if not 1 <= ttl_seconds <= 3600:
             raise SidecarExecutionError("Service TTL is invalid.", code="service_ttl_invalid")
+        if preview_port is not None and not 1024 <= preview_port <= 65535:
+            raise SidecarExecutionError(
+                "Preview port is invalid.", code="service_preview_invalid"
+            )
         async with self._lock:
             active = sum(
                 service.task_id == task_id and service.state == "running"
@@ -134,6 +140,7 @@ class SidecarExecutor:
                 started_at=now,
                 expires_at=now + ttl_seconds,
                 output=bytearray(),
+                preview_port=preview_port,
             )
             self._services[service.service_id] = service
             service.monitor = asyncio.create_task(self._monitor(service, ttl_seconds))
@@ -246,6 +253,7 @@ class SidecarExecutor:
             "expires_at": service.expires_at,
             "exit_code": service.exit_code,
             "reason": service.reason,
+            "preview_port": service.preview_port,
         }
         if include_output and service.state != "running":
             result["output"] = bytes(service.output).decode("utf-8", errors="replace")

--- a/server/coding_worker/executor.py
+++ b/server/coding_worker/executor.py
@@ -1,0 +1,286 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import shutil
+import signal
+import time
+import uuid
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+
+class SidecarExecutionError(RuntimeError):
+    def __init__(self, message: str, *, code: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+@dataclass(slots=True)
+class _Service:
+    service_id: str
+    task_id: str
+    process: asyncio.subprocess.Process
+    started_at: float
+    expires_at: float
+    output: bytearray
+    state: str = "running"
+    exit_code: int | None = None
+    reason: str | None = None
+    monitor: asyncio.Task[None] | None = None
+
+
+class SidecarExecutor:
+    """Runs task commands inside one non-root slot sidecar."""
+
+    def __init__(
+        self,
+        workspace_resolver: Callable[[str], Path],
+        *,
+        runtime_root: Path,
+        max_output_bytes: int = 2 * 1024 * 1024,
+        max_services_per_task: int = 4,
+    ) -> None:
+        self._workspace_resolver = workspace_resolver
+        self._runtime_root = Path(runtime_root)
+        self._max_output_bytes = max_output_bytes
+        self._max_services_per_task = max_services_per_task
+        self._services: dict[str, _Service] = {}
+        self._lock = asyncio.Lock()
+
+    async def run_process(
+        self,
+        *,
+        workspace_id: str,
+        argv: Sequence[str],
+        timeout_seconds: int,
+        isolated: bool,
+        environment_overrides: Mapping[str, str] | None = None,
+    ) -> dict[str, object]:
+        repository = self._workspace_resolver(workspace_id)
+        execution_root: Path | None = None
+        execution_repository = repository
+        try:
+            if isolated:
+                execution_root = self._runtime_root / "checks" / f"run_{uuid.uuid4().hex}"
+                execution_root.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copytree(repository, execution_root, ignore=shutil.ignore_patterns(".git"))
+                execution_repository = execution_root
+            process = await asyncio.create_subprocess_exec(
+                *argv,
+                cwd=execution_repository,
+                env=self._environment(execution_repository, environment_overrides),
+                stdin=asyncio.subprocess.DEVNULL,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+                start_new_session=os.name != "nt",
+            )
+            try:
+                output = await asyncio.wait_for(
+                    self._collect(process), timeout=timeout_seconds
+                )
+            except TimeoutError:
+                process.kill()
+                await process.wait()
+                raise SidecarExecutionError("Command timed out.", code="command_timeout")
+            except asyncio.CancelledError:
+                process.kill()
+                await process.wait()
+                raise
+            return {
+                "argv": list(argv),
+                "exit_code": int(process.returncode or 0),
+                "output": output.decode("utf-8", errors="replace"),
+            }
+        finally:
+            if execution_root is not None:
+                shutil.rmtree(execution_root, ignore_errors=True)
+
+    async def start_service(
+        self,
+        *,
+        task_id: str,
+        workspace_id: str,
+        argv: Sequence[str],
+        ttl_seconds: int,
+    ) -> dict[str, object]:
+        if not 1 <= ttl_seconds <= 3600:
+            raise SidecarExecutionError("Service TTL is invalid.", code="service_ttl_invalid")
+        async with self._lock:
+            active = sum(
+                service.task_id == task_id and service.state == "running"
+                for service in self._services.values()
+            )
+            if active >= self._max_services_per_task:
+                raise SidecarExecutionError(
+                    "Task service capacity is exhausted.", code="service_capacity_exhausted"
+                )
+            now = time.time()
+            process = await asyncio.create_subprocess_exec(
+                *argv,
+                cwd=self._workspace_resolver(workspace_id),
+                env=self._environment(self._workspace_resolver(workspace_id)),
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+                start_new_session=os.name != "nt",
+            )
+            service = _Service(
+                service_id=f"service_{uuid.uuid4().hex}",
+                task_id=task_id,
+                process=process,
+                started_at=now,
+                expires_at=now + ttl_seconds,
+                output=bytearray(),
+            )
+            self._services[service.service_id] = service
+            service.monitor = asyncio.create_task(self._monitor(service, ttl_seconds))
+            return self._service_result(service, include_output=False)
+
+    def service_status(self, *, task_id: str, service_id: str) -> dict[str, object]:
+        return self._service_result(self._require_service(task_id, service_id), include_output=True)
+
+    async def service_input(self, *, task_id: str, service_id: str, data: str) -> None:
+        if not data or len(data.encode("utf-8")) > 64 * 1024:
+            raise SidecarExecutionError("Service input is invalid.", code="service_input_invalid")
+        service = self._require_service(task_id, service_id)
+        if service.state != "running" or service.process.stdin is None:
+            raise SidecarExecutionError("Service is not running.", code="service_not_running")
+        service.process.stdin.write(data.encode("utf-8"))
+        await service.process.stdin.drain()
+
+    async def stop_service(self, *, task_id: str, service_id: str) -> dict[str, object]:
+        service = self._require_service(task_id, service_id)
+        if service.state == "running":
+            service.reason = "user_interrupted"
+            await self._interrupt(service.process)
+            if service.monitor is not None:
+                await service.monitor
+        return self._service_result(service, include_output=True)
+
+    async def stop_task(self, task_id: str) -> None:
+        services = [
+            service
+            for service in self._services.values()
+            if service.task_id == task_id and service.state == "running"
+        ]
+        for service in services:
+            service.reason = "task_closed"
+            await self._interrupt(service.process)
+        await asyncio.gather(
+            *(service.monitor for service in services if service.monitor is not None),
+            return_exceptions=True,
+        )
+
+    async def _monitor(self, service: _Service, ttl_seconds: int) -> None:
+        drain = asyncio.create_task(self._drain(service))
+        try:
+            try:
+                await asyncio.wait_for(service.process.wait(), timeout=ttl_seconds)
+            except TimeoutError:
+                service.reason = "service_ttl_expired"
+                await self._interrupt(service.process)
+            await drain
+        finally:
+            if not drain.done():
+                drain.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await drain
+            service.exit_code = service.process.returncode
+            if service.reason is not None:
+                service.state = "stopped"
+            elif service.exit_code == 0:
+                service.state = "completed"
+            else:
+                service.state = "failed"
+                service.reason = "service_exited"
+
+    async def _drain(self, service: _Service) -> None:
+        if service.process.stdout is None:
+            return
+        while True:
+            chunk = await service.process.stdout.read(64 * 1024)
+            if not chunk:
+                return
+            if len(service.output) + len(chunk) > self._max_output_bytes:
+                remaining = self._max_output_bytes - len(service.output)
+                service.output.extend(chunk[: max(remaining, 0)])
+                service.reason = "service_output_limit"
+                service.process.kill()
+                return
+            service.output.extend(chunk)
+
+    async def _collect(self, process: asyncio.subprocess.Process) -> bytes:
+        if process.stdout is None:
+            raise SidecarExecutionError("Command output is unavailable.", code="command_failed")
+        output = bytearray()
+        while True:
+            chunk = await process.stdout.read(64 * 1024)
+            if not chunk:
+                break
+            output.extend(chunk)
+            if len(output) > self._max_output_bytes:
+                process.kill()
+                await process.wait()
+                raise SidecarExecutionError(
+                    "Command output is too large.", code="tool_output_too_large"
+                )
+        await process.wait()
+        return bytes(output)
+
+    def _require_service(self, task_id: str, service_id: str) -> _Service:
+        service = self._services.get(service_id)
+        if service is None or service.task_id != task_id:
+            raise SidecarExecutionError("Service was not found.", code="service_not_found")
+        return service
+
+    @staticmethod
+    def _service_result(service: _Service, *, include_output: bool) -> dict[str, object]:
+        result: dict[str, object] = {
+            "service_id": service.service_id,
+            "task_id": service.task_id,
+            "state": service.state,
+            "started_at": service.started_at,
+            "expires_at": service.expires_at,
+            "exit_code": service.exit_code,
+            "reason": service.reason,
+        }
+        if include_output and service.state != "running":
+            result["output"] = bytes(service.output).decode("utf-8", errors="replace")
+        return result
+
+    @staticmethod
+    async def _interrupt(process: asyncio.subprocess.Process) -> None:
+        if process.returncode is not None:
+            return
+        with contextlib.suppress(ProcessLookupError):
+            if os.name == "nt":
+                process.terminate()
+            else:
+                os.killpg(process.pid, signal.SIGINT)
+        try:
+            await asyncio.wait_for(process.wait(), timeout=2)
+        except TimeoutError:
+            process.kill()
+            await process.wait()
+
+    @staticmethod
+    def _environment(
+        repository: Path, overrides: Mapping[str, str] | None = None
+    ) -> dict[str, str]:
+        home = repository.parent / "home"
+        home.mkdir(exist_ok=True)
+        environment = {
+            "HOME": str(home),
+            "LANG": "C.UTF-8",
+            "LC_ALL": "C.UTF-8",
+            "PATH": "/usr/local/bin:/usr/bin:/bin",
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_TERMINAL_PROMPT": "0",
+            "GIT_NO_LAZY_FETCH": "1",
+            "GIT_NO_REPLACE_OBJECTS": "1",
+        }
+        environment.update(overrides or {})
+        return environment

--- a/server/coding_worker/executor.py
+++ b/server/coding_worker/executor.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import json
 import os
+import secrets
 import shutil
 import signal
 import time
@@ -10,12 +12,22 @@ import uuid
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
+
+from .contracts import SAFE_ID
+
+
+MAX_EXECUTOR_RPC_BYTES = 8 * 1024 * 1024
 
 
 class SidecarExecutionError(RuntimeError):
     def __init__(self, message: str, *, code: str) -> None:
         super().__init__(message)
         self.code = code
+
+
+class ExecutorRPCError(SidecarExecutionError):
+    pass
 
 
 @dataclass(slots=True)
@@ -299,3 +311,210 @@ class SidecarExecutor:
         }
         environment.update(overrides or {})
         return environment
+
+
+class ExecutorRPCServer:
+    """Credential-free command host for one fixed workspace slot."""
+
+    def __init__(self, executor: SidecarExecutor, *, token: str) -> None:
+        if len(token) < 32:
+            raise ValueError("executor RPC token is too short")
+        self.executor = executor
+        self._token = token
+        self._server: asyncio.AbstractServer | None = None
+        self.endpoint: str | None = None
+        self._task_id: str | None = None
+        self._workspace_id: str | None = None
+
+    async def start_unix(self, socket_path: Path) -> str:
+        socket_path = Path(socket_path)
+        socket_path.parent.mkdir(parents=True, exist_ok=True)
+        socket_path.unlink(missing_ok=True)
+        self._server = await asyncio.start_unix_server(
+            self._handle, path=str(socket_path), limit=MAX_EXECUTOR_RPC_BYTES
+        )
+        socket_path.chmod(0o660)
+        self.endpoint = f"unix:{socket_path}"
+        return self.endpoint
+
+    async def start_tcp_for_tests(self) -> str:
+        self._server = await asyncio.start_server(
+            self._handle, "127.0.0.1", 0, limit=MAX_EXECUTOR_RPC_BYTES
+        )
+        address = self._server.sockets[0].getsockname()
+        self.endpoint = f"tcp:127.0.0.1:{address[1]}"
+        return self.endpoint
+
+    async def close(self) -> None:
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+        if self._task_id is not None:
+            await self.executor.stop_task(self._task_id)
+        self._server = None
+        self.endpoint = None
+        self._task_id = None
+        self._workspace_id = None
+
+    async def _handle(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        try:
+            raw = await reader.readline()
+            if not raw or len(raw) > MAX_EXECUTOR_RPC_BYTES or not raw.endswith(b"\n"):
+                raise ExecutorRPCError("Executor request is invalid.", code="executor_request_invalid")
+            value = json.loads(raw)
+            token = value.get("token") if isinstance(value, dict) else None
+            action = value.get("action") if isinstance(value, dict) else None
+            payload = value.get("payload") if isinstance(value, dict) else None
+            if not isinstance(token, str) or not secrets.compare_digest(token, self._token):
+                raise ExecutorRPCError("Executor authentication failed.", code="executor_unauthorized")
+            if not isinstance(action, str) or not isinstance(payload, dict):
+                raise ExecutorRPCError("Executor request is invalid.", code="executor_request_invalid")
+            result = await self._dispatch(action, payload)
+            response = {"ok": True, "result": result}
+        except Exception as exc:
+            response = {
+                "ok": False,
+                "error": {
+                    "code": getattr(exc, "code", "executor_failed"),
+                    "message": str(exc)
+                    if isinstance(exc, (ExecutorRPCError, SidecarExecutionError, ValueError))
+                    else "Executor request failed.",
+                },
+            }
+        encoded = json.dumps(response, separators=(",", ":")).encode() + b"\n"
+        writer.write(encoded)
+        await writer.drain()
+        writer.close()
+        with contextlib.suppress(Exception):
+            await writer.wait_closed()
+
+    async def _dispatch(self, action: str, payload: dict[str, Any]) -> dict[str, Any]:
+        task_id = str(payload.get("task_id", ""))
+        workspace_id = str(payload.get("workspace_id", ""))
+        if action == "bind_task":
+            if SAFE_ID.fullmatch(task_id) is None or SAFE_ID.fullmatch(workspace_id) is None:
+                raise ExecutorRPCError("Executor binding is invalid.", code="executor_binding_invalid")
+            if self._task_id not in {None, task_id} or self._workspace_id not in {
+                None,
+                workspace_id,
+            }:
+                raise ExecutorRPCError("Executor slot is busy.", code="executor_slot_busy")
+            self.executor._workspace_resolver(workspace_id)
+            self._task_id, self._workspace_id = task_id, workspace_id
+            return {"bound": True}
+        if action == "close_task":
+            self._require_binding(task_id, workspace_id)
+            await self.executor.stop_task(task_id)
+            self._task_id = self._workspace_id = None
+            return {"closed": True}
+        self._require_binding(task_id, workspace_id)
+        if action == "execute_process":
+            return await self.executor.run_process(
+                workspace_id=workspace_id,
+                argv=tuple(payload.get("argv", ())),
+                timeout_seconds=int(payload.get("timeout_seconds", 0)),
+                isolated=payload.get("isolated") is True,
+                environment_overrides=payload.get("environment_overrides"),
+            )
+        if action == "start_service":
+            return await self.executor.start_service(
+                task_id=task_id,
+                workspace_id=workspace_id,
+                argv=tuple(payload.get("argv", ())),
+                ttl_seconds=int(payload.get("ttl_seconds", 0)),
+                preview_port=(
+                    int(payload["preview_port"])
+                    if payload.get("preview_port") is not None
+                    else None
+                ),
+            )
+        if action == "service_status":
+            return self.executor.service_status(
+                task_id=task_id, service_id=str(payload.get("service_id", ""))
+            )
+        if action == "service_input":
+            await self.executor.service_input(
+                task_id=task_id,
+                service_id=str(payload.get("service_id", "")),
+                data=str(payload.get("data", "")),
+            )
+            return {"accepted": True}
+        if action == "stop_service":
+            return await self.executor.stop_service(
+                task_id=task_id, service_id=str(payload.get("service_id", ""))
+            )
+        raise ExecutorRPCError("Executor action is invalid.", code="executor_request_invalid")
+
+    def _require_binding(self, task_id: str, workspace_id: str) -> None:
+        if self._task_id != task_id or self._workspace_id != workspace_id:
+            raise ExecutorRPCError("Executor task is not bound.", code="executor_binding_invalid")
+
+
+class ExecutorSidecarClientPool:
+    """Routes task commands to the credential-free executor for a fixed slot."""
+
+    def __init__(
+        self,
+        *,
+        endpoints: Mapping[str, str],
+        tokens: Mapping[str, str],
+        workspace_slot_resolver: Callable[[str], str],
+    ) -> None:
+        if set(endpoints) != set(tokens) or not endpoints:
+            raise ValueError("executor sidecar bindings are incomplete")
+        self._endpoints = dict(endpoints)
+        self._tokens = dict(tokens)
+        self._workspace_slot_resolver = workspace_slot_resolver
+
+    async def bind_task(self, task_id: str, workspace_id: str) -> None:
+        await self._workspace_call(workspace_id, "bind_task", {"task_id": task_id, "workspace_id": workspace_id})
+
+    async def close_task(self, task_id: str, workspace_id: str) -> None:
+        await self._workspace_call(workspace_id, "close_task", {"task_id": task_id, "workspace_id": workspace_id})
+
+    async def run_process(self, *, task_id: str, workspace_id: str, argv: Sequence[str], timeout_seconds: int, isolated: bool, environment_overrides: Mapping[str, str] | None = None) -> dict[str, Any]:
+        return await self._workspace_call(workspace_id, "execute_process", {"task_id": task_id, "workspace_id": workspace_id, "argv": list(argv), "timeout_seconds": timeout_seconds, "isolated": isolated, "environment_overrides": dict(environment_overrides or {})})
+
+    async def start_service(self, *, task_id: str, workspace_id: str, argv: Sequence[str], ttl_seconds: int, preview_port: int | None = None) -> dict[str, Any]:
+        return await self._workspace_call(workspace_id, "start_service", {"task_id": task_id, "workspace_id": workspace_id, "argv": list(argv), "ttl_seconds": ttl_seconds, "preview_port": preview_port})
+
+    async def service_status(self, *, task_id: str, workspace_id: str, service_id: str) -> dict[str, Any]:
+        return await self._workspace_call(workspace_id, "service_status", {"task_id": task_id, "workspace_id": workspace_id, "service_id": service_id})
+
+    async def service_input(self, *, task_id: str, workspace_id: str, service_id: str, data: str) -> dict[str, Any]:
+        return await self._workspace_call(workspace_id, "service_input", {"task_id": task_id, "workspace_id": workspace_id, "service_id": service_id, "data": data})
+
+    async def stop_service(self, *, task_id: str, workspace_id: str, service_id: str) -> dict[str, Any]:
+        return await self._workspace_call(workspace_id, "stop_service", {"task_id": task_id, "workspace_id": workspace_id, "service_id": service_id})
+
+    async def _workspace_call(self, workspace_id: str, action: str, payload: dict[str, Any]) -> dict[str, Any]:
+        slot_id = self._workspace_slot_resolver(workspace_id)
+        endpoint = self._endpoints.get(slot_id)
+        token = self._tokens.get(slot_id)
+        if endpoint is None or token is None:
+            raise ExecutorRPCError("Executor slot is unavailable.", code="executor_unavailable")
+        if endpoint.startswith("unix:"):
+            reader, writer = await asyncio.open_unix_connection(endpoint[5:])
+        elif endpoint.startswith("tcp:127.0.0.1:"):
+            reader, writer = await asyncio.open_connection("127.0.0.1", int(endpoint.rsplit(":", 1)[1]))
+        else:
+            raise ExecutorRPCError("Executor endpoint is invalid.", code="executor_unavailable")
+        try:
+            request = json.dumps({"token": token, "action": action, "payload": payload}, separators=(",", ":")).encode() + b"\n"
+            writer.write(request)
+            await writer.drain()
+            raw = await reader.readline()
+            value = json.loads(raw)
+            if not isinstance(value, dict) or value.get("ok") is not True:
+                error = value.get("error", {}) if isinstance(value, dict) else {}
+                raise ExecutorRPCError(str(error.get("message", "Executor request failed.")), code=str(error.get("code", "executor_failed")))
+            result = value.get("result")
+            if not isinstance(result, dict):
+                raise ExecutorRPCError("Executor response is invalid.", code="executor_invalid_response")
+            return result
+        finally:
+            writer.close()
+            with contextlib.suppress(Exception):
+                await writer.wait_closed()

--- a/server/coding_worker/network_policy.py
+++ b/server/coding_worker/network_policy.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
 import ipaddress
+import base64
+import hashlib
+import hmac
+import json
+import secrets
 import re
 import time
 from collections.abc import Callable, Iterable
-from urllib.parse import urlsplit
+from urllib.parse import quote, urlsplit
 
 from .contracts import CapabilityLease
 
@@ -27,12 +32,94 @@ class EgressPolicy:
         enabled: bool = False,
         allowed_domains: Iterable[str] = (),
         clock: Callable[[], float] = time.time,
+        grant_key: bytes | str | None = None,
     ) -> None:
         self.enabled = enabled
         self.allowed_domains = frozenset(
             self._normalize_domain(domain) for domain in allowed_domains
         )
         self._clock = clock
+        self._grant_key = (
+            grant_key.encode("utf-8") if isinstance(grant_key, str) else grant_key
+        )
+        if self.enabled and (self._grant_key is None or len(self._grant_key) < 32):
+            raise NetworkPolicyError(
+                "Egress grant key is unavailable.", code="network_grant_key_invalid"
+            )
+
+    def proxy_url(
+        self,
+        *,
+        base_url: str,
+        lease: CapabilityLease,
+        task_id: str,
+        purpose: str,
+    ) -> str:
+        self.validate_lease_scope(
+            lease=lease,
+            domains=tuple(str(item) for item in lease.scope.get("domains", ())),
+            purpose=purpose,
+        )
+        payload = {
+            "task_id": task_id,
+            "domains": lease.scope["domains"],
+            "purpose": purpose,
+            "expires_at": lease.expires_at,
+            "nonce": secrets.token_hex(16),
+        }
+        encoded = self._encode_payload(payload)
+        assert self._grant_key is not None
+        signature = hmac.new(self._grant_key, encoded, hashlib.sha256).digest()
+        token = self._urlsafe(encoded) + "." + self._urlsafe(signature)
+        parsed = urlsplit(base_url)
+        if parsed.scheme != "http" or parsed.hostname is None:
+            raise NetworkPolicyError(
+                "Egress proxy is invalid.", code="network_proxy_invalid"
+            )
+        authority = parsed.hostname
+        if parsed.port is not None:
+            authority += f":{parsed.port}"
+        return f"http://grant:{quote(token, safe='')}@{authority}"
+
+    def validate_grant(self, token: str, *, domain: str) -> dict[str, object]:
+        self._require_enabled()
+        try:
+            payload_part, signature_part = token.split(".", 1)
+            encoded = self._urlsafe_decode(payload_part)
+            signature = self._urlsafe_decode(signature_part)
+        except (ValueError, UnicodeError) as exc:
+            raise NetworkPolicyError(
+                "Egress grant is invalid.", code="network_grant_invalid"
+            ) from exc
+        assert self._grant_key is not None
+        expected = hmac.new(self._grant_key, encoded, hashlib.sha256).digest()
+        if not hmac.compare_digest(expected, signature):
+            raise NetworkPolicyError(
+                "Egress grant is invalid.", code="network_grant_invalid"
+            )
+        try:
+            payload = json.loads(encoded)
+        except (json.JSONDecodeError, UnicodeError) as exc:
+            raise NetworkPolicyError(
+                "Egress grant is invalid.", code="network_grant_invalid"
+            ) from exc
+        normalized = self._normalize_domain(domain)
+        if (
+            not isinstance(payload, dict)
+            or not isinstance(payload.get("task_id"), str)
+            or not isinstance(payload.get("purpose"), str)
+            or not isinstance(payload.get("domains"), list)
+            or normalized not in payload["domains"]
+            or normalized not in self.allowed_domains
+            or not isinstance(payload.get("expires_at"), (int, float))
+            or isinstance(payload.get("expires_at"), bool)
+            or float(payload["expires_at"]) <= self._clock()
+        ):
+            raise NetworkPolicyError(
+                "Egress grant does not match the destination.",
+                code="network_grant_invalid",
+            )
+        return payload
 
     def approval_scope(self, *, domains: Iterable[str], purpose: str) -> dict[str, object]:
         self._require_enabled()
@@ -121,6 +208,18 @@ class EgressPolicy:
     def _require_enabled(self) -> None:
         if not self.enabled:
             raise NetworkPolicyError("Worker network access is disabled.", code="network_disabled")
+
+    @staticmethod
+    def _encode_payload(value: dict[str, object]) -> bytes:
+        return json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+    @staticmethod
+    def _urlsafe(value: bytes) -> str:
+        return base64.urlsafe_b64encode(value).decode("ascii").rstrip("=")
+
+    @staticmethod
+    def _urlsafe_decode(value: str) -> bytes:
+        return base64.urlsafe_b64decode(value + "=" * (-len(value) % 4))
 
     @staticmethod
     def _normalize_domain(value: str) -> str:

--- a/server/coding_worker/network_policy.py
+++ b/server/coding_worker/network_policy.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import ipaddress
+import re
+import time
+from collections.abc import Callable, Iterable
+from urllib.parse import urlsplit
+
+from .contracts import CapabilityLease
+
+
+PURPOSE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$")
+
+
+class NetworkPolicyError(RuntimeError):
+    def __init__(self, message: str, *, code: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+class EgressPolicy:
+    """Validates a task-scoped HTTPS egress lease before a proxy opens a socket."""
+
+    def __init__(
+        self,
+        *,
+        enabled: bool = False,
+        allowed_domains: Iterable[str] = (),
+        clock: Callable[[], float] = time.time,
+    ) -> None:
+        self.enabled = enabled
+        self.allowed_domains = frozenset(
+            self._normalize_domain(domain) for domain in allowed_domains
+        )
+        self._clock = clock
+
+    def approval_scope(self, *, domains: Iterable[str], purpose: str) -> dict[str, object]:
+        self._require_enabled()
+        if PURPOSE.fullmatch(purpose) is None:
+            raise NetworkPolicyError("Network purpose is invalid.", code="network_scope_invalid")
+        normalized = tuple(dict.fromkeys(self._normalize_domain(item) for item in domains))
+        if not normalized or any(item not in self.allowed_domains for item in normalized):
+            raise NetworkPolicyError(
+                "Requested domains are outside the deployment allowlist.",
+                code="network_domain_not_allowed",
+            )
+        return {"domains": list(normalized), "purpose": purpose}
+
+    def authorize(
+        self,
+        *,
+        url: str,
+        lease: CapabilityLease,
+        purpose: str,
+        resolved_addresses: Iterable[str],
+    ) -> str:
+        self._require_enabled()
+        if lease.capability != "network" or lease.expires_at <= self._clock():
+            raise NetworkPolicyError("Network lease is unavailable.", code="network_lease_invalid")
+        if lease.scope.get("purpose") != purpose:
+            raise NetworkPolicyError("Network purpose does not match the lease.", code="network_scope_invalid")
+        parsed = urlsplit(url)
+        if (
+            parsed.scheme.lower() != "https"
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.hostname is None
+            or parsed.port not in {None, 443}
+        ):
+            raise NetworkPolicyError(
+                "Only credential-free HTTPS destinations are permitted.",
+                code="network_url_not_allowed",
+            )
+        host = self._normalize_domain(parsed.hostname)
+        leased_domains = lease.scope.get("domains")
+        if (
+            not isinstance(leased_domains, list)
+            or host not in leased_domains
+            or host not in self.allowed_domains
+        ):
+            raise NetworkPolicyError(
+                "Destination is outside the task lease.", code="network_domain_not_allowed"
+            )
+        addresses = tuple(resolved_addresses)
+        if not addresses:
+            raise NetworkPolicyError(
+                "Destination must be resolved by the egress proxy.", code="network_resolution_required"
+            )
+        for value in addresses:
+            try:
+                address = ipaddress.ip_address(value)
+            except ValueError as exc:
+                raise NetworkPolicyError(
+                    "Destination resolution is invalid.", code="network_resolution_invalid"
+                ) from exc
+            if not address.is_global:
+                raise NetworkPolicyError(
+                    "Private and non-global destinations are forbidden.",
+                    code="network_private_address_denied",
+                )
+        return host
+
+    def _require_enabled(self) -> None:
+        if not self.enabled:
+            raise NetworkPolicyError("Worker network access is disabled.", code="network_disabled")
+
+    @staticmethod
+    def _normalize_domain(value: str) -> str:
+        candidate = value.strip().lower().rstrip(".")
+        try:
+            ipaddress.ip_address(candidate)
+        except ValueError:
+            pass
+        else:
+            raise NetworkPolicyError(
+                "IP literal destinations are forbidden.", code="network_ip_literal_denied"
+            )
+        try:
+            ascii_domain = candidate.encode("idna").decode("ascii")
+        except UnicodeError as exc:
+            raise NetworkPolicyError("Domain is invalid.", code="network_domain_invalid") from exc
+        labels = ascii_domain.split(".")
+        if (
+            len(labels) < 2
+            or any(not label or len(label) > 63 for label in labels)
+            or any(label.startswith("-") or label.endswith("-") for label in labels)
+            or any(re.fullmatch(r"[a-z0-9-]+", label) is None for label in labels)
+            or ascii_domain.endswith((".local", ".localhost", ".internal"))
+        ):
+            raise NetworkPolicyError("Domain is invalid.", code="network_domain_invalid")
+        return ascii_domain

--- a/server/coding_worker/network_policy.py
+++ b/server/coding_worker/network_policy.py
@@ -100,6 +100,24 @@ class EgressPolicy:
                 )
         return host
 
+    def validate_lease_scope(
+        self,
+        *,
+        lease: CapabilityLease,
+        domains: Iterable[str],
+        purpose: str,
+    ) -> None:
+        expected = self.approval_scope(domains=domains, purpose=purpose)
+        if (
+            lease.capability != "network"
+            or lease.expires_at <= self._clock()
+            or lease.scope != expected
+        ):
+            raise NetworkPolicyError(
+                "Network lease does not match the requested purpose.",
+                code="network_lease_invalid",
+            )
+
     def _require_enabled(self) -> None:
         if not self.enabled:
             raise NetworkPolicyError("Worker network access is disabled.", code="network_disabled")

--- a/server/coding_worker/opencode_provider.py
+++ b/server/coding_worker/opencode_provider.py
@@ -16,6 +16,7 @@ from urllib.parse import quote
 import httpx
 from pydantic import Field
 
+from .broker_rpc import BrokerRPCServer
 from .contracts import PolicyProfile, StrictModel
 from .provider import (
     CodingAgentProvider,
@@ -88,13 +89,19 @@ class OpenCodeProvider(CodingAgentProvider):
         routes: Mapping[str, OpenCodeRoute],
         executable: str = "/usr/local/bin/opencode",
         tool_broker_command: tuple[str, ...] | None = None,
+        broker_rpc: BrokerRPCServer | None = None,
         server_factory: ServerFactory | None = None,
     ) -> None:
         self._workspace_resolver = workspace_resolver
         self._runtime_root = Path(runtime_root)
         self._routes = dict(routes)
         self._executable = executable
-        self._tool_broker_command = tool_broker_command
+        self._broker_rpc = broker_rpc
+        self._tool_broker_command = tool_broker_command or (
+            ("python", "-m", "coding_worker.broker_mcp")
+            if broker_rpc is not None
+            else None
+        )
         self._server_factory = server_factory or self._launch_server
         self._handles: dict[str, OpenCodeServerHandle] = {}
         self._requests: dict[str, ProviderOpenRequest] = {}
@@ -353,6 +360,7 @@ class OpenCodeProvider(CodingAgentProvider):
         home.mkdir(exist_ok=True)
         password = secrets.token_urlsafe(32)
         port = _unused_loopback_port()
+        broker_environment, revoke_broker = self._broker_environment(request.task_id)
         environment = {
             "PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"),
             "HOME": str(home),
@@ -373,20 +381,25 @@ class OpenCodeProvider(CodingAgentProvider):
             "CODING_WORKER_ROUTE_KEY": route.api_key,
             "NO_PROXY": "127.0.0.1,localhost,new-api",
             "no_proxy": "127.0.0.1,localhost,new-api",
+            **broker_environment,
         }
-        process = await asyncio.create_subprocess_exec(
-            self._executable,
-            "serve",
-            "--hostname",
-            "127.0.0.1",
-            "--port",
-            str(port),
-            cwd=workspace,
-            env=environment,
-            stdin=asyncio.subprocess.DEVNULL,
-            stdout=asyncio.subprocess.DEVNULL,
-            stderr=asyncio.subprocess.DEVNULL,
-        )
+        try:
+            process = await asyncio.create_subprocess_exec(
+                self._executable,
+                "serve",
+                "--hostname",
+                "127.0.0.1",
+                "--port",
+                str(port),
+                cwd=workspace,
+                env=environment,
+                stdin=asyncio.subprocess.DEVNULL,
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+        except Exception:
+            revoke_broker()
+            raise
         auth = base64.b64encode(f"opencode:{password}".encode()).decode("ascii")
         client = httpx.AsyncClient(
             base_url=f"http://127.0.0.1:{port}",
@@ -406,11 +419,13 @@ class OpenCodeProvider(CodingAgentProvider):
         except Exception:
             await client.aclose()
             await _stop_process(process)
+            revoke_broker()
             raise
 
         async def close() -> None:
             await client.aclose()
             await _stop_process(process)
+            revoke_broker()
 
         return OpenCodeServerHandle(
             task_id=request.task_id,
@@ -419,6 +434,29 @@ class OpenCodeProvider(CodingAgentProvider):
             client=client,
             close_callback=close,
         )
+
+    def _broker_environment(self, task_id: str) -> tuple[dict[str, str], Callable[[], None]]:
+        if self._broker_rpc is None:
+            return {}, lambda: None
+        endpoint = self._broker_rpc.endpoint
+        if endpoint is None:
+            raise OpenCodeProviderError(
+                "Tool Broker RPC is unavailable.", code="tool_broker_unavailable"
+            )
+        token = self._broker_rpc.register_task(task_id)
+        revoked = False
+
+        def revoke() -> None:
+            nonlocal revoked
+            if not revoked:
+                self._broker_rpc.revoke_task(task_id)
+                revoked = True
+
+        return {
+            "CODING_WORKER_BROKER_ENDPOINT": endpoint,
+            "CODING_WORKER_BROKER_TOKEN": token,
+            "CODING_WORKER_TASK_ID": task_id,
+        }, revoke
 
     def _require_route(self, route_id: str) -> OpenCodeRoute:
         route = self._routes.get(route_id)

--- a/server/coding_worker/opencode_provider.py
+++ b/server/coding_worker/opencode_provider.py
@@ -105,6 +105,7 @@ class OpenCodeProvider(CodingAgentProvider):
         self._server_factory = server_factory or self._launch_server
         self._handles: dict[str, OpenCodeServerHandle] = {}
         self._requests: dict[str, ProviderOpenRequest] = {}
+        self._public_context: dict[str, list[str]] = {}
         self._broker_bindings: dict[str, tuple[str, str]] = {}
         self._lock = asyncio.Lock()
 
@@ -171,6 +172,7 @@ class OpenCodeProvider(CodingAgentProvider):
                 )
             self._handles[session_id] = handle
             self._requests[session_id] = request
+            self._public_context[session_id] = []
         return ProviderSession(
             session_id=session_id,
             task_id=request.task_id,
@@ -208,6 +210,13 @@ class OpenCodeProvider(CodingAgentProvider):
                 mapped = self._map_event(payload, session.session_id)
                 if mapped is None:
                     continue
+                if mapped.kind is ProviderEventKind.MESSAGE:
+                    text_part = mapped.data.get("text")
+                    if isinstance(text_part, str) and text_part:
+                        public = self._public_context.setdefault(session.session_id, [])
+                        public.append(text_part[:16_384])
+                        if len(public) > 64:
+                            del public[:-64]
                 yield mapped
                 if mapped.kind in {
                     ProviderEventKind.TURN_COMPLETED,
@@ -242,77 +251,39 @@ class OpenCodeProvider(CodingAgentProvider):
         return value is True
 
     async def checkpoint(self, session: ProviderSession) -> ProviderCheckpoint:
-        handle, request = self._require_session(session)
-        try:
-            session_response, messages_response = await asyncio.gather(
-                handle.client.get(
-                    self._url(f"/session/{quote(session.session_id)}", handle.workspace)
-                ),
-                handle.client.get(
-                    self._url(
-                        f"/session/{quote(session.session_id)}/message", handle.workspace
-                    )
-                ),
-            )
-            session_response.raise_for_status()
-            messages_response.raise_for_status()
-        except httpx.HTTPError as exc:
-            raise OpenCodeProviderError(
-                "OpenCode checkpoint failed.", code="provider_unavailable"
-            ) from exc
+        _handle, request = self._require_session(session)
+        public_text = "".join(self._public_context.get(session.session_id, ()))
         return ProviderCheckpoint(
             checkpoint_id=f"checkpoint_{secrets.token_hex(16)}",
             payload={
                 "engine": "opencode-1.18.9",
-                "session_id": session.session_id,
                 "task_id": request.task_id,
-                "session": session_response.json(),
-                "messages": messages_response.json(),
+                "public_output": public_text[-32_768:],
             },
         )
 
     async def restore(
         self, request: ProviderOpenRequest, checkpoint: ProviderCheckpoint
     ) -> ProviderSession:
-        session_id = checkpoint.payload.get("session_id")
         if (
             checkpoint.payload.get("engine") != "opencode-1.18.9"
             or checkpoint.payload.get("task_id") != request.task_id
-            or not isinstance(session_id, str)
-            or not session_id.startswith("ses")
+            or not isinstance(checkpoint.payload.get("public_output", ""), str)
         ):
             raise OpenCodeProviderError(
                 "OpenCode checkpoint binding is invalid.", code="checkpoint_invalid"
             )
-        route = self._require_route(request.model_route)
-        workspace = self._workspace_resolver(request.workspace_id).resolve()
-        handle = await self._server_factory(request, workspace, route)
-        try:
-            response = await handle.client.get(
-                self._url(f"/session/{quote(session_id)}", workspace)
-            )
-            response.raise_for_status()
-            payload = response.json()
-            if not isinstance(payload, dict) or payload.get("id") != session_id:
-                raise OpenCodeProviderError(
-                    "OpenCode checkpoint is unavailable.", code="checkpoint_unavailable"
-                )
-        except Exception:
-            await handle.close()
-            raise
-        async with self._lock:
-            self._handles[session_id] = handle
-            self._requests[session_id] = request
-        return ProviderSession(
-            session_id=session_id,
-            task_id=request.task_id,
-            provider_capabilities=await self.capabilities(),
-        )
+        # A provider process is never resurrected. Restore opens a fresh, pinned
+        # engine session; the control plane supplies the public checkpoint
+        # summary in the next message. Raw vendor frames and hidden reasoning
+        # are intentionally absent from the durable checkpoint.
+        return await self.open(request)
 
     async def close(self, session: ProviderSession) -> None:
         async with self._lock:
             handle = self._handles.pop(session.session_id, None)
             self._requests.pop(session.session_id, None)
+            self._public_context.pop(session.session_id, None)
         if handle is not None:
             await handle.close()
 

--- a/server/coding_worker/opencode_provider.py
+++ b/server/coding_worker/opencode_provider.py
@@ -1,0 +1,539 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import contextlib
+import json
+import os
+import secrets
+import socket
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+from pydantic import Field
+
+from .contracts import PolicyProfile, StrictModel
+from .provider import (
+    CodingAgentProvider,
+    ProviderCapabilities,
+    ProviderCheckpoint,
+    ProviderEvent,
+    ProviderEventKind,
+    ProviderOpenRequest,
+    ProviderSession,
+)
+
+
+OPENCODE_VERSION = "1.18.9"
+DIRECT_TOOL_NAMES = frozenset(
+    {
+        "bash",
+        "edit",
+        "write",
+        "patch",
+        "webfetch",
+        "websearch",
+        "skill",
+        "task",
+        "question",
+        "todowrite",
+    }
+)
+
+
+class OpenCodeProviderError(RuntimeError):
+    def __init__(self, message: str, *, code: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+class OpenCodeRoute(StrictModel):
+    route_id: str
+    model_id: str
+    base_url: str
+    api_key: str = Field(min_length=1, repr=False, exclude=True)
+    context_tokens: int = Field(default=128_000, ge=8_192, le=2_000_000)
+    output_tokens: int = Field(default=32_000, ge=1_024, le=262_144)
+
+
+@dataclass(slots=True)
+class OpenCodeServerHandle:
+    task_id: str
+    workspace: Path
+    state_root: Path
+    client: httpx.AsyncClient
+    close_callback: Callable[[], Awaitable[None]]
+
+    async def close(self) -> None:
+        await self.close_callback()
+
+
+ServerFactory = Callable[
+    [ProviderOpenRequest, Path, OpenCodeRoute], Awaitable[OpenCodeServerHandle]
+]
+
+
+class OpenCodeProvider(CodingAgentProvider):
+    """OpenCode 1.18.9 headless adapter; raw HTTP details remain private."""
+
+    def __init__(
+        self,
+        *,
+        workspace_resolver: Callable[[str], Path],
+        runtime_root: Path,
+        routes: Mapping[str, OpenCodeRoute],
+        executable: str = "/usr/local/bin/opencode",
+        tool_broker_command: tuple[str, ...] | None = None,
+        server_factory: ServerFactory | None = None,
+    ) -> None:
+        self._workspace_resolver = workspace_resolver
+        self._runtime_root = Path(runtime_root)
+        self._routes = dict(routes)
+        self._executable = executable
+        self._tool_broker_command = tool_broker_command
+        self._server_factory = server_factory or self._launch_server
+        self._handles: dict[str, OpenCodeServerHandle] = {}
+        self._requests: dict[str, ProviderOpenRequest] = {}
+        self._lock = asyncio.Lock()
+
+    async def capabilities(self) -> ProviderCapabilities:
+        return ProviderCapabilities(
+            supports_streaming=True,
+            supports_cancel=True,
+            supports_checkpoint=True,
+            supports_restore=True,
+            supports_steering=True,
+        )
+
+    async def open(self, request: ProviderOpenRequest) -> ProviderSession:
+        route = self._require_route(request.model_route)
+        workspace = self._workspace_resolver(request.workspace_id).resolve()
+        if not workspace.is_dir() or workspace.is_symlink():
+            raise OpenCodeProviderError("Workspace is unavailable.", code="workspace_unavailable")
+        handle = await self._server_factory(request, workspace, route)
+        try:
+            response = await handle.client.post(
+                self._url("/session", workspace),
+                json={
+                    "title": f"ModelMirror {request.task_id}",
+                    "agent": "modelmirror-worker",
+                    "model": {
+                        "providerID": "modelmirror",
+                        "id": route.model_id,
+                    },
+                },
+            )
+            response.raise_for_status()
+            payload = response.json()
+            session_id = payload.get("id") if isinstance(payload, dict) else None
+            if not isinstance(session_id, str) or not session_id.startswith("ses"):
+                raise OpenCodeProviderError(
+                    "OpenCode returned an invalid session.", code="provider_invalid_response"
+                )
+        except Exception:
+            await handle.close()
+            raise
+        async with self._lock:
+            if session_id in self._handles:
+                await handle.close()
+                raise OpenCodeProviderError(
+                    "OpenCode session collision.", code="provider_invalid_response"
+                )
+            self._handles[session_id] = handle
+            self._requests[session_id] = request
+        return ProviderSession(
+            session_id=session_id,
+            task_id=request.task_id,
+            provider_capabilities=await self.capabilities(),
+        )
+
+    async def message(
+        self, session: ProviderSession, text: str
+    ) -> AsyncIterator[ProviderEvent]:
+        if not text.strip():
+            raise ValueError("provider message cannot be blank")
+        handle, request = self._require_session(session)
+        route = self._require_route(request.model_route)
+        event_response: httpx.Response | None = None
+        try:
+            event_request = handle.client.build_request(
+                "GET", self._url("/event", handle.workspace)
+            )
+            event_response = await handle.client.send(event_request, stream=True)
+            event_response.raise_for_status()
+            prompt = await handle.client.post(
+                self._url(f"/session/{quote(session.session_id)}/prompt_async", handle.workspace),
+                json={
+                    "model": {
+                        "providerID": "modelmirror",
+                        "modelID": route.model_id,
+                    },
+                    "agent": "modelmirror-worker",
+                    "tools": self._prompt_tools(),
+                    "parts": [{"type": "text", "text": text}],
+                },
+            )
+            prompt.raise_for_status()
+            async for payload in _iter_sse_json(event_response):
+                mapped = self._map_event(payload, session.session_id)
+                if mapped is None:
+                    continue
+                yield mapped
+                if mapped.kind in {
+                    ProviderEventKind.TURN_COMPLETED,
+                    ProviderEventKind.CANCELLED,
+                    ProviderEventKind.FAILED,
+                }:
+                    return
+            raise OpenCodeProviderError(
+                "OpenCode event stream ended before a terminal event.",
+                code="provider_stream_ended",
+            )
+        except httpx.HTTPError as exc:
+            raise OpenCodeProviderError(
+                "OpenCode request failed.", code="provider_unavailable"
+            ) from exc
+        finally:
+            if event_response is not None:
+                await event_response.aclose()
+
+    async def cancel(self, session: ProviderSession) -> bool:
+        handle, _request = self._require_session(session)
+        try:
+            response = await handle.client.post(
+                self._url(f"/session/{quote(session.session_id)}/abort", handle.workspace)
+            )
+            response.raise_for_status()
+            value = response.json()
+        except httpx.HTTPError as exc:
+            raise OpenCodeProviderError(
+                "OpenCode cancel failed.", code="provider_unavailable"
+            ) from exc
+        return value is True
+
+    async def checkpoint(self, session: ProviderSession) -> ProviderCheckpoint:
+        handle, request = self._require_session(session)
+        try:
+            session_response, messages_response = await asyncio.gather(
+                handle.client.get(
+                    self._url(f"/session/{quote(session.session_id)}", handle.workspace)
+                ),
+                handle.client.get(
+                    self._url(
+                        f"/session/{quote(session.session_id)}/message", handle.workspace
+                    )
+                ),
+            )
+            session_response.raise_for_status()
+            messages_response.raise_for_status()
+        except httpx.HTTPError as exc:
+            raise OpenCodeProviderError(
+                "OpenCode checkpoint failed.", code="provider_unavailable"
+            ) from exc
+        return ProviderCheckpoint(
+            checkpoint_id=f"checkpoint_{secrets.token_hex(16)}",
+            payload={
+                "engine": "opencode-1.18.9",
+                "session_id": session.session_id,
+                "task_id": request.task_id,
+                "session": session_response.json(),
+                "messages": messages_response.json(),
+            },
+        )
+
+    async def restore(
+        self, request: ProviderOpenRequest, checkpoint: ProviderCheckpoint
+    ) -> ProviderSession:
+        session_id = checkpoint.payload.get("session_id")
+        if (
+            checkpoint.payload.get("engine") != "opencode-1.18.9"
+            or checkpoint.payload.get("task_id") != request.task_id
+            or not isinstance(session_id, str)
+            or not session_id.startswith("ses")
+        ):
+            raise OpenCodeProviderError(
+                "OpenCode checkpoint binding is invalid.", code="checkpoint_invalid"
+            )
+        route = self._require_route(request.model_route)
+        workspace = self._workspace_resolver(request.workspace_id).resolve()
+        handle = await self._server_factory(request, workspace, route)
+        try:
+            response = await handle.client.get(
+                self._url(f"/session/{quote(session_id)}", workspace)
+            )
+            response.raise_for_status()
+            payload = response.json()
+            if not isinstance(payload, dict) or payload.get("id") != session_id:
+                raise OpenCodeProviderError(
+                    "OpenCode checkpoint is unavailable.", code="checkpoint_unavailable"
+                )
+        except Exception:
+            await handle.close()
+            raise
+        async with self._lock:
+            self._handles[session_id] = handle
+            self._requests[session_id] = request
+        return ProviderSession(
+            session_id=session_id,
+            task_id=request.task_id,
+            provider_capabilities=await self.capabilities(),
+        )
+
+    async def close(self, session: ProviderSession) -> None:
+        async with self._lock:
+            handle = self._handles.pop(session.session_id, None)
+            self._requests.pop(session.session_id, None)
+        if handle is not None:
+            await handle.close()
+
+    def build_config(self, route: OpenCodeRoute) -> dict[str, Any]:
+        permission: dict[str, str] = {
+            "*": "deny",
+            "external_directory": "deny",
+            "doom_loop": "deny",
+            "question": "deny",
+        }
+        mcp: dict[str, Any] = {}
+        if self._tool_broker_command is not None:
+            permission["modelmirror-tool-broker_*"] = "allow"
+            mcp["modelmirror-tool-broker"] = {
+                "type": "local",
+                "command": list(self._tool_broker_command),
+                "enabled": True,
+                "timeout": 310_000,
+            }
+        return {
+            "$schema": "https://opencode.ai/config.json",
+            "model": f"modelmirror/{route.model_id}",
+            "default_agent": "modelmirror-worker",
+            "agent": {
+                "modelmirror-worker": {
+                    "description": "ModelMirror provider-neutral coding worker",
+                    "mode": "primary",
+                    "permission": permission,
+                }
+            },
+            "permission": permission,
+            "provider": {
+                "modelmirror": {
+                    "npm": "@ai-sdk/openai-compatible",
+                    "name": "ModelMirror Internal Gateway",
+                    "options": {
+                        "baseURL": route.base_url,
+                        "apiKey": "{env:CODING_WORKER_ROUTE_KEY}",
+                    },
+                    "models": {
+                        route.model_id: {
+                            "name": "ModelMirror controlled model route",
+                            "limit": {
+                                "context": route.context_tokens,
+                                "output": route.output_tokens,
+                            },
+                        }
+                    },
+                }
+            },
+            "plugin": [],
+            "mcp": mcp,
+            "instructions": [],
+            "share": "disabled",
+            "autoupdate": False,
+        }
+
+    async def _launch_server(
+        self, request: ProviderOpenRequest, workspace: Path, route: OpenCodeRoute
+    ) -> OpenCodeServerHandle:
+        state_root = self._runtime_root / request.task_id
+        state_root.mkdir(parents=True, exist_ok=True)
+        home = state_root / "home"
+        home.mkdir(exist_ok=True)
+        password = secrets.token_urlsafe(32)
+        port = _unused_loopback_port()
+        environment = {
+            "PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"),
+            "HOME": str(home),
+            "XDG_CONFIG_HOME": str(home / ".config"),
+            "XDG_DATA_HOME": str(home / ".local/share"),
+            "XDG_STATE_HOME": str(home / ".local/state"),
+            "XDG_CACHE_HOME": str(home / ".cache"),
+            "OPENCODE_CONFIG_CONTENT": json.dumps(
+                self.build_config(route), ensure_ascii=False, separators=(",", ":")
+            ),
+            "OPENCODE_DISABLE_PROJECT_CONFIG": "1",
+            "OPENCODE_PURE": "1",
+            "OPENCODE_DISABLE_AUTOUPDATE": "1",
+            "OPENCODE_DISABLE_AUTOCOMPACT": "1",
+            "OPENCODE_DISABLE_MODELS_FETCH": "1",
+            "OPENCODE_AUTH_CONTENT": "{}",
+            "OPENCODE_SERVER_PASSWORD": password,
+            "CODING_WORKER_ROUTE_KEY": route.api_key,
+            "NO_PROXY": "127.0.0.1,localhost,new-api",
+            "no_proxy": "127.0.0.1,localhost,new-api",
+        }
+        process = await asyncio.create_subprocess_exec(
+            self._executable,
+            "serve",
+            "--hostname",
+            "127.0.0.1",
+            "--port",
+            str(port),
+            cwd=workspace,
+            env=environment,
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        auth = base64.b64encode(f"opencode:{password}".encode()).decode("ascii")
+        client = httpx.AsyncClient(
+            base_url=f"http://127.0.0.1:{port}",
+            headers={"Authorization": f"Basic {auth}"},
+            timeout=httpx.Timeout(120.0, connect=5.0),
+            trust_env=False,
+        )
+        try:
+            await _wait_for_server(client, process)
+            health = await client.get("/global/health")
+            health.raise_for_status()
+            payload = health.json()
+            if payload != {"healthy": True, "version": OPENCODE_VERSION}:
+                raise OpenCodeProviderError(
+                    "OpenCode version is not the pinned version.", code="provider_version_mismatch"
+                )
+        except Exception:
+            await client.aclose()
+            await _stop_process(process)
+            raise
+
+        async def close() -> None:
+            await client.aclose()
+            await _stop_process(process)
+
+        return OpenCodeServerHandle(
+            task_id=request.task_id,
+            workspace=workspace,
+            state_root=state_root,
+            client=client,
+            close_callback=close,
+        )
+
+    def _require_route(self, route_id: str) -> OpenCodeRoute:
+        route = self._routes.get(route_id)
+        if route is None or route.route_id != route_id:
+            raise OpenCodeProviderError("Model route is unavailable.", code="model_route_unavailable")
+        return route
+
+    def _require_session(
+        self, session: ProviderSession
+    ) -> tuple[OpenCodeServerHandle, ProviderOpenRequest]:
+        handle = self._handles.get(session.session_id)
+        request = self._requests.get(session.session_id)
+        if handle is None or request is None or request.task_id != session.task_id:
+            raise OpenCodeProviderError("Provider session was not found.", code="session_not_found")
+        return handle, request
+
+    def _prompt_tools(self) -> dict[str, bool]:
+        tools = {name: False for name in DIRECT_TOOL_NAMES}
+        if self._tool_broker_command is not None:
+            tools["modelmirror-tool-broker_*"] = True
+        return tools
+
+    @staticmethod
+    def _url(path: str, workspace: Path) -> str:
+        return f"{path}?directory={quote(str(workspace), safe='')}"
+
+    @staticmethod
+    def _map_event(payload: dict[str, Any], session_id: str) -> ProviderEvent | None:
+        event_type = payload.get("type")
+        properties = payload.get("properties")
+        if not isinstance(event_type, str) or not isinstance(properties, dict):
+            return None
+        event_session = properties.get("sessionID") or properties.get("sessionId")
+        if event_session is not None and event_session != session_id:
+            return None
+        if event_type in {"message.part.updated", "message.part.delta"}:
+            part = properties.get("part")
+            delta = properties.get("delta")
+            text = None
+            if isinstance(part, dict) and part.get("type") == "text":
+                text = delta if isinstance(delta, str) else part.get("text")
+            if isinstance(text, str) and text:
+                return ProviderEvent(kind=ProviderEventKind.MESSAGE, data={"text": text})
+        if event_type in {"permission.asked", "permission.updated"}:
+            return ProviderEvent(
+                kind=ProviderEventKind.APPROVAL_REQUIRED,
+                data={"request": properties},
+            )
+        if event_type in {"session.idle", "session.completed"}:
+            return ProviderEvent(kind=ProviderEventKind.TURN_COMPLETED)
+        if event_type in {"session.aborted", "session.cancelled"}:
+            return ProviderEvent(kind=ProviderEventKind.CANCELLED)
+        if event_type in {"session.error", "message.error"}:
+            return ProviderEvent(kind=ProviderEventKind.FAILED, data={"error": "provider_failed"})
+        return None
+
+
+async def _iter_sse_json(response: httpx.Response) -> AsyncIterator[dict[str, Any]]:
+    data_lines: list[str] = []
+    async for line in response.aiter_lines():
+        if not line:
+            if data_lines:
+                try:
+                    value = json.loads("\n".join(data_lines))
+                except json.JSONDecodeError:
+                    value = None
+                if isinstance(value, dict):
+                    yield value
+                data_lines.clear()
+            continue
+        if line.startswith("data:"):
+            data_lines.append(line[5:].lstrip())
+    if data_lines:
+        try:
+            value = json.loads("\n".join(data_lines))
+        except json.JSONDecodeError:
+            return
+        if isinstance(value, dict):
+            yield value
+
+
+async def _wait_for_server(
+    client: httpx.AsyncClient,
+    process: asyncio.subprocess.Process,
+    *,
+    timeout: float = 10.0,
+) -> None:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        if process.returncode is not None:
+            raise OpenCodeProviderError("OpenCode exited during startup.", code="provider_unavailable")
+        try:
+            response = await client.get("/global/health", timeout=0.25)
+            if response.status_code == 200:
+                return
+        except httpx.HTTPError:
+            pass
+        await asyncio.sleep(0.05)
+    raise OpenCodeProviderError("OpenCode startup timed out.", code="provider_unavailable")
+
+
+async def _stop_process(process: asyncio.subprocess.Process) -> None:
+    if process.returncode is not None:
+        return
+    with contextlib.suppress(ProcessLookupError):
+        process.terminate()
+    try:
+        await asyncio.wait_for(process.wait(), timeout=5.0)
+    except TimeoutError:
+        with contextlib.suppress(ProcessLookupError):
+            process.kill()
+        await process.wait()
+
+
+def _unused_loopback_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as candidate:
+        candidate.bind(("127.0.0.1", 0))
+        return int(candidate.getsockname()[1])

--- a/server/coding_worker/opencode_provider.py
+++ b/server/coding_worker/opencode_provider.py
@@ -105,7 +105,26 @@ class OpenCodeProvider(CodingAgentProvider):
         self._server_factory = server_factory or self._launch_server
         self._handles: dict[str, OpenCodeServerHandle] = {}
         self._requests: dict[str, ProviderOpenRequest] = {}
+        self._broker_bindings: dict[str, tuple[str, str]] = {}
         self._lock = asyncio.Lock()
+
+    def bind_broker(self, task_id: str, endpoint: str, token: str) -> None:
+        if not (
+            endpoint.startswith("unix:")
+            or endpoint.startswith("tcp:127.0.0.1:")
+        ) or len(token) < 32:
+            raise OpenCodeProviderError(
+                "Tool Broker binding is invalid.", code="tool_broker_unavailable"
+            )
+        existing = self._broker_bindings.get(task_id)
+        if existing is not None and existing != (endpoint, token):
+            raise OpenCodeProviderError(
+                "Tool Broker binding changed.", code="tool_broker_binding_changed"
+            )
+        self._broker_bindings[task_id] = (endpoint, token)
+
+    def unbind_broker(self, task_id: str) -> None:
+        self._broker_bindings.pop(task_id, None)
 
     async def capabilities(self) -> ProviderCapabilities:
         return ProviderCapabilities(
@@ -436,20 +455,27 @@ class OpenCodeProvider(CodingAgentProvider):
         )
 
     def _broker_environment(self, task_id: str) -> tuple[dict[str, str], Callable[[], None]]:
-        if self._broker_rpc is None:
-            return {}, lambda: None
-        endpoint = self._broker_rpc.endpoint
-        if endpoint is None:
-            raise OpenCodeProviderError(
-                "Tool Broker RPC is unavailable.", code="tool_broker_unavailable"
-            )
-        token = self._broker_rpc.register_task(task_id)
+        if self._broker_rpc is not None:
+            endpoint = self._broker_rpc.endpoint
+            if endpoint is None:
+                raise OpenCodeProviderError(
+                    "Tool Broker RPC is unavailable.", code="tool_broker_unavailable"
+                )
+            token = self._broker_rpc.register_task(task_id)
+        else:
+            binding = self._broker_bindings.get(task_id)
+            if binding is None:
+                return {}, lambda: None
+            endpoint, token = binding
         revoked = False
 
         def revoke() -> None:
             nonlocal revoked
             if not revoked:
-                self._broker_rpc.revoke_task(task_id)
+                if self._broker_rpc is not None:
+                    self._broker_rpc.revoke_task(task_id)
+                else:
+                    self.unbind_broker(task_id)
                 revoked = True
 
         return {

--- a/server/coding_worker/opencode_provider.py
+++ b/server/coding_worker/opencode_provider.py
@@ -465,7 +465,7 @@ class OpenCodeProvider(CodingAgentProvider):
         if event_type in {"permission.asked", "permission.updated"}:
             return ProviderEvent(
                 kind=ProviderEventKind.APPROVAL_REQUIRED,
-                data={"request": properties},
+                data={"capability": "provider_permission"},
             )
         if event_type in {"session.idle", "session.completed"}:
             return ProviderEvent(kind=ProviderEventKind.TURN_COMPLETED)

--- a/server/coding_worker/process_manager.py
+++ b/server/coding_worker/process_manager.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import signal
+import subprocess
+import time
+import uuid
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Literal
+
+from pydantic import Field
+
+from .contracts import StrictModel
+from .store import CodingWorkerStore, WorkerNotFoundError
+from .workspace import WorkspaceBroker
+
+
+class ProcessManagerError(RuntimeError):
+    def __init__(self, message: str, *, code: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+class ManagedProcess(StrictModel):
+    service_id: str
+    task_id: str
+    state: Literal["running", "completed", "failed", "stopped"]
+    started_at: float
+    expires_at: float
+    exit_code: int | None = None
+    output_artifact_id: str | None = None
+    reason: str | None = None
+
+
+@dataclass(slots=True)
+class _LiveProcess:
+    record: ManagedProcess
+    process: asyncio.subprocess.Process
+    output: bytearray
+    monitor: asyncio.Task[None] | None = None
+    reason: str | None = None
+
+
+class BackgroundProcessManager:
+    """Owns task processes and archives bounded output; it never exposes a PID."""
+
+    def __init__(
+        self,
+        *,
+        store: CodingWorkerStore,
+        workspace_broker: WorkspaceBroker,
+        environment_factory: Callable[[str], Mapping[str, str]],
+        max_processes_per_task: int = 4,
+        max_output_bytes: int = 2 * 1024 * 1024,
+        clock: Callable[[], float] = time.time,
+    ) -> None:
+        if not 1 <= max_processes_per_task <= 16:
+            raise ValueError("process capacity is invalid")
+        if not 1024 <= max_output_bytes <= 16 * 1024 * 1024:
+            raise ValueError("process output limit is invalid")
+        self.store = store
+        self.workspace_broker = workspace_broker
+        self.environment_factory = environment_factory
+        self.max_processes_per_task = max_processes_per_task
+        self.max_output_bytes = max_output_bytes
+        self._clock = clock
+        self._processes: dict[str, _LiveProcess] = {}
+        self._lock = asyncio.Lock()
+
+    async def start(
+        self,
+        *,
+        task_id: str,
+        workspace_id: str,
+        argv: Sequence[str],
+        ttl_seconds: int,
+    ) -> ManagedProcess:
+        if not 1 <= ttl_seconds <= 3600:
+            raise ProcessManagerError("Service TTL is invalid.", code="service_ttl_invalid")
+        async with self._lock:
+            active = sum(
+                item.record.task_id == task_id and item.record.state == "running"
+                for item in self._processes.values()
+            )
+            if active >= self.max_processes_per_task:
+                raise ProcessManagerError(
+                    "Task service capacity is exhausted.", code="service_capacity_exhausted"
+                )
+            now = self._clock()
+            service_id = f"service_{uuid.uuid4().hex}"
+            kwargs: dict[str, object] = {}
+            if os.name == "nt":
+                kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+            else:
+                kwargs["start_new_session"] = True
+            process = await asyncio.create_subprocess_exec(
+                *argv,
+                cwd=self.workspace_broker.repository_path(workspace_id),
+                env=dict(self.environment_factory(workspace_id)),
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+                **kwargs,
+            )
+            live = _LiveProcess(
+                record=ManagedProcess(
+                    service_id=service_id,
+                    task_id=task_id,
+                    state="running",
+                    started_at=now,
+                    expires_at=now + ttl_seconds,
+                ),
+                process=process,
+                output=bytearray(),
+            )
+            self._processes[service_id] = live
+            live.monitor = asyncio.create_task(
+                self._monitor(live, ttl_seconds), name=f"worker-service-{service_id}"
+            )
+            self.store.append_event(task_id, "service_started", {"service_id": service_id})
+            return live.record
+
+    async def send_input(self, *, task_id: str, service_id: str, data: bytes) -> None:
+        if not data or len(data) > 64 * 1024:
+            raise ProcessManagerError("Service input is invalid.", code="service_input_invalid")
+        live = self._require(task_id, service_id)
+        if live.process.stdin is None or live.record.state != "running":
+            raise ProcessManagerError("Service is not running.", code="service_not_running")
+        live.process.stdin.write(data)
+        await live.process.stdin.drain()
+
+    async def interrupt(self, *, task_id: str, service_id: str) -> ManagedProcess:
+        live = self._require(task_id, service_id)
+        if live.record.state != "running":
+            return live.record
+        live.reason = "user_interrupted"
+        await self._interrupt_process(live.process)
+        if live.monitor is not None:
+            await live.monitor
+        return live.record
+
+    def status(self, *, task_id: str, service_id: str) -> ManagedProcess:
+        return self._require(task_id, service_id).record
+
+    def list(self, task_id: str) -> tuple[ManagedProcess, ...]:
+        self.store.get_task(task_id)
+        return tuple(
+            item.record for item in self._processes.values() if item.record.task_id == task_id
+        )
+
+    async def shutdown(self) -> None:
+        running = [item for item in self._processes.values() if item.record.state == "running"]
+        for item in running:
+            item.reason = "manager_shutdown"
+            await self._interrupt_process(item.process)
+        await asyncio.gather(
+            *(item.monitor for item in running if item.monitor is not None),
+            return_exceptions=True,
+        )
+
+    async def _monitor(self, live: _LiveProcess, ttl_seconds: int) -> None:
+        drain = asyncio.create_task(self._drain_output(live))
+        try:
+            try:
+                await asyncio.wait_for(live.process.wait(), timeout=ttl_seconds)
+            except TimeoutError:
+                live.reason = "service_ttl_expired"
+                await self._interrupt_process(live.process)
+            await drain
+        finally:
+            if not drain.done():
+                drain.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await drain
+            exit_code = live.process.returncode
+            reason = live.reason
+            state: Literal["completed", "failed", "stopped"]
+            if reason is not None:
+                state = "stopped"
+            elif exit_code == 0:
+                state = "completed"
+            else:
+                state = "failed"
+                reason = "service_exited"
+            artifact = self.store.create_artifact(
+                task_id=live.record.task_id,
+                media_type="text/plain; charset=utf-8",
+                content=bytes(live.output),
+                metadata={"service_id": live.record.service_id, "reason": reason},
+            )
+            live.record = live.record.model_copy(
+                update={
+                    "state": state,
+                    "exit_code": exit_code,
+                    "output_artifact_id": artifact.artifact_id,
+                    "reason": reason,
+                }
+            )
+            self.store.append_event(
+                live.record.task_id,
+                "service_stopped",
+                {
+                    "service_id": live.record.service_id,
+                    "state": state,
+                    "artifact_id": artifact.artifact_id,
+                    "reason": reason,
+                },
+            )
+
+    async def _drain_output(self, live: _LiveProcess) -> None:
+        if live.process.stdout is None:
+            return
+        while True:
+            chunk = await live.process.stdout.read(64 * 1024)
+            if not chunk:
+                return
+            if len(live.output) + len(chunk) > self.max_output_bytes:
+                remaining = self.max_output_bytes - len(live.output)
+                if remaining > 0:
+                    live.output.extend(chunk[:remaining])
+                live.reason = "service_output_limit"
+                with contextlib.suppress(ProcessLookupError):
+                    live.process.kill()
+                return
+            live.output.extend(chunk)
+
+    @staticmethod
+    async def _interrupt_process(process: asyncio.subprocess.Process) -> None:
+        if process.returncode is not None:
+            return
+        with contextlib.suppress(ProcessLookupError):
+            if os.name == "nt":
+                process.send_signal(signal.CTRL_BREAK_EVENT)
+            else:
+                os.killpg(process.pid, signal.SIGINT)
+        try:
+            await asyncio.wait_for(process.wait(), timeout=2.0)
+        except TimeoutError:
+            with contextlib.suppress(ProcessLookupError):
+                process.kill()
+            await process.wait()
+
+    def _require(self, task_id: str, service_id: str) -> _LiveProcess:
+        item = self._processes.get(service_id)
+        if item is None or item.record.task_id != task_id:
+            raise WorkerNotFoundError("Service was not found.", code="service_not_found")
+        return item

--- a/server/coding_worker/provider_rpc.py
+++ b/server/coding_worker/provider_rpc.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import secrets
 from collections.abc import AsyncIterator, Callable, Mapping, Sequence
@@ -60,6 +61,7 @@ class ProviderRPCServer:
         self.endpoint: str | None = None
         self._active_task_id: str | None = None
         self._lock = asyncio.Lock()
+        self._connections: dict[asyncio.Task[None], asyncio.StreamWriter] = {}
 
     async def start_unix(self, socket_path: Path) -> str:
         if self._server is not None:
@@ -87,13 +89,23 @@ class ProviderRPCServer:
     async def close(self) -> None:
         if self._server is not None:
             self._server.close()
-            await self._server.wait_closed()
+        connections = tuple(self._connections.items())
+        for task, writer in connections:
+            writer.close()
+            task.cancel()
+        if connections:
+            await asyncio.wait(tuple(task for task, _writer in connections), timeout=2)
+        if self._server is not None:
+            await asyncio.wait_for(self._server.wait_closed(), timeout=2)
         self._server = None
         self.endpoint = None
 
     async def _handle(
         self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
     ) -> None:
+        current = asyncio.current_task()
+        if current is not None:
+            self._connections[current] = writer
         try:
             request = await self._read_request(reader)
             if request.action == "message":
@@ -125,7 +137,10 @@ class ProviderRPCServer:
             )
         finally:
             writer.close()
-            await writer.wait_closed()
+            with contextlib.suppress(Exception):
+                await asyncio.wait_for(writer.wait_closed(), timeout=1)
+            if current is not None:
+                self._connections.pop(current, None)
 
     async def _dispatch(self, request: ProviderRPCRequest) -> dict[str, Any]:
         if request.action == "capabilities":

--- a/server/coding_worker/provider_rpc.py
+++ b/server/coding_worker/provider_rpc.py
@@ -20,7 +20,7 @@ from .provider import (
     ProviderOpenRequest,
     ProviderSession,
 )
-from .executor import SidecarExecutor
+from .executor import ExecutorSidecarClientPool, SidecarExecutor
 
 
 MAX_PROVIDER_RPC_BYTES = 8 * 1024 * 1024
@@ -283,6 +283,7 @@ class ProviderSidecarClientPool(CodingAgentProvider):
         tokens: Mapping[str, str],
         workspace_slot_resolver: Callable[[str], str],
         broker_rpc: BrokerRPCServer,
+        executor_pool: ExecutorSidecarClientPool | None = None,
     ) -> None:
         if set(endpoints) != set(tokens) or not endpoints:
             raise ValueError("provider sidecar bindings are incomplete")
@@ -290,7 +291,8 @@ class ProviderSidecarClientPool(CodingAgentProvider):
         self._tokens = dict(tokens)
         self._workspace_slot_resolver = workspace_slot_resolver
         self._broker_rpc = broker_rpc
-        self._sessions: dict[str, tuple[str, str]] = {}
+        self._executor_pool = executor_pool
+        self._sessions: dict[str, tuple[str, str, str]] = {}
 
     async def capabilities(self) -> ProviderCapabilities:
         values = [
@@ -324,6 +326,14 @@ class ProviderSidecarClientPool(CodingAgentProvider):
                 "Provider slot is unavailable.", code="provider_unavailable"
             )
         broker_token = self._broker_rpc.register_task(request.task_id)
+        if self._executor_pool is not None:
+            try:
+                await self._executor_pool.bind_task(
+                    request.task_id, request.workspace_id
+                )
+            except Exception:
+                self._broker_rpc.revoke_task(request.task_id)
+                raise
         payload: dict[str, Any] = {
             "request": request.model_dump(mode="json"),
             "broker_endpoint": broker_endpoint,
@@ -339,13 +349,22 @@ class ProviderSidecarClientPool(CodingAgentProvider):
             )
         except Exception:
             self._broker_rpc.revoke_task(request.task_id)
+            if self._executor_pool is not None:
+                with contextlib.suppress(Exception):
+                    await self._executor_pool.close_task(
+                        request.task_id, request.workspace_id
+                    )
             raise
         if session.task_id != request.task_id:
             self._broker_rpc.revoke_task(request.task_id)
             raise ProviderRPCError(
                 "Provider session binding is invalid.", code="provider_invalid_response"
             )
-        self._sessions[session.session_id] = (slot_id, session.task_id)
+        self._sessions[session.session_id] = (
+            slot_id,
+            session.task_id,
+            request.workspace_id,
+        )
         return session
 
     async def message(
@@ -399,6 +418,9 @@ class ProviderSidecarClientPool(CodingAgentProvider):
                 slot_id, "close", {"session": session.model_dump(mode="json")}
             )
         finally:
+            if self._executor_pool is not None:
+                with contextlib.suppress(Exception):
+                    await self._executor_pool.close_task(session.task_id, binding[2])
             self._broker_rpc.revoke_task(session.task_id)
 
     async def run_process(
@@ -411,6 +433,15 @@ class ProviderSidecarClientPool(CodingAgentProvider):
         isolated: bool,
         environment_overrides: Mapping[str, str] | None = None,
     ) -> dict[str, Any]:
+        if self._executor_pool is not None:
+            return await self._executor_pool.run_process(
+                task_id=task_id,
+                workspace_id=workspace_id,
+                argv=argv,
+                timeout_seconds=timeout_seconds,
+                isolated=isolated,
+                environment_overrides=environment_overrides,
+            )
         return await self._workspace_call(
             workspace_id,
             "execute_process",
@@ -433,6 +464,14 @@ class ProviderSidecarClientPool(CodingAgentProvider):
         ttl_seconds: int,
         preview_port: int | None = None,
     ) -> dict[str, Any]:
+        if self._executor_pool is not None:
+            return await self._executor_pool.start_service(
+                task_id=task_id,
+                workspace_id=workspace_id,
+                argv=argv,
+                ttl_seconds=ttl_seconds,
+                preview_port=preview_port,
+            )
         return await self._workspace_call(
             workspace_id,
             "start_service",
@@ -446,12 +485,18 @@ class ProviderSidecarClientPool(CodingAgentProvider):
         )
 
     async def service_status(self, *, task_id: str, workspace_id: str, service_id: str) -> dict[str, Any]:
+        if self._executor_pool is not None:
+            return await self._executor_pool.service_status(task_id=task_id, workspace_id=workspace_id, service_id=service_id)
         return await self._workspace_call(workspace_id, "service_status", {"task_id": task_id, "service_id": service_id})
 
     async def service_input(self, *, task_id: str, workspace_id: str, service_id: str, data: str) -> dict[str, Any]:
+        if self._executor_pool is not None:
+            return await self._executor_pool.service_input(task_id=task_id, workspace_id=workspace_id, service_id=service_id, data=data)
         return await self._workspace_call(workspace_id, "service_input", {"task_id": task_id, "service_id": service_id, "data": data})
 
     async def stop_service(self, *, task_id: str, workspace_id: str, service_id: str) -> dict[str, Any]:
+        if self._executor_pool is not None:
+            return await self._executor_pool.stop_service(task_id=task_id, workspace_id=workspace_id, service_id=service_id)
         return await self._workspace_call(workspace_id, "stop_service", {"task_id": task_id, "service_id": service_id})
 
     async def _workspace_call(self, workspace_id: str, action: str, payload: dict[str, Any]) -> dict[str, Any]:

--- a/server/coding_worker/provider_rpc.py
+++ b/server/coding_worker/provider_rpc.py
@@ -1,0 +1,409 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import secrets
+from collections.abc import AsyncIterator, Callable, Mapping
+from pathlib import Path
+from typing import Any
+
+from pydantic import Field
+
+from .broker_rpc import BrokerRPCServer
+from .contracts import StrictModel
+from .provider import (
+    CodingAgentProvider,
+    ProviderCapabilities,
+    ProviderCheckpoint,
+    ProviderEvent,
+    ProviderOpenRequest,
+    ProviderSession,
+)
+
+
+MAX_PROVIDER_RPC_BYTES = 8 * 1024 * 1024
+
+
+class ProviderRPCError(RuntimeError):
+    def __init__(self, message: str, *, code: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+class ProviderRPCRequest(StrictModel):
+    token: str = Field(min_length=32, max_length=256)
+    action: str = Field(pattern=r"^[a-z_]{1,32}$")
+    payload: dict[str, Any] = Field(default_factory=dict)
+
+
+class ProviderRPCServer:
+    """Single-slot provider host. Only provider-neutral frames cross this boundary."""
+
+    def __init__(
+        self,
+        provider: CodingAgentProvider,
+        *,
+        token: str,
+        bind_broker: Callable[[str, str, str], None] | None = None,
+        unbind_broker: Callable[[str], None] | None = None,
+    ) -> None:
+        if len(token) < 32:
+            raise ValueError("provider RPC token is too short")
+        self.provider = provider
+        self._token = token
+        self._bind_broker = bind_broker
+        self._unbind_broker = unbind_broker
+        self._server: asyncio.AbstractServer | None = None
+        self.endpoint: str | None = None
+        self._active_task_id: str | None = None
+        self._lock = asyncio.Lock()
+
+    async def start_unix(self, socket_path: Path) -> str:
+        if self._server is not None:
+            raise RuntimeError("provider RPC server is already running")
+        socket_path = Path(socket_path)
+        socket_path.parent.mkdir(parents=True, exist_ok=True)
+        socket_path.unlink(missing_ok=True)
+        self._server = await asyncio.start_unix_server(
+            self._handle, path=str(socket_path), limit=MAX_PROVIDER_RPC_BYTES
+        )
+        socket_path.chmod(0o660)
+        self.endpoint = f"unix:{socket_path}"
+        return self.endpoint
+
+    async def start_tcp_for_tests(self) -> str:
+        if self._server is not None:
+            raise RuntimeError("provider RPC server is already running")
+        self._server = await asyncio.start_server(
+            self._handle, "127.0.0.1", 0, limit=MAX_PROVIDER_RPC_BYTES
+        )
+        address = self._server.sockets[0].getsockname()
+        self.endpoint = f"tcp:127.0.0.1:{address[1]}"
+        return self.endpoint
+
+    async def close(self) -> None:
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+        self._server = None
+        self.endpoint = None
+
+    async def _handle(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        try:
+            request = await self._read_request(reader)
+            if request.action == "message":
+                session = ProviderSession.model_validate(request.payload.get("session"))
+                text = request.payload.get("text")
+                if not isinstance(text, str):
+                    raise ProviderRPCError(
+                        "Provider message is invalid.", code="provider_request_invalid"
+                    )
+                self._require_active(session.task_id)
+                async for event in self.provider.message(session, text):
+                    await self._write(writer, {"ok": True, "event": event.model_dump(mode="json")})
+                await self._write(writer, {"ok": True, "done": True})
+                return
+            result = await self._dispatch(request)
+            await self._write(writer, {"ok": True, "result": result})
+        except Exception as exc:
+            await self._write(
+                writer,
+                {
+                    "ok": False,
+                    "error": {
+                        "code": getattr(exc, "code", "provider_failed"),
+                        "message": str(exc)
+                        if isinstance(exc, (ProviderRPCError, ValueError))
+                        else "Provider request failed.",
+                    },
+                },
+            )
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+    async def _dispatch(self, request: ProviderRPCRequest) -> dict[str, Any]:
+        if request.action == "capabilities":
+            return (await self.provider.capabilities()).model_dump(mode="json")
+        if request.action in {"open", "restore"}:
+            opened = ProviderOpenRequest.model_validate(request.payload.get("request"))
+            broker_endpoint = request.payload.get("broker_endpoint")
+            broker_token = request.payload.get("broker_token")
+            if not isinstance(broker_endpoint, str) or not isinstance(broker_token, str):
+                raise ProviderRPCError(
+                    "Tool Broker binding is missing.", code="tool_broker_unavailable"
+                )
+            async with self._lock:
+                if self._active_task_id not in {None, opened.task_id}:
+                    raise ProviderRPCError(
+                        "Provider slot is busy.", code="provider_slot_busy"
+                    )
+                if self._bind_broker is not None:
+                    self._bind_broker(opened.task_id, broker_endpoint, broker_token)
+                try:
+                    if request.action == "restore":
+                        checkpoint = ProviderCheckpoint.model_validate(
+                            request.payload.get("checkpoint")
+                        )
+                        session = await self.provider.restore(opened, checkpoint)
+                    else:
+                        session = await self.provider.open(opened)
+                except Exception:
+                    if self._unbind_broker is not None:
+                        self._unbind_broker(opened.task_id)
+                    raise
+                self._active_task_id = opened.task_id
+                return session.model_dump(mode="json")
+        session = ProviderSession.model_validate(request.payload.get("session"))
+        self._require_active(session.task_id)
+        if request.action == "cancel":
+            return {"cancelled": await self.provider.cancel(session)}
+        if request.action == "checkpoint":
+            return (await self.provider.checkpoint(session)).model_dump(mode="json")
+        if request.action == "close":
+            await self.provider.close(session)
+            async with self._lock:
+                if self._active_task_id == session.task_id:
+                    self._active_task_id = None
+                if self._unbind_broker is not None:
+                    self._unbind_broker(session.task_id)
+            return {"closed": True}
+        raise ProviderRPCError(
+            "Provider action is invalid.", code="provider_request_invalid"
+        )
+
+    def _require_active(self, task_id: str) -> None:
+        if self._active_task_id != task_id:
+            raise ProviderRPCError(
+                "Provider session was not found.", code="session_not_found"
+            )
+
+    async def _read_request(self, reader: asyncio.StreamReader) -> ProviderRPCRequest:
+        raw = await reader.readline()
+        if not raw or len(raw) > MAX_PROVIDER_RPC_BYTES or not raw.endswith(b"\n"):
+            raise ProviderRPCError(
+                "Provider request is invalid.", code="provider_request_invalid"
+            )
+        request = ProviderRPCRequest.model_validate_json(raw)
+        if not secrets.compare_digest(request.token, self._token):
+            raise ProviderRPCError(
+                "Provider authentication failed.", code="provider_unauthorized"
+            )
+        return request
+
+    @staticmethod
+    async def _write(writer: asyncio.StreamWriter, value: dict[str, Any]) -> None:
+        encoded = json.dumps(value, separators=(",", ":")).encode("utf-8") + b"\n"
+        if len(encoded) > MAX_PROVIDER_RPC_BYTES:
+            encoded = b'{"ok":false,"error":{"code":"provider_response_too_large","message":"Provider response is too large."}}\n'
+        writer.write(encoded)
+        await writer.drain()
+
+
+class ProviderSidecarClientPool(CodingAgentProvider):
+    """Routes each workspace to its fixed provider sidecar slot."""
+
+    def __init__(
+        self,
+        *,
+        endpoints: Mapping[str, str],
+        tokens: Mapping[str, str],
+        workspace_slot_resolver: Callable[[str], str],
+        broker_rpc: BrokerRPCServer,
+    ) -> None:
+        if set(endpoints) != set(tokens) or not endpoints:
+            raise ValueError("provider sidecar bindings are incomplete")
+        self._endpoints = dict(endpoints)
+        self._tokens = dict(tokens)
+        self._workspace_slot_resolver = workspace_slot_resolver
+        self._broker_rpc = broker_rpc
+        self._sessions: dict[str, tuple[str, str]] = {}
+
+    async def capabilities(self) -> ProviderCapabilities:
+        values = [
+            ProviderCapabilities.model_validate(
+                await self._call(slot_id, "capabilities", {})
+            )
+            for slot_id in self._endpoints
+        ]
+        first = values[0]
+        if any(value != first for value in values[1:]):
+            raise ProviderRPCError(
+                "Provider slot capabilities differ.", code="provider_capability_mismatch"
+            )
+        return first
+
+    async def open(self, request: ProviderOpenRequest) -> ProviderSession:
+        return await self._open_or_restore(request, None)
+
+    async def restore(
+        self, request: ProviderOpenRequest, checkpoint: ProviderCheckpoint
+    ) -> ProviderSession:
+        return await self._open_or_restore(request, checkpoint)
+
+    async def _open_or_restore(
+        self, request: ProviderOpenRequest, checkpoint: ProviderCheckpoint | None
+    ) -> ProviderSession:
+        slot_id = self._workspace_slot_resolver(request.workspace_id)
+        broker_endpoint = self._broker_rpc.endpoint
+        if slot_id not in self._endpoints or broker_endpoint is None:
+            raise ProviderRPCError(
+                "Provider slot is unavailable.", code="provider_unavailable"
+            )
+        broker_token = self._broker_rpc.register_task(request.task_id)
+        payload: dict[str, Any] = {
+            "request": request.model_dump(mode="json"),
+            "broker_endpoint": broker_endpoint,
+            "broker_token": broker_token,
+        }
+        action = "open"
+        if checkpoint is not None:
+            action = "restore"
+            payload["checkpoint"] = checkpoint.model_dump(mode="json")
+        try:
+            session = ProviderSession.model_validate(
+                await self._call(slot_id, action, payload)
+            )
+        except Exception:
+            self._broker_rpc.revoke_task(request.task_id)
+            raise
+        if session.task_id != request.task_id:
+            self._broker_rpc.revoke_task(request.task_id)
+            raise ProviderRPCError(
+                "Provider session binding is invalid.", code="provider_invalid_response"
+            )
+        self._sessions[session.session_id] = (slot_id, session.task_id)
+        return session
+
+    async def message(
+        self, session: ProviderSession, text: str
+    ) -> AsyncIterator[ProviderEvent]:
+        slot_id = self._require_session(session)
+        reader, writer = await self._connect(slot_id)
+        await self._send(
+            writer,
+            "message",
+            {"session": session.model_dump(mode="json"), "text": text},
+            slot_id,
+        )
+        try:
+            while True:
+                value = await self._read(reader)
+                if value.get("done") is True:
+                    return
+                event = value.get("event")
+                if not isinstance(event, dict):
+                    raise ProviderRPCError(
+                        "Provider stream is invalid.", code="provider_invalid_response"
+                    )
+                yield ProviderEvent.model_validate(event)
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+    async def cancel(self, session: ProviderSession) -> bool:
+        slot_id = self._require_session(session)
+        result = await self._call(
+            slot_id, "cancel", {"session": session.model_dump(mode="json")}
+        )
+        return result.get("cancelled") is True
+
+    async def checkpoint(self, session: ProviderSession) -> ProviderCheckpoint:
+        slot_id = self._require_session(session)
+        return ProviderCheckpoint.model_validate(
+            await self._call(
+                slot_id, "checkpoint", {"session": session.model_dump(mode="json")}
+            )
+        )
+
+    async def close(self, session: ProviderSession) -> None:
+        binding = self._sessions.pop(session.session_id, None)
+        if binding is None or binding[1] != session.task_id:
+            return
+        slot_id = binding[0]
+        try:
+            await self._call(
+                slot_id, "close", {"session": session.model_dump(mode="json")}
+            )
+        finally:
+            self._broker_rpc.revoke_task(session.task_id)
+
+    def _require_session(self, session: ProviderSession) -> str:
+        binding = self._sessions.get(session.session_id)
+        if binding is None or binding[1] != session.task_id:
+            raise ProviderRPCError(
+                "Provider session was not found.", code="session_not_found"
+            )
+        return binding[0]
+
+    async def _call(
+        self, slot_id: str, action: str, payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        reader, writer = await self._connect(slot_id)
+        await self._send(writer, action, payload, slot_id)
+        try:
+            value = await self._read(reader)
+            result = value.get("result")
+            if not isinstance(result, dict):
+                raise ProviderRPCError(
+                    "Provider response is invalid.", code="provider_invalid_response"
+                )
+            return result
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+    async def _send(
+        self,
+        writer: asyncio.StreamWriter,
+        action: str,
+        payload: dict[str, Any],
+        slot_id: str,
+    ) -> None:
+        request = ProviderRPCRequest(
+            token=self._tokens[slot_id], action=action, payload=payload
+        )
+        encoded = request.model_dump_json().encode("utf-8") + b"\n"
+        if len(encoded) > MAX_PROVIDER_RPC_BYTES:
+            raise ProviderRPCError(
+                "Provider request is too large.", code="provider_request_too_large"
+            )
+        writer.write(encoded)
+        await writer.drain()
+
+    async def _connect(
+        self, slot_id: str
+    ) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+        endpoint = self._endpoints[slot_id]
+        if endpoint.startswith("unix:"):
+            return await asyncio.open_unix_connection(
+                endpoint.removeprefix("unix:"), limit=MAX_PROVIDER_RPC_BYTES
+            )
+        if endpoint.startswith("tcp:127.0.0.1:"):
+            return await asyncio.open_connection(
+                "127.0.0.1", int(endpoint.rsplit(":", 1)[1]), limit=MAX_PROVIDER_RPC_BYTES
+            )
+        raise ProviderRPCError(
+            "Provider endpoint is invalid.", code="provider_endpoint_invalid"
+        )
+
+    @staticmethod
+    async def _read(reader: asyncio.StreamReader) -> dict[str, Any]:
+        raw = await reader.readline()
+        if not raw or len(raw) > MAX_PROVIDER_RPC_BYTES:
+            raise ProviderRPCError(
+                "Provider response is invalid.", code="provider_invalid_response"
+            )
+        value = json.loads(raw)
+        if not isinstance(value, dict) or value.get("ok") is not True:
+            error = value.get("error") if isinstance(value, dict) else None
+            code = error.get("code") if isinstance(error, dict) else "provider_failed"
+            message = (
+                error.get("message")
+                if isinstance(error, dict)
+                else "Provider request failed."
+            )
+            raise ProviderRPCError(str(message), code=str(code))
+        return value

--- a/server/coding_worker/provider_rpc.py
+++ b/server/coding_worker/provider_rpc.py
@@ -163,6 +163,11 @@ class ProviderRPCServer:
                 workspace_id=str(request.payload.get("workspace_id", "")),
                 argv=tuple(request.payload.get("argv", ())),
                 ttl_seconds=int(request.payload.get("ttl_seconds", 0)),
+                preview_port=(
+                    int(request.payload["preview_port"])
+                    if request.payload.get("preview_port") is not None
+                    else None
+                ),
             )
         if request.action == "service_status":
             self._require_active(str(request.payload.get("task_id", "")))
@@ -420,12 +425,24 @@ class ProviderSidecarClientPool(CodingAgentProvider):
         )
 
     async def start_service(
-        self, *, task_id: str, workspace_id: str, argv: Sequence[str], ttl_seconds: int
+        self,
+        *,
+        task_id: str,
+        workspace_id: str,
+        argv: Sequence[str],
+        ttl_seconds: int,
+        preview_port: int | None = None,
     ) -> dict[str, Any]:
         return await self._workspace_call(
             workspace_id,
             "start_service",
-            {"task_id": task_id, "workspace_id": workspace_id, "argv": list(argv), "ttl_seconds": ttl_seconds},
+            {
+                "task_id": task_id,
+                "workspace_id": workspace_id,
+                "argv": list(argv),
+                "ttl_seconds": ttl_seconds,
+                "preview_port": preview_port,
+            },
         )
 
     async def service_status(self, *, task_id: str, workspace_id: str, service_id: str) -> dict[str, Any]:

--- a/server/coding_worker/provider_rpc.py
+++ b/server/coding_worker/provider_rpc.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import secrets
-from collections.abc import AsyncIterator, Callable, Mapping
+from collections.abc import AsyncIterator, Callable, Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
@@ -19,6 +19,7 @@ from .provider import (
     ProviderOpenRequest,
     ProviderSession,
 )
+from .executor import SidecarExecutor
 
 
 MAX_PROVIDER_RPC_BYTES = 8 * 1024 * 1024
@@ -46,6 +47,7 @@ class ProviderRPCServer:
         token: str,
         bind_broker: Callable[[str, str, str], None] | None = None,
         unbind_broker: Callable[[str], None] | None = None,
+        executor: SidecarExecutor | None = None,
     ) -> None:
         if len(token) < 32:
             raise ValueError("provider RPC token is too short")
@@ -53,6 +55,7 @@ class ProviderRPCServer:
         self._token = token
         self._bind_broker = bind_broker
         self._unbind_broker = unbind_broker
+        self._executor = executor
         self._server: asyncio.AbstractServer | None = None
         self.endpoint: str | None = None
         self._active_task_id: str | None = None
@@ -127,6 +130,45 @@ class ProviderRPCServer:
     async def _dispatch(self, request: ProviderRPCRequest) -> dict[str, Any]:
         if request.action == "capabilities":
             return (await self.provider.capabilities()).model_dump(mode="json")
+        if request.action == "execute_process":
+            executor = self._require_executor()
+            self._require_active(str(request.payload.get("task_id", "")))
+            return await executor.run_process(
+                workspace_id=str(request.payload.get("workspace_id", "")),
+                argv=tuple(request.payload.get("argv", ())),
+                timeout_seconds=int(request.payload.get("timeout_seconds", 0)),
+                isolated=request.payload.get("isolated") is True,
+                environment_overrides=request.payload.get("environment_overrides"),
+            )
+        if request.action == "start_service":
+            executor = self._require_executor()
+            self._require_active(str(request.payload.get("task_id", "")))
+            return await executor.start_service(
+                task_id=str(request.payload.get("task_id", "")),
+                workspace_id=str(request.payload.get("workspace_id", "")),
+                argv=tuple(request.payload.get("argv", ())),
+                ttl_seconds=int(request.payload.get("ttl_seconds", 0)),
+            )
+        if request.action == "service_status":
+            self._require_active(str(request.payload.get("task_id", "")))
+            return self._require_executor().service_status(
+                task_id=str(request.payload.get("task_id", "")),
+                service_id=str(request.payload.get("service_id", "")),
+            )
+        if request.action == "service_input":
+            self._require_active(str(request.payload.get("task_id", "")))
+            await self._require_executor().service_input(
+                task_id=str(request.payload.get("task_id", "")),
+                service_id=str(request.payload.get("service_id", "")),
+                data=str(request.payload.get("data", "")),
+            )
+            return {"accepted": True}
+        if request.action == "stop_service":
+            self._require_active(str(request.payload.get("task_id", "")))
+            return await self._require_executor().stop_service(
+                task_id=str(request.payload.get("task_id", "")),
+                service_id=str(request.payload.get("service_id", "")),
+            )
         if request.action in {"open", "restore"}:
             opened = ProviderOpenRequest.model_validate(request.payload.get("request"))
             broker_endpoint = request.payload.get("broker_endpoint")
@@ -164,6 +206,8 @@ class ProviderRPCServer:
             return (await self.provider.checkpoint(session)).model_dump(mode="json")
         if request.action == "close":
             await self.provider.close(session)
+            if self._executor is not None:
+                await self._executor.stop_task(session.task_id)
             async with self._lock:
                 if self._active_task_id == session.task_id:
                     self._active_task_id = None
@@ -173,6 +217,13 @@ class ProviderRPCServer:
         raise ProviderRPCError(
             "Provider action is invalid.", code="provider_request_invalid"
         )
+
+    def _require_executor(self) -> SidecarExecutor:
+        if self._executor is None:
+            raise ProviderRPCError(
+                "Provider executor is unavailable.", code="executor_unavailable"
+            )
+        return self._executor
 
     def _require_active(self, task_id: str) -> None:
         if self._active_task_id != task_id:
@@ -329,6 +380,53 @@ class ProviderSidecarClientPool(CodingAgentProvider):
             )
         finally:
             self._broker_rpc.revoke_task(session.task_id)
+
+    async def run_process(
+        self,
+        *,
+        task_id: str,
+        workspace_id: str,
+        argv: Sequence[str],
+        timeout_seconds: int,
+        isolated: bool,
+        environment_overrides: Mapping[str, str] | None = None,
+    ) -> dict[str, Any]:
+        return await self._workspace_call(
+            workspace_id,
+            "execute_process",
+            {
+                "task_id": task_id,
+                "workspace_id": workspace_id,
+                "argv": list(argv),
+                "timeout_seconds": timeout_seconds,
+                "isolated": isolated,
+                "environment_overrides": dict(environment_overrides or {}),
+            },
+        )
+
+    async def start_service(
+        self, *, task_id: str, workspace_id: str, argv: Sequence[str], ttl_seconds: int
+    ) -> dict[str, Any]:
+        return await self._workspace_call(
+            workspace_id,
+            "start_service",
+            {"task_id": task_id, "workspace_id": workspace_id, "argv": list(argv), "ttl_seconds": ttl_seconds},
+        )
+
+    async def service_status(self, *, task_id: str, workspace_id: str, service_id: str) -> dict[str, Any]:
+        return await self._workspace_call(workspace_id, "service_status", {"task_id": task_id, "service_id": service_id})
+
+    async def service_input(self, *, task_id: str, workspace_id: str, service_id: str, data: str) -> dict[str, Any]:
+        return await self._workspace_call(workspace_id, "service_input", {"task_id": task_id, "service_id": service_id, "data": data})
+
+    async def stop_service(self, *, task_id: str, workspace_id: str, service_id: str) -> dict[str, Any]:
+        return await self._workspace_call(workspace_id, "stop_service", {"task_id": task_id, "service_id": service_id})
+
+    async def _workspace_call(self, workspace_id: str, action: str, payload: dict[str, Any]) -> dict[str, Any]:
+        slot_id = self._workspace_slot_resolver(workspace_id)
+        if slot_id not in self._endpoints:
+            raise ProviderRPCError("Provider slot is unavailable.", code="provider_unavailable")
+        return await self._call(slot_id, action, payload)
 
     def _require_session(self, session: ProviderSession) -> str:
         binding = self._sessions.get(session.session_id)

--- a/server/coding_worker/runtime.py
+++ b/server/coding_worker/runtime.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from pathlib import Path
+
+from .broker_rpc import BrokerRPCServer
+from .evidence import HarnessRunner
+from .network_policy import EgressPolicy
+from .provider_rpc import ProviderSidecarClientPool
+from .service import CodingWorkerService
+from .store import CodingWorkerStore, DEFAULT_RETENTION_SECONDS
+from .tool_broker import FrozenCheck, ToolBroker
+from .workspace import WorkspaceBroker, WorkspaceSourceAdapter
+
+
+class CodingWorkerRuntimeError(RuntimeError):
+    def __init__(self, message: str, *, code: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+class CodingWorkerRuntime:
+    """Production lifecycle for the store, broker and two fixed sidecars."""
+
+    def __init__(
+        self,
+        *,
+        storage_root: Path,
+        slot_roots: Mapping[str, Path],
+        source_adapters: Mapping[str, WorkspaceSourceAdapter],
+        frozen_checks: Mapping[str, FrozenCheck],
+        provider_endpoints: Mapping[str, str],
+        provider_tokens: Mapping[str, str],
+        broker_socket_path: Path | None,
+        retention_seconds: int = DEFAULT_RETENTION_SECONDS,
+        max_active_tasks: int = 2,
+        network_enabled: bool = False,
+        network_domains: tuple[str, ...] = (),
+        egress_proxy_url: str | None = None,
+        sidecar_uid: int = 65532,
+        sidecar_gid: int = 65532,
+    ) -> None:
+        if (
+            set(slot_roots) != set(provider_endpoints)
+            or set(slot_roots) != set(provider_tokens)
+        ):
+            raise CodingWorkerRuntimeError(
+                "Worker slot configuration is incomplete.",
+                code="coding_worker_config_invalid",
+            )
+        storage_root = Path(storage_root)
+        self.store = CodingWorkerStore(
+            storage_root, retention_seconds=retention_seconds
+        )
+        self.workspace_broker = WorkspaceBroker(
+            storage_root,
+            source_adapters,
+            id_key=self._workspace_key(storage_root),
+            slot_roots=slot_roots,
+            slot_owner=(sidecar_uid, sidecar_gid),
+        )
+        self.tool_broker = ToolBroker(
+            store=self.store,
+            workspace_broker=self.workspace_broker,
+            frozen_checks=frozen_checks,
+            egress_policy=EgressPolicy(
+                enabled=network_enabled, allowed_domains=network_domains
+            ),
+            egress_proxy_url=egress_proxy_url,
+        )
+        self.broker_rpc = BrokerRPCServer(self.tool_broker)
+        self.provider = ProviderSidecarClientPool(
+            endpoints=provider_endpoints,
+            tokens=provider_tokens,
+            workspace_slot_resolver=self.workspace_broker.workspace_slot,
+            broker_rpc=self.broker_rpc,
+        )
+        self.tool_broker.executor = self.provider
+        self.harness = HarnessRunner(
+            store=self.store,
+            workspace_broker=self.workspace_broker,
+            tool_broker=self.tool_broker,
+        )
+        self.service = CodingWorkerService(
+            store=self.store,
+            workspace_broker=self.workspace_broker,
+            provider=self.provider,
+            harness_runner=self.harness,
+            max_active_tasks=max_active_tasks,
+        )
+        self.broker_socket_path = broker_socket_path
+        self.sidecar_gid = sidecar_gid
+        self.network_enabled = network_enabled
+        self._started = False
+
+    async def start(self) -> CodingWorkerService:
+        if self._started:
+            return self.service
+        if self.broker_socket_path is None:
+            await self.broker_rpc.start_tcp_for_tests()
+        else:
+            await self.broker_rpc.start_unix(
+                self.broker_socket_path, group_id=self.sidecar_gid
+            )
+        await self.service.start()
+        self._started = True
+        return self.service
+
+    async def close(self) -> None:
+        if not self._started:
+            return
+        await self.service.shutdown()
+        await self.broker_rpc.close()
+        self._started = False
+
+    @staticmethod
+    def _workspace_key(storage_root: Path) -> bytes:
+        path = storage_root / "workspace-id.key"
+        if path.exists():
+            value = path.read_bytes()
+            if len(value) != 32:
+                raise CodingWorkerRuntimeError(
+                    "Workspace key is invalid.", code="coding_worker_key_invalid"
+                )
+            return value
+        value = os.urandom(32)
+        descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(value)
+            handle.flush()
+            os.fsync(handle.fileno())
+        return value
+
+
+_SOURCE_ADAPTERS: dict[str, WorkspaceSourceAdapter] = {}
+_FROZEN_CHECKS: dict[str, FrozenCheck] = {}
+
+
+def register_workspace_source_adapter(
+    kind: str, adapter: WorkspaceSourceAdapter
+) -> None:
+    if kind in _SOURCE_ADAPTERS and _SOURCE_ADAPTERS[kind] is not adapter:
+        raise CodingWorkerRuntimeError(
+            "Workspace source adapter is already registered.",
+            code="coding_worker_adapter_conflict",
+        )
+    _SOURCE_ADAPTERS[kind] = adapter
+
+
+def register_frozen_check(check: FrozenCheck) -> None:
+    existing = _FROZEN_CHECKS.get(check.check_id)
+    if existing is not None and existing != check:
+        raise CodingWorkerRuntimeError(
+            "Frozen check is already registered.",
+            code="coding_worker_check_conflict",
+        )
+    _FROZEN_CHECKS[check.check_id] = check
+
+
+def build_runtime_from_environment() -> CodingWorkerRuntime:
+    root = Path(
+        os.getenv("CODING_WORKER_STATE_ROOT", "/var/lib/modelmirror/coding-worker")
+    )
+    slot_roots = {
+        "slot-a": Path(
+            os.getenv("CODING_WORKER_SLOT_A_ROOT", "/worker-slots/slot-a")
+        ),
+        "slot-b": Path(
+            os.getenv("CODING_WORKER_SLOT_B_ROOT", "/worker-slots/slot-b")
+        ),
+    }
+    endpoints = {
+        "slot-a": os.getenv(
+            "CODING_WORKER_SLOT_A_ENDPOINT",
+            "unix:/run/modelmirror-coding-slot-a/provider.sock",
+        ),
+        "slot-b": os.getenv(
+            "CODING_WORKER_SLOT_B_ENDPOINT",
+            "unix:/run/modelmirror-coding-slot-b/provider.sock",
+        ),
+    }
+    tokens = {
+        "slot-a": os.getenv("CODING_WORKER_SLOT_A_TOKEN", ""),
+        "slot-b": os.getenv("CODING_WORKER_SLOT_B_TOKEN", ""),
+    }
+    if any(len(value) < 32 for value in tokens.values()):
+        raise CodingWorkerRuntimeError(
+            "Worker sidecar tokens are missing.",
+            code="coding_worker_config_invalid",
+        )
+    network_enabled = os.getenv(
+        "CODING_WORKER_NETWORK_ENABLED", "false"
+    ).lower() in {"1", "true", "yes", "on"}
+    domains = tuple(
+        value.strip().lower()
+        for value in os.getenv("CODING_WORKER_NETWORK_DOMAINS", "").split(",")
+        if value.strip()
+    )
+    return CodingWorkerRuntime(
+        storage_root=root,
+        slot_roots=slot_roots,
+        source_adapters=_SOURCE_ADAPTERS,
+        frozen_checks=_FROZEN_CHECKS,
+        provider_endpoints=endpoints,
+        provider_tokens=tokens,
+        broker_socket_path=Path(
+            os.getenv(
+                "CODING_WORKER_BROKER_SOCKET",
+                "/run/modelmirror-coding-broker/broker.sock",
+            )
+        ),
+        retention_seconds=int(
+            os.getenv(
+                "CODING_WORKER_RETENTION_SECONDS", str(DEFAULT_RETENTION_SECONDS)
+            )
+        ),
+        max_active_tasks=int(os.getenv("CODING_WORKER_MAX_ACTIVE_TASKS", "2")),
+        network_enabled=network_enabled,
+        network_domains=domains,
+        egress_proxy_url=os.getenv("CODING_WORKER_EGRESS_PROXY_URL") or None,
+    )

--- a/server/coding_worker/runtime.py
+++ b/server/coding_worker/runtime.py
@@ -91,6 +91,7 @@ class CodingWorkerRuntime:
             provider=self.provider,
             harness_runner=self.harness,
             max_active_tasks=max_active_tasks,
+            tool_broker=self.tool_broker,
         )
         self.broker_socket_path = broker_socket_path
         self.sidecar_gid = sidecar_gid

--- a/server/coding_worker/runtime.py
+++ b/server/coding_worker/runtime.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from .broker_rpc import BrokerRPCServer
 from .evidence import HarnessRunner
+from .executor import ExecutorSidecarClientPool
 from .network_policy import EgressPolicy
 from .provider_rpc import ProviderSidecarClientPool
 from .service import CodingWorkerService
@@ -32,6 +33,8 @@ class CodingWorkerRuntime:
         frozen_checks: Mapping[str, FrozenCheck],
         provider_endpoints: Mapping[str, str],
         provider_tokens: Mapping[str, str],
+        executor_endpoints: Mapping[str, str] | None = None,
+        executor_tokens: Mapping[str, str] | None = None,
         broker_socket_path: Path | None,
         retention_seconds: int = DEFAULT_RETENTION_SECONDS,
         max_active_tasks: int = 2,
@@ -73,11 +76,29 @@ class CodingWorkerRuntime:
             egress_proxy_url=egress_proxy_url,
         )
         self.broker_rpc = BrokerRPCServer(self.tool_broker)
+        executor_pool = None
+        if executor_endpoints is not None or executor_tokens is not None:
+            if (
+                executor_endpoints is None
+                or executor_tokens is None
+                or set(slot_roots) != set(executor_endpoints)
+                or set(slot_roots) != set(executor_tokens)
+            ):
+                raise CodingWorkerRuntimeError(
+                    "Worker executor configuration is incomplete.",
+                    code="coding_worker_config_invalid",
+                )
+            executor_pool = ExecutorSidecarClientPool(
+                endpoints=executor_endpoints,
+                tokens=executor_tokens,
+                workspace_slot_resolver=self.workspace_broker.workspace_slot,
+            )
         self.provider = ProviderSidecarClientPool(
             endpoints=provider_endpoints,
             tokens=provider_tokens,
             workspace_slot_resolver=self.workspace_broker.workspace_slot,
             broker_rpc=self.broker_rpc,
+            executor_pool=executor_pool,
         )
         self.tool_broker.executor = self.provider
         self.harness = HarnessRunner(
@@ -188,7 +209,21 @@ def build_runtime_from_environment() -> CodingWorkerRuntime:
         "slot-a": os.getenv("CODING_WORKER_SLOT_A_TOKEN", ""),
         "slot-b": os.getenv("CODING_WORKER_SLOT_B_TOKEN", ""),
     }
-    if any(len(value) < 32 for value in tokens.values()):
+    executor_endpoints = {
+        "slot-a": os.getenv(
+            "CODING_WORKER_EXECUTOR_A_ENDPOINT",
+            "unix:/run/modelmirror-coding-executor-a/executor.sock",
+        ),
+        "slot-b": os.getenv(
+            "CODING_WORKER_EXECUTOR_B_ENDPOINT",
+            "unix:/run/modelmirror-coding-executor-b/executor.sock",
+        ),
+    }
+    executor_tokens = {
+        "slot-a": os.getenv("CODING_WORKER_EXECUTOR_A_TOKEN", ""),
+        "slot-b": os.getenv("CODING_WORKER_EXECUTOR_B_TOKEN", ""),
+    }
+    if any(len(value) < 32 for value in (*tokens.values(), *executor_tokens.values())):
         raise CodingWorkerRuntimeError(
             "Worker sidecar tokens are missing.",
             code="coding_worker_config_invalid",
@@ -208,6 +243,8 @@ def build_runtime_from_environment() -> CodingWorkerRuntime:
         frozen_checks=_FROZEN_CHECKS,
         provider_endpoints=endpoints,
         provider_tokens=tokens,
+        executor_endpoints=executor_endpoints,
+        executor_tokens=executor_tokens,
         broker_socket_path=Path(
             os.getenv(
                 "CODING_WORKER_BROKER_SOCKET",

--- a/server/coding_worker/runtime.py
+++ b/server/coding_worker/runtime.py
@@ -38,6 +38,7 @@ class CodingWorkerRuntime:
         network_enabled: bool = False,
         network_domains: tuple[str, ...] = (),
         egress_proxy_url: str | None = None,
+        network_grant_key: bytes | str | None = None,
         sidecar_uid: int = 65532,
         sidecar_gid: int = 65532,
     ) -> None:
@@ -65,7 +66,9 @@ class CodingWorkerRuntime:
             workspace_broker=self.workspace_broker,
             frozen_checks=frozen_checks,
             egress_policy=EgressPolicy(
-                enabled=network_enabled, allowed_domains=network_domains
+                enabled=network_enabled,
+                allowed_domains=network_domains,
+                grant_key=network_grant_key,
             ),
             egress_proxy_url=egress_proxy_url,
         )
@@ -219,4 +222,5 @@ def build_runtime_from_environment() -> CodingWorkerRuntime:
         network_enabled=network_enabled,
         network_domains=domains,
         egress_proxy_url=os.getenv("CODING_WORKER_EGRESS_PROXY_URL") or None,
+        network_grant_key=os.getenv("CODING_WORKER_EGRESS_GRANT_KEY") or None,
     )

--- a/server/coding_worker/service.py
+++ b/server/coding_worker/service.py
@@ -273,6 +273,7 @@ class CodingWorkerService:
                 budget=task.spec.budget,
             )
             resume_phase: str | None = None
+            resume_context: dict[str, object] | None = None
             completed_turns = 0
             checkpoint = self.store.latest_checkpoint(task_id)
             if checkpoint is not None:
@@ -293,6 +294,11 @@ class CodingWorkerService:
                     )
                     resume_phase = str(checkpoint.payload["phase"])
                     completed_turns = int(checkpoint.payload["completed_turns"])
+                    raw_context = checkpoint.payload.get("context_summary")
+                    if raw_context is not None:
+                        if not isinstance(raw_context, dict):
+                            raise TypeError("context summary is invalid")
+                        resume_context = raw_context
                 except (KeyError, TypeError, ValueError) as exc:
                     raise WorkerConflictError(
                         "Checkpoint payload is invalid.", code="checkpoint_invalid"
@@ -318,6 +324,7 @@ class CodingWorkerService:
                 task,
                 session,
                 resume_phase=resume_phase,
+                resume_context=resume_context,
                 completed_turns=completed_turns,
             )
         except TimeoutError:
@@ -356,6 +363,7 @@ class CodingWorkerService:
         session: ProviderSession,
         *,
         resume_phase: str | None,
+        resume_context: dict[str, object] | None,
         completed_turns: int,
     ) -> None:
         task_id = task.task_id
@@ -366,7 +374,7 @@ class CodingWorkerService:
                 feedback = await self._evaluate_acceptance(task, turns)
                 if feedback is None:
                     return
-                message = feedback
+                message = self._restored_context_message(resume_context, feedback)
             while True:
                 turns += 1
                 turn_completed = False
@@ -406,6 +414,13 @@ class CodingWorkerService:
                             "phase": "testing",
                             "completed_turns": turns,
                             "provider": provider_checkpoint.model_dump(mode="json"),
+                            "context_summary": self._context_summary(
+                                task_id,
+                                tree_hash=tree_hash,
+                                public_output=str(
+                                    provider_checkpoint.payload.get("public_output", "")
+                                ),
+                            ),
                         },
                     )
                 except Exception:
@@ -420,6 +435,65 @@ class CodingWorkerService:
                 if feedback is None:
                     return
                 message = feedback
+
+    def _context_summary(
+        self, task_id: str, *, tree_hash: str, public_output: str
+    ) -> dict[str, object]:
+        task = self.store.get_task(task_id)
+        latest: dict[str, WorkerEvidence] = {}
+        for item in self.store.list_evidence(task_id, current_tree_hash=tree_hash):
+            latest[item.check_id] = item
+        failures = [
+            {
+                "check_id": item.check_id,
+                "evidence_id": item.evidence_id,
+                "artifact_id": item.artifact_id,
+                "exit_code": item.exit_code,
+            }
+            for item in latest.values()
+            if item.status is EvidenceStatus.FAILED
+        ]
+        return {
+            "version": 1,
+            "objective": task.spec.objective,
+            "required_checks": [
+                item.check_id for item in task.spec.acceptance.required_checks
+            ],
+            "required_artifacts": [
+                item.artifact_id for item in task.spec.acceptance.required_artifacts
+            ],
+            "state": task.state.value,
+            "workspace_tree_hash": tree_hash,
+            "failure_evidence": failures,
+            "public_output": public_output[-16_384:],
+            "next_step": "run_required_acceptance",
+        }
+
+    @staticmethod
+    def _restored_context_message(
+        summary: dict[str, object] | None, feedback: str
+    ) -> str:
+        if summary is None:
+            return feedback
+        objective = summary.get("objective")
+        checks = summary.get("required_checks")
+        if not isinstance(objective, str) or not isinstance(checks, list) or not all(
+            isinstance(item, str) for item in checks
+        ):
+            raise WorkerConflictError(
+                "Checkpoint context is invalid.", code="checkpoint_invalid"
+            )
+        public_output = summary.get("public_output")
+        prior = public_output if isinstance(public_output, str) else ""
+        text = (
+            "Restored public task context. Hidden reasoning and raw provider frames were "
+            "not persisted.\n"
+            f"Objective: {objective}\n"
+            f"Required checks: {', '.join(checks)}\n"
+        )
+        if prior:
+            text += f"Last public provider output:\n{prior}\n"
+        return (text + feedback)[:32_768]
 
     async def _evaluate_acceptance(self, task: TaskRecord, turns: int) -> str | None:
         task_id = task.task_id

--- a/server/coding_worker/service.py
+++ b/server/coding_worker/service.py
@@ -23,7 +23,7 @@ from .provider import (
     ProviderSession,
 )
 from .store import CodingWorkerStore, WorkerConflictError
-from .tool_broker import ToolBrokerError
+from .tool_broker import ToolBroker, ToolBrokerError
 from .workspace import WorkspaceBroker, WorkspaceError
 
 
@@ -38,6 +38,7 @@ class CodingWorkerService:
         provider: CodingAgentProvider,
         harness_runner: HarnessRunner | None = None,
         max_active_tasks: int = 2,
+        tool_broker: ToolBroker | None = None,
     ) -> None:
         if not 1 <= max_active_tasks <= 16:
             raise ValueError("active task capacity is outside the allowed range")
@@ -46,6 +47,7 @@ class CodingWorkerService:
         self.provider = provider
         self.harness_runner = harness_runner
         self.max_active_tasks = max_active_tasks
+        self.tool_broker = tool_broker
         self._active: dict[str, asyncio.Task[None]] = {}
         self._task_slots: dict[str, str] = {}
         self._sessions: dict[str, ProviderSession] = {}

--- a/server/coding_worker/service.py
+++ b/server/coding_worker/service.py
@@ -5,13 +5,16 @@ import contextlib
 from collections.abc import Callable
 
 from .contracts import (
+    EvidenceStatus,
     Origin,
     TaskCreateRequest,
     TaskRecord,
     TaskSpec,
     TaskState,
     TERMINAL_STATES,
+    WorkerEvidence,
 )
+from .evidence import HarnessRunner
 from .provider import (
     CodingAgentProvider,
     ProviderEventKind,
@@ -19,6 +22,7 @@ from .provider import (
     ProviderSession,
 )
 from .store import CodingWorkerStore, WorkerConflictError
+from .tool_broker import ToolBrokerError
 from .workspace import WorkspaceBroker, WorkspaceError
 
 
@@ -31,6 +35,7 @@ class CodingWorkerService:
         store: CodingWorkerStore,
         workspace_broker: WorkspaceBroker,
         provider: CodingAgentProvider,
+        harness_runner: HarnessRunner | None = None,
         max_active_tasks: int = 2,
     ) -> None:
         if not 1 <= max_active_tasks <= 16:
@@ -38,6 +43,7 @@ class CodingWorkerService:
         self.store = store
         self.workspace_broker = workspace_broker
         self.provider = provider
+        self.harness_runner = harness_runner
         self.max_active_tasks = max_active_tasks
         self._active: dict[str, asyncio.Task[None]] = {}
         self._sessions: dict[str, ProviderSession] = {}
@@ -226,35 +232,13 @@ class CodingWorkerService:
             )
             if not self.store.list_messages(task_id):
                 self.store.append_message(task_id, role="user", content=task.spec.objective)
-            terminal = False
-            async for event in self.provider.message(session, task.spec.objective):
-                self.store.append_event(
-                    task_id,
-                    "provider_event",
-                    {"kind": event.kind.value, "data": event.data},
-                )
-                if event.kind is ProviderEventKind.TURN_COMPLETED:
-                    self.store.transition(task_id, TaskState.TESTING)
+            await self._drive_session(task, session)
+        except TimeoutError:
+            current = self.store.get_task(task_id)
+            if current.state not in TERMINAL_STATES:
+                with contextlib.suppress(WorkerConflictError):
                     self.store.transition(
-                        task_id,
-                        TaskState.BLOCKED,
-                        reason="acceptance_runner_pending",
-                    )
-                    terminal = True
-                    break
-                if event.kind is ProviderEventKind.CANCELLED:
-                    self.store.transition(task_id, TaskState.CANCELLED, reason="provider_cancelled")
-                    terminal = True
-                    break
-                if event.kind is ProviderEventKind.FAILED:
-                    self.store.transition(task_id, TaskState.FAILED, reason="provider_failed")
-                    terminal = True
-                    break
-            if not terminal:
-                current = self.store.get_task(task_id)
-                if current.state not in TERMINAL_STATES:
-                    self.store.transition(
-                        task_id, TaskState.INTERRUPTED, reason="provider_stream_ended"
+                        task_id, TaskState.BUDGET_LIMITED, reason="time_budget_exhausted"
                     )
         except asyncio.CancelledError:
             current = self.store.get_task(task_id)
@@ -278,3 +262,130 @@ class CodingWorkerService:
             if session is not None:
                 with contextlib.suppress(Exception):
                     await self.provider.close(session)
+
+    async def _drive_session(self, task: TaskRecord, session: ProviderSession) -> None:
+        task_id = task.task_id
+        message = task.spec.objective
+        turns = 0
+        async with asyncio.timeout(task.spec.budget.max_seconds):
+            while True:
+                turns += 1
+                turn_completed = False
+                async for event in self.provider.message(session, message):
+                    self.store.append_event(
+                        task_id,
+                        "provider_event",
+                        {"kind": event.kind.value, "data": event.data},
+                    )
+                    if event.kind is ProviderEventKind.TURN_COMPLETED:
+                        turn_completed = True
+                        break
+                    if event.kind is ProviderEventKind.CANCELLED:
+                        self.store.transition(
+                            task_id, TaskState.CANCELLED, reason="provider_cancelled"
+                        )
+                        return
+                    if event.kind is ProviderEventKind.FAILED:
+                        self.store.transition(task_id, TaskState.FAILED, reason="provider_failed")
+                        return
+                if not turn_completed:
+                    current = self.store.get_task(task_id)
+                    if current.state not in TERMINAL_STATES:
+                        self.store.transition(
+                            task_id, TaskState.INTERRUPTED, reason="provider_stream_ended"
+                        )
+                    return
+
+                self.store.transition(
+                    task_id, TaskState.TESTING, expected_state=TaskState.RUNNING
+                )
+                if self.harness_runner is None:
+                    self.store.transition(
+                        task_id,
+                        TaskState.BLOCKED,
+                        reason="acceptance_runner_pending",
+                        expected_state=TaskState.TESTING,
+                    )
+                    return
+                try:
+                    evidence = await self.harness_runner.run_required_checks(task_id)
+                except ToolBrokerError as exc:
+                    self.store.transition(
+                        task_id,
+                        TaskState.BLOCKED,
+                        reason=exc.code,
+                        expected_state=TaskState.TESTING,
+                    )
+                    return
+                self.store.append_event(
+                    task_id,
+                    "acceptance_evaluated",
+                    {
+                        "turn": turns,
+                        "evidence": [
+                            {
+                                "check_id": item.check_id,
+                                "status": item.status.value,
+                                "artifact_id": item.artifact_id,
+                            }
+                            for item in evidence
+                        ],
+                    },
+                )
+                if self.harness_runner.acceptance_satisfied(task_id):
+                    self.store.transition(
+                        task_id,
+                        TaskState.COMPLETED,
+                        expected_state=TaskState.TESTING,
+                    )
+                    return
+                if turns >= task.spec.budget.max_turns:
+                    self.store.transition(
+                        task_id,
+                        TaskState.BUDGET_LIMITED,
+                        reason="turn_budget_exhausted",
+                        expected_state=TaskState.TESTING,
+                    )
+                    return
+                message = self._acceptance_feedback(task_id, evidence)
+                self.store.append_message(task_id, role="system", content=message)
+                self.store.append_event(task_id, "acceptance_retry", {"turn": turns + 1})
+                self.store.transition(
+                    task_id,
+                    TaskState.RUNNING,
+                    reason="acceptance_failed",
+                    expected_state=TaskState.TESTING,
+                )
+
+    def _acceptance_feedback(
+        self, task_id: str, evidence: tuple[WorkerEvidence, ...]
+    ) -> str:
+        task = self.store.get_task(task_id)
+        lines = [
+            "Required acceptance checks are not yet satisfied.",
+            "Fix the workspace without weakening or rewriting the acceptance contract, "
+            "then finish the turn for an exact retest.",
+        ]
+        for item in evidence:
+            if item.status is EvidenceStatus.PASSED:
+                continue
+            output = self.store.read_artifact(item.artifact_id, task_id=task_id)
+            excerpt = output.decode("utf-8", errors="replace")[:4000]
+            lines.append(
+                f"\nCheck {item.check_id} failed with exit code {item.exit_code}:\n{excerpt}"
+            )
+        current_hash = self.workspace_broker.current_tree_hash(task.workspace_id or "")
+        artifacts = self.store.list_artifacts(task_id)
+        supplied = {
+            str(item.metadata.get("requirement_id"))
+            for item in artifacts
+            if item.metadata.get("workspace_tree_hash") == current_hash
+        }
+        missing = [
+            item.artifact_id
+            for item in task.spec.acceptance.required_artifacts
+            if item.artifact_id not in supplied
+        ]
+        if missing:
+            lines.append("\nMissing required artifacts: " + ", ".join(missing))
+        return "\n".join(lines)[:16_384]

--- a/server/coding_worker/service.py
+++ b/server/coding_worker/service.py
@@ -17,6 +17,7 @@ from .contracts import (
 from .evidence import HarnessRunner
 from .provider import (
     CodingAgentProvider,
+    ProviderCheckpoint,
     ProviderEventKind,
     ProviderOpenRequest,
     ProviderSession,
@@ -221,7 +222,38 @@ class CodingWorkerService:
                 policy_profile=task.spec.policy_profile,
                 budget=task.spec.budget,
             )
-            session = await self.provider.open(request)
+            resume_phase: str | None = None
+            completed_turns = 0
+            checkpoint = self.store.latest_checkpoint(task_id)
+            if checkpoint is not None:
+                current_tree_hash = self.workspace_broker.current_tree_hash(
+                    workspace.workspace_id
+                )
+                if checkpoint.workspace_tree_hash != current_tree_hash:
+                    self.store.transition(
+                        task_id,
+                        TaskState.BLOCKED,
+                        reason="checkpoint_workspace_changed",
+                        expected_state=TaskState.PREPARING,
+                    )
+                    return
+                try:
+                    provider_checkpoint = ProviderCheckpoint.model_validate(
+                        checkpoint.payload["provider"]
+                    )
+                    resume_phase = str(checkpoint.payload["phase"])
+                    completed_turns = int(checkpoint.payload["completed_turns"])
+                except (KeyError, TypeError, ValueError) as exc:
+                    raise WorkerConflictError(
+                        "Checkpoint payload is invalid.", code="checkpoint_invalid"
+                    ) from exc
+                if resume_phase != "testing" or completed_turns < 1:
+                    raise WorkerConflictError(
+                        "Checkpoint phase is invalid.", code="checkpoint_invalid"
+                    )
+                session = await self.provider.restore(request, provider_checkpoint)
+            else:
+                session = await self.provider.open(request)
             self._sessions[task_id] = session
             self.store.transition(
                 task_id,
@@ -232,7 +264,12 @@ class CodingWorkerService:
             )
             if not self.store.list_messages(task_id):
                 self.store.append_message(task_id, role="user", content=task.spec.objective)
-            await self._drive_session(task, session)
+            await self._drive_session(
+                task,
+                session,
+                resume_phase=resume_phase,
+                completed_turns=completed_turns,
+            )
         except TimeoutError:
             current = self.store.get_task(task_id)
             if current.state not in TERMINAL_STATES:
@@ -263,11 +300,23 @@ class CodingWorkerService:
                 with contextlib.suppress(Exception):
                     await self.provider.close(session)
 
-    async def _drive_session(self, task: TaskRecord, session: ProviderSession) -> None:
+    async def _drive_session(
+        self,
+        task: TaskRecord,
+        session: ProviderSession,
+        *,
+        resume_phase: str | None,
+        completed_turns: int,
+    ) -> None:
         task_id = task.task_id
         message = task.spec.objective
-        turns = 0
+        turns = completed_turns
         async with asyncio.timeout(task.spec.budget.max_seconds):
+            if resume_phase == "testing":
+                feedback = await self._evaluate_acceptance(task, turns)
+                if feedback is None:
+                    return
+                message = feedback
             while True:
                 turns += 1
                 turn_completed = False
@@ -295,67 +344,96 @@ class CodingWorkerService:
                             task_id, TaskState.INTERRUPTED, reason="provider_stream_ended"
                         )
                     return
-
-                self.store.transition(
-                    task_id, TaskState.TESTING, expected_state=TaskState.RUNNING
-                )
-                if self.harness_runner is None:
-                    self.store.transition(
-                        task_id,
-                        TaskState.BLOCKED,
-                        reason="acceptance_runner_pending",
-                        expected_state=TaskState.TESTING,
-                    )
-                    return
                 try:
-                    evidence = await self.harness_runner.run_required_checks(task_id)
-                except ToolBrokerError as exc:
+                    provider_checkpoint = await self.provider.checkpoint(session)
+                    tree_hash = self.workspace_broker.current_tree_hash(
+                        self.store.get_task(task_id).workspace_id or ""
+                    )
+                    self.store.create_checkpoint(
+                        task_id=task_id,
+                        workspace_tree_hash=tree_hash,
+                        payload={
+                            "phase": "testing",
+                            "completed_turns": turns,
+                            "provider": provider_checkpoint.model_dump(mode="json"),
+                        },
+                    )
+                except Exception:
                     self.store.transition(
                         task_id,
                         TaskState.BLOCKED,
-                        reason=exc.code,
-                        expected_state=TaskState.TESTING,
+                        reason="checkpoint_failed",
+                        expected_state=TaskState.RUNNING,
                     )
                     return
-                self.store.append_event(
-                    task_id,
-                    "acceptance_evaluated",
+                feedback = await self._evaluate_acceptance(task, turns)
+                if feedback is None:
+                    return
+                message = feedback
+
+    async def _evaluate_acceptance(self, task: TaskRecord, turns: int) -> str | None:
+        task_id = task.task_id
+        self.store.transition(
+            task_id, TaskState.TESTING, expected_state=TaskState.RUNNING
+        )
+        if self.harness_runner is None:
+            self.store.transition(
+                task_id,
+                TaskState.BLOCKED,
+                reason="acceptance_runner_pending",
+                expected_state=TaskState.TESTING,
+            )
+            return None
+        try:
+            evidence = await self.harness_runner.run_required_checks(task_id)
+        except ToolBrokerError as exc:
+            self.store.transition(
+                task_id,
+                TaskState.BLOCKED,
+                reason=exc.code,
+                expected_state=TaskState.TESTING,
+            )
+            return None
+        self.store.append_event(
+            task_id,
+            "acceptance_evaluated",
+            {
+                "turn": turns,
+                "evidence": [
                     {
-                        "turn": turns,
-                        "evidence": [
-                            {
-                                "check_id": item.check_id,
-                                "status": item.status.value,
-                                "artifact_id": item.artifact_id,
-                            }
-                            for item in evidence
-                        ],
-                    },
-                )
-                if self.harness_runner.acceptance_satisfied(task_id):
-                    self.store.transition(
-                        task_id,
-                        TaskState.COMPLETED,
-                        expected_state=TaskState.TESTING,
-                    )
-                    return
-                if turns >= task.spec.budget.max_turns:
-                    self.store.transition(
-                        task_id,
-                        TaskState.BUDGET_LIMITED,
-                        reason="turn_budget_exhausted",
-                        expected_state=TaskState.TESTING,
-                    )
-                    return
-                message = self._acceptance_feedback(task_id, evidence)
-                self.store.append_message(task_id, role="system", content=message)
-                self.store.append_event(task_id, "acceptance_retry", {"turn": turns + 1})
-                self.store.transition(
-                    task_id,
-                    TaskState.RUNNING,
-                    reason="acceptance_failed",
-                    expected_state=TaskState.TESTING,
-                )
+                        "check_id": item.check_id,
+                        "status": item.status.value,
+                        "artifact_id": item.artifact_id,
+                    }
+                    for item in evidence
+                ],
+            },
+        )
+        if self.harness_runner.acceptance_satisfied(task_id):
+            self.store.transition(
+                task_id,
+                TaskState.COMPLETED,
+                expected_state=TaskState.TESTING,
+            )
+            return None
+        if turns >= task.spec.budget.max_turns:
+            self.store.transition(
+                task_id,
+                TaskState.BUDGET_LIMITED,
+                reason="turn_budget_exhausted",
+                expected_state=TaskState.TESTING,
+            )
+            return None
+        message = self._acceptance_feedback(task_id, evidence)
+        self.store.append_message(task_id, role="system", content=message)
+        self.store.append_event(task_id, "acceptance_retry", {"turn": turns + 1})
+        self.store.transition(
+            task_id,
+            TaskState.RUNNING,
+            reason="acceptance_failed",
+            expected_state=TaskState.TESTING,
+        )
+        return message
 
     def _acceptance_feedback(
         self, task_id: str, evidence: tuple[WorkerEvidence, ...]

--- a/server/coding_worker/service.py
+++ b/server/coding_worker/service.py
@@ -47,6 +47,7 @@ class CodingWorkerService:
         self.harness_runner = harness_runner
         self.max_active_tasks = max_active_tasks
         self._active: dict[str, asyncio.Task[None]] = {}
+        self._task_slots: dict[str, str] = {}
         self._sessions: dict[str, ProviderSession] = {}
         self._wake = asyncio.Event()
         self._scheduler: asyncio.Task[None] | None = None
@@ -87,6 +88,7 @@ class CodingWorkerService:
             with contextlib.suppress(asyncio.CancelledError):
                 await self._scheduler
         self._active.clear()
+        self._task_slots.clear()
         self._sessions.clear()
         self._scheduler = None
         self._started = False
@@ -176,11 +178,17 @@ class CodingWorkerService:
         while True:
             await self._wake.wait()
             self._wake.clear()
-            while not self._closing and len(self._active) < self.max_active_tasks:
-                queued = self.store.list_queued_tasks(limit=1)
-                if not queued:
+            capacity = min(
+                self.max_active_tasks,
+                len(self.workspace_broker.slot_ids)
+                if self.workspace_broker.dedicated_slots
+                else self.max_active_tasks,
+            )
+            while not self._closing and len(self._active) < capacity:
+                selected = self._select_queued_task()
+                if selected is None:
                     break
-                record = queued[0]
+                record, slot_id = selected
                 try:
                     self.store.transition(
                         record.task_id,
@@ -189,8 +197,11 @@ class CodingWorkerService:
                     )
                 except WorkerConflictError:
                     continue
+                if slot_id is not None:
+                    self._task_slots[record.task_id] = slot_id
                 runner = asyncio.create_task(
-                    self._run_task(record.task_id), name=f"coding-worker-{record.task_id}"
+                    self._run_task(record.task_id, slot_id=slot_id),
+                    name=f"coding-worker-{record.task_id}",
                 )
                 self._active[record.task_id] = runner
                 runner.add_done_callback(
@@ -199,21 +210,58 @@ class CodingWorkerService:
                     )
                 )
 
+    def _select_queued_task(self) -> tuple[TaskRecord, str | None] | None:
+        queued = self.store.list_queued_tasks(limit=128)
+        if not queued:
+            return None
+        if not self.workspace_broker.dedicated_slots:
+            return queued[0], None
+        occupied = set(self._task_slots.values())
+        available = [
+            slot_id
+            for slot_id in self.workspace_broker.slot_ids
+            if slot_id not in occupied
+        ]
+        if not available:
+            return None
+        for record in queued:
+            required_slot: str | None = None
+            if record.workspace_id is not None:
+                try:
+                    required_slot = self.workspace_broker.workspace_slot(
+                        record.workspace_id
+                    )
+                except WorkspaceError:
+                    # Let the runner persist the precise workspace failure.
+                    required_slot = available[0]
+            if required_slot is None:
+                return record, available[0]
+            if required_slot in available:
+                return record, required_slot
+        return None
+
     def _task_finished(self, task_id: str, _task: asyncio.Task[None]) -> None:
         self._active.pop(task_id, None)
+        self._task_slots.pop(task_id, None)
         self._sessions.pop(task_id, None)
         if not self._closing:
             self._wake.set()
 
-    async def _run_task(self, task_id: str) -> None:
+    async def _run_task(self, task_id: str, *, slot_id: str | None = None) -> None:
         session: ProviderSession | None = None
         try:
             task = self.store.get_task(task_id)
             workspace = (
                 self.workspace_broker.get(task.workspace_id)
                 if task.workspace_id is not None
-                else await self.workspace_broker.prepare(task.spec.workspace_source)
+                else await self.workspace_broker.prepare(
+                    task.spec.workspace_source, slot_id=slot_id
+                )
             )
+            if slot_id is not None and workspace.slot_id != slot_id:
+                raise WorkspaceError(
+                    "Workspace slot binding changed.", code="workspace_slot_changed"
+                )
             request = ProviderOpenRequest(
                 task_id=task_id,
                 workspace_id=workspace.workspace_id,

--- a/server/coding_worker/sidecar.py
+++ b/server/coding_worker/sidecar.py
@@ -4,12 +4,13 @@ import asyncio
 import contextlib
 import os
 import signal
+from collections.abc import Awaitable, Callable
 from pathlib import Path
 
 from .contracts import SAFE_ID
 from .opencode_provider import OpenCodeProvider, OpenCodeRoute
 from .provider_rpc import ProviderRPCServer
-from .executor import SidecarExecutor
+from .executor import ExecutorRPCServer, SidecarExecutor
 
 
 def _required_environment(name: str) -> str:
@@ -50,6 +51,16 @@ async def run() -> None:
     runtime_root = Path(
         os.getenv("CODING_WORKER_RUNTIME_ROOT", "/worker-runtime")
     ).resolve()
+    if os.getenv("CODING_WORKER_MODE", "provider").strip() == "executor":
+        executor = SidecarExecutor(
+            _workspace_resolver(workspace_root), runtime_root=runtime_root
+        )
+        executor_server = ExecutorRPCServer(
+            executor, token=_required_environment("CODING_WORKER_EXECUTOR_TOKEN")
+        )
+        await executor_server.start_unix(socket_path)
+        await _wait_for_stop(executor_server.close)
+        return
     route_id = os.getenv("CODING_WORKER_ROUTE_ID", "coding/default").strip()
     route = OpenCodeRoute(
         route_id=route_id,
@@ -63,17 +74,17 @@ async def run() -> None:
         routes={route_id: route},
         tool_broker_command=("python", "-m", "coding_worker.broker_mcp"),
     )
-    executor = SidecarExecutor(
-        _workspace_resolver(workspace_root), runtime_root=runtime_root
-    )
     server = ProviderRPCServer(
         provider,
         token=_required_environment("CODING_WORKER_SIDECAR_TOKEN"),
         bind_broker=provider.bind_broker,
         unbind_broker=provider.unbind_broker,
-        executor=executor,
     )
     await server.start_unix(socket_path)
+    await _wait_for_stop(server.close)
+
+
+async def _wait_for_stop(close: Callable[[], Awaitable[None]]) -> None:
     stop = asyncio.Event()
     loop = asyncio.get_running_loop()
     for signal_name in (signal.SIGINT, signal.SIGTERM):
@@ -82,7 +93,7 @@ async def run() -> None:
     try:
         await stop.wait()
     finally:
-        await server.close()
+        await close()
 
 
 def main() -> None:

--- a/server/coding_worker/sidecar.py
+++ b/server/coding_worker/sidecar.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from .contracts import SAFE_ID
 from .opencode_provider import OpenCodeProvider, OpenCodeRoute
 from .provider_rpc import ProviderRPCServer
+from .executor import SidecarExecutor
 
 
 def _required_environment(name: str) -> str:
@@ -62,11 +63,15 @@ async def run() -> None:
         routes={route_id: route},
         tool_broker_command=("python", "-m", "coding_worker.broker_mcp"),
     )
+    executor = SidecarExecutor(
+        _workspace_resolver(workspace_root), runtime_root=runtime_root
+    )
     server = ProviderRPCServer(
         provider,
         token=_required_environment("CODING_WORKER_SIDECAR_TOKEN"),
         bind_broker=provider.bind_broker,
         unbind_broker=provider.unbind_broker,
+        executor=executor,
     )
     await server.start_unix(socket_path)
     stop = asyncio.Event()

--- a/server/coding_worker/sidecar.py
+++ b/server/coding_worker/sidecar.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import signal
+from pathlib import Path
+
+from .contracts import SAFE_ID
+from .opencode_provider import OpenCodeProvider, OpenCodeRoute
+from .provider_rpc import ProviderRPCServer
+
+
+def _required_environment(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise RuntimeError(f"{name} is required")
+    return value
+
+
+def _workspace_resolver(root: Path):
+    resolved_root = root.resolve()
+
+    def resolve(workspace_id: str) -> Path:
+        if SAFE_ID.fullmatch(workspace_id) is None:
+            raise ValueError("workspace id is invalid")
+        candidate = resolved_root / "workspaces" / workspace_id / "repo"
+        resolved = candidate.resolve(strict=True)
+        if (
+            not resolved.is_relative_to(resolved_root)
+            or not resolved.is_dir()
+            or candidate.is_symlink()
+        ):
+            raise ValueError("workspace is unavailable")
+        return resolved
+
+    return resolve
+
+
+async def run() -> None:
+    socket_path = Path(
+        os.getenv(
+            "CODING_WORKER_PROVIDER_SOCKET", "/run/modelmirror-coding/provider.sock"
+        )
+    )
+    workspace_root = Path(
+        os.getenv("CODING_WORKER_SLOT_ROOT", "/worker-data")
+    ).resolve()
+    runtime_root = Path(
+        os.getenv("CODING_WORKER_RUNTIME_ROOT", "/worker-runtime")
+    ).resolve()
+    route_id = os.getenv("CODING_WORKER_ROUTE_ID", "coding/default").strip()
+    route = OpenCodeRoute(
+        route_id=route_id,
+        model_id=_required_environment("CODING_WORKER_MODEL_ID"),
+        base_url=_required_environment("CODING_WORKER_MODEL_BASE_URL"),
+        api_key=_required_environment("CODING_WORKER_ROUTE_KEY"),
+    )
+    provider = OpenCodeProvider(
+        workspace_resolver=_workspace_resolver(workspace_root),
+        runtime_root=runtime_root,
+        routes={route_id: route},
+        tool_broker_command=("python", "-m", "coding_worker.broker_mcp"),
+    )
+    server = ProviderRPCServer(
+        provider,
+        token=_required_environment("CODING_WORKER_SIDECAR_TOKEN"),
+        bind_broker=provider.bind_broker,
+        unbind_broker=provider.unbind_broker,
+    )
+    await server.start_unix(socket_path)
+    stop = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    for signal_name in (signal.SIGINT, signal.SIGTERM):
+        with contextlib.suppress(NotImplementedError):
+            loop.add_signal_handler(signal_name, stop.set)
+    try:
+        await stop.wait()
+    finally:
+        await server.close()
+
+
+def main() -> None:
+    asyncio.run(run())
+
+
+if __name__ == "__main__":
+    main()

--- a/server/coding_worker/store.py
+++ b/server/coding_worker/store.py
@@ -10,13 +10,19 @@ from pathlib import Path
 from typing import Any
 
 from .contracts import (
+    ApprovalStatus,
+    CapabilityName,
+    CapabilityLease,
+    OperationState,
     TERMINAL_STATES,
     Origin,
     TaskRecord,
     TaskSpec,
     TaskState,
     WorkerEvent,
+    WorkerApproval,
     WorkerMessage,
+    WorkerOperation,
     require_transition,
 )
 from .crypto import WorkerCryptoError, WorkerEncryptedCodec
@@ -74,6 +80,7 @@ class CodingWorkerStore:
         self.workspaces_root.mkdir(parents=True, exist_ok=True)
         self._initialize()
         self.mark_inflight_interrupted()
+        self.mark_inflight_operations_unknown()
 
     def create_task(self, spec: TaskSpec) -> TaskRecord:
         now = self._now()
@@ -320,6 +327,330 @@ class CodingWorkerStore:
             )
         return self.get_task(task_id)
 
+    def create_approval(
+        self,
+        *,
+        task_id: str,
+        operation_id: str,
+        capability: CapabilityName,
+        request: dict[str, Any],
+    ) -> WorkerApproval:
+        now = self._now()
+        approval_id = f"approval_{uuid.uuid4().hex}"
+        encrypted_request = self._codec.encrypt(request)
+        with self._lock, self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            self._require_task_row(connection, task_id)
+            existing = connection.execute(
+                "SELECT * FROM worker_approvals WHERE operation_id = ?",
+                (operation_id,),
+            ).fetchone()
+            if existing is not None:
+                approval = self._approval(existing)
+                if (
+                    approval.task_id != task_id
+                    or approval.capability != capability
+                    or approval.request != request
+                ):
+                    raise WorkerConflictError(
+                        "Approval operation id is bound to another intent.",
+                        code="approval_intent_conflict",
+                    )
+                return approval
+            connection.execute(
+                """
+                INSERT INTO worker_approvals (
+                    approval_id, task_id, operation_id, capability, status,
+                    request_ciphertext, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    approval_id,
+                    task_id,
+                    operation_id,
+                    capability,
+                    ApprovalStatus.PENDING.value,
+                    encrypted_request,
+                    now,
+                ),
+            )
+            self._append_event_locked(
+                connection,
+                task_id=task_id,
+                event_type="approval_requested",
+                payload={"approval_id": approval_id, "capability": capability},
+                created_at=now,
+            )
+        return self.get_approval(approval_id)
+
+    def get_approval(self, approval_id: str) -> WorkerApproval:
+        with self._connect() as connection:
+            row = connection.execute(
+                "SELECT * FROM worker_approvals WHERE approval_id = ?", (approval_id,)
+            ).fetchone()
+        if row is None:
+            raise WorkerNotFoundError("Approval was not found.", code="approval_not_found")
+        return self._approval(row)
+
+    def list_approvals(self, task_id: str) -> list[WorkerApproval]:
+        with self._connect() as connection:
+            self._require_task_row(connection, task_id)
+            rows = connection.execute(
+                "SELECT * FROM worker_approvals WHERE task_id = ? ORDER BY created_at",
+                (task_id,),
+            ).fetchall()
+        return [self._approval(row) for row in rows]
+
+    def decide_approval(
+        self,
+        approval_id: str,
+        *,
+        approved: bool,
+        task_scope: bool = False,
+        ttl_seconds: int = 900,
+    ) -> WorkerApproval:
+        if isinstance(ttl_seconds, bool) or not 30 <= ttl_seconds <= 3600:
+            raise ValueError("approval ttl is outside the allowed range")
+        now = self._now()
+        with self._lock, self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            row = connection.execute(
+                "SELECT * FROM worker_approvals WHERE approval_id = ?", (approval_id,)
+            ).fetchone()
+            if row is None:
+                raise WorkerNotFoundError("Approval was not found.", code="approval_not_found")
+            if row["status"] != ApprovalStatus.PENDING.value:
+                raise WorkerConflictError(
+                    "Approval has already been decided.", code="approval_already_decided"
+                )
+            lease: CapabilityLease | None = None
+            status = ApprovalStatus.APPROVED if approved else ApprovalStatus.REJECTED
+            if approved:
+                task_row = self._require_task_row(connection, str(row["task_id"]))
+                lease = CapabilityLease(
+                    lease_id=f"lease_{uuid.uuid4().hex}",
+                    task_id=str(row["task_id"]),
+                    capability=str(row["capability"]),  # type: ignore[arg-type]
+                    scope=self._decrypt_dict(row["request_ciphertext"]),
+                    issued_at=now,
+                    expires_at=min(now + ttl_seconds, float(task_row["expires_at"])),
+                    operation_limit=1024 if task_scope else 1,
+                )
+                connection.execute(
+                    """
+                    INSERT INTO worker_leases (
+                        lease_id, task_id, capability, scope_ciphertext,
+                        issued_at, expires_at, remaining_operations
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        lease.lease_id,
+                        lease.task_id,
+                        lease.capability,
+                        self._codec.encrypt(lease.scope),
+                        lease.issued_at,
+                        lease.expires_at,
+                        lease.operation_limit,
+                    ),
+                )
+            connection.execute(
+                """
+                UPDATE worker_approvals SET status = ?, lease_ciphertext = ?, decided_at = ?
+                WHERE approval_id = ?
+                """,
+                (
+                    status.value,
+                    self._codec.encrypt(lease.model_dump(mode="json")) if lease else None,
+                    now,
+                    approval_id,
+                ),
+            )
+            self._append_event_locked(
+                connection,
+                task_id=str(row["task_id"]),
+                event_type="approval_decided",
+                payload={"approval_id": approval_id, "status": status.value},
+                created_at=now,
+            )
+        return self.get_approval(approval_id)
+
+    def consume_lease(
+        self, lease_id: str, *, task_id: str, capability: CapabilityName
+    ) -> CapabilityLease:
+        now = self._now()
+        with self._lock, self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            row = connection.execute(
+                "SELECT * FROM worker_leases WHERE lease_id = ?", (lease_id,)
+            ).fetchone()
+            if (
+                row is None
+                or row["task_id"] != task_id
+                or row["capability"] != capability
+                or float(row["expires_at"]) <= now
+                or int(row["remaining_operations"]) <= 0
+            ):
+                raise WorkerConflictError(
+                    "Capability lease is unavailable.", code="lease_unavailable"
+                )
+            remaining = int(row["remaining_operations"]) - 1
+            connection.execute(
+                "UPDATE worker_leases SET remaining_operations = ? WHERE lease_id = ?",
+                (remaining, lease_id),
+            )
+            return CapabilityLease(
+                lease_id=lease_id,
+                task_id=task_id,
+                capability=capability,  # type: ignore[arg-type]
+                scope=self._decrypt_dict(row["scope_ciphertext"]),
+                issued_at=float(row["issued_at"]),
+                expires_at=float(row["expires_at"]),
+                operation_limit=remaining + 1,
+            )
+
+    def create_operation(
+        self,
+        *,
+        task_id: str,
+        operation_id: str,
+        tool_name: str,
+        intent_sha256: str,
+        request: dict[str, Any],
+    ) -> WorkerOperation:
+        now = self._now()
+        with self._lock, self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            self._require_task_row(connection, task_id)
+            existing = connection.execute(
+                "SELECT * FROM worker_operations WHERE operation_id = ?", (operation_id,)
+            ).fetchone()
+            if existing is not None:
+                operation = self._operation(existing)
+                if (
+                    operation.task_id != task_id
+                    or operation.tool_name != tool_name
+                    or operation.intent_sha256 != intent_sha256
+                    or operation.request != request
+                ):
+                    raise WorkerConflictError(
+                        "Tool operation id is bound to another intent.",
+                        code="operation_intent_conflict",
+                    )
+                return operation
+            connection.execute(
+                """
+                INSERT INTO worker_operations (
+                    operation_id, task_id, tool_name, intent_sha256, state,
+                    request_ciphertext, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    operation_id,
+                    task_id,
+                    tool_name,
+                    intent_sha256,
+                    OperationState.PREPARED.value,
+                    self._codec.encrypt(request),
+                    now,
+                    now,
+                ),
+            )
+        return self.get_operation(operation_id)
+
+    def get_operation(self, operation_id: str) -> WorkerOperation:
+        with self._connect() as connection:
+            row = connection.execute(
+                "SELECT * FROM worker_operations WHERE operation_id = ?", (operation_id,)
+            ).fetchone()
+        if row is None:
+            raise WorkerNotFoundError("Tool operation was not found.", code="operation_not_found")
+        return self._operation(row)
+
+    def transition_operation(
+        self,
+        operation_id: str,
+        target: OperationState,
+        *,
+        result: dict[str, Any] | None = None,
+        expected_state: OperationState | None = None,
+    ) -> WorkerOperation:
+        now = self._now()
+        with self._lock, self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            row = connection.execute(
+                "SELECT * FROM worker_operations WHERE operation_id = ?", (operation_id,)
+            ).fetchone()
+            if row is None:
+                raise WorkerNotFoundError("Tool operation was not found.", code="operation_not_found")
+            current = OperationState(row["state"])
+            if expected_state is not None and current is not expected_state:
+                raise WorkerConflictError(
+                    "Tool operation state changed.", code="operation_state_conflict"
+                )
+            allowed = {
+                OperationState.PREPARED: {OperationState.RUNNING, OperationState.FAILED},
+                OperationState.RUNNING: {
+                    OperationState.COMPLETED,
+                    OperationState.FAILED,
+                    OperationState.UNKNOWN,
+                },
+                OperationState.UNKNOWN: {
+                    OperationState.COMPLETED,
+                    OperationState.FAILED,
+                },
+                OperationState.COMPLETED: set(),
+                OperationState.FAILED: set(),
+            }
+            if current is not target and target not in allowed[current]:
+                raise WorkerConflictError(
+                    "Tool operation transition is invalid.", code="operation_state_conflict"
+                )
+            connection.execute(
+                """
+                UPDATE worker_operations SET state = ?, result_ciphertext = ?, updated_at = ?
+                WHERE operation_id = ?
+                """,
+                (
+                    target.value,
+                    self._codec.encrypt(result) if result is not None else row["result_ciphertext"],
+                    now,
+                    operation_id,
+                ),
+            )
+            self._append_event_locked(
+                connection,
+                task_id=str(row["task_id"]),
+                event_type="tool_operation",
+                payload={"operation_id": operation_id, "state": target.value},
+                created_at=now,
+            )
+        return self.get_operation(operation_id)
+
+    def mark_inflight_operations_unknown(self) -> int:
+        now = self._now()
+        with self._lock, self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            rows = connection.execute(
+                "SELECT operation_id, task_id FROM worker_operations WHERE state = ?",
+                (OperationState.RUNNING.value,),
+            ).fetchall()
+            for row in rows:
+                connection.execute(
+                    "UPDATE worker_operations SET state = ?, updated_at = ? WHERE operation_id = ?",
+                    (OperationState.UNKNOWN.value, now, row["operation_id"]),
+                )
+                self._append_event_locked(
+                    connection,
+                    task_id=str(row["task_id"]),
+                    event_type="tool_operation",
+                    payload={
+                        "operation_id": str(row["operation_id"]),
+                        "state": OperationState.UNKNOWN.value,
+                    },
+                    created_at=now,
+                )
+        return len(rows)
+
     def delete_task(self, task_id: str) -> bool:
         with self._lock, self._connect() as connection:
             row = self._require_task_row(connection, task_id)
@@ -432,6 +763,44 @@ class CodingWorkerStore:
                     UNIQUE(task_id, sequence),
                     FOREIGN KEY(task_id) REFERENCES worker_tasks(task_id) ON DELETE CASCADE
                 );
+                CREATE TABLE IF NOT EXISTS worker_approvals (
+                    approval_id TEXT PRIMARY KEY,
+                    task_id TEXT NOT NULL,
+                    operation_id TEXT NOT NULL UNIQUE,
+                    capability TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    request_ciphertext TEXT NOT NULL,
+                    lease_ciphertext TEXT,
+                    created_at REAL NOT NULL,
+                    decided_at REAL,
+                    FOREIGN KEY(task_id) REFERENCES worker_tasks(task_id) ON DELETE CASCADE
+                );
+                CREATE INDEX IF NOT EXISTS idx_worker_approvals_task
+                    ON worker_approvals(task_id, created_at);
+                CREATE TABLE IF NOT EXISTS worker_leases (
+                    lease_id TEXT PRIMARY KEY,
+                    task_id TEXT NOT NULL,
+                    capability TEXT NOT NULL,
+                    scope_ciphertext TEXT NOT NULL,
+                    issued_at REAL NOT NULL,
+                    expires_at REAL NOT NULL,
+                    remaining_operations INTEGER NOT NULL,
+                    FOREIGN KEY(task_id) REFERENCES worker_tasks(task_id) ON DELETE CASCADE
+                );
+                CREATE TABLE IF NOT EXISTS worker_operations (
+                    operation_id TEXT PRIMARY KEY,
+                    task_id TEXT NOT NULL,
+                    tool_name TEXT NOT NULL,
+                    intent_sha256 TEXT NOT NULL,
+                    state TEXT NOT NULL,
+                    request_ciphertext TEXT NOT NULL,
+                    result_ciphertext TEXT,
+                    created_at REAL NOT NULL,
+                    updated_at REAL NOT NULL,
+                    FOREIGN KEY(task_id) REFERENCES worker_tasks(task_id) ON DELETE CASCADE
+                );
+                CREATE INDEX IF NOT EXISTS idx_worker_operations_task
+                    ON worker_operations(task_id, created_at);
                 """
             )
 
@@ -486,6 +855,55 @@ class CodingWorkerStore:
             (task_id, event_type, self._codec.encrypt(payload), created_at),
         )
         return int(cursor.lastrowid)
+
+    def _approval(self, row: sqlite3.Row) -> WorkerApproval:
+        try:
+            lease_value = (
+                self._codec.decrypt(str(row["lease_ciphertext"]))
+                if row["lease_ciphertext"] is not None
+                else None
+            )
+            lease = CapabilityLease.model_validate(lease_value) if lease_value else None
+            return WorkerApproval(
+                approval_id=str(row["approval_id"]),
+                task_id=str(row["task_id"]),
+                operation_id=str(row["operation_id"]),
+                capability=str(row["capability"]),
+                status=ApprovalStatus(row["status"]),
+                request=self._decrypt_dict(row["request_ciphertext"]),
+                lease=lease,
+                created_at=float(row["created_at"]),
+                decided_at=(
+                    float(row["decided_at"]) if row["decided_at"] is not None else None
+                ),
+            )
+        except (WorkerCryptoError, ValueError) as exc:
+            raise WorkerStoreError(
+                "Worker approval data is corrupt.", code="worker_data_corrupt"
+            ) from exc
+
+    def _operation(self, row: sqlite3.Row) -> WorkerOperation:
+        try:
+            result = (
+                self._decrypt_dict(row["result_ciphertext"])
+                if row["result_ciphertext"] is not None
+                else None
+            )
+            return WorkerOperation(
+                operation_id=str(row["operation_id"]),
+                task_id=str(row["task_id"]),
+                tool_name=str(row["tool_name"]),
+                intent_sha256=str(row["intent_sha256"]),
+                state=OperationState(row["state"]),
+                request=self._decrypt_dict(row["request_ciphertext"]),
+                result=result,
+                created_at=float(row["created_at"]),
+                updated_at=float(row["updated_at"]),
+            )
+        except (WorkerCryptoError, ValueError) as exc:
+            raise WorkerStoreError(
+                "Worker operation data is corrupt.", code="worker_data_corrupt"
+            ) from exc
 
     @staticmethod
     def _require_task_row(connection: sqlite3.Connection, task_id: str) -> sqlite3.Row:

--- a/server/coding_worker/store.py
+++ b/server/coding_worker/store.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import base64
+import hashlib
 import math
 import sqlite3
 import threading
@@ -12,6 +14,7 @@ from typing import Any
 from .contracts import (
     ApprovalStatus,
     CapabilityName,
+    EvidenceStatus,
     CapabilityLease,
     OperationState,
     TERMINAL_STATES,
@@ -20,6 +23,8 @@ from .contracts import (
     TaskSpec,
     TaskState,
     WorkerEvent,
+    WorkerEvidence,
+    WorkerArtifact,
     WorkerApproval,
     WorkerMessage,
     WorkerOperation,
@@ -651,6 +656,183 @@ class CodingWorkerStore:
                 )
         return len(rows)
 
+    def create_artifact(
+        self,
+        *,
+        task_id: str,
+        media_type: str,
+        content: bytes,
+        metadata: dict[str, Any] | None = None,
+    ) -> WorkerArtifact:
+        if not media_type or len(media_type) > 120:
+            raise ValueError("artifact media type is invalid")
+        if len(content) > 16 * 1024 * 1024:
+            raise ValueError("artifact is too large")
+        now = self._now()
+        artifact_id = f"artifact_{uuid.uuid4().hex}"
+        digest = hashlib.sha256(content).hexdigest()
+        with self._lock, self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            self._require_task_row(connection, task_id)
+            connection.execute(
+                """
+                INSERT INTO worker_artifacts (
+                    artifact_id, task_id, media_type, sha256, size,
+                    metadata_ciphertext, content_ciphertext, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    artifact_id,
+                    task_id,
+                    media_type,
+                    digest,
+                    len(content),
+                    self._codec.encrypt(metadata or {}),
+                    self._codec.encrypt({"base64": base64.b64encode(content).decode("ascii")}),
+                    now,
+                ),
+            )
+            self._append_event_locked(
+                connection,
+                task_id=task_id,
+                event_type="artifact_created",
+                payload={"artifact_id": artifact_id, "media_type": media_type},
+                created_at=now,
+            )
+        return self.get_artifact(artifact_id)
+
+    def get_artifact(self, artifact_id: str) -> WorkerArtifact:
+        with self._connect() as connection:
+            row = connection.execute(
+                "SELECT * FROM worker_artifacts WHERE artifact_id = ?", (artifact_id,)
+            ).fetchone()
+        if row is None:
+            raise WorkerNotFoundError("Artifact was not found.", code="artifact_not_found")
+        return self._artifact(row)
+
+    def list_artifacts(self, task_id: str) -> list[WorkerArtifact]:
+        with self._connect() as connection:
+            self._require_task_row(connection, task_id)
+            rows = connection.execute(
+                "SELECT * FROM worker_artifacts WHERE task_id = ? ORDER BY created_at",
+                (task_id,),
+            ).fetchall()
+        return [self._artifact(row) for row in rows]
+
+    def read_artifact(self, artifact_id: str, *, task_id: str) -> bytes:
+        with self._connect() as connection:
+            row = connection.execute(
+                "SELECT * FROM worker_artifacts WHERE artifact_id = ? AND task_id = ?",
+                (artifact_id, task_id),
+            ).fetchone()
+        if row is None:
+            raise WorkerNotFoundError("Artifact was not found.", code="artifact_not_found")
+        try:
+            value = self._decrypt_dict(row["content_ciphertext"])
+            content = base64.b64decode(str(value["base64"]), validate=True)
+        except (KeyError, ValueError, WorkerCryptoError) as exc:
+            raise WorkerStoreError(
+                "Worker artifact data is corrupt.", code="worker_data_corrupt"
+            ) from exc
+        if (
+            len(content) != int(row["size"])
+            or hashlib.sha256(content).hexdigest() != str(row["sha256"])
+        ):
+            raise WorkerStoreError(
+                "Worker artifact data is corrupt.", code="worker_data_corrupt"
+            )
+        return content
+
+    def record_evidence(
+        self,
+        *,
+        task_id: str,
+        check_id: str,
+        operation_id: str,
+        workspace_tree_hash: str,
+        exit_code: int,
+        artifact_id: str,
+    ) -> WorkerEvidence:
+        now = self._now()
+        evidence_id = f"evidence_{uuid.uuid4().hex}"
+        status = EvidenceStatus.PASSED if exit_code == 0 else EvidenceStatus.FAILED
+        with self._lock, self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            task = self._task(self._require_task_row(connection, task_id), connection)
+            if check_id not in {item.check_id for item in task.spec.acceptance.required_checks}:
+                raise WorkerConflictError(
+                    "Evidence check is not in the acceptance contract.",
+                    code="acceptance_check_unknown",
+                )
+            artifact = connection.execute(
+                "SELECT task_id FROM worker_artifacts WHERE artifact_id = ?", (artifact_id,)
+            ).fetchone()
+            if artifact is None or str(artifact["task_id"]) != task_id:
+                raise WorkerConflictError(
+                    "Evidence artifact is not bound to this task.",
+                    code="artifact_binding_conflict",
+                )
+            connection.execute(
+                """
+                INSERT INTO worker_evidence (
+                    evidence_id, task_id, check_id, operation_id,
+                    workspace_tree_hash, status, exit_code, artifact_id, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    evidence_id,
+                    task_id,
+                    check_id,
+                    operation_id,
+                    workspace_tree_hash,
+                    status.value,
+                    exit_code,
+                    artifact_id,
+                    now,
+                ),
+            )
+            self._append_event_locked(
+                connection,
+                task_id=task_id,
+                event_type="evidence_recorded",
+                payload={
+                    "evidence_id": evidence_id,
+                    "check_id": check_id,
+                    "status": status.value,
+                    "workspace_tree_hash": workspace_tree_hash,
+                },
+                created_at=now,
+            )
+        return self.get_evidence(evidence_id)
+
+    def get_evidence(self, evidence_id: str) -> WorkerEvidence:
+        with self._connect() as connection:
+            row = connection.execute(
+                "SELECT * FROM worker_evidence WHERE evidence_id = ?", (evidence_id,)
+            ).fetchone()
+        if row is None:
+            raise WorkerNotFoundError("Evidence was not found.", code="evidence_not_found")
+        return self._evidence(row)
+
+    def list_evidence(
+        self, task_id: str, *, current_tree_hash: str | None = None
+    ) -> list[WorkerEvidence]:
+        with self._connect() as connection:
+            self._require_task_row(connection, task_id)
+            rows = connection.execute(
+                "SELECT * FROM worker_evidence WHERE task_id = ? ORDER BY created_at",
+                (task_id,),
+            ).fetchall()
+        evidence = [self._evidence(row) for row in rows]
+        if current_tree_hash is None:
+            return evidence
+        return [
+            item.model_copy(update={"status": EvidenceStatus.INVALIDATED})
+            if item.workspace_tree_hash != current_tree_hash
+            else item
+            for item in evidence
+        ]
+
     def delete_task(self, task_id: str) -> bool:
         with self._lock, self._connect() as connection:
             row = self._require_task_row(connection, task_id)
@@ -801,6 +983,34 @@ class CodingWorkerStore:
                 );
                 CREATE INDEX IF NOT EXISTS idx_worker_operations_task
                     ON worker_operations(task_id, created_at);
+                CREATE TABLE IF NOT EXISTS worker_artifacts (
+                    artifact_id TEXT PRIMARY KEY,
+                    task_id TEXT NOT NULL,
+                    media_type TEXT NOT NULL,
+                    sha256 TEXT NOT NULL,
+                    size INTEGER NOT NULL,
+                    metadata_ciphertext TEXT NOT NULL,
+                    content_ciphertext TEXT NOT NULL,
+                    created_at REAL NOT NULL,
+                    FOREIGN KEY(task_id) REFERENCES worker_tasks(task_id) ON DELETE CASCADE
+                );
+                CREATE INDEX IF NOT EXISTS idx_worker_artifacts_task
+                    ON worker_artifacts(task_id, created_at);
+                CREATE TABLE IF NOT EXISTS worker_evidence (
+                    evidence_id TEXT PRIMARY KEY,
+                    task_id TEXT NOT NULL,
+                    check_id TEXT NOT NULL,
+                    operation_id TEXT NOT NULL,
+                    workspace_tree_hash TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    exit_code INTEGER NOT NULL,
+                    artifact_id TEXT NOT NULL,
+                    created_at REAL NOT NULL,
+                    FOREIGN KEY(task_id) REFERENCES worker_tasks(task_id) ON DELETE CASCADE,
+                    FOREIGN KEY(artifact_id) REFERENCES worker_artifacts(artifact_id) ON DELETE CASCADE
+                );
+                CREATE INDEX IF NOT EXISTS idx_worker_evidence_task
+                    ON worker_evidence(task_id, check_id, created_at);
                 """
             )
 
@@ -903,6 +1113,41 @@ class CodingWorkerStore:
         except (WorkerCryptoError, ValueError) as exc:
             raise WorkerStoreError(
                 "Worker operation data is corrupt.", code="worker_data_corrupt"
+            ) from exc
+
+    def _artifact(self, row: sqlite3.Row) -> WorkerArtifact:
+        try:
+            return WorkerArtifact(
+                artifact_id=str(row["artifact_id"]),
+                task_id=str(row["task_id"]),
+                media_type=str(row["media_type"]),
+                sha256=str(row["sha256"]),
+                size=int(row["size"]),
+                metadata=self._decrypt_dict(row["metadata_ciphertext"]),
+                created_at=float(row["created_at"]),
+            )
+        except (WorkerCryptoError, ValueError) as exc:
+            raise WorkerStoreError(
+                "Worker artifact data is corrupt.", code="worker_data_corrupt"
+            ) from exc
+
+    @staticmethod
+    def _evidence(row: sqlite3.Row) -> WorkerEvidence:
+        try:
+            return WorkerEvidence(
+                evidence_id=str(row["evidence_id"]),
+                task_id=str(row["task_id"]),
+                check_id=str(row["check_id"]),
+                operation_id=str(row["operation_id"]),
+                workspace_tree_hash=str(row["workspace_tree_hash"]),
+                status=EvidenceStatus(row["status"]),
+                exit_code=int(row["exit_code"]),
+                artifact_id=str(row["artifact_id"]),
+                created_at=float(row["created_at"]),
+            )
+        except ValueError as exc:
+            raise WorkerStoreError(
+                "Worker evidence data is corrupt.", code="worker_data_corrupt"
             ) from exc
 
     @staticmethod

--- a/server/coding_worker/store.py
+++ b/server/coding_worker/store.py
@@ -26,6 +26,7 @@ from .contracts import (
     WorkerEvidence,
     WorkerArtifact,
     WorkerApproval,
+    WorkerCheckpoint,
     WorkerMessage,
     WorkerOperation,
     require_transition,
@@ -710,6 +711,63 @@ class CodingWorkerStore:
             raise WorkerNotFoundError("Artifact was not found.", code="artifact_not_found")
         return self._artifact(row)
 
+    def create_checkpoint(
+        self,
+        *,
+        task_id: str,
+        workspace_tree_hash: str,
+        payload: dict[str, Any],
+    ) -> WorkerCheckpoint:
+        now = self._now()
+        checkpoint = WorkerCheckpoint(
+            checkpoint_id=f"checkpoint_{uuid.uuid4().hex}",
+            task_id=task_id,
+            workspace_tree_hash=workspace_tree_hash,
+            payload=payload,
+            created_at=now,
+        )
+        with self._lock, self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            self._require_task_row(connection, task_id)
+            connection.execute(
+                """
+                INSERT INTO worker_checkpoints (
+                    checkpoint_id, task_id, workspace_tree_hash,
+                    payload_ciphertext, created_at
+                ) VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    checkpoint.checkpoint_id,
+                    task_id,
+                    workspace_tree_hash,
+                    self._codec.encrypt(payload),
+                    now,
+                ),
+            )
+            self._append_event_locked(
+                connection,
+                task_id=task_id,
+                event_type="checkpoint_created",
+                payload={
+                    "checkpoint_id": checkpoint.checkpoint_id,
+                    "workspace_tree_hash": workspace_tree_hash,
+                },
+                created_at=now,
+            )
+        return checkpoint
+
+    def latest_checkpoint(self, task_id: str) -> WorkerCheckpoint | None:
+        with self._connect() as connection:
+            self._require_task_row(connection, task_id)
+            row = connection.execute(
+                """
+                SELECT * FROM worker_checkpoints
+                WHERE task_id = ? ORDER BY created_at DESC, checkpoint_id DESC LIMIT 1
+                """,
+                (task_id,),
+            ).fetchone()
+        return self._checkpoint(row) if row is not None else None
+
     def list_artifacts(self, task_id: str) -> list[WorkerArtifact]:
         with self._connect() as connection:
             self._require_task_row(connection, task_id)
@@ -1011,6 +1069,16 @@ class CodingWorkerStore:
                 );
                 CREATE INDEX IF NOT EXISTS idx_worker_evidence_task
                     ON worker_evidence(task_id, check_id, created_at);
+                CREATE TABLE IF NOT EXISTS worker_checkpoints (
+                    checkpoint_id TEXT PRIMARY KEY,
+                    task_id TEXT NOT NULL,
+                    workspace_tree_hash TEXT NOT NULL,
+                    payload_ciphertext TEXT NOT NULL,
+                    created_at REAL NOT NULL,
+                    FOREIGN KEY(task_id) REFERENCES worker_tasks(task_id) ON DELETE CASCADE
+                );
+                CREATE INDEX IF NOT EXISTS idx_worker_checkpoints_task
+                    ON worker_checkpoints(task_id, created_at);
                 """
             )
 
@@ -1129,6 +1197,20 @@ class CodingWorkerStore:
         except (WorkerCryptoError, ValueError) as exc:
             raise WorkerStoreError(
                 "Worker artifact data is corrupt.", code="worker_data_corrupt"
+            ) from exc
+
+    def _checkpoint(self, row: sqlite3.Row) -> WorkerCheckpoint:
+        try:
+            return WorkerCheckpoint(
+                checkpoint_id=str(row["checkpoint_id"]),
+                task_id=str(row["task_id"]),
+                workspace_tree_hash=str(row["workspace_tree_hash"]),
+                payload=self._decrypt_dict(row["payload_ciphertext"]),
+                created_at=float(row["created_at"]),
+            )
+        except (WorkerCryptoError, ValueError) as exc:
+            raise WorkerStoreError(
+                "Worker checkpoint data is corrupt.", code="worker_data_corrupt"
             ) from exc
 
     @staticmethod

--- a/server/coding_worker/tool_broker.py
+++ b/server/coding_worker/tool_broker.py
@@ -12,7 +12,7 @@ from typing import Any
 
 from pydantic import Field
 
-from .contracts import CapabilityName, OperationState, PolicyProfile, StrictModel
+from .contracts import CapabilityName, OperationState, PolicyProfile, StrictModel, TaskState
 from .store import CodingWorkerStore, WorkerConflictError
 from .workspace import WorkspaceBroker, WorkspaceError
 
@@ -100,7 +100,6 @@ class ToolBroker:
             raise ToolBrokerError("Task workspace is unavailable.", code="workspace_unavailable")
         request = {
             "arguments": self._json_object(arguments),
-            "lease_id": lease_id,
             "workspace_id": task.workspace_id,
         }
         intent_sha256 = self._intent_sha256(tool_name, request)
@@ -125,7 +124,14 @@ class ToolBroker:
                 "Tool operation cannot be replayed.", code="operation_not_replayable"
             )
         try:
-            self._authorize(task.spec.policy_profile, tool_name, lease_id, task_id, request)
+            self._authorize(
+                task.spec.policy_profile,
+                tool_name,
+                lease_id,
+                task_id,
+                operation_id,
+                request,
+            )
             self.store.transition_operation(
                 operation_id,
                 OperationState.RUNNING,
@@ -152,7 +158,15 @@ class ToolBroker:
             asyncio.TimeoutError,
         ) as exc:
             current = self.store.get_operation(operation_id)
-            if current.state in {OperationState.PREPARED, OperationState.RUNNING}:
+            awaiting_approval = (
+                isinstance(exc, ToolBrokerError)
+                and exc.code == "approval_required"
+                and current.state is OperationState.PREPARED
+            )
+            if not awaiting_approval and current.state in {
+                OperationState.PREPARED,
+                OperationState.RUNNING,
+            }:
                 self.store.transition_operation(
                     operation_id,
                     OperationState.FAILED,
@@ -223,6 +237,7 @@ class ToolBroker:
         tool_name: str,
         lease_id: str | None,
         task_id: str,
+        operation_id: str,
         request: dict[str, Any],
     ) -> None:
         readonly = {"list_files", "read_file", "search_text", "diff"}
@@ -238,6 +253,15 @@ class ToolBroker:
         else:
             raise ToolBrokerError("Tool is not available.", code="tool_not_allowed")
         if lease_id is None:
+            self.store.create_approval(
+                task_id=task_id,
+                operation_id=operation_id,
+                capability=capability,
+                request=request["arguments"],
+            )
+            task = self.store.get_task(task_id)
+            if task.state is TaskState.RUNNING:
+                self.store.transition(task_id, TaskState.WAITING_APPROVAL)
             raise ToolBrokerError("Tool requires approval.", code="approval_required")
         lease = self.store.consume_lease(lease_id, task_id=task_id, capability=capability)
         requested_argv = request["arguments"].get("argv")

--- a/server/coding_worker/tool_broker.py
+++ b/server/coding_worker/tool_broker.py
@@ -10,7 +10,7 @@ import tempfile
 import uuid
 from collections.abc import Mapping, Sequence
 from pathlib import Path, PurePosixPath
-from typing import Any
+from typing import Any, Protocol
 from urllib.parse import urlsplit
 
 from pydantic import Field
@@ -67,6 +67,14 @@ class ToolResult(StrictModel):
     data: dict[str, Any] = Field(default_factory=dict)
 
 
+class ToolExecutor(Protocol):
+    async def run_process(self, *, task_id: str, workspace_id: str, argv: Sequence[str], timeout_seconds: int, isolated: bool, environment_overrides: Mapping[str, str] | None = None) -> dict[str, Any]: ...
+    async def start_service(self, *, task_id: str, workspace_id: str, argv: Sequence[str], ttl_seconds: int) -> dict[str, Any]: ...
+    async def service_status(self, *, task_id: str, workspace_id: str, service_id: str) -> dict[str, Any]: ...
+    async def service_input(self, *, task_id: str, workspace_id: str, service_id: str, data: str) -> dict[str, Any]: ...
+    async def stop_service(self, *, task_id: str, workspace_id: str, service_id: str) -> dict[str, Any]: ...
+
+
 class ToolBroker:
     """The sole side-effect boundary exposed to a coding provider.
 
@@ -84,6 +92,7 @@ class ToolBroker:
         egress_policy: EgressPolicy | None = None,
         egress_proxy_url: str | None = None,
         max_output_bytes: int = MAX_TOOL_OUTPUT_BYTES,
+        executor: ToolExecutor | None = None,
     ) -> None:
         if not 1024 <= max_output_bytes <= 16 * 1024 * 1024:
             raise ValueError("tool output limit is invalid")
@@ -94,6 +103,7 @@ class ToolBroker:
         self.egress_policy = egress_policy
         self.egress_proxy_url = self._validate_proxy_url(egress_proxy_url)
         self.max_output_bytes = max_output_bytes
+        self.executor = executor
 
     async def execute(
         self,
@@ -193,6 +203,18 @@ class ToolBroker:
             if isinstance(exc, ToolBrokerError):
                 raise
             raise ToolBrokerError("Tool operation failed.", code=getattr(exc, "code", "tool_failed")) from exc
+        except Exception as exc:
+            current = self.store.get_operation(operation_id)
+            if current.state in {OperationState.PREPARED, OperationState.RUNNING}:
+                self.store.transition_operation(
+                    operation_id,
+                    OperationState.FAILED,
+                    result={"code": getattr(exc, "code", "tool_failed")},
+                    expected_state=current.state,
+                )
+            raise ToolBrokerError(
+                "Tool operation failed.", code=getattr(exc, "code", "tool_failed")
+            ) from exc
 
     def reconcile(self, operation_id: str) -> ToolResult:
         operation = self.store.get_operation(operation_id)
@@ -387,6 +409,7 @@ class ToolBroker:
             if check is None:
                 raise ToolBrokerError("Check is not registered.", code="check_not_found")
             return await self._run_process(
+                task_id,
                 workspace_id,
                 check.argv,
                 check.timeout_seconds,
@@ -400,9 +423,8 @@ class ToolBroker:
                 raise ToolBrokerError("Command argv is invalid.", code="tool_input_invalid")
             if isinstance(timeout, bool) or not isinstance(timeout, int) or not 1 <= timeout <= 1800:
                 raise ToolBrokerError("Command timeout is invalid.", code="tool_input_invalid")
-            return await self._run_process(workspace_id, tuple(argv), timeout)
+            return await self._run_process(task_id, workspace_id, tuple(argv), timeout)
         if tool_name == "start_service":
-            manager = self._require_process_manager()
             argv = arguments.get("argv")
             ttl = arguments.get("ttl_seconds", 900)
             if (
@@ -412,7 +434,14 @@ class ToolBroker:
                 or not isinstance(ttl, int)
             ):
                 raise ToolBrokerError("Service input is invalid.", code="tool_input_invalid")
-            record = await manager.start(
+            if self.executor is not None:
+                return await self.executor.start_service(
+                    task_id=task_id,
+                    workspace_id=workspace_id,
+                    argv=self._validate_argv(argv),
+                    ttl_seconds=ttl,
+                )
+            record = await self._require_process_manager().start(
                 task_id=task_id,
                 workspace_id=workspace_id,
                 argv=self._validate_argv(argv),
@@ -420,6 +449,13 @@ class ToolBroker:
             )
             return record.model_dump(mode="json")
         if tool_name == "service_status":
+            if self.executor is not None:
+                result = await self.executor.service_status(
+                    task_id=task_id,
+                    workspace_id=workspace_id,
+                    service_id=str(arguments.get("service_id", "")),
+                )
+                return self._archive_service_output(task_id, result)
             record = self._require_process_manager().status(
                 task_id=task_id,
                 service_id=str(arguments.get("service_id", "")),
@@ -430,6 +466,13 @@ class ToolBroker:
             data = arguments.get("data")
             if not isinstance(data, str):
                 raise ToolBrokerError("Service input is invalid.", code="tool_input_invalid")
+            if self.executor is not None:
+                return await self.executor.service_input(
+                    task_id=task_id,
+                    workspace_id=workspace_id,
+                    service_id=service_id,
+                    data=data,
+                )
             await self._require_process_manager().send_input(
                 task_id=task_id,
                 service_id=service_id,
@@ -437,6 +480,13 @@ class ToolBroker:
             )
             return {"service_id": service_id, "accepted": True}
         if tool_name == "stop_service":
+            if self.executor is not None:
+                result = await self.executor.stop_service(
+                    task_id=task_id,
+                    workspace_id=workspace_id,
+                    service_id=str(arguments.get("service_id", "")),
+                )
+                return self._archive_service_output(task_id, result)
             record = await self._require_process_manager().interrupt(
                 task_id=task_id,
                 service_id=str(arguments.get("service_id", "")),
@@ -451,6 +501,7 @@ class ToolBroker:
             if self.egress_proxy_url is None:
                 raise ToolBrokerError("Egress proxy is unavailable.", code="network_disabled")
             result = await self._run_process(
+                task_id,
                 workspace_id,
                 ("npm", "ci", "--ignore-scripts", "--no-audit", "--no-fund"),
                 1800,
@@ -483,6 +534,30 @@ class ToolBroker:
         if self.process_manager is None:
             raise ToolBrokerError("Service manager is unavailable.", code="service_unavailable")
         return self.process_manager
+
+    def _archive_service_output(
+        self, task_id: str, result: dict[str, Any]
+    ) -> dict[str, Any]:
+        output = result.pop("output", None)
+        if not isinstance(output, str):
+            return result
+        service_id = str(result.get("service_id", ""))
+        existing = next(
+            (
+                item
+                for item in self.store.list_artifacts(task_id)
+                if item.metadata.get("kind") == "service_output"
+                and item.metadata.get("service_id") == service_id
+            ),
+            None,
+        )
+        artifact = existing or self.store.create_artifact(
+            task_id=task_id,
+            media_type="text/plain; charset=utf-8",
+            content=output.encode("utf-8"),
+            metadata={"kind": "service_output", "service_id": service_id},
+        )
+        return {**result, "output_artifact_id": artifact.artifact_id}
 
     def _require_egress_policy(self) -> EgressPolicy:
         if self.egress_policy is None:
@@ -532,6 +607,7 @@ class ToolBroker:
 
     async def _run_process(
         self,
+        task_id: str,
         workspace_id: str,
         argv: Sequence[str],
         timeout_seconds: int,
@@ -541,6 +617,15 @@ class ToolBroker:
         environment_overrides: Mapping[str, str] | None = None,
     ) -> dict[str, Any]:
         normalized = self._validate_argv(argv, trusted=trusted)
+        if self.executor is not None:
+            return await self.executor.run_process(
+                task_id=task_id,
+                workspace_id=workspace_id,
+                argv=normalized,
+                timeout_seconds=timeout_seconds,
+                isolated=isolated,
+                environment_overrides=environment_overrides,
+            )
         repository = self.workspace_broker.repository_path(workspace_id)
         execution_root: Path | None = None
         execution_repository = repository

--- a/server/coding_worker/tool_broker.py
+++ b/server/coding_worker/tool_broker.py
@@ -11,11 +11,13 @@ import uuid
 from collections.abc import Mapping, Sequence
 from pathlib import Path, PurePosixPath
 from typing import Any
+from urllib.parse import urlsplit
 
 from pydantic import Field
 
 from .contracts import CapabilityName, OperationState, PolicyProfile, StrictModel, TaskState
 from .process_manager import BackgroundProcessManager, ProcessManagerError
+from .network_policy import EgressPolicy, NetworkPolicyError
 from .store import CodingWorkerStore, WorkerConflictError
 from .workspace import WorkspaceBroker, WorkspaceError
 
@@ -79,6 +81,8 @@ class ToolBroker:
         workspace_broker: WorkspaceBroker,
         frozen_checks: Mapping[str, FrozenCheck] | None = None,
         process_manager: BackgroundProcessManager | None = None,
+        egress_policy: EgressPolicy | None = None,
+        egress_proxy_url: str | None = None,
         max_output_bytes: int = MAX_TOOL_OUTPUT_BYTES,
     ) -> None:
         if not 1024 <= max_output_bytes <= 16 * 1024 * 1024:
@@ -87,6 +91,8 @@ class ToolBroker:
         self.workspace_broker = workspace_broker
         self.frozen_checks = dict(frozen_checks or {})
         self.process_manager = process_manager
+        self.egress_policy = egress_policy
+        self.egress_proxy_url = self._validate_proxy_url(egress_proxy_url)
         self.max_output_bytes = max_output_bytes
 
     async def execute(
@@ -97,6 +103,7 @@ class ToolBroker:
         tool_name: str,
         arguments: Mapping[str, Any],
         lease_id: str | None = None,
+        network_lease_id: str | None = None,
     ) -> ToolResult:
         if SAFE_TOOL_NAME.fullmatch(tool_name) is None:
             raise ToolBrokerError("Tool name is invalid.", code="tool_not_allowed")
@@ -136,6 +143,7 @@ class ToolBroker:
                 task_id,
                 operation_id,
                 request,
+                network_lease_id,
             )
             self.store.transition_operation(
                 operation_id,
@@ -162,6 +170,7 @@ class ToolBroker:
             WorkerConflictError,
             WorkspaceError,
             ProcessManagerError,
+            NetworkPolicyError,
             OSError,
             asyncio.TimeoutError,
         ) as exc:
@@ -247,6 +256,7 @@ class ToolBroker:
         task_id: str,
         operation_id: str,
         request: dict[str, Any],
+        network_lease_id: str | None,
     ) -> None:
         readonly = {"list_files", "read_file", "search_text", "diff", "service_status"}
         if tool_name in readonly:
@@ -266,8 +276,21 @@ class ToolBroker:
             capability = "command"
         elif tool_name == "start_service":
             capability = "service"
+        elif tool_name == "install_dependencies":
+            if profile is not PolicyProfile.DEVELOP_NETWORKED:
+                raise ToolBrokerError(
+                    "Dependency installation requires networked development policy.",
+                    code="approval_required",
+                )
+            capability = "dependency_install"
         else:
             raise ToolBrokerError("Tool is not available.", code="tool_not_allowed")
+        network_scope: dict[str, object] | None = None
+        if tool_name == "install_dependencies":
+            policy = self._require_egress_policy()
+            network_scope = policy.approval_scope(
+                domains=("registry.npmjs.org",), purpose="dependency-install"
+            )
         if lease_id is None:
             self.store.create_approval(
                 task_id=task_id,
@@ -275,6 +298,17 @@ class ToolBroker:
                 capability=capability,
                 request=request["arguments"],
             )
+        if network_scope is not None and network_lease_id is None:
+            network_operation_id = "network_" + hashlib.sha256(
+                operation_id.encode("utf-8")
+            ).hexdigest()[:32]
+            self.store.create_approval(
+                task_id=task_id,
+                operation_id=network_operation_id,
+                capability="network",
+                request=network_scope,
+            )
+        if lease_id is None or (network_scope is not None and network_lease_id is None):
             task = self.store.get_task(task_id)
             if task.state is TaskState.RUNNING:
                 self.store.transition(task_id, TaskState.WAITING_APPROVAL)
@@ -282,6 +316,15 @@ class ToolBroker:
         lease = self.store.consume_lease(lease_id, task_id=task_id, capability=capability)
         if lease.scope != request["arguments"]:
             raise ToolBrokerError("Approval does not match the request.", code="lease_scope_mismatch")
+        if network_scope is not None:
+            network_lease = self.store.consume_lease(
+                str(network_lease_id), task_id=task_id, capability="network"
+            )
+            self._require_egress_policy().validate_lease_scope(
+                lease=network_lease,
+                domains=("registry.npmjs.org",),
+                purpose="dependency-install",
+            )
 
     async def _dispatch(
         self,
@@ -399,12 +442,52 @@ class ToolBroker:
                 service_id=str(arguments.get("service_id", "")),
             )
             return record.model_dump(mode="json")
+        if tool_name == "install_dependencies":
+            if arguments != {"manager": "npm", "action": "ci"}:
+                raise ToolBrokerError(
+                    "Only frozen npm lockfile installation is supported.",
+                    code="dependency_plan_invalid",
+                )
+            if self.egress_proxy_url is None:
+                raise ToolBrokerError("Egress proxy is unavailable.", code="network_disabled")
+            result = await self._run_process(
+                workspace_id,
+                ("npm", "ci", "--ignore-scripts", "--no-audit", "--no-fund"),
+                1800,
+                environment_overrides={
+                    "HTTPS_PROXY": self.egress_proxy_url,
+                    "HTTP_PROXY": self.egress_proxy_url,
+                    "NO_PROXY": "",
+                    "npm_config_registry": "https://registry.npmjs.org/",
+                    "npm_config_ignore_scripts": "true",
+                    "npm_config_audit": "false",
+                    "npm_config_fund": "false",
+                },
+            )
+            source = {
+                "manager": "npm",
+                "action": "ci",
+                "registry_domains": ["registry.npmjs.org"],
+                "exit_code": result["exit_code"],
+            }
+            artifact = self.store.create_artifact(
+                task_id=task_id,
+                media_type="application/json",
+                content=json.dumps(source, sort_keys=True, separators=(",", ":")).encode(),
+                metadata={"kind": "dependency_source"},
+            )
+            return {**result, "source_artifact_id": artifact.artifact_id}
         raise ToolBrokerError("Tool is not available.", code="tool_not_allowed")
 
     def _require_process_manager(self) -> BackgroundProcessManager:
         if self.process_manager is None:
             raise ToolBrokerError("Service manager is unavailable.", code="service_unavailable")
         return self.process_manager
+
+    def _require_egress_policy(self) -> EgressPolicy:
+        if self.egress_policy is None:
+            raise NetworkPolicyError("Worker network access is disabled.", code="network_disabled")
+        return self.egress_policy
 
     def _write_file(self, workspace_id: str, arguments: dict[str, Any]) -> dict[str, Any]:
         path = str(arguments.get("path", ""))
@@ -455,6 +538,7 @@ class ToolBroker:
         *,
         trusted: bool = False,
         isolated: bool = False,
+        environment_overrides: Mapping[str, str] | None = None,
     ) -> dict[str, Any]:
         normalized = self._validate_argv(argv, trusted=trusted)
         repository = self.workspace_broker.repository_path(workspace_id)
@@ -475,10 +559,12 @@ class ToolBroker:
                     ignore=shutil.ignore_patterns(".git"),
                 )
                 execution_repository = execution_root
+            environment = self._safe_environment(execution_repository)
+            environment.update(environment_overrides or {})
             process = await asyncio.create_subprocess_exec(
                 *normalized,
                 cwd=execution_repository,
-                env=self._safe_environment(execution_repository),
+                env=environment,
                 stdin=asyncio.subprocess.DEVNULL,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,
@@ -587,6 +673,23 @@ class ToolBroker:
             environment["SYSTEMROOT"] = os.environ.get("SYSTEMROOT", "C:\\Windows")
         Path(environment["HOME"]).mkdir(exist_ok=True)
         return environment
+
+    @staticmethod
+    def _validate_proxy_url(value: str | None) -> str | None:
+        if value is None:
+            return None
+        parsed = urlsplit(value)
+        if (
+            parsed.scheme != "http"
+            or parsed.hostname is None
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.path not in {"", "/"}
+            or parsed.query
+            or parsed.fragment
+        ):
+            raise ValueError("egress proxy URL is invalid")
+        return value.rstrip("/")
 
     @staticmethod
     def _intent_sha256(tool_name: str, request: dict[str, Any]) -> str:

--- a/server/coding_worker/tool_broker.py
+++ b/server/coding_worker/tool_broker.py
@@ -586,6 +586,7 @@ class ToolBroker:
                 handle.write(encoded)
                 handle.flush()
                 os.fsync(handle.fileno())
+            self.workspace_broker.apply_slot_owner(workspace_id, Path(temporary))
             os.replace(temporary, target)
         finally:
             try:
@@ -715,6 +716,7 @@ class ToolBroker:
                     raise ToolBrokerError("Workspace path changed.", code="workspace_changed")
             elif create_parents:
                 parent.mkdir()
+                self.workspace_broker.apply_slot_owner(workspace_id, parent)
             else:
                 raise ToolBrokerError("Workspace path was not found.", code="entry_not_found")
         target = parent / path.name

--- a/server/coding_worker/tool_broker.py
+++ b/server/coding_worker/tool_broker.py
@@ -1,0 +1,470 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import re
+import tempfile
+from collections.abc import Mapping, Sequence
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from pydantic import Field
+
+from .contracts import CapabilityName, OperationState, PolicyProfile, StrictModel
+from .store import CodingWorkerStore, WorkerConflictError
+from .workspace import WorkspaceBroker, WorkspaceError
+
+
+MAX_TOOL_OUTPUT_BYTES = 2 * 1024 * 1024
+MAX_WRITE_BYTES = 8 * 1024 * 1024
+SAFE_TOOL_NAME = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
+ALWAYS_DENIED_EXECUTABLES = frozenset(
+    {
+        "bash",
+        "cmd",
+        "curl",
+        "docker",
+        "mount",
+        "nc",
+        "netcat",
+        "powershell",
+        "pwsh",
+        "scp",
+        "sh",
+        "ssh",
+        "sudo",
+        "wget",
+    }
+)
+DENIED_GIT_SUBCOMMANDS = frozenset(
+    {"clone", "fetch", "ls-remote", "pull", "push", "remote", "submodule"}
+)
+
+
+class ToolBrokerError(RuntimeError):
+    def __init__(self, message: str, *, code: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+class FrozenCheck(StrictModel):
+    check_id: str = Field(pattern=r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$")
+    argv: tuple[str, ...] = Field(min_length=1, max_length=64)
+    timeout_seconds: int = Field(default=300, ge=1, le=1800)
+
+
+class ToolResult(StrictModel):
+    operation_id: str
+    tool_name: str
+    state: OperationState
+    data: dict[str, Any] = Field(default_factory=dict)
+
+
+class ToolBroker:
+    """The sole side-effect boundary exposed to a coding provider.
+
+    Requests contain only task/workspace-relative values. Commands are argv arrays,
+    never shell strings, and execute with a minimal credential-free environment.
+    """
+
+    def __init__(
+        self,
+        *,
+        store: CodingWorkerStore,
+        workspace_broker: WorkspaceBroker,
+        frozen_checks: Mapping[str, FrozenCheck] | None = None,
+        max_output_bytes: int = MAX_TOOL_OUTPUT_BYTES,
+    ) -> None:
+        if not 1024 <= max_output_bytes <= 16 * 1024 * 1024:
+            raise ValueError("tool output limit is invalid")
+        self.store = store
+        self.workspace_broker = workspace_broker
+        self.frozen_checks = dict(frozen_checks or {})
+        self.max_output_bytes = max_output_bytes
+
+    async def execute(
+        self,
+        *,
+        task_id: str,
+        operation_id: str,
+        tool_name: str,
+        arguments: Mapping[str, Any],
+        lease_id: str | None = None,
+    ) -> ToolResult:
+        if SAFE_TOOL_NAME.fullmatch(tool_name) is None:
+            raise ToolBrokerError("Tool name is invalid.", code="tool_not_allowed")
+        task = self.store.get_task(task_id)
+        if task.workspace_id is None:
+            raise ToolBrokerError("Task workspace is unavailable.", code="workspace_unavailable")
+        request = {
+            "arguments": self._json_object(arguments),
+            "lease_id": lease_id,
+            "workspace_id": task.workspace_id,
+        }
+        intent_sha256 = self._intent_sha256(tool_name, request)
+        operation = self.store.create_operation(
+            task_id=task_id,
+            operation_id=operation_id,
+            tool_name=tool_name,
+            intent_sha256=intent_sha256,
+            request=request,
+        )
+        if operation.state is OperationState.COMPLETED:
+            return ToolResult(
+                operation_id=operation_id,
+                tool_name=tool_name,
+                state=operation.state,
+                data=operation.result or {},
+            )
+        if operation.state is OperationState.UNKNOWN:
+            return self.reconcile(operation_id)
+        if operation.state is not OperationState.PREPARED:
+            raise ToolBrokerError(
+                "Tool operation cannot be replayed.", code="operation_not_replayable"
+            )
+        try:
+            self._authorize(task.spec.policy_profile, tool_name, lease_id, task_id, request)
+            self.store.transition_operation(
+                operation_id,
+                OperationState.RUNNING,
+                expected_state=OperationState.PREPARED,
+            )
+            data = await self._dispatch(task.workspace_id, tool_name, request["arguments"])
+            completed = self.store.transition_operation(
+                operation_id,
+                OperationState.COMPLETED,
+                result=data,
+                expected_state=OperationState.RUNNING,
+            )
+            return ToolResult(
+                operation_id=operation_id,
+                tool_name=tool_name,
+                state=completed.state,
+                data=completed.result or {},
+            )
+        except (
+            ToolBrokerError,
+            WorkerConflictError,
+            WorkspaceError,
+            OSError,
+            asyncio.TimeoutError,
+        ) as exc:
+            current = self.store.get_operation(operation_id)
+            if current.state in {OperationState.PREPARED, OperationState.RUNNING}:
+                self.store.transition_operation(
+                    operation_id,
+                    OperationState.FAILED,
+                    result={"code": getattr(exc, "code", "tool_failed")},
+                    expected_state=current.state,
+                )
+            if isinstance(exc, ToolBrokerError):
+                raise
+            raise ToolBrokerError("Tool operation failed.", code=getattr(exc, "code", "tool_failed")) from exc
+
+    def reconcile(self, operation_id: str) -> ToolResult:
+        operation = self.store.get_operation(operation_id)
+        if operation.state is OperationState.COMPLETED:
+            return ToolResult(
+                operation_id=operation_id,
+                tool_name=operation.tool_name,
+                state=operation.state,
+                data=operation.result or {},
+            )
+        if operation.state is not OperationState.UNKNOWN:
+            raise ToolBrokerError(
+                "Tool operation is not awaiting reconciliation.",
+                code="operation_not_reconcilable",
+            )
+        workspace_id = str(operation.request["workspace_id"])
+        arguments = self._json_object(operation.request["arguments"])
+        if operation.tool_name == "write_file":
+            target = self._target(workspace_id, str(arguments.get("path", "")))
+            expected = str(arguments.get("content_sha256", ""))
+            if target.is_file() and not target.is_symlink():
+                actual = hashlib.sha256(target.read_bytes()).hexdigest()
+                if actual == expected:
+                    resolved = self.store.transition_operation(
+                        operation_id,
+                        OperationState.COMPLETED,
+                        result={"path": str(arguments["path"]), "sha256": actual},
+                        expected_state=OperationState.UNKNOWN,
+                    )
+                    return ToolResult(
+                        operation_id=operation_id,
+                        tool_name=operation.tool_name,
+                        state=resolved.state,
+                        data=resolved.result or {},
+                    )
+        elif operation.tool_name == "delete_file":
+            target = self._target(workspace_id, str(arguments.get("path", "")))
+            if not target.exists() and not target.is_symlink():
+                resolved = self.store.transition_operation(
+                    operation_id,
+                    OperationState.COMPLETED,
+                    result={"path": str(arguments["path"]), "deleted": True},
+                    expected_state=OperationState.UNKNOWN,
+                )
+                return ToolResult(
+                    operation_id=operation_id,
+                    tool_name=operation.tool_name,
+                    state=resolved.state,
+                    data=resolved.result or {},
+                )
+        raise ToolBrokerError(
+            "Tool result is unknown and must not be replayed.",
+            code="operation_result_unknown",
+        )
+
+    def _authorize(
+        self,
+        profile: PolicyProfile,
+        tool_name: str,
+        lease_id: str | None,
+        task_id: str,
+        request: dict[str, Any],
+    ) -> None:
+        readonly = {"list_files", "read_file", "search_text", "diff"}
+        if tool_name in readonly:
+            return
+        if tool_name in {"write_file", "delete_file", "run_check"}:
+            if profile not in {PolicyProfile.DEVELOP, PolicyProfile.DEVELOP_NETWORKED}:
+                raise ToolBrokerError("Task policy is read-only.", code="approval_required")
+            return
+        capability: CapabilityName
+        if tool_name == "run_command":
+            capability = "command"
+        else:
+            raise ToolBrokerError("Tool is not available.", code="tool_not_allowed")
+        if lease_id is None:
+            raise ToolBrokerError("Tool requires approval.", code="approval_required")
+        lease = self.store.consume_lease(lease_id, task_id=task_id, capability=capability)
+        requested_argv = request["arguments"].get("argv")
+        if lease.scope.get("argv") != requested_argv:
+            raise ToolBrokerError("Approval does not match the command.", code="lease_scope_mismatch")
+
+    async def _dispatch(
+        self, workspace_id: str, tool_name: str, arguments: dict[str, Any]
+    ) -> dict[str, Any]:
+        if tool_name == "list_files":
+            return {
+                "entries": [
+                    entry.model_dump(mode="json")
+                    for entry in self.workspace_broker.tree(workspace_id)
+                ]
+            }
+        if tool_name == "read_file":
+            target = self._target(workspace_id, str(arguments.get("path", "")))
+            content = target.read_bytes()
+            if len(content) > self.max_output_bytes:
+                raise ToolBrokerError("File is too large.", code="tool_output_too_large")
+            try:
+                text = content.decode("utf-8")
+            except UnicodeDecodeError:
+                return {
+                    "path": str(arguments["path"]),
+                    "binary": True,
+                    "size": len(content),
+                    "sha256": hashlib.sha256(content).hexdigest(),
+                }
+            return {"path": str(arguments["path"]), "binary": False, "content": text}
+        if tool_name == "search_text":
+            needle = str(arguments.get("query", ""))
+            if not needle or len(needle) > 512:
+                raise ToolBrokerError("Search query is invalid.", code="tool_input_invalid")
+            matches: list[dict[str, Any]] = []
+            for entry in self.workspace_broker.tree(workspace_id):
+                if entry.kind != "file" or entry.size > 1024 * 1024:
+                    continue
+                target = self._target(workspace_id, entry.display_path)
+                try:
+                    lines = target.read_text(encoding="utf-8").splitlines()
+                except UnicodeDecodeError:
+                    continue
+                for number, line in enumerate(lines, 1):
+                    if needle in line:
+                        matches.append({"path": entry.display_path, "line": number, "text": line[:1000]})
+                        if len(matches) >= 1000:
+                            return {"matches": matches, "truncated": True}
+            return {"matches": matches, "truncated": False}
+        if tool_name == "diff":
+            value = self.workspace_broker.diff(workspace_id, max_bytes=self.max_output_bytes)
+            return {"diff": value.decode("utf-8", errors="replace")}
+        if tool_name == "write_file":
+            return self._write_file(workspace_id, arguments)
+        if tool_name == "delete_file":
+            return self._delete_file(workspace_id, arguments)
+        if tool_name == "run_check":
+            check_id = str(arguments.get("check_id", ""))
+            check = self.frozen_checks.get(check_id)
+            if check is None:
+                raise ToolBrokerError("Check is not registered.", code="check_not_found")
+            return await self._run_process(
+                workspace_id, check.argv, check.timeout_seconds, trusted=True
+            )
+        if tool_name == "run_command":
+            argv = arguments.get("argv")
+            timeout = arguments.get("timeout_seconds", 300)
+            if not isinstance(argv, list) or not all(isinstance(item, str) for item in argv):
+                raise ToolBrokerError("Command argv is invalid.", code="tool_input_invalid")
+            if isinstance(timeout, bool) or not isinstance(timeout, int) or not 1 <= timeout <= 1800:
+                raise ToolBrokerError("Command timeout is invalid.", code="tool_input_invalid")
+            return await self._run_process(workspace_id, tuple(argv), timeout)
+        raise ToolBrokerError("Tool is not available.", code="tool_not_allowed")
+
+    def _write_file(self, workspace_id: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        path = str(arguments.get("path", ""))
+        content = arguments.get("content")
+        expected = str(arguments.get("content_sha256", ""))
+        if not isinstance(content, str):
+            raise ToolBrokerError("File content must be text.", code="tool_input_invalid")
+        encoded = content.encode("utf-8")
+        actual = hashlib.sha256(encoded).hexdigest()
+        if len(encoded) > MAX_WRITE_BYTES or expected != actual:
+            raise ToolBrokerError("File content binding is invalid.", code="tool_input_invalid")
+        target = self._target(workspace_id, path, create_parents=True)
+        if target.exists() and (not target.is_file() or target.is_symlink()):
+            raise ToolBrokerError("Target is not a regular file.", code="workspace_changed")
+        repository = self.workspace_broker.repository_path(workspace_id)
+        stage_root = repository.parent / "broker-stage"
+        stage_root.mkdir(exist_ok=True)
+        fd, temporary = tempfile.mkstemp(prefix="write-", dir=stage_root)
+        try:
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(encoded)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary, target)
+        finally:
+            try:
+                os.unlink(temporary)
+            except FileNotFoundError:
+                pass
+        return {"path": path, "sha256": actual, "size": len(encoded)}
+
+    def _delete_file(self, workspace_id: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        path = str(arguments.get("path", ""))
+        target = self._target(workspace_id, path)
+        expected = str(arguments.get("expected_sha256", ""))
+        if not target.is_file() or target.is_symlink():
+            raise ToolBrokerError("Target is not a regular file.", code="workspace_changed")
+        if hashlib.sha256(target.read_bytes()).hexdigest() != expected:
+            raise ToolBrokerError("Target changed before deletion.", code="workspace_changed")
+        target.unlink()
+        return {"path": path, "deleted": True}
+
+    async def _run_process(
+        self,
+        workspace_id: str,
+        argv: Sequence[str],
+        timeout_seconds: int,
+        *,
+        trusted: bool = False,
+    ) -> dict[str, Any]:
+        normalized = self._validate_argv(argv, trusted=trusted)
+        repository = self.workspace_broker.repository_path(workspace_id)
+        process = await asyncio.create_subprocess_exec(
+            *normalized,
+            cwd=repository,
+            env=self._safe_environment(repository),
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+        try:
+            output, _ = await asyncio.wait_for(process.communicate(), timeout=timeout_seconds)
+        except asyncio.TimeoutError:
+            process.kill()
+            await process.wait()
+            raise ToolBrokerError("Command timed out.", code="command_timeout")
+        if len(output) > self.max_output_bytes:
+            raise ToolBrokerError("Command output is too large.", code="tool_output_too_large")
+        return {
+            "argv": list(normalized),
+            "exit_code": int(process.returncode or 0),
+            "output": output.decode("utf-8", errors="replace"),
+        }
+
+    def _target(self, workspace_id: str, value: str, *, create_parents: bool = False) -> Path:
+        path = PurePosixPath(value)
+        if (
+            not value
+            or "\\" in value
+            or path.is_absolute()
+            or any(part in {"", ".", "..", ".git"} for part in path.parts)
+        ):
+            raise ToolBrokerError("Workspace path is invalid.", code="workspace_path_invalid")
+        repository = self.workspace_broker.repository_path(workspace_id)
+        parent = repository
+        for part in path.parts[:-1]:
+            parent = parent / part
+            if parent.exists():
+                if not parent.is_dir() or parent.is_symlink():
+                    raise ToolBrokerError("Workspace path changed.", code="workspace_changed")
+            elif create_parents:
+                parent.mkdir()
+            else:
+                raise ToolBrokerError("Workspace path was not found.", code="entry_not_found")
+        target = parent / path.name
+        if target.parent.resolve() != parent.resolve() or repository not in target.parents:
+            raise ToolBrokerError("Workspace path escaped the task.", code="workspace_path_invalid")
+        return target
+
+    @staticmethod
+    def _validate_argv(argv: Sequence[str], *, trusted: bool = False) -> tuple[str, ...]:
+        if not argv or len(argv) > 64 or any(not item or "\x00" in item for item in argv):
+            raise ToolBrokerError("Command argv is invalid.", code="tool_input_invalid")
+        executable = Path(argv[0]).name.lower()
+        if executable.endswith(".exe"):
+            executable = executable[:-4]
+        if executable in ALWAYS_DENIED_EXECUTABLES or (
+            Path(argv[0]).is_absolute() and not trusted
+        ):
+            raise ToolBrokerError("Command is always denied.", code="command_denied")
+        if executable == "git" and len(argv) > 1 and argv[1].lower() in DENIED_GIT_SUBCOMMANDS:
+            raise ToolBrokerError("Git remote operations are denied.", code="command_denied")
+        for item in argv[1:]:
+            path = PurePosixPath(item.replace("\\", "/"))
+            if Path(item).is_absolute() or ".." in path.parts:
+                raise ToolBrokerError("Command contains a host path.", code="command_denied")
+        return tuple(argv)
+
+    @staticmethod
+    def _safe_environment(repository: Path) -> dict[str, str]:
+        environment = {
+            "HOME": str(repository.parent / "home"),
+            "LANG": "C.UTF-8",
+            "LC_ALL": "C.UTF-8",
+            "PATH": "/usr/local/bin:/usr/bin:/bin",
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_TERMINAL_PROMPT": "0",
+            "GIT_NO_LAZY_FETCH": "1",
+            "GIT_NO_REPLACE_OBJECTS": "1",
+        }
+        if os.name == "nt":
+            environment["PATH"] = os.environ.get("PATH", "")
+            environment["SYSTEMROOT"] = os.environ.get("SYSTEMROOT", "C:\\Windows")
+        Path(environment["HOME"]).mkdir(exist_ok=True)
+        return environment
+
+    @staticmethod
+    def _intent_sha256(tool_name: str, request: dict[str, Any]) -> str:
+        encoded = json.dumps(
+            {"tool": tool_name, "request": request},
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+    @staticmethod
+    def _json_object(value: Mapping[str, Any] | Any) -> dict[str, Any]:
+        try:
+            encoded = json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+            decoded = json.loads(encoded)
+        except (TypeError, ValueError) as exc:
+            raise ToolBrokerError("Tool input is not JSON.", code="tool_input_invalid") from exc
+        if not isinstance(decoded, dict):
+            raise ToolBrokerError("Tool input must be an object.", code="tool_input_invalid")
+        return decoded

--- a/server/coding_worker/tool_broker.py
+++ b/server/coding_worker/tool_broker.py
@@ -15,7 +15,14 @@ from urllib.parse import urlsplit
 
 from pydantic import Field
 
-from .contracts import CapabilityName, OperationState, PolicyProfile, StrictModel, TaskState
+from .contracts import (
+    CapabilityLease,
+    CapabilityName,
+    OperationState,
+    PolicyProfile,
+    StrictModel,
+    TaskState,
+)
 from .process_manager import BackgroundProcessManager, ProcessManagerError
 from .network_policy import EgressPolicy, NetworkPolicyError
 from .store import CodingWorkerStore, WorkerConflictError
@@ -146,7 +153,7 @@ class ToolBroker:
                 "Tool operation cannot be replayed.", code="operation_not_replayable"
             )
         try:
-            self._authorize(
+            network_lease = self._authorize(
                 task.spec.policy_profile,
                 tool_name,
                 lease_id,
@@ -161,7 +168,11 @@ class ToolBroker:
                 expected_state=OperationState.PREPARED,
             )
             data = await self._dispatch(
-                task_id, task.workspace_id, tool_name, request["arguments"]
+                task_id,
+                task.workspace_id,
+                tool_name,
+                request["arguments"],
+                network_lease=network_lease,
             )
             completed = self.store.transition_operation(
                 operation_id,
@@ -279,10 +290,10 @@ class ToolBroker:
         operation_id: str,
         request: dict[str, Any],
         network_lease_id: str | None,
-    ) -> None:
+    ) -> CapabilityLease | None:
         readonly = {"list_files", "read_file", "search_text", "diff", "service_status"}
         if tool_name in readonly:
-            return
+            return None
         if tool_name in {
             "write_file",
             "delete_file",
@@ -292,7 +303,7 @@ class ToolBroker:
         }:
             if profile not in {PolicyProfile.DEVELOP, PolicyProfile.DEVELOP_NETWORKED}:
                 raise ToolBrokerError("Task policy is read-only.", code="approval_required")
-            return
+            return None
         capability: CapabilityName
         if tool_name == "run_command":
             capability = "command"
@@ -338,15 +349,17 @@ class ToolBroker:
         lease = self.store.consume_lease(lease_id, task_id=task_id, capability=capability)
         if lease.scope != request["arguments"]:
             raise ToolBrokerError("Approval does not match the request.", code="lease_scope_mismatch")
+        consumed_network_lease: CapabilityLease | None = None
         if network_scope is not None:
-            network_lease = self.store.consume_lease(
+            consumed_network_lease = self.store.consume_lease(
                 str(network_lease_id), task_id=task_id, capability="network"
             )
             self._require_egress_policy().validate_lease_scope(
-                lease=network_lease,
+                lease=consumed_network_lease,
                 domains=("registry.npmjs.org",),
                 purpose="dependency-install",
             )
+        return consumed_network_lease
 
     async def _dispatch(
         self,
@@ -354,6 +367,8 @@ class ToolBroker:
         workspace_id: str,
         tool_name: str,
         arguments: dict[str, Any],
+        *,
+        network_lease: CapabilityLease | None,
     ) -> dict[str, Any]:
         if tool_name == "list_files":
             return {
@@ -500,14 +515,24 @@ class ToolBroker:
                 )
             if self.egress_proxy_url is None:
                 raise ToolBrokerError("Egress proxy is unavailable.", code="network_disabled")
+            if network_lease is None:
+                raise ToolBrokerError(
+                    "Network lease is unavailable.", code="network_lease_invalid"
+                )
+            authenticated_proxy = self._require_egress_policy().proxy_url(
+                base_url=self.egress_proxy_url,
+                lease=network_lease,
+                task_id=task_id,
+                purpose="dependency-install",
+            )
             result = await self._run_process(
                 task_id,
                 workspace_id,
                 ("npm", "ci", "--ignore-scripts", "--no-audit", "--no-fund"),
                 1800,
                 environment_overrides={
-                    "HTTPS_PROXY": self.egress_proxy_url,
-                    "HTTP_PROXY": self.egress_proxy_url,
+                    "HTTPS_PROXY": authenticated_proxy,
+                    "HTTP_PROXY": authenticated_proxy,
                     "NO_PROXY": "",
                     "npm_config_registry": "https://registry.npmjs.org/",
                     "npm_config_ignore_scripts": "true",

--- a/server/coding_worker/tool_broker.py
+++ b/server/coding_worker/tool_broker.py
@@ -421,17 +421,17 @@ class ToolBroker:
                 stderr=asyncio.subprocess.STDOUT,
             )
             try:
-                output, _ = await asyncio.wait_for(
-                    process.communicate(), timeout=timeout_seconds
+                output = await asyncio.wait_for(
+                    self._collect_bounded_output(process), timeout=timeout_seconds
                 )
             except asyncio.TimeoutError:
                 process.kill()
                 await process.wait()
                 raise ToolBrokerError("Command timed out.", code="command_timeout")
-            if len(output) > self.max_output_bytes:
-                raise ToolBrokerError(
-                    "Command output is too large.", code="tool_output_too_large"
-                )
+            except asyncio.CancelledError:
+                process.kill()
+                await process.wait()
+                raise
             return {
                 "argv": list(normalized),
                 "exit_code": int(process.returncode or 0),
@@ -440,6 +440,28 @@ class ToolBroker:
         finally:
             if execution_root is not None:
                 self.workspace_broker._remove_tree(execution_root)
+
+    async def _collect_bounded_output(
+        self, process: asyncio.subprocess.Process
+    ) -> bytes:
+        if process.stdout is None:
+            raise ToolBrokerError("Command output is unavailable.", code="command_failed")
+        chunks: list[bytes] = []
+        size = 0
+        while True:
+            chunk = await process.stdout.read(64 * 1024)
+            if not chunk:
+                break
+            size += len(chunk)
+            if size > self.max_output_bytes:
+                process.kill()
+                await process.wait()
+                raise ToolBrokerError(
+                    "Command output is too large.", code="tool_output_too_large"
+                )
+            chunks.append(chunk)
+        await process.wait()
+        return b"".join(chunks)
 
     def _target(self, workspace_id: str, value: str, *, create_parents: bool = False) -> Path:
         path = PurePosixPath(value)

--- a/server/coding_worker/tool_broker.py
+++ b/server/coding_worker/tool_broker.py
@@ -5,7 +5,9 @@ import hashlib
 import json
 import os
 import re
+import shutil
 import tempfile
+import uuid
 from collections.abc import Mapping, Sequence
 from pathlib import Path, PurePosixPath
 from typing import Any
@@ -325,7 +327,11 @@ class ToolBroker:
             if check is None:
                 raise ToolBrokerError("Check is not registered.", code="check_not_found")
             return await self._run_process(
-                workspace_id, check.argv, check.timeout_seconds, trusted=True
+                workspace_id,
+                check.argv,
+                check.timeout_seconds,
+                trusted=True,
+                isolated=True,
             )
         if tool_name == "run_command":
             argv = arguments.get("argv")
@@ -385,30 +391,55 @@ class ToolBroker:
         timeout_seconds: int,
         *,
         trusted: bool = False,
+        isolated: bool = False,
     ) -> dict[str, Any]:
         normalized = self._validate_argv(argv, trusted=trusted)
         repository = self.workspace_broker.repository_path(workspace_id)
-        process = await asyncio.create_subprocess_exec(
-            *normalized,
-            cwd=repository,
-            env=self._safe_environment(repository),
-            stdin=asyncio.subprocess.DEVNULL,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT,
-        )
+        execution_root: Path | None = None
+        execution_repository = repository
         try:
-            output, _ = await asyncio.wait_for(process.communicate(), timeout=timeout_seconds)
-        except asyncio.TimeoutError:
-            process.kill()
-            await process.wait()
-            raise ToolBrokerError("Command timed out.", code="command_timeout")
-        if len(output) > self.max_output_bytes:
-            raise ToolBrokerError("Command output is too large.", code="tool_output_too_large")
-        return {
-            "argv": list(normalized),
-            "exit_code": int(process.returncode or 0),
-            "output": output.decode("utf-8", errors="replace"),
-        }
+            if isolated:
+                self.workspace_broker.tree(workspace_id)
+                execution_root = (
+                    self.workspace_broker.root
+                    / "harness-runs"
+                    / f"run_{uuid.uuid4().hex}"
+                )
+                execution_root.parent.mkdir(exist_ok=True)
+                shutil.copytree(
+                    repository,
+                    execution_root,
+                    ignore=shutil.ignore_patterns(".git"),
+                )
+                execution_repository = execution_root
+            process = await asyncio.create_subprocess_exec(
+                *normalized,
+                cwd=execution_repository,
+                env=self._safe_environment(execution_repository),
+                stdin=asyncio.subprocess.DEVNULL,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+            )
+            try:
+                output, _ = await asyncio.wait_for(
+                    process.communicate(), timeout=timeout_seconds
+                )
+            except asyncio.TimeoutError:
+                process.kill()
+                await process.wait()
+                raise ToolBrokerError("Command timed out.", code="command_timeout")
+            if len(output) > self.max_output_bytes:
+                raise ToolBrokerError(
+                    "Command output is too large.", code="tool_output_too_large"
+                )
+            return {
+                "argv": list(normalized),
+                "exit_code": int(process.returncode or 0),
+                "output": output.decode("utf-8", errors="replace"),
+            }
+        finally:
+            if execution_root is not None:
+                self.workspace_broker._remove_tree(execution_root)
 
     def _target(self, workspace_id: str, value: str, *, create_parents: bool = False) -> Path:
         path = PurePosixPath(value)

--- a/server/coding_worker/tool_broker.py
+++ b/server/coding_worker/tool_broker.py
@@ -76,7 +76,7 @@ class ToolResult(StrictModel):
 
 class ToolExecutor(Protocol):
     async def run_process(self, *, task_id: str, workspace_id: str, argv: Sequence[str], timeout_seconds: int, isolated: bool, environment_overrides: Mapping[str, str] | None = None) -> dict[str, Any]: ...
-    async def start_service(self, *, task_id: str, workspace_id: str, argv: Sequence[str], ttl_seconds: int) -> dict[str, Any]: ...
+    async def start_service(self, *, task_id: str, workspace_id: str, argv: Sequence[str], ttl_seconds: int, preview_port: int | None = None) -> dict[str, Any]: ...
     async def service_status(self, *, task_id: str, workspace_id: str, service_id: str) -> dict[str, Any]: ...
     async def service_input(self, *, task_id: str, workspace_id: str, service_id: str, data: str) -> dict[str, Any]: ...
     async def stop_service(self, *, task_id: str, workspace_id: str, service_id: str) -> dict[str, Any]: ...
@@ -442,20 +442,36 @@ class ToolBroker:
         if tool_name == "start_service":
             argv = arguments.get("argv")
             ttl = arguments.get("ttl_seconds", 900)
+            preview_port = arguments.get("preview_port")
             if (
                 not isinstance(argv, list)
                 or not all(isinstance(item, str) for item in argv)
                 or isinstance(ttl, bool)
                 or not isinstance(ttl, int)
+                or (
+                    preview_port is not None
+                    and (
+                        isinstance(preview_port, bool)
+                        or not isinstance(preview_port, int)
+                        or not 1024 <= preview_port <= 65535
+                    )
+                )
             ):
                 raise ToolBrokerError("Service input is invalid.", code="tool_input_invalid")
             if self.executor is not None:
-                return await self.executor.start_service(
+                result = await self.executor.start_service(
                     task_id=task_id,
                     workspace_id=workspace_id,
                     argv=self._validate_argv(argv),
                     ttl_seconds=ttl,
+                    preview_port=preview_port,
                 )
+                if preview_port is not None:
+                    result["preview_url"] = (
+                        f"/api/coding-worker/v1/tasks/{task_id}/services/"
+                        f"{result['service_id']}/preview/"
+                    )
+                return result
             record = await self._require_process_manager().start(
                 task_id=task_id,
                 workspace_id=workspace_id,

--- a/server/coding_worker/tool_broker.py
+++ b/server/coding_worker/tool_broker.py
@@ -15,6 +15,7 @@ from typing import Any
 from pydantic import Field
 
 from .contracts import CapabilityName, OperationState, PolicyProfile, StrictModel, TaskState
+from .process_manager import BackgroundProcessManager, ProcessManagerError
 from .store import CodingWorkerStore, WorkerConflictError
 from .workspace import WorkspaceBroker, WorkspaceError
 
@@ -77,6 +78,7 @@ class ToolBroker:
         store: CodingWorkerStore,
         workspace_broker: WorkspaceBroker,
         frozen_checks: Mapping[str, FrozenCheck] | None = None,
+        process_manager: BackgroundProcessManager | None = None,
         max_output_bytes: int = MAX_TOOL_OUTPUT_BYTES,
     ) -> None:
         if not 1024 <= max_output_bytes <= 16 * 1024 * 1024:
@@ -84,6 +86,7 @@ class ToolBroker:
         self.store = store
         self.workspace_broker = workspace_broker
         self.frozen_checks = dict(frozen_checks or {})
+        self.process_manager = process_manager
         self.max_output_bytes = max_output_bytes
 
     async def execute(
@@ -139,7 +142,9 @@ class ToolBroker:
                 OperationState.RUNNING,
                 expected_state=OperationState.PREPARED,
             )
-            data = await self._dispatch(task.workspace_id, tool_name, request["arguments"])
+            data = await self._dispatch(
+                task_id, task.workspace_id, tool_name, request["arguments"]
+            )
             completed = self.store.transition_operation(
                 operation_id,
                 OperationState.COMPLETED,
@@ -156,6 +161,7 @@ class ToolBroker:
             ToolBrokerError,
             WorkerConflictError,
             WorkspaceError,
+            ProcessManagerError,
             OSError,
             asyncio.TimeoutError,
         ) as exc:
@@ -242,16 +248,24 @@ class ToolBroker:
         operation_id: str,
         request: dict[str, Any],
     ) -> None:
-        readonly = {"list_files", "read_file", "search_text", "diff"}
+        readonly = {"list_files", "read_file", "search_text", "diff", "service_status"}
         if tool_name in readonly:
             return
-        if tool_name in {"write_file", "delete_file", "run_check"}:
+        if tool_name in {
+            "write_file",
+            "delete_file",
+            "run_check",
+            "service_input",
+            "stop_service",
+        }:
             if profile not in {PolicyProfile.DEVELOP, PolicyProfile.DEVELOP_NETWORKED}:
                 raise ToolBrokerError("Task policy is read-only.", code="approval_required")
             return
         capability: CapabilityName
         if tool_name == "run_command":
             capability = "command"
+        elif tool_name == "start_service":
+            capability = "service"
         else:
             raise ToolBrokerError("Tool is not available.", code="tool_not_allowed")
         if lease_id is None:
@@ -266,12 +280,15 @@ class ToolBroker:
                 self.store.transition(task_id, TaskState.WAITING_APPROVAL)
             raise ToolBrokerError("Tool requires approval.", code="approval_required")
         lease = self.store.consume_lease(lease_id, task_id=task_id, capability=capability)
-        requested_argv = request["arguments"].get("argv")
-        if lease.scope.get("argv") != requested_argv:
-            raise ToolBrokerError("Approval does not match the command.", code="lease_scope_mismatch")
+        if lease.scope != request["arguments"]:
+            raise ToolBrokerError("Approval does not match the request.", code="lease_scope_mismatch")
 
     async def _dispatch(
-        self, workspace_id: str, tool_name: str, arguments: dict[str, Any]
+        self,
+        task_id: str,
+        workspace_id: str,
+        tool_name: str,
+        arguments: dict[str, Any],
     ) -> dict[str, Any]:
         if tool_name == "list_files":
             return {
@@ -341,7 +358,53 @@ class ToolBroker:
             if isinstance(timeout, bool) or not isinstance(timeout, int) or not 1 <= timeout <= 1800:
                 raise ToolBrokerError("Command timeout is invalid.", code="tool_input_invalid")
             return await self._run_process(workspace_id, tuple(argv), timeout)
+        if tool_name == "start_service":
+            manager = self._require_process_manager()
+            argv = arguments.get("argv")
+            ttl = arguments.get("ttl_seconds", 900)
+            if (
+                not isinstance(argv, list)
+                or not all(isinstance(item, str) for item in argv)
+                or isinstance(ttl, bool)
+                or not isinstance(ttl, int)
+            ):
+                raise ToolBrokerError("Service input is invalid.", code="tool_input_invalid")
+            record = await manager.start(
+                task_id=task_id,
+                workspace_id=workspace_id,
+                argv=self._validate_argv(argv),
+                ttl_seconds=ttl,
+            )
+            return record.model_dump(mode="json")
+        if tool_name == "service_status":
+            record = self._require_process_manager().status(
+                task_id=task_id,
+                service_id=str(arguments.get("service_id", "")),
+            )
+            return record.model_dump(mode="json")
+        if tool_name == "service_input":
+            service_id = str(arguments.get("service_id", ""))
+            data = arguments.get("data")
+            if not isinstance(data, str):
+                raise ToolBrokerError("Service input is invalid.", code="tool_input_invalid")
+            await self._require_process_manager().send_input(
+                task_id=task_id,
+                service_id=service_id,
+                data=data.encode("utf-8"),
+            )
+            return {"service_id": service_id, "accepted": True}
+        if tool_name == "stop_service":
+            record = await self._require_process_manager().interrupt(
+                task_id=task_id,
+                service_id=str(arguments.get("service_id", "")),
+            )
+            return record.model_dump(mode="json")
         raise ToolBrokerError("Tool is not available.", code="tool_not_allowed")
+
+    def _require_process_manager(self) -> BackgroundProcessManager:
+        if self.process_manager is None:
+            raise ToolBrokerError("Service manager is unavailable.", code="service_unavailable")
+        return self.process_manager
 
     def _write_file(self, workspace_id: str, arguments: dict[str, Any]) -> dict[str, Any]:
         path = str(arguments.get("path", ""))

--- a/server/coding_worker/workspace.py
+++ b/server/coding_worker/workspace.py
@@ -6,6 +6,7 @@ import json
 import os
 import re
 import shutil
+import stat
 import subprocess
 import tempfile
 import uuid
@@ -393,4 +394,20 @@ class WorkspaceBroker:
     @staticmethod
     def _remove_tree(path: Path) -> None:
         if path.exists():
-            shutil.rmtree(path)
+            root = path.resolve()
+
+            def remove_owned_readonly(
+                function: object, name: str, error: tuple[type[BaseException], BaseException, object]
+            ) -> None:
+                failure = error[1]
+                target = Path(name)
+                try:
+                    metadata = os.lstat(target)
+                    if stat.S_ISLNK(metadata.st_mode) or not target.resolve().is_relative_to(root):
+                        raise failure
+                    os.chmod(target, metadata.st_mode | stat.S_IWRITE)
+                    function(name)  # type: ignore[operator]
+                except Exception:
+                    raise failure
+
+            shutil.rmtree(path, onerror=remove_owned_readonly)

--- a/server/coding_worker/workspace.py
+++ b/server/coding_worker/workspace.py
@@ -44,6 +44,7 @@ class SourceSnapshot(StrictModel):
 
 class WorkspaceRecord(StrictModel):
     workspace_id: str
+    slot_id: str = "default"
     source: WorkspaceSource
     baseline_commit: str = Field(pattern=r"^[a-f0-9]{40}$")
     baseline_tree_hash: str = Field(pattern=r"^[a-f0-9]{64}$")
@@ -87,18 +88,37 @@ class WorkspaceBroker:
         adapters: Mapping[str, WorkspaceSourceAdapter],
         *,
         id_key: bytes,
+        slot_roots: Mapping[str, Path] | None = None,
     ) -> None:
         if len(id_key) < 32:
             raise ValueError("workspace id key is too short")
         self.root = Path(root).resolve()
-        self.workspaces_root = self.root / "workspaces"
-        self.staging_root = self.root / "workspace-staging"
+        self.dedicated_slots = slot_roots is not None
+        configured = slot_roots or {"default": self.root}
+        if not configured or any(
+            re.fullmatch(r"[a-z0-9][a-z0-9-]{0,31}", key) is None
+            for key in configured
+        ):
+            raise ValueError("workspace slot id is invalid")
+        self._slot_roots = {
+            key: Path(value).resolve() for key, value in configured.items()
+        }
+        first_root = next(iter(self._slot_roots.values()))
+        self.workspaces_root = first_root / "workspaces"
+        self.staging_root = first_root / "workspace-staging"
         self._adapters = dict(adapters)
         self._id_key = bytes(id_key)
-        self.workspaces_root.mkdir(parents=True, exist_ok=True)
-        self.staging_root.mkdir(parents=True, exist_ok=True)
+        for slot_root in self._slot_roots.values():
+            (slot_root / "workspaces").mkdir(parents=True, exist_ok=True)
+            (slot_root / "workspace-staging").mkdir(parents=True, exist_ok=True)
 
-    async def prepare(self, source: WorkspaceSource) -> WorkspaceRecord:
+    @property
+    def slot_ids(self) -> tuple[str, ...]:
+        return tuple(self._slot_roots)
+
+    async def prepare(
+        self, source: WorkspaceSource, *, slot_id: str | None = None
+    ) -> WorkspaceRecord:
         adapter = self._adapters.get(source.kind)
         if adapter is None:
             raise WorkspaceError("Workspace source kind is unavailable.", code="source_unavailable")
@@ -106,9 +126,15 @@ class WorkspaceBroker:
         if snapshot.source != source:
             raise WorkspaceError("Workspace source binding changed.", code="source_changed")
         normalized = self._validate_snapshot(snapshot.files)
+        selected_slot = slot_id or (None if self.dedicated_slots else "default")
+        slot_root = self._slot_roots.get(selected_slot or "")
+        if slot_root is None:
+            raise WorkspaceError(
+                "Workspace slot is unavailable.", code="workspace_slot_unavailable"
+            )
         workspace_id = f"workspace_{uuid.uuid4().hex}"
-        stage = self.staging_root / workspace_id
-        destination = self.workspaces_root / workspace_id
+        stage = slot_root / "workspace-staging" / workspace_id
+        destination = slot_root / "workspaces" / workspace_id
         if stage.exists() or destination.exists():
             raise WorkspaceError("Workspace id collision.", code="workspace_unavailable")
         repository = stage / "repo"
@@ -125,6 +151,7 @@ class WorkspaceBroker:
             total_bytes = sum(len(file.content) for _, file in normalized)
             metadata = WorkspaceRecord(
                 workspace_id=workspace_id,
+                slot_id=selected_slot or "",
                 source=source,
                 baseline_commit=baseline_commit,
                 baseline_tree_hash=baseline_tree_hash,
@@ -152,15 +179,22 @@ class WorkspaceBroker:
             ) from exc
 
     def get(self, workspace_id: str) -> WorkspaceRecord:
-        root = self._workspace_root(workspace_id)
+        slot_id, root = self._workspace_location(workspace_id)
         try:
             value = json.loads((root / "metadata.json").read_text(encoding="utf-8"))
             record = WorkspaceRecord.model_validate(value)
         except (OSError, json.JSONDecodeError, ValueError) as exc:
             raise WorkspaceError("Workspace metadata is invalid.", code="workspace_corrupt") from exc
-        if record.workspace_id != workspace_id or not (root / "repo").is_dir():
+        if (
+            record.workspace_id != workspace_id
+            or record.slot_id != slot_id
+            or not (root / "repo").is_dir()
+        ):
             raise WorkspaceError("Workspace metadata is invalid.", code="workspace_corrupt")
         return record
+
+    def workspace_slot(self, workspace_id: str) -> str:
+        return self._workspace_location(workspace_id)[0]
 
     def repository_path(self, workspace_id: str) -> Path:
         root = self._workspace_root(workspace_id)
@@ -255,12 +289,20 @@ class WorkspaceBroker:
         self._remove_tree(self._workspace_root(workspace_id))
 
     def _workspace_root(self, workspace_id: str) -> Path:
+        return self._workspace_location(workspace_id)[1]
+
+    def _workspace_location(self, workspace_id: str) -> tuple[str, Path]:
         if SAFE_WORKSPACE_ID.fullmatch(workspace_id) is None:
             raise WorkspaceError("Workspace id is invalid.", code="workspace_not_found")
-        candidate = self.workspaces_root / workspace_id
-        if not candidate.is_dir() or candidate.is_symlink():
+        matches = [
+            (slot_id, slot_root / "workspaces" / workspace_id)
+            for slot_id, slot_root in self._slot_roots.items()
+            if (slot_root / "workspaces" / workspace_id).is_dir()
+            and not (slot_root / "workspaces" / workspace_id).is_symlink()
+        ]
+        if len(matches) != 1:
             raise WorkspaceError("Workspace was not found.", code="workspace_not_found")
-        return candidate
+        return matches[0]
 
     @staticmethod
     def _validate_snapshot(files: Sequence[SourceFile]) -> list[tuple[PurePosixPath, SourceFile]]:

--- a/server/coding_worker/workspace.py
+++ b/server/coding_worker/workspace.py
@@ -199,6 +199,20 @@ class WorkspaceBroker:
     def workspace_slot(self, workspace_id: str) -> str:
         return self._workspace_location(workspace_id)[0]
 
+    def apply_slot_owner(self, workspace_id: str, path: Path) -> None:
+        if self._slot_owner is None or os.name == "nt":
+            return
+        workspace_root = self._workspace_root(workspace_id)
+        candidate = Path(path)
+        resolved = candidate.resolve(strict=True)
+        if not resolved.is_relative_to(workspace_root) or candidate.is_symlink():
+            raise WorkspaceError(
+                "Workspace ownership target is invalid.", code="workspace_changed"
+            )
+        uid, gid = self._slot_owner
+        os.chown(candidate, uid, gid)
+        candidate.chmod(0o770 if candidate.is_dir() else 0o660)
+
     def repository_path(self, workspace_id: str) -> Path:
         root = self._workspace_root(workspace_id)
         repository = root / "repo"

--- a/server/coding_worker/workspace.py
+++ b/server/coding_worker/workspace.py
@@ -89,6 +89,7 @@ class WorkspaceBroker:
         *,
         id_key: bytes,
         slot_roots: Mapping[str, Path] | None = None,
+        slot_owner: tuple[int, int] | None = None,
     ) -> None:
         if len(id_key) < 32:
             raise ValueError("workspace id key is too short")
@@ -103,6 +104,7 @@ class WorkspaceBroker:
         self._slot_roots = {
             key: Path(value).resolve() for key, value in configured.items()
         }
+        self._slot_owner = slot_owner
         first_root = next(iter(self._slot_roots.values()))
         self.workspaces_root = first_root / "workspaces"
         self.staging_root = first_root / "workspace-staging"
@@ -168,6 +170,7 @@ class WorkspaceBroker:
                 ).encode("utf-8"),
             )
             os.replace(stage, destination)
+            self._apply_slot_owner(destination)
             return self.get(workspace_id)
         except WorkspaceError:
             self._remove_tree(stage)
@@ -453,3 +456,15 @@ class WorkspaceBroker:
                     raise failure
 
             shutil.rmtree(path, onerror=remove_owned_readonly)
+
+    def _apply_slot_owner(self, root: Path) -> None:
+        if self._slot_owner is None or os.name == "nt":
+            return
+        uid, gid = self._slot_owner
+        for candidate in (root, *root.rglob("*")):
+            if candidate.is_symlink():
+                raise WorkspaceError(
+                    "Workspace contains a link.", code="workspace_link_detected"
+                )
+            os.chown(candidate, uid, gid)
+            candidate.chmod(0o770 if candidate.is_dir() else 0o660)

--- a/server/tests/test_coding_worker_api.py
+++ b/server/tests/test_coding_worker_api.py
@@ -163,3 +163,50 @@ def test_approval_endpoints_are_task_bound_and_single_decision(tmp_path: Path) -
             json={"approval_id": approval.approval_id, "decision": "reject"},
         )
         assert replay.status_code == 409
+
+
+def test_evidence_and_artifact_download_are_opaque_and_task_bound(
+    tmp_path: Path,
+) -> None:
+    client, service = _client(tmp_path)
+    with client:
+        first = client.post("/api/coding-worker/v1/tasks", json=_payload()).json()
+        second = client.post(
+            "/api/coding-worker/v1/tasks", json=_payload("api-task-02")
+        ).json()
+        task_id = first["task_id"]
+        asyncio.run(service.wait_for(task_id, lambda item: item.state.value == "blocked"))
+        workspace_id = service.store.get_task(task_id).workspace_id
+        tree_hash = service.workspace_broker.current_tree_hash(workspace_id)
+        artifact = service.store.create_artifact(
+            task_id=task_id,
+            media_type="text/plain; charset=utf-8",
+            content=b"2 passed in 0.10s\n",
+            metadata={"check_id": "pytest", "workspace_tree_hash": tree_hash},
+        )
+        evidence = service.store.record_evidence(
+            task_id=task_id,
+            check_id="pytest",
+            operation_id="api-evidence-operation",
+            workspace_tree_hash=tree_hash,
+            exit_code=0,
+            artifact_id=artifact.artifact_id,
+        )
+
+        listed = client.get(f"/api/coding-worker/v1/tasks/{task_id}/evidence")
+        assert listed.status_code == 200
+        assert listed.json()["evidence"][0]["evidence_id"] == evidence.evidence_id
+        artifacts = client.get(f"/api/coding-worker/v1/tasks/{task_id}/artifacts")
+        assert artifacts.status_code == 200
+        assert artifacts.json()["artifacts"][0]["artifact_id"] == artifact.artifact_id
+        download = client.get(
+            f"/api/coding-worker/v1/tasks/{task_id}/artifacts/{artifact.artifact_id}"
+        )
+        assert download.status_code == 200
+        assert download.content == b"2 passed in 0.10s\n"
+        assert download.headers["cache-control"] == "no-store"
+        assert "C:" not in download.headers["content-disposition"]
+        foreign = client.get(
+            f"/api/coding-worker/v1/tasks/{second['task_id']}/artifacts/{artifact.artifact_id}"
+        )
+        assert foreign.status_code == 404

--- a/server/tests/test_coding_worker_api.py
+++ b/server/tests/test_coding_worker_api.py
@@ -4,11 +4,14 @@ import asyncio
 from pathlib import Path
 
 import pytest
+import httpx
+from unittest.mock import AsyncMock
 from cryptography.fernet import Fernet
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from server.coding_worker.api import configure_coding_worker_for_tests, router
+import server.coding_worker.api as worker_api
 from server.coding_worker.provider import FakeCodingAgentProvider
 from server.coding_worker.service import CodingWorkerService
 from server.coding_worker.store import CodingWorkerStore
@@ -229,3 +232,40 @@ def test_evidence_and_artifact_download_are_opaque_and_task_bound(
             f"/api/coding-worker/v1/tasks/{second['task_id']}/artifacts/{artifact.artifact_id}"
         )
         assert foreign.status_code == 404
+
+
+def test_preview_proxy_uses_only_task_slot_and_registered_port(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    client, service = _client(tmp_path)
+    executor = AsyncMock()
+    service.tool_broker = AsyncMock()
+    service.tool_broker.executor = executor
+    with client:
+        task = client.post("/api/coding-worker/v1/tasks", json=_payload()).json()
+        task_id = task["task_id"]
+        asyncio.run(
+            service.wait_for(task_id, lambda item: item.workspace_id is not None)
+        )
+        executor.service_status.return_value = {
+            "service_id": "service_" + "a" * 32,
+            "task_id": task_id,
+            "state": "running",
+            "preview_port": 4173,
+        }
+        seen: list[str] = []
+
+        async def fetch(url: str) -> httpx.Response:
+            seen.append(url)
+            return httpx.Response(200, content=b"<h1>preview</h1>", headers={"content-type": "text/html"})
+
+        monkeypatch.setattr(worker_api, "_fetch_preview", fetch)
+        response = client.get(
+            f"/api/coding-worker/v1/tasks/{task_id}/services/"
+            f"service_{'a' * 32}/preview/app?mode=test"
+        )
+        assert response.status_code == 200
+        assert response.content == b"<h1>preview</h1>"
+        assert seen == ["http://coding-worker-default:4173/app?mode=test"]
+        assert response.headers["cache-control"] == "no-store"
+        assert "sandbox" in response.headers["content-security-policy"]

--- a/server/tests/test_coding_worker_api.py
+++ b/server/tests/test_coding_worker_api.py
@@ -127,3 +127,39 @@ def test_pin_unpin_and_delete_keep_active_task_safe(tmp_path: Path) -> None:
         assert client.delete(f"/api/coding-worker/v1/tasks/{task_id}").status_code == 409
         assert client.post(f"/api/coding-worker/v1/tasks/{task_id}/cancel").status_code == 200
         assert client.delete(f"/api/coding-worker/v1/tasks/{task_id}").status_code == 204
+
+
+def test_approval_endpoints_are_task_bound_and_single_decision(tmp_path: Path) -> None:
+    client, service = _client(tmp_path, blocked=True)
+    with client:
+        first = client.post("/api/coding-worker/v1/tasks", json=_payload()).json()
+        second = client.post(
+            "/api/coding-worker/v1/tasks", json=_payload("api-task-02")
+        ).json()
+        approval = service.store.create_approval(
+            task_id=first["task_id"],
+            operation_id="api-approval-operation",
+            capability="command",
+            request={"argv": ["python", "-m", "pytest"]},
+        )
+        listed = client.get(
+            f"/api/coding-worker/v1/tasks/{first['task_id']}/approvals"
+        )
+        assert listed.status_code == 200
+        assert listed.json()["approvals"][0]["approval_id"] == approval.approval_id
+        foreign = client.post(
+            f"/api/coding-worker/v1/tasks/{second['task_id']}/approvals",
+            json={"approval_id": approval.approval_id, "decision": "approve_once"},
+        )
+        assert foreign.status_code == 404
+        decided = client.post(
+            f"/api/coding-worker/v1/tasks/{first['task_id']}/approvals",
+            json={"approval_id": approval.approval_id, "decision": "approve_once"},
+        )
+        assert decided.status_code == 200
+        assert decided.json()["lease"]["operation_limit"] == 1
+        replay = client.post(
+            f"/api/coding-worker/v1/tasks/{first['task_id']}/approvals",
+            json={"approval_id": approval.approval_id, "decision": "reject"},
+        )
+        assert replay.status_code == 409

--- a/server/tests/test_coding_worker_api.py
+++ b/server/tests/test_coding_worker_api.py
@@ -68,6 +68,25 @@ def test_feature_flag_is_default_deny(monkeypatch: pytest.MonkeyPatch) -> None:
     assert client.post("/api/coding-worker/v1/tasks", json=_payload()).status_code == 404
 
 
+def test_enabled_runtime_fails_closed_when_sidecar_tokens_are_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CODING_WORKER_V14_ENABLED", "true")
+    monkeypatch.delenv("CODING_WORKER_SLOT_A_TOKEN", raising=False)
+    monkeypatch.delenv("CODING_WORKER_SLOT_B_TOKEN", raising=False)
+    configure_coding_worker_for_tests(None, enabled=None)
+    app = FastAPI()
+    app.include_router(router)
+    with TestClient(app) as client:
+        status = client.get("/api/coding-worker/v1").json()
+        assert status["enabled"] is True
+        assert status["available"] is False
+        assert status["reason"] == "coding_worker_config_invalid"
+        unavailable = client.post("/api/coding-worker/v1/tasks", json=_payload())
+        assert unavailable.status_code == 503
+        assert unavailable.json()["detail"]["reason"] == "coding_worker_config_invalid"
+
+
 def test_create_is_idempotent_and_server_owns_origin(tmp_path: Path) -> None:
     client, _service = _client(tmp_path)
     with client:

--- a/server/tests/test_coding_worker_approvals.py
+++ b/server/tests/test_coding_worker_approvals.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from cryptography.fernet import Fernet
+
+from server.coding_worker.contracts import (
+    AcceptanceCheck,
+    AcceptanceContract,
+    OperationState,
+    Origin,
+    TaskSpec,
+    WorkspaceSource,
+)
+from server.coding_worker.store import CodingWorkerStore, WorkerConflictError
+
+
+def _store(
+    tmp_path: Path,
+    *,
+    clock=lambda: 100.0,
+    key: bytes | None = None,
+) -> tuple[CodingWorkerStore, str]:
+    store = CodingWorkerStore(
+        tmp_path / "worker", master_key=key or Fernet.generate_key(), clock=clock
+    )
+    task = store.create_task(
+        TaskSpec(
+            client_task_id="client-01",
+            origin=Origin(module="test", object_id="one"),
+            objective="work",
+            workspace_source=WorkspaceSource(
+                kind="manifest", source_id="source-01", revision="revision-01"
+            ),
+            acceptance=AcceptanceContract(
+                contract_id="contract-01",
+                required_checks=(
+                    AcceptanceCheck(check_id="pytest", label="pytest", kind="command"),
+                ),
+            ),
+            model_route="coding/default",
+        )
+    )
+    return store, task.task_id
+
+
+def test_approval_is_durable_single_decision_and_once_lease_is_consumed(tmp_path: Path) -> None:
+    store, task_id = _store(tmp_path)
+    approval = store.create_approval(
+        task_id=task_id,
+        operation_id="operation-01",
+        capability="command",
+        request={"argv": ["python", "-m", "pytest"]},
+    )
+    same = store.create_approval(
+        task_id=task_id,
+        operation_id="operation-01",
+        capability="command",
+        request={"argv": ["python", "-m", "pytest"]},
+    )
+    assert same.approval_id == approval.approval_id
+    decided = store.decide_approval(approval.approval_id, approved=True)
+    assert decided.lease is not None and decided.lease.operation_limit == 1
+    store.consume_lease(
+        decided.lease.lease_id, task_id=task_id, capability="command"
+    )
+    with pytest.raises(WorkerConflictError) as spent:
+        store.consume_lease(
+            decided.lease.lease_id, task_id=task_id, capability="command"
+        )
+    assert spent.value.code == "lease_unavailable"
+    with pytest.raises(WorkerConflictError) as replay:
+        store.decide_approval(approval.approval_id, approved=False)
+    assert replay.value.code == "approval_already_decided"
+
+
+def test_task_lease_is_bound_to_task_capability_ttl_and_encrypted(tmp_path: Path) -> None:
+    now = [100.0]
+    store, task_id = _store(tmp_path, clock=lambda: now[0])
+    approval = store.create_approval(
+        task_id=task_id,
+        operation_id="operation-network",
+        capability="network",
+        request={"domains": ["registry.npmjs.org"], "purpose": "install"},
+    )
+    decided = store.decide_approval(
+        approval.approval_id, approved=True, task_scope=True, ttl_seconds=60
+    )
+    assert decided.lease is not None and decided.lease.operation_limit == 1024
+    with pytest.raises(WorkerConflictError):
+        store.consume_lease(
+            decided.lease.lease_id, task_id="task_other", capability="network"
+        )
+    now[0] = 161.0
+    with pytest.raises(WorkerConflictError):
+        store.consume_lease(
+            decided.lease.lease_id, task_id=task_id, capability="network"
+        )
+    raw = store.database_path.read_bytes()
+    assert b"registry.npmjs.org" not in raw and b"install" not in raw
+
+
+def test_running_operation_becomes_unknown_after_restart_and_cannot_blind_replay(
+    tmp_path: Path,
+) -> None:
+    key = Fernet.generate_key()
+    root = tmp_path / "worker"
+    store, task_id = _store(tmp_path, key=key)
+    operation = store.create_operation(
+        task_id=task_id,
+        operation_id="operation-write",
+        tool_name="write_file",
+        intent_sha256="a" * 64,
+        request={"path": "result.txt", "sha256": "b" * 64},
+    )
+    store.transition_operation(
+        operation.operation_id,
+        OperationState.RUNNING,
+        expected_state=OperationState.PREPARED,
+    )
+    restarted = CodingWorkerStore(root, master_key=key)
+    unknown = restarted.get_operation(operation.operation_id)
+    assert unknown.state is OperationState.UNKNOWN
+    with pytest.raises(WorkerConflictError):
+        store.transition_operation(
+            operation.operation_id,
+            OperationState.RUNNING,
+            expected_state=OperationState.PREPARED,
+        )
+
+
+def test_operation_id_binds_exact_intent_and_completed_result_is_idempotent(
+    tmp_path: Path,
+) -> None:
+    store, task_id = _store(tmp_path)
+    operation = store.create_operation(
+        task_id=task_id,
+        operation_id="operation-01",
+        tool_name="run_check",
+        intent_sha256="c" * 64,
+        request={"check_id": "pytest"},
+    )
+    with pytest.raises(WorkerConflictError) as conflict:
+        store.create_operation(
+            task_id=task_id,
+            operation_id="operation-01",
+            tool_name="run_check",
+            intent_sha256="d" * 64,
+            request={"check_id": "pytest"},
+        )
+    assert conflict.value.code == "operation_intent_conflict"
+    store.transition_operation(operation.operation_id, OperationState.RUNNING)
+    completed = store.transition_operation(
+        operation.operation_id,
+        OperationState.COMPLETED,
+        result={"exit_code": 0, "artifact_id": "artifact-01"},
+    )
+    assert completed.result == {"exit_code": 0, "artifact_id": "artifact-01"}

--- a/server/tests/test_coding_worker_broker_rpc.py
+++ b/server/tests/test_coding_worker_broker_rpc.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from cryptography.fernet import Fernet
+
+from server.coding_worker.broker_rpc import BrokerRPCClient, BrokerRPCError, BrokerRPCServer
+from server.coding_worker.broker_mcp import build_server
+from server.coding_worker.contracts import (
+    AcceptanceCheck,
+    AcceptanceContract,
+    Origin,
+    TaskSpec,
+    TaskState,
+    WorkspaceSource,
+)
+from server.coding_worker.store import CodingWorkerStore
+from server.coding_worker.tool_broker import ToolBroker
+from server.coding_worker.workspace import InMemoryWorkspaceSourceAdapter, WorkspaceBroker
+
+
+async def _rpc(tmp_path: Path) -> tuple[BrokerRPCServer, str, str]:
+    source = WorkspaceSource(kind="manifest", source_id="rpc", revision="h0")
+    workspace = WorkspaceBroker(
+        tmp_path / "workspace",
+        {"manifest": InMemoryWorkspaceSourceAdapter({("rpc", "h0"): {"app.py": b"hello\n"}})},
+        id_key=b"r" * 32,
+    )
+    prepared = await workspace.prepare(source)
+    store = CodingWorkerStore(tmp_path / "store", master_key=Fernet.generate_key())
+    task = store.create_task(
+        TaskSpec(
+            client_task_id="rpc",
+            origin=Origin(module="tests", object_id="rpc"),
+            objective="inspect",
+            workspace_source=source,
+            acceptance=AcceptanceContract(
+                contract_id="contract",
+                required_checks=(
+                    AcceptanceCheck(check_id="check", label="check", kind="command"),
+                ),
+            ),
+            model_route="coding/default",
+        )
+    )
+    store.transition(task.task_id, TaskState.PREPARING)
+    store.transition(task.task_id, TaskState.RUNNING, workspace_id=prepared.workspace_id)
+    server = BrokerRPCServer(ToolBroker(store=store, workspace_broker=workspace))
+    endpoint = await server.start_tcp_for_tests()
+    return server, task.task_id, endpoint
+
+
+@pytest.mark.asyncio
+async def test_rpc_is_task_token_bound_and_returns_provider_neutral_result(
+    tmp_path: Path,
+) -> None:
+    server, task_id, endpoint = await _rpc(tmp_path)
+    token = server.register_task(task_id)
+    client = BrokerRPCClient(endpoint, token=token, task_id=task_id)
+    result = await client.call(
+        operation_id="rpc-list", tool_name="list_files", arguments={}
+    )
+    assert result["tool_name"] == "list_files"
+    assert result["data"]["entries"][0]["display_path"] == "app.py"
+    assert "workspace" not in result and "path" not in result
+    server.revoke_task(task_id)
+    with pytest.raises(BrokerRPCError) as revoked:
+        await client.call(operation_id="rpc-revoked", tool_name="list_files", arguments={})
+    assert revoked.value.code == "broker_unauthorized"
+    await server.close()
+
+
+@pytest.mark.asyncio
+async def test_rpc_rejects_wrong_token_without_executing_operation(tmp_path: Path) -> None:
+    server, task_id, endpoint = await _rpc(tmp_path)
+    server.register_task(task_id)
+    attacker = BrokerRPCClient(endpoint, token="x" * 48, task_id=task_id)
+    with pytest.raises(BrokerRPCError) as denied:
+        await attacker.call(
+            operation_id="rpc-attacker", tool_name="list_files", arguments={}
+        )
+    assert denied.value.code == "broker_unauthorized"
+    with pytest.raises(Exception):
+        server.broker.store.get_operation("rpc-attacker")
+    await server.close()
+
+
+@pytest.mark.asyncio
+async def test_mcp_exposes_only_modelmirror_broker_tools() -> None:
+    client = BrokerRPCClient(
+        "tcp:127.0.0.1:1", token="x" * 48, task_id="task_schema"
+    )
+    tools = await build_server(client).list_tools()
+    names = {tool.name for tool in tools}
+    assert names == {
+        "list_files",
+        "read_file",
+        "search_text",
+        "workspace_diff",
+        "write_file",
+        "delete_file",
+        "run_check",
+        "run_command",
+        "install_dependencies",
+        "start_service",
+        "service_status",
+        "service_input",
+        "stop_service",
+    }
+    write = next(tool for tool in tools if tool.name == "write_file")
+    assert {"operation_id", "path", "content", "content_sha256"}.issubset(
+        write.inputSchema["required"]
+    )

--- a/server/tests/test_coding_worker_deployment.py
+++ b/server/tests/test_coding_worker_deployment.py
@@ -9,15 +9,20 @@ def test_v14_sidecar_is_non_root_and_has_no_host_control_mounts() -> None:
     assert "USER 65532:65532" in dockerfile
     assert 'CMD ["python", "-m", "coding_worker.sidecar"]' in dockerfile
     assert "OPENCODE_VERSION=1.18.9" in dockerfile
+    assert "coding-worker-provider-a:" in compose
+    assert "coding-worker-provider-b:" in compose
     assert "coding-worker-slot-a:" in compose
     assert "coding-worker-slot-b:" in compose
     assert "CODING_WORKER_V14_ENABLED: ${CODING_WORKER_V14_ENABLED:-false}" in compose
     assert "/var/run/docker.sock" not in compose
     assert ".ssh" not in compose
     assert "network_mode: host" not in compose
-    assert compose.count('user: "65532:65532"') == 2  # slot B inherits slot A
+    assert compose.count('user: "65532:65532"') == 3  # provider/executor B inherit A
     assert ":/worker-data" in compose
     assert ":/run/modelmirror-coding-broker:ro" in compose
+    assert "CODING_WORKER_MODE: executor" in compose
+    assert "CODING_WORKER_ROUTE_KEY" not in compose.split("coding-worker-slot-a:", 1)[1].split("coding-worker-egress:", 1)[0]
+    assert "coding_worker_slot_a:/worker-data:ro" in compose
     assert "coding-worker-network" in compose
     assert 'command: ["python", "-m", "coding_worker.egress_proxy"]' in compose
     assert "CODING_WORKER_EGRESS_GRANT_KEY: ${CODING_WORKER_EGRESS_GRANT_KEY:-}" in compose

--- a/server/tests/test_coding_worker_deployment.py
+++ b/server/tests/test_coding_worker_deployment.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+
+def test_v14_sidecar_is_non_root_and_has_no_host_control_mounts() -> None:
+    root = Path(__file__).parents[2]
+    dockerfile = (root / "server/coding_worker/Dockerfile.v14").read_text()
+    compose = (root / "docker-compose.coding-worker-v14.yml").read_text()
+
+    assert "USER 65532:65532" in dockerfile
+    assert 'CMD ["python", "-m", "coding_worker.sidecar"]' in dockerfile
+    assert "OPENCODE_VERSION=1.18.9" in dockerfile
+    assert "coding-worker-slot-a:" in compose
+    assert "coding-worker-slot-b:" in compose
+    assert "CODING_WORKER_V14_ENABLED: ${CODING_WORKER_V14_ENABLED:-false}" in compose
+    assert "/var/run/docker.sock" not in compose
+    assert ".ssh" not in compose
+    assert "network_mode: host" not in compose
+    assert compose.count('user: "65532:65532"') == 1  # slot B inherits slot A
+    assert ":/worker-data" in compose
+    assert ":/run/modelmirror-coding-broker:ro" in compose

--- a/server/tests/test_coding_worker_deployment.py
+++ b/server/tests/test_coding_worker_deployment.py
@@ -15,6 +15,9 @@ def test_v14_sidecar_is_non_root_and_has_no_host_control_mounts() -> None:
     assert "/var/run/docker.sock" not in compose
     assert ".ssh" not in compose
     assert "network_mode: host" not in compose
-    assert compose.count('user: "65532:65532"') == 1  # slot B inherits slot A
+    assert compose.count('user: "65532:65532"') == 2  # slot B inherits slot A
     assert ":/worker-data" in compose
     assert ":/run/modelmirror-coding-broker:ro" in compose
+    assert "coding-worker-network" in compose
+    assert 'command: ["python", "-m", "coding_worker.egress_proxy"]' in compose
+    assert "CODING_WORKER_EGRESS_GRANT_KEY: ${CODING_WORKER_EGRESS_GRANT_KEY:-}" in compose

--- a/server/tests/test_coding_worker_evidence.py
+++ b/server/tests/test_coding_worker_evidence.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import hashlib
+import sys
+from pathlib import Path
+
+import pytest
+from cryptography.fernet import Fernet
+
+from server.coding_worker.contracts import (
+    AcceptanceCheck,
+    AcceptanceContract,
+    EvidenceStatus,
+    Origin,
+    PolicyProfile,
+    TaskSpec,
+    TaskState,
+    WorkspaceSource,
+)
+from server.coding_worker.evidence import HarnessRunner
+from server.coding_worker.store import CodingWorkerStore, WorkerConflictError
+from server.coding_worker.tool_broker import FrozenCheck, ToolBroker
+from server.coding_worker.workspace import InMemoryWorkspaceSourceAdapter, WorkspaceBroker
+
+
+async def _harness(tmp_path: Path) -> tuple[HarnessRunner, CodingWorkerStore, ToolBroker, str, Path]:
+    source = WorkspaceSource(kind="manifest", source_id="evidence", revision="h0")
+    workspace = WorkspaceBroker(
+        tmp_path / "workspace",
+        {"manifest": InMemoryWorkspaceSourceAdapter({("evidence", "h0"): {"app.py": b"bad python\n"}})},
+        id_key=b"e" * 32,
+    )
+    prepared = await workspace.prepare(source)
+    store = CodingWorkerStore(tmp_path / "store", master_key=Fernet.generate_key())
+    task = store.create_task(
+        TaskSpec(
+            client_task_id="evidence-task",
+            origin=Origin(module="tests", object_id="evidence"),
+            objective="fix syntax",
+            workspace_source=source,
+            acceptance=AcceptanceContract(
+                contract_id="contract",
+                required_checks=(AcceptanceCheck(check_id="syntax", label="syntax", kind="command"),),
+            ),
+            policy_profile=PolicyProfile.DEVELOP,
+            model_route="coding/default",
+        )
+    )
+    store.transition(task.task_id, TaskState.PREPARING)
+    store.transition(task.task_id, TaskState.RUNNING, workspace_id=prepared.workspace_id)
+    broker = ToolBroker(
+        store=store,
+        workspace_broker=workspace,
+        frozen_checks={"syntax": FrozenCheck(check_id="syntax", argv=(sys.executable, "-m", "py_compile", "app.py"))},
+    )
+    return (
+        HarnessRunner(store=store, workspace_broker=workspace, tool_broker=broker),
+        store,
+        broker,
+        task.task_id,
+        workspace.repository_path(prepared.workspace_id),
+    )
+
+
+@pytest.mark.asyncio
+async def test_failed_check_blocks_completion_then_fix_and_retest_passes(tmp_path: Path) -> None:
+    harness, store, broker, task_id, repository = await _harness(tmp_path)
+    failed = await harness.run_required_checks(task_id)
+    assert failed[0].status is EvidenceStatus.FAILED
+    assert not harness.acceptance_satisfied(task_id)
+    content = "print('fixed')\n"
+    await broker.execute(
+        task_id=task_id,
+        operation_id="fix-file",
+        tool_name="write_file",
+        arguments={
+            "path": "app.py",
+            "content": content,
+            "content_sha256": hashlib.sha256(content.encode()).hexdigest(),
+        },
+    )
+    invalidated = store.list_evidence(
+        task_id,
+        current_tree_hash=harness.workspace_broker.current_tree_hash(store.get_task(task_id).workspace_id),
+    )
+    assert invalidated[0].status is EvidenceStatus.INVALIDATED
+    passed = await harness.run_required_checks(task_id)
+    assert passed[0].status is EvidenceStatus.PASSED
+    assert harness.acceptance_satisfied(task_id)
+    assert repository.joinpath("app.py").read_text() == content
+
+
+@pytest.mark.asyncio
+async def test_artifact_and_evidence_are_encrypted_and_task_bound(tmp_path: Path) -> None:
+    harness, store, _, task_id, _ = await _harness(tmp_path)
+    evidence = (await harness.run_required_checks(task_id))[0]
+    content = store.read_artifact(evidence.artifact_id, task_id=task_id)
+    assert b"SyntaxError" in content
+    raw = store.database_path.read_bytes()
+    assert b"SyntaxError" not in raw and b"bad python" not in raw
+    other = store.create_task(store.get_task(task_id).spec.model_copy(update={"client_task_id": "other"}))
+    with pytest.raises(Exception):
+        store.read_artifact(evidence.artifact_id, task_id=other.task_id)
+
+
+@pytest.mark.asyncio
+async def test_acceptance_contract_cannot_be_replaced_by_agent_evidence(tmp_path: Path) -> None:
+    harness, store, _, task_id, _ = await _harness(tmp_path)
+    artifact = store.create_artifact(
+        task_id=task_id,
+        media_type="text/plain",
+        content=b"pretend pass",
+        metadata={},
+    )
+    with pytest.raises(WorkerConflictError) as unknown:
+        store.record_evidence(
+            task_id=task_id,
+            check_id="agent-replaced-check",
+            operation_id="forged-operation",
+            workspace_tree_hash=harness.workspace_broker.current_tree_hash(store.get_task(task_id).workspace_id),
+            exit_code=0,
+            artifact_id=artifact.artifact_id,
+        )
+    assert unknown.value.code == "acceptance_check_unknown"
+    assert not harness.acceptance_satisfied(task_id)

--- a/server/tests/test_coding_worker_network.py
+++ b/server/tests/test_coding_worker_network.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import pytest
+
+from server.coding_worker.contracts import CapabilityLease
+from server.coding_worker.network_policy import EgressPolicy, NetworkPolicyError
+
+
+def _lease(scope: dict[str, object], *, expires_at: float = 200.0) -> CapabilityLease:
+    return CapabilityLease(
+        lease_id="lease_network",
+        task_id="task_network",
+        capability="network",
+        scope=scope,
+        issued_at=100.0,
+        expires_at=expires_at,
+    )
+
+
+def test_network_is_default_deny_and_scope_is_deployment_allowlisted() -> None:
+    disabled = EgressPolicy(allowed_domains={"registry.npmjs.org"})
+    with pytest.raises(NetworkPolicyError) as denied:
+        disabled.approval_scope(domains=["registry.npmjs.org"], purpose="npm-install")
+    assert denied.value.code == "network_disabled"
+
+    policy = EgressPolicy(enabled=True, allowed_domains={"registry.npmjs.org"})
+    assert policy.approval_scope(
+        domains=["REGISTRY.NPMJS.ORG."], purpose="npm-install"
+    ) == {"domains": ["registry.npmjs.org"], "purpose": "npm-install"}
+    with pytest.raises(NetworkPolicyError) as outside:
+        policy.approval_scope(domains=["example.com"], purpose="npm-install")
+    assert outside.value.code == "network_domain_not_allowed"
+
+
+@pytest.mark.parametrize(
+    "domain",
+    ["127.0.0.1", "::1", "localhost", "metadata.internal", "service.local"],
+)
+def test_ip_literals_and_local_names_are_rejected(domain: str) -> None:
+    with pytest.raises(NetworkPolicyError):
+        EgressPolicy(enabled=True, allowed_domains={domain})
+
+
+def test_https_destination_is_bound_to_task_purpose_dns_and_ttl() -> None:
+    policy = EgressPolicy(
+        enabled=True,
+        allowed_domains={"registry.npmjs.org", "cdn.example.com"},
+        clock=lambda: 150.0,
+    )
+    scope = policy.approval_scope(
+        domains=["registry.npmjs.org"], purpose="npm-install"
+    )
+    lease = _lease(scope)
+    assert (
+        policy.authorize(
+            url="https://registry.npmjs.org/package",
+            lease=lease,
+            purpose="npm-install",
+            resolved_addresses=["104.16.24.34"],
+        )
+        == "registry.npmjs.org"
+    )
+    with pytest.raises(NetworkPolicyError) as private:
+        policy.authorize(
+            url="https://registry.npmjs.org/package",
+            lease=lease,
+            purpose="npm-install",
+            resolved_addresses=["10.0.0.8"],
+        )
+    assert private.value.code == "network_private_address_denied"
+    with pytest.raises(NetworkPolicyError) as expired:
+        policy.authorize(
+            url="https://registry.npmjs.org/package",
+            lease=_lease(scope, expires_at=149.0),
+            purpose="npm-install",
+            resolved_addresses=["104.16.24.34"],
+        )
+    assert expired.value.code == "network_lease_invalid"
+
+
+def test_redirect_must_remain_inside_the_exact_lease_domain() -> None:
+    policy = EgressPolicy(
+        enabled=True,
+        allowed_domains={"registry.npmjs.org", "cdn.example.com"},
+        clock=lambda: 150.0,
+    )
+    lease = _lease(
+        policy.approval_scope(
+            domains=["registry.npmjs.org"], purpose="dependency-download"
+        )
+    )
+    with pytest.raises(NetworkPolicyError) as redirect:
+        policy.authorize(
+            url="https://cdn.example.com/package.tgz",
+            lease=lease,
+            purpose="dependency-download",
+            resolved_addresses=["93.184.216.34"],
+        )
+    assert redirect.value.code == "network_domain_not_allowed"
+
+
+def test_credentials_non_https_and_nonstandard_ports_are_rejected() -> None:
+    policy = EgressPolicy(
+        enabled=True, allowed_domains={"registry.npmjs.org"}, clock=lambda: 150.0
+    )
+    lease = _lease(
+        policy.approval_scope(domains=["registry.npmjs.org"], purpose="install")
+    )
+    for url in (
+        "http://registry.npmjs.org/a",
+        "https://user:secret@registry.npmjs.org/a",
+        "https://registry.npmjs.org:8443/a",
+    ):
+        with pytest.raises(NetworkPolicyError) as denied:
+            policy.authorize(
+                url=url,
+                lease=lease,
+                purpose="install",
+                resolved_addresses=["104.16.24.34"],
+            )
+        assert denied.value.code == "network_url_not_allowed"

--- a/server/tests/test_coding_worker_network.py
+++ b/server/tests/test_coding_worker_network.py
@@ -23,7 +23,7 @@ def test_network_is_default_deny_and_scope_is_deployment_allowlisted() -> None:
         disabled.approval_scope(domains=["registry.npmjs.org"], purpose="npm-install")
     assert denied.value.code == "network_disabled"
 
-    policy = EgressPolicy(enabled=True, allowed_domains={"registry.npmjs.org"})
+    policy = EgressPolicy(enabled=True, allowed_domains={"registry.npmjs.org"}, grant_key=b"k" * 32)
     assert policy.approval_scope(
         domains=["REGISTRY.NPMJS.ORG."], purpose="npm-install"
     ) == {"domains": ["registry.npmjs.org"], "purpose": "npm-install"}
@@ -46,6 +46,7 @@ def test_https_destination_is_bound_to_task_purpose_dns_and_ttl() -> None:
         enabled=True,
         allowed_domains={"registry.npmjs.org", "cdn.example.com"},
         clock=lambda: 150.0,
+        grant_key=b"k" * 32,
     )
     scope = policy.approval_scope(
         domains=["registry.npmjs.org"], purpose="npm-install"
@@ -83,6 +84,7 @@ def test_redirect_must_remain_inside_the_exact_lease_domain() -> None:
         enabled=True,
         allowed_domains={"registry.npmjs.org", "cdn.example.com"},
         clock=lambda: 150.0,
+        grant_key=b"k" * 32,
     )
     lease = _lease(
         policy.approval_scope(
@@ -101,7 +103,7 @@ def test_redirect_must_remain_inside_the_exact_lease_domain() -> None:
 
 def test_credentials_non_https_and_nonstandard_ports_are_rejected() -> None:
     policy = EgressPolicy(
-        enabled=True, allowed_domains={"registry.npmjs.org"}, clock=lambda: 150.0
+        enabled=True, allowed_domains={"registry.npmjs.org"}, clock=lambda: 150.0, grant_key=b"k" * 32
     )
     lease = _lease(
         policy.approval_scope(domains=["registry.npmjs.org"], purpose="install")
@@ -119,3 +121,31 @@ def test_credentials_non_https_and_nonstandard_ports_are_rejected() -> None:
                 resolved_addresses=["104.16.24.34"],
             )
         assert denied.value.code == "network_url_not_allowed"
+
+
+def test_signed_proxy_grant_is_exact_task_domain_purpose_and_ttl() -> None:
+    policy = EgressPolicy(
+        enabled=True,
+        allowed_domains={"registry.npmjs.org"},
+        clock=lambda: 150.0,
+        grant_key=b"g" * 32,
+    )
+    lease = _lease(
+        policy.approval_scope(
+            domains=["registry.npmjs.org"], purpose="dependency-install"
+        )
+    )
+    proxy_url = policy.proxy_url(
+        base_url="http://worker-egress:8080",
+        lease=lease,
+        task_id="task_network",
+        purpose="dependency-install",
+    )
+    token = proxy_url.split("grant:", 1)[1].split("@", 1)[0]
+    payload = policy.validate_grant(token, domain="registry.npmjs.org")
+    assert payload["task_id"] == "task_network"
+    with pytest.raises(NetworkPolicyError):
+        policy.validate_grant(token, domain="example.com")
+    tampered = token[:-1] + ("a" if token[-1] != "a" else "b")
+    with pytest.raises(NetworkPolicyError):
+        policy.validate_grant(tampered, domain="registry.npmjs.org")

--- a/server/tests/test_coding_worker_opencode.py
+++ b/server/tests/test_coding_worker_opencode.py
@@ -5,14 +5,27 @@ from pathlib import Path
 
 import httpx
 import pytest
+from cryptography.fernet import Fernet
 
-from server.coding_worker.contracts import TaskBudget
+from server.coding_worker.broker_rpc import BrokerRPCServer
+from server.coding_worker.contracts import (
+    AcceptanceCheck,
+    AcceptanceContract,
+    Origin,
+    TaskBudget,
+    TaskSpec,
+    TaskState,
+    WorkspaceSource,
+)
 from server.coding_worker.opencode_provider import (
     DIRECT_TOOL_NAMES,
     OpenCodeProvider,
     OpenCodeRoute,
     OpenCodeServerHandle,
 )
+from server.coding_worker.store import CodingWorkerStore
+from server.coding_worker.tool_broker import ToolBroker
+from server.coding_worker.workspace import InMemoryWorkspaceSourceAdapter, WorkspaceBroker
 from server.coding_worker.provider import ProviderEventKind, ProviderOpenRequest
 
 
@@ -184,3 +197,48 @@ def test_raw_permission_frame_never_enters_provider_neutral_event() -> None:
     assert event is not None
     assert event.kind is ProviderEventKind.APPROVAL_REQUIRED
     assert event.data == {"capability": "provider_permission"}
+
+
+@pytest.mark.asyncio
+async def test_provider_gives_mcp_only_a_revocable_task_broker_binding(
+    tmp_path: Path,
+) -> None:
+    source = WorkspaceSource(kind="manifest", source_id="broker", revision="h0")
+    workspace_broker = WorkspaceBroker(
+        tmp_path / "workspace-broker",
+        {"manifest": InMemoryWorkspaceSourceAdapter({("broker", "h0"): {"a.py": b""}})},
+        id_key=b"o" * 32,
+    )
+    prepared = await workspace_broker.prepare(source)
+    store = CodingWorkerStore(tmp_path / "store", master_key=Fernet.generate_key())
+    spec = TaskSpec(
+        client_task_id="broker-binding",
+        origin=Origin(module="tests", object_id="broker-binding"),
+        objective="inspect",
+        workspace_source=source,
+        acceptance=AcceptanceContract(
+            contract_id="contract",
+            required_checks=(
+                AcceptanceCheck(check_id="check", label="check", kind="command"),
+            ),
+        ),
+        model_route="coding/default",
+    )
+    task = store.create_task(spec)
+    store.transition(task.task_id, TaskState.PREPARING)
+    store.transition(task.task_id, TaskState.RUNNING, workspace_id=prepared.workspace_id)
+    rpc = BrokerRPCServer(ToolBroker(store=store, workspace_broker=workspace_broker))
+    await rpc.start_tcp_for_tests()
+    provider = OpenCodeProvider(
+        workspace_resolver=lambda _workspace_id: workspace,
+        runtime_root=tmp_path / "runtime",
+        routes={"coding/default": _route()},
+        broker_rpc=rpc,
+    )
+    environment, revoke = provider._broker_environment(task.task_id)
+    assert environment["CODING_WORKER_TASK_ID"] == task.task_id
+    assert "coding_worker.broker_mcp" in " ".join(provider._tool_broker_command or ())
+    assert "CODING_WORKER_ROUTE_KEY" not in environment
+    revoke()
+    assert task.task_id not in rpc._tokens
+    await rpc.close()

--- a/server/tests/test_coding_worker_opencode.py
+++ b/server/tests/test_coding_worker_opencode.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+from server.coding_worker.contracts import TaskBudget
+from server.coding_worker.opencode_provider import (
+    DIRECT_TOOL_NAMES,
+    OpenCodeProvider,
+    OpenCodeRoute,
+    OpenCodeServerHandle,
+)
+from server.coding_worker.provider import ProviderEventKind, ProviderOpenRequest
+
+
+def _request() -> ProviderOpenRequest:
+    return ProviderOpenRequest(
+        task_id="task-01",
+        workspace_id="workspace-01",
+        objective="Inspect and fix the project.",
+        model_route="coding/default",
+        policy_profile="develop",
+        budget=TaskBudget(),
+    )
+
+
+def _route() -> OpenCodeRoute:
+    return OpenCodeRoute(
+        route_id="coding/default",
+        model_id="test-model",
+        base_url="http://new-api:3000/v1",
+        api_key="ephemeral-route-key",
+    )
+
+
+def test_config_disables_direct_tools_plugins_sharing_and_supplier_surface(tmp_path: Path) -> None:
+    provider = OpenCodeProvider(
+        workspace_resolver=lambda _workspace_id: tmp_path,
+        runtime_root=tmp_path / "runtime",
+        routes={"coding/default": _route()},
+        tool_broker_command=("python", "-m", "coding_worker.tool_mcp"),
+    )
+    config = provider.build_config(_route())
+    permission = config["permission"]
+    assert permission["*"] == "deny"
+    assert permission["modelmirror-tool-broker_*"] == "allow"
+    assert config["plugin"] == [] and config["share"] == "disabled"
+    assert config["instructions"] == []
+    assert config["provider"]["modelmirror"]["options"]["apiKey"] == (
+        "{env:CODING_WORKER_ROUTE_KEY}"
+    )
+    assert all(provider._prompt_tools()[name] is False for name in DIRECT_TOOL_NAMES)
+
+
+@pytest.mark.asyncio
+async def test_headless_adapter_maps_events_cancel_and_checkpoint_without_public_frames(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    closed: list[bool] = []
+    state = {"session": {"id": "ses_test"}, "messages": []}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path == "/session" and request.method == "POST":
+            body = json.loads(request.content)
+            assert body["model"] == {"providerID": "modelmirror", "id": "test-model"}
+            return httpx.Response(200, json=state["session"])
+        if path == "/event":
+            content = (
+                'data: {"type":"message.part.updated","properties":{"sessionID":"ses_test","part":{"type":"text","text":"done"}}}\n\n'
+                'data: {"type":"session.idle","properties":{"sessionID":"ses_test"}}\n\n'
+            )
+            return httpx.Response(200, text=content, headers={"content-type": "text/event-stream"})
+        if path.endswith("/prompt_async"):
+            body = json.loads(request.content)
+            assert body["tools"]["bash"] is False
+            return httpx.Response(204)
+        if path.endswith("/abort"):
+            return httpx.Response(200, json=True)
+        if path.endswith("/message"):
+            return httpx.Response(200, json=state["messages"])
+        if path == "/session/ses_test":
+            return httpx.Response(200, json=state["session"])
+        return httpx.Response(404)
+
+    async def factory(
+        request: ProviderOpenRequest, resolved: Path, route: OpenCodeRoute
+    ) -> OpenCodeServerHandle:
+        assert request.task_id == "task-01" and resolved == workspace.resolve()
+        assert route.route_id == "coding/default"
+        client = httpx.AsyncClient(
+            base_url="http://127.0.0.1:4096",
+            transport=httpx.MockTransport(handler),
+        )
+
+        async def close() -> None:
+            closed.append(True)
+            await client.aclose()
+
+        return OpenCodeServerHandle(
+            task_id=request.task_id,
+            workspace=resolved,
+            state_root=tmp_path / "state",
+            client=client,
+            close_callback=close,
+        )
+
+    provider = OpenCodeProvider(
+        workspace_resolver=lambda _workspace_id: workspace,
+        runtime_root=tmp_path / "runtime",
+        routes={"coding/default": _route()},
+        server_factory=factory,
+    )
+    session = await provider.open(_request())
+    events = [event async for event in provider.message(session, "continue")]
+    assert [event.kind for event in events] == [
+        ProviderEventKind.MESSAGE,
+        ProviderEventKind.TURN_COMPLETED,
+    ]
+    assert await provider.cancel(session) is True
+    checkpoint = await provider.checkpoint(session)
+    assert checkpoint.payload["session_id"] == "ses_test"
+    assert "http" not in checkpoint.payload and "port" not in checkpoint.payload
+    await provider.close(session)
+    assert closed == [True]
+
+
+def test_provider_session_is_excluded_from_public_task_record() -> None:
+    from server.coding_worker.contracts import (
+        AcceptanceCheck,
+        AcceptanceContract,
+        Origin,
+        TaskRecord,
+        TaskSpec,
+        TaskState,
+        WorkspaceSource,
+    )
+
+    record = TaskRecord(
+        task_id="task-01",
+        spec=TaskSpec(
+            client_task_id="client-01",
+            origin=Origin(module="test", object_id="one"),
+            objective="work",
+            workspace_source=WorkspaceSource(
+                kind="manifest", source_id="source-01", revision="revision-01"
+            ),
+            acceptance=AcceptanceContract(
+                contract_id="contract-01",
+                required_checks=(
+                    AcceptanceCheck(check_id="check", label="check", kind="command"),
+                ),
+            ),
+            model_route="coding/default",
+        ),
+        state=TaskState.RUNNING,
+        provider_session_id="ses_private",
+        created_at=1,
+        updated_at=1,
+        expires_at=2,
+    )
+    assert record.provider_session_id == "ses_private"
+    assert "provider_session_id" not in record.model_dump(mode="json")

--- a/server/tests/test_coding_worker_opencode.py
+++ b/server/tests/test_coding_worker_opencode.py
@@ -137,10 +137,18 @@ async def test_headless_adapter_maps_events_cancel_and_checkpoint_without_public
     ]
     assert await provider.cancel(session) is True
     checkpoint = await provider.checkpoint(session)
-    assert checkpoint.payload["session_id"] == "ses_test"
+    assert checkpoint.payload == {
+        "engine": "opencode-1.18.9",
+        "task_id": "task-01",
+        "public_output": "done",
+    }
     assert "http" not in checkpoint.payload and "port" not in checkpoint.payload
+    assert "session" not in checkpoint.payload and "messages" not in checkpoint.payload
     await provider.close(session)
-    assert closed == [True]
+    restored = await provider.restore(_request(), checkpoint)
+    assert restored.task_id == session.task_id
+    await provider.close(restored)
+    assert closed == [True, True]
 
 
 def test_provider_session_is_excluded_from_public_task_record() -> None:

--- a/server/tests/test_coding_worker_opencode.py
+++ b/server/tests/test_coding_worker_opencode.py
@@ -166,3 +166,21 @@ def test_provider_session_is_excluded_from_public_task_record() -> None:
     )
     assert record.provider_session_id == "ses_private"
     assert "provider_session_id" not in record.model_dump(mode="json")
+
+
+def test_raw_permission_frame_never_enters_provider_neutral_event() -> None:
+    event = OpenCodeProvider._map_event(
+        {
+            "type": "permission.asked",
+            "properties": {
+                "sessionID": "ses_test",
+                "path": "C:/private/project",
+                "port": 47123,
+                "vendorRequest": {"tool": "bash"},
+            },
+        },
+        "ses_test",
+    )
+    assert event is not None
+    assert event.kind is ProviderEventKind.APPROVAL_REQUIRED
+    assert event.data == {"capability": "provider_permission"}

--- a/server/tests/test_coding_worker_opencode.py
+++ b/server/tests/test_coding_worker_opencode.py
@@ -242,3 +242,21 @@ async def test_provider_gives_mcp_only_a_revocable_task_broker_binding(
     revoke()
     assert task.task_id not in rpc._tokens
     await rpc.close()
+
+
+def test_opencode_provider_accepts_sidecar_broker_binding(tmp_path: Path) -> None:
+    provider = OpenCodeProvider(
+        workspace_resolver=lambda _workspace_id: tmp_path,
+        runtime_root=tmp_path / "runtime",
+        routes={"coding/default": _route()},
+        tool_broker_command=("python", "-m", "coding_worker.broker_mcp"),
+    )
+    provider.bind_broker("task_sidecar", "unix:/run/broker.sock", "t" * 48)
+    environment, revoke = provider._broker_environment("task_sidecar")
+    assert environment == {
+        "CODING_WORKER_BROKER_ENDPOINT": "unix:/run/broker.sock",
+        "CODING_WORKER_BROKER_TOKEN": "t" * 48,
+        "CODING_WORKER_TASK_ID": "task_sidecar",
+    }
+    revoke()
+    assert "task_sidecar" not in provider._broker_bindings

--- a/server/tests/test_coding_worker_processes.py
+++ b/server/tests/test_coding_worker_processes.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from cryptography.fernet import Fernet
+
+from server.coding_worker.contracts import (
+    AcceptanceCheck,
+    AcceptanceContract,
+    Origin,
+    TaskSpec,
+    WorkspaceSource,
+)
+from server.coding_worker.process_manager import (
+    BackgroundProcessManager,
+    ProcessManagerError,
+)
+from server.coding_worker.store import CodingWorkerStore, WorkerNotFoundError
+from server.coding_worker.workspace import InMemoryWorkspaceSourceAdapter, WorkspaceBroker
+
+
+async def _manager(
+    tmp_path: Path, *, max_output_bytes: int = 4096
+) -> tuple[BackgroundProcessManager, CodingWorkerStore, str, str]:
+    source = WorkspaceSource(kind="manifest", source_id="process", revision="h0")
+    workspace = WorkspaceBroker(
+        tmp_path / "workspace",
+        {"manifest": InMemoryWorkspaceSourceAdapter({("process", "h0"): {"app.py": b""}})},
+        id_key=b"p" * 32,
+    )
+    prepared = await workspace.prepare(source)
+    store = CodingWorkerStore(tmp_path / "store", master_key=Fernet.generate_key())
+    task = store.create_task(
+        TaskSpec(
+            client_task_id="process-task",
+            origin=Origin(module="tests", object_id="process"),
+            objective="run service",
+            workspace_source=source,
+            acceptance=AcceptanceContract(
+                contract_id="contract",
+                required_checks=(
+                    AcceptanceCheck(check_id="check", label="check", kind="command"),
+                ),
+            ),
+            model_route="coding/default",
+        )
+    )
+
+    def environment(_workspace_id: str) -> dict[str, str]:
+        return {
+            "PATH": os.environ.get("PATH", ""),
+            "SYSTEMROOT": os.environ.get("SYSTEMROOT", "C:\\Windows"),
+            "PYTHONIOENCODING": "utf-8",
+        }
+
+    return (
+        BackgroundProcessManager(
+            store=store,
+            workspace_broker=workspace,
+            environment_factory=environment,
+            max_output_bytes=max_output_bytes,
+        ),
+        store,
+        task.task_id,
+        prepared.workspace_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_service_output_is_archived_without_exposing_pid(tmp_path: Path) -> None:
+    manager, store, task_id, workspace_id = await _manager(tmp_path)
+    started = await manager.start(
+        task_id=task_id,
+        workspace_id=workspace_id,
+        argv=(sys.executable, "-c", "print('ready')"),
+        ttl_seconds=30,
+    )
+    assert started.state == "running" and "pid" not in started.model_dump()
+    while manager.status(task_id=task_id, service_id=started.service_id).state == "running":
+        await asyncio.sleep(0.01)
+    completed = manager.status(task_id=task_id, service_id=started.service_id)
+    assert completed.state == "completed" and completed.output_artifact_id
+    assert store.read_artifact(completed.output_artifact_id, task_id=task_id) == b"ready\r\n"
+
+
+@pytest.mark.asyncio
+async def test_interrupt_and_lookup_are_task_bound(tmp_path: Path) -> None:
+    manager, store, task_id, workspace_id = await _manager(tmp_path)
+    other = store.create_task(
+        store.get_task(task_id).spec.model_copy(
+            update={"client_task_id": "other", "origin": Origin(module="tests", object_id="other")}
+        )
+    )
+    started = await manager.start(
+        task_id=task_id,
+        workspace_id=workspace_id,
+        argv=(sys.executable, "-c", "import time;print('up', flush=True);time.sleep(30)"),
+        ttl_seconds=60,
+    )
+    with pytest.raises(WorkerNotFoundError):
+        manager.status(task_id=other.task_id, service_id=started.service_id)
+    stopped = await manager.interrupt(task_id=task_id, service_id=started.service_id)
+    assert stopped.state == "stopped" and stopped.reason == "user_interrupted"
+    await manager.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_output_limit_stops_background_service_and_records_reason(tmp_path: Path) -> None:
+    manager, _, task_id, workspace_id = await _manager(tmp_path, max_output_bytes=1024)
+    started = await manager.start(
+        task_id=task_id,
+        workspace_id=workspace_id,
+        argv=(sys.executable, "-c", "print('x' * 5000)"),
+        ttl_seconds=30,
+    )
+    while manager.status(task_id=task_id, service_id=started.service_id).state == "running":
+        await asyncio.sleep(0.01)
+    stopped = manager.status(task_id=task_id, service_id=started.service_id)
+    assert stopped.state == "stopped" and stopped.reason == "service_output_limit"
+
+
+@pytest.mark.asyncio
+async def test_ttl_and_capacity_are_bounded(tmp_path: Path) -> None:
+    manager, _, task_id, workspace_id = await _manager(tmp_path)
+    manager.max_processes_per_task = 1
+    started = await manager.start(
+        task_id=task_id,
+        workspace_id=workspace_id,
+        argv=(sys.executable, "-c", "import time;time.sleep(30)"),
+        ttl_seconds=1,
+    )
+    with pytest.raises(ProcessManagerError) as capacity:
+        await manager.start(
+            task_id=task_id,
+            workspace_id=workspace_id,
+            argv=(sys.executable, "-c", "print('no')"),
+            ttl_seconds=30,
+        )
+    assert capacity.value.code == "service_capacity_exhausted"
+    while manager.status(task_id=task_id, service_id=started.service_id).state == "running":
+        await asyncio.sleep(0.02)
+    expired = manager.status(task_id=task_id, service_id=started.service_id)
+    assert expired.reason == "service_ttl_expired"

--- a/server/tests/test_coding_worker_processes.py
+++ b/server/tests/test_coding_worker_processes.py
@@ -84,7 +84,9 @@ async def test_service_output_is_archived_without_exposing_pid(tmp_path: Path) -
         await asyncio.sleep(0.01)
     completed = manager.status(task_id=task_id, service_id=started.service_id)
     assert completed.state == "completed" and completed.output_artifact_id
-    assert store.read_artifact(completed.output_artifact_id, task_id=task_id) == b"ready\r\n"
+    assert store.read_artifact(
+        completed.output_artifact_id, task_id=task_id
+    ).splitlines() == [b"ready"]
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_coding_worker_provider_rpc.py
+++ b/server/tests/test_coding_worker_provider_rpc.py
@@ -17,6 +17,12 @@ from server.coding_worker.provider_rpc import (
     ProviderRPCServer,
     ProviderSidecarClientPool,
 )
+from server.coding_worker.executor import (
+    ExecutorRPCError,
+    ExecutorRPCServer,
+    ExecutorSidecarClientPool,
+    SidecarExecutor,
+)
 from server.coding_worker.store import CodingWorkerStore
 from server.coding_worker.tool_broker import ToolBroker
 from server.coding_worker.workspace import WorkspaceBroker
@@ -116,3 +122,54 @@ async def test_provider_sidecar_rejects_wrong_token_and_second_active_task(
     await pool.close(first)
     await server.close()
     await broker_rpc.close()
+
+
+@pytest.mark.asyncio
+async def test_credential_free_executor_requires_exact_task_workspace_binding(
+    tmp_path: Path,
+) -> None:
+    repository = tmp_path / "slots" / "workspaces" / "workspace_one" / "repo"
+    repository.mkdir(parents=True)
+    (repository / "main.py").write_text("print('isolated')\n")
+    executor = SidecarExecutor(
+        lambda workspace_id: repository if workspace_id == "workspace_one" else tmp_path / "missing",
+        runtime_root=tmp_path / "runtime",
+    )
+    server = ExecutorRPCServer(executor, token="e" * 48)
+    endpoint = await server.start_tcp_for_tests()
+    pool = ExecutorSidecarClientPool(
+        endpoints={"slot-a": endpoint},
+        tokens={"slot-a": "e" * 48},
+        workspace_slot_resolver=lambda _workspace_id: "slot-a",
+    )
+    with pytest.raises(ExecutorRPCError) as unbound:
+        await pool.run_process(
+            task_id="task_one",
+            workspace_id="workspace_one",
+            argv=("python", "main.py"),
+            timeout_seconds=10,
+            isolated=False,
+        )
+    assert unbound.value.code == "executor_binding_invalid"
+    await pool.bind_task("task_one", "workspace_one")
+    result = await pool.run_process(
+        task_id="task_one",
+        workspace_id="workspace_one",
+        argv=("python", "main.py"),
+        timeout_seconds=10,
+        isolated=False,
+    )
+    assert result["exit_code"] == 0 and str(result["output"]).splitlines() == [
+        "isolated"
+    ]
+    with pytest.raises(ExecutorRPCError) as foreign:
+        await pool.run_process(
+            task_id="task_two",
+            workspace_id="workspace_one",
+            argv=("python", "main.py"),
+            timeout_seconds=10,
+            isolated=False,
+        )
+    assert foreign.value.code == "executor_binding_invalid"
+    await pool.close_task("task_one", "workspace_one")
+    await server.close()

--- a/server/tests/test_coding_worker_provider_rpc.py
+++ b/server/tests/test_coding_worker_provider_rpc.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from cryptography.fernet import Fernet
+
+from server.coding_worker.broker_rpc import BrokerRPCServer
+from server.coding_worker.contracts import PolicyProfile, TaskBudget
+from server.coding_worker.provider import (
+    FakeCodingAgentProvider,
+    ProviderEventKind,
+    ProviderOpenRequest,
+)
+from server.coding_worker.provider_rpc import (
+    ProviderRPCError,
+    ProviderRPCServer,
+    ProviderSidecarClientPool,
+)
+from server.coding_worker.store import CodingWorkerStore
+from server.coding_worker.tool_broker import ToolBroker
+from server.coding_worker.workspace import WorkspaceBroker
+
+
+def _request(task_id: str, workspace_id: str) -> ProviderOpenRequest:
+    return ProviderOpenRequest(
+        task_id=task_id,
+        workspace_id=workspace_id,
+        objective="Fix and test the project",
+        model_route="coding/default",
+        policy_profile=PolicyProfile.DEVELOP,
+        budget=TaskBudget(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_provider_sidecar_pool_streams_neutral_events_and_revokes_broker_token(
+    tmp_path: Path,
+) -> None:
+    store = CodingWorkerStore(tmp_path / "control", master_key=Fernet.generate_key())
+    workspace = WorkspaceBroker(tmp_path / "workspace", {}, id_key=b"w" * 32)
+    broker_rpc = BrokerRPCServer(ToolBroker(store=store, workspace_broker=workspace))
+    await broker_rpc.start_tcp_for_tests()
+    server = ProviderRPCServer(FakeCodingAgentProvider(), token="s" * 48)
+    endpoint = await server.start_tcp_for_tests()
+    pool = ProviderSidecarClientPool(
+        endpoints={"slot-a": endpoint},
+        tokens={"slot-a": "s" * 48},
+        workspace_slot_resolver=lambda _workspace_id: "slot-a",
+        broker_rpc=broker_rpc,
+    )
+    # Broker tokens bind to persisted tasks, just as the production service does.
+    from server.tests.test_coding_worker_service import _request as task_request
+    from server.coding_worker.contracts import Origin, TaskSpec
+
+    task_id = store.create_task(
+        TaskSpec(**task_request("rpc-task").model_dump(), origin=Origin(module="test", object_id="rpc"))
+    ).task_id
+    session = await pool.open(_request(task_id, "workspace_fake"))
+    events = [event async for event in pool.message(session, "continue")]
+    assert [event.kind for event in events] == [
+        ProviderEventKind.PLAN,
+        ProviderEventKind.TURN_COMPLETED,
+    ]
+    checkpoint = await pool.checkpoint(session)
+    assert checkpoint.payload["fake_session"] == session.session_id
+    assert task_id in broker_rpc._tokens
+    await pool.close(session)
+    assert task_id not in broker_rpc._tokens
+    await server.close()
+    await broker_rpc.close()
+
+
+@pytest.mark.asyncio
+async def test_provider_sidecar_rejects_wrong_token_and_second_active_task(
+    tmp_path: Path,
+) -> None:
+    store = CodingWorkerStore(tmp_path / "control", master_key=Fernet.generate_key())
+    workspace = WorkspaceBroker(tmp_path / "workspace", {}, id_key=b"x" * 32)
+    broker_rpc = BrokerRPCServer(ToolBroker(store=store, workspace_broker=workspace))
+    await broker_rpc.start_tcp_for_tests()
+    server = ProviderRPCServer(FakeCodingAgentProvider(), token="a" * 48)
+    endpoint = await server.start_tcp_for_tests()
+    bad = ProviderSidecarClientPool(
+        endpoints={"slot-a": endpoint},
+        tokens={"slot-a": "b" * 48},
+        workspace_slot_resolver=lambda _workspace_id: "slot-a",
+        broker_rpc=broker_rpc,
+    )
+    with pytest.raises(ProviderRPCError) as unauthorized:
+        await bad.capabilities()
+    assert unauthorized.value.code == "provider_unauthorized"
+
+    from server.tests.test_coding_worker_service import _request as task_request
+    from server.coding_worker.contracts import Origin, TaskSpec
+
+    task_ids = [
+        store.create_task(
+            TaskSpec(
+                **task_request(f"rpc-busy-{index}").model_dump(),
+                origin=Origin(module="test", object_id=f"rpc-{index}"),
+            )
+        ).task_id
+        for index in range(2)
+    ]
+    pool = ProviderSidecarClientPool(
+        endpoints={"slot-a": endpoint},
+        tokens={"slot-a": "a" * 48},
+        workspace_slot_resolver=lambda _workspace_id: "slot-a",
+        broker_rpc=broker_rpc,
+    )
+    first = await pool.open(_request(task_ids[0], "workspace_one"))
+    with pytest.raises(ProviderRPCError) as busy:
+        await pool.open(_request(task_ids[1], "workspace_two"))
+    assert busy.value.code == "provider_slot_busy"
+    await pool.close(first)
+    await server.close()
+    await broker_rpc.close()

--- a/server/tests/test_coding_worker_provider_rpc.py
+++ b/server/tests/test_coding_worker_provider_rpc.py
@@ -173,3 +173,60 @@ async def test_credential_free_executor_requires_exact_task_workspace_binding(
     assert foreign.value.code == "executor_binding_invalid"
     await pool.close_task("task_one", "workspace_one")
     await server.close()
+
+
+@pytest.mark.asyncio
+async def test_provider_pool_binds_and_closes_separate_executor(tmp_path: Path) -> None:
+    store = CodingWorkerStore(tmp_path / "control", master_key=Fernet.generate_key())
+    workspace = WorkspaceBroker(tmp_path / "workspace", {}, id_key=b"z" * 32)
+    broker_rpc = BrokerRPCServer(ToolBroker(store=store, workspace_broker=workspace))
+    await broker_rpc.start_tcp_for_tests()
+    provider_server = ProviderRPCServer(FakeCodingAgentProvider(), token="p" * 48)
+    provider_endpoint = await provider_server.start_tcp_for_tests()
+    repository = tmp_path / "repo"
+    repository.mkdir()
+    executor_server = ExecutorRPCServer(
+        SidecarExecutor(lambda _workspace_id: repository, runtime_root=tmp_path / "run"),
+        token="x" * 48,
+    )
+    executor_endpoint = await executor_server.start_tcp_for_tests()
+    executor_pool = ExecutorSidecarClientPool(
+        endpoints={"slot-a": executor_endpoint},
+        tokens={"slot-a": "x" * 48},
+        workspace_slot_resolver=lambda _workspace_id: "slot-a",
+    )
+    pool = ProviderSidecarClientPool(
+        endpoints={"slot-a": provider_endpoint},
+        tokens={"slot-a": "p" * 48},
+        workspace_slot_resolver=lambda _workspace_id: "slot-a",
+        broker_rpc=broker_rpc,
+        executor_pool=executor_pool,
+    )
+    from server.tests.test_coding_worker_service import _request as task_request
+    from server.coding_worker.contracts import Origin, TaskSpec
+
+    task_id = store.create_task(
+        TaskSpec(**task_request("split-slot").model_dump(), origin=Origin(module="test", object_id="split"))
+    ).task_id
+    session = await pool.open(_request(task_id, "workspace_split"))
+    result = await pool.run_process(
+        task_id=task_id,
+        workspace_id="workspace_split",
+        argv=("python", "-c", "print('executor-only')"),
+        timeout_seconds=10,
+        isolated=False,
+    )
+    assert result["exit_code"] == 0
+    await pool.close(session)
+    with pytest.raises(ExecutorRPCError) as closed:
+        await executor_pool.run_process(
+            task_id=task_id,
+            workspace_id="workspace_split",
+            argv=("python", "-c", "print('no')"),
+            timeout_seconds=10,
+            isolated=False,
+        )
+    assert closed.value.code == "executor_binding_invalid"
+    await provider_server.close()
+    await executor_server.close()
+    await broker_rpc.close()

--- a/server/tests/test_coding_worker_runtime.py
+++ b/server/tests/test_coding_worker_runtime.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from server.coding_worker.contracts import (
+    AcceptanceCheck,
+    AcceptanceContract,
+    Origin,
+    TaskCreateRequest,
+    TaskState,
+    WorkspaceSource,
+)
+from server.coding_worker.provider import FakeCodingAgentProvider
+from server.coding_worker.provider_rpc import ProviderRPCServer
+from server.coding_worker.runtime import CodingWorkerRuntime
+from server.coding_worker.workspace import InMemoryWorkspaceSourceAdapter
+
+
+@pytest.mark.asyncio
+async def test_runtime_connects_two_dedicated_provider_slots(tmp_path: Path) -> None:
+    blockers = {slot: asyncio.Event() for slot in ("slot-a", "slot-b")}
+    servers = {
+        slot: ProviderRPCServer(
+            FakeCodingAgentProvider(block=blockers[slot]), token=token
+        )
+        for slot, token in {"slot-a": "a" * 48, "slot-b": "b" * 48}.items()
+    }
+    endpoints = {
+        slot: await server.start_tcp_for_tests() for slot, server in servers.items()
+    }
+    runtime = CodingWorkerRuntime(
+        storage_root=tmp_path / "control",
+        slot_roots={
+            "slot-a": tmp_path / "slot-a",
+            "slot-b": tmp_path / "slot-b",
+        },
+        source_adapters={
+            "manifest": InMemoryWorkspaceSourceAdapter(
+                {("source", "h0"): {"main.py": b"print('ok')\n"}}
+            )
+        },
+        frozen_checks={},
+        provider_endpoints=endpoints,
+        provider_tokens={"slot-a": "a" * 48, "slot-b": "b" * 48},
+        broker_socket_path=None,
+        sidecar_uid=-1,
+        sidecar_gid=-1,
+    )
+    await runtime.start()
+    source = WorkspaceSource(kind="manifest", source_id="source", revision="h0")
+    tasks = [
+        await runtime.service.create_task(
+            Origin(module="test", object_id=str(index)),
+            TaskCreateRequest(
+                client_task_id=f"runtime-{index}",
+                objective="inspect",
+                workspace_source=source,
+                acceptance=AcceptanceContract(
+                    contract_id="syntax",
+                    required_checks=(
+                        AcceptanceCheck(
+                            check_id="syntax", label="syntax", kind="command"
+                        ),
+                    ),
+                ),
+                model_route="coding/default",
+            ),
+        )
+        for index in range(2)
+    ]
+    for task in tasks:
+        running = await runtime.service.wait_for(
+            task.task_id, lambda item: item.state is TaskState.RUNNING
+        )
+        assert running.workspace_id is not None
+    assert {
+        runtime.workspace_broker.workspace_slot(
+            runtime.store.get_task(task.task_id).workspace_id or ""
+        )
+        for task in tasks
+    } == {"slot-a", "slot-b"}
+    for task in tasks:
+        await runtime.service.cancel(task.task_id)
+    await runtime.close()
+    for server in servers.values():
+        await server.close()

--- a/server/tests/test_coding_worker_service.py
+++ b/server/tests/test_coding_worker_service.py
@@ -281,6 +281,13 @@ async def test_failed_acceptance_is_repaired_and_retested_before_completion(
     assert "Check pytest failed" in provider.messages[1]
     statuses = [item.status.value for item in service.store.list_evidence(task.task_id)]
     assert statuses[-1] == "passed"
+    checkpoint = service.store.latest_checkpoint(task.task_id)
+    assert checkpoint is not None
+    summary = checkpoint.payload["context_summary"]
+    assert summary["objective"] == "Complete repair"
+    assert summary["required_checks"] == ["pytest"]
+    assert summary["next_step"] == "run_required_acceptance"
+    assert "private" not in checkpoint.payload["provider"]
     await service.shutdown()
 
 

--- a/server/tests/test_coding_worker_service.py
+++ b/server/tests/test_coding_worker_service.py
@@ -16,6 +16,7 @@ from server.coding_worker.contracts import (
     PolicyProfile,
     TaskBudget,
     TaskCreateRequest,
+    TaskSpec,
     TaskState,
     WorkspaceSource,
 )
@@ -23,6 +24,8 @@ from server.coding_worker.evidence import HarnessRunner
 from server.coding_worker.provider import (
     FakeCodingAgentProvider,
     ProviderEvent,
+    ProviderCheckpoint,
+    ProviderOpenRequest,
     ProviderSession,
 )
 from server.coding_worker.service import CodingWorkerService
@@ -73,6 +76,26 @@ class _RepairingProvider(FakeCodingAgentProvider):
             await self.repair()
         async for event in super().message(session, text):
             yield event
+
+
+class _RestoreTrackingProvider(FakeCodingAgentProvider):
+    def __init__(self) -> None:
+        super().__init__()
+        self.restore_count = 0
+        self.message_count = 0
+
+    async def message(
+        self, session: ProviderSession, text: str
+    ) -> AsyncIterator[ProviderEvent]:
+        self.message_count += 1
+        async for event in super().message(session, text):
+            yield event
+
+    async def restore(
+        self, request: ProviderOpenRequest, checkpoint: ProviderCheckpoint
+    ) -> ProviderSession:
+        self.restore_count += 1
+        return await super().restore(request, checkpoint)
 
 
 def _service_with_harness(
@@ -223,4 +246,95 @@ async def test_required_check_failure_exhausts_turn_budget_without_completion(
     assert limited.reason == "turn_budget_exhausted"
     assert limited.state is not TaskState.COMPLETED
     assert len(service.store.list_evidence(task.task_id)) == 2
+    await service.shutdown()
+
+
+async def _checkpointed_task(
+    service: CodingWorkerService,
+    broker: ToolBroker,
+    *,
+    mutate_after_checkpoint: bool,
+) -> str:
+    request = _request("restore").model_copy(
+        update={"policy_profile": PolicyProfile.DEVELOP}
+    )
+    prepared = await service.workspace_broker.prepare(request.workspace_source)
+    task = service.store.create_task(
+        TaskSpec(**request.model_dump(), origin=Origin(module="test", object_id="restore"))
+    )
+    service.store.transition(task.task_id, TaskState.PREPARING)
+    service.store.transition(
+        task.task_id, TaskState.RUNNING, workspace_id=prepared.workspace_id
+    )
+    content = "print('checkpoint')\n"
+    await broker.execute(
+        task_id=task.task_id,
+        operation_id="checkpoint-write",
+        tool_name="write_file",
+        arguments={
+            "path": "main.py",
+            "content": content,
+            "content_sha256": hashlib.sha256(content.encode()).hexdigest(),
+        },
+    )
+    tree_hash = service.workspace_broker.current_tree_hash(prepared.workspace_id)
+    provider_checkpoint = ProviderCheckpoint(
+        checkpoint_id="checkpoint_provider",
+        payload={"private_context": "resume-only"},
+    )
+    service.store.create_checkpoint(
+        task_id=task.task_id,
+        workspace_tree_hash=tree_hash,
+        payload={
+            "phase": "testing",
+            "completed_turns": 1,
+            "provider": provider_checkpoint.model_dump(mode="json"),
+        },
+    )
+    if mutate_after_checkpoint:
+        changed = "print('changed after checkpoint')\n"
+        await broker.execute(
+            task_id=task.task_id,
+            operation_id="post-checkpoint-write",
+            tool_name="write_file",
+            arguments={
+                "path": "main.py",
+                "content": changed,
+                "content_sha256": hashlib.sha256(changed.encode()).hexdigest(),
+            },
+        )
+    service.store.transition(task.task_id, TaskState.INTERRUPTED)
+    return task.task_id
+
+
+@pytest.mark.asyncio
+async def test_explicit_resume_restores_exact_checkpoint_and_runs_acceptance_first(
+    tmp_path: Path,
+) -> None:
+    provider = _RestoreTrackingProvider()
+    service, broker = _service_with_harness(tmp_path, provider)
+    task_id = await _checkpointed_task(
+        service, broker, mutate_after_checkpoint=False
+    )
+    await service.resume(task_id)
+    completed = await service.wait_for(
+        task_id, lambda item: item.state is TaskState.COMPLETED
+    )
+    assert completed.reason is None
+    assert provider.restore_count == 1
+    assert provider.message_count == 0
+    await service.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_resume_rejects_workspace_changed_after_checkpoint(tmp_path: Path) -> None:
+    provider = _RestoreTrackingProvider()
+    service, broker = _service_with_harness(tmp_path, provider)
+    task_id = await _checkpointed_task(service, broker, mutate_after_checkpoint=True)
+    await service.resume(task_id)
+    blocked = await service.wait_for(
+        task_id, lambda item: item.state is TaskState.BLOCKED
+    )
+    assert blocked.reason == "checkpoint_workspace_changed"
+    assert provider.restore_count == 0
     await service.shutdown()

--- a/server/tests/test_coding_worker_service.py
+++ b/server/tests/test_coding_worker_service.py
@@ -193,6 +193,62 @@ async def test_shutdown_interrupts_without_replaying_and_resume_is_explicit(tmp_
 
 
 @pytest.mark.asyncio
+async def test_dedicated_slots_queue_third_task_and_resume_on_original_slot(
+    tmp_path: Path,
+) -> None:
+    blocker = asyncio.Event()
+    provider = FakeCodingAgentProvider(block=blocker)
+    store = CodingWorkerStore(tmp_path / "control", master_key=Fernet.generate_key())
+    broker = WorkspaceBroker(
+        tmp_path / "control",
+        {
+            "manifest": InMemoryWorkspaceSourceAdapter(
+                {("source-01", "revision-01"): {"main.py": b"print('ok')\n"}}
+            )
+        },
+        id_key=b"z" * 32,
+        slot_roots={
+            "slot-a": tmp_path / "slot-a",
+            "slot-b": tmp_path / "slot-b",
+        },
+    )
+    service = CodingWorkerService(
+        store=store,
+        workspace_broker=broker,
+        provider=provider,
+        max_active_tasks=2,
+    )
+    origin = Origin(module="test", object_id="dedicated-slots")
+    tasks = [
+        await service.create_task(origin, _request(f"slot-task-{index}"))
+        for index in range(3)
+    ]
+
+    for task in tasks[:2]:
+        await service.wait_for(task.task_id, lambda item: item.state is TaskState.RUNNING)
+    first_workspace = service.store.get_task(tasks[0].task_id).workspace_id
+    second_workspace = service.store.get_task(tasks[1].task_id).workspace_id
+    assert first_workspace is not None and second_workspace is not None
+    assert {
+        broker.workspace_slot(first_workspace),
+        broker.workspace_slot(second_workspace),
+    } == {"slot-a", "slot-b"}
+    original_slot = broker.workspace_slot(first_workspace)
+    assert service.store.get_task(tasks[2].task_id).state is TaskState.QUEUED
+
+    await service.pause(tasks[0].task_id)
+    await service.wait_for(tasks[2].task_id, lambda item: item.state is TaskState.RUNNING)
+    await service.pause(tasks[2].task_id)
+    await service.resume(tasks[0].task_id)
+    await service.wait_for(tasks[0].task_id, lambda item: item.state is TaskState.RUNNING)
+    assert broker.workspace_slot(first_workspace) == original_slot
+
+    await service.cancel(tasks[0].task_id)
+    await service.cancel(tasks[1].task_id)
+    await service.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_failed_acceptance_is_repaired_and_retested_before_completion(
     tmp_path: Path,
 ) -> None:

--- a/server/tests/test_coding_worker_service.py
+++ b/server/tests/test_coding_worker_service.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import sys
+from collections.abc import AsyncIterator, Awaitable, Callable
 from pathlib import Path
 
 import pytest
@@ -10,13 +13,21 @@ from server.coding_worker.contracts import (
     AcceptanceCheck,
     AcceptanceContract,
     Origin,
+    PolicyProfile,
+    TaskBudget,
     TaskCreateRequest,
     TaskState,
     WorkspaceSource,
 )
-from server.coding_worker.provider import FakeCodingAgentProvider
+from server.coding_worker.evidence import HarnessRunner
+from server.coding_worker.provider import (
+    FakeCodingAgentProvider,
+    ProviderEvent,
+    ProviderSession,
+)
 from server.coding_worker.service import CodingWorkerService
 from server.coding_worker.store import CodingWorkerStore
+from server.coding_worker.tool_broker import FrozenCheck, ToolBroker
 from server.coding_worker.workspace import InMemoryWorkspaceSourceAdapter, WorkspaceBroker
 
 
@@ -46,6 +57,59 @@ def _service(tmp_path: Path, provider: FakeCodingAgentProvider) -> CodingWorkerS
         tmp_path / "worker", {"manifest": adapter}, id_key=b"s" * 32
     )
     return CodingWorkerService(store=store, workspace_broker=broker, provider=provider)
+
+
+class _RepairingProvider(FakeCodingAgentProvider):
+    def __init__(self) -> None:
+        super().__init__()
+        self.messages: list[str] = []
+        self.repair: Callable[[], Awaitable[None]] | None = None
+
+    async def message(
+        self, session: ProviderSession, text: str
+    ) -> AsyncIterator[ProviderEvent]:
+        self.messages.append(text)
+        if len(self.messages) == 2 and self.repair is not None:
+            await self.repair()
+        async for event in super().message(session, text):
+            yield event
+
+
+def _service_with_harness(
+    tmp_path: Path, provider: FakeCodingAgentProvider
+) -> tuple[CodingWorkerService, ToolBroker]:
+    store = CodingWorkerStore(tmp_path / "worker", master_key=Fernet.generate_key())
+    workspace = WorkspaceBroker(
+        tmp_path / "worker",
+        {
+            "manifest": InMemoryWorkspaceSourceAdapter(
+                {("source-01", "revision-01"): {"main.py": b"bad python\n"}}
+            )
+        },
+        id_key=b"h" * 32,
+    )
+    broker = ToolBroker(
+        store=store,
+        workspace_broker=workspace,
+        frozen_checks={
+            "pytest": FrozenCheck(
+                check_id="pytest",
+                argv=(sys.executable, "-m", "py_compile", "main.py"),
+            )
+        },
+    )
+    harness = HarnessRunner(
+        store=store, workspace_broker=workspace, tool_broker=broker
+    )
+    return (
+        CodingWorkerService(
+            store=store,
+            workspace_broker=workspace,
+            provider=provider,
+            harness_runner=harness,
+        ),
+        broker,
+    )
 
 
 @pytest.mark.asyncio
@@ -102,4 +166,61 @@ async def test_shutdown_interrupts_without_replaying_and_resume_is_explicit(tmp_
     await service.wait_for(task.task_id, lambda item: item.state is TaskState.RUNNING)
     assert service.store.get_task(task.task_id).workspace_id == workspace_id
     await service.cancel(task.task_id)
+    await service.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_failed_acceptance_is_repaired_and_retested_before_completion(
+    tmp_path: Path,
+) -> None:
+    provider = _RepairingProvider()
+    service, broker = _service_with_harness(tmp_path, provider)
+    request = _request("repair").model_copy(
+        update={"policy_profile": PolicyProfile.DEVELOP}
+    )
+    task = await service.create_task(Origin(module="test", object_id="repair"), request)
+
+    async def repair() -> None:
+        content = "print('fixed')\n"
+        await broker.execute(
+            task_id=task.task_id,
+            operation_id="repair-main",
+            tool_name="write_file",
+            arguments={
+                "path": "main.py",
+                "content": content,
+                "content_sha256": hashlib.sha256(content.encode()).hexdigest(),
+            },
+        )
+
+    provider.repair = repair
+    completed = await service.wait_for(
+        task.task_id, lambda item: item.state is TaskState.COMPLETED
+    )
+    assert completed.reason is None
+    assert len(provider.messages) == 2
+    assert "Check pytest failed" in provider.messages[1]
+    statuses = [item.status.value for item in service.store.list_evidence(task.task_id)]
+    assert statuses[-1] == "passed"
+    await service.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_required_check_failure_exhausts_turn_budget_without_completion(
+    tmp_path: Path,
+) -> None:
+    service, _ = _service_with_harness(tmp_path, FakeCodingAgentProvider())
+    request = _request("budget").model_copy(
+        update={
+            "policy_profile": PolicyProfile.DEVELOP,
+            "budget": TaskBudget(max_turns=2),
+        }
+    )
+    task = await service.create_task(Origin(module="test", object_id="budget"), request)
+    limited = await service.wait_for(
+        task.task_id, lambda item: item.state is TaskState.BUDGET_LIMITED
+    )
+    assert limited.reason == "turn_budget_exhausted"
+    assert limited.state is not TaskState.COMPLETED
+    assert len(service.store.list_evidence(task.task_id)) == 2
     await service.shutdown()

--- a/server/tests/test_coding_worker_store.py
+++ b/server/tests/test_coding_worker_store.py
@@ -107,6 +107,28 @@ def test_pin_retention_cleanup_and_immediate_delete(tmp_path: Path) -> None:
     assert store.delete_task(pinned.task_id) is True
 
 
+def test_checkpoint_is_encrypted_tree_bound_and_survives_restart(tmp_path: Path) -> None:
+    key = Fernet.generate_key()
+    root = tmp_path / "worker"
+    store = CodingWorkerStore(root, master_key=key)
+    task = store.create_task(_spec(client_task_id="checkpoint"))
+    checkpoint = store.create_checkpoint(
+        task_id=task.task_id,
+        workspace_tree_hash="a" * 64,
+        payload={
+            "phase": "testing",
+            "provider": {"checkpoint_id": "private-provider-session"},
+        },
+    )
+    assert b"private-provider-session" not in store.database_path.read_bytes()
+
+    restarted = CodingWorkerStore(root, master_key=key)
+    loaded = restarted.latest_checkpoint(task.task_id)
+    assert loaded == checkpoint
+    assert loaded is not None and loaded.workspace_tree_hash == "a" * 64
+    assert loaded.payload["phase"] == "testing"
+
+
 def test_existing_database_without_key_fails_closed(tmp_path: Path) -> None:
     root = tmp_path / "worker"
     store = CodingWorkerStore(root, master_key=Fernet.generate_key())

--- a/server/tests/test_coding_worker_tool_broker.py
+++ b/server/tests/test_coding_worker_tool_broker.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import sys
+from unittest.mock import AsyncMock
 from pathlib import Path
 
 import pytest
@@ -19,6 +20,7 @@ from server.coding_worker.contracts import (
 )
 from server.coding_worker.store import CodingWorkerStore
 from server.coding_worker.process_manager import BackgroundProcessManager
+from server.coding_worker.network_policy import EgressPolicy
 from server.coding_worker.tool_broker import FrozenCheck, ToolBroker, ToolBrokerError
 from server.coding_worker.workspace import InMemoryWorkspaceSourceAdapter, WorkspaceBroker
 
@@ -330,3 +332,65 @@ async def test_background_service_requires_exact_lease_and_remains_task_owned(
     )
     assert stopped.data["reason"] == "user_interrupted"
     await manager.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_dependency_install_requires_both_exact_leases_and_records_source(
+    tmp_path: Path,
+) -> None:
+    broker, store, task_id, _ = await _broker(
+        tmp_path, profile=PolicyProfile.DEVELOP_NETWORKED
+    )
+    broker.egress_policy = EgressPolicy(
+        enabled=True, allowed_domains={"registry.npmjs.org"}
+    )
+    broker.egress_proxy_url = "http://worker-egress:8080"
+    broker._run_process = AsyncMock(
+        return_value={"argv": ["npm", "ci"], "exit_code": 0, "output": "installed"}
+    )
+    arguments = {"manager": "npm", "action": "ci"}
+    with pytest.raises(ToolBrokerError) as approval_required:
+        await broker.execute(
+            task_id=task_id,
+            operation_id="dependency-install",
+            tool_name="install_dependencies",
+            arguments=arguments,
+        )
+    assert approval_required.value.code == "approval_required"
+    approvals = store.list_approvals(task_id)
+    assert {item.capability for item in approvals} == {"dependency_install", "network"}
+    decided = {
+        item.capability: store.decide_approval(item.approval_id, approved=True).lease
+        for item in approvals
+    }
+    store.transition(task_id, TaskState.RUNNING)
+    result = await broker.execute(
+        task_id=task_id,
+        operation_id="dependency-install",
+        tool_name="install_dependencies",
+        arguments=arguments,
+        lease_id=decided["dependency_install"].lease_id,
+        network_lease_id=decided["network"].lease_id,
+    )
+    assert result.data["exit_code"] == 0
+    source = store.read_artifact(result.data["source_artifact_id"], task_id=task_id)
+    assert b"registry.npmjs.org" in source and b"worker-egress" not in source
+    call = broker._run_process.await_args
+    assert call.kwargs["environment_overrides"]["HTTPS_PROXY"] == "http://worker-egress:8080"
+
+
+@pytest.mark.asyncio
+async def test_dependency_install_is_disabled_without_global_egress_policy(
+    tmp_path: Path,
+) -> None:
+    broker, _, task_id, _ = await _broker(
+        tmp_path, profile=PolicyProfile.DEVELOP_NETWORKED
+    )
+    with pytest.raises(ToolBrokerError) as disabled:
+        await broker.execute(
+            task_id=task_id,
+            operation_id="dependency-disabled",
+            tool_name="install_dependencies",
+            arguments={"manager": "npm", "action": "ci"},
+        )
+    assert disabled.value.code == "network_disabled"

--- a/server/tests/test_coding_worker_tool_broker.py
+++ b/server/tests/test_coding_worker_tool_broker.py
@@ -426,7 +426,9 @@ async def test_dependency_install_requires_both_exact_leases_and_records_source(
         tmp_path, profile=PolicyProfile.DEVELOP_NETWORKED
     )
     broker.egress_policy = EgressPolicy(
-        enabled=True, allowed_domains={"registry.npmjs.org"}
+        enabled=True,
+        allowed_domains={"registry.npmjs.org"},
+        grant_key=b"g" * 32,
     )
     broker.egress_proxy_url = "http://worker-egress:8080"
     broker._run_process = AsyncMock(
@@ -460,7 +462,8 @@ async def test_dependency_install_requires_both_exact_leases_and_records_source(
     source = store.read_artifact(result.data["source_artifact_id"], task_id=task_id)
     assert b"registry.npmjs.org" in source and b"worker-egress" not in source
     call = broker._run_process.await_args
-    assert call.kwargs["environment_overrides"]["HTTPS_PROXY"] == "http://worker-egress:8080"
+    proxy = call.kwargs["environment_overrides"]["HTTPS_PROXY"]
+    assert proxy.startswith("http://grant:") and proxy.endswith("@worker-egress:8080")
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_coding_worker_tool_broker.py
+++ b/server/tests/test_coding_worker_tool_broker.py
@@ -214,6 +214,30 @@ async def test_unknown_write_reconciles_but_command_never_replays(tmp_path: Path
 
 
 @pytest.mark.asyncio
+async def test_command_is_killed_while_output_limit_is_crossed(tmp_path: Path) -> None:
+    broker, store, task_id, _ = await _broker(tmp_path)
+    broker.max_output_bytes = 1024
+    argv = ["python", "-c", "print('x' * 5000)"]
+    approval = store.create_approval(
+        task_id=task_id,
+        operation_id="approve-large-output",
+        capability="command",
+        request={"argv": argv},
+    )
+    lease = store.decide_approval(approval.approval_id, approved=True).lease
+    assert lease is not None
+    with pytest.raises(ToolBrokerError) as too_large:
+        await broker.execute(
+            task_id=task_id,
+            operation_id="large-output",
+            tool_name="run_command",
+            arguments={"argv": argv},
+            lease_id=lease.lease_id,
+        )
+    assert too_large.value.code == "tool_output_too_large"
+
+
+@pytest.mark.asyncio
 async def test_missing_command_lease_creates_one_approval_and_same_operation_resumes(
     tmp_path: Path,
 ) -> None:

--- a/server/tests/test_coding_worker_tool_broker.py
+++ b/server/tests/test_coding_worker_tool_broker.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import sys
 from unittest.mock import AsyncMock
@@ -21,6 +22,7 @@ from server.coding_worker.contracts import (
 from server.coding_worker.store import CodingWorkerStore
 from server.coding_worker.process_manager import BackgroundProcessManager
 from server.coding_worker.network_policy import EgressPolicy
+from server.coding_worker.executor import SidecarExecutor
 from server.coding_worker.tool_broker import FrozenCheck, ToolBroker, ToolBrokerError
 from server.coding_worker.workspace import InMemoryWorkspaceSourceAdapter, WorkspaceBroker
 
@@ -100,6 +102,88 @@ async def test_develop_can_write_search_diff_and_run_frozen_check(tmp_path: Path
     )
     assert check.data["exit_code"] == 0
     assert repository.joinpath("app.py").read_text() == content
+
+
+@pytest.mark.asyncio
+async def test_command_execution_can_be_delegated_to_sidecar(tmp_path: Path) -> None:
+    broker, store, task_id, _ = await _broker(tmp_path)
+    executor = AsyncMock()
+    executor.run_process.return_value = {
+        "argv": ["python", "-V"],
+        "exit_code": 0,
+        "output": "Python sidecar",
+    }
+    broker.executor = executor
+    arguments = {"argv": ["python", "-V"], "timeout_seconds": 30}
+    approval = store.create_approval(
+        task_id=task_id,
+        operation_id="sidecar-command",
+        capability="command",
+        request=arguments,
+    )
+    lease = store.decide_approval(
+        approval.approval_id, approved=True, task_scope=False
+    ).lease
+    assert lease is not None
+    result = await broker.execute(
+        task_id=task_id,
+        operation_id="sidecar-command",
+        tool_name="run_command",
+        arguments=arguments,
+        lease_id=lease.lease_id,
+    )
+    assert result.data["output"] == "Python sidecar"
+    executor.run_process.assert_awaited_once()
+    executor.service_status.return_value = {
+        "service_id": "service_" + "a" * 32,
+        "task_id": task_id,
+        "state": "completed",
+        "output": "archived sidecar output",
+    }
+    status = await broker.execute(
+        task_id=task_id,
+        operation_id="sidecar-status",
+        tool_name="service_status",
+        arguments={"service_id": "service_" + "a" * 32},
+    )
+    assert "output" not in status.data
+    artifact_id = status.data["output_artifact_id"]
+    assert store.read_artifact(artifact_id, task_id=task_id) == b"archived sidecar output"
+
+
+@pytest.mark.asyncio
+async def test_sidecar_executor_owns_commands_and_background_services(
+    tmp_path: Path,
+) -> None:
+    repository = tmp_path / "slot" / "workspaces" / "workspace_one" / "repo"
+    repository.mkdir(parents=True)
+    executor = SidecarExecutor(
+        lambda _workspace_id: repository,
+        runtime_root=tmp_path / "slot" / "runtime",
+    )
+    command = await executor.run_process(
+        workspace_id="workspace_one",
+        argv=(sys.executable, "-c", "print('sidecar-command')"),
+        timeout_seconds=10,
+        isolated=False,
+    )
+    assert command["exit_code"] == 0
+    assert command["output"].strip() == "sidecar-command"
+    service = await executor.start_service(
+        task_id="task_sidecar",
+        workspace_id="workspace_one",
+        argv=(sys.executable, "-c", "print('sidecar-service')"),
+        ttl_seconds=10,
+    )
+    for _ in range(100):
+        status = executor.service_status(
+            task_id="task_sidecar", service_id=str(service["service_id"])
+        )
+        if status["state"] != "running":
+            break
+        await asyncio.sleep(0.01)
+    assert status["state"] == "completed"
+    assert str(status["output"]).strip() == "sidecar-service"
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_coding_worker_tool_broker.py
+++ b/server/tests/test_coding_worker_tool_broker.py
@@ -204,10 +204,39 @@ async def test_unknown_write_reconciles_but_command_never_replays(tmp_path: Path
         operation_id="unknown-command",
         tool_name="run_command",
         intent_sha256="f" * 64,
-        request={"arguments": {"argv": ["python", "-V"]}, "lease_id": "lease", "workspace_id": store.get_task(task_id).workspace_id},
+        request={"arguments": {"argv": ["python", "-V"]}, "workspace_id": store.get_task(task_id).workspace_id},
     )
     store.transition_operation(command.operation_id, OperationState.RUNNING)
     store.mark_inflight_operations_unknown()
     with pytest.raises(ToolBrokerError) as unknown:
         broker.reconcile(command.operation_id)
     assert unknown.value.code == "operation_result_unknown"
+
+
+@pytest.mark.asyncio
+async def test_missing_command_lease_creates_one_approval_and_same_operation_resumes(
+    tmp_path: Path,
+) -> None:
+    broker, store, task_id, _ = await _broker(tmp_path)
+    argv = ["python", "-c", "print('approved')"]
+    with pytest.raises(ToolBrokerError) as pending:
+        await broker.execute(
+            task_id=task_id,
+            operation_id="approval-command",
+            tool_name="run_command",
+            arguments={"argv": argv},
+        )
+    assert pending.value.code == "approval_required"
+    approvals = store.list_approvals(task_id)
+    assert len(approvals) == 1
+    decided = store.decide_approval(approvals[0].approval_id, approved=True)
+    assert decided.lease is not None
+    store.transition(task_id, TaskState.RUNNING)
+    result = await broker.execute(
+        task_id=task_id,
+        operation_id="approval-command",
+        tool_name="run_command",
+        arguments={"argv": argv},
+        lease_id=decided.lease.lease_id,
+    )
+    assert result.data["output"].strip() == "approved"

--- a/server/tests/test_coding_worker_tool_broker.py
+++ b/server/tests/test_coding_worker_tool_broker.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import hashlib
+import sys
+from pathlib import Path
+
+import pytest
+from cryptography.fernet import Fernet
+
+from server.coding_worker.contracts import (
+    AcceptanceCheck,
+    AcceptanceContract,
+    Origin,
+    PolicyProfile,
+    OperationState,
+    TaskSpec,
+    TaskState,
+    WorkspaceSource,
+)
+from server.coding_worker.store import CodingWorkerStore
+from server.coding_worker.tool_broker import FrozenCheck, ToolBroker, ToolBrokerError
+from server.coding_worker.workspace import InMemoryWorkspaceSourceAdapter, WorkspaceBroker
+
+
+async def _broker(
+    tmp_path: Path, *, profile: PolicyProfile = PolicyProfile.DEVELOP
+) -> tuple[ToolBroker, CodingWorkerStore, str, Path]:
+    source = WorkspaceSource(kind="manifest", source_id="source", revision="h0")
+    workspace = WorkspaceBroker(
+        tmp_path / "broker",
+        {"manifest": InMemoryWorkspaceSourceAdapter({("source", "h0"): {"app.py": b"print('old')\n"}})},
+        id_key=b"w" * 32,
+    )
+    prepared = await workspace.prepare(source)
+    store = CodingWorkerStore(tmp_path / "store", master_key=Fernet.generate_key())
+    task = store.create_task(
+        TaskSpec(
+            client_task_id="client",
+            origin=Origin(module="tests", object_id="broker"),
+            objective="change app",
+            workspace_source=source,
+            acceptance=AcceptanceContract(
+                contract_id="contract",
+                required_checks=(AcceptanceCheck(check_id="syntax", label="syntax", kind="command"),),
+            ),
+            policy_profile=profile,
+            model_route="coding/default",
+        )
+    )
+    store.transition(task.task_id, TaskState.PREPARING)
+    store.transition(task.task_id, TaskState.RUNNING, workspace_id=prepared.workspace_id)
+    broker = ToolBroker(
+        store=store,
+        workspace_broker=workspace,
+        frozen_checks={
+            "syntax": FrozenCheck(check_id="syntax", argv=(sys.executable, "-m", "py_compile", "app.py"))
+        },
+    )
+    return broker, store, task.task_id, workspace.repository_path(prepared.workspace_id)
+
+
+@pytest.mark.asyncio
+async def test_develop_can_write_search_diff_and_run_frozen_check(tmp_path: Path) -> None:
+    broker, _, task_id, repository = await _broker(tmp_path)
+    content = "print('new')\n"
+    digest = hashlib.sha256(content.encode()).hexdigest()
+    written = await broker.execute(
+        task_id=task_id,
+        operation_id="write-01",
+        tool_name="write_file",
+        arguments={"path": "app.py", "content": content, "content_sha256": digest},
+    )
+    assert written.data["sha256"] == digest
+    same = await broker.execute(
+        task_id=task_id,
+        operation_id="write-01",
+        tool_name="write_file",
+        arguments={"path": "app.py", "content": content, "content_sha256": digest},
+    )
+    assert same == written
+    search = await broker.execute(
+        task_id=task_id,
+        operation_id="search-01",
+        tool_name="search_text",
+        arguments={"query": "new"},
+    )
+    assert search.data["matches"][0]["path"] == "app.py"
+    diff = await broker.execute(
+        task_id=task_id, operation_id="diff-01", tool_name="diff", arguments={}
+    )
+    assert "+print('new')" in diff.data["diff"]
+    check = await broker.execute(
+        task_id=task_id,
+        operation_id="check-01",
+        tool_name="run_check",
+        arguments={"check_id": "syntax"},
+    )
+    assert check.data["exit_code"] == 0
+    assert repository.joinpath("app.py").read_text() == content
+
+
+@pytest.mark.asyncio
+async def test_inspect_policy_and_paths_fail_closed(tmp_path: Path) -> None:
+    broker, _, task_id, repository = await _broker(tmp_path, profile=PolicyProfile.INSPECT)
+    content = "bad\n"
+    with pytest.raises(ToolBrokerError) as readonly:
+        await broker.execute(
+            task_id=task_id,
+            operation_id="write-readonly",
+            tool_name="write_file",
+            arguments={
+                "path": "app.py",
+                "content": content,
+                "content_sha256": hashlib.sha256(content.encode()).hexdigest(),
+            },
+        )
+    assert readonly.value.code == "approval_required"
+    with pytest.raises(ToolBrokerError) as traversal:
+        await broker.execute(
+            task_id=task_id,
+            operation_id="read-traversal",
+            tool_name="read_file",
+            arguments={"path": "../secret"},
+        )
+    assert traversal.value.code == "workspace_path_invalid"
+    assert repository.joinpath("app.py").read_text() == "print('old')\n"
+
+
+@pytest.mark.asyncio
+async def test_command_requires_exact_once_lease_and_denies_shell_remote_and_environment(
+    tmp_path: Path,
+) -> None:
+    broker, store, task_id, _ = await _broker(tmp_path)
+    argv = ["python", "-c", "import os;print(os.getenv('LLM_GATEWAY_KEY'))"]
+    approval = store.create_approval(
+        task_id=task_id,
+        operation_id="approve-command",
+        capability="command",
+        request={"argv": argv},
+    )
+    lease = store.decide_approval(approval.approval_id, approved=True).lease
+    assert lease is not None
+    result = await broker.execute(
+        task_id=task_id,
+        operation_id="command-01",
+        tool_name="run_command",
+        arguments={"argv": argv},
+        lease_id=lease.lease_id,
+    )
+    assert result.data["output"].strip() == "None"
+    with pytest.raises(ToolBrokerError):
+        await broker.execute(
+            task_id=task_id,
+            operation_id="command-02",
+            tool_name="run_command",
+            arguments={"argv": argv},
+            lease_id=lease.lease_id,
+        )
+    for denied in (["sh", "-c", "id"], ["git", "push", "origin", "main"]):
+        approval = store.create_approval(
+            task_id=task_id,
+            operation_id=f"approve-{denied[0]}-{denied[1]}",
+            capability="command",
+            request={"argv": denied},
+        )
+        denied_lease = store.decide_approval(approval.approval_id, approved=True).lease
+        assert denied_lease is not None
+        with pytest.raises(ToolBrokerError) as error:
+            await broker.execute(
+                task_id=task_id,
+                operation_id=f"command-{denied[0]}-{denied[1]}",
+                tool_name="run_command",
+                arguments={"argv": denied},
+                lease_id=denied_lease.lease_id,
+            )
+        assert error.value.code == "command_denied"
+
+
+@pytest.mark.asyncio
+async def test_unknown_write_reconciles_but_command_never_replays(tmp_path: Path) -> None:
+    broker, store, task_id, repository = await _broker(tmp_path)
+    content = "print('reconciled')\n"
+    digest = hashlib.sha256(content.encode()).hexdigest()
+    request = {
+        "arguments": {"path": "app.py", "content": content, "content_sha256": digest},
+        "lease_id": None,
+        "workspace_id": store.get_task(task_id).workspace_id,
+    }
+    operation = store.create_operation(
+        task_id=task_id,
+        operation_id="unknown-write",
+        tool_name="write_file",
+        intent_sha256=broker._intent_sha256("write_file", request),
+        request=request,
+    )
+    store.transition_operation(operation.operation_id, OperationState.RUNNING)
+    repository.joinpath("app.py").write_bytes(content.encode("utf-8"))
+    store.mark_inflight_operations_unknown()
+    reconciled = broker.reconcile(operation.operation_id)
+    assert reconciled.state.value == "completed"
+
+    command = store.create_operation(
+        task_id=task_id,
+        operation_id="unknown-command",
+        tool_name="run_command",
+        intent_sha256="f" * 64,
+        request={"arguments": {"argv": ["python", "-V"]}, "lease_id": "lease", "workspace_id": store.get_task(task_id).workspace_id},
+    )
+    store.transition_operation(command.operation_id, OperationState.RUNNING)
+    store.mark_inflight_operations_unknown()
+    with pytest.raises(ToolBrokerError) as unknown:
+        broker.reconcile(command.operation_id)
+    assert unknown.value.code == "operation_result_unknown"

--- a/server/tests/test_coding_worker_tool_broker.py
+++ b/server/tests/test_coding_worker_tool_broker.py
@@ -174,6 +174,7 @@ async def test_sidecar_executor_owns_commands_and_background_services(
         workspace_id="workspace_one",
         argv=(sys.executable, "-c", "print('sidecar-service')"),
         ttl_seconds=10,
+        preview_port=4173,
     )
     for _ in range(100):
         status = executor.service_status(
@@ -184,6 +185,7 @@ async def test_sidecar_executor_owns_commands_and_background_services(
         await asyncio.sleep(0.01)
     assert status["state"] == "completed"
     assert str(status["output"]).strip() == "sidecar-service"
+    assert status["preview_port"] == 4173
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_coding_worker_tool_broker.py
+++ b/server/tests/test_coding_worker_tool_broker.py
@@ -18,6 +18,7 @@ from server.coding_worker.contracts import (
     WorkspaceSource,
 )
 from server.coding_worker.store import CodingWorkerStore
+from server.coding_worker.process_manager import BackgroundProcessManager
 from server.coding_worker.tool_broker import FrozenCheck, ToolBroker, ToolBrokerError
 from server.coding_worker.workspace import InMemoryWorkspaceSourceAdapter, WorkspaceBroker
 
@@ -264,3 +265,68 @@ async def test_missing_command_lease_creates_one_approval_and_same_operation_res
         lease_id=decided.lease.lease_id,
     )
     assert result.data["output"].strip() == "approved"
+
+
+@pytest.mark.asyncio
+async def test_background_service_requires_exact_lease_and_remains_task_owned(
+    tmp_path: Path,
+) -> None:
+    broker, store, task_id, _ = await _broker(tmp_path)
+    manager = BackgroundProcessManager(
+        store=store,
+        workspace_broker=broker.workspace_broker,
+        environment_factory=lambda workspace_id: broker._safe_environment(
+            broker.workspace_broker.repository_path(workspace_id)
+        ),
+    )
+    broker.process_manager = manager
+    arguments = {
+        "argv": [
+            "python",
+            "-c",
+            "import sys,time;print('ready',flush=True);"
+            "line=sys.stdin.readline();print(line,flush=True);time.sleep(30)",
+        ],
+        "ttl_seconds": 60,
+    }
+    with pytest.raises(ToolBrokerError) as approval_required:
+        await broker.execute(
+            task_id=task_id,
+            operation_id="start-service",
+            tool_name="start_service",
+            arguments=arguments,
+        )
+    assert approval_required.value.code == "approval_required"
+    approval = store.list_approvals(task_id)[-1]
+    lease = store.decide_approval(approval.approval_id, approved=True).lease
+    assert lease is not None
+    store.transition(task_id, TaskState.RUNNING)
+    started = await broker.execute(
+        task_id=task_id,
+        operation_id="start-service",
+        tool_name="start_service",
+        arguments=arguments,
+        lease_id=lease.lease_id,
+    )
+    service_id = str(started.data["service_id"])
+    await broker.execute(
+        task_id=task_id,
+        operation_id="service-input",
+        tool_name="service_input",
+        arguments={"service_id": service_id, "data": "hello\n"},
+    )
+    status = await broker.execute(
+        task_id=task_id,
+        operation_id="service-status",
+        tool_name="service_status",
+        arguments={"service_id": service_id},
+    )
+    assert status.data["task_id"] == task_id and "pid" not in status.data
+    stopped = await broker.execute(
+        task_id=task_id,
+        operation_id="service-stop",
+        tool_name="stop_service",
+        arguments={"service_id": service_id},
+    )
+    assert stopped.data["reason"] == "user_interrupted"
+    await manager.shutdown()

--- a/server/tests/test_coding_worker_workspace.py
+++ b/server/tests/test_coding_worker_workspace.py
@@ -114,3 +114,36 @@ async def test_workspace_tree_detects_links_and_diff_uses_private_index(tmp_path
         (repository / "unsafe-link").symlink_to(repository / "tracked.txt")
         with pytest.raises(WorkspaceError, match="link"):
             broker.tree(record.workspace_id)
+
+
+@pytest.mark.asyncio
+async def test_dedicated_slots_keep_workspace_files_in_separate_roots(
+    tmp_path: Path,
+) -> None:
+    source = _source()
+    broker = WorkspaceBroker(
+        tmp_path / "control",
+        {
+            "manifest": InMemoryWorkspaceSourceAdapter(
+                {(source.source_id, source.revision): {"main.py": b"print('ok')\n"}}
+            )
+        },
+        id_key=b"s" * 32,
+        slot_roots={
+            "slot-a": tmp_path / "slot-a",
+            "slot-b": tmp_path / "slot-b",
+        },
+    )
+
+    first = await broker.prepare(source, slot_id="slot-a")
+    second = await broker.prepare(source, slot_id="slot-b")
+
+    assert first.slot_id == "slot-a"
+    assert second.slot_id == "slot-b"
+    assert broker.workspace_slot(first.workspace_id) == "slot-a"
+    assert broker.workspace_slot(second.workspace_id) == "slot-b"
+    assert broker.repository_path(first.workspace_id).is_relative_to(tmp_path / "slot-a")
+    assert broker.repository_path(second.workspace_id).is_relative_to(tmp_path / "slot-b")
+    with pytest.raises(WorkspaceError) as raised:
+        await broker.prepare(source)
+    assert raised.value.code == "workspace_slot_unavailable"


### PR DESCRIPTION
## Summary
- add pinned OpenCode 1.18.9 behind the provider-neutral Worker contract; raw supplier frames, session IDs and hidden reasoning never enter the public or durable checkpoint
- add encrypted approvals, single-use leases, side-effect reconciliation, evidence ledger, deterministic public context summaries and explicit checkpoint restore
- add the MCP-only Tool Broker for files, commands, dependency installs, background services, acceptance fix-retest and opaque preview URLs
- deploy two fixed logical slots, each split into a read-only provider container and a credential-free executor container; the third task remains durably queued
- add default-deny signed egress grants bound to task, purpose, exact domain and TTL

## Validation
- V14 focused: 83 passed
- Agent Workspace: 44 passed
- all Coding tests: 702 passed, 9 skipped
- Compose merged configuration: passed (default network-off topology)
- every commit changes at most five files; diff-check passed

## Status
Draft and stacked on PR #122. Docker image build could not be completed because the local Docker BuildKit daemon stopped responding; no running container or preview was stopped. Module SDK, legacy bridges, v13 writeback adapter and shared Worker Console remain PR C.