### PR TITLE
feature: V14 通用 Coding Worker 平台集成

### DIFF
--- a/client/src/components/CodingWorkerConsole.test.tsx
+++ b/client/src/components/CodingWorkerConsole.test.tsx
@@ -7,6 +7,7 @@ const api = vi.hoisted(() => ({
   getCodingWorkerStatus: vi.fn(),
   listCodingWorkerTasks: vi.fn(),
   getCodingWorkerTask: vi.fn(),
+  handoffCodingWorkerTask: vi.fn(),
   listCodingWorkerApprovals: vi.fn(),
   listCodingWorkerEvidence: vi.fn(),
   listCodingWorkerArtifacts: vi.fn(),
@@ -87,5 +88,26 @@ describe("CodingWorkerConsole", () => {
     render(<CodingWorkerConsole context="agent" />);
     expect((await screen.findAllByText("修复失败测试并生成证据")).length).toBe(2);
     expect(screen.queryByText("宿主写回")).not.toBeInTheDocument();
+  });
+
+  it("hands a completed Host Snapshot task to the v13 confirmation chain", async () => {
+    const completed = { ...task, state: "completed" as const };
+    api.listCodingWorkerTasks.mockResolvedValue([completed]);
+    api.getCodingWorkerTask.mockResolvedValue(completed);
+    api.handoffCodingWorkerTask.mockResolvedValue({
+      id: "session_1234567890abcdef1234567890abcdef",
+      status: "ready",
+      project: { id: "hostgit_1234567890abcdef1234567890abcdef" },
+      revision: 1,
+      task_id: task.task_id,
+    });
+    const onCodingHandoff = vi.fn();
+    const user = userEvent.setup();
+    render(<CodingWorkerConsole context="coding" onCodingHandoff={onCodingHandoff} />);
+
+    await user.click(await screen.findByRole("button", { name: "进入 v13 写回确认" }));
+
+    await waitFor(() => expect(api.handoffCodingWorkerTask).toHaveBeenCalledWith(task.task_id));
+    expect(onCodingHandoff).toHaveBeenCalledWith(expect.objectContaining({ revision: 1 }));
   });
 });

--- a/client/src/components/CodingWorkerConsole.test.tsx
+++ b/client/src/components/CodingWorkerConsole.test.tsx
@@ -32,7 +32,7 @@ const task = {
     workspace_source: { kind: "host_snapshot", source_id: "source_1", revision: "rev_1" },
     acceptance: {
       contract_id: "contract_1",
-      required_checks: [{ check_id: "tests", kind: "command", label: "运行测试" }],
+      required_checks: [{ check_id: "tests", kind: "command", label: "运行测试", required: true }],
       required_artifacts: [],
     },
     policy_profile: "develop",

--- a/client/src/components/CodingWorkerConsole.test.tsx
+++ b/client/src/components/CodingWorkerConsole.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import CodingWorkerConsole from "./CodingWorkerConsole";
+
+const api = vi.hoisted(() => ({
+  getCodingWorkerStatus: vi.fn(),
+  listCodingWorkerTasks: vi.fn(),
+  getCodingWorkerTask: vi.fn(),
+  listCodingWorkerApprovals: vi.fn(),
+  listCodingWorkerEvidence: vi.fn(),
+  listCodingWorkerArtifacts: vi.fn(),
+  listCodingWorkerTree: vi.fn(),
+  readCodingWorkerDiff: vi.fn(),
+  connectCodingWorkerEvents: vi.fn(),
+  decideCodingWorkerApproval: vi.fn(),
+  changeCodingWorkerTask: vi.fn(),
+  createCodingWorkerTask: vi.fn(),
+  readCodingWorkerEntry: vi.fn(),
+  sendCodingWorkerMessage: vi.fn(),
+  codingWorkerArtifactUrl: vi.fn((taskId: string, artifactId: string) => `/artifact/${taskId}/${artifactId}`),
+}));
+
+vi.mock("../utils/codingWorkerApi", () => api);
+
+const task = {
+  task_id: "task_1234567890abcdef1234567890abcdef",
+  spec: {
+    client_task_id: "console_1234567890abcdef1234567890abcdef",
+    origin: { module: "worker-console", object_id: "local-user" },
+    objective: "修复失败测试并生成证据",
+    workspace_source: { kind: "host_snapshot", source_id: "source_1", revision: "rev_1" },
+    acceptance: {
+      contract_id: "contract_1",
+      required_checks: [{ check_id: "tests", kind: "command", label: "运行测试" }],
+      required_artifacts: [],
+    },
+    policy_profile: "develop",
+    model_route: "coding/default",
+    budget: { max_seconds: 3600, max_turns: 64, max_tool_calls: 512, max_output_bytes: 8_388_608 },
+    context_refs: [],
+  },
+  state: "waiting_approval",
+  workspace_id: "workspace_1234567890abcdef1234567890abcdef",
+  created_at: 1,
+  updated_at: 2,
+  expires_at: 100,
+  pinned: false,
+  last_event_sequence: 1,
+  reason: null,
+} as const;
+
+beforeEach(() => {
+  Object.values(api).forEach((mock) => "mockReset" in mock && mock.mockReset());
+  api.codingWorkerArtifactUrl.mockImplementation((taskId: string, artifactId: string) => `/artifact/${taskId}/${artifactId}`);
+  api.getCodingWorkerStatus.mockResolvedValue({ enabled: true, available: true, version: "v1", max_active_tasks: 2, retention_seconds: 604800, network_enabled: false, reason: null });
+  api.listCodingWorkerTasks.mockResolvedValue([task]);
+  api.getCodingWorkerTask.mockResolvedValue(task);
+  api.listCodingWorkerApprovals.mockResolvedValue([{ approval_id: "approval_1234567890abcdef1234567890abcdef", task_id: task.task_id, operation_id: "operation_1", capability: "command", status: "pending", request: { command: "pytest" }, lease: null, created_at: 1, decided_at: null }]);
+  api.listCodingWorkerEvidence.mockResolvedValue([{ evidence_id: "evidence_1", task_id: task.task_id, check_id: "tests", operation_id: "operation_1", workspace_tree_hash: "a".repeat(64), status: "failed", exit_code: 1, artifact_id: "artifact_1", created_at: 2 }]);
+  api.listCodingWorkerArtifacts.mockResolvedValue([]);
+  api.listCodingWorkerTree.mockResolvedValue({ workspace_id: task.workspace_id, tree_hash: "a".repeat(64), entries: [{ entry_id: "entry_1", name: "app.py", display_path: "src/app.py", kind: "file", size: 12, sha256: "b".repeat(64) }] });
+  api.readCodingWorkerDiff.mockResolvedValue("diff --git a/src/app.py b/src/app.py");
+  api.connectCodingWorkerEvents.mockReturnValue(() => undefined);
+  api.decideCodingWorkerApproval.mockResolvedValue({});
+});
+
+describe("CodingWorkerConsole", () => {
+  it("shows task state, workspace, approval and Coding writeback boundary", async () => {
+    const user = userEvent.setup();
+    render(<CodingWorkerConsole context="coding" />);
+
+    expect((await screen.findAllByText("修复失败测试并生成证据")).length).toBe(2);
+    expect(screen.getByText("宿主写回")).toBeInTheDocument();
+    expect(await screen.findByText("src/app.py")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("tab", { name: "证据" }));
+    await user.click(await screen.findByRole("button", { name: "批准一次" }));
+    await waitFor(() => expect(api.decideCodingWorkerApproval).toHaveBeenCalledWith(
+      task.task_id,
+      "approval_1234567890abcdef1234567890abcdef",
+      "approve_once",
+    ));
+  });
+
+  it("keeps domain writeback controls out of the generic Agent context", async () => {
+    render(<CodingWorkerConsole context="agent" />);
+    expect((await screen.findAllByText("修复失败测试并生成证据")).length).toBe(2);
+    expect(screen.queryByText("宿主写回")).not.toBeInTheDocument();
+  });
+});

--- a/client/src/components/CodingWorkerConsole.test.tsx
+++ b/client/src/components/CodingWorkerConsole.test.tsx
@@ -54,7 +54,7 @@ const task = {
 beforeEach(() => {
   Object.values(api).forEach((mock) => "mockReset" in mock && mock.mockReset());
   api.codingWorkerArtifactUrl.mockImplementation((taskId: string, artifactId: string) => `/artifact/${taskId}/${artifactId}`);
-  api.getCodingWorkerStatus.mockResolvedValue({ enabled: true, available: true, version: "v1", max_active_tasks: 2, retention_seconds: 604800, network_enabled: false, reason: null });
+  api.getCodingWorkerStatus.mockResolvedValue({ enabled: true, available: true, version: "v1", max_active_tasks: 2, retention_seconds: 604800, network_enabled: false, acceptance_checks: ["python-pytest", "react-build"], reason: null });
   api.listCodingWorkerTasks.mockResolvedValue([task]);
   api.getCodingWorkerTask.mockResolvedValue(task);
   api.listCodingWorkerApprovals.mockResolvedValue([{ approval_id: "approval_1234567890abcdef1234567890abcdef", task_id: task.task_id, operation_id: "operation_1", capability: "command", status: "pending", request: { command: "pytest" }, lease: null, created_at: 1, decided_at: null }]);

--- a/client/src/components/CodingWorkerConsole.tsx
+++ b/client/src/components/CodingWorkerConsole.tsx
@@ -189,7 +189,7 @@ export default function CodingWorkerConsole({ context }: CodingWorkerConsoleProp
       workspace_source: { kind: context === "coding" ? "host_snapshot" : "builtin", source_id: sourceId.trim(), revision: revision.trim() },
       acceptance: {
         contract_id: `contract_${suffix}`,
-        required_checks: [{ check_id: checkId.trim(), kind: "command", label: "必需检查" }],
+        required_checks: [{ check_id: checkId.trim(), kind: "command", label: "必需检查", required: true }],
         required_artifacts: [],
       },
       policy_profile: "develop",

--- a/client/src/components/CodingWorkerConsole.tsx
+++ b/client/src/components/CodingWorkerConsole.tsx
@@ -32,6 +32,7 @@ import {
   decideCodingWorkerApproval,
   getCodingWorkerTask,
   getCodingWorkerStatus,
+  handoffCodingWorkerTask,
   listCodingWorkerApprovals,
   listCodingWorkerArtifacts,
   listCodingWorkerEvidence,
@@ -40,6 +41,7 @@ import {
   readCodingWorkerDiff,
   readCodingWorkerEntry,
   sendCodingWorkerMessage,
+  type CodingWorkerHandoffResult,
 } from "../utils/codingWorkerApi";
 
 type ConsoleContext = "coding" | "agent";
@@ -68,9 +70,10 @@ function payloadText(event: CodingWorkerEvent) {
 
 interface CodingWorkerConsoleProps {
   context: ConsoleContext;
+  onCodingHandoff?: (result: CodingWorkerHandoffResult) => void;
 }
 
-export default function CodingWorkerConsole({ context }: CodingWorkerConsoleProps) {
+export default function CodingWorkerConsole({ context, onCodingHandoff }: CodingWorkerConsoleProps) {
   const [status, setStatus] = useState<CodingWorkerStatus | null>(null);
   const [tasks, setTasks] = useState<CodingWorkerTask[]>([]);
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
@@ -227,6 +230,12 @@ export default function CodingWorkerConsole({ context }: CodingWorkerConsoleProp
     setPreview({ path: entry.display_path, content });
   });
 
+  const handoffToWriteback = () => run(async () => {
+    if (!selectedTask || selectedTask.state !== "completed") return;
+    const result = await handoffCodingWorkerTask(selectedTask.task_id);
+    onCodingHandoff?.(result);
+  });
+
   if (loading) return <div className="min-h-[60vh] animate-pulse rounded-xl bg-white/5" aria-label="正在加载 Coding Worker" />;
 
   if (!status?.enabled || !status.available) {
@@ -326,7 +335,7 @@ export default function CodingWorkerConsole({ context }: CodingWorkerConsoleProp
             {tab === "evidence" && <div className="space-y-4"><section><h3 className="font-semibold text-white">审批</h3>{approvals.filter((item) => item.status === "pending").map((item) => <div key={item.approval_id} className="mt-2 rounded-lg bg-amber-300/10 p-3"><p className="text-amber-100">{item.capability}</p><p className="mt-1 break-words text-xs text-slate-300">{JSON.stringify(item.request)}</p><div className="mt-3 flex flex-wrap gap-2"><button type="button" disabled={busy} onClick={() => void decide(item.approval_id, "approve_once")} className="min-h-11 rounded-lg bg-cyan-400 px-3 font-semibold text-slate-950">批准一次</button><button type="button" disabled={busy} onClick={() => void decide(item.approval_id, "approve_task")} className="min-h-11 rounded-lg border border-cyan-300/40 px-3 text-cyan-100">本任务批准</button><button type="button" disabled={busy} onClick={() => void decide(item.approval_id, "reject")} className="min-h-11 rounded-lg border border-white/15 px-3 text-slate-200">拒绝</button></div></div>)}</section><section><h3 className="font-semibold text-white">检查证据</h3><ul className="mt-2 space-y-2">{evidence.map((item) => <li key={item.evidence_id} className="rounded-lg bg-white/5 p-3"><span className={item.status === "passed" ? "text-emerald-300" : item.status === "failed" ? "text-rose-300" : "text-amber-300"}>{item.status}</span><span className="ml-2 break-all text-slate-200">{item.check_id}</span><span className="mt-1 block text-xs text-slate-400">exit {item.exit_code}</span></li>)}</ul></section><section><h3 className="font-semibold text-white">Artifacts</h3><ul className="mt-2 space-y-1">{artifacts.map((item) => <li key={item.artifact_id}><a className="block min-h-10 break-all rounded-md px-2 py-2 text-cyan-200 hover:bg-white/5" href={codingWorkerArtifactUrl(item.task_id, item.artifact_id)}>{item.artifact_id} · {item.media_type}</a></li>)}</ul></section></div>}
             {tab === "terminal" && <div><p className="mb-2 text-xs text-slate-400">命令归属和输出只来自 Tool Broker 公开事件。</p><pre className="overflow-auto whitespace-pre-wrap break-words rounded-lg bg-slate-950/80 p-3 text-xs text-slate-200">{events.filter((event) => event.type === "tool_operation" || event.type === "provider_event").map((event) => `#${event.sequence} ${event.type}\n${payloadText(event) ?? JSON.stringify(event.payload)}`).join("\n\n") || "尚无工具输出。"}</pre></div>}
           </div>
-          {context === "coding" && selectedTask && <section className="mt-3 border-t border-white/10 pt-3"><div className="flex items-center gap-2"><GitCompareArrows className="h-4 w-4 text-cyan-300" /><h3 className="font-semibold text-white">宿主写回</h3></div><p className="mt-1 text-xs text-slate-400">完成后继续使用 v13 的应用、提交、撤销和发布确认链。Worker 不直接写用户仓库。</p><div className="mt-3 flex flex-wrap gap-2" aria-label="Coding 领域动作"><span className="rounded-full bg-white/5 px-3 py-1 text-xs text-slate-300">应用</span><span className="rounded-full bg-white/5 px-3 py-1 text-xs text-slate-300">提交</span><span className="rounded-full bg-white/5 px-3 py-1 text-xs text-slate-300">撤销</span><span className="rounded-full bg-white/5 px-3 py-1 text-xs text-slate-300">发布</span></div></section>}
+          {context === "coding" && selectedTask && <section className="mt-3 border-t border-white/10 pt-3"><div className="flex items-center gap-2"><GitCompareArrows className="h-4 w-4 text-cyan-300" /><h3 className="font-semibold text-white">宿主写回</h3></div><p className="mt-1 text-xs text-slate-400">完成后继续使用 v13 的应用、提交、撤销和发布确认链。Worker 不直接写用户仓库。</p>{selectedTask.state === "completed" && selectedTask.spec.workspace_source.kind === "host_snapshot" ? <button type="button" onClick={() => void handoffToWriteback()} disabled={busy} className="mt-3 min-h-11 w-full rounded-lg bg-cyan-400 px-3 text-sm font-semibold text-slate-950 transition hover:bg-cyan-300 disabled:opacity-50">进入 v13 写回确认</button> : <p className="mt-3 text-xs text-slate-500">Host Snapshot 任务通过全部必需检查后，才会开放写回确认。</p>}<div className="mt-3 flex flex-wrap gap-2" aria-label="Coding 领域动作"><span className="rounded-full bg-white/5 px-3 py-1 text-xs text-slate-300">应用</span><span className="rounded-full bg-white/5 px-3 py-1 text-xs text-slate-300">提交</span><span className="rounded-full bg-white/5 px-3 py-1 text-xs text-slate-300">撤销</span><span className="rounded-full bg-white/5 px-3 py-1 text-xs text-slate-300">发布</span></div></section>}
         </aside>
       </div>
     </div>

--- a/client/src/components/CodingWorkerConsole.tsx
+++ b/client/src/components/CodingWorkerConsole.tsx
@@ -137,7 +137,13 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
     let active = true;
     setLoading(true);
     void Promise.all([getCodingWorkerStatus(), refreshTasks()])
-      .then(([nextStatus]) => { if (active) setStatus(nextStatus); })
+      .then(([nextStatus]) => {
+        if (!active) return;
+        setStatus(nextStatus);
+        setCheckId((current) => nextStatus.acceptance_checks.includes(current)
+          ? current
+          : nextStatus.acceptance_checks[0] ?? "");
+      })
       .catch((caught) => { if (active) setError(errorMessage(caught, "Coding Worker 加载失败")); })
       .finally(() => { if (active) setLoading(false); });
     return () => { active = false; };
@@ -269,8 +275,8 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
           </label>
           <label className="text-sm text-slate-200">不透明来源 ID<input value={sourceId} onChange={(event) => setSourceId(event.target.value)} className="mt-1 min-h-11 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 text-white" /></label>
           <label className="text-sm text-slate-200">基准 revision<input value={revision} onChange={(event) => setRevision(event.target.value)} className="mt-1 min-h-11 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 text-white" /></label>
-          <label className="text-sm text-slate-200">必需检查 ID<input value={checkId} onChange={(event) => setCheckId(event.target.value)} className="mt-1 min-h-11 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 text-white" /></label>
-          <div className="flex items-end md:col-span-2 xl:col-span-5"><button type="submit" disabled={busy} className="min-h-11 rounded-lg bg-cyan-400 px-5 text-sm font-semibold text-slate-950 disabled:opacity-50">提交到队列</button></div>
+          <label className="text-sm text-slate-200">冻结验收检查<select value={checkId} onChange={(event) => setCheckId(event.target.value)} disabled={!status.acceptance_checks.length} className="mt-1 min-h-11 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 text-white disabled:opacity-60">{status.acceptance_checks.map((item) => <option key={item} value={item}>{item}</option>)}</select></label>
+          <div className="flex items-end md:col-span-2 xl:col-span-5"><button type="submit" disabled={busy || !checkId} className="min-h-11 rounded-lg bg-cyan-400 px-5 text-sm font-semibold text-slate-950 disabled:opacity-50">提交到队列</button></div>
         </form>
       )}
 

--- a/client/src/components/CodingWorkerConsole.tsx
+++ b/client/src/components/CodingWorkerConsole.tsx
@@ -1,0 +1,334 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  CheckCircle2,
+  CircleAlert,
+  FileCode2,
+  FolderTree,
+  GitCompareArrows,
+  MessageSquareText,
+  Pause,
+  Pin,
+  Play,
+  Plus,
+  ShieldCheck,
+  Square,
+  TerminalSquare,
+} from "lucide-react";
+import type {
+  CodingWorkerApproval,
+  CodingWorkerArtifact,
+  CodingWorkerEntry,
+  CodingWorkerEvent,
+  CodingWorkerEvidence,
+  CodingWorkerStatus,
+  CodingWorkerTask,
+  CodingWorkerTaskSpec,
+} from "../types/codingWorker";
+import {
+  changeCodingWorkerTask,
+  codingWorkerArtifactUrl,
+  connectCodingWorkerEvents,
+  createCodingWorkerTask,
+  decideCodingWorkerApproval,
+  getCodingWorkerTask,
+  getCodingWorkerStatus,
+  listCodingWorkerApprovals,
+  listCodingWorkerArtifacts,
+  listCodingWorkerEvidence,
+  listCodingWorkerTasks,
+  listCodingWorkerTree,
+  readCodingWorkerDiff,
+  readCodingWorkerEntry,
+  sendCodingWorkerMessage,
+} from "../utils/codingWorkerApi";
+
+type ConsoleContext = "coding" | "agent";
+type InspectorTab = "files" | "diff" | "evidence" | "terminal";
+
+const terminalStates = new Set([
+  "completed", "blocked", "failed", "cancelled", "budget_limited", "expired",
+]);
+
+const stateCopy: Record<string, string> = {
+  queued: "排队中", preparing: "准备工作区", running: "执行中",
+  waiting_approval: "等待批准", paused: "已暂停", testing: "运行验收",
+  interrupted: "已中断", completed: "已完成", blocked: "已阻塞",
+  failed: "失败", cancelled: "已取消", budget_limited: "预算已用完", expired: "已过期",
+};
+
+function errorMessage(error: unknown, fallback: string) {
+  return error instanceof Error ? error.message : fallback;
+}
+
+function payloadText(event: CodingWorkerEvent) {
+  const candidates = [event.payload.message, event.payload.text, event.payload.summary, event.payload.output];
+  const value = candidates.find((item) => typeof item === "string");
+  return typeof value === "string" ? value : null;
+}
+
+interface CodingWorkerConsoleProps {
+  context: ConsoleContext;
+}
+
+export default function CodingWorkerConsole({ context }: CodingWorkerConsoleProps) {
+  const [status, setStatus] = useState<CodingWorkerStatus | null>(null);
+  const [tasks, setTasks] = useState<CodingWorkerTask[]>([]);
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+  const [events, setEvents] = useState<CodingWorkerEvent[]>([]);
+  const [approvals, setApprovals] = useState<CodingWorkerApproval[]>([]);
+  const [evidence, setEvidence] = useState<CodingWorkerEvidence[]>([]);
+  const [artifacts, setArtifacts] = useState<CodingWorkerArtifact[]>([]);
+  const [entries, setEntries] = useState<CodingWorkerEntry[]>([]);
+  const [treeHash, setTreeHash] = useState("");
+  const [preview, setPreview] = useState<{ path: string; content: string } | null>(null);
+  const [diff, setDiff] = useState("");
+  const [tab, setTab] = useState<InspectorTab>("files");
+  const [message, setMessage] = useState("");
+  const [showCreate, setShowCreate] = useState(false);
+  const [objective, setObjective] = useState("");
+  const [sourceId, setSourceId] = useState("");
+  const [revision, setRevision] = useState("");
+  const [checkId, setCheckId] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [transportWarning, setTransportWarning] = useState(false);
+  const [error, setError] = useState("");
+  const operationRef = useRef(false);
+
+  const selectedTask = useMemo(
+    () => tasks.find((task) => task.task_id === selectedTaskId) ?? null,
+    [selectedTaskId, tasks],
+  );
+
+  const refreshTasks = useCallback(async (preferredId?: string) => {
+    const next = await listCodingWorkerTasks();
+    setTasks(next);
+    setSelectedTaskId((current) => {
+      const candidate = preferredId ?? current;
+      return candidate && next.some((task) => task.task_id === candidate)
+        ? candidate
+        : next[0]?.task_id ?? null;
+    });
+    return next;
+  }, []);
+
+  const refreshTaskPanels = useCallback(async (taskId: string) => {
+    const [task, approvalItems, evidenceItems, artifactItems, tree, nextDiff] = await Promise.all([
+      getCodingWorkerTask(taskId),
+      listCodingWorkerApprovals(taskId),
+      listCodingWorkerEvidence(taskId),
+      listCodingWorkerArtifacts(taskId),
+      listCodingWorkerTree(taskId).catch(() => null),
+      readCodingWorkerDiff(taskId).catch(() => ""),
+    ]);
+    setTasks((current) => current.map((item) => item.task_id === taskId ? task : item));
+    setApprovals(approvalItems);
+    setEvidence(evidenceItems);
+    setArtifacts(artifactItems);
+    setEntries(tree?.entries ?? []);
+    setTreeHash(tree?.tree_hash ?? "");
+    setDiff(nextDiff);
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    void Promise.all([getCodingWorkerStatus(), refreshTasks()])
+      .then(([nextStatus]) => { if (active) setStatus(nextStatus); })
+      .catch((caught) => { if (active) setError(errorMessage(caught, "Coding Worker 加载失败")); })
+      .finally(() => { if (active) setLoading(false); });
+    return () => { active = false; };
+  }, [refreshTasks]);
+
+  useEffect(() => {
+    if (!selectedTaskId) {
+      setEvents([]); setApprovals([]); setEvidence([]); setArtifacts([]);
+      setEntries([]); setPreview(null); setDiff(""); setTreeHash("");
+      return;
+    }
+    let active = true;
+    let cursor = 0;
+    setEvents([]);
+    setPreview(null);
+    setTransportWarning(false);
+    void refreshTaskPanels(selectedTaskId).catch((caught) => {
+      if (active) setError(errorMessage(caught, "任务详情加载失败"));
+    });
+    const disconnect = connectCodingWorkerEvents(selectedTaskId, cursor, {
+      onEvent: (event) => {
+        if (!active || event.sequence <= cursor) return;
+        cursor = event.sequence;
+        setEvents((current) => [...current, event].slice(-400));
+        setTransportWarning(false);
+        void refreshTaskPanels(selectedTaskId).catch(() => setTransportWarning(true));
+      },
+      onTransportError: () => { if (active) setTransportWarning(true); },
+    });
+    return () => { active = false; disconnect(); };
+  }, [refreshTaskPanels, selectedTaskId]);
+
+  const run = useCallback(async (operation: () => Promise<unknown>) => {
+    if (operationRef.current) return;
+    operationRef.current = true;
+    setBusy(true);
+    setError("");
+    try { await operation(); }
+    catch (caught) { setError(errorMessage(caught, "操作失败")); }
+    finally { operationRef.current = false; setBusy(false); }
+  }, []);
+
+  const createTask = () => run(async () => {
+    if (!objective.trim() || !sourceId.trim() || !revision.trim() || !checkId.trim()) {
+      setError("请填写目标、来源 ID、基准 revision 和必需检查 ID。");
+      return;
+    }
+    const suffix = crypto.randomUUID().replaceAll("-", "");
+    const spec: CodingWorkerTaskSpec = {
+      client_task_id: `console_${suffix}`,
+      objective: objective.trim(),
+      workspace_source: { kind: context === "coding" ? "host_snapshot" : "builtin", source_id: sourceId.trim(), revision: revision.trim() },
+      acceptance: {
+        contract_id: `contract_${suffix}`,
+        required_checks: [{ check_id: checkId.trim(), kind: "command", label: "必需检查" }],
+        required_artifacts: [],
+      },
+      policy_profile: "develop",
+      model_route: "coding/default",
+      budget: { max_seconds: 3600, max_turns: 64, max_tool_calls: 512, max_output_bytes: 8 * 1024 * 1024 },
+      context_refs: [],
+    };
+    const task = await createCodingWorkerTask(spec);
+    await refreshTasks(task.task_id);
+    setShowCreate(false); setObjective(""); setSourceId(""); setRevision(""); setCheckId("");
+  });
+
+  const submitMessage = () => run(async () => {
+    if (!selectedTask || !message.trim()) return;
+    await sendCodingWorkerMessage(selectedTask.task_id, message.trim());
+    setMessage("");
+    await refreshTaskPanels(selectedTask.task_id);
+  });
+
+  const taskAction = (action: "pause" | "resume" | "cancel" | "pin" | "unpin") => run(async () => {
+    if (!selectedTask) return;
+    const task = await changeCodingWorkerTask(selectedTask.task_id, action);
+    setTasks((current) => current.map((item) => item.task_id === task.task_id ? task : item));
+  });
+
+  const decide = (approvalId: string, decision: "approve_once" | "approve_task" | "reject") => run(async () => {
+    if (!selectedTask) return;
+    await decideCodingWorkerApproval(selectedTask.task_id, approvalId, decision);
+    await refreshTaskPanels(selectedTask.task_id);
+  });
+
+  const openEntry = (entry: CodingWorkerEntry) => run(async () => {
+    if (!selectedTask || entry.kind !== "file") return;
+    const content = await readCodingWorkerEntry(selectedTask.task_id, entry.entry_id);
+    setPreview({ path: entry.display_path, content });
+  });
+
+  if (loading) return <div className="min-h-[60vh] animate-pulse rounded-xl bg-white/5" aria-label="正在加载 Coding Worker" />;
+
+  if (!status?.enabled || !status.available) {
+    return (
+      <section className="mx-auto max-w-3xl px-4 py-20 text-center" role="status">
+        <CircleAlert className="mx-auto h-9 w-9 text-amber-300" aria-hidden="true" />
+        <h1 className="mt-4 text-xl font-semibold text-white">Coding Worker 尚未启用</h1>
+        <p className="mx-auto mt-2 max-w-[65ch] text-sm text-slate-300">
+          管理员启用 CODING_WORKER_V14_ENABLED 后，新任务会进入统一 Worker。已有会话继续使用原执行面。
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <div className="mx-auto flex min-h-[calc(100vh-5rem)] max-w-[1800px] flex-col gap-3 px-3 py-4 lg:px-5">
+      <header className="flex flex-wrap items-center justify-between gap-3 border-b border-white/10 pb-3">
+        <div className="min-w-0">
+          <h1 className="text-xl font-semibold text-white">Coding Worker</h1>
+          <p className="mt-1 text-sm text-slate-300">两个隔离槽位，任务证据与 Diff 可在重启后继续读取。</p>
+        </div>
+        <button type="button" onClick={() => setShowCreate((value) => !value)} className="inline-flex min-h-11 items-center gap-2 rounded-lg bg-cyan-400 px-4 text-sm font-semibold text-slate-950 transition hover:bg-cyan-300 disabled:opacity-50" disabled={busy}>
+          <Plus className="h-4 w-4" aria-hidden="true" />创建任务
+        </button>
+      </header>
+
+      {showCreate && (
+        <form className="grid gap-3 border-b border-white/10 pb-4 md:grid-cols-2 xl:grid-cols-5" onSubmit={(event) => { event.preventDefault(); void createTask(); }}>
+          <label className="md:col-span-2 xl:col-span-2 text-sm text-slate-200">任务目标
+            <textarea value={objective} onChange={(event) => setObjective(event.target.value)} className="mt-1 min-h-24 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 py-2 text-white" maxLength={1_048_576} />
+          </label>
+          <label className="text-sm text-slate-200">不透明来源 ID<input value={sourceId} onChange={(event) => setSourceId(event.target.value)} className="mt-1 min-h-11 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 text-white" /></label>
+          <label className="text-sm text-slate-200">基准 revision<input value={revision} onChange={(event) => setRevision(event.target.value)} className="mt-1 min-h-11 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 text-white" /></label>
+          <label className="text-sm text-slate-200">必需检查 ID<input value={checkId} onChange={(event) => setCheckId(event.target.value)} className="mt-1 min-h-11 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 text-white" /></label>
+          <div className="flex items-end md:col-span-2 xl:col-span-5"><button type="submit" disabled={busy} className="min-h-11 rounded-lg bg-cyan-400 px-5 text-sm font-semibold text-slate-950 disabled:opacity-50">提交到队列</button></div>
+        </form>
+      )}
+
+      {error && <div className="rounded-lg bg-rose-500/15 px-4 py-3 text-sm text-rose-100" role="alert">{error}</div>}
+      {transportWarning && <div className="rounded-lg bg-amber-400/10 px-4 py-3 text-sm text-amber-100" role="status">事件连接已中断，任务状态仍可从持久存储恢复。</div>}
+
+      <div className="grid min-h-0 flex-1 gap-3 lg:grid-cols-[16rem_minmax(0,1fr)] xl:grid-cols-[16rem_minmax(0,1fr)_26rem]">
+        <aside className="min-h-0 border-r border-white/10 pr-3" aria-label="Worker 任务列表">
+          <div className="mb-2 flex items-center justify-between"><h2 className="text-sm font-semibold text-slate-200">任务</h2><span className="text-xs text-slate-400">{tasks.length}</span></div>
+          <div className="flex max-h-[38vh] flex-col gap-1 overflow-y-auto lg:max-h-[calc(100vh-11rem)]">
+            {tasks.length === 0 && <p className="rounded-lg bg-white/5 p-3 text-sm text-slate-300">还没有任务。先从受控来源创建一个任务。</p>}
+            {tasks.map((task) => (
+              <button key={task.task_id} type="button" onClick={() => setSelectedTaskId(task.task_id)} className={`min-h-14 rounded-lg px-3 py-2 text-left transition ${task.task_id === selectedTaskId ? "bg-cyan-400/15 text-white" : "text-slate-300 hover:bg-white/5"}`}>
+                <span className="block truncate text-sm font-medium">{task.spec.objective}</span>
+                <span className="mt-1 flex items-center justify-between gap-2 text-xs text-slate-400"><span>{stateCopy[task.state] ?? task.state}</span><span>{task.spec.origin.module}</span></span>
+              </button>
+            ))}
+          </div>
+        </aside>
+
+        <main className="min-w-0">
+          {!selectedTask ? (
+            <div className="flex min-h-80 items-center justify-center text-sm text-slate-400">选择任务后查看目标、计划和运行事件。</div>
+          ) : (
+            <div className="flex h-full min-h-[32rem] flex-col">
+              <div className="flex flex-wrap items-start justify-between gap-3 border-b border-white/10 pb-3">
+                <div className="min-w-0"><p className="break-words text-lg font-semibold text-white">{selectedTask.spec.objective}</p><p className="mt-1 break-all text-xs text-slate-400">{selectedTask.task_id} · {stateCopy[selectedTask.state] ?? selectedTask.state}</p></div>
+                <div className="flex flex-wrap gap-2">
+                  {selectedTask.state === "running" || selectedTask.state === "testing" ? <button type="button" onClick={() => void taskAction("pause")} disabled={busy} className="inline-flex min-h-11 items-center gap-1 rounded-lg border border-white/15 px-3 text-sm text-slate-200"><Pause className="h-4 w-4" />暂停</button> : null}
+                  {selectedTask.state === "paused" || selectedTask.state === "interrupted" ? <button type="button" onClick={() => void taskAction("resume")} disabled={busy} className="inline-flex min-h-11 items-center gap-1 rounded-lg border border-cyan-300/40 px-3 text-sm text-cyan-100"><Play className="h-4 w-4" />继续</button> : null}
+                  {!terminalStates.has(selectedTask.state) && <button type="button" onClick={() => void taskAction("cancel")} disabled={busy} className="inline-flex min-h-11 items-center gap-1 rounded-lg border border-white/15 px-3 text-sm text-slate-200"><Square className="h-4 w-4" />取消</button>}
+                  <button type="button" onClick={() => void taskAction(selectedTask.pinned ? "unpin" : "pin")} disabled={busy} aria-pressed={selectedTask.pinned} className="inline-flex min-h-11 items-center gap-1 rounded-lg border border-white/15 px-3 text-sm text-slate-200"><Pin className="h-4 w-4" />{selectedTask.pinned ? "取消固定" : "固定"}</button>
+                </div>
+              </div>
+
+              <section className="mt-3 border-b border-white/10 pb-3" aria-labelledby="goal-heading">
+                <div className="flex items-center gap-2"><CheckCircle2 className="h-4 w-4 text-cyan-300" /><h2 id="goal-heading" className="text-sm font-semibold text-white">目标与验收</h2></div>
+                <ul className="mt-2 space-y-1 text-sm text-slate-300">{selectedTask.spec.acceptance.required_checks.map((check) => <li key={check.check_id}>• {check.label} <code className="break-all text-xs text-slate-400">{check.check_id}</code></li>)}</ul>
+              </section>
+
+              <section className="min-h-0 flex-1 overflow-y-auto py-3" aria-label="任务事件" aria-live="polite">
+                {events.length === 0 ? <p className="text-sm text-slate-400">等待 Worker 事件。公开事件只包含计划、状态和工具摘要。</p> : events.map((event) => (
+                  <article key={event.sequence} className="mb-3 flex gap-3"><span className="mt-1 h-2 w-2 shrink-0 rounded-full bg-cyan-300" aria-hidden="true" /><div className="min-w-0"><p className="text-xs font-medium text-slate-400">{event.type} · #{event.sequence}</p><p className="mt-1 whitespace-pre-wrap break-words text-sm text-slate-200">{payloadText(event) ?? JSON.stringify(event.payload)}</p></div></article>
+                ))}
+              </section>
+
+              <form className="border-t border-white/10 pt-3" onSubmit={(event) => { event.preventDefault(); void submitMessage(); }}>
+                <label className="sr-only" htmlFor="worker-message">追加指令</label>
+                <div className="flex gap-2"><textarea id="worker-message" value={message} onChange={(event) => setMessage(event.target.value)} disabled={busy || terminalStates.has(selectedTask.state)} placeholder="追加指令或运行中 steering" className="min-h-12 flex-1 resize-y rounded-lg border border-white/15 bg-slate-950/70 px-3 py-2 text-sm text-white placeholder:text-slate-400 disabled:opacity-60" /><button type="submit" disabled={busy || !message.trim() || terminalStates.has(selectedTask.state)} className="min-h-12 rounded-lg bg-cyan-400 px-4 text-sm font-semibold text-slate-950 disabled:opacity-50">发送指令</button></div>
+              </form>
+            </div>
+          )}
+        </main>
+
+        <aside className="min-w-0 border-t border-white/10 pt-3 xl:border-l xl:border-t-0 xl:pl-3 xl:pt-0" aria-label="任务检查器">
+          <div className="flex overflow-x-auto border-b border-white/10" role="tablist">
+            {([ ["files", FolderTree, "文件"], ["diff", GitCompareArrows, "Diff"], ["evidence", ShieldCheck, "证据"], ["terminal", TerminalSquare, "终端"] ] as const).map(([value, Icon, label]) => <button key={value} type="button" role="tab" aria-selected={tab === value} onClick={() => setTab(value)} className={`inline-flex min-h-11 items-center gap-1 px-3 text-sm ${tab === value ? "border-b-2 border-cyan-300 text-white" : "text-slate-400"}`}><Icon className="h-4 w-4" />{label}</button>)}
+          </div>
+          <div className="max-h-[46rem] overflow-auto py-3 text-sm">
+            {tab === "files" && <div><p className="mb-2 break-all text-xs text-slate-400">tree {treeHash || "尚未创建"}</p>{preview ? <div><button type="button" className="mb-2 min-h-11 text-cyan-200" onClick={() => setPreview(null)}>返回文件树</button><p className="mb-2 break-all text-slate-300">{preview.path}</p><pre className="overflow-auto whitespace-pre-wrap break-words rounded-lg bg-slate-950/80 p-3 text-xs text-slate-200">{preview.content}</pre></div> : <ul className="space-y-1">{entries.map((entry) => <li key={entry.entry_id}><button type="button" disabled={entry.kind !== "file" || busy} onClick={() => void openEntry(entry)} className="flex min-h-10 w-full items-center gap-2 rounded-md px-2 text-left text-slate-300 hover:bg-white/5 disabled:cursor-default"><FileCode2 className="h-4 w-4 shrink-0" /><span className="min-w-0 break-all">{entry.display_path}</span></button></li>)}</ul>}</div>}
+            {tab === "diff" && <pre className="overflow-auto whitespace-pre-wrap break-words rounded-lg bg-slate-950/80 p-3 text-xs text-slate-200">{diff || "工作区还没有变更。"}</pre>}
+            {tab === "evidence" && <div className="space-y-4"><section><h3 className="font-semibold text-white">审批</h3>{approvals.filter((item) => item.status === "pending").map((item) => <div key={item.approval_id} className="mt-2 rounded-lg bg-amber-300/10 p-3"><p className="text-amber-100">{item.capability}</p><p className="mt-1 break-words text-xs text-slate-300">{JSON.stringify(item.request)}</p><div className="mt-3 flex flex-wrap gap-2"><button type="button" disabled={busy} onClick={() => void decide(item.approval_id, "approve_once")} className="min-h-11 rounded-lg bg-cyan-400 px-3 font-semibold text-slate-950">批准一次</button><button type="button" disabled={busy} onClick={() => void decide(item.approval_id, "approve_task")} className="min-h-11 rounded-lg border border-cyan-300/40 px-3 text-cyan-100">本任务批准</button><button type="button" disabled={busy} onClick={() => void decide(item.approval_id, "reject")} className="min-h-11 rounded-lg border border-white/15 px-3 text-slate-200">拒绝</button></div></div>)}</section><section><h3 className="font-semibold text-white">检查证据</h3><ul className="mt-2 space-y-2">{evidence.map((item) => <li key={item.evidence_id} className="rounded-lg bg-white/5 p-3"><span className={item.status === "passed" ? "text-emerald-300" : item.status === "failed" ? "text-rose-300" : "text-amber-300"}>{item.status}</span><span className="ml-2 break-all text-slate-200">{item.check_id}</span><span className="mt-1 block text-xs text-slate-400">exit {item.exit_code}</span></li>)}</ul></section><section><h3 className="font-semibold text-white">Artifacts</h3><ul className="mt-2 space-y-1">{artifacts.map((item) => <li key={item.artifact_id}><a className="block min-h-10 break-all rounded-md px-2 py-2 text-cyan-200 hover:bg-white/5" href={codingWorkerArtifactUrl(item.task_id, item.artifact_id)}>{item.artifact_id} · {item.media_type}</a></li>)}</ul></section></div>}
+            {tab === "terminal" && <div><p className="mb-2 text-xs text-slate-400">命令归属和输出只来自 Tool Broker 公开事件。</p><pre className="overflow-auto whitespace-pre-wrap break-words rounded-lg bg-slate-950/80 p-3 text-xs text-slate-200">{events.filter((event) => event.type === "tool_operation" || event.type === "provider_event").map((event) => `#${event.sequence} ${event.type}\n${payloadText(event) ?? JSON.stringify(event.payload)}`).join("\n\n") || "尚无工具输出。"}</pre></div>}
+          </div>
+          {context === "coding" && selectedTask && <section className="mt-3 border-t border-white/10 pt-3"><div className="flex items-center gap-2"><GitCompareArrows className="h-4 w-4 text-cyan-300" /><h3 className="font-semibold text-white">宿主写回</h3></div><p className="mt-1 text-xs text-slate-400">完成后继续使用 v13 的应用、提交、撤销和发布确认链。Worker 不直接写用户仓库。</p><div className="mt-3 flex flex-wrap gap-2" aria-label="Coding 领域动作"><span className="rounded-full bg-white/5 px-3 py-1 text-xs text-slate-300">应用</span><span className="rounded-full bg-white/5 px-3 py-1 text-xs text-slate-300">提交</span><span className="rounded-full bg-white/5 px-3 py-1 text-xs text-slate-300">撤销</span><span className="rounded-full bg-white/5 px-3 py-1 text-xs text-slate-300">发布</span></div></section>}
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/AgentWorkbenchPage.test.tsx
+++ b/client/src/pages/AgentWorkbenchPage.test.tsx
@@ -481,6 +481,8 @@ describe("AgentWorkbenchPage", () => {
 
     expect(await screen.findByText("Agent 工作区已关闭")).toBeVisible();
     expect(screen.getByRole("button", { name: "一句话创建 Agent" })).toBeDisabled();
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenNthCalledWith(1, "/api/coding-worker/v1", undefined);
+    expect(fetchMock).toHaveBeenNthCalledWith(2, "/api/agent-workspace/status", undefined);
   });
 });

--- a/client/src/pages/AgentWorkbenchPage.tsx
+++ b/client/src/pages/AgentWorkbenchPage.tsx
@@ -15,6 +15,7 @@ import { Link } from "react-router-dom";
 import ConversationPanel from "../components/agent-workspace/ConversationPanel";
 import SessionSidebar from "../components/agent-workspace/SessionSidebar";
 import WorkspacePanel from "../components/agent-workspace/WorkspacePanel";
+import CodingWorkerConsole from "../components/CodingWorkerConsole";
 import PageContainer from "../components/PageContainer";
 import { useModelPreference } from "../context/ModelPreferenceContext";
 import {
@@ -54,6 +55,7 @@ import {
   stopAgentTask,
   updateAgentSessionApprovalMode,
 } from "../utils/agentWorkspaceApi";
+import { getCodingWorkerStatus } from "../utils/codingWorkerApi";
 
 interface WorkspacePreview {
   path: string;
@@ -75,7 +77,7 @@ const refreshEventTypes = new Set([
 
 const workspaceEventTypes = new Set(["tool_output", "completed", "agent_generated"]);
 
-export default function AgentWorkbenchPage() {
+function LegacyAgentWorkbenchPage() {
   const { preferredModelId, setPreferredModelId } = useModelPreference();
   const [enabled, setEnabled] = useState(true);
   const [loading, setLoading] = useState(true);
@@ -718,4 +720,28 @@ export default function AgentWorkbenchPage() {
       ) : null}
     </PageContainer>
   );
+}
+
+export default function AgentWorkbenchPage() {
+  const [surface, setSurface] = useState<"loading" | "legacy" | "worker">("loading");
+
+  useEffect(() => {
+    let active = true;
+    void getCodingWorkerStatus()
+      .then(async (status) => {
+        if (!status.enabled || !status.available) return "legacy" as const;
+        const legacySessions = await listAgentSessions();
+        return legacySessions.length === 0 ? "worker" as const : "legacy" as const;
+      })
+      .then((nextSurface) => { if (active) setSurface(nextSurface); })
+      .catch(() => { if (active) setSurface("legacy"); });
+    return () => { active = false; };
+  }, []);
+
+  if (surface === "loading") {
+    return <div className="mx-auto mt-10 min-h-[60vh] max-w-7xl animate-pulse rounded-xl bg-white/5" aria-label="正在选择 Agent 执行面" />;
+  }
+  return surface === "worker"
+    ? <CodingWorkerConsole context="agent" />
+    : <LegacyAgentWorkbenchPage />;
 }

--- a/client/src/pages/CodingPage.tsx
+++ b/client/src/pages/CodingPage.tsx
@@ -2885,6 +2885,12 @@ export default function CodingPage() {
     return <div className="mx-auto mt-10 min-h-[60vh] max-w-7xl animate-pulse rounded-xl bg-white/5" aria-label="正在选择 Coding 执行面" />;
   }
   return surface === "worker"
-    ? <CodingWorkerConsole context="coding" />
+    ? <CodingWorkerConsole
+        context="coding"
+        onCodingHandoff={(result) => {
+          storeCodingSession(result.id, 0, result.project.id);
+          setSurface("legacy");
+        }}
+      />
     : <LegacyCodingPage />;
 }

--- a/client/src/pages/CodingPage.tsx
+++ b/client/src/pages/CodingPage.tsx
@@ -30,6 +30,7 @@ import CodingRecoveryCard, {
   type CodingRecoveryAction,
 } from "../components/CodingRecoveryCard";
 import PageContainer from "../components/PageContainer";
+import CodingWorkerConsole from "../components/CodingWorkerConsole";
 import type {
   CodingApplyResult,
   CodingCapabilities,
@@ -81,6 +82,7 @@ import {
   undoCodingCommit,
   validateCodingChanges,
 } from "../utils/codingApi";
+import { getCodingWorkerStatus } from "../utils/codingWorkerApi";
 
 type RunState = "idle" | "starting" | "running" | "stopping" | "error";
 type CapabilityState = "loading" | "ready" | "error";
@@ -465,7 +467,7 @@ function CodingCommandConfirmation({
   );
 }
 
-export default function CodingPage() {
+function LegacyCodingPage() {
   const restoredSessionRef = useRef<StoredCodingSession | null>(
     readStoredCodingSession(),
   );
@@ -2860,4 +2862,29 @@ export default function CodingPage() {
       </div>
     </PageContainer>
   );
+}
+
+export default function CodingPage() {
+  const hasLegacySession = readStoredCodingSession() !== null;
+  const [surface, setSurface] = useState<"loading" | "legacy" | "worker">(
+    hasLegacySession ? "legacy" : "loading",
+  );
+
+  useEffect(() => {
+    if (hasLegacySession) return;
+    let active = true;
+    void Promise.all([getCodingWorkerStatus(), getCodingRecovery()])
+      .then(([status, recovery]) => {
+        if (active) setSurface(status.enabled && status.available && !recovery.pending ? "worker" : "legacy");
+      })
+      .catch(() => { if (active) setSurface("legacy"); });
+    return () => { active = false; };
+  }, [hasLegacySession]);
+
+  if (surface === "loading") {
+    return <div className="mx-auto mt-10 min-h-[60vh] max-w-7xl animate-pulse rounded-xl bg-white/5" aria-label="正在选择 Coding 执行面" />;
+  }
+  return surface === "worker"
+    ? <CodingWorkerConsole context="coding" />
+    : <LegacyCodingPage />;
 }

--- a/client/src/types/codingWorker.ts
+++ b/client/src/types/codingWorker.ts
@@ -52,7 +52,9 @@ export interface CodingWorkerTaskSpec {
 
 export interface CodingWorkerTask {
   task_id: string;
-  spec: CodingWorkerTaskSpec & { origin: { module: string; object_id: string } };
+  spec: Omit<CodingWorkerTaskSpec, "origin"> & {
+    origin: { module: string; object_id: string };
+  };
   state: CodingWorkerTaskState;
   workspace_id: string | null;
   created_at: number;
@@ -79,4 +81,51 @@ export interface CodingWorkerStatus {
   retention_seconds: number;
   network_enabled: boolean;
   reason: string | null;
+}
+
+export interface CodingWorkerApproval {
+  approval_id: string;
+  task_id: string;
+  operation_id: string;
+  capability: string;
+  status: "pending" | "approved" | "rejected" | "cancelled" | "expired";
+  request: Record<string, unknown>;
+  lease: {
+    lease_id: string;
+    expires_at: number;
+    operation_limit: number;
+  } | null;
+  created_at: number;
+  decided_at: number | null;
+}
+
+export interface CodingWorkerEvidence {
+  evidence_id: string;
+  task_id: string;
+  check_id: string;
+  operation_id: string;
+  workspace_tree_hash: string;
+  status: "passed" | "failed" | "invalidated";
+  exit_code: number;
+  artifact_id: string;
+  created_at: number;
+}
+
+export interface CodingWorkerArtifact {
+  artifact_id: string;
+  task_id: string;
+  media_type: string;
+  sha256: string;
+  size: number;
+  metadata: Record<string, unknown>;
+  created_at: number;
+}
+
+export interface CodingWorkerEntry {
+  entry_id: string;
+  name: string;
+  display_path: string;
+  kind: string;
+  size: number;
+  sha256: string | null;
 }

--- a/client/src/types/codingWorker.ts
+++ b/client/src/types/codingWorker.ts
@@ -1,0 +1,82 @@
+export type CodingWorkerTaskState =
+  | "queued"
+  | "preparing"
+  | "running"
+  | "waiting_approval"
+  | "paused"
+  | "testing"
+  | "interrupted"
+  | "completed"
+  | "blocked"
+  | "failed"
+  | "cancelled"
+  | "budget_limited"
+  | "expired";
+
+export type CodingWorkerPolicyProfile = "inspect" | "develop" | "develop_networked";
+
+export interface CodingWorkerSource {
+  kind: "builtin" | "manifest" | "host_snapshot";
+  source_id: string;
+  revision: string;
+}
+
+export interface CodingWorkerAcceptanceCheck {
+  check_id: string;
+  kind: "command" | "artifact" | "policy";
+  label: string;
+}
+
+export interface CodingWorkerAcceptanceContract {
+  contract_id: string;
+  required_checks: CodingWorkerAcceptanceCheck[];
+  required_artifacts: Array<{ artifact_id: string; label: string }>;
+}
+
+export interface CodingWorkerTaskSpec {
+  client_task_id: string;
+  objective: string;
+  workspace_source: CodingWorkerSource;
+  acceptance: CodingWorkerAcceptanceContract;
+  policy_profile: CodingWorkerPolicyProfile;
+  model_route: string;
+  budget: {
+    max_seconds: number;
+    max_turns: number;
+    max_tool_calls: number;
+    max_output_bytes: number;
+  };
+  context_refs: Array<{ ref_id: string; kind: "artifact" | "resource" | "file" | "image" }>;
+  origin?: never;
+}
+
+export interface CodingWorkerTask {
+  task_id: string;
+  spec: CodingWorkerTaskSpec & { origin: { module: string; object_id: string } };
+  state: CodingWorkerTaskState;
+  workspace_id: string | null;
+  created_at: number;
+  updated_at: number;
+  expires_at: number;
+  pinned: boolean;
+  last_event_sequence: number;
+  reason: string | null;
+}
+
+export interface CodingWorkerEvent {
+  sequence: number;
+  task_id: string;
+  type: string;
+  payload: Record<string, unknown>;
+  created_at: number;
+}
+
+export interface CodingWorkerStatus {
+  enabled: boolean;
+  available: boolean;
+  version: "v1";
+  max_active_tasks: number;
+  retention_seconds: number;
+  network_enabled: boolean;
+  reason: string | null;
+}

--- a/client/src/types/codingWorker.ts
+++ b/client/src/types/codingWorker.ts
@@ -86,6 +86,7 @@ export interface CodingWorkerStatus {
   max_active_tasks: number;
   retention_seconds: number;
   network_enabled: boolean;
+  acceptance_checks: string[];
   reason: string | null;
 }
 

--- a/client/src/types/codingWorker.ts
+++ b/client/src/types/codingWorker.ts
@@ -23,14 +23,20 @@ export interface CodingWorkerSource {
 
 export interface CodingWorkerAcceptanceCheck {
   check_id: string;
-  kind: "command" | "artifact" | "policy";
+  kind: "command" | "diff" | "artifact" | "custom";
   label: string;
+  required: true;
 }
 
 export interface CodingWorkerAcceptanceContract {
   contract_id: string;
   required_checks: CodingWorkerAcceptanceCheck[];
-  required_artifacts: Array<{ artifact_id: string; label: string }>;
+  required_artifacts: Array<{
+    artifact_id: string;
+    media_type: string;
+    label: string;
+    required: true;
+  }>;
 }
 
 export interface CodingWorkerTaskSpec {

--- a/client/src/utils/codingWorkerApi.ts
+++ b/client/src/utils/codingWorkerApi.ts
@@ -11,6 +11,14 @@ import type {
 
 const API_ROOT = "/api/coding-worker/v1";
 
+export interface CodingWorkerHandoffResult {
+  id: string;
+  status: string;
+  project: { id: string; [key: string]: unknown };
+  revision: number;
+  task_id: string;
+}
+
 export class CodingWorkerApiError extends Error {
   status: number;
   code: string | null;
@@ -69,6 +77,12 @@ export const createCodingWorkerTask = (spec: CodingWorkerTaskSpec) =>
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(spec),
   });
+
+export const handoffCodingWorkerTask = (taskId: string) =>
+  request<CodingWorkerHandoffResult>(
+    `/api/coding/worker-tasks/${encodeURIComponent(taskId)}/handoff`,
+    { method: "POST" },
+  );
 
 export const sendCodingWorkerMessage = (taskId: string, message: string) =>
   request<CodingWorkerTask>(`${API_ROOT}/tasks/${encodeURIComponent(taskId)}/messages`, {

--- a/client/src/utils/codingWorkerApi.ts
+++ b/client/src/utils/codingWorkerApi.ts
@@ -1,0 +1,161 @@
+import type {
+  CodingWorkerApproval,
+  CodingWorkerArtifact,
+  CodingWorkerEntry,
+  CodingWorkerEvent,
+  CodingWorkerEvidence,
+  CodingWorkerStatus,
+  CodingWorkerTask,
+  CodingWorkerTaskSpec,
+} from "../types/codingWorker";
+
+const API_ROOT = "/api/coding-worker/v1";
+
+export class CodingWorkerApiError extends Error {
+  status: number;
+  code: string | null;
+
+  constructor(message: string, status: number, code: string | null = null) {
+    super(message);
+    this.name = "CodingWorkerApiError";
+    this.status = status;
+    this.code = code;
+  }
+}
+
+async function request<T>(url: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(url, init);
+  const payload = await response.json().catch(() => null);
+  if (!response.ok) {
+    const detail = payload && typeof payload === "object" && "detail" in payload
+      ? (payload as { detail?: unknown }).detail
+      : null;
+    const structured = detail && typeof detail === "object"
+      ? detail as { code?: unknown; message?: unknown }
+      : null;
+    throw new CodingWorkerApiError(
+      typeof structured?.message === "string"
+        ? structured.message
+        : typeof detail === "string"
+          ? detail
+          : `Coding Worker 请求失败（${response.status}）`,
+      response.status,
+      typeof structured?.code === "string" ? structured.code : null,
+    );
+  }
+  return payload as T;
+}
+
+const taskEventTypes = [
+  "task_created", "task_state", "provider_event", "steering_queued",
+  "approval_requested", "approval_decided", "tool_operation",
+  "artifact_created", "evidence_recorded", "evidence_invalidated",
+  "checkpoint_created", "acceptance_evaluated", "acceptance_retry",
+  "task_pinned", "task_unpinned",
+] as const;
+
+export const getCodingWorkerStatus = () => request<CodingWorkerStatus>(API_ROOT);
+
+export async function listCodingWorkerTasks() {
+  return (await request<{ tasks: CodingWorkerTask[] }>(`${API_ROOT}/tasks`)).tasks;
+}
+
+export const getCodingWorkerTask = (taskId: string) =>
+  request<CodingWorkerTask>(`${API_ROOT}/tasks/${encodeURIComponent(taskId)}`);
+
+export const createCodingWorkerTask = (spec: CodingWorkerTaskSpec) =>
+  request<CodingWorkerTask>(`${API_ROOT}/tasks`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(spec),
+  });
+
+export const sendCodingWorkerMessage = (taskId: string, message: string) =>
+  request<CodingWorkerTask>(`${API_ROOT}/tasks/${encodeURIComponent(taskId)}/messages`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ message }),
+  });
+
+export const changeCodingWorkerTask = (
+  taskId: string,
+  action: "pause" | "resume" | "cancel" | "pin" | "unpin",
+) => request<CodingWorkerTask>(
+  `${API_ROOT}/tasks/${encodeURIComponent(taskId)}/${action === "unpin" ? "pin" : action}`,
+  { method: action === "unpin" ? "DELETE" : "POST" },
+);
+
+export async function listCodingWorkerApprovals(taskId: string) {
+  return (await request<{ approvals: CodingWorkerApproval[] }>(
+    `${API_ROOT}/tasks/${encodeURIComponent(taskId)}/approvals`,
+  )).approvals;
+}
+
+export const decideCodingWorkerApproval = (
+  taskId: string,
+  approvalId: string,
+  decision: "approve_once" | "approve_task" | "reject",
+) => request<CodingWorkerApproval>(
+  `${API_ROOT}/tasks/${encodeURIComponent(taskId)}/approvals`,
+  {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ approval_id: approvalId, decision, ttl_seconds: 900 }),
+  },
+);
+
+export async function listCodingWorkerEvidence(taskId: string) {
+  return (await request<{ evidence: CodingWorkerEvidence[] }>(
+    `${API_ROOT}/tasks/${encodeURIComponent(taskId)}/evidence`,
+  )).evidence;
+}
+
+export async function listCodingWorkerArtifacts(taskId: string) {
+  return (await request<{ artifacts: CodingWorkerArtifact[] }>(
+    `${API_ROOT}/tasks/${encodeURIComponent(taskId)}/artifacts`,
+  )).artifacts;
+}
+
+export async function listCodingWorkerTree(taskId: string) {
+  return request<{ workspace_id: string; tree_hash: string; entries: CodingWorkerEntry[] }>(
+    `${API_ROOT}/tasks/${encodeURIComponent(taskId)}/workspace/tree`,
+  );
+}
+
+async function requestText(url: string) {
+  const response = await fetch(url);
+  if (!response.ok) throw new CodingWorkerApiError(`内容读取失败（${response.status}）`, response.status);
+  return response.text();
+}
+
+export const readCodingWorkerEntry = (taskId: string, entryId: string) =>
+  requestText(`${API_ROOT}/tasks/${encodeURIComponent(taskId)}/workspace/entries/${encodeURIComponent(entryId)}`);
+
+export const readCodingWorkerDiff = (taskId: string) =>
+  requestText(`${API_ROOT}/tasks/${encodeURIComponent(taskId)}/workspace/diff`);
+
+export const codingWorkerArtifactUrl = (taskId: string, artifactId: string) =>
+  `${API_ROOT}/tasks/${encodeURIComponent(taskId)}/artifacts/${encodeURIComponent(artifactId)}`;
+
+export function connectCodingWorkerEvents(
+  taskId: string,
+  after: number,
+  handlers: { onEvent: (event: CodingWorkerEvent) => void; onTransportError: () => void },
+) {
+  const source = new EventSource(
+    `${API_ROOT}/tasks/${encodeURIComponent(taskId)}/events?after=${Math.max(0, after)}`,
+  );
+  const receive = (message: MessageEvent<string>) => {
+    try {
+      const event = JSON.parse(message.data) as CodingWorkerEvent;
+      if (!Number.isFinite(event.sequence) || typeof event.type !== "string") throw new Error("invalid event");
+      handlers.onEvent(event);
+    } catch {
+      source.close();
+      handlers.onTransportError();
+    }
+  };
+  taskEventTypes.forEach((type) => source.addEventListener(type, receive as EventListener));
+  source.onerror = handlers.onTransportError;
+  return () => source.close();
+}

--- a/docker-compose.coding-worker-v14.yml
+++ b/docker-compose.coding-worker-v14.yml
@@ -21,6 +21,9 @@ services:
       CODING_WORKER_EGRESS_PROXY_URL: http://coding-worker-egress:8080
       CODING_WORKER_EGRESS_GRANT_KEY: ${CODING_WORKER_EGRESS_GRANT_KEY:-}
       CODING_WORKER_PROJECT_SNAPSHOT_ROOT: /project-snapshots
+      CODING_WORKER_BUILTIN_SOURCE_ROOT: /builtin-source
+      CODING_WORKER_BUILTIN_SOURCE_ID: modelmirror
+      CODING_WORKER_BUILTIN_REVISION: ${CODING_WORKER_BUILTIN_REVISION:?set the full ModelMirror source commit}
     volumes:
       - coding_worker_state:/var/lib/modelmirror/coding-worker
       - coding_worker_slot_a:/worker-slots/slot-a
@@ -31,6 +34,12 @@ services:
       - coding_worker_executor_b:/run/modelmirror-coding-executor-b
       - coding_worker_broker:/run/modelmirror-coding-broker
       - coding_project_snapshot:/project-snapshots:ro
+      - type: bind
+        source: ${CODING_IMPLEMENTATION_WORKTREE:?set the absolute ModelMirror implementation worktree}
+        target: /builtin-source
+        read_only: true
+        bind:
+          create_host_path: false
 
   coding-worker-provider-a:
     image: modelmirror-coding-worker-v14:local

--- a/docker-compose.coding-worker-v14.yml
+++ b/docker-compose.coding-worker-v14.yml
@@ -20,6 +20,7 @@ services:
       CODING_WORKER_NETWORK_DOMAINS: ${CODING_WORKER_NETWORK_DOMAINS:-registry.npmjs.org}
       CODING_WORKER_EGRESS_PROXY_URL: http://coding-worker-egress:8080
       CODING_WORKER_EGRESS_GRANT_KEY: ${CODING_WORKER_EGRESS_GRANT_KEY:-}
+      CODING_WORKER_PROJECT_SNAPSHOT_ROOT: /project-snapshots
     volumes:
       - coding_worker_state:/var/lib/modelmirror/coding-worker
       - coding_worker_slot_a:/worker-slots/slot-a
@@ -29,6 +30,7 @@ services:
       - coding_worker_executor_a:/run/modelmirror-coding-executor-a
       - coding_worker_executor_b:/run/modelmirror-coding-executor-b
       - coding_worker_broker:/run/modelmirror-coding-broker
+      - coding_project_snapshot:/project-snapshots:ro
 
   coding-worker-provider-a:
     image: modelmirror-coding-worker-v14:local
@@ -167,6 +169,7 @@ services:
     restart: unless-stopped
 
 volumes:
+  coding_project_snapshot:
   coding_worker_state:
   coding_worker_slot_a:
   coding_worker_slot_b:

--- a/docker-compose.coding-worker-v14.yml
+++ b/docker-compose.coding-worker-v14.yml
@@ -108,7 +108,7 @@ services:
       dockerfile: server/coding_worker/Dockerfile.v14
     container_name: modelmirror-coding-worker-slot-a
     networks:
-      - coding_internal
+      - coding_worker_tools
     user: "65532:65532"
     read_only: true
     cap_drop:
@@ -159,7 +159,7 @@ services:
     container_name: modelmirror-coding-worker-egress
     command: ["python", "-m", "coding_worker.egress_proxy"]
     networks:
-      - coding_internal
+      - coding_worker_tools
       - coding_worker_egress
     user: "65532:65532"
     read_only: true
@@ -189,5 +189,8 @@ volumes:
   coding_worker_broker:
 
 networks:
+  coding_worker_tools:
+    driver: bridge
+    internal: true
   coding_worker_egress:
     driver: bridge

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -37,7 +37,7 @@ Dify 不再承载 `/workflow` 或 `/rag` 主路径。仓库仍保留
 | DuckDB | Data X 项目隔离分析。 |
 | Browser / Sandbox sidecar | 受控浏览器和无网络沙箱执行。 |
 | OmniRoute sidecar | 可选兼容、诊断和紧急回退；不是普通用户控制面。 |
-| OpenCode + 最小 ACP Worker | 实验性代码问答与修改草稿执行面；单实例、默认关闭。 |
+| Coding Worker V14 | 供应商中立的持久任务控制面；双槽、默认关闭，OpenCode 1.18.9 为首个内部 Provider，ACP 为回退。 |
 | Coding Project Source | 无网络的受控项目清单与单槽 Git HEAD 快照服务；只有它可读取清单 `CODING_PROJECTS_ROOT`。 |
 | Coding Project Writer | 对清单中逐项目授权的无远程本地克隆执行原子写入、撤销、本地提交与对账。 |
 | Windows Project Host v2 | 在用户电脑上保存项目路径并执行受控原子写入、当前分支本地提交和精确对账；Server 只看到不透明项目 ID。 |
@@ -288,3 +288,38 @@ flowchart LR
   远端合并、目录操作、多 Agent、分布式
   Worker 或生产多租户。
 - Dify 代理属于 legacy compatibility；除非形成新的产品决策，不恢复为主路由。
+
+## V14 通用 Coding Worker
+
+V14 将新的平台级代码任务放入 `server/coding_worker/`，不再把任务控制、工具执行和验收继续堆进 `coding_runtime/api.py`。现有 Coding Runtime 与 Agent Workspace 的活动会话保持 legacy；新会话仅在 `CODING_WORKER_V14_ENABLED=true` 且 Worker 健康时渐进转发。
+
+```mermaid
+flowchart LR
+  MODULE["平台模块 / 浏览器"] --> API["/api/coding-worker/v1"]
+  API --> STORE["加密 Worker Store + Event Log"]
+  API --> SCHED["双槽调度器"]
+  SOURCE["builtin / manifest / host_snapshot"] --> WS["任务独立合成 Git H0"]
+  SCHED --> PA["Provider A"]
+  SCHED --> PB["Provider B"]
+  PA --> BROKER["Tool Broker"]
+  PB --> BROKER
+  BROKER --> EA["Executor A"]
+  BROKER --> EB["Executor B"]
+  EA -. "批准的网络租约" .-> EGRESS["allowlisted egress proxy"]
+  EB -. "批准的网络租约" .-> EGRESS
+  WS --> EVIDENCE["Harness Runner + Evidence Ledger"]
+  EVIDENCE --> CONSOLE["共享 Worker Console"]
+  CONSOLE -. "完成的 Host Snapshot" .-> V13["v13 写回确认链"]
+```
+
+核心边界：
+
+- `TaskSpec.origin` 由 Server 写入；浏览器和模块不能传物理路径、环境变量、remote URL、凭据、供应商名或原始执行端点。
+- 每个任务使用独立 Workspace、事件、审批、进程、Artifact 与 checkpoint；两个固定槽可并行，第三个任务持久排队。
+- Provider 与 Executor 分离。Provider 只连接受控模型网络；Executor 只连接内部 `coding_worker_tools` 网络，无法直接访问 Server/newAPI。网络租约只能经独立 egress proxy 生效。
+- OpenCode 1.18.9 的端口、认证和原始帧属于 Provider 私有实现；公共契约只包含 capability、open、message、event stream、cancel、checkpoint、restore、close。
+- 必需检查由后端冻结并绑定 Workspace tree hash。模型停止调用工具只进入验收阶段；全部必需 Evidence 通过后才能 `completed`，树变化会使旧证据失效。
+- 重启不会恢复旧进程或重放未知副作用。只恢复与当前 tree hash 匹配的确定 checkpoint；其余任务进入 `interrupted`，等待显式 resume。
+- `host_snapshot` 在任务真正出队时才向 Windows Helper 请求一次性快照并导入 Project Source；Server 始终不获得宿主物理路径。完成后仅能显式交给现有 v13 写回链，Worker 本身不写用户仓库。
+
+`/coding` 和 `/agents/workbench` 使用同一个 Worker Console。前者保留 v13 apply/commit/undo/publish 领域动作；后者只显示通用任务、文件、Diff、审批、Evidence、Artifact 与终端语义。下游 Skill/MCP 创建、AI 应用、3D 引擎和用户开发模块只注册来源、上下文和验收适配器，不向 Worker 内核加入领域逻辑。

--- a/docs/CODING_AGENT_INTEGRATION.md
+++ b/docs/CODING_AGENT_INTEGRATION.md
@@ -702,3 +702,43 @@ docker compose -p modelmirror --profile coding stop coding-runtime
 恢复 SQLite 是 Coding 专用、可选的单槽存储，不迁移其他业务数据库。需要整轮
 回退时，省略恢复 overlay 并按独立提交逆序撤销；已有外部文件和本地提交不会被
 自动删除。
+
+## V14 平台 Coding Worker 契约
+
+V14 的公共入口是版本化 `/api/coding-worker/v1`。OpenCode、ACP、sidecar socket、端口和 session ID 均为内部实现，不进入浏览器或模块契约。
+
+| 接口 | 用途 |
+| --- | --- |
+| `GET /api/coding-worker/v1` | 功能开关、并发、保留期与可选择的冻结检查 ID |
+| `POST /api/coding-worker/v1/tasks` | 使用 `client_task_id` 幂等创建任务；`origin` 由 Server 写入 |
+| `GET /tasks`、`GET /tasks/{id}` | 列表与任务状态 |
+| `GET /tasks/{id}/events?after=` | 可补发事件流；断线后从最后 event ID 继续 |
+| `POST /tasks/{id}/messages` | 追加指令或运行中 steering |
+| `GET/POST /tasks/{id}/approvals` | 查询和签发一次性或任务级能力租约 |
+| `POST /tasks/{id}/pause|resume|cancel|pin` | 显式生命周期控制 |
+| `GET /tasks/{id}/workspace/tree` | 获取 opaque `entry_id` 文件树 |
+| `GET /tasks/{id}/workspace/entries/{entry_id}` | 受限文本预览 |
+| `GET /tasks/{id}/workspace/diff` | 当前合成 Git 基线 Diff |
+| `GET /tasks/{id}/evidence` | 绑定当前 tree hash 的必需检查证据 |
+| `GET /tasks/{id}/artifacts/{artifact_id}` | 下载任务绑定 Artifact |
+| `GET /tasks/{id}/services/{service_id}/preview/{path}` | 短期安全预览 |
+
+`TaskSpec` 固定包含调用方幂等键、Server origin、目标、opaque Workspace 来源与 revision、冻结 AcceptanceContract、policy profile、平台模型路由、低于系统上限的预算和受控 context refs。浏览器或模块提交物理路径、环境变量、供应商名、remote URL、凭据或原始执行端点时必须拒绝。
+
+模块集成使用 `server/coding_worker/sdk.py`：
+
+- 模块可注册 `builtin`、`manifest`、`host_snapshot` 范围内的来源适配器、上下文和冻结检查；
+- 模块只能通过内部客户端创建/查询/steer 任务，不能直接取得 Provider、Executor、进程或权限对象；
+- AcceptanceContract 创建后不可删除或降级；当前公开基础检查为 `python-compile`、`python-pytest`、`react-test`、`react-build`；
+- 新增 Skill/MCP 创建、AI 应用或 3D 引擎适配时，只增加模块侧来源、上下文与验收，不修改 Worker 内核的领域逻辑。
+
+来源语义：
+
+- `builtin` 从部署时固定的只读 ModelMirror source commit 构造合成 Git `H0`；
+- `manifest` 复用 Project Source 单槽快照，模块只持 opaque project/revision；
+- `host_snapshot` 在任务出队后惰性请求 v13 Windows Helper 快照，复核 project/head/fingerprint，导入完成即释放租约；
+- 每个任务的 Workspace、进程、事件、审批、checkpoint、Evidence 和 Artifact 按 `task_id` 隔离，二进制 Diff 只记录身份与元数据。
+
+`/coding` 与 `/agents/workbench` 的新会话可渐进使用同一 `CodingWorkerConsole`；已有活动会话仍走 legacy。Coding 场景中的 completed `host_snapshot` 任务可调用 `POST /api/coding/worker-tasks/{task_id}/handoff`，把严格 UTF-8 文本 Diff 交给 v13 Recovery，然后由用户确认 apply/commit/undo/publish。二进制变更、未通过验收、Workspace 变化或 Host 身份变化均不得进入写回。
+
+模型停止输出不代表完成。服务端先进入 `testing`，Harness Runner 运行冻结检查并写 Evidence Ledger；只有全部必需检查对当前 tree hash 为 passed，任务才进入 `completed`。运行中命令在重启时停止，任务标记 `interrupted`；resume 只恢复确定 checkpoint，不恢复旧进程或盲重放未知 operation ID。

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -550,3 +550,45 @@ curl http://localhost:5173/studio
 - 可选 profile 故障不得通过删除核心数据解决。
 
 legacy `/api/dify/*` 健康只表示兼容代理配置状态，不是平台健康门禁。
+
+## Coding Worker V14 部署
+
+V14 默认关闭，使用独立 overlay `docker-compose.coding-worker-v14.yml`。它增加两个 Provider、两个单槽 Executor、持久 Store/Workspace 卷，以及可选的网络 egress proxy；不替换 v13 Project Host、Coding Recovery 或 Agent Workspace 数据。
+
+在绝对 `MODELMIRROR_DATA_ROOT` 对应的 `server/.env` 中设置以下值，不要把真实值提交到仓库：
+
+```dotenv
+CODING_WORKER_V14_ENABLED=false
+CODING_WORKER_MAX_ACTIVE_TASKS=2
+CODING_WORKER_RETENTION_SECONDS=604800
+CODING_WORKER_NETWORK_ENABLED=false
+CODING_WORKER_SLOT_A_TOKEN=<random>
+CODING_WORKER_SLOT_B_TOKEN=<random>
+CODING_WORKER_EXECUTOR_A_TOKEN=<random>
+CODING_WORKER_EXECUTOR_B_TOKEN=<random>
+CODING_WORKER_MODEL_ID=<controlled-model-id>
+CODING_WORKER_ROUTE_KEY=<dedicated-route-key>
+CODING_WORKER_BUILTIN_REVISION=<full-source-commit>
+```
+
+`CODING_WORKER_MODEL_BASE_URL` 默认使用 `http://new-api:3000/v1`。若启用 `develop_networked`，还必须显式设置 `CODING_WORKER_NETWORK_ENABLED=true`、随机 `CODING_WORKER_EGRESS_GRANT_KEY` 和最小 `CODING_WORKER_NETWORK_DOMAINS`，并加载 `coding-worker-network` profile。不要把模型网关密钥复用为 slot、executor 或 egress token。
+
+只做配置展开检查、不启动服务：
+
+```powershell
+docker compose -f docker-compose.yml -f docker-compose.coding-worker-v14.yml -p modelmirror --profile coding config --quiet
+```
+
+Host Snapshot 场景还需按既有顺序加载 Project Host overlay；若同时启用清单项目，继续遵守 project-source/full compatibility overlay 的顺序。`CODING_IMPLEMENTATION_WORKTREE` 必须是当前验收 HEAD 的绝对只读来源，`CODING_WORKER_BUILTIN_REVISION` 必须是同一完整 commit。
+
+只有在用户确认共享栈独占窗口、最新主线和正式环境变量后，才可执行重建：
+
+```powershell
+docker compose -f docker-compose.yml -f docker-compose.coding-project-host.yml -f docker-compose.coding-worker-v14.yml -p modelmirror --profile coding up -d --build --force-recreate server coding-worker-provider-a coding-worker-provider-b coding-worker-slot-a coding-worker-slot-b
+```
+
+网络默认保持关闭；需要依赖下载时再追加 `--profile coding-worker-network`，批准结束后关闭 profile。Provider 在 `coding_internal` 访问受控模型网关，Executor 仅在内部 `coding_worker_tools`；只有 egress proxy 同时加入工具网络和外部网络。
+
+验收至少包括：两个任务并行、第三个排队；失败检查后的自动修复与复测；审批拒绝/过期；SSE 断线补发；Server、两个 Provider/Executor 逐个重启；Host Snapshot 经过 v13 写回。真实 OpenCode、Windows Helper 和用户项目写回必须单列人工结果，不能用 Fake Provider 或 Compose `config` 代替。
+
+回退只需设置 `CODING_WORKER_V14_ENABLED=false` 并重建 Server，使新会话回到 legacy。不要删除 `coding_worker_state`、slot Workspace 卷、v13 Recovery 或 Agent Workspace 数据；已有任务保持可审计，已有宿主副作用不会自动撤销。

--- a/docs/HARNESS_ENGINEERING.md
+++ b/docs/HARNESS_ENGINEERING.md
@@ -381,3 +381,27 @@ curl http://localhost:5173/models
     任何 build/up/recreate 前都要取得用户确认的独占窗口；若 `origin/main` 前进，应在新验收
     集成工作树定向引入批次并 range-diff。人工验收后还要再次核对主线、全 Diff、敏感信息
     和禁止产物，才允许 push 或 PR。
+42. **通用 Coding Worker 只接受供应商中立任务。** 模块只能提交目标、opaque 来源、上下文引用、
+    冻结验收 ID 和低于系统上限的预算；`origin` 由 Server 写入。物理路径、环境变量、remote URL、
+    凭据、供应商名和原始执行端点不得进入 `TaskSpec`。领域适配放在调用模块，不进入 Worker 内核。
+43. **Provider、Executor 与网络出口必须分层隔离。** Provider 可以访问受控模型网络，但不能直接执行
+    Workspace 命令；Executor 只能加入内部工具网络，不能访问 Server/newAPI。网络动作必须经绑定任务、
+    用途、域名和 TTL 的租约以及独立 egress proxy；IP 字面量、私网和重定向越界保持拒绝。
+44. **任务完成由冻结验收和当前树证据决定。** 模型停止调用工具只进入 `testing`。必需检查的 argv、
+    timeout 和交付物由后端注册，Agent 与调用模块不能删除、替换或降级；Workspace tree hash 改变后旧
+    Evidence 必须失效，未全部通过不得进入 `completed`。
+45. **双槽任务和进程必须按任务归属。** 两个任务可并行，第三个持久排队；取消、输入、输出、服务、
+    审批和 Artifact 都要绑定 `task_id` 与 slot。取消一个任务不得终止另一个任务的进程，也不得把其
+    Workspace、事件或 Artifact 读给另一个调用方。
+46. **恢复只重放控制意图，不重放未知副作用。** Server 或 Worker 重启后，运行中进程停止并把任务
+    标记 `interrupted`。只有 provider checkpoint 与当前 tree hash 精确匹配才可由显式 resume 恢复；
+    副作用工具使用稳定 operation ID，未知结果先 reconcile，禁止换 ID 盲重放。
+47. **来源租约应尽可能晚取得并及时释放。** `host_snapshot` 只在任务真正出队时请求 Windows Helper，
+    导入并校验 project/head/fingerprint 后立即释放 Project Source 租约；排队任务不能占用单槽快照。
+    Server、Provider、Executor 和模型始终只看 opaque ID 或隔离 Workspace，不得获得宿主物理路径。
+48. **宿主写回继续由 v13 执行。** Worker 在合成 Git H0 内生成 Diff，不在用户仓库原地运行。只有
+    completed、必需检查通过且仍绑定原 Host Snapshot 的文本变更，才可由用户显式交给 v13
+    apply/commit/undo/publish 链；Worker 不新增第二套宿主写事务。
+49. **共享 Console 必须区分展示与能力。** `/coding` 和 `/agents/workbench` 可复用任务、对话、文件、
+    Diff、审批、Evidence、Artifact 与终端组件；只有 Coding 上下文展示 v13 领域动作。开关关闭、Provider
+    不可用或 legacy 活动会话存在时必须清晰降级，不能把 Mock/静态状态误报为真实引擎就绪。

--- a/docs/tasks/CODING_WORKER_V14.md
+++ b/docs/tasks/CODING_WORKER_V14.md
@@ -27,8 +27,44 @@ V14 不在宿主仓库原地执行，不开放 Git remote/push、自动 PR、任
 
 关闭 `CODING_WORKER_V14_ENABLED` 后，新任务继续走 legacy；不得删除 Worker Store、Workspace、Coding Recovery 或 Agent Workspace 数据。已有活动 legacy 会话不迁移。
 
-## PR A 当前接口
+## 顺序 PR 状态
 
-`/api/coding-worker/v1` 默认关闭。Kernel 阶段提供任务幂等创建、状态、SSE 事件补发、消息、暂停/继续/取消/pin，以及用 opaque `entry_id` 读取的 Workspace tree、文本预览与 Diff。`origin` 始终由 Server 写入；模型路由必须命中 `CODING_WORKER_MODEL_ROUTES`。
+| PR | 范围 | 当前状态 |
+| --- | --- | --- |
+| PR A `#122` | 契约、加密任务 Store、事件补发、Workspace Broker、双槽调度与 Fake Provider | 已完成并作为后续堆叠基线 |
+| PR B `#125` | OpenCode Provider、Tool Broker、审批/网络/服务租约、Evidence Ledger、checkpoint 恢复 | 已完成并作为 PR C 基线 |
+| PR C `#130` | 模块 SDK、共享 Console、三类来源、冻结验收、v13 写回桥、部署与文档 | Draft；自动门禁尚未全部完成 |
 
-PR A 使用 Fake Provider 验证状态机，模型停止后只进入 `testing` 并以 `acceptance_runner_pending` 阻断，绝不伪造完成。OpenCode、Tool Broker、Harness Runner 和 legacy 转发在后续顺序 PR 接入；未配置真实 Provider 时即使误开开关，API 也返回 503，而不会回退到未隔离执行。
+每个实现提交继续限制在不超过五个文件。PR C 不迁移已有活动 legacy 会话；只有新会话在开关开启且 Worker 可用时进入 V14。
+
+## 当前公共能力
+
+`/api/coding-worker/v1` 默认关闭，提供：
+
+- 幂等创建与查询任务、SSE 事件补发、消息 steering、审批、暂停、继续、取消、pin 和删除；
+- 使用 opaque `entry_id` 的 Workspace tree、文本预览、Diff、Evidence、Artifact 与安全预览；
+- `builtin`、`manifest`、`host_snapshot` 三种受控来源；来源适配器和冻结检查只能由 Server 模块注册；
+- 两个固定任务槽；第三个任务持久排队，重启后的运行中任务进入 `interrupted`；
+- 供应商中立的 Provider 契约。首个真实实现固定为 OpenCode 1.18.9，ACP 保留回退，公共 API 不暴露两者；
+- 通过 Tool Broker 执行文件、命令、服务与网络动作。Executor 默认只在内部工具网络，只有带批准租约且启用专用 profile 时才经 egress proxy 访问允许域名；
+- 后端冻结的 `python-compile`、`python-pytest`、`react-test`、`react-build` 检查。调用方只能选择公开 ID，不能改写 argv 或降低验收；
+- `/coding` 与 `/agents/workbench` 共用 Worker Console；Coding 场景中的已完成 `host_snapshot` 任务可显式转入 v13 apply/commit/undo/publish 确认链。
+
+## 当前自动验证证据
+
+- V14 Worker 17 个专项文件：`96 passed`；
+- Project Host API：`19 passed`；
+- 前端：`29` 个文件、`134 passed`；
+- 前端 production build 通过，`CodingPage` gzip `37.60 kB`；
+- V14 Compose 组合 `config --quiet` 与部署静态测试通过；
+- 分支已推送至 Draft PR `#130`。
+
+这些结果不等同于完整发布验收。全部 Coding + Agent Workspace、后端全量、真实 OpenCode headless、真实 Windows Helper、共享栈重建和用户项目写回仍须分别完成并记录。
+
+## 发布与人工验收门禁
+
+1. 运行新增专项、全部 Agent Workspace、全部 Coding、后端全量、前端测试/build、Compose config、敏感信息与禁止产物扫描。
+2. 在独立临时环境验证真实 OpenCode 1.18.9、两个任务并行、第三个排队、失败后自动修复复测、SSE 补发与逐个重启。
+3. 取得用户确认的共享栈独占窗口后，重新 fetch 最新主线、核对堆叠 PR 和环境变量，再重建；不得停止仍在运行的独立预览器。
+4. 使用用户明确选择的测试项目验证 Host Snapshot → Worker → v13 apply/commit/undo；真实写入前再次确认项目、分支与 Diff。
+5. 只有以上证据齐全且人工验收通过，PR C 才可由 Draft 转为 Ready。

--- a/docs/tasks/CODING_WORKER_V14.md
+++ b/docs/tasks/CODING_WORKER_V14.md
@@ -55,17 +55,19 @@ V14 不在宿主仓库原地执行，不开放 Git remote/push、自动 PR、任
 - V14 Worker 17 个专项文件：`96 passed`；
 - Project Host API：`19 passed`；
 - 全部 Coding + Agent Workspace：`762 passed, 9 skipped`；
-- 后端全量：`2131 passed, 21 skipped, 1 failed`。唯一失败是现有 `modelmirror-server`
+- 本地后端全量：`2131 passed, 21 skipped, 1 failed`。唯一失败是陈旧 `modelmirror-server`
   测试镜像内 Node `20.20.2` 无法直接导入 TypeScript；该节点及数据未被 PR C 修改，使用本机
-  Node `24.18.0` 单独复跑为 `1 passed`，因此记录为测试镜像环境门禁而非绿色全量；
+  Node `24.18.0` 单独复跑为 `1 passed`；GitHub 当前 HEAD 的 `Backend quality` 已通过；
 - 前端：`29` 个文件、`134 passed`；
 - 前端 production build 通过，`CodingPage` gzip `37.60 kB`；
 - V14 Compose 组合 `config --quiet` 与部署静态测试通过；
 - 真实 Worker 镜像中的 OpenCode `1.18.9` 已在非 root、只读根、无网络、无宿主端口的
   临时容器中完成 Basic Auth `serve` 与 `/global/health` 冒烟；这不等同于带真实模型的修复循环；
+- GitHub 当前 HEAD 的 `Backend quality`、`Frontend quality`、`Windows Project Host` 与
+  `readiness` 均通过；
 - 分支已推送至 Draft PR `#130`。
 
-这些结果不等同于完整发布验收。后端全量仍需在支持 TypeScript strip 的正式 Node 镜像复跑；真实 OpenCode 模型任务循环、真实 Windows Helper、共享栈重建和用户项目写回仍须分别完成并记录。
+这些结果不等同于完整发布验收。真实 OpenCode 模型任务循环、真实 Windows Helper、共享栈重建和用户项目写回仍须分别完成并记录。
 
 ## 发布与人工验收门禁
 

--- a/docs/tasks/CODING_WORKER_V14.md
+++ b/docs/tasks/CODING_WORKER_V14.md
@@ -61,9 +61,11 @@ V14 不在宿主仓库原地执行，不开放 Git remote/push、自动 PR、任
 - 前端：`29` 个文件、`134 passed`；
 - 前端 production build 通过，`CodingPage` gzip `37.60 kB`；
 - V14 Compose 组合 `config --quiet` 与部署静态测试通过；
+- 真实 Worker 镜像中的 OpenCode `1.18.9` 已在非 root、只读根、无网络、无宿主端口的
+  临时容器中完成 Basic Auth `serve` 与 `/global/health` 冒烟；这不等同于带真实模型的修复循环；
 - 分支已推送至 Draft PR `#130`。
 
-这些结果不等同于完整发布验收。后端全量仍需在支持 TypeScript strip 的正式 Node 镜像复跑；真实 OpenCode headless、真实 Windows Helper、共享栈重建和用户项目写回仍须分别完成并记录。
+这些结果不等同于完整发布验收。后端全量仍需在支持 TypeScript strip 的正式 Node 镜像复跑；真实 OpenCode 模型任务循环、真实 Windows Helper、共享栈重建和用户项目写回仍须分别完成并记录。
 
 ## 发布与人工验收门禁
 

--- a/docs/tasks/CODING_WORKER_V14.md
+++ b/docs/tasks/CODING_WORKER_V14.md
@@ -54,12 +54,16 @@ V14 不在宿主仓库原地执行，不开放 Git remote/push、自动 PR、任
 
 - V14 Worker 17 个专项文件：`96 passed`；
 - Project Host API：`19 passed`；
+- 全部 Coding + Agent Workspace：`762 passed, 9 skipped`；
+- 后端全量：`2131 passed, 21 skipped, 1 failed`。唯一失败是现有 `modelmirror-server`
+  测试镜像内 Node `20.20.2` 无法直接导入 TypeScript；该节点及数据未被 PR C 修改，使用本机
+  Node `24.18.0` 单独复跑为 `1 passed`，因此记录为测试镜像环境门禁而非绿色全量；
 - 前端：`29` 个文件、`134 passed`；
 - 前端 production build 通过，`CodingPage` gzip `37.60 kB`；
 - V14 Compose 组合 `config --quiet` 与部署静态测试通过；
 - 分支已推送至 Draft PR `#130`。
 
-这些结果不等同于完整发布验收。全部 Coding + Agent Workspace、后端全量、真实 OpenCode headless、真实 Windows Helper、共享栈重建和用户项目写回仍须分别完成并记录。
+这些结果不等同于完整发布验收。后端全量仍需在支持 TypeScript strip 的正式 Node 镜像复跑；真实 OpenCode headless、真实 Windows Helper、共享栈重建和用户项目写回仍须分别完成并记录。
 
 ## 发布与人工验收门禁
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -49,6 +49,7 @@ COPY multimodal ./multimodal
 COPY model_router ./model_router
 COPY context_engine ./context_engine
 COPY coding_runtime ./coding_runtime
+COPY coding_worker ./coding_worker
 
 EXPOSE 8000
 

--- a/server/coding_runtime/api.py
+++ b/server/coding_runtime/api.py
@@ -1318,6 +1318,149 @@ class CodingService:
                 self._sessions[session_id] = record
             return record
 
+    async def adopt_worker_patch(
+        self,
+        *,
+        project_id: str,
+        expected_head: str,
+        patch: str,
+        paths: list[str],
+    ) -> CodingApiSession:
+        """Import a completed V14 patch into the existing v13 writeback chain."""
+
+        async with self._create_lock:
+            return await self._adopt_worker_patch_locked(
+                project_id=project_id,
+                expected_head=expected_head,
+                patch=patch,
+                paths=paths,
+            )
+
+    async def _adopt_worker_patch_locked(
+        self,
+        *,
+        project_id: str,
+        expected_head: str,
+        patch: str,
+        paths: list[str],
+    ) -> CodingApiSession:
+        if "GIT binary patch" in patch or "Binary files " in patch:
+            raise _http_error(
+                status.HTTP_409_CONFLICT, "worker_writeback_patch_unsupported"
+            )
+
+        await self._require_available()
+        if self.mode != "draft":
+            raise _http_error(status.HTTP_409_CONFLICT, "draft_unavailable")
+        if not self.recovery_enabled or self.recovery_store is None:
+            raise _http_error(
+                status.HTTP_503_SERVICE_UNAVAILABLE,
+                self.recovery_reason or "recovery_unavailable",
+            )
+        safe_patch = _safe_diff(patch)
+        safe_paths = _diff_paths(safe_patch)
+        if not safe_patch or safe_paths != paths:
+            raise _http_error(
+                status.HTTP_409_CONFLICT, "worker_writeback_patch_unsupported"
+            )
+        await self.cleanup_expired()
+        if await self._load_recovery_record() is not None:
+            raise _http_error(status.HTTP_409_CONFLICT, "recovery_pending")
+        async with self._lock:
+            if self._sessions:
+                raise _http_error(status.HTTP_409_CONFLICT, "concurrency_limit")
+
+        source: dict[str, Any] | None = None
+        try:
+            source, project = await self._acquire_host_project(
+                project_id,
+                expected_head=expected_head,
+            )
+            fingerprint = source.get("fingerprint")
+            if (
+                not isinstance(fingerprint, str)
+                or SNAPSHOT_FINGERPRINT_PATTERN.fullmatch(fingerprint) is None
+            ):
+                raise _http_error(
+                    status.HTTP_503_SERVICE_UNAVAILABLE,
+                    "invalid_project_source_response",
+                )
+            result = await self.worker.restore_session(
+                revision=1,
+                patch=safe_patch,
+                paths=safe_paths,
+                snapshot_fingerprint=fingerprint,
+                verification=None,
+                source=source,
+            )
+        except CodingWorkerError as exc:
+            await self._release_project_source(source)
+            raise _worker_http_error(exc) from exc
+        except Exception:
+            await self._release_project_source(source)
+            raise
+
+        session_id = result.get("session_id")
+        event_data = result.get("event")
+        restored_changes = _public_changes(result.get("changes"))
+        if (
+            not isinstance(session_id, str)
+            or SAFE_IDENTIFIER.fullmatch(session_id) is None
+            or result.get("mode") != self.mode
+            or not isinstance(event_data, dict)
+            or not _worker_project_matches(result.get("project"), project)
+            or restored_changes["revision"] != 1
+            or [item["path"] for item in restored_changes["files"]] != safe_paths
+            or restored_changes["can_download"] is not True
+        ):
+            if isinstance(session_id, str) and session_id:
+                await self._close_worker_session_and_release(
+                    session_id, source, required=False
+                )
+            else:
+                await self._release_project_source(source)
+            raise _http_error(
+                status.HTTP_503_SERVICE_UNAVAILABLE, "invalid_worker_response"
+            )
+        record = CodingApiSession(
+            session_id=session_id,
+            worker_session_id=session_id,
+            project=project,
+            project_source=source,
+        )
+        initial = _event_from_payload(event_data)
+        if (
+            initial.kind is not CodingEventKind.SESSION_STARTED
+            or initial.seq != 1
+            or initial.session_id != session_id
+        ):
+            await self._close_worker_session_and_release(
+                session_id, source, required=False
+            )
+            raise _http_error(
+                status.HTTP_503_SERVICE_UNAVAILABLE, "invalid_worker_response"
+            )
+        await self._append_event(record, initial)
+        try:
+            persisted = await self._persist_recovery(record, required=True)
+            if not persisted:
+                raise _http_error(
+                    status.HTTP_503_SERVICE_UNAVAILABLE,
+                    "recovery_storage_unavailable",
+                )
+            async with self._lock:
+                if self._sessions:
+                    raise _http_error(
+                        status.HTTP_409_CONFLICT, "concurrency_limit"
+                    )
+                self._sessions[session_id] = record
+        except Exception:
+            await self._close_worker_session_and_release(
+                session_id, source, required=False
+            )
+            raise
+        return record
+
     async def _acquire_host_project(
         self,
         project_id: str,
@@ -5152,6 +5295,76 @@ async def create_coding_session(
         "status": record.state,
         "project": record.project,
     }
+
+
+@router.post(
+    "/worker-tasks/{task_id}/handoff",
+    status_code=status.HTTP_201_CREATED,
+)
+async def handoff_coding_worker_task(task_id: str) -> dict[str, Any]:
+    try:
+        try:
+            from server.coding_worker.api import get_coding_worker_service
+            from server.coding_worker.contracts import TaskState
+        except ModuleNotFoundError:
+            from coding_worker.api import get_coding_worker_service
+            from coding_worker.contracts import TaskState
+
+        worker_service = get_coding_worker_service()
+        task = worker_service.store.get_task(task_id)
+        if (
+            task.state is not TaskState.COMPLETED
+            or task.workspace_id is None
+            or task.spec.workspace_source.kind != "host_snapshot"
+        ):
+            raise _http_error(
+                status.HTTP_409_CONFLICT, "worker_task_not_writeback_ready"
+            )
+        if (
+            worker_service.harness_runner is None
+            or not worker_service.harness_runner.acceptance_satisfied(task_id)
+        ):
+            raise _http_error(
+                status.HTTP_409_CONFLICT, "worker_acceptance_invalidated"
+            )
+        patch_bytes = worker_service.workspace_broker.diff(task.workspace_id)
+        try:
+            patch = patch_bytes.decode("utf-8", errors="strict")
+        except UnicodeDecodeError as exc:
+            raise _http_error(
+                status.HTTP_409_CONFLICT, "worker_writeback_patch_unsupported"
+            ) from exc
+        if not worker_service.harness_runner.acceptance_satisfied(task_id):
+            raise _http_error(
+                status.HTTP_409_CONFLICT, "worker_acceptance_invalidated"
+            )
+        paths = _diff_paths(patch)
+        if not paths:
+            raise _http_error(status.HTTP_409_CONFLICT, "draft_is_empty")
+        record = await get_coding_service().adopt_worker_patch(
+            project_id=task.spec.workspace_source.source_id,
+            expected_head=task.spec.workspace_source.revision,
+            patch=patch,
+            paths=paths,
+        )
+        changes = await get_coding_service().changes(record.session_id)
+        return {
+            "id": record.session_id,
+            "status": record.state,
+            "project": record.project,
+            "revision": changes["revision"],
+            "task_id": task_id,
+        }
+    except HTTPException:
+        raise
+    except Exception as exc:
+        code = getattr(exc, "code", "worker_handoff_failed")
+        http_status = (
+            status.HTTP_404_NOT_FOUND
+            if code in {"task_not_found", "workspace_not_found"}
+            else status.HTTP_409_CONFLICT
+        )
+        raise _http_error(http_status, _safe_code(code)) from exc
 
 
 @router.post(

--- a/server/coding_worker/api.py
+++ b/server/coding_worker/api.py
@@ -151,6 +151,11 @@ async def coding_worker_status() -> dict[str, Any]:
             _service.store.retention_seconds if _service is not None else 604800
         ),
         "network_enabled": _runtime.network_enabled if _runtime is not None else False,
+        "acceptance_checks": (
+            sorted(_service.tool_broker.frozen_checks)
+            if _service is not None and _service.tool_broker is not None
+            else []
+        ),
         "reason": _startup_error,
     }
 

--- a/server/coding_worker/runtime.py
+++ b/server/coding_worker/runtime.py
@@ -165,6 +165,27 @@ class CodingWorkerRuntime:
 
 _SOURCE_ADAPTERS: dict[str, WorkspaceSourceAdapter] = {}
 _FROZEN_CHECKS: dict[str, FrozenCheck] = {}
+_DEFAULT_FROZEN_CHECKS = {
+    "python-compile": FrozenCheck(
+        check_id="python-compile",
+        argv=("python", "-m", "compileall", "-q", "."),
+    ),
+    "python-pytest": FrozenCheck(
+        check_id="python-pytest",
+        argv=("python", "-m", "pytest", "-q"),
+        timeout_seconds=900,
+    ),
+    "react-test": FrozenCheck(
+        check_id="react-test",
+        argv=("npm", "test", "--", "--run"),
+        timeout_seconds=900,
+    ),
+    "react-build": FrozenCheck(
+        check_id="react-build",
+        argv=("npm", "run", "build"),
+        timeout_seconds=900,
+    ),
+}
 
 
 def register_workspace_source_adapter(
@@ -179,7 +200,9 @@ def register_workspace_source_adapter(
 
 
 def register_frozen_check(check: FrozenCheck) -> None:
-    existing = _FROZEN_CHECKS.get(check.check_id)
+    existing = _DEFAULT_FROZEN_CHECKS.get(check.check_id) or _FROZEN_CHECKS.get(
+        check.check_id
+    )
     if existing is not None and existing != check:
         raise CodingWorkerRuntimeError(
             "Frozen check is already registered.",
@@ -295,7 +318,7 @@ def build_runtime_from_environment() -> CodingWorkerRuntime:
         storage_root=root,
         slot_roots=slot_roots,
         source_adapters=source_adapters,
-        frozen_checks=_FROZEN_CHECKS,
+        frozen_checks={**_DEFAULT_FROZEN_CHECKS, **_FROZEN_CHECKS},
         provider_endpoints=endpoints,
         provider_tokens=tokens,
         executor_endpoints=executor_endpoints,

--- a/server/coding_worker/runtime.py
+++ b/server/coding_worker/runtime.py
@@ -15,6 +15,7 @@ from .tool_broker import FrozenCheck, ToolBroker
 from .workspace import WorkspaceBroker, WorkspaceSourceAdapter
 from .source_adapters import (
     BuiltinGitWorkspaceSourceAdapter,
+    HostSnapshotWorkspaceSourceAdapter,
     ProjectSnapshotWorkspaceSourceAdapter,
 )
 
@@ -265,12 +266,31 @@ def build_runtime_from_environment() -> CodingWorkerRuntime:
             )
         except ModuleNotFoundError:
             from coding_runtime.project_source_client import CodingProjectSourceClient
+        project_source_client = CodingProjectSourceClient(project_source_socket)
         project_adapter = ProjectSnapshotWorkspaceSourceAdapter(
-            CodingProjectSourceClient(project_source_socket),
+            project_source_client,
             Path(os.getenv("CODING_WORKER_PROJECT_SNAPSHOT_ROOT", "/project-snapshots")),
         )
         source_adapters.setdefault("manifest", project_adapter)
-        source_adapters.setdefault("host_snapshot", project_adapter)
+        try:
+            from server.coding_runtime.api import get_coding_service
+        except ModuleNotFoundError:
+            from coding_runtime.api import get_coding_service
+        coding_service = get_coding_service()
+        if coding_service.project_host is not None:
+            source_adapters.setdefault(
+                "host_snapshot",
+                HostSnapshotWorkspaceSourceAdapter(
+                    coding_service.project_host,
+                    project_source_client,
+                    Path(
+                        os.getenv(
+                            "CODING_WORKER_PROJECT_SNAPSHOT_ROOT",
+                            "/project-snapshots",
+                        )
+                    ),
+                ),
+            )
     return CodingWorkerRuntime(
         storage_root=root,
         slot_roots=slot_roots,

--- a/server/coding_worker/runtime.py
+++ b/server/coding_worker/runtime.py
@@ -13,7 +13,10 @@ from .service import CodingWorkerService
 from .store import CodingWorkerStore, DEFAULT_RETENTION_SECONDS
 from .tool_broker import FrozenCheck, ToolBroker
 from .workspace import WorkspaceBroker, WorkspaceSourceAdapter
-from .source_adapters import ProjectSnapshotWorkspaceSourceAdapter
+from .source_adapters import (
+    BuiltinGitWorkspaceSourceAdapter,
+    ProjectSnapshotWorkspaceSourceAdapter,
+)
 
 
 class CodingWorkerRuntimeError(RuntimeError):
@@ -238,6 +241,22 @@ def build_runtime_from_environment() -> CodingWorkerRuntime:
         if value.strip()
     )
     source_adapters = dict(_SOURCE_ADAPTERS)
+    builtin_root = os.getenv("CODING_WORKER_BUILTIN_SOURCE_ROOT")
+    builtin_revision = os.getenv("CODING_WORKER_BUILTIN_REVISION")
+    if bool(builtin_root) != bool(builtin_revision):
+        raise CodingWorkerRuntimeError(
+            "Builtin Worker source configuration is incomplete.",
+            code="coding_worker_config_invalid",
+        )
+    if builtin_root and builtin_revision:
+        source_adapters.setdefault(
+            "builtin",
+            BuiltinGitWorkspaceSourceAdapter(
+                Path(builtin_root),
+                source_id=os.getenv("CODING_WORKER_BUILTIN_SOURCE_ID", "modelmirror"),
+                revision=builtin_revision,
+            ),
+        )
     project_source_socket = os.getenv("CODING_PROJECT_SOURCE_SOCKET_PATH")
     if project_source_socket:
         try:

--- a/server/coding_worker/runtime.py
+++ b/server/coding_worker/runtime.py
@@ -13,6 +13,7 @@ from .service import CodingWorkerService
 from .store import CodingWorkerStore, DEFAULT_RETENTION_SECONDS
 from .tool_broker import FrozenCheck, ToolBroker
 from .workspace import WorkspaceBroker, WorkspaceSourceAdapter
+from .source_adapters import ProjectSnapshotWorkspaceSourceAdapter
 
 
 class CodingWorkerRuntimeError(RuntimeError):
@@ -236,10 +237,25 @@ def build_runtime_from_environment() -> CodingWorkerRuntime:
         for value in os.getenv("CODING_WORKER_NETWORK_DOMAINS", "").split(",")
         if value.strip()
     )
+    source_adapters = dict(_SOURCE_ADAPTERS)
+    project_source_socket = os.getenv("CODING_PROJECT_SOURCE_SOCKET_PATH")
+    if project_source_socket:
+        try:
+            from server.coding_runtime.project_source_client import (
+                CodingProjectSourceClient,
+            )
+        except ModuleNotFoundError:
+            from coding_runtime.project_source_client import CodingProjectSourceClient
+        project_adapter = ProjectSnapshotWorkspaceSourceAdapter(
+            CodingProjectSourceClient(project_source_socket),
+            Path(os.getenv("CODING_WORKER_PROJECT_SNAPSHOT_ROOT", "/project-snapshots")),
+        )
+        source_adapters.setdefault("manifest", project_adapter)
+        source_adapters.setdefault("host_snapshot", project_adapter)
     return CodingWorkerRuntime(
         storage_root=root,
         slot_roots=slot_roots,
-        source_adapters=_SOURCE_ADAPTERS,
+        source_adapters=source_adapters,
         frozen_checks=_FROZEN_CHECKS,
         provider_endpoints=endpoints,
         provider_tokens=tokens,

--- a/server/coding_worker/sdk.py
+++ b/server/coding_worker/sdk.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+
+from .contracts import (
+    ContextReference,
+    Origin,
+    TaskCreateRequest,
+    TaskRecord,
+)
+from .runtime import register_frozen_check, register_workspace_source_adapter
+from .service import CodingWorkerService
+from .tool_broker import FrozenCheck
+from .workspace import WorkspaceSourceAdapter
+
+
+class CodingWorkerSDKError(RuntimeError):
+    def __init__(self, message: str, *, code: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+ContextValidator = Callable[[str], bool]
+
+
+class CodingWorkerModuleClient:
+    """Trusted module boundary for creating provider-neutral Worker tasks.
+
+    The client fixes the module identity and allowlists source, context, check,
+    and model route identifiers. It deliberately exposes no provider, process,
+    environment, network endpoint, credential, or physical path controls.
+    """
+
+    def __init__(
+        self,
+        *,
+        module: str,
+        service: CodingWorkerService,
+        source_kinds: frozenset[str],
+        check_ids: frozenset[str],
+        model_routes: frozenset[str],
+        context_validators: Mapping[str, ContextValidator] | None = None,
+    ) -> None:
+        if not module or not source_kinds or not check_ids or not model_routes:
+            raise ValueError("coding worker module policy is incomplete")
+        self.module = module
+        self.service = service
+        self.source_kinds = source_kinds
+        self.check_ids = check_ids
+        self.model_routes = model_routes
+        self.context_validators = dict(context_validators or {})
+
+    async def create_task(
+        self, *, business_object_id: str, request: TaskCreateRequest
+    ) -> TaskRecord:
+        if request.workspace_source.kind not in self.source_kinds:
+            raise CodingWorkerSDKError(
+                "Workspace source is not registered for this module.",
+                code="worker_source_not_registered",
+            )
+        required_checks = {
+            item.check_id for item in request.acceptance.required_checks
+        }
+        if not required_checks.issubset(self.check_ids):
+            raise CodingWorkerSDKError(
+                "Acceptance check is not registered for this module.",
+                code="worker_acceptance_not_registered",
+            )
+        if request.model_route not in self.model_routes:
+            raise CodingWorkerSDKError(
+                "Model route is not registered for this module.",
+                code="worker_model_route_not_registered",
+            )
+        self._validate_context(request.context_refs)
+        return await self.service.create_task(
+            Origin(module=self.module, object_id=business_object_id), request
+        )
+
+    def _validate_context(self, references: tuple[ContextReference, ...]) -> None:
+        for reference in references:
+            validator = self.context_validators.get(reference.kind)
+            if validator is None or not validator(reference.ref_id):
+                raise CodingWorkerSDKError(
+                    "Context reference is not registered for this module.",
+                    code="worker_context_not_registered",
+                )
+
+
+def register_module_source(kind: str, adapter: WorkspaceSourceAdapter) -> None:
+    """Register a trusted opaque source adapter; paths stay inside the adapter."""
+
+    register_workspace_source_adapter(kind, adapter)
+
+
+def register_module_acceptance(check: FrozenCheck) -> None:
+    """Register a deployment-frozen check, never a caller supplied command."""
+
+    register_frozen_check(check)

--- a/server/coding_worker/service.py
+++ b/server/coding_worker/service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 
 from .contracts import (
     EvidenceStatus,
@@ -96,12 +96,13 @@ class CodingWorkerService:
         self._started = False
 
     async def create_task(self, origin: Origin, request: TaskCreateRequest) -> TaskRecord:
-        if self.tool_broker is not None:
+        frozen_checks = getattr(self.tool_broker, "frozen_checks", None)
+        if isinstance(frozen_checks, Mapping):
             unknown = [
                 check.check_id
                 for check in request.acceptance.required_checks
                 if check.kind == "command"
-                and check.check_id not in self.tool_broker.frozen_checks
+                and check.check_id not in frozen_checks
             ]
             if unknown:
                 raise WorkerConflictError(

--- a/server/coding_worker/service.py
+++ b/server/coding_worker/service.py
@@ -96,6 +96,18 @@ class CodingWorkerService:
         self._started = False
 
     async def create_task(self, origin: Origin, request: TaskCreateRequest) -> TaskRecord:
+        if self.tool_broker is not None:
+            unknown = [
+                check.check_id
+                for check in request.acceptance.required_checks
+                if check.kind == "command"
+                and check.check_id not in self.tool_broker.frozen_checks
+            ]
+            if unknown:
+                raise WorkerConflictError(
+                    "Acceptance check is not registered.",
+                    code="worker_acceptance_not_registered",
+                )
         await self.start()
         spec = TaskSpec(**request.model_dump(), origin=origin)
         task = self.store.create_task(spec)

--- a/server/coding_worker/source_adapters.py
+++ b/server/coding_worker/source_adapters.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import os
+import re
 import stat
+import subprocess
 from pathlib import Path, PurePosixPath
 from typing import Any, Protocol
 
@@ -24,6 +26,223 @@ class ProjectSnapshotClient(Protocol):
     ) -> dict[str, Any]: ...
 
     async def release(self, project_id: str, lease_id: str) -> bool: ...
+
+
+_DANGEROUS_CONFIG = re.compile(
+    r"^(?:include(?:if)?\.|filter\.|credential\.|url\.|diff\..*\.textconv$|"
+    r"core\.worktree$|core\.excludesfile$|extensions\.(?:worktreeconfig|partialclone|refstorage)$|"
+    r"remote\..*\.(?:promisor|partialclonefilter)$)",
+    re.IGNORECASE,
+)
+
+
+class BuiltinGitWorkspaceSourceAdapter:
+    """Read tracked blobs from one deployment-fixed ModelMirror revision."""
+
+    def __init__(self, root: Path, *, source_id: str, revision: str) -> None:
+        self._root = Path(root)
+        self._source_id = source_id
+        self._revision = revision.lower()
+        if re.fullmatch(r"[a-f0-9]{40}", self._revision) is None:
+            raise ValueError("builtin revision must be a full commit id")
+
+    async def acquire(self, source: WorkspaceSource) -> SourceSnapshot:
+        if (
+            source.kind != "builtin"
+            or source.source_id != self._source_id
+            or source.revision != self._revision
+        ):
+            raise WorkspaceError(
+                "Builtin source is not registered at this revision.",
+                code="source_not_found",
+            )
+        return await asyncio.to_thread(self._read_revision, source)
+
+    def _read_revision(self, source: WorkspaceSource) -> SourceSnapshot:
+        try:
+            root_metadata = self._root.lstat()
+            git_metadata = (self._root / ".git").lstat()
+        except OSError as exc:
+            raise WorkspaceError(
+                "Builtin source is unavailable.", code="source_not_found"
+            ) from exc
+        if (
+            not stat.S_ISDIR(root_metadata.st_mode)
+            or stat.S_ISLNK(root_metadata.st_mode)
+            or stat.S_ISLNK(git_metadata.st_mode)
+            or not (
+                stat.S_ISDIR(git_metadata.st_mode)
+                or stat.S_ISREG(git_metadata.st_mode)
+            )
+        ):
+            raise WorkspaceError(
+                "Builtin source repository is unsafe.",
+                code="source_snapshot_unsafe",
+            )
+        config = self._git("config", "--local", "--no-includes", "--name-only", "--list")
+        names = config.stdout.decode("utf-8", errors="strict").splitlines()
+        if any(_DANGEROUS_CONFIG.search(name.strip()) for name in names):
+            raise WorkspaceError(
+                "Builtin source configuration is unsafe.",
+                code="source_snapshot_unsafe",
+            )
+        resolved = self._git("rev-parse", "--verify", f"{self._revision}^{{commit}}")
+        if resolved.stdout.decode("ascii", errors="strict").strip().lower() != self._revision:
+            raise WorkspaceError(
+                "Builtin revision changed.", code="source_revision_changed"
+            )
+        tree = self._git("ls-tree", "-r", "-z", "-l", self._revision)
+        if len(tree.stdout) > 16 * 1024 * 1024:
+            raise WorkspaceError(
+                "Builtin tree metadata is too large.", code="source_limit_exceeded"
+            )
+        entries: list[tuple[str, str, int, bool]] = []
+        total_bytes = 0
+        for raw in tree.stdout.split(b"\0"):
+            if not raw:
+                continue
+            try:
+                header, encoded_path = raw.split(b"\t", 1)
+                mode, object_type, object_id, encoded_size = header.split()
+                relative = encoded_path.decode("utf-8", errors="strict")
+                size = int(encoded_size)
+            except (ValueError, UnicodeError) as exc:
+                raise WorkspaceError(
+                    "Builtin tree is invalid.", code="source_snapshot_unsafe"
+                ) from exc
+            pure = PurePosixPath(relative)
+            if (
+                object_type != b"blob"
+                or mode not in {b"100644", b"100755"}
+                or pure.is_absolute()
+                or ".." in pure.parts
+                or not pure.parts
+                or pure.parts[0] == ".git"
+                or size < 0
+                or size > MAX_SOURCE_FILE_BYTES
+            ):
+                raise WorkspaceError(
+                    "Builtin tree contains an unsupported entry.",
+                    code="source_snapshot_unsafe",
+                )
+            total_bytes += size
+            if len(entries) >= MAX_SOURCE_FILES or total_bytes > MAX_SOURCE_BYTES:
+                raise WorkspaceError(
+                    "Builtin tree exceeds Worker limits.",
+                    code="source_limit_exceeded",
+                )
+            entries.append(
+                (
+                    relative,
+                    object_id.decode("ascii", errors="strict"),
+                    size,
+                    mode == b"100755",
+                )
+            )
+        contents = self._read_blobs(entries)
+        return SourceSnapshot(
+            source=source,
+            files=tuple(
+                SourceFile(path=path, content=content, executable=executable)
+                for (path, _object_id, _size, executable), content in zip(
+                    entries, contents, strict=True
+                )
+            ),
+        )
+
+    def _read_blobs(
+        self, entries: list[tuple[str, str, int, bool]]
+    ) -> list[bytes]:
+        command = self._git_command("cat-file", "--batch")
+        try:
+            process = subprocess.Popen(
+                command,
+                cwd=self._root,
+                env=self._git_environment(),
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+        except OSError as exc:
+            raise WorkspaceError(
+                "Builtin object reader is unavailable.", code="source_not_found"
+            ) from exc
+        assert process.stdin is not None and process.stdout is not None
+        result: list[bytes] = []
+        try:
+            for _path, object_id, expected_size, _executable in entries:
+                process.stdin.write(object_id.encode("ascii") + b"\n")
+                process.stdin.flush()
+                header = process.stdout.readline()
+                parts = header.rstrip(b"\n").split(b" ")
+                if (
+                    len(parts) != 3
+                    or parts[0].decode("ascii", errors="strict") != object_id
+                    or parts[1] != b"blob"
+                    or int(parts[2]) != expected_size
+                ):
+                    raise WorkspaceError(
+                        "Builtin object response is invalid.",
+                        code="source_revision_changed",
+                    )
+                content = process.stdout.read(expected_size)
+                if len(content) != expected_size or process.stdout.read(1) != b"\n":
+                    raise WorkspaceError(
+                        "Builtin object response is truncated.",
+                        code="source_revision_changed",
+                    )
+                result.append(content)
+            process.stdin.close()
+            if process.wait(timeout=15) != 0:
+                raise WorkspaceError(
+                    "Builtin object reader failed.", code="source_revision_changed"
+                )
+            return result
+        except Exception:
+            process.kill()
+            process.wait(timeout=5)
+            raise
+
+    def _git(self, *args: str) -> subprocess.CompletedProcess[bytes]:
+        try:
+            return subprocess.run(
+                self._git_command(*args),
+                cwd=self._root,
+                env=self._git_environment(),
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=True,
+                timeout=20,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            raise WorkspaceError(
+                "Builtin repository could not be inspected.",
+                code="source_snapshot_unsafe",
+            ) from exc
+
+    def _git_command(self, *args: str) -> list[str]:
+        null = os.devnull
+        return [
+            "git", "-c", f"core.hooksPath={null}", "-c", f"core.attributesFile={null}",
+            "-c", f"core.excludesFile={null}", "-c", "credential.helper=", "-c", "protocol.file.allow=never",
+            "-c", "protocol.ext.allow=never", *args,
+        ]
+
+    @staticmethod
+    def _git_environment() -> dict[str, str]:
+        keep = {key: value for key, value in os.environ.items() if key.upper() in {"PATH", "SYSTEMROOT", "WINDIR"}}
+        return {
+            **keep,
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_TERMINAL_PROMPT": "0",
+            "GIT_ASKPASS": "",
+            "GIT_SSH_COMMAND": "false",
+            "GIT_NO_LAZY_FETCH": "1",
+            "GIT_NO_REPLACE_OBJECTS": "1",
+            "GIT_OPTIONAL_LOCKS": "0",
+        }
 
 
 class ProjectSnapshotWorkspaceSourceAdapter:

--- a/server/coding_worker/source_adapters.py
+++ b/server/coding_worker/source_adapters.py
@@ -27,6 +27,30 @@ class ProjectSnapshotClient(Protocol):
 
     async def release(self, project_id: str, lease_id: str) -> bool: ...
 
+    async def import_uploaded(
+        self,
+        *,
+        upload_id: str,
+        archive_sha256: str,
+        project_id: str,
+        name: str,
+        branch: str,
+        head: str,
+    ) -> dict[str, Any]: ...
+
+
+class ProjectHostSnapshotClient(Protocol):
+    async def request_snapshot(
+        self,
+        project_id: str,
+        *,
+        expected_head: str | None = None,
+        expected_branch: str | None = None,
+        managed_operation_id: str | None = None,
+    ) -> dict[str, Any]: ...
+
+    def finish_transfer(self, transfer_id: str) -> None: ...
+
 
 _DANGEROUS_CONFIG = re.compile(
     r"^(?:include(?:if)?\.|filter\.|credential\.|url\.|diff\..*\.textconv$|"
@@ -252,7 +276,7 @@ class ProjectSnapshotWorkspaceSourceAdapter:
     snapshot volume and Project Source socket stay behind this trusted adapter.
     """
 
-    _KINDS = {"manifest": "local_clone", "host_snapshot": "host_git"}
+    _KINDS = {"manifest": "local_clone"}
 
     def __init__(self, client: ProjectSnapshotClient, snapshot_root: Path) -> None:
         self._client = client
@@ -267,6 +291,15 @@ class ProjectSnapshotWorkspaceSourceAdapter:
         lease = await self._client.acquire(
             source.source_id, expected_head=source.revision
         )
+        return await self.consume_lease(source, lease, expected_kind=expected_kind)
+
+    async def consume_lease(
+        self,
+        source: WorkspaceSource,
+        lease: dict[str, Any],
+        *,
+        expected_kind: str,
+    ) -> SourceSnapshot:
         lease_id = lease.get("lease_id")
         if (
             lease.get("kind") != expected_kind
@@ -424,3 +457,75 @@ class ProjectSnapshotWorkspaceSourceAdapter:
                 for relative, content, executable in records
             ),
         )
+
+
+class HostSnapshotWorkspaceSourceAdapter:
+    """Lazily transfer one exact Windows Helper snapshot into the Worker.
+
+    Queued tasks do not occupy the single Project Source lease. The physical
+    path remains in the Helper; this adapter sees only the opaque project id,
+    revision, transfer metadata, and the fixed Project Source snapshot mount.
+    """
+
+    def __init__(
+        self,
+        host: ProjectHostSnapshotClient,
+        project_source: ProjectSnapshotClient,
+        snapshot_root: Path,
+    ) -> None:
+        self._host = host
+        self._project_source = project_source
+        self._reader = ProjectSnapshotWorkspaceSourceAdapter(
+            project_source, snapshot_root
+        )
+
+    async def acquire(self, source: WorkspaceSource) -> SourceSnapshot:
+        if source.kind != "host_snapshot":
+            raise WorkspaceError(
+                "Workspace source kind is unsupported.", code="source_not_found"
+            )
+        transfer_id: str | None = None
+        try:
+            transfer = await self._host.request_snapshot(
+                source.source_id,
+                expected_head=source.revision,
+            )
+            project = transfer.get("project")
+            transfer_id = transfer.get("upload_id")
+            archive_sha256 = transfer.get("archive_sha256")
+            if (
+                not isinstance(project, dict)
+                or project.get("id") != source.source_id
+                or project.get("head") != source.revision
+                or not isinstance(project.get("name"), str)
+                or not isinstance(project.get("branch"), str)
+                or not isinstance(transfer_id, str)
+                or re.fullmatch(r"[a-f0-9]{32}", transfer_id) is None
+                or not isinstance(archive_sha256, str)
+                or re.fullmatch(r"[a-f0-9]{64}", archive_sha256) is None
+            ):
+                raise WorkspaceError(
+                    "Host snapshot response is inconsistent.",
+                    code="source_revision_changed",
+                )
+            lease = await self._project_source.import_uploaded(
+                upload_id=transfer_id,
+                archive_sha256=archive_sha256,
+                project_id=source.source_id,
+                name=project["name"],
+                branch=project["branch"],
+                head=source.revision,
+            )
+            return await self._reader.consume_lease(
+                source, lease, expected_kind="host_git"
+            )
+        except WorkspaceError:
+            raise
+        except Exception as exc:
+            raise WorkspaceError(
+                "Host snapshot is unavailable.",
+                code=str(getattr(exc, "code", "source_unavailable")),
+            ) from exc
+        finally:
+            if transfer_id is not None:
+                self._host.finish_transfer(transfer_id)

--- a/server/coding_worker/source_adapters.py
+++ b/server/coding_worker/source_adapters.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import os
+import stat
+from pathlib import Path, PurePosixPath
+from typing import Any, Protocol
+
+from .contracts import WorkspaceSource
+from .workspace import (
+    MAX_SOURCE_BYTES,
+    MAX_SOURCE_FILE_BYTES,
+    MAX_SOURCE_FILES,
+    SourceFile,
+    SourceSnapshot,
+    WorkspaceError,
+)
+
+
+class ProjectSnapshotClient(Protocol):
+    async def acquire(
+        self, project_id: str, *, expected_head: str | None = None
+    ) -> dict[str, Any]: ...
+
+    async def release(self, project_id: str, lease_id: str) -> bool: ...
+
+
+class ProjectSnapshotWorkspaceSourceAdapter:
+    """Copy one exact Project Source lease into a Worker-owned snapshot.
+
+    The caller supplies only opaque project and revision identifiers. The fixed
+    snapshot volume and Project Source socket stay behind this trusted adapter.
+    """
+
+    _KINDS = {"manifest": "local_clone", "host_snapshot": "host_git"}
+
+    def __init__(self, client: ProjectSnapshotClient, snapshot_root: Path) -> None:
+        self._client = client
+        self._snapshot_root = Path(snapshot_root)
+
+    async def acquire(self, source: WorkspaceSource) -> SourceSnapshot:
+        expected_kind = self._KINDS.get(source.kind)
+        if expected_kind is None:
+            raise WorkspaceError(
+                "Workspace source kind is unsupported.", code="source_not_found"
+            )
+        lease = await self._client.acquire(
+            source.source_id, expected_head=source.revision
+        )
+        lease_id = lease.get("lease_id")
+        if (
+            lease.get("kind") != expected_kind
+            or lease.get("project_id") != source.source_id
+            or lease.get("head") != source.revision
+            or not isinstance(lease_id, str)
+        ):
+            await self._release(source.source_id, lease_id)
+            raise WorkspaceError(
+                "Project source lease is inconsistent.",
+                code="source_revision_changed",
+            )
+
+        snapshot: SourceSnapshot | None = None
+        failure: BaseException | None = None
+        try:
+            snapshot = await asyncio.to_thread(self._read_snapshot, source, lease)
+        except BaseException as exc:
+            failure = exc
+        released = await self._release(source.source_id, lease_id)
+        if not released:
+            raise WorkspaceError(
+                "Project source lease could not be released.",
+                code="source_release_failed",
+            ) from failure
+        if failure is not None:
+            raise failure
+        assert snapshot is not None
+        return snapshot
+
+    async def _release(self, project_id: str, lease_id: object) -> bool:
+        if not isinstance(lease_id, str):
+            return False
+        try:
+            return await self._client.release(project_id, lease_id)
+        except Exception as exc:
+            raise WorkspaceError(
+                "Project source lease could not be released.",
+                code="source_release_failed",
+            ) from exc
+
+    def _read_snapshot(
+        self, source: WorkspaceSource, lease: dict[str, Any]
+    ) -> SourceSnapshot:
+        root = self._snapshot_root / "current" / "workspace"
+        try:
+            root_stat = root.lstat()
+        except OSError as exc:
+            raise WorkspaceError(
+                "Project snapshot is unavailable.", code="source_not_found"
+            ) from exc
+        if not stat.S_ISDIR(root_stat.st_mode) or stat.S_ISLNK(root_stat.st_mode):
+            raise WorkspaceError(
+                "Project snapshot is unsafe.", code="source_snapshot_unsafe"
+            )
+
+        records: list[tuple[str, bytes, bool]] = []
+        total_bytes = 0
+        stack = [root]
+        while stack:
+            directory = stack.pop()
+            try:
+                children = sorted(os.scandir(directory), key=lambda item: item.name)
+            except OSError as exc:
+                raise WorkspaceError(
+                    "Project snapshot is unavailable.", code="source_not_found"
+                ) from exc
+            for child in children:
+                path = Path(child.path)
+                try:
+                    metadata = child.stat(follow_symlinks=False)
+                except OSError as exc:
+                    raise WorkspaceError(
+                        "Project snapshot changed while reading.",
+                        code="source_revision_changed",
+                    ) from exc
+                relative = path.relative_to(root).as_posix()
+                pure = PurePosixPath(relative)
+                if (
+                    not relative
+                    or pure.is_absolute()
+                    or ".." in pure.parts
+                    or pure.parts[0] == ".git"
+                ):
+                    raise WorkspaceError(
+                        "Project snapshot contains an unsafe path.",
+                        code="source_snapshot_unsafe",
+                    )
+                if stat.S_ISLNK(metadata.st_mode):
+                    raise WorkspaceError(
+                        "Project snapshot contains a link.",
+                        code="source_snapshot_unsafe",
+                    )
+                if stat.S_ISDIR(metadata.st_mode):
+                    stack.append(path)
+                    continue
+                if not stat.S_ISREG(metadata.st_mode):
+                    raise WorkspaceError(
+                        "Project snapshot contains an unsupported entry.",
+                        code="source_snapshot_unsafe",
+                    )
+                if metadata.st_size > MAX_SOURCE_FILE_BYTES:
+                    raise WorkspaceError(
+                        "Project snapshot file is too large.",
+                        code="source_file_limit_exceeded",
+                    )
+                try:
+                    content = path.read_bytes()
+                    after = path.stat(follow_symlinks=False)
+                except OSError as exc:
+                    raise WorkspaceError(
+                        "Project snapshot changed while reading.",
+                        code="source_revision_changed",
+                    ) from exc
+                if (
+                    len(content) != metadata.st_size
+                    or (metadata.st_dev, metadata.st_ino, metadata.st_mtime_ns)
+                    != (after.st_dev, after.st_ino, after.st_mtime_ns)
+                ):
+                    raise WorkspaceError(
+                        "Project snapshot changed while reading.",
+                        code="source_revision_changed",
+                    )
+                total_bytes += len(content)
+                if len(records) >= MAX_SOURCE_FILES or total_bytes > MAX_SOURCE_BYTES:
+                    raise WorkspaceError(
+                        "Project snapshot exceeds Worker limits.",
+                        code="source_limit_exceeded",
+                    )
+                records.append(
+                    (relative, content, bool(metadata.st_mode & stat.S_IXUSR))
+                )
+
+        records.sort(key=lambda item: item[0])
+        fingerprint = hashlib.sha256()
+        for relative, content, _executable in records:
+            fingerprint.update(relative.encode("utf-8"))
+            fingerprint.update(b"\0")
+            fingerprint.update(str(len(content)).encode("ascii"))
+            fingerprint.update(b"\0")
+            fingerprint.update(hashlib.sha256(content).digest())
+        if (
+            lease.get("file_count") != len(records)
+            or lease.get("total_bytes") != total_bytes
+            or lease.get("fingerprint") != fingerprint.hexdigest()
+        ):
+            raise WorkspaceError(
+                "Project snapshot does not match its lease.",
+                code="source_revision_changed",
+            )
+        return SourceSnapshot(
+            source=source,
+            files=tuple(
+                SourceFile(path=relative, content=content, executable=executable)
+                for relative, content, executable in records
+            ),
+        )

--- a/server/tests/test_coding_project_host_api.py
+++ b/server/tests/test_coding_project_host_api.py
@@ -5,11 +5,12 @@ import hashlib
 import json
 import time
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, AsyncIterator
 
 import httpx
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 
 from server.coding_runtime.api import (
     CodingService,
@@ -33,6 +34,8 @@ from server.coding_runtime.project_host_api import (
 )
 from server.coding_runtime.project_writer_client import ProjectWriterClientError
 from server.coding_runtime.projects import ProjectFeatures, ProjectKind
+from server.coding_worker.api import configure_coding_worker_for_tests
+from server.coding_worker.contracts import TaskState
 from server.coding_runtime.recovery import CodingRecoveryStore, RecoveryProjectContext
 from server.coding_runtime.worker import CodingWorkerError, CodingWorkerServer
 from server.tests.test_coding_runtime_api import FakeWorker
@@ -505,6 +508,111 @@ async def test_host_project_catalog_and_session_use_one_path_free_snapshot() -> 
     await service.shutdown()
     assert source.released == [(PROJECT_ID, "lease_host_k8r3_202608")]
     configure_coding_service(None)
+
+
+@pytest.mark.asyncio
+async def test_completed_worker_patch_enters_existing_host_recovery_chain(
+    tmp_path: Path,
+) -> None:
+    store = CodingRecoveryStore(tmp_path / "worker-handoff-recovery")
+    service, worker, source, host = _service(store)
+    patch = worker._diff_content()
+
+    record = await service.adopt_worker_patch(
+        project_id=PROJECT_ID,
+        expected_head=PROJECT_HEAD,
+        patch=patch,
+        paths=[worker.change_path],
+    )
+
+    assert record.project["kind"] == "host_git"
+    assert record.project_source == _lease()
+    assert worker.restore_calls == [
+        {
+            "revision": 1,
+            "patch": patch,
+            "paths": [worker.change_path],
+            "snapshot_fingerprint": PROJECT_FINGERPRINT,
+            "verification": None,
+            "source": _lease(),
+        }
+    ]
+    recovery = store.load()
+    assert recovery is not None
+    assert recovery.payload.patch == patch
+    context = store.load_project_context(recovery.recovery_id)
+    assert context is not None
+    assert context.project_id == PROJECT_ID
+    assert source.released == []
+    assert host.snapshot_calls == [(PROJECT_ID, PROJECT_HEAD, None, None)]
+
+
+@pytest.mark.asyncio
+async def test_worker_handoff_rejects_binary_patch_before_host_snapshot(
+    tmp_path: Path,
+) -> None:
+    service, worker, _source, host = _service(
+        CodingRecoveryStore(tmp_path / "binary-handoff-recovery")
+    )
+    patch = (
+        "diff --git a/image.png b/image.png\n"
+        "Binary files a/image.png and b/image.png differ\n"
+    )
+
+    with pytest.raises(HTTPException) as caught:
+        await service.adopt_worker_patch(
+            project_id=PROJECT_ID,
+            expected_head=PROJECT_HEAD,
+            patch=patch,
+            paths=["image.png"],
+        )
+
+    assert caught.value.status_code == 409
+    assert caught.value.detail["code"] == "worker_writeback_patch_unsupported"
+    assert worker.restore_calls == []
+    assert host.snapshot_calls == []
+
+
+@pytest.mark.asyncio
+async def test_completed_worker_task_handoff_route_uses_v13_recovery(
+    tmp_path: Path,
+) -> None:
+    store = CodingRecoveryStore(tmp_path / "worker-route-recovery")
+    service, worker, _source, _host = _service(store)
+    task_id = "task_" + "a" * 32
+    task = SimpleNamespace(
+        state=TaskState.COMPLETED,
+        workspace_id="workspace_" + "b" * 32,
+        spec=SimpleNamespace(
+            workspace_source=SimpleNamespace(
+                kind="host_snapshot",
+                source_id=PROJECT_ID,
+                revision=PROJECT_HEAD,
+            )
+        ),
+    )
+    worker_service = SimpleNamespace(
+        store=SimpleNamespace(get_task=lambda value: task if value == task_id else None),
+        harness_runner=SimpleNamespace(acceptance_satisfied=lambda value: value == task_id),
+        workspace_broker=SimpleNamespace(
+            diff=lambda value: worker._diff_content().encode("utf-8")
+        ),
+    )
+    configure_coding_worker_for_tests(worker_service, enabled=True)  # type: ignore[arg-type]
+    try:
+        async with _client(service) as client:
+            response = await client.post(f"/api/coding/worker-tasks/{task_id}/handoff")
+    finally:
+        configure_coding_worker_for_tests(None, enabled=None)
+        configure_coding_service(None)
+
+    assert response.status_code == 201, response.text
+    assert response.json()["task_id"] == task_id
+    assert response.json()["project"]["id"] == PROJECT_ID
+    assert response.json()["revision"] == 1
+    recovery = store.load()
+    assert recovery is not None
+    assert recovery.payload.patch == worker._diff_content()
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_coding_worker_api.py
+++ b/server/tests/test_coding_worker_api.py
@@ -93,6 +93,7 @@ def test_enabled_runtime_fails_closed_when_sidecar_tokens_are_missing(
 def test_create_is_idempotent_and_server_owns_origin(tmp_path: Path) -> None:
     client, _service = _client(tmp_path)
     with client:
+        assert client.get("/api/coding-worker/v1").json()["acceptance_checks"] == []
         first = client.post("/api/coding-worker/v1/tasks", json=_payload())
         second = client.post("/api/coding-worker/v1/tasks", json=_payload())
     assert first.status_code == 202

--- a/server/tests/test_coding_worker_deployment.py
+++ b/server/tests/test_coding_worker_deployment.py
@@ -4,8 +4,10 @@ from pathlib import Path
 def test_v14_sidecar_is_non_root_and_has_no_host_control_mounts() -> None:
     root = Path(__file__).parents[2]
     dockerfile = (root / "server/coding_worker/Dockerfile.v14").read_text()
+    server_dockerfile = (root / "server/Dockerfile").read_text()
     compose = (root / "docker-compose.coding-worker-v14.yml").read_text()
 
+    assert "COPY coding_worker ./coding_worker" in server_dockerfile
     assert "USER 65532:65532" in dockerfile
     assert 'CMD ["python", "-m", "coding_worker.sidecar"]' in dockerfile
     assert "OPENCODE_VERSION=1.18.9" in dockerfile

--- a/server/tests/test_coding_worker_deployment.py
+++ b/server/tests/test_coding_worker_deployment.py
@@ -25,6 +25,12 @@ def test_v14_sidecar_is_non_root_and_has_no_host_control_mounts() -> None:
     assert "CODING_WORKER_MODE: executor" in compose
     assert "CODING_WORKER_ROUTE_KEY" not in compose.split("coding-worker-slot-a:", 1)[1].split("coding-worker-egress:", 1)[0]
     assert "coding_worker_slot_a:/worker-data:ro" in compose
+    executor = compose.split("coding-worker-slot-a:", 1)[1].split(
+        "coding-worker-slot-b:", 1
+    )[0]
+    assert "coding_worker_tools" in executor
+    assert "coding_internal" not in executor
+    assert "coding_worker_tools:" in compose and "internal: true" in compose
     assert "coding-worker-network" in compose
     assert 'command: ["python", "-m", "coding_worker.egress_proxy"]' in compose
     assert "CODING_WORKER_EGRESS_GRANT_KEY: ${CODING_WORKER_EGRESS_GRANT_KEY:-}" in compose

--- a/server/tests/test_coding_worker_runtime.py
+++ b/server/tests/test_coding_worker_runtime.py
@@ -16,6 +16,7 @@ from server.coding_worker.contracts import (
 from server.coding_worker.provider import FakeCodingAgentProvider
 from server.coding_worker.provider_rpc import ProviderRPCServer
 from server.coding_worker.runtime import CodingWorkerRuntime
+from server.coding_worker.tool_broker import FrozenCheck
 from server.coding_worker.workspace import InMemoryWorkspaceSourceAdapter
 
 
@@ -42,7 +43,11 @@ async def test_runtime_connects_two_dedicated_provider_slots(tmp_path: Path) -> 
                 {("source", "h0"): {"main.py": b"print('ok')\n"}}
             )
         },
-        frozen_checks={},
+        frozen_checks={
+            "syntax": FrozenCheck(
+                check_id="syntax", argv=("python", "-m", "py_compile", "main.py")
+            )
+        },
         provider_endpoints=endpoints,
         provider_tokens={"slot-a": "a" * 48, "slot-b": "b" * 48},
         broker_socket_path=None,

--- a/server/tests/test_coding_worker_sdk.py
+++ b/server/tests/test_coding_worker_sdk.py
@@ -1,0 +1,87 @@
+from pathlib import Path
+
+import pytest
+from cryptography.fernet import Fernet
+
+from server.coding_worker.contracts import (
+    AcceptanceCheck,
+    AcceptanceContract,
+    ContextReference,
+    TaskCreateRequest,
+    WorkspaceSource,
+)
+from server.coding_worker.provider import FakeCodingAgentProvider
+from server.coding_worker.sdk import CodingWorkerModuleClient, CodingWorkerSDKError
+from server.coding_worker.service import CodingWorkerService
+from server.coding_worker.store import CodingWorkerStore
+from server.coding_worker.workspace import WorkspaceBroker
+
+
+def _client(tmp_path: Path) -> CodingWorkerModuleClient:
+    store = CodingWorkerStore(tmp_path / "store", master_key=Fernet.generate_key())
+    service = CodingWorkerService(
+        store=store,
+        workspace_broker=WorkspaceBroker(tmp_path / "work", {}, id_key=b"m" * 32),
+        provider=FakeCodingAgentProvider(),
+    )
+    return CodingWorkerModuleClient(
+        module="skill-creator",
+        service=service,
+        source_kinds=frozenset({"manifest"}),
+        check_ids=frozenset({"python-tests"}),
+        model_routes=frozenset({"coding/default"}),
+        context_validators={"artifact": lambda value: value == "artifact_context"},
+    )
+
+
+def _request() -> TaskCreateRequest:
+    return TaskCreateRequest(
+        client_task_id="module-task-01",
+        objective="Implement the requested module change.",
+        workspace_source=WorkspaceSource(
+            kind="manifest", source_id="source_01", revision="revision_01"
+        ),
+        acceptance=AcceptanceContract(
+            contract_id="contract_01",
+            required_checks=(
+                AcceptanceCheck(
+                    check_id="python-tests", label="Python tests", kind="command"
+                ),
+            ),
+        ),
+        model_route="coding/default",
+        context_refs=(ContextReference(ref_id="artifact_context", kind="artifact"),),
+    )
+
+
+@pytest.mark.asyncio
+async def test_module_client_owns_origin_and_preserves_idempotency(tmp_path: Path) -> None:
+    client = _client(tmp_path)
+    first = await client.create_task(business_object_id="skill_01", request=_request())
+    same = await client.create_task(business_object_id="skill_01", request=_request())
+    assert same.task_id == first.task_id
+    assert first.spec.origin.module == "skill-creator"
+    assert first.spec.origin.object_id == "skill_01"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("field", "expected"),
+    (("source", "worker_source_not_registered"), ("check", "worker_acceptance_not_registered"), ("route", "worker_model_route_not_registered"), ("context", "worker_context_not_registered")),
+)
+async def test_module_client_rejects_unregistered_execution_inputs(
+    tmp_path: Path, field: str, expected: str
+) -> None:
+    client = _client(tmp_path)
+    request = _request()
+    if field == "source":
+        request = request.model_copy(update={"workspace_source": request.workspace_source.model_copy(update={"kind": "host_git"})})
+    elif field == "check":
+        request = request.model_copy(update={"acceptance": AcceptanceContract(contract_id="other", required_checks=(AcceptanceCheck(check_id="shell", label="shell", kind="command"),))})
+    elif field == "route":
+        request = request.model_copy(update={"model_route": "coding/other"})
+    else:
+        request = request.model_copy(update={"context_refs": (ContextReference(ref_id="artifact_other", kind="artifact"),)})
+    with pytest.raises(CodingWorkerSDKError) as raised:
+        await client.create_task(business_object_id="skill_01", request=request)
+    assert raised.value.code == expected

--- a/server/tests/test_coding_worker_service.py
+++ b/server/tests/test_coding_worker_service.py
@@ -29,7 +29,7 @@ from server.coding_worker.provider import (
     ProviderSession,
 )
 from server.coding_worker.service import CodingWorkerService
-from server.coding_worker.store import CodingWorkerStore
+from server.coding_worker.store import CodingWorkerStore, WorkerConflictError
 from server.coding_worker.tool_broker import FrozenCheck, ToolBroker
 from server.coding_worker.workspace import InMemoryWorkspaceSourceAdapter, WorkspaceBroker
 
@@ -130,9 +130,42 @@ def _service_with_harness(
             workspace_broker=workspace,
             provider=provider,
             harness_runner=harness,
+            tool_broker=broker,
         ),
         broker,
     )
+
+
+@pytest.mark.asyncio
+async def test_unregistered_command_check_is_rejected_before_queue(
+    tmp_path: Path,
+) -> None:
+    service, _broker = _service_with_harness(
+        tmp_path, FakeCodingAgentProvider()
+    )
+    request = _request("unknown-check").model_copy(
+        update={
+            "acceptance": AcceptanceContract(
+                contract_id="unknown-contract",
+                required_checks=(
+                    AcceptanceCheck(
+                        check_id="caller-shell",
+                        label="Caller shell",
+                        kind="command",
+                    ),
+                ),
+            )
+        }
+    )
+
+    with pytest.raises(WorkerConflictError) as caught:
+        await service.create_task(
+            Origin(module="test", object_id="unknown-check"), request
+        )
+
+    assert caught.value.code == "worker_acceptance_not_registered"
+    assert service.store.list_tasks() == []
+    await service.shutdown()
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_coding_worker_source_adapters.py
+++ b/server/tests/test_coding_worker_source_adapters.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import hashlib
 from pathlib import Path
+import subprocess
 
 import pytest
 
 from server.coding_worker.contracts import WorkspaceSource
 from server.coding_worker.source_adapters import (
+    BuiltinGitWorkspaceSourceAdapter,
     ProjectSnapshotWorkspaceSourceAdapter,
 )
 from server.coding_worker.workspace import WorkspaceError
@@ -131,3 +133,57 @@ async def test_project_snapshot_adapter_fails_closed_when_release_is_uncertain(
         ).acquire(source)
 
     assert caught.value.code == "source_release_failed"
+
+
+def _git(root: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=root,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    ).stdout.strip()
+
+
+@pytest.mark.asyncio
+async def test_builtin_adapter_reads_only_tracked_blobs_from_exact_revision(
+    tmp_path: Path,
+) -> None:
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.name", "ModelMirror Test")
+    _git(tmp_path, "config", "user.email", "test@modelmirror.local")
+    (tmp_path / "app.py").write_text("print('tracked')\n", encoding="utf-8")
+    _git(tmp_path, "add", "app.py")
+    _git(tmp_path, "commit", "-m", "baseline")
+    revision = _git(tmp_path, "rev-parse", "HEAD")
+    (tmp_path / "secret.env").write_text("TOKEN=do-not-copy\n", encoding="utf-8")
+    source = WorkspaceSource(
+        kind="builtin", source_id="modelmirror", revision=revision
+    )
+
+    snapshot = await BuiltinGitWorkspaceSourceAdapter(
+        tmp_path, source_id="modelmirror", revision=revision
+    ).acquire(source)
+
+    assert [(item.path, item.content) for item in snapshot.files] == [
+        ("app.py", b"print('tracked')\n")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_builtin_adapter_rejects_unregistered_revision_before_reading(
+    tmp_path: Path,
+) -> None:
+    _git(tmp_path, "init")
+    source = WorkspaceSource(
+        kind="builtin", source_id="modelmirror", revision="b" * 40
+    )
+    adapter = BuiltinGitWorkspaceSourceAdapter(
+        tmp_path, source_id="modelmirror", revision="a" * 40
+    )
+
+    with pytest.raises(WorkspaceError) as caught:
+        await adapter.acquire(source)
+
+    assert caught.value.code == "source_not_found"

--- a/server/tests/test_coding_worker_source_adapters.py
+++ b/server/tests/test_coding_worker_source_adapters.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from server.coding_worker.contracts import WorkspaceSource
+from server.coding_worker.source_adapters import (
+    ProjectSnapshotWorkspaceSourceAdapter,
+)
+from server.coding_worker.workspace import WorkspaceError
+
+
+class FakeProjectSource:
+    def __init__(self, lease: dict[str, object]) -> None:
+        self.lease = lease
+        self.acquired: list[tuple[str, str | None]] = []
+        self.released: list[tuple[str, str]] = []
+        self.release_result = True
+
+    async def acquire(
+        self, project_id: str, *, expected_head: str | None = None
+    ) -> dict[str, object]:
+        self.acquired.append((project_id, expected_head))
+        return dict(self.lease)
+
+    async def release(self, project_id: str, lease_id: str) -> bool:
+        self.released.append((project_id, lease_id))
+        return self.release_result
+
+
+def _fingerprint(files: dict[str, bytes]) -> str:
+    digest = hashlib.sha256()
+    for path, content in sorted(files.items()):
+        digest.update(path.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(str(len(content)).encode("ascii"))
+        digest.update(b"\0")
+        digest.update(hashlib.sha256(content).digest())
+    return digest.hexdigest()
+
+
+def _source_root(tmp_path: Path, files: dict[str, bytes]) -> Path:
+    workspace = tmp_path / "current" / "workspace"
+    workspace.mkdir(parents=True)
+    for relative, content in files.items():
+        target = workspace / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(content)
+    return tmp_path
+
+
+def _lease(kind: str, files: dict[str, bytes]) -> dict[str, object]:
+    return {
+        "kind": kind,
+        "lease_id": "lease_1",
+        "project_id": "hostgit_" + "1" * 32 if kind == "host_git" else "local-" + "1" * 24,
+        "head": "a" * 40,
+        "file_count": len(files),
+        "total_bytes": sum(map(len, files.values())),
+        "fingerprint": _fingerprint(files),
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("source_kind", "lease_kind"),
+    (("manifest", "local_clone"), ("host_snapshot", "host_git")),
+)
+async def test_project_snapshot_adapter_copies_exact_lease_and_releases(
+    tmp_path: Path, source_kind: str, lease_kind: str
+) -> None:
+    files = {"README.md": b"hello\n", "src/app.py": b"print('ok')\n"}
+    lease = _lease(lease_kind, files)
+    client = FakeProjectSource(lease)
+    source = WorkspaceSource(
+        kind=source_kind,
+        source_id=str(lease["project_id"]),
+        revision=str(lease["head"]),
+    )
+
+    snapshot = await ProjectSnapshotWorkspaceSourceAdapter(
+        client, _source_root(tmp_path, files)
+    ).acquire(source)
+
+    assert [(item.path, item.content) for item in snapshot.files] == sorted(files.items())
+    assert client.acquired == [(source.source_id, source.revision)]
+    assert client.released == [(source.source_id, "lease_1")]
+
+
+@pytest.mark.asyncio
+async def test_project_snapshot_adapter_rejects_changed_fingerprint_and_releases(
+    tmp_path: Path,
+) -> None:
+    files = {"README.md": b"changed\n"}
+    lease = _lease("host_git", {"README.md": b"original\n"})
+    client = FakeProjectSource(lease)
+    source = WorkspaceSource(
+        kind="host_snapshot",
+        source_id=str(lease["project_id"]),
+        revision=str(lease["head"]),
+    )
+
+    with pytest.raises(WorkspaceError, match="does not match") as caught:
+        await ProjectSnapshotWorkspaceSourceAdapter(
+            client, _source_root(tmp_path, files)
+        ).acquire(source)
+
+    assert caught.value.code == "source_revision_changed"
+    assert client.released == [(source.source_id, "lease_1")]
+
+
+@pytest.mark.asyncio
+async def test_project_snapshot_adapter_fails_closed_when_release_is_uncertain(
+    tmp_path: Path,
+) -> None:
+    files = {"README.md": b"hello\n"}
+    lease = _lease("local_clone", files)
+    client = FakeProjectSource(lease)
+    client.release_result = False
+    source = WorkspaceSource(
+        kind="manifest",
+        source_id=str(lease["project_id"]),
+        revision=str(lease["head"]),
+    )
+
+    with pytest.raises(WorkspaceError, match="released") as caught:
+        await ProjectSnapshotWorkspaceSourceAdapter(
+            client, _source_root(tmp_path, files)
+        ).acquire(source)
+
+    assert caught.value.code == "source_release_failed"

--- a/server/tests/test_coding_worker_source_adapters.py
+++ b/server/tests/test_coding_worker_source_adapters.py
@@ -199,6 +199,12 @@ def test_runtime_wires_host_snapshot_to_live_project_host(
         runtime.workspace_broker._adapters["manifest"],
         ProjectSnapshotWorkspaceSourceAdapter,
     )
+    assert set(runtime.tool_broker.frozen_checks) >= {
+        "python-compile",
+        "python-pytest",
+        "react-test",
+        "react-build",
+    }
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_coding_worker_source_adapters.py
+++ b/server/tests/test_coding_worker_source_adapters.py
@@ -3,15 +3,18 @@ from __future__ import annotations
 import hashlib
 from pathlib import Path
 import subprocess
+from types import SimpleNamespace
 
 import pytest
 
 from server.coding_worker.contracts import WorkspaceSource
 from server.coding_worker.source_adapters import (
     BuiltinGitWorkspaceSourceAdapter,
+    HostSnapshotWorkspaceSourceAdapter,
     ProjectSnapshotWorkspaceSourceAdapter,
 )
 from server.coding_worker.workspace import WorkspaceError
+from server.coding_worker.runtime import build_runtime_from_environment
 
 
 class FakeProjectSource:
@@ -20,6 +23,7 @@ class FakeProjectSource:
         self.acquired: list[tuple[str, str | None]] = []
         self.released: list[tuple[str, str]] = []
         self.release_result = True
+        self.imports: list[dict[str, str]] = []
 
     async def acquire(
         self, project_id: str, *, expected_head: str | None = None
@@ -30,6 +34,35 @@ class FakeProjectSource:
     async def release(self, project_id: str, lease_id: str) -> bool:
         self.released.append((project_id, lease_id))
         return self.release_result
+
+    async def import_uploaded(self, **payload: str) -> dict[str, object]:
+        self.imports.append(payload)
+        return dict(self.lease)
+
+
+class FakeProjectHost:
+    def __init__(self, project: dict[str, object]) -> None:
+        self.project = project
+        self.requests: list[tuple[str, str | None]] = []
+        self.finished: list[str] = []
+
+    async def request_snapshot(
+        self,
+        project_id: str,
+        *,
+        expected_head: str | None = None,
+        expected_branch: str | None = None,
+        managed_operation_id: str | None = None,
+    ) -> dict[str, object]:
+        self.requests.append((project_id, expected_head))
+        return {
+            "upload_id": "1" * 32,
+            "archive_sha256": "2" * 64,
+            "project": dict(self.project),
+        }
+
+    def finish_transfer(self, transfer_id: str) -> None:
+        self.finished.append(transfer_id)
 
 
 def _fingerprint(files: dict[str, bytes]) -> str:
@@ -66,18 +99,14 @@ def _lease(kind: str, files: dict[str, bytes]) -> dict[str, object]:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("source_kind", "lease_kind"),
-    (("manifest", "local_clone"), ("host_snapshot", "host_git")),
-)
 async def test_project_snapshot_adapter_copies_exact_lease_and_releases(
-    tmp_path: Path, source_kind: str, lease_kind: str
+    tmp_path: Path,
 ) -> None:
     files = {"README.md": b"hello\n", "src/app.py": b"print('ok')\n"}
-    lease = _lease(lease_kind, files)
+    lease = _lease("local_clone", files)
     client = FakeProjectSource(lease)
     source = WorkspaceSource(
-        kind=source_kind,
+        kind="manifest",
         source_id=str(lease["project_id"]),
         revision=str(lease["head"]),
     )
@@ -89,6 +118,87 @@ async def test_project_snapshot_adapter_copies_exact_lease_and_releases(
     assert [(item.path, item.content) for item in snapshot.files] == sorted(files.items())
     assert client.acquired == [(source.source_id, source.revision)]
     assert client.released == [(source.source_id, "lease_1")]
+
+
+@pytest.mark.asyncio
+async def test_host_snapshot_adapter_requests_imports_and_releases_exact_transfer(
+    tmp_path: Path,
+) -> None:
+    files = {"README.md": b"hello\n", "src/app.py": b"print('ok')\n"}
+    lease = _lease("host_git", files)
+    project = {
+        "id": lease["project_id"],
+        "name": "中文 Host Project",
+        "branch": "feature/v14",
+        "head": lease["head"],
+    }
+    client = FakeProjectSource(lease)
+    host = FakeProjectHost(project)
+    source = WorkspaceSource(
+        kind="host_snapshot",
+        source_id=str(lease["project_id"]),
+        revision=str(lease["head"]),
+    )
+
+    snapshot = await HostSnapshotWorkspaceSourceAdapter(
+        host, client, _source_root(tmp_path, files)
+    ).acquire(source)
+
+    assert [(item.path, item.content) for item in snapshot.files] == sorted(files.items())
+    assert host.requests == [(source.source_id, source.revision)]
+    assert client.acquired == []
+    assert client.imports == [
+        {
+            "upload_id": "1" * 32,
+            "archive_sha256": "2" * 64,
+            "project_id": source.source_id,
+            "name": "中文 Host Project",
+            "branch": "feature/v14",
+            "head": source.revision,
+        }
+    ]
+    assert client.released == [(source.source_id, "lease_1")]
+    assert host.finished == ["1" * 32]
+
+
+def test_runtime_wires_host_snapshot_to_live_project_host(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    host = FakeProjectHost({})
+    import server.coding_runtime.api as coding_api
+
+    monkeypatch.setattr(
+        coding_api,
+        "get_coding_service",
+        lambda: SimpleNamespace(project_host=host),
+    )
+    environment = {
+        "CODING_WORKER_STATE_ROOT": str(tmp_path / "state"),
+        "CODING_WORKER_SLOT_A_ROOT": str(tmp_path / "slot-a"),
+        "CODING_WORKER_SLOT_B_ROOT": str(tmp_path / "slot-b"),
+        "CODING_WORKER_SLOT_A_TOKEN": "a" * 32,
+        "CODING_WORKER_SLOT_B_TOKEN": "b" * 32,
+        "CODING_WORKER_EXECUTOR_A_TOKEN": "c" * 32,
+        "CODING_WORKER_EXECUTOR_B_TOKEN": "d" * 32,
+        "CODING_PROJECT_SOURCE_SOCKET_PATH": str(tmp_path / "source.sock"),
+        "CODING_WORKER_PROJECT_SNAPSHOT_ROOT": str(tmp_path / "snapshots"),
+        "CODING_WORKER_BROKER_SOCKET": str(tmp_path / "broker.sock"),
+    }
+    for key, value in environment.items():
+        monkeypatch.setenv(key, value)
+    monkeypatch.delenv("CODING_WORKER_BUILTIN_SOURCE_ROOT", raising=False)
+    monkeypatch.delenv("CODING_WORKER_BUILTIN_REVISION", raising=False)
+
+    runtime = build_runtime_from_environment()
+
+    assert isinstance(
+        runtime.workspace_broker._adapters["host_snapshot"],
+        HostSnapshotWorkspaceSourceAdapter,
+    )
+    assert isinstance(
+        runtime.workspace_broker._adapters["manifest"],
+        ProjectSnapshotWorkspaceSourceAdapter,
+    )
 
 
 @pytest.mark.asyncio
@@ -104,13 +214,21 @@ async def test_project_snapshot_adapter_rejects_changed_fingerprint_and_releases
         revision=str(lease["head"]),
     )
 
+    project = {
+        "id": lease["project_id"],
+        "name": "Host Project",
+        "branch": "feature/v14",
+        "head": lease["head"],
+    }
+    host = FakeProjectHost(project)
     with pytest.raises(WorkspaceError, match="does not match") as caught:
-        await ProjectSnapshotWorkspaceSourceAdapter(
-            client, _source_root(tmp_path, files)
+        await HostSnapshotWorkspaceSourceAdapter(
+            host, client, _source_root(tmp_path, files)
         ).acquire(source)
 
     assert caught.value.code == "source_revision_changed"
     assert client.released == [(source.source_id, "lease_1")]
+    assert host.finished == ["1" * 32]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add the provider-neutral `server/coding_worker` module SDK and versioned `/api/coding-worker/v1` integration surface
- add the shared Worker Console for `/coding` and `/agents/workbench`, while keeping active legacy sessions on their existing runtimes
- add lazy `builtin`, `manifest`, and Windows Helper `host_snapshot` sources with isolated synthetic Git workspaces
- add backend-frozen acceptance check selection and exact Evidence/tree binding
- bridge completed text-only Host Snapshot tasks into the existing v13 apply/commit/undo/publish confirmation chain
- package the Worker kernel in the Server image and isolate Provider, Executor, and optional egress networks
- document architecture, deployment, module integration, harness rules, rollback, and remaining manual gates

## Safety boundaries
- browser and module callers never submit host paths, environment variables, provider names, remote URLs, credentials, or raw endpoints
- two fixed task slots are isolated; a third task remains durably queued
- Executor slots cannot directly reach Server/newAPI; approved network actions go through the dedicated allowlisted egress proxy
- Worker never edits a user repository in place; host writeback remains exclusively in the v13 Project Host chain
- all 19 PR C commits change at most five files; no forbidden artifacts or suspected credentials were found

## Validation
- V14 Worker focused suite: `96 passed`
- Project Host API: `19 passed`
- all Coding + Agent Workspace tests: `762 passed, 9 skipped`
- frontend: `29` files / `134 passed`; production build passed; CodingPage gzip `37.60 kB`
- V14 Compose `config --quiet`, deployment static test, `git diff --check`, secret/artifact scan, and Python `compileall` passed
- real OpenCode 1.18.9 binary smoke passed in a non-root, read-only, network-disabled container with Basic Auth and /global/health; the real model repair loop remains pending
- local backend full suite: `2131 passed, 21 skipped, 1 failed`; the only local failure is the stale `modelmirror-server` image using Node `20.20.2` for a TypeScript-import parity test. The untouched node passes independently under Node `24.18.0` (`1 passed`), and GitHub `Backend quality` passes on the current head.

## Status / remaining gates
Draft and stacked on PR #125.

Before Ready:
- run a real OpenCode 1.18.9 headless two-slot / repair-loop / restart E2E
- run the real Windows Helper Host Snapshot and v13 apply/commit/undo flow on a user-approved test repository
- rebuild and manually verify the shared stack only in a user-approved exclusive window, without stopping independent preview processes