### PR TITLE
feature: 完善 Skill Creator 资源构建与脚本实测

### DIFF
--- a/docs/SKILL_EXPERIENCE_AUDIT.md
+++ b/docs/SKILL_EXPERIENCE_AUDIT.md
@@ -146,6 +146,8 @@ node scripts/audit-skill-experience.mjs
 
 资源化增强 PR 1 已建立 `resource-authoring-v2` 的不可变规划合同：固定 Creator 先提出必要澄清问题，再给出可编辑、可冻结的工作流与资源计划；简单 Skill 可以明确选择零附加资源。该阶段不生成文件，不写 Authoring Proposal，也不改变既有评测和安装门。`SKILL_CREATOR_RESOURCE_AUTHORING_ENABLED` 默认关闭，独立预览验收时才显式开启；PR 2 完成资源构建与脚本实测、PR 3 完成工作台迁移后再成为新 Session 默认流程。
 
+资源化增强 PR 2 已补齐服务端构建合同：确认后的计划按依赖顺序逐项生成，单个资源可在服务端内部拆成最多三个 8 KiB 片段，完整组装、静态校验与脚本离线实测后才进入一次用户评审。`skill_authoring_v1` Sidecar 配置将 `inputs/` 与 `skills/` 设为只读，只允许 `work/`、`.tmp/` 写入及 `python`、`python3`、`node`、`rg` 命令；脚本 receipt 与内容 digest 绑定。所有资源确认后才生成 `SKILL.md`，通过资源闭环与 Creator 初稿完整度门后形成普通待审提案，仍不能绕过三例行为评测或独立安装确认。功能开关继续默认关闭，PR 3 再提供完整工作台和旧会话迁移。
+
 ### 4.4 外部市场
 
 SkillHub 和其他外部市场继续延后。此次来源页读取仅为核验当前索引中的既有条目，不产生新目录、不做市场搜索、不自动同步外部条目。

--- a/server/.env.example
+++ b/server/.env.example
@@ -13,7 +13,7 @@ WORKFLOW_AGENT_STRATEGY_V2_ENABLED=true
 # 私有控制台 Skill Creator V1 默认开启；公共 Xpert App 始终禁用。
 # 设为 false 并重启 Server 可同时关闭 Creator API 与界面入口。
 SKILL_CREATOR_V2_ENABLED=true
-# 资源化 Creator 仍按串行 PR 逐步交付。PR 1 仅开放规划，默认关闭以保持旧流程。
+# 资源化 Creator 已具备规划、分段构建和脚本离线实测；PR 3 工作台完成前默认关闭。
 SKILL_CREATOR_RESOURCE_AUTHORING_ENABLED=false
 # 可选运维覆盖；实时目录和前端默认选择不依赖这两个旧回退值。
 OPENROUTER_TEXT_FALLBACK_MODEL=deepseek/deepseek-chat

--- a/server/main.py
+++ b/server/main.py
@@ -129,6 +129,7 @@ try:
     from server.skills.creator_api import (
         configure_skill_creator,
         configure_skill_creator_evaluation,
+        configure_skill_creator_resource_build,
         configure_skill_creator_resource_planning,
         router as skill_creator_router,
     )
@@ -139,6 +140,15 @@ try:
         WorkflowCreatorGenerationExecutor,
     )
     from server.skills.creator_resource_plan import SkillResourcePlanStore
+    from server.skills.creator_resource_build import SkillResourceBuildStore
+    from server.skills.creator_resource_build_runtime import (
+        ResourceBuildWorkflowInvocation,
+        SandboxCreatorScriptRunner,
+        WorkflowCreatorResourceBuilder,
+    )
+    from server.skills.creator_resource_build_service import (
+        SkillCreatorResourceBuildService,
+    )
     from server.skills.creator_resource_runtime import (
         ResourcePlannerWorkflowInvocation,
         WorkflowCreatorResourcePlanner,
@@ -181,6 +191,7 @@ except ModuleNotFoundError:
     from skills.creator_api import (
         configure_skill_creator,
         configure_skill_creator_evaluation,
+        configure_skill_creator_resource_build,
         configure_skill_creator_resource_planning,
         router as skill_creator_router,
     )
@@ -191,6 +202,13 @@ except ModuleNotFoundError:
         WorkflowCreatorGenerationExecutor,
     )
     from skills.creator_resource_plan import SkillResourcePlanStore
+    from skills.creator_resource_build import SkillResourceBuildStore
+    from skills.creator_resource_build_runtime import (
+        ResourceBuildWorkflowInvocation,
+        SandboxCreatorScriptRunner,
+        WorkflowCreatorResourceBuilder,
+    )
+    from skills.creator_resource_build_service import SkillCreatorResourceBuildService
     from skills.creator_resource_runtime import (
         ResourcePlannerWorkflowInvocation,
         WorkflowCreatorResourcePlanner,
@@ -823,7 +841,9 @@ WORKFLOW_AGENT_MAX_ITERATIONS_DEFAULT = 5
 WORKFLOW_AGENT_MAX_TOKENS = 1024
 SKILL_CREATOR_AGENT_MAX_TOKENS = 12_288
 SKILL_CREATOR_RESOURCE_PLANNER_MAX_TOKENS = 8_192
+SKILL_CREATOR_RESOURCE_BUILDER_MAX_TOKENS = 8_192
 SKILL_CREATOR_RESOURCE_PLANNER_TEMPERATURE = 0.1
+SKILL_CREATOR_RESOURCE_BUILDER_TEMPERATURE = 0.1
 SKILL_EVALUATION_AGENT_MAX_TOKENS = 4_096
 AGENT_TASK_STORAGE_DIR = os.getenv("AGENT_TASK_STORAGE_DIR", "").strip()
 
@@ -848,6 +868,8 @@ def workflow_agent_token_budget(runtime_metadata: dict[str, Any] | None) -> int:
         metadata = dict(runtime_metadata or {})
         if metadata.get("creator_phase") == "resource_plan":
             return SKILL_CREATOR_RESOURCE_PLANNER_MAX_TOKENS
+        if metadata.get("creator_phase") == "resource_build":
+            return SKILL_CREATOR_RESOURCE_BUILDER_MAX_TOKENS
         return SKILL_CREATOR_AGENT_MAX_TOKENS
     metadata = dict(runtime_metadata or {})
     if is_trusted_skill_evaluation_metadata(metadata):
@@ -1118,6 +1140,15 @@ skill_creator_resource_planning_service = SkillCreatorResourcePlanningService(
     skill_creator_service,
     skill_creator_resource_plan_store,
 )
+skill_creator_resource_build_store = SkillResourceBuildStore(
+    storage_dir=AGENT_TASK_STORAGE_DIR or None
+)
+skill_creator_resource_build_service = SkillCreatorResourceBuildService(
+    skill_creator_service,
+    skill_creator_resource_planning_service,
+    skill_creator_resource_build_store,
+    script_runner=SandboxCreatorScriptRunner(sandbox_sidecar_client),
+)
 workflow_xpert_authoring_provider = AuthoringToolsetProvider(
     authoring_service, "xpert"
 )
@@ -1127,6 +1158,7 @@ workflow_skill_creator_provider = AuthoringToolsetProvider(
 configure_runtime_authoring(authoring_service)
 configure_skill_creator(skill_creator_service)
 configure_skill_creator_resource_planning(skill_creator_resource_planning_service)
+configure_skill_creator_resource_build(skill_creator_resource_build_service)
 runtime_capabilities.register(
     "mcp_tools",
     workflow_mcp_provider,
@@ -10474,10 +10506,15 @@ async def _run_workflow_response(
                         actual_model_missing_count = 0
                         evaluation_token_usage: dict[str, int] = {}
                         agent_temperature = (
-                            SKILL_CREATOR_RESOURCE_PLANNER_TEMPERATURE
+                            (
+                                SKILL_CREATOR_RESOURCE_PLANNER_TEMPERATURE
+                                if run_context.get("creator_phase") == "resource_plan"
+                                else SKILL_CREATOR_RESOURCE_BUILDER_TEMPERATURE
+                            )
                             if (
                                 is_trusted_skill_creator_runtime(run_context)
-                                and run_context.get("creator_phase") == "resource_plan"
+                                and run_context.get("creator_phase")
+                                in {"resource_plan", "resource_build"}
                             )
                             else skill_evaluation_model_temperature(
                                 run_context,
@@ -13065,6 +13102,37 @@ skill_creator_resource_planner = WorkflowCreatorResourcePlanner(
 skill_creator_resource_planning_service.planner = skill_creator_resource_planner
 
 
+async def run_skill_creator_resource_build(
+    invocation: ResourceBuildWorkflowInvocation,
+) -> str:
+    payload = WorkflowRunRequest.model_validate(
+        {"workflow": invocation.workflow, "inputs": invocation.inputs}
+    )
+    build_id = str(invocation.runtime_metadata.get("resource_build_id") or "").strip()
+    response = await _run_workflow_response(
+        payload,
+        None,
+        runtime_run_type="workflow",
+        runtime_source_id=build_id,
+        runtime_metadata=dict(invocation.runtime_metadata),
+    )
+    final_event = await consume_workflow_stream(response)
+    if final_event.get("event") in {"runtime_approval_pending", "client_tool_waiting"}:
+        raise RuntimeError("The dedicated Skill Creator resource builder cannot pause for tools.")
+    output = str(final_event.get("final_output") or "").strip()
+    if not output:
+        raise RuntimeError("The Skill Creator resource builder returned no content.")
+    return output
+
+
+skill_creator_resource_builder = WorkflowCreatorResourceBuilder(
+    model_id=TEXT_FALLBACK_MODEL,
+    model_available=lambda: bool(get_llm_gateway_config()[0]),
+    runner=run_skill_creator_resource_build,
+)
+skill_creator_resource_build_service.builder = skill_creator_resource_builder
+
+
 async def execute_external_xpert_resource(
     resource: dict[str, Any],
     task: str,
@@ -15562,6 +15630,11 @@ async def start_mcp_ttl_cleanup() -> None:
     get_xpert_evaluation_executor().start()
     start_skill_creator_evaluation_runtime()
     get_benchmark_job_executor().start()
+    if skill_creator_resource_build_service.enabled:
+        try:
+            await asyncio.to_thread(skill_creator_resource_build_store.recover_interrupted)
+        except Exception as exc:
+            logger.warning("Skill Creator resource build recovery is unavailable: %s", exc)
     get_xpert_evolution_executor().start()
     get_handoff_executor().start()
     get_goal_coordinator().start()

--- a/server/sandbox_sidecar/engine.py
+++ b/server/sandbox_sidecar/engine.py
@@ -22,7 +22,9 @@ DEFAULT_ALLOWED_COMMANDS = {"python", "python3", "node", "npm", "npx", "git", "r
 SKILL_EVALUATION_ALLOWED_COMMANDS = {"python", "python3", "node", "rg"}
 DEFAULT_PROFILE = "default"
 SKILL_EVALUATION_PROFILE = "skill_evaluation_v1"
-SUPPORTED_PROFILES = {DEFAULT_PROFILE, SKILL_EVALUATION_PROFILE}
+SKILL_AUTHORING_PROFILE = "skill_authoring_v1"
+PROTECTED_SKILL_PROFILES = {SKILL_EVALUATION_PROFILE, SKILL_AUTHORING_PROFILE}
+SUPPORTED_PROFILES = {DEFAULT_PROFILE, *PROTECTED_SKILL_PROFILES}
 MAX_REQUEST_BYTES = 16 * 1024 * 1024
 MAX_OUTPUT_BYTES = 64 * 1024
 MAX_MANIFEST_FILES = 500
@@ -63,46 +65,40 @@ class SandboxEngine:
                         "allowed_commands": sorted(self.allowed_commands),
                         "network_policy": "container_network_none_required",
                     },
-                    SKILL_EVALUATION_PROFILE: {
-                        "allowed_commands": sorted(SKILL_EVALUATION_ALLOWED_COMMANDS),
-                        "network_policy": "container_network_none_required",
-                        "read_only_roots": ["inputs", "skills"],
-                        "writable_roots": ["work", ".tmp"],
-                        "write_file_roots": ["work"],
-                        "provisioning": "capability_bound",
-                        "lifecycle_actions": [
-                            "ensure_workspace",
-                            "seed_file",
-                            "seal_workspace",
-                            "collect_work_manifest",
-                            "cleanup_workspace",
-                        ],
-                    },
+                    SKILL_EVALUATION_PROFILE: self._protected_profile_attestation(),
+                    SKILL_AUTHORING_PROFILE: self._protected_profile_attestation(),
                 },
             }
         profile = self._profile(request.get("profile"))
         workspace_id = self._workspace_id(request.get("workspace_id"))
-        if profile == SKILL_EVALUATION_PROFILE:
+        if profile in PROTECTED_SKILL_PROFILES:
             if action == "ensure_workspace":
-                return self._ensure_evaluation_workspace(workspace_id, request)
-            workspace = self._evaluation_workspace(workspace_id, request)
+                return self._ensure_protected_workspace(workspace_id, request, profile)
+            workspace = self._protected_workspace(workspace_id, request, profile)
             if action == "seed_file":
-                return self._idempotent(workspace, action, request, self._seed_evaluation_file)
+                return self._idempotent(
+                    workspace,
+                    action,
+                    request,
+                    lambda bound_workspace, bound_request: self._seed_protected_file(
+                        bound_workspace, bound_request, profile
+                    ),
+                )
             if action == "seal_workspace":
-                self._seal_evaluation_workspace(workspace)
+                self._seal_protected_workspace(workspace)
                 return {"ok": True, "workspace_id": workspace_id, "sealed": True}
             if action == "collect_work_manifest":
-                self._seal_evaluation_workspace(workspace)
+                self._seal_protected_workspace(workspace)
                 return self._collect_work_manifest(workspace)
             if action == "cleanup_workspace":
                 shutil.rmtree(workspace)
                 return {"ok": True, "workspace_id": workspace_id, "removed": True}
             if action == "publish_artifact":
                 raise SandboxEngineError(
-                    "Artifact publishing is unavailable in the Skill evaluation profile.",
+                    "Artifact publishing is unavailable in protected Skill profiles.",
                     code="profile_action_denied",
                 )
-            self._seal_evaluation_workspace(workspace)
+            self._seal_protected_workspace(workspace)
         else:
             workspace = self._ensure_workspace(workspace_id)
         if action == "ensure_workspace":
@@ -128,7 +124,7 @@ class SandboxEngine:
         marker = workspace / ".modelmirror" / "profile.json"
         if marker.exists():
             stored = self._read_profile_marker(marker)
-            if stored.get("profile") == SKILL_EVALUATION_PROFILE:
+            if stored.get("profile") in PROTECTED_SKILL_PROFILES:
                 raise SandboxEngineError(
                     "Workspace is bound to a different sandbox profile.",
                     code="sandbox_profile_mismatch",
@@ -137,21 +133,22 @@ class SandboxEngine:
             (workspace / name).mkdir(parents=True, exist_ok=True)
         return workspace
 
-    def _ensure_evaluation_workspace(
+    def _ensure_protected_workspace(
         self,
         workspace_id: str,
         request: dict[str, Any],
+        profile: str,
     ) -> dict[str, Any]:
         workspace = (self.root / workspace_id).resolve()
         if workspace.parent != self.root:
             raise SandboxEngineError("Unsafe workspace identifier.", code="unsafe_workspace")
         marker = workspace / ".modelmirror" / "profile.json"
         if marker.exists():
-            self._validate_evaluation_capability(workspace, request)
+            self._validate_protected_capability(workspace, request, profile)
             return {
                 "ok": True,
                 "workspace_id": workspace_id,
-                "profile": SKILL_EVALUATION_PROFILE,
+                "profile": profile,
                 "sealed": bool(self._read_profile_marker(marker).get("sealed")),
             }
         if workspace.exists() and any(workspace.iterdir()):
@@ -159,10 +156,15 @@ class SandboxEngine:
                 "Existing workspace cannot be rebound to the Skill evaluation profile.",
                 code="sandbox_profile_mismatch",
             )
+        skill_alias = (
+            "evaluation-skill"
+            if profile == SKILL_EVALUATION_PROFILE
+            else "authoring-resource"
+        )
         for name in (
             "inputs",
             "work",
-            "skills/evaluation-skill",
+            f"skills/{skill_alias}",
             ".modelmirror/operations",
             ".tmp",
         ):
@@ -171,7 +173,7 @@ class SandboxEngine:
         self._write_profile_marker(
             marker,
             {
-                "profile": SKILL_EVALUATION_PROFILE,
+                "profile": profile,
                 "capability_sha256": hashlib.sha256(capability.encode("utf-8")).hexdigest(),
                 "sealed": False,
             },
@@ -179,12 +181,14 @@ class SandboxEngine:
         return {
             "ok": True,
             "workspace_id": workspace_id,
-            "profile": SKILL_EVALUATION_PROFILE,
+            "profile": profile,
             "provisioning_capability": capability,
             "sealed": False,
         }
 
-    def _evaluation_workspace(self, workspace_id: str, request: dict[str, Any]) -> Path:
+    def _protected_workspace(
+        self, workspace_id: str, request: dict[str, Any], profile: str
+    ) -> Path:
         workspace = (self.root / workspace_id).resolve()
         if workspace.parent != self.root:
             raise SandboxEngineError("Unsafe workspace identifier.", code="unsafe_workspace")
@@ -193,13 +197,14 @@ class SandboxEngine:
                 "Skill evaluation workspace has not been initialized.",
                 code="workspace_not_found",
             )
-        self._validate_evaluation_capability(workspace, request)
+        self._validate_protected_capability(workspace, request, profile)
         return workspace
 
-    def _validate_evaluation_capability(
+    def _validate_protected_capability(
         self,
         workspace: Path,
         request: dict[str, Any],
+        profile: str,
     ) -> None:
         marker = workspace / ".modelmirror" / "profile.json"
         if not marker.exists():
@@ -208,7 +213,7 @@ class SandboxEngine:
                 code="sandbox_profile_mismatch",
             )
         stored = self._read_profile_marker(marker)
-        if stored.get("profile") != SKILL_EVALUATION_PROFILE:
+        if stored.get("profile") != profile:
             raise SandboxEngineError(
                 "Workspace is bound to a different sandbox profile.",
                 code="sandbox_profile_mismatch",
@@ -222,7 +227,7 @@ class SandboxEngine:
                 code="sandbox_profile_capability_invalid",
             )
 
-    def _seal_evaluation_workspace(self, workspace: Path) -> None:
+    def _seal_protected_workspace(self, workspace: Path) -> None:
         marker = workspace / ".modelmirror" / "profile.json"
         stored = self._read_profile_marker(marker)
         if stored.get("sealed") is True:
@@ -230,10 +235,11 @@ class SandboxEngine:
         stored["sealed"] = True
         self._write_profile_marker(marker, stored)
 
-    def _seed_evaluation_file(
+    def _seed_protected_file(
         self,
         workspace: Path,
         request: dict[str, Any],
+        profile: str,
     ) -> dict[str, Any]:
         marker = workspace / ".modelmirror" / "profile.json"
         if self._read_profile_marker(marker).get("sealed") is True:
@@ -243,12 +249,17 @@ class SandboxEngine:
             )
         target = self._safe_path(workspace, request.get("path"), for_write=True)
         relative = target.relative_to(workspace)
+        skill_alias = (
+            "evaluation-skill"
+            if profile == SKILL_EVALUATION_PROFILE
+            else "authoring-resource"
+        )
         if not (
             relative.parts[0] == "inputs"
-            or relative.parts[:2] == ("skills", "evaluation-skill")
+            or relative.parts[:2] == ("skills", skill_alias)
         ):
             raise SandboxEngineError(
-                "Evaluation seed files must be under inputs/ or skills/evaluation-skill/.",
+                "Protected Skill seed files must use the profile-bound inputs/ or skills/ root.",
                 code="seed_scope_denied",
             )
         content = self._request_content(request)
@@ -340,12 +351,12 @@ class SandboxEngine:
         target = self._safe_path(workspace, request.get("path"), for_write=True)
         relative = target.relative_to(workspace)
         profile = self._profile(request.get("profile"))
-        allowed_roots = {"work"} if profile == SKILL_EVALUATION_PROFILE else {"inputs", "work", "skills"}
+        allowed_roots = {"work"} if profile in PROTECTED_SKILL_PROFILES else {"inputs", "work", "skills"}
         if relative.parts[0] not in allowed_roots:
             raise SandboxEngineError(
                 (
                     "Files may only be written under work/ in the Skill evaluation profile."
-                    if profile == SKILL_EVALUATION_PROFILE
+                    if profile in PROTECTED_SKILL_PROFILES
                     else "Files may only be written under inputs/, work/, or skills/."
                 ),
                 code="write_scope_denied",
@@ -408,7 +419,7 @@ class SandboxEngine:
         profile = self._profile(request.get("profile"))
         profile_allowed_commands = (
             SKILL_EVALUATION_ALLOWED_COMMANDS
-            if profile == SKILL_EVALUATION_PROFILE
+            if profile in PROTECTED_SKILL_PROFILES
             else self.allowed_commands
         )
         if "/" in command or "\\" in command or command not in profile_allowed_commands:
@@ -433,7 +444,11 @@ class SandboxEngine:
                 *(
                     ["--skill-evaluation"]
                     if profile == SKILL_EVALUATION_PROFILE
-                    else []
+                    else (
+                        ["--skill-authoring"]
+                        if profile == SKILL_AUTHORING_PROFILE
+                        else []
+                    )
                 ),
                 "--",
                 *argv,
@@ -638,6 +653,24 @@ class SandboxEngine:
                 code="sandbox_profile_unsupported",
             )
         return profile
+
+    @staticmethod
+    def _protected_profile_attestation() -> dict[str, Any]:
+        return {
+            "allowed_commands": sorted(SKILL_EVALUATION_ALLOWED_COMMANDS),
+            "network_policy": "container_network_none_required",
+            "read_only_roots": ["inputs", "skills"],
+            "writable_roots": ["work", ".tmp"],
+            "write_file_roots": ["work"],
+            "provisioning": "capability_bound",
+            "lifecycle_actions": [
+                "ensure_workspace",
+                "seed_file",
+                "seal_workspace",
+                "collect_work_manifest",
+                "cleanup_workspace",
+            ],
+        }
 
     @staticmethod
     def _read_profile_marker(marker: Path) -> dict[str, Any]:

--- a/server/sandbox_sidecar/landlock_exec.py
+++ b/server/sandbox_sidecar/landlock_exec.py
@@ -157,7 +157,12 @@ def main() -> int:
     separator_index = 2
     while separator_index < len(sys.argv) and sys.argv[separator_index] != "--":
         option = sys.argv[separator_index]
-        if option not in {"--read-only", "--compute-limits", "--skill-evaluation"}:
+        if option not in {
+            "--read-only",
+            "--compute-limits",
+            "--skill-evaluation",
+            "--skill-authoring",
+        }:
             print(f"unsupported sandbox option: {option}", file=sys.stderr)
             return 64
         options.add(option)
@@ -165,7 +170,7 @@ def main() -> int:
     if len(sys.argv) <= separator_index or sys.argv[separator_index] != "--":
         print(
             "usage: landlock_exec.py WORKSPACE [--read-only] "
-            "[--compute-limits] [--skill-evaluation] -- COMMAND [ARGS...]",
+            "[--compute-limits] [--skill-evaluation|--skill-authoring] -- COMMAND [ARGS...]",
             file=sys.stderr,
         )
         return 64
@@ -180,7 +185,9 @@ def main() -> int:
         _apply_landlock(
             workspace,
             workspace_writable="--read-only" not in options,
-            skill_evaluation="--skill-evaluation" in options,
+            skill_evaluation=bool(
+                {"--skill-evaluation", "--skill-authoring"} & options
+            ),
         )
     except Exception as exc:
         print(f"sandbox isolation failed: {exc}", file=sys.stderr)

--- a/server/skills/creator_api.py
+++ b/server/skills/creator_api.py
@@ -15,6 +15,7 @@ from .creator_evaluation import (
     SkillEvaluationValidationError,
 )
 from .creator_evaluation_service import SkillCreatorEvaluationService
+from .creator_resource_build_service import SkillCreatorResourceBuildService
 from .creator_resource_service import SkillCreatorResourcePlanningService
 from .creator_service import SkillCreatorService
 from .creator_store import (
@@ -44,6 +45,7 @@ router = APIRouter(prefix="/api/skills/creator", tags=["skill-creator"])
 _service: SkillCreatorService | None = None
 _evaluation_service: SkillCreatorEvaluationService | None = None
 _resource_planning_service: SkillCreatorResourcePlanningService | None = None
+_resource_build_service: SkillCreatorResourceBuildService | None = None
 
 
 class CreatorSessionCreateRequest(BaseModel):
@@ -123,6 +125,30 @@ class CreatorResourcePlanPatchRequest(CreatorResourcePlanWriteRequest):
     output_contract: list[str] | None = Field(default=None, max_length=20)
     failure_modes: list[str] | None = Field(default=None, max_length=20)
     resources: list[dict[str, Any]] | None = Field(default=None, max_length=20)
+
+
+class CreatorResourceBuildStartRequest(CreatorResourcePlanWriteRequest):
+    pass
+
+
+class CreatorResourceBuildMutationRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    expected_session_revision: int = Field(ge=1)
+    expected_revision: int = Field(ge=1)
+    expected_digest: str = Field(
+        min_length=64, max_length=64, pattern=r"^[0-9a-fA-F]{64}$"
+    )
+
+
+class CreatorResourceReviewRequest(CreatorResourceBuildMutationRequest):
+    decision: Literal["accept", "revise"]
+    feedback: str = Field(default="", max_length=4_000)
+
+
+class CreatorResourceFinalizeRequest(CreatorResourceBuildMutationRequest):
+    decision: Literal["accept", "revise"]
+    feedback: str = Field(default="", max_length=4_000)
 
 
 class CreatorBlankDraftRequest(BaseModel):
@@ -231,6 +257,13 @@ def configure_skill_creator_resource_planning(
     _resource_planning_service = service
 
 
+def configure_skill_creator_resource_build(
+    service: SkillCreatorResourceBuildService | None,
+) -> None:
+    global _resource_build_service
+    _resource_build_service = service
+
+
 def get_skill_creator_service() -> SkillCreatorService:
     if _service is None:
         raise SkillCreatorValidationError(
@@ -259,6 +292,17 @@ def get_skill_creator_resource_planning_service() -> SkillCreatorResourcePlannin
         )
     _resource_planning_service.require_enabled()
     return _resource_planning_service
+
+
+def get_skill_creator_resource_build_service() -> SkillCreatorResourceBuildService:
+    get_skill_creator_resource_planning_service()
+    if _resource_build_service is None:
+        raise SkillCreatorValidationError(
+            "Skill Creator resource build is unavailable.",
+            code="skill_creator_resource_authoring_disabled",
+        )
+    _resource_build_service.require_enabled()
+    return _resource_build_service
 
 
 def _api_error(exc: Exception) -> HTTPException:
@@ -311,6 +355,11 @@ def _api_error(exc: Exception) -> HTTPException:
         } else 400
         if code == "model_gateway_unconfigured":
             status = 503
+        elif code in {
+            "skill_creator_sandbox_unavailable",
+            "skill_creator_sandbox_profile_invalid",
+        }:
+            status = 503
         elif code == "skill_creator_source_unavailable":
             status = 501
         elif code in {
@@ -319,6 +368,8 @@ def _api_error(exc: Exception) -> HTTPException:
             "skill_creator_tool_not_called",
             "skill_creator_resource_planner_failed",
             "skill_creator_resource_planner_invalid",
+            "skill_creator_resource_builder_failed",
+            "skill_creator_resource_builder_invalid",
         }:
             status = 502
         elif code == "skill_creator_proposal_binding_invalid":
@@ -379,6 +430,12 @@ def _session_response(
             and _resource_planning_service.enabled
             else None
         ),
+        "resource_build": (
+            _resource_build_service.current_projection(session.session_id)
+            if _resource_build_service is not None
+            and _resource_build_service.enabled
+            else None
+        ),
     }
     return response
 
@@ -398,6 +455,10 @@ async def get_creator_status():
             "resource_authoring_enabled": False,
             "resource_authoring_version": None,
             "resource_planner_available": False,
+            "resource_build_enabled": False,
+            "resource_build_version": None,
+            "resource_builder_available": False,
+            "script_sandbox_configured": False,
         }
     status = _service.status()
     status["evaluation_available"] = _evaluation_service is not None
@@ -414,6 +475,16 @@ async def get_creator_status():
             "resource_authoring_enabled": False,
             "resource_authoring_version": None,
             "resource_planner_available": False,
+        }
+    )
+    status.update(
+        _resource_build_service.status()
+        if _resource_build_service is not None
+        else {
+            "resource_build_enabled": False,
+            "resource_build_version": None,
+            "resource_builder_available": False,
+            "script_sandbox_configured": False,
         }
     )
     return status
@@ -678,6 +749,114 @@ async def confirm_creator_resource_plan(
             plan, session=session, draft=draft
         )
         return response
+    except (SkillCreatorError, SkillDraftError) as exc:
+        raise _api_error(exc) from exc
+
+
+@router.post("/sessions/{session_id}/resource-build", status_code=201)
+async def start_creator_resource_build(
+    session_id: str, payload: CreatorResourceBuildStartRequest
+):
+    try:
+        build_service = get_skill_creator_resource_build_service()
+        build = await build_service.start(
+            session_id,
+            plan_id=payload.plan_id,
+            expected_session_revision=payload.expected_session_revision,
+            expected_plan_revision=payload.expected_plan_revision,
+            expected_plan_digest=payload.expected_plan_digest.lower(),
+        )
+        return {
+            "version": build_service.VERSION,
+            "resource_build": build_service.build_store.serialize(build),
+        }
+    except (SkillCreatorError, SkillDraftError) as exc:
+        raise _api_error(exc) from exc
+
+
+@router.get("/resource-builds/{build_id}")
+async def get_creator_resource_build(build_id: str):
+    try:
+        build_service = get_skill_creator_resource_build_service()
+        build = await asyncio.to_thread(build_service.build_store.require, build_id)
+        projection = build_service.current_projection(build.session_id)
+        if projection is None or projection.get("build_id") != build_id:
+            raise SkillCreatorConflictError("Resource build is no longer current for this session.")
+        return {"version": build_service.VERSION, "resource_build": projection}
+    except (SkillCreatorError, SkillDraftError) as exc:
+        raise _api_error(exc) from exc
+
+
+@router.post("/resource-builds/{build_id}/next")
+async def advance_creator_resource_build(
+    build_id: str, payload: CreatorResourceBuildMutationRequest
+):
+    try:
+        build_service = get_skill_creator_resource_build_service()
+        build = await build_service.next(
+            build_id,
+            expected_session_revision=payload.expected_session_revision,
+            expected_revision=payload.expected_revision,
+            expected_digest=payload.expected_digest.lower(),
+        )
+        return {
+            "version": build_service.VERSION,
+            "resource_build": build_service.build_store.serialize(build),
+        }
+    except (SkillCreatorError, SkillDraftError) as exc:
+        raise _api_error(exc) from exc
+
+
+@router.post("/resource-builds/{build_id}/resources/{resource_id}/review")
+async def review_creator_resource(
+    build_id: str,
+    resource_id: str,
+    payload: CreatorResourceReviewRequest,
+):
+    try:
+        build_service = get_skill_creator_resource_build_service()
+        build = await asyncio.to_thread(
+            build_service.review_resource,
+            build_id,
+            resource_id=resource_id,
+            expected_session_revision=payload.expected_session_revision,
+            expected_revision=payload.expected_revision,
+            expected_digest=payload.expected_digest.lower(),
+            decision=payload.decision,
+            feedback=payload.feedback,
+        )
+        return {
+            "version": build_service.VERSION,
+            "resource_build": build_service.build_store.serialize(build),
+        }
+    except (SkillCreatorError, SkillDraftError) as exc:
+        raise _api_error(exc) from exc
+
+
+@router.post("/resource-builds/{build_id}/finalize")
+async def finalize_creator_resource_build(
+    build_id: str, payload: CreatorResourceFinalizeRequest
+):
+    try:
+        build_service = get_skill_creator_resource_build_service()
+        build, proposal = await asyncio.to_thread(
+            build_service.finalize,
+            build_id,
+            expected_session_revision=payload.expected_session_revision,
+            expected_revision=payload.expected_revision,
+            expected_digest=payload.expected_digest.lower(),
+            decision=payload.decision,
+            feedback=payload.feedback,
+        )
+        return {
+            "version": build_service.VERSION,
+            "resource_build": build_service.build_store.serialize(build),
+            "proposal": (
+                AuthoringProposalStore.serialize(proposal, include_payload=True)
+                if proposal is not None
+                else None
+            ),
+        }
     except (SkillCreatorError, SkillDraftError) as exc:
         raise _api_error(exc) from exc
 

--- a/server/skills/creator_quality.py
+++ b/server/skills/creator_quality.py
@@ -17,6 +17,10 @@ MAX_CREATOR_SKILL_MARKDOWN_CHARS = 6_000
 MAX_CREATOR_RESOURCES = 6
 MAX_CREATOR_RESOURCE_CHARS = 6_000
 MAX_CREATOR_PAYLOAD_BYTES = 24_000
+MAX_RESOURCE_BUILD_SKILL_MARKDOWN_CHARS = 20 * 1024
+MAX_RESOURCE_BUILD_RESOURCES = 20
+MAX_RESOURCE_BUILD_RESOURCE_CHARS = 24 * 1024
+MAX_RESOURCE_BUILD_PAYLOAD_BYTES = 180 * 1024
 
 _REFERENCE_DIR = Path(__file__).resolve().parent / "creator_reference"
 _PLAYBOOK_PATH = _REFERENCE_DIR / "authoring-playbook-v1.md"
@@ -217,6 +221,7 @@ def evaluate_creator_payload(
     *,
     requirements: Sequence[CreatorRequirement] = (),
     requirement_ids: Sequence[str] = (),
+    resource_build: bool = False,
 ) -> CreatorDraftQualityReport:
     """Evaluate a workflow-agent Creator draft without affecting generic Skills.
 
@@ -240,7 +245,7 @@ def evaluate_creator_payload(
         )
         return _report(issues, checks, expected_ids, contract_version)
 
-    _validate_generation_budget(payload, issues)
+    _validate_generation_budget(payload, issues, resource_build=resource_build)
 
     raw_contract = payload.get("creator_contract_version")
     if isinstance(raw_contract, str):
@@ -600,16 +605,37 @@ def _validate_wrapped_skill(
 
 
 def _validate_generation_budget(
-    payload: Mapping[str, Any], issues: list[CreatorQualityIssue]
+    payload: Mapping[str, Any],
+    issues: list[CreatorQualityIssue],
+    *,
+    resource_build: bool,
 ) -> None:
+    skill_markdown_limit = (
+        MAX_RESOURCE_BUILD_SKILL_MARKDOWN_CHARS
+        if resource_build
+        else MAX_CREATOR_SKILL_MARKDOWN_CHARS
+    )
+    resource_count_limit = (
+        MAX_RESOURCE_BUILD_RESOURCES if resource_build else MAX_CREATOR_RESOURCES
+    )
+    resource_size_limit = (
+        MAX_RESOURCE_BUILD_RESOURCE_CHARS
+        if resource_build
+        else MAX_CREATOR_RESOURCE_CHARS
+    )
+    payload_limit = (
+        MAX_RESOURCE_BUILD_PAYLOAD_BYTES
+        if resource_build
+        else MAX_CREATOR_PAYLOAD_BYTES
+    )
     raw_skill = payload.get("skill")
     if isinstance(raw_skill, Mapping):
         markdown = raw_skill.get("skill_markdown")
-        if isinstance(markdown, str) and len(markdown) > MAX_CREATOR_SKILL_MARKDOWN_CHARS:
+        if isinstance(markdown, str) and len(markdown) > skill_markdown_limit:
             issues.append(
                 CreatorQualityIssue(
                     code="creator_skill_markdown_budget_exceeded",
-                    message=f"Creator SKILL.md is limited to {MAX_CREATOR_SKILL_MARKDOWN_CHARS} characters per generation.",
+                    message=f"Creator SKILL.md is limited to {skill_markdown_limit} characters per generation.",
                     path="SKILL.md",
                 )
             )
@@ -620,21 +646,21 @@ def _validate_generation_budget(
                 for path in files
                 if isinstance(path, str) and not path.startswith("agents/")
             ]
-            if len(resource_paths) > MAX_CREATOR_RESOURCES:
+            if len(resource_paths) > resource_count_limit:
                 issues.append(
                     CreatorQualityIssue(
                         code="creator_resource_count_budget_exceeded",
-                        message=f"Creator generation is limited to {MAX_CREATOR_RESOURCES} bundled resources.",
+                        message=f"Creator generation is limited to {resource_count_limit} bundled resources.",
                         field="skill.files",
                     )
                 )
             for path in resource_paths:
                 content = files.get(path)
-                if isinstance(content, str) and len(content) > MAX_CREATOR_RESOURCE_CHARS:
+                if isinstance(content, str) and len(content) > resource_size_limit:
                     issues.append(
                         CreatorQualityIssue(
                             code="creator_resource_budget_exceeded",
-                            message=f"Each generated resource is limited to {MAX_CREATOR_RESOURCE_CHARS} characters.",
+                            message=f"Each generated resource is limited to {resource_size_limit} characters.",
                             path=path,
                         )
                     )
@@ -649,11 +675,11 @@ def _validate_generation_budget(
         )
     except (TypeError, ValueError, OverflowError):
         return
-    if payload_bytes > MAX_CREATOR_PAYLOAD_BYTES:
+    if payload_bytes > payload_limit:
         issues.append(
             CreatorQualityIssue(
                 code="creator_payload_budget_exceeded",
-                message=f"Creator generation is limited to {MAX_CREATOR_PAYLOAD_BYTES} UTF-8 bytes.",
+                message=f"Creator generation is limited to {payload_limit} UTF-8 bytes.",
                 field="payload",
             )
         )

--- a/server/skills/creator_resource_build.py
+++ b/server/skills/creator_resource_build.py
@@ -1,0 +1,1295 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import os
+import re
+import threading
+import time
+import uuid
+from dataclasses import asdict, dataclass, field, replace
+from pathlib import Path, PurePosixPath
+from typing import Any, Literal, Mapping
+
+from .creator_resource_plan import SkillResourcePlan
+from .creator_store import (
+    SkillCreatorConflictError,
+    SkillCreatorNotFoundError,
+    SkillCreatorStorageError,
+    SkillCreatorValidationError,
+)
+from .package_validation import scan_skill_package_credentials
+
+
+RESOURCE_BUILD_VERSION = "skill-resource-build-v1"
+ResourceBuildState = Literal[
+    "planned",
+    "generating",
+    "awaiting_review",
+    "accepted",
+    "revision_requested",
+    "failed",
+    "stale",
+]
+ResourceArtifactState = Literal[
+    "planned",
+    "generating",
+    "awaiting_review",
+    "accepted",
+    "revision_requested",
+    "failed",
+]
+ResourceBuildPhase = Literal["resources", "skill_markdown", "proposal"]
+
+MAX_BUILD_RESOURCES = 20
+MAX_SEGMENT_BYTES = 8 * 1024
+MAX_RESOURCE_BYTES = 24 * 1024
+MAX_SKILL_MARKDOWN_BYTES = 20 * 1024
+MAX_PACKAGE_BYTES = 160 * 1024
+MAX_SCRIPT_TESTS = 3
+MAX_SCRIPT_FIXTURES_PER_TEST = 8
+MAX_SCRIPT_FIXTURE_BYTES_TOTAL = 64 * 1024
+MAX_BUILD_SCRIPT_FIXTURE_BYTES = 160 * 1024
+SKILL_AUTHORING_PROFILE = "skill_authoring_v1"
+
+_IDENTIFIER_RE = re.compile(r"^[a-z][a-z0-9_-]{0,79}$")
+_DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
+_FORBIDDEN_PACKAGE_NAMES = {
+    "readme.md",
+    "installation_guide.md",
+    "quick_reference.md",
+    "changelog.md",
+    "_user_meta.json",
+    "user-meta.json",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class ResourceScriptFixture:
+    path: str
+    content: str
+
+
+@dataclass(frozen=True, slots=True)
+class ResourceScriptTest:
+    test_id: str
+    args: list[str]
+    fixtures: list[ResourceScriptFixture]
+    expected_exit_code: int
+    stdout_contains: list[str]
+    stderr_contains: list[str]
+
+
+@dataclass(frozen=True, slots=True)
+class ResourceScriptTestResult:
+    test_id: str
+    passed: bool
+    exit_code: int
+    stdout_sha256: str
+    stderr_sha256: str
+    duration_ms: float
+    issues: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True, slots=True)
+class ResourceScriptTestReceipt:
+    receipt_id: str
+    script_digest: str
+    profile: str
+    passed: bool
+    results: list[ResourceScriptTestResult]
+    created_at: float = field(default_factory=time.time)
+
+
+@dataclass(frozen=True, slots=True)
+class SkillResourceBuildItem:
+    resource_id: str
+    spec_digest: str
+    kind: Literal["script", "reference", "asset"]
+    action: Literal["keep", "create", "update", "delete"]
+    path: str
+    purpose: str
+    source_ids: list[str]
+    used_by_steps: list[str]
+    depends_on: list[str]
+    acceptance_checks: list[str]
+    state: ResourceArtifactState
+    attempt: int = 1
+    repair_count: int = 0
+    chunks: list[str] = field(default_factory=list)
+    content: str | None = None
+    content_digest: str | None = None
+    base_content: str | None = None
+    base_digest: str | None = None
+    script_tests: list[ResourceScriptTest] = field(default_factory=list)
+    script_receipt: ResourceScriptTestReceipt | None = None
+    validation_issues: list[dict[str, Any]] = field(default_factory=list)
+    feedback: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class SkillResourceBuild:
+    build_id: str
+    session_id: str
+    revision: int
+    digest: str
+    state: ResourceBuildState
+    phase: ResourceBuildPhase
+    session_revision: int
+    plan_id: str
+    plan_revision: int
+    plan_digest: str
+    draft_id: str | None
+    draft_revision: int | None
+    draft_digest: str | None
+    skill_name: str
+    skill_description: str
+    workflow_steps: list[dict[str, str]]
+    output_contract: list[str]
+    failure_modes: list[str]
+    resources: list[SkillResourceBuildItem]
+    current_resource_id: str | None = None
+    skill_chunks: list[str] = field(default_factory=list)
+    skill_markdown: str | None = None
+    skill_markdown_digest: str | None = None
+    skill_attempt: int = 1
+    skill_repair_count: int = 0
+    skill_validation_issues: list[dict[str, Any]] = field(default_factory=list)
+    skill_feedback: str = ""
+    requirement_coverage: list[dict[str, Any]] = field(default_factory=list)
+    proposal_id: str | None = None
+    created_at: float = field(default_factory=time.time)
+    updated_at: float = field(default_factory=time.time)
+
+
+class SkillResourceBuildStore:
+    """Atomic current-state records for resumable Creator resource builds."""
+
+    SCHEMA_VERSION = 1
+    MAX_BUILDS = 300
+
+    def __init__(self, storage_dir: str | Path | None = None) -> None:
+        package_dir = Path(__file__).resolve().parent
+        runtime_dir = os.getenv("AGENT_TASK_STORAGE_DIR", "").strip()
+        self.storage_dir = Path(storage_dir or runtime_dir or package_dir / "storage")
+        self.snapshot_path = self.storage_dir / "skill_creator_resource_builds.json"
+        self._lock = threading.RLock()
+        self._builds: dict[str, SkillResourceBuild] = {}
+        self._session_index: dict[str, str] = {}
+        self._quarantine: list[dict[str, Any]] = []
+        self._load_error: str | None = None
+        self._load()
+
+    @property
+    def load_error(self) -> str | None:
+        return self._load_error
+
+    def current_for_session(self, session_id: str) -> SkillResourceBuild | None:
+        clean = self._required_text(session_id, "session_id", 200)
+        with self._lock:
+            self._ensure_readable_unlocked()
+            build_id = self._session_index.get(clean)
+            return copy.deepcopy(self._builds.get(build_id)) if build_id else None
+
+    def require(self, build_id: str) -> SkillResourceBuild:
+        clean = self._required_text(build_id, "build_id", 200)
+        with self._lock:
+            self._ensure_readable_unlocked()
+            item = self._builds.get(clean)
+            if item is None:
+                raise SkillCreatorNotFoundError(f"Resource build not found: {clean}")
+            return copy.deepcopy(item)
+
+    def create(
+        self,
+        *,
+        plan: SkillResourcePlan,
+        existing_files: Mapping[str, str] | None = None,
+        previous_build: SkillResourceBuild | None = None,
+    ) -> SkillResourceBuild:
+        if plan.state != "confirmed":
+            raise SkillCreatorValidationError(
+                "Only a confirmed resource plan can start a build.",
+                code="skill_creator_resource_plan_unconfirmed",
+            )
+        if len(plan.resources) > MAX_BUILD_RESOURCES:
+            raise SkillCreatorValidationError(
+                "Resource build contains too many planned resources.",
+                code="skill_creator_resource_build_limit",
+            )
+        with self._lock:
+            self._ensure_writable_unlocked()
+            current_id = self._session_index.get(plan.session_id)
+            current = self._builds.get(current_id) if current_id else None
+            if current is not None:
+                if (
+                    current.plan_id == plan.plan_id
+                    and current.plan_revision == plan.revision
+                    and current.plan_digest == plan.digest
+                ):
+                    return copy.deepcopy(current)
+                if current.state not in {"accepted", "stale", "failed"}:
+                    raise SkillCreatorConflictError(
+                        "This Creator session already has an active resource build."
+                    )
+        files = dict(existing_files or {})
+        reusable: dict[str, SkillResourceBuildItem] = {}
+        reusable_script_receipts: dict[str, SkillResourceBuildItem] = {}
+        if (
+            previous_build is not None
+            and previous_build.session_id == plan.session_id
+            and previous_build.state in {"accepted", "stale", "failed"}
+        ):
+            reusable_script_receipts = {
+                item.path: item
+                for item in previous_build.resources
+                if item.kind == "script"
+                and item.content is not None
+                and item.content_digest is not None
+                and item.script_receipt is not None
+                and item.script_receipt.passed
+                and item.script_receipt.script_digest == item.content_digest
+            }
+        if (
+            previous_build is not None
+            and previous_build.session_id == plan.session_id
+            and previous_build.session_revision == plan.session_revision
+            and previous_build.draft_id == plan.draft_id
+            and previous_build.draft_revision == plan.draft_revision
+            and previous_build.draft_digest == plan.draft_digest
+            and previous_build.state in {"accepted", "stale", "failed"}
+        ):
+            reusable = {
+                item.resource_id: item
+                for item in previous_build.resources
+                if item.state == "accepted" and item.content is not None
+            }
+        resources: list[SkillResourceBuildItem] = []
+        for planned in plan.resources:
+            base_content = files.get(planned.path)
+            if planned.action in {"keep", "update", "delete"} and base_content is None:
+                raise SkillCreatorConflictError(
+                    f"Planned existing resource is missing: {planned.path}"
+                )
+            if planned.action == "create" and base_content is not None:
+                raise SkillCreatorConflictError(
+                    f"Planned new resource already exists: {planned.path}"
+                )
+            if base_content is not None:
+                self._validate_resource_bytes(planned.path, base_content)
+            previous = reusable.get(planned.resource_id)
+            may_reuse = bool(
+                previous is not None
+                and previous.spec_digest == planned.spec_digest
+                and previous.kind == planned.kind
+                and previous.action == planned.action
+                and previous.path == planned.path
+            )
+            state: ResourceArtifactState = "accepted" if planned.action in {"keep", "delete"} or may_reuse else "planned"
+            active_content = (
+                previous.content
+                if may_reuse and previous is not None
+                else (base_content if planned.action == "keep" else None)
+            )
+            active_digest = self._sha256(active_content) if active_content is not None else None
+            reused_tests = list(previous.script_tests) if may_reuse and previous else []
+            reused_receipt = previous.script_receipt if may_reuse and previous else None
+            if planned.action == "keep" and planned.kind == "script":
+                receipt_source = reusable_script_receipts.get(planned.path)
+                if (
+                    receipt_source is not None
+                    and receipt_source.content_digest == active_digest
+                ):
+                    reused_tests = list(receipt_source.script_tests)
+                    reused_receipt = receipt_source.script_receipt
+                if (
+                    reused_receipt is None
+                    or not reused_receipt.passed
+                    or reused_receipt.script_digest != active_digest
+                ):
+                    raise SkillCreatorValidationError(
+                        "A kept script requires a reusable digest-bound test receipt; plan it as update to retest.",
+                        code="skill_creator_script_receipt_required",
+                    )
+            resources.append(
+                SkillResourceBuildItem(
+                    resource_id=planned.resource_id,
+                    spec_digest=planned.spec_digest,
+                    kind=planned.kind,
+                    action=planned.action,
+                    path=planned.path,
+                    purpose=planned.purpose,
+                    source_ids=list(planned.source_ids),
+                    used_by_steps=list(planned.used_by_steps),
+                    depends_on=list(planned.depends_on),
+                    acceptance_checks=list(planned.acceptance_checks),
+                    state=state,
+                    content=active_content,
+                    content_digest=active_digest,
+                    base_content=base_content,
+                    base_digest=(self._sha256(base_content) if base_content is not None else None),
+                    script_tests=reused_tests,
+                    script_receipt=reused_receipt,
+                )
+            )
+        self._ensure_package_budget(resources, skill_markdown=None)
+        with self._lock:
+            self._ensure_writable_unlocked()
+            current_id = self._session_index.get(plan.session_id)
+            current = self._builds.get(current_id) if current_id else None
+            if current is not None:
+                if (
+                    current.plan_id == plan.plan_id
+                    and current.plan_revision == plan.revision
+                    and current.plan_digest == plan.digest
+                ):
+                    return copy.deepcopy(current)
+                if current.state not in {"accepted", "stale", "failed"}:
+                    raise SkillCreatorConflictError(
+                        "This Creator session already has an active resource build."
+                    )
+            if len(self._builds) >= self.MAX_BUILDS:
+                raise SkillCreatorValidationError(
+                    "Skill Creator resource build limit reached.",
+                    code="skill_creator_resource_build_limit",
+                )
+            now = time.time()
+            build = self._build(
+                build_id=f"skillbuild_{uuid.uuid4().hex}",
+                session_id=plan.session_id,
+                revision=1,
+                state="planned",
+                phase="resources" if self._has_pending_resources(resources) else "skill_markdown",
+                session_revision=plan.session_revision,
+                plan_id=plan.plan_id,
+                plan_revision=plan.revision,
+                plan_digest=plan.digest,
+                draft_id=plan.draft_id,
+                draft_revision=plan.draft_revision,
+                draft_digest=plan.draft_digest,
+                skill_name=plan.skill_name,
+                skill_description=plan.skill_description,
+                workflow_steps=[asdict(item) for item in plan.workflow_steps],
+                output_contract=list(plan.output_contract),
+                failure_modes=list(plan.failure_modes),
+                resources=resources,
+                created_at=now,
+                updated_at=now,
+            )
+            return self._publish_unlocked(build)
+
+    def claim_next(
+        self, build_id: str, *, expected_revision: int, expected_digest: str
+    ) -> SkillResourceBuild:
+        with self._lock:
+            current = self._require_match_unlocked(
+                build_id, expected_revision=expected_revision, expected_digest=expected_digest
+            )
+            if current.state == "awaiting_review":
+                raise SkillCreatorConflictError(
+                    "The assembled resource must be reviewed before generation continues."
+                )
+            if current.state in {"accepted", "stale"}:
+                raise SkillCreatorConflictError("This resource build cannot continue.")
+            if current.state == "generating":
+                return copy.deepcopy(current)
+            values = asdict(current)
+            values["revision"] = current.revision + 1
+            values["updated_at"] = time.time()
+            if current.phase == "resources":
+                selected = self._next_resource(current.resources)
+                if selected is None:
+                    if self._has_pending_resources(current.resources):
+                        raise SkillCreatorConflictError(
+                            "Resource dependencies are not ready for generation."
+                        )
+                    values["phase"] = "skill_markdown"
+                    values["state"] = "generating"
+                    values["current_resource_id"] = None
+                else:
+                    values["state"] = "generating"
+                    values["current_resource_id"] = selected.resource_id
+                    for resource in values["resources"]:
+                        if resource["resource_id"] == selected.resource_id:
+                            resource["state"] = "generating"
+                            break
+            elif current.phase == "skill_markdown":
+                values["state"] = "generating"
+                values["current_resource_id"] = None
+            else:
+                raise SkillCreatorConflictError("The final package is already assembled.")
+            return self._publish_unlocked(self._decode(values, verify_digest=False))
+
+    def append_segment(
+        self,
+        build_id: str,
+        *,
+        expected_revision: int,
+        expected_digest: str,
+        target_id: str,
+        segment_index: int,
+        content: str,
+        complete: bool,
+        script_tests: list[Mapping[str, Any]] | None = None,
+    ) -> SkillResourceBuild:
+        segment = str(content or "")
+        if not segment:
+            raise SkillCreatorValidationError(
+                "Generated resource segment is empty.",
+                code="skill_creator_resource_segment_invalid",
+            )
+        if len(segment.encode("utf-8")) > MAX_SEGMENT_BYTES:
+            raise SkillCreatorValidationError(
+                "Generated resource segment exceeds 8 KiB.",
+                code="skill_creator_resource_segment_too_large",
+            )
+        with self._lock:
+            current = self._require_match_unlocked(
+                build_id, expected_revision=expected_revision, expected_digest=expected_digest
+            )
+            if current.state != "generating":
+                raise SkillCreatorConflictError("Resource build is not generating a segment.")
+            values = asdict(current)
+            if current.phase == "resources":
+                if target_id != current.current_resource_id:
+                    raise SkillCreatorConflictError("Generated segment target changed.")
+                resource = self._resource_dict(values, target_id)
+                chunks = list(resource["chunks"])
+                if int(segment_index) != len(chunks):
+                    raise SkillCreatorConflictError("Generated resource segments are out of order.")
+                self._reject_credentials(path=resource["path"], content=segment)
+                chunks.append(segment)
+                assembled = "".join(chunks)
+                self._validate_resource_bytes(resource["path"], assembled)
+                resource["chunks"] = chunks
+                if complete:
+                    resource["content"] = assembled
+                    resource["content_digest"] = self._sha256(assembled)
+                    resource["script_tests"] = [
+                        asdict(item) for item in self._normalize_script_tests(
+                            script_tests or [], required=resource["kind"] == "script"
+                        )
+                    ]
+                    resource["script_receipt"] = None
+                    resource["state"] = "awaiting_review"
+                    values["state"] = "awaiting_review"
+                else:
+                    values["state"] = "generating"
+            elif current.phase == "skill_markdown":
+                if target_id != "SKILL.md":
+                    raise SkillCreatorConflictError("Generated SKILL.md target changed.")
+                chunks = list(values["skill_chunks"])
+                if int(segment_index) != len(chunks):
+                    raise SkillCreatorConflictError("Generated SKILL.md segments are out of order.")
+                self._reject_credentials(path="SKILL.md", content=segment)
+                chunks.append(segment)
+                assembled = "".join(chunks)
+                if len(assembled.encode("utf-8")) > MAX_SKILL_MARKDOWN_BYTES:
+                    raise SkillCreatorValidationError(
+                        "Generated SKILL.md exceeds 20 KiB.",
+                        code="skill_creator_skill_markdown_too_large",
+                    )
+                values["skill_chunks"] = chunks
+                if complete:
+                    values["skill_markdown"] = assembled
+                    values["skill_markdown_digest"] = self._sha256(assembled)
+                    values["state"] = "awaiting_review"
+                else:
+                    values["state"] = "generating"
+            else:
+                raise SkillCreatorConflictError("The resource build is already finalized.")
+            values["revision"] = current.revision + 1
+            values["updated_at"] = time.time()
+            candidate = self._decode(values, verify_digest=False)
+            self._ensure_package_budget(candidate.resources, candidate.skill_markdown)
+            return self._publish_unlocked(candidate)
+
+    def record_validation(
+        self,
+        build_id: str,
+        *,
+        expected_revision: int,
+        expected_digest: str,
+        target_id: str,
+        issues: list[Mapping[str, Any]],
+        script_receipt: ResourceScriptTestReceipt | None = None,
+    ) -> SkillResourceBuild:
+        clean_issues = self._issues(issues)
+        with self._lock:
+            current = self._require_match_unlocked(
+                build_id, expected_revision=expected_revision, expected_digest=expected_digest
+            )
+            if current.state != "awaiting_review":
+                raise SkillCreatorConflictError("Generated content is not awaiting validation.")
+            values = asdict(current)
+            valid = not clean_issues and (
+                script_receipt is None or script_receipt.passed
+            )
+            if current.phase == "resources":
+                if target_id != current.current_resource_id:
+                    raise SkillCreatorConflictError("Resource validation target changed.")
+                resource = self._resource_dict(values, target_id)
+                resource["validation_issues"] = clean_issues
+                resource["script_receipt"] = (
+                    asdict(script_receipt) if script_receipt is not None else None
+                )
+                if valid:
+                    resource["state"] = "awaiting_review"
+                    values["state"] = "awaiting_review"
+                elif int(resource["repair_count"]) < 1:
+                    resource["repair_count"] = int(resource["repair_count"]) + 1
+                    resource["attempt"] = int(resource["attempt"]) + 1
+                    resource["chunks"] = []
+                    resource["content"] = None
+                    resource["content_digest"] = None
+                    resource["script_tests"] = []
+                    resource["script_receipt"] = None
+                    resource["state"] = "planned"
+                    values["state"] = "planned"
+                    values["current_resource_id"] = None
+                else:
+                    resource["state"] = "failed"
+                    values["state"] = "failed"
+            elif current.phase == "skill_markdown":
+                if target_id != "SKILL.md":
+                    raise SkillCreatorConflictError("SKILL.md validation target changed.")
+                values["skill_validation_issues"] = clean_issues
+                if valid:
+                    values["state"] = "awaiting_review"
+                elif int(values["skill_repair_count"]) < 1:
+                    values["skill_repair_count"] = int(values["skill_repair_count"]) + 1
+                    values["skill_attempt"] = int(values["skill_attempt"]) + 1
+                    values["skill_chunks"] = []
+                    values["skill_markdown"] = None
+                    values["skill_markdown_digest"] = None
+                    values["state"] = "planned"
+                else:
+                    values["state"] = "failed"
+            else:
+                raise SkillCreatorConflictError("The resource build is already finalized.")
+            values["revision"] = current.revision + 1
+            values["updated_at"] = time.time()
+            return self._publish_unlocked(self._decode(values, verify_digest=False))
+
+    def review_resource(
+        self,
+        build_id: str,
+        *,
+        resource_id: str,
+        expected_revision: int,
+        expected_digest: str,
+        decision: Literal["accept", "revise"],
+        feedback: str = "",
+    ) -> SkillResourceBuild:
+        if decision not in {"accept", "revise"}:
+            raise SkillCreatorValidationError("Invalid resource review decision.")
+        clean_feedback = str(feedback or "").strip()
+        if decision == "revise" and not clean_feedback:
+            raise SkillCreatorValidationError(
+                "Revision feedback is required.",
+                code="skill_creator_resource_feedback_required",
+            )
+        if clean_feedback:
+            self._reject_credentials(path="feedback", content=clean_feedback)
+        with self._lock:
+            current = self._require_match_unlocked(
+                build_id, expected_revision=expected_revision, expected_digest=expected_digest
+            )
+            if current.phase != "resources" or current.current_resource_id != resource_id:
+                raise SkillCreatorConflictError("Resource review target changed.")
+            values = asdict(current)
+            resource = self._resource_dict(values, resource_id)
+            if resource["state"] not in {"awaiting_review", "failed"}:
+                raise SkillCreatorConflictError("Resource is not ready for review.")
+            if decision == "accept":
+                if resource["validation_issues"]:
+                    raise SkillCreatorValidationError(
+                        "A resource with validation failures cannot be accepted."
+                    )
+                receipt = resource.get("script_receipt")
+                if resource["kind"] == "script" and (
+                    not isinstance(receipt, dict)
+                    or not receipt.get("passed")
+                    or receipt.get("script_digest") != resource.get("content_digest")
+                ):
+                    raise SkillCreatorValidationError(
+                        "A generated script requires a passing digest-bound test receipt.",
+                        code="skill_creator_script_receipt_required",
+                    )
+                resource["state"] = "accepted"
+                resource["feedback"] = ""
+                values["current_resource_id"] = None
+                if self._has_pending_resource_dicts(values["resources"]):
+                    values["state"] = "planned"
+                else:
+                    values["phase"] = "skill_markdown"
+                    values["state"] = "planned"
+            else:
+                resource["attempt"] = int(resource["attempt"]) + 1
+                resource["repair_count"] = 0
+                resource["chunks"] = []
+                resource["content"] = None
+                resource["content_digest"] = None
+                resource["script_tests"] = []
+                resource["script_receipt"] = None
+                resource["validation_issues"] = []
+                resource["feedback"] = clean_feedback[:4_000]
+                resource["state"] = "revision_requested"
+                values["current_resource_id"] = None
+                values["state"] = "revision_requested"
+            values["revision"] = current.revision + 1
+            values["updated_at"] = time.time()
+            return self._publish_unlocked(self._decode(values, verify_digest=False))
+
+    def review_skill_markdown(
+        self,
+        build_id: str,
+        *,
+        expected_revision: int,
+        expected_digest: str,
+        decision: Literal["accept", "revise"],
+        feedback: str = "",
+        requirement_coverage: list[Mapping[str, Any]] | None = None,
+    ) -> SkillResourceBuild:
+        if decision not in {"accept", "revise"}:
+            raise SkillCreatorValidationError("Invalid SKILL.md review decision.")
+        clean_feedback = str(feedback or "").strip()
+        if decision == "revise" and not clean_feedback:
+            raise SkillCreatorValidationError(
+                "SKILL.md revision feedback is required.",
+                code="skill_creator_resource_feedback_required",
+            )
+        if clean_feedback:
+            self._reject_credentials(path="feedback", content=clean_feedback)
+        with self._lock:
+            current = self._require_match_unlocked(
+                build_id, expected_revision=expected_revision, expected_digest=expected_digest
+            )
+            if current.phase != "skill_markdown" or current.state not in {
+                "awaiting_review", "failed"
+            }:
+                raise SkillCreatorConflictError("SKILL.md is not ready for review.")
+            values = asdict(current)
+            if decision == "accept":
+                if current.skill_validation_issues:
+                    raise SkillCreatorValidationError(
+                        "SKILL.md with validation failures cannot be accepted."
+                    )
+                values["state"] = "accepted"
+                values["phase"] = "proposal"
+                values["requirement_coverage"] = copy.deepcopy(
+                    list(requirement_coverage or current.requirement_coverage)
+                )
+                values["skill_feedback"] = ""
+            else:
+                values["skill_attempt"] = current.skill_attempt + 1
+                values["skill_repair_count"] = 0
+                values["skill_chunks"] = []
+                values["skill_markdown"] = None
+                values["skill_markdown_digest"] = None
+                values["skill_validation_issues"] = []
+                values["skill_feedback"] = clean_feedback[:4_000]
+                values["state"] = "revision_requested"
+            values["revision"] = current.revision + 1
+            values["updated_at"] = time.time()
+            return self._publish_unlocked(self._decode(values, verify_digest=False))
+
+    def record_proposal(
+        self,
+        build_id: str,
+        *,
+        expected_revision: int,
+        expected_digest: str,
+        proposal_id: str,
+    ) -> SkillResourceBuild:
+        with self._lock:
+            current = self._require_match_unlocked(
+                build_id, expected_revision=expected_revision, expected_digest=expected_digest
+            )
+            if current.phase != "proposal" or current.state != "accepted":
+                raise SkillCreatorConflictError("Final package has not been accepted.")
+            if current.proposal_id:
+                if current.proposal_id != proposal_id:
+                    raise SkillCreatorConflictError("Resource build already created another proposal.")
+                return copy.deepcopy(current)
+            values = asdict(current)
+            values["proposal_id"] = self._required_text(proposal_id, "proposal_id", 200)
+            values["revision"] = current.revision + 1
+            values["updated_at"] = time.time()
+            return self._publish_unlocked(self._decode(values, verify_digest=False))
+
+    def mark_stale(self, build_id: str) -> SkillResourceBuild:
+        with self._lock:
+            current = self._require_unlocked(build_id)
+            if current.state == "stale":
+                return copy.deepcopy(current)
+            values = asdict(current)
+            values["state"] = "stale"
+            values["revision"] = current.revision + 1
+            values["updated_at"] = time.time()
+            return self._publish_unlocked(self._decode(values, verify_digest=False))
+
+    def recover_interrupted(self) -> list[str]:
+        recovered: list[str] = []
+        with self._lock:
+            self._ensure_writable_unlocked()
+            previous = copy.deepcopy(self._builds)
+            for build_id, current in list(self._builds.items()):
+                if current.state != "generating":
+                    continue
+                values = asdict(current)
+                values["revision"] = current.revision + 1
+                values["state"] = "planned"
+                values["updated_at"] = time.time()
+                if current.phase == "resources" and current.current_resource_id:
+                    resource = self._resource_dict(values, current.current_resource_id)
+                    if resource["state"] == "generating":
+                        resource["state"] = "planned"
+                        resource["chunks"] = []
+                        resource["content"] = None
+                        resource["content_digest"] = None
+                        resource["script_tests"] = []
+                        resource["script_receipt"] = None
+                    values["current_resource_id"] = None
+                elif current.phase == "skill_markdown":
+                    values["skill_chunks"] = []
+                    values["skill_markdown"] = None
+                    values["skill_markdown_digest"] = None
+                self._builds[build_id] = self._decode(values, verify_digest=False)
+                recovered.append(build_id)
+            if recovered:
+                try:
+                    self._save_unlocked()
+                except BaseException:
+                    self._builds = previous
+                    raise
+        return recovered
+
+    @staticmethod
+    def serialize(item: SkillResourceBuild) -> dict[str, Any]:
+        return asdict(item)
+
+    @staticmethod
+    def active_files(item: SkillResourceBuild) -> dict[str, str]:
+        result: dict[str, str] = {}
+        for resource in item.resources:
+            if resource.action == "delete":
+                continue
+            if resource.state != "accepted" or resource.content is None:
+                raise SkillCreatorConflictError("Resource package is not fully accepted.")
+            result[resource.path] = resource.content
+        return result
+
+    @staticmethod
+    def _next_resource(resources: list[SkillResourceBuildItem]) -> SkillResourceBuildItem | None:
+        accepted = {item.resource_id for item in resources if item.state == "accepted"}
+        for item in resources:
+            if item.state in {"planned", "revision_requested"} and set(item.depends_on) <= accepted:
+                return item
+        return None
+
+    @staticmethod
+    def _has_pending_resources(resources: list[SkillResourceBuildItem]) -> bool:
+        return any(item.state != "accepted" for item in resources)
+
+    @staticmethod
+    def _has_pending_resource_dicts(resources: list[dict[str, Any]]) -> bool:
+        return any(item.get("state") != "accepted" for item in resources)
+
+    def _require_match_unlocked(
+        self, build_id: str, *, expected_revision: int, expected_digest: str
+    ) -> SkillResourceBuild:
+        self._ensure_writable_unlocked()
+        current = self._require_unlocked(build_id)
+        if (
+            current.revision != int(expected_revision)
+            or current.digest != self._digest(expected_digest, "expected_digest")
+        ):
+            raise SkillCreatorConflictError("Resource build changed. Reload it first.")
+        return current
+
+    def _require_unlocked(self, build_id: str) -> SkillResourceBuild:
+        clean = self._required_text(build_id, "build_id", 200)
+        current = self._builds.get(clean)
+        if current is None:
+            raise SkillCreatorNotFoundError(f"Resource build not found: {clean}")
+        return current
+
+    @staticmethod
+    def _resource_dict(values: dict[str, Any], resource_id: str) -> dict[str, Any]:
+        for resource in values["resources"]:
+            if resource["resource_id"] == resource_id:
+                return resource
+        raise SkillCreatorNotFoundError(f"Resource not found in build: {resource_id}")
+
+    def _publish_unlocked(self, item: SkillResourceBuild) -> SkillResourceBuild:
+        self._ensure_writable_unlocked()
+        previous = copy.deepcopy(self._builds)
+        previous_index = dict(self._session_index)
+        self._builds[item.build_id] = item
+        self._session_index[item.session_id] = item.build_id
+        try:
+            self._save_unlocked()
+        except BaseException:
+            self._builds = previous
+            self._session_index = previous_index
+            raise
+        return copy.deepcopy(item)
+
+    def _build(self, **values: Any) -> SkillResourceBuild:
+        item = SkillResourceBuild(digest="", **values)
+        payload = asdict(item)
+        payload.pop("digest", None)
+        digest = self._sha256(self._canonical_json(payload))
+        return replace(item, digest=digest)
+
+    def _decode(self, raw: Mapping[str, Any], *, verify_digest: bool = True) -> SkillResourceBuild:
+        values = copy.deepcopy(dict(raw))
+        resources: list[SkillResourceBuildItem] = []
+        for record in list(values.get("resources") or []):
+            tests = [
+                ResourceScriptTest(
+                    **{
+                        **test,
+                        "fixtures": [ResourceScriptFixture(**item) for item in test.get("fixtures", [])],
+                    }
+                )
+                for test in record.get("script_tests", [])
+            ]
+            receipt_raw = record.get("script_receipt")
+            receipt = None
+            if isinstance(receipt_raw, dict):
+                receipt = ResourceScriptTestReceipt(
+                    **{
+                        **receipt_raw,
+                        "results": [ResourceScriptTestResult(**item) for item in receipt_raw.get("results", [])],
+                    }
+                )
+            resources.append(
+                SkillResourceBuildItem(
+                    **{
+                        **record,
+                        "script_tests": tests,
+                        "script_receipt": receipt,
+                    }
+                )
+            )
+        supplied_digest = values.pop("digest", None)
+        values["resources"] = resources
+        item = self._build(**values)
+        if verify_digest and supplied_digest != item.digest:
+            raise ValueError("resource build digest mismatch")
+        self._validate_loaded(item)
+        return item
+
+    def _validate_loaded(self, item: SkillResourceBuild) -> None:
+        if item.state not in {
+            "planned", "generating", "awaiting_review", "accepted",
+            "revision_requested", "failed", "stale",
+        } or item.phase not in {"resources", "skill_markdown", "proposal"}:
+            raise ValueError("invalid resource build state")
+        if item.revision < 1 or len(item.resources) > MAX_BUILD_RESOURCES:
+            raise ValueError("invalid resource build revision")
+        self._digest(item.plan_digest, "plan_digest")
+        if item.draft_digest is not None:
+            self._digest(item.draft_digest, "draft_digest")
+        resource_ids = {resource.resource_id for resource in item.resources}
+        if len(resource_ids) != len(item.resources):
+            raise ValueError("duplicate resource build item id")
+        resource_paths: set[str] = set()
+        for resource in item.resources:
+            if resource.kind not in {"script", "reference", "asset"}:
+                raise ValueError("invalid resource kind")
+            if resource.action not in {"keep", "create", "update", "delete"}:
+                raise ValueError("invalid resource action")
+            if resource.state not in {
+                "planned", "generating", "awaiting_review", "accepted",
+                "revision_requested", "failed",
+            }:
+                raise ValueError("invalid resource state")
+            self._validate_resource_path(resource.kind, resource.path)
+            folded_path = resource.path.casefold()
+            if folded_path in resource_paths:
+                raise ValueError("duplicate resource build path")
+            resource_paths.add(folded_path)
+            if resource.resource_id in resource.depends_on or any(
+                dependency not in resource_ids for dependency in resource.depends_on
+            ):
+                raise ValueError("invalid resource dependency")
+            self._digest(resource.spec_digest, "spec_digest")
+            if resource.content is not None:
+                self._validate_resource_bytes(resource.path, resource.content)
+                if resource.content_digest != self._sha256(resource.content):
+                    raise ValueError("resource content digest mismatch")
+            elif resource.state == "accepted" and resource.action != "delete":
+                raise ValueError("accepted resource content is missing")
+            if resource.kind != "script" and (
+                resource.script_tests or resource.script_receipt is not None
+            ):
+                raise ValueError("non-script resource contains script test state")
+            normalized_tests = self._normalize_script_tests(
+                [asdict(test) for test in resource.script_tests],
+                required=resource.kind == "script" and resource.content is not None,
+            )
+            if normalized_tests != resource.script_tests:
+                raise ValueError("script tests are not canonical")
+            if resource.script_receipt is not None:
+                receipt = resource.script_receipt
+                expected_passed = bool(receipt.results) and all(
+                    result.passed for result in receipt.results
+                )
+                if (
+                    resource.kind != "script"
+                    or receipt.profile != SKILL_AUTHORING_PROFILE
+                    or receipt.script_digest != resource.content_digest
+                    or receipt.passed != expected_passed
+                    or {result.test_id for result in receipt.results}
+                    != {test.test_id for test in resource.script_tests}
+                ):
+                    raise ValueError("script receipt digest mismatch")
+        unresolved = {
+            resource.resource_id: set(resource.depends_on)
+            for resource in item.resources
+        }
+        while unresolved:
+            ready = {
+                resource_id
+                for resource_id, dependencies in unresolved.items()
+                if not (dependencies & unresolved.keys())
+            }
+            if not ready:
+                raise ValueError("resource dependency cycle")
+            for resource_id in ready:
+                unresolved.pop(resource_id)
+        if item.current_resource_id is not None and item.current_resource_id not in resource_ids:
+            raise ValueError("current resource id is missing")
+        if item.phase == "resources":
+            if item.state in {"generating", "awaiting_review", "failed"} and item.current_resource_id is None:
+                raise ValueError("active resource target is missing")
+            if item.state in {"planned", "revision_requested"} and item.current_resource_id is not None:
+                raise ValueError("inactive resource target is set")
+        else:
+            if item.current_resource_id is not None:
+                raise ValueError("non-resource phase has a resource target")
+            if any(resource.state != "accepted" for resource in item.resources):
+                raise ValueError("final phases require accepted resources")
+        if item.phase == "proposal" and (
+            item.state != "accepted" or item.skill_markdown is None
+        ):
+            raise ValueError("proposal phase is incomplete")
+        build_fixture_bytes = sum(
+            len(fixture.content.encode("utf-8"))
+            for resource in item.resources
+            for test in resource.script_tests
+            for fixture in test.fixtures
+        )
+        if build_fixture_bytes > MAX_BUILD_SCRIPT_FIXTURE_BYTES:
+            raise ValueError("resource build script fixtures exceed 160 KiB")
+        self._ensure_package_budget(item.resources, item.skill_markdown)
+        self._reject_credentials(
+            path="SKILL.md",
+            content=item.skill_markdown or "",
+            files={
+                resource.path: resource.content
+                for resource in item.resources
+                if resource.content is not None
+            },
+        )
+
+    def _normalize_script_tests(
+        self, value: list[Mapping[str, Any]], *, required: bool
+    ) -> list[ResourceScriptTest]:
+        if not isinstance(value, list) or len(value) > MAX_SCRIPT_TESTS:
+            raise SkillCreatorValidationError("A script may define at most three offline tests.")
+        if required and not value:
+            raise SkillCreatorValidationError(
+                "Generated scripts require one to three offline tests.",
+                code="skill_creator_script_tests_required",
+            )
+        result: list[ResourceScriptTest] = []
+        seen: set[str] = set()
+        fixture_bytes_total = 0
+        for index, raw in enumerate(value):
+            if not isinstance(raw, Mapping):
+                raise SkillCreatorValidationError("Invalid script test case.")
+            test_id = str(raw.get("test_id") or f"case_{index + 1}").strip()
+            if not _IDENTIFIER_RE.fullmatch(test_id) or test_id in seen:
+                raise SkillCreatorValidationError("Script test IDs must be unique identifiers.")
+            seen.add(test_id)
+            args = [str(item) for item in list(raw.get("args") or [])]
+            if len(args) > 16 or any(not item or len(item) > 500 or "\x00" in item or "\n" in item for item in args):
+                raise SkillCreatorValidationError("Script test arguments are invalid.")
+            for argument_index, argument in enumerate(args):
+                self._reject_credentials(
+                    path=f"script-tests/{test_id}/arg-{argument_index}.txt",
+                    content=argument,
+                )
+            fixtures: list[ResourceScriptFixture] = []
+            raw_fixtures = raw.get("fixtures") or []
+            if (
+                not isinstance(raw_fixtures, list)
+                or len(raw_fixtures) > MAX_SCRIPT_FIXTURES_PER_TEST
+            ):
+                raise SkillCreatorValidationError("Script test fixture count is invalid.")
+            fixture_paths: set[str] = set()
+            for fixture in raw_fixtures:
+                if not isinstance(fixture, Mapping):
+                    raise SkillCreatorValidationError("Invalid script test fixture.")
+                path = self._relative_path(fixture.get("path"), root="inputs")
+                if path.casefold() in fixture_paths:
+                    raise SkillCreatorValidationError("Script test fixture paths must be unique.")
+                fixture_paths.add(path.casefold())
+                raw_content = fixture.get("content")
+                if not isinstance(raw_content, str):
+                    raise SkillCreatorValidationError("Script test fixture content must be UTF-8 text.")
+                content = raw_content
+                content_bytes = len(content.encode("utf-8"))
+                fixture_bytes_total += content_bytes
+                if content_bytes > MAX_RESOURCE_BYTES:
+                    raise SkillCreatorValidationError("Script test fixture exceeds 24 KiB.")
+                if fixture_bytes_total > MAX_SCRIPT_FIXTURE_BYTES_TOTAL:
+                    raise SkillCreatorValidationError("Script test fixtures exceed 64 KiB in total.")
+                self._reject_credentials(path=path, content=content)
+                fixtures.append(ResourceScriptFixture(path=path, content=content))
+            expected_exit_code = int(raw.get("expected_exit_code", 0))
+            if not -255 <= expected_exit_code <= 255:
+                raise SkillCreatorValidationError("Script test exit code is invalid.")
+            stdout_contains = self._text_list(raw.get("stdout_contains") or [], 10, 500)
+            stderr_contains = self._text_list(raw.get("stderr_contains") or [], 10, 500)
+            for stream_name, expected_values in (
+                ("stdout", stdout_contains),
+                ("stderr", stderr_contains),
+            ):
+                for value_index, expected_value in enumerate(expected_values):
+                    self._reject_credentials(
+                        path=(
+                            f"script-tests/{test_id}/{stream_name}-{value_index}.txt"
+                        ),
+                        content=expected_value,
+                    )
+            result.append(
+                ResourceScriptTest(
+                    test_id=test_id,
+                    args=args,
+                    fixtures=fixtures,
+                    expected_exit_code=expected_exit_code,
+                    stdout_contains=stdout_contains,
+                    stderr_contains=stderr_contains,
+                )
+            )
+        return result
+
+    @staticmethod
+    def _issues(value: list[Mapping[str, Any]]) -> list[dict[str, Any]]:
+        result: list[dict[str, Any]] = []
+        for raw in list(value or [])[:20]:
+            if not isinstance(raw, Mapping):
+                continue
+            result.append(
+                {
+                    "code": str(raw.get("code") or "resource_validation")[:120],
+                    "message": str(raw.get("message") or "Resource validation failed.")[:500],
+                    "path": str(raw.get("path") or "")[:240] or None,
+                    "severity": "error",
+                }
+            )
+        return result
+
+    @staticmethod
+    def _validate_resource_bytes(path: str, content: str) -> None:
+        suffix = PurePosixPath(path).suffix.lower()
+        if suffix not in {".md", ".txt", ".json", ".yaml", ".yml", ".py", ".js", ".mjs", ".cjs", ".csv", ".tsv", ".html", ".css"}:
+            raise SkillCreatorValidationError("Resource must be a supported UTF-8 text file.")
+        if len(content.encode("utf-8")) > MAX_RESOURCE_BYTES:
+            raise SkillCreatorValidationError(
+                "Resource exceeds 24 KiB.", code="skill_creator_resource_too_large"
+            )
+
+    @staticmethod
+    def _validate_resource_path(kind: str, path: str) -> None:
+        root = {"script": "scripts", "reference": "references", "asset": "assets"}[kind]
+        normalized = SkillResourceBuildStore._relative_path(path, root=root)
+        if normalized != path or forbidden_resource_path(path):
+            raise SkillCreatorValidationError(
+                "Resource path does not match its planned type.",
+                code="skill_creator_resource_path_invalid",
+            )
+
+    @staticmethod
+    def _ensure_package_budget(
+        resources: list[SkillResourceBuildItem], skill_markdown: str | None
+    ) -> None:
+        total = len((skill_markdown or "").encode("utf-8"))
+        total += sum(
+            len((item.content or "").encode("utf-8"))
+            for item in resources
+            if item.action != "delete"
+        )
+        if total > MAX_PACKAGE_BYTES:
+            raise SkillCreatorValidationError(
+                "Generated Skill package exceeds 160 KiB.",
+                code="skill_creator_resource_package_too_large",
+            )
+
+    @staticmethod
+    def _reject_credentials(
+        *, path: str, content: str, files: Mapping[str, str] | None = None
+    ) -> None:
+        issues = scan_skill_package_credentials(
+            skill_markdown=content if path == "SKILL.md" else None,
+            files=dict(files or ({path: content} if content else {})),
+        )
+        if issues:
+            raise SkillCreatorValidationError(
+                "Generated resource contains blocked credential material.",
+                code="skill_credentials_blocked",
+            )
+
+    @staticmethod
+    def _relative_path(value: Any, *, root: str) -> str:
+        raw = str(value or "").strip().replace("\\", "/")
+        pure = PurePosixPath(raw)
+        if (
+            not raw or pure.is_absolute() or not pure.parts
+            or any(part in {"", ".", ".."} for part in pure.parts)
+        ):
+            raise SkillCreatorValidationError("Unsafe relative path.")
+        return f"{root}/{pure.as_posix()}" if pure.parts[0] != root else pure.as_posix()
+
+    @staticmethod
+    def _text_list(value: Any, maximum: int, item_maximum: int) -> list[str]:
+        if not isinstance(value, list) or len(value) > maximum:
+            raise SkillCreatorValidationError("Invalid text list.")
+        result = [str(item or "").strip() for item in value]
+        if any(not item or len(item) > item_maximum for item in result):
+            raise SkillCreatorValidationError("Invalid text list item.")
+        return result
+
+    @staticmethod
+    def _required_text(value: Any, field_name: str, maximum: int) -> str:
+        clean = str(value or "").strip()
+        if not clean or len(clean) > maximum:
+            raise SkillCreatorValidationError(f"Invalid {field_name}.")
+        return clean
+
+    @staticmethod
+    def _digest(value: Any, field_name: str) -> str:
+        clean = str(value or "").strip().lower()
+        if not _DIGEST_RE.fullmatch(clean):
+            raise SkillCreatorValidationError(f"Invalid {field_name}.")
+        return clean
+
+    @staticmethod
+    def _sha256(value: str) -> str:
+        return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def _canonical_json(value: Any) -> str:
+        return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+    @staticmethod
+    def _jsonable(value: Any) -> Any:
+        if hasattr(value, "__dataclass_fields__"):
+            return asdict(value)
+        if isinstance(value, Mapping):
+            return {str(key): SkillResourceBuildStore._jsonable(item) for key, item in value.items()}
+        if isinstance(value, list):
+            return [SkillResourceBuildStore._jsonable(item) for item in value]
+        return value
+
+    def _load(self) -> None:
+        if not self.snapshot_path.exists():
+            return
+        try:
+            raw = json.loads(self.snapshot_path.read_text(encoding="utf-8"))
+            if (
+                not isinstance(raw, dict)
+                or raw.get("version") != self.SCHEMA_VERSION
+                or not isinstance(raw.get("items"), list)
+                or not isinstance(raw.get("quarantine", []), list)
+            ):
+                raise ValueError("invalid resource build snapshot")
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            self._load_error = f"skill_resource_build_store_corrupt: {str(exc)[:300]}"
+            return
+        self._quarantine = [
+            dict(item) for item in raw.get("quarantine", []) if isinstance(item, dict)
+        ][:500]
+        for index, record in enumerate(raw["items"]):
+            try:
+                item = self._decode(record)
+                if item.build_id in self._builds or item.session_id in self._session_index:
+                    raise ValueError("duplicate resource build mapping")
+                self._builds[item.build_id] = item
+                self._session_index[item.session_id] = item.build_id
+            except Exception as exc:
+                self._quarantine.append(self._quarantine_record(record, index, exc))
+        if len(self._quarantine) != len(raw.get("quarantine", [])):
+            try:
+                self._save_unlocked()
+            except OSError as exc:
+                self._load_error = f"skill_resource_build_store_rewrite_failed: {str(exc)[:300]}"
+
+    def _save_unlocked(self) -> None:
+        self.storage_dir.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "version": self.SCHEMA_VERSION,
+            "items": [asdict(item) for item in sorted(self._builds.values(), key=lambda value: value.created_at)],
+            "quarantine": self._quarantine[-500:],
+        }
+        temporary = self.snapshot_path.with_suffix(".tmp")
+        with temporary.open("w", encoding="utf-8", newline="\n") as handle:
+            json.dump(payload, handle, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, self.snapshot_path)
+
+    def _ensure_readable_unlocked(self) -> None:
+        if self._load_error:
+            raise SkillCreatorStorageError(self._load_error)
+
+    def _ensure_writable_unlocked(self) -> None:
+        self._ensure_readable_unlocked()
+
+    @staticmethod
+    def _quarantine_record(record: Any, index: int, exc: Exception) -> dict[str, Any]:
+        try:
+            encoded = json.dumps(record, ensure_ascii=False, sort_keys=True).encode("utf-8")
+        except Exception:
+            encoded = repr(type(record)).encode("utf-8")
+        return {
+            "index": index,
+            "record_sha256": hashlib.sha256(encoded).hexdigest(),
+            "size_bytes": len(encoded),
+            "reason": type(exc).__name__,
+        }
+
+
+def forbidden_resource_path(path: str) -> bool:
+    pure = PurePosixPath(str(path or "").replace("\\", "/"))
+    lowered = pure.as_posix().casefold()
+    return bool(
+        pure.name.casefold() in _FORBIDDEN_PACKAGE_NAMES
+        or lowered.startswith("eval/")
+        or lowered.startswith("evals/")
+        or "user-meta" in lowered
+    )
+
+
+__all__ = [
+    "MAX_BUILD_RESOURCES",
+    "MAX_PACKAGE_BYTES",
+    "MAX_RESOURCE_BYTES",
+    "MAX_SEGMENT_BYTES",
+    "MAX_SKILL_MARKDOWN_BYTES",
+    "RESOURCE_BUILD_VERSION",
+    "ResourceScriptFixture",
+    "ResourceScriptTest",
+    "ResourceScriptTestReceipt",
+    "ResourceScriptTestResult",
+    "SkillResourceBuild",
+    "SkillResourceBuildItem",
+    "SkillResourceBuildStore",
+    "forbidden_resource_path",
+]

--- a/server/skills/creator_resource_build.py
+++ b/server/skills/creator_resource_build.py
@@ -572,6 +572,83 @@ class SkillResourceBuildStore:
             values["updated_at"] = time.time()
             return self._publish_unlocked(self._decode(values, verify_digest=False))
 
+    def record_generation_error(
+        self,
+        build_id: str,
+        *,
+        expected_revision: int,
+        expected_digest: str,
+        target_id: str,
+        code: str,
+        message: str,
+    ) -> SkillResourceBuild:
+        """Persist a model-contract failure and consume the one internal repair."""
+
+        with self._lock:
+            current = self._require_match_unlocked(
+                build_id,
+                expected_revision=expected_revision,
+                expected_digest=expected_digest,
+            )
+            if current.state != "generating":
+                raise SkillCreatorConflictError("Resource build is not generating content.")
+            values = asdict(current)
+            issue_path = "SKILL.md"
+            if current.phase == "resources":
+                issue_path = self._resource_dict(values, target_id)["path"]
+            issue = self._issues(
+                [
+                    {
+                        "code": str(
+                            code or "skill_creator_resource_builder_invalid"
+                        )[:120],
+                        "message": str(
+                            message
+                            or "Generated resource did not satisfy the frozen contract."
+                        )[:500],
+                        "path": issue_path,
+                        "severity": "error",
+                    }
+                ]
+            )
+            if current.phase == "resources":
+                if target_id != current.current_resource_id:
+                    raise SkillCreatorConflictError("Generated resource target changed.")
+                resource = self._resource_dict(values, target_id)
+                resource["validation_issues"] = issue
+                if int(resource["repair_count"]) < 1:
+                    resource["repair_count"] = int(resource["repair_count"]) + 1
+                    resource["attempt"] = int(resource["attempt"]) + 1
+                    resource["chunks"] = []
+                    resource["content"] = None
+                    resource["content_digest"] = None
+                    resource["script_tests"] = []
+                    resource["script_receipt"] = None
+                    resource["state"] = "planned"
+                    values["state"] = "planned"
+                    values["current_resource_id"] = None
+                else:
+                    resource["state"] = "failed"
+                    values["state"] = "failed"
+            elif current.phase == "skill_markdown":
+                if target_id != "SKILL.md":
+                    raise SkillCreatorConflictError("Generated SKILL.md target changed.")
+                values["skill_validation_issues"] = issue
+                if int(values["skill_repair_count"]) < 1:
+                    values["skill_repair_count"] = int(values["skill_repair_count"]) + 1
+                    values["skill_attempt"] = int(values["skill_attempt"]) + 1
+                    values["skill_chunks"] = []
+                    values["skill_markdown"] = None
+                    values["skill_markdown_digest"] = None
+                    values["state"] = "planned"
+                else:
+                    values["state"] = "failed"
+            else:
+                raise SkillCreatorConflictError("The resource build is already finalized.")
+            values["revision"] = current.revision + 1
+            values["updated_at"] = time.time()
+            return self._publish_unlocked(self._decode(values, verify_digest=False))
+
     def review_resource(
         self,
         build_id: str,
@@ -1017,7 +1094,13 @@ class SkillResourceBuildStore:
             if not _IDENTIFIER_RE.fullmatch(test_id) or test_id in seen:
                 raise SkillCreatorValidationError("Script test IDs must be unique identifiers.")
             seen.add(test_id)
-            args = [str(item) for item in list(raw.get("args") or [])]
+            raw_args = raw.get("args", [])
+            if not isinstance(raw_args, list):
+                raise SkillCreatorValidationError(
+                    "Script test args must be a JSON array of strings.",
+                    code="skill_creator_script_test_contract_invalid",
+                )
+            args = [str(item) for item in raw_args]
             if len(args) > 16 or any(not item or len(item) > 500 or "\x00" in item or "\n" in item for item in args):
                 raise SkillCreatorValidationError("Script test arguments are invalid.")
             for argument_index, argument in enumerate(args):
@@ -1026,12 +1109,15 @@ class SkillResourceBuildStore:
                     content=argument,
                 )
             fixtures: list[ResourceScriptFixture] = []
-            raw_fixtures = raw.get("fixtures") or []
+            raw_fixtures = raw.get("fixtures", [])
             if (
                 not isinstance(raw_fixtures, list)
                 or len(raw_fixtures) > MAX_SCRIPT_FIXTURES_PER_TEST
             ):
-                raise SkillCreatorValidationError("Script test fixture count is invalid.")
+                raise SkillCreatorValidationError(
+                    "Script test fixtures must be a JSON array with at most eight objects.",
+                    code="skill_creator_script_test_contract_invalid",
+                )
             fixture_paths: set[str] = set()
             for fixture in raw_fixtures:
                 if not isinstance(fixture, Mapping):
@@ -1052,11 +1138,29 @@ class SkillResourceBuildStore:
                     raise SkillCreatorValidationError("Script test fixtures exceed 64 KiB in total.")
                 self._reject_credentials(path=path, content=content)
                 fixtures.append(ResourceScriptFixture(path=path, content=content))
-            expected_exit_code = int(raw.get("expected_exit_code", 0))
+            try:
+                expected_exit_code = int(raw.get("expected_exit_code", 0))
+            except (TypeError, ValueError, OverflowError) as exc:
+                raise SkillCreatorValidationError(
+                    "Script test expected_exit_code must be an integer.",
+                    code="skill_creator_script_test_contract_invalid",
+                ) from exc
             if not -255 <= expected_exit_code <= 255:
                 raise SkillCreatorValidationError("Script test exit code is invalid.")
-            stdout_contains = self._text_list(raw.get("stdout_contains") or [], 10, 500)
-            stderr_contains = self._text_list(raw.get("stderr_contains") or [], 10, 500)
+            raw_stdout_contains = raw.get("stdout_contains", [])
+            raw_stderr_contains = raw.get("stderr_contains", [])
+            if not isinstance(raw_stdout_contains, list):
+                raise SkillCreatorValidationError(
+                    "Script test stdout_contains must be a JSON array of strings.",
+                    code="skill_creator_script_test_contract_invalid",
+                )
+            if not isinstance(raw_stderr_contains, list):
+                raise SkillCreatorValidationError(
+                    "Script test stderr_contains must be a JSON array of strings.",
+                    code="skill_creator_script_test_contract_invalid",
+                )
+            stdout_contains = self._text_list(raw_stdout_contains, 10, 500)
+            stderr_contains = self._text_list(raw_stderr_contains, 10, 500)
             for stream_name, expected_values in (
                 ("stdout", stdout_contains),
                 ("stderr", stderr_contains),

--- a/server/skills/creator_resource_build.py
+++ b/server/skills/creator_resource_build.py
@@ -760,13 +760,24 @@ class SkillResourceBuildStore:
                 )
                 values["skill_feedback"] = ""
             else:
+                prior_feedback = current.skill_feedback.strip()
+                cumulative_feedback = (
+                    f"{prior_feedback}\n\nAdditional revision requirements:\n{clean_feedback}"
+                    if prior_feedback and clean_feedback not in prior_feedback
+                    else (prior_feedback or clean_feedback)
+                )
+                if len(cumulative_feedback) > 12_000:
+                    raise SkillCreatorValidationError(
+                        "Cumulative SKILL.md revision feedback is too large.",
+                        code="skill_creator_resource_feedback_too_large",
+                    )
                 values["skill_attempt"] = current.skill_attempt + 1
                 values["skill_repair_count"] = 0
                 values["skill_chunks"] = []
                 values["skill_markdown"] = None
                 values["skill_markdown_digest"] = None
                 values["skill_validation_issues"] = []
-                values["skill_feedback"] = clean_feedback[:4_000]
+                values["skill_feedback"] = cumulative_feedback
                 values["state"] = "revision_requested"
             values["revision"] = current.revision + 1
             values["updated_at"] = time.time()
@@ -842,6 +853,43 @@ class SkillResourceBuildStore:
                     self._builds = previous
                     raise
         return recovered
+
+    def requeue_interrupted(
+        self,
+        build_id: str,
+        *,
+        expected_revision: int,
+        expected_digest: str,
+    ) -> SkillResourceBuild:
+        """Release one transiently failed generation claim without consuming repair budget."""
+
+        with self._lock:
+            current = self._require_match_unlocked(
+                build_id,
+                expected_revision=expected_revision,
+                expected_digest=expected_digest,
+            )
+            if current.state != "generating":
+                return copy.deepcopy(current)
+            values = asdict(current)
+            values["revision"] = current.revision + 1
+            values["state"] = "planned"
+            values["updated_at"] = time.time()
+            if current.phase == "resources" and current.current_resource_id:
+                resource = self._resource_dict(values, current.current_resource_id)
+                if resource["state"] == "generating":
+                    resource["state"] = "planned"
+                    resource["chunks"] = []
+                    resource["content"] = None
+                    resource["content_digest"] = None
+                    resource["script_tests"] = []
+                    resource["script_receipt"] = None
+                values["current_resource_id"] = None
+            elif current.phase == "skill_markdown":
+                values["skill_chunks"] = []
+                values["skill_markdown"] = None
+                values["skill_markdown_digest"] = None
+            return self._publish_unlocked(self._decode(values, verify_digest=False))
 
     @staticmethod
     def serialize(item: SkillResourceBuild) -> dict[str, Any]:
@@ -1052,7 +1100,7 @@ class SkillResourceBuildStore:
             if any(resource.state != "accepted" for resource in item.resources):
                 raise ValueError("final phases require accepted resources")
         if item.phase == "proposal" and (
-            item.state != "accepted" or item.skill_markdown is None
+            item.state not in {"accepted", "stale"} or item.skill_markdown is None
         ):
             raise ValueError("proposal phase is incomplete")
         build_fixture_bytes = sum(

--- a/server/skills/creator_resource_build_runtime.py
+++ b/server/skills/creator_resource_build_runtime.py
@@ -1,0 +1,506 @@
+from __future__ import annotations
+
+import ast
+import hashlib
+import json
+import re
+import uuid
+from dataclasses import asdict, dataclass
+from pathlib import PurePosixPath
+from typing import Any, Awaitable, Callable
+
+from .creator_resource_build import (
+    MAX_SEGMENT_BYTES,
+    RESOURCE_BUILD_VERSION,
+    ResourceScriptTestReceipt,
+    ResourceScriptTestResult,
+    SkillResourceBuild,
+    SkillResourceBuildItem,
+)
+from .creator_runtime import CREATOR_WORKFLOW_VERSION
+from .creator_store import CREATOR_ASSISTANT_AGENT_ID, SkillCreatorValidationError
+from .package_validation import validate_skill_package
+
+try:
+    from server.xpert_runtime.sandbox_client import (
+        SandboxClientError,
+        SandboxClientProtocol,
+    )
+except ModuleNotFoundError:
+    from xpert_runtime.sandbox_client import SandboxClientError, SandboxClientProtocol
+
+
+RESOURCE_BUILDER_WORKFLOW_VERSION = "skill-creator-resource-builder-v1"
+SKILL_AUTHORING_PROFILE = "skill_authoring_v1"
+SCRIPT_TEST_TIMEOUT_SECONDS = 10
+_LONG_REFERENCE_LINES = 100
+_SCRIPT_SUFFIXES = {".py": "python", ".js": "node", ".mjs": "node", ".cjs": "node"}
+_FORBIDDEN_PATH_PARTS = {"eval", "evals"}
+
+
+@dataclass(frozen=True, slots=True)
+class ResourceBuildWorkflowInvocation:
+    workflow: dict[str, Any]
+    inputs: dict[str, str]
+    runtime_metadata: dict[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class ResourceBuildGenerationRequest:
+    build: SkillResourceBuild
+    target_id: str
+    segment_index: int
+
+
+@dataclass(frozen=True, slots=True)
+class ResourceBuildSegment:
+    target_id: str
+    segment_index: int
+    content: str
+    complete: bool
+    script_tests: list[dict[str, Any]]
+
+
+ResourceBuilderWorkflowRunner = Callable[[ResourceBuildWorkflowInvocation], Awaitable[str]]
+
+
+class WorkflowCreatorResourceBuilder:
+    """Generate exactly one server-selected resource segment per invocation."""
+
+    def __init__(
+        self,
+        *,
+        model_id: str,
+        model_available: Callable[[], bool],
+        runner: ResourceBuilderWorkflowRunner,
+    ) -> None:
+        self.model_id = str(model_id or "").strip()
+        self.model_available = model_available
+        self.runner = runner
+
+    def available(self) -> bool:
+        return bool(self.model_id and self.model_available())
+
+    async def generate(self, request: ResourceBuildGenerationRequest) -> ResourceBuildSegment:
+        invocation = build_resource_builder_invocation(request, model_id=self.model_id)
+        output = await self.runner(invocation)
+        return parse_resource_build_segment(
+            output,
+            expected_target_id=request.target_id,
+            expected_segment_index=request.segment_index,
+        )
+
+
+def build_resource_builder_invocation(
+    request: ResourceBuildGenerationRequest,
+    *,
+    model_id: str,
+) -> ResourceBuildWorkflowInvocation:
+    build = request.build
+    target = _target(build, request.target_id)
+    dependency_ids = set(target.get("depends_on") or [])
+    accepted_resources = {
+        item.path: item.content
+        for item in build.resources
+        if item.state == "accepted"
+        and item.action != "delete"
+        and item.content is not None
+        and (request.target_id == "SKILL.md" or item.resource_id in dependency_ids)
+    }
+    context = {
+        "resource_build_version": RESOURCE_BUILD_VERSION,
+        "build_id": build.build_id,
+        "target": target,
+        "segment_index": request.segment_index,
+        "existing_segments": (
+            list(target.get("chunks") or []) if request.target_id != "SKILL.md" else list(build.skill_chunks)
+        ),
+        "skill": {
+            "name": build.skill_name,
+            "description": build.skill_description,
+            "workflow_steps": build.workflow_steps,
+            "output_contract": build.output_contract,
+            "failure_modes": build.failure_modes,
+        },
+        "accepted_resource_index": [
+            {"path": path, "sha256": _sha256(content), "size_bytes": len(content.encode("utf-8"))}
+            for path, content in sorted(accepted_resources.items())
+        ],
+        "accepted_resource_content": accepted_resources,
+        "generation_limits": {
+            "segment_bytes_max": MAX_SEGMENT_BYTES,
+            "resource_bytes_max": 24 * 1024,
+            "skill_markdown_bytes_max": 20 * 1024,
+            "script_test_count": [1, 3],
+            "script_languages": ["python", "javascript"],
+            "assets_utf8_text_only": True,
+        },
+    }
+    context_text = json.dumps(context, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    if len(context_text.encode("utf-8")) > 240_000:
+        raise SkillCreatorValidationError(
+            "Creator resource build context is too large.",
+            code="skill_creator_context_too_large",
+        )
+    workflow = {
+        "id": f"skill-resource-build-{build.build_id}",
+        "title": "Skill Creator resource build",
+        "nodes": [
+            {"id": "builder-input", "type": "input", "data": {"kind": "input", "variableName": "creator_request"}},
+            {
+                "id": "builder-agent",
+                "type": "workflow_agent",
+                "data": {
+                    "kind": "workflow_agent",
+                    "agentName": CREATOR_ASSISTANT_AGENT_ID,
+                    "modelId": str(model_id or "").strip(),
+                    "agentStrategy": "function_calling",
+                    "rolePrompt": _builder_prompt(request.target_id, target),
+                    "taskInput": "{{creator_request}}",
+                    "outputVariable": "resource_segment",
+                    "toolMode": "none",
+                    "toolNames": "",
+                    "maxIterations": "1",
+                    "maxToolCalls": "1",
+                    "maxToolConcurrency": "1",
+                    "parallelToolCalls": "false",
+                    "retryOnFailure": "false",
+                    "temperature": "0.1",
+                },
+            },
+            {"id": "builder-output", "type": "output", "data": {"kind": "output", "outputVariable": "resource_segment"}},
+        ],
+        "edges": [
+            {"id": "builder-input-agent", "source": "builder-input", "target": "builder-agent"},
+            {"id": "builder-agent-output", "source": "builder-agent", "target": "builder-output"},
+        ],
+    }
+    return ResourceBuildWorkflowInvocation(
+        workflow=workflow,
+        inputs={"creator_request": context_text},
+        runtime_metadata={
+            "creator_session_id": build.session_id,
+            "assistant_agent_id": CREATOR_ASSISTANT_AGENT_ID,
+            "creator_workflow_version": CREATOR_WORKFLOW_VERSION,
+            "creator_phase": "resource_build",
+            "resource_builder_workflow_version": RESOURCE_BUILDER_WORKFLOW_VERSION,
+            "resource_build_id": build.build_id,
+            "resource_target_id": request.target_id,
+        },
+    )
+
+
+def parse_resource_build_segment(
+    value: Any,
+    *,
+    expected_target_id: str,
+    expected_segment_index: int,
+) -> ResourceBuildSegment:
+    if not isinstance(value, str):
+        raise SkillCreatorValidationError("Resource builder returned non-text output.", code="skill_creator_resource_builder_invalid")
+    text = value.strip()
+    if text.startswith("```"):
+        lines = text.splitlines()
+        if len(lines) >= 3 and lines[-1].strip() == "```":
+            text = "\n".join(lines[1:-1]).strip()
+            if text.startswith("json\n"):
+                text = text[5:].strip()
+    try:
+        payload = json.loads(text)
+    except (ValueError, json.JSONDecodeError) as exc:
+        raise SkillCreatorValidationError("Resource builder did not return valid JSON.", code="skill_creator_resource_builder_invalid") from exc
+    if not isinstance(payload, dict) or payload.get("resource_build_version") != RESOURCE_BUILD_VERSION:
+        raise SkillCreatorValidationError("Resource builder contract is invalid.", code="skill_creator_resource_builder_invalid")
+    if payload.get("target_id") != expected_target_id or payload.get("segment_index") != expected_segment_index:
+        raise SkillCreatorValidationError("Resource builder changed the frozen target.", code="skill_creator_resource_builder_target_changed")
+    content = payload.get("content")
+    if not isinstance(content, str) or not content or len(content.encode("utf-8")) > MAX_SEGMENT_BYTES:
+        raise SkillCreatorValidationError("Resource builder segment is empty or exceeds 8 KiB.", code="skill_creator_resource_segment_invalid")
+    tests = payload.get("script_tests") or []
+    if not isinstance(tests, list):
+        raise SkillCreatorValidationError("Resource builder returned invalid script tests.", code="skill_creator_resource_builder_invalid")
+    return ResourceBuildSegment(
+        target_id=expected_target_id,
+        segment_index=expected_segment_index,
+        content=content,
+        complete=bool(payload.get("complete")),
+        script_tests=[dict(item) for item in tests if isinstance(item, dict)],
+    )
+
+
+def validate_resource_content(item: SkillResourceBuildItem) -> list[dict[str, Any]]:
+    content = item.content or ""
+    issues: list[dict[str, Any]] = []
+    if item.kind == "reference" and len(content.splitlines()) > _LONG_REFERENCE_LINES:
+        head = "\n".join(content.splitlines()[:40]).lower()
+        if not re.search(r"(?m)^#{1,3}\s+(table of contents|contents|目录|目次)\s*$", head):
+            issues.append(_issue("skill_creator_reference_toc_missing", "References longer than 100 lines require a table of contents.", item.path))
+    if item.kind == "script":
+        suffix = PurePosixPath(item.path).suffix.lower()
+        if suffix not in _SCRIPT_SUFFIXES:
+            issues.append(_issue("skill_creator_script_language_unsupported", "Generated scripts must be Python or JavaScript.", item.path))
+        if not re.search(r"(?i)(usage|argparse|process\.argv|sys\.argv)", content):
+            issues.append(_issue("skill_creator_script_cli_missing", "Generated scripts require an explicit command-line interface.", item.path))
+        if not re.search(r"(?i)(sys\.exit|process\.exit|raise\s+SystemExit|returncode|exit code|catch\s*\(|except\s+)", content):
+            issues.append(_issue("skill_creator_script_failure_missing", "Generated scripts require conservative non-zero failure behavior.", item.path))
+        if suffix == ".py":
+            try:
+                ast.parse(content)
+            except (SyntaxError, ValueError, RecursionError):
+                issues.append(_issue("python_syntax_invalid", "Generated Python script has invalid syntax.", item.path))
+    if item.kind == "asset" and not re.search(r"(?i)(template|placeholder|copy|render|replace|模板|占位|复制|渲染|替换)", content):
+        issues.append(_issue("skill_creator_asset_contract_missing", "Text assets must be usable templates or boilerplate.", item.path))
+    probe = validate_skill_package(
+        root_name="resource-probe",
+        skill_markdown=(
+            "---\nname: resource-probe\n"
+            "description: Validate one generated resource. Use when the Creator checks a file; do not use elsewhere.\n"
+            "---\n\n# Resource probe\n\nRead `" + item.path + "`.\n"
+        ),
+        files={item.path: content},
+    )
+    issues.extend(
+        issue.to_dict()
+        for issue in probe.issues
+        if issue.path == item.path
+    )
+    return issues
+
+
+def validate_final_resource_package(build: SkillResourceBuild) -> list[dict[str, Any]]:
+    if not build.skill_markdown:
+        return [_issue("skill_creator_skill_markdown_missing", "SKILL.md is missing.", "SKILL.md")]
+    files = {}
+    issues: list[dict[str, Any]] = []
+    for item in build.resources:
+        path = PurePosixPath(item.path)
+        if path.name.lower() == "readme.md" or any(part.lower() in _FORBIDDEN_PATH_PARTS for part in path.parts) or path.name.lower() in {"_user_meta.json", "user-meta.json"}:
+            issues.append(_issue("skill_creator_resource_path_forbidden", "README, eval data, and user metadata do not belong in a Skill package.", item.path))
+        if item.action == "delete":
+            continue
+        if item.state != "accepted" or item.content is None:
+            issues.append(_issue("skill_creator_resource_unaccepted", "Every active resource must be accepted before SKILL.md.", item.path))
+            continue
+        files[item.path] = item.content
+        if item.path not in build.skill_markdown:
+            issues.append(_issue("skill_creator_resource_unreferenced", "Every resource must be referenced directly from SKILL.md.", item.path))
+        else:
+            nearby_mentions = [
+                build.skill_markdown[max(0, match.start() - 180): match.end() + 180]
+                for match in re.finditer(re.escape(item.path), build.skill_markdown)
+            ]
+            if item.kind == "asset" and not any(
+                re.search(r"(?i)(copy|render|template|复制|渲染|模板)", nearby)
+                for nearby in nearby_mentions
+            ):
+                issues.append(_issue("skill_creator_asset_usage_missing", "SKILL.md must explain when an asset is copied or rendered.", item.path))
+            if item.kind == "script" and not any(
+                re.search(r"(?i)(run|execute|python|node|运行|执行)", nearby)
+                for nearby in nearby_mentions
+            ):
+                issues.append(_issue("skill_creator_script_usage_missing", "SKILL.md must explain when a script is executed.", item.path))
+        if item.kind == "script" and (
+            item.script_receipt is None
+            or not item.script_receipt.passed
+            or item.script_receipt.script_digest != item.content_digest
+        ):
+            issues.append(_issue("skill_creator_script_receipt_missing", "Every script requires a passing digest-bound offline test receipt.", item.path))
+        issues.extend(validate_resource_content(item))
+        if item.kind == "reference":
+            linked_references = {
+                match
+                for match in re.findall(r"references/[A-Za-z0-9._/-]+", item.content or "")
+                if match.rstrip("`.,):]") != item.path
+            }
+            if linked_references:
+                issues.append(_issue("skill_creator_reference_chain_forbidden", "References must be directly reachable from SKILL.md rather than through nested reference chains.", item.path))
+            skill_paragraphs = _substantive_paragraphs(build.skill_markdown)
+            copied = skill_paragraphs & _substantive_paragraphs(item.content or "")
+            if copied:
+                issues.append(_issue("skill_creator_reference_duplicate_body", "References must not duplicate large SKILL.md passages.", item.path))
+    references = [item for item in build.resources if item.kind == "reference" and item.action != "delete"]
+    if (len(references) >= 2 or any(len((item.content or "").splitlines()) > _LONG_REFERENCE_LINES for item in references)) and not re.search(r"(?i)(\brg\b|sandbox_search_files)", build.skill_markdown):
+        issues.append(_issue("skill_creator_reference_search_missing", "Multiple or long references require a bounded rg or sandbox_search_files example in SKILL.md.", "SKILL.md"))
+    validation = validate_skill_package(
+        root_name=build.skill_name,
+        skill_markdown=build.skill_markdown,
+        files=files,
+    )
+    issues.extend(issue.to_dict() for issue in validation.issues)
+    return issues[:40]
+
+
+class SandboxCreatorScriptRunner:
+    """Run planned script fixtures in the profile-bound offline Sidecar."""
+
+    def __init__(self, client: SandboxClientProtocol) -> None:
+        self.client = client
+
+    async def health(self) -> dict[str, Any]:
+        try:
+            response = await self.client.health(required_profile=SKILL_AUTHORING_PROFILE)
+        except SandboxClientError as exc:
+            raise SkillCreatorValidationError(
+                "Skill authoring Sandbox sidecar is unavailable.",
+                code="skill_creator_sandbox_unavailable",
+            ) from exc
+        profile = dict(response.get("profiles", {}).get(SKILL_AUTHORING_PROFILE) or {})
+        if profile.get("network_policy") != "container_network_none_required" or profile.get("read_only_roots") != ["inputs", "skills"] or profile.get("writable_roots") != ["work", ".tmp"]:
+            raise SkillCreatorValidationError("Sandbox authoring profile attestation failed.", code="skill_creator_sandbox_profile_invalid")
+        return response
+
+    async def run(self, item: SkillResourceBuildItem) -> ResourceScriptTestReceipt:
+        if item.kind != "script" or item.content is None or item.content_digest is None:
+            raise SkillCreatorValidationError("Script content is not ready for testing.", code="skill_creator_script_not_ready")
+        command = _SCRIPT_SUFFIXES.get(PurePosixPath(item.path).suffix.lower())
+        if command is None:
+            raise SkillCreatorValidationError("Unsupported script language.", code="skill_creator_script_language_unsupported")
+        await self.health()
+        results: list[ResourceScriptTestResult] = []
+        for test in item.script_tests:
+            workspace_id = f"skill-authoring-{uuid.uuid4().hex}"
+            created = await self.client.request({"action": "ensure_workspace", "workspace_id": workspace_id, "profile": SKILL_AUTHORING_PROFILE})
+            capability = str(created.get("provisioning_capability") or "")
+            auth = {"workspace_id": workspace_id, "profile": SKILL_AUTHORING_PROFILE, "provisioning_capability": capability}
+            try:
+                script_name = PurePosixPath(item.path).name
+                script_path = f"skills/authoring-resource/{script_name}"
+                await self.client.request({**auth, "action": "seed_file", "path": script_path, "content": item.content, "operation_id": "seed-script"})
+                for index, fixture in enumerate(test.fixtures):
+                    await self.client.request({**auth, "action": "seed_file", "path": fixture.path, "content": fixture.content, "operation_id": f"seed-fixture-{index}"})
+                await self.client.request({**auth, "action": "seal_workspace"})
+                response = await self.client.request({
+                    **auth,
+                    "action": "shell",
+                    "argv": [command, f"../{script_path}", *test.args],
+                    "timeout_seconds": SCRIPT_TEST_TIMEOUT_SECONDS,
+                    "operation_id": "run-script",
+                })
+                stdout = str(response.get("stdout") or "")
+                stderr = str(response.get("stderr") or "")
+                exit_code = int(response.get("exit_code") or 0)
+                test_issues = []
+                if exit_code != test.expected_exit_code:
+                    test_issues.append("unexpected_exit_code")
+                if any(expected not in stdout for expected in test.stdout_contains):
+                    test_issues.append("stdout_assertion_failed")
+                if any(expected not in stderr for expected in test.stderr_contains):
+                    test_issues.append("stderr_assertion_failed")
+                results.append(ResourceScriptTestResult(
+                    test_id=test.test_id,
+                    passed=not test_issues,
+                    exit_code=exit_code,
+                    stdout_sha256=_sha256(stdout),
+                    stderr_sha256=_sha256(stderr),
+                    duration_ms=float(response.get("duration_ms") or 0),
+                    issues=test_issues,
+                ))
+            except SandboxClientError as exc:
+                results.append(ResourceScriptTestResult(
+                    test_id=test.test_id,
+                    passed=False,
+                    exit_code=-1,
+                    stdout_sha256=_sha256(""),
+                    stderr_sha256=_sha256(""),
+                    duration_ms=0,
+                    issues=[str(exc.code)[:120]],
+                ))
+            finally:
+                try:
+                    await self.client.request({**auth, "action": "cleanup_workspace"})
+                except Exception:
+                    pass
+        return ResourceScriptTestReceipt(
+            receipt_id=f"script_receipt_{uuid.uuid4().hex}",
+            script_digest=item.content_digest,
+            profile=SKILL_AUTHORING_PROFILE,
+            passed=bool(results) and all(result.passed for result in results),
+            results=results,
+        )
+
+
+def _target(build: SkillResourceBuild, target_id: str) -> dict[str, Any]:
+    if target_id == "SKILL.md":
+        return {
+            "target_id": "SKILL.md",
+            "kind": "skill_markdown",
+            "path": "SKILL.md",
+            "feedback": build.skill_feedback,
+            "validation_issues": build.skill_validation_issues,
+        }
+    for item in build.resources:
+        if item.resource_id == target_id:
+            return asdict(item)
+    raise SkillCreatorValidationError("Resource build target was not found.", code="skill_creator_resource_not_found")
+
+
+def _builder_prompt(target_id: str, target: dict[str, Any]) -> str:
+    kind = str(target.get("kind") or "")
+    common = (
+        "You are ModelMirror's fixed private Skill Creator resource builder. The server has "
+        "already frozen the target, path, dependencies, segment index, and limits. Generate "
+        "only that target. Do not invent domain facts: use accepted sources, state assumptions, "
+        "or implement a conservative fail-closed behavior. Continue existing_segments without "
+        "repeating them. One JSON result only. Each segment is at most 8 KiB. Set complete=false "
+        "when more content is necessary."
+    )
+    if target_id == "SKILL.md":
+        specifics = (
+            " Write SKILL.md last with strict frontmatter name and description, then canonical "
+            "sections: Purpose and scope, Inputs and preconditions, Workflow with at least four "
+            "numbered executable steps, Output contract, Failure and degradation, Quality checks, "
+            "and Resources. Reference every accepted resource by exact path. For multiple or long "
+            "references include a bounded rg or sandbox_search_files command. Explain when scripts "
+            "run and when assets are copied or rendered. Do not add README/eval/evals/user-meta."
+        )
+    elif kind == "reference":
+        specifics = " Write focused factual guidance, not a copy of SKILL.md. If the final file exceeds 100 lines, include a concise table of contents near the top."
+    elif kind == "script":
+        specifics = (
+            " Write a deterministic Python or JavaScript CLI with explicit arguments, stable "
+            "UTF-8 output, conservative validation, and non-zero failure exit. On the final "
+            "segment include one to three offline script_tests in the required JSON field. "
+            "Fixture paths are rooted under inputs/; arguments run from work/, so refer to a "
+            "fixture as ../inputs/<path>."
+        )
+    else:
+        specifics = " Write a reusable UTF-8 template or boilerplate. Make placeholders and copy/render instructions explicit; do not use the asset as a knowledge reference."
+    schema = (
+        f' Return exactly {{"resource_build_version":"{RESOURCE_BUILD_VERSION}",'
+        f'"target_id":{json.dumps(target_id)},"segment_index":<current integer>,'
+        '"content":"segment text","complete":true|false,"script_tests":[]}. '
+        "Only a completed script may populate script_tests with test_id, args, fixtures, "
+        "expected_exit_code, stdout_contains, and stderr_contains."
+    )
+    return common + specifics + schema
+
+
+def _issue(code: str, message: str, path: str) -> dict[str, Any]:
+    return {"code": code, "message": message, "path": path, "severity": "error"}
+
+
+def _substantive_paragraphs(value: str) -> set[str]:
+    return {
+        re.sub(r"\s+", " ", paragraph).strip().lower()
+        for paragraph in re.split(r"\n\s*\n", value)
+        if len(re.sub(r"\s+", " ", paragraph).strip()) >= 200
+    }
+
+
+def _sha256(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+__all__ = [
+    "RESOURCE_BUILDER_WORKFLOW_VERSION",
+    "SKILL_AUTHORING_PROFILE",
+    "ResourceBuildGenerationRequest",
+    "ResourceBuildSegment",
+    "ResourceBuildWorkflowInvocation",
+    "SandboxCreatorScriptRunner",
+    "WorkflowCreatorResourceBuilder",
+    "build_resource_builder_invocation",
+    "parse_resource_build_segment",
+    "validate_final_resource_package",
+    "validate_resource_content",
+]

--- a/server/skills/creator_resource_build_runtime.py
+++ b/server/skills/creator_resource_build_runtime.py
@@ -10,7 +10,9 @@ from pathlib import PurePosixPath
 from typing import Any, Awaitable, Callable
 
 from .creator_resource_build import (
+    MAX_RESOURCE_BYTES,
     MAX_SEGMENT_BYTES,
+    MAX_SKILL_MARKDOWN_BYTES,
     RESOURCE_BUILD_VERSION,
     ResourceScriptTestReceipt,
     ResourceScriptTestResult,
@@ -200,14 +202,8 @@ def parse_resource_build_segment(
     if not isinstance(value, str):
         raise SkillCreatorValidationError("Resource builder returned non-text output.", code="skill_creator_resource_builder_invalid")
     text = value.strip()
-    if text.startswith("```"):
-        lines = text.splitlines()
-        if len(lines) >= 3 and lines[-1].strip() == "```":
-            text = "\n".join(lines[1:-1]).strip()
-            if text.startswith("json\n"):
-                text = text[5:].strip()
     try:
-        payload = json.loads(text)
+        payload = _decode_resource_build_json(text)
     except (ValueError, json.JSONDecodeError) as exc:
         raise SkillCreatorValidationError("Resource builder did not return valid JSON.", code="skill_creator_resource_builder_invalid") from exc
     if not isinstance(payload, dict) or payload.get("resource_build_version") != RESOURCE_BUILD_VERSION:
@@ -215,8 +211,16 @@ def parse_resource_build_segment(
     if payload.get("target_id") != expected_target_id or payload.get("segment_index") != expected_segment_index:
         raise SkillCreatorValidationError("Resource builder changed the frozen target.", code="skill_creator_resource_builder_target_changed")
     content = payload.get("content")
-    if not isinstance(content, str) or not content or len(content.encode("utf-8")) > MAX_SEGMENT_BYTES:
-        raise SkillCreatorValidationError("Resource builder segment is empty or exceeds 8 KiB.", code="skill_creator_resource_segment_invalid")
+    target_budget = (
+        MAX_SKILL_MARKDOWN_BYTES
+        if expected_target_id == "SKILL.md"
+        else MAX_RESOURCE_BYTES
+    )
+    if not isinstance(content, str) or not content or len(content.encode("utf-8")) > target_budget:
+        raise SkillCreatorValidationError(
+            "Resource builder output is empty or exceeds the frozen target budget.",
+            code="skill_creator_resource_segment_invalid",
+        )
     tests = payload.get("script_tests") or []
     if not isinstance(tests, list):
         raise SkillCreatorValidationError("Resource builder returned invalid script tests.", code="skill_creator_resource_builder_invalid")
@@ -227,6 +231,42 @@ def parse_resource_build_segment(
         complete=bool(payload.get("complete")),
         script_tests=[dict(item) for item in tests if isinstance(item, dict)],
     )
+
+
+def _decode_resource_build_json(text: str) -> Any:
+    """Decode one versioned segment without repairing or guessing model output."""
+
+    if not text:
+        raise ValueError("empty resource builder output")
+    try:
+        return json.loads(text)
+    except (ValueError, json.JSONDecodeError):
+        pass
+
+    decoder = json.JSONDecoder()
+    candidates: dict[str, dict[str, Any]] = {}
+    for index, char in enumerate(text):
+        if char != "{":
+            continue
+        try:
+            candidate, _end = decoder.raw_decode(text[index:])
+        except (ValueError, json.JSONDecodeError):
+            continue
+        if not isinstance(candidate, dict):
+            continue
+        if candidate.get("resource_build_version") != RESOURCE_BUILD_VERSION:
+            continue
+        fingerprint = json.dumps(
+            candidate,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        candidates[fingerprint] = candidate
+
+    if len(candidates) != 1:
+        raise ValueError("resource builder output must contain one versioned JSON object")
+    return next(iter(candidates.values()))
 
 
 def validate_resource_content(item: SkillResourceBuildItem) -> list[dict[str, Any]]:
@@ -240,6 +280,22 @@ def validate_resource_content(item: SkillResourceBuildItem) -> list[dict[str, An
         suffix = PurePosixPath(item.path).suffix.lower()
         if suffix not in _SCRIPT_SUFFIXES:
             issues.append(_issue("skill_creator_script_language_unsupported", "Generated scripts must be Python or JavaScript.", item.path))
+        duplicate_entrypoint = len(re.findall(r"(?m)^#!", content)) > 1
+        if suffix == ".py":
+            duplicate_entrypoint = duplicate_entrypoint or len(
+                re.findall(
+                    r"(?m)^\s*if\s+__name__\s*==\s*['\"]__main__['\"]\s*:",
+                    content,
+                )
+            ) > 1
+        if duplicate_entrypoint:
+            issues.append(
+                _issue(
+                    "skill_creator_script_duplicate_entrypoint",
+                    "Generated scripts must contain exactly one complete program, not concatenated revisions.",
+                    item.path,
+                )
+            )
         if not re.search(r"(?i)(usage|argparse|process\.argv|sys\.argv)", content):
             issues.append(_issue("skill_creator_script_cli_missing", "Generated scripts require an explicit command-line interface.", item.path))
         if not re.search(r"(?i)(sys\.exit|process\.exit|raise\s+SystemExit|returncode|exit code|catch\s*\(|except\s+)", content):
@@ -328,6 +384,19 @@ def validate_final_resource_package(build: SkillResourceBuild) -> list[dict[str,
         files=files,
     )
     issues.extend(issue.to_dict() for issue in validation.issues)
+    if validation.valid and validation.package is not None:
+        if validation.package.name != build.skill_name:
+            issues.append(_issue(
+                "skill_package_name_mismatch",
+                "SKILL.md frontmatter name must exactly match the confirmed resource plan.",
+                "SKILL.md",
+            ))
+        if validation.package.description != build.skill_description:
+            issues.append(_issue(
+                "skill_package_description_mismatch",
+                "SKILL.md frontmatter description must exactly match the confirmed resource plan.",
+                "SKILL.md",
+            ))
     return issues[:40]
 
 
@@ -448,7 +517,9 @@ def _builder_prompt(target_id: str, target: dict[str, Any]) -> str:
     )
     if target_id == "SKILL.md":
         specifics = (
-            " Write SKILL.md last with strict frontmatter name and description, then canonical "
+            " Write SKILL.md last with strict frontmatter, then copy skill.name and "
+            "skill.description from the frozen input context verbatim into "
+            "frontmatter; never paraphrase, fold, or otherwise rewrite either value. Then write "
             "sections: Purpose and scope, Inputs and preconditions, Workflow with at least four "
             "numbered executable steps, Output contract, Failure and degradation, Quality checks, "
             "and Resources. Reference every accepted resource by exact path. For multiple or long "
@@ -461,7 +532,12 @@ def _builder_prompt(target_id: str, target: dict[str, Any]) -> str:
         specifics = (
             " Write a deterministic Python or JavaScript CLI with explicit arguments, stable "
             "UTF-8 output, conservative validation, and non-zero failure exit. On the final "
+            "response return exactly one complete program: never append a prior draft, repeat "
+            "a shebang, or repeat a main entry point. "
             "segment include one to three offline script_tests in the required JSON field. "
+            "The Sidecar does not pipe fixture content to stdin: a script may support stdin, "
+            "but every generated offline test must pass its fixture through an explicit UTF-8 "
+            "file-path argument that the script actually reads. "
             "Each test uses fixtures as a JSON array of at most eight objects shaped exactly "
             "{\"path\":\"case.txt\",\"content\":\"UTF-8 text\"}. Fixture paths are rooted "
             "under inputs/; arguments run from work/, so refer to a fixture as "
@@ -478,7 +554,10 @@ def _builder_prompt(target_id: str, target: dict[str, Any]) -> str:
         '"fixtures":[{"path":"case.txt","content":"UTF-8 text"}],'
         '"expected_exit_code":0,"stdout_contains":["expected text"],'
         '"stderr_contains":[]}. args, fixtures, stdout_contains, and stderr_contains are always '
-        "JSON arrays, including when empty."
+        "JSON arrays, including when empty. A completed script defines one to three tests; "
+        "each test has at most 16 non-empty args, at most eight fixtures, and at most ten "
+        "non-empty strings in each stdout_contains or stderr_contains array. Keep assertions "
+        "minimal and observable instead of listing every output line."
     )
     return common + specifics + schema
 

--- a/server/skills/creator_resource_build_runtime.py
+++ b/server/skills/creator_resource_build_runtime.py
@@ -132,6 +132,7 @@ def build_resource_builder_invocation(
             "resource_bytes_max": 24 * 1024,
             "skill_markdown_bytes_max": 20 * 1024,
             "script_test_count": [1, 3],
+            "script_fixture_count_per_test_max": 8,
             "script_languages": ["python", "javascript"],
             "assets_utf8_text_only": True,
         },
@@ -442,7 +443,8 @@ def _builder_prompt(target_id: str, target: dict[str, Any]) -> str:
         "only that target. Do not invent domain facts: use accepted sources, state assumptions, "
         "or implement a conservative fail-closed behavior. Continue existing_segments without "
         "repeating them. One JSON result only. Each segment is at most 8 KiB. Set complete=false "
-        "when more content is necessary."
+        "when more content is necessary. Honor target feedback. If validation_issues are present, "
+        "correct each issue instead of repeating the rejected result."
     )
     if target_id == "SKILL.md":
         specifics = (
@@ -460,8 +462,10 @@ def _builder_prompt(target_id: str, target: dict[str, Any]) -> str:
             " Write a deterministic Python or JavaScript CLI with explicit arguments, stable "
             "UTF-8 output, conservative validation, and non-zero failure exit. On the final "
             "segment include one to three offline script_tests in the required JSON field. "
-            "Fixture paths are rooted under inputs/; arguments run from work/, so refer to a "
-            "fixture as ../inputs/<path>."
+            "Each test uses fixtures as a JSON array of at most eight objects shaped exactly "
+            "{\"path\":\"case.txt\",\"content\":\"UTF-8 text\"}. Fixture paths are rooted "
+            "under inputs/; arguments run from work/, so refer to a fixture as "
+            "../inputs/<path>."
         )
     else:
         specifics = " Write a reusable UTF-8 template or boilerplate. Make placeholders and copy/render instructions explicit; do not use the asset as a knowledge reference."
@@ -469,8 +473,12 @@ def _builder_prompt(target_id: str, target: dict[str, Any]) -> str:
         f' Return exactly {{"resource_build_version":"{RESOURCE_BUILD_VERSION}",'
         f'"target_id":{json.dumps(target_id)},"segment_index":<current integer>,'
         '"content":"segment text","complete":true|false,"script_tests":[]}. '
-        "Only a completed script may populate script_tests with test_id, args, fixtures, "
-        "expected_exit_code, stdout_contains, and stderr_contains."
+        "Only a completed script may populate script_tests. Every test must use this exact "
+        'shape: {"test_id":"case_1","args":["../inputs/case.txt"],'
+        '"fixtures":[{"path":"case.txt","content":"UTF-8 text"}],'
+        '"expected_exit_code":0,"stdout_contains":["expected text"],'
+        '"stderr_contains":[]}. args, fixtures, stdout_contains, and stderr_contains are always '
+        "JSON arrays, including when empty."
     )
     return common + specifics + schema
 

--- a/server/skills/creator_resource_build_service.py
+++ b/server/skills/creator_resource_build_service.py
@@ -13,6 +13,7 @@ from .creator_quality import (
     evaluate_creator_payload,
 )
 from .creator_resource_build import (
+    MAX_SEGMENT_BYTES,
     SkillResourceBuild,
     SkillResourceBuildStore,
 )
@@ -135,10 +136,20 @@ class SkillCreatorResourceBuildService:
             self._require_plan(plan, session=session, draft=draft, expected_revision=expected_plan_revision, expected_digest=expected_plan_digest)
             if plan.state != "confirmed":
                 raise SkillCreatorConflictError("Confirm the resource plan before starting generation.")
+            previous_build = self.build_store.current_for_session(session_id)
+            if previous_build is not None and (
+                previous_build.plan_id != plan.plan_id
+                or previous_build.plan_revision != plan.revision
+                or previous_build.plan_digest != plan.digest
+            ):
+                # A newly confirmed immutable plan supersedes every in-flight
+                # artifact from the prior plan. Preserve the old build for
+                # audit/reuse, but never let it block the replacement build.
+                previous_build = self.build_store.mark_stale(previous_build.build_id)
             return self.build_store.create(
                 plan=plan,
                 existing_files=(draft.files if draft else {}),
-                previous_build=self.build_store.current_for_session(session_id),
+                previous_build=previous_build,
             )
 
     async def next(
@@ -195,23 +206,45 @@ class SkillCreatorResourceBuildService:
                             segment_index=segment_index,
                         )
                     )
+                except asyncio.CancelledError:
+                    # Client disconnects and task cancellation must not strand
+                    # the immutable target in a permanent generating state.
+                    self.build_store.requeue_interrupted(
+                        current.build_id,
+                        expected_revision=current.revision,
+                        expected_digest=current.digest,
+                    )
+                    raise
                 except (SkillCreatorConflictError, SkillCreatorValidationError):
                     raise
                 except Exception as exc:
+                    self.build_store.requeue_interrupted(
+                        current.build_id,
+                        expected_revision=current.revision,
+                        expected_digest=current.digest,
+                    )
                     raise SkillCreatorValidationError(
                         "The Skill Creator resource builder failed.",
                         code="skill_creator_resource_builder_failed",
                     ) from exc
-                current = self.build_store.append_segment(
-                    current.build_id,
-                    expected_revision=current.revision,
-                    expected_digest=current.digest,
-                    target_id=segment.target_id,
-                    segment_index=segment.segment_index,
-                    content=segment.content,
-                    complete=segment.complete,
-                    script_tests=segment.script_tests,
-                )
+                parts = self._split_utf8_segments(segment.content)
+                if segment.segment_index + len(parts) > 3:
+                    raise SkillCreatorValidationError(
+                        "The generated target exceeded the three-segment limit.",
+                        code="skill_creator_resource_segment_limit",
+                    )
+                for part_offset, part in enumerate(parts):
+                    final_part = part_offset == len(parts) - 1
+                    current = self.build_store.append_segment(
+                        current.build_id,
+                        expected_revision=current.revision,
+                        expected_digest=current.digest,
+                        target_id=segment.target_id,
+                        segment_index=segment.segment_index + part_offset,
+                        content=part,
+                        complete=segment.complete and final_part,
+                        script_tests=(segment.script_tests if final_part else []),
+                    )
                 if segment.complete:
                     return await self._validate_current(current)
             raise SkillCreatorValidationError(
@@ -499,6 +532,25 @@ class SkillCreatorResourceBuildService:
             if item.resource_id == target_id:
                 return target_id, len(item.chunks)
         raise SkillCreatorConflictError("Resource build has no active target.")
+
+    @staticmethod
+    def _split_utf8_segments(content: str) -> list[str]:
+        """Mechanically split one complete model response without changing its bytes."""
+
+        parts: list[str] = []
+        current: list[str] = []
+        current_bytes = 0
+        for character in content:
+            character_bytes = len(character.encode("utf-8"))
+            if current and current_bytes + character_bytes > MAX_SEGMENT_BYTES:
+                parts.append("".join(current))
+                current = []
+                current_bytes = 0
+            current.append(character)
+            current_bytes += character_bytes
+        if current:
+            parts.append("".join(current))
+        return parts
 
     @staticmethod
     def _is_stale(build: SkillResourceBuild, *, session: SkillCreatorSession, draft: WorkspaceSkillDraft | None) -> bool:

--- a/server/skills/creator_resource_build_service.py
+++ b/server/skills/creator_resource_build_service.py
@@ -162,18 +162,48 @@ class SkillCreatorResourceBuildService:
                 raise SkillCreatorValidationError("Resource builder status is unavailable.", code="skill_creator_resource_builder_failed") from exc
             if not available or builder is None:
                 raise SkillCreatorValidationError("The Skill Creator model gateway is not configured.", code="model_gateway_unconfigured")
-            current = self.build_store.claim_next(build_id, expected_revision=expected_revision, expected_digest=expected_digest)
-            # One API action assembles the complete target. Segmentation remains internal.
+            current = self.build_store.claim_next(
+                build_id,
+                expected_revision=expected_revision,
+                expected_digest=expected_digest,
+            )
+            validated = await self._generate_and_validate(current, builder=builder)
+            # Static/test failures get exactly one server-controlled regeneration.
+            if validated.state in {"planned", "revision_requested"}:
+                repaired = self.build_store.claim_next(
+                    build_id,
+                    expected_revision=validated.revision,
+                    expected_digest=validated.digest,
+                )
+                validated = await self._generate_and_validate(repaired, builder=builder)
+            return validated
+
+    async def _generate_and_validate(
+        self, current: SkillResourceBuild, *, builder: ResourceBuilderExecutor
+    ) -> SkillResourceBuild:
+        """Assemble one frozen target and turn contract errors into one repair."""
+
+        target_id, _ = self._segment_target(current)
+        try:
             for _ in range(3):
                 target_id, segment_index = self._segment_target(current)
                 try:
-                    segment = await builder.generate(ResourceBuildGenerationRequest(build=current, target_id=target_id, segment_index=segment_index))
+                    segment = await builder.generate(
+                        ResourceBuildGenerationRequest(
+                            build=current,
+                            target_id=target_id,
+                            segment_index=segment_index,
+                        )
+                    )
                 except (SkillCreatorConflictError, SkillCreatorValidationError):
                     raise
                 except Exception as exc:
-                    raise SkillCreatorValidationError("The Skill Creator resource builder failed.", code="skill_creator_resource_builder_failed") from exc
+                    raise SkillCreatorValidationError(
+                        "The Skill Creator resource builder failed.",
+                        code="skill_creator_resource_builder_failed",
+                    ) from exc
                 current = self.build_store.append_segment(
-                    build_id,
+                    current.build_id,
                     expected_revision=current.revision,
                     expected_digest=current.digest,
                     target_id=segment.target_id,
@@ -183,36 +213,27 @@ class SkillCreatorResourceBuildService:
                     script_tests=segment.script_tests,
                 )
                 if segment.complete:
-                    break
-            else:
-                raise SkillCreatorValidationError("The generated target exceeded the three-segment limit.", code="skill_creator_resource_segment_limit")
-            validated = await self._validate_current(current)
-            # Static/test failures get exactly one server-controlled regeneration.
-            if validated.state in {"planned", "revision_requested"}:
-                repaired = self.build_store.claim_next(
-                    build_id,
-                    expected_revision=validated.revision,
-                    expected_digest=validated.digest,
-                )
-                for _ in range(3):
-                    target_id, segment_index = self._segment_target(repaired)
-                    segment = await builder.generate(ResourceBuildGenerationRequest(build=repaired, target_id=target_id, segment_index=segment_index))
-                    repaired = self.build_store.append_segment(
-                        build_id,
-                        expected_revision=repaired.revision,
-                        expected_digest=repaired.digest,
-                        target_id=segment.target_id,
-                        segment_index=segment.segment_index,
-                        content=segment.content,
-                        complete=segment.complete,
-                        script_tests=segment.script_tests,
-                    )
-                    if segment.complete:
-                        break
-                else:
-                    raise SkillCreatorValidationError("The repaired target exceeded the three-segment limit.", code="skill_creator_resource_segment_limit")
-                validated = await self._validate_current(repaired)
-            return validated
+                    return await self._validate_current(current)
+            raise SkillCreatorValidationError(
+                "The generated target exceeded the three-segment limit.",
+                code="skill_creator_resource_segment_limit",
+            )
+        except SkillCreatorValidationError as exc:
+            if exc.code in {
+                "model_gateway_unconfigured",
+                "skill_creator_resource_builder_failed",
+                "skill_creator_sandbox_unavailable",
+                "skill_creator_sandbox_profile_invalid",
+            }:
+                raise
+            return self.build_store.record_generation_error(
+                current.build_id,
+                expected_revision=current.revision,
+                expected_digest=current.digest,
+                target_id=target_id,
+                code=exc.code,
+                message=str(exc),
+            )
 
     def review_resource(
         self,

--- a/server/skills/creator_resource_build_service.py
+++ b/server/skills/creator_resource_build_service.py
@@ -1,0 +1,534 @@
+from __future__ import annotations
+
+import asyncio
+import copy
+import os
+import threading
+from dataclasses import asdict
+from typing import Any, Protocol
+
+from .creator_quality import (
+    CREATOR_CONTRACT_VERSION,
+    build_session_requirements,
+    evaluate_creator_payload,
+)
+from .creator_resource_build import (
+    SkillResourceBuild,
+    SkillResourceBuildStore,
+)
+from .creator_resource_build_runtime import (
+    ResourceBuildGenerationRequest,
+    ResourceBuildSegment,
+    SandboxCreatorScriptRunner,
+    validate_final_resource_package,
+    validate_resource_content,
+)
+from .creator_resource_plan import SkillResourcePlan
+from .creator_resource_service import SkillCreatorResourcePlanningService
+from .creator_service import SkillCreatorService
+from .creator_store import (
+    SkillCreatorConflictError,
+    SkillCreatorSession,
+    SkillCreatorValidationError,
+)
+from .draft_store import WorkspaceSkillDraft
+
+try:
+    from server.xpert_runtime.authoring_store import (
+        AuthoringProposal,
+        AuthoringProposalError,
+        AuthoringProposalStore,
+    )
+except ModuleNotFoundError:
+    from xpert_runtime.authoring_store import (
+        AuthoringProposal,
+        AuthoringProposalError,
+        AuthoringProposalStore,
+    )
+
+
+RESOURCE_BUILD_SERVICE_VERSION = "resource-authoring-build-v1"
+
+
+class ResourceBuilderExecutor(Protocol):
+    def available(self) -> bool: ...
+
+    async def generate(self, request: ResourceBuildGenerationRequest) -> ResourceBuildSegment: ...
+
+
+class SkillCreatorResourceBuildService:
+    """Coordinate confirmed plans, segmented generation, review, and proposal creation."""
+
+    VERSION = RESOURCE_BUILD_SERVICE_VERSION
+
+    def __init__(
+        self,
+        creator_service: SkillCreatorService,
+        planning_service: SkillCreatorResourcePlanningService,
+        build_store: SkillResourceBuildStore,
+        *,
+        builder: ResourceBuilderExecutor | None = None,
+        script_runner: SandboxCreatorScriptRunner | None = None,
+        enabled: bool | None = None,
+    ) -> None:
+        self.creator_service = creator_service
+        self.planning_service = planning_service
+        self.build_store = build_store
+        self.builder = builder
+        self.script_runner = script_runner
+        self.enabled = (
+            os.getenv("SKILL_CREATOR_RESOURCE_AUTHORING_ENABLED", "false").strip().lower()
+            in {"1", "true", "yes", "on"}
+            if enabled is None
+            else bool(enabled)
+        )
+        self._locks_guard = threading.RLock()
+        self._locks: dict[str, asyncio.Lock] = {}
+
+    def status(self) -> dict[str, Any]:
+        try:
+            builder_available = bool(self.builder and self.builder.available())
+        except Exception:
+            builder_available = False
+        return {
+            "resource_build_version": self.VERSION,
+            "resource_build_enabled": self.enabled,
+            "resource_builder_available": self.enabled and builder_available,
+            "script_sandbox_configured": self.enabled and self.script_runner is not None,
+        }
+
+    def require_enabled(self) -> None:
+        self.planning_service.require_enabled()
+        if not self.enabled:
+            raise SkillCreatorValidationError(
+                "Skill Creator resource build is disabled.",
+                code="skill_creator_resource_authoring_disabled",
+            )
+
+    def current_projection(self, session_id: str) -> dict[str, Any] | None:
+        self.require_enabled()
+        session, draft = self.creator_service.get_session(session_id)
+        build = self.build_store.current_for_session(session_id)
+        if build is None:
+            return None
+        stale = self._is_stale(build, session=session, draft=draft)
+        if stale and build.state != "stale":
+            build = self.build_store.mark_stale(build.build_id)
+        result = self.build_store.serialize(build)
+        result["stale"] = stale
+        return result
+
+    async def start(
+        self,
+        session_id: str,
+        *,
+        plan_id: str,
+        expected_session_revision: int,
+        expected_plan_revision: int,
+        expected_plan_digest: str,
+    ) -> SkillResourceBuild:
+        self.require_enabled()
+        async with self._lock(session_id):
+            session, draft = self.creator_service.get_session(session_id)
+            self._require_session_revision(session, expected_session_revision)
+            plan = self.planning_service.plan_store.require(plan_id)
+            self._require_plan(plan, session=session, draft=draft, expected_revision=expected_plan_revision, expected_digest=expected_plan_digest)
+            if plan.state != "confirmed":
+                raise SkillCreatorConflictError("Confirm the resource plan before starting generation.")
+            return self.build_store.create(
+                plan=plan,
+                existing_files=(draft.files if draft else {}),
+                previous_build=self.build_store.current_for_session(session_id),
+            )
+
+    async def next(
+        self,
+        build_id: str,
+        *,
+        expected_session_revision: int,
+        expected_revision: int,
+        expected_digest: str,
+    ) -> SkillResourceBuild:
+        self.require_enabled()
+        initial = self.build_store.require(build_id)
+        async with self._lock(initial.session_id):
+            session, draft = self.creator_service.get_session(initial.session_id)
+            self._require_session_revision(session, expected_session_revision)
+            self._require_build_scope(initial, session=session, draft=draft)
+            builder = self.builder
+            try:
+                available = bool(builder and builder.available())
+            except Exception as exc:
+                raise SkillCreatorValidationError("Resource builder status is unavailable.", code="skill_creator_resource_builder_failed") from exc
+            if not available or builder is None:
+                raise SkillCreatorValidationError("The Skill Creator model gateway is not configured.", code="model_gateway_unconfigured")
+            current = self.build_store.claim_next(build_id, expected_revision=expected_revision, expected_digest=expected_digest)
+            # One API action assembles the complete target. Segmentation remains internal.
+            for _ in range(3):
+                target_id, segment_index = self._segment_target(current)
+                try:
+                    segment = await builder.generate(ResourceBuildGenerationRequest(build=current, target_id=target_id, segment_index=segment_index))
+                except (SkillCreatorConflictError, SkillCreatorValidationError):
+                    raise
+                except Exception as exc:
+                    raise SkillCreatorValidationError("The Skill Creator resource builder failed.", code="skill_creator_resource_builder_failed") from exc
+                current = self.build_store.append_segment(
+                    build_id,
+                    expected_revision=current.revision,
+                    expected_digest=current.digest,
+                    target_id=segment.target_id,
+                    segment_index=segment.segment_index,
+                    content=segment.content,
+                    complete=segment.complete,
+                    script_tests=segment.script_tests,
+                )
+                if segment.complete:
+                    break
+            else:
+                raise SkillCreatorValidationError("The generated target exceeded the three-segment limit.", code="skill_creator_resource_segment_limit")
+            validated = await self._validate_current(current)
+            # Static/test failures get exactly one server-controlled regeneration.
+            if validated.state in {"planned", "revision_requested"}:
+                repaired = self.build_store.claim_next(
+                    build_id,
+                    expected_revision=validated.revision,
+                    expected_digest=validated.digest,
+                )
+                for _ in range(3):
+                    target_id, segment_index = self._segment_target(repaired)
+                    segment = await builder.generate(ResourceBuildGenerationRequest(build=repaired, target_id=target_id, segment_index=segment_index))
+                    repaired = self.build_store.append_segment(
+                        build_id,
+                        expected_revision=repaired.revision,
+                        expected_digest=repaired.digest,
+                        target_id=segment.target_id,
+                        segment_index=segment.segment_index,
+                        content=segment.content,
+                        complete=segment.complete,
+                        script_tests=segment.script_tests,
+                    )
+                    if segment.complete:
+                        break
+                else:
+                    raise SkillCreatorValidationError("The repaired target exceeded the three-segment limit.", code="skill_creator_resource_segment_limit")
+                validated = await self._validate_current(repaired)
+            return validated
+
+    def review_resource(
+        self,
+        build_id: str,
+        *,
+        resource_id: str,
+        expected_session_revision: int,
+        expected_revision: int,
+        expected_digest: str,
+        decision: str,
+        feedback: str = "",
+    ) -> SkillResourceBuild:
+        self.require_enabled()
+        current = self.build_store.require(build_id)
+        session, draft = self.creator_service.get_session(current.session_id)
+        self._require_session_revision(session, expected_session_revision)
+        self._require_build_scope(current, session=session, draft=draft)
+        return self.build_store.review_resource(
+            build_id,
+            resource_id=resource_id,
+            expected_revision=expected_revision,
+            expected_digest=expected_digest,
+            decision=decision,  # type: ignore[arg-type]
+            feedback=feedback,
+        )
+
+    def finalize(
+        self,
+        build_id: str,
+        *,
+        expected_session_revision: int,
+        expected_revision: int,
+        expected_digest: str,
+        decision: str,
+        feedback: str = "",
+    ) -> tuple[SkillResourceBuild, AuthoringProposal | None]:
+        self.require_enabled()
+        current = self.build_store.require(build_id)
+        session, draft = self.creator_service.get_session(current.session_id)
+        self._require_session_revision(session, expected_session_revision)
+        self._require_build_scope(current, session=session, draft=draft)
+        if current.phase == "proposal":
+            if current.proposal_id:
+                proposal = self.creator_service.authoring_service.proposal_store.require(
+                    current.proposal_id
+                )
+                return current, proposal
+            coverage = self._coverage(session)
+            proposal = self._proposal(current, session=session, draft=draft, coverage=coverage)
+            recorded = self.build_store.record_proposal(
+                build_id,
+                expected_revision=current.revision,
+                expected_digest=current.digest,
+                proposal_id=proposal.proposal_id,
+            )
+            return recorded, proposal
+        if decision == "revise":
+            return (
+                self.build_store.review_skill_markdown(
+                    build_id,
+                    expected_revision=expected_revision,
+                    expected_digest=expected_digest,
+                    decision="revise",
+                    feedback=feedback,
+                ),
+                None,
+            )
+        if decision != "accept":
+            raise SkillCreatorValidationError("Invalid final resource build decision.")
+        coverage = self._coverage(session)
+        preflight_payload = self._proposal_payload(
+            current, session=session, draft=draft, coverage=coverage
+        )
+        preflight = evaluate_creator_payload(
+            preflight_payload,
+            requirement_ids=preflight_payload["creator_requirement_ids"],
+            resource_build=True,
+        )
+        if not preflight.ready:
+            raise SkillCreatorValidationError(
+                "The finalized Skill package did not pass the Creator draft gate: "
+                + ", ".join(issue.code for issue in preflight.issues[:8]),
+                code="skill_creator_resource_proposal_invalid",
+            )
+        accepted = self.build_store.review_skill_markdown(
+            build_id,
+            expected_revision=expected_revision,
+            expected_digest=expected_digest,
+            decision="accept",
+            requirement_coverage=coverage,
+        )
+        proposal = self._proposal(accepted, session=session, draft=draft, coverage=coverage)
+        recorded = self.build_store.record_proposal(
+            build_id,
+            expected_revision=accepted.revision,
+            expected_digest=accepted.digest,
+            proposal_id=proposal.proposal_id,
+        )
+        return recorded, proposal
+
+    async def _validate_current(self, current: SkillResourceBuild) -> SkillResourceBuild:
+        if current.state != "awaiting_review":
+            return current
+        target_id, _ = self._segment_target(current)
+        receipt = None
+        if current.phase == "resources":
+            item = next(item for item in current.resources if item.resource_id == target_id)
+            issues = validate_resource_content(item)
+            if item.kind == "script" and not issues:
+                if self.script_runner is None:
+                    issues.append({"code": "skill_creator_sandbox_unavailable", "message": "Script testing requires the Skill authoring Sandbox profile.", "path": item.path, "severity": "error"})
+                else:
+                    receipt = await self.script_runner.run(item)
+                    if not receipt.passed:
+                        issues.append({"code": "skill_creator_script_test_failed", "message": "Generated script failed its offline tests.", "path": item.path, "severity": "error"})
+        else:
+            issues = validate_final_resource_package(current)
+        return self.build_store.record_validation(
+            current.build_id,
+            expected_revision=current.revision,
+            expected_digest=current.digest,
+            target_id=target_id,
+            issues=issues,
+            script_receipt=receipt,
+        )
+
+    def _proposal(
+        self,
+        build: SkillResourceBuild,
+        *,
+        session: SkillCreatorSession,
+        draft: WorkspaceSkillDraft | None,
+        coverage: list[dict[str, Any]],
+    ) -> AuthoringProposal:
+        proposals = self.creator_service.authoring_service.proposal_store.list(
+            source_type="skill_creator",
+            source_id=build.build_id,
+            limit=10,
+        )
+        payload = self._proposal_payload(
+            build, session=session, draft=draft, coverage=coverage
+        )
+        if proposals:
+            existing = proposals[0]
+            if existing.payload != payload:
+                raise SkillCreatorConflictError("The finalized resource proposal changed. Reload the build.")
+            return existing
+        kind = "skill_update" if draft is not None else "skill_create"
+        try:
+            proposal = self.creator_service.authoring_service.proposal_store.create(
+                kind=kind,
+                title=f"Review resource-built Skill: {build.skill_name}",
+                payload=payload,
+                source_type="skill_creator",
+                source_id=build.build_id,
+                target_id=(draft.draft_id if draft else None),
+                base_revision=(draft.revision if draft else None),
+                base_digest=(draft.content_digest if draft else None),
+                creator_session_id=session.session_id,
+                creator_session_revision=session.session_revision,
+                actor_kind="workflow_agent",
+                actor_id="skill-creator-assistant-v1",
+            )
+            proposal = self.creator_service.authoring_service.validate(
+                proposal.proposal_id, revision=proposal.revision
+            )
+        except AuthoringProposalError as exc:
+            raise SkillCreatorValidationError(
+                "The finalized Skill package could not form a review proposal.",
+                code=str(getattr(exc, "code", "skill_creator_resource_proposal_invalid")),
+            ) from exc
+        if not proposal.validation.get("valid"):
+            issue_codes = [str(item.get("code") or "") for item in proposal.validation.get("issues", []) if isinstance(item, dict)]
+            raise SkillCreatorValidationError(
+                "The finalized Skill package did not pass the Creator draft gate: " + ", ".join(issue_codes[:8]),
+                code="skill_creator_resource_proposal_invalid",
+            )
+        return proposal
+
+    @staticmethod
+    def _proposal_payload(
+        build: SkillResourceBuild,
+        *,
+        session: SkillCreatorSession,
+        draft: WorkspaceSkillDraft | None,
+        coverage: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        resources = [
+            {
+                "path": item.path,
+                "purpose": item.purpose,
+                "used_by_steps": list(item.used_by_steps),
+            }
+            for item in build.resources
+            if item.action != "delete"
+        ]
+        workflow_steps = [
+            {"id": str(item.get("step_id") or item.get("id") or f"step_{index + 1}"), "description": str(item.get("instruction") or item.get("description") or "")}
+            for index, item in enumerate(build.workflow_steps)
+        ]
+        package_files = SkillResourceBuildStore.active_files(build)
+        if draft is not None:
+            package_files.update(
+                {
+                    path: content
+                    for path, content in draft.files.items()
+                    if path.startswith("agents/")
+                }
+            )
+        return {
+            "skill": {
+                "name": build.skill_name,
+                "slug": build.skill_name,
+                "description": build.skill_description,
+                "skill_markdown": build.skill_markdown,
+                "files": package_files,
+            },
+            "design": {
+                "workflow_steps": workflow_steps,
+                "output_contract": [{"id": f"output_{index + 1}", "description": value} for index, value in enumerate(build.output_contract)],
+                "failure_modes": [{"id": f"failure_{index + 1}", "description": value} for index, value in enumerate(build.failure_modes)],
+                "resources": resources,
+                "assumptions": ["Use only the confirmed Creator definition, selected evidence, and accepted resource contents."],
+                "requirement_coverage": copy.deepcopy(coverage),
+            },
+            "creator_contract_version": CREATOR_CONTRACT_VERSION,
+            "creator_requirement_ids": [item.requirement_id for item in build_session_requirements(
+                intent=session.intent,
+                positive_examples=session.positive_examples,
+                near_miss_examples=session.near_miss_examples,
+                expected_output=session.expected_output,
+                success_criteria=session.success_criteria,
+            )],
+            "creator_resource_build": {
+                "version": RESOURCE_BUILD_SERVICE_VERSION,
+                "build_id": build.build_id,
+                "build_digest": build.digest,
+                "plan_id": build.plan_id,
+                "plan_digest": build.plan_digest,
+            },
+        }
+
+    @staticmethod
+    def _coverage(session: SkillCreatorSession) -> list[dict[str, Any]]:
+        result = []
+        for requirement in build_session_requirements(
+            intent=session.intent,
+            positive_examples=session.positive_examples,
+            near_miss_examples=session.near_miss_examples,
+            expected_output=session.expected_output,
+            success_criteria=session.success_criteria,
+        ):
+            section = "Output contract" if requirement.kind == "expected_output" else "Quality checks" if requirement.kind == "success_criterion" else "Purpose and scope"
+            result.append({"requirement_id": requirement.requirement_id, "locations": [{"path": "SKILL.md", "section": section}]})
+        return result
+
+    @staticmethod
+    def _segment_target(build: SkillResourceBuild) -> tuple[str, int]:
+        if build.phase == "skill_markdown":
+            return "SKILL.md", len(build.skill_chunks)
+        target_id = str(build.current_resource_id or "")
+        for item in build.resources:
+            if item.resource_id == target_id:
+                return target_id, len(item.chunks)
+        raise SkillCreatorConflictError("Resource build has no active target.")
+
+    @staticmethod
+    def _is_stale(build: SkillResourceBuild, *, session: SkillCreatorSession, draft: WorkspaceSkillDraft | None) -> bool:
+        return bool(
+            build.session_revision != session.session_revision
+            or build.draft_id != (draft.draft_id if draft else None)
+            or build.draft_revision != (draft.revision if draft else None)
+            or build.draft_digest != (draft.content_digest if draft else None)
+        )
+
+    @classmethod
+    def _require_build_scope(cls, build: SkillResourceBuild, *, session: SkillCreatorSession, draft: WorkspaceSkillDraft | None) -> None:
+        if cls._is_stale(build, session=session, draft=draft):
+            raise SkillCreatorConflictError("Resource build no longer matches the current Creator session and draft.")
+
+    @staticmethod
+    def _require_plan(
+        plan: SkillResourcePlan,
+        *,
+        session: SkillCreatorSession,
+        draft: WorkspaceSkillDraft | None,
+        expected_revision: int,
+        expected_digest: str,
+    ) -> None:
+        if (
+            plan.session_id != session.session_id
+            or plan.session_revision != session.session_revision
+            or plan.draft_id != (draft.draft_id if draft else None)
+            or plan.draft_revision != (draft.revision if draft else None)
+            or plan.draft_digest != (draft.content_digest if draft else None)
+            or plan.revision != int(expected_revision)
+            or plan.digest != str(expected_digest).lower()
+        ):
+            raise SkillCreatorConflictError("Resource plan changed. Reload it before starting the build.")
+
+    @staticmethod
+    def _require_session_revision(session: SkillCreatorSession, expected: int) -> None:
+        if session.session_revision != int(expected):
+            raise SkillCreatorConflictError("Creator session changed. Reload it before continuing.")
+
+    def _lock(self, session_id: str) -> asyncio.Lock:
+        with self._locks_guard:
+            lock = self._locks.get(session_id)
+            if lock is None:
+                lock = asyncio.Lock()
+                self._locks[session_id] = lock
+            return lock
+
+
+__all__ = [
+    "RESOURCE_BUILD_SERVICE_VERSION",
+    "ResourceBuilderExecutor",
+    "SkillCreatorResourceBuildService",
+]

--- a/server/skills/creator_resource_plan.py
+++ b/server/skills/creator_resource_plan.py
@@ -38,6 +38,52 @@ _RESOURCE_ROOTS = {
     "reference": "references",
     "asset": "assets",
 }
+_RESOURCE_KIND_ALIASES = {
+    "script": "script",
+    "scripts": "script",
+    "脚本": "script",
+    "reference": "reference",
+    "references": "reference",
+    "参考": "reference",
+    "参考资料": "reference",
+    "asset": "asset",
+    "assets": "asset",
+    "template": "asset",
+    "模板": "asset",
+}
+_RESOURCE_ACTION_ALIASES = {
+    "keep": "keep",
+    "retain": "keep",
+    "reuse": "keep",
+    "保留": "keep",
+    "复用": "keep",
+    "create": "create",
+    "add": "create",
+    "new": "create",
+    "generate": "create",
+    "创建": "create",
+    "新增": "create",
+    "update": "update",
+    "modify": "update",
+    "replace": "update",
+    "修改": "update",
+    "更新": "update",
+    "delete": "delete",
+    "remove": "delete",
+    "删除": "delete",
+    "移除": "delete",
+}
+_RESOURCE_COST_ALIASES = {
+    "low": "low",
+    "small": "low",
+    "低": "low",
+    "medium": "medium",
+    "moderate": "medium",
+    "中": "medium",
+    "high": "high",
+    "large": "high",
+    "高": "high",
+}
 _WINDOWS_RESERVED_NAMES = {
     "con", "prn", "aux", "nul",
     *(f"com{index}" for index in range(1, 10)),
@@ -280,9 +326,9 @@ class SkillResourcePlanStore:
             current = self._require_current_unlocked(
                 plan_id, expected_revision=expected_revision, expected_digest=expected_digest
             )
-            if current.state not in {"ready", "needs_regeneration"}:
+            if current.state not in {"ready", "needs_regeneration", "confirmed"}:
                 raise SkillCreatorConflictError(
-                    "Only an unconfirmed ready plan can be edited."
+                    "Only the current resource plan can be revised."
                 )
             path_by_id = {item.resource_id: item.path for item in current.resources}
             resource_payload = []
@@ -423,15 +469,30 @@ class SkillResourcePlanStore:
         for raw in value:
             if not isinstance(raw, dict):
                 raise SkillCreatorValidationError("Invalid resource plan item.")
-            kind = str(raw.get("kind") or "").strip()
-            action = str(raw.get("action") or "create").strip()
-            generation_cost = str(raw.get("generation_cost") or "").strip()
-            if (
-                kind not in _RESOURCE_ROOTS
-                or action not in {"keep", "create", "update", "delete"}
-                or generation_cost not in {"low", "medium", "high"}
-            ):
-                raise SkillCreatorValidationError("Invalid resource kind or action.")
+            kind = _RESOURCE_KIND_ALIASES.get(
+                str(raw.get("kind") or "").strip().casefold()
+            )
+            action = _RESOURCE_ACTION_ALIASES.get(
+                str(raw.get("action") or "create").strip().casefold()
+            )
+            generation_cost = _RESOURCE_COST_ALIASES.get(
+                str(raw.get("generation_cost") or "medium").strip().casefold()
+            )
+            if kind is None:
+                raise SkillCreatorValidationError(
+                    "Invalid resource kind; use script, reference, or asset.",
+                    code="skill_creator_resource_kind_invalid",
+                )
+            if action is None:
+                raise SkillCreatorValidationError(
+                    "Invalid resource action; use keep, create, update, or delete.",
+                    code="skill_creator_resource_action_invalid",
+                )
+            if generation_cost is None:
+                raise SkillCreatorValidationError(
+                    "Invalid resource generation cost; use low, medium, or high.",
+                    code="skill_creator_resource_cost_invalid",
+                )
             path = self._resource_path(raw.get("path"), expected_root=_RESOURCE_ROOTS[kind])
             if path.casefold() in {item.casefold() for item in paths}:
                 raise SkillCreatorValidationError("Resource plan paths must be unique.")

--- a/server/skills/creator_resource_runtime.py
+++ b/server/skills/creator_resource_runtime.py
@@ -174,14 +174,8 @@ def parse_resource_plan_output(value: Any) -> dict[str, Any]:
             code="skill_creator_resource_planner_invalid",
         )
     text = value.strip()
-    if text.startswith("```"):
-        lines = text.splitlines()
-        if len(lines) >= 3 and lines[-1].strip() == "```":
-            text = "\n".join(lines[1:-1]).strip()
-            if text.startswith("json\n"):
-                text = text[5:].strip()
     try:
-        payload = json.loads(text)
+        payload = _decode_resource_plan_json(text)
     except (ValueError, json.JSONDecodeError) as exc:
         raise SkillCreatorValidationError(
             "Creator resource planner did not return valid JSON.",
@@ -193,6 +187,49 @@ def parse_resource_plan_output(value: Any) -> dict[str, Any]:
             code="skill_creator_resource_planner_invalid",
         )
     return payload
+
+
+def _decode_resource_plan_json(text: str) -> Any:
+    """Decode one versioned plan while tolerating harmless model narration.
+
+    The planner contract remains strict JSON. This helper only strips transport-style
+    narration or Markdown fences by locating a unique, fully valid JSON object carrying
+    the expected contract version. It never repairs JSON syntax or guesses between
+    different candidate plans.
+    """
+
+    if not text:
+        raise ValueError("empty planner output")
+
+    try:
+        return json.loads(text)
+    except (ValueError, json.JSONDecodeError):
+        pass
+
+    decoder = json.JSONDecoder()
+    candidates: dict[str, dict[str, Any]] = {}
+    for index, char in enumerate(text):
+        if char != "{":
+            continue
+        try:
+            candidate, _end = decoder.raw_decode(text[index:])
+        except (ValueError, json.JSONDecodeError):
+            continue
+        if not isinstance(candidate, dict):
+            continue
+        if candidate.get("resource_plan_version") != RESOURCE_PLAN_VERSION:
+            continue
+        fingerprint = json.dumps(
+            candidate,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        candidates[fingerprint] = candidate
+
+    if len(candidates) != 1:
+        raise ValueError("planner output must contain one versioned JSON object")
+    return next(iter(candidates.values()))
 
 
 def _resource_planner_prompt() -> str:

--- a/server/tests/test_skill_authoring_sandbox_profile.py
+++ b/server/tests/test_skill_authoring_sandbox_profile.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from server.sandbox_sidecar.engine import SandboxEngine, SandboxEngineError
+from server.xpert_runtime.sandbox_client import LocalSandboxClient
+
+
+PROFILE = "skill_authoring_v1"
+
+
+def _workspace(engine: SandboxEngine, workspace_id: str = "authoring-1") -> dict[str, str]:
+    created = engine.dispatch({"action": "ensure_workspace", "workspace_id": workspace_id, "profile": PROFILE})
+    return {
+        "workspace_id": workspace_id,
+        "profile": PROFILE,
+        "provisioning_capability": str(created["provisioning_capability"]),
+    }
+
+
+def test_authoring_profile_health_and_scope(tmp_path: Path) -> None:
+    engine = SandboxEngine(tmp_path / "workspaces", require_landlock=False)
+    health = asyncio.run(LocalSandboxClient(engine).health(required_profile=PROFILE))
+    assert health["profiles"][PROFILE] == health["profiles"]["skill_evaluation_v1"]
+    auth = _workspace(engine)
+    seeded = engine.dispatch({
+        **auth,
+        "action": "seed_file",
+        "path": "skills/authoring-resource/normalize.py",
+        "content": "print('ok')",
+        "operation_id": "script",
+    })
+    assert seeded["path"] == "skills/authoring-resource/normalize.py"
+    with pytest.raises(SandboxEngineError) as wrong_alias:
+        engine.dispatch({
+            **auth,
+            "action": "seed_file",
+            "path": "skills/evaluation-skill/normalize.py",
+            "content": "print('wrong')",
+            "operation_id": "wrong-alias",
+        })
+    assert wrong_alias.value.code == "seed_scope_denied"
+    with pytest.raises(SandboxEngineError) as denied:
+        engine.dispatch({**auth, "action": "shell", "argv": ["npm", "--version"], "operation_id": "npm"})
+    assert denied.value.code == "command_denied"
+    with pytest.raises(SandboxEngineError) as downgrade:
+        engine.dispatch({"action": "read_file", "workspace_id": "authoring-1", "path": "skills/authoring-resource/normalize.py"})
+    assert downgrade.value.code == "sandbox_profile_mismatch"
+
+
+@pytest.mark.skipif(os.name != "posix", reason="Landlock is Linux-only")
+def test_authoring_landlock_keeps_inputs_and_skills_read_only(tmp_path: Path) -> None:
+    engine = SandboxEngine(tmp_path / "workspaces", require_landlock=True)
+    auth = _workspace(engine)
+    engine.dispatch({**auth, "action": "seed_file", "path": "inputs/case.txt", "content": "input", "operation_id": "input"})
+    probe = """
+import json
+from pathlib import Path
+result = {}
+for name in ('../inputs/case.txt', '../skills/authoring-resource/probe.py', 'result.txt', '../.tmp/cache.txt'):
+    try:
+        Path(name).write_text('changed', encoding='utf-8')
+    except OSError:
+        result[name] = False
+    else:
+        result[name] = True
+print(json.dumps(result, sort_keys=True))
+""".strip()
+    engine.dispatch({**auth, "action": "seed_file", "path": "skills/authoring-resource/probe.py", "content": probe, "operation_id": "probe"})
+    result = engine.dispatch({**auth, "action": "shell", "argv": ["python", "../skills/authoring-resource/probe.py"], "operation_id": "run"})
+    assert result["exit_code"] == 0, result["stderr"]
+    assert json.loads(result["stdout"]) == {
+        "../.tmp/cache.txt": True,
+        "../inputs/case.txt": False,
+        "../skills/authoring-resource/probe.py": False,
+        "result.txt": True,
+    }
+
+
+def test_profile_never_changes_default_workspace_contract(tmp_path: Path) -> None:
+    engine = SandboxEngine(tmp_path / "workspaces", require_landlock=False)
+    _workspace(engine, "authoring-bound")
+    written = engine.dispatch({
+        "action": "write_file",
+        "workspace_id": "default-workspace",
+        "path": "inputs/default.txt",
+        "content": "default remains writable",
+        "operation_id": "default",
+    })
+    assert written["path"] == "inputs/default.txt"

--- a/server/tests/test_skill_creator_quality.py
+++ b/server/tests/test_skill_creator_quality.py
@@ -505,6 +505,14 @@ def test_creator_generation_limits_resource_count() -> None:
     assert "creator_resource_count_budget_exceeded" in {
         issue.code for issue in report.issues
     }
+    resource_build_report = evaluate_creator_payload(
+        payload,
+        requirements=_requirements(),
+        resource_build=True,
+    )
+    assert "creator_resource_count_budget_exceeded" not in {
+        issue.code for issue in resource_build_report.issues
+    }
 
 
 def test_playbook_and_license_are_local_versioned_attributed_resources() -> None:

--- a/server/tests/test_skill_creator_resource_build.py
+++ b/server/tests/test_skill_creator_resource_build.py
@@ -1,0 +1,467 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from server.skills.creator_resource_build import (
+    ResourceScriptTestReceipt,
+    ResourceScriptTestResult,
+    SkillResourceBuildStore,
+)
+from server.skills.creator_resource_plan import SkillResourcePlanStore
+from server.skills.creator_store import (
+    SkillCreatorConflictError,
+    SkillCreatorStorageError,
+    SkillCreatorValidationError,
+)
+
+
+SOURCE_IDS = {
+    "intent",
+    "positive_example:0",
+    "near_miss:0",
+    "expected_output",
+    "success_criterion:0",
+}
+
+
+def _confirmed_plan(
+    tmp_path: Path,
+    *,
+    resources: list[dict] | None = None,
+    draft_id: str | None = None,
+    draft_revision: int | None = None,
+    draft_digest: str | None = None,
+):
+    store = SkillResourcePlanStore(tmp_path / "plan")
+    plan = store.save_generated(
+        session_id="skillcreator_build",
+        session_revision=3,
+        draft_id=draft_id,
+        draft_revision=draft_revision,
+        draft_digest=draft_digest,
+        allowed_source_ids=SOURCE_IDS,
+        payload={
+            "skill_name": "review-incidents",
+            "skill_description": (
+                "Create evidence-bound incident reviews when users need a timeline and "
+                "corrective actions; do not use for generic rewriting."
+            ),
+            "workflow_steps": [
+                {"id": "collect", "instruction": "Collect explicit incident facts."},
+                {"id": "normalize", "instruction": "Normalize timeline records."},
+                {"id": "analyze", "instruction": "Separate known facts from gaps."},
+                {"id": "deliver", "instruction": "Render and verify the report."},
+            ],
+            "output_contract": ["Return a Chinese Markdown incident report."],
+            "failure_modes": ["Mark unavailable facts as pending confirmation."],
+            "resources": resources or [],
+            "clarifications": [],
+        },
+    )
+    return store.confirm(
+        plan.plan_id,
+        expected_revision=plan.revision,
+        expected_digest=plan.digest,
+        session_revision=plan.session_revision,
+        draft_revision=draft_revision,
+        draft_digest=draft_digest,
+    )
+
+
+def _complex_resources() -> list[dict]:
+    return [
+        {
+            "kind": "reference",
+            "action": "create",
+            "generation_cost": "medium",
+            "path": "references/evidence-policy.md",
+            "purpose": "Keep detailed evidence rules separate.",
+            "source_ids": ["intent", "near_miss:0"],
+            "used_by_steps": ["collect", "analyze"],
+            "depends_on": [],
+            "acceptance_checks": ["Defines known, unknown, and unsupported claims."],
+        },
+        {
+            "kind": "script",
+            "action": "create",
+            "generation_cost": "high",
+            "path": "scripts/normalize_timeline.py",
+            "purpose": "Normalize timeline rows deterministically.",
+            "source_ids": ["positive_example:0", "success_criterion:0"],
+            "used_by_steps": ["normalize"],
+            "depends_on": ["references/evidence-policy.md"],
+            "acceptance_checks": ["Rejects malformed timestamps with a non-zero exit."],
+        },
+        {
+            "kind": "asset",
+            "action": "create",
+            "generation_cost": "low",
+            "path": "assets/report-template.md",
+            "purpose": "Provide the report output skeleton.",
+            "source_ids": ["expected_output"],
+            "used_by_steps": ["deliver"],
+            "depends_on": [],
+            "acceptance_checks": ["Contains every required report section."],
+        },
+    ]
+
+
+def _append_complete(
+    store: SkillResourceBuildStore,
+    build,
+    *,
+    target_id: str,
+    content: str,
+    script_tests: list[dict] | None = None,
+):
+    claimed = store.claim_next(
+        build.build_id,
+        expected_revision=build.revision,
+        expected_digest=build.digest,
+    )
+    return store.append_segment(
+        claimed.build_id,
+        expected_revision=claimed.revision,
+        expected_digest=claimed.digest,
+        target_id=target_id,
+        segment_index=0,
+        content=content,
+        complete=True,
+        script_tests=script_tests,
+    )
+
+
+def test_zero_resource_build_moves_directly_to_skill_markdown(tmp_path: Path) -> None:
+    plan = _confirmed_plan(tmp_path)
+    store = SkillResourceBuildStore(tmp_path / "build")
+    build = store.create(plan=plan)
+    assert build.phase == "skill_markdown"
+    assert build.state == "planned"
+    assert store.create(plan=plan).build_id == build.build_id
+
+    generated = _append_complete(
+        store,
+        build,
+        target_id="SKILL.md",
+        content="---\nname: review-incidents\ndescription: Use when reviewing incidents.\n---\n# Review\n",
+    )
+    assert generated.state == "awaiting_review"
+    assert generated.skill_markdown_digest
+
+
+def test_dependencies_review_and_script_receipt_are_digest_bound(tmp_path: Path) -> None:
+    plan = _confirmed_plan(tmp_path, resources=_complex_resources())
+    store = SkillResourceBuildStore(tmp_path / "build")
+    build = store.create(plan=plan)
+
+    reference = next(item for item in build.resources if item.kind == "reference")
+    generated = _append_complete(
+        store,
+        build,
+        target_id=reference.resource_id,
+        content="# Evidence policy\n\nUse only explicit facts.\n",
+    )
+    validated = store.record_validation(
+        generated.build_id,
+        expected_revision=generated.revision,
+        expected_digest=generated.digest,
+        target_id=reference.resource_id,
+        issues=[],
+    )
+    accepted = store.review_resource(
+        validated.build_id,
+        resource_id=reference.resource_id,
+        expected_revision=validated.revision,
+        expected_digest=validated.digest,
+        decision="accept",
+    )
+
+    script = next(item for item in accepted.resources if item.kind == "script")
+    script_tests = [
+        {
+            "test_id": "valid_input",
+            "args": ["../inputs/valid/input.json"],
+            "fixtures": [
+                {"path": "valid/input.json", "content": '{"time":"09:00"}'}
+            ],
+            "expected_exit_code": 0,
+            "stdout_contains": ["09:00"],
+            "stderr_contains": [],
+        }
+    ]
+    script_generated = _append_complete(
+        store,
+        accepted,
+        target_id=script.resource_id,
+        content="import sys\nprint('09:00')\n",
+        script_tests=script_tests,
+    )
+    script_item = next(
+        item for item in script_generated.resources if item.resource_id == script.resource_id
+    )
+    with pytest.raises(SkillCreatorValidationError, match="receipt"):
+        store.review_resource(
+            script_generated.build_id,
+            resource_id=script.resource_id,
+            expected_revision=script_generated.revision,
+            expected_digest=script_generated.digest,
+            decision="accept",
+        )
+
+    receipt = ResourceScriptTestReceipt(
+        receipt_id="receipt_test",
+        script_digest=script_item.content_digest or "",
+        profile="skill_authoring_v1",
+        passed=True,
+        results=[
+            ResourceScriptTestResult(
+                test_id="valid_input",
+                passed=True,
+                exit_code=0,
+                stdout_sha256="1" * 64,
+                stderr_sha256="2" * 64,
+                duration_ms=3.5,
+            )
+        ],
+    )
+    script_validated = store.record_validation(
+        script_generated.build_id,
+        expected_revision=script_generated.revision,
+        expected_digest=script_generated.digest,
+        target_id=script.resource_id,
+        issues=[],
+        script_receipt=receipt,
+    )
+    script_accepted = store.review_resource(
+        script_validated.build_id,
+        resource_id=script.resource_id,
+        expected_revision=script_validated.revision,
+        expected_digest=script_validated.digest,
+        decision="accept",
+    )
+    assert next(
+        item for item in script_accepted.resources if item.resource_id == script.resource_id
+    ).script_receipt == receipt
+
+
+def test_validation_failure_gets_one_internal_repair_then_fails(tmp_path: Path) -> None:
+    plan = _confirmed_plan(tmp_path, resources=[_complex_resources()[0]])
+    store = SkillResourceBuildStore(tmp_path / "build")
+    build = store.create(plan=plan)
+    resource_id = build.resources[0].resource_id
+
+    first = _append_complete(
+        store, build, target_id=resource_id, content="# Invalid\n"
+    )
+    repair = store.record_validation(
+        first.build_id,
+        expected_revision=first.revision,
+        expected_digest=first.digest,
+        target_id=resource_id,
+        issues=[{"code": "missing_policy", "message": "Policy details are missing."}],
+    )
+    assert repair.state == "planned"
+    assert repair.resources[0].repair_count == 1
+    assert repair.resources[0].content is None
+
+    second = _append_complete(
+        store, repair, target_id=resource_id, content="# Still invalid\n"
+    )
+    failed = store.record_validation(
+        second.build_id,
+        expected_revision=second.revision,
+        expected_digest=second.digest,
+        target_id=resource_id,
+        issues=[{"code": "missing_policy", "message": "Policy details are missing."}],
+    )
+    assert failed.state == "failed"
+    assert failed.resources[0].state == "failed"
+
+
+def test_script_test_arguments_and_assertions_are_scanned_before_persistence(
+    tmp_path: Path,
+) -> None:
+    script_resource = {**_complex_resources()[1], "depends_on": []}
+    plan = _confirmed_plan(tmp_path, resources=[script_resource])
+    store = SkillResourceBuildStore(tmp_path / "build")
+    build = store.create(plan=plan)
+    secret = "sk-" + "x" * 48
+
+    with pytest.raises(SkillCreatorValidationError) as blocked:
+        _append_complete(
+            store,
+            build,
+            target_id=build.resources[0].resource_id,
+            content="import sys\nprint('usage: normalize')\nraise SystemExit(0)\n",
+            script_tests=[
+                {
+                    "test_id": "blocked_secret",
+                    "args": [secret],
+                    "fixtures": [],
+                    "expected_exit_code": 0,
+                    "stdout_contains": [],
+                    "stderr_contains": [],
+                }
+            ],
+        )
+    assert blocked.value.code == "skill_credentials_blocked"
+    assert secret not in store.snapshot_path.read_text(encoding="utf-8")
+
+
+def test_script_test_fixture_count_is_bounded(tmp_path: Path) -> None:
+    script_resource = {**_complex_resources()[1], "depends_on": []}
+    plan = _confirmed_plan(tmp_path, resources=[script_resource])
+    store = SkillResourceBuildStore(tmp_path / "build")
+    build = store.create(plan=plan)
+
+    with pytest.raises(SkillCreatorValidationError, match="fixture count"):
+        _append_complete(
+            store,
+            build,
+            target_id=build.resources[0].resource_id,
+            content="import sys\nprint('usage: normalize')\nraise SystemExit(0)\n",
+            script_tests=[
+                {
+                    "test_id": "too_many_fixtures",
+                    "args": ["../inputs/case-0.txt"],
+                    "fixtures": [
+                        {"path": f"case-{index}.txt", "content": str(index)}
+                        for index in range(9)
+                    ],
+                    "expected_exit_code": 0,
+                    "stdout_contains": [],
+                    "stderr_contains": [],
+                }
+            ],
+        )
+
+
+def test_recovery_restarts_only_unconfirmed_resource(tmp_path: Path) -> None:
+    plan = _confirmed_plan(tmp_path, resources=_complex_resources())
+    store = SkillResourceBuildStore(tmp_path / "build")
+    build = store.create(plan=plan)
+    first_id = build.resources[0].resource_id
+    generated = _append_complete(
+        store, build, target_id=first_id, content="# Policy\n\nRules.\n"
+    )
+    validated = store.record_validation(
+        generated.build_id,
+        expected_revision=generated.revision,
+        expected_digest=generated.digest,
+        target_id=first_id,
+        issues=[],
+    )
+    accepted = store.review_resource(
+        validated.build_id,
+        resource_id=first_id,
+        expected_revision=validated.revision,
+        expected_digest=validated.digest,
+        decision="accept",
+    )
+    claimed = store.claim_next(
+        accepted.build_id,
+        expected_revision=accepted.revision,
+        expected_digest=accepted.digest,
+    )
+    assert claimed.state == "generating"
+
+    restored = SkillResourceBuildStore(tmp_path / "build")
+    recovered = restored.recover_interrupted()
+    assert recovered == [claimed.build_id]
+    current = restored.require(claimed.build_id)
+    assert current.state == "planned"
+    assert current.resources[0].state == "accepted"
+    assert current.resources[0].content == "# Policy\n\nRules.\n"
+    assert current.current_resource_id is None
+
+
+def test_atomic_failure_secret_block_and_top_level_corruption(tmp_path: Path, monkeypatch) -> None:
+    plan = _confirmed_plan(tmp_path)
+    store = SkillResourceBuildStore(tmp_path / "build")
+    build = store.create(plan=plan)
+
+    claimed = store.claim_next(
+        build.build_id,
+        expected_revision=build.revision,
+        expected_digest=build.digest,
+    )
+    secret = "sk-" + "x" * 48
+    with pytest.raises(SkillCreatorValidationError) as blocked:
+        store.append_segment(
+            claimed.build_id,
+            expected_revision=claimed.revision,
+            expected_digest=claimed.digest,
+            target_id="SKILL.md",
+            segment_index=0,
+            content=f"OPENROUTER_API_KEY={secret}",
+            complete=True,
+        )
+    assert blocked.value.code == "skill_credentials_blocked"
+    assert secret not in store.snapshot_path.read_text(encoding="utf-8")
+
+    before = store.require(build.build_id)
+    monkeypatch.setattr(store, "_save_unlocked", lambda: (_ for _ in ()).throw(OSError("disk full")))
+    with pytest.raises(OSError, match="disk full"):
+        store.mark_stale(build.build_id)
+    assert store.require(build.build_id) == before
+
+    broken_dir = tmp_path / "broken"
+    broken_dir.mkdir()
+    snapshot = broken_dir / "skill_creator_resource_builds.json"
+    snapshot.write_text("{broken", encoding="utf-8")
+    broken = SkillResourceBuildStore(broken_dir)
+    with pytest.raises(SkillCreatorStorageError):
+        broken.current_for_session("skillcreator_build")
+    assert snapshot.read_text(encoding="utf-8") == "{broken"
+
+
+def test_corrupt_record_is_quarantined_without_preserving_secret(tmp_path: Path) -> None:
+    plan = _confirmed_plan(tmp_path)
+    store = SkillResourceBuildStore(tmp_path / "build")
+    build = store.create(plan=plan)
+    payload = json.loads(store.snapshot_path.read_text(encoding="utf-8"))
+    poison = dict(payload["items"][0])
+    poison["build_id"] = "skillbuild_poison"
+    poison["session_id"] = "skillcreator_poison"
+    poison["skill_description"] = "OPENROUTER_API_KEY=sk-" + "x" * 48
+    payload["items"].append(poison)
+    store.snapshot_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    restored = SkillResourceBuildStore(tmp_path / "build")
+    assert restored.require(build.build_id).digest == build.digest
+    rewritten = restored.snapshot_path.read_text(encoding="utf-8")
+    assert "OPENROUTER_API_KEY" not in rewritten
+    assert "record_sha256" in rewritten
+
+
+def test_kept_script_requires_a_reusable_digest_bound_receipt(tmp_path: Path) -> None:
+    script_path = "scripts/normalize.py"
+    plan = _confirmed_plan(
+        tmp_path,
+        draft_id="skilldraft_existing",
+        draft_revision=4,
+        draft_digest="d" * 64,
+        resources=[
+            {
+                "kind": "script",
+                "action": "keep",
+                "generation_cost": "low",
+                "path": script_path,
+                "purpose": "Preserve a previously verified deterministic normalizer.",
+                "source_ids": ["positive_example:0"],
+                "used_by_steps": ["normalize"],
+                "depends_on": [],
+                "acceptance_checks": ["Existing digest still has a passing offline receipt."],
+            }
+        ],
+    )
+    store = SkillResourceBuildStore(tmp_path / "build")
+    with pytest.raises(SkillCreatorValidationError) as caught:
+        store.create(
+            plan=plan,
+            existing_files={script_path: "print('stable')\n"},
+        )
+    assert caught.value.code == "skill_creator_script_receipt_required"

--- a/server/tests/test_skill_creator_resource_build.py
+++ b/server/tests/test_skill_creator_resource_build.py
@@ -317,7 +317,7 @@ def test_script_test_fixture_count_is_bounded(tmp_path: Path) -> None:
     store = SkillResourceBuildStore(tmp_path / "build")
     build = store.create(plan=plan)
 
-    with pytest.raises(SkillCreatorValidationError, match="fixture count"):
+    with pytest.raises(SkillCreatorValidationError, match="at most eight"):
         _append_complete(
             store,
             build,
@@ -337,6 +337,112 @@ def test_script_test_fixture_count_is_bounded(tmp_path: Path) -> None:
                 }
             ],
         )
+
+
+@pytest.mark.parametrize(
+    ("field", "invalid_value", "message"),
+    [
+        ("args", "../inputs/case.txt", "args must be a JSON array"),
+        ("fixtures", {}, "fixtures must be a JSON array"),
+        ("stdout_contains", "timeline", "stdout_contains must be a JSON array"),
+        ("stderr_contains", "warning", "stderr_contains must be a JSON array"),
+    ],
+)
+def test_script_test_list_fields_reject_scalar_strings(
+    tmp_path: Path, field: str, invalid_value: str, message: str
+) -> None:
+    script_resource = {**_complex_resources()[1], "depends_on": []}
+    plan = _confirmed_plan(tmp_path, resources=[script_resource])
+    store = SkillResourceBuildStore(tmp_path / field)
+    build = store.create(plan=plan)
+    test_case = {
+        "test_id": "strict_shape",
+        "args": [],
+        "fixtures": [],
+        "expected_exit_code": 0,
+        "stdout_contains": [],
+        "stderr_contains": [],
+    }
+    test_case[field] = invalid_value
+
+    with pytest.raises(SkillCreatorValidationError, match=message) as caught:
+        _append_complete(
+            store,
+            build,
+            target_id=build.resources[0].resource_id,
+            content="import sys\nprint('usage: normalize')\nraise SystemExit(0)\n",
+            script_tests=[test_case],
+        )
+    assert caught.value.code == "skill_creator_script_test_contract_invalid"
+
+
+def test_script_test_exit_code_rejects_non_integer_values(tmp_path: Path) -> None:
+    script_resource = {**_complex_resources()[1], "depends_on": []}
+    plan = _confirmed_plan(tmp_path, resources=[script_resource])
+    store = SkillResourceBuildStore(tmp_path / "exit-code")
+    build = store.create(plan=plan)
+
+    with pytest.raises(SkillCreatorValidationError, match="must be an integer") as caught:
+        _append_complete(
+            store,
+            build,
+            target_id=build.resources[0].resource_id,
+            content="import sys\nprint('usage: normalize')\nraise SystemExit(0)\n",
+            script_tests=[
+                {
+                    "test_id": "invalid_exit",
+                    "args": [],
+                    "fixtures": [],
+                    "expected_exit_code": "not-an-integer",
+                    "stdout_contains": [],
+                    "stderr_contains": [],
+                }
+            ],
+        )
+    assert caught.value.code == "skill_creator_script_test_contract_invalid"
+
+
+def test_generation_contract_error_consumes_the_single_internal_repair(
+    tmp_path: Path,
+) -> None:
+    script_resource = {**_complex_resources()[1], "depends_on": []}
+    plan = _confirmed_plan(tmp_path, resources=[script_resource])
+    store = SkillResourceBuildStore(tmp_path / "build")
+    build = store.create(plan=plan)
+    resource_id = build.resources[0].resource_id
+
+    first = store.claim_next(
+        build.build_id,
+        expected_revision=build.revision,
+        expected_digest=build.digest,
+    )
+    repaired = store.record_generation_error(
+        first.build_id,
+        expected_revision=first.revision,
+        expected_digest=first.digest,
+        target_id=resource_id,
+        code="skill_creator_invalid",
+        message="Script test fixture count is invalid.",
+    )
+    assert repaired.state == "planned"
+    assert repaired.resources[0].repair_count == 1
+    assert repaired.resources[0].attempt == 2
+
+    second = store.claim_next(
+        repaired.build_id,
+        expected_revision=repaired.revision,
+        expected_digest=repaired.digest,
+    )
+    failed = store.record_generation_error(
+        second.build_id,
+        expected_revision=second.revision,
+        expected_digest=second.digest,
+        target_id=resource_id,
+        code="skill_creator_invalid",
+        message="Script test fixture count is invalid.",
+    )
+    assert failed.state == "failed"
+    assert failed.resources[0].state == "failed"
 
 
 def test_recovery_restarts_only_unconfirmed_resource(tmp_path: Path) -> None:

--- a/server/tests/test_skill_creator_resource_build.py
+++ b/server/tests/test_skill_creator_resource_build.py
@@ -152,6 +152,89 @@ def test_zero_resource_build_moves_directly_to_skill_markdown(tmp_path: Path) ->
     assert generated.skill_markdown_digest
 
 
+def test_stale_proposal_build_remains_loadable(tmp_path: Path) -> None:
+    plan = _confirmed_plan(tmp_path)
+    store = SkillResourceBuildStore(tmp_path / "build")
+    generated = _append_complete(
+        store,
+        store.create(plan=plan),
+        target_id="SKILL.md",
+        content=(
+            "---\nname: review-incidents\ndescription: "
+            + plan.skill_description
+            + "\n---\n\n# Review incidents\n"
+        ),
+    )
+    validated = store.record_validation(
+        generated.build_id,
+        expected_revision=generated.revision,
+        expected_digest=generated.digest,
+        target_id="SKILL.md",
+        issues=[],
+    )
+    accepted = store.review_skill_markdown(
+        validated.build_id,
+        expected_revision=validated.revision,
+        expected_digest=validated.digest,
+        decision="accept",
+    )
+
+    stale = store.mark_stale(accepted.build_id)
+
+    assert stale.phase == "proposal"
+    assert stale.state == "stale"
+    assert SkillResourceBuildStore(tmp_path / "build").require(stale.build_id) == stale
+
+
+def test_skill_markdown_revision_feedback_is_cumulative(tmp_path: Path) -> None:
+    plan = _confirmed_plan(tmp_path)
+    store = SkillResourceBuildStore(tmp_path / "build")
+    generated = _append_complete(
+        store,
+        store.create(plan=plan),
+        target_id="SKILL.md",
+        content="---\nname: review-incidents\ndescription: Use when reviewing incidents.\n---\n# Review\n",
+    )
+    validated = store.record_validation(
+        generated.build_id,
+        expected_revision=generated.revision,
+        expected_digest=generated.digest,
+        target_id="SKILL.md",
+        issues=[],
+    )
+    first = store.review_skill_markdown(
+        validated.build_id,
+        expected_revision=validated.revision,
+        expected_digest=validated.digest,
+        decision="revise",
+        feedback="Keep the trigger boundary explicit.",
+    )
+    second_generated = _append_complete(
+        store,
+        first,
+        target_id="SKILL.md",
+        content="---\nname: review-incidents\ndescription: Use when reviewing incidents.\n---\n# Review again\n",
+    )
+    second_validated = store.record_validation(
+        second_generated.build_id,
+        expected_revision=second_generated.revision,
+        expected_digest=second_generated.digest,
+        target_id="SKILL.md",
+        issues=[],
+    )
+    second = store.review_skill_markdown(
+        second_validated.build_id,
+        expected_revision=second_validated.revision,
+        expected_digest=second_validated.digest,
+        decision="revise",
+        feedback="Explain exactly when the script is executed.",
+    )
+
+    assert "Keep the trigger boundary explicit." in second.skill_feedback
+    assert "Explain exactly when the script is executed." in second.skill_feedback
+    assert "Additional revision requirements:" in second.skill_feedback
+
+
 def test_dependencies_review_and_script_receipt_are_digest_bound(tmp_path: Path) -> None:
     plan = _confirmed_plan(tmp_path, resources=_complex_resources())
     store = SkillResourceBuildStore(tmp_path / "build")
@@ -482,6 +565,32 @@ def test_recovery_restarts_only_unconfirmed_resource(tmp_path: Path) -> None:
     assert current.resources[0].state == "accepted"
     assert current.resources[0].content == "# Policy\n\nRules.\n"
     assert current.current_resource_id is None
+
+
+def test_targeted_requeue_preserves_repair_budget(tmp_path: Path) -> None:
+    plan = _confirmed_plan(
+        tmp_path,
+        resources=[{**_complex_resources()[0], "depends_on": []}],
+    )
+    store = SkillResourceBuildStore(tmp_path / "build-requeue")
+    created = store.create(plan=plan)
+    claimed = store.claim_next(
+        created.build_id,
+        expected_revision=created.revision,
+        expected_digest=created.digest,
+    )
+
+    requeued = store.requeue_interrupted(
+        claimed.build_id,
+        expected_revision=claimed.revision,
+        expected_digest=claimed.digest,
+    )
+
+    assert requeued.state == "planned"
+    assert requeued.current_resource_id is None
+    assert requeued.resources[0].state == "planned"
+    assert requeued.resources[0].repair_count == 0
+    assert requeued.resources[0].attempt == 1
 
 
 def test_atomic_failure_secret_block_and_top_level_corruption(tmp_path: Path, monkeypatch) -> None:

--- a/server/tests/test_skill_creator_resource_build_api.py
+++ b/server/tests/test_skill_creator_resource_build_api.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from server.skills import creator_api
+
+
+class _BuildStore:
+    def __init__(self) -> None:
+        self.item = SimpleNamespace(
+            build_id="skillbuild_api",
+            session_id="skillcreator_api",
+            revision=1,
+            digest="a" * 64,
+        )
+
+    def require(self, build_id: str):
+        assert build_id == self.item.build_id
+        return self.item
+
+    @staticmethod
+    def serialize(item):
+        return {
+            "build_id": item.build_id,
+            "session_id": item.session_id,
+            "revision": item.revision,
+            "digest": item.digest,
+        }
+
+
+class _BuildService:
+    VERSION = "resource-authoring-build-v1"
+    enabled = True
+
+    def __init__(self) -> None:
+        self.build_store = _BuildStore()
+        self.calls: list[str] = []
+
+    def require_enabled(self) -> None:
+        return None
+
+    def status(self):
+        return {
+            "resource_build_enabled": True,
+            "resource_build_version": self.VERSION,
+            "resource_builder_available": True,
+            "script_sandbox_configured": True,
+        }
+
+    def current_projection(self, _session_id: str):
+        return self.build_store.serialize(self.build_store.item)
+
+    async def start(self, *_args, **_kwargs):
+        self.calls.append("start")
+        return self.build_store.item
+
+    async def next(self, *_args, **_kwargs):
+        self.calls.append("next")
+        return self.build_store.item
+
+    def review_resource(self, *_args, **_kwargs):
+        self.calls.append("review")
+        return self.build_store.item
+
+    def finalize(self, *_args, **_kwargs):
+        self.calls.append("finalize")
+        return self.build_store.item, None
+
+
+@pytest.mark.asyncio
+async def test_resource_build_routes_use_versioned_optimistic_requests() -> None:
+    previous_creator = creator_api._service
+    previous_planning = creator_api._resource_planning_service
+    previous_build = creator_api._resource_build_service
+    creator = SimpleNamespace(require_enabled=lambda: None)
+    planning = SimpleNamespace(require_enabled=lambda: None)
+    build = _BuildService()
+    app = FastAPI()
+    app.include_router(creator_api.router)
+    try:
+        creator_api.configure_skill_creator(creator)
+        creator_api.configure_skill_creator_resource_planning(planning)
+        creator_api.configure_skill_creator_resource_build(build)
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            started = await client.post(
+                "/api/skills/creator/sessions/skillcreator_api/resource-build",
+                json={
+                    "plan_id": "skillplan_api",
+                    "expected_session_revision": 3,
+                    "expected_plan_revision": 2,
+                    "expected_plan_digest": "b" * 64,
+                },
+            )
+            assert started.status_code == 201, started.text
+            fetched = await client.get("/api/skills/creator/resource-builds/skillbuild_api")
+            assert fetched.status_code == 200, fetched.text
+            mutation = {
+                "expected_session_revision": 3,
+                "expected_revision": 1,
+                "expected_digest": "a" * 64,
+            }
+            advanced = await client.post(
+                "/api/skills/creator/resource-builds/skillbuild_api/next",
+                json=mutation,
+            )
+            assert advanced.status_code == 200, advanced.text
+            reviewed = await client.post(
+                "/api/skills/creator/resource-builds/skillbuild_api/resources/resource_one/review",
+                json={**mutation, "decision": "accept", "feedback": ""},
+            )
+            assert reviewed.status_code == 200, reviewed.text
+            finalized = await client.post(
+                "/api/skills/creator/resource-builds/skillbuild_api/finalize",
+                json={**mutation, "decision": "revise", "feedback": "Clarify failure behavior."},
+            )
+            assert finalized.status_code == 200, finalized.text
+            assert finalized.json()["proposal"] is None
+        assert build.calls == ["start", "next", "review", "finalize"]
+    finally:
+        creator_api.configure_skill_creator(previous_creator)
+        creator_api.configure_skill_creator_resource_planning(previous_planning)
+        creator_api.configure_skill_creator_resource_build(previous_build)

--- a/server/tests/test_skill_creator_resource_build_runtime.py
+++ b/server/tests/test_skill_creator_resource_build_runtime.py
@@ -356,6 +356,143 @@ class _ScriptRunner:
         )
 
 
+class _InvalidFirstScriptBuilder(_Builder):
+    def __init__(self) -> None:
+        self.script_calls = 0
+
+    async def generate(
+        self, request: ResourceBuildGenerationRequest
+    ) -> ResourceBuildSegment:
+        item = next(
+            (item for item in request.build.resources if item.resource_id == request.target_id),
+            None,
+        )
+        if item is not None and item.kind == "script":
+            self.script_calls += 1
+            if self.script_calls == 1:
+                segment = await super().generate(request)
+                invalid = [dict(segment.script_tests[0])]
+                invalid[0]["fixtures"] = [
+                    {"path": f"case-{index}.txt", "content": str(index)}
+                    for index in range(9)
+                ]
+                return replace(segment, script_tests=invalid)
+        return await super().generate(request)
+
+
+def test_service_repairs_a_generated_script_contract_once(tmp_path: Path) -> None:
+    runtime = tmp_path / "runtime"
+    plan_store = SkillResourcePlanStore(runtime)
+    plan = _plan(
+        plan_store,
+        resources=[
+            {
+                "kind": "script",
+                "action": "create",
+                "path": "scripts/normalize.py",
+                "purpose": "Normalize timeline values deterministically.",
+                "source_ids": ["positive_example:0"],
+                "used_by_steps": ["normalize"],
+                "depends_on": [],
+                "acceptance_checks": ["Returns non-zero for missing input."],
+            }
+        ],
+    )
+    draft_store = WorkspaceSkillDraftStore(runtime)
+    authoring = AuthoringService(
+        AuthoringProposalStore(runtime),
+        XpertStore(tmp_path / "xperts"),
+        draft_store,
+        local_console_actor_id="console-test",
+    )
+    session = SkillCreatorSession(
+        session_id=plan.session_id,
+        session_revision=1,
+        intent="Create an evidence-bound incident review.",
+        positive_examples=["Review the 09:02 outage timeline."],
+        near_miss_examples=["Rewrite this paragraph."],
+        expected_output="Return six stable Markdown sections.",
+        success_criteria=["Preserve times and never invent a cause."],
+        evidence_confirmed=True,
+        state="editing_draft",
+    )
+    creator = SimpleNamespace(
+        authoring_service=authoring,
+        get_session=lambda _id: (session, None),
+        require_enabled=lambda: None,
+    )
+    planning = SimpleNamespace(plan_store=plan_store, require_enabled=lambda: None)
+    builder = _InvalidFirstScriptBuilder()
+    service = SkillCreatorResourceBuildService(
+        creator,
+        planning,
+        SkillResourceBuildStore(runtime),
+        builder=builder,
+        script_runner=_ScriptRunner(),
+        enabled=True,
+    )
+    build = asyncio.run(
+        service.start(
+            session.session_id,
+            plan_id=plan.plan_id,
+            expected_session_revision=1,
+            expected_plan_revision=plan.revision,
+            expected_plan_digest=plan.digest,
+        )
+    )
+    generated = asyncio.run(
+        service.next(
+            build.build_id,
+            expected_session_revision=1,
+            expected_revision=build.revision,
+            expected_digest=build.digest,
+        )
+    )
+    assert generated.state == "awaiting_review"
+    assert generated.resources[0].repair_count == 1
+    assert generated.resources[0].attempt == 2
+    assert builder.script_calls == 2
+
+
+def test_script_prompt_freezes_fixture_shape_and_limit(tmp_path: Path) -> None:
+    plan = _plan(
+        SkillResourcePlanStore(tmp_path),
+        resources=[
+            {
+                "kind": "script",
+                "action": "create",
+                "path": "scripts/normalize.py",
+                "purpose": "Normalize the timeline.",
+                "source_ids": ["intent"],
+                "used_by_steps": ["normalize"],
+                "depends_on": [],
+                "acceptance_checks": ["Rejects invalid input."],
+            }
+        ],
+    )
+    store = SkillResourceBuildStore(tmp_path / "build")
+    build = store.create(plan=plan)
+    claimed = store.claim_next(
+        build.build_id,
+        expected_revision=build.revision,
+        expected_digest=build.digest,
+    )
+    resource_id = claimed.current_resource_id
+    assert resource_id
+    invocation = build_resource_builder_invocation(
+        ResourceBuildGenerationRequest(
+            build=claimed, target_id=resource_id, segment_index=0
+        ),
+        model_id="provider/model",
+    )
+    context = json.loads(invocation.inputs["creator_request"])
+    assert context["generation_limits"]["script_fixture_count_per_test_max"] == 8
+    role_prompt = invocation.workflow["nodes"][1]["data"]["rolePrompt"]
+    assert '"path":"case.txt","content":"UTF-8 text"' in role_prompt
+    assert '"stdout_contains":["expected text"]' in role_prompt
+    assert "are always JSON arrays" in role_prompt
+
+
 def test_complex_build_reaches_valid_standard_proposal(tmp_path: Path) -> None:
     runtime = tmp_path / "runtime"
     plan_store = SkillResourcePlanStore(runtime)

--- a/server/tests/test_skill_creator_resource_build_runtime.py
+++ b/server/tests/test_skill_creator_resource_build_runtime.py
@@ -1,0 +1,405 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from server.sandbox_sidecar.engine import SandboxEngine
+from server.skills.creator_resource_build import (
+    ResourceScriptTest,
+    ResourceScriptTestReceipt,
+    ResourceScriptTestResult,
+    SkillResourceBuildStore,
+)
+from server.skills.creator_resource_build_runtime import (
+    RESOURCE_BUILDER_WORKFLOW_VERSION,
+    ResourceBuildGenerationRequest,
+    ResourceBuildSegment,
+    SandboxCreatorScriptRunner,
+    build_resource_builder_invocation,
+    parse_resource_build_segment,
+    validate_resource_content,
+)
+from server.skills.creator_resource_plan import SkillResourcePlanStore
+from server.skills.creator_resource_build_service import SkillCreatorResourceBuildService
+from server.skills.creator_store import SkillCreatorSession, SkillCreatorValidationError
+from server.skills.draft_store import WorkspaceSkillDraftStore
+from server.xpert_runtime.authoring_service import AuthoringService
+from server.xpert_runtime.authoring_store import AuthoringProposalStore
+from server.xpert_runtime.sandbox_client import LocalSandboxClient
+from server.xperts.store import XpertStore
+
+
+DESCRIPTION = (
+    "Create evidence-bound incident reviews with timelines and corrective actions. Use when "
+    "users provide incident facts; do not use for generic rewriting or fictional narratives."
+)
+
+
+def _plan(store: SkillResourcePlanStore, *, resources: list[dict] | None = None):
+    raw = store.save_generated(
+        session_id="skillcreator_resource_build",
+        session_revision=1,
+        draft_id=None,
+        draft_revision=None,
+        draft_digest=None,
+        allowed_source_ids={"intent", "positive_example:0", "near_miss:0", "expected_output", "success_criterion:0"},
+        payload={
+            "skill_name": "incident-review",
+            "skill_description": DESCRIPTION,
+            "workflow_steps": [
+                {"id": "collect", "instruction": "Collect explicit incident facts and missing fields."},
+                {"id": "normalize", "instruction": "Normalize the timeline deterministically."},
+                {"id": "analyze", "instruction": "Separate known causes from unknown claims."},
+                {"id": "deliver", "instruction": "Render and verify the final review."},
+            ],
+            "output_contract": ["Return a Chinese Markdown incident review with six stable sections."],
+            "failure_modes": ["Mark unavailable facts as pending confirmation and never invent them."],
+            "resources": [{"generation_cost": "medium", **item} for item in (resources or [])],
+            "clarifications": [],
+        },
+    )
+    return store.confirm(
+        raw.plan_id,
+        expected_revision=raw.revision,
+        expected_digest=raw.digest,
+        session_revision=1,
+        draft_revision=None,
+        draft_digest=None,
+    )
+
+
+def _skill_markdown() -> str:
+    return f"""---
+name: incident-review
+description: {DESCRIPTION}
+---
+
+# Incident review
+
+## Purpose and scope
+
+Use this Skill only for evidence-bound incident reviews. It preserves supplied facts, rejects
+fictional additions, distinguishes missing evidence, and does not replace a general rewriting
+workflow. The report remains useful when the root cause is unknown.
+
+## Inputs and preconditions
+
+Require an incident description with observable events. Accept partial records, but label every
+missing time, owner, impact, cause, or corrective action as pending confirmation. Never treat the
+reference policy as evidence about the current incident.
+
+## Workflow
+
+1. Collect explicit facts and classify unsupported claims with `references/evidence-policy.md`.
+2. Normalize timeline rows using `scripts/normalize.py`; stop on malformed input.
+3. Separate known, unknown, and contradicted claims before drawing conclusions.
+4. Copy and render `assets/review-template.md`, then verify every required section.
+
+## Output contract
+
+Return Chinese Markdown with event summary, timeline, impact, root cause, corrective actions, and
+pending confirmations. Preserve every supplied time and owner. Mark unknown causes explicitly.
+
+## Failure and degradation
+
+If the script rejects an input, report the validation failure and retain the raw fact for manual
+review. If a required field is absent, write pending confirmation. Never guess a root cause or
+silently omit conflicting evidence.
+
+## Quality checks
+
+Confirm chronological ordering, exact preservation of supplied facts, complete section coverage,
+and a clear distinction between completed and proposed corrective actions. Re-run the script after
+any timeline edit and inspect its non-zero failure result before delivery.
+
+## Resources
+
+- Read `references/evidence-policy.md` only when classifying a claim.
+- Run `scripts/normalize.py ../inputs/timeline.txt` for deterministic normalization.
+- Copy and render `assets/review-template.md` in the delivery step.
+- For a focused lookup, run `rg -n \"unknown|unsupported\" references/evidence-policy.md`.
+"""
+
+
+def test_segment_parser_and_invocation_freeze_target(tmp_path: Path) -> None:
+    plan = _plan(SkillResourcePlanStore(tmp_path), resources=[])
+    # Directly move the real build to its server-selected SKILL.md target.
+    store = SkillResourceBuildStore(tmp_path / "build-store")
+    build = store.create(plan=plan)
+    build = store.claim_next(build.build_id, expected_revision=build.revision, expected_digest=build.digest)
+    invocation = build_resource_builder_invocation(
+        ResourceBuildGenerationRequest(build=build, target_id="SKILL.md", segment_index=0),
+        model_id="provider/model",
+    )
+    assert invocation.runtime_metadata["resource_builder_workflow_version"] == RESOURCE_BUILDER_WORKFLOW_VERSION
+    assert invocation.runtime_metadata["resource_target_id"] == "SKILL.md"
+    parsed = parse_resource_build_segment(
+        json.dumps({
+            "resource_build_version": "skill-resource-build-v1",
+            "target_id": "SKILL.md",
+            "segment_index": 0,
+            "content": "segment",
+            "complete": True,
+            "script_tests": [],
+        }),
+        expected_target_id="SKILL.md",
+        expected_segment_index=0,
+    )
+    assert parsed.complete is True
+    with pytest.raises(SkillCreatorValidationError):
+        parse_resource_build_segment(
+            json.dumps({"resource_build_version": "skill-resource-build-v1", "target_id": "other", "segment_index": 0, "content": "x", "complete": True}),
+            expected_target_id="SKILL.md",
+            expected_segment_index=0,
+        )
+
+
+def test_resource_invocation_only_loads_direct_dependency_content(
+    tmp_path: Path,
+) -> None:
+    plan = _plan(
+        SkillResourcePlanStore(tmp_path),
+        resources=[
+            {
+                "kind": "reference",
+                "action": "create",
+                "path": "references/policy.md",
+                "purpose": "Define evidence boundaries.",
+                "source_ids": ["intent"],
+                "used_by_steps": ["collect"],
+                "depends_on": [],
+                "acceptance_checks": ["Defines supported claims."],
+            },
+            {
+                "kind": "script",
+                "action": "create",
+                "path": "scripts/normalize.py",
+                "purpose": "Normalize timeline facts.",
+                "source_ids": ["positive_example:0"],
+                "used_by_steps": ["normalize"],
+                "depends_on": ["references/policy.md"],
+                "acceptance_checks": ["Rejects malformed input."],
+            },
+            {
+                "kind": "asset",
+                "action": "create",
+                "path": "assets/report.md",
+                "purpose": "Render the report.",
+                "source_ids": ["expected_output"],
+                "used_by_steps": ["deliver"],
+                "depends_on": [],
+                "acceptance_checks": ["Contains required placeholders."],
+            },
+        ],
+    )
+    build = SkillResourceBuildStore(tmp_path / "build").create(plan=plan)
+    reference, script, asset = build.resources
+    reference_content = "# Policy\n\nUse explicit facts.\n"
+    asset_content = "# Template\n\n{{summary}}\n"
+    build = replace(
+        build,
+        resources=[
+            replace(
+                reference,
+                state="accepted",
+                content=reference_content,
+                content_digest=__import__("hashlib").sha256(
+                    reference_content.encode()
+                ).hexdigest(),
+            ),
+            script,
+            replace(
+                asset,
+                state="accepted",
+                content=asset_content,
+                content_digest=__import__("hashlib").sha256(
+                    asset_content.encode()
+                ).hexdigest(),
+            ),
+        ],
+    )
+    invocation = build_resource_builder_invocation(
+        ResourceBuildGenerationRequest(
+            build=build,
+            target_id=script.resource_id,
+            segment_index=0,
+        ),
+        model_id="provider/model",
+    )
+    context = json.loads(invocation.inputs["creator_request"])
+    assert context["accepted_resource_content"] == {
+        "references/policy.md": reference_content
+    }
+
+
+def test_script_runner_produces_digest_bound_receipt(tmp_path: Path) -> None:
+    engine = SandboxEngine(tmp_path / "sidecar", require_landlock=False)
+    runner = SandboxCreatorScriptRunner(LocalSandboxClient(engine))
+    content = """import sys
+if len(sys.argv) != 2:
+    raise SystemExit(2)
+print(sys.argv[1].upper())
+"""
+    item = SimpleNamespace(
+        kind="script",
+        path="scripts/upper.py",
+        content=content,
+        content_digest=__import__("hashlib").sha256(content.encode()).hexdigest(),
+        script_tests=[ResourceScriptTest(test_id="happy", args=["hello"], fixtures=[], expected_exit_code=0, stdout_contains=["HELLO"], stderr_contains=[])],
+    )
+    receipt = asyncio.run(runner.run(item))
+    assert receipt.passed is True
+    assert receipt.script_digest == item.content_digest
+    assert receipt.profile == "skill_authoring_v1"
+
+
+def test_script_runner_executes_javascript_cli_offline(tmp_path: Path) -> None:
+    engine = SandboxEngine(tmp_path / "sidecar-js", require_landlock=False)
+    runner = SandboxCreatorScriptRunner(LocalSandboxClient(engine))
+    content = """const value = process.argv[2];
+if (!value) {
+  console.error('usage: upper.js VALUE');
+  process.exit(2);
+}
+console.log(value.toUpperCase());
+"""
+    item = SimpleNamespace(
+        kind="script",
+        path="scripts/upper.js",
+        content=content,
+        content_digest=__import__("hashlib").sha256(content.encode()).hexdigest(),
+        script_tests=[
+            ResourceScriptTest(
+                test_id="happy_js",
+                args=["hello"],
+                fixtures=[],
+                expected_exit_code=0,
+                stdout_contains=["HELLO"],
+                stderr_contains=[],
+            )
+        ],
+    )
+    receipt = asyncio.run(runner.run(item))
+    assert receipt.passed is True
+    assert receipt.results[0].exit_code == 0
+
+
+@pytest.mark.parametrize(
+    ("path", "content", "expected_code"),
+    [
+        (
+            "scripts/broken.py",
+            "import sys\nprint(sys.argv[1]\nraise SystemExit(2)\n",
+            "python_syntax_invalid",
+        ),
+        (
+            "scripts/broken.js",
+            "const value = ;\nprocess.argv; process.exit(2);\n",
+            "javascript_syntax_invalid",
+        ),
+    ],
+)
+def test_resource_validation_rejects_script_syntax_errors(
+    path: str, content: str, expected_code: str
+) -> None:
+    issues = validate_resource_content(
+        SimpleNamespace(kind="script", path=path, content=content)
+    )
+    assert expected_code in {str(issue.get("code")) for issue in issues}
+
+
+class _Builder:
+    def available(self) -> bool:
+        return True
+
+    async def generate(self, request: ResourceBuildGenerationRequest) -> ResourceBuildSegment:
+        target = request.target_id
+        if target == "SKILL.md":
+            content = _skill_markdown()
+            tests = []
+        else:
+            item = next(item for item in request.build.resources if item.resource_id == target)
+            if item.kind == "reference":
+                content = "# Evidence policy\n\nKnown claims have direct support. Unknown claims stay pending. Unsupported claims are rejected.\n"
+                tests = []
+            elif item.kind == "asset":
+                content = "# Incident review template\n\nCopy this template and replace placeholders: {{summary}}, {{timeline}}, {{actions}}.\n"
+                tests = []
+            else:
+                content = """import sys
+def main() -> int:
+    if len(sys.argv) != 2:
+        print('usage: normalize.py VALUE', file=sys.stderr)
+        return 2
+    print(sys.argv[1].strip())
+    return 0
+if __name__ == '__main__':
+    raise SystemExit(main())
+"""
+                tests = [{"test_id": "happy", "args": ["09:02"], "fixtures": [], "expected_exit_code": 0, "stdout_contains": ["09:02"], "stderr_contains": []}]
+        return ResourceBuildSegment(target_id=target, segment_index=request.segment_index, content=content, complete=True, script_tests=tests)
+
+
+class _ScriptRunner:
+    async def run(self, item):
+        return ResourceScriptTestReceipt(
+            receipt_id="script_receipt_test",
+            script_digest=item.content_digest,
+            profile="skill_authoring_v1",
+            passed=True,
+            results=[ResourceScriptTestResult(test_id="happy", passed=True, exit_code=0, stdout_sha256="a" * 64, stderr_sha256="b" * 64, duration_ms=1)],
+        )
+
+
+def test_complex_build_reaches_valid_standard_proposal(tmp_path: Path) -> None:
+    runtime = tmp_path / "runtime"
+    plan_store = SkillResourcePlanStore(runtime)
+    plan = _plan(plan_store, resources=[
+        {"kind": "reference", "action": "create", "path": "references/evidence-policy.md", "purpose": "Keep claim boundaries separate.", "source_ids": ["intent", "near_miss:0"], "used_by_steps": ["collect", "analyze"], "depends_on": [], "acceptance_checks": ["Defines known, unknown, and unsupported claims."]},
+        {"kind": "script", "action": "create", "path": "scripts/normalize.py", "purpose": "Normalize timeline values deterministically.", "source_ids": ["positive_example:0"], "used_by_steps": ["normalize"], "depends_on": ["references/evidence-policy.md"], "acceptance_checks": ["Returns non-zero for missing input."]},
+        {"kind": "asset", "action": "create", "path": "assets/review-template.md", "purpose": "Provide reusable output boilerplate.", "source_ids": ["expected_output"], "used_by_steps": ["deliver"], "depends_on": [], "acceptance_checks": ["Contains all output placeholders."]},
+    ])
+    draft_store = WorkspaceSkillDraftStore(runtime)
+    authoring = AuthoringService(AuthoringProposalStore(runtime), XpertStore(tmp_path / "xperts"), draft_store, local_console_actor_id="console-test")
+    session = SkillCreatorSession(
+        session_id=plan.session_id,
+        session_revision=1,
+        intent="Create an evidence-bound incident review.",
+        positive_examples=["Review the 09:02 outage timeline."],
+        near_miss_examples=["Rewrite this paragraph."],
+        expected_output="Return six stable Markdown sections.",
+        success_criteria=["Preserve times and never invent a cause."],
+        evidence_confirmed=True,
+        state="editing_draft",
+    )
+    creator = SimpleNamespace(authoring_service=authoring, get_session=lambda _id: (session, None), require_enabled=lambda: None)
+    planning = SimpleNamespace(plan_store=plan_store, require_enabled=lambda: None)
+    service = SkillCreatorResourceBuildService(
+        creator,
+        planning,
+        SkillResourceBuildStore(runtime),
+        builder=_Builder(),
+        script_runner=_ScriptRunner(),
+        enabled=True,
+    )
+    build = asyncio.run(service.start(session.session_id, plan_id=plan.plan_id, expected_session_revision=1, expected_plan_revision=plan.revision, expected_plan_digest=plan.digest))
+    while build.phase == "resources":
+        build = asyncio.run(service.next(build.build_id, expected_session_revision=1, expected_revision=build.revision, expected_digest=build.digest))
+        assert build.state == "awaiting_review"
+        resource_id = build.current_resource_id
+        assert resource_id
+        build = service.review_resource(build.build_id, resource_id=resource_id, expected_session_revision=1, expected_revision=build.revision, expected_digest=build.digest, decision="accept")
+    build = asyncio.run(service.next(build.build_id, expected_session_revision=1, expected_revision=build.revision, expected_digest=build.digest))
+    assert build.state == "awaiting_review", build.skill_validation_issues
+    build, proposal = service.finalize(build.build_id, expected_session_revision=1, expected_revision=build.revision, expected_digest=build.digest, decision="accept")
+    assert proposal is not None
+    assert proposal.validation["valid"] is True
+    assert build.proposal_id == proposal.proposal_id
+    assert proposal.payload["skill"]["files"].keys() == {
+        "references/evidence-policy.md", "scripts/normalize.py", "assets/review-template.md"
+    }

--- a/server/tests/test_skill_creator_resource_build_runtime.py
+++ b/server/tests/test_skill_creator_resource_build_runtime.py
@@ -22,6 +22,7 @@ from server.skills.creator_resource_build_runtime import (
     SandboxCreatorScriptRunner,
     build_resource_builder_invocation,
     parse_resource_build_segment,
+    validate_final_resource_package,
     validate_resource_content,
 )
 from server.skills.creator_resource_plan import SkillResourcePlanStore
@@ -157,6 +158,171 @@ def test_segment_parser_and_invocation_freeze_target(tmp_path: Path) -> None:
             expected_target_id="SKILL.md",
             expected_segment_index=0,
         )
+
+    invocation = build_resource_builder_invocation(
+        ResourceBuildGenerationRequest(
+            build=build,
+            target_id="SKILL.md",
+            segment_index=0,
+        ),
+        model_id="test-model",
+    )
+    role_prompt = invocation.workflow["nodes"][1]["data"]["rolePrompt"]
+    assert "one to three tests" in role_prompt
+    assert "at most ten" in role_prompt
+    assert "stdout_contains" in role_prompt
+    assert "copy skill.name and skill.description" in role_prompt
+
+
+def test_segment_parser_accepts_one_versioned_object_with_narration() -> None:
+    payload = {
+        "resource_build_version": "skill-resource-build-v1",
+        "target_id": "resource_1",
+        "segment_index": 0,
+        "content": "generated content",
+        "complete": True,
+        "script_tests": [],
+    }
+    parsed = parse_resource_build_segment(
+        "Generated result follows:\n```json\n"
+        + json.dumps(payload)
+        + "\n```\nNo other resource was generated.",
+        expected_target_id="resource_1",
+        expected_segment_index=0,
+    )
+
+    assert parsed.content == "generated content"
+
+
+def test_segment_parser_rejects_ambiguous_versioned_objects() -> None:
+    first = {
+        "resource_build_version": "skill-resource-build-v1",
+        "target_id": "resource_1",
+        "segment_index": 0,
+        "content": "first",
+        "complete": True,
+        "script_tests": [],
+    }
+    second = {**first, "content": "second"}
+
+    with pytest.raises(SkillCreatorValidationError) as caught:
+        parse_resource_build_segment(
+            json.dumps(first) + "\n" + json.dumps(second),
+            expected_target_id="resource_1",
+            expected_segment_index=0,
+        )
+
+    assert caught.value.code == "skill_creator_resource_builder_invalid"
+
+
+def test_complete_skill_output_can_be_mechanically_segmented() -> None:
+    content = "资源化 Skill 正文。\n" * 700
+    assert len(content.encode("utf-8")) > 8 * 1024
+    payload = {
+        "resource_build_version": "skill-resource-build-v1",
+        "target_id": "SKILL.md",
+        "segment_index": 0,
+        "content": content,
+        "complete": True,
+        "script_tests": [],
+    }
+
+    parsed = parse_resource_build_segment(
+        json.dumps(payload, ensure_ascii=False),
+        expected_target_id="SKILL.md",
+        expected_segment_index=0,
+    )
+    parts = SkillCreatorResourceBuildService._split_utf8_segments(parsed.content)
+
+    assert "".join(parts) == content
+    assert 2 <= len(parts) <= 3
+    assert all(len(part.encode("utf-8")) <= 8 * 1024 for part in parts)
+
+
+def test_skill_output_still_rejects_the_total_target_budget() -> None:
+    payload = {
+        "resource_build_version": "skill-resource-build-v1",
+        "target_id": "SKILL.md",
+        "segment_index": 0,
+        "content": "x" * (20 * 1024 + 1),
+        "complete": True,
+        "script_tests": [],
+    }
+
+    with pytest.raises(SkillCreatorValidationError) as caught:
+        parse_resource_build_segment(
+            json.dumps(payload),
+            expected_target_id="SKILL.md",
+            expected_segment_index=0,
+        )
+
+    assert caught.value.code == "skill_creator_resource_segment_invalid"
+
+
+def test_script_builder_prompt_freezes_fixture_transport(tmp_path: Path) -> None:
+    plan = _plan(
+        SkillResourcePlanStore(tmp_path),
+        resources=[
+            {
+                "kind": "script",
+                "action": "create",
+                "path": "scripts/normalize.py",
+                "purpose": "Normalize timeline rows deterministically.",
+                "source_ids": ["positive_example:0"],
+                "used_by_steps": ["normalize"],
+                "depends_on": [],
+                "acceptance_checks": ["Returns non-zero for invalid input."],
+            }
+        ],
+    )
+    store = SkillResourceBuildStore(tmp_path / "script-build")
+    created = store.create(plan=plan)
+    claimed = store.claim_next(
+        created.build_id,
+        expected_revision=created.revision,
+        expected_digest=created.digest,
+    )
+    invocation = build_resource_builder_invocation(
+        ResourceBuildGenerationRequest(
+            build=claimed,
+            target_id=claimed.current_resource_id or "",
+            segment_index=0,
+        ),
+        model_id="test-model",
+    )
+
+    role_prompt = invocation.workflow["nodes"][1]["data"]["rolePrompt"]
+    assert "does not pipe fixture content to stdin" in role_prompt
+    assert "file-path argument" in role_prompt
+
+
+def test_final_package_rejects_frontmatter_metadata_drift(tmp_path: Path) -> None:
+    plan = _plan(SkillResourcePlanStore(tmp_path), resources=[])
+    store = SkillResourceBuildStore(tmp_path / "build-store")
+    generated = store.claim_next(
+        (build := store.create(plan=plan)).build_id,
+        expected_revision=build.revision,
+        expected_digest=build.digest,
+    )
+    assembled = store.append_segment(
+        generated.build_id,
+        expected_revision=generated.revision,
+        expected_digest=generated.digest,
+        target_id="SKILL.md",
+        segment_index=0,
+        content=(
+            "---\nname: incident-review\n"
+            "description: A rewritten description. Use when reviewing incidents; "
+            "do not use for fiction.\n---\n\n# Incident review\n"
+        ),
+        complete=True,
+    )
+
+    issues = validate_final_resource_package(assembled)
+
+    assert "skill_package_description_mismatch" in {
+        issue["code"] for issue in issues
+    }
 
 
 def test_resource_invocation_only_loads_direct_dependency_content(
@@ -302,6 +468,16 @@ console.log(value.toUpperCase());
             "const value = ;\nprocess.argv; process.exit(2);\n",
             "javascript_syntax_invalid",
         ),
+        (
+            "scripts/duplicated.py",
+            (
+                "#!/usr/bin/env python3\nimport sys\n"
+                "if __name__ == '__main__':\n    raise SystemExit(0)\n"
+                "#!/usr/bin/env python3\n"
+                "if __name__ == '__main__':\n    raise SystemExit(0)\n"
+            ),
+            "skill_creator_script_duplicate_entrypoint",
+        ),
     ],
 )
 def test_resource_validation_rejects_script_syntax_errors(
@@ -378,6 +554,289 @@ class _InvalidFirstScriptBuilder(_Builder):
                 ]
                 return replace(segment, script_tests=invalid)
         return await super().generate(request)
+
+
+class _TransientFirstBuilder(_Builder):
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def generate(
+        self, request: ResourceBuildGenerationRequest
+    ) -> ResourceBuildSegment:
+        self.calls += 1
+        if self.calls == 1:
+            raise RuntimeError("temporary provider failure")
+        return await super().generate(request)
+
+
+class _CancelledFirstBuilder(_Builder):
+    async def generate(
+        self, request: ResourceBuildGenerationRequest
+    ) -> ResourceBuildSegment:
+        raise asyncio.CancelledError
+
+
+@pytest.mark.asyncio
+async def test_service_requeues_transient_builder_failure_without_repair_budget(
+    tmp_path: Path,
+) -> None:
+    runtime = tmp_path / "runtime-transient"
+    plan_store = SkillResourcePlanStore(runtime)
+    plan = _plan(
+        plan_store,
+        resources=[
+            {
+                "kind": "reference",
+                "action": "create",
+                "path": "references/evidence-policy.md",
+                "purpose": "Keep evidence rules separate from the workflow.",
+                "source_ids": ["intent"],
+                "used_by_steps": ["collect"],
+                "depends_on": [],
+                "acceptance_checks": ["Defines supported evidence boundaries."],
+            }
+        ],
+    )
+    session = SkillCreatorSession(
+        session_id=plan.session_id,
+        session_revision=1,
+        intent="Create an evidence-bound incident review.",
+        positive_examples=["Review an incident timeline."],
+        near_miss_examples=["Rewrite this paragraph."],
+        expected_output="Return a Chinese Markdown incident review.",
+        success_criteria=["Never invent a root cause."],
+        evidence_confirmed=True,
+        state="editing_draft",
+    )
+    creator = SimpleNamespace(
+        authoring_service=None,
+        get_session=lambda _id: (session, None),
+        require_enabled=lambda: None,
+    )
+    planning = SimpleNamespace(plan_store=plan_store, require_enabled=lambda: None)
+    store = SkillResourceBuildStore(runtime)
+    builder = _TransientFirstBuilder()
+    service = SkillCreatorResourceBuildService(
+        creator,
+        planning,
+        store,
+        builder=builder,
+        enabled=True,
+    )
+    build = await service.start(
+        session.session_id,
+        plan_id=plan.plan_id,
+        expected_session_revision=1,
+        expected_plan_revision=plan.revision,
+        expected_plan_digest=plan.digest,
+    )
+
+    with pytest.raises(SkillCreatorValidationError) as caught:
+        await service.next(
+            build.build_id,
+            expected_session_revision=1,
+            expected_revision=build.revision,
+            expected_digest=build.digest,
+        )
+    assert caught.value.code == "skill_creator_resource_builder_failed"
+    requeued = store.require(build.build_id)
+    assert requeued.state == "planned"
+    assert requeued.resources[0].state == "planned"
+    assert requeued.resources[0].repair_count == 0
+    assert requeued.resources[0].attempt == 1
+
+    generated = await service.next(
+        build.build_id,
+        expected_session_revision=1,
+        expected_revision=requeued.revision,
+        expected_digest=requeued.digest,
+    )
+    assert generated.state == "awaiting_review"
+    assert builder.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_service_requeues_cancelled_builder_without_stranding_target(
+    tmp_path: Path,
+) -> None:
+    runtime = tmp_path / "runtime-cancelled"
+    plan_store = SkillResourcePlanStore(runtime)
+    plan = _plan(
+        plan_store,
+        resources=[
+            {
+                "kind": "reference",
+                "action": "create",
+                "path": "references/evidence-policy.md",
+                "purpose": "Keep evidence rules separate from the workflow.",
+                "source_ids": ["intent"],
+                "used_by_steps": ["collect"],
+                "depends_on": [],
+                "acceptance_checks": ["Defines supported evidence boundaries."],
+            }
+        ],
+    )
+    session = SkillCreatorSession(
+        session_id=plan.session_id,
+        session_revision=1,
+        intent="Create an evidence-bound incident review.",
+        positive_examples=["Review an incident timeline."],
+        near_miss_examples=["Rewrite this paragraph."],
+        expected_output="Return a Chinese Markdown incident review.",
+        success_criteria=["Never invent a root cause."],
+        evidence_confirmed=True,
+        state="editing_draft",
+    )
+    creator = SimpleNamespace(
+        authoring_service=None,
+        get_session=lambda _id: (session, None),
+        require_enabled=lambda: None,
+    )
+    planning = SimpleNamespace(plan_store=plan_store, require_enabled=lambda: None)
+    store = SkillResourceBuildStore(runtime)
+    service = SkillCreatorResourceBuildService(
+        creator,
+        planning,
+        store,
+        builder=_CancelledFirstBuilder(),
+        enabled=True,
+    )
+    build = await service.start(
+        session.session_id,
+        plan_id=plan.plan_id,
+        expected_session_revision=1,
+        expected_plan_revision=plan.revision,
+        expected_plan_digest=plan.digest,
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await service.next(
+            build.build_id,
+            expected_session_revision=1,
+            expected_revision=build.revision,
+            expected_digest=build.digest,
+        )
+
+    requeued = store.require(build.build_id)
+    assert requeued.state == "planned"
+    assert requeued.resources[0].state == "planned"
+    assert requeued.resources[0].attempt == 1
+    assert requeued.resources[0].repair_count == 0
+
+
+@pytest.mark.asyncio
+async def test_new_confirmed_plan_supersedes_active_prior_build(
+    tmp_path: Path,
+) -> None:
+    runtime = tmp_path / "runtime-plan-revision"
+    plan_store = SkillResourcePlanStore(runtime)
+    plan = _plan(
+        plan_store,
+        resources=[
+            {
+                "kind": "reference",
+                "action": "create",
+                "path": "references/evidence-policy.md",
+                "purpose": "Keep evidence rules separate from the workflow.",
+                "source_ids": ["intent"],
+                "used_by_steps": ["collect"],
+                "depends_on": [],
+                "acceptance_checks": ["Defines supported evidence boundaries."],
+            }
+        ],
+    )
+    session = SkillCreatorSession(
+        session_id=plan.session_id,
+        session_revision=1,
+        intent="Create an evidence-bound incident review.",
+        positive_examples=["Review an incident timeline."],
+        near_miss_examples=["Rewrite this paragraph."],
+        expected_output="Return a Chinese Markdown incident review.",
+        success_criteria=["Never invent a root cause."],
+        evidence_confirmed=True,
+        state="editing_draft",
+    )
+    creator = SimpleNamespace(
+        authoring_service=None,
+        get_session=lambda _id: (session, None),
+        require_enabled=lambda: None,
+    )
+    planning = SimpleNamespace(plan_store=plan_store, require_enabled=lambda: None)
+    store = SkillResourceBuildStore(runtime)
+    service = SkillCreatorResourceBuildService(
+        creator,
+        planning,
+        store,
+        builder=_Builder(),
+        enabled=True,
+    )
+    first = await service.start(
+        session.session_id,
+        plan_id=plan.plan_id,
+        expected_session_revision=1,
+        expected_plan_revision=plan.revision,
+        expected_plan_digest=plan.digest,
+    )
+    awaiting_review = await service.next(
+        first.build_id,
+        expected_session_revision=1,
+        expected_revision=first.revision,
+        expected_digest=first.digest,
+    )
+    assert awaiting_review.state == "awaiting_review"
+
+    resource = plan.resources[0]
+    revised = plan_store.patch(
+        plan.plan_id,
+        expected_revision=plan.revision,
+        expected_digest=plan.digest,
+        allowed_source_ids={
+            "intent",
+            "positive_example:0",
+            "near_miss:0",
+            "expected_output",
+            "success_criterion:0",
+        },
+        changes={
+            "resources": [
+                {
+                    "kind": resource.kind,
+                    "action": resource.action,
+                    "generation_cost": resource.generation_cost,
+                    "path": resource.path,
+                    "purpose": resource.purpose,
+                    "source_ids": resource.source_ids,
+                    "used_by_steps": resource.used_by_steps,
+                    "depends_on": [],
+                    "acceptance_checks": [
+                        "Defines supported evidence boundaries and explicit failure behavior."
+                    ],
+                }
+            ]
+        },
+    )
+    revised = plan_store.confirm(
+        revised.plan_id,
+        expected_revision=revised.revision,
+        expected_digest=revised.digest,
+        session_revision=1,
+        draft_revision=None,
+        draft_digest=None,
+    )
+
+    replacement = await service.start(
+        session.session_id,
+        plan_id=revised.plan_id,
+        expected_session_revision=1,
+        expected_plan_revision=revised.revision,
+        expected_plan_digest=revised.digest,
+    )
+
+    assert replacement.build_id != first.build_id
+    assert replacement.plan_revision == revised.revision
+    assert replacement.plan_digest == revised.digest
+    assert replacement.resources[0].state == "planned"
+    assert store.require(first.build_id).state == "stale"
 
 
 def test_service_repairs_a_generated_script_contract_once(tmp_path: Path) -> None:

--- a/server/tests/test_skill_creator_resource_plan.py
+++ b/server/tests/test_skill_creator_resource_plan.py
@@ -152,6 +152,128 @@ def test_complex_plan_assigns_stable_ids_and_dependencies(tmp_path: Path) -> Non
     assert patched.digest != plan.digest
 
 
+def test_confirmed_plan_revision_can_update_metadata_and_reuse_resources(
+    tmp_path: Path,
+) -> None:
+    store = SkillResourcePlanStore(tmp_path)
+    plan = _save(
+        store,
+        _payload(
+            resources=[
+                {
+                    "kind": "reference",
+                    "action": "create",
+                    "path": "references/evidence-policy.md",
+                    "purpose": "Keep detailed evidence boundaries out of SKILL.md.",
+                    "source_ids": ["intent"],
+                    "used_by_steps": ["collect"],
+                    "depends_on": [],
+                    "acceptance_checks": ["Contains the supplied evidence policy."],
+                }
+            ]
+        ),
+    )
+    confirmed = store.confirm(
+        plan.plan_id,
+        expected_revision=plan.revision,
+        expected_digest=plan.digest,
+        session_revision=plan.session_revision,
+        draft_revision=None,
+        draft_digest=None,
+    )
+
+    revised = store.patch(
+        confirmed.plan_id,
+        expected_revision=confirmed.revision,
+        expected_digest=confirmed.digest,
+        allowed_source_ids=SOURCE_IDS,
+        changes={
+            "skill_description": (
+                "Create evidence-bound incident reviews. Use when users need a verified "
+                "timeline; do not use for generic rewriting."
+            )
+        },
+    )
+
+    assert revised.state == "ready"
+    assert revised.revision == confirmed.revision + 1
+    assert revised.resources[0].resource_id == confirmed.resources[0].resource_id
+    assert revised.resources[0].spec_digest == confirmed.resources[0].spec_digest
+    assert store.require(confirmed.plan_id, revision=confirmed.revision) == confirmed
+
+
+def test_model_enum_aliases_are_normalized_before_persistence(tmp_path: Path) -> None:
+    store = SkillResourcePlanStore(tmp_path)
+    payload = _payload(
+        resources=[
+            {
+                "kind": "references",
+                "action": "add",
+                "generation_cost": "moderate",
+                "path": "references/rules.md",
+                "purpose": "Keep detailed scoring rules out of SKILL.md.",
+                "source_ids": ["intent"],
+                "used_by_steps": ["collect"],
+                "acceptance_checks": ["Contains the supplied scoring rules."],
+            },
+            {
+                "kind": "脚本",
+                "action": "创建",
+                "generation_cost": "高",
+                "path": "scripts/calculate.py",
+                "purpose": "Calculate standings deterministically.",
+                "source_ids": ["success_criterion:0"],
+                "used_by_steps": ["normalize"],
+                "acceptance_checks": ["Returns a non-zero exit for invalid rows."],
+            },
+            {
+                "kind": "template",
+                "path": "assets/report.md",
+                "purpose": "Provide the reusable report skeleton.",
+                "source_ids": ["expected_output"],
+                "used_by_steps": ["deliver"],
+                "acceptance_checks": ["Contains every required report section."],
+            },
+        ]
+    )
+
+    plan = _save(store, payload)
+
+    assert [(item.kind, item.action, item.generation_cost) for item in plan.resources] == [
+        ("reference", "create", "medium"),
+        ("script", "create", "high"),
+        ("asset", "create", "medium"),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "code"),
+    [
+        ("kind", "database", "skill_creator_resource_kind_invalid"),
+        ("action", "publish", "skill_creator_resource_action_invalid"),
+        ("generation_cost", "unbounded", "skill_creator_resource_cost_invalid"),
+    ],
+)
+def test_unknown_model_enum_values_still_fail_closed(
+    tmp_path: Path, field: str, value: str, code: str
+) -> None:
+    resource = {
+        "kind": "reference",
+        "action": "create",
+        "generation_cost": "medium",
+        "path": "references/rules.md",
+        "purpose": "Keep detailed rules out of SKILL.md.",
+        "source_ids": ["intent"],
+        "used_by_steps": ["collect"],
+        "acceptance_checks": ["Contains the supplied rules."],
+    }
+    resource[field] = value
+
+    with pytest.raises(SkillCreatorValidationError) as caught:
+        _save(SkillResourcePlanStore(tmp_path), _payload(resources=[resource]))
+    assert caught.value.code == code
+
+
 def test_clarification_answers_are_immutable_and_require_regeneration(tmp_path: Path) -> None:
     store = SkillResourcePlanStore(tmp_path)
     plan = _save(
@@ -225,13 +347,23 @@ def test_confirm_is_bound_to_session_and_draft_snapshot(tmp_path: Path) -> None:
     assert confirmed.state == "confirmed"
     assert confirmed.revision == plan.revision + 1
 
+    revised = store.patch(
+        plan.plan_id,
+        expected_revision=confirmed.revision,
+        expected_digest=confirmed.digest,
+        allowed_source_ids=SOURCE_IDS,
+        changes={"skill_name": "changed-name"},
+    )
+    assert revised.state == "ready"
+    assert revised.skill_name == "changed-name"
+
     with pytest.raises(SkillCreatorConflictError):
         store.patch(
             plan.plan_id,
             expected_revision=confirmed.revision,
             expected_digest=confirmed.digest,
             allowed_source_ids=SOURCE_IDS,
-            changes={"skill_name": "changed-name"},
+            changes={"skill_name": "stale-write"},
         )
 
 

--- a/server/tests/test_skill_creator_resource_service.py
+++ b/server/tests/test_skill_creator_resource_service.py
@@ -13,6 +13,11 @@ from server.skills.creator_resource_plan import (
     RESOURCE_PLAN_VERSION,
     SkillResourcePlanStore,
 )
+from server.skills.creator_resource_build import SkillResourceBuildStore
+from server.skills.creator_resource_build_runtime import (
+    ResourceBuildGenerationRequest,
+    build_resource_builder_invocation,
+)
 from server.skills.creator_resource_runtime import (
     WorkflowCreatorResourcePlanner,
     build_resource_planner_invocation,
@@ -338,6 +343,7 @@ async def test_resource_planner_direct_runtime_uses_creator_token_budget(
         current_plan=None,
         allowed_source_ids=["intent", "expected_output"],
     )
+
     invocation = build_resource_planner_invocation(
         request, model_id="gateway/default-text"
     )
@@ -402,6 +408,91 @@ async def test_resource_planner_direct_runtime_uses_creator_token_budget(
         )
         == main_module.SKILL_CREATOR_AGENT_MAX_TOKENS
     )
+
+
+@pytest.mark.asyncio
+async def test_resource_builder_direct_runtime_uses_frozen_budget_and_temperature(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan_store = SkillResourcePlanStore(tmp_path / "plans")
+    plan = plan_store.save_generated(
+        session_id="skillcreator_resource_builder_budget",
+        session_revision=1,
+        draft_id=None,
+        draft_revision=None,
+        draft_digest=None,
+        payload=_plan_payload(),
+        allowed_source_ids={"intent"},
+    )
+    plan = plan_store.confirm(
+        plan.plan_id,
+        expected_revision=plan.revision,
+        expected_digest=plan.digest,
+        session_revision=1,
+        draft_revision=None,
+        draft_digest=None,
+    )
+    build_store = SkillResourceBuildStore(tmp_path / "builds")
+    build = build_store.create(plan=plan)
+    build = build_store.claim_next(
+        build.build_id,
+        expected_revision=build.revision,
+        expected_digest=build.digest,
+    )
+    invocation = build_resource_builder_invocation(
+        ResourceBuildGenerationRequest(
+            build=build,
+            target_id="SKILL.md",
+            segment_index=0,
+        ),
+        model_id="gateway/default-text",
+    )
+    observed: dict[str, object] = {}
+
+    async def fake_stream_messages(
+        model_id,
+        messages,
+        *,
+        temperature=0.7,
+        max_tokens=2048,
+    ):
+        observed.update(
+            model_id=model_id,
+            message_count=len(messages),
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+        yield json.dumps(
+            {
+                "resource_build_version": "skill-resource-build-v1",
+                "target_id": "SKILL.md",
+                "segment_index": 0,
+                "content": "segment",
+                "complete": True,
+                "script_tests": [],
+            }
+        )
+
+    monkeypatch.setattr(main_module, "stream_workflow_llm_messages", fake_stream_messages)
+    monkeypatch.setattr(
+        main_module,
+        "get_llm_gateway_config",
+        lambda: ("http://test-gateway.local/v1/chat/completions", "test-key"),
+    )
+    monkeypatch.setattr(main_module, "run_registry", RunRegistry())
+    monkeypatch.setattr(
+        main_module,
+        "workflow_execution_store",
+        WorkflowExecutionStore(tmp_path / "executions-builder"),
+    )
+    monkeypatch.setattr(main_module, "workflow_task_store", {})
+
+    output = await main_module.run_skill_creator_resource_build(invocation)
+
+    assert json.loads(output)["resource_build_version"] == "skill-resource-build-v1"
+    assert observed["temperature"] == main_module.SKILL_CREATOR_RESOURCE_BUILDER_TEMPERATURE
+    assert observed["max_tokens"] == main_module.SKILL_CREATOR_RESOURCE_BUILDER_MAX_TOKENS
 
 
 def test_resource_authoring_flag_fails_closed(tmp_path: Path) -> None:

--- a/server/tests/test_skill_creator_resource_service.py
+++ b/server/tests/test_skill_creator_resource_service.py
@@ -21,6 +21,7 @@ from server.skills.creator_resource_build_runtime import (
 from server.skills.creator_resource_runtime import (
     WorkflowCreatorResourcePlanner,
     build_resource_planner_invocation,
+    parse_resource_plan_output,
 )
 from server.skills.creator_resource_service import (
     ResourcePlanningRequest,
@@ -321,6 +322,41 @@ async def test_workflow_resource_planner_accepts_only_versioned_json() -> None:
     with pytest.raises(SkillCreatorValidationError) as caught:
         await invalid.plan(request)
     assert caught.value.code == "skill_creator_resource_planner_invalid"
+
+
+def test_resource_planner_extracts_one_versioned_json_from_model_narration() -> None:
+    payload = {
+        "resource_plan_version": RESOURCE_PLAN_VERSION,
+        **_plan_payload(),
+    }
+    encoded = json.dumps(payload, ensure_ascii=False)
+
+    assert parse_resource_plan_output(f"<think>plan first</think>\n{encoded}\nDone.") == payload
+    assert parse_resource_plan_output(f"Here is the plan:\n```json\n{encoded}\n```\n") == payload
+
+
+def test_resource_planner_rejects_ambiguous_or_syntax_repaired_output() -> None:
+    first = {
+        "resource_plan_version": RESOURCE_PLAN_VERSION,
+        **_plan_payload(),
+    }
+    second = {
+        **first,
+        "skill_name": "different-plan",
+    }
+
+    with pytest.raises(SkillCreatorValidationError) as ambiguous:
+        parse_resource_plan_output(
+            f"{json.dumps(first, ensure_ascii=False)}\n"
+            f"{json.dumps(second, ensure_ascii=False)}"
+        )
+    assert ambiguous.value.code == "skill_creator_resource_planner_invalid"
+
+    with pytest.raises(SkillCreatorValidationError) as invalid_python:
+        parse_resource_plan_output(
+            "{'resource_plan_version':'skill-resource-plan-v1'}"
+        )
+    assert invalid_python.value.code == "skill_creator_resource_planner_invalid"
 
 
 @pytest.mark.asyncio

--- a/server/xpert_runtime/authoring_service.py
+++ b/server/xpert_runtime/authoring_service.py
@@ -443,9 +443,18 @@ class AuthoringService:
             "base_digest": target_draft.content_digest if target_draft else None,
         }
         if proposal.source_type == "skill_creator":
+            resource_receipt = payload.get("creator_resource_build")
+            trusted_resource_build = bool(
+                isinstance(resource_receipt, dict)
+                and proposal.actor_kind == "workflow_agent"
+                and proposal.actor_id == "skill-creator-assistant-v1"
+                and proposal.source_id
+                == str(resource_receipt.get("build_id") or "").strip()
+            )
             report = evaluate_creator_payload(
                 payload,
                 requirement_ids=payload.get("creator_requirement_ids") or (),
+                resource_build=trusted_resource_build,
             )
             details["creator_quality"] = report.to_dict()
         return details


### PR DESCRIPTION
## 增量

- 新增持久化 SkillResourceBuild、依赖顺序生成、分段组装、资源级确认/重做、崩溃恢复与最终提案闭环。
- 新增 skill_authoring_v1 离线 Sidecar 配置；Python/JavaScript 脚本按固定摘要执行 1–3 个用例并保存测试凭据。
- 为 reference、asset、SKILL.md 增加体量、导航、资源闭环、失败降级与禁止额外流程文件的校验。
- 加固真实模型输出：唯一 JSON 提取、kind/action 规范化、取消和瞬时失败重排队、旧 Build 失效、重复脚本入口拒绝及完整输出机械分段。

## 验证

- 重放最新 main 后，Creator、Evaluation、Skill 安装与 Runtime Router 回归：262 passed。
- 关键恢复窄测：7 passed。
- 独立预览器真实 Provider 合成数据验收：完整度 100，Sidecar 脚本 3/3 通过，用户人工验收通过。
- 20 个白名单路径；diff-check、敏感信息与临时预览污染审计通过。

## 边界

- SKILL_CREATOR_RESOURCE_AUTHORING_ENABLED 继续默认关闭；本 PR 不包含前端工作台增量。
- 生成提案仍需现有三例行为评测、人工接受与独立安装确认。
- receipt 当前未持久化实际 provider/model 标识，不宣称已记录具体模型。
- 部署验收需同时更新 sandbox-sidecar 与 server；本次开发未操作共享栈。