### PR TITLE
feature: 添加可解释 RAG 策略路由

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -694,6 +694,15 @@ Office 自动化是高风险客户端副作用路径。修改 `server/xpert_runt
 
 ## 24. Git 规范
 
+### RAG Strategy Router 护栏
+
+- Router V1 只能读取聚合语料画像并修改 Pipeline Draft 的 Chunker 与 Retrieval Profile；不得创建 Job/Version、切换活动索引或修改 Processor、视觉及 Embedding 模型。
+- 所有推荐必须记录 `rules_version`、语料 hash、活动版本、Draft version、证据分类、反例边界和配置 diff。规则变化必须先更新 `docs/RAG_STRATEGY_RESEARCH.md`。
+- Hash Embedding 不得作为语义或跨语言质量证据。Rerank Provider 未就绪时不得推荐启用；`score_threshold` 在 Auto Tuner 前固定为 `0`。
+- `insufficient_data` 禁止应用；低置信推荐必须显式确认；语料、活动版本或 Draft 漂移必须返回冲突并重新分析。
+- Router API、metadata、日志和前端不得返回完整文档、物理路径、embedding、Prompt、模型隐藏推理或密钥。
+- 修改该路径至少运行 `test_rag_strategy_router.py`、RAG Pipeline/Graph/Integration 回归、前端生产构建和敏感信息扫描。
+
 ### 自编写高风险路径
 
 - `xpert_authoring` 与 `skill_creator` 只能创建提案，不得加入发布、安装、删除或直接覆盖工具。

--- a/client/src/components/RagStrategyRouterPanel.tsx
+++ b/client/src/components/RagStrategyRouterPanel.tsx
@@ -1,0 +1,282 @@
+import { AlertTriangle, Check, LoaderCircle, RefreshCw, Route, X } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+type Objective = "balanced" | "quality" | "low_latency";
+type Requirement = "exact_terms" | "semantic_rewrite" | "cross_language" | "long_context" | "confusable_content" | "citation_precision";
+
+interface Profile {
+  profile_id: string;
+  title: string;
+  confidence: "low" | "medium" | "high";
+  reasons: string[];
+  evidence: Array<{ rule_id: string; classification: string; source: string }>;
+  warnings: string[];
+  diff: Array<{ field: string; current: unknown; recommended: unknown }>;
+}
+
+interface Recommendation {
+  recommendation_id: string;
+  rules_version: string;
+  state: "ready" | "applied" | "stale" | "insufficient_data";
+  draft_version: number;
+  corpus_profile: Record<string, unknown>;
+  profiles: Profile[];
+  warnings: string[];
+  insufficient_reasons: string[];
+  created_at: number;
+}
+
+interface Capabilities {
+  rules_version: string;
+  score_threshold_fixed: number;
+  embedding: { provider: string; degraded: boolean };
+  rerank: { available: boolean };
+}
+
+interface Props {
+  kbId: string;
+  open: boolean;
+  onClose: () => void;
+  onApplied: () => Promise<void> | void;
+}
+
+const OBJECTIVES: Array<{ id: Objective; label: string }> = [
+  { id: "balanced", label: "均衡" },
+  { id: "quality", label: "质量优先" },
+  { id: "low_latency", label: "低延迟" },
+];
+
+const REQUIREMENTS: Array<{ id: Requirement; label: string; hint: string }> = [
+  { id: "exact_terms", label: "精确术语", hint: "编号、代码与专有名词" },
+  { id: "semantic_rewrite", label: "语义改写", hint: "问题与原文措辞差异较大" },
+  { id: "cross_language", label: "跨语言", hint: "查询与文档语言不同" },
+  { id: "long_context", label: "长上下文", hint: "答案依赖章节级上下文" },
+  { id: "confusable_content", label: "易混淆内容", hint: "相似或冲突条款较多" },
+  { id: "citation_precision", label: "引用精度", hint: "需要细粒度稳定证据" },
+];
+
+const EMPTY_REQUIREMENTS: Record<Requirement, boolean> = {
+  exact_terms: false,
+  semantic_rewrite: false,
+  cross_language: false,
+  long_context: false,
+  confusable_content: false,
+  citation_precision: false,
+};
+
+function errorMessage(data: unknown, fallback: string) {
+  if (!data || typeof data !== "object") return fallback;
+  const detail = (data as { detail?: unknown }).detail;
+  return typeof detail === "string" ? detail : fallback;
+}
+
+function displayValue(value: unknown) {
+  if (Array.isArray(value)) return value.map((item) => String(item).replaceAll("\n", "\\n")).join(" · ");
+  if (value && typeof value === "object") return JSON.stringify(value);
+  if (typeof value === "boolean") return value ? "启用" : "关闭";
+  return value === null || value === undefined || value === "" ? "未设置" : String(value);
+}
+
+function stateLabel(state: Recommendation["state"]) {
+  if (state === "ready") return "可应用";
+  if (state === "applied") return "已应用";
+  if (state === "stale") return "已过期";
+  return "证据不足";
+}
+
+export default function RagStrategyRouterPanel({ kbId, open, onClose, onApplied }: Props) {
+  const [objective, setObjective] = useState<Objective>("balanced");
+  const [requirements, setRequirements] = useState(EMPTY_REQUIREMENTS);
+  const [capabilities, setCapabilities] = useState<Capabilities | null>(null);
+  const [items, setItems] = useState<Recommendation[]>([]);
+  const [selectedId, setSelectedId] = useState("");
+  const [profileId, setProfileId] = useState("primary");
+  const [confirmLow, setConfirmLow] = useState(false);
+  const [busy, setBusy] = useState<"load" | "recommend" | "apply" | "">("");
+  const [message, setMessage] = useState<{ tone: "error" | "ok"; text: string } | null>(null);
+
+  const selected = useMemo(
+    () => items.find((item) => item.recommendation_id === selectedId) ?? items[0] ?? null,
+    [items, selectedId],
+  );
+  const profile = useMemo(
+    () => selected?.profiles.find((item) => item.profile_id === profileId) ?? selected?.profiles[0] ?? null,
+    [profileId, selected],
+  );
+
+  const load = useCallback(async () => {
+    setBusy("load");
+    setMessage(null);
+    try {
+      const [capResponse, listResponse] = await Promise.all([
+        fetch("/api/rag/strategy-router/capabilities"),
+        fetch(`/api/rag/strategy-router/recommendations?kb_id=${encodeURIComponent(kbId)}`),
+      ]);
+      if (!capResponse.ok) throw new Error("策略能力加载失败。");
+      setCapabilities((await capResponse.json()) as Capabilities);
+      if (listResponse.ok) {
+        const recommendations = ((await listResponse.json()) as { recommendations: Recommendation[] }).recommendations || [];
+        setItems(recommendations);
+        setSelectedId((current) => current || recommendations[0]?.recommendation_id || "");
+      }
+    } catch (caught) {
+      setMessage({ tone: "error", text: caught instanceof Error ? caught.message : "策略能力加载失败。" });
+    } finally {
+      setBusy("");
+    }
+  }, [kbId]);
+
+  useEffect(() => { if (open) void load(); }, [load, open]);
+  useEffect(() => {
+    setProfileId(selected?.profiles[0]?.profile_id || "primary");
+    setConfirmLow(false);
+  }, [selected?.recommendation_id, selected?.profiles]);
+
+  async function createRecommendation() {
+    setBusy("recommend");
+    setMessage(null);
+    try {
+      const response = await fetch("/api/rag/strategy-router/recommendations", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ kb_id: kbId, objective, requirements }),
+      });
+      const payload = await response.json().catch(() => null);
+      if (!response.ok) throw new Error(errorMessage(payload, "语料分析失败。"));
+      const recommendation = payload as Recommendation;
+      setItems((current) => [recommendation, ...current]);
+      setSelectedId(recommendation.recommendation_id);
+      setProfileId(recommendation.profiles[0]?.profile_id || "primary");
+      setMessage({
+        tone: "ok",
+        text: recommendation.state === "insufficient_data"
+          ? "分析完成，但当前证据不足，未生成可应用配置。"
+          : "分析完成。请检查依据与配置差异后再应用。",
+      });
+    } catch (caught) {
+      setMessage({ tone: "error", text: caught instanceof Error ? caught.message : "语料分析失败。" });
+    } finally {
+      setBusy("");
+    }
+  }
+
+  async function applyRecommendation() {
+    if (!selected || !profile) return;
+    setBusy("apply");
+    setMessage(null);
+    try {
+      const response = await fetch(
+        `/api/rag/strategy-router/recommendations/${encodeURIComponent(selected.recommendation_id)}/apply`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            expected_draft_version: selected.draft_version,
+            profile_id: profile.profile_id,
+            confirm_low_confidence: confirmLow,
+          }),
+        },
+      );
+      const payload = await response.json().catch(() => null);
+      if (!response.ok) throw new Error(errorMessage(payload, "推荐应用失败。"));
+      const updated = (payload as { recommendation: Recommendation }).recommendation;
+      setItems((current) => current.map((item) => item.recommendation_id === updated.recommendation_id ? updated : item));
+      setMessage({ tone: "ok", text: "已写入 Pipeline Draft，并同步画布配置。活动索引未改变。" });
+      await onApplied();
+    } catch (caught) {
+      setMessage({ tone: "error", text: caught instanceof Error ? caught.message : "推荐应用失败。" });
+    } finally {
+      setBusy("");
+    }
+  }
+
+  if (!open) return null;
+  const canApply = Boolean(selected && profile && selected.state === "ready" && (profile.confidence !== "low" || confirmLow));
+  const corpus = selected?.corpus_profile || {};
+
+  return (
+    <div className="fixed inset-0 z-50 flex justify-end bg-surface-950/70" role="dialog" aria-modal="true" aria-label="RAG 策略路由">
+      <button className="absolute inset-0 cursor-default" aria-label="关闭策略路由" onClick={onClose} type="button" />
+      <aside className="relative flex h-full w-full max-w-[640px] flex-col border-l border-white/10 bg-surface-950 shadow-2xl">
+        <header className="flex items-start justify-between gap-4 border-b border-white/10 px-5 py-4">
+          <div className="flex min-w-0 gap-3">
+            <span className="mt-0.5 grid h-9 w-9 shrink-0 place-items-center rounded-lg bg-cyan-300/10 text-cyan-200"><Route aria-hidden="true" size={18} /></span>
+            <div><h2 className="text-base font-semibold text-white">RAG 策略路由</h2><p className="mt-1 text-xs leading-5 text-slate-400">分析语料后推荐分块与检索配置，只写入草稿。</p></div>
+          </div>
+          <button className="grid h-9 w-9 shrink-0 place-items-center rounded-md text-slate-400 hover:bg-white/[0.06] hover:text-white focus:outline-none focus:ring-2 focus:ring-cyan-300/50" onClick={onClose} title="关闭" type="button"><X aria-hidden="true" size={18} /></button>
+        </header>
+
+        <div className="flex-1 overflow-y-auto">
+          <section className="border-b border-white/10 px-5 py-5">
+            <div className="flex items-center justify-between gap-3"><h3 className="text-sm font-semibold text-white">需求画像</h3>{capabilities ? <span className="font-mono text-[10px] text-slate-500">{capabilities.rules_version}</span> : null}</div>
+            <div className="mt-3 grid grid-cols-3 gap-2" role="group" aria-label="优化目标">
+              {OBJECTIVES.map((item) => <button className={`rounded-md border px-3 py-2 text-xs font-semibold ${objective === item.id ? "border-cyan-300/45 bg-cyan-300/10 text-cyan-50" : "border-white/10 text-slate-300 hover:bg-white/[0.05]"}`} key={item.id} onClick={() => setObjective(item.id)} type="button">{item.label}</button>)}
+            </div>
+            <div className="mt-4 grid gap-2 sm:grid-cols-2">
+              {REQUIREMENTS.map((item) => <label className="flex min-h-14 cursor-pointer items-start gap-3 rounded-md border border-white/10 bg-white/[0.025] px-3 py-2 hover:bg-white/[0.05]" key={item.id}><input checked={requirements[item.id]} className="mt-1 h-4 w-4 accent-cyan-300" onChange={(event) => setRequirements((current) => ({ ...current, [item.id]: event.target.checked }))} type="checkbox" /><span><span className="block text-xs font-semibold text-slate-200">{item.label}</span><span className="mt-0.5 block text-[10px] leading-4 text-slate-500">{item.hint}</span></span></label>)}
+            </div>
+            <button className="mt-4 flex w-full items-center justify-center gap-2 rounded-md bg-cyan-300 px-4 py-2.5 text-sm font-bold text-surface-950 hover:bg-cyan-200 disabled:opacity-50" disabled={Boolean(busy)} onClick={() => void createRecommendation()} type="button">{busy === "recommend" ? <LoaderCircle className="animate-spin" size={16} /> : <RefreshCw size={16} />}分析并生成推荐</button>
+            <p className="mt-2 text-[10px] leading-4 text-slate-500">最多分析 100 个文档、500,000 字符。不会调用模型或创建索引版本。</p>
+          </section>
+
+          {busy === "load" ? <div className="space-y-3 px-5 py-6"><div className="h-16 animate-pulse rounded-md bg-white/[0.05]" /><div className="h-32 animate-pulse rounded-md bg-white/[0.05]" /></div> : null}
+
+          {selected ? (
+            <>
+              <section className="border-b border-white/10 px-5 py-5">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div><h3 className="text-sm font-semibold text-white">语料画像</h3><p className="mt-1 text-[10px] text-slate-500">Draft v{selected.draft_version} · {new Date(selected.created_at * 1000).toLocaleString("zh-CN", { hour12: false })}</p></div>
+                  <span className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${selected.state === "ready" ? "bg-emerald-300/10 text-emerald-200" : selected.state === "applied" ? "bg-cyan-300/10 text-cyan-200" : "bg-amber-300/10 text-amber-200"}`}>{stateLabel(selected.state)}</span>
+                </div>
+                <div className="mt-4 grid grid-cols-2 gap-x-6 gap-y-3 sm:grid-cols-4">
+                  <Metric label="已分析文档" value={`${Number(corpus.analyzed_document_count || 0)} / ${Number(corpus.document_count || 0)}`} />
+                  <Metric label="采样字符" value={Number(corpus.sampled_character_count || 0).toLocaleString()} />
+                  <Metric label="结构块" value={Number(corpus.block_count || 0).toLocaleString()} />
+                  <Metric label="长块比例" value={`${Math.round(Number(corpus.long_block_ratio || 0) * 100)}%`} />
+                </div>
+                <div className="mt-4 flex flex-wrap gap-2 text-[10px] text-slate-400">
+                  <span className="rounded-full bg-white/[0.05] px-2.5 py-1">Embedding: {capabilities?.embedding.provider || "unknown"}{capabilities?.embedding.degraded ? "（降级）" : ""}</span>
+                  <span className="rounded-full bg-white/[0.05] px-2.5 py-1">Rerank: {capabilities?.rerank.available ? "可用" : "未就绪"}</span>
+                  <span className="rounded-full bg-white/[0.05] px-2.5 py-1">Threshold: {capabilities?.score_threshold_fixed ?? 0}</span>
+                </div>
+              </section>
+
+              {selected.state === "insufficient_data" ? (
+                <section className="px-5 py-5"><div className="flex gap-3 rounded-md bg-amber-300/10 p-4 text-amber-100"><AlertTriangle className="mt-0.5 shrink-0" size={17} /><div><h3 className="text-sm font-semibold">当前证据不足</h3>{selected.insufficient_reasons.map((reason) => <p className="mt-1 text-xs leading-5" key={reason}>{reason}</p>)}</div></div></section>
+              ) : null}
+
+              {profile ? (
+                <>
+                  <section className="border-b border-white/10 px-5 py-5">
+                    <div className="flex items-center justify-between gap-3"><h3 className="text-sm font-semibold text-white">推荐方案</h3><span className="text-[11px] font-semibold text-slate-400">置信度：{profile.confidence === "medium" ? "中" : profile.confidence === "high" ? "高" : "低"}</span></div>
+                    {selected.profiles.length > 1 ? <div className="mt-3 flex gap-2 overflow-x-auto pb-1">{selected.profiles.map((item) => <button className={`shrink-0 rounded-md border px-3 py-2 text-xs font-semibold ${profile.profile_id === item.profile_id ? "border-cyan-300/45 bg-cyan-300/10 text-cyan-50" : "border-white/10 text-slate-300 hover:bg-white/[0.05]"}`} key={item.profile_id} onClick={() => setProfileId(item.profile_id)} type="button">{item.title}</button>)}</div> : null}
+                    <div className="mt-4 space-y-2">{profile.reasons.map((reason) => <div className="flex gap-2 text-xs leading-5 text-slate-300" key={reason}><Check className="mt-0.5 shrink-0 text-emerald-300" size={14} /><span>{reason}</span></div>)}</div>
+                    <div className="mt-4 flex flex-wrap gap-2">{profile.evidence.map((item) => <span className="rounded-full border border-white/10 px-2.5 py-1 font-mono text-[10px] text-slate-400" key={`${item.rule_id}-${item.source}`}>{item.rule_id} · {item.classification} · {item.source}</span>)}</div>
+                  </section>
+
+                  <section className="border-b border-white/10 px-5 py-5">
+                    <h3 className="text-sm font-semibold text-white">配置差异</h3>
+                    {profile.diff.length ? <div className="mt-3 overflow-hidden rounded-md border border-white/10"><div className="grid grid-cols-[minmax(120px,0.8fr)_1fr_1fr] bg-white/[0.04] px-3 py-2 text-[10px] font-semibold text-slate-400"><span>字段</span><span>当前</span><span>推荐</span></div>{profile.diff.map((item) => <div className="grid grid-cols-[minmax(120px,0.8fr)_1fr_1fr] gap-3 border-t border-white/[0.07] px-3 py-2 text-[11px] leading-5" key={item.field}><code className="break-all text-slate-300">{item.field}</code><span className="break-all text-slate-500">{displayValue(item.current)}</span><span className="break-all font-medium text-cyan-100">{displayValue(item.recommended)}</span></div>)}</div> : <p className="mt-3 text-xs text-slate-500">当前草稿已与该方案一致。</p>}
+                  </section>
+
+                  <section className="px-5 py-5">
+                    {[...selected.warnings, ...profile.warnings].filter((value, index, values) => values.indexOf(value) === index).map((warning) => <p className="mb-2 flex gap-2 text-xs leading-5 text-amber-100/90" key={warning}><AlertTriangle className="mt-0.5 shrink-0" size={14} /><span>{warning}</span></p>)}
+                    {profile.confidence === "low" && selected.state === "ready" ? <label className="mt-4 flex cursor-pointer items-start gap-3 rounded-md border border-amber-300/20 bg-amber-300/[0.06] p-3 text-xs leading-5 text-amber-50"><input checked={confirmLow} className="mt-1 h-4 w-4 accent-amber-300" onChange={(event) => setConfirmLow(event.target.checked)} type="checkbox" /><span>我已检查证据与配置差异，确认将低置信方案写入草稿。</span></label> : null}
+                    <button className="mt-4 flex w-full items-center justify-center gap-2 rounded-md border border-cyan-300/35 bg-cyan-300/10 px-4 py-2.5 text-sm font-semibold text-cyan-50 hover:bg-cyan-300/15 disabled:opacity-45" disabled={!canApply || Boolean(busy)} onClick={() => void applyRecommendation()} type="button">{busy === "apply" ? <LoaderCircle className="animate-spin" size={16} /> : <Check size={16} />}应用到 Pipeline Draft</button>
+                    <p className="mt-2 text-center text-[10px] leading-4 text-slate-500">不会执行流水线、创建候选版本或切换活动索引。</p>
+                  </section>
+                </>
+              ) : null}
+            </>
+          ) : busy !== "load" ? <div className="px-5 py-10 text-center text-sm text-slate-500">选择需求后生成第一条策略推荐。</div> : null}
+        </div>
+
+        {message ? <div className={`border-t px-5 py-3 text-xs leading-5 ${message.tone === "error" ? "border-rose-300/20 bg-rose-300/10 text-rose-100" : "border-emerald-300/20 bg-emerald-300/10 text-emerald-100"}`} aria-live="polite">{message.text}</div> : null}
+      </aside>
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return <div><p className="text-[10px] text-slate-500">{label}</p><p className="mt-1 text-sm font-semibold text-slate-100">{value}</p></div>;
+}

--- a/client/src/pages/KnowledgePipelineCanvasPage.tsx
+++ b/client/src/pages/KnowledgePipelineCanvasPage.tsx
@@ -17,8 +17,10 @@ import {
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { Route } from "lucide-react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import PageContainer from "../components/PageContainer";
+import RagStrategyRouterPanel from "../components/RagStrategyRouterPanel";
 import {
   DEFAULT_EMBEDDING_MODEL_ID,
   embeddingModelOptions,
@@ -296,6 +298,7 @@ export default function KnowledgePipelineCanvasPage() {
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   const [workbenchTab, setWorkbenchTab] = useState<"config" | "preview" | "run">("config");
   const [paletteOpen, setPaletteOpen] = useState(false);
+  const [strategyOpen, setStrategyOpen] = useState(false);
   const [selectedDocumentId, setSelectedDocumentId] = useState("");
   const [preview, setPreview] = useState<NodePreview | null>(null);
   const [jobs, setJobs] = useState<PipelineJob[]>([]);
@@ -594,6 +597,7 @@ export default function KnowledgePipelineCanvasPage() {
           </div>
           <div className="flex flex-wrap items-center gap-2">
             <Link className="rounded-lg border border-emerald-300/25 bg-emerald-300/10 px-3 py-2 text-sm font-semibold text-emerald-100 hover:bg-emerald-300/15" to={`/rag/${encodeURIComponent(kbId)}/evaluation`}>质量评估</Link>
+            <button className="inline-flex items-center gap-2 rounded-lg border border-cyan-300/25 bg-cyan-300/10 px-3 py-2 text-sm font-semibold text-cyan-100 hover:bg-cyan-300/15" onClick={() => setStrategyOpen(true)} type="button"><Route size={15} />策略路由</button>
             <button className="rounded-lg border border-white/10 bg-white/[0.05] px-3 py-2 text-sm font-semibold text-slate-200 hover:bg-white/[0.09] disabled:opacity-50" disabled={Boolean(busy)} onClick={() => void validateGraph()} type="button">校验</button>
             <button className="rounded-lg border border-hire-300/25 bg-hire-300/10 px-3 py-2 text-sm font-semibold text-hire-100 hover:bg-hire-300/15 disabled:opacity-50" disabled={Boolean(busy)} onClick={() => void saveGraph()} type="button">保存草稿</button>
             <button className="rounded-lg bg-hire-300 px-4 py-2 text-sm font-bold text-surface-950 hover:bg-hire-200 disabled:opacity-50" disabled={Boolean(busy) || documents.length === 0} onClick={() => void executeGraph()} type="button">执行流水线</button>
@@ -693,6 +697,7 @@ export default function KnowledgePipelineCanvasPage() {
           </section>
         ) : null}
       </div>
+      <RagStrategyRouterPanel kbId={kbId} onApplied={loadPage} onClose={() => setStrategyOpen(false)} open={strategyOpen} />
     </PageContainer>
   );
 }

--- a/docs/RAG_INTEGRATION.md
+++ b/docs/RAG_INTEGRATION.md
@@ -9,6 +9,35 @@
 > Promotion Gate。下方按日期保留的段落是增量记录；较早段落中的“planned”
 > 只代表当时状态。
 
+## 2026-08-10 增量：可解释 RAG Strategy Router V1
+
+知识流水线画布新增确定性策略路由。用户选择 `balanced / quality / low_latency`
+目标及精确术语、语义改写、跨语言、长上下文、易混淆内容和引用精度需求后，
+Router 复用现有结构解析器，对最多 100 个文档、500,000 字符生成聚合语料画像。
+
+推荐严格来自 `rag-strategy-rules-v1`，返回主方案、最多两个比较方案、置信度、
+规则/实验依据、warnings 与字段级配置差异。Hash Embedding 不被当作语义检索证据；
+Rerank Provider 未就绪时不会建议启用；`score_threshold` 固定为 `0`，留待固定
+评测集校准。
+
+推荐与语料 hash、活动索引 ID 和 Pipeline Draft version 绑定。语料、活动索引或
+草稿漂移后状态变为 `stale`；低置信方案必须显式确认；`insufficient_data` 不可应用。
+应用只更新 Chunker 与 Retrieval Profile，并同步已有 Pipeline Graph。它不会执行
+流水线、创建候选版本、修改 Processor/视觉/Embedding，或切换活动索引。
+
+接口：
+
+```text
+GET  /api/rag/strategy-router/capabilities
+POST /api/rag/strategy-router/recommendations
+GET  /api/rag/strategy-router/recommendations?kb_id=
+GET  /api/rag/strategy-router/recommendations/{recommendation_id}
+POST /api/rag/strategy-router/recommendations/{recommendation_id}/apply
+```
+
+研究证据、反例和延期策略见 `docs/RAG_STRATEGY_RESEARCH.md`。Router V1 不调用
+LLM，也不实现 Semantic Chunking、Contextual Retrieval、Late Chunking 或 RAPTOR。
+
 ## 2026-08-09 增量：知识库定向 Gold 生成与校准
 
 `/rag/:kbId/evaluation` 可以针对一个固定 `ready / active` 索引版本生成待审核评测集。

--- a/docs/RAG_STRATEGY_RESEARCH.md
+++ b/docs/RAG_STRATEGY_RESEARCH.md
@@ -1,0 +1,253 @@
+# RAG Strategy Research
+
+> Phase A research artifact for `XPERT-RAG-STRATEGY-ROUTER-01`.
+>
+> Status: **awaiting user review**. This document does not authorize Phase B implementation.
+
+## 1. Purpose and boundaries
+
+This study asks a narrower question than "which chunking strategy is best":
+
+> Given the corpus shape, retrieval task, available index and cost objective, which **currently supported ModelMirror profile** is a defensible starting point, and when is the evidence too weak to recommend one?
+
+Phase A did not change production code, API, UI, Runtime schema, active indexes, or Pipeline Drafts. It produced:
+
+- a project-authored synthetic fixture set at `docs/research/rag-strategy/fixtures.json`;
+- a machine-readable evidence matrix at `docs/research/rag-strategy/evidence-matrix.json`;
+- the implementation gap analysis and draft `RAG Strategy Rules V1` in this document.
+
+The local experiment used deterministic hash embeddings and did not call a rerank provider. Therefore it can characterize the offline fallback and exact-term retrieval, but it cannot establish defaults for a real semantic embedding or rerank model.
+
+## 2. Executive conclusions
+
+1. **There is no evidence for a universal winner.** The best aggregate Recall@5 in this small experiment came from recursive 1000/10%, but the lead over the best parent-child profile was only `0.028`; corpus-level results include ties and ranking/recall trade-offs.
+2. **Structure preservation should precede size selection.** Markdown headings, tables and code are already parsed into blocks. Splitting is then applied within each block, so many short structured blocks are unaffected by changing 400/700/1000 character limits.
+3. **Current parent-child is a selective context-expansion option, not a default.** It indexes child chunks but returns parent text. In this experiment it consumed roughly `1.7x-2.3x` the returned context of comparable recursive profiles without a general recall gain.
+4. **Hash vector results are not semantic-vector evidence.** On exact-term-heavy synthetic data, full-text substantially outperformed the deterministic hash vector. Hybrid inherited noise from the weak vector channel. A Router must detect this capability boundary instead of recommending Hybrid by habit.
+5. **Overlap has a cost but no universal gain here.** Recursive 700 with 10% and 20% overlap produced the same aggregate quality; 20% indexed about 4.5% more characters. Overlap should be conditional on long blocks and boundary risk.
+6. **`score_threshold=0` cannot abstain.** Every no-answer query returned candidates, yielding no-result accuracy `0`. Threshold calibration belongs in the next Benchmark Auto Tuner round, not in deterministic Router V1.
+7. **Top-K is a task and cost choice.** Raising Top-K from 5 to 10 did not improve Recall@5 in the selected profiles. Multi-evidence tasks may still need wider candidate pools, but that requires target-specific evaluation.
+8. **Semantic chunking, Contextual Retrieval, Late Chunking and RAPTOR remain deferred.** They are meaningful research directions, but ModelMirror does not currently expose compatible execution primitives for them and this experiment did not test them.
+
+## 3. Literature evidence
+
+| Topic | Evidence | Implication for ModelMirror | Classification |
+| --- | --- | --- | --- |
+| Chunk size and overlap | Azure documents fixed, variable and semantic chunking and notes that overlap and size depend on content; character counts are not token counts. [Azure AI Search](https://learn.microsoft.com/en-us/azure/search/vector-search-how-to-chunk-documents) | Do not represent character limits as model-context tokens. Keep recommendations bounded and explain the unit. | `evidence-backed` |
+| Structure-aware chunking | Unstructured chunks document elements after partitioning; `by_title` preserves section boundaries and tables remain separate. It also warns that overlap across complete elements can mix independent units. [Unstructured](https://docs.unstructured.io/open-source/core-functionality/chunking) | Prefer the existing structured Processor for headings, tables and code; only apply overlap to blocks that actually split. | `evidence-backed` |
+| Semantic splitting | LlamaIndex groups sentences and uses embedding dissimilarity percentiles to choose breakpoints. [LlamaIndex](https://docs.llamaindex.ai/en/stable/api_reference/node_parsers/semantic_splitter/) | Requires a real embedding model and threshold calibration; hash embedding is not a valid basis. | `literature-only` |
+| Exact identifiers and hybrid retrieval | Anthropic notes BM25's value for exact identifiers, combines lexical and embedding retrieval, and measures contextual chunks and reranking against a use-case-specific corpus. [Anthropic](https://www.anthropic.com/engineering/contextual-retrieval) | Exact-term signals should favor full-text. Hybrid and rerank remain evaluation-dependent rather than universal defaults. | `literature-only` plus local support |
+| RRF fusion | RRF combines independent ranked lists using reciprocal ranks rather than assuming comparable raw scores. [Elastic](https://www.elastic.co/docs/reference/elasticsearch/rest-apis/reciprocal-rank-fusion) | Current weighted RRF is appropriate as a fusion primitive, but its normalized output is candidate-set-relative. | `evidence-backed` |
+| Late Chunking | Late Chunking embeds long context first and derives chunk representations afterwards. [paper](https://arxiv.org/abs/2409.04701) | Needs long-context embedding support and a different indexing path. | `deferred` |
+| Hierarchical summaries | RAPTOR recursively clusters and summarizes text for multi-level retrieval. [paper](https://arxiv.org/abs/2401.18059) | Requires generated hierarchy, summary persistence and evaluation beyond current parent-child windows. | `deferred` |
+| Evidence sparsity | HiChunk/HiCBench argues that sparse evidence benchmarks can obscure chunking differences. [ACL 2026](https://aclanthology.org/2026.acl-long.1372/) | A strategy benchmark must contain long split-worthy blocks and boundary-sensitive evidence; easy sparse facts are insufficient. | `evidence-backed` |
+
+No published percentage or default from an external study is copied into Rules V1. External results establish dimensions and failure modes; local evidence determines only the limited defaults below.
+
+## 4. Strategy comparison
+
+| Strategy | Strengths | Failure modes and cost | Router V1 status |
+| --- | --- | --- | --- |
+| Recursive character | Deterministic, inexpensive, offset-preserving, supports custom separators | Character unit differs from tokens; can cut semantic units when blocks are long | Implemented; eligible |
+| Structure-aware blocks | Preserves headings, tables, code, lists and PDF pages before splitting | Parser quality bounds results; current block-level split may fragment chapter context | Implemented by Processor; mandatory signal |
+| Parent-child | Retrieves focused child and returns broader parent context | Larger context, duplicate parent returns, current implementation cannot form parents across adjacent blocks | Implemented; eligible with low-confidence constraints |
+| Sentence window | Keeps citation unit small while expanding neighboring sentences | Requires stable sentence segmentation and window metadata | Not implemented; deferred |
+| Semantic chunking | Breakpoints follow semantic change | Embedding and threshold sensitive; higher indexing cost | Research only |
+| Contextual Retrieval | Adds document/chunk context before embedding and lexical indexing | Requires generation cost, cache and provenance; may alter exact-term distribution | Research only |
+| Late Chunking | Chunk representations retain long-document context | Requires long-context embedding architecture and new index contract | Research only |
+| RAPTOR | Supports hierarchical and global questions | Clustering/summarization cost, nondeterminism and complex citation mapping | Research only |
+
+## 5. Current ModelMirror implementation audit
+
+| Area | Current behavior | Router consequence |
+| --- | --- | --- |
+| Processor | `StructuredDocumentProcessor` emits headings, paragraphs, lists, tables, code and PDF pages with heading/page metadata. | Profile the processed blocks, not only raw file length. |
+| Recursive splitter | `TextSplitter` uses character windows, preferred separators and exact source offsets. | Rules and UI must say characters, not tokens. |
+| Parent-child splitter | `ParentChildTextSplitter` creates parent windows and child retrieval chunks. Pipeline execution applies it to each processed block. | Parent context cannot cross adjacent blocks; chapter-level hierarchy is not yet present. |
+| Full-text | SQLite FTS5/BM25 orders candidates; outward score is rank-normalized. | Strong exact-term candidate; threshold is not a calibrated BM25 score. |
+| Vector | Uses configured embeddings; local fallback is deterministic hash embedding. | Router must distinguish semantic-provider readiness from hash fallback. |
+| Hybrid | Weighted RRF uses `k=60` and min-max normalizes the current candidate set. | Weights are meaningful within a run; thresholds are not portable across corpora/modes. |
+| Rerank | API-first/LLM fallback, fail-open to fused order. | Do not enable without provider readiness and target-specific evaluation. |
+| Versioning | Pipeline profiles are pinned to candidate versions with activation and rollback. | Router should only write Draft/Graph; version build remains explicit. |
+| Evaluation | RAG evaluation and targeted Gold generation exist. | Next-round tuner can compare candidate profiles without inventing another evaluator. |
+
+### Implementation gaps relevant to strategy selection
+
+1. No deterministic corpus profiler or versioned strategy-rule service exists.
+2. Parent-child parents are block-local, not section- or chapter-spanning.
+3. No token-aware chunk budget is available; all current split settings are characters.
+4. No cross-profile score calibration exists, so threshold recommendation is unsafe.
+5. No real-embedding benchmark in Phase A establishes Vector/Hybrid defaults.
+6. No rerank provider was approved for this study; effectiveness, latency and cost are unknown.
+7. No sentence-window, semantic, contextual, late-chunking or RAPTOR index contract exists.
+8. Retry can reuse completed work within a job, but there is no strategy-search cache keyed across independent candidate jobs.
+
+## 6. Local experiment design
+
+### Corpus and Gold
+
+- 17 synthetic Markdown documents across six families.
+- 41 fixed Gold queries authored before retrieval.
+- Query types: fact, paraphrase, exact term, cross-language, section context, multi-evidence, confusable, table, code and no-answer.
+- All corpus families share the same mixed-domain index so retrieval faces distractors.
+- Long dense blocks were included specifically to trigger actual splitting; short blocks remain useful for detecting no-op configuration changes.
+- Gold anchors were never rewritten based on retrieval outcomes.
+
+### Production logic reused
+
+- Markdown block parsing from `StructuredDocumentProcessor`.
+- Pipeline-style per-block splitting and heading-prefix indexing.
+- `TextSplitter` and `ParentChildTextSplitter`.
+- SQLite FTS5 lexical retrieval.
+- Deterministic 384-dimensional hash embeddings.
+- Weighted RRF with vector/full-text weights `0.7/0.3`, `k=60`.
+
+The harness only omitted file/network kernel dependencies unavailable in the bundled research Python. It did not replace splitter, block parser, FTS5, hash embedding or RRF behavior.
+
+### Profiles
+
+Stage 1 used Hybrid Top-K 10 for eight chunking profiles:
+
+- Recursive: `400/0`, `400/40`, `700/70`, `700/140`, `1000/100` (`size/overlap`).
+- Parent-child: `1200/300`, `1800/450`, `2400/600` (`parent/child`) with approximately 10% parent and child overlap.
+
+Stage 2 selected a representative recursive and parent-child profile per corpus and compared Full-text, Vector and Hybrid with Top-K 5 and 10. Rerank was not tested.
+
+Metrics include Recall@5, MRR@10, NDCG@10, citation/anchor coverage, no-result accuracy, chunk count, indexed/returned characters, index time and retrieval P95. Timings on this tiny corpus are directional only.
+
+## 7. Evidence matrix summary
+
+### 7.1 Chunking profiles
+
+Aggregate over the six corpus families under fixed Hybrid retrieval:
+
+| Profile | Chunks | Recall@5 | MRR@10 | NDCG@10 | Indexed chars | Returned context chars | Index ms | Retrieval P95 ms |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Recursive 1000 / 100 | 118 | **0.600** | 0.458 | 0.484 | 14,790 | 14,790 | 67.5 | 10.8 |
+| Parent-child 2400 / 600 | 125 | 0.572 | 0.467 | 0.481 | 15,465 | 26,628 | 73.0 | 11.6 |
+| Recursive 700 / 70 | 122 | 0.572 | 0.452 | 0.470 | 15,215 | 15,215 | 72.6 | 11.1 |
+| Recursive 700 / 140 | 123 | 0.572 | 0.452 | 0.470 | 15,901 | 15,901 | 72.9 | 11.5 |
+| Parent-child 1800 / 450 | 130 | 0.544 | **0.468** | **0.485** | 15,835 | 34,114 | 64.7 | 11.8 |
+| Recursive 400 / 40 | 131 | 0.544 | 0.467 | 0.484 | 15,863 | 15,863 | 69.1 | 12.6 |
+| Recursive 400 / 0 | 130 | 0.517 | 0.438 | 0.462 | 15,163 | 15,163 | 76.2 | 11.8 |
+| Parent-child 1200 / 300 | 142 | 0.517 | 0.433 | 0.446 | 16,915 | 34,762 | 75.3 | 12.1 |
+
+Interpretation:
+
+- The recall range is only `0.083`; this is insufficient to declare a universal strategy winner.
+- Parent-child 1800/450 has the best MRR/NDCG by very small margins, but returns more than twice the context of recursive 700/70.
+- Recursive 700 at 10% and 20% overlap has identical quality. The extra overlap only increased indexed characters in this fixture.
+- Smaller chunks increased chunk count but did not generally improve retrieval.
+
+### 7.2 Corpus-level contrasts
+
+| Corpus | Representative recursive | Representative parent-child | Finding |
+| --- | --- | --- | --- |
+| Long policy | 400/40: R@5 0.833, MRR 0.833 | 1800/450: 0.833, 0.833 | Quality tie; parent-child costs more context. |
+| Short FAQ | 400/0: 0.600, 0.622 | 2400/600: 0.600, 0.622 | Most blocks do not split; evidence insufficient. |
+| Technical IDs | 1000/100: 0.500, 0.233 | 2400/600: 0.333, 0.357 | Recursive improves recall; parent-child improves ranking. |
+| Bilingual narrative | 400/0: 0.333, 0.250 | 2400/600: 0.333, 0.222 | Both weak; hash embedding cannot support cross-language routing. |
+| Tables and code | 1000/100: 0.333, 0.333 | 2400/600: 0.333, 0.333 | Tie; preserved structure and lexical signals matter more here. |
+| Confusable sections | 1000/100: 1.000, 0.583 | 2400/600: 1.000, 0.547 | Recall tie; recursive ranks slightly better. |
+
+### 7.3 Retrieval modes
+
+Aggregate over the representative profiles:
+
+| Mode | Top-K | Recall@5 | MRR@10 | NDCG@10 | No-result accuracy |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Full-text | 5 | **0.800** | 0.737 | 0.730 | 0.000 |
+| Full-text | 10 | **0.800** | **0.741** | **0.739** | 0.000 |
+| Hybrid | 5 | 0.586 | 0.475 | 0.479 | 0.000 |
+| Hybrid | 10 | 0.586 | 0.481 | 0.493 | 0.000 |
+| Vector | 5 | 0.461 | 0.377 | 0.376 | 0.000 |
+| Vector | 10 | 0.461 | 0.390 | 0.407 | 0.000 |
+
+Interpretation:
+
+- This synthetic corpus contains deliberate exact identifiers, terminology and anchors, which favor FTS5.
+- The hash vector channel is weak for paraphrase and cross-language semantics and lowers the fixed 0.7-vector Hybrid result.
+- This result **does not** prove that Full-text beats a real semantic embedding. It proves that Router V1 must know whether the vector provider is semantic or hash fallback.
+- With threshold `0`, every no-answer query returns candidates. Router V1 must warn rather than pretend to solve abstention.
+
+### 7.4 Evidence sparsity check
+
+An initial pilot used isolated corpus families and split whole documents. Recall saturated near 1.0 and hid strategy differences. That pilot was discarded. The final matrix instead:
+
+- uses production block parsing and per-block splitting;
+- adds long split-worthy blocks;
+- mixes all 17 documents into the retrieval index;
+- de-duplicates overlapping chunks when scoring fixed anchors.
+
+Even after correction, several corpora remain ties. Those ties are reported as `insufficient_data`, not converted into arbitrary rules.
+
+## 8. RAG Strategy Rules V1 draft
+
+Every rule below is deliberately conservative. `Confidence` describes confidence in the recommendation under the listed preconditions, not expected answer quality.
+
+| ID | Signal | Recommendation | Confidence | Counterexample / warning | Basis |
+| --- | --- | --- | --- | --- | --- |
+| R1 | Most processed blocks are shorter than the current chunk size; low boundary pressure | Keep current profile or use Recursive 700/70 as a neutral editable starting point | Low | Size changes may be no-ops; do not claim improvement | Local EXP-SHORT-01, heuristic default |
+| R2 | Many blocks exceed 1,200 chars **and** user selects long-context/quality | Offer Parent-child 1800/450 as an alternative, not automatic winner | Low | Current parents are block-local and may double returned context | Local EXP-LONG-01; literature supports hierarchy, not these exact values |
+| R3 | High density of IDs, codes, exact terms, table keys or legal clauses | Recommend Full-text, Top-K 5; show Hybrid as a benchmark-required alternative | Medium | Natural-language paraphrases may need semantic embeddings | Local EXP-LEXICAL-01 plus Anthropic exact-term rationale |
+| R4 | Embedding provider is deterministic hash and requirements include semantic rewrite or cross-language | Return `insufficient_data`; do not recommend Vector/Hybrid as quality strategy | High | Full-text may still work for bilingual documents containing both terms | Local EXP-HASH-01 capability boundary |
+| R5 | Real semantic embedding is ready and requirements mix exact terms with paraphrase | Offer Hybrid 0.7/0.3 only as a low-confidence starting candidate | Low | Weight is an existing default, not established by this experiment; must benchmark | Literature-only plus existing product default |
+| R6 | Long blocks actually split and boundary-sensitive evidence is expected | Start near 10% overlap; do not auto-select 20% | Low-Medium | Lists/tables/code should not overlap across complete blocks | Local EXP-OVERLAP-01 plus Unstructured warning |
+| R7 | Table/code ratio is material | Preserve structure; prefer Full-text and a moderate Recursive profile | Medium | Semantic prose around tables can still require Hybrid | Local EXP-STRUCTURE-01 plus structure literature |
+| R8 | Confusable sections, quality objective, real rerank provider ready | Recommend evaluating rerank; do not enable automatically in V1 | Low | No local rerank evidence or cost measurement exists | Literature-only; deferred measurement |
+| R9 | Low-latency/single-fact objective | Top-K 5 | Low-Medium | Multi-evidence tasks can need a wider candidate pool | Local EXP-TOPK-01 |
+| R10 | Multi-evidence or broad chapter context selected | Offer Top-K 10 with context-cost warning | Low | Local Recall@5 did not improve from wider return count | Heuristic; target benchmark required |
+| R11 | No-answer/abstention is required while threshold remains 0 | Keep threshold 0 in V1 and emit explicit warning; defer calibration | High | Returning fewer candidates is not equivalent to calibrated abstention | Local EXP-NOANSWER-01 |
+| R12 | UI or requirement treats characters as tokens | Emit unit mismatch warning; never convert without tokenizer/model context | High | CJK and English have different character/token ratios | Azure guidance and current splitter contract |
+| R13 | User requests semantic chunking, Contextual Retrieval, Late Chunking or RAPTOR | Mark `deferred`, explain missing runtime/index contract | High | Do not simulate advanced strategies with renamed recursive settings | Literature and implementation audit |
+
+### Rule precedence
+
+1. Capability boundaries (`R4`, `R11`, `R12`, `R13`) override recommendations.
+2. Structure signals (`R7`) constrain chunking before retrieval mode selection.
+3. Exact-term vs semantic requirements (`R3`, `R5`) select retrieval candidates.
+4. Objective and evidence breadth (`R2`, `R9`, `R10`) refine context and Top-K.
+5. If two eligible profiles differ only weakly or signals conflict, return alternatives with low confidence rather than selecting a winner.
+
+### Proposed confidence policy
+
+- `high`: hard capability/safety boundary or repeated evidence with no material counterexample.
+- `medium`: local and literature evidence align, but a target-specific benchmark is still recommended.
+- `low`: heuristic starting point or small local difference; UI must require explicit confirmation before apply.
+- `insufficient_data`: strategy cannot be justified from available corpus/provider signals; application is disabled.
+
+## 9. Phase B boundary if approved
+
+Router V1 may recommend and write only:
+
+- Recursive vs current parent-child strategy and supported character parameters.
+- Full-text, Vector or Hybrid mode and existing weights.
+- Top-K and candidate multiplier within current bounds.
+- Rerank only when a provider is ready, and only as an evaluation-required suggestion.
+
+It must not:
+
+- claim token-aware sizing;
+- calibrate `score_threshold`;
+- build, activate, promote or roll back an index;
+- change Processor, visual settings or embedding model;
+- implement semantic chunking, sentence windows, contextual chunks, Late Chunking or RAPTOR;
+- convert low-confidence evidence into an automatic apply.
+
+## 10. Review gate
+
+Decision recorded on 2026-08-10: the four Rules V1 decisions below were reviewed
+and accepted. Phase B is authorized to implement only the bounded deterministic
+Router described in section 9. This approval does not authorize Auto Tuning,
+provider calls, candidate index construction, threshold calibration, or activation.
+
+Phase B should begin only if the user accepts these four decisions:
+
+1. Short structured corpora and hash-based cross-language requirements may return `insufficient_data` instead of a forced recommendation.
+2. Parent-child remains a low-confidence option for long-block/long-context workloads, not the default strategy.
+3. Exact-term-heavy hash indexes may prefer Full-text; Hybrid with a real embedding remains a benchmark-required candidate, not a guaranteed improvement.
+4. Router V1 keeps `score_threshold=0` and surfaces an abstention warning; threshold calibration is reserved for the next Auto Tuner round.
+
+`RAG Strategy Rules V1` is therefore the fixed rule source for Router V1. Any
+rule change must update its evidence classification, counterexample and local
+experiment reference before production behavior changes.

--- a/docs/research/rag-strategy/evidence-matrix.json
+++ b/docs/research/rag-strategy/evidence-matrix.json
@@ -1,0 +1,17331 @@
+{
+  "schema_version": 1,
+  "experiment_id": "rag-strategy-phase-a-v1",
+  "modelmirror_commit": "4a43f23ff8abb09a2857b5cc2cf24e0510e05a06",
+  "fixture_sha256": "15215cbfbfaad4ff7d6c25f9b442ad2b1678d869b3a84f04d6156295b19fc854",
+  "environment": {
+    "python": "3.12.13",
+    "platform": "Windows-11-10.0.26200-SP0",
+    "embedding": "ModelMirror deterministic hash embedding, dimension 384",
+    "lexical": "ModelMirror SQLite FTS5 BM25 ordering",
+    "hybrid": "ModelMirror weighted RRF, vector 0.7, fulltext 0.3, k=60",
+    "rerank": "not tested"
+  },
+  "method_notes": [
+    "Gold anchor phrases were authored before retrieval and were not changed by results.",
+    "All six corpus families share one 17-document mixed-domain index so Top-K faces distractors.",
+    "Markdown fixtures use the production StructuredDocumentProcessor and pipeline-style per-block splitting with heading prefixes.",
+    "Anchor metrics accept any chunk containing the fixed phrase, avoiding overlap-duplicate bias.",
+    "retrieval_core_p95_ms excludes query embedding; query_embedding_p95_ms is reported separately.",
+    "Tiny synthetic corpora make latency and indexing timings directional only.",
+    "Hash-vector outcomes only characterize ModelMirror offline fallback, not production semantic embeddings."
+  ],
+  "corpus_profiles": [
+    {
+      "corpus_id": "long_policy",
+      "document_count": 3,
+      "character_count": 1339,
+      "heading_count": 19,
+      "table_row_count": 0,
+      "code_fence_count": 0,
+      "case_count": 7,
+      "query_types": [
+        "confusable",
+        "fact",
+        "multi_evidence",
+        "no_answer",
+        "paraphrase",
+        "section_context"
+      ]
+    },
+    {
+      "corpus_id": "short_faq",
+      "document_count": 2,
+      "character_count": 420,
+      "heading_count": 20,
+      "table_row_count": 0,
+      "code_fence_count": 0,
+      "case_count": 6,
+      "query_types": [
+        "confusable",
+        "exact_term",
+        "fact",
+        "no_answer",
+        "paraphrase",
+        "section_context"
+      ]
+    },
+    {
+      "corpus_id": "technical_ids",
+      "document_count": 3,
+      "character_count": 2695,
+      "heading_count": 13,
+      "table_row_count": 0,
+      "code_fence_count": 0,
+      "case_count": 7,
+      "query_types": [
+        "confusable",
+        "exact_term",
+        "fact",
+        "no_answer"
+      ]
+    },
+    {
+      "corpus_id": "bilingual_narrative",
+      "document_count": 3,
+      "character_count": 2668,
+      "heading_count": 15,
+      "table_row_count": 0,
+      "code_fence_count": 0,
+      "case_count": 7,
+      "query_types": [
+        "cross_language",
+        "fact",
+        "no_answer",
+        "paraphrase",
+        "section_context"
+      ]
+    },
+    {
+      "corpus_id": "tables_code",
+      "document_count": 3,
+      "character_count": 1909,
+      "heading_count": 7,
+      "table_row_count": 9,
+      "code_fence_count": 2,
+      "case_count": 7,
+      "query_types": [
+        "code",
+        "confusable",
+        "exact_term",
+        "no_answer",
+        "section_context",
+        "table"
+      ]
+    },
+    {
+      "corpus_id": "confusable_sections",
+      "document_count": 3,
+      "character_count": 2923,
+      "heading_count": 17,
+      "table_row_count": 0,
+      "code_fence_count": 0,
+      "case_count": 7,
+      "query_types": [
+        "confusable",
+        "fact",
+        "no_answer",
+        "section_context"
+      ]
+    }
+  ],
+  "stage1": {
+    "fixed_retrieval": {
+      "mode": "hybrid",
+      "vector_weight": 0.7,
+      "fulltext_weight": 0.3,
+      "top_k": 10
+    },
+    "rows": [
+      {
+        "corpus_id": "long_policy",
+        "config_id": "recursive_400_o0",
+        "strategy": "recursive_character",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 130,
+        "indexed_character_count": 15163,
+        "returned_context_character_count": 15163,
+        "index_time_ms": 79.432,
+        "query_embedding_p95_ms": 0.148,
+        "retrieval_core_p95_ms": 14.86,
+        "metrics": {
+          "recall_at_5": 0.833333,
+          "mrr_at_10": 0.833333,
+          "ndcg_at_10": 0.819954,
+          "citation_hit_rate": 0.1,
+          "citation_coverage": 0.833333,
+          "context_anchor_coverage_at_5": 0.833333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "lp_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:continuity_manual:5",
+              "long_policy:recursive_400_o0:continuity_manual:4",
+              "long_policy:recursive_400_o0:continuity_manual:1"
+            ]
+          },
+          {
+            "case_id": "lp_paraphrase",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:continuity_manual:7",
+              "long_policy:recursive_400_o0:policy_dense:2",
+              "long_policy:recursive_400_o0:policy_dense:3"
+            ]
+          },
+          {
+            "case_id": "lp_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:continuity_manual:11",
+              "long_policy:recursive_400_o0:north_program:7",
+              "long_policy:recursive_400_o0:harbor_report:1"
+            ]
+          },
+          {
+            "case_id": "lp_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:continuity_manual:11",
+              "long_policy:recursive_400_o0:continuity_manual:9",
+              "long_policy:recursive_400_o0:harbor_cn:3"
+            ]
+          },
+          {
+            "case_id": "lp_multi",
+            "query_type": "multi_evidence",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 0.919721,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:vendor_manual:3",
+              "long_policy:recursive_400_o0:vendor_manual:2",
+              "long_policy:recursive_400_o0:continuity_manual:7"
+            ]
+          },
+          {
+            "case_id": "lp_dense",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:policy_dense:3",
+              "long_policy:recursive_400_o0:policy_dense:0",
+              "long_policy:recursive_400_o0:vendor_manual:4"
+            ]
+          },
+          {
+            "case_id": "lp_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:continuity_manual:1",
+              "long_policy:recursive_400_o0:harbor_cn:3",
+              "long_policy:recursive_400_o0:billing_faq:2"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "long_policy",
+        "config_id": "recursive_400_o40",
+        "strategy": "recursive_character",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 131,
+        "indexed_character_count": 15863,
+        "returned_context_character_count": 15863,
+        "index_time_ms": 70.197,
+        "query_embedding_p95_ms": 0.101,
+        "retrieval_core_p95_ms": 11.514,
+        "metrics": {
+          "recall_at_5": 0.833333,
+          "mrr_at_10": 0.833333,
+          "ndcg_at_10": 0.819954,
+          "citation_hit_rate": 0.1,
+          "citation_coverage": 0.833333,
+          "context_anchor_coverage_at_5": 0.833333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "lp_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o40:continuity_manual:5",
+              "long_policy:recursive_400_o40:continuity_manual:4",
+              "long_policy:recursive_400_o40:continuity_manual:1"
+            ]
+          },
+          {
+            "case_id": "lp_paraphrase",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o40:continuity_manual:7",
+              "long_policy:recursive_400_o40:policy_dense:2",
+              "long_policy:recursive_400_o40:policy_dense:3"
+            ]
+          },
+          {
+            "case_id": "lp_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o40:continuity_manual:11",
+              "long_policy:recursive_400_o40:north_program:7",
+              "long_policy:recursive_400_o40:harbor_report:1"
+            ]
+          },
+          {
+            "case_id": "lp_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o40:continuity_manual:11",
+              "long_policy:recursive_400_o40:continuity_manual:9",
+              "long_policy:recursive_400_o40:harbor_cn:3"
+            ]
+          },
+          {
+            "case_id": "lp_multi",
+            "query_type": "multi_evidence",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 0.919721,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o40:vendor_manual:3",
+              "long_policy:recursive_400_o40:vendor_manual:2",
+              "long_policy:recursive_400_o40:continuity_manual:7"
+            ]
+          },
+          {
+            "case_id": "lp_dense",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o40:policy_dense:3",
+              "long_policy:recursive_400_o40:policy_dense:0",
+              "long_policy:recursive_400_o40:vendor_manual:4"
+            ]
+          },
+          {
+            "case_id": "lp_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o40:continuity_manual:1",
+              "long_policy:recursive_400_o40:harbor_cn:3",
+              "long_policy:recursive_400_o40:billing_faq:2"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "long_policy",
+        "config_id": "recursive_700_o70",
+        "strategy": "recursive_character",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 122,
+        "indexed_character_count": 15215,
+        "returned_context_character_count": 15215,
+        "index_time_ms": 80.213,
+        "query_embedding_p95_ms": 0.1,
+        "retrieval_core_p95_ms": 12.504,
+        "metrics": {
+          "recall_at_5": 0.833333,
+          "mrr_at_10": 0.75,
+          "ndcg_at_10": 0.758442,
+          "citation_hit_rate": 0.1,
+          "citation_coverage": 0.833333,
+          "context_anchor_coverage_at_5": 0.833333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "lp_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_700_o70:continuity_manual:5",
+              "long_policy:recursive_700_o70:continuity_manual:4",
+              "long_policy:recursive_700_o70:continuity_manual:1"
+            ]
+          },
+          {
+            "case_id": "lp_paraphrase",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_700_o70:continuity_manual:7",
+              "long_policy:recursive_700_o70:policy_dense:2",
+              "long_policy:recursive_700_o70:continuity_manual:1"
+            ]
+          },
+          {
+            "case_id": "lp_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_700_o70:continuity_manual:11",
+              "long_policy:recursive_700_o70:continuity_manual:9",
+              "long_policy:recursive_700_o70:north_program:7"
+            ]
+          },
+          {
+            "case_id": "lp_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_700_o70:continuity_manual:11",
+              "long_policy:recursive_700_o70:continuity_manual:9",
+              "long_policy:recursive_700_o70:harbor_cn:3"
+            ]
+          },
+          {
+            "case_id": "lp_multi",
+            "query_type": "multi_evidence",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 0.919721,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_700_o70:vendor_manual:3",
+              "long_policy:recursive_700_o70:vendor_manual:2",
+              "long_policy:recursive_700_o70:continuity_manual:7"
+            ]
+          },
+          {
+            "case_id": "lp_dense",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.5,
+              "ndcg_at_10": 0.63093,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_700_o70:policy_dense:0",
+              "long_policy:recursive_700_o70:policy_dense:2",
+              "long_policy:recursive_700_o70:policy_dense:1"
+            ]
+          },
+          {
+            "case_id": "lp_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_700_o70:continuity_manual:1",
+              "long_policy:recursive_700_o70:harbor_cn:3",
+              "long_policy:recursive_700_o70:billing_faq:2"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "long_policy",
+        "config_id": "recursive_700_o140",
+        "strategy": "recursive_character",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 123,
+        "indexed_character_count": 15901,
+        "returned_context_character_count": 15901,
+        "index_time_ms": 72.959,
+        "query_embedding_p95_ms": 0.273,
+        "retrieval_core_p95_ms": 13.205,
+        "metrics": {
+          "recall_at_5": 0.833333,
+          "mrr_at_10": 0.75,
+          "ndcg_at_10": 0.758442,
+          "citation_hit_rate": 0.1,
+          "citation_coverage": 0.833333,
+          "context_anchor_coverage_at_5": 0.833333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "lp_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_700_o140:continuity_manual:5",
+              "long_policy:recursive_700_o140:continuity_manual:4",
+              "long_policy:recursive_700_o140:continuity_manual:1"
+            ]
+          },
+          {
+            "case_id": "lp_paraphrase",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_700_o140:continuity_manual:7",
+              "long_policy:recursive_700_o140:policy_dense:2",
+              "long_policy:recursive_700_o140:continuity_manual:1"
+            ]
+          },
+          {
+            "case_id": "lp_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_700_o140:continuity_manual:11",
+              "long_policy:recursive_700_o140:continuity_manual:9",
+              "long_policy:recursive_700_o140:north_program:7"
+            ]
+          },
+          {
+            "case_id": "lp_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_700_o140:continuity_manual:11",
+              "long_policy:recursive_700_o140:continuity_manual:9",
+              "long_policy:recursive_700_o140:harbor_cn:3"
+            ]
+          },
+          {
+            "case_id": "lp_multi",
+            "query_type": "multi_evidence",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 0.919721,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_700_o140:vendor_manual:3",
+              "long_policy:recursive_700_o140:vendor_manual:2",
+              "long_policy:recursive_700_o140:continuity_manual:7"
+            ]
+          },
+          {
+            "case_id": "lp_dense",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.5,
+              "ndcg_at_10": 0.63093,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_700_o140:policy_dense:0",
+              "long_policy:recursive_700_o140:policy_dense:2",
+              "long_policy:recursive_700_o140:policy_dense:1"
+            ]
+          },
+          {
+            "case_id": "lp_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_700_o140:continuity_manual:1",
+              "long_policy:recursive_700_o140:harbor_cn:3",
+              "long_policy:recursive_700_o140:billing_faq:2"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "long_policy",
+        "config_id": "recursive_1000_o100",
+        "strategy": "recursive_character",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 118,
+        "indexed_character_count": 14790,
+        "returned_context_character_count": 14790,
+        "index_time_ms": 67.114,
+        "query_embedding_p95_ms": 0.092,
+        "retrieval_core_p95_ms": 12.615,
+        "metrics": {
+          "recall_at_5": 0.833333,
+          "mrr_at_10": 0.75,
+          "ndcg_at_10": 0.758442,
+          "citation_hit_rate": 0.1,
+          "citation_coverage": 0.833333,
+          "context_anchor_coverage_at_5": 0.833333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "lp_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_1000_o100:continuity_manual:5",
+              "long_policy:recursive_1000_o100:continuity_manual:4",
+              "long_policy:recursive_1000_o100:continuity_manual:1"
+            ]
+          },
+          {
+            "case_id": "lp_paraphrase",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_1000_o100:continuity_manual:7",
+              "long_policy:recursive_1000_o100:policy_dense:2",
+              "long_policy:recursive_1000_o100:continuity_manual:1"
+            ]
+          },
+          {
+            "case_id": "lp_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_1000_o100:continuity_manual:11",
+              "long_policy:recursive_1000_o100:continuity_manual:9",
+              "long_policy:recursive_1000_o100:north_program:7"
+            ]
+          },
+          {
+            "case_id": "lp_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_1000_o100:continuity_manual:11",
+              "long_policy:recursive_1000_o100:continuity_manual:9",
+              "long_policy:recursive_1000_o100:harbor_cn:3"
+            ]
+          },
+          {
+            "case_id": "lp_multi",
+            "query_type": "multi_evidence",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 0.919721,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_1000_o100:vendor_manual:3",
+              "long_policy:recursive_1000_o100:vendor_manual:2",
+              "long_policy:recursive_1000_o100:continuity_manual:7"
+            ]
+          },
+          {
+            "case_id": "lp_dense",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.5,
+              "ndcg_at_10": 0.63093,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_1000_o100:policy_dense:0",
+              "long_policy:recursive_1000_o100:policy_dense:2",
+              "long_policy:recursive_1000_o100:policy_dense:1"
+            ]
+          },
+          {
+            "case_id": "lp_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_1000_o100:continuity_manual:1",
+              "long_policy:recursive_1000_o100:harbor_cn:3",
+              "long_policy:recursive_1000_o100:billing_faq:2"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "long_policy",
+        "config_id": "parent_child_1200_300",
+        "strategy": "parent_child",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 142,
+        "indexed_character_count": 16915,
+        "returned_context_character_count": 34762,
+        "index_time_ms": 94.12,
+        "query_embedding_p95_ms": 0.106,
+        "retrieval_core_p95_ms": 13.868,
+        "metrics": {
+          "recall_at_5": 0.833333,
+          "mrr_at_10": 0.722222,
+          "ndcg_at_10": 0.73662,
+          "citation_hit_rate": 0.1,
+          "citation_coverage": 0.833333,
+          "context_anchor_coverage_at_5": 0.833333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "lp_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1200_300:continuity_manual:5",
+              "long_policy:parent_child_1200_300:continuity_manual:4",
+              "long_policy:parent_child_1200_300:continuity_manual:1"
+            ]
+          },
+          {
+            "case_id": "lp_paraphrase",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1200_300:continuity_manual:7",
+              "long_policy:parent_child_1200_300:policy_dense:2",
+              "long_policy:parent_child_1200_300:policy_dense:3"
+            ]
+          },
+          {
+            "case_id": "lp_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1200_300:continuity_manual:11",
+              "long_policy:parent_child_1200_300:north_program:7",
+              "long_policy:parent_child_1200_300:harbor_report:1"
+            ]
+          },
+          {
+            "case_id": "lp_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1200_300:continuity_manual:11",
+              "long_policy:parent_child_1200_300:continuity_manual:9",
+              "long_policy:parent_child_1200_300:harbor_cn:3"
+            ]
+          },
+          {
+            "case_id": "lp_multi",
+            "query_type": "multi_evidence",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 0.919721,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1200_300:vendor_manual:3",
+              "long_policy:parent_child_1200_300:vendor_manual:2",
+              "long_policy:parent_child_1200_300:continuity_manual:7"
+            ]
+          },
+          {
+            "case_id": "lp_dense",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.333333,
+              "ndcg_at_10": 0.5,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1200_300:policy_dense:4",
+              "long_policy:parent_child_1200_300:policy_dense:0",
+              "long_policy:parent_child_1200_300:policy_dense:3"
+            ]
+          },
+          {
+            "case_id": "lp_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1200_300:continuity_manual:1",
+              "long_policy:parent_child_1200_300:harbor_cn:3",
+              "long_policy:parent_child_1200_300:billing_faq:2"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "long_policy",
+        "config_id": "parent_child_1800_450",
+        "strategy": "parent_child",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 130,
+        "indexed_character_count": 15835,
+        "returned_context_character_count": 34114,
+        "index_time_ms": 78.292,
+        "query_embedding_p95_ms": 0.103,
+        "retrieval_core_p95_ms": 12.189,
+        "metrics": {
+          "recall_at_5": 0.833333,
+          "mrr_at_10": 0.833333,
+          "ndcg_at_10": 0.819954,
+          "citation_hit_rate": 0.1,
+          "citation_coverage": 0.833333,
+          "context_anchor_coverage_at_5": 0.833333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "lp_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:continuity_manual:5",
+              "long_policy:parent_child_1800_450:continuity_manual:4",
+              "long_policy:parent_child_1800_450:continuity_manual:1"
+            ]
+          },
+          {
+            "case_id": "lp_paraphrase",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:continuity_manual:7",
+              "long_policy:parent_child_1800_450:policy_dense:2",
+              "long_policy:parent_child_1800_450:continuity_manual:1"
+            ]
+          },
+          {
+            "case_id": "lp_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:continuity_manual:11",
+              "long_policy:parent_child_1800_450:north_program:7",
+              "long_policy:parent_child_1800_450:harbor_report:1"
+            ]
+          },
+          {
+            "case_id": "lp_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:continuity_manual:11",
+              "long_policy:parent_child_1800_450:continuity_manual:9",
+              "long_policy:parent_child_1800_450:harbor_cn:3"
+            ]
+          },
+          {
+            "case_id": "lp_multi",
+            "query_type": "multi_evidence",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 0.919721,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:vendor_manual:3",
+              "long_policy:parent_child_1800_450:vendor_manual:2",
+              "long_policy:parent_child_1800_450:continuity_manual:7"
+            ]
+          },
+          {
+            "case_id": "lp_dense",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:policy_dense:3",
+              "long_policy:parent_child_1800_450:policy_dense:0",
+              "long_policy:parent_child_1800_450:vendor_manual:4"
+            ]
+          },
+          {
+            "case_id": "lp_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:continuity_manual:1",
+              "long_policy:parent_child_1800_450:harbor_cn:3",
+              "long_policy:parent_child_1800_450:billing_faq:2"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "long_policy",
+        "config_id": "parent_child_2400_600",
+        "strategy": "parent_child",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 125,
+        "indexed_character_count": 15465,
+        "returned_context_character_count": 26628,
+        "index_time_ms": 63.497,
+        "query_embedding_p95_ms": 0.099,
+        "retrieval_core_p95_ms": 16.492,
+        "metrics": {
+          "recall_at_5": 0.833333,
+          "mrr_at_10": 0.722222,
+          "ndcg_at_10": 0.73662,
+          "citation_hit_rate": 0.1,
+          "citation_coverage": 0.833333,
+          "context_anchor_coverage_at_5": 0.833333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "lp_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_2400_600:continuity_manual:5",
+              "long_policy:parent_child_2400_600:continuity_manual:4",
+              "long_policy:parent_child_2400_600:continuity_manual:1"
+            ]
+          },
+          {
+            "case_id": "lp_paraphrase",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_2400_600:continuity_manual:7",
+              "long_policy:parent_child_2400_600:policy_dense:2",
+              "long_policy:parent_child_2400_600:continuity_manual:1"
+            ]
+          },
+          {
+            "case_id": "lp_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_2400_600:continuity_manual:11",
+              "long_policy:parent_child_2400_600:continuity_manual:9",
+              "long_policy:parent_child_2400_600:north_program:7"
+            ]
+          },
+          {
+            "case_id": "lp_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_2400_600:continuity_manual:11",
+              "long_policy:parent_child_2400_600:continuity_manual:9",
+              "long_policy:parent_child_2400_600:harbor_cn:3"
+            ]
+          },
+          {
+            "case_id": "lp_multi",
+            "query_type": "multi_evidence",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 0.919721,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_2400_600:vendor_manual:3",
+              "long_policy:parent_child_2400_600:vendor_manual:2",
+              "long_policy:parent_child_2400_600:continuity_manual:7"
+            ]
+          },
+          {
+            "case_id": "lp_dense",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.333333,
+              "ndcg_at_10": 0.5,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_2400_600:policy_dense:3",
+              "long_policy:parent_child_2400_600:policy_dense:0",
+              "long_policy:parent_child_2400_600:policy_dense:2"
+            ]
+          },
+          {
+            "case_id": "lp_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_2400_600:continuity_manual:1",
+              "long_policy:parent_child_2400_600:harbor_cn:3",
+              "long_policy:parent_child_2400_600:billing_faq:2"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "short_faq",
+        "config_id": "recursive_400_o0",
+        "strategy": "recursive_character",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 130,
+        "indexed_character_count": 15163,
+        "returned_context_character_count": 15163,
+        "index_time_ms": 78.339,
+        "query_embedding_p95_ms": 0.092,
+        "retrieval_core_p95_ms": 10.868,
+        "metrics": {
+          "recall_at_5": 0.6,
+          "mrr_at_10": 0.622222,
+          "ndcg_at_10": 0.582835,
+          "citation_hit_rate": 0.08,
+          "citation_coverage": 0.8,
+          "context_anchor_coverage_at_5": 0.6,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 5,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "faq_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o0:account_faq:2",
+              "short_faq:recursive_400_o0:account_faq:1",
+              "short_faq:recursive_400_o0:billing_faq:6"
+            ]
+          },
+          {
+            "case_id": "faq_paraphrase",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0.111111,
+              "ndcg_at_10": 0.30103,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o0:vendor_manual:3",
+              "short_faq:recursive_400_o0:account_faq:10",
+              "short_faq:recursive_400_o0:vendor_manual:1"
+            ]
+          },
+          {
+            "case_id": "faq_exact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o0:account_faq:6",
+              "short_faq:recursive_400_o0:account_faq:5",
+              "short_faq:recursive_400_o0:limits_table:4"
+            ]
+          },
+          {
+            "case_id": "faq_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 0.613147,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o0:billing_faq:2",
+              "short_faq:recursive_400_o0:billing_faq:1",
+              "short_faq:recursive_400_o0:policy_dense:2"
+            ]
+          },
+          {
+            "case_id": "faq_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o0:account_faq:8",
+              "short_faq:recursive_400_o0:account_faq:7",
+              "short_faq:recursive_400_o0:policy_dense:3"
+            ]
+          },
+          {
+            "case_id": "faq_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o0:billing_faq:8",
+              "short_faq:recursive_400_o0:billing_faq:7",
+              "short_faq:recursive_400_o0:technical_dense:6"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "short_faq",
+        "config_id": "recursive_400_o40",
+        "strategy": "recursive_character",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 131,
+        "indexed_character_count": 15863,
+        "returned_context_character_count": 15863,
+        "index_time_ms": 82.213,
+        "query_embedding_p95_ms": 0.187,
+        "retrieval_core_p95_ms": 12.422,
+        "metrics": {
+          "recall_at_5": 0.6,
+          "mrr_at_10": 0.62,
+          "ndcg_at_10": 0.580442,
+          "citation_hit_rate": 0.08,
+          "citation_coverage": 0.8,
+          "context_anchor_coverage_at_5": 0.6,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 5,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "faq_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o40:account_faq:2",
+              "short_faq:recursive_400_o40:account_faq:1",
+              "short_faq:recursive_400_o40:billing_faq:6"
+            ]
+          },
+          {
+            "case_id": "faq_paraphrase",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0.1,
+              "ndcg_at_10": 0.289065,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o40:vendor_manual:3",
+              "short_faq:recursive_400_o40:account_faq:10",
+              "short_faq:recursive_400_o40:vendor_manual:1"
+            ]
+          },
+          {
+            "case_id": "faq_exact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o40:account_faq:6",
+              "short_faq:recursive_400_o40:account_faq:5",
+              "short_faq:recursive_400_o40:limits_table:4"
+            ]
+          },
+          {
+            "case_id": "faq_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 0.613147,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o40:billing_faq:2",
+              "short_faq:recursive_400_o40:billing_faq:1",
+              "short_faq:recursive_400_o40:policy_dense:2"
+            ]
+          },
+          {
+            "case_id": "faq_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o40:account_faq:8",
+              "short_faq:recursive_400_o40:account_faq:7",
+              "short_faq:recursive_400_o40:policy_dense:3"
+            ]
+          },
+          {
+            "case_id": "faq_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o40:billing_faq:8",
+              "short_faq:recursive_400_o40:billing_faq:7",
+              "short_faq:recursive_400_o40:technical_dense:5"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "short_faq",
+        "config_id": "recursive_700_o70",
+        "strategy": "recursive_character",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 122,
+        "indexed_character_count": 15215,
+        "returned_context_character_count": 15215,
+        "index_time_ms": 81.035,
+        "query_embedding_p95_ms": 0.105,
+        "retrieval_core_p95_ms": 11.718,
+        "metrics": {
+          "recall_at_5": 0.6,
+          "mrr_at_10": 0.62,
+          "ndcg_at_10": 0.580442,
+          "citation_hit_rate": 0.08,
+          "citation_coverage": 0.8,
+          "context_anchor_coverage_at_5": 0.6,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 5,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "faq_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_700_o70:account_faq:2",
+              "short_faq:recursive_700_o70:account_faq:1",
+              "short_faq:recursive_700_o70:billing_faq:6"
+            ]
+          },
+          {
+            "case_id": "faq_paraphrase",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0.1,
+              "ndcg_at_10": 0.289065,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_700_o70:vendor_manual:3",
+              "short_faq:recursive_700_o70:account_faq:10",
+              "short_faq:recursive_700_o70:vendor_manual:1"
+            ]
+          },
+          {
+            "case_id": "faq_exact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_700_o70:account_faq:6",
+              "short_faq:recursive_700_o70:account_faq:5",
+              "short_faq:recursive_700_o70:limits_table:4"
+            ]
+          },
+          {
+            "case_id": "faq_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 0.613147,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_700_o70:billing_faq:2",
+              "short_faq:recursive_700_o70:billing_faq:1",
+              "short_faq:recursive_700_o70:continuity_manual:1"
+            ]
+          },
+          {
+            "case_id": "faq_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_700_o70:account_faq:8",
+              "short_faq:recursive_700_o70:account_faq:7",
+              "short_faq:recursive_700_o70:policy_dense:2"
+            ]
+          },
+          {
+            "case_id": "faq_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_700_o70:billing_faq:8",
+              "short_faq:recursive_700_o70:billing_faq:7",
+              "short_faq:recursive_700_o70:technical_dense:4"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "short_faq",
+        "config_id": "recursive_700_o140",
+        "strategy": "recursive_character",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 123,
+        "indexed_character_count": 15901,
+        "returned_context_character_count": 15901,
+        "index_time_ms": 79.911,
+        "query_embedding_p95_ms": 0.103,
+        "retrieval_core_p95_ms": 12.615,
+        "metrics": {
+          "recall_at_5": 0.6,
+          "mrr_at_10": 0.62,
+          "ndcg_at_10": 0.580442,
+          "citation_hit_rate": 0.08,
+          "citation_coverage": 0.8,
+          "context_anchor_coverage_at_5": 0.6,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 5,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "faq_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_700_o140:account_faq:2",
+              "short_faq:recursive_700_o140:account_faq:1",
+              "short_faq:recursive_700_o140:billing_faq:6"
+            ]
+          },
+          {
+            "case_id": "faq_paraphrase",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0.1,
+              "ndcg_at_10": 0.289065,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_700_o140:vendor_manual:3",
+              "short_faq:recursive_700_o140:account_faq:10",
+              "short_faq:recursive_700_o140:vendor_manual:1"
+            ]
+          },
+          {
+            "case_id": "faq_exact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_700_o140:account_faq:6",
+              "short_faq:recursive_700_o140:account_faq:5",
+              "short_faq:recursive_700_o140:limits_table:4"
+            ]
+          },
+          {
+            "case_id": "faq_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 0.613147,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_700_o140:billing_faq:2",
+              "short_faq:recursive_700_o140:billing_faq:1",
+              "short_faq:recursive_700_o140:continuity_manual:1"
+            ]
+          },
+          {
+            "case_id": "faq_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_700_o140:account_faq:8",
+              "short_faq:recursive_700_o140:account_faq:7",
+              "short_faq:recursive_700_o140:policy_dense:2"
+            ]
+          },
+          {
+            "case_id": "faq_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_700_o140:billing_faq:8",
+              "short_faq:recursive_700_o140:billing_faq:7",
+              "short_faq:recursive_700_o140:technical_dense:4"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "short_faq",
+        "config_id": "recursive_1000_o100",
+        "strategy": "recursive_character",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 118,
+        "indexed_character_count": 14790,
+        "returned_context_character_count": 14790,
+        "index_time_ms": 72.119,
+        "query_embedding_p95_ms": 0.11,
+        "retrieval_core_p95_ms": 10.753,
+        "metrics": {
+          "recall_at_5": 0.6,
+          "mrr_at_10": 0.62,
+          "ndcg_at_10": 0.580442,
+          "citation_hit_rate": 0.08,
+          "citation_coverage": 0.8,
+          "context_anchor_coverage_at_5": 0.6,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 5,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "faq_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_1000_o100:account_faq:2",
+              "short_faq:recursive_1000_o100:account_faq:1",
+              "short_faq:recursive_1000_o100:billing_faq:6"
+            ]
+          },
+          {
+            "case_id": "faq_paraphrase",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0.1,
+              "ndcg_at_10": 0.289065,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_1000_o100:vendor_manual:3",
+              "short_faq:recursive_1000_o100:account_faq:10",
+              "short_faq:recursive_1000_o100:vendor_manual:1"
+            ]
+          },
+          {
+            "case_id": "faq_exact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_1000_o100:account_faq:6",
+              "short_faq:recursive_1000_o100:account_faq:5",
+              "short_faq:recursive_1000_o100:limits_table:4"
+            ]
+          },
+          {
+            "case_id": "faq_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 0.613147,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_1000_o100:billing_faq:2",
+              "short_faq:recursive_1000_o100:billing_faq:1",
+              "short_faq:recursive_1000_o100:continuity_manual:1"
+            ]
+          },
+          {
+            "case_id": "faq_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_1000_o100:account_faq:8",
+              "short_faq:recursive_1000_o100:account_faq:7",
+              "short_faq:recursive_1000_o100:policy_dense:2"
+            ]
+          },
+          {
+            "case_id": "faq_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_1000_o100:billing_faq:8",
+              "short_faq:recursive_1000_o100:billing_faq:7",
+              "short_faq:recursive_1000_o100:technical_dense:3"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "short_faq",
+        "config_id": "parent_child_1200_300",
+        "strategy": "parent_child",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 142,
+        "indexed_character_count": 16915,
+        "returned_context_character_count": 34762,
+        "index_time_ms": 75.284,
+        "query_embedding_p95_ms": 0.105,
+        "retrieval_core_p95_ms": 11.956,
+        "metrics": {
+          "recall_at_5": 0.6,
+          "mrr_at_10": 0.6,
+          "ndcg_at_10": 0.522629,
+          "citation_hit_rate": 0.06,
+          "citation_coverage": 0.6,
+          "context_anchor_coverage_at_5": 0.6,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 5,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "faq_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_1200_300:account_faq:2",
+              "short_faq:parent_child_1200_300:account_faq:1",
+              "short_faq:parent_child_1200_300:billing_faq:6"
+            ]
+          },
+          {
+            "case_id": "faq_paraphrase",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_1200_300:vendor_manual:3",
+              "short_faq:parent_child_1200_300:account_faq:10",
+              "short_faq:parent_child_1200_300:vendor_manual:1"
+            ]
+          },
+          {
+            "case_id": "faq_exact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_1200_300:account_faq:6",
+              "short_faq:parent_child_1200_300:account_faq:5",
+              "short_faq:parent_child_1200_300:limits_table:4"
+            ]
+          },
+          {
+            "case_id": "faq_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 0.613147,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_1200_300:billing_faq:2",
+              "short_faq:parent_child_1200_300:billing_faq:1",
+              "short_faq:parent_child_1200_300:policy_dense:2"
+            ]
+          },
+          {
+            "case_id": "faq_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_1200_300:account_faq:8",
+              "short_faq:parent_child_1200_300:account_faq:7",
+              "short_faq:parent_child_1200_300:policy_dense:4"
+            ]
+          },
+          {
+            "case_id": "faq_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_1200_300:billing_faq:8",
+              "short_faq:parent_child_1200_300:billing_faq:7",
+              "short_faq:parent_child_1200_300:gateway_codes:9"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "short_faq",
+        "config_id": "parent_child_1800_450",
+        "strategy": "parent_child",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 130,
+        "indexed_character_count": 15835,
+        "returned_context_character_count": 34114,
+        "index_time_ms": 55.571,
+        "query_embedding_p95_ms": 0.136,
+        "retrieval_core_p95_ms": 13.808,
+        "metrics": {
+          "recall_at_5": 0.6,
+          "mrr_at_10": 0.622222,
+          "ndcg_at_10": 0.582835,
+          "citation_hit_rate": 0.08,
+          "citation_coverage": 0.8,
+          "context_anchor_coverage_at_5": 0.6,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 5,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "faq_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_1800_450:account_faq:2",
+              "short_faq:parent_child_1800_450:account_faq:1",
+              "short_faq:parent_child_1800_450:billing_faq:6"
+            ]
+          },
+          {
+            "case_id": "faq_paraphrase",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0.111111,
+              "ndcg_at_10": 0.30103,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_1800_450:vendor_manual:3",
+              "short_faq:parent_child_1800_450:account_faq:10",
+              "short_faq:parent_child_1800_450:vendor_manual:1"
+            ]
+          },
+          {
+            "case_id": "faq_exact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_1800_450:account_faq:6",
+              "short_faq:parent_child_1800_450:account_faq:5",
+              "short_faq:parent_child_1800_450:limits_table:4"
+            ]
+          },
+          {
+            "case_id": "faq_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 0.613147,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_1800_450:billing_faq:2",
+              "short_faq:parent_child_1800_450:billing_faq:1",
+              "short_faq:parent_child_1800_450:policy_dense:2"
+            ]
+          },
+          {
+            "case_id": "faq_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_1800_450:account_faq:8",
+              "short_faq:parent_child_1800_450:account_faq:7",
+              "short_faq:parent_child_1800_450:policy_dense:3"
+            ]
+          },
+          {
+            "case_id": "faq_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_1800_450:billing_faq:8",
+              "short_faq:parent_child_1800_450:billing_faq:7",
+              "short_faq:parent_child_1800_450:technical_dense:5"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "short_faq",
+        "config_id": "parent_child_2400_600",
+        "strategy": "parent_child",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 125,
+        "indexed_character_count": 15465,
+        "returned_context_character_count": 26628,
+        "index_time_ms": 71.285,
+        "query_embedding_p95_ms": 0.095,
+        "retrieval_core_p95_ms": 12.66,
+        "metrics": {
+          "recall_at_5": 0.6,
+          "mrr_at_10": 0.622222,
+          "ndcg_at_10": 0.582835,
+          "citation_hit_rate": 0.08,
+          "citation_coverage": 0.8,
+          "context_anchor_coverage_at_5": 0.6,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 5,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "faq_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_2400_600:account_faq:2",
+              "short_faq:parent_child_2400_600:account_faq:1",
+              "short_faq:parent_child_2400_600:billing_faq:6"
+            ]
+          },
+          {
+            "case_id": "faq_paraphrase",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0.111111,
+              "ndcg_at_10": 0.30103,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_2400_600:vendor_manual:3",
+              "short_faq:parent_child_2400_600:account_faq:10",
+              "short_faq:parent_child_2400_600:vendor_manual:1"
+            ]
+          },
+          {
+            "case_id": "faq_exact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_2400_600:account_faq:6",
+              "short_faq:parent_child_2400_600:account_faq:5",
+              "short_faq:parent_child_2400_600:limits_table:4"
+            ]
+          },
+          {
+            "case_id": "faq_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 0.613147,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_2400_600:billing_faq:2",
+              "short_faq:parent_child_2400_600:billing_faq:1",
+              "short_faq:parent_child_2400_600:continuity_manual:1"
+            ]
+          },
+          {
+            "case_id": "faq_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_2400_600:account_faq:8",
+              "short_faq:parent_child_2400_600:account_faq:7",
+              "short_faq:parent_child_2400_600:policy_dense:3"
+            ]
+          },
+          {
+            "case_id": "faq_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_2400_600:billing_faq:8",
+              "short_faq:parent_child_2400_600:billing_faq:7",
+              "short_faq:parent_child_2400_600:gateway_codes:9"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "technical_ids",
+        "config_id": "recursive_400_o0",
+        "strategy": "recursive_character",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 130,
+        "indexed_character_count": 15163,
+        "returned_context_character_count": 15163,
+        "index_time_ms": 79.153,
+        "query_embedding_p95_ms": 0.113,
+        "retrieval_core_p95_ms": 10.808,
+        "metrics": {
+          "recall_at_5": 0.333333,
+          "mrr_at_10": 0.273809,
+          "ndcg_at_10": 0.327377,
+          "citation_hit_rate": 0.05,
+          "citation_coverage": 0.5,
+          "context_anchor_coverage_at_5": 0.333333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "tid_fact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_400_o0:gateway_codes:8",
+              "technical_ids:recursive_400_o0:gateway_codes:4",
+              "technical_ids:recursive_400_o0:gateway_codes:6"
+            ]
+          },
+          {
+            "case_id": "tid_action",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_400_o0:gateway_codes:5",
+              "technical_ids:recursive_400_o0:continuity_manual:10",
+              "technical_ids:recursive_400_o0:gateway_codes:3"
+            ]
+          },
+          {
+            "case_id": "tid_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_400_o0:device_codes:1",
+              "technical_ids:recursive_400_o0:device_codes:2",
+              "technical_ids:recursive_400_o0:device_codes:3"
+            ]
+          },
+          {
+            "case_id": "tid_format",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0.142857,
+              "ndcg_at_10": 0.333333,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_400_o0:gateway_codes:4",
+              "technical_ids:recursive_400_o0:technical_dense:3",
+              "technical_ids:recursive_400_o0:technical_dense:6"
+            ]
+          },
+          {
+            "case_id": "tid_command",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_400_o0:confusable_dense:6",
+              "technical_ids:recursive_400_o0:confusable_dense:5",
+              "technical_ids:recursive_400_o0:harbor_dense:4"
+            ]
+          },
+          {
+            "case_id": "tid_dense",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.5,
+              "ndcg_at_10": 0.63093,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_400_o0:confusable_dense:5",
+              "technical_ids:recursive_400_o0:technical_dense:6",
+              "technical_ids:recursive_400_o0:gateway_codes:6"
+            ]
+          },
+          {
+            "case_id": "tid_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_400_o0:gateway_codes:8",
+              "technical_ids:recursive_400_o0:gateway_codes:6",
+              "technical_ids:recursive_400_o0:gateway_codes:10"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "technical_ids",
+        "config_id": "recursive_400_o40",
+        "strategy": "recursive_character",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 131,
+        "indexed_character_count": 15863,
+        "returned_context_character_count": 15863,
+        "index_time_ms": 72.313,
+        "query_embedding_p95_ms": 0.095,
+        "retrieval_core_p95_ms": 14.541,
+        "metrics": {
+          "recall_at_5": 0.333333,
+          "mrr_at_10": 0.351852,
+          "ndcg_at_10": 0.383505,
+          "citation_hit_rate": 0.05,
+          "citation_coverage": 0.5,
+          "context_anchor_coverage_at_5": 0.333333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "tid_fact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_400_o40:gateway_codes:8",
+              "technical_ids:recursive_400_o40:gateway_codes:6",
+              "technical_ids:recursive_400_o40:gateway_codes:4"
+            ]
+          },
+          {
+            "case_id": "tid_action",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_400_o40:gateway_codes:5",
+              "technical_ids:recursive_400_o40:continuity_manual:10",
+              "technical_ids:recursive_400_o40:gateway_codes:3"
+            ]
+          },
+          {
+            "case_id": "tid_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_400_o40:device_codes:1",
+              "technical_ids:recursive_400_o40:device_codes:2",
+              "technical_ids:recursive_400_o40:device_codes:3"
+            ]
+          },
+          {
+            "case_id": "tid_format",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0.111111,
+              "ndcg_at_10": 0.30103,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_400_o40:gateway_codes:4",
+              "technical_ids:recursive_400_o40:technical_dense:6",
+              "technical_ids:recursive_400_o40:technical_dense:3"
+            ]
+          },
+          {
+            "case_id": "tid_command",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_400_o40:confusable_dense:6",
+              "technical_ids:recursive_400_o40:confusable_dense:5",
+              "technical_ids:recursive_400_o40:harbor_dense:4"
+            ]
+          },
+          {
+            "case_id": "tid_dense",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_400_o40:technical_dense:6",
+              "technical_ids:recursive_400_o40:gateway_codes:6",
+              "technical_ids:recursive_400_o40:gateway_codes:10"
+            ]
+          },
+          {
+            "case_id": "tid_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_400_o40:gateway_codes:8",
+              "technical_ids:recursive_400_o40:gateway_codes:6",
+              "technical_ids:recursive_400_o40:gateway_codes:10"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "technical_ids",
+        "config_id": "recursive_700_o70",
+        "strategy": "recursive_character",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 122,
+        "indexed_character_count": 15215,
+        "returned_context_character_count": 15215,
+        "index_time_ms": 72.887,
+        "query_embedding_p95_ms": 0.14,
+        "retrieval_core_p95_ms": 11.06,
+        "metrics": {
+          "recall_at_5": 0.333333,
+          "mrr_at_10": 0.246032,
+          "ndcg_at_10": 0.305555,
+          "citation_hit_rate": 0.05,
+          "citation_coverage": 0.5,
+          "context_anchor_coverage_at_5": 0.333333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "tid_fact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_700_o70:gateway_codes:8",
+              "technical_ids:recursive_700_o70:gateway_codes:6",
+              "technical_ids:recursive_700_o70:gateway_codes:4"
+            ]
+          },
+          {
+            "case_id": "tid_action",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_700_o70:gateway_codes:5",
+              "technical_ids:recursive_700_o70:continuity_manual:10",
+              "technical_ids:recursive_700_o70:gateway_codes:3"
+            ]
+          },
+          {
+            "case_id": "tid_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_700_o70:device_codes:1",
+              "technical_ids:recursive_700_o70:device_codes:2",
+              "technical_ids:recursive_700_o70:device_codes:3"
+            ]
+          },
+          {
+            "case_id": "tid_format",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0.142857,
+              "ndcg_at_10": 0.333333,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_700_o70:gateway_codes:4",
+              "technical_ids:recursive_700_o70:technical_dense:4",
+              "technical_ids:recursive_700_o70:harbor_dense:4"
+            ]
+          },
+          {
+            "case_id": "tid_command",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_700_o70:confusable_dense:3",
+              "technical_ids:recursive_700_o70:confusable_dense:4",
+              "technical_ids:recursive_700_o70:harbor_dense:3"
+            ]
+          },
+          {
+            "case_id": "tid_dense",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.333333,
+              "ndcg_at_10": 0.5,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_700_o70:confusable_dense:3",
+              "technical_ids:recursive_700_o70:harbor_dense:4",
+              "technical_ids:recursive_700_o70:technical_dense:4"
+            ]
+          },
+          {
+            "case_id": "tid_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_700_o70:gateway_codes:8",
+              "technical_ids:recursive_700_o70:gateway_codes:6",
+              "technical_ids:recursive_700_o70:gateway_codes:10"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "technical_ids",
+        "config_id": "recursive_700_o140",
+        "strategy": "recursive_character",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 123,
+        "indexed_character_count": 15901,
+        "returned_context_character_count": 15901,
+        "index_time_ms": 75.954,
+        "query_embedding_p95_ms": 0.11,
+        "retrieval_core_p95_ms": 10.687,
+        "metrics": {
+          "recall_at_5": 0.333333,
+          "mrr_at_10": 0.246032,
+          "ndcg_at_10": 0.305555,
+          "citation_hit_rate": 0.05,
+          "citation_coverage": 0.5,
+          "context_anchor_coverage_at_5": 0.333333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "tid_fact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_700_o140:gateway_codes:8",
+              "technical_ids:recursive_700_o140:gateway_codes:6",
+              "technical_ids:recursive_700_o140:gateway_codes:4"
+            ]
+          },
+          {
+            "case_id": "tid_action",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_700_o140:gateway_codes:5",
+              "technical_ids:recursive_700_o140:continuity_manual:10",
+              "technical_ids:recursive_700_o140:gateway_codes:3"
+            ]
+          },
+          {
+            "case_id": "tid_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_700_o140:device_codes:1",
+              "technical_ids:recursive_700_o140:device_codes:2",
+              "technical_ids:recursive_700_o140:device_codes:3"
+            ]
+          },
+          {
+            "case_id": "tid_format",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0.142857,
+              "ndcg_at_10": 0.333333,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_700_o140:gateway_codes:4",
+              "technical_ids:recursive_700_o140:technical_dense:3",
+              "technical_ids:recursive_700_o140:technical_dense:4"
+            ]
+          },
+          {
+            "case_id": "tid_command",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_700_o140:confusable_dense:3",
+              "technical_ids:recursive_700_o140:confusable_dense:4",
+              "technical_ids:recursive_700_o140:harbor_dense:3"
+            ]
+          },
+          {
+            "case_id": "tid_dense",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.333333,
+              "ndcg_at_10": 0.5,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_700_o140:confusable_dense:3",
+              "technical_ids:recursive_700_o140:confusable_dense:4",
+              "technical_ids:recursive_700_o140:technical_dense:5"
+            ]
+          },
+          {
+            "case_id": "tid_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_700_o140:gateway_codes:8",
+              "technical_ids:recursive_700_o140:gateway_codes:6",
+              "technical_ids:recursive_700_o140:gateway_codes:10"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "technical_ids",
+        "config_id": "recursive_1000_o100",
+        "strategy": "recursive_character",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 118,
+        "indexed_character_count": 14790,
+        "returned_context_character_count": 14790,
+        "index_time_ms": 68.816,
+        "query_embedding_p95_ms": 0.126,
+        "retrieval_core_p95_ms": 8.911,
+        "metrics": {
+          "recall_at_5": 0.5,
+          "mrr_at_10": 0.233333,
+          "ndcg_at_10": 0.295618,
+          "citation_hit_rate": 0.05,
+          "citation_coverage": 0.5,
+          "context_anchor_coverage_at_5": 0.5,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "tid_fact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:gateway_codes:8",
+              "technical_ids:recursive_1000_o100:gateway_codes:4",
+              "technical_ids:recursive_1000_o100:gateway_codes:6"
+            ]
+          },
+          {
+            "case_id": "tid_action",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:gateway_codes:5",
+              "technical_ids:recursive_1000_o100:continuity_manual:10",
+              "technical_ids:recursive_1000_o100:gateway_codes:3"
+            ]
+          },
+          {
+            "case_id": "tid_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:device_codes:1",
+              "technical_ids:recursive_1000_o100:device_codes:2",
+              "technical_ids:recursive_1000_o100:device_codes:3"
+            ]
+          },
+          {
+            "case_id": "tid_format",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.2,
+              "ndcg_at_10": 0.386853,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:technical_dense:2",
+              "technical_ids:recursive_1000_o100:gateway_codes:4",
+              "technical_ids:recursive_1000_o100:technical_dense:3"
+            ]
+          },
+          {
+            "case_id": "tid_command",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:confusable_dense:3",
+              "technical_ids:recursive_1000_o100:harbor_dense:2",
+              "technical_ids:recursive_1000_o100:harbor_dense:3"
+            ]
+          },
+          {
+            "case_id": "tid_dense",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.2,
+              "ndcg_at_10": 0.386853,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:confusable_dense:2",
+              "technical_ids:recursive_1000_o100:harbor_dense:2",
+              "technical_ids:recursive_1000_o100:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "tid_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:gateway_codes:8",
+              "technical_ids:recursive_1000_o100:gateway_codes:6",
+              "technical_ids:recursive_1000_o100:gateway_codes:10"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "technical_ids",
+        "config_id": "parent_child_1200_300",
+        "strategy": "parent_child",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 142,
+        "indexed_character_count": 16915,
+        "returned_context_character_count": 34762,
+        "index_time_ms": 67.939,
+        "query_embedding_p95_ms": 0.242,
+        "retrieval_core_p95_ms": 12.605,
+        "metrics": {
+          "recall_at_5": 0.333333,
+          "mrr_at_10": 0.354167,
+          "ndcg_at_10": 0.385911,
+          "citation_hit_rate": 0.05,
+          "citation_coverage": 0.5,
+          "context_anchor_coverage_at_5": 0.333333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "tid_fact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_1200_300:gateway_codes:8",
+              "technical_ids:parent_child_1200_300:gateway_codes:6",
+              "technical_ids:parent_child_1200_300:gateway_codes:4"
+            ]
+          },
+          {
+            "case_id": "tid_action",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_1200_300:gateway_codes:5",
+              "technical_ids:parent_child_1200_300:continuity_manual:10",
+              "technical_ids:parent_child_1200_300:gateway_codes:3"
+            ]
+          },
+          {
+            "case_id": "tid_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_1200_300:device_codes:1",
+              "technical_ids:parent_child_1200_300:device_codes:2",
+              "technical_ids:parent_child_1200_300:device_codes:3"
+            ]
+          },
+          {
+            "case_id": "tid_format",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0.125,
+              "ndcg_at_10": 0.315465,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_1200_300:gateway_codes:4",
+              "technical_ids:parent_child_1200_300:technical_dense:8",
+              "technical_ids:parent_child_1200_300:gateway_codes:2"
+            ]
+          },
+          {
+            "case_id": "tid_command",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_1200_300:confusable_dense:6",
+              "technical_ids:parent_child_1200_300:confusable_dense:7",
+              "technical_ids:parent_child_1200_300:confusable_dense:9"
+            ]
+          },
+          {
+            "case_id": "tid_dense",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_1200_300:technical_dense:9",
+              "technical_ids:parent_child_1200_300:confusable_dense:5",
+              "technical_ids:parent_child_1200_300:gateway_codes:6"
+            ]
+          },
+          {
+            "case_id": "tid_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_1200_300:gateway_codes:8",
+              "technical_ids:parent_child_1200_300:gateway_codes:6",
+              "technical_ids:parent_child_1200_300:gateway_codes:10"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "technical_ids",
+        "config_id": "parent_child_1800_450",
+        "strategy": "parent_child",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 130,
+        "indexed_character_count": 15835,
+        "returned_context_character_count": 34114,
+        "index_time_ms": 65.67,
+        "query_embedding_p95_ms": 0.236,
+        "retrieval_core_p95_ms": 12.3,
+        "metrics": {
+          "recall_at_5": 0.333333,
+          "mrr_at_10": 0.354167,
+          "ndcg_at_10": 0.385911,
+          "citation_hit_rate": 0.05,
+          "citation_coverage": 0.5,
+          "context_anchor_coverage_at_5": 0.333333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "tid_fact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_1800_450:gateway_codes:8",
+              "technical_ids:parent_child_1800_450:gateway_codes:6",
+              "technical_ids:parent_child_1800_450:gateway_codes:4"
+            ]
+          },
+          {
+            "case_id": "tid_action",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_1800_450:gateway_codes:5",
+              "technical_ids:parent_child_1800_450:continuity_manual:10",
+              "technical_ids:parent_child_1800_450:gateway_codes:3"
+            ]
+          },
+          {
+            "case_id": "tid_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_1800_450:device_codes:1",
+              "technical_ids:parent_child_1800_450:device_codes:2",
+              "technical_ids:parent_child_1800_450:device_codes:3"
+            ]
+          },
+          {
+            "case_id": "tid_format",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0.125,
+              "ndcg_at_10": 0.315465,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_1800_450:gateway_codes:4",
+              "technical_ids:parent_child_1800_450:technical_dense:5",
+              "technical_ids:parent_child_1800_450:technical_dense:3"
+            ]
+          },
+          {
+            "case_id": "tid_command",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_1800_450:confusable_dense:6",
+              "technical_ids:parent_child_1800_450:confusable_dense:5",
+              "technical_ids:parent_child_1800_450:technical_dense:5"
+            ]
+          },
+          {
+            "case_id": "tid_dense",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_1800_450:technical_dense:6",
+              "technical_ids:parent_child_1800_450:confusable_dense:5",
+              "technical_ids:parent_child_1800_450:gateway_codes:10"
+            ]
+          },
+          {
+            "case_id": "tid_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_1800_450:gateway_codes:8",
+              "technical_ids:parent_child_1800_450:gateway_codes:6",
+              "technical_ids:parent_child_1800_450:gateway_codes:10"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "technical_ids",
+        "config_id": "parent_child_2400_600",
+        "strategy": "parent_child",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 125,
+        "indexed_character_count": 15465,
+        "returned_context_character_count": 26628,
+        "index_time_ms": 80.381,
+        "query_embedding_p95_ms": 0.117,
+        "retrieval_core_p95_ms": 9.389,
+        "metrics": {
+          "recall_at_5": 0.333333,
+          "mrr_at_10": 0.357143,
+          "ndcg_at_10": 0.388889,
+          "citation_hit_rate": 0.05,
+          "citation_coverage": 0.5,
+          "context_anchor_coverage_at_5": 0.333333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "tid_fact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:gateway_codes:8",
+              "technical_ids:parent_child_2400_600:gateway_codes:6",
+              "technical_ids:parent_child_2400_600:gateway_codes:4"
+            ]
+          },
+          {
+            "case_id": "tid_action",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:gateway_codes:5",
+              "technical_ids:parent_child_2400_600:continuity_manual:10",
+              "technical_ids:parent_child_2400_600:gateway_codes:3"
+            ]
+          },
+          {
+            "case_id": "tid_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:device_codes:1",
+              "technical_ids:parent_child_2400_600:device_codes:2",
+              "technical_ids:parent_child_2400_600:device_codes:3"
+            ]
+          },
+          {
+            "case_id": "tid_format",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0.142857,
+              "ndcg_at_10": 0.333333,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:gateway_codes:4",
+              "technical_ids:parent_child_2400_600:technical_dense:4",
+              "technical_ids:parent_child_2400_600:technical_dense:3"
+            ]
+          },
+          {
+            "case_id": "tid_command",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:confusable_dense:4",
+              "technical_ids:parent_child_2400_600:harbor_dense:3",
+              "technical_ids:parent_child_2400_600:technical_dense:4"
+            ]
+          },
+          {
+            "case_id": "tid_dense",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:technical_dense:5",
+              "technical_ids:parent_child_2400_600:confusable_dense:3",
+              "technical_ids:parent_child_2400_600:confusable_dense:4"
+            ]
+          },
+          {
+            "case_id": "tid_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:gateway_codes:8",
+              "technical_ids:parent_child_2400_600:gateway_codes:6",
+              "technical_ids:parent_child_2400_600:gateway_codes:10"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "bilingual_narrative",
+        "config_id": "recursive_400_o0",
+        "strategy": "recursive_character",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 130,
+        "indexed_character_count": 15163,
+        "returned_context_character_count": 15163,
+        "index_time_ms": 72.657,
+        "query_embedding_p95_ms": 0.108,
+        "retrieval_core_p95_ms": 9.9,
+        "metrics": {
+          "recall_at_5": 0.333333,
+          "mrr_at_10": 0.25,
+          "ndcg_at_10": 0.271822,
+          "citation_hit_rate": 0.033333,
+          "citation_coverage": 0.333333,
+          "context_anchor_coverage_at_5": 0.333333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "bi_en_to_cn",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:harbor_cn:1",
+              "bilingual_narrative:recursive_400_o0:vendor_manual:0",
+              "bilingual_narrative:recursive_400_o0:harbor_cn:3"
+            ]
+          },
+          {
+            "case_id": "bi_cn_to_en",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:harbor_report:3",
+              "bilingual_narrative:recursive_400_o0:harbor_dense:4",
+              "bilingual_narrative:recursive_400_o0:harbor_dense:6"
+            ]
+          },
+          {
+            "case_id": "bi_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:harbor_cn:5",
+              "bilingual_narrative:recursive_400_o0:harbor_report:5",
+              "bilingual_narrative:recursive_400_o0:gateway_codes:6"
+            ]
+          },
+          {
+            "case_id": "bi_threshold",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.5,
+              "ndcg_at_10": 0.63093,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:harbor_dense:4",
+              "bilingual_narrative:recursive_400_o0:harbor_report:5",
+              "bilingual_narrative:recursive_400_o0:confusable_dense:5"
+            ]
+          },
+          {
+            "case_id": "bi_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:technical_dense:2",
+              "bilingual_narrative:recursive_400_o0:harbor_dense:5",
+              "bilingual_narrative:recursive_400_o0:harbor_dense:2"
+            ]
+          },
+          {
+            "case_id": "bi_dense",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:harbor_cn:5",
+              "bilingual_narrative:recursive_400_o0:account_faq:9",
+              "bilingual_narrative:recursive_400_o0:account_faq:4"
+            ]
+          },
+          {
+            "case_id": "bi_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:harbor_report:7",
+              "bilingual_narrative:recursive_400_o0:harbor_dense:5",
+              "bilingual_narrative:recursive_400_o0:harbor_report:5"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "bilingual_narrative",
+        "config_id": "recursive_400_o40",
+        "strategy": "recursive_character",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 131,
+        "indexed_character_count": 15863,
+        "returned_context_character_count": 15863,
+        "index_time_ms": 66.896,
+        "query_embedding_p95_ms": 0.122,
+        "retrieval_core_p95_ms": 15.876,
+        "metrics": {
+          "recall_at_5": 0.333333,
+          "mrr_at_10": 0.222222,
+          "ndcg_at_10": 0.25,
+          "citation_hit_rate": 0.033333,
+          "citation_coverage": 0.333333,
+          "context_anchor_coverage_at_5": 0.333333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "bi_en_to_cn",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o40:harbor_cn:1",
+              "bilingual_narrative:recursive_400_o40:vendor_manual:0",
+              "bilingual_narrative:recursive_400_o40:harbor_cn:3"
+            ]
+          },
+          {
+            "case_id": "bi_cn_to_en",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o40:harbor_report:3",
+              "bilingual_narrative:recursive_400_o40:harbor_dense:7",
+              "bilingual_narrative:recursive_400_o40:harbor_dense:5"
+            ]
+          },
+          {
+            "case_id": "bi_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o40:harbor_cn:5",
+              "bilingual_narrative:recursive_400_o40:harbor_report:5",
+              "bilingual_narrative:recursive_400_o40:gateway_codes:6"
+            ]
+          },
+          {
+            "case_id": "bi_threshold",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.333333,
+              "ndcg_at_10": 0.5,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o40:harbor_dense:5",
+              "bilingual_narrative:recursive_400_o40:confusable_dense:5",
+              "bilingual_narrative:recursive_400_o40:harbor_report:5"
+            ]
+          },
+          {
+            "case_id": "bi_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o40:harbor_dense:6",
+              "bilingual_narrative:recursive_400_o40:technical_dense:2",
+              "bilingual_narrative:recursive_400_o40:harbor_dense:2"
+            ]
+          },
+          {
+            "case_id": "bi_dense",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o40:harbor_cn:5",
+              "bilingual_narrative:recursive_400_o40:account_faq:9",
+              "bilingual_narrative:recursive_400_o40:account_faq:4"
+            ]
+          },
+          {
+            "case_id": "bi_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o40:harbor_report:7",
+              "bilingual_narrative:recursive_400_o40:harbor_dense:3",
+              "bilingual_narrative:recursive_400_o40:harbor_dense:6"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "bilingual_narrative",
+        "config_id": "recursive_700_o70",
+        "strategy": "recursive_character",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 122,
+        "indexed_character_count": 15215,
+        "returned_context_character_count": 15215,
+        "index_time_ms": 59.907,
+        "query_embedding_p95_ms": 0.125,
+        "retrieval_core_p95_ms": 11.361,
+        "metrics": {
+          "recall_at_5": 0.333333,
+          "mrr_at_10": 0.208333,
+          "ndcg_at_10": 0.238446,
+          "citation_hit_rate": 0.033333,
+          "citation_coverage": 0.333333,
+          "context_anchor_coverage_at_5": 0.333333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "bi_en_to_cn",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_700_o70:harbor_cn:1",
+              "bilingual_narrative:recursive_700_o70:vendor_manual:0",
+              "bilingual_narrative:recursive_700_o70:harbor_cn:3"
+            ]
+          },
+          {
+            "case_id": "bi_cn_to_en",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_700_o70:harbor_report:3",
+              "bilingual_narrative:recursive_700_o70:harbor_dense:3",
+              "bilingual_narrative:recursive_700_o70:harbor_dense:4"
+            ]
+          },
+          {
+            "case_id": "bi_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_700_o70:harbor_cn:5",
+              "bilingual_narrative:recursive_700_o70:harbor_report:5",
+              "bilingual_narrative:recursive_700_o70:gateway_codes:6"
+            ]
+          },
+          {
+            "case_id": "bi_threshold",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.25,
+              "ndcg_at_10": 0.430677,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_700_o70:confusable_dense:3",
+              "bilingual_narrative:recursive_700_o70:technical_dense:4",
+              "bilingual_narrative:recursive_700_o70:harbor_dense:3"
+            ]
+          },
+          {
+            "case_id": "bi_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_700_o70:technical_dense:2",
+              "bilingual_narrative:recursive_700_o70:harbor_dense:2",
+              "bilingual_narrative:recursive_700_o70:technical_dense:3"
+            ]
+          },
+          {
+            "case_id": "bi_dense",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_700_o70:harbor_cn:5",
+              "bilingual_narrative:recursive_700_o70:account_faq:9",
+              "bilingual_narrative:recursive_700_o70:account_faq:4"
+            ]
+          },
+          {
+            "case_id": "bi_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_700_o70:harbor_report:7",
+              "bilingual_narrative:recursive_700_o70:harbor_dense:2",
+              "bilingual_narrative:recursive_700_o70:confusable_dense:4"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "bilingual_narrative",
+        "config_id": "recursive_700_o140",
+        "strategy": "recursive_character",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 123,
+        "indexed_character_count": 15901,
+        "returned_context_character_count": 15901,
+        "index_time_ms": 67.365,
+        "query_embedding_p95_ms": 0.111,
+        "retrieval_core_p95_ms": 10.116,
+        "metrics": {
+          "recall_at_5": 0.333333,
+          "mrr_at_10": 0.208333,
+          "ndcg_at_10": 0.238446,
+          "citation_hit_rate": 0.033333,
+          "citation_coverage": 0.333333,
+          "context_anchor_coverage_at_5": 0.333333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "bi_en_to_cn",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_700_o140:harbor_cn:1",
+              "bilingual_narrative:recursive_700_o140:vendor_manual:0",
+              "bilingual_narrative:recursive_700_o140:harbor_cn:3"
+            ]
+          },
+          {
+            "case_id": "bi_cn_to_en",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_700_o140:harbor_report:3",
+              "bilingual_narrative:recursive_700_o140:harbor_dense:4",
+              "bilingual_narrative:recursive_700_o140:harbor_dense:3"
+            ]
+          },
+          {
+            "case_id": "bi_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_700_o140:harbor_cn:5",
+              "bilingual_narrative:recursive_700_o140:harbor_report:5",
+              "bilingual_narrative:recursive_700_o140:gateway_codes:6"
+            ]
+          },
+          {
+            "case_id": "bi_threshold",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.25,
+              "ndcg_at_10": 0.430677,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_700_o140:confusable_dense:3",
+              "bilingual_narrative:recursive_700_o140:confusable_dense:4",
+              "bilingual_narrative:recursive_700_o140:harbor_dense:3"
+            ]
+          },
+          {
+            "case_id": "bi_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_700_o140:technical_dense:2",
+              "bilingual_narrative:recursive_700_o140:harbor_dense:2",
+              "bilingual_narrative:recursive_700_o140:technical_dense:3"
+            ]
+          },
+          {
+            "case_id": "bi_dense",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_700_o140:harbor_cn:5",
+              "bilingual_narrative:recursive_700_o140:account_faq:9",
+              "bilingual_narrative:recursive_700_o140:account_faq:4"
+            ]
+          },
+          {
+            "case_id": "bi_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_700_o140:harbor_report:7",
+              "bilingual_narrative:recursive_700_o140:harbor_dense:2",
+              "bilingual_narrative:recursive_700_o140:confusable_dense:4"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "bilingual_narrative",
+        "config_id": "recursive_1000_o100",
+        "strategy": "recursive_character",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 118,
+        "indexed_character_count": 14790,
+        "returned_context_character_count": 14790,
+        "index_time_ms": 70.461,
+        "query_embedding_p95_ms": 0.106,
+        "retrieval_core_p95_ms": 11.895,
+        "metrics": {
+          "recall_at_5": 0.333333,
+          "mrr_at_10": 0.226852,
+          "ndcg_at_10": 0.288618,
+          "citation_hit_rate": 0.05,
+          "citation_coverage": 0.5,
+          "context_anchor_coverage_at_5": 0.333333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "bi_en_to_cn",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_1000_o100:harbor_cn:1",
+              "bilingual_narrative:recursive_1000_o100:vendor_manual:0",
+              "bilingual_narrative:recursive_1000_o100:harbor_cn:3"
+            ]
+          },
+          {
+            "case_id": "bi_cn_to_en",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_1000_o100:harbor_report:3",
+              "bilingual_narrative:recursive_1000_o100:harbor_dense:3",
+              "bilingual_narrative:recursive_1000_o100:harbor_report:7"
+            ]
+          },
+          {
+            "case_id": "bi_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_1000_o100:harbor_cn:5",
+              "bilingual_narrative:recursive_1000_o100:harbor_report:5",
+              "bilingual_narrative:recursive_1000_o100:gateway_codes:6"
+            ]
+          },
+          {
+            "case_id": "bi_threshold",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.25,
+              "ndcg_at_10": 0.430677,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_1000_o100:confusable_dense:3",
+              "bilingual_narrative:recursive_1000_o100:technical_dense:3",
+              "bilingual_narrative:recursive_1000_o100:harbor_dense:3"
+            ]
+          },
+          {
+            "case_id": "bi_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0.111111,
+              "ndcg_at_10": 0.30103,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_1000_o100:technical_dense:2",
+              "bilingual_narrative:recursive_1000_o100:harbor_dense:2",
+              "bilingual_narrative:recursive_1000_o100:technical_dense:3"
+            ]
+          },
+          {
+            "case_id": "bi_dense",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_1000_o100:harbor_cn:5",
+              "bilingual_narrative:recursive_1000_o100:account_faq:9",
+              "bilingual_narrative:recursive_1000_o100:account_faq:4"
+            ]
+          },
+          {
+            "case_id": "bi_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_1000_o100:harbor_report:7",
+              "bilingual_narrative:recursive_1000_o100:harbor_dense:2",
+              "bilingual_narrative:recursive_1000_o100:confusable_dense:3"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "bilingual_narrative",
+        "config_id": "parent_child_1200_300",
+        "strategy": "parent_child",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 142,
+        "indexed_character_count": 16915,
+        "returned_context_character_count": 34762,
+        "index_time_ms": 68.853,
+        "query_embedding_p95_ms": 0.129,
+        "retrieval_core_p95_ms": 10.818,
+        "metrics": {
+          "recall_at_5": 0.333333,
+          "mrr_at_10": 0.2,
+          "ndcg_at_10": 0.231142,
+          "citation_hit_rate": 0.033333,
+          "citation_coverage": 0.333333,
+          "context_anchor_coverage_at_5": 0.333333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "bi_en_to_cn",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_1200_300:harbor_cn:1",
+              "bilingual_narrative:parent_child_1200_300:vendor_manual:0",
+              "bilingual_narrative:parent_child_1200_300:harbor_cn:3"
+            ]
+          },
+          {
+            "case_id": "bi_cn_to_en",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_1200_300:harbor_report:3",
+              "bilingual_narrative:parent_child_1200_300:harbor_dense:10",
+              "bilingual_narrative:parent_child_1200_300:harbor_dense:6"
+            ]
+          },
+          {
+            "case_id": "bi_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_1200_300:harbor_cn:5",
+              "bilingual_narrative:parent_child_1200_300:harbor_report:5",
+              "bilingual_narrative:parent_child_1200_300:gateway_codes:6"
+            ]
+          },
+          {
+            "case_id": "bi_threshold",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.2,
+              "ndcg_at_10": 0.386853,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_1200_300:harbor_dense:7",
+              "bilingual_narrative:parent_child_1200_300:confusable_dense:7",
+              "bilingual_narrative:parent_child_1200_300:confusable_dense:6"
+            ]
+          },
+          {
+            "case_id": "bi_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_1200_300:harbor_dense:9",
+              "bilingual_narrative:parent_child_1200_300:technical_dense:3",
+              "bilingual_narrative:parent_child_1200_300:harbor_dense:4"
+            ]
+          },
+          {
+            "case_id": "bi_dense",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_1200_300:harbor_cn:5",
+              "bilingual_narrative:parent_child_1200_300:policy_dense:2",
+              "bilingual_narrative:parent_child_1200_300:account_faq:9"
+            ]
+          },
+          {
+            "case_id": "bi_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_1200_300:harbor_report:7",
+              "bilingual_narrative:parent_child_1200_300:harbor_report:5",
+              "bilingual_narrative:parent_child_1200_300:harbor_dense:5"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "bilingual_narrative",
+        "config_id": "parent_child_1800_450",
+        "strategy": "parent_child",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 130,
+        "indexed_character_count": 15835,
+        "returned_context_character_count": 34114,
+        "index_time_ms": 59.845,
+        "query_embedding_p95_ms": 0.106,
+        "retrieval_core_p95_ms": 12.156,
+        "metrics": {
+          "recall_at_5": 0.333333,
+          "mrr_at_10": 0.222222,
+          "ndcg_at_10": 0.25,
+          "citation_hit_rate": 0.033333,
+          "citation_coverage": 0.333333,
+          "context_anchor_coverage_at_5": 0.333333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "bi_en_to_cn",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_1800_450:harbor_cn:1",
+              "bilingual_narrative:parent_child_1800_450:vendor_manual:0",
+              "bilingual_narrative:parent_child_1800_450:harbor_cn:3"
+            ]
+          },
+          {
+            "case_id": "bi_cn_to_en",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_1800_450:harbor_report:3",
+              "bilingual_narrative:parent_child_1800_450:harbor_dense:6",
+              "bilingual_narrative:parent_child_1800_450:harbor_dense:4"
+            ]
+          },
+          {
+            "case_id": "bi_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_1800_450:harbor_cn:5",
+              "bilingual_narrative:parent_child_1800_450:harbor_report:5",
+              "bilingual_narrative:parent_child_1800_450:gateway_codes:6"
+            ]
+          },
+          {
+            "case_id": "bi_threshold",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.333333,
+              "ndcg_at_10": 0.5,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_1800_450:harbor_dense:4",
+              "bilingual_narrative:parent_child_1800_450:confusable_dense:5",
+              "bilingual_narrative:parent_child_1800_450:harbor_report:5"
+            ]
+          },
+          {
+            "case_id": "bi_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_1800_450:technical_dense:2",
+              "bilingual_narrative:parent_child_1800_450:harbor_dense:5",
+              "bilingual_narrative:parent_child_1800_450:harbor_dense:2"
+            ]
+          },
+          {
+            "case_id": "bi_dense",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_1800_450:harbor_cn:5",
+              "bilingual_narrative:parent_child_1800_450:account_faq:9",
+              "bilingual_narrative:parent_child_1800_450:account_faq:4"
+            ]
+          },
+          {
+            "case_id": "bi_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_1800_450:harbor_report:7",
+              "bilingual_narrative:parent_child_1800_450:harbor_dense:3",
+              "bilingual_narrative:parent_child_1800_450:harbor_dense:5"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "bilingual_narrative",
+        "config_id": "parent_child_2400_600",
+        "strategy": "parent_child",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 125,
+        "indexed_character_count": 15465,
+        "returned_context_character_count": 26628,
+        "index_time_ms": 69.507,
+        "query_embedding_p95_ms": 0.152,
+        "retrieval_core_p95_ms": 10.993,
+        "metrics": {
+          "recall_at_5": 0.333333,
+          "mrr_at_10": 0.222222,
+          "ndcg_at_10": 0.25,
+          "citation_hit_rate": 0.033333,
+          "citation_coverage": 0.333333,
+          "context_anchor_coverage_at_5": 0.333333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "bi_en_to_cn",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:harbor_cn:1",
+              "bilingual_narrative:parent_child_2400_600:vendor_manual:0",
+              "bilingual_narrative:parent_child_2400_600:harbor_cn:3"
+            ]
+          },
+          {
+            "case_id": "bi_cn_to_en",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:harbor_report:3",
+              "bilingual_narrative:parent_child_2400_600:harbor_dense:5",
+              "bilingual_narrative:parent_child_2400_600:harbor_dense:3"
+            ]
+          },
+          {
+            "case_id": "bi_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:harbor_cn:5",
+              "bilingual_narrative:parent_child_2400_600:harbor_report:5",
+              "bilingual_narrative:parent_child_2400_600:gateway_codes:6"
+            ]
+          },
+          {
+            "case_id": "bi_threshold",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.333333,
+              "ndcg_at_10": 0.5,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:confusable_dense:4",
+              "bilingual_narrative:parent_child_2400_600:harbor_dense:4",
+              "bilingual_narrative:parent_child_2400_600:harbor_report:5"
+            ]
+          },
+          {
+            "case_id": "bi_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:harbor_dense:2",
+              "bilingual_narrative:parent_child_2400_600:technical_dense:2",
+              "bilingual_narrative:parent_child_2400_600:technical_dense:3"
+            ]
+          },
+          {
+            "case_id": "bi_dense",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:harbor_cn:5",
+              "bilingual_narrative:parent_child_2400_600:account_faq:9",
+              "bilingual_narrative:parent_child_2400_600:account_faq:4"
+            ]
+          },
+          {
+            "case_id": "bi_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:harbor_report:7",
+              "bilingual_narrative:parent_child_2400_600:harbor_report:5",
+              "bilingual_narrative:parent_child_2400_600:harbor_dense:4"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "tables_code",
+        "config_id": "recursive_400_o0",
+        "strategy": "recursive_character",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 130,
+        "indexed_character_count": 15163,
+        "returned_context_character_count": 15163,
+        "index_time_ms": 81.677,
+        "query_embedding_p95_ms": 0.169,
+        "retrieval_core_p95_ms": 14.066,
+        "metrics": {
+          "recall_at_5": 0.333333,
+          "mrr_at_10": 0.222222,
+          "ndcg_at_10": 0.25,
+          "citation_hit_rate": 0.033333,
+          "citation_coverage": 0.333333,
+          "context_anchor_coverage_at_5": 0.333333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "tc_table",
+            "query_type": "table",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_400_o0:sdk_config:3",
+              "tables_code:recursive_400_o0:confusable_dense:4",
+              "tables_code:recursive_400_o0:harbor_dense:4"
+            ]
+          },
+          {
+            "case_id": "tc_table_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_400_o0:limits_table:2",
+              "tables_code:recursive_400_o0:confusable_dense:5",
+              "tables_code:recursive_400_o0:north_program:8"
+            ]
+          },
+          {
+            "case_id": "tc_code",
+            "query_type": "code",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_400_o0:harbor_report:3",
+              "tables_code:recursive_400_o0:harbor_report:2",
+              "tables_code:recursive_400_o0:harbor_dense:3"
+            ]
+          },
+          {
+            "case_id": "tc_semantics",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_400_o0:sdk_config:3",
+              "tables_code:recursive_400_o0:harbor_report:1",
+              "tables_code:recursive_400_o0:harbor_report:7"
+            ]
+          },
+          {
+            "case_id": "tc_exact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_400_o0:technical_dense:2",
+              "tables_code:recursive_400_o0:confusable_dense:5",
+              "tables_code:recursive_400_o0:harbor_dense:4"
+            ]
+          },
+          {
+            "case_id": "tc_dense",
+            "query_type": "code",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.333333,
+              "ndcg_at_10": 0.5,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_400_o0:code_dense:4",
+              "tables_code:recursive_400_o0:technical_dense:5",
+              "tables_code:recursive_400_o0:code_dense:3"
+            ]
+          },
+          {
+            "case_id": "tc_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_400_o0:sdk_config:3",
+              "tables_code:recursive_400_o0:harbor_dense:4",
+              "tables_code:recursive_400_o0:code_dense:2"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "tables_code",
+        "config_id": "recursive_400_o40",
+        "strategy": "recursive_character",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 131,
+        "indexed_character_count": 15863,
+        "returned_context_character_count": 15863,
+        "index_time_ms": 67.149,
+        "query_embedding_p95_ms": 0.291,
+        "retrieval_core_p95_ms": 10.473,
+        "metrics": {
+          "recall_at_5": 0.333333,
+          "mrr_at_10": 0.222222,
+          "ndcg_at_10": 0.25,
+          "citation_hit_rate": 0.033333,
+          "citation_coverage": 0.333333,
+          "context_anchor_coverage_at_5": 0.333333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "tc_table",
+            "query_type": "table",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_400_o40:sdk_config:3",
+              "tables_code:recursive_400_o40:confusable_dense:4",
+              "tables_code:recursive_400_o40:harbor_dense:4"
+            ]
+          },
+          {
+            "case_id": "tc_table_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_400_o40:limits_table:2",
+              "tables_code:recursive_400_o40:confusable_dense:5",
+              "tables_code:recursive_400_o40:north_program:8"
+            ]
+          },
+          {
+            "case_id": "tc_code",
+            "query_type": "code",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_400_o40:harbor_report:3",
+              "tables_code:recursive_400_o40:harbor_report:2",
+              "tables_code:recursive_400_o40:sdk_config:3"
+            ]
+          },
+          {
+            "case_id": "tc_semantics",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_400_o40:sdk_config:3",
+              "tables_code:recursive_400_o40:harbor_report:1",
+              "tables_code:recursive_400_o40:harbor_report:3"
+            ]
+          },
+          {
+            "case_id": "tc_exact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_400_o40:technical_dense:2",
+              "tables_code:recursive_400_o40:technical_dense:3",
+              "tables_code:recursive_400_o40:gateway_codes:10"
+            ]
+          },
+          {
+            "case_id": "tc_dense",
+            "query_type": "code",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.333333,
+              "ndcg_at_10": 0.5,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_400_o40:code_dense:4",
+              "tables_code:recursive_400_o40:technical_dense:5",
+              "tables_code:recursive_400_o40:code_dense:3"
+            ]
+          },
+          {
+            "case_id": "tc_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_400_o40:sdk_config:3",
+              "tables_code:recursive_400_o40:code_dense:2",
+              "tables_code:recursive_400_o40:harbor_dense:5"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "tables_code",
+        "config_id": "recursive_700_o70",
+        "strategy": "recursive_character",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 122,
+        "indexed_character_count": 15215,
+        "returned_context_character_count": 15215,
+        "index_time_ms": 65.375,
+        "query_embedding_p95_ms": 0.146,
+        "retrieval_core_p95_ms": 10.609,
+        "metrics": {
+          "recall_at_5": 0.333333,
+          "mrr_at_10": 0.333333,
+          "ndcg_at_10": 0.333333,
+          "citation_hit_rate": 0.033333,
+          "citation_coverage": 0.333333,
+          "context_anchor_coverage_at_5": 0.333333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "tc_table",
+            "query_type": "table",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_700_o70:sdk_config:3",
+              "tables_code:recursive_700_o70:harbor_dense:3",
+              "tables_code:recursive_700_o70:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "tc_table_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_700_o70:limits_table:2",
+              "tables_code:recursive_700_o70:confusable_dense:3",
+              "tables_code:recursive_700_o70:north_program:8"
+            ]
+          },
+          {
+            "case_id": "tc_code",
+            "query_type": "code",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_700_o70:harbor_report:3",
+              "tables_code:recursive_700_o70:harbor_report:2",
+              "tables_code:recursive_700_o70:harbor_dense:4"
+            ]
+          },
+          {
+            "case_id": "tc_semantics",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_700_o70:sdk_config:3",
+              "tables_code:recursive_700_o70:technical_dense:4",
+              "tables_code:recursive_700_o70:harbor_dense:3"
+            ]
+          },
+          {
+            "case_id": "tc_exact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_700_o70:technical_dense:2",
+              "tables_code:recursive_700_o70:harbor_dense:3",
+              "tables_code:recursive_700_o70:gateway_codes:10"
+            ]
+          },
+          {
+            "case_id": "tc_dense",
+            "query_type": "code",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_700_o70:code_dense:3",
+              "tables_code:recursive_700_o70:code_dense:0",
+              "tables_code:recursive_700_o70:technical_dense:4"
+            ]
+          },
+          {
+            "case_id": "tc_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_700_o70:sdk_config:3",
+              "tables_code:recursive_700_o70:limits_table:3",
+              "tables_code:recursive_700_o70:harbor_dense:3"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "tables_code",
+        "config_id": "recursive_700_o140",
+        "strategy": "recursive_character",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 123,
+        "indexed_character_count": 15901,
+        "returned_context_character_count": 15901,
+        "index_time_ms": 75.697,
+        "query_embedding_p95_ms": 0.163,
+        "retrieval_core_p95_ms": 10.776,
+        "metrics": {
+          "recall_at_5": 0.333333,
+          "mrr_at_10": 0.333333,
+          "ndcg_at_10": 0.333333,
+          "citation_hit_rate": 0.033333,
+          "citation_coverage": 0.333333,
+          "context_anchor_coverage_at_5": 0.333333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "tc_table",
+            "query_type": "table",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_700_o140:sdk_config:3",
+              "tables_code:recursive_700_o140:confusable_dense:3",
+              "tables_code:recursive_700_o140:harbor_dense:3"
+            ]
+          },
+          {
+            "case_id": "tc_table_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_700_o140:limits_table:2",
+              "tables_code:recursive_700_o140:confusable_dense:3",
+              "tables_code:recursive_700_o140:confusable_dense:4"
+            ]
+          },
+          {
+            "case_id": "tc_code",
+            "query_type": "code",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_700_o140:harbor_report:3",
+              "tables_code:recursive_700_o140:harbor_report:2",
+              "tables_code:recursive_700_o140:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "tc_semantics",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_700_o140:sdk_config:3",
+              "tables_code:recursive_700_o140:confusable_dense:3",
+              "tables_code:recursive_700_o140:harbor_dense:4"
+            ]
+          },
+          {
+            "case_id": "tc_exact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_700_o140:technical_dense:2",
+              "tables_code:recursive_700_o140:harbor_dense:3",
+              "tables_code:recursive_700_o140:gateway_codes:10"
+            ]
+          },
+          {
+            "case_id": "tc_dense",
+            "query_type": "code",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_700_o140:code_dense:3",
+              "tables_code:recursive_700_o140:code_dense:0",
+              "tables_code:recursive_700_o140:technical_dense:4"
+            ]
+          },
+          {
+            "case_id": "tc_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_700_o140:sdk_config:3",
+              "tables_code:recursive_700_o140:confusable_dense:3",
+              "tables_code:recursive_700_o140:limits_table:3"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "tables_code",
+        "config_id": "recursive_1000_o100",
+        "strategy": "recursive_character",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 118,
+        "indexed_character_count": 14790,
+        "returned_context_character_count": 14790,
+        "index_time_ms": 66.981,
+        "query_embedding_p95_ms": 0.142,
+        "retrieval_core_p95_ms": 10.422,
+        "metrics": {
+          "recall_at_5": 0.333333,
+          "mrr_at_10": 0.333333,
+          "ndcg_at_10": 0.333333,
+          "citation_hit_rate": 0.033333,
+          "citation_coverage": 0.333333,
+          "context_anchor_coverage_at_5": 0.333333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "tc_table",
+            "query_type": "table",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:sdk_config:3",
+              "tables_code:recursive_1000_o100:harbor_dense:3",
+              "tables_code:recursive_1000_o100:harbor_report:7"
+            ]
+          },
+          {
+            "case_id": "tc_table_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:limits_table:2",
+              "tables_code:recursive_1000_o100:confusable_dense:3",
+              "tables_code:recursive_1000_o100:north_program:8"
+            ]
+          },
+          {
+            "case_id": "tc_code",
+            "query_type": "code",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:harbor_report:3",
+              "tables_code:recursive_1000_o100:harbor_report:2",
+              "tables_code:recursive_1000_o100:harbor_dense:3"
+            ]
+          },
+          {
+            "case_id": "tc_semantics",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:sdk_config:3",
+              "tables_code:recursive_1000_o100:harbor_report:1",
+              "tables_code:recursive_1000_o100:harbor_report:7"
+            ]
+          },
+          {
+            "case_id": "tc_exact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:gateway_codes:10",
+              "tables_code:recursive_1000_o100:technical_dense:2",
+              "tables_code:recursive_1000_o100:harbor_dense:3"
+            ]
+          },
+          {
+            "case_id": "tc_dense",
+            "query_type": "code",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:code_dense:2",
+              "tables_code:recursive_1000_o100:code_dense:0",
+              "tables_code:recursive_1000_o100:technical_dense:3"
+            ]
+          },
+          {
+            "case_id": "tc_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:sdk_config:3",
+              "tables_code:recursive_1000_o100:limits_table:3",
+              "tables_code:recursive_1000_o100:harbor_dense:3"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "tables_code",
+        "config_id": "parent_child_1200_300",
+        "strategy": "parent_child",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 142,
+        "indexed_character_count": 16915,
+        "returned_context_character_count": 34762,
+        "index_time_ms": 72.878,
+        "query_embedding_p95_ms": 0.327,
+        "retrieval_core_p95_ms": 11.402,
+        "metrics": {
+          "recall_at_5": 0.333333,
+          "mrr_at_10": 0.2,
+          "ndcg_at_10": 0.231142,
+          "citation_hit_rate": 0.033333,
+          "citation_coverage": 0.333333,
+          "context_anchor_coverage_at_5": 0.333333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "tc_table",
+            "query_type": "table",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_1200_300:sdk_config:3",
+              "tables_code:parent_child_1200_300:confusable_dense:5",
+              "tables_code:parent_child_1200_300:harbor_dense:6"
+            ]
+          },
+          {
+            "case_id": "tc_table_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_1200_300:limits_table:2",
+              "tables_code:parent_child_1200_300:confusable_dense:6",
+              "tables_code:parent_child_1200_300:confusable_dense:7"
+            ]
+          },
+          {
+            "case_id": "tc_code",
+            "query_type": "code",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_1200_300:harbor_report:3",
+              "tables_code:parent_child_1200_300:harbor_report:2",
+              "tables_code:parent_child_1200_300:harbor_dense:9"
+            ]
+          },
+          {
+            "case_id": "tc_semantics",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_1200_300:sdk_config:3",
+              "tables_code:parent_child_1200_300:harbor_report:1",
+              "tables_code:parent_child_1200_300:harbor_report:7"
+            ]
+          },
+          {
+            "case_id": "tc_exact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_1200_300:technical_dense:2",
+              "tables_code:parent_child_1200_300:confusable_dense:8",
+              "tables_code:parent_child_1200_300:technical_dense:3"
+            ]
+          },
+          {
+            "case_id": "tc_dense",
+            "query_type": "code",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.2,
+              "ndcg_at_10": 0.386853,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_1200_300:code_dense:5",
+              "tables_code:parent_child_1200_300:technical_dense:7",
+              "tables_code:parent_child_1200_300:confusable_dense:6"
+            ]
+          },
+          {
+            "case_id": "tc_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_1200_300:sdk_config:3",
+              "tables_code:parent_child_1200_300:confusable_dense:4",
+              "tables_code:parent_child_1200_300:confusable_dense:9"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "tables_code",
+        "config_id": "parent_child_1800_450",
+        "strategy": "parent_child",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 130,
+        "indexed_character_count": 15835,
+        "returned_context_character_count": 34114,
+        "index_time_ms": 66.722,
+        "query_embedding_p95_ms": 0.188,
+        "retrieval_core_p95_ms": 10.054,
+        "metrics": {
+          "recall_at_5": 0.333333,
+          "mrr_at_10": 0.222222,
+          "ndcg_at_10": 0.25,
+          "citation_hit_rate": 0.033333,
+          "citation_coverage": 0.333333,
+          "context_anchor_coverage_at_5": 0.333333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "tc_table",
+            "query_type": "table",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_1800_450:sdk_config:3",
+              "tables_code:parent_child_1800_450:confusable_dense:4",
+              "tables_code:parent_child_1800_450:harbor_dense:4"
+            ]
+          },
+          {
+            "case_id": "tc_table_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_1800_450:limits_table:2",
+              "tables_code:parent_child_1800_450:confusable_dense:5",
+              "tables_code:parent_child_1800_450:north_program:8"
+            ]
+          },
+          {
+            "case_id": "tc_code",
+            "query_type": "code",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_1800_450:harbor_report:3",
+              "tables_code:parent_child_1800_450:harbor_report:2",
+              "tables_code:parent_child_1800_450:harbor_dense:6"
+            ]
+          },
+          {
+            "case_id": "tc_semantics",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_1800_450:sdk_config:3",
+              "tables_code:parent_child_1800_450:harbor_report:1",
+              "tables_code:parent_child_1800_450:technical_dense:5"
+            ]
+          },
+          {
+            "case_id": "tc_exact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_1800_450:technical_dense:2",
+              "tables_code:parent_child_1800_450:confusable_dense:5",
+              "tables_code:parent_child_1800_450:harbor_dense:4"
+            ]
+          },
+          {
+            "case_id": "tc_dense",
+            "query_type": "code",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.333333,
+              "ndcg_at_10": 0.5,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_1800_450:code_dense:4",
+              "tables_code:parent_child_1800_450:technical_dense:5",
+              "tables_code:parent_child_1800_450:code_dense:3"
+            ]
+          },
+          {
+            "case_id": "tc_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_1800_450:sdk_config:3",
+              "tables_code:parent_child_1800_450:code_dense:2",
+              "tables_code:parent_child_1800_450:confusable_dense:6"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "tables_code",
+        "config_id": "parent_child_2400_600",
+        "strategy": "parent_child",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 125,
+        "indexed_character_count": 15465,
+        "returned_context_character_count": 26628,
+        "index_time_ms": 63.074,
+        "query_embedding_p95_ms": 0.318,
+        "retrieval_core_p95_ms": 9.85,
+        "metrics": {
+          "recall_at_5": 0.333333,
+          "mrr_at_10": 0.333333,
+          "ndcg_at_10": 0.333333,
+          "citation_hit_rate": 0.033333,
+          "citation_coverage": 0.333333,
+          "context_anchor_coverage_at_5": 0.333333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "tc_table",
+            "query_type": "table",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:sdk_config:3",
+              "tables_code:parent_child_2400_600:confusable_dense:3",
+              "tables_code:parent_child_2400_600:harbor_dense:3"
+            ]
+          },
+          {
+            "case_id": "tc_table_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:limits_table:2",
+              "tables_code:parent_child_2400_600:confusable_dense:4",
+              "tables_code:parent_child_2400_600:north_program:8"
+            ]
+          },
+          {
+            "case_id": "tc_code",
+            "query_type": "code",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:harbor_report:3",
+              "tables_code:parent_child_2400_600:harbor_report:2",
+              "tables_code:parent_child_2400_600:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "tc_semantics",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:sdk_config:3",
+              "tables_code:parent_child_2400_600:harbor_report:1",
+              "tables_code:parent_child_2400_600:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "tc_exact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:technical_dense:2",
+              "tables_code:parent_child_2400_600:harbor_dense:4",
+              "tables_code:parent_child_2400_600:gateway_codes:10"
+            ]
+          },
+          {
+            "case_id": "tc_dense",
+            "query_type": "code",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:code_dense:3",
+              "tables_code:parent_child_2400_600:code_dense:0",
+              "tables_code:parent_child_2400_600:technical_dense:4"
+            ]
+          },
+          {
+            "case_id": "tc_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:sdk_config:3",
+              "tables_code:parent_child_2400_600:limits_table:3",
+              "tables_code:parent_child_2400_600:confusable_dense:3"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "confusable_sections",
+        "config_id": "recursive_400_o0",
+        "strategy": "recursive_character",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 130,
+        "indexed_character_count": 15163,
+        "returned_context_character_count": 15163,
+        "index_time_ms": 66.082,
+        "query_embedding_p95_ms": 0.131,
+        "retrieval_core_p95_ms": 10.185,
+        "metrics": {
+          "recall_at_5": 0.666667,
+          "mrr_at_10": 0.423611,
+          "ndcg_at_10": 0.520022,
+          "citation_hit_rate": 0.1,
+          "citation_coverage": 1,
+          "context_anchor_coverage_at_5": 0.666667,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "cs_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.5,
+              "ndcg_at_10": 0.63093,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_400_o0:confusable_dense:3",
+              "confusable_sections:recursive_400_o0:north_program:2",
+              "confusable_sections:recursive_400_o0:confusable_dense:2"
+            ]
+          },
+          {
+            "case_id": "cs_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0.166667,
+              "ndcg_at_10": 0.356207,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_400_o0:confusable_dense:3",
+              "confusable_sections:recursive_400_o0:confusable_dense:4",
+              "confusable_sections:recursive_400_o0:confusable_dense:6"
+            ]
+          },
+          {
+            "case_id": "cs_region",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_400_o0:south_program:6",
+              "confusable_sections:recursive_400_o0:north_program:6",
+              "confusable_sections:recursive_400_o0:confusable_dense:4"
+            ]
+          },
+          {
+            "case_id": "cs_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.5,
+              "ndcg_at_10": 0.386853,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_400_o0:confusable_dense:2",
+              "confusable_sections:recursive_400_o0:north_program:4",
+              "confusable_sections:recursive_400_o0:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "cs_negative",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0.125,
+              "ndcg_at_10": 0.315465,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_400_o0:confusable_dense:4",
+              "confusable_sections:recursive_400_o0:confusable_dense:3",
+              "confusable_sections:recursive_400_o0:confusable_dense:6"
+            ]
+          },
+          {
+            "case_id": "cs_dense",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.25,
+              "ndcg_at_10": 0.430677,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_400_o0:north_program:6",
+              "confusable_sections:recursive_400_o0:confusable_dense:3",
+              "confusable_sections:recursive_400_o0:confusable_dense:4"
+            ]
+          },
+          {
+            "case_id": "cs_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_400_o0:south_program:4",
+              "confusable_sections:recursive_400_o0:confusable_dense:4",
+              "confusable_sections:recursive_400_o0:confusable_dense:6"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "confusable_sections",
+        "config_id": "recursive_400_o40",
+        "strategy": "recursive_character",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 131,
+        "indexed_character_count": 15863,
+        "returned_context_character_count": 15863,
+        "index_time_ms": 55.778,
+        "query_embedding_p95_ms": 0.139,
+        "retrieval_core_p95_ms": 10.872,
+        "metrics": {
+          "recall_at_5": 0.833333,
+          "mrr_at_10": 0.554167,
+          "ndcg_at_10": 0.620017,
+          "citation_hit_rate": 0.1,
+          "citation_coverage": 1,
+          "context_anchor_coverage_at_5": 0.833333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "cs_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.5,
+              "ndcg_at_10": 0.63093,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_400_o40:confusable_dense:3",
+              "confusable_sections:recursive_400_o40:north_program:2",
+              "confusable_sections:recursive_400_o40:confusable_dense:2"
+            ]
+          },
+          {
+            "case_id": "cs_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.2,
+              "ndcg_at_10": 0.386853,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_400_o40:confusable_dense:3",
+              "confusable_sections:recursive_400_o40:confusable_dense:6",
+              "confusable_sections:recursive_400_o40:south_program:4"
+            ]
+          },
+          {
+            "case_id": "cs_region",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_400_o40:south_program:6",
+              "confusable_sections:recursive_400_o40:north_program:6",
+              "confusable_sections:recursive_400_o40:confusable_dense:4"
+            ]
+          },
+          {
+            "case_id": "cs_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.5,
+              "ndcg_at_10": 0.386853,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_400_o40:confusable_dense:2",
+              "confusable_sections:recursive_400_o40:north_program:4",
+              "confusable_sections:recursive_400_o40:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "cs_negative",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0.125,
+              "ndcg_at_10": 0.315465,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_400_o40:confusable_dense:5",
+              "confusable_sections:recursive_400_o40:confusable_dense:4",
+              "confusable_sections:recursive_400_o40:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "cs_dense",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_400_o40:confusable_dense:6",
+              "confusable_sections:recursive_400_o40:north_program:6",
+              "confusable_sections:recursive_400_o40:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "cs_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_400_o40:confusable_dense:4",
+              "confusable_sections:recursive_400_o40:south_program:4",
+              "confusable_sections:recursive_400_o40:confusable_dense:6"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "confusable_sections",
+        "config_id": "recursive_700_o70",
+        "strategy": "recursive_character",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 122,
+        "indexed_character_count": 15215,
+        "returned_context_character_count": 15215,
+        "index_time_ms": 76.074,
+        "query_embedding_p95_ms": 0.132,
+        "retrieval_core_p95_ms": 9.427,
+        "metrics": {
+          "recall_at_5": 1,
+          "mrr_at_10": 0.555555,
+          "ndcg_at_10": 0.600905,
+          "citation_hit_rate": 0.1,
+          "citation_coverage": 1,
+          "context_anchor_coverage_at_5": 1,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "cs_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.5,
+              "ndcg_at_10": 0.63093,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_700_o70:confusable_dense:2",
+              "confusable_sections:recursive_700_o70:north_program:2",
+              "confusable_sections:recursive_700_o70:north_program:8"
+            ]
+          },
+          {
+            "case_id": "cs_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.25,
+              "ndcg_at_10": 0.430677,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_700_o70:south_program:4",
+              "confusable_sections:recursive_700_o70:confusable_dense:2",
+              "confusable_sections:recursive_700_o70:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "cs_region",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_700_o70:south_program:6",
+              "confusable_sections:recursive_700_o70:north_program:6",
+              "confusable_sections:recursive_700_o70:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "cs_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 0.613147,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_700_o70:north_program:4",
+              "confusable_sections:recursive_700_o70:confusable_dense:2",
+              "confusable_sections:recursive_700_o70:north_program:2"
+            ]
+          },
+          {
+            "case_id": "cs_negative",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.25,
+              "ndcg_at_10": 0.430677,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_700_o70:confusable_dense:3",
+              "confusable_sections:recursive_700_o70:south_program:6",
+              "confusable_sections:recursive_700_o70:confusable_dense:4"
+            ]
+          },
+          {
+            "case_id": "cs_dense",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.333333,
+              "ndcg_at_10": 0.5,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_700_o70:confusable_dense:3",
+              "confusable_sections:recursive_700_o70:north_program:6",
+              "confusable_sections:recursive_700_o70:confusable_dense:4"
+            ]
+          },
+          {
+            "case_id": "cs_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_700_o70:south_program:4",
+              "confusable_sections:recursive_700_o70:confusable_dense:3",
+              "confusable_sections:recursive_700_o70:confusable_dense:4"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "confusable_sections",
+        "config_id": "recursive_700_o140",
+        "strategy": "recursive_character",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 123,
+        "indexed_character_count": 15901,
+        "returned_context_character_count": 15901,
+        "index_time_ms": 65.558,
+        "query_embedding_p95_ms": 0.145,
+        "retrieval_core_p95_ms": 11.487,
+        "metrics": {
+          "recall_at_5": 1,
+          "mrr_at_10": 0.555555,
+          "ndcg_at_10": 0.600905,
+          "citation_hit_rate": 0.1,
+          "citation_coverage": 1,
+          "context_anchor_coverage_at_5": 1,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "cs_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.5,
+              "ndcg_at_10": 0.63093,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_700_o140:confusable_dense:2",
+              "confusable_sections:recursive_700_o140:north_program:2",
+              "confusable_sections:recursive_700_o140:north_program:8"
+            ]
+          },
+          {
+            "case_id": "cs_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.25,
+              "ndcg_at_10": 0.430677,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_700_o140:confusable_dense:3",
+              "confusable_sections:recursive_700_o140:confusable_dense:2",
+              "confusable_sections:recursive_700_o140:south_program:4"
+            ]
+          },
+          {
+            "case_id": "cs_region",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_700_o140:south_program:6",
+              "confusable_sections:recursive_700_o140:north_program:6",
+              "confusable_sections:recursive_700_o140:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "cs_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 0.613147,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_700_o140:north_program:4",
+              "confusable_sections:recursive_700_o140:confusable_dense:2",
+              "confusable_sections:recursive_700_o140:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "cs_negative",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.25,
+              "ndcg_at_10": 0.430677,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_700_o140:confusable_dense:3",
+              "confusable_sections:recursive_700_o140:confusable_dense:4",
+              "confusable_sections:recursive_700_o140:south_program:6"
+            ]
+          },
+          {
+            "case_id": "cs_dense",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.333333,
+              "ndcg_at_10": 0.5,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_700_o140:confusable_dense:3",
+              "confusable_sections:recursive_700_o140:north_program:6",
+              "confusable_sections:recursive_700_o140:confusable_dense:4"
+            ]
+          },
+          {
+            "case_id": "cs_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_700_o140:confusable_dense:4",
+              "confusable_sections:recursive_700_o140:south_program:4",
+              "confusable_sections:recursive_700_o140:confusable_dense:3"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "confusable_sections",
+        "config_id": "recursive_1000_o100",
+        "strategy": "recursive_character",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 118,
+        "indexed_character_count": 14790,
+        "returned_context_character_count": 14790,
+        "index_time_ms": 59.265,
+        "query_embedding_p95_ms": 0.14,
+        "retrieval_core_p95_ms": 10.333,
+        "metrics": {
+          "recall_at_5": 1,
+          "mrr_at_10": 0.583333,
+          "ndcg_at_10": 0.646523,
+          "citation_hit_rate": 0.1,
+          "citation_coverage": 1,
+          "context_anchor_coverage_at_5": 1,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "cs_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:north_program:2",
+              "confusable_sections:recursive_1000_o100:confusable_dense:2",
+              "confusable_sections:recursive_1000_o100:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "cs_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.25,
+              "ndcg_at_10": 0.430677,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:confusable_dense:2",
+              "confusable_sections:recursive_1000_o100:south_program:4",
+              "confusable_sections:recursive_1000_o100:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "cs_region",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:south_program:6",
+              "confusable_sections:recursive_1000_o100:north_program:6",
+              "confusable_sections:recursive_1000_o100:confusable_dense:2"
+            ]
+          },
+          {
+            "case_id": "cs_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.5,
+              "ndcg_at_10": 0.386853,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:confusable_dense:2",
+              "confusable_sections:recursive_1000_o100:north_program:4",
+              "confusable_sections:recursive_1000_o100:north_program:2"
+            ]
+          },
+          {
+            "case_id": "cs_negative",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.25,
+              "ndcg_at_10": 0.430677,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:confusable_dense:3",
+              "confusable_sections:recursive_1000_o100:confusable_dense:2",
+              "confusable_sections:recursive_1000_o100:south_program:6"
+            ]
+          },
+          {
+            "case_id": "cs_dense",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.5,
+              "ndcg_at_10": 0.63093,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:north_program:6",
+              "confusable_sections:recursive_1000_o100:confusable_dense:3",
+              "confusable_sections:recursive_1000_o100:harbor_dense:3"
+            ]
+          },
+          {
+            "case_id": "cs_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:confusable_dense:3",
+              "confusable_sections:recursive_1000_o100:south_program:4",
+              "confusable_sections:recursive_1000_o100:confusable_dense:2"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "confusable_sections",
+        "config_id": "parent_child_1200_300",
+        "strategy": "parent_child",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 142,
+        "indexed_character_count": 16915,
+        "returned_context_character_count": 34762,
+        "index_time_ms": 72.44,
+        "query_embedding_p95_ms": 0.158,
+        "retrieval_core_p95_ms": 12.133,
+        "metrics": {
+          "recall_at_5": 0.666667,
+          "mrr_at_10": 0.520833,
+          "ndcg_at_10": 0.569291,
+          "citation_hit_rate": 0.1,
+          "citation_coverage": 1,
+          "context_anchor_coverage_at_5": 0.666667,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "cs_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.5,
+              "ndcg_at_10": 0.63093,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_1200_300:confusable_dense:3",
+              "confusable_sections:parent_child_1200_300:north_program:2",
+              "confusable_sections:parent_child_1200_300:confusable_dense:2"
+            ]
+          },
+          {
+            "case_id": "cs_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0.166667,
+              "ndcg_at_10": 0.356207,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_1200_300:confusable_dense:9",
+              "confusable_sections:parent_child_1200_300:confusable_dense:3",
+              "confusable_sections:parent_child_1200_300:confusable_dense:4"
+            ]
+          },
+          {
+            "case_id": "cs_region",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_1200_300:south_program:6",
+              "confusable_sections:parent_child_1200_300:north_program:6",
+              "confusable_sections:parent_child_1200_300:confusable_dense:5"
+            ]
+          },
+          {
+            "case_id": "cs_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 0.613147,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_1200_300:north_program:4",
+              "confusable_sections:parent_child_1200_300:confusable_dense:2",
+              "confusable_sections:parent_child_1200_300:confusable_dense:4"
+            ]
+          },
+          {
+            "case_id": "cs_negative",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0.125,
+              "ndcg_at_10": 0.315465,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_1200_300:confusable_dense:6",
+              "confusable_sections:parent_child_1200_300:confusable_dense:5",
+              "confusable_sections:parent_child_1200_300:confusable_dense:7"
+            ]
+          },
+          {
+            "case_id": "cs_dense",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.333333,
+              "ndcg_at_10": 0.5,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_1200_300:confusable_dense:4",
+              "confusable_sections:parent_child_1200_300:north_program:6",
+              "confusable_sections:parent_child_1200_300:confusable_dense:9"
+            ]
+          },
+          {
+            "case_id": "cs_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_1200_300:confusable_dense:6",
+              "confusable_sections:parent_child_1200_300:south_program:4",
+              "confusable_sections:parent_child_1200_300:confusable_dense:3"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "confusable_sections",
+        "config_id": "parent_child_1800_450",
+        "strategy": "parent_child",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 130,
+        "indexed_character_count": 15835,
+        "returned_context_character_count": 34114,
+        "index_time_ms": 61.839,
+        "query_embedding_p95_ms": 0.321,
+        "retrieval_core_p95_ms": 10.539,
+        "metrics": {
+          "recall_at_5": 0.833333,
+          "mrr_at_10": 0.554167,
+          "ndcg_at_10": 0.620017,
+          "citation_hit_rate": 0.1,
+          "citation_coverage": 1,
+          "context_anchor_coverage_at_5": 0.833333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "cs_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.5,
+              "ndcg_at_10": 0.63093,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_1800_450:confusable_dense:3",
+              "confusable_sections:parent_child_1800_450:north_program:2",
+              "confusable_sections:parent_child_1800_450:confusable_dense:2"
+            ]
+          },
+          {
+            "case_id": "cs_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.2,
+              "ndcg_at_10": 0.386853,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_1800_450:confusable_dense:3",
+              "confusable_sections:parent_child_1800_450:confusable_dense:6",
+              "confusable_sections:parent_child_1800_450:south_program:4"
+            ]
+          },
+          {
+            "case_id": "cs_region",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_1800_450:south_program:6",
+              "confusable_sections:parent_child_1800_450:north_program:6",
+              "confusable_sections:parent_child_1800_450:confusable_dense:4"
+            ]
+          },
+          {
+            "case_id": "cs_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.5,
+              "ndcg_at_10": 0.386853,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_1800_450:confusable_dense:2",
+              "confusable_sections:parent_child_1800_450:north_program:4",
+              "confusable_sections:parent_child_1800_450:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "cs_negative",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0.125,
+              "ndcg_at_10": 0.315465,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_1800_450:confusable_dense:4",
+              "confusable_sections:parent_child_1800_450:confusable_dense:5",
+              "confusable_sections:parent_child_1800_450:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "cs_dense",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_1800_450:confusable_dense:6",
+              "confusable_sections:parent_child_1800_450:confusable_dense:4",
+              "confusable_sections:parent_child_1800_450:north_program:6"
+            ]
+          },
+          {
+            "case_id": "cs_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_1800_450:south_program:4",
+              "confusable_sections:parent_child_1800_450:confusable_dense:4",
+              "confusable_sections:parent_child_1800_450:confusable_dense:5"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "confusable_sections",
+        "config_id": "parent_child_2400_600",
+        "strategy": "parent_child",
+        "indexed_document_count": 17,
+        "processed_block_count": 115,
+        "chunk_count": 125,
+        "indexed_character_count": 15465,
+        "returned_context_character_count": 26628,
+        "index_time_ms": 90.35,
+        "query_embedding_p95_ms": 0.453,
+        "retrieval_core_p95_ms": 10.434,
+        "metrics": {
+          "recall_at_5": 1,
+          "mrr_at_10": 0.547222,
+          "ndcg_at_10": 0.593601,
+          "citation_hit_rate": 0.1,
+          "citation_coverage": 1,
+          "context_anchor_coverage_at_5": 1,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "cs_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.5,
+              "ndcg_at_10": 0.63093,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:confusable_dense:2",
+              "confusable_sections:parent_child_2400_600:north_program:2",
+              "confusable_sections:parent_child_2400_600:confusable_dense:4"
+            ]
+          },
+          {
+            "case_id": "cs_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.25,
+              "ndcg_at_10": 0.430677,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:confusable_dense:3",
+              "confusable_sections:parent_child_2400_600:south_program:4",
+              "confusable_sections:parent_child_2400_600:confusable_dense:2"
+            ]
+          },
+          {
+            "case_id": "cs_region",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:south_program:6",
+              "confusable_sections:parent_child_2400_600:north_program:6",
+              "confusable_sections:parent_child_2400_600:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "cs_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 0.613147,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:north_program:4",
+              "confusable_sections:parent_child_2400_600:confusable_dense:2",
+              "confusable_sections:parent_child_2400_600:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "cs_negative",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.2,
+              "ndcg_at_10": 0.386853,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:confusable_dense:4",
+              "confusable_sections:parent_child_2400_600:confusable_dense:3",
+              "confusable_sections:parent_child_2400_600:south_program:6"
+            ]
+          },
+          {
+            "case_id": "cs_dense",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.333333,
+              "ndcg_at_10": 0.5,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:confusable_dense:3",
+              "confusable_sections:parent_child_2400_600:north_program:6",
+              "confusable_sections:parent_child_2400_600:confusable_dense:4"
+            ]
+          },
+          {
+            "case_id": "cs_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:confusable_dense:4",
+              "confusable_sections:parent_child_2400_600:south_program:4",
+              "confusable_sections:parent_child_2400_600:confusable_dense:3"
+            ]
+          }
+        ]
+      }
+    ],
+    "selected_for_stage2": {
+      "long_policy": [
+        "recursive_400_o0",
+        "parent_child_1800_450"
+      ],
+      "short_faq": [
+        "recursive_400_o0",
+        "parent_child_2400_600"
+      ],
+      "technical_ids": [
+        "recursive_1000_o100",
+        "parent_child_2400_600"
+      ],
+      "bilingual_narrative": [
+        "recursive_400_o0",
+        "parent_child_2400_600"
+      ],
+      "tables_code": [
+        "recursive_1000_o100",
+        "parent_child_2400_600"
+      ],
+      "confusable_sections": [
+        "recursive_1000_o100",
+        "parent_child_2400_600"
+      ]
+    }
+  },
+  "stage2": {
+    "modes": [
+      "fulltext",
+      "vector",
+      "hybrid"
+    ],
+    "top_k": [
+      5,
+      10
+    ],
+    "rows": [
+      {
+        "corpus_id": "long_policy",
+        "config_id": "recursive_400_o0",
+        "strategy": "recursive_character",
+        "mode": "fulltext",
+        "top_k": 5,
+        "retrieval_core_p95_ms": 5.971,
+        "metrics": {
+          "recall_at_5": 0.833333,
+          "mrr_at_10": 0.722222,
+          "ndcg_at_10": 0.75,
+          "citation_hit_rate": 0.2,
+          "citation_coverage": 0.833333,
+          "context_anchor_coverage_at_5": 0.833333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "lp_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:continuity_manual:5",
+              "long_policy:recursive_400_o0:continuity_manual:4",
+              "long_policy:recursive_400_o0:vendor_manual:3"
+            ]
+          },
+          {
+            "case_id": "lp_paraphrase",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:continuity_manual:7",
+              "long_policy:recursive_400_o0:continuity_manual:3",
+              "long_policy:recursive_400_o0:continuity_manual:5"
+            ]
+          },
+          {
+            "case_id": "lp_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:continuity_manual:9",
+              "long_policy:recursive_400_o0:continuity_manual:11",
+              "long_policy:recursive_400_o0:billing_faq:7"
+            ]
+          },
+          {
+            "case_id": "lp_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:continuity_manual:11",
+              "long_policy:recursive_400_o0:continuity_manual:9",
+              "long_policy:recursive_400_o0:account_faq:4"
+            ]
+          },
+          {
+            "case_id": "lp_multi",
+            "query_type": "multi_evidence",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.4,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:vendor_manual:3",
+              "long_policy:recursive_400_o0:continuity_manual:7",
+              "long_policy:recursive_400_o0:vendor_manual:2"
+            ]
+          },
+          {
+            "case_id": "lp_dense",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.333333,
+              "ndcg_at_10": 0.5,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:policy_dense:1",
+              "long_policy:recursive_400_o0:policy_dense:0",
+              "long_policy:recursive_400_o0:policy_dense:3"
+            ]
+          },
+          {
+            "case_id": "lp_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:continuity_manual:1",
+              "long_policy:recursive_400_o0:billing_faq:4",
+              "long_policy:recursive_400_o0:billing_faq:6"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "long_policy",
+        "config_id": "recursive_400_o0",
+        "strategy": "recursive_character",
+        "mode": "fulltext",
+        "top_k": 10,
+        "retrieval_core_p95_ms": 3.555,
+        "metrics": {
+          "recall_at_5": 0.833333,
+          "mrr_at_10": 0.722222,
+          "ndcg_at_10": 0.75,
+          "citation_hit_rate": 0.1,
+          "citation_coverage": 0.833333,
+          "context_anchor_coverage_at_5": 0.833333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "lp_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:continuity_manual:5",
+              "long_policy:recursive_400_o0:continuity_manual:4",
+              "long_policy:recursive_400_o0:vendor_manual:3"
+            ]
+          },
+          {
+            "case_id": "lp_paraphrase",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:continuity_manual:7",
+              "long_policy:recursive_400_o0:continuity_manual:3",
+              "long_policy:recursive_400_o0:continuity_manual:5"
+            ]
+          },
+          {
+            "case_id": "lp_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:continuity_manual:9",
+              "long_policy:recursive_400_o0:continuity_manual:11",
+              "long_policy:recursive_400_o0:billing_faq:7"
+            ]
+          },
+          {
+            "case_id": "lp_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:continuity_manual:11",
+              "long_policy:recursive_400_o0:continuity_manual:9",
+              "long_policy:recursive_400_o0:account_faq:4"
+            ]
+          },
+          {
+            "case_id": "lp_multi",
+            "query_type": "multi_evidence",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:vendor_manual:3",
+              "long_policy:recursive_400_o0:continuity_manual:7",
+              "long_policy:recursive_400_o0:vendor_manual:2"
+            ]
+          },
+          {
+            "case_id": "lp_dense",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.333333,
+              "ndcg_at_10": 0.5,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:policy_dense:1",
+              "long_policy:recursive_400_o0:policy_dense:0",
+              "long_policy:recursive_400_o0:policy_dense:3"
+            ]
+          },
+          {
+            "case_id": "lp_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:continuity_manual:1",
+              "long_policy:recursive_400_o0:billing_faq:4",
+              "long_policy:recursive_400_o0:billing_faq:6"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "long_policy",
+        "config_id": "recursive_400_o0",
+        "strategy": "recursive_character",
+        "mode": "vector",
+        "top_k": 5,
+        "retrieval_core_p95_ms": 6.589,
+        "metrics": {
+          "recall_at_5": 0.833333,
+          "mrr_at_10": 0.833333,
+          "ndcg_at_10": 0.819954,
+          "citation_hit_rate": 0.2,
+          "citation_coverage": 0.833333,
+          "context_anchor_coverage_at_5": 0.833333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "lp_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:continuity_manual:5",
+              "long_policy:recursive_400_o0:continuity_manual:4",
+              "long_policy:recursive_400_o0:continuity_manual:1"
+            ]
+          },
+          {
+            "case_id": "lp_paraphrase",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:continuity_manual:7",
+              "long_policy:recursive_400_o0:policy_dense:2",
+              "long_policy:recursive_400_o0:vendor_manual:1"
+            ]
+          },
+          {
+            "case_id": "lp_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:north_program:7",
+              "long_policy:recursive_400_o0:harbor_report:1",
+              "long_policy:recursive_400_o0:harbor_report:0"
+            ]
+          },
+          {
+            "case_id": "lp_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:continuity_manual:11",
+              "long_policy:recursive_400_o0:continuity_manual:9",
+              "long_policy:recursive_400_o0:harbor_cn:3"
+            ]
+          },
+          {
+            "case_id": "lp_multi",
+            "query_type": "multi_evidence",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 0.919721,
+              "citation_hit_rate": 0.4,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:vendor_manual:3",
+              "long_policy:recursive_400_o0:vendor_manual:2",
+              "long_policy:recursive_400_o0:continuity_manual:7"
+            ]
+          },
+          {
+            "case_id": "lp_dense",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:policy_dense:3",
+              "long_policy:recursive_400_o0:policy_dense:0",
+              "long_policy:recursive_400_o0:vendor_manual:4"
+            ]
+          },
+          {
+            "case_id": "lp_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:continuity_manual:1",
+              "long_policy:recursive_400_o0:harbor_cn:3",
+              "long_policy:recursive_400_o0:harbor_cn:4"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "long_policy",
+        "config_id": "recursive_400_o0",
+        "strategy": "recursive_character",
+        "mode": "vector",
+        "top_k": 10,
+        "retrieval_core_p95_ms": 7.029,
+        "metrics": {
+          "recall_at_5": 0.833333,
+          "mrr_at_10": 0.833333,
+          "ndcg_at_10": 0.819954,
+          "citation_hit_rate": 0.1,
+          "citation_coverage": 0.833333,
+          "context_anchor_coverage_at_5": 0.833333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "lp_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:continuity_manual:5",
+              "long_policy:recursive_400_o0:continuity_manual:4",
+              "long_policy:recursive_400_o0:continuity_manual:1"
+            ]
+          },
+          {
+            "case_id": "lp_paraphrase",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:continuity_manual:7",
+              "long_policy:recursive_400_o0:policy_dense:2",
+              "long_policy:recursive_400_o0:vendor_manual:1"
+            ]
+          },
+          {
+            "case_id": "lp_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:north_program:7",
+              "long_policy:recursive_400_o0:harbor_report:1",
+              "long_policy:recursive_400_o0:harbor_report:0"
+            ]
+          },
+          {
+            "case_id": "lp_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:continuity_manual:11",
+              "long_policy:recursive_400_o0:continuity_manual:9",
+              "long_policy:recursive_400_o0:harbor_cn:3"
+            ]
+          },
+          {
+            "case_id": "lp_multi",
+            "query_type": "multi_evidence",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 0.919721,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:vendor_manual:3",
+              "long_policy:recursive_400_o0:vendor_manual:2",
+              "long_policy:recursive_400_o0:continuity_manual:7"
+            ]
+          },
+          {
+            "case_id": "lp_dense",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:policy_dense:3",
+              "long_policy:recursive_400_o0:policy_dense:0",
+              "long_policy:recursive_400_o0:vendor_manual:4"
+            ]
+          },
+          {
+            "case_id": "lp_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:continuity_manual:1",
+              "long_policy:recursive_400_o0:harbor_cn:3",
+              "long_policy:recursive_400_o0:harbor_cn:4"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "long_policy",
+        "config_id": "recursive_400_o0",
+        "strategy": "recursive_character",
+        "mode": "hybrid",
+        "top_k": 5,
+        "retrieval_core_p95_ms": 10.151,
+        "metrics": {
+          "recall_at_5": 0.833333,
+          "mrr_at_10": 0.833333,
+          "ndcg_at_10": 0.819954,
+          "citation_hit_rate": 0.2,
+          "citation_coverage": 0.833333,
+          "context_anchor_coverage_at_5": 0.833333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "lp_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:continuity_manual:5",
+              "long_policy:recursive_400_o0:continuity_manual:4",
+              "long_policy:recursive_400_o0:continuity_manual:1"
+            ]
+          },
+          {
+            "case_id": "lp_paraphrase",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:continuity_manual:7",
+              "long_policy:recursive_400_o0:policy_dense:2",
+              "long_policy:recursive_400_o0:policy_dense:3"
+            ]
+          },
+          {
+            "case_id": "lp_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:continuity_manual:11",
+              "long_policy:recursive_400_o0:north_program:7",
+              "long_policy:recursive_400_o0:harbor_report:1"
+            ]
+          },
+          {
+            "case_id": "lp_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:continuity_manual:11",
+              "long_policy:recursive_400_o0:continuity_manual:9",
+              "long_policy:recursive_400_o0:harbor_cn:3"
+            ]
+          },
+          {
+            "case_id": "lp_multi",
+            "query_type": "multi_evidence",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 0.919721,
+              "citation_hit_rate": 0.4,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:vendor_manual:3",
+              "long_policy:recursive_400_o0:vendor_manual:2",
+              "long_policy:recursive_400_o0:continuity_manual:7"
+            ]
+          },
+          {
+            "case_id": "lp_dense",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:policy_dense:3",
+              "long_policy:recursive_400_o0:policy_dense:0",
+              "long_policy:recursive_400_o0:vendor_manual:4"
+            ]
+          },
+          {
+            "case_id": "lp_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:continuity_manual:1",
+              "long_policy:recursive_400_o0:harbor_cn:3",
+              "long_policy:recursive_400_o0:billing_faq:2"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "long_policy",
+        "config_id": "recursive_400_o0",
+        "strategy": "recursive_character",
+        "mode": "hybrid",
+        "top_k": 10,
+        "retrieval_core_p95_ms": 10.141,
+        "metrics": {
+          "recall_at_5": 0.833333,
+          "mrr_at_10": 0.833333,
+          "ndcg_at_10": 0.819954,
+          "citation_hit_rate": 0.1,
+          "citation_coverage": 0.833333,
+          "context_anchor_coverage_at_5": 0.833333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "lp_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:continuity_manual:5",
+              "long_policy:recursive_400_o0:continuity_manual:4",
+              "long_policy:recursive_400_o0:continuity_manual:1"
+            ]
+          },
+          {
+            "case_id": "lp_paraphrase",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:continuity_manual:7",
+              "long_policy:recursive_400_o0:policy_dense:2",
+              "long_policy:recursive_400_o0:policy_dense:3"
+            ]
+          },
+          {
+            "case_id": "lp_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:continuity_manual:11",
+              "long_policy:recursive_400_o0:north_program:7",
+              "long_policy:recursive_400_o0:harbor_report:1"
+            ]
+          },
+          {
+            "case_id": "lp_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:continuity_manual:11",
+              "long_policy:recursive_400_o0:continuity_manual:9",
+              "long_policy:recursive_400_o0:harbor_cn:3"
+            ]
+          },
+          {
+            "case_id": "lp_multi",
+            "query_type": "multi_evidence",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 0.919721,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:vendor_manual:3",
+              "long_policy:recursive_400_o0:vendor_manual:2",
+              "long_policy:recursive_400_o0:continuity_manual:7"
+            ]
+          },
+          {
+            "case_id": "lp_dense",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:policy_dense:3",
+              "long_policy:recursive_400_o0:policy_dense:0",
+              "long_policy:recursive_400_o0:vendor_manual:4"
+            ]
+          },
+          {
+            "case_id": "lp_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:recursive_400_o0:continuity_manual:1",
+              "long_policy:recursive_400_o0:harbor_cn:3",
+              "long_policy:recursive_400_o0:billing_faq:2"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "long_policy",
+        "config_id": "parent_child_1800_450",
+        "strategy": "parent_child",
+        "mode": "fulltext",
+        "top_k": 5,
+        "retrieval_core_p95_ms": 3.263,
+        "metrics": {
+          "recall_at_5": 0.833333,
+          "mrr_at_10": 0.75,
+          "ndcg_at_10": 0.771822,
+          "citation_hit_rate": 0.2,
+          "citation_coverage": 0.833333,
+          "context_anchor_coverage_at_5": 0.833333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "lp_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:continuity_manual:5",
+              "long_policy:parent_child_1800_450:continuity_manual:4",
+              "long_policy:parent_child_1800_450:vendor_manual:3"
+            ]
+          },
+          {
+            "case_id": "lp_paraphrase",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:continuity_manual:7",
+              "long_policy:parent_child_1800_450:continuity_manual:3",
+              "long_policy:parent_child_1800_450:continuity_manual:5"
+            ]
+          },
+          {
+            "case_id": "lp_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:continuity_manual:9",
+              "long_policy:parent_child_1800_450:continuity_manual:11",
+              "long_policy:parent_child_1800_450:billing_faq:7"
+            ]
+          },
+          {
+            "case_id": "lp_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:continuity_manual:11",
+              "long_policy:parent_child_1800_450:continuity_manual:9",
+              "long_policy:parent_child_1800_450:account_faq:4"
+            ]
+          },
+          {
+            "case_id": "lp_multi",
+            "query_type": "multi_evidence",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.4,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:vendor_manual:3",
+              "long_policy:parent_child_1800_450:continuity_manual:7",
+              "long_policy:parent_child_1800_450:vendor_manual:2"
+            ]
+          },
+          {
+            "case_id": "lp_dense",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.5,
+              "ndcg_at_10": 0.63093,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:policy_dense:1",
+              "long_policy:parent_child_1800_450:policy_dense:3",
+              "long_policy:parent_child_1800_450:policy_dense:0"
+            ]
+          },
+          {
+            "case_id": "lp_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:continuity_manual:1",
+              "long_policy:parent_child_1800_450:billing_faq:4",
+              "long_policy:parent_child_1800_450:billing_faq:6"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "long_policy",
+        "config_id": "parent_child_1800_450",
+        "strategy": "parent_child",
+        "mode": "fulltext",
+        "top_k": 10,
+        "retrieval_core_p95_ms": 4.125,
+        "metrics": {
+          "recall_at_5": 0.833333,
+          "mrr_at_10": 0.75,
+          "ndcg_at_10": 0.771822,
+          "citation_hit_rate": 0.1,
+          "citation_coverage": 0.833333,
+          "context_anchor_coverage_at_5": 0.833333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "lp_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:continuity_manual:5",
+              "long_policy:parent_child_1800_450:continuity_manual:4",
+              "long_policy:parent_child_1800_450:vendor_manual:3"
+            ]
+          },
+          {
+            "case_id": "lp_paraphrase",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:continuity_manual:7",
+              "long_policy:parent_child_1800_450:continuity_manual:3",
+              "long_policy:parent_child_1800_450:continuity_manual:5"
+            ]
+          },
+          {
+            "case_id": "lp_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:continuity_manual:9",
+              "long_policy:parent_child_1800_450:continuity_manual:11",
+              "long_policy:parent_child_1800_450:billing_faq:7"
+            ]
+          },
+          {
+            "case_id": "lp_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:continuity_manual:11",
+              "long_policy:parent_child_1800_450:continuity_manual:9",
+              "long_policy:parent_child_1800_450:account_faq:4"
+            ]
+          },
+          {
+            "case_id": "lp_multi",
+            "query_type": "multi_evidence",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:vendor_manual:3",
+              "long_policy:parent_child_1800_450:continuity_manual:7",
+              "long_policy:parent_child_1800_450:vendor_manual:2"
+            ]
+          },
+          {
+            "case_id": "lp_dense",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.5,
+              "ndcg_at_10": 0.63093,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:policy_dense:1",
+              "long_policy:parent_child_1800_450:policy_dense:3",
+              "long_policy:parent_child_1800_450:policy_dense:0"
+            ]
+          },
+          {
+            "case_id": "lp_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:continuity_manual:1",
+              "long_policy:parent_child_1800_450:billing_faq:4",
+              "long_policy:parent_child_1800_450:billing_faq:6"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "long_policy",
+        "config_id": "parent_child_1800_450",
+        "strategy": "parent_child",
+        "mode": "vector",
+        "top_k": 5,
+        "retrieval_core_p95_ms": 6.44,
+        "metrics": {
+          "recall_at_5": 0.833333,
+          "mrr_at_10": 0.833333,
+          "ndcg_at_10": 0.819954,
+          "citation_hit_rate": 0.2,
+          "citation_coverage": 0.833333,
+          "context_anchor_coverage_at_5": 0.833333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "lp_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:continuity_manual:5",
+              "long_policy:parent_child_1800_450:continuity_manual:4",
+              "long_policy:parent_child_1800_450:continuity_manual:1"
+            ]
+          },
+          {
+            "case_id": "lp_paraphrase",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:continuity_manual:7",
+              "long_policy:parent_child_1800_450:policy_dense:2",
+              "long_policy:parent_child_1800_450:vendor_manual:1"
+            ]
+          },
+          {
+            "case_id": "lp_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:north_program:7",
+              "long_policy:parent_child_1800_450:harbor_report:1",
+              "long_policy:parent_child_1800_450:harbor_report:0"
+            ]
+          },
+          {
+            "case_id": "lp_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:continuity_manual:11",
+              "long_policy:parent_child_1800_450:continuity_manual:9",
+              "long_policy:parent_child_1800_450:harbor_cn:3"
+            ]
+          },
+          {
+            "case_id": "lp_multi",
+            "query_type": "multi_evidence",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 0.919721,
+              "citation_hit_rate": 0.4,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:vendor_manual:3",
+              "long_policy:parent_child_1800_450:vendor_manual:2",
+              "long_policy:parent_child_1800_450:continuity_manual:7"
+            ]
+          },
+          {
+            "case_id": "lp_dense",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:policy_dense:3",
+              "long_policy:parent_child_1800_450:policy_dense:0",
+              "long_policy:parent_child_1800_450:vendor_manual:4"
+            ]
+          },
+          {
+            "case_id": "lp_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:continuity_manual:1",
+              "long_policy:parent_child_1800_450:harbor_cn:3",
+              "long_policy:parent_child_1800_450:harbor_cn:4"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "long_policy",
+        "config_id": "parent_child_1800_450",
+        "strategy": "parent_child",
+        "mode": "vector",
+        "top_k": 10,
+        "retrieval_core_p95_ms": 7.145,
+        "metrics": {
+          "recall_at_5": 0.833333,
+          "mrr_at_10": 0.833333,
+          "ndcg_at_10": 0.819954,
+          "citation_hit_rate": 0.1,
+          "citation_coverage": 0.833333,
+          "context_anchor_coverage_at_5": 0.833333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "lp_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:continuity_manual:5",
+              "long_policy:parent_child_1800_450:continuity_manual:4",
+              "long_policy:parent_child_1800_450:continuity_manual:1"
+            ]
+          },
+          {
+            "case_id": "lp_paraphrase",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:continuity_manual:7",
+              "long_policy:parent_child_1800_450:policy_dense:2",
+              "long_policy:parent_child_1800_450:vendor_manual:1"
+            ]
+          },
+          {
+            "case_id": "lp_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:north_program:7",
+              "long_policy:parent_child_1800_450:harbor_report:1",
+              "long_policy:parent_child_1800_450:harbor_report:0"
+            ]
+          },
+          {
+            "case_id": "lp_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:continuity_manual:11",
+              "long_policy:parent_child_1800_450:continuity_manual:9",
+              "long_policy:parent_child_1800_450:harbor_cn:3"
+            ]
+          },
+          {
+            "case_id": "lp_multi",
+            "query_type": "multi_evidence",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 0.919721,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:vendor_manual:3",
+              "long_policy:parent_child_1800_450:vendor_manual:2",
+              "long_policy:parent_child_1800_450:continuity_manual:7"
+            ]
+          },
+          {
+            "case_id": "lp_dense",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:policy_dense:3",
+              "long_policy:parent_child_1800_450:policy_dense:0",
+              "long_policy:parent_child_1800_450:vendor_manual:4"
+            ]
+          },
+          {
+            "case_id": "lp_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:continuity_manual:1",
+              "long_policy:parent_child_1800_450:harbor_cn:3",
+              "long_policy:parent_child_1800_450:harbor_cn:4"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "long_policy",
+        "config_id": "parent_child_1800_450",
+        "strategy": "parent_child",
+        "mode": "hybrid",
+        "top_k": 5,
+        "retrieval_core_p95_ms": 11.435,
+        "metrics": {
+          "recall_at_5": 0.833333,
+          "mrr_at_10": 0.833333,
+          "ndcg_at_10": 0.819954,
+          "citation_hit_rate": 0.2,
+          "citation_coverage": 0.833333,
+          "context_anchor_coverage_at_5": 0.833333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "lp_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:continuity_manual:5",
+              "long_policy:parent_child_1800_450:continuity_manual:4",
+              "long_policy:parent_child_1800_450:continuity_manual:1"
+            ]
+          },
+          {
+            "case_id": "lp_paraphrase",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:continuity_manual:7",
+              "long_policy:parent_child_1800_450:policy_dense:2",
+              "long_policy:parent_child_1800_450:continuity_manual:1"
+            ]
+          },
+          {
+            "case_id": "lp_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:continuity_manual:11",
+              "long_policy:parent_child_1800_450:north_program:7",
+              "long_policy:parent_child_1800_450:harbor_report:1"
+            ]
+          },
+          {
+            "case_id": "lp_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:continuity_manual:11",
+              "long_policy:parent_child_1800_450:continuity_manual:9",
+              "long_policy:parent_child_1800_450:harbor_cn:3"
+            ]
+          },
+          {
+            "case_id": "lp_multi",
+            "query_type": "multi_evidence",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 0.919721,
+              "citation_hit_rate": 0.4,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:vendor_manual:3",
+              "long_policy:parent_child_1800_450:vendor_manual:2",
+              "long_policy:parent_child_1800_450:continuity_manual:7"
+            ]
+          },
+          {
+            "case_id": "lp_dense",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:policy_dense:3",
+              "long_policy:parent_child_1800_450:policy_dense:0",
+              "long_policy:parent_child_1800_450:vendor_manual:4"
+            ]
+          },
+          {
+            "case_id": "lp_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:continuity_manual:1",
+              "long_policy:parent_child_1800_450:harbor_cn:3",
+              "long_policy:parent_child_1800_450:billing_faq:2"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "long_policy",
+        "config_id": "parent_child_1800_450",
+        "strategy": "parent_child",
+        "mode": "hybrid",
+        "top_k": 10,
+        "retrieval_core_p95_ms": 14.381,
+        "metrics": {
+          "recall_at_5": 0.833333,
+          "mrr_at_10": 0.833333,
+          "ndcg_at_10": 0.819954,
+          "citation_hit_rate": 0.1,
+          "citation_coverage": 0.833333,
+          "context_anchor_coverage_at_5": 0.833333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "lp_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:continuity_manual:5",
+              "long_policy:parent_child_1800_450:continuity_manual:4",
+              "long_policy:parent_child_1800_450:continuity_manual:1"
+            ]
+          },
+          {
+            "case_id": "lp_paraphrase",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:continuity_manual:7",
+              "long_policy:parent_child_1800_450:policy_dense:2",
+              "long_policy:parent_child_1800_450:continuity_manual:1"
+            ]
+          },
+          {
+            "case_id": "lp_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:continuity_manual:11",
+              "long_policy:parent_child_1800_450:north_program:7",
+              "long_policy:parent_child_1800_450:harbor_report:1"
+            ]
+          },
+          {
+            "case_id": "lp_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:continuity_manual:11",
+              "long_policy:parent_child_1800_450:continuity_manual:9",
+              "long_policy:parent_child_1800_450:harbor_cn:3"
+            ]
+          },
+          {
+            "case_id": "lp_multi",
+            "query_type": "multi_evidence",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 0.919721,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:vendor_manual:3",
+              "long_policy:parent_child_1800_450:vendor_manual:2",
+              "long_policy:parent_child_1800_450:continuity_manual:7"
+            ]
+          },
+          {
+            "case_id": "lp_dense",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:policy_dense:3",
+              "long_policy:parent_child_1800_450:policy_dense:0",
+              "long_policy:parent_child_1800_450:vendor_manual:4"
+            ]
+          },
+          {
+            "case_id": "lp_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "long_policy:parent_child_1800_450:continuity_manual:1",
+              "long_policy:parent_child_1800_450:harbor_cn:3",
+              "long_policy:parent_child_1800_450:billing_faq:2"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "short_faq",
+        "config_id": "recursive_400_o0",
+        "strategy": "recursive_character",
+        "mode": "fulltext",
+        "top_k": 5,
+        "retrieval_core_p95_ms": 3.599,
+        "metrics": {
+          "recall_at_5": 0.8,
+          "mrr_at_10": 0.7,
+          "ndcg_at_10": 0.648815,
+          "citation_hit_rate": 0.16,
+          "citation_coverage": 0.8,
+          "context_anchor_coverage_at_5": 0.8,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 5,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "faq_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.5,
+              "ndcg_at_10": 0.63093,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o0:account_faq:1",
+              "short_faq:recursive_400_o0:account_faq:2",
+              "short_faq:recursive_400_o0:billing_faq:5"
+            ]
+          },
+          {
+            "case_id": "faq_paraphrase",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o0:account_faq:8",
+              "short_faq:recursive_400_o0:vendor_manual:3",
+              "short_faq:recursive_400_o0:account_faq:10"
+            ]
+          },
+          {
+            "case_id": "faq_exact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o0:account_faq:6",
+              "short_faq:recursive_400_o0:account_faq:5",
+              "short_faq:recursive_400_o0:billing_faq:7"
+            ]
+          },
+          {
+            "case_id": "faq_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 0.613147,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o0:billing_faq:2",
+              "short_faq:recursive_400_o0:billing_faq:1",
+              "short_faq:recursive_400_o0:billing_faq:6"
+            ]
+          },
+          {
+            "case_id": "faq_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o0:account_faq:8",
+              "short_faq:recursive_400_o0:account_faq:7",
+              "short_faq:recursive_400_o0:account_faq:0"
+            ]
+          },
+          {
+            "case_id": "faq_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o0:billing_faq:8",
+              "short_faq:recursive_400_o0:billing_faq:7",
+              "short_faq:recursive_400_o0:device_codes:4"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "short_faq",
+        "config_id": "recursive_400_o0",
+        "strategy": "recursive_character",
+        "mode": "fulltext",
+        "top_k": 10,
+        "retrieval_core_p95_ms": 3.94,
+        "metrics": {
+          "recall_at_5": 0.8,
+          "mrr_at_10": 0.7,
+          "ndcg_at_10": 0.648815,
+          "citation_hit_rate": 0.08,
+          "citation_coverage": 0.8,
+          "context_anchor_coverage_at_5": 0.8,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 5,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "faq_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.5,
+              "ndcg_at_10": 0.63093,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o0:account_faq:1",
+              "short_faq:recursive_400_o0:account_faq:2",
+              "short_faq:recursive_400_o0:billing_faq:5"
+            ]
+          },
+          {
+            "case_id": "faq_paraphrase",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o0:account_faq:8",
+              "short_faq:recursive_400_o0:vendor_manual:3",
+              "short_faq:recursive_400_o0:account_faq:10"
+            ]
+          },
+          {
+            "case_id": "faq_exact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o0:account_faq:6",
+              "short_faq:recursive_400_o0:account_faq:5",
+              "short_faq:recursive_400_o0:billing_faq:7"
+            ]
+          },
+          {
+            "case_id": "faq_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 0.613147,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o0:billing_faq:2",
+              "short_faq:recursive_400_o0:billing_faq:1",
+              "short_faq:recursive_400_o0:billing_faq:6"
+            ]
+          },
+          {
+            "case_id": "faq_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o0:account_faq:8",
+              "short_faq:recursive_400_o0:account_faq:7",
+              "short_faq:recursive_400_o0:account_faq:0"
+            ]
+          },
+          {
+            "case_id": "faq_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o0:billing_faq:8",
+              "short_faq:recursive_400_o0:billing_faq:7",
+              "short_faq:recursive_400_o0:device_codes:4"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "short_faq",
+        "config_id": "recursive_400_o0",
+        "strategy": "recursive_character",
+        "mode": "vector",
+        "top_k": 5,
+        "retrieval_core_p95_ms": 5.796,
+        "metrics": {
+          "recall_at_5": 0.6,
+          "mrr_at_10": 0.6,
+          "ndcg_at_10": 0.522629,
+          "citation_hit_rate": 0.12,
+          "citation_coverage": 0.6,
+          "context_anchor_coverage_at_5": 0.6,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 5,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "faq_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o0:account_faq:2",
+              "short_faq:recursive_400_o0:account_faq:1",
+              "short_faq:recursive_400_o0:vendor_manual:4"
+            ]
+          },
+          {
+            "case_id": "faq_paraphrase",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o0:vendor_manual:3",
+              "short_faq:recursive_400_o0:vendor_manual:1",
+              "short_faq:recursive_400_o0:account_faq:10"
+            ]
+          },
+          {
+            "case_id": "faq_exact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o0:account_faq:6",
+              "short_faq:recursive_400_o0:harbor_report:6",
+              "short_faq:recursive_400_o0:limits_table:4"
+            ]
+          },
+          {
+            "case_id": "faq_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 0.613147,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o0:billing_faq:2",
+              "short_faq:recursive_400_o0:billing_faq:1",
+              "short_faq:recursive_400_o0:policy_dense:2"
+            ]
+          },
+          {
+            "case_id": "faq_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o0:account_faq:8",
+              "short_faq:recursive_400_o0:account_faq:7",
+              "short_faq:recursive_400_o0:policy_dense:3"
+            ]
+          },
+          {
+            "case_id": "faq_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o0:technical_dense:6",
+              "short_faq:recursive_400_o0:gateway_codes:9",
+              "short_faq:recursive_400_o0:technical_dense:5"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "short_faq",
+        "config_id": "recursive_400_o0",
+        "strategy": "recursive_character",
+        "mode": "vector",
+        "top_k": 10,
+        "retrieval_core_p95_ms": 8.587,
+        "metrics": {
+          "recall_at_5": 0.6,
+          "mrr_at_10": 0.6,
+          "ndcg_at_10": 0.522629,
+          "citation_hit_rate": 0.06,
+          "citation_coverage": 0.6,
+          "context_anchor_coverage_at_5": 0.6,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 5,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "faq_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o0:account_faq:2",
+              "short_faq:recursive_400_o0:account_faq:1",
+              "short_faq:recursive_400_o0:vendor_manual:4"
+            ]
+          },
+          {
+            "case_id": "faq_paraphrase",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o0:vendor_manual:3",
+              "short_faq:recursive_400_o0:vendor_manual:1",
+              "short_faq:recursive_400_o0:account_faq:10"
+            ]
+          },
+          {
+            "case_id": "faq_exact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o0:account_faq:6",
+              "short_faq:recursive_400_o0:harbor_report:6",
+              "short_faq:recursive_400_o0:limits_table:4"
+            ]
+          },
+          {
+            "case_id": "faq_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 0.613147,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o0:billing_faq:2",
+              "short_faq:recursive_400_o0:billing_faq:1",
+              "short_faq:recursive_400_o0:policy_dense:2"
+            ]
+          },
+          {
+            "case_id": "faq_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o0:account_faq:8",
+              "short_faq:recursive_400_o0:account_faq:7",
+              "short_faq:recursive_400_o0:policy_dense:3"
+            ]
+          },
+          {
+            "case_id": "faq_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o0:technical_dense:6",
+              "short_faq:recursive_400_o0:gateway_codes:9",
+              "short_faq:recursive_400_o0:technical_dense:5"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "short_faq",
+        "config_id": "recursive_400_o0",
+        "strategy": "recursive_character",
+        "mode": "hybrid",
+        "top_k": 5,
+        "retrieval_core_p95_ms": 11.719,
+        "metrics": {
+          "recall_at_5": 0.6,
+          "mrr_at_10": 0.6,
+          "ndcg_at_10": 0.522629,
+          "citation_hit_rate": 0.12,
+          "citation_coverage": 0.6,
+          "context_anchor_coverage_at_5": 0.6,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 5,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "faq_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o0:account_faq:2",
+              "short_faq:recursive_400_o0:account_faq:1",
+              "short_faq:recursive_400_o0:billing_faq:6"
+            ]
+          },
+          {
+            "case_id": "faq_paraphrase",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o0:vendor_manual:3",
+              "short_faq:recursive_400_o0:account_faq:10",
+              "short_faq:recursive_400_o0:vendor_manual:1"
+            ]
+          },
+          {
+            "case_id": "faq_exact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o0:account_faq:6",
+              "short_faq:recursive_400_o0:account_faq:5",
+              "short_faq:recursive_400_o0:limits_table:4"
+            ]
+          },
+          {
+            "case_id": "faq_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 0.613147,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o0:billing_faq:2",
+              "short_faq:recursive_400_o0:billing_faq:1",
+              "short_faq:recursive_400_o0:policy_dense:2"
+            ]
+          },
+          {
+            "case_id": "faq_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o0:account_faq:8",
+              "short_faq:recursive_400_o0:account_faq:7",
+              "short_faq:recursive_400_o0:policy_dense:3"
+            ]
+          },
+          {
+            "case_id": "faq_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o0:billing_faq:8",
+              "short_faq:recursive_400_o0:billing_faq:7",
+              "short_faq:recursive_400_o0:technical_dense:6"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "short_faq",
+        "config_id": "recursive_400_o0",
+        "strategy": "recursive_character",
+        "mode": "hybrid",
+        "top_k": 10,
+        "retrieval_core_p95_ms": 11.111,
+        "metrics": {
+          "recall_at_5": 0.6,
+          "mrr_at_10": 0.622222,
+          "ndcg_at_10": 0.582835,
+          "citation_hit_rate": 0.08,
+          "citation_coverage": 0.8,
+          "context_anchor_coverage_at_5": 0.6,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 5,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "faq_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o0:account_faq:2",
+              "short_faq:recursive_400_o0:account_faq:1",
+              "short_faq:recursive_400_o0:billing_faq:6"
+            ]
+          },
+          {
+            "case_id": "faq_paraphrase",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0.111111,
+              "ndcg_at_10": 0.30103,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o0:vendor_manual:3",
+              "short_faq:recursive_400_o0:account_faq:10",
+              "short_faq:recursive_400_o0:vendor_manual:1"
+            ]
+          },
+          {
+            "case_id": "faq_exact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o0:account_faq:6",
+              "short_faq:recursive_400_o0:account_faq:5",
+              "short_faq:recursive_400_o0:limits_table:4"
+            ]
+          },
+          {
+            "case_id": "faq_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 0.613147,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o0:billing_faq:2",
+              "short_faq:recursive_400_o0:billing_faq:1",
+              "short_faq:recursive_400_o0:policy_dense:2"
+            ]
+          },
+          {
+            "case_id": "faq_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o0:account_faq:8",
+              "short_faq:recursive_400_o0:account_faq:7",
+              "short_faq:recursive_400_o0:policy_dense:3"
+            ]
+          },
+          {
+            "case_id": "faq_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:recursive_400_o0:billing_faq:8",
+              "short_faq:recursive_400_o0:billing_faq:7",
+              "short_faq:recursive_400_o0:technical_dense:6"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "short_faq",
+        "config_id": "parent_child_2400_600",
+        "strategy": "parent_child",
+        "mode": "fulltext",
+        "top_k": 5,
+        "retrieval_core_p95_ms": 5.02,
+        "metrics": {
+          "recall_at_5": 0.8,
+          "mrr_at_10": 0.7,
+          "ndcg_at_10": 0.648815,
+          "citation_hit_rate": 0.16,
+          "citation_coverage": 0.8,
+          "context_anchor_coverage_at_5": 0.8,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 5,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "faq_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.5,
+              "ndcg_at_10": 0.63093,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_2400_600:account_faq:1",
+              "short_faq:parent_child_2400_600:account_faq:2",
+              "short_faq:parent_child_2400_600:billing_faq:5"
+            ]
+          },
+          {
+            "case_id": "faq_paraphrase",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_2400_600:account_faq:8",
+              "short_faq:parent_child_2400_600:vendor_manual:3",
+              "short_faq:parent_child_2400_600:account_faq:10"
+            ]
+          },
+          {
+            "case_id": "faq_exact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_2400_600:account_faq:6",
+              "short_faq:parent_child_2400_600:account_faq:5",
+              "short_faq:parent_child_2400_600:billing_faq:7"
+            ]
+          },
+          {
+            "case_id": "faq_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 0.613147,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_2400_600:billing_faq:2",
+              "short_faq:parent_child_2400_600:billing_faq:1",
+              "short_faq:parent_child_2400_600:billing_faq:6"
+            ]
+          },
+          {
+            "case_id": "faq_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_2400_600:account_faq:8",
+              "short_faq:parent_child_2400_600:account_faq:7",
+              "short_faq:parent_child_2400_600:account_faq:0"
+            ]
+          },
+          {
+            "case_id": "faq_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_2400_600:billing_faq:8",
+              "short_faq:parent_child_2400_600:billing_faq:7",
+              "short_faq:parent_child_2400_600:billing_faq:6"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "short_faq",
+        "config_id": "parent_child_2400_600",
+        "strategy": "parent_child",
+        "mode": "fulltext",
+        "top_k": 10,
+        "retrieval_core_p95_ms": 7.279,
+        "metrics": {
+          "recall_at_5": 0.8,
+          "mrr_at_10": 0.7,
+          "ndcg_at_10": 0.648815,
+          "citation_hit_rate": 0.08,
+          "citation_coverage": 0.8,
+          "context_anchor_coverage_at_5": 0.8,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 5,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "faq_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.5,
+              "ndcg_at_10": 0.63093,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_2400_600:account_faq:1",
+              "short_faq:parent_child_2400_600:account_faq:2",
+              "short_faq:parent_child_2400_600:billing_faq:5"
+            ]
+          },
+          {
+            "case_id": "faq_paraphrase",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_2400_600:account_faq:8",
+              "short_faq:parent_child_2400_600:vendor_manual:3",
+              "short_faq:parent_child_2400_600:account_faq:10"
+            ]
+          },
+          {
+            "case_id": "faq_exact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_2400_600:account_faq:6",
+              "short_faq:parent_child_2400_600:account_faq:5",
+              "short_faq:parent_child_2400_600:billing_faq:7"
+            ]
+          },
+          {
+            "case_id": "faq_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 0.613147,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_2400_600:billing_faq:2",
+              "short_faq:parent_child_2400_600:billing_faq:1",
+              "short_faq:parent_child_2400_600:billing_faq:6"
+            ]
+          },
+          {
+            "case_id": "faq_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_2400_600:account_faq:8",
+              "short_faq:parent_child_2400_600:account_faq:7",
+              "short_faq:parent_child_2400_600:account_faq:0"
+            ]
+          },
+          {
+            "case_id": "faq_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_2400_600:billing_faq:8",
+              "short_faq:parent_child_2400_600:billing_faq:7",
+              "short_faq:parent_child_2400_600:billing_faq:6"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "short_faq",
+        "config_id": "parent_child_2400_600",
+        "strategy": "parent_child",
+        "mode": "vector",
+        "top_k": 5,
+        "retrieval_core_p95_ms": 5.721,
+        "metrics": {
+          "recall_at_5": 0.6,
+          "mrr_at_10": 0.6,
+          "ndcg_at_10": 0.522629,
+          "citation_hit_rate": 0.12,
+          "citation_coverage": 0.6,
+          "context_anchor_coverage_at_5": 0.6,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 5,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "faq_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_2400_600:account_faq:2",
+              "short_faq:parent_child_2400_600:account_faq:1",
+              "short_faq:parent_child_2400_600:vendor_manual:4"
+            ]
+          },
+          {
+            "case_id": "faq_paraphrase",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_2400_600:vendor_manual:3",
+              "short_faq:parent_child_2400_600:vendor_manual:1",
+              "short_faq:parent_child_2400_600:account_faq:10"
+            ]
+          },
+          {
+            "case_id": "faq_exact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_2400_600:account_faq:6",
+              "short_faq:parent_child_2400_600:harbor_report:6",
+              "short_faq:parent_child_2400_600:limits_table:4"
+            ]
+          },
+          {
+            "case_id": "faq_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 0.613147,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_2400_600:billing_faq:2",
+              "short_faq:parent_child_2400_600:billing_faq:1",
+              "short_faq:parent_child_2400_600:policy_dense:2"
+            ]
+          },
+          {
+            "case_id": "faq_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_2400_600:account_faq:8",
+              "short_faq:parent_child_2400_600:account_faq:7",
+              "short_faq:parent_child_2400_600:policy_dense:3"
+            ]
+          },
+          {
+            "case_id": "faq_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_2400_600:gateway_codes:9",
+              "short_faq:parent_child_2400_600:technical_dense:4",
+              "short_faq:parent_child_2400_600:technical_dense:3"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "short_faq",
+        "config_id": "parent_child_2400_600",
+        "strategy": "parent_child",
+        "mode": "vector",
+        "top_k": 10,
+        "retrieval_core_p95_ms": 7.158,
+        "metrics": {
+          "recall_at_5": 0.6,
+          "mrr_at_10": 0.6,
+          "ndcg_at_10": 0.522629,
+          "citation_hit_rate": 0.06,
+          "citation_coverage": 0.6,
+          "context_anchor_coverage_at_5": 0.6,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 5,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "faq_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_2400_600:account_faq:2",
+              "short_faq:parent_child_2400_600:account_faq:1",
+              "short_faq:parent_child_2400_600:vendor_manual:4"
+            ]
+          },
+          {
+            "case_id": "faq_paraphrase",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_2400_600:vendor_manual:3",
+              "short_faq:parent_child_2400_600:vendor_manual:1",
+              "short_faq:parent_child_2400_600:account_faq:10"
+            ]
+          },
+          {
+            "case_id": "faq_exact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_2400_600:account_faq:6",
+              "short_faq:parent_child_2400_600:harbor_report:6",
+              "short_faq:parent_child_2400_600:limits_table:4"
+            ]
+          },
+          {
+            "case_id": "faq_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 0.613147,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_2400_600:billing_faq:2",
+              "short_faq:parent_child_2400_600:billing_faq:1",
+              "short_faq:parent_child_2400_600:policy_dense:2"
+            ]
+          },
+          {
+            "case_id": "faq_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_2400_600:account_faq:8",
+              "short_faq:parent_child_2400_600:account_faq:7",
+              "short_faq:parent_child_2400_600:policy_dense:3"
+            ]
+          },
+          {
+            "case_id": "faq_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_2400_600:gateway_codes:9",
+              "short_faq:parent_child_2400_600:technical_dense:4",
+              "short_faq:parent_child_2400_600:technical_dense:3"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "short_faq",
+        "config_id": "parent_child_2400_600",
+        "strategy": "parent_child",
+        "mode": "hybrid",
+        "top_k": 5,
+        "retrieval_core_p95_ms": 9.058,
+        "metrics": {
+          "recall_at_5": 0.6,
+          "mrr_at_10": 0.6,
+          "ndcg_at_10": 0.522629,
+          "citation_hit_rate": 0.12,
+          "citation_coverage": 0.6,
+          "context_anchor_coverage_at_5": 0.6,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 5,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "faq_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_2400_600:account_faq:2",
+              "short_faq:parent_child_2400_600:account_faq:1",
+              "short_faq:parent_child_2400_600:billing_faq:6"
+            ]
+          },
+          {
+            "case_id": "faq_paraphrase",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_2400_600:vendor_manual:3",
+              "short_faq:parent_child_2400_600:account_faq:10",
+              "short_faq:parent_child_2400_600:vendor_manual:1"
+            ]
+          },
+          {
+            "case_id": "faq_exact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_2400_600:account_faq:6",
+              "short_faq:parent_child_2400_600:account_faq:5",
+              "short_faq:parent_child_2400_600:limits_table:4"
+            ]
+          },
+          {
+            "case_id": "faq_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 0.613147,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_2400_600:billing_faq:2",
+              "short_faq:parent_child_2400_600:billing_faq:1",
+              "short_faq:parent_child_2400_600:continuity_manual:1"
+            ]
+          },
+          {
+            "case_id": "faq_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_2400_600:account_faq:8",
+              "short_faq:parent_child_2400_600:account_faq:7",
+              "short_faq:parent_child_2400_600:policy_dense:3"
+            ]
+          },
+          {
+            "case_id": "faq_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_2400_600:billing_faq:8",
+              "short_faq:parent_child_2400_600:billing_faq:7",
+              "short_faq:parent_child_2400_600:gateway_codes:9"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "short_faq",
+        "config_id": "parent_child_2400_600",
+        "strategy": "parent_child",
+        "mode": "hybrid",
+        "top_k": 10,
+        "retrieval_core_p95_ms": 9.094,
+        "metrics": {
+          "recall_at_5": 0.6,
+          "mrr_at_10": 0.622222,
+          "ndcg_at_10": 0.582835,
+          "citation_hit_rate": 0.08,
+          "citation_coverage": 0.8,
+          "context_anchor_coverage_at_5": 0.6,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 5,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "faq_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_2400_600:account_faq:2",
+              "short_faq:parent_child_2400_600:account_faq:1",
+              "short_faq:parent_child_2400_600:billing_faq:6"
+            ]
+          },
+          {
+            "case_id": "faq_paraphrase",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0.111111,
+              "ndcg_at_10": 0.30103,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_2400_600:vendor_manual:3",
+              "short_faq:parent_child_2400_600:account_faq:10",
+              "short_faq:parent_child_2400_600:vendor_manual:1"
+            ]
+          },
+          {
+            "case_id": "faq_exact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_2400_600:account_faq:6",
+              "short_faq:parent_child_2400_600:account_faq:5",
+              "short_faq:parent_child_2400_600:limits_table:4"
+            ]
+          },
+          {
+            "case_id": "faq_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 0.613147,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_2400_600:billing_faq:2",
+              "short_faq:parent_child_2400_600:billing_faq:1",
+              "short_faq:parent_child_2400_600:continuity_manual:1"
+            ]
+          },
+          {
+            "case_id": "faq_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_2400_600:account_faq:8",
+              "short_faq:parent_child_2400_600:account_faq:7",
+              "short_faq:parent_child_2400_600:policy_dense:3"
+            ]
+          },
+          {
+            "case_id": "faq_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "short_faq:parent_child_2400_600:billing_faq:8",
+              "short_faq:parent_child_2400_600:billing_faq:7",
+              "short_faq:parent_child_2400_600:gateway_codes:9"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "technical_ids",
+        "config_id": "recursive_1000_o100",
+        "strategy": "recursive_character",
+        "mode": "fulltext",
+        "top_k": 5,
+        "retrieval_core_p95_ms": 3.289,
+        "metrics": {
+          "recall_at_5": 0.666667,
+          "mrr_at_10": 0.583333,
+          "ndcg_at_10": 0.605155,
+          "citation_hit_rate": 0.133333,
+          "citation_coverage": 0.666667,
+          "context_anchor_coverage_at_5": 0.666667,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "tid_fact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.5,
+              "ndcg_at_10": 0.63093,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:gateway_codes:7",
+              "technical_ids:recursive_1000_o100:gateway_codes:8",
+              "technical_ids:recursive_1000_o100:gateway_codes:6"
+            ]
+          },
+          {
+            "case_id": "tid_action",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:vendor_manual:1",
+              "technical_ids:recursive_1000_o100:policy_dense:0",
+              "technical_ids:recursive_1000_o100:gateway_codes:5"
+            ]
+          },
+          {
+            "case_id": "tid_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:device_codes:1",
+              "technical_ids:recursive_1000_o100:device_codes:2",
+              "technical_ids:recursive_1000_o100:device_codes:3"
+            ]
+          },
+          {
+            "case_id": "tid_format",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:gateway_codes:10",
+              "technical_ids:recursive_1000_o100:technical_dense:3",
+              "technical_ids:recursive_1000_o100:gateway_codes:4"
+            ]
+          },
+          {
+            "case_id": "tid_command",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:device_codes:4",
+              "technical_ids:recursive_1000_o100:confusable_dense:3",
+              "technical_ids:recursive_1000_o100:south_program:6"
+            ]
+          },
+          {
+            "case_id": "tid_dense",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:technical_dense:3",
+              "technical_ids:recursive_1000_o100:gateway_codes:1",
+              "technical_ids:recursive_1000_o100:gateway_codes:3"
+            ]
+          },
+          {
+            "case_id": "tid_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:gateway_codes:6",
+              "technical_ids:recursive_1000_o100:gateway_codes:1",
+              "technical_ids:recursive_1000_o100:gateway_codes:3"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "technical_ids",
+        "config_id": "recursive_1000_o100",
+        "strategy": "recursive_character",
+        "mode": "fulltext",
+        "top_k": 10,
+        "retrieval_core_p95_ms": 2.968,
+        "metrics": {
+          "recall_at_5": 0.666667,
+          "mrr_at_10": 0.611111,
+          "ndcg_at_10": 0.664523,
+          "citation_hit_rate": 0.090476,
+          "citation_coverage": 0.833333,
+          "context_anchor_coverage_at_5": 0.666667,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "tid_fact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.5,
+              "ndcg_at_10": 0.63093,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:gateway_codes:7",
+              "technical_ids:recursive_1000_o100:gateway_codes:8",
+              "technical_ids:recursive_1000_o100:gateway_codes:6"
+            ]
+          },
+          {
+            "case_id": "tid_action",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0.166667,
+              "ndcg_at_10": 0.356207,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:vendor_manual:1",
+              "technical_ids:recursive_1000_o100:policy_dense:0",
+              "technical_ids:recursive_1000_o100:gateway_codes:5"
+            ]
+          },
+          {
+            "case_id": "tid_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:device_codes:1",
+              "technical_ids:recursive_1000_o100:device_codes:2",
+              "technical_ids:recursive_1000_o100:device_codes:3"
+            ]
+          },
+          {
+            "case_id": "tid_format",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:gateway_codes:10",
+              "technical_ids:recursive_1000_o100:technical_dense:3",
+              "technical_ids:recursive_1000_o100:gateway_codes:4"
+            ]
+          },
+          {
+            "case_id": "tid_command",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.142857,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:device_codes:4",
+              "technical_ids:recursive_1000_o100:confusable_dense:3",
+              "technical_ids:recursive_1000_o100:south_program:6"
+            ]
+          },
+          {
+            "case_id": "tid_dense",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:technical_dense:3",
+              "technical_ids:recursive_1000_o100:gateway_codes:1",
+              "technical_ids:recursive_1000_o100:gateway_codes:3"
+            ]
+          },
+          {
+            "case_id": "tid_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:gateway_codes:6",
+              "technical_ids:recursive_1000_o100:gateway_codes:1",
+              "technical_ids:recursive_1000_o100:gateway_codes:3"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "technical_ids",
+        "config_id": "recursive_1000_o100",
+        "strategy": "recursive_character",
+        "mode": "vector",
+        "top_k": 5,
+        "retrieval_core_p95_ms": 6.99,
+        "metrics": {
+          "recall_at_5": 0.166667,
+          "mrr_at_10": 0.166667,
+          "ndcg_at_10": 0.166667,
+          "citation_hit_rate": 0.033333,
+          "citation_coverage": 0.166667,
+          "context_anchor_coverage_at_5": 0.166667,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "tid_fact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:gateway_codes:8",
+              "technical_ids:recursive_1000_o100:gateway_codes:4",
+              "technical_ids:recursive_1000_o100:gateway_codes:2"
+            ]
+          },
+          {
+            "case_id": "tid_action",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:gateway_codes:5",
+              "technical_ids:recursive_1000_o100:gateway_codes:3",
+              "technical_ids:recursive_1000_o100:gateway_codes:7"
+            ]
+          },
+          {
+            "case_id": "tid_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:device_codes:1",
+              "technical_ids:recursive_1000_o100:device_codes:2",
+              "technical_ids:recursive_1000_o100:device_codes:3"
+            ]
+          },
+          {
+            "case_id": "tid_format",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:technical_dense:2",
+              "technical_ids:recursive_1000_o100:gateway_codes:4",
+              "technical_ids:recursive_1000_o100:harbor_dense:3"
+            ]
+          },
+          {
+            "case_id": "tid_command",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:confusable_dense:3",
+              "technical_ids:recursive_1000_o100:confusable_dense:2",
+              "technical_ids:recursive_1000_o100:harbor_dense:2"
+            ]
+          },
+          {
+            "case_id": "tid_dense",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:confusable_dense:2",
+              "technical_ids:recursive_1000_o100:harbor_report:1",
+              "technical_ids:recursive_1000_o100:north_program:8"
+            ]
+          },
+          {
+            "case_id": "tid_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:gateway_codes:8",
+              "technical_ids:recursive_1000_o100:harbor_report:1",
+              "technical_ids:recursive_1000_o100:harbor_report:5"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "technical_ids",
+        "config_id": "recursive_1000_o100",
+        "strategy": "recursive_character",
+        "mode": "vector",
+        "top_k": 10,
+        "retrieval_core_p95_ms": 6.475,
+        "metrics": {
+          "recall_at_5": 0.166667,
+          "mrr_at_10": 0.185185,
+          "ndcg_at_10": 0.216838,
+          "citation_hit_rate": 0.033333,
+          "citation_coverage": 0.333333,
+          "context_anchor_coverage_at_5": 0.166667,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "tid_fact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:gateway_codes:8",
+              "technical_ids:recursive_1000_o100:gateway_codes:4",
+              "technical_ids:recursive_1000_o100:gateway_codes:2"
+            ]
+          },
+          {
+            "case_id": "tid_action",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:gateway_codes:5",
+              "technical_ids:recursive_1000_o100:gateway_codes:3",
+              "technical_ids:recursive_1000_o100:gateway_codes:7"
+            ]
+          },
+          {
+            "case_id": "tid_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:device_codes:1",
+              "technical_ids:recursive_1000_o100:device_codes:2",
+              "technical_ids:recursive_1000_o100:device_codes:3"
+            ]
+          },
+          {
+            "case_id": "tid_format",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0.111111,
+              "ndcg_at_10": 0.30103,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:technical_dense:2",
+              "technical_ids:recursive_1000_o100:gateway_codes:4",
+              "technical_ids:recursive_1000_o100:harbor_dense:3"
+            ]
+          },
+          {
+            "case_id": "tid_command",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:confusable_dense:3",
+              "technical_ids:recursive_1000_o100:confusable_dense:2",
+              "technical_ids:recursive_1000_o100:harbor_dense:2"
+            ]
+          },
+          {
+            "case_id": "tid_dense",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:confusable_dense:2",
+              "technical_ids:recursive_1000_o100:harbor_report:1",
+              "technical_ids:recursive_1000_o100:north_program:8"
+            ]
+          },
+          {
+            "case_id": "tid_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:gateway_codes:8",
+              "technical_ids:recursive_1000_o100:harbor_report:1",
+              "technical_ids:recursive_1000_o100:harbor_report:5"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "technical_ids",
+        "config_id": "recursive_1000_o100",
+        "strategy": "recursive_character",
+        "mode": "hybrid",
+        "top_k": 5,
+        "retrieval_core_p95_ms": 10.929,
+        "metrics": {
+          "recall_at_5": 0.5,
+          "mrr_at_10": 0.233333,
+          "ndcg_at_10": 0.295618,
+          "citation_hit_rate": 0.1,
+          "citation_coverage": 0.5,
+          "context_anchor_coverage_at_5": 0.5,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "tid_fact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:gateway_codes:8",
+              "technical_ids:recursive_1000_o100:gateway_codes:4",
+              "technical_ids:recursive_1000_o100:gateway_codes:6"
+            ]
+          },
+          {
+            "case_id": "tid_action",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:gateway_codes:5",
+              "technical_ids:recursive_1000_o100:continuity_manual:10",
+              "technical_ids:recursive_1000_o100:gateway_codes:3"
+            ]
+          },
+          {
+            "case_id": "tid_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:device_codes:1",
+              "technical_ids:recursive_1000_o100:device_codes:2",
+              "technical_ids:recursive_1000_o100:device_codes:3"
+            ]
+          },
+          {
+            "case_id": "tid_format",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.2,
+              "ndcg_at_10": 0.386853,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:technical_dense:2",
+              "technical_ids:recursive_1000_o100:gateway_codes:4",
+              "technical_ids:recursive_1000_o100:technical_dense:3"
+            ]
+          },
+          {
+            "case_id": "tid_command",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:confusable_dense:3",
+              "technical_ids:recursive_1000_o100:harbor_dense:2",
+              "technical_ids:recursive_1000_o100:harbor_dense:3"
+            ]
+          },
+          {
+            "case_id": "tid_dense",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.2,
+              "ndcg_at_10": 0.386853,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:confusable_dense:2",
+              "technical_ids:recursive_1000_o100:harbor_dense:2",
+              "technical_ids:recursive_1000_o100:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "tid_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:gateway_codes:8",
+              "technical_ids:recursive_1000_o100:gateway_codes:6",
+              "technical_ids:recursive_1000_o100:gateway_codes:10"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "technical_ids",
+        "config_id": "recursive_1000_o100",
+        "strategy": "recursive_character",
+        "mode": "hybrid",
+        "top_k": 10,
+        "retrieval_core_p95_ms": 9.37,
+        "metrics": {
+          "recall_at_5": 0.5,
+          "mrr_at_10": 0.233333,
+          "ndcg_at_10": 0.295618,
+          "citation_hit_rate": 0.05,
+          "citation_coverage": 0.5,
+          "context_anchor_coverage_at_5": 0.5,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "tid_fact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:gateway_codes:8",
+              "technical_ids:recursive_1000_o100:gateway_codes:4",
+              "technical_ids:recursive_1000_o100:gateway_codes:6"
+            ]
+          },
+          {
+            "case_id": "tid_action",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:gateway_codes:5",
+              "technical_ids:recursive_1000_o100:continuity_manual:10",
+              "technical_ids:recursive_1000_o100:gateway_codes:3"
+            ]
+          },
+          {
+            "case_id": "tid_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:device_codes:1",
+              "technical_ids:recursive_1000_o100:device_codes:2",
+              "technical_ids:recursive_1000_o100:device_codes:3"
+            ]
+          },
+          {
+            "case_id": "tid_format",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.2,
+              "ndcg_at_10": 0.386853,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:technical_dense:2",
+              "technical_ids:recursive_1000_o100:gateway_codes:4",
+              "technical_ids:recursive_1000_o100:technical_dense:3"
+            ]
+          },
+          {
+            "case_id": "tid_command",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:confusable_dense:3",
+              "technical_ids:recursive_1000_o100:harbor_dense:2",
+              "technical_ids:recursive_1000_o100:harbor_dense:3"
+            ]
+          },
+          {
+            "case_id": "tid_dense",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.2,
+              "ndcg_at_10": 0.386853,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:confusable_dense:2",
+              "technical_ids:recursive_1000_o100:harbor_dense:2",
+              "technical_ids:recursive_1000_o100:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "tid_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:recursive_1000_o100:gateway_codes:8",
+              "technical_ids:recursive_1000_o100:gateway_codes:6",
+              "technical_ids:recursive_1000_o100:gateway_codes:10"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "technical_ids",
+        "config_id": "parent_child_2400_600",
+        "strategy": "parent_child",
+        "mode": "fulltext",
+        "top_k": 5,
+        "retrieval_core_p95_ms": 5.942,
+        "metrics": {
+          "recall_at_5": 0.666667,
+          "mrr_at_10": 0.583333,
+          "ndcg_at_10": 0.605155,
+          "citation_hit_rate": 0.133333,
+          "citation_coverage": 0.666667,
+          "context_anchor_coverage_at_5": 0.666667,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "tid_fact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.5,
+              "ndcg_at_10": 0.63093,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:gateway_codes:7",
+              "technical_ids:parent_child_2400_600:gateway_codes:8",
+              "technical_ids:parent_child_2400_600:gateway_codes:6"
+            ]
+          },
+          {
+            "case_id": "tid_action",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:vendor_manual:1",
+              "technical_ids:parent_child_2400_600:policy_dense:0",
+              "technical_ids:parent_child_2400_600:gateway_codes:5"
+            ]
+          },
+          {
+            "case_id": "tid_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:device_codes:1",
+              "technical_ids:parent_child_2400_600:device_codes:2",
+              "technical_ids:parent_child_2400_600:device_codes:3"
+            ]
+          },
+          {
+            "case_id": "tid_format",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:gateway_codes:10",
+              "technical_ids:parent_child_2400_600:technical_dense:4",
+              "technical_ids:parent_child_2400_600:technical_dense:3"
+            ]
+          },
+          {
+            "case_id": "tid_command",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:device_codes:4",
+              "technical_ids:parent_child_2400_600:confusable_dense:4",
+              "technical_ids:parent_child_2400_600:south_program:6"
+            ]
+          },
+          {
+            "case_id": "tid_dense",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:technical_dense:5",
+              "technical_ids:parent_child_2400_600:gateway_codes:1",
+              "technical_ids:parent_child_2400_600:gateway_codes:3"
+            ]
+          },
+          {
+            "case_id": "tid_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:gateway_codes:6",
+              "technical_ids:parent_child_2400_600:gateway_codes:1",
+              "technical_ids:parent_child_2400_600:gateway_codes:3"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "technical_ids",
+        "config_id": "parent_child_2400_600",
+        "strategy": "parent_child",
+        "mode": "fulltext",
+        "top_k": 10,
+        "retrieval_core_p95_ms": 6.369,
+        "metrics": {
+          "recall_at_5": 0.666667,
+          "mrr_at_10": 0.604167,
+          "ndcg_at_10": 0.657733,
+          "citation_hit_rate": 0.094445,
+          "citation_coverage": 0.833333,
+          "context_anchor_coverage_at_5": 0.666667,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "tid_fact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.5,
+              "ndcg_at_10": 0.63093,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:gateway_codes:7",
+              "technical_ids:parent_child_2400_600:gateway_codes:8",
+              "technical_ids:parent_child_2400_600:gateway_codes:6"
+            ]
+          },
+          {
+            "case_id": "tid_action",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0.125,
+              "ndcg_at_10": 0.315465,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:vendor_manual:1",
+              "technical_ids:parent_child_2400_600:policy_dense:0",
+              "technical_ids:parent_child_2400_600:gateway_codes:5"
+            ]
+          },
+          {
+            "case_id": "tid_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:device_codes:1",
+              "technical_ids:parent_child_2400_600:device_codes:2",
+              "technical_ids:parent_child_2400_600:device_codes:3"
+            ]
+          },
+          {
+            "case_id": "tid_format",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:gateway_codes:10",
+              "technical_ids:parent_child_2400_600:technical_dense:4",
+              "technical_ids:parent_child_2400_600:technical_dense:3"
+            ]
+          },
+          {
+            "case_id": "tid_command",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.166667,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:device_codes:4",
+              "technical_ids:parent_child_2400_600:confusable_dense:4",
+              "technical_ids:parent_child_2400_600:south_program:6"
+            ]
+          },
+          {
+            "case_id": "tid_dense",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:technical_dense:5",
+              "technical_ids:parent_child_2400_600:gateway_codes:1",
+              "technical_ids:parent_child_2400_600:gateway_codes:3"
+            ]
+          },
+          {
+            "case_id": "tid_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:gateway_codes:6",
+              "technical_ids:parent_child_2400_600:gateway_codes:1",
+              "technical_ids:parent_child_2400_600:gateway_codes:3"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "technical_ids",
+        "config_id": "parent_child_2400_600",
+        "strategy": "parent_child",
+        "mode": "vector",
+        "top_k": 5,
+        "retrieval_core_p95_ms": 6.23,
+        "metrics": {
+          "recall_at_5": 0.166667,
+          "mrr_at_10": 0.166667,
+          "ndcg_at_10": 0.166667,
+          "citation_hit_rate": 0.033333,
+          "citation_coverage": 0.166667,
+          "context_anchor_coverage_at_5": 0.166667,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "tid_fact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:gateway_codes:8",
+              "technical_ids:parent_child_2400_600:gateway_codes:4",
+              "technical_ids:parent_child_2400_600:gateway_codes:2"
+            ]
+          },
+          {
+            "case_id": "tid_action",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:gateway_codes:5",
+              "technical_ids:parent_child_2400_600:gateway_codes:3",
+              "technical_ids:parent_child_2400_600:gateway_codes:7"
+            ]
+          },
+          {
+            "case_id": "tid_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:device_codes:1",
+              "technical_ids:parent_child_2400_600:device_codes:2",
+              "technical_ids:parent_child_2400_600:device_codes:3"
+            ]
+          },
+          {
+            "case_id": "tid_format",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:gateway_codes:4",
+              "technical_ids:parent_child_2400_600:technical_dense:2",
+              "technical_ids:parent_child_2400_600:harbor_dense:4"
+            ]
+          },
+          {
+            "case_id": "tid_command",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:confusable_dense:4",
+              "technical_ids:parent_child_2400_600:confusable_dense:3",
+              "technical_ids:parent_child_2400_600:harbor_dense:2"
+            ]
+          },
+          {
+            "case_id": "tid_dense",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:harbor_report:1",
+              "technical_ids:parent_child_2400_600:confusable_dense:2",
+              "technical_ids:parent_child_2400_600:north_program:8"
+            ]
+          },
+          {
+            "case_id": "tid_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:gateway_codes:8",
+              "technical_ids:parent_child_2400_600:harbor_report:1",
+              "technical_ids:parent_child_2400_600:harbor_report:5"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "technical_ids",
+        "config_id": "parent_child_2400_600",
+        "strategy": "parent_child",
+        "mode": "vector",
+        "top_k": 10,
+        "retrieval_core_p95_ms": 8.062,
+        "metrics": {
+          "recall_at_5": 0.166667,
+          "mrr_at_10": 0.166667,
+          "ndcg_at_10": 0.166667,
+          "citation_hit_rate": 0.016667,
+          "citation_coverage": 0.166667,
+          "context_anchor_coverage_at_5": 0.166667,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "tid_fact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:gateway_codes:8",
+              "technical_ids:parent_child_2400_600:gateway_codes:4",
+              "technical_ids:parent_child_2400_600:gateway_codes:2"
+            ]
+          },
+          {
+            "case_id": "tid_action",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:gateway_codes:5",
+              "technical_ids:parent_child_2400_600:gateway_codes:3",
+              "technical_ids:parent_child_2400_600:gateway_codes:7"
+            ]
+          },
+          {
+            "case_id": "tid_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:device_codes:1",
+              "technical_ids:parent_child_2400_600:device_codes:2",
+              "technical_ids:parent_child_2400_600:device_codes:3"
+            ]
+          },
+          {
+            "case_id": "tid_format",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:gateway_codes:4",
+              "technical_ids:parent_child_2400_600:technical_dense:2",
+              "technical_ids:parent_child_2400_600:harbor_dense:4"
+            ]
+          },
+          {
+            "case_id": "tid_command",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:confusable_dense:4",
+              "technical_ids:parent_child_2400_600:confusable_dense:3",
+              "technical_ids:parent_child_2400_600:harbor_dense:2"
+            ]
+          },
+          {
+            "case_id": "tid_dense",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:harbor_report:1",
+              "technical_ids:parent_child_2400_600:confusable_dense:2",
+              "technical_ids:parent_child_2400_600:north_program:8"
+            ]
+          },
+          {
+            "case_id": "tid_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:gateway_codes:8",
+              "technical_ids:parent_child_2400_600:harbor_report:1",
+              "technical_ids:parent_child_2400_600:harbor_report:5"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "technical_ids",
+        "config_id": "parent_child_2400_600",
+        "strategy": "parent_child",
+        "mode": "hybrid",
+        "top_k": 5,
+        "retrieval_core_p95_ms": 11.795,
+        "metrics": {
+          "recall_at_5": 0.333333,
+          "mrr_at_10": 0.333333,
+          "ndcg_at_10": 0.333333,
+          "citation_hit_rate": 0.066667,
+          "citation_coverage": 0.333333,
+          "context_anchor_coverage_at_5": 0.333333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "tid_fact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:gateway_codes:8",
+              "technical_ids:parent_child_2400_600:gateway_codes:6",
+              "technical_ids:parent_child_2400_600:gateway_codes:4"
+            ]
+          },
+          {
+            "case_id": "tid_action",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:gateway_codes:5",
+              "technical_ids:parent_child_2400_600:continuity_manual:10",
+              "technical_ids:parent_child_2400_600:gateway_codes:3"
+            ]
+          },
+          {
+            "case_id": "tid_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:device_codes:1",
+              "technical_ids:parent_child_2400_600:device_codes:2",
+              "technical_ids:parent_child_2400_600:device_codes:3"
+            ]
+          },
+          {
+            "case_id": "tid_format",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:gateway_codes:4",
+              "technical_ids:parent_child_2400_600:technical_dense:4",
+              "technical_ids:parent_child_2400_600:technical_dense:3"
+            ]
+          },
+          {
+            "case_id": "tid_command",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:confusable_dense:4",
+              "technical_ids:parent_child_2400_600:harbor_dense:3",
+              "technical_ids:parent_child_2400_600:technical_dense:4"
+            ]
+          },
+          {
+            "case_id": "tid_dense",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:technical_dense:5",
+              "technical_ids:parent_child_2400_600:confusable_dense:3",
+              "technical_ids:parent_child_2400_600:confusable_dense:4"
+            ]
+          },
+          {
+            "case_id": "tid_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:gateway_codes:8",
+              "technical_ids:parent_child_2400_600:gateway_codes:6",
+              "technical_ids:parent_child_2400_600:gateway_codes:10"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "technical_ids",
+        "config_id": "parent_child_2400_600",
+        "strategy": "parent_child",
+        "mode": "hybrid",
+        "top_k": 10,
+        "retrieval_core_p95_ms": 14.077,
+        "metrics": {
+          "recall_at_5": 0.333333,
+          "mrr_at_10": 0.357143,
+          "ndcg_at_10": 0.388889,
+          "citation_hit_rate": 0.05,
+          "citation_coverage": 0.5,
+          "context_anchor_coverage_at_5": 0.333333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "tid_fact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:gateway_codes:8",
+              "technical_ids:parent_child_2400_600:gateway_codes:6",
+              "technical_ids:parent_child_2400_600:gateway_codes:4"
+            ]
+          },
+          {
+            "case_id": "tid_action",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:gateway_codes:5",
+              "technical_ids:parent_child_2400_600:continuity_manual:10",
+              "technical_ids:parent_child_2400_600:gateway_codes:3"
+            ]
+          },
+          {
+            "case_id": "tid_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:device_codes:1",
+              "technical_ids:parent_child_2400_600:device_codes:2",
+              "technical_ids:parent_child_2400_600:device_codes:3"
+            ]
+          },
+          {
+            "case_id": "tid_format",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0.142857,
+              "ndcg_at_10": 0.333333,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:gateway_codes:4",
+              "technical_ids:parent_child_2400_600:technical_dense:4",
+              "technical_ids:parent_child_2400_600:technical_dense:3"
+            ]
+          },
+          {
+            "case_id": "tid_command",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:confusable_dense:4",
+              "technical_ids:parent_child_2400_600:harbor_dense:3",
+              "technical_ids:parent_child_2400_600:technical_dense:4"
+            ]
+          },
+          {
+            "case_id": "tid_dense",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:technical_dense:5",
+              "technical_ids:parent_child_2400_600:confusable_dense:3",
+              "technical_ids:parent_child_2400_600:confusable_dense:4"
+            ]
+          },
+          {
+            "case_id": "tid_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "technical_ids:parent_child_2400_600:gateway_codes:8",
+              "technical_ids:parent_child_2400_600:gateway_codes:6",
+              "technical_ids:parent_child_2400_600:gateway_codes:10"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "bilingual_narrative",
+        "config_id": "recursive_400_o0",
+        "strategy": "recursive_character",
+        "mode": "fulltext",
+        "top_k": 5,
+        "retrieval_core_p95_ms": 6.223,
+        "metrics": {
+          "recall_at_5": 0.5,
+          "mrr_at_10": 0.388889,
+          "ndcg_at_10": 0.416667,
+          "citation_hit_rate": 0.1,
+          "citation_coverage": 0.5,
+          "context_anchor_coverage_at_5": 0.5,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "bi_en_to_cn",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:harbor_cn:1",
+              "bilingual_narrative:recursive_400_o0:device_codes:1",
+              "bilingual_narrative:recursive_400_o0:harbor_cn:3"
+            ]
+          },
+          {
+            "case_id": "bi_cn_to_en",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:harbor_report:3",
+              "bilingual_narrative:recursive_400_o0:north_program:2",
+              "bilingual_narrative:recursive_400_o0:south_program:2"
+            ]
+          },
+          {
+            "case_id": "bi_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:harbor_cn:5",
+              "bilingual_narrative:recursive_400_o0:account_faq:9",
+              "bilingual_narrative:recursive_400_o0:account_faq:10"
+            ]
+          },
+          {
+            "case_id": "bi_threshold",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:harbor_report:5",
+              "bilingual_narrative:recursive_400_o0:harbor_dense:4",
+              "bilingual_narrative:recursive_400_o0:harbor_dense:6"
+            ]
+          },
+          {
+            "case_id": "bi_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.333333,
+              "ndcg_at_10": 0.5,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:harbor_dense:2",
+              "bilingual_narrative:recursive_400_o0:confusable_dense:3",
+              "bilingual_narrative:recursive_400_o0:harbor_report:3"
+            ]
+          },
+          {
+            "case_id": "bi_dense",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:continuity_manual:9",
+              "bilingual_narrative:recursive_400_o0:continuity_manual:11",
+              "bilingual_narrative:recursive_400_o0:harbor_cn:5"
+            ]
+          },
+          {
+            "case_id": "bi_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:harbor_report:1",
+              "bilingual_narrative:recursive_400_o0:harbor_report:7",
+              "bilingual_narrative:recursive_400_o0:harbor_report:0"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "bilingual_narrative",
+        "config_id": "recursive_400_o0",
+        "strategy": "recursive_character",
+        "mode": "fulltext",
+        "top_k": 10,
+        "retrieval_core_p95_ms": 6.497,
+        "metrics": {
+          "recall_at_5": 0.5,
+          "mrr_at_10": 0.388889,
+          "ndcg_at_10": 0.416667,
+          "citation_hit_rate": 0.054167,
+          "citation_coverage": 0.5,
+          "context_anchor_coverage_at_5": 0.5,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "bi_en_to_cn",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:harbor_cn:1",
+              "bilingual_narrative:recursive_400_o0:device_codes:1",
+              "bilingual_narrative:recursive_400_o0:harbor_cn:3"
+            ]
+          },
+          {
+            "case_id": "bi_cn_to_en",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:harbor_report:3",
+              "bilingual_narrative:recursive_400_o0:north_program:2",
+              "bilingual_narrative:recursive_400_o0:south_program:2"
+            ]
+          },
+          {
+            "case_id": "bi_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:harbor_cn:5",
+              "bilingual_narrative:recursive_400_o0:account_faq:9",
+              "bilingual_narrative:recursive_400_o0:account_faq:10"
+            ]
+          },
+          {
+            "case_id": "bi_threshold",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.125,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:harbor_report:5",
+              "bilingual_narrative:recursive_400_o0:harbor_dense:4",
+              "bilingual_narrative:recursive_400_o0:harbor_dense:6"
+            ]
+          },
+          {
+            "case_id": "bi_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.333333,
+              "ndcg_at_10": 0.5,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:harbor_dense:2",
+              "bilingual_narrative:recursive_400_o0:confusable_dense:3",
+              "bilingual_narrative:recursive_400_o0:harbor_report:3"
+            ]
+          },
+          {
+            "case_id": "bi_dense",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:continuity_manual:9",
+              "bilingual_narrative:recursive_400_o0:continuity_manual:11",
+              "bilingual_narrative:recursive_400_o0:harbor_cn:5"
+            ]
+          },
+          {
+            "case_id": "bi_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:harbor_report:1",
+              "bilingual_narrative:recursive_400_o0:harbor_report:7",
+              "bilingual_narrative:recursive_400_o0:harbor_report:0"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "bilingual_narrative",
+        "config_id": "recursive_400_o0",
+        "strategy": "recursive_character",
+        "mode": "vector",
+        "top_k": 5,
+        "retrieval_core_p95_ms": 6.773,
+        "metrics": {
+          "recall_at_5": 0.166667,
+          "mrr_at_10": 0.055556,
+          "ndcg_at_10": 0.083333,
+          "citation_hit_rate": 0.033333,
+          "citation_coverage": 0.166667,
+          "context_anchor_coverage_at_5": 0.166667,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "bi_en_to_cn",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:harbor_cn:1",
+              "bilingual_narrative:recursive_400_o0:vendor_manual:0",
+              "bilingual_narrative:recursive_400_o0:continuity_manual:13"
+            ]
+          },
+          {
+            "case_id": "bi_cn_to_en",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:harbor_dense:4",
+              "bilingual_narrative:recursive_400_o0:harbor_report:3",
+              "bilingual_narrative:recursive_400_o0:harbor_dense:6"
+            ]
+          },
+          {
+            "case_id": "bi_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.333333,
+              "ndcg_at_10": 0.5,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:gateway_codes:6",
+              "bilingual_narrative:recursive_400_o0:harbor_report:5",
+              "bilingual_narrative:recursive_400_o0:harbor_cn:5"
+            ]
+          },
+          {
+            "case_id": "bi_threshold",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:technical_dense:5",
+              "bilingual_narrative:recursive_400_o0:code_dense:2",
+              "bilingual_narrative:recursive_400_o0:harbor_dense:4"
+            ]
+          },
+          {
+            "case_id": "bi_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:harbor_dense:5",
+              "bilingual_narrative:recursive_400_o0:technical_dense:5",
+              "bilingual_narrative:recursive_400_o0:technical_dense:2"
+            ]
+          },
+          {
+            "case_id": "bi_dense",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:device_codes:3",
+              "bilingual_narrative:recursive_400_o0:harbor_cn:5",
+              "bilingual_narrative:recursive_400_o0:account_faq:4"
+            ]
+          },
+          {
+            "case_id": "bi_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:harbor_dense:2",
+              "bilingual_narrative:recursive_400_o0:confusable_dense:3",
+              "bilingual_narrative:recursive_400_o0:harbor_dense:5"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "bilingual_narrative",
+        "config_id": "recursive_400_o0",
+        "strategy": "recursive_character",
+        "mode": "vector",
+        "top_k": 10,
+        "retrieval_core_p95_ms": 7.015,
+        "metrics": {
+          "recall_at_5": 0.166667,
+          "mrr_at_10": 0.072222,
+          "ndcg_at_10": 0.131511,
+          "citation_hit_rate": 0.033333,
+          "citation_coverage": 0.333333,
+          "context_anchor_coverage_at_5": 0.166667,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "bi_en_to_cn",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:harbor_cn:1",
+              "bilingual_narrative:recursive_400_o0:vendor_manual:0",
+              "bilingual_narrative:recursive_400_o0:continuity_manual:13"
+            ]
+          },
+          {
+            "case_id": "bi_cn_to_en",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:harbor_dense:4",
+              "bilingual_narrative:recursive_400_o0:harbor_report:3",
+              "bilingual_narrative:recursive_400_o0:harbor_dense:6"
+            ]
+          },
+          {
+            "case_id": "bi_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.333333,
+              "ndcg_at_10": 0.5,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:gateway_codes:6",
+              "bilingual_narrative:recursive_400_o0:harbor_report:5",
+              "bilingual_narrative:recursive_400_o0:harbor_cn:5"
+            ]
+          },
+          {
+            "case_id": "bi_threshold",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0.1,
+              "ndcg_at_10": 0.289065,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:technical_dense:5",
+              "bilingual_narrative:recursive_400_o0:code_dense:2",
+              "bilingual_narrative:recursive_400_o0:harbor_dense:4"
+            ]
+          },
+          {
+            "case_id": "bi_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:harbor_dense:5",
+              "bilingual_narrative:recursive_400_o0:technical_dense:5",
+              "bilingual_narrative:recursive_400_o0:technical_dense:2"
+            ]
+          },
+          {
+            "case_id": "bi_dense",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:device_codes:3",
+              "bilingual_narrative:recursive_400_o0:harbor_cn:5",
+              "bilingual_narrative:recursive_400_o0:account_faq:4"
+            ]
+          },
+          {
+            "case_id": "bi_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:harbor_dense:2",
+              "bilingual_narrative:recursive_400_o0:confusable_dense:3",
+              "bilingual_narrative:recursive_400_o0:harbor_dense:5"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "bilingual_narrative",
+        "config_id": "recursive_400_o0",
+        "strategy": "recursive_character",
+        "mode": "hybrid",
+        "top_k": 5,
+        "retrieval_core_p95_ms": 10.967,
+        "metrics": {
+          "recall_at_5": 0.333333,
+          "mrr_at_10": 0.25,
+          "ndcg_at_10": 0.271822,
+          "citation_hit_rate": 0.066667,
+          "citation_coverage": 0.333333,
+          "context_anchor_coverage_at_5": 0.333333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "bi_en_to_cn",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:harbor_cn:1",
+              "bilingual_narrative:recursive_400_o0:vendor_manual:0",
+              "bilingual_narrative:recursive_400_o0:harbor_cn:3"
+            ]
+          },
+          {
+            "case_id": "bi_cn_to_en",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:harbor_report:3",
+              "bilingual_narrative:recursive_400_o0:harbor_dense:4",
+              "bilingual_narrative:recursive_400_o0:harbor_dense:6"
+            ]
+          },
+          {
+            "case_id": "bi_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:harbor_cn:5",
+              "bilingual_narrative:recursive_400_o0:harbor_report:5",
+              "bilingual_narrative:recursive_400_o0:gateway_codes:6"
+            ]
+          },
+          {
+            "case_id": "bi_threshold",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.5,
+              "ndcg_at_10": 0.63093,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:harbor_dense:4",
+              "bilingual_narrative:recursive_400_o0:harbor_report:5",
+              "bilingual_narrative:recursive_400_o0:confusable_dense:5"
+            ]
+          },
+          {
+            "case_id": "bi_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:technical_dense:2",
+              "bilingual_narrative:recursive_400_o0:harbor_dense:5",
+              "bilingual_narrative:recursive_400_o0:harbor_dense:2"
+            ]
+          },
+          {
+            "case_id": "bi_dense",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:harbor_cn:5",
+              "bilingual_narrative:recursive_400_o0:account_faq:9",
+              "bilingual_narrative:recursive_400_o0:account_faq:4"
+            ]
+          },
+          {
+            "case_id": "bi_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:harbor_report:7",
+              "bilingual_narrative:recursive_400_o0:harbor_dense:5",
+              "bilingual_narrative:recursive_400_o0:harbor_report:5"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "bilingual_narrative",
+        "config_id": "recursive_400_o0",
+        "strategy": "recursive_character",
+        "mode": "hybrid",
+        "top_k": 10,
+        "retrieval_core_p95_ms": 10.442,
+        "metrics": {
+          "recall_at_5": 0.333333,
+          "mrr_at_10": 0.25,
+          "ndcg_at_10": 0.271822,
+          "citation_hit_rate": 0.033333,
+          "citation_coverage": 0.333333,
+          "context_anchor_coverage_at_5": 0.333333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "bi_en_to_cn",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:harbor_cn:1",
+              "bilingual_narrative:recursive_400_o0:vendor_manual:0",
+              "bilingual_narrative:recursive_400_o0:harbor_cn:3"
+            ]
+          },
+          {
+            "case_id": "bi_cn_to_en",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:harbor_report:3",
+              "bilingual_narrative:recursive_400_o0:harbor_dense:4",
+              "bilingual_narrative:recursive_400_o0:harbor_dense:6"
+            ]
+          },
+          {
+            "case_id": "bi_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:harbor_cn:5",
+              "bilingual_narrative:recursive_400_o0:harbor_report:5",
+              "bilingual_narrative:recursive_400_o0:gateway_codes:6"
+            ]
+          },
+          {
+            "case_id": "bi_threshold",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.5,
+              "ndcg_at_10": 0.63093,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:harbor_dense:4",
+              "bilingual_narrative:recursive_400_o0:harbor_report:5",
+              "bilingual_narrative:recursive_400_o0:confusable_dense:5"
+            ]
+          },
+          {
+            "case_id": "bi_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:technical_dense:2",
+              "bilingual_narrative:recursive_400_o0:harbor_dense:5",
+              "bilingual_narrative:recursive_400_o0:harbor_dense:2"
+            ]
+          },
+          {
+            "case_id": "bi_dense",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:harbor_cn:5",
+              "bilingual_narrative:recursive_400_o0:account_faq:9",
+              "bilingual_narrative:recursive_400_o0:account_faq:4"
+            ]
+          },
+          {
+            "case_id": "bi_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:recursive_400_o0:harbor_report:7",
+              "bilingual_narrative:recursive_400_o0:harbor_dense:5",
+              "bilingual_narrative:recursive_400_o0:harbor_report:5"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "bilingual_narrative",
+        "config_id": "parent_child_2400_600",
+        "strategy": "parent_child",
+        "mode": "fulltext",
+        "top_k": 5,
+        "retrieval_core_p95_ms": 5.501,
+        "metrics": {
+          "recall_at_5": 0.5,
+          "mrr_at_10": 0.5,
+          "ndcg_at_10": 0.5,
+          "citation_hit_rate": 0.1,
+          "citation_coverage": 0.5,
+          "context_anchor_coverage_at_5": 0.5,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "bi_en_to_cn",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:harbor_cn:1",
+              "bilingual_narrative:parent_child_2400_600:device_codes:1",
+              "bilingual_narrative:parent_child_2400_600:harbor_cn:3"
+            ]
+          },
+          {
+            "case_id": "bi_cn_to_en",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:harbor_report:3",
+              "bilingual_narrative:parent_child_2400_600:north_program:2",
+              "bilingual_narrative:parent_child_2400_600:south_program:2"
+            ]
+          },
+          {
+            "case_id": "bi_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:harbor_cn:5",
+              "bilingual_narrative:parent_child_2400_600:account_faq:9",
+              "bilingual_narrative:parent_child_2400_600:account_faq:10"
+            ]
+          },
+          {
+            "case_id": "bi_threshold",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:harbor_report:5",
+              "bilingual_narrative:parent_child_2400_600:harbor_dense:4",
+              "bilingual_narrative:parent_child_2400_600:technical_dense:5"
+            ]
+          },
+          {
+            "case_id": "bi_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:harbor_report:3",
+              "bilingual_narrative:parent_child_2400_600:harbor_dense:2",
+              "bilingual_narrative:parent_child_2400_600:technical_dense:2"
+            ]
+          },
+          {
+            "case_id": "bi_dense",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:continuity_manual:9",
+              "bilingual_narrative:parent_child_2400_600:continuity_manual:11",
+              "bilingual_narrative:parent_child_2400_600:harbor_cn:5"
+            ]
+          },
+          {
+            "case_id": "bi_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:harbor_report:1",
+              "bilingual_narrative:parent_child_2400_600:harbor_report:7",
+              "bilingual_narrative:parent_child_2400_600:harbor_report:0"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "bilingual_narrative",
+        "config_id": "parent_child_2400_600",
+        "strategy": "parent_child",
+        "mode": "fulltext",
+        "top_k": 10,
+        "retrieval_core_p95_ms": 3.953,
+        "metrics": {
+          "recall_at_5": 0.5,
+          "mrr_at_10": 0.5,
+          "ndcg_at_10": 0.5,
+          "citation_hit_rate": 0.057143,
+          "citation_coverage": 0.5,
+          "context_anchor_coverage_at_5": 0.5,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "bi_en_to_cn",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:harbor_cn:1",
+              "bilingual_narrative:parent_child_2400_600:device_codes:1",
+              "bilingual_narrative:parent_child_2400_600:harbor_cn:3"
+            ]
+          },
+          {
+            "case_id": "bi_cn_to_en",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:harbor_report:3",
+              "bilingual_narrative:parent_child_2400_600:north_program:2",
+              "bilingual_narrative:parent_child_2400_600:south_program:2"
+            ]
+          },
+          {
+            "case_id": "bi_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:harbor_cn:5",
+              "bilingual_narrative:parent_child_2400_600:account_faq:9",
+              "bilingual_narrative:parent_child_2400_600:account_faq:10"
+            ]
+          },
+          {
+            "case_id": "bi_threshold",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.142857,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:harbor_report:5",
+              "bilingual_narrative:parent_child_2400_600:harbor_dense:4",
+              "bilingual_narrative:parent_child_2400_600:technical_dense:5"
+            ]
+          },
+          {
+            "case_id": "bi_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:harbor_report:3",
+              "bilingual_narrative:parent_child_2400_600:harbor_dense:2",
+              "bilingual_narrative:parent_child_2400_600:technical_dense:2"
+            ]
+          },
+          {
+            "case_id": "bi_dense",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:continuity_manual:9",
+              "bilingual_narrative:parent_child_2400_600:continuity_manual:11",
+              "bilingual_narrative:parent_child_2400_600:harbor_cn:5"
+            ]
+          },
+          {
+            "case_id": "bi_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:harbor_report:1",
+              "bilingual_narrative:parent_child_2400_600:harbor_report:7",
+              "bilingual_narrative:parent_child_2400_600:harbor_report:0"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "bilingual_narrative",
+        "config_id": "parent_child_2400_600",
+        "strategy": "parent_child",
+        "mode": "vector",
+        "top_k": 5,
+        "retrieval_core_p95_ms": 6.594,
+        "metrics": {
+          "recall_at_5": 0.166667,
+          "mrr_at_10": 0.055556,
+          "ndcg_at_10": 0.083333,
+          "citation_hit_rate": 0.033333,
+          "citation_coverage": 0.166667,
+          "context_anchor_coverage_at_5": 0.166667,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "bi_en_to_cn",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:harbor_cn:1",
+              "bilingual_narrative:parent_child_2400_600:vendor_manual:0",
+              "bilingual_narrative:parent_child_2400_600:continuity_manual:13"
+            ]
+          },
+          {
+            "case_id": "bi_cn_to_en",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:harbor_report:3",
+              "bilingual_narrative:parent_child_2400_600:harbor_dense:5",
+              "bilingual_narrative:parent_child_2400_600:harbor_dense:3"
+            ]
+          },
+          {
+            "case_id": "bi_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.333333,
+              "ndcg_at_10": 0.5,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:gateway_codes:6",
+              "bilingual_narrative:parent_child_2400_600:harbor_report:5",
+              "bilingual_narrative:parent_child_2400_600:harbor_cn:5"
+            ]
+          },
+          {
+            "case_id": "bi_threshold",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:technical_dense:4",
+              "bilingual_narrative:parent_child_2400_600:confusable_dense:4",
+              "bilingual_narrative:parent_child_2400_600:code_dense:2"
+            ]
+          },
+          {
+            "case_id": "bi_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:harbor_dense:2",
+              "bilingual_narrative:parent_child_2400_600:technical_dense:2",
+              "bilingual_narrative:parent_child_2400_600:harbor_dense:4"
+            ]
+          },
+          {
+            "case_id": "bi_dense",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:device_codes:3",
+              "bilingual_narrative:parent_child_2400_600:harbor_cn:5",
+              "bilingual_narrative:parent_child_2400_600:account_faq:4"
+            ]
+          },
+          {
+            "case_id": "bi_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:harbor_dense:2",
+              "bilingual_narrative:parent_child_2400_600:confusable_dense:3",
+              "bilingual_narrative:parent_child_2400_600:harbor_dense:4"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "bilingual_narrative",
+        "config_id": "parent_child_2400_600",
+        "strategy": "parent_child",
+        "mode": "vector",
+        "top_k": 10,
+        "retrieval_core_p95_ms": 7.068,
+        "metrics": {
+          "recall_at_5": 0.166667,
+          "mrr_at_10": 0.076389,
+          "ndcg_at_10": 0.135911,
+          "citation_hit_rate": 0.033333,
+          "citation_coverage": 0.333333,
+          "context_anchor_coverage_at_5": 0.166667,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "bi_en_to_cn",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:harbor_cn:1",
+              "bilingual_narrative:parent_child_2400_600:vendor_manual:0",
+              "bilingual_narrative:parent_child_2400_600:continuity_manual:13"
+            ]
+          },
+          {
+            "case_id": "bi_cn_to_en",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:harbor_report:3",
+              "bilingual_narrative:parent_child_2400_600:harbor_dense:5",
+              "bilingual_narrative:parent_child_2400_600:harbor_dense:3"
+            ]
+          },
+          {
+            "case_id": "bi_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.333333,
+              "ndcg_at_10": 0.5,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:gateway_codes:6",
+              "bilingual_narrative:parent_child_2400_600:harbor_report:5",
+              "bilingual_narrative:parent_child_2400_600:harbor_cn:5"
+            ]
+          },
+          {
+            "case_id": "bi_threshold",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0.125,
+              "ndcg_at_10": 0.315465,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:technical_dense:4",
+              "bilingual_narrative:parent_child_2400_600:confusable_dense:4",
+              "bilingual_narrative:parent_child_2400_600:code_dense:2"
+            ]
+          },
+          {
+            "case_id": "bi_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:harbor_dense:2",
+              "bilingual_narrative:parent_child_2400_600:technical_dense:2",
+              "bilingual_narrative:parent_child_2400_600:harbor_dense:4"
+            ]
+          },
+          {
+            "case_id": "bi_dense",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:device_codes:3",
+              "bilingual_narrative:parent_child_2400_600:harbor_cn:5",
+              "bilingual_narrative:parent_child_2400_600:account_faq:4"
+            ]
+          },
+          {
+            "case_id": "bi_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:harbor_dense:2",
+              "bilingual_narrative:parent_child_2400_600:confusable_dense:3",
+              "bilingual_narrative:parent_child_2400_600:harbor_dense:4"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "bilingual_narrative",
+        "config_id": "parent_child_2400_600",
+        "strategy": "parent_child",
+        "mode": "hybrid",
+        "top_k": 5,
+        "retrieval_core_p95_ms": 11.206,
+        "metrics": {
+          "recall_at_5": 0.333333,
+          "mrr_at_10": 0.222222,
+          "ndcg_at_10": 0.25,
+          "citation_hit_rate": 0.066667,
+          "citation_coverage": 0.333333,
+          "context_anchor_coverage_at_5": 0.333333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "bi_en_to_cn",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:harbor_cn:1",
+              "bilingual_narrative:parent_child_2400_600:vendor_manual:0",
+              "bilingual_narrative:parent_child_2400_600:harbor_cn:3"
+            ]
+          },
+          {
+            "case_id": "bi_cn_to_en",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:harbor_report:3",
+              "bilingual_narrative:parent_child_2400_600:harbor_dense:5",
+              "bilingual_narrative:parent_child_2400_600:harbor_dense:3"
+            ]
+          },
+          {
+            "case_id": "bi_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:harbor_cn:5",
+              "bilingual_narrative:parent_child_2400_600:harbor_report:5",
+              "bilingual_narrative:parent_child_2400_600:gateway_codes:6"
+            ]
+          },
+          {
+            "case_id": "bi_threshold",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.333333,
+              "ndcg_at_10": 0.5,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:confusable_dense:4",
+              "bilingual_narrative:parent_child_2400_600:harbor_dense:4",
+              "bilingual_narrative:parent_child_2400_600:harbor_report:5"
+            ]
+          },
+          {
+            "case_id": "bi_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:harbor_dense:2",
+              "bilingual_narrative:parent_child_2400_600:technical_dense:2",
+              "bilingual_narrative:parent_child_2400_600:technical_dense:3"
+            ]
+          },
+          {
+            "case_id": "bi_dense",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:harbor_cn:5",
+              "bilingual_narrative:parent_child_2400_600:account_faq:9",
+              "bilingual_narrative:parent_child_2400_600:account_faq:4"
+            ]
+          },
+          {
+            "case_id": "bi_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:harbor_report:7",
+              "bilingual_narrative:parent_child_2400_600:harbor_report:5",
+              "bilingual_narrative:parent_child_2400_600:harbor_dense:4"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "bilingual_narrative",
+        "config_id": "parent_child_2400_600",
+        "strategy": "parent_child",
+        "mode": "hybrid",
+        "top_k": 10,
+        "retrieval_core_p95_ms": 9.075,
+        "metrics": {
+          "recall_at_5": 0.333333,
+          "mrr_at_10": 0.222222,
+          "ndcg_at_10": 0.25,
+          "citation_hit_rate": 0.033333,
+          "citation_coverage": 0.333333,
+          "context_anchor_coverage_at_5": 0.333333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "bi_en_to_cn",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:harbor_cn:1",
+              "bilingual_narrative:parent_child_2400_600:vendor_manual:0",
+              "bilingual_narrative:parent_child_2400_600:harbor_cn:3"
+            ]
+          },
+          {
+            "case_id": "bi_cn_to_en",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:harbor_report:3",
+              "bilingual_narrative:parent_child_2400_600:harbor_dense:5",
+              "bilingual_narrative:parent_child_2400_600:harbor_dense:3"
+            ]
+          },
+          {
+            "case_id": "bi_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:harbor_cn:5",
+              "bilingual_narrative:parent_child_2400_600:harbor_report:5",
+              "bilingual_narrative:parent_child_2400_600:gateway_codes:6"
+            ]
+          },
+          {
+            "case_id": "bi_threshold",
+            "query_type": "paraphrase",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.333333,
+              "ndcg_at_10": 0.5,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:confusable_dense:4",
+              "bilingual_narrative:parent_child_2400_600:harbor_dense:4",
+              "bilingual_narrative:parent_child_2400_600:harbor_report:5"
+            ]
+          },
+          {
+            "case_id": "bi_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:harbor_dense:2",
+              "bilingual_narrative:parent_child_2400_600:technical_dense:2",
+              "bilingual_narrative:parent_child_2400_600:technical_dense:3"
+            ]
+          },
+          {
+            "case_id": "bi_dense",
+            "query_type": "cross_language",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:harbor_cn:5",
+              "bilingual_narrative:parent_child_2400_600:account_faq:9",
+              "bilingual_narrative:parent_child_2400_600:account_faq:4"
+            ]
+          },
+          {
+            "case_id": "bi_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "bilingual_narrative:parent_child_2400_600:harbor_report:7",
+              "bilingual_narrative:parent_child_2400_600:harbor_report:5",
+              "bilingual_narrative:parent_child_2400_600:harbor_dense:4"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "tables_code",
+        "config_id": "recursive_1000_o100",
+        "strategy": "recursive_character",
+        "mode": "fulltext",
+        "top_k": 5,
+        "retrieval_core_p95_ms": 5.605,
+        "metrics": {
+          "recall_at_5": 1,
+          "mrr_at_10": 1,
+          "ndcg_at_10": 1,
+          "citation_hit_rate": 0.2,
+          "citation_coverage": 1,
+          "context_anchor_coverage_at_5": 1,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "tc_table",
+            "query_type": "table",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:limits_table:1",
+              "tables_code:recursive_1000_o100:limits_table:2",
+              "tables_code:recursive_1000_o100:sdk_config:3"
+            ]
+          },
+          {
+            "case_id": "tc_table_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:limits_table:1",
+              "tables_code:recursive_1000_o100:limits_table:2",
+              "tables_code:recursive_1000_o100:south_program:6"
+            ]
+          },
+          {
+            "case_id": "tc_code",
+            "query_type": "code",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:sdk_config:2",
+              "tables_code:recursive_1000_o100:harbor_report:2",
+              "tables_code:recursive_1000_o100:sdk_config:3"
+            ]
+          },
+          {
+            "case_id": "tc_semantics",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:sdk_config:3",
+              "tables_code:recursive_1000_o100:south_program:6",
+              "tables_code:recursive_1000_o100:sdk_config:2"
+            ]
+          },
+          {
+            "case_id": "tc_exact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:sdk_config:2",
+              "tables_code:recursive_1000_o100:gateway_codes:4",
+              "tables_code:recursive_1000_o100:gateway_codes:10"
+            ]
+          },
+          {
+            "case_id": "tc_dense",
+            "query_type": "code",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:code_dense:2",
+              "tables_code:recursive_1000_o100:south_program:4",
+              "tables_code:recursive_1000_o100:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "tc_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:limits_table:3",
+              "tables_code:recursive_1000_o100:limits_table:4",
+              "tables_code:recursive_1000_o100:sdk_config:3"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "tables_code",
+        "config_id": "recursive_1000_o100",
+        "strategy": "recursive_character",
+        "mode": "fulltext",
+        "top_k": 10,
+        "retrieval_core_p95_ms": 4.722,
+        "metrics": {
+          "recall_at_5": 1,
+          "mrr_at_10": 1,
+          "ndcg_at_10": 1,
+          "citation_hit_rate": 0.116667,
+          "citation_coverage": 1,
+          "context_anchor_coverage_at_5": 1,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "tc_table",
+            "query_type": "table",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:limits_table:1",
+              "tables_code:recursive_1000_o100:limits_table:2",
+              "tables_code:recursive_1000_o100:sdk_config:3"
+            ]
+          },
+          {
+            "case_id": "tc_table_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:limits_table:1",
+              "tables_code:recursive_1000_o100:limits_table:2",
+              "tables_code:recursive_1000_o100:south_program:6"
+            ]
+          },
+          {
+            "case_id": "tc_code",
+            "query_type": "code",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:sdk_config:2",
+              "tables_code:recursive_1000_o100:harbor_report:2",
+              "tables_code:recursive_1000_o100:sdk_config:3"
+            ]
+          },
+          {
+            "case_id": "tc_semantics",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:sdk_config:3",
+              "tables_code:recursive_1000_o100:south_program:6",
+              "tables_code:recursive_1000_o100:sdk_config:2"
+            ]
+          },
+          {
+            "case_id": "tc_exact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:sdk_config:2",
+              "tables_code:recursive_1000_o100:gateway_codes:4",
+              "tables_code:recursive_1000_o100:gateway_codes:10"
+            ]
+          },
+          {
+            "case_id": "tc_dense",
+            "query_type": "code",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:code_dense:2",
+              "tables_code:recursive_1000_o100:south_program:4",
+              "tables_code:recursive_1000_o100:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "tc_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:limits_table:3",
+              "tables_code:recursive_1000_o100:limits_table:4",
+              "tables_code:recursive_1000_o100:sdk_config:3"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "tables_code",
+        "config_id": "recursive_1000_o100",
+        "strategy": "recursive_character",
+        "mode": "vector",
+        "top_k": 5,
+        "retrieval_core_p95_ms": 6.416,
+        "metrics": {
+          "recall_at_5": 0.333333,
+          "mrr_at_10": 0.222222,
+          "ndcg_at_10": 0.25,
+          "citation_hit_rate": 0.066667,
+          "citation_coverage": 0.333333,
+          "context_anchor_coverage_at_5": 0.333333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "tc_table",
+            "query_type": "table",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:sdk_config:3",
+              "tables_code:recursive_1000_o100:harbor_dense:3",
+              "tables_code:recursive_1000_o100:harbor_report:7"
+            ]
+          },
+          {
+            "case_id": "tc_table_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:limits_table:2",
+              "tables_code:recursive_1000_o100:harbor_dense:2",
+              "tables_code:recursive_1000_o100:technical_dense:2"
+            ]
+          },
+          {
+            "case_id": "tc_code",
+            "query_type": "code",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:harbor_report:3",
+              "tables_code:recursive_1000_o100:harbor_dense:3",
+              "tables_code:recursive_1000_o100:harbor_report:7"
+            ]
+          },
+          {
+            "case_id": "tc_semantics",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:sdk_config:3",
+              "tables_code:recursive_1000_o100:harbor_report:7",
+              "tables_code:recursive_1000_o100:harbor_report:1"
+            ]
+          },
+          {
+            "case_id": "tc_exact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:harbor_dense:2",
+              "tables_code:recursive_1000_o100:technical_dense:2",
+              "tables_code:recursive_1000_o100:harbor_dense:3"
+            ]
+          },
+          {
+            "case_id": "tc_dense",
+            "query_type": "code",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.333333,
+              "ndcg_at_10": 0.5,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:code_dense:0",
+              "tables_code:recursive_1000_o100:sdk_config:3",
+              "tables_code:recursive_1000_o100:code_dense:2"
+            ]
+          },
+          {
+            "case_id": "tc_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:sdk_config:1",
+              "tables_code:recursive_1000_o100:sdk_config:5",
+              "tables_code:recursive_1000_o100:sdk_config:3"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "tables_code",
+        "config_id": "recursive_1000_o100",
+        "strategy": "recursive_character",
+        "mode": "vector",
+        "top_k": 10,
+        "retrieval_core_p95_ms": 7.426,
+        "metrics": {
+          "recall_at_5": 0.333333,
+          "mrr_at_10": 0.222222,
+          "ndcg_at_10": 0.25,
+          "citation_hit_rate": 0.033333,
+          "citation_coverage": 0.333333,
+          "context_anchor_coverage_at_5": 0.333333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "tc_table",
+            "query_type": "table",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:sdk_config:3",
+              "tables_code:recursive_1000_o100:harbor_dense:3",
+              "tables_code:recursive_1000_o100:harbor_report:7"
+            ]
+          },
+          {
+            "case_id": "tc_table_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:limits_table:2",
+              "tables_code:recursive_1000_o100:harbor_dense:2",
+              "tables_code:recursive_1000_o100:technical_dense:2"
+            ]
+          },
+          {
+            "case_id": "tc_code",
+            "query_type": "code",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:harbor_report:3",
+              "tables_code:recursive_1000_o100:harbor_dense:3",
+              "tables_code:recursive_1000_o100:harbor_report:7"
+            ]
+          },
+          {
+            "case_id": "tc_semantics",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:sdk_config:3",
+              "tables_code:recursive_1000_o100:harbor_report:7",
+              "tables_code:recursive_1000_o100:harbor_report:1"
+            ]
+          },
+          {
+            "case_id": "tc_exact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:harbor_dense:2",
+              "tables_code:recursive_1000_o100:technical_dense:2",
+              "tables_code:recursive_1000_o100:harbor_dense:3"
+            ]
+          },
+          {
+            "case_id": "tc_dense",
+            "query_type": "code",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.333333,
+              "ndcg_at_10": 0.5,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:code_dense:0",
+              "tables_code:recursive_1000_o100:sdk_config:3",
+              "tables_code:recursive_1000_o100:code_dense:2"
+            ]
+          },
+          {
+            "case_id": "tc_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:sdk_config:1",
+              "tables_code:recursive_1000_o100:sdk_config:5",
+              "tables_code:recursive_1000_o100:sdk_config:3"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "tables_code",
+        "config_id": "recursive_1000_o100",
+        "strategy": "recursive_character",
+        "mode": "hybrid",
+        "top_k": 5,
+        "retrieval_core_p95_ms": 8.226,
+        "metrics": {
+          "recall_at_5": 0.333333,
+          "mrr_at_10": 0.333333,
+          "ndcg_at_10": 0.333333,
+          "citation_hit_rate": 0.066667,
+          "citation_coverage": 0.333333,
+          "context_anchor_coverage_at_5": 0.333333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "tc_table",
+            "query_type": "table",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:sdk_config:3",
+              "tables_code:recursive_1000_o100:harbor_dense:3",
+              "tables_code:recursive_1000_o100:harbor_report:7"
+            ]
+          },
+          {
+            "case_id": "tc_table_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:limits_table:2",
+              "tables_code:recursive_1000_o100:confusable_dense:3",
+              "tables_code:recursive_1000_o100:north_program:8"
+            ]
+          },
+          {
+            "case_id": "tc_code",
+            "query_type": "code",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:harbor_report:3",
+              "tables_code:recursive_1000_o100:harbor_report:2",
+              "tables_code:recursive_1000_o100:harbor_dense:3"
+            ]
+          },
+          {
+            "case_id": "tc_semantics",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:sdk_config:3",
+              "tables_code:recursive_1000_o100:harbor_report:1",
+              "tables_code:recursive_1000_o100:harbor_dense:3"
+            ]
+          },
+          {
+            "case_id": "tc_exact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:gateway_codes:10",
+              "tables_code:recursive_1000_o100:technical_dense:2",
+              "tables_code:recursive_1000_o100:harbor_dense:3"
+            ]
+          },
+          {
+            "case_id": "tc_dense",
+            "query_type": "code",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:code_dense:2",
+              "tables_code:recursive_1000_o100:code_dense:0",
+              "tables_code:recursive_1000_o100:technical_dense:3"
+            ]
+          },
+          {
+            "case_id": "tc_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:sdk_config:3",
+              "tables_code:recursive_1000_o100:limits_table:3",
+              "tables_code:recursive_1000_o100:harbor_dense:3"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "tables_code",
+        "config_id": "recursive_1000_o100",
+        "strategy": "recursive_character",
+        "mode": "hybrid",
+        "top_k": 10,
+        "retrieval_core_p95_ms": 9.553,
+        "metrics": {
+          "recall_at_5": 0.333333,
+          "mrr_at_10": 0.333333,
+          "ndcg_at_10": 0.333333,
+          "citation_hit_rate": 0.033333,
+          "citation_coverage": 0.333333,
+          "context_anchor_coverage_at_5": 0.333333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "tc_table",
+            "query_type": "table",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:sdk_config:3",
+              "tables_code:recursive_1000_o100:harbor_dense:3",
+              "tables_code:recursive_1000_o100:harbor_report:7"
+            ]
+          },
+          {
+            "case_id": "tc_table_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:limits_table:2",
+              "tables_code:recursive_1000_o100:confusable_dense:3",
+              "tables_code:recursive_1000_o100:north_program:8"
+            ]
+          },
+          {
+            "case_id": "tc_code",
+            "query_type": "code",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:harbor_report:3",
+              "tables_code:recursive_1000_o100:harbor_report:2",
+              "tables_code:recursive_1000_o100:harbor_dense:3"
+            ]
+          },
+          {
+            "case_id": "tc_semantics",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:sdk_config:3",
+              "tables_code:recursive_1000_o100:harbor_report:1",
+              "tables_code:recursive_1000_o100:harbor_report:7"
+            ]
+          },
+          {
+            "case_id": "tc_exact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:gateway_codes:10",
+              "tables_code:recursive_1000_o100:technical_dense:2",
+              "tables_code:recursive_1000_o100:harbor_dense:3"
+            ]
+          },
+          {
+            "case_id": "tc_dense",
+            "query_type": "code",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:code_dense:2",
+              "tables_code:recursive_1000_o100:code_dense:0",
+              "tables_code:recursive_1000_o100:technical_dense:3"
+            ]
+          },
+          {
+            "case_id": "tc_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:recursive_1000_o100:sdk_config:3",
+              "tables_code:recursive_1000_o100:limits_table:3",
+              "tables_code:recursive_1000_o100:harbor_dense:3"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "tables_code",
+        "config_id": "parent_child_2400_600",
+        "strategy": "parent_child",
+        "mode": "fulltext",
+        "top_k": 5,
+        "retrieval_core_p95_ms": 2.081,
+        "metrics": {
+          "recall_at_5": 1,
+          "mrr_at_10": 1,
+          "ndcg_at_10": 1,
+          "citation_hit_rate": 0.2,
+          "citation_coverage": 1,
+          "context_anchor_coverage_at_5": 1,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "tc_table",
+            "query_type": "table",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:limits_table:1",
+              "tables_code:parent_child_2400_600:limits_table:2",
+              "tables_code:parent_child_2400_600:sdk_config:3"
+            ]
+          },
+          {
+            "case_id": "tc_table_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:limits_table:1",
+              "tables_code:parent_child_2400_600:limits_table:2",
+              "tables_code:parent_child_2400_600:south_program:6"
+            ]
+          },
+          {
+            "case_id": "tc_code",
+            "query_type": "code",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:sdk_config:2",
+              "tables_code:parent_child_2400_600:harbor_report:2",
+              "tables_code:parent_child_2400_600:sdk_config:3"
+            ]
+          },
+          {
+            "case_id": "tc_semantics",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:sdk_config:3",
+              "tables_code:parent_child_2400_600:south_program:6",
+              "tables_code:parent_child_2400_600:sdk_config:2"
+            ]
+          },
+          {
+            "case_id": "tc_exact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:sdk_config:2",
+              "tables_code:parent_child_2400_600:gateway_codes:4",
+              "tables_code:parent_child_2400_600:gateway_codes:10"
+            ]
+          },
+          {
+            "case_id": "tc_dense",
+            "query_type": "code",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:code_dense:3",
+              "tables_code:parent_child_2400_600:south_program:4",
+              "tables_code:parent_child_2400_600:confusable_dense:4"
+            ]
+          },
+          {
+            "case_id": "tc_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:limits_table:3",
+              "tables_code:parent_child_2400_600:limits_table:4",
+              "tables_code:parent_child_2400_600:sdk_config:3"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "tables_code",
+        "config_id": "parent_child_2400_600",
+        "strategy": "parent_child",
+        "mode": "fulltext",
+        "top_k": 10,
+        "retrieval_core_p95_ms": 3.216,
+        "metrics": {
+          "recall_at_5": 1,
+          "mrr_at_10": 1,
+          "ndcg_at_10": 1,
+          "citation_hit_rate": 0.116667,
+          "citation_coverage": 1,
+          "context_anchor_coverage_at_5": 1,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "tc_table",
+            "query_type": "table",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:limits_table:1",
+              "tables_code:parent_child_2400_600:limits_table:2",
+              "tables_code:parent_child_2400_600:sdk_config:3"
+            ]
+          },
+          {
+            "case_id": "tc_table_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:limits_table:1",
+              "tables_code:parent_child_2400_600:limits_table:2",
+              "tables_code:parent_child_2400_600:south_program:6"
+            ]
+          },
+          {
+            "case_id": "tc_code",
+            "query_type": "code",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:sdk_config:2",
+              "tables_code:parent_child_2400_600:harbor_report:2",
+              "tables_code:parent_child_2400_600:sdk_config:3"
+            ]
+          },
+          {
+            "case_id": "tc_semantics",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:sdk_config:3",
+              "tables_code:parent_child_2400_600:south_program:6",
+              "tables_code:parent_child_2400_600:sdk_config:2"
+            ]
+          },
+          {
+            "case_id": "tc_exact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:sdk_config:2",
+              "tables_code:parent_child_2400_600:gateway_codes:4",
+              "tables_code:parent_child_2400_600:gateway_codes:10"
+            ]
+          },
+          {
+            "case_id": "tc_dense",
+            "query_type": "code",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:code_dense:3",
+              "tables_code:parent_child_2400_600:south_program:4",
+              "tables_code:parent_child_2400_600:confusable_dense:4"
+            ]
+          },
+          {
+            "case_id": "tc_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:limits_table:3",
+              "tables_code:parent_child_2400_600:limits_table:4",
+              "tables_code:parent_child_2400_600:sdk_config:3"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "tables_code",
+        "config_id": "parent_child_2400_600",
+        "strategy": "parent_child",
+        "mode": "vector",
+        "top_k": 5,
+        "retrieval_core_p95_ms": 5.78,
+        "metrics": {
+          "recall_at_5": 0.333333,
+          "mrr_at_10": 0.25,
+          "ndcg_at_10": 0.271822,
+          "citation_hit_rate": 0.066667,
+          "citation_coverage": 0.333333,
+          "context_anchor_coverage_at_5": 0.333333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "tc_table",
+            "query_type": "table",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:sdk_config:3",
+              "tables_code:parent_child_2400_600:confusable_dense:3",
+              "tables_code:parent_child_2400_600:harbor_dense:4"
+            ]
+          },
+          {
+            "case_id": "tc_table_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:limits_table:2",
+              "tables_code:parent_child_2400_600:technical_dense:2",
+              "tables_code:parent_child_2400_600:harbor_dense:2"
+            ]
+          },
+          {
+            "case_id": "tc_code",
+            "query_type": "code",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:harbor_report:3",
+              "tables_code:parent_child_2400_600:harbor_report:7",
+              "tables_code:parent_child_2400_600:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "tc_semantics",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:sdk_config:3",
+              "tables_code:parent_child_2400_600:harbor_report:7",
+              "tables_code:parent_child_2400_600:harbor_report:1"
+            ]
+          },
+          {
+            "case_id": "tc_exact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:harbor_dense:2",
+              "tables_code:parent_child_2400_600:harbor_dense:3",
+              "tables_code:parent_child_2400_600:technical_dense:2"
+            ]
+          },
+          {
+            "case_id": "tc_dense",
+            "query_type": "code",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.5,
+              "ndcg_at_10": 0.63093,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:code_dense:0",
+              "tables_code:parent_child_2400_600:code_dense:3",
+              "tables_code:parent_child_2400_600:sdk_config:3"
+            ]
+          },
+          {
+            "case_id": "tc_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:sdk_config:1",
+              "tables_code:parent_child_2400_600:sdk_config:5",
+              "tables_code:parent_child_2400_600:sdk_config:3"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "tables_code",
+        "config_id": "parent_child_2400_600",
+        "strategy": "parent_child",
+        "mode": "vector",
+        "top_k": 10,
+        "retrieval_core_p95_ms": 6.34,
+        "metrics": {
+          "recall_at_5": 0.333333,
+          "mrr_at_10": 0.25,
+          "ndcg_at_10": 0.271822,
+          "citation_hit_rate": 0.033333,
+          "citation_coverage": 0.333333,
+          "context_anchor_coverage_at_5": 0.333333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "tc_table",
+            "query_type": "table",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:sdk_config:3",
+              "tables_code:parent_child_2400_600:confusable_dense:3",
+              "tables_code:parent_child_2400_600:harbor_dense:4"
+            ]
+          },
+          {
+            "case_id": "tc_table_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:limits_table:2",
+              "tables_code:parent_child_2400_600:technical_dense:2",
+              "tables_code:parent_child_2400_600:harbor_dense:2"
+            ]
+          },
+          {
+            "case_id": "tc_code",
+            "query_type": "code",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:harbor_report:3",
+              "tables_code:parent_child_2400_600:harbor_report:7",
+              "tables_code:parent_child_2400_600:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "tc_semantics",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:sdk_config:3",
+              "tables_code:parent_child_2400_600:harbor_report:7",
+              "tables_code:parent_child_2400_600:harbor_report:1"
+            ]
+          },
+          {
+            "case_id": "tc_exact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:harbor_dense:2",
+              "tables_code:parent_child_2400_600:harbor_dense:3",
+              "tables_code:parent_child_2400_600:technical_dense:2"
+            ]
+          },
+          {
+            "case_id": "tc_dense",
+            "query_type": "code",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.5,
+              "ndcg_at_10": 0.63093,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:code_dense:0",
+              "tables_code:parent_child_2400_600:code_dense:3",
+              "tables_code:parent_child_2400_600:sdk_config:3"
+            ]
+          },
+          {
+            "case_id": "tc_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:sdk_config:1",
+              "tables_code:parent_child_2400_600:sdk_config:5",
+              "tables_code:parent_child_2400_600:sdk_config:3"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "tables_code",
+        "config_id": "parent_child_2400_600",
+        "strategy": "parent_child",
+        "mode": "hybrid",
+        "top_k": 5,
+        "retrieval_core_p95_ms": 10.835,
+        "metrics": {
+          "recall_at_5": 0.333333,
+          "mrr_at_10": 0.333333,
+          "ndcg_at_10": 0.333333,
+          "citation_hit_rate": 0.066667,
+          "citation_coverage": 0.333333,
+          "context_anchor_coverage_at_5": 0.333333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "tc_table",
+            "query_type": "table",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:sdk_config:3",
+              "tables_code:parent_child_2400_600:confusable_dense:3",
+              "tables_code:parent_child_2400_600:harbor_dense:3"
+            ]
+          },
+          {
+            "case_id": "tc_table_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:limits_table:2",
+              "tables_code:parent_child_2400_600:confusable_dense:4",
+              "tables_code:parent_child_2400_600:north_program:8"
+            ]
+          },
+          {
+            "case_id": "tc_code",
+            "query_type": "code",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:harbor_report:3",
+              "tables_code:parent_child_2400_600:harbor_report:2",
+              "tables_code:parent_child_2400_600:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "tc_semantics",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:sdk_config:3",
+              "tables_code:parent_child_2400_600:harbor_report:1",
+              "tables_code:parent_child_2400_600:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "tc_exact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:technical_dense:2",
+              "tables_code:parent_child_2400_600:harbor_dense:4",
+              "tables_code:parent_child_2400_600:gateway_codes:10"
+            ]
+          },
+          {
+            "case_id": "tc_dense",
+            "query_type": "code",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:code_dense:3",
+              "tables_code:parent_child_2400_600:code_dense:0",
+              "tables_code:parent_child_2400_600:technical_dense:4"
+            ]
+          },
+          {
+            "case_id": "tc_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:sdk_config:3",
+              "tables_code:parent_child_2400_600:limits_table:3",
+              "tables_code:parent_child_2400_600:confusable_dense:3"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "tables_code",
+        "config_id": "parent_child_2400_600",
+        "strategy": "parent_child",
+        "mode": "hybrid",
+        "top_k": 10,
+        "retrieval_core_p95_ms": 9.841,
+        "metrics": {
+          "recall_at_5": 0.333333,
+          "mrr_at_10": 0.333333,
+          "ndcg_at_10": 0.333333,
+          "citation_hit_rate": 0.033333,
+          "citation_coverage": 0.333333,
+          "context_anchor_coverage_at_5": 0.333333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "tc_table",
+            "query_type": "table",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:sdk_config:3",
+              "tables_code:parent_child_2400_600:confusable_dense:3",
+              "tables_code:parent_child_2400_600:harbor_dense:3"
+            ]
+          },
+          {
+            "case_id": "tc_table_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:limits_table:2",
+              "tables_code:parent_child_2400_600:confusable_dense:4",
+              "tables_code:parent_child_2400_600:north_program:8"
+            ]
+          },
+          {
+            "case_id": "tc_code",
+            "query_type": "code",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:harbor_report:3",
+              "tables_code:parent_child_2400_600:harbor_report:2",
+              "tables_code:parent_child_2400_600:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "tc_semantics",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:sdk_config:3",
+              "tables_code:parent_child_2400_600:harbor_report:1",
+              "tables_code:parent_child_2400_600:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "tc_exact",
+            "query_type": "exact_term",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:technical_dense:2",
+              "tables_code:parent_child_2400_600:harbor_dense:4",
+              "tables_code:parent_child_2400_600:gateway_codes:10"
+            ]
+          },
+          {
+            "case_id": "tc_dense",
+            "query_type": "code",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:code_dense:3",
+              "tables_code:parent_child_2400_600:code_dense:0",
+              "tables_code:parent_child_2400_600:technical_dense:4"
+            ]
+          },
+          {
+            "case_id": "tc_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "tables_code:parent_child_2400_600:sdk_config:3",
+              "tables_code:parent_child_2400_600:limits_table:3",
+              "tables_code:parent_child_2400_600:confusable_dense:3"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "confusable_sections",
+        "config_id": "recursive_1000_o100",
+        "strategy": "recursive_character",
+        "mode": "fulltext",
+        "top_k": 5,
+        "retrieval_core_p95_ms": 5.44,
+        "metrics": {
+          "recall_at_5": 1,
+          "mrr_at_10": 0.916667,
+          "ndcg_at_10": 0.874013,
+          "citation_hit_rate": 0.2,
+          "citation_coverage": 1,
+          "context_anchor_coverage_at_5": 1,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "cs_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:north_program:2",
+              "confusable_sections:recursive_1000_o100:south_program:2",
+              "confusable_sections:recursive_1000_o100:north_program:1"
+            ]
+          },
+          {
+            "case_id": "cs_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:north_program:6",
+              "confusable_sections:recursive_1000_o100:south_program:4",
+              "confusable_sections:recursive_1000_o100:north_program:8"
+            ]
+          },
+          {
+            "case_id": "cs_region",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:south_program:6",
+              "confusable_sections:recursive_1000_o100:north_program:6",
+              "confusable_sections:recursive_1000_o100:south_program:4"
+            ]
+          },
+          {
+            "case_id": "cs_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 0.613147,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:north_program:4",
+              "confusable_sections:recursive_1000_o100:confusable_dense:2",
+              "confusable_sections:recursive_1000_o100:north_program:2"
+            ]
+          },
+          {
+            "case_id": "cs_negative",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:north_program:8",
+              "confusable_sections:recursive_1000_o100:confusable_dense:3",
+              "confusable_sections:recursive_1000_o100:gateway_codes:4"
+            ]
+          },
+          {
+            "case_id": "cs_dense",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.5,
+              "ndcg_at_10": 0.63093,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:north_program:6",
+              "confusable_sections:recursive_1000_o100:confusable_dense:3",
+              "confusable_sections:recursive_1000_o100:confusable_dense:2"
+            ]
+          },
+          {
+            "case_id": "cs_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:south_program:4",
+              "confusable_sections:recursive_1000_o100:north_program:6",
+              "confusable_sections:recursive_1000_o100:confusable_dense:3"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "confusable_sections",
+        "config_id": "recursive_1000_o100",
+        "strategy": "recursive_character",
+        "mode": "fulltext",
+        "top_k": 10,
+        "retrieval_core_p95_ms": 4.033,
+        "metrics": {
+          "recall_at_5": 1,
+          "mrr_at_10": 0.916667,
+          "ndcg_at_10": 0.874013,
+          "citation_hit_rate": 0.1,
+          "citation_coverage": 1,
+          "context_anchor_coverage_at_5": 1,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "cs_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:north_program:2",
+              "confusable_sections:recursive_1000_o100:south_program:2",
+              "confusable_sections:recursive_1000_o100:north_program:1"
+            ]
+          },
+          {
+            "case_id": "cs_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:north_program:6",
+              "confusable_sections:recursive_1000_o100:south_program:4",
+              "confusable_sections:recursive_1000_o100:north_program:8"
+            ]
+          },
+          {
+            "case_id": "cs_region",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:south_program:6",
+              "confusable_sections:recursive_1000_o100:north_program:6",
+              "confusable_sections:recursive_1000_o100:south_program:4"
+            ]
+          },
+          {
+            "case_id": "cs_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 0.613147,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:north_program:4",
+              "confusable_sections:recursive_1000_o100:confusable_dense:2",
+              "confusable_sections:recursive_1000_o100:north_program:2"
+            ]
+          },
+          {
+            "case_id": "cs_negative",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:north_program:8",
+              "confusable_sections:recursive_1000_o100:confusable_dense:3",
+              "confusable_sections:recursive_1000_o100:gateway_codes:4"
+            ]
+          },
+          {
+            "case_id": "cs_dense",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.5,
+              "ndcg_at_10": 0.63093,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:north_program:6",
+              "confusable_sections:recursive_1000_o100:confusable_dense:3",
+              "confusable_sections:recursive_1000_o100:confusable_dense:2"
+            ]
+          },
+          {
+            "case_id": "cs_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:south_program:4",
+              "confusable_sections:recursive_1000_o100:north_program:6",
+              "confusable_sections:recursive_1000_o100:confusable_dense:3"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "confusable_sections",
+        "config_id": "recursive_1000_o100",
+        "strategy": "recursive_character",
+        "mode": "vector",
+        "top_k": 5,
+        "retrieval_core_p95_ms": 5.32,
+        "metrics": {
+          "recall_at_5": 0.833333,
+          "mrr_at_10": 0.408333,
+          "ndcg_at_10": 0.472552,
+          "citation_hit_rate": 0.166667,
+          "citation_coverage": 0.833333,
+          "context_anchor_coverage_at_5": 0.833333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "cs_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.5,
+              "ndcg_at_10": 0.63093,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:confusable_dense:2",
+              "confusable_sections:recursive_1000_o100:north_program:2",
+              "confusable_sections:recursive_1000_o100:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "cs_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.2,
+              "ndcg_at_10": 0.386853,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:confusable_dense:2",
+              "confusable_sections:recursive_1000_o100:confusable_dense:3",
+              "confusable_sections:recursive_1000_o100:south_program:4"
+            ]
+          },
+          {
+            "case_id": "cs_region",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:south_program:6",
+              "confusable_sections:recursive_1000_o100:north_program:6",
+              "confusable_sections:recursive_1000_o100:confusable_dense:2"
+            ]
+          },
+          {
+            "case_id": "cs_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.5,
+              "ndcg_at_10": 0.386853,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:confusable_dense:2",
+              "confusable_sections:recursive_1000_o100:north_program:4",
+              "confusable_sections:recursive_1000_o100:north_program:8"
+            ]
+          },
+          {
+            "case_id": "cs_negative",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:confusable_dense:3",
+              "confusable_sections:recursive_1000_o100:confusable_dense:2",
+              "confusable_sections:recursive_1000_o100:south_program:6"
+            ]
+          },
+          {
+            "case_id": "cs_dense",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.25,
+              "ndcg_at_10": 0.430677,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:harbor_report:7",
+              "confusable_sections:recursive_1000_o100:north_program:6",
+              "confusable_sections:recursive_1000_o100:harbor_dense:3"
+            ]
+          },
+          {
+            "case_id": "cs_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:confusable_dense:3",
+              "confusable_sections:recursive_1000_o100:confusable_dense:2",
+              "confusable_sections:recursive_1000_o100:south_program:4"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "confusable_sections",
+        "config_id": "recursive_1000_o100",
+        "strategy": "recursive_character",
+        "mode": "vector",
+        "top_k": 10,
+        "retrieval_core_p95_ms": 6.536,
+        "metrics": {
+          "recall_at_5": 0.833333,
+          "mrr_at_10": 0.432143,
+          "ndcg_at_10": 0.528108,
+          "citation_hit_rate": 0.1,
+          "citation_coverage": 1,
+          "context_anchor_coverage_at_5": 0.833333,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "cs_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.5,
+              "ndcg_at_10": 0.63093,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:confusable_dense:2",
+              "confusable_sections:recursive_1000_o100:north_program:2",
+              "confusable_sections:recursive_1000_o100:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "cs_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.2,
+              "ndcg_at_10": 0.386853,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:confusable_dense:2",
+              "confusable_sections:recursive_1000_o100:confusable_dense:3",
+              "confusable_sections:recursive_1000_o100:south_program:4"
+            ]
+          },
+          {
+            "case_id": "cs_region",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:south_program:6",
+              "confusable_sections:recursive_1000_o100:north_program:6",
+              "confusable_sections:recursive_1000_o100:confusable_dense:2"
+            ]
+          },
+          {
+            "case_id": "cs_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.5,
+              "ndcg_at_10": 0.386853,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:confusable_dense:2",
+              "confusable_sections:recursive_1000_o100:north_program:4",
+              "confusable_sections:recursive_1000_o100:north_program:8"
+            ]
+          },
+          {
+            "case_id": "cs_negative",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0.142857,
+              "ndcg_at_10": 0.333333,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:confusable_dense:3",
+              "confusable_sections:recursive_1000_o100:confusable_dense:2",
+              "confusable_sections:recursive_1000_o100:south_program:6"
+            ]
+          },
+          {
+            "case_id": "cs_dense",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.25,
+              "ndcg_at_10": 0.430677,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:harbor_report:7",
+              "confusable_sections:recursive_1000_o100:north_program:6",
+              "confusable_sections:recursive_1000_o100:harbor_dense:3"
+            ]
+          },
+          {
+            "case_id": "cs_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:confusable_dense:3",
+              "confusable_sections:recursive_1000_o100:confusable_dense:2",
+              "confusable_sections:recursive_1000_o100:south_program:4"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "confusable_sections",
+        "config_id": "recursive_1000_o100",
+        "strategy": "recursive_character",
+        "mode": "hybrid",
+        "top_k": 5,
+        "retrieval_core_p95_ms": 9.828,
+        "metrics": {
+          "recall_at_5": 1,
+          "mrr_at_10": 0.583333,
+          "ndcg_at_10": 0.646523,
+          "citation_hit_rate": 0.2,
+          "citation_coverage": 1,
+          "context_anchor_coverage_at_5": 1,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "cs_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:north_program:2",
+              "confusable_sections:recursive_1000_o100:confusable_dense:2",
+              "confusable_sections:recursive_1000_o100:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "cs_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.25,
+              "ndcg_at_10": 0.430677,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:confusable_dense:2",
+              "confusable_sections:recursive_1000_o100:south_program:4",
+              "confusable_sections:recursive_1000_o100:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "cs_region",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:south_program:6",
+              "confusable_sections:recursive_1000_o100:north_program:6",
+              "confusable_sections:recursive_1000_o100:confusable_dense:2"
+            ]
+          },
+          {
+            "case_id": "cs_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.5,
+              "ndcg_at_10": 0.386853,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:confusable_dense:2",
+              "confusable_sections:recursive_1000_o100:north_program:4",
+              "confusable_sections:recursive_1000_o100:north_program:2"
+            ]
+          },
+          {
+            "case_id": "cs_negative",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.25,
+              "ndcg_at_10": 0.430677,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:confusable_dense:3",
+              "confusable_sections:recursive_1000_o100:confusable_dense:2",
+              "confusable_sections:recursive_1000_o100:south_program:6"
+            ]
+          },
+          {
+            "case_id": "cs_dense",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.5,
+              "ndcg_at_10": 0.63093,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:north_program:6",
+              "confusable_sections:recursive_1000_o100:confusable_dense:3",
+              "confusable_sections:recursive_1000_o100:harbor_dense:3"
+            ]
+          },
+          {
+            "case_id": "cs_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:confusable_dense:3",
+              "confusable_sections:recursive_1000_o100:south_program:4",
+              "confusable_sections:recursive_1000_o100:confusable_dense:2"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "confusable_sections",
+        "config_id": "recursive_1000_o100",
+        "strategy": "recursive_character",
+        "mode": "hybrid",
+        "top_k": 10,
+        "retrieval_core_p95_ms": 10.247,
+        "metrics": {
+          "recall_at_5": 1,
+          "mrr_at_10": 0.583333,
+          "ndcg_at_10": 0.646523,
+          "citation_hit_rate": 0.1,
+          "citation_coverage": 1,
+          "context_anchor_coverage_at_5": 1,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "cs_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:north_program:2",
+              "confusable_sections:recursive_1000_o100:confusable_dense:2",
+              "confusable_sections:recursive_1000_o100:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "cs_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.25,
+              "ndcg_at_10": 0.430677,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:confusable_dense:2",
+              "confusable_sections:recursive_1000_o100:south_program:4",
+              "confusable_sections:recursive_1000_o100:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "cs_region",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:south_program:6",
+              "confusable_sections:recursive_1000_o100:north_program:6",
+              "confusable_sections:recursive_1000_o100:confusable_dense:2"
+            ]
+          },
+          {
+            "case_id": "cs_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.5,
+              "ndcg_at_10": 0.386853,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:confusable_dense:2",
+              "confusable_sections:recursive_1000_o100:north_program:4",
+              "confusable_sections:recursive_1000_o100:north_program:2"
+            ]
+          },
+          {
+            "case_id": "cs_negative",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.25,
+              "ndcg_at_10": 0.430677,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:confusable_dense:3",
+              "confusable_sections:recursive_1000_o100:confusable_dense:2",
+              "confusable_sections:recursive_1000_o100:south_program:6"
+            ]
+          },
+          {
+            "case_id": "cs_dense",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.5,
+              "ndcg_at_10": 0.63093,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:north_program:6",
+              "confusable_sections:recursive_1000_o100:confusable_dense:3",
+              "confusable_sections:recursive_1000_o100:harbor_dense:3"
+            ]
+          },
+          {
+            "case_id": "cs_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:recursive_1000_o100:confusable_dense:3",
+              "confusable_sections:recursive_1000_o100:south_program:4",
+              "confusable_sections:recursive_1000_o100:confusable_dense:2"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "confusable_sections",
+        "config_id": "parent_child_2400_600",
+        "strategy": "parent_child",
+        "mode": "fulltext",
+        "top_k": 5,
+        "retrieval_core_p95_ms": 4.763,
+        "metrics": {
+          "recall_at_5": 1,
+          "mrr_at_10": 1,
+          "ndcg_at_10": 0.935524,
+          "citation_hit_rate": 0.2,
+          "citation_coverage": 1,
+          "context_anchor_coverage_at_5": 1,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "cs_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:north_program:2",
+              "confusable_sections:parent_child_2400_600:south_program:2",
+              "confusable_sections:parent_child_2400_600:confusable_dense:2"
+            ]
+          },
+          {
+            "case_id": "cs_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:north_program:6",
+              "confusable_sections:parent_child_2400_600:south_program:4",
+              "confusable_sections:parent_child_2400_600:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "cs_region",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:south_program:6",
+              "confusable_sections:parent_child_2400_600:north_program:6",
+              "confusable_sections:parent_child_2400_600:south_program:4"
+            ]
+          },
+          {
+            "case_id": "cs_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 0.613147,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:north_program:4",
+              "confusable_sections:parent_child_2400_600:confusable_dense:3",
+              "confusable_sections:parent_child_2400_600:north_program:2"
+            ]
+          },
+          {
+            "case_id": "cs_negative",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:north_program:8",
+              "confusable_sections:parent_child_2400_600:gateway_codes:4",
+              "confusable_sections:parent_child_2400_600:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "cs_dense",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:confusable_dense:4",
+              "confusable_sections:parent_child_2400_600:north_program:6",
+              "confusable_sections:parent_child_2400_600:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "cs_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:south_program:4",
+              "confusable_sections:parent_child_2400_600:north_program:6",
+              "confusable_sections:parent_child_2400_600:confusable_dense:4"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "confusable_sections",
+        "config_id": "parent_child_2400_600",
+        "strategy": "parent_child",
+        "mode": "fulltext",
+        "top_k": 10,
+        "retrieval_core_p95_ms": 6.161,
+        "metrics": {
+          "recall_at_5": 1,
+          "mrr_at_10": 1,
+          "ndcg_at_10": 0.935524,
+          "citation_hit_rate": 0.1,
+          "citation_coverage": 1,
+          "context_anchor_coverage_at_5": 1,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "cs_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:north_program:2",
+              "confusable_sections:parent_child_2400_600:south_program:2",
+              "confusable_sections:parent_child_2400_600:confusable_dense:2"
+            ]
+          },
+          {
+            "case_id": "cs_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:north_program:6",
+              "confusable_sections:parent_child_2400_600:south_program:4",
+              "confusable_sections:parent_child_2400_600:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "cs_region",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:south_program:6",
+              "confusable_sections:parent_child_2400_600:north_program:6",
+              "confusable_sections:parent_child_2400_600:south_program:4"
+            ]
+          },
+          {
+            "case_id": "cs_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 0.613147,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:north_program:4",
+              "confusable_sections:parent_child_2400_600:confusable_dense:3",
+              "confusable_sections:parent_child_2400_600:north_program:2"
+            ]
+          },
+          {
+            "case_id": "cs_negative",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:north_program:8",
+              "confusable_sections:parent_child_2400_600:gateway_codes:4",
+              "confusable_sections:parent_child_2400_600:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "cs_dense",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:confusable_dense:4",
+              "confusable_sections:parent_child_2400_600:north_program:6",
+              "confusable_sections:parent_child_2400_600:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "cs_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:south_program:4",
+              "confusable_sections:parent_child_2400_600:north_program:6",
+              "confusable_sections:parent_child_2400_600:confusable_dense:4"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "confusable_sections",
+        "config_id": "parent_child_2400_600",
+        "strategy": "parent_child",
+        "mode": "vector",
+        "top_k": 5,
+        "retrieval_core_p95_ms": 8.974,
+        "metrics": {
+          "recall_at_5": 0.5,
+          "mrr_at_10": 0.333333,
+          "ndcg_at_10": 0.336297,
+          "citation_hit_rate": 0.1,
+          "citation_coverage": 0.5,
+          "context_anchor_coverage_at_5": 0.666667,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "cs_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.5,
+              "ndcg_at_10": 0.63093,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:confusable_dense:2",
+              "confusable_sections:parent_child_2400_600:north_program:2",
+              "confusable_sections:parent_child_2400_600:confusable_dense:4"
+            ]
+          },
+          {
+            "case_id": "cs_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:confusable_dense:2",
+              "confusable_sections:parent_child_2400_600:confusable_dense:3",
+              "confusable_sections:parent_child_2400_600:south_program:4"
+            ]
+          },
+          {
+            "case_id": "cs_region",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:south_program:6",
+              "confusable_sections:parent_child_2400_600:north_program:6",
+              "confusable_sections:parent_child_2400_600:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "cs_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.5,
+              "ndcg_at_10": 0.386853,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:confusable_dense:2",
+              "confusable_sections:parent_child_2400_600:north_program:4",
+              "confusable_sections:parent_child_2400_600:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "cs_negative",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:confusable_dense:4",
+              "confusable_sections:parent_child_2400_600:confusable_dense:3",
+              "confusable_sections:parent_child_2400_600:harbor_dense:4"
+            ]
+          },
+          {
+            "case_id": "cs_dense",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0,
+              "ndcg_at_10": 0,
+              "citation_hit_rate": 0,
+              "citation_coverage": 0,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:confusable_dense:3",
+              "confusable_sections:parent_child_2400_600:harbor_report:7",
+              "confusable_sections:parent_child_2400_600:north_program:6"
+            ]
+          },
+          {
+            "case_id": "cs_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:confusable_dense:4",
+              "confusable_sections:parent_child_2400_600:south_program:4",
+              "confusable_sections:parent_child_2400_600:confusable_dense:2"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "confusable_sections",
+        "config_id": "parent_child_2400_600",
+        "strategy": "parent_child",
+        "mode": "vector",
+        "top_k": 10,
+        "retrieval_core_p95_ms": 7.437,
+        "metrics": {
+          "recall_at_5": 0.5,
+          "mrr_at_10": 0.405556,
+          "ndcg_at_10": 0.50321,
+          "citation_hit_rate": 0.1,
+          "citation_coverage": 1,
+          "context_anchor_coverage_at_5": 0.666667,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "cs_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.5,
+              "ndcg_at_10": 0.63093,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:confusable_dense:2",
+              "confusable_sections:parent_child_2400_600:north_program:2",
+              "confusable_sections:parent_child_2400_600:confusable_dense:4"
+            ]
+          },
+          {
+            "case_id": "cs_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0.166667,
+              "ndcg_at_10": 0.356207,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:confusable_dense:2",
+              "confusable_sections:parent_child_2400_600:confusable_dense:3",
+              "confusable_sections:parent_child_2400_600:south_program:4"
+            ]
+          },
+          {
+            "case_id": "cs_region",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:south_program:6",
+              "confusable_sections:parent_child_2400_600:north_program:6",
+              "confusable_sections:parent_child_2400_600:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "cs_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.5,
+              "ndcg_at_10": 0.386853,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:confusable_dense:2",
+              "confusable_sections:parent_child_2400_600:north_program:4",
+              "confusable_sections:parent_child_2400_600:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "cs_negative",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0.1,
+              "ndcg_at_10": 0.289065,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 0
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:confusable_dense:4",
+              "confusable_sections:parent_child_2400_600:confusable_dense:3",
+              "confusable_sections:parent_child_2400_600:harbor_dense:4"
+            ]
+          },
+          {
+            "case_id": "cs_dense",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 0,
+              "mrr_at_10": 0.166667,
+              "ndcg_at_10": 0.356207,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:confusable_dense:3",
+              "confusable_sections:parent_child_2400_600:harbor_report:7",
+              "confusable_sections:parent_child_2400_600:north_program:6"
+            ]
+          },
+          {
+            "case_id": "cs_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:confusable_dense:4",
+              "confusable_sections:parent_child_2400_600:south_program:4",
+              "confusable_sections:parent_child_2400_600:confusable_dense:2"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "confusable_sections",
+        "config_id": "parent_child_2400_600",
+        "strategy": "parent_child",
+        "mode": "hybrid",
+        "top_k": 5,
+        "retrieval_core_p95_ms": 9.297,
+        "metrics": {
+          "recall_at_5": 1,
+          "mrr_at_10": 0.547222,
+          "ndcg_at_10": 0.593601,
+          "citation_hit_rate": 0.2,
+          "citation_coverage": 1,
+          "context_anchor_coverage_at_5": 1,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "cs_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.5,
+              "ndcg_at_10": 0.63093,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:confusable_dense:2",
+              "confusable_sections:parent_child_2400_600:north_program:2",
+              "confusable_sections:parent_child_2400_600:confusable_dense:4"
+            ]
+          },
+          {
+            "case_id": "cs_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.25,
+              "ndcg_at_10": 0.430677,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:confusable_dense:3",
+              "confusable_sections:parent_child_2400_600:south_program:4",
+              "confusable_sections:parent_child_2400_600:confusable_dense:2"
+            ]
+          },
+          {
+            "case_id": "cs_region",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:south_program:6",
+              "confusable_sections:parent_child_2400_600:north_program:6",
+              "confusable_sections:parent_child_2400_600:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "cs_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 0.613147,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:north_program:4",
+              "confusable_sections:parent_child_2400_600:confusable_dense:2",
+              "confusable_sections:parent_child_2400_600:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "cs_negative",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.2,
+              "ndcg_at_10": 0.386853,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:confusable_dense:4",
+              "confusable_sections:parent_child_2400_600:confusable_dense:3",
+              "confusable_sections:parent_child_2400_600:south_program:6"
+            ]
+          },
+          {
+            "case_id": "cs_dense",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.333333,
+              "ndcg_at_10": 0.5,
+              "citation_hit_rate": 0.2,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:confusable_dense:3",
+              "confusable_sections:parent_child_2400_600:north_program:6",
+              "confusable_sections:parent_child_2400_600:confusable_dense:4"
+            ]
+          },
+          {
+            "case_id": "cs_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:confusable_dense:4",
+              "confusable_sections:parent_child_2400_600:south_program:4",
+              "confusable_sections:parent_child_2400_600:confusable_dense:3"
+            ]
+          }
+        ]
+      },
+      {
+        "corpus_id": "confusable_sections",
+        "config_id": "parent_child_2400_600",
+        "strategy": "parent_child",
+        "mode": "hybrid",
+        "top_k": 10,
+        "retrieval_core_p95_ms": 10.228,
+        "metrics": {
+          "recall_at_5": 1,
+          "mrr_at_10": 0.547222,
+          "ndcg_at_10": 0.593601,
+          "citation_hit_rate": 0.1,
+          "citation_coverage": 1,
+          "context_anchor_coverage_at_5": 1,
+          "no_result_accuracy": 0,
+          "false_positive_rate": 1,
+          "positive_cases": 6,
+          "no_result_cases": 1
+        },
+        "cases": [
+          {
+            "case_id": "cs_fact",
+            "query_type": "fact",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.5,
+              "ndcg_at_10": 0.63093,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:confusable_dense:2",
+              "confusable_sections:parent_child_2400_600:north_program:2",
+              "confusable_sections:parent_child_2400_600:confusable_dense:4"
+            ]
+          },
+          {
+            "case_id": "cs_confusable",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.25,
+              "ndcg_at_10": 0.430677,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:confusable_dense:3",
+              "confusable_sections:parent_child_2400_600:south_program:4",
+              "confusable_sections:parent_child_2400_600:confusable_dense:2"
+            ]
+          },
+          {
+            "case_id": "cs_region",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 1,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:south_program:6",
+              "confusable_sections:parent_child_2400_600:north_program:6",
+              "confusable_sections:parent_child_2400_600:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "cs_context",
+            "query_type": "section_context",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 1,
+              "ndcg_at_10": 0.613147,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:north_program:4",
+              "confusable_sections:parent_child_2400_600:confusable_dense:2",
+              "confusable_sections:parent_child_2400_600:confusable_dense:3"
+            ]
+          },
+          {
+            "case_id": "cs_negative",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.2,
+              "ndcg_at_10": 0.386853,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:confusable_dense:4",
+              "confusable_sections:parent_child_2400_600:confusable_dense:3",
+              "confusable_sections:parent_child_2400_600:south_program:6"
+            ]
+          },
+          {
+            "case_id": "cs_dense",
+            "query_type": "confusable",
+            "expected_no_result": false,
+            "metrics": {
+              "recall_at_5": 1,
+              "mrr_at_10": 0.333333,
+              "ndcg_at_10": 0.5,
+              "citation_hit_rate": 0.1,
+              "citation_coverage": 1,
+              "context_anchor_coverage_at_5": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:confusable_dense:3",
+              "confusable_sections:parent_child_2400_600:north_program:6",
+              "confusable_sections:parent_child_2400_600:confusable_dense:4"
+            ]
+          },
+          {
+            "case_id": "cs_none",
+            "query_type": "no_answer",
+            "expected_no_result": true,
+            "metrics": {
+              "no_result_accuracy": 0,
+              "false_positive_rate": 1
+            },
+            "top_chunk_ids": [
+              "confusable_sections:parent_child_2400_600:confusable_dense:4",
+              "confusable_sections:parent_child_2400_600:south_program:4",
+              "confusable_sections:parent_child_2400_600:confusable_dense:3"
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/docs/research/rag-strategy/fixtures.json
+++ b/docs/research/rag-strategy/fixtures.json
@@ -1,0 +1,774 @@
+{
+  "schema_version": 1,
+  "license": "ModelMirror project-authored synthetic research data",
+  "corpora": [
+    {
+      "corpus_id": "long_policy",
+      "title": "Long policy and procedure manual",
+      "documents": [
+        {
+          "document_key": "continuity_manual",
+          "name": "业务连续性与变更控制手册.md",
+          "text": "# 业务连续性总则\n\n本手册适用于北辰平台的生产变更、灾备演练和紧急恢复。所有常规变更必须在发布窗口前完成风险登记。\n\n## 常规变更\n\n常规变更需要服务负责人和当班运维双人批准。批准记录保留十二个月，实施前必须完成回滚检查。普通数据库索引调整归入常规变更，不得使用紧急口令。\n\n## 紧急变更\n\n只有影响核心交易且无法等待常规窗口时才可启动紧急变更。紧急授权口令为 ORION-742，口令只能由值班经理在事件频道中确认。使用口令后必须在二十四小时内补交复盘。\n\n## 冷静期\n\n高风险网络策略变更通过审批后仍需等待七十二小时，等待期称为冷静期。安全负责人可以延长冷静期，但不能缩短。演练环境不适用该规则。\n\n## 灾备切换\n\n主站不可用超过十五分钟时，值班经理可以发起 Boreal 流程。Boreal 流程要求先冻结写入，再验证副本延迟低于三十秒，最后切换只读流量。\n\n## 恢复与回切\n\n主站恢复后使用 Mistral 流程回切。Mistral 要求连续观察四十五分钟，并由数据库负责人确认校验和一致。Boreal 的十五分钟触发条件不得用于 Mistral。\n\n## 审计与例外\n\n审计人员每季度抽查十个变更。任何例外都必须关联事件编号、批准人和到期日；没有到期日的例外视为无效。"
+        },
+        {
+          "document_key": "vendor_manual",
+          "name": "供应商访问附录.md",
+          "text": "# 供应商访问\n\n外部供应商只能通过临时账号进入测试环境。账号默认有效八小时，不得访问生产数据库。\n\n## 续期\n\n供应商账号续期需要项目经理批准，每次最多延长四小时。紧急变更口令不适用于账号续期。\n\n## 证据\n\n访问日志保存九十天，屏幕录像保存三十天。发现共享账号时必须立即停用并通知安全团队。"
+        },
+        {
+          "document_key": "policy_dense",
+          "name": "跨区域恢复长段落.md",
+          "text": "# 跨区域恢复补充规则",
+          "append_blocks": [
+            {
+              "heading": "组合审批长段落",
+              "segments": [
+                "跨区域恢复首先由来源区域提交容量证明，容量证明必须覆盖未来六小时的峰值流量。",
+                "目标区域收到证明后核验复制延迟，延迟超过四十秒时只能进入只读准备状态。",
+                "只读准备状态不允许执行账号迁移，也不能提前释放来源区域的写锁。",
+                "网络团队随后检查东西向链路，链路丢包率连续五分钟低于百分之一才算通过。",
+                "数据库团队必须分别验证订单、账单和审计三个校验和，任何一个不一致都应终止。",
+                "缓存预热至少覆盖最近二十四小时的热点键，但不得复制已经吊销的会话。",
+                "完成预热后，值班经理发起百分之十的影子流量，并观察错误率十五分钟。",
+                "影子流量错误率高于千分之三时应回到只读准备状态，而不是继续扩大流量。",
+                "通过观察后可以依次扩大到百分之三十、百分之六十和百分之百。",
+                "每次扩大流量之间必须保留十分钟观察窗口，窗口不能合并。",
+                "客户通知由服务负责人发送，通知中只写影响范围和恢复时间，不包含内部口令。",
+                "安全团队在全量切换后重新签发临时凭据，并撤销来源区域的应急访问。",
+                "审计人员需要关联容量证明、链路报告、三个校验和与客户通知副本。",
+                "如果目标区域在观察期内出现磁盘告警，应立即停止扩大流量并保留现有读流量。",
+                "来源区域恢复后仍需保持一小时热备，之后才能释放灾备资源。",
+                "多区域恢复的唯一协调标识是 POLAR-318，其他事件口令不能替代该标识。",
+                "协调标识只用于关联证据，不赋予绕过审批、冷静期或审计的权限。",
+                "全部步骤完成后，值班经理、数据库负责人和安全负责人必须共同签署关闭记录。"
+              ]
+            }
+          ]
+        }
+      ],
+      "cases": [
+        {
+          "case_id": "lp_fact",
+          "query_type": "fact",
+          "query": "生产紧急变更使用什么授权口令？",
+          "anchors": [
+            {
+              "document_key": "continuity_manual",
+              "phrase": "紧急授权口令为 ORION-742"
+            }
+          ]
+        },
+        {
+          "case_id": "lp_paraphrase",
+          "query_type": "paraphrase",
+          "query": "高风险网络改动获批后，至少还要等多久才能实施？",
+          "anchors": [
+            {
+              "document_key": "continuity_manual",
+              "phrase": "仍需等待七十二小时"
+            }
+          ]
+        },
+        {
+          "case_id": "lp_context",
+          "query_type": "section_context",
+          "query": "Boreal 切换需要依次满足哪些操作和延迟条件？",
+          "anchors": [
+            {
+              "document_key": "continuity_manual",
+              "phrase": "先冻结写入，再验证副本延迟低于三十秒，最后切换只读流量"
+            }
+          ]
+        },
+        {
+          "case_id": "lp_confusable",
+          "query_type": "confusable",
+          "query": "回切主站时需要观察多久，使用哪个流程？",
+          "anchors": [
+            {
+              "document_key": "continuity_manual",
+              "phrase": "Mistral 要求连续观察四十五分钟"
+            }
+          ]
+        },
+        {
+          "case_id": "lp_multi",
+          "query_type": "multi_evidence",
+          "query": "对比供应商账号续期和高风险网络变更的最长延长时间与最短等待时间。",
+          "anchors": [
+            {
+              "document_key": "vendor_manual",
+              "phrase": "每次最多延长四小时"
+            },
+            {
+              "document_key": "continuity_manual",
+              "phrase": "仍需等待七十二小时"
+            }
+          ]
+        },
+        {
+          "case_id": "lp_dense",
+          "query_type": "section_context",
+          "query": "跨区域恢复用于关联全部证据、但不能绕过审批的协调标识是什么？",
+          "anchors": [
+            {
+              "document_key": "policy_dense",
+              "phrase": "唯一协调标识是 POLAR-318"
+            }
+          ]
+        },
+        {
+          "case_id": "lp_none",
+          "query_type": "no_answer",
+          "query": "手册规定月球差旅费用由谁报销？",
+          "anchors": [],
+          "expected_no_result": true
+        }
+      ]
+    },
+    {
+      "corpus_id": "short_faq",
+      "title": "Short independent FAQ entries",
+      "documents": [
+        {
+          "document_key": "account_faq",
+          "name": "账户常见问题.md",
+          "text": "# 账户常见问题\n\n## 如何重置密码？\n\n在登录页选择忘记密码，验证码十分钟内有效。连续请求三次后需等待一小时。\n\n## 如何修改邮箱？\n\n进入安全设置，验证旧邮箱后提交新邮箱。旧邮箱不可用时需要人工工单。\n\n## 如何导出数据？\n\n个人版可导出 JSON，团队版还可导出 CSV。导出链接有效二十四小时。\n\n## 如何关闭账户？\n\n关闭账户有十四天撤销期。撤销期结束后，公开资料先删除，备份在三十天内轮转清除。\n\n## 如何查看登录记录？\n\n安全设置显示最近九十天的登录记录，最多展示五百条。"
+        },
+        {
+          "document_key": "billing_faq",
+          "name": "计费常见问题.md",
+          "text": "# 计费常见问题\n\n## 发票何时生成？\n\n月度发票在次月第三个工作日生成。年度订阅在付款完成后立即生成。\n\n## 如何退款？\n\n首次购买七天内可申请退款，已消耗的按量费用不退。\n\n## 配额何时重置？\n\n月度配额在每个自然月第一天零点重置，未使用配额不结转。\n\n## 支持哪些币种？\n\n结算支持人民币、美元和欧元，显示币种不影响实际税率。"
+        }
+      ],
+      "cases": [
+        {
+          "case_id": "faq_fact",
+          "query_type": "fact",
+          "query": "密码重置验证码能用多久？",
+          "anchors": [
+            {
+              "document_key": "account_faq",
+              "phrase": "验证码十分钟内有效"
+            }
+          ]
+        },
+        {
+          "case_id": "faq_paraphrase",
+          "query_type": "paraphrase",
+          "query": "删除账号后反悔的窗口是多少天？",
+          "anchors": [
+            {
+              "document_key": "account_faq",
+              "phrase": "关闭账户有十四天撤销期"
+            }
+          ]
+        },
+        {
+          "case_id": "faq_exact",
+          "query_type": "exact_term",
+          "query": "团队版导出支持 CSV 吗？",
+          "anchors": [
+            {
+              "document_key": "account_faq",
+              "phrase": "团队版还可导出 CSV"
+            }
+          ]
+        },
+        {
+          "case_id": "faq_confusable",
+          "query_type": "confusable",
+          "query": "月度账单和年度订阅的发票分别何时生成？",
+          "anchors": [
+            {
+              "document_key": "billing_faq",
+              "phrase": "月度发票在次月第三个工作日生成"
+            },
+            {
+              "document_key": "billing_faq",
+              "phrase": "年度订阅在付款完成后立即生成"
+            }
+          ]
+        },
+        {
+          "case_id": "faq_context",
+          "query_type": "section_context",
+          "query": "账户关闭后公开资料和备份按什么顺序清理？",
+          "anchors": [
+            {
+              "document_key": "account_faq",
+              "phrase": "公开资料先删除，备份在三十天内轮转清除"
+            }
+          ]
+        },
+        {
+          "case_id": "faq_none",
+          "query_type": "no_answer",
+          "query": "FAQ 是否支持用比特币结算？",
+          "anchors": [],
+          "expected_no_result": true
+        }
+      ]
+    },
+    {
+      "corpus_id": "technical_ids",
+      "title": "Technical identifiers and exact codes",
+      "documents": [
+        {
+          "document_key": "gateway_codes",
+          "name": "Gateway error registry.md",
+          "text": "# Gateway Error Registry\n\n## GX-104\n\nGX-104 means the request signature timestamp is outside the accepted 90-second window. Refresh the client clock and sign the request again.\n\n## GX-140\n\nGX-140 means the tenant header is missing. Add X-Tenant-Ref but do not reuse the billing account identifier.\n\n## GX-401\n\nGX-401 indicates a revoked service token. Rotating only the request signature does not restore access; issue a new service token.\n\n## GX-410\n\nGX-410 indicates that an idempotency key was reused with a different payload. Preserve the original payload or create a new key.\n\n## Trace format\n\nTrace identifiers use the prefix trc_, followed by sixteen lowercase hexadecimal characters. Example: trc_91af04c220be771d."
+        },
+        {
+          "document_key": "device_codes",
+          "name": "设备型号与寄存器.md",
+          "text": "# 设备型号\n\nALP-9 是低温传感器，采样寄存器为 0x2A，校准寄存器为 0x2B。\n\nALP-90 是高温传感器，采样寄存器为 0x3A，校准寄存器为 0x3B。型号名称相近但寄存器不可互换。\n\nBET-9 是压力传感器，状态寄存器 0x7F 的第三位表示过载。\n\n固件升级命令是 fwctl apply --slot B；查询版本使用 fwctl inspect，不得把 inspect 当作升级操作。"
+        },
+        {
+          "document_key": "technical_dense",
+          "name": "Extended gateway diagnostics.md",
+          "text": "# Extended Gateway Diagnostics",
+          "append_blocks": [
+            {
+              "heading": "Dense diagnostic registry",
+              "segments": [
+                "GX-701 reports that the ingress queue is paused while a routing table is being replaced.",
+                "GX-702 reports a missing regional capability header and should not be confused with tenant identity.",
+                "GX-703 means the request body hash was calculated before content encoding was applied.",
+                "GX-704 identifies a stale certificate chain whose leaf certificate is still locally cached.",
+                "GX-705 indicates that the response envelope exceeded the negotiated compression window.",
+                "GX-706 means a retry arrived before the previous lease had reached its terminal state.",
+                "GX-707 records a shard map mismatch between the gateway and the catalog service.",
+                "GX-708 indicates that a trace identifier used uppercase hexadecimal characters.",
+                "GX-709 means the audit sink acknowledged the event but rejected its retention class.",
+                "GX-710 reports that a read-only token attempted to create a connection profile.",
+                "GX-711 identifies an unsupported locale in a signed metadata field.",
+                "GX-712 indicates that the client compressed a payload marked as identity encoding.",
+                "GX-713 reports that the replay cache has not finished loading after a regional restart.",
+                "GX-714 means the requested schema version predates the minimum compatibility floor.",
+                "GX-715 indicates that a batch contains two records with the same operation identifier.",
+                "GX-716 reports that a callback URL changed after the authorization challenge began.",
+                "GX-717 identifies an attempt to mix sandbox and production workspace identifiers.",
+                "GX-718 means the gateway could not verify the declared content length after decoding.",
+                "GX-777 is the only code for a routing lease that was accepted but never activated.",
+                "For GX-777, operators must release lease amber-17 before creating a replacement lease."
+              ]
+            }
+          ]
+        }
+      ],
+      "cases": [
+        {
+          "case_id": "tid_fact",
+          "query_type": "exact_term",
+          "query": "What does GX-410 mean?",
+          "anchors": [
+            {
+              "document_key": "gateway_codes",
+              "phrase": "an idempotency key was reused with a different payload"
+            }
+          ]
+        },
+        {
+          "case_id": "tid_action",
+          "query_type": "fact",
+          "query": "GX-401 能否只通过重新签名恢复？",
+          "anchors": [
+            {
+              "document_key": "gateway_codes",
+              "phrase": "issue a new service token"
+            }
+          ]
+        },
+        {
+          "case_id": "tid_confusable",
+          "query_type": "confusable",
+          "query": "ALP-90 的采样寄存器是什么？",
+          "anchors": [
+            {
+              "document_key": "device_codes",
+              "phrase": "ALP-90 是高温传感器，采样寄存器为 0x3A"
+            }
+          ]
+        },
+        {
+          "case_id": "tid_format",
+          "query_type": "fact",
+          "query": "Give the required trace identifier prefix and suffix length.",
+          "anchors": [
+            {
+              "document_key": "gateway_codes",
+              "phrase": "prefix trc_, followed by sixteen lowercase hexadecimal characters"
+            }
+          ]
+        },
+        {
+          "case_id": "tid_command",
+          "query_type": "exact_term",
+          "query": "Which command applies firmware to slot B?",
+          "anchors": [
+            {
+              "document_key": "device_codes",
+              "phrase": "fwctl apply --slot B"
+            }
+          ]
+        },
+        {
+          "case_id": "tid_dense",
+          "query_type": "confusable",
+          "query": "Which lease must operators release when error GX-777 occurs?",
+          "anchors": [
+            {
+              "document_key": "technical_dense",
+              "phrase": "release lease amber-17"
+            }
+          ]
+        },
+        {
+          "case_id": "tid_none",
+          "query_type": "no_answer",
+          "query": "What does error GX-999 mean?",
+          "anchors": [],
+          "expected_no_result": true
+        }
+      ]
+    },
+    {
+      "corpus_id": "bilingual_narrative",
+      "title": "Bilingual narrative and cross-language retrieval",
+      "documents": [
+        {
+          "document_key": "harbor_report",
+          "name": "Harbor restoration report.md",
+          "text": "# Harbor Restoration Report\n\nThe Lumen Harbor project began after the eastern breakwater was damaged by winter storms. Engineers selected basalt blocks from Quarry Seven because laboratory tests showed low salt absorption.\n\n## Schedule\n\nThe first closure window starts on 18 September and lasts eleven nights. Fishing boats may use the western channel during daylight hours.\n\n## Monitoring\n\nA yellow buoy named Kestrel records wave height every six minutes. If the rolling average exceeds 2.4 meters, crane work pauses automatically.\n\n## Community notice\n\nResidents asked for quieter work near the old lighthouse. The project therefore prohibits pile driving between 21:00 and 07:00."
+        },
+        {
+          "document_key": "harbor_cn",
+          "name": "港口修复中文简报.md",
+          "text": "# 港口修复中文简报\n\nLumen 港东侧防波堤因冬季风暴受损。工程团队选用七号采石场的玄武岩，原因是实验显示其盐分吸收率较低。\n\n## 航道安排\n\n首次封闭窗口从九月十八日开始，共持续十一个夜晚。渔船白天可以使用西侧航道。\n\n## 波浪监测\n\n名为 Kestrel 的黄色浮标每六分钟记录一次浪高。滚动平均值超过 2.4 米时，起重机作业自动暂停。\n\n## 社区约束\n\n老灯塔附近在晚上九点至早上七点之间禁止打桩，以降低对居民的噪声影响。"
+        },
+        {
+          "document_key": "harbor_dense",
+          "name": "Western channel field journal.md",
+          "text": "# Western Channel Field Journal",
+          "append_blocks": [
+            {
+              "heading": "Long bilingual context source",
+              "segments": [
+                "Survey teams began at the southern marker before sunrise and recorded the tide against the temporary gauge.",
+                "The northern marker was inspected later because a maintenance vessel occupied the approach lane.",
+                "Crews logged seabed samples in sealed grey boxes and photographed every label before transport.",
+                "Samples from shallow water contained shell fragments, while deeper samples were mostly fine sand.",
+                "A separate acoustic pass measured traffic noise during the morning ferry schedule.",
+                "The acoustic instruments were calibrated against the lighthouse clock at 06:30 local time.",
+                "Engineers used orange flags for temporary exclusions and white flags for completed survey lines.",
+                "No dredging was authorized during this survey, even where sediment depth exceeded the planning estimate.",
+                "The weather station reported stable pressure but a rising crosswind after midday.",
+                "Workboats moved to the sheltered berth when the crosswind exceeded the local handling limit.",
+                "The environmental observer recorded two seal sightings outside the active work boundary.",
+                "Both sightings paused sonar transmission for ten minutes but did not stop visual inspection.",
+                "A paper register was kept as a fallback when the mobile network briefly lost coverage.",
+                "The register used blue ink for verified entries and red ink for measurements awaiting review.",
+                "At the end of each shift, the supervisor reconciled the paper register with the digital log.",
+                "The final cross-language handover is identified as the Blue Ledger protocol.",
+                "Under the Blue Ledger protocol, unresolved red entries must be translated and reviewed before the next crew starts.",
+                "The protocol name describes the handover process and does not authorize navigation or dredging."
+              ]
+            }
+          ]
+        }
+      ],
+      "cases": [
+        {
+          "case_id": "bi_en_to_cn",
+          "query_type": "cross_language",
+          "query": "哪一个采石场提供了低盐吸收率的石料？",
+          "anchors": [
+            {
+              "document_key": "harbor_report",
+              "phrase": "basalt blocks from Quarry Seven"
+            }
+          ]
+        },
+        {
+          "case_id": "bi_cn_to_en",
+          "query_type": "cross_language",
+          "query": "When does the first harbor closure begin, and how long does it last?",
+          "anchors": [
+            {
+              "document_key": "harbor_cn",
+              "phrase": "从九月十八日开始，共持续十一个夜晚"
+            }
+          ]
+        },
+        {
+          "case_id": "bi_fact",
+          "query_type": "fact",
+          "query": "Kestrel 多久记录一次浪高？",
+          "anchors": [
+            {
+              "document_key": "harbor_cn",
+              "phrase": "每六分钟记录一次浪高"
+            }
+          ]
+        },
+        {
+          "case_id": "bi_threshold",
+          "query_type": "paraphrase",
+          "query": "At what wave condition must crane operations stop?",
+          "anchors": [
+            {
+              "document_key": "harbor_report",
+              "phrase": "rolling average exceeds 2.4 meters"
+            }
+          ]
+        },
+        {
+          "case_id": "bi_context",
+          "query_type": "section_context",
+          "query": "What daytime alternative remains available while the closure is in effect?",
+          "anchors": [
+            {
+              "document_key": "harbor_report",
+              "phrase": "Fishing boats may use the western channel during daylight hours"
+            }
+          ]
+        },
+        {
+          "case_id": "bi_dense",
+          "query_type": "cross_language",
+          "query": "交接时，哪一项流程要求先翻译并复核尚未解决的红色记录？",
+          "anchors": [
+            {
+              "document_key": "harbor_dense",
+              "phrase": "Under the Blue Ledger protocol"
+            }
+          ]
+        },
+        {
+          "case_id": "bi_none",
+          "query_type": "no_answer",
+          "query": "Which company supplies electric ferries for Lumen Harbor?",
+          "anchors": [],
+          "expected_no_result": true
+        }
+      ]
+    },
+    {
+      "corpus_id": "tables_code",
+      "title": "Markdown tables and code blocks",
+      "documents": [
+        {
+          "document_key": "limits_table",
+          "name": "Service limits.md",
+          "text": "# Service Limits\n\n| Plan | Requests per minute | Burst | Retention |\n| --- | ---: | ---: | ---: |\n| Cedar | 120 | 30 | 7 days |\n| Juniper | 480 | 90 | 30 days |\n| Sequoia | 900 | 150 | 90 days |\n\nLimits are applied per workspace, not per API key. A burst does not increase the sustained requests-per-minute allowance.\n\n## Export limits\n\n| Format | Maximum rows | Compression |\n| JSONL | 250000 | gzip |\n| CSV | 100000 | zip |\n| Parquet | 1000000 | snappy |"
+        },
+        {
+          "document_key": "sdk_config",
+          "name": "SDK configuration.md",
+          "text": "# SDK Configuration\n\nUse the following configuration for deterministic retries:\n\n```python\nclient = MirrorClient(\n    retry_limit=4,\n    backoff_seconds=[1, 2, 5, 10],\n    idempotency_header=\"X-Mirror-Once\",\n)\n```\n\nThe retry_limit counts retries after the initial attempt. Validation errors are never retried.\n\n## JavaScript\n\n```javascript\nconst client = new MirrorClient({\n  retryLimit: 4,\n  requestTimeoutMs: 18000,\n  idempotencyHeader: 'X-Mirror-Once'\n});\n```\n\nThe browser build ignores proxy environment variables."
+        },
+        {
+          "document_key": "code_dense",
+          "name": "Archival worker configuration.md",
+          "text": "# Archival Worker Configuration",
+          "append_blocks": [
+            {
+              "heading": "Complete local configuration",
+              "kind": "code",
+              "lines": [
+                "worker_name = archival_delta",
+                "queue_name = cold_records",
+                "reader_threads = 3",
+                "writer_threads = 2",
+                "scan_interval_seconds = 45",
+                "lease_timeout_seconds = 180",
+                "retry_limit = 5",
+                "retry_backoff_seconds = 8",
+                "checkpoint_every_rows = 5000",
+                "source_format = jsonl",
+                "source_compression = gzip",
+                "destination_format = parquet",
+                "destination_compression = snappy",
+                "partition_field = event_date",
+                "partition_timezone = UTC",
+                "minimum_partition_age_hours = 36",
+                "maximum_open_partitions = 12",
+                "manifest_mode = append_only",
+                "manifest_checksum = sha256",
+                "verify_after_write = true",
+                "delete_source_after_verify = false",
+                "metrics_interval_seconds = 15",
+                "warning_threshold_rows = 900000",
+                "abort_threshold_rows = 1200000",
+                "archive_batch_size = 173",
+                "archive_batch_jitter = 11",
+                "dead_letter_queue = cold_records_failed",
+                "dead_letter_retention_days = 21",
+                "operator_notice_channel = archival_ops",
+                "configuration_marker = CFG-ARCHIVE-62"
+              ]
+            }
+          ]
+        }
+      ],
+      "cases": [
+        {
+          "case_id": "tc_table",
+          "query_type": "table",
+          "query": "What are the Juniper burst limit and retention period?",
+          "anchors": [
+            {
+              "document_key": "limits_table",
+              "phrase": "| Juniper | 480 | 90 | 30 days |"
+            }
+          ]
+        },
+        {
+          "case_id": "tc_table_confusable",
+          "query_type": "confusable",
+          "query": "Which plan permits 900 sustained requests per minute?",
+          "anchors": [
+            {
+              "document_key": "limits_table",
+              "phrase": "| Sequoia | 900 | 150 | 90 days |"
+            }
+          ]
+        },
+        {
+          "case_id": "tc_code",
+          "query_type": "code",
+          "query": "What Python retry schedule is configured?",
+          "anchors": [
+            {
+              "document_key": "sdk_config",
+              "phrase": "backoff_seconds=[1, 2, 5, 10]"
+            }
+          ]
+        },
+        {
+          "case_id": "tc_semantics",
+          "query_type": "section_context",
+          "query": "Does retry_limit=4 mean four total attempts or four retries after the first attempt?",
+          "anchors": [
+            {
+              "document_key": "sdk_config",
+              "phrase": "counts retries after the initial attempt"
+            }
+          ]
+        },
+        {
+          "case_id": "tc_exact",
+          "query_type": "exact_term",
+          "query": "Which idempotency header is shared by both SDK examples?",
+          "anchors": [
+            {
+              "document_key": "sdk_config",
+              "phrase": "X-Mirror-Once"
+            }
+          ]
+        },
+        {
+          "case_id": "tc_dense",
+          "query_type": "code",
+          "query": "What archive batch size is paired with configuration marker CFG-ARCHIVE-62?",
+          "anchors": [
+            {
+              "document_key": "code_dense",
+              "phrase": "archive_batch_size = 173"
+            }
+          ]
+        },
+        {
+          "case_id": "tc_none",
+          "query_type": "no_answer",
+          "query": "What XML export row limit is configured?",
+          "anchors": [],
+          "expected_no_result": true
+        }
+      ]
+    },
+    {
+      "corpus_id": "confusable_sections",
+      "title": "Highly similar and conflicting sections",
+      "documents": [
+        {
+          "document_key": "north_program",
+          "name": "North region programs.md",
+          "text": "# North Region Programs\n\n## Aurora Basic\n\nAurora Basic renews on the first Monday of each quarter. It includes 14 analyst seats and stores reports for 45 days. Support hours are 08:00-17:00 UTC.\n\n## Aurora Plus\n\nAurora Plus renews on the second Monday of each quarter. It includes 41 analyst seats and stores reports for 54 days. Support hours are 07:00-19:00 UTC.\n\n## Aurora Plus exception\n\nFor the North research unit only, Aurora Plus uses contract marker N-PLUS-88 and allows a 6-hour emergency extension. This exception expires on 30 November 2028.\n\n## Borealis Plus\n\nBorealis Plus renews on the second Tuesday of each quarter. It includes 41 operator seats and stores reports for 54 days. It is not an Aurora plan."
+        },
+        {
+          "document_key": "south_program",
+          "name": "South region programs.md",
+          "text": "# South Region Programs\n\n## Aurora Basic\n\nAurora Basic renews on the first Tuesday of each quarter. It includes 14 analyst seats and stores reports for 45 days. Support hours are 09:00-18:00 UTC.\n\n## Aurora Plus\n\nAurora Plus renews on the second Monday of each quarter. It includes 41 analyst seats and stores reports for 54 days. The South contract marker is S-PLUS-61.\n\n## Extension policy\n\nSouth Aurora Plus permits a 4-hour emergency extension after regional approval. The extension does not apply to Borealis Plus."
+        },
+        {
+          "document_key": "confusable_dense",
+          "name": "Aurora regional comparison notes.md",
+          "text": "# Aurora Regional Comparison Notes",
+          "append_blocks": [
+            {
+              "heading": "Dense comparison paragraph",
+              "segments": [
+                "North Aurora Basic uses a Monday renewal, while South Aurora Basic uses a Tuesday renewal.",
+                "North Aurora Plus and South Aurora Plus both renew on the second Monday but use different approval records.",
+                "North Aurora Plus stores reports for 54 days, and South Aurora Plus also stores reports for 54 days.",
+                "North Aurora Basic stores reports for 45 days, matching the retention of South Aurora Basic.",
+                "Borealis Plus has 41 operator seats, while both Aurora Plus variants have 41 analyst seats.",
+                "The North basic support window starts one hour earlier than the South basic support window.",
+                "The North plus support window is wider than either basic support window.",
+                "Only the North research unit receives a six-hour extension under its local exception.",
+                "The South extension is four hours and requires a separate regional approval record.",
+                "Neither extension changes report retention or the quarterly renewal day.",
+                "Borealis Plus cannot inherit an Aurora extension even when its seat count is numerically similar.",
+                "The North marker N-PLUS-88 and South marker S-PLUS-61 identify different contracts.",
+                "A support schedule must be read together with its region and plan tier to avoid a false match.",
+                "A retention value alone is insufficient because several plans share 45-day or 54-day values.",
+                "A seat count alone is also insufficient because Aurora Plus and Borealis Plus both show 41 seats.",
+                "The audit team therefore uses a separate exception code for the North six-hour rule.",
+                "That North-only exception code is AUR-NX-204 and it expires with the N-PLUS-88 contract.",
+                "AUR-NX-204 never applies to South Aurora Plus, Aurora Basic, or Borealis Plus."
+              ]
+            }
+          ]
+        }
+      ],
+      "cases": [
+        {
+          "case_id": "cs_fact",
+          "query_type": "fact",
+          "query": "How many analyst seats does North Aurora Basic include?",
+          "anchors": [
+            {
+              "document_key": "north_program",
+              "phrase": "It includes 14 analyst seats"
+            }
+          ]
+        },
+        {
+          "case_id": "cs_confusable",
+          "query_type": "confusable",
+          "query": "What is the North research unit contract marker for Aurora Plus?",
+          "anchors": [
+            {
+              "document_key": "north_program",
+              "phrase": "contract marker N-PLUS-88"
+            }
+          ]
+        },
+        {
+          "case_id": "cs_region",
+          "query_type": "confusable",
+          "query": "How long is the South Aurora Plus emergency extension?",
+          "anchors": [
+            {
+              "document_key": "south_program",
+              "phrase": "permits a 4-hour emergency extension"
+            }
+          ]
+        },
+        {
+          "case_id": "cs_context",
+          "query_type": "section_context",
+          "query": "When does North Aurora Plus renew and what are its support hours?",
+          "anchors": [
+            {
+              "document_key": "north_program",
+              "phrase": "renews on the second Monday of each quarter"
+            },
+            {
+              "document_key": "north_program",
+              "phrase": "Support hours are 07:00-19:00 UTC"
+            }
+          ]
+        },
+        {
+          "case_id": "cs_negative",
+          "query_type": "confusable",
+          "query": "Which similarly sized plan is explicitly not an Aurora plan?",
+          "anchors": [
+            {
+              "document_key": "north_program",
+              "phrase": "It is not an Aurora plan"
+            }
+          ]
+        },
+        {
+          "case_id": "cs_dense",
+          "query_type": "confusable",
+          "query": "Which code is limited to the North six-hour exception and expires with N-PLUS-88?",
+          "anchors": [
+            {
+              "document_key": "confusable_dense",
+              "phrase": "exception code is AUR-NX-204"
+            }
+          ]
+        },
+        {
+          "case_id": "cs_none",
+          "query_type": "no_answer",
+          "query": "What is the East region Aurora Plus contract marker?",
+          "anchors": [],
+          "expected_no_result": true
+        }
+      ]
+    }
+  ],
+  "chunking_configs": [
+    {
+      "config_id": "recursive_400_o0",
+      "strategy": "recursive_character",
+      "chunk_size": 400,
+      "chunk_overlap": 0
+    },
+    {
+      "config_id": "recursive_400_o40",
+      "strategy": "recursive_character",
+      "chunk_size": 400,
+      "chunk_overlap": 40
+    },
+    {
+      "config_id": "recursive_700_o70",
+      "strategy": "recursive_character",
+      "chunk_size": 700,
+      "chunk_overlap": 70
+    },
+    {
+      "config_id": "recursive_700_o140",
+      "strategy": "recursive_character",
+      "chunk_size": 700,
+      "chunk_overlap": 140
+    },
+    {
+      "config_id": "recursive_1000_o100",
+      "strategy": "recursive_character",
+      "chunk_size": 1000,
+      "chunk_overlap": 100
+    },
+    {
+      "config_id": "parent_child_1200_300",
+      "strategy": "parent_child",
+      "parent_chunk_size": 1200,
+      "parent_chunk_overlap": 120,
+      "child_chunk_size": 300,
+      "child_chunk_overlap": 30
+    },
+    {
+      "config_id": "parent_child_1800_450",
+      "strategy": "parent_child",
+      "parent_chunk_size": 1800,
+      "parent_chunk_overlap": 180,
+      "child_chunk_size": 450,
+      "child_chunk_overlap": 45
+    },
+    {
+      "config_id": "parent_child_2400_600",
+      "strategy": "parent_child",
+      "parent_chunk_size": 2400,
+      "parent_chunk_overlap": 240,
+      "child_chunk_size": 600,
+      "child_chunk_overlap": 60
+    }
+  ]
+}

--- a/server/rag/api.py
+++ b/server/rag/api.py
@@ -47,6 +47,13 @@ from .evaluation import (
     KnowledgeEvaluationStore,
 )
 from .evaluation_executor import KnowledgeEvaluationExecutor
+from .strategy_router import (
+    RagStrategyConflictError,
+    RagStrategyRecommendationNotFoundError,
+    RagStrategyService,
+    RagStrategyStateError,
+    RagStrategyValidationError,
+)
 
 
 MAX_UPLOAD_BYTES = 10 * 1024 * 1024
@@ -291,6 +298,29 @@ class PipelineDraftUpdateRequest(BaseModel):
     stages: dict[str, PipelineDraftStageUpdate] = Field(default_factory=dict)
     embedding_profile: dict[str, Any] | None = None
     retrieval_profile: RetrievalOptionsPayload | None = None
+
+
+class RagStrategyRequirementsPayload(BaseModel):
+    exact_terms: bool = False
+    semantic_rewrite: bool = False
+    cross_language: bool = False
+    long_context: bool = False
+    confusable_content: bool = False
+    citation_precision: bool = False
+
+
+class RagStrategyRecommendationRequest(BaseModel):
+    kb_id: str = Field(min_length=1, max_length=160)
+    objective: Literal["balanced", "quality", "low_latency"] = "balanced"
+    requirements: RagStrategyRequirementsPayload = Field(
+        default_factory=RagStrategyRequirementsPayload
+    )
+
+
+class RagStrategyApplyRequest(BaseModel):
+    expected_draft_version: int = Field(ge=1)
+    profile_id: str = Field(default="primary", min_length=1, max_length=80)
+    confirm_low_confidence: bool = False
 
 
 class PipelineGraphNodePayload(BaseModel):
@@ -770,6 +800,10 @@ def _require_knowledge_base(kb_id: str) -> None:
         raise HTTPException(status_code=404, detail="Knowledge base not found.")
 
 
+def get_rag_strategy_service() -> RagStrategyService:
+    return RagStrategyService(get_rag_service())
+
+
 @router.get("/retrieval-capabilities")
 async def get_retrieval_capabilities() -> dict[str, Any]:
     return get_rag_service().retrieval_capabilities()
@@ -783,6 +817,70 @@ async def get_processor_capabilities() -> dict[str, Any]:
 @router.get("/vision-capabilities")
 async def get_vision_capabilities() -> dict[str, Any]:
     return get_rag_service().vision_capabilities()
+
+
+@router.get("/strategy-router/capabilities")
+async def get_strategy_router_capabilities() -> dict[str, Any]:
+    return get_rag_strategy_service().capabilities()
+
+
+@router.post("/strategy-router/recommendations")
+async def create_strategy_router_recommendation(
+    payload: RagStrategyRecommendationRequest,
+) -> dict[str, Any]:
+    try:
+        return get_rag_strategy_service().create_recommendation(
+            payload.kb_id,
+            objective=payload.objective,
+            requirements=payload.requirements.model_dump(),
+        )
+    except KnowledgeBaseNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except RagStrategyValidationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.get("/strategy-router/recommendations")
+async def list_strategy_router_recommendations(kb_id: str) -> dict[str, Any]:
+    try:
+        recommendations = get_rag_strategy_service().list_recommendations(kb_id)
+        return {
+            "kb_id": kb_id,
+            "recommendations": recommendations,
+            "recommendation_count": len(recommendations),
+        }
+    except KnowledgeBaseNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.get("/strategy-router/recommendations/{recommendation_id}")
+async def get_strategy_router_recommendation(
+    recommendation_id: str,
+) -> dict[str, Any]:
+    try:
+        return get_rag_strategy_service().get_recommendation(recommendation_id)
+    except RagStrategyRecommendationNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.post("/strategy-router/recommendations/{recommendation_id}/apply")
+async def apply_strategy_router_recommendation(
+    recommendation_id: str,
+    payload: RagStrategyApplyRequest,
+) -> dict[str, Any]:
+    try:
+        return get_rag_strategy_service().apply_recommendation(
+            recommendation_id,
+            expected_draft_version=payload.expected_draft_version,
+            profile_id=payload.profile_id,
+            confirm_low_confidence=payload.confirm_low_confidence,
+        )
+    except RagStrategyRecommendationNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except RagStrategyConflictError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except (RagStrategyStateError, RagStrategyValidationError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 @router.post("/knowledge_bases", response_model=KnowledgeBasePayload)

--- a/server/rag/rag_service.py
+++ b/server/rag/rag_service.py
@@ -504,6 +504,13 @@ class RagService:
             metadata["pipeline_drafts"].pop(kb_id, None)
             metadata["pipeline_graphs"].pop(kb_id, None)
             metadata["pipeline_active_versions"].pop(kb_id, None)
+            metadata["rag_strategy_recommendations"] = {
+                recommendation_id: item
+                for recommendation_id, item in metadata[
+                    "rag_strategy_recommendations"
+                ].items()
+                if not isinstance(item, dict) or str(item.get("kb_id")) != kb_id
+            }
             metadata["knowledge_write_proposals"] = {
                 proposal_id: item
                 for proposal_id, item in metadata["knowledge_write_proposals"].items()
@@ -4959,6 +4966,7 @@ class RagService:
             "pipeline_jobs": {},
             "pipeline_versions": {},
             "pipeline_active_versions": {},
+            "rag_strategy_recommendations": {},
             "knowledge_write_proposals": {},
         }
 
@@ -4985,6 +4993,7 @@ class RagService:
             "pipeline_jobs": data.get("pipeline_jobs") if isinstance(data.get("pipeline_jobs"), dict) else {},
             "pipeline_versions": data.get("pipeline_versions") if isinstance(data.get("pipeline_versions"), dict) else {},
             "pipeline_active_versions": data.get("pipeline_active_versions") if isinstance(data.get("pipeline_active_versions"), dict) else {},
+            "rag_strategy_recommendations": data.get("rag_strategy_recommendations") if isinstance(data.get("rag_strategy_recommendations"), dict) else {},
             "knowledge_write_proposals": data.get("knowledge_write_proposals") if isinstance(data.get("knowledge_write_proposals"), dict) else {},
         }
         for document in metadata["documents"].values():

--- a/server/rag/strategy_router.py
+++ b/server/rag/strategy_router.py
@@ -1,0 +1,994 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+import time
+import uuid
+from collections import Counter
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from .retrieval import RetrievalConfig
+
+if TYPE_CHECKING:
+    from .rag_service import RagService
+
+
+RULES_VERSION = "rag-strategy-rules-v1"
+SUPPORTED_OBJECTIVES = {"balanced", "quality", "low_latency"}
+REQUIREMENT_KEYS = (
+    "exact_terms",
+    "semantic_rewrite",
+    "cross_language",
+    "long_context",
+    "confusable_content",
+    "citation_precision",
+)
+MAX_PROFILE_DOCUMENTS = 100
+MAX_PROFILE_CHARACTERS = 500_000
+
+_EXACT_TERM = re.compile(
+    r"(?:\b[A-Z][A-Z0-9_./-]{2,}\b|\b[A-Za-z]{1,12}-\d{2,}\b|\b\d{4,}\b)"
+)
+_CJK = re.compile(r"[\u3400-\u4dbf\u4e00-\u9fff]")
+_LATIN_WORD = re.compile(r"\b[A-Za-z]{2,}\b")
+
+
+class RagStrategyRecommendationNotFoundError(KeyError):
+    pass
+
+
+class RagStrategyConflictError(RuntimeError):
+    pass
+
+
+class RagStrategyStateError(RuntimeError):
+    pass
+
+
+class RagStrategyValidationError(ValueError):
+    pass
+
+
+class RagStrategyService:
+    """Deterministic, explainable strategy recommendations over the existing RAG draft."""
+
+    def __init__(self, rag_service: RagService) -> None:
+        self.rag_service = rag_service
+
+    def capabilities(self) -> dict[str, Any]:
+        embedding = self.rag_service.retrieval_capabilities().get("embedding", {})
+        rerank = self.rag_service.reranker.capabilities()
+        return {
+            "rules_version": RULES_VERSION,
+            "objectives": sorted(SUPPORTED_OBJECTIVES),
+            "requirements": list(REQUIREMENT_KEYS),
+            "limits": {
+                "max_documents": MAX_PROFILE_DOCUMENTS,
+                "max_characters": MAX_PROFILE_CHARACTERS,
+                "max_alternatives": 2,
+            },
+            "chunking_strategies": ["recursive_character", "parent_child"],
+            "retrieval_modes": ["fulltext", "vector", "hybrid"],
+            "score_threshold_fixed": 0.0,
+            "embedding": {
+                "provider": str(embedding.get("provider") or "hash"),
+                "degraded": bool(embedding.get("degraded", True)),
+            },
+            "rerank": {
+                "available": bool(
+                    rerank.get("api_configured") or rerank.get("llm_configured")
+                ),
+                "api_configured": bool(rerank.get("api_configured")),
+                "llm_configured": bool(rerank.get("llm_configured")),
+            },
+            "deferred_strategies": [
+                "sentence_window",
+                "semantic_chunking",
+                "contextual_retrieval",
+                "late_chunking",
+                "raptor",
+            ],
+            "rules": [
+                {
+                    "rule_id": f"R{index}",
+                    "classification": classification,
+                    "summary": summary,
+                }
+                for index, classification, summary in _RULE_SUMMARIES
+            ],
+        }
+
+    def create_recommendation(
+        self,
+        kb_id: str,
+        *,
+        objective: str,
+        requirements: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        clean_objective = str(objective or "balanced").strip().lower()
+        if clean_objective not in SUPPORTED_OBJECTIVES:
+            raise RagStrategyValidationError(
+                "objective must be balanced, quality, or low_latency."
+            )
+        normalized_requirements = self._normalize_requirements(requirements)
+        snapshot = self._build_snapshot(kb_id, clean_objective, normalized_requirements)
+        recommendation = self._recommend(snapshot)
+        now = time.time()
+        record = {
+            "recommendation_id": f"ragrec_{uuid.uuid4().hex}",
+            "kb_id": kb_id,
+            "rules_version": RULES_VERSION,
+            "state": recommendation["state"],
+            "objective": clean_objective,
+            "requirements": normalized_requirements,
+            "corpus_hash": snapshot["corpus_hash"],
+            "snapshot_hash": snapshot["snapshot_hash"],
+            "target_version_id": snapshot["target_version_id"],
+            "draft_id": snapshot["draft_id"],
+            "draft_version": snapshot["draft_version"],
+            "corpus_profile": snapshot["corpus_profile"],
+            "current_profile": snapshot["current_profile"],
+            "profiles": recommendation["profiles"],
+            "warnings": recommendation["warnings"],
+            "insufficient_reasons": recommendation["insufficient_reasons"],
+            "recommendation_checksum": recommendation["recommendation_checksum"],
+            "created_at": now,
+            "updated_at": now,
+            "applied_at": None,
+            "applied_profile_id": None,
+            "applied_draft_version": None,
+        }
+        with self.rag_service._metadata_lock:
+            metadata = self.rag_service._read_metadata_unlocked()
+            self.rag_service._ensure_kb_exists(metadata, kb_id)
+            metadata["rag_strategy_recommendations"][record["recommendation_id"]] = record
+            self.rag_service._write_metadata_unlocked(metadata)
+        return self._payload(record, state=record["state"])
+
+    def list_recommendations(self, kb_id: str) -> list[dict[str, Any]]:
+        metadata = self.rag_service._read_metadata()
+        self.rag_service._ensure_kb_exists(metadata, kb_id)
+        records = [
+            item
+            for item in metadata["rag_strategy_recommendations"].values()
+            if isinstance(item, dict) and str(item.get("kb_id")) == kb_id
+        ]
+        return [
+            self._payload(item, state=self._current_state(item, metadata))
+            for item in sorted(
+                records,
+                key=lambda value: float(value.get("created_at") or 0),
+                reverse=True,
+            )
+        ]
+
+    def get_recommendation(self, recommendation_id: str) -> dict[str, Any]:
+        metadata = self.rag_service._read_metadata()
+        record = metadata["rag_strategy_recommendations"].get(recommendation_id)
+        if not isinstance(record, dict):
+            raise RagStrategyRecommendationNotFoundError(
+                "RAG strategy recommendation not found."
+            )
+        return self._payload(record, state=self._current_state(record, metadata))
+
+    def apply_recommendation(
+        self,
+        recommendation_id: str,
+        *,
+        expected_draft_version: int,
+        profile_id: str = "primary",
+        confirm_low_confidence: bool = False,
+    ) -> dict[str, Any]:
+        with self.rag_service._metadata_lock:
+            metadata = self.rag_service._read_metadata_unlocked()
+            record = metadata["rag_strategy_recommendations"].get(recommendation_id)
+            if not isinstance(record, dict):
+                raise RagStrategyRecommendationNotFoundError(
+                    "RAG strategy recommendation not found."
+                )
+            kb_id = str(record.get("kb_id") or "")
+            self.rag_service._ensure_kb_exists(metadata, kb_id)
+            state = self._current_state(record, metadata)
+            if state == "stale":
+                raise RagStrategyConflictError(
+                    "Recommendation is stale; analyze the current corpus and draft again."
+                )
+            if state == "insufficient_data":
+                raise RagStrategyStateError(
+                    "Insufficient evidence recommendations cannot be applied."
+                )
+            if state == "applied":
+                raise RagStrategyStateError("Recommendation has already been applied.")
+
+            draft = self.rag_service._pipeline_draft_record(metadata, kb_id)
+            current_version = int(draft["version"])
+            if int(expected_draft_version) != current_version:
+                raise RagStrategyConflictError(
+                    "Pipeline draft changed; reload before applying the recommendation."
+                )
+            if current_version != int(record.get("draft_version") or 0):
+                raise RagStrategyConflictError(
+                    "Recommendation was created for an older pipeline draft."
+                )
+
+            selected = next(
+                (
+                    item
+                    for item in record.get("profiles", [])
+                    if isinstance(item, dict)
+                    and str(item.get("profile_id") or "") == profile_id
+                ),
+                None,
+            )
+            if not isinstance(selected, dict):
+                raise RagStrategyValidationError("Recommendation profile not found.")
+            if (
+                str(selected.get("confidence") or "low") == "low"
+                and not confirm_low_confidence
+            ):
+                raise RagStrategyStateError(
+                    "Low confidence recommendations require explicit confirmation."
+                )
+
+            draft_payload = self.rag_service.update_pipeline_draft(
+                kb_id,
+                {
+                    "stage_chunker": {
+                        "config": dict(selected.get("chunker") or {})
+                    }
+                },
+                retrieval_profile=dict(selected.get("retrieval") or {}),
+            )
+            latest = self.rag_service._read_metadata_unlocked()
+            stored = latest["rag_strategy_recommendations"].get(recommendation_id)
+            if isinstance(stored, dict):
+                stored["state"] = "applied"
+                stored["applied_at"] = time.time()
+                stored["updated_at"] = stored["applied_at"]
+                stored["applied_profile_id"] = profile_id
+                stored["applied_draft_version"] = int(draft_payload["version"])
+                self.rag_service._write_metadata_unlocked(latest)
+                record = stored
+            return {
+                "recommendation": self._payload(record, state="applied"),
+                "draft": draft_payload,
+            }
+
+    def _build_snapshot(
+        self,
+        kb_id: str,
+        objective: str,
+        requirements: dict[str, bool],
+    ) -> dict[str, Any]:
+        metadata = self.rag_service._read_metadata()
+        self.rag_service._ensure_kb_exists(metadata, kb_id)
+        draft = self.rag_service._pipeline_draft_record(metadata, kb_id)
+        documents = self._documents_for_kb(metadata, kb_id)
+        corpus_hash = self._corpus_hash(documents)
+        corpus_profile = self._profile_corpus(documents, draft)
+        active_version_id = metadata["pipeline_active_versions"].get(kb_id)
+        current_profile = {
+            "chunker": json.loads(json.dumps(draft["stages"]["stage_chunker"])),
+            "retrieval": json.loads(json.dumps(draft["retrieval_profile"])),
+            "embedding": json.loads(json.dumps(draft["embedding_profile"])),
+        }
+        snapshot_payload = {
+            "rules_version": RULES_VERSION,
+            "kb_id": kb_id,
+            "corpus_hash": corpus_hash,
+            "target_version_id": active_version_id,
+            "draft_id": draft["draft_id"],
+            "draft_version": int(draft["version"]),
+            "objective": objective,
+            "requirements": requirements,
+            "corpus_profile": corpus_profile,
+            "current_profile": current_profile,
+        }
+        return {
+            **snapshot_payload,
+            "snapshot_hash": _checksum(snapshot_payload),
+        }
+
+    def _profile_corpus(
+        self,
+        documents: list[dict[str, Any]],
+        draft: dict[str, Any],
+    ) -> dict[str, Any]:
+        sampled = documents[:MAX_PROFILE_DOCUMENTS]
+        block_lengths: list[int] = []
+        kind_counts: Counter[str] = Counter()
+        exact_term_count = 0
+        cjk_count = 0
+        latin_word_count = 0
+        analyzed_characters = 0
+        analyzed_documents = 0
+        visual_documents = 0
+        skipped_documents = 0
+        warning_counts: Counter[str] = Counter()
+        max_heading_depth = 0
+        character_limit_reached = False
+        processor_config = dict(draft["stages"].get("stage_processor") or {})
+
+        for document in sampled:
+            if analyzed_characters >= MAX_PROFILE_CHARACTERS:
+                character_limit_reached = True
+                break
+            filename = str(document.get("filename") or "")
+            if bool(document.get("visual_candidate")):
+                visual_documents += 1
+            path = Path(str(document.get("stored_path") or ""))
+            if not path.is_file():
+                skipped_documents += 1
+                warning_counts["source unavailable"] += 1
+                continue
+            try:
+                processed = self.rag_service.document_processor.process(
+                    path,
+                    filename=filename,
+                    source_id=str(document.get("id") or ""),
+                    config=processor_config,
+                )
+            except Exception as exc:  # Parsing failures are a profile warning, not an API failure.
+                skipped_documents += 1
+                warning_counts[type(exc).__name__] += 1
+                continue
+            analyzed_documents += 1
+            for block in processed.blocks:
+                remaining = MAX_PROFILE_CHARACTERS - analyzed_characters
+                if remaining <= 0:
+                    character_limit_reached = True
+                    break
+                text = block.text[:remaining]
+                if not text:
+                    continue
+                length = len(text)
+                analyzed_characters += length
+                block_lengths.append(length)
+                kind_counts[str(block.kind or "paragraph")] += 1
+                exact_term_count += len(_EXACT_TERM.findall(text))
+                cjk_count += len(_CJK.findall(text))
+                latin_word_count += len(_LATIN_WORD.findall(text))
+                max_heading_depth = max(max_heading_depth, len(block.heading_path))
+                if length < len(block.text):
+                    character_limit_reached = True
+                    break
+            if character_limit_reached:
+                break
+
+        block_count = len(block_lengths)
+        structured = sum(
+            kind_counts.get(kind, 0) for kind in ("heading", "list", "table", "code")
+        )
+        table_code = kind_counts.get("table", 0) + kind_counts.get("code", 0)
+        language_units = cjk_count + latin_word_count
+        warnings = [
+            f"{count} document(s) could not be analyzed ({reason})."
+            for reason, count in sorted(warning_counts.items())
+        ]
+        return {
+            "document_count": len(documents),
+            "sampled_document_count": len(sampled),
+            "analyzed_document_count": analyzed_documents,
+            "skipped_document_count": skipped_documents,
+            "visual_document_count": visual_documents,
+            "sampled_character_count": analyzed_characters,
+            "character_limit_reached": character_limit_reached,
+            "document_limit_reached": len(documents) > len(sampled),
+            "block_count": block_count,
+            "block_kind_counts": dict(sorted(kind_counts.items())),
+            "median_block_characters": _percentile(block_lengths, 0.5),
+            "p95_block_characters": _percentile(block_lengths, 0.95),
+            "max_block_characters": max(block_lengths, default=0),
+            "short_block_ratio": _ratio(
+                sum(1 for value in block_lengths if value < 700), block_count
+            ),
+            "long_block_ratio": _ratio(
+                sum(1 for value in block_lengths if value >= 1200), block_count
+            ),
+            "structured_block_ratio": _ratio(structured, block_count),
+            "table_code_ratio": _ratio(table_code, block_count),
+            "heading_depth_max": max_heading_depth,
+            "exact_term_density_per_1000": round(
+                exact_term_count * 1000 / max(1, analyzed_characters), 4
+            ),
+            "cjk_ratio": _ratio(cjk_count, language_units),
+            "latin_ratio": _ratio(latin_word_count, language_units),
+            "bilingual": bool(cjk_count >= 20 and latin_word_count >= 20),
+            "warnings": warnings[:20],
+        }
+
+    def _recommend(self, snapshot: dict[str, Any]) -> dict[str, Any]:
+        profile = snapshot["corpus_profile"]
+        requirements = snapshot["requirements"]
+        objective = snapshot["objective"]
+        current = snapshot["current_profile"]
+        embedding = current["embedding"]
+        embedding_degraded = bool(embedding.get("degraded")) or str(
+            embedding.get("provider") or "hash"
+        ) == "hash"
+        rerank_capabilities = self.rag_service.reranker.capabilities()
+        rerank_ready = bool(
+            rerank_capabilities.get("api_configured")
+            or rerank_capabilities.get("llm_configured")
+        )
+
+        warnings = list(profile.get("warnings") or [])
+        insufficient_reasons: list[str] = []
+        if int(profile.get("analyzed_document_count") or 0) == 0:
+            insufficient_reasons.append("No text document could be analyzed.")
+        if int(profile.get("sampled_character_count") or 0) < 500:
+            insufficient_reasons.append(
+                "The analyzed corpus is too small for a defensible strategy recommendation."
+            )
+        if embedding_degraded and (
+            requirements["semantic_rewrite"] or requirements["cross_language"]
+        ) and not requirements["exact_terms"]:
+            insufficient_reasons.append(
+                "Semantic or cross-language routing requires a real embedding provider; hash fallback is insufficient."
+            )
+        if profile.get("visual_document_count"):
+            warnings.append(
+                "Visual candidates are represented only by text that the current processor can parse; Router V1 does not change vision settings."
+            )
+
+        if insufficient_reasons:
+            checksum = _checksum(
+                {
+                    "snapshot_hash": snapshot["snapshot_hash"],
+                    "state": "insufficient_data",
+                    "reasons": insufficient_reasons,
+                }
+            )
+            return {
+                "state": "insufficient_data",
+                "profiles": [],
+                "warnings": _dedupe(warnings),
+                "insufficient_reasons": insufficient_reasons,
+                "recommendation_checksum": checksum,
+            }
+
+        chunker, chunk_rules, chunk_reasons, confidence = self._select_chunker(
+            profile, objective, requirements, current["chunker"]
+        )
+        retrieval, retrieval_rules, retrieval_reasons, retrieval_confidence = (
+            self._select_retrieval(
+                profile,
+                objective,
+                requirements,
+                embedding_degraded=embedding_degraded,
+            )
+        )
+        confidence = _lower_confidence(confidence, retrieval_confidence)
+        if requirements["confusable_content"] and objective == "quality":
+            if rerank_ready:
+                warnings.append(
+                    "Rerank is available but remains an evaluation-required alternative; the primary profile keeps it disabled."
+                )
+            else:
+                warnings.append(
+                    "Confusable content may benefit from rerank, but no rerank provider is ready."
+                )
+        if embedding_degraded:
+            warnings.append(
+                "Embedding is using deterministic hash fallback; vector and hybrid quality are not treated as semantic evidence."
+            )
+        warnings.append(
+            "Score threshold remains 0 until a fixed evaluation set calibrates abstention."
+        )
+
+        profiles: list[dict[str, Any]] = []
+        profiles.append(
+            self._profile_payload(
+                "primary",
+                "Recommended starting profile",
+                chunker,
+                retrieval,
+                confidence=confidence,
+                reasons=[*chunk_reasons, *retrieval_reasons],
+                rule_ids=[*chunk_rules, *retrieval_rules],
+                warnings=warnings,
+                current=current,
+            )
+        )
+
+        alternative_chunker = self._alternative_chunker(chunker, profile)
+        if alternative_chunker is not None:
+            profiles.append(
+                self._profile_payload(
+                    "alternative_chunking",
+                    "Chunking comparison candidate",
+                    alternative_chunker,
+                    retrieval,
+                    confidence="low",
+                    reasons=[
+                        "Use as a controlled candidate when the primary chunking evidence is weak."
+                    ],
+                    rule_ids=["R1", "R2"],
+                    warnings=[
+                        "This alternative requires a fixed knowledge evaluation set before activation."
+                    ],
+                    current=current,
+                )
+            )
+        if (
+            len(profiles) < 3
+            and requirements["confusable_content"]
+            and objective == "quality"
+            and rerank_ready
+        ):
+            rerank_retrieval = dict(retrieval)
+            rerank_retrieval.update(
+                {
+                    "rerank_enabled": True,
+                    "rerank_provider": "auto",
+                    "rerank_top_n": int(retrieval["top_k"]),
+                }
+            )
+            profiles.append(
+                self._profile_payload(
+                    "alternative_rerank",
+                    "Rerank evaluation candidate",
+                    chunker,
+                    rerank_retrieval,
+                    confidence="low",
+                    reasons=[
+                        "Confusable content and a quality objective justify testing rerank, not enabling it by default."
+                    ],
+                    rule_ids=["R8"],
+                    warnings=[
+                        "Provider latency, cost, and ranking benefit were not measured in Phase A."
+                    ],
+                    current=current,
+                )
+            )
+
+        checksum = _checksum(
+            {
+                "snapshot_hash": snapshot["snapshot_hash"],
+                "profiles": profiles,
+                "warnings": _dedupe(warnings),
+            }
+        )
+        return {
+            "state": "ready",
+            "profiles": profiles[:3],
+            "warnings": _dedupe(warnings),
+            "insufficient_reasons": [],
+            "recommendation_checksum": checksum,
+        }
+
+    def _select_chunker(
+        self,
+        corpus: dict[str, Any],
+        objective: str,
+        requirements: dict[str, bool],
+        current: dict[str, Any],
+    ) -> tuple[dict[str, Any], list[str], list[str], str]:
+        long_ratio = float(corpus.get("long_block_ratio") or 0)
+        short_ratio = float(corpus.get("short_block_ratio") or 0)
+        table_code_ratio = float(corpus.get("table_code_ratio") or 0)
+        p95 = int(corpus.get("p95_block_characters") or 0)
+
+        if (
+            long_ratio >= 0.2
+            and requirements["long_context"]
+            and objective == "quality"
+        ):
+            return (
+                _parent_child_config(1800, 450),
+                ["R2", "R6"],
+                [
+                    "Long processed blocks and a quality/long-context objective make parent expansion worth evaluating.",
+                    "The current implementation builds parents within each processed block, not across whole chapters.",
+                ],
+                "low",
+            )
+        if table_code_ratio >= 0.08:
+            return (
+                _recursive_config(1000, 100),
+                ["R6", "R7"],
+                [
+                    "Table/code structure is already preserved by the processor; a moderate recursive window limits destructive splitting."
+                ],
+                "medium",
+            )
+        if requirements["confusable_content"] or objective == "low_latency":
+            return (
+                _recursive_config(1000, 100),
+                ["R6", "R9"],
+                [
+                    "A larger recursive window reduces chunk count while retaining a 10% boundary overlap."
+                ],
+                "low",
+            )
+        if short_ratio >= 0.8 and p95 <= 700:
+            keep = dict(current)
+            keep["strategy"] = str(keep.get("strategy") or "recursive_character")
+            return (
+                keep,
+                ["R1"],
+                [
+                    "Most processed blocks are already short; changing chunk sizes may be a no-op, so the current chunker is preserved."
+                ],
+                "low",
+            )
+        return (
+            _recursive_config(700, 70),
+            ["R1", "R6"],
+            [
+                "The corpus has no strong hierarchical or structure-specific signal; Recursive 700/70 is a neutral benchmark starting point."
+            ],
+            "low",
+        )
+
+    def _select_retrieval(
+        self,
+        corpus: dict[str, Any],
+        objective: str,
+        requirements: dict[str, bool],
+        *,
+        embedding_degraded: bool,
+    ) -> tuple[dict[str, Any], list[str], list[str], str]:
+        exact_signal = bool(requirements["exact_terms"]) or float(
+            corpus.get("exact_term_density_per_1000") or 0
+        ) >= 1.0
+        semantic_signal = bool(
+            requirements["semantic_rewrite"] or requirements["cross_language"]
+        )
+        top_k = 10 if requirements["long_context"] else 5
+        rules = ["R9" if top_k == 5 else "R10", "R11"]
+        reasons: list[str] = []
+        confidence = "low"
+        if embedding_degraded:
+            mode = "fulltext"
+            weights = (0.0, 1.0)
+            rules.append("R3" if exact_signal else "R4")
+            reasons.append(
+                "Hash embedding is not semantic evidence; FTS5 is the defensible offline retrieval channel."
+            )
+            if exact_signal:
+                reasons.append(
+                    "The corpus or requirement contains exact identifiers and terminology suited to full-text retrieval."
+                )
+                confidence = "medium"
+        elif exact_signal and semantic_signal:
+            mode = "hybrid"
+            weights = (0.7, 0.3)
+            rules.append("R5")
+            reasons.append(
+                "Exact-term and semantic requirements justify a Hybrid candidate with the existing 0.7/0.3 starting weights."
+            )
+        elif semantic_signal:
+            mode = "vector"
+            weights = (1.0, 0.0)
+            rules.append("R5")
+            reasons.append(
+                "A real embedding provider and semantic requirement support a Vector starting candidate."
+            )
+        elif exact_signal:
+            mode = "fulltext"
+            weights = (0.0, 1.0)
+            rules.append("R3")
+            reasons.append(
+                "Exact identifiers and terminology favor full-text retrieval."
+            )
+            confidence = "medium"
+        else:
+            mode = "hybrid"
+            weights = (0.7, 0.3)
+            rules.append("R5")
+            reasons.append(
+                "No dominant lexical or semantic signal was detected; Hybrid remains a low-confidence starting candidate."
+            )
+
+        if objective == "low_latency":
+            top_k = 5
+        return (
+            RetrievalConfig.from_mapping(
+                {
+                    "mode": mode,
+                    "vector_weight": weights[0],
+                    "fulltext_weight": weights[1],
+                    "top_k": top_k,
+                    "score_threshold": 0.0,
+                    "candidate_multiplier": 4,
+                    "rerank_enabled": False,
+                    "rerank_provider": "none",
+                    "rerank_model": "",
+                    "rerank_top_n": top_k,
+                }
+            ).payload(),
+            rules,
+            reasons,
+            confidence,
+        )
+
+    def _alternative_chunker(
+        self,
+        primary: dict[str, Any],
+        corpus: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        if str(primary.get("strategy")) == "parent_child":
+            return _recursive_config(1000, 100)
+        if float(corpus.get("long_block_ratio") or 0) >= 0.2:
+            return _parent_child_config(1800, 450)
+        return None
+
+    def _profile_payload(
+        self,
+        profile_id: str,
+        title: str,
+        chunker: dict[str, Any],
+        retrieval: dict[str, Any],
+        *,
+        confidence: str,
+        reasons: list[str],
+        rule_ids: list[str],
+        warnings: list[str],
+        current: dict[str, Any],
+    ) -> dict[str, Any]:
+        payload = {
+            "profile_id": profile_id,
+            "title": title,
+            "confidence": confidence,
+            "chunker": json.loads(json.dumps(chunker)),
+            "retrieval": json.loads(json.dumps(retrieval)),
+            "reasons": _dedupe(reasons),
+            "evidence": [
+                _RULE_EVIDENCE[rule_id]
+                for rule_id in _dedupe(rule_ids)
+                if rule_id in _RULE_EVIDENCE
+            ],
+            "warnings": _dedupe(warnings),
+            "diff": _profile_diff(current, chunker, retrieval),
+        }
+        payload["checksum"] = _checksum(
+            {"chunker": payload["chunker"], "retrieval": payload["retrieval"]}
+        )
+        return payload
+
+    def _current_state(
+        self,
+        record: dict[str, Any],
+        metadata: dict[str, Any],
+    ) -> str:
+        kb_id = str(record.get("kb_id") or "")
+        if kb_id not in metadata["knowledge_bases"]:
+            return "stale"
+        documents = self._documents_for_kb(metadata, kb_id)
+        if self._corpus_hash(documents) != str(record.get("corpus_hash") or ""):
+            return "stale"
+        if metadata["pipeline_active_versions"].get(kb_id) != record.get(
+            "target_version_id"
+        ):
+            return "stale"
+        draft = self.rag_service._pipeline_draft_record(metadata, kb_id)
+        stored_state = str(record.get("state") or "ready")
+        if stored_state == "applied":
+            return (
+                "applied"
+                if int(draft["version"])
+                == int(record.get("applied_draft_version") or 0)
+                else "stale"
+            )
+        if int(draft["version"]) != int(record.get("draft_version") or 0):
+            return "stale"
+        return stored_state
+
+    def _documents_for_kb(
+        self,
+        metadata: dict[str, Any],
+        kb_id: str,
+    ) -> list[dict[str, Any]]:
+        return sorted(
+            [
+                item
+                for item in metadata["documents"].values()
+                if isinstance(item, dict)
+                and str(item.get("kb_id")) == kb_id
+                and not item.get("deletion_status")
+            ],
+            key=lambda item: str(item.get("id") or ""),
+        )
+
+    def _corpus_hash(self, documents: list[dict[str, Any]]) -> str:
+        return _checksum(
+            [
+                {
+                    "document_id": str(item.get("id") or ""),
+                    "content_hash": str(item.get("content_hash") or ""),
+                    "size": int(item.get("size") or 0),
+                }
+                for item in documents
+            ]
+        )
+
+    def _normalize_requirements(
+        self,
+        requirements: dict[str, Any] | None,
+    ) -> dict[str, bool]:
+        raw = dict(requirements or {})
+        unknown = set(raw) - set(REQUIREMENT_KEYS)
+        if unknown:
+            raise RagStrategyValidationError(
+                f"Unknown strategy requirements: {', '.join(sorted(unknown))}"
+            )
+        normalized: dict[str, bool] = {}
+        for key in REQUIREMENT_KEYS:
+            value = raw.get(key, False)
+            if not isinstance(value, bool):
+                raise RagStrategyValidationError(f"{key} must be a boolean.")
+            normalized[key] = value
+        return normalized
+
+    def _payload(self, record: dict[str, Any], *, state: str) -> dict[str, Any]:
+        payload = json.loads(json.dumps(record))
+        payload["state"] = state
+        return payload
+
+
+def _recursive_config(size: int, overlap: int) -> dict[str, Any]:
+    return {
+        "strategy": "recursive_character",
+        "chunk_size": size,
+        "chunk_overlap": overlap,
+        "separators": ["\n\n", "\n", "。", "！", "？", ". ", " ", ""],
+        "parent_chunk_size": 1500,
+        "parent_chunk_overlap": 100,
+        "child_chunk_size": 400,
+        "child_chunk_overlap": 50,
+        "parent_separators": ["\n\n", "\n", "。", "！", "？", ". ", " ", ""],
+        "child_separators": ["\n\n", "\n", "。", "！", "？", ". ", " ", ""],
+    }
+
+
+def _parent_child_config(parent_size: int, child_size: int) -> dict[str, Any]:
+    return {
+        "strategy": "parent_child",
+        "chunk_size": 700,
+        "chunk_overlap": 70,
+        "separators": ["\n\n", "\n", "。", "！", "？", ". ", " ", ""],
+        "parent_chunk_size": parent_size,
+        "parent_chunk_overlap": max(1, round(parent_size * 0.1)),
+        "child_chunk_size": child_size,
+        "child_chunk_overlap": max(1, round(child_size * 0.1)),
+        "parent_separators": ["\n\n", "\n", "。", "！", "？", ". ", " ", ""],
+        "child_separators": ["\n\n", "\n", "。", "！", "？", ". ", " ", ""],
+    }
+
+
+def _profile_diff(
+    current: dict[str, Any],
+    chunker: dict[str, Any],
+    retrieval: dict[str, Any],
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for prefix, before, after in (
+        ("chunker", dict(current.get("chunker") or {}), chunker),
+        ("retrieval", dict(current.get("retrieval") or {}), retrieval),
+    ):
+        for key in sorted(after):
+            if before.get(key) == after.get(key):
+                continue
+            rows.append(
+                {
+                    "field": f"{prefix}.{key}",
+                    "current": before.get(key),
+                    "recommended": after.get(key),
+                }
+            )
+    return rows
+
+
+def _percentile(values: list[int], percentile: float) -> int:
+    if not values:
+        return 0
+    ordered = sorted(values)
+    index = max(0, min(len(ordered) - 1, math.ceil(len(ordered) * percentile) - 1))
+    return int(ordered[index])
+
+
+def _ratio(numerator: int, denominator: int) -> float:
+    return round(numerator / denominator, 6) if denominator else 0.0
+
+
+def _checksum(value: Any) -> str:
+    encoded = json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    return list(dict.fromkeys(str(value) for value in values if str(value).strip()))
+
+
+def _lower_confidence(left: str, right: str) -> str:
+    order = {"low": 0, "medium": 1, "high": 2}
+    return left if order.get(left, 0) <= order.get(right, 0) else right
+
+
+_RULE_SUMMARIES = (
+    (1, "heuristic", "Preserve current chunking when most structured blocks are short."),
+    (2, "heuristic", "Treat parent-child as a long-context candidate, not a universal default."),
+    (3, "evidence-backed", "Prefer full-text for exact identifiers and terminology."),
+    (4, "evidence-backed", "Do not infer semantic quality from hash embeddings."),
+    (5, "heuristic", "Use Hybrid weights only as an evaluation starting point."),
+    (6, "evidence-backed", "Use modest overlap only when blocks actually split."),
+    (7, "evidence-backed", "Preserve table and code structure before retrieval routing."),
+    (8, "literature-only", "Rerank confusable content only as an evaluated candidate."),
+    (9, "heuristic", "Use Top-K 5 for bounded single-fact or low-latency tasks."),
+    (10, "heuristic", "Offer Top-K 10 for broader evidence with a context-cost warning."),
+    (11, "evidence-backed", "Keep threshold zero until benchmark calibration."),
+    (12, "evidence-backed", "Keep character and token units explicit."),
+    (13, "deferred", "Do not emulate unsupported advanced chunking strategies."),
+)
+
+_RULE_EVIDENCE = {
+    "R1": {
+        "rule_id": "R1",
+        "classification": "heuristic",
+        "source": "EXP-SHORT-01",
+    },
+    "R2": {
+        "rule_id": "R2",
+        "classification": "heuristic",
+        "source": "EXP-LONG-01",
+    },
+    "R3": {
+        "rule_id": "R3",
+        "classification": "evidence-backed",
+        "source": "EXP-LEXICAL-01",
+    },
+    "R4": {
+        "rule_id": "R4",
+        "classification": "evidence-backed",
+        "source": "EXP-HASH-01",
+    },
+    "R5": {
+        "rule_id": "R5",
+        "classification": "heuristic",
+        "source": "ModelMirror existing retrieval default",
+    },
+    "R6": {
+        "rule_id": "R6",
+        "classification": "evidence-backed",
+        "source": "EXP-OVERLAP-01",
+    },
+    "R7": {
+        "rule_id": "R7",
+        "classification": "evidence-backed",
+        "source": "EXP-STRUCTURE-01",
+    },
+    "R8": {
+        "rule_id": "R8",
+        "classification": "literature-only",
+        "source": "Contextual Retrieval literature",
+    },
+    "R9": {
+        "rule_id": "R9",
+        "classification": "heuristic",
+        "source": "EXP-TOPK-01",
+    },
+    "R10": {
+        "rule_id": "R10",
+        "classification": "heuristic",
+        "source": "target benchmark required",
+    },
+    "R11": {
+        "rule_id": "R11",
+        "classification": "evidence-backed",
+        "source": "EXP-NOANSWER-01",
+    },
+    "R12": {
+        "rule_id": "R12",
+        "classification": "evidence-backed",
+        "source": "current splitter contract",
+    },
+}

--- a/server/tests/test_rag_strategy_router.py
+++ b/server/tests/test_rag_strategy_router.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from server.main import app
+from server.rag.api import set_rag_service_for_tests
+from server.rag.embedder import EmbeddingClient
+from server.rag.rag_service import RagService
+from server.rag.vector_store import LocalJsonVectorStore
+
+
+@pytest_asyncio.fixture
+async def router_client(tmp_path: Path):
+    service = RagService(
+        storage_dir=tmp_path / "storage",
+        uploads_dir=tmp_path / "uploads",
+        embedder=EmbeddingClient(api_key="", dimension=128),
+        vector_store=LocalJsonVectorStore(tmp_path / "storage" / "vectors.json"),
+        llm_enabled=False,
+    )
+    set_rag_service_for_tests(service)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://testserver",
+    ) as client:
+        yield client, service
+    set_rag_service_for_tests(None)
+
+
+async def _create_kb(client: httpx.AsyncClient, name: str) -> str:
+    response = await client.post("/api/rag/knowledge_bases", json={"name": name})
+    assert response.status_code == 200, response.text
+    return response.json()["id"]
+
+
+async def _upload_text(
+    client: httpx.AsyncClient,
+    kb_id: str,
+    text: str,
+    *,
+    filename: str = "strategy.md",
+) -> dict:
+    response = await client.post(
+        f"/api/rag/knowledge_bases/{kb_id}/documents",
+        files={"file": (filename, text.encode("utf-8"), "text/markdown")},
+    )
+    assert response.status_code == 200, response.text
+    return response.json()
+
+
+def _long_policy_text() -> str:
+    sentence = (
+        "Policy MM-2026-ALPHA requires reviewers to retain the numbered control "
+        "identifier and compare the conflicting exception before approval. "
+    )
+    return "# Review policy\n\n" + sentence * 32
+
+
+@pytest.mark.asyncio
+async def test_strategy_router_capabilities_and_empty_corpus(
+    router_client,
+) -> None:
+    client, _ = router_client
+    kb_id = await _create_kb(client, "empty strategy")
+
+    capabilities = await client.get("/api/rag/strategy-router/capabilities")
+    assert capabilities.status_code == 200, capabilities.text
+    payload = capabilities.json()
+    assert payload["rules_version"] == "rag-strategy-rules-v1"
+    assert payload["score_threshold_fixed"] == 0.0
+    assert payload["embedding"]["degraded"] is True
+    assert "semantic_chunking" in payload["deferred_strategies"]
+
+    response = await client.post(
+        "/api/rag/strategy-router/recommendations",
+        json={"kb_id": kb_id, "objective": "balanced", "requirements": {}},
+    )
+    assert response.status_code == 200, response.text
+    recommendation = response.json()
+    assert recommendation["state"] == "insufficient_data"
+    assert recommendation["profiles"] == []
+    assert recommendation["insufficient_reasons"]
+
+    apply_response = await client.post(
+        f"/api/rag/strategy-router/recommendations/{recommendation['recommendation_id']}/apply",
+        json={"expected_draft_version": 1},
+    )
+    assert apply_response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_strategy_router_is_deterministic_and_hash_safe(
+    router_client,
+) -> None:
+    client, _ = router_client
+    kb_id = await _create_kb(client, "deterministic strategy")
+    await _upload_text(client, kb_id, _long_policy_text())
+    request = {
+        "kb_id": kb_id,
+        "objective": "balanced",
+        "requirements": {
+            "exact_terms": True,
+            "citation_precision": True,
+        },
+    }
+
+    first = await client.post("/api/rag/strategy-router/recommendations", json=request)
+    second = await client.post("/api/rag/strategy-router/recommendations", json=request)
+    assert first.status_code == second.status_code == 200
+    first_payload = first.json()
+    second_payload = second.json()
+    assert first_payload["snapshot_hash"] == second_payload["snapshot_hash"]
+    assert (
+        first_payload["recommendation_checksum"]
+        == second_payload["recommendation_checksum"]
+    )
+    assert first_payload["profiles"][0]["retrieval"]["mode"] == "fulltext"
+    assert first_payload["profiles"][0]["retrieval"]["score_threshold"] == 0.0
+    assert first_payload["profiles"][0]["retrieval"]["rerank_enabled"] is False
+
+    semantic_only = await client.post(
+        "/api/rag/strategy-router/recommendations",
+        json={
+            "kb_id": kb_id,
+            "objective": "quality",
+            "requirements": {"semantic_rewrite": True, "cross_language": True},
+        },
+    )
+    assert semantic_only.status_code == 200, semantic_only.text
+    assert semantic_only.json()["state"] == "insufficient_data"
+    assert "real embedding provider" in " ".join(
+        semantic_only.json()["insufficient_reasons"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_low_confidence_apply_updates_only_draft_and_saved_graph(
+    router_client,
+) -> None:
+    client, service = router_client
+    kb_id = await _create_kb(client, "long context strategy")
+    await _upload_text(client, kb_id, _long_policy_text())
+
+    graph_response = await client.get(f"/api/rag/pipeline/graph?kb_id={kb_id}")
+    assert graph_response.status_code == 200, graph_response.text
+    graph = graph_response.json()
+    save_response = await client.put(
+        f"/api/rag/pipeline/graph/{kb_id}",
+        json={"expected_revision": graph["graph_revision"], "graph": graph["graph"]},
+    )
+    assert save_response.status_code == 200, save_response.text
+    saved_graph_revision = save_response.json()["graph_revision"]
+    active_before = service._read_metadata()["pipeline_active_versions"].get(kb_id)
+
+    response = await client.post(
+        "/api/rag/strategy-router/recommendations",
+        json={
+            "kb_id": kb_id,
+            "objective": "quality",
+            "requirements": {"long_context": True, "citation_precision": True},
+        },
+    )
+    assert response.status_code == 200, response.text
+    recommendation = response.json()
+    primary = recommendation["profiles"][0]
+    assert primary["chunker"]["strategy"] == "parent_child"
+    assert primary["confidence"] == "low"
+
+    unconfirmed = await client.post(
+        f"/api/rag/strategy-router/recommendations/{recommendation['recommendation_id']}/apply",
+        json={"expected_draft_version": recommendation["draft_version"]},
+    )
+    assert unconfirmed.status_code == 400
+
+    applied = await client.post(
+        f"/api/rag/strategy-router/recommendations/{recommendation['recommendation_id']}/apply",
+        json={
+            "expected_draft_version": recommendation["draft_version"],
+            "profile_id": "primary",
+            "confirm_low_confidence": True,
+        },
+    )
+    assert applied.status_code == 200, applied.text
+    payload = applied.json()
+    assert payload["recommendation"]["state"] == "applied"
+    assert payload["draft"]["version"] == recommendation["draft_version"] + 1
+    chunker = next(
+        stage for stage in payload["draft"]["stages"] if stage["id"] == "stage_chunker"
+    )
+    assert chunker["config"]["strategy"] == "parent_child"
+
+    graph_after = await client.get(f"/api/rag/pipeline/graph?kb_id={kb_id}")
+    assert graph_after.status_code == 200, graph_after.text
+    graph_payload = graph_after.json()
+    assert graph_payload["graph_revision"] == saved_graph_revision + 1
+    assert graph_payload["compiled_draft_version"] == payload["draft"]["version"]
+    assert service._read_metadata()["pipeline_active_versions"].get(kb_id) == active_before
+
+
+@pytest.mark.asyncio
+async def test_strategy_router_rejects_stale_draft_and_hides_sensitive_data(
+    router_client,
+) -> None:
+    client, _ = router_client
+    kb_id = await _create_kb(client, "stale strategy")
+    secret_marker = "PRIVATE-CORPUS-TEXT-DO-NOT-RETURN"
+    await _upload_text(client, kb_id, _long_policy_text() + secret_marker)
+
+    response = await client.post(
+        "/api/rag/strategy-router/recommendations",
+        json={
+            "kb_id": kb_id,
+            "objective": "balanced",
+            "requirements": {"exact_terms": True},
+        },
+    )
+    assert response.status_code == 200, response.text
+    recommendation = response.json()
+    serialized = json.dumps(recommendation, ensure_ascii=False)
+    assert secret_marker not in serialized
+    assert "stored_path" not in serialized
+    assert "OPENROUTER_API_KEY" not in serialized
+
+    draft = await client.get(f"/api/rag/pipeline/draft?kb_id={kb_id}")
+    assert draft.status_code == 200, draft.text
+    changed = await client.patch(
+        f"/api/rag/pipeline/draft/{kb_id}",
+        json={
+            "retrieval_profile": {
+                **draft.json()["retrieval_profile"],
+                "top_k": 7,
+            }
+        },
+    )
+    assert changed.status_code == 200, changed.text
+
+    detail = await client.get(
+        f"/api/rag/strategy-router/recommendations/{recommendation['recommendation_id']}"
+    )
+    assert detail.status_code == 200, detail.text
+    assert detail.json()["state"] == "stale"
+
+    apply_response = await client.post(
+        f"/api/rag/strategy-router/recommendations/{recommendation['recommendation_id']}/apply",
+        json={"expected_draft_version": changed.json()["version"]},
+    )
+    assert apply_response.status_code == 409
+
+    listing = await client.get(
+        f"/api/rag/strategy-router/recommendations?kb_id={kb_id}"
+    )
+    assert listing.status_code == 200, listing.text
+    assert listing.json()["recommendation_count"] == 1
+    assert listing.json()["recommendations"][0]["state"] == "stale"
+
+
+@pytest.mark.asyncio
+async def test_strategy_router_preserves_short_corpus_chunker_config(
+    router_client,
+) -> None:
+    client, _ = router_client
+    kb_id = await _create_kb(client, "short structured strategy")
+    await _upload_text(
+        client,
+        kb_id,
+        ("# Terms\n\nTERM-2026 remains active.\n\n" * 30),
+        filename="short.md",
+    )
+    draft = await client.get(f"/api/rag/pipeline/draft?kb_id={kb_id}")
+    assert draft.status_code == 200, draft.text
+    original = next(
+        stage
+        for stage in draft.json()["stages"]
+        if stage["id"] == "stage_chunker"
+    )["config"]
+
+    response = await client.post(
+        "/api/rag/strategy-router/recommendations",
+        json={
+            "kb_id": kb_id,
+            "objective": "balanced",
+            "requirements": {"exact_terms": True},
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    chunker = response.json()["profiles"][0]["chunker"]
+    assert chunker == original
+    assert "config" not in chunker


### PR DESCRIPTION
## Summary

- add the evidence-first `rag-strategy-rules-v1` research report, synthetic fixtures, and reproducible experiment matrix
- add a deterministic corpus profiler and explainable chunking/retrieval recommendation service
- add version/hash-bound recommendation persistence, stale detection, low-confidence confirmation, and draft-only application
- add the Strategy Router drawer to the existing Knowledge Pipeline Canvas
- document runtime boundaries and Harness safeguards

## Behavior

Router V1 analyzes at most 100 documents and 500,000 characters. It recommends a primary profile and up to two alternatives with confidence, evidence classification, warnings, and field-level diff.

Applying a recommendation only updates the Pipeline Draft chunker and retrieval profile. It does not call an LLM, execute ingestion, create a candidate index version, change the processor/vision/embedding model, or switch the active index. Hash embedding is never treated as semantic evidence, rerank is only suggested when a provider is ready, and score threshold remains zero until benchmark calibration.

## Validation

- focused Router/RAG suite: `37 passed`
- full backend baseline before final focused rerun: `2326 passed, 21 skipped`; one unrelated environment failure because the existing server image uses Node 20 and cannot import the TypeScript Skill matcher test (`ERR_UNKNOWN_FILE_EXTENSION`)
- frontend production build passed on the latest `main`
- backend `py_compile` and `git diff --check` passed
- desktop and 390px mobile preview passed with no browser console errors
- independent preview API smoke confirmed Draft `v1 -> v2` while the active index pointer remained unchanged
- sensitive scan found no real key, local path, Runtime storage, or generated index data

## Accepted Preview

The independent preview was manually accepted before publication. Shared stack containers were not rebuilt or modified.

## Locked Follow-up

The next Router round is `XPERT-RAG-STRATEGY-AUTO-TUNER-02`: use a fixed knowledge evaluation set to build isolated candidate index versions, search chunk/retrieval profiles, calibrate Top-K, Hybrid weights, score threshold and rerank, then rank quality, latency and index cost. It must remain candidate-only and never auto-activate an index.