### PR TITLE
feature: 完成 Skill Creator 资源化工作台闭环

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -13,10 +13,11 @@
   `server/skills/creator_reference/authoring-playbook-v1.md`
 
 ModelMirror adapts only the upstream creation-stage method: capture concrete
-usage intent, plan reusable resources, write progressively disclosed Skill
-instructions, and validate the resulting package. The local playbook was
-rewritten for ModelMirror's typed proposal contract, UTF-8-only package rules,
-trusted session requirement coverage, and PR2/PR3 quality boundary. It omits
+usage intent, plan reusable resources, confirm the plan, build resources in
+dependency order, write progressively disclosed Skill instructions, and
+validate the resulting package. The local playbook was rewritten for
+ModelMirror's typed proposal contract, UTF-8-only package rules, trusted
+session requirement coverage, and separate evaluation and installation gates. It omits
 the upstream evaluation runner, graders, result viewer, description optimizer,
 packaging scripts, and Claude-specific execution paths.
 

--- a/client/src/components/skill-creator/SkillResourceBuildPanel.test.tsx
+++ b/client/src/components/skill-creator/SkillResourceBuildPanel.test.tsx
@@ -1,0 +1,208 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  SkillCreatorSession,
+  SkillCreatorStatus,
+  SkillResourceBuild,
+  SkillResourcePlan,
+} from "../../utils/skillCreatorApi";
+import SkillResourceBuildPanel from "./SkillResourceBuildPanel";
+
+function jsonResponse(payload: unknown, status = 200) {
+  return Promise.resolve(new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  }));
+}
+
+const plan: SkillResourcePlan = {
+  plan_id: "plan_1",
+  session_id: "creator_1",
+  revision: 2,
+  digest: "b".repeat(64),
+  state: "confirmed",
+  session_revision: 3,
+  skill_name: "review-incidents",
+  skill_description: "Create incident reviews when users need a factual timeline.",
+  workflow_steps: [{ step_id: "collect", instruction: "Collect facts." }],
+  output_contract: ["Return Markdown."],
+  failure_modes: ["Mark missing facts."],
+  resources: [],
+  clarifications: [],
+  clarification_answers: {},
+  created_at: 1,
+  updated_at: 2,
+};
+
+const status: SkillCreatorStatus = {
+  enabled: true,
+  version: "skill-creator-v2",
+  model_available: true,
+  assistant_agent_id: "skill-creator-assistant-v1",
+  supported_sources: ["blank"],
+  resource_authoring_enabled: true,
+  resource_planner_available: true,
+  resource_build_enabled: true,
+  resource_builder_available: true,
+  script_sandbox_configured: true,
+};
+
+const baseSession: SkillCreatorSession = {
+  session_id: "creator_1",
+  session_revision: 3,
+  draft_state_revision: 0,
+  mode: "blank",
+  assistant_agent_id: "skill-creator-assistant-v1",
+  authoring_flow: "resource",
+  intent: "Create factual incident reviews.",
+  positive_examples: ["Review this incident."],
+  near_miss_examples: ["Rewrite this sentence."],
+  expected_output: "Markdown report.",
+  success_criteria: ["Do not invent facts."],
+  selected_evidence: [],
+  evidence_confirmed: true,
+  state: "selecting_evidence",
+  resource_plan: plan,
+  created_at: 1,
+  updated_at: 2,
+};
+
+const build: SkillResourceBuild = {
+  build_id: "build_1",
+  session_id: "creator_1",
+  revision: 5,
+  digest: "c".repeat(64),
+  state: "awaiting_review",
+  phase: "resources",
+  session_revision: 3,
+  plan_id: plan.plan_id,
+  plan_revision: plan.revision,
+  plan_digest: plan.digest,
+  skill_name: plan.skill_name,
+  skill_description: plan.skill_description,
+  workflow_steps: plan.workflow_steps,
+  output_contract: plan.output_contract,
+  failure_modes: plan.failure_modes,
+  resources: [{
+    resource_id: "resource_1",
+    spec_digest: "d".repeat(64),
+    kind: "reference",
+    action: "create",
+    path: "references/evidence-policy.md",
+    purpose: "Keep detailed evidence rules separate.",
+    source_ids: ["intent"],
+    used_by_steps: ["collect"],
+    depends_on: [],
+    acceptance_checks: ["Defines unsupported claims."],
+    state: "awaiting_review",
+    attempt: 1,
+    repair_count: 0,
+    chunks: ["# Evidence policy\n\nUse facts.\n"],
+    content: "# Evidence policy\n\nUse facts.\n",
+    content_digest: "e".repeat(64),
+    script_tests: [],
+    validation_issues: [],
+    feedback: "",
+  }],
+  current_resource_id: "resource_1",
+  skill_chunks: [],
+  skill_attempt: 1,
+  skill_repair_count: 0,
+  skill_validation_issues: [],
+  skill_feedback: "",
+  requirement_coverage: [],
+  created_at: 1,
+  updated_at: 2,
+};
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("SkillResourceBuildPanel", () => {
+  it("starts a build only after the immutable plan is confirmed", async () => {
+    const started = { ...build, state: "planned" as const, phase: "resources" as const };
+    const fetchMock = vi.fn<
+      (_input: RequestInfo | URL, _init?: RequestInit) => Promise<Response>
+    >((_input, _init) => jsonResponse({ resource_build: started }, 201));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<SkillResourceBuildPanel onProposal={vi.fn()} onSessionRefresh={vi.fn()} session={baseSession} status={status} />);
+    await userEvent.click(screen.getByRole("button", { name: "创建资源构建" }));
+
+    expect(await screen.findByRole("heading", { name: "资源构建工作台" })).toBeVisible();
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url).endsWith("/resource-build")).toBe(true);
+    expect(JSON.parse(String(init?.body))).toMatchObject({
+      plan_id: plan.plan_id,
+      expected_session_revision: baseSession.session_revision,
+      expected_plan_revision: plan.revision,
+      expected_plan_digest: plan.digest,
+    });
+  });
+
+  it("saves a complete direct edit as a new server revision", async () => {
+    const edited = {
+      ...build,
+      revision: 6,
+      digest: "f".repeat(64),
+      resources: [{
+        ...build.resources[0],
+        content: "# Evidence policy\n\nUse facts and mark gaps.\n",
+      }],
+    };
+    const fetchMock = vi.fn<
+      (_input: RequestInfo | URL, _init?: RequestInit) => Promise<Response>
+    >((_input, _init) => jsonResponse({ resource_build: edited }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<SkillResourceBuildPanel onProposal={vi.fn()} onSessionRefresh={vi.fn()} session={{ ...baseSession, resource_build: build }} status={status} />);
+    await userEvent.click(screen.getByRole("button", { name: "直接编辑完整资源" }));
+    const editor = screen.getByLabelText("编辑完整资源");
+    await userEvent.clear(editor);
+    await userEvent.type(editor, "# Evidence policy\n\nUse facts and mark gaps.\n");
+    await userEvent.click(screen.getByRole("button", { name: "保存资源 revision" }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url).endsWith("/resources/resource_1")).toBe(true);
+    expect(init?.method).toBe("PUT");
+    expect(JSON.parse(String(init?.body))).toMatchObject({
+      expected_revision: build.revision,
+      expected_digest: build.digest,
+      content: "# Evidence policy\n\nUse facts and mark gaps.\n",
+    });
+    expect(await screen.findByText(/已保存 references\/evidence-policy.md 的新构建 revision/)).toBeVisible();
+  });
+
+  it("follows the server-frozen current resource after advancing", async () => {
+    const nextResource = {
+      ...build,
+      revision: 6,
+      digest: "9".repeat(64),
+      current_resource_id: "resource_2",
+      resources: [
+        { ...build.resources[0], state: "accepted" as const },
+        {
+          ...build.resources[0],
+          resource_id: "resource_2",
+          path: "assets/report-template.md",
+          kind: "asset" as const,
+          state: "awaiting_review" as const,
+          content: "# Report template\n",
+          content_digest: "8".repeat(64),
+        },
+      ],
+    };
+    const fetchMock = vi.fn<
+      (_input: RequestInfo | URL, _init?: RequestInit) => Promise<Response>
+    >((_input, _init) => jsonResponse({ resource_build: nextResource }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<SkillResourceBuildPanel onProposal={vi.fn()} onSessionRefresh={vi.fn()} session={{ ...baseSession, resource_build: { ...build, state: "planned" } }} status={status} />);
+    await userEvent.click(screen.getByRole("button", { name: "生成下一个资源" }));
+
+    expect(await screen.findByRole("heading", { name: "assets/report-template.md" })).toBeVisible();
+    expect(screen.getByText("# Report template")).toBeVisible();
+  });
+});

--- a/client/src/components/skill-creator/SkillResourceBuildPanel.tsx
+++ b/client/src/components/skill-creator/SkillResourceBuildPanel.tsx
@@ -1,0 +1,404 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  CheckCircle2,
+  CircleAlert,
+  Code2,
+  FileDiff,
+  FileText,
+  FlaskConical,
+  LoaderCircle,
+  Pencil,
+  Play,
+  RefreshCw,
+  RotateCcw,
+  Save,
+} from "lucide-react";
+
+import {
+  advanceSkillCreatorResourceBuild,
+  editSkillCreatorResource,
+  finalizeSkillCreatorResourceBuild,
+  readSkillCreatorResourceBuild,
+  reviewSkillCreatorResource,
+  startSkillCreatorResourceBuild,
+  type SkillCreatorProposal,
+  type SkillCreatorSession,
+  type SkillCreatorStatus,
+  type SkillResourceBuild,
+  type SkillResourceBuildItem,
+} from "../../utils/skillCreatorApi";
+
+const STATE_LABELS: Record<SkillResourceBuildItem["state"], string> = {
+  planned: "待生成",
+  generating: "生成中",
+  awaiting_review: "等待确认",
+  accepted: "已确认",
+  revision_requested: "等待重做",
+  failed: "需要处理",
+  stale: "已过期",
+};
+
+const KIND_LABELS = {
+  script: "脚本",
+  reference: "参考资料",
+  asset: "输出模板",
+} as const;
+
+function byteSize(value?: string | null) {
+  return new TextEncoder().encode(value ?? "").length;
+}
+
+function shortDigest(value?: string | null) {
+  return value ? value.slice(0, 10) : "未生成";
+}
+
+function errorMessage(value: unknown, fallback: string) {
+  return value instanceof Error && value.message ? value.message : fallback;
+}
+
+interface Props {
+  session: SkillCreatorSession;
+  status: SkillCreatorStatus;
+  onProposal: (proposal: SkillCreatorProposal) => void | Promise<void>;
+  onSessionRefresh: () => void | Promise<void>;
+}
+
+function Receipt({ item }: { item: SkillResourceBuildItem }) {
+  if (item.kind !== "script") return null;
+  const receipt = item.script_receipt;
+  return (
+    <section className="border-t border-white/10 pt-4" aria-labelledby={`receipt-${item.resource_id}`}>
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h4 className="flex items-center gap-2 text-sm font-semibold text-white" id={`receipt-${item.resource_id}`}>
+          <FlaskConical aria-hidden="true" size={15} />脚本实测
+        </h4>
+        <span className={`rounded-full px-2.5 py-1 text-xs font-semibold ${receipt?.passed ? "bg-emerald-300/10 text-emerald-100" : "bg-amber-300/10 text-amber-100"}`}>
+          {receipt?.passed ? "全部通过" : "尚无有效 receipt"}
+        </span>
+      </div>
+      {receipt ? (
+        <div className="mt-3 space-y-2">
+          <p className="font-mono text-[11px] text-slate-500">{receipt.profile} · {shortDigest(receipt.script_digest)}</p>
+          {receipt.results.map((result) => (
+            <div className="flex flex-wrap items-center justify-between gap-2 border-t border-white/[0.06] py-2 text-xs" key={result.test_id}>
+              <span className="font-mono text-slate-300">{result.test_id}</span>
+              <span className={result.passed ? "text-emerald-100" : "text-rose-100"}>
+                {result.passed ? "通过" : `失败，退出码 ${result.exit_code}`} · {Math.round(result.duration_ms)} ms
+              </span>
+            </div>
+          ))}
+        </div>
+      ) : <p className="mt-2 text-xs leading-5 text-slate-400">脚本必须在离线 Sidecar 中完成 1–3 个用例，内容摘要变化后旧 receipt 自动失效。</p>}
+    </section>
+  );
+}
+
+export default function SkillResourceBuildPanel({
+  session,
+  status,
+  onProposal,
+  onSessionRefresh,
+}: Props) {
+  const [build, setBuild] = useState<SkillResourceBuild | null>(session.resource_build ?? null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [busy, setBusy] = useState("");
+  const [error, setError] = useState("");
+  const [notice, setNotice] = useState("");
+  const [feedback, setFeedback] = useState("");
+  const [editing, setEditing] = useState(false);
+  const [editedContent, setEditedContent] = useState("");
+
+  useEffect(() => {
+    if (session.resource_build) setBuild(session.resource_build);
+  }, [session.resource_build?.digest]);
+
+  useEffect(() => {
+    if (!build) return;
+    if (build.phase !== "resources") {
+      setSelectedId(null);
+      return;
+    }
+    if (build.current_resource_id) {
+      setSelectedId(build.current_resource_id);
+      return;
+    }
+    const preferred = build.resources.find((item) => item.state !== "accepted")?.resource_id
+      ?? build.resources[0]?.resource_id
+      ?? null;
+    setSelectedId((current) => (
+      current && build.resources.some((item) => item.resource_id === current)
+        ? current
+        : preferred
+    ));
+  }, [build?.digest]);
+
+  useEffect(() => {
+    if (!build || busy !== "next") return;
+    const timer = window.setInterval(() => {
+      void readSkillCreatorResourceBuild(build.build_id).then(setBuild).catch(() => undefined);
+    }, 1_500);
+    return () => window.clearInterval(timer);
+  }, [build?.build_id, busy]);
+
+  const selected = useMemo(
+    () => build?.resources.find((item) => item.resource_id === selectedId) ?? null,
+    [build, selectedId],
+  );
+  const acceptedCount = build?.resources.filter((item) => item.state === "accepted").length ?? 0;
+  const totalCount = build?.resources.length ?? 0;
+  const generatedBytes = build
+    ? build.resources.reduce((sum, item) => sum + byteSize(item.content), 0) + byteSize(build.skill_markdown)
+    : 0;
+  const builderReady = Boolean(status.resource_builder_available);
+
+  function update(next: SkillResourceBuild, message = "") {
+    setBuild(next);
+    if (message) setNotice(message);
+    setError("");
+  }
+
+  async function run(label: string, operation: () => Promise<SkillResourceBuild>, success: string) {
+    setBusy(label);
+    setError("");
+    setNotice("");
+    try {
+      update(await operation(), success);
+    } catch (caught) {
+      setError(errorMessage(caught, "资源构建操作失败。"));
+    } finally {
+      setBusy("");
+    }
+  }
+
+  async function start() {
+    await run("start", () => startSkillCreatorResourceBuild(session), "资源构建已创建，可以按依赖顺序生成。 ");
+  }
+
+  async function next() {
+    if (!build) return;
+    await run(
+      "next",
+      () => advanceSkillCreatorResourceBuild(session, build),
+      build.phase === "skill_markdown" ? "最终 SKILL.md 已组装并完成校验。" : "当前资源已完整组装并完成校验。",
+    );
+  }
+
+  async function reviewResource(decision: "accept" | "revise") {
+    if (!build || !selected) return;
+    if (decision === "revise" && !feedback.trim()) {
+      setError("请说明需要重做的具体内容。");
+      return;
+    }
+    await run(
+      decision,
+      () => reviewSkillCreatorResource(session, build, selected.resource_id, decision, feedback),
+      decision === "accept" ? `已确认 ${selected.path}。` : `已记录反馈，${selected.path} 将重新生成。`,
+    );
+    setFeedback("");
+    setEditing(false);
+  }
+
+  async function saveEdit() {
+    if (!build || !selected) return;
+    await run(
+      "edit",
+      () => editSkillCreatorResource(session, build, selected.resource_id, editedContent),
+      `已保存 ${selected.path} 的新构建 revision，并重新执行校验。`,
+    );
+    setEditing(false);
+  }
+
+  async function finalize(decision: "accept" | "revise") {
+    if (!build) return;
+    if (decision === "revise" && !feedback.trim()) {
+      setError("请说明最终 SKILL.md 需要修改的内容。");
+      return;
+    }
+    setBusy("finalize");
+    setError("");
+    setNotice("");
+    try {
+      const result = await finalizeSkillCreatorResourceBuild(session, build, decision, feedback);
+      update(result.build, decision === "accept" ? "最终包已形成标准草稿提案。" : "已记录最终文档重做要求。");
+      if (result.proposal) await onProposal(result.proposal);
+      await onSessionRefresh();
+      setFeedback("");
+    } catch (caught) {
+      setError(errorMessage(caught, "最终包确认失败。"));
+    } finally {
+      setBusy("");
+    }
+  }
+
+  if (!session.resource_plan || session.resource_plan.state !== "confirmed") {
+    return (
+      <section className="rounded-lg border border-amber-300/20 bg-amber-300/[0.06] p-5 text-sm text-amber-50">
+        请先在“素材与资源计划”中确认并冻结资源计划。
+      </section>
+    );
+  }
+
+  if (!build) {
+    return (
+      <section className="rounded-lg border border-white/10 bg-surface-900/80 p-5 sm:p-6" aria-labelledby="resource-build-start-heading">
+        <h2 className="text-xl font-semibold text-white" id="resource-build-start-heading">按确认计划构建 Skill</h2>
+        <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-400">服务端固定路径和依赖顺序，每次只生成一个完整资源。内部可分段，但只在组装、校验和脚本实测完成后请求一次确认。</p>
+        <div className="mt-5 flex flex-wrap items-center gap-3">
+          <button className="inline-flex min-h-11 items-center gap-2 rounded-full bg-hire-300 px-5 py-2.5 text-sm font-semibold text-ink-950 disabled:cursor-not-allowed disabled:opacity-40" disabled={!builderReady || Boolean(busy)} onClick={() => void start()} type="button">
+            {busy === "start" ? <LoaderCircle aria-hidden="true" className="animate-spin motion-reduce:animate-none" size={16} /> : <Play aria-hidden="true" size={16} />}
+            {busy === "start" ? "正在创建构建…" : "创建资源构建"}
+          </button>
+          <span className="text-xs text-slate-500">{session.resource_plan.resources.length} 个附加资源，随后生成 SKILL.md</span>
+        </div>
+        {!builderReady ? <p className="mt-3 text-xs text-amber-200">模型网关不可用，当前只能查看已保存计划，不能开始生成。</p> : null}
+      </section>
+    );
+  }
+
+  const activeTarget = build.phase === "skill_markdown" ? "SKILL.md" : selected?.path;
+  const canEdit = Boolean(selected && ["create", "update"].includes(selected.action) && !build.proposal_id && build.state !== "generating");
+
+  return (
+    <section className="space-y-5" aria-labelledby="resource-build-heading">
+      <div className="border-y border-white/10 py-5">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <h2 className="text-xl font-semibold text-white" id="resource-build-heading">资源构建工作台</h2>
+            <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-400">{activeTarget ? `当前目标：${activeTarget}` : "所有附加资源已完成，准备最终文档。"}</p>
+          </div>
+          <div className="flex flex-wrap gap-2 text-xs">
+            <span className="rounded-full bg-white/[0.055] px-3 py-1.5 text-slate-300">build r{build.revision}</span>
+            <span className="rounded-full bg-brand-300/10 px-3 py-1.5 text-brand-100">{acceptedCount}/{totalCount} 资源已确认</span>
+            <span className="rounded-full bg-white/[0.055] px-3 py-1.5 text-slate-400">{Math.ceil(generatedBytes / 1024)} KiB / 160 KiB</span>
+          </div>
+        </div>
+        <div className="mt-4 h-1.5 overflow-hidden rounded-full bg-white/[0.06]" aria-label={`资源确认进度 ${acceptedCount}/${totalCount}`}>
+          <div className="h-full bg-hire-300 transition-[width] duration-300 motion-reduce:transition-none" style={{ width: `${totalCount ? (acceptedCount / totalCount) * 100 : build.skill_markdown ? 100 : 0}%` }} />
+        </div>
+      </div>
+
+      {error ? <p className="rounded-md border border-rose-300/25 bg-rose-300/10 px-4 py-3 text-sm text-rose-50" role="alert">{error}</p> : null}
+      {notice ? <p className="rounded-md border border-emerald-300/20 bg-emerald-300/10 px-4 py-3 text-sm text-emerald-50" role="status">{notice}</p> : null}
+      {build.stale || build.state === "stale" ? (
+        <div className="rounded-md border border-amber-300/25 bg-amber-300/10 p-4 text-sm text-amber-50"><CircleAlert className="mr-2 inline" size={16} />用途、计划或草稿已变化。此构建只读保留，请回到上一步重新规划。</div>
+      ) : null}
+
+      <div className="grid gap-5 xl:grid-cols-[280px_minmax(0,1fr)]">
+        <nav className="min-w-0 border-b border-white/10 pb-4 xl:border-b-0 xl:border-r xl:pb-0 xl:pr-4" aria-label="资源文件进度">
+          <div className="space-y-1">
+            {build.resources.map((item) => (
+              <button
+                className={`flex min-h-11 w-full items-center gap-3 rounded-md px-3 py-2 text-left transition ${selectedId === item.resource_id ? "bg-brand-300/10 text-white" : "text-slate-300 hover:bg-white/[0.045]"}`}
+                key={item.resource_id}
+                onClick={() => { setSelectedId(item.resource_id); setEditing(false); }}
+                type="button"
+              >
+                {item.kind === "script" ? <Code2 aria-hidden="true" size={15} /> : <FileText aria-hidden="true" size={15} />}
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate font-mono text-xs">{item.path}</span>
+                  <span className={`mt-1 block text-[11px] ${item.state === "accepted" ? "text-emerald-100" : item.state === "failed" ? "text-rose-100" : "text-slate-500"}`}>{STATE_LABELS[item.state]}</span>
+                </span>
+              </button>
+            ))}
+            <button className={`flex min-h-11 w-full items-center gap-3 rounded-md px-3 py-2 text-left ${build.phase === "skill_markdown" || build.phase === "proposal" ? "bg-brand-300/10 text-white" : "text-slate-500"}`} onClick={() => setSelectedId(null)} type="button">
+              <FileDiff aria-hidden="true" size={15} /><span><span className="block font-mono text-xs">SKILL.md</span><span className="mt-1 block text-[11px]">{build.skill_markdown ? (build.phase === "proposal" ? "已确认" : "等待确认") : "最后生成"}</span></span>
+            </button>
+          </div>
+        </nav>
+
+        <div className="min-w-0">
+          {selected ? (
+            <div className="space-y-5">
+              <header className="flex flex-wrap items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="text-xs font-semibold text-brand-100">{KIND_LABELS[selected.kind]} · {selected.action}</p>
+                  <h3 className="mt-1 break-all font-mono text-base font-semibold text-white">{selected.path}</h3>
+                  <p className="mt-2 text-sm leading-6 text-slate-400">{selected.purpose}</p>
+                </div>
+                <span className="rounded-full bg-white/[0.055] px-3 py-1.5 text-xs text-slate-300">{STATE_LABELS[selected.state]}</span>
+              </header>
+
+              <div className="flex flex-wrap gap-x-5 gap-y-2 border-y border-white/10 py-3 text-xs text-slate-400">
+                <span>内部片段：{selected.chunks.length}</span><span>内容：{byteSize(selected.content)} bytes</span><span>摘要：{shortDigest(selected.content_digest)}</span><span>尝试：{selected.attempt}</span>
+              </div>
+
+              {selected.validation_issues.length ? (
+                <div className="rounded-md border border-rose-300/20 bg-rose-300/[0.07] p-4">
+                  <p className="text-sm font-semibold text-rose-50">校验问题</p>
+                  <ul className="mt-2 space-y-1 text-xs leading-5 text-rose-100">{selected.validation_issues.map((issue, index) => <li key={`${issue.code}-${index}`}>{issue.code}：{issue.message}</li>)}</ul>
+                </div>
+              ) : null}
+
+              {editing ? (
+                <div>
+                  <label className="text-sm font-semibold text-white" htmlFor={`resource-editor-${selected.resource_id}`}>编辑完整资源</label>
+                  <textarea className="mt-2 min-h-[360px] w-full resize-y rounded-md border border-white/10 bg-ink-950 px-4 py-3 font-mono text-xs leading-6 text-slate-100 focus:border-brand-300/50 focus:outline-none" id={`resource-editor-${selected.resource_id}`} onChange={(event) => setEditedContent(event.target.value)} value={editedContent} />
+                  <div className="mt-3 flex flex-wrap justify-end gap-2">
+                    <button className="min-h-11 rounded-full border border-white/15 px-4 py-2 text-sm font-semibold text-white" onClick={() => setEditing(false)} type="button">取消编辑</button>
+                    <button className="inline-flex min-h-11 items-center gap-2 rounded-full bg-hire-300 px-4 py-2 text-sm font-semibold text-ink-950 disabled:opacity-40" disabled={!editedContent.trim() || busy === "edit"} onClick={() => void saveEdit()} type="button"><Save aria-hidden="true" size={15} />{busy === "edit" ? "保存并校验…" : "保存资源 revision"}</button>
+                  </div>
+                </div>
+              ) : selected.content ? (
+                <pre className="max-h-[560px] overflow-auto whitespace-pre-wrap break-words rounded-md bg-ink-950 p-4 font-mono text-xs leading-6 text-slate-200">{selected.content}</pre>
+              ) : <p className="rounded-md border border-dashed border-white/15 p-6 text-center text-sm text-slate-400">该资源尚未生成完整内容。</p>}
+
+              <Receipt item={selected} />
+
+              {canEdit && selected.content && !editing ? <button className="inline-flex min-h-11 items-center gap-2 rounded-full border border-white/15 px-4 py-2 text-sm font-semibold text-white" onClick={() => { setEditedContent(selected.content ?? ""); setEditing(true); }} type="button"><Pencil aria-hidden="true" size={15} />直接编辑完整资源</button> : null}
+
+              {build.current_resource_id === selected.resource_id && ["awaiting_review", "failed"].includes(build.state) ? (
+                <div className="border-t border-white/10 pt-4">
+                  <label className="text-sm font-semibold text-white" htmlFor="resource-review-feedback">重做反馈</label>
+                  <textarea className="mt-2 min-h-24 w-full rounded-md border border-white/10 bg-ink-950 px-3 py-2 text-sm leading-6 text-white" id="resource-review-feedback" maxLength={4000} onChange={(event) => setFeedback(event.target.value)} placeholder="仅在需要重做时填写具体修改要求。" value={feedback} />
+                  <div className="mt-3 flex flex-wrap justify-end gap-2">
+                    <button className="inline-flex min-h-11 items-center gap-2 rounded-full border border-white/15 px-4 py-2 text-sm font-semibold text-white disabled:opacity-40" disabled={!feedback.trim() || Boolean(busy)} onClick={() => void reviewResource("revise")} type="button"><RotateCcw aria-hidden="true" size={15} />按反馈重做</button>
+                    <button className="inline-flex min-h-11 items-center gap-2 rounded-full bg-hire-300 px-4 py-2 text-sm font-semibold text-ink-950 disabled:opacity-40" disabled={selected.validation_issues.length > 0 || (selected.kind === "script" && !selected.script_receipt?.passed) || Boolean(busy)} onClick={() => void reviewResource("accept")} type="button"><CheckCircle2 aria-hidden="true" size={15} />确认完整资源</button>
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          ) : (
+            <div className="space-y-5">
+              <header>
+                <p className="text-xs font-semibold text-brand-100">最终 Skill 文档</p>
+                <h3 className="mt-1 text-lg font-semibold text-white">SKILL.md 与全包差异</h3>
+                <p className="mt-2 text-sm leading-6 text-slate-400">附加资源全部确认后才生成。文档应精确导航资源，并保留输出合同与失败降级。</p>
+              </header>
+              {build.skill_validation_issues.length ? <ul className="rounded-md border border-rose-300/20 bg-rose-300/[0.07] p-4 text-xs leading-5 text-rose-100">{build.skill_validation_issues.map((issue, index) => <li key={`${issue.code}-${index}`}>{issue.code}：{issue.message}</li>)}</ul> : null}
+              {build.skill_markdown ? <pre className="max-h-[640px] overflow-auto whitespace-pre-wrap break-words rounded-md bg-ink-950 p-4 font-mono text-xs leading-6 text-slate-200">{build.skill_markdown}</pre> : <p className="rounded-md border border-dashed border-white/15 p-6 text-center text-sm text-slate-400">等待生成最终 SKILL.md。</p>}
+              {build.skill_markdown ? (
+                <details className="rounded-md border border-white/10 p-4">
+                  <summary className="cursor-pointer text-sm font-semibold text-white">查看完整包文件差异</summary>
+                  <div className="mt-4 space-y-4">
+                    {build.resources.map((item) => <article className="border-t border-white/10 pt-3" key={item.resource_id}><p className="font-mono text-xs text-brand-100">{item.action} {item.path}</p>{item.base_content != null ? <pre className="mt-2 max-h-40 overflow-auto whitespace-pre-wrap rounded-md bg-black/20 p-3 font-mono text-[11px] text-slate-500">原版本：\n{item.base_content}</pre> : null}{item.action !== "delete" && item.content != null ? <pre className="mt-2 max-h-52 overflow-auto whitespace-pre-wrap rounded-md bg-ink-950 p-3 font-mono text-[11px] text-slate-300">新版本：\n{item.content}</pre> : null}</article>)}
+                  </div>
+                </details>
+              ) : null}
+              {build.phase === "skill_markdown" && ["awaiting_review", "failed"].includes(build.state) ? (
+                <div className="border-t border-white/10 pt-4">
+                  <label className="text-sm font-semibold text-white" htmlFor="skill-review-feedback">最终文档反馈</label>
+                  <textarea className="mt-2 min-h-24 w-full rounded-md border border-white/10 bg-ink-950 px-3 py-2 text-sm leading-6 text-white" id="skill-review-feedback" maxLength={4000} onChange={(event) => setFeedback(event.target.value)} value={feedback} />
+                  <div className="mt-3 flex flex-wrap justify-end gap-2">
+                    <button className="inline-flex min-h-11 items-center gap-2 rounded-full border border-white/15 px-4 py-2 text-sm font-semibold text-white disabled:opacity-40" disabled={!feedback.trim() || Boolean(busy)} onClick={() => void finalize("revise")} type="button"><RotateCcw aria-hidden="true" size={15} />按反馈重做 SKILL.md</button>
+                    <button className="inline-flex min-h-11 items-center gap-2 rounded-full bg-hire-300 px-4 py-2 text-sm font-semibold text-ink-950 disabled:opacity-40" disabled={build.skill_validation_issues.length > 0 || Boolean(busy)} onClick={() => void finalize("accept")} type="button"><CheckCircle2 aria-hidden="true" size={15} />确认最终包并形成提案</button>
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {!build.stale && ["planned", "revision_requested"].includes(build.state) ? (
+        <div className="sticky bottom-20 z-10 flex flex-wrap items-center justify-between gap-3 border border-white/10 bg-ink-950 px-4 py-3 sm:bottom-4">
+          <p className="text-xs text-slate-400">{build.phase === "resources" ? "生成下一个依赖已满足的完整资源" : "生成最终 SKILL.md 并执行全包校验"}</p>
+          <button className="inline-flex min-h-11 items-center gap-2 rounded-full bg-brand-200 px-5 py-2 text-sm font-semibold text-ink-950 disabled:opacity-40" disabled={!builderReady || Boolean(busy)} onClick={() => void next()} type="button">{busy === "next" ? <LoaderCircle aria-hidden="true" className="animate-spin motion-reduce:animate-none" size={16} /> : <Play aria-hidden="true" size={16} />}{busy === "next" ? "正在分段生成并校验…" : build.phase === "resources" ? "生成下一个资源" : "生成最终 SKILL.md"}</button>
+        </div>
+      ) : null}
+
+      {build.state === "generating" ? <p className="flex items-center gap-2 text-sm text-brand-100" aria-live="polite"><LoaderCircle aria-hidden="true" className="animate-spin motion-reduce:animate-none" size={16} />模型正在生成 {activeTarget}，刷新不会丢失已保存片段。</p> : null}
+      {build.phase === "proposal" && build.proposal_id ? <p className="flex items-center gap-2 rounded-md border border-emerald-300/20 bg-emerald-300/[0.07] p-4 text-sm text-emerald-50"><CheckCircle2 aria-hidden="true" size={16} />最终包已确认，等待在下方审阅标准草稿提案。</p> : null}
+      {build.state === "failed" ? <button className="inline-flex min-h-11 items-center gap-2 rounded-full border border-white/15 px-4 py-2 text-sm font-semibold text-white" onClick={() => void readSkillCreatorResourceBuild(build.build_id).then((value) => update(value, "已重新读取构建状态。"))} type="button"><RefreshCw aria-hidden="true" size={15} />重新读取构建</button> : null}
+    </section>
+  );
+}

--- a/client/src/components/skill-creator/SkillResourcePlanPanel.test.tsx
+++ b/client/src/components/skill-creator/SkillResourcePlanPanel.test.tsx
@@ -70,6 +70,7 @@ const session: SkillCreatorSession = {
   session_id: "creator_1",
   session_revision: 3,
   draft_state_revision: 1,
+  authoring_flow: "resource",
   mode: "blank",
   assistant_agent_id: "skill-creator-assistant-v1",
   intent: "Create factual incident reviews.",

--- a/client/src/components/skill-creator/SkillResourcePlanPanel.tsx
+++ b/client/src/components/skill-creator/SkillResourcePlanPanel.tsx
@@ -62,6 +62,7 @@ function errorMessage(value: unknown, fallback: string) {
 
 export default function SkillResourcePlanPanel({ session, status, onSession }: Props) {
   const plan = session.resource_plan ?? null;
+  const legacyFlow = session.authoring_flow !== "resource";
   const [busy, setBusy] = useState("");
   const [error, setError] = useState("");
   const [notice, setNotice] = useState("");
@@ -246,7 +247,11 @@ export default function SkillResourcePlanPanel({ session, status, onSession }: P
 
       {!plan ? (
         <div className="mt-5 rounded-md border border-white/10 bg-ink-950/45 p-4">
-          <p className="text-sm text-slate-300">素材确认后，让固定 Creator 助手只生成一份可编辑计划，不生成任何文件。</p>
+          <p className="text-sm text-slate-300">
+            {legacyFlow
+              ? "这是旧版 Creator 会话。现有提案和草稿保持可读；只有你主动进入资源规划后，才切换到逐资源生成流程。"
+              : "素材确认后，让固定 Creator 助手只生成一份可编辑计划，不生成任何文件。"}
+          </p>
           <button
             className="mt-4 inline-flex min-h-11 items-center gap-2 rounded-full bg-hire-300 px-5 py-2.5 text-sm font-semibold text-ink-950 transition hover:bg-hire-200 disabled:cursor-not-allowed disabled:opacity-40"
             disabled={!session.evidence_confirmed || plannerUnavailable || Boolean(busy)}
@@ -254,7 +259,7 @@ export default function SkillResourcePlanPanel({ session, status, onSession }: P
             type="button"
           >
             {busy === "generate" ? <LoaderCircle className="animate-spin" aria-hidden="true" size={16} /> : <Sparkles aria-hidden="true" size={16} />}
-            {busy === "generate" ? "正在分析需求…" : "生成资源计划"}
+            {busy === "generate" ? "正在分析需求…" : legacyFlow ? "进入资源规划并生成计划" : "生成资源计划"}
           </button>
           {plannerUnavailable ? <p className="mt-3 text-xs text-amber-200">模型网关未配置，暂时不能生成资源计划。</p> : null}
         </div>

--- a/client/src/pages/SkillCreatorStudioPage.tsx
+++ b/client/src/pages/SkillCreatorStudioPage.tsx
@@ -21,6 +21,7 @@ import SkillEvaluationDesigner from "../components/skill-creator/SkillEvaluation
 import SkillEvaluationReview from "../components/skill-creator/SkillEvaluationReview";
 import SkillPackageEditor from "../components/skill-creator/SkillPackageEditor";
 import SkillProposalReview from "../components/skill-creator/SkillProposalReview";
+import SkillResourceBuildPanel from "../components/skill-creator/SkillResourceBuildPanel";
 import SkillResourcePlanPanel from "../components/skill-creator/SkillResourcePlanPanel";
 import { useSkillCreatorStatus } from "../hooks/useSkillCreatorStatus";
 import {
@@ -66,6 +67,8 @@ type CreatorStep = {
 const RESOURCE_STEPS: readonly CreatorStep[] = LEGACY_STEPS.map((step, index) => (
   index === 1
     ? { ...step, title: "素材与资源计划", detail: "确认素材并规划可复用资源" }
+    : index === 2
+      ? { ...step, title: "构建资源", detail: "逐项生成、实测并确认完整文件" }
     : step
 ));
 
@@ -252,6 +255,13 @@ export default function SkillCreatorStudioPage() {
     if (!hydratedProposal && value.proposal_id) {
       hydratedProposal = await readSkillCreatorProposal(value.proposal_id);
     }
+    if (!hydratedProposal && value.resource_build?.proposal_id) {
+      try {
+        hydratedProposal = await readSkillCreatorProposal(value.resource_build.proposal_id);
+      } catch {
+        hydratedProposal = null;
+      }
+    }
     let hydratedRun = value.evaluation_run ?? null;
     const runId = value.active_evaluation_run_id ?? value.latest_evaluation_run_id;
     if (!hydratedRun && runId) {
@@ -268,8 +278,10 @@ export default function SkillCreatorStudioPage() {
     setEvaluationRun(hydratedRun);
     syncSessionForm(value);
     let restoredStep = 0;
+    const resourceFlow = value.authoring_flow === "resource";
     if (!hydratedDraft && value.evidence_confirmed) restoredStep = 1;
-    if (hydratedDraft) restoredStep = 2;
+    if (resourceFlow && (value.resource_build || value.resource_plan?.state === "confirmed")) restoredStep = 2;
+    if (hydratedDraft) restoredStep = resourceFlow ? 3 : 2;
     if (value.state === "designing_tests") restoredStep = 3;
     if (hydratedRun || value.state === "reviewing_results") restoredStep = 4;
     if (
@@ -277,7 +289,7 @@ export default function SkillCreatorStudioPage() {
       value.review_state === "revise" || value.review_state === "accepted" || value.review_state === "waived" ||
       value.quality_status === "accepted" || value.quality_status === "eval_waived"
     ) restoredStep = 5;
-    if (hydratedProposal?.status === "pending" && value.review_state !== "revise") restoredStep = 1;
+    if (hydratedProposal?.status === "pending" && value.review_state !== "revise") restoredStep = resourceFlow ? 2 : 1;
     setActiveStep((current) => Math.max(current, restoredStep));
   }, [syncSessionForm]);
 
@@ -449,7 +461,7 @@ export default function SkillCreatorStudioPage() {
     try {
       await approveSkillCreatorProposal(proposal);
       await loadSession();
-      setActiveStep(2);
+      setActiveStep(session?.authoring_flow === "resource" ? 3 : 2);
       setNotice("提案已写入不可变草稿版本。该草稿仍需完成当前摘要的三例对照评测后才能安装。");
     } catch (caught) {
       handleError(caught, "提案批准失败。");
@@ -567,19 +579,27 @@ export default function SkillCreatorStudioPage() {
     };
   }, [draftDirty]);
 
-  const steps = status?.resource_authoring_enabled ? RESOURCE_STEPS : LEGACY_STEPS;
+  const resourceFlow = Boolean(status?.resource_authoring_enabled && session?.authoring_flow === "resource");
+  const steps = resourceFlow ? RESOURCE_STEPS : LEGACY_STEPS;
   const currentStep = steps[activeStep];
   const qualityStatus = session?.quality_status ?? draft?.quality_status ?? "not_evaluated";
   const installState = session?.install_state ?? draft?.install_state ?? "not_installed";
   const evaluationTerminal = Boolean(evaluationRun && ["completed", "failed", "cancelled", "stale"].includes(evaluationRun.status));
-  const availableSteps = useMemo(() => [
+  const availableSteps = useMemo(() => resourceFlow ? [
+    true,
+    true,
+    Boolean(session?.resource_build || session?.resource_plan?.state === "confirmed"),
+    Boolean(draft),
+    Boolean(evaluationRun),
+    Boolean(draft && (evaluationTerminal || session?.review_state === "revise" || qualityStatus === "accepted" || qualityStatus === "eval_waived")),
+  ] : [
     true,
     true,
     Boolean(draft),
     Boolean(draft),
     Boolean(evaluationRun),
     Boolean(draft && (evaluationTerminal || session?.review_state === "revise" || qualityStatus === "accepted" || qualityStatus === "eval_waived")),
-  ], [draft, evaluationRun, evaluationTerminal, qualityStatus, session?.review_state]);
+  ], [draft, evaluationRun, evaluationTerminal, qualityStatus, resourceFlow, session?.resource_build, session?.resource_plan?.state, session?.review_state]);
 
   async function acceptHydratedSession(value: SkillCreatorSession) {
     await hydrate(value);
@@ -772,7 +792,7 @@ export default function SkillCreatorStudioPage() {
                 <SkillResourcePlanPanel onSession={acceptHydratedSession} session={session} status={status} />
               ) : null}
 
-              {!status.resource_authoring_enabled && proposal?.status !== "pending" ? (
+              {!resourceFlow && proposal?.status !== "pending" ? (
                 <section className={`grid gap-5 ${draft ? "lg:grid-cols-1" : "lg:grid-cols-2"}`}>
                   <div className="rounded-lg border border-brand-300/20 bg-surface-900/80 p-5">
                     <div className="flex items-center gap-3">
@@ -834,9 +854,33 @@ export default function SkillCreatorStudioPage() {
             </div>
           ) : null}
 
-          {activeStep === 2 && draft ? (
+          {activeStep === 2 && resourceFlow ? (
+            <div className="mt-5 space-y-5">
+              <SkillResourceBuildPanel
+                onProposal={async (nextProposal) => {
+                  setProposal(nextProposal);
+                  setNotice("最终资源包已形成标准提案，请检查全包差异后批准写入草稿。");
+                }}
+                onSessionRefresh={loadSession}
+                session={session}
+                status={status}
+              />
+              {proposal?.status === "pending" ? (
+                <SkillProposalReview
+                  approving={busy === "approve"}
+                  baseDraft={draft}
+                  onApprove={approveProposal}
+                  onReject={rejectProposal}
+                  proposal={proposal}
+                  rejecting={busy === "reject"}
+                />
+              ) : null}
+            </div>
+          ) : null}
+
+          {activeStep === 2 && !resourceFlow && draft ? (
             <div className="mt-5">
-              {!status.resource_authoring_enabled && proposal?.status !== "pending" ? (
+              {proposal?.status !== "pending" ? (
                 <section className="mb-4 rounded-lg border border-brand-300/20 bg-brand-300/[0.06] p-4" aria-labelledby="creator-update-proposal-heading">
                   <div className="min-w-0">
                     <h2 className="text-sm font-semibold text-white" id="creator-update-proposal-heading">AI 生成可评测更新初稿</h2>

--- a/client/src/utils/skillCreatorApi.ts
+++ b/client/src/utils/skillCreatorApi.ts
@@ -374,12 +374,108 @@ export interface SkillResourcePlan {
   updated_at: number;
 }
 
+export type SkillResourceBuildState =
+  | "planned"
+  | "generating"
+  | "awaiting_review"
+  | "accepted"
+  | "revision_requested"
+  | "failed"
+  | "stale";
+
+export interface SkillResourceScriptTestResult {
+  test_id: string;
+  passed: boolean;
+  exit_code: number;
+  stdout_sha256: string;
+  stderr_sha256: string;
+  duration_ms: number;
+  issues: string[];
+}
+
+export interface SkillResourceScriptReceipt {
+  receipt_id: string;
+  script_digest: string;
+  profile: string;
+  passed: boolean;
+  results: SkillResourceScriptTestResult[];
+  created_at: number;
+}
+
+export interface SkillResourceBuildItem {
+  resource_id: string;
+  spec_digest: string;
+  kind: "script" | "reference" | "asset";
+  action: "keep" | "create" | "update" | "delete";
+  path: string;
+  purpose: string;
+  source_ids: string[];
+  used_by_steps: string[];
+  depends_on: string[];
+  acceptance_checks: string[];
+  state: SkillResourceBuildState;
+  attempt: number;
+  repair_count: number;
+  chunks: string[];
+  content?: string | null;
+  content_digest?: string | null;
+  base_content?: string | null;
+  base_digest?: string | null;
+  script_tests: Array<{
+    test_id: string;
+    args: string[];
+    fixtures: Array<{ path: string; content: string }>;
+    expected_exit_code: number;
+    stdout_contains: string[];
+    stderr_contains: string[];
+  }>;
+  script_receipt?: SkillResourceScriptReceipt | null;
+  validation_issues: SkillPackageIssue[];
+  feedback: string;
+}
+
+export interface SkillResourceBuild {
+  build_id: string;
+  session_id: string;
+  revision: number;
+  digest: string;
+  state: SkillResourceBuildState;
+  phase: "resources" | "skill_markdown" | "proposal";
+  session_revision: number;
+  plan_id: string;
+  plan_revision: number;
+  plan_digest: string;
+  draft_id?: string | null;
+  draft_revision?: number | null;
+  draft_digest?: string | null;
+  skill_name: string;
+  skill_description: string;
+  workflow_steps: SkillResourcePlanStep[];
+  output_contract: string[];
+  failure_modes: string[];
+  resources: SkillResourceBuildItem[];
+  current_resource_id?: string | null;
+  skill_chunks: string[];
+  skill_markdown?: string | null;
+  skill_markdown_digest?: string | null;
+  skill_attempt: number;
+  skill_repair_count: number;
+  skill_validation_issues: SkillPackageIssue[];
+  skill_feedback: string;
+  requirement_coverage: Array<Record<string, unknown>>;
+  proposal_id?: string | null;
+  stale?: boolean;
+  created_at: number;
+  updated_at: number;
+}
+
 export interface SkillCreatorSession {
   session_id: string;
   session_revision: number;
   draft_state_revision: number;
   mode: "blank" | "run";
   assistant_agent_id: "skill-creator-assistant-v1" | string;
+  authoring_flow?: "legacy" | "resource";
   intent: string;
   positive_examples: string[];
   near_miss_examples: string[];
@@ -420,6 +516,7 @@ export interface SkillCreatorSession {
   proposal?: SkillCreatorProposal | null;
   draft?: SkillCreatorDraft | null;
   resource_plan?: SkillResourcePlan | null;
+  resource_build?: SkillResourceBuild | null;
   created_at: number;
   updated_at: number;
 }
@@ -435,6 +532,10 @@ export interface SkillCreatorStatus {
   resource_authoring_enabled?: boolean;
   resource_authoring_version?: string | null;
   resource_planner_available?: boolean;
+  resource_build_enabled?: boolean;
+  resource_build_version?: string | null;
+  resource_builder_available?: boolean;
+  script_sandbox_configured?: boolean;
 }
 
 export interface SkillCreatorListResponse {
@@ -525,6 +626,7 @@ function unwrapSession(
         cases_revision?: number;
         evaluation_run?: SkillEvaluationRun | null;
         resource_plan?: SkillResourcePlan | null;
+        resource_build?: SkillResourceBuild | null;
       },
 ): SkillCreatorSession {
   if (!("session" in payload)) return payload;
@@ -536,6 +638,7 @@ function unwrapSession(
     cases_revision: payload.cases_revision ?? payload.session.cases_revision,
     evaluation_run: payload.evaluation_run ?? payload.session.evaluation_run,
     resource_plan: payload.resource_plan ?? payload.session.resource_plan,
+    resource_build: payload.resource_build ?? payload.session.resource_build,
   };
 }
 
@@ -912,6 +1015,100 @@ export async function confirmSkillCreatorResourcePlan(session: SkillCreatorSessi
     `/api/skills/creator/sessions/${encodeURIComponent(session.session_id)}/resource-plan/confirm`,
     jsonRequest("POST", resourcePlanWritePayload(session, plan)),
   ));
+}
+
+function resourceBuildMutationPayload(
+  session: SkillCreatorSession,
+  build: SkillResourceBuild,
+) {
+  return {
+    expected_session_revision: session.session_revision,
+    expected_revision: build.revision,
+    expected_digest: build.digest,
+  };
+}
+
+function unwrapResourceBuild(
+  payload: SkillResourceBuild | { resource_build: SkillResourceBuild },
+) {
+  return "resource_build" in payload ? payload.resource_build : payload;
+}
+
+export async function startSkillCreatorResourceBuild(session: SkillCreatorSession) {
+  const plan = session.resource_plan;
+  if (!plan) throw new Error("Resource plan is unavailable.");
+  return unwrapResourceBuild(await request<{ resource_build: SkillResourceBuild }>(
+    `/api/skills/creator/sessions/${encodeURIComponent(session.session_id)}/resource-build`,
+    jsonRequest("POST", resourcePlanWritePayload(session, plan)),
+  ));
+}
+
+export async function readSkillCreatorResourceBuild(buildId: string) {
+  return unwrapResourceBuild(await request<{ resource_build: SkillResourceBuild }>(
+    `/api/skills/creator/resource-builds/${encodeURIComponent(buildId)}`,
+  ));
+}
+
+export async function advanceSkillCreatorResourceBuild(
+  session: SkillCreatorSession,
+  build: SkillResourceBuild,
+) {
+  return unwrapResourceBuild(await request<{ resource_build: SkillResourceBuild }>(
+    `/api/skills/creator/resource-builds/${encodeURIComponent(build.build_id)}/next`,
+    jsonRequest("POST", resourceBuildMutationPayload(session, build)),
+  ));
+}
+
+export async function reviewSkillCreatorResource(
+  session: SkillCreatorSession,
+  build: SkillResourceBuild,
+  resourceId: string,
+  decision: "accept" | "revise",
+  feedback = "",
+) {
+  return unwrapResourceBuild(await request<{ resource_build: SkillResourceBuild }>(
+    `/api/skills/creator/resource-builds/${encodeURIComponent(build.build_id)}/resources/${encodeURIComponent(resourceId)}/review`,
+    jsonRequest("POST", {
+      ...resourceBuildMutationPayload(session, build),
+      decision,
+      feedback,
+    }),
+  ));
+}
+
+export async function editSkillCreatorResource(
+  session: SkillCreatorSession,
+  build: SkillResourceBuild,
+  resourceId: string,
+  content: string,
+) {
+  return unwrapResourceBuild(await request<{ resource_build: SkillResourceBuild }>(
+    `/api/skills/creator/resource-builds/${encodeURIComponent(build.build_id)}/resources/${encodeURIComponent(resourceId)}`,
+    jsonRequest("PUT", {
+      ...resourceBuildMutationPayload(session, build),
+      content,
+    }),
+  ));
+}
+
+export async function finalizeSkillCreatorResourceBuild(
+  session: SkillCreatorSession,
+  build: SkillResourceBuild,
+  decision: "accept" | "revise",
+  feedback = "",
+) {
+  const result = await request<{
+    resource_build: SkillResourceBuild;
+    proposal?: SkillCreatorProposal | null;
+  }>(
+    `/api/skills/creator/resource-builds/${encodeURIComponent(build.build_id)}/finalize`,
+    jsonRequest("POST", {
+      ...resourceBuildMutationPayload(session, build),
+      decision,
+      feedback,
+    }),
+  );
+  return { build: result.resource_build, proposal: result.proposal ?? null };
 }
 
 export async function generateSkillCreatorProposal(session: SkillCreatorSession) {

--- a/docs/SKILL_EXPERIENCE_AUDIT.md
+++ b/docs/SKILL_EXPERIENCE_AUDIT.md
@@ -1,7 +1,7 @@
 # Skill 体验治理与候选能力审计
 
-最后更新日期：2026-08-08
-状态：Creator V1 核心闭环已实现；资源化增强、上传与外部市场接入延后
+最后更新日期：2026-08-10
+状态：Creator V1 与资源化创作闭环已实现；上传与外部市场接入延后
 
 ## 1. 当前边界
 
@@ -92,7 +92,7 @@ node scripts/audit-skill-experience.mjs
 
 ## 4. 候选能力审计
 
-本节记录三项候选能力的审计结论与当前落地边界。“按需求寻找 Skill”与私有控制台 Creator V1 核心闭环已实现；上传 Skill、Creator 资源化创作增强与外部市场继续延后。
+本节记录三项候选能力的审计结论与当前落地边界。“按需求寻找 Skill”与私有控制台 Creator V1（含资源化创作）已实现；上传 Skill 与外部市场继续延后。
 
 ### 4.1 允许用户上传 Skill
 
@@ -131,9 +131,7 @@ node scripts/audit-skill-experience.mjs
 
 评测合同：客观 Skill 必须完成与当前 digest 绑定的恰好 3 个用例；主观创作类 Skill 可运行同一三例，或由本地控制台填写原因并二次确认豁免。新 Skill 的 baseline 不加载 Skill；升级 Skill 的 baseline 固定为会话开始时已安装的 digest；Candidate 使用当前不可变 Overlay。两侧使用同一实际模型与参数，只开放 `skill_read`、`skill_stage` 和固定离线 Sandbox；不开放网络、MCP、浏览器、安装或 HITL。接受或豁免均不会自动安装，当前 digest 仍需单独确认全局安装。
 
-该闭环已建立行为质量证据，但仍不等同于 Creator 已达到官方案例的资源组织质量；需要依据真实评测结果再进入一轮独立的“资源化创作增强”。
-
-后续资源化增强轮聚焦：
+资源化创作在行为质量门之前增加了“澄清 → 资源计划 → 用户确认 → 逐资源生成与验证 → 最终 `SKILL.md` → 提案确认”的阶段：
 
 - 根据任务重复性与确定性，主动判断是否应生成 `scripts/`，并要求脚本具有清晰入口、失败行为、语法检查和实际测试证据；不为凑目录生成脆弱脚本。
 - 将较长的领域规则、格式约定和查证材料拆入 `references/`，在 `SKILL.md` 中提供按需导航；运行时支持按文件读取，并为大量参考资料提供受限的 `rg` 检索路径，避免一次性注入全部上下文。
@@ -142,11 +140,13 @@ node scripts/audit-skill-experience.mjs
 
 该增强轮也不将 `eval/`、`evals/`、`README.md` 或 user-meta 写入 Skill 包；评测数据继续由 ModelMirror 的独立 Evaluation Store 管理，用户与来源元数据继续由 Creator Session 和可信运行记录管理。保存草稿、通过评测、安装到本地和未来发布到共享市场仍是彼此独立的权限动作。
 
-阶段性结论：Creator V1 已能生成“结构完整、可评测的初稿”并建立行为质量证据；下一轮资源化增强再对齐官方 Creator 案例中按需拆分、检索和加载资源的成熟度。
+阶段性结论：Creator V1 已能先规划再生成，并按实际复杂度组织可评测初稿；资源数量不是质量指标，简单 Skill 可以保持零附加资源，复杂 Skill 才按需拆分。
 
-资源化增强 PR 1 已建立 `resource-authoring-v2` 的不可变规划合同：固定 Creator 先提出必要澄清问题，再给出可编辑、可冻结的工作流与资源计划；简单 Skill 可以明确选择零附加资源。该阶段不生成文件，不写 Authoring Proposal，也不改变既有评测和安装门。`SKILL_CREATOR_RESOURCE_AUTHORING_ENABLED` 默认关闭，独立预览验收时才显式开启；PR 2 完成资源构建与脚本实测、PR 3 完成工作台迁移后再成为新 Session 默认流程。
+资源化增强 PR 1 建立了 `resource-authoring-v2` 的不可变规划合同：固定 Creator 先提出必要澄清问题，再给出可编辑、可冻结的工作流与资源计划；简单 Skill 可以明确选择零附加资源。该阶段不生成文件，不写 Authoring Proposal，也不改变既有评测和安装门。
 
-资源化增强 PR 2 已补齐服务端构建合同：确认后的计划按依赖顺序逐项生成，单个资源可在服务端内部拆成最多三个 8 KiB 片段，完整组装、静态校验与脚本离线实测后才进入一次用户评审。`skill_authoring_v1` Sidecar 配置将 `inputs/` 与 `skills/` 设为只读，只允许 `work/`、`.tmp/` 写入及 `python`、`python3`、`node`、`rg` 命令；脚本 receipt 与内容 digest 绑定。所有资源确认后才生成 `SKILL.md`，通过资源闭环与 Creator 初稿完整度门后形成普通待审提案，仍不能绕过三例行为评测或独立安装确认。功能开关继续默认关闭，PR 3 再提供完整工作台和旧会话迁移。
+资源化增强 PR 2 补齐了服务端构建合同：确认后的计划按依赖顺序逐项生成，单个资源可在服务端内部拆成最多三个 8 KiB 片段，完整组装、静态校验与脚本离线实测后才进入一次用户评审。`skill_authoring_v1` Sidecar 配置将 `inputs/` 与 `skills/` 设为只读，只允许 `work/`、`.tmp/` 写入及 `python`、`python3`、`node`、`rg` 命令；脚本 receipt 与内容 digest 绑定。所有资源确认后才生成 `SKILL.md`，通过资源闭环与 Creator 初稿完整度门后形成普通待审提案，仍不能绕过三例行为评测或独立安装确认。
+
+资源化增强 PR 3 将该合同接入工作台：新 Session 默认使用资源化流程，旧 Session 只读兼容并需用户主动迁移；页面按完整资源展示一次接受或重做，支持直接编辑生成新构建 revision，并在资源全部确认后单独评审最终 `SKILL.md` 与全包差异。`SKILL_CREATOR_RESOURCE_AUTHORING_ENABLED` 默认开启；设为 `false` 可回退到旧提案流程，不影响 Creator 的评测与安装质量门。
 
 ### 4.4 外部市场
 

--- a/docs/SKILL_INTEGRATION.md
+++ b/docs/SKILL_INTEGRATION.md
@@ -230,7 +230,7 @@ curl -X DELETE http://localhost:8000/api/skills/anthropics-skills-skills-pdf
 - `技能市场`：合并手工精选与两个生成目录，支持关键词、功能分类、Skill/SkillSet、可安装状态筛选；默认分批渲染 48 项，避免一次挂载全部索引卡片。
 - 父级组合包显示“安装技能包”；成员集合显示“成员可安装”和“查看成员”，详情支持本地名称/路径搜索、每页 50 项分页、成员逐项安装，以及按顺序调用现有接口的“一键安装全部成员”。该操作会跳过已安装成员并在首个失败处停止，不使用整仓安装或新增后端批量协议。
 - `已安装`：调用 `/api/skills/installed`，展示本地已安装 Skill，提供卸载按钮。
-- `工作区草稿`、`待审提案`：保留通用创作与审批入口；默认开启的私有 `/skills/create` 提供 Creator V1 工作台。Creator 草稿须完成当前摘要的三例隔离对照评测，或仅对主观创作类记录明确人工豁免。质量门通过后仍需独立确认安装，评测不会自动安装。其后的 `scripts/`、`references/`、可选 `assets/` 资源化增强边界见 [Skill 体验治理与候选能力审计](./SKILL_EXPERIENCE_AUDIT.md#43-通过-skill-creator-创建-skill)。
+- `工作区草稿`、`待审提案`：保留通用创作与审批入口；默认开启的私有 `/skills/create` 提供 Creator V1 工作台。新 Session 先确认资源计划，再按需生成和验证 `scripts/`、`references/`、可选 `assets/`，最后评审 `SKILL.md`；简单 Skill 可以不生成附加资源。Creator 草稿仍须完成当前摘要的三例隔离对照评测，或仅对主观创作类记录明确人工豁免。质量门通过后仍需独立确认安装，评测不会自动安装。详细边界见 [Skill 体验治理与候选能力审计](./SKILL_EXPERIENCE_AUDIT.md#43-通过-skill-creator-创建-skill)。
 
 社区资源卡片同时显示原始来源与收录索引。安装第三方条目只会复制目录，不会在安装阶段自动执行脚本；用户仍需在激活前检查依赖、外部服务和凭据要求。
 
@@ -291,4 +291,3 @@ cd client && npm.cmd run build
 4. 切换到 `已安装`，确认可见。
 5. 打开任意 `/chat/:modelId`，在 Skill 下拉框选择刚安装的 Skill。
 6. 发送“你能做什么？”，观察回复是否体现该 Skill 的能力。
-

--- a/server/.env.example
+++ b/server/.env.example
@@ -14,7 +14,7 @@ WORKFLOW_AGENT_STRATEGY_V2_ENABLED=true
 # 设为 false 并重启 Server 可同时关闭 Creator API 与界面入口。
 SKILL_CREATOR_V2_ENABLED=true
 # 资源化 Creator 已具备规划、分段构建和脚本离线实测；PR 3 工作台完成前默认关闭。
-SKILL_CREATOR_RESOURCE_AUTHORING_ENABLED=false
+SKILL_CREATOR_RESOURCE_AUTHORING_ENABLED=true
 # 可选运维覆盖；实时目录和前端默认选择不依赖这两个旧回退值。
 OPENROUTER_TEXT_FALLBACK_MODEL=deepseek/deepseek-chat
 OPENROUTER_VISION_FALLBACK_MODEL=qwen/qwen2.5-vl-72b-instruct

--- a/server/THIRD_PARTY_NOTICES.md
+++ b/server/THIRD_PARTY_NOTICES.md
@@ -184,7 +184,8 @@ ModelMirror includes a modified creation-stage authoring playbook derived from
   `/app/skills/creator_reference/LICENSE-ANTHROPIC-SKILL-CREATOR.txt`
 
 The playbook was rewritten for ModelMirror's typed proposal, UTF-8 package,
-trusted requirement-coverage and PR2/PR3 quality contracts. It excludes the
+interactive resource-planning and build flow, trusted requirement coverage,
+and separate evaluation and installation gates. It excludes the
 upstream evaluator, graders, result viewer, description optimizer, packaging
 scripts and Claude-specific execution paths. Anthropic does not endorse
 ModelMirror; this notice uses the project name only to identify provenance.

--- a/server/skills/creator_api.py
+++ b/server/skills/creator_api.py
@@ -146,6 +146,10 @@ class CreatorResourceReviewRequest(CreatorResourceBuildMutationRequest):
     feedback: str = Field(default="", max_length=4_000)
 
 
+class CreatorResourceEditRequest(CreatorResourceBuildMutationRequest):
+    content: str = Field(min_length=1, max_length=24 * 1024)
+
+
 class CreatorResourceFinalizeRequest(CreatorResourceBuildMutationRequest):
     decision: Literal["accept", "revise"]
     feedback: str = Field(default="", max_length=4_000)
@@ -240,6 +244,25 @@ class CreatorEvaluationIterateRequest(CreatorEvaluationWriteRequest):
 
 def configure_skill_creator(service: SkillCreatorService | None) -> None:
     global _service
+    global _evaluation_service
+    global _resource_planning_service
+    global _resource_build_service
+    if service is not _service:
+        if (
+            _evaluation_service is not None
+            and getattr(_evaluation_service, "creator_service", None) is not service
+        ):
+            _evaluation_service = None
+        if (
+            _resource_planning_service is not None
+            and getattr(_resource_planning_service, "creator_service", None) is not service
+        ):
+            _resource_planning_service = None
+        if (
+            _resource_build_service is not None
+            and getattr(_resource_build_service, "creator_service", None) is not service
+        ):
+            _resource_build_service = None
     _service = service
 
 
@@ -508,8 +531,15 @@ async def list_creator_sessions(limit: int = Query(default=100, ge=1, le=500)):
 async def create_creator_session(payload: CreatorSessionCreateRequest):
     try:
         service = get_skill_creator_service()
+        values = payload.model_dump(mode="python")
+        values["authoring_flow"] = (
+            "resource"
+            if _resource_planning_service is not None
+            and _resource_planning_service.enabled
+            else "legacy"
+        )
         session = await asyncio.to_thread(
-            service.create_session, **payload.model_dump(mode="python")
+            service.create_session, **values
         )
         return _session_response(service, session)
     except (SkillCreatorError, SkillDraftError) as exc:
@@ -824,6 +854,30 @@ async def review_creator_resource(
             expected_digest=payload.expected_digest.lower(),
             decision=payload.decision,
             feedback=payload.feedback,
+        )
+        return {
+            "version": build_service.VERSION,
+            "resource_build": build_service.build_store.serialize(build),
+        }
+    except (SkillCreatorError, SkillDraftError) as exc:
+        raise _api_error(exc) from exc
+
+
+@router.put("/resource-builds/{build_id}/resources/{resource_id}")
+async def edit_creator_resource(
+    build_id: str,
+    resource_id: str,
+    payload: CreatorResourceEditRequest,
+):
+    try:
+        build_service = get_skill_creator_resource_build_service()
+        build = await build_service.edit_resource(
+            build_id,
+            resource_id=resource_id,
+            expected_session_revision=payload.expected_session_revision,
+            expected_revision=payload.expected_revision,
+            expected_digest=payload.expected_digest.lower(),
+            content=payload.content,
         )
         return {
             "version": build_service.VERSION,

--- a/server/skills/creator_resource_build.py
+++ b/server/skills/creator_resource_build.py
@@ -514,6 +514,7 @@ class SkillResourceBuildStore:
         target_id: str,
         issues: list[Mapping[str, Any]],
         script_receipt: ResourceScriptTestReceipt | None = None,
+        auto_repair: bool = True,
     ) -> SkillResourceBuild:
         clean_issues = self._issues(issues)
         with self._lock:
@@ -537,7 +538,7 @@ class SkillResourceBuildStore:
                 if valid:
                     resource["state"] = "awaiting_review"
                     values["state"] = "awaiting_review"
-                elif int(resource["repair_count"]) < 1:
+                elif auto_repair and int(resource["repair_count"]) < 1:
                     resource["repair_count"] = int(resource["repair_count"]) + 1
                     resource["attempt"] = int(resource["attempt"]) + 1
                     resource["chunks"] = []
@@ -548,29 +549,110 @@ class SkillResourceBuildStore:
                     resource["state"] = "planned"
                     values["state"] = "planned"
                     values["current_resource_id"] = None
-                else:
+                elif auto_repair:
                     resource["state"] = "failed"
                     values["state"] = "failed"
+                else:
+                    resource["state"] = "awaiting_review"
+                    values["state"] = "awaiting_review"
             elif current.phase == "skill_markdown":
                 if target_id != "SKILL.md":
                     raise SkillCreatorConflictError("SKILL.md validation target changed.")
                 values["skill_validation_issues"] = clean_issues
                 if valid:
                     values["state"] = "awaiting_review"
-                elif int(values["skill_repair_count"]) < 1:
+                elif auto_repair and int(values["skill_repair_count"]) < 1:
                     values["skill_repair_count"] = int(values["skill_repair_count"]) + 1
                     values["skill_attempt"] = int(values["skill_attempt"]) + 1
                     values["skill_chunks"] = []
                     values["skill_markdown"] = None
                     values["skill_markdown_digest"] = None
                     values["state"] = "planned"
-                else:
+                elif auto_repair:
                     values["state"] = "failed"
+                else:
+                    values["state"] = "awaiting_review"
             else:
                 raise SkillCreatorConflictError("The resource build is already finalized.")
             values["revision"] = current.revision + 1
             values["updated_at"] = time.time()
             return self._publish_unlocked(self._decode(values, verify_digest=False))
+
+    def replace_resource_content(
+        self,
+        build_id: str,
+        *,
+        resource_id: str,
+        expected_revision: int,
+        expected_digest: str,
+        content: str,
+    ) -> SkillResourceBuild:
+        """Create a new build revision for a user-edited, path-frozen resource."""
+
+        clean_content = str(content or "")
+        if not clean_content.strip():
+            raise SkillCreatorValidationError(
+                "Edited resource content is empty.",
+                code="skill_creator_resource_content_invalid",
+            )
+        with self._lock:
+            current = self._require_match_unlocked(
+                build_id,
+                expected_revision=expected_revision,
+                expected_digest=expected_digest,
+            )
+            if current.proposal_id or current.phase == "proposal":
+                raise SkillCreatorConflictError(
+                    "The finalized proposal is immutable. Start a new resource plan to change it."
+                )
+            if current.state == "generating":
+                raise SkillCreatorConflictError(
+                    "Wait for the active generation request before editing a resource."
+                )
+            if current.current_resource_id not in {None, resource_id} and current.state in {
+                "awaiting_review",
+                "failed",
+            }:
+                raise SkillCreatorConflictError(
+                    "Review the current generated resource before editing another one."
+                )
+            values = asdict(current)
+            resource = self._resource_dict(values, resource_id)
+            if resource["action"] not in {"create", "update"}:
+                raise SkillCreatorConflictError(
+                    "Only created or updated resources can be edited in this build."
+                )
+            self._reject_credentials(path=resource["path"], content=clean_content)
+            self._validate_resource_bytes(resource["path"], clean_content)
+            content_digest = self._sha256(clean_content)
+            if (
+                resource.get("content_digest") == content_digest
+                and resource.get("content") == clean_content
+            ):
+                return copy.deepcopy(current)
+            resource["attempt"] = int(resource["attempt"]) + 1
+            resource["repair_count"] = 0
+            resource["chunks"] = [clean_content]
+            resource["content"] = clean_content
+            resource["content_digest"] = content_digest
+            resource["script_receipt"] = None
+            resource["validation_issues"] = []
+            resource["feedback"] = ""
+            resource["state"] = "awaiting_review"
+            values["phase"] = "resources"
+            values["state"] = "awaiting_review"
+            values["current_resource_id"] = resource_id
+            values["skill_chunks"] = []
+            values["skill_markdown"] = None
+            values["skill_markdown_digest"] = None
+            values["skill_validation_issues"] = []
+            values["skill_feedback"] = ""
+            values["requirement_coverage"] = []
+            values["revision"] = current.revision + 1
+            values["updated_at"] = time.time()
+            candidate = self._decode(values, verify_digest=False)
+            self._ensure_package_budget(candidate.resources, skill_markdown=None)
+            return self._publish_unlocked(candidate)
 
     def record_generation_error(
         self,

--- a/server/skills/creator_resource_build_service.py
+++ b/server/skills/creator_resource_build_service.py
@@ -78,7 +78,7 @@ class SkillCreatorResourceBuildService:
         self.builder = builder
         self.script_runner = script_runner
         self.enabled = (
-            os.getenv("SKILL_CREATOR_RESOURCE_AUTHORING_ENABLED", "false").strip().lower()
+            os.getenv("SKILL_CREATOR_RESOURCE_AUTHORING_ENABLED", "true").strip().lower()
             in {"1", "true", "yes", "on"}
             if enabled is None
             else bool(enabled)
@@ -293,6 +293,31 @@ class SkillCreatorResourceBuildService:
             feedback=feedback,
         )
 
+    async def edit_resource(
+        self,
+        build_id: str,
+        *,
+        resource_id: str,
+        expected_session_revision: int,
+        expected_revision: int,
+        expected_digest: str,
+        content: str,
+    ) -> SkillResourceBuild:
+        self.require_enabled()
+        current = self.build_store.require(build_id)
+        async with self._lock(current.session_id):
+            session, draft = self.creator_service.get_session(current.session_id)
+            self._require_session_revision(session, expected_session_revision)
+            self._require_build_scope(current, session=session, draft=draft)
+            edited = self.build_store.replace_resource_content(
+                build_id,
+                resource_id=resource_id,
+                expected_revision=expected_revision,
+                expected_digest=expected_digest,
+                content=content,
+            )
+            return await self._validate_current(edited, auto_repair=False)
+
     def finalize(
         self,
         build_id: str,
@@ -367,7 +392,12 @@ class SkillCreatorResourceBuildService:
         )
         return recorded, proposal
 
-    async def _validate_current(self, current: SkillResourceBuild) -> SkillResourceBuild:
+    async def _validate_current(
+        self,
+        current: SkillResourceBuild,
+        *,
+        auto_repair: bool = True,
+    ) -> SkillResourceBuild:
         if current.state != "awaiting_review":
             return current
         target_id, _ = self._segment_target(current)
@@ -391,6 +421,7 @@ class SkillCreatorResourceBuildService:
             target_id=target_id,
             issues=issues,
             script_receipt=receipt,
+            auto_repair=auto_repair,
         )
 
     def _proposal(
@@ -401,11 +432,27 @@ class SkillCreatorResourceBuildService:
         draft: WorkspaceSkillDraft | None,
         coverage: list[dict[str, Any]],
     ) -> AuthoringProposal:
-        proposals = self.creator_service.authoring_service.proposal_store.list(
-            source_type="skill_creator",
-            source_id=build.build_id,
-            limit=10,
-        )
+        proposal_candidates = [
+            *self.creator_service.authoring_service.proposal_store.list(
+                source_type="skill_creator",
+                source_id=session.session_id,
+                limit=20,
+            ),
+            # PR2 previews used the build id as the proposal source. Keep those
+            # immutable records discoverable while all new proposals use the
+            # Creator session id required by session recovery.
+            *self.creator_service.authoring_service.proposal_store.list(
+                source_type="skill_creator",
+                source_id=build.build_id,
+                limit=20,
+            ),
+        ]
+        proposals = [
+            item
+            for item in {candidate.proposal_id: candidate for candidate in proposal_candidates}.values()
+            if isinstance(item.payload.get("creator_resource_build"), dict)
+            and item.payload["creator_resource_build"].get("build_id") == build.build_id
+        ]
         payload = self._proposal_payload(
             build, session=session, draft=draft, coverage=coverage
         )
@@ -421,7 +468,7 @@ class SkillCreatorResourceBuildService:
                 title=f"Review resource-built Skill: {build.skill_name}",
                 payload=payload,
                 source_type="skill_creator",
-                source_id=build.build_id,
+                source_id=session.session_id,
                 target_id=(draft.draft_id if draft else None),
                 base_revision=(draft.revision if draft else None),
                 base_digest=(draft.content_digest if draft else None),

--- a/server/skills/creator_resource_service.py
+++ b/server/skills/creator_resource_service.py
@@ -51,7 +51,7 @@ class SkillCreatorResourcePlanningService:
         self.plan_store = plan_store
         self.planner = planner
         self.enabled = (
-            os.getenv("SKILL_CREATOR_RESOURCE_AUTHORING_ENABLED", "false")
+            os.getenv("SKILL_CREATOR_RESOURCE_AUTHORING_ENABLED", "true")
             .strip()
             .lower()
             in {"1", "true", "yes", "on"}
@@ -115,6 +115,12 @@ class SkillCreatorResourcePlanningService:
     ) -> SkillResourcePlan:
         session, draft = self.creator_service.get_session(session_id)
         self._require_session_revision(session, expected_session_revision)
+        if session.authoring_flow == "legacy":
+            self.creator_service._cancel_pending_proposal(session)
+            session = self.creator_service.session_store.activate_resource_authoring(
+                session.session_id,
+                expected_session_revision=session.session_revision,
+            )
         self.creator_service._require_ready_for_generation(session)
         current = self.plan_store.current_for_session(session_id)
         self._require_expected_plan(

--- a/server/skills/creator_service.py
+++ b/server/skills/creator_service.py
@@ -10,6 +10,7 @@ from typing import Any, Protocol
 
 from .creator_store import (
     CREATOR_ASSISTANT_AGENT_ID,
+    CreatorAuthoringFlow,
     CreatorMode,
     CreatorSourceKind,
     SkillCreatorConflictError,
@@ -179,6 +180,7 @@ class SkillCreatorService:
         source_xpert_id: str | None = None,
         source_conversation_id: str | None = None,
         source_message_id: str | None = None,
+        authoring_flow: CreatorAuthoringFlow = "legacy",
     ) -> SkillCreatorSession:
         self.require_enabled()
         if mode == "run":
@@ -210,6 +212,7 @@ class SkillCreatorService:
             source_xpert_id=source_xpert_id,
             source_conversation_id=source_conversation_id,
             source_message_id=source_message_id,
+            authoring_flow=authoring_flow,
         )
 
     def list_sessions(self, *, limit: int) -> list[SkillCreatorSession]:

--- a/server/skills/creator_store.py
+++ b/server/skills/creator_store.py
@@ -17,6 +17,7 @@ CREATOR_ASSISTANT_AGENT_ID = "skill-creator-assistant-v1"
 CreatorMode = Literal["blank", "run"]
 CreatorSourceKind = Literal["blank", "xpert_chat", "workflow_classic"]
 CreatorQualityMode = Literal["objective", "subjective"]
+CreatorAuthoringFlow = Literal["legacy", "resource"]
 CreatorReviewState = Literal["none", "pending", "accepted", "revise", "waived"]
 CreatorSessionState = Literal[
     "defining",
@@ -59,6 +60,7 @@ class SkillCreatorSession:
     draft_state_revision: int = 0
     mode: CreatorMode = "blank"
     assistant_agent_id: str = CREATOR_ASSISTANT_AGENT_ID
+    authoring_flow: CreatorAuthoringFlow = "legacy"
     intent: str = ""
     positive_examples: list[str] = field(default_factory=list)
     near_miss_examples: list[str] = field(default_factory=list)
@@ -131,10 +133,12 @@ class SkillCreatorSessionStore:
         source_xpert_id: str | None = None,
         source_conversation_id: str | None = None,
         source_message_id: str | None = None,
+        authoring_flow: CreatorAuthoringFlow = "legacy",
     ) -> SkillCreatorSession:
         session = SkillCreatorSession(
             session_id=f"skillcreator_{uuid.uuid4().hex}",
             mode=self._mode(mode),
+            authoring_flow=self._authoring_flow(authoring_flow),
             intent=self._text(intent, "intent", maximum=8_000),
             positive_examples=self._text_list(
                 positive_examples or [], "positive_examples", maximum_items=10
@@ -174,6 +178,29 @@ class SkillCreatorSessionStore:
                 self._items.pop(session.session_id, None)
                 raise
         return self._copy(session)
+
+    def activate_resource_authoring(
+        self,
+        session_id: str,
+        *,
+        expected_session_revision: int,
+    ) -> SkillCreatorSession:
+        """Persist an explicit opt-in for legacy Creator sessions."""
+
+        with self._lock:
+            item = self._require_mutable_unlocked(
+                session_id, expected_session_revision=expected_session_revision
+            )
+            if item.authoring_flow == "resource":
+                return self._copy(item)
+            if item.state == "archived":
+                raise SkillCreatorConflictError("Archived Creator sessions are read-only.")
+            previous = self._copy(item)
+            item.authoring_flow = "resource"
+            item.proposal_id = None
+            item.session_revision += 1
+            item.updated_at = time.time()
+            return self._save_or_restore_unlocked(item, previous)
 
     def require(self, session_id: str) -> SkillCreatorSession:
         with self._lock:
@@ -615,6 +642,12 @@ class SkillCreatorSessionStore:
         return value
 
     @staticmethod
+    def _authoring_flow(value: Any) -> CreatorAuthoringFlow:
+        if value not in {"legacy", "resource"}:
+            raise SkillCreatorValidationError("Invalid Creator authoring flow.")
+        return value
+
+    @staticmethod
     def _review_state(value: Any) -> CreatorReviewState:
         if value not in {"none", "pending", "accepted", "revise", "waived"}:
             raise SkillCreatorValidationError("Invalid Creator review state.")
@@ -836,6 +869,7 @@ class SkillCreatorSessionStore:
         if item.assistant_agent_id != CREATOR_ASSISTANT_AGENT_ID:
             raise ValueError("Creator assistant identity is immutable.")
         item.mode = self._mode(item.mode)
+        item.authoring_flow = self._authoring_flow(item.authoring_flow)
         item.source_kind = self._source_kind(item.source_kind)
         item.quality_mode = self._quality_mode(item.quality_mode)
         item.review_state = self._review_state(item.review_state)

--- a/server/tests/test_skill_creator_resource_build.py
+++ b/server/tests/test_skill_creator_resource_build.py
@@ -330,6 +330,72 @@ def test_dependencies_review_and_script_receipt_are_digest_bound(tmp_path: Path)
     ).script_receipt == receipt
 
 
+def test_direct_resource_edit_creates_revision_and_invalidates_final_skill(
+    tmp_path: Path,
+) -> None:
+    plan = _confirmed_plan(tmp_path, resources=[_complex_resources()[0]])
+    store = SkillResourceBuildStore(tmp_path / "direct-edit")
+    created = store.create(plan=plan)
+    resource_id = created.resources[0].resource_id
+    generated = _append_complete(
+        store,
+        created,
+        target_id=resource_id,
+        content="# Evidence policy\n\nUse explicit facts.\n",
+    )
+    validated = store.record_validation(
+        generated.build_id,
+        expected_revision=generated.revision,
+        expected_digest=generated.digest,
+        target_id=resource_id,
+        issues=[],
+    )
+    accepted = store.review_resource(
+        validated.build_id,
+        resource_id=resource_id,
+        expected_revision=validated.revision,
+        expected_digest=validated.digest,
+        decision="accept",
+    )
+    skill = _append_complete(
+        store,
+        accepted,
+        target_id="SKILL.md",
+        content="---\nname: review-incidents\ndescription: Use for incident review.\n---\n# Review\n",
+    )
+
+    edited = store.replace_resource_content(
+        skill.build_id,
+        resource_id=resource_id,
+        expected_revision=skill.revision,
+        expected_digest=skill.digest,
+        content="# Evidence policy\n\nUse explicit facts and mark gaps.\n",
+    )
+
+    item = edited.resources[0]
+    assert edited.revision == skill.revision + 1
+    assert edited.phase == "resources"
+    assert edited.state == "awaiting_review"
+    assert edited.current_resource_id == resource_id
+    assert edited.skill_markdown is None
+    assert edited.skill_markdown_digest is None
+    assert item.state == "awaiting_review"
+    assert item.content_digest != validated.resources[0].content_digest
+    assert item.script_receipt is None
+
+    persisted_invalid = store.record_validation(
+        edited.build_id,
+        expected_revision=edited.revision,
+        expected_digest=edited.digest,
+        target_id=resource_id,
+        issues=[{"code": "missing_policy", "message": "Policy is incomplete."}],
+        auto_repair=False,
+    )
+    assert persisted_invalid.state == "awaiting_review"
+    assert persisted_invalid.resources[0].content is not None
+    assert persisted_invalid.resources[0].validation_issues[0]["code"] == "missing_policy"
+
+
 def test_validation_failure_gets_one_internal_repair_then_fails(tmp_path: Path) -> None:
     plan = _confirmed_plan(tmp_path, resources=[_complex_resources()[0]])
     store = SkillResourceBuildStore(tmp_path / "build")

--- a/server/tests/test_skill_creator_resource_build_api.py
+++ b/server/tests/test_skill_creator_resource_build_api.py
@@ -62,6 +62,10 @@ class _BuildService:
         self.calls.append("next")
         return self.build_store.item
 
+    async def edit_resource(self, *_args, **_kwargs):
+        self.calls.append("edit")
+        return self.build_store.item
+
     def review_resource(self, *_args, **_kwargs):
         self.calls.append("review")
         return self.build_store.item
@@ -114,13 +118,18 @@ async def test_resource_build_routes_use_versioned_optimistic_requests() -> None
                 json={**mutation, "decision": "accept", "feedback": ""},
             )
             assert reviewed.status_code == 200, reviewed.text
+            edited = await client.put(
+                "/api/skills/creator/resource-builds/skillbuild_api/resources/resource_one",
+                json={**mutation, "content": "# Edited resource\n"},
+            )
+            assert edited.status_code == 200, edited.text
             finalized = await client.post(
                 "/api/skills/creator/resource-builds/skillbuild_api/finalize",
                 json={**mutation, "decision": "revise", "feedback": "Clarify failure behavior."},
             )
             assert finalized.status_code == 200, finalized.text
             assert finalized.json()["proposal"] is None
-        assert build.calls == ["start", "next", "review", "finalize"]
+        assert build.calls == ["start", "next", "review", "edit", "finalize"]
     finally:
         creator_api.configure_skill_creator(previous_creator)
         creator_api.configure_skill_creator_resource_planning(previous_planning)

--- a/server/tests/test_skill_creator_resource_service.py
+++ b/server/tests/test_skill_creator_resource_service.py
@@ -132,7 +132,7 @@ async def test_planning_service_clarifies_regenerates_and_confirms(tmp_path: Pat
             _plan_payload(),
         ]
     )
-    _, planning, _, session = _services(tmp_path, planner)
+    creator, planning, _, session = _services(tmp_path, planner)
 
     first = await planning.generate(
         session.session_id,
@@ -141,6 +141,7 @@ async def test_planning_service_clarifies_regenerates_and_confirms(tmp_path: Pat
         expected_plan_digest=None,
     )
     assert first.state == "needs_input"
+    session, _ = creator.get_session(session.session_id)
     answered = planning.save_answers(
         session.session_id,
         plan_id=first.plan_id,
@@ -179,6 +180,7 @@ async def test_definition_change_makes_existing_plan_projection_stale(tmp_path: 
         expected_plan_revision=None,
         expected_plan_digest=None,
     )
+    session, _ = creator.get_session(session.session_id)
     confirmed = planning.confirm(
         session.session_id,
         plan_id=plan.plan_id,
@@ -563,12 +565,20 @@ async def test_resource_plan_api_projects_plan_and_confirms(tmp_path: Path) -> N
             assert status.json()["resource_authoring_enabled"] is True
             assert status.json()["resource_planner_available"] is True
 
+            created = await client.post(
+                "/api/skills/creator/sessions",
+                json={"mode": "blank", "intent": "Plan a reusable review workflow."},
+            )
+            assert created.status_code == 201, created.text
+            assert created.json()["session"]["authoring_flow"] == "resource"
+
             generated = await client.post(
                 f"/api/skills/creator/sessions/{session.session_id}/resource-plan/generate",
                 json={"expected_session_revision": session.session_revision},
             )
             assert generated.status_code == 200, generated.text
-            plan = generated.json()["resource_plan"]
+            generated_payload = generated.json()
+            plan = generated_payload["resource_plan"]
             assert plan["state"] == "ready"
             assert plan["stale"] is False
 
@@ -576,7 +586,7 @@ async def test_resource_plan_api_projects_plan_and_confirms(tmp_path: Path) -> N
                 f"/api/skills/creator/sessions/{session.session_id}/resource-plan/confirm",
                 json={
                     "plan_id": plan["plan_id"],
-                    "expected_session_revision": session.session_revision,
+                    "expected_session_revision": generated_payload["session"]["session_revision"],
                     "expected_plan_revision": plan["revision"],
                     "expected_plan_digest": plan["digest"],
                 },

--- a/server/tests/test_skill_creator_sessions.py
+++ b/server/tests/test_skill_creator_sessions.py
@@ -225,6 +225,28 @@ def test_session_store_is_atomic_fail_closed_and_secret_safe(tmp_path: Path) -> 
     assert (corrupt_dir / "skill_creator_sessions.json").read_text() == "{not-json"
 
 
+def test_legacy_session_resource_authoring_opt_in_is_explicit_and_durable(
+    tmp_path: Path,
+) -> None:
+    store = SkillCreatorSessionStore(tmp_path / "resource-flow")
+    legacy = store.create(mode="blank", intent="Review incidents")
+    assert legacy.authoring_flow == "legacy"
+
+    migrated = store.activate_resource_authoring(
+        legacy.session_id,
+        expected_session_revision=legacy.session_revision,
+    )
+
+    assert migrated.authoring_flow == "resource"
+    assert migrated.session_revision == legacy.session_revision + 1
+    assert (
+        SkillCreatorSessionStore(tmp_path / "resource-flow")
+        .require(legacy.session_id)
+        .authoring_flow
+        == "resource"
+    )
+
+
 def test_selected_evidence_keeps_sanitized_title_across_reload(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## 变更摘要

完成 Skill Creator 资源化增强的第三阶段，将已实现的资源计划与资源构建能力接入完整工作台：

- 新 Session 默认采用 resource-authoring-v2，旧 Session 保持 legacy 兼容并可显式迁移。
- Step 2 展示素材与资源计划；Step 3 提供逐文件构建、完整预览、脚本测试 receipt、单次确认与重做。
- 支持直接编辑完整资源，并自动使对应脚本 receipt、最终 SKILL.md 与旧质量状态失效。
- 所有资源确认后生成最终 SKILL.md、全包差异和标准 Authoring Proposal。
- 简单 Skill 仍可选择零附加资源；不以资源数量作为质量指标。
- 390px 使用单资源布局，避免三栏挤压和页面横向溢出。
- 资源化流程默认启用；关闭 SKILL_CREATOR_RESOURCE_AUTHORING_ENABLED 可回退旧生成流程。
- 更新 Creator 集成文档与 Apache-2.0 第三方修改声明。

## 用户影响

Creator 现在遵循“规划 → 确认 → 逐项构建 → 资源确认 → 最终 SKILL.md → 标准提案”的交互闭环。资源提案仍只是可评测初稿，不会绕过既有三例 baseline/with-skill 评测、人工接受或独立安装确认。

## 验证

- 后端 Creator、Evaluation、安装与 Runtime Router 广回归：279 passed。
- 前端 Vitest：30 files / 140 tests passed。
- TypeScript 类型检查通过。
- Vite 生产构建通过；Creator Studio 保持独立懒加载 chunk。
- 独立预览完成资源、脚本 receipt、最终 SKILL.md、全包 diff 与提案审阅。
- 390px：scrollWidth=380、clientWidth=380，无页面横向溢出。
- 21 个差异路径全部命中白名单，敏感信息与临时预览配置扫描无残留。

## 边界与回退

- 未修改 MCP、/coding、多模态、上传、SkillHub、外部市场、二进制 assets、LLM Judge 或自动安装。
- 未重建或重启共享 Docker 栈。
- 可分别回退后端迁移提交与前端工作台提交；关闭资源化开关可回退旧 Creator 流程。