### PR TITLE
fix: 收口 V14 Worker 实机验收问题

### DIFF
--- a/client/src/components/CodingWorkerConsole.test.tsx
+++ b/client/src/components/CodingWorkerConsole.test.tsx
@@ -24,6 +24,15 @@ const api = vi.hoisted(() => ({
 
 vi.mock("../utils/codingWorkerApi", () => api);
 
+const projectApi = vi.hoisted(() => ({
+  createCodingProjectSelection: vi.fn(),
+  getCodingProjectSelection: vi.fn(),
+  getCodingProjects: vi.fn(),
+  getCodingWorkerHostSource: vi.fn(),
+}));
+
+vi.mock("../utils/codingApi", () => projectApi);
+
 const task = {
   task_id: "task_1234567890abcdef1234567890abcdef",
   spec: {
@@ -53,6 +62,7 @@ const task = {
 
 beforeEach(() => {
   Object.values(api).forEach((mock) => "mockReset" in mock && mock.mockReset());
+  Object.values(projectApi).forEach((mock) => "mockReset" in mock && mock.mockReset());
   api.codingWorkerArtifactUrl.mockImplementation((taskId: string, artifactId: string) => `/artifact/${taskId}/${artifactId}`);
   api.getCodingWorkerStatus.mockResolvedValue({ enabled: true, available: true, version: "v1", max_active_tasks: 2, retention_seconds: 604800, network_enabled: false, acceptance_checks: ["python-pytest", "react-build"], reason: null });
   api.listCodingWorkerTasks.mockResolvedValue([task]);
@@ -64,6 +74,44 @@ beforeEach(() => {
   api.readCodingWorkerDiff.mockResolvedValue("diff --git a/src/app.py b/src/app.py");
   api.connectCodingWorkerEvents.mockReturnValue(() => undefined);
   api.decideCodingWorkerApproval.mockResolvedValue({});
+  projectApi.getCodingProjects.mockResolvedValue({
+    enabled: true,
+    configured: true,
+    available: true,
+    selection: true,
+    default_project_id: "modelmirror",
+    max_projects: 50,
+    projects: [{
+      id: "hostgit_existing",
+      name: "现有项目",
+      kind: "host_git",
+      state: "available",
+      reason: null,
+      branch: "main",
+      head: "a".repeat(40),
+      features: {
+        chat: true,
+        draft: true,
+        diff: true,
+        download: true,
+        recovery: true,
+        verification: true,
+        apply: true,
+        commit: true,
+        publish: false,
+        commands: true,
+      },
+      writeback_reason: null,
+    }],
+  });
+  projectApi.getCodingWorkerHostSource.mockImplementation(async (projectId: string) => ({
+    source_id: projectId,
+    name: "已授权项目",
+    branch: "main",
+    revision: projectId === "hostgit_python_sample"
+      ? "c8c27a695d3a6562b5ff8fe3df28548ecc388df4"
+      : "b".repeat(40),
+  }));
 });
 
 describe("CodingWorkerConsole", () => {
@@ -109,5 +157,109 @@ describe("CodingWorkerConsole", () => {
 
     await waitFor(() => expect(api.handoffCodingWorkerTask).toHaveBeenCalledWith(task.task_id));
     expect(onCodingHandoff).toHaveBeenCalledWith(expect.objectContaining({ revision: 1 }));
+  });
+
+  it("requests a Helper folder selection and binds the returned project revision", async () => {
+    const newProject = {
+      id: "hostgit_python_sample",
+      name: "Python 折扣样例",
+      kind: "host_git",
+      state: "available",
+      reason: null,
+      branch: "main",
+      head: "c8c27a695d3a6562b5ff8fe3df28548ecc388df4",
+      features: {
+        chat: true,
+        draft: true,
+        diff: true,
+        download: true,
+        recovery: true,
+        verification: true,
+        apply: true,
+        commit: true,
+        publish: false,
+        commands: true,
+      },
+      writeback_reason: null,
+    } as const;
+    projectApi.createCodingProjectSelection.mockResolvedValue({
+      request_id: "selection_1",
+      status: "completed",
+      project_id: newProject.id,
+      error: null,
+      expires_at: 100,
+    });
+    projectApi.getCodingProjects
+      .mockResolvedValueOnce(await projectApi.getCodingProjects())
+      .mockResolvedValueOnce({
+        enabled: true,
+        configured: true,
+        available: true,
+        selection: true,
+        default_project_id: "modelmirror",
+        max_projects: 50,
+        projects: [newProject],
+      });
+
+    const user = userEvent.setup();
+    render(<CodingWorkerConsole context="coding" />);
+    await user.click(await screen.findByRole("button", { name: "创建任务" }));
+    await user.click(screen.getByRole("button", { name: "添加本地项目" }));
+
+    await waitFor(() => expect(screen.getByLabelText("本地项目")).toHaveValue(newProject.id));
+    expect(screen.getByLabelText("基准 revision")).toHaveValue(newProject.head);
+    expect(projectApi.createCodingProjectSelection).toHaveBeenCalledTimes(1);
+  });
+
+  it("recovers a project registered after the selection request expires", async () => {
+    const lateProject = {
+      id: "hostgit_late_sample",
+      name: "延迟返回样例",
+      kind: "host_git",
+      state: "available",
+      reason: null,
+      branch: "main",
+      head: "b".repeat(40),
+      features: {
+        chat: true,
+        draft: true,
+        diff: true,
+        download: true,
+        recovery: true,
+        verification: true,
+        apply: true,
+        commit: true,
+        publish: false,
+        commands: true,
+      },
+      writeback_reason: null,
+    } as const;
+    projectApi.createCodingProjectSelection.mockResolvedValue({
+      request_id: "selection_late",
+      status: "expired",
+      project_id: null,
+      error: "project_selection_expired",
+      expires_at: 100,
+    });
+    projectApi.getCodingProjects
+      .mockResolvedValueOnce(await projectApi.getCodingProjects())
+      .mockResolvedValueOnce({
+        enabled: true,
+        configured: true,
+        available: true,
+        selection: true,
+        default_project_id: "modelmirror",
+        max_projects: 50,
+        projects: [lateProject],
+      });
+
+    const user = userEvent.setup();
+    render(<CodingWorkerConsole context="coding" />);
+    await user.click(await screen.findByRole("button", { name: "创建任务" }));
+    await user.click(screen.getByRole("button", { name: "添加本地项目" }));
+
+    await waitFor(() => expect(screen.getByLabelText("本地项目")).toHaveValue(lateProject.id));
+    expect(screen.getByLabelText("基准 revision")).toHaveValue(lateProject.head);
+    expect(screen.queryByText("选择请求已超时", { exact: false })).not.toBeInTheDocument();
   });
 });

--- a/client/src/components/CodingWorkerConsole.tsx
+++ b/client/src/components/CodingWorkerConsole.tsx
@@ -3,6 +3,7 @@ import {
   CheckCircle2,
   CircleAlert,
   FileCode2,
+  FolderPlus,
   FolderTree,
   GitCompareArrows,
   MessageSquareText,
@@ -43,6 +44,13 @@ import {
   sendCodingWorkerMessage,
   type CodingWorkerHandoffResult,
 } from "../utils/codingWorkerApi";
+import type { CodingProjectSelection, CodingProjectSummary } from "../types/coding";
+import {
+  createCodingProjectSelection,
+  getCodingProjectSelection,
+  getCodingProjects,
+  getCodingWorkerHostSource,
+} from "../utils/codingApi";
 
 type ConsoleContext = "coding" | "agent";
 type InspectorTab = "files" | "diff" | "evidence" | "terminal";
@@ -92,16 +100,51 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
   const [sourceId, setSourceId] = useState("");
   const [revision, setRevision] = useState("");
   const [checkId, setCheckId] = useState("");
+  const [codingProjects, setCodingProjects] = useState<CodingProjectSummary[]>([]);
+  const [selection, setSelection] = useState<CodingProjectSelection | null>(null);
   const [busy, setBusy] = useState(false);
   const [loading, setLoading] = useState(true);
   const [transportWarning, setTransportWarning] = useState(false);
   const [error, setError] = useState("");
   const operationRef = useRef(false);
+  const selectionProjectIdsRef = useRef<Set<string>>(new Set());
 
   const selectedTask = useMemo(
     () => tasks.find((task) => task.task_id === selectedTaskId) ?? null,
     [selectedTaskId, tasks],
   );
+
+  const refreshCodingProjects = useCallback(async (preferredId?: string, selectNew = false) => {
+    if (context !== "coding") return null;
+    const response = await getCodingProjects();
+    const hostProjects = response.projects.filter((project) => project.kind === "host_git");
+    setCodingProjects(hostProjects);
+    const preferred = hostProjects.find(
+      (project) => project.id === preferredId && project.state === "available" && project.head,
+    );
+    const newlyAdded = selectNew
+      ? hostProjects.filter(
+        (project) => !selectionProjectIdsRef.current.has(project.id)
+          && project.state === "available"
+          && project.head,
+      )
+      : [];
+    const selected = preferred ?? (newlyAdded.length === 1 ? newlyAdded[0] : undefined);
+    if (selected?.head) {
+      const binding = await getCodingWorkerHostSource(selected.id);
+      if (
+        binding.source_id !== selected.id
+        || binding.branch !== selected.branch
+        || !binding.revision.startsWith(selected.head)
+      ) {
+        throw new Error("本地项目基准已改变，请刷新后重新选择。");
+      }
+      setSourceId(binding.source_id);
+      setRevision(binding.revision);
+      return selected.id;
+    }
+    return null;
+  }, [context]);
 
   const refreshTasks = useCallback(async (preferredId?: string) => {
     const next = await listCodingWorkerTasks();
@@ -148,6 +191,48 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
       .finally(() => { if (active) setLoading(false); });
     return () => { active = false; };
   }, [refreshTasks]);
+
+  useEffect(() => {
+    if (context !== "coding") return;
+    void refreshCodingProjects().catch((caught) => {
+      setError(errorMessage(caught, "本地项目列表加载失败"));
+    });
+  }, [context, refreshCodingProjects]);
+
+  useEffect(() => {
+    if (!selection || !["pending", "dispatched"].includes(selection.status)) return;
+    let active = true;
+    let timer = 0;
+    const poll = async () => {
+      try {
+        const next = await getCodingProjectSelection(selection.request_id);
+        if (!active) return;
+        setSelection(next);
+        if (next.status === "completed" && next.project_id) {
+          await refreshCodingProjects(next.project_id);
+          return;
+        }
+        if (next.status === "failed" || next.status === "expired") {
+          const recoveredProjectId = await refreshCodingProjects(undefined, true);
+          if (recoveredProjectId) return;
+          setError(next.error === "project_selection_cancelled"
+            ? "已取消选择，本地项目列表没有变化。"
+            : next.status === "expired"
+              ? "选择请求已超时；若 Helper 已完成授权，请从本地项目列表中选择该项目。"
+              : "没有添加项目，请重新选择一个干净的 Git 仓库。");
+          return;
+        }
+        timer = window.setTimeout(() => void poll(), 800);
+      } catch (caught) {
+        if (active) setError(errorMessage(caught, "本地项目选择失败"));
+      }
+    };
+    timer = window.setTimeout(() => void poll(), 500);
+    return () => {
+      active = false;
+      window.clearTimeout(timer);
+    };
+  }, [refreshCodingProjects, selection]);
 
   useEffect(() => {
     if (!selectedTaskId) {
@@ -209,6 +294,42 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
     const task = await createCodingWorkerTask(spec);
     await refreshTasks(task.task_id);
     setShowCreate(false); setObjective(""); setSourceId(""); setRevision(""); setCheckId("");
+  });
+
+  const addCodingProject = () => run(async () => {
+    selectionProjectIdsRef.current = new Set(codingProjects.map((project) => project.id));
+    const next = await createCodingProjectSelection();
+    setSelection(next);
+    if (next.status === "completed" && next.project_id) {
+      await refreshCodingProjects(next.project_id);
+    } else if (next.status === "failed" || next.status === "expired") {
+      const recoveredProjectId = await refreshCodingProjects(undefined, true);
+      if (recoveredProjectId) return;
+      setError(next.error === "project_selection_cancelled"
+        ? "已取消选择，本地项目列表没有变化。"
+        : next.status === "expired"
+          ? "选择请求已超时；若 Helper 已完成授权，请从本地项目列表中选择该项目。"
+          : "没有添加项目，请重新选择一个干净的 Git 仓库。");
+    }
+  });
+
+  const selectCodingProject = (projectId: string) => run(async () => {
+    const project = codingProjects.find((item) => item.id === projectId);
+    if (!project || project.state !== "available" || !project.head) {
+      setSourceId("");
+      setRevision("");
+      return;
+    }
+    const binding = await getCodingWorkerHostSource(project.id);
+    if (
+      binding.source_id !== project.id
+      || binding.branch !== project.branch
+      || !binding.revision.startsWith(project.head)
+    ) {
+      throw new Error("本地项目基准已改变，请刷新后重新选择。");
+    }
+    setSourceId(binding.source_id);
+    setRevision(binding.revision);
   });
 
   const submitMessage = () => run(async () => {
@@ -273,8 +394,47 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
           <label className="md:col-span-2 xl:col-span-2 text-sm text-slate-200">任务目标
             <textarea value={objective} onChange={(event) => setObjective(event.target.value)} className="mt-1 min-h-24 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 py-2 text-white" maxLength={1_048_576} />
           </label>
-          <label className="text-sm text-slate-200">不透明来源 ID<input value={sourceId} onChange={(event) => setSourceId(event.target.value)} className="mt-1 min-h-11 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 text-white" /></label>
-          <label className="text-sm text-slate-200">基准 revision<input value={revision} onChange={(event) => setRevision(event.target.value)} className="mt-1 min-h-11 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 text-white" /></label>
+          {context === "coding" ? (
+            <div className="text-sm text-slate-200">
+              <label htmlFor="worker-host-project">本地项目</label>
+              <select
+                id="worker-host-project"
+                value={sourceId}
+                onChange={(event) => void selectCodingProject(event.target.value)}
+                className="mt-1 min-h-11 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 text-white outline-none focus:border-cyan-300/70 focus:ring-4 focus:ring-cyan-300/10"
+              >
+                <option value="">选择已授权项目</option>
+                {codingProjects.map((project) => (
+                  <option
+                    key={project.id}
+                    value={project.id}
+                    disabled={project.state !== "available" || !project.head}
+                  >
+                    {project.name}{project.branch ? ` · ${project.branch}` : ""}
+                    {project.head ? ` · ${project.head.slice(0, 12)}` : ""}
+                    {project.state !== "available" ? " · 当前不可用" : ""}
+                  </option>
+                ))}
+              </select>
+              <button
+                type="button"
+                onClick={() => void addCodingProject()}
+                disabled={busy || selection?.status === "pending" || selection?.status === "dispatched"}
+                className="mt-2 inline-flex min-h-11 w-full items-center justify-center gap-2 rounded-lg border border-cyan-300/35 px-3 text-sm font-semibold text-cyan-100 transition hover:bg-cyan-300/10 focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-cyan-300/20 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <FolderPlus className="h-4 w-4" aria-hidden="true" />
+                {selection?.status === "pending" || selection?.status === "dispatched"
+                  ? "等待 Helper 选择"
+                  : "添加本地项目"}
+              </button>
+              <p className="mt-2 text-xs leading-5 text-slate-400">
+                点击后在 Helper 弹出的窗口中选择干净的 Git 仓库，物理路径不会发送到 Server。
+              </p>
+            </div>
+          ) : (
+            <label className="text-sm text-slate-200">不透明来源 ID<input value={sourceId} onChange={(event) => setSourceId(event.target.value)} className="mt-1 min-h-11 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 text-white" /></label>
+          )}
+          <label className="text-sm text-slate-200">基准 revision<input value={revision} onChange={(event) => setRevision(event.target.value)} readOnly={context === "coding"} className="mt-1 min-h-11 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 text-white read-only:text-slate-300" /></label>
           <label className="text-sm text-slate-200">冻结验收检查<select value={checkId} onChange={(event) => setCheckId(event.target.value)} disabled={!status.acceptance_checks.length} className="mt-1 min-h-11 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 text-white disabled:opacity-60">{status.acceptance_checks.map((item) => <option key={item} value={item}>{item}</option>)}</select></label>
           <div className="flex items-end md:col-span-2 xl:col-span-5"><button type="submit" disabled={busy || !checkId} className="min-h-11 rounded-lg bg-cyan-400 px-5 text-sm font-semibold text-slate-950 disabled:opacity-50">提交到队列</button></div>
         </form>

--- a/client/src/utils/codingApi.ts
+++ b/client/src/utils/codingApi.ts
@@ -87,6 +87,15 @@ export function getCodingProjects() {
   return requestJson<CodingProjectsResponse>("/api/coding/projects");
 }
 
+export function getCodingWorkerHostSource(projectId: string) {
+  return requestJson<{
+    source_id: string;
+    name: string;
+    branch: string;
+    revision: string;
+  }>(`/api/coding/worker-sources/${encodeURIComponent(projectId)}`);
+}
+
 export function getCodingProjectHost() {
   return requestJson<CodingProjectHostStatus>("/api/coding/project-host");
 }

--- a/server/coding_applier/engine.py
+++ b/server/coding_applier/engine.py
@@ -10,7 +10,7 @@ import tempfile
 import threading
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 from server.coding_runtime.apply_models import (
     APPLY_ID_PATTERN,
@@ -548,7 +548,7 @@ class CodingApplierEngine:
                     entries.add(("file", relative))
                     file_hashes.append((relative, content_hash))
                     next_cache[relative] = (signature, content_hash)
-            file_hashes.sort()
+            file_hashes.sort(key=lambda item: PurePosixPath(item[0]).parts)
             for relative, content_hash in file_hashes:
                 size = next_cache[relative][0][0]
                 digest.update(relative.encode("utf-8"))

--- a/server/coding_runtime/api.py
+++ b/server/coding_runtime/api.py
@@ -5242,6 +5242,18 @@ async def coding_projects(response: Response) -> dict[str, Any]:
     return await get_coding_service().project_catalog()
 
 
+@router.get("/worker-sources/{project_id}")
+async def coding_worker_source(project_id: str, response: Response) -> dict[str, str]:
+    response.headers["Cache-Control"] = "no-store"
+    service = get_coding_service()
+    if service.project_host is None:
+        raise _http_error(status.HTTP_503_SERVICE_UNAVAILABLE, "project_host_unavailable")
+    try:
+        return service.project_host.worker_source(project_id)
+    except ProjectHostError as exc:
+        raise _project_host_http_error(exc) from exc
+
+
 @router.get("/recovery")
 async def coding_recovery_status(response: Response) -> dict[str, Any]:
     response.headers["Cache-Control"] = "no-store"

--- a/server/coding_runtime/project_host_api.py
+++ b/server/coding_runtime/project_host_api.py
@@ -173,6 +173,20 @@ class ProjectHostRuntime:
             project.to_public_dict(host_online=host.status == "online")
         )
 
+    def worker_source(self, project_id: str) -> dict[str, str]:
+        project = self.store.require_project(project_id)
+        host = self.store.require_host(project.host_id)
+        if host.status != "online":
+            raise ProjectHostError("project_host_offline")
+        if project.state != "available":
+            raise ProjectHostError(project.reason or "project_changed")
+        return {
+            "source_id": project.project_id,
+            "name": project.name,
+            "branch": project.branch,
+            "revision": project.head,
+        }
+
     def check_project(self, project_id: str, head: str, branch: str | None) -> dict[str, Any]:
         project = self.store.require_project(project_id)
         host = self.store.require_host(project.host_id)

--- a/server/coding_worker/broker_mcp.py
+++ b/server/coding_worker/broker_mcp.py
@@ -71,47 +71,45 @@ def build_server(client: BrokerRPCClient) -> FastMCP:
         )
 
     @mcp.tool()
+    async def list_acceptance_checks() -> dict[str, Any]:
+        """List the immutable acceptance checks allowed for this task."""
+        return await call("list_acceptance_checks", {})
+
+    @mcp.tool()
     async def run_check(check_id: str) -> dict[str, Any]:
-        """Run one immutable server-defined acceptance check."""
+        """Run one check returned by list_acceptance_checks."""
         return await call("run_check", {"check_id": check_id})
 
     @mcp.tool()
     async def run_command(
         operation_id: str,
         argv: list[str],
-        lease_id: str,
         timeout_seconds: int = 300,
     ) -> dict[str, Any]:
-        """Run an argv-only command after an exact command lease is approved."""
+        """Request approval, then run one exact argv-only command."""
         return await call(
             "run_command",
             {"argv": argv, "timeout_seconds": timeout_seconds},
             operation_id=operation_id,
-            lease_id=lease_id,
         )
 
     @mcp.tool()
-    async def install_dependencies(
-        operation_id: str, lease_id: str, network_lease_id: str
-    ) -> dict[str, Any]:
-        """Run frozen npm-ci through the approved egress lease and proxy."""
+    async def install_dependencies(operation_id: str) -> dict[str, Any]:
+        """Request approval, then run frozen npm-ci through controlled egress."""
         return await call(
             "install_dependencies",
             {"manager": "npm", "action": "ci"},
             operation_id=operation_id,
-            lease_id=lease_id,
-            network_lease_id=network_lease_id,
         )
 
     @mcp.tool()
     async def start_service(
         operation_id: str,
         argv: list[str],
-        lease_id: str,
         ttl_seconds: int = 900,
         preview_port: int | None = None,
     ) -> dict[str, Any]:
-        """Start one approved task-owned background service."""
+        """Request approval, then start one task-owned background service."""
         return await call(
             "start_service",
             {
@@ -120,7 +118,6 @@ def build_server(client: BrokerRPCClient) -> FastMCP:
                 "preview_port": preview_port,
             },
             operation_id=operation_id,
-            lease_id=lease_id,
         )
 
     @mcp.tool()

--- a/server/coding_worker/broker_mcp.py
+++ b/server/coding_worker/broker_mcp.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import os
 import uuid
 from typing import Any
@@ -49,10 +50,9 @@ def build_server(client: BrokerRPCClient) -> FastMCP:
         return await call("diff", {})
 
     @mcp.tool()
-    async def write_file(
-        operation_id: str, path: str, content: str, content_sha256: str
-    ) -> dict[str, Any]:
-        """Atomically write UTF-8 text using a stable operation id and content digest."""
+    async def write_file(operation_id: str, path: str, content: str) -> dict[str, Any]:
+        """Atomically write UTF-8 text using a stable operation id."""
+        content_sha256 = hashlib.sha256(content.encode("utf-8")).hexdigest()
         return await call(
             "write_file",
             {"path": path, "content": content, "content_sha256": content_sha256},

--- a/server/coding_worker/broker_rpc.py
+++ b/server/coding_worker/broker_rpc.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import os
 import secrets
@@ -9,8 +10,14 @@ from typing import Any
 
 from pydantic import Field
 
-from .contracts import StrictModel
-from .tool_broker import ToolBroker, ToolBrokerError
+from .contracts import (
+    ApprovalStatus,
+    OperationState,
+    StrictModel,
+    TaskState,
+    TERMINAL_STATES,
+)
+from .tool_broker import ToolBroker, ToolBrokerError, ToolResult
 
 
 MAX_RPC_BYTES = 1024 * 1024
@@ -96,14 +103,7 @@ class BrokerRPCServer:
             expected = self._tokens.get(request.task_id)
             if expected is None or not secrets.compare_digest(expected, request.token):
                 raise BrokerRPCError("Broker authentication failed.", code="broker_unauthorized")
-            result = await self.broker.execute(
-                task_id=request.task_id,
-                operation_id=request.operation_id,
-                tool_name=request.tool_name,
-                arguments=request.arguments,
-                lease_id=request.lease_id,
-                network_lease_id=request.network_lease_id,
-            )
+            result = await self._execute(request)
             response = {"ok": True, "result": result.model_dump(mode="json")}
         except Exception as exc:
             response = {
@@ -122,6 +122,96 @@ class BrokerRPCServer:
         await writer.drain()
         writer.close()
         await writer.wait_closed()
+
+    async def _execute(self, request: BrokerRPCRequest) -> ToolResult:
+        try:
+            return await self.broker.execute(
+                task_id=request.task_id,
+                operation_id=request.operation_id,
+                tool_name=request.tool_name,
+                arguments=request.arguments,
+                lease_id=request.lease_id,
+                network_lease_id=request.network_lease_id,
+            )
+        except ToolBrokerError as exc:
+            if exc.code != "approval_required" or request.lease_id is not None:
+                raise
+        lease_id, network_lease_id = await self._wait_for_approval(request)
+        return await self.broker.execute(
+            task_id=request.task_id,
+            operation_id=request.operation_id,
+            tool_name=request.tool_name,
+            arguments=request.arguments,
+            lease_id=lease_id,
+            network_lease_id=network_lease_id,
+        )
+
+    async def _wait_for_approval(
+        self, request: BrokerRPCRequest
+    ) -> tuple[str, str | None]:
+        required_ids = [request.operation_id]
+        if request.tool_name == "install_dependencies":
+            required_ids.append(
+                "network_"
+                + hashlib.sha256(request.operation_id.encode("utf-8")).hexdigest()[:32]
+            )
+        while True:
+            task = self.broker.store.get_task(request.task_id)
+            if task.state in TERMINAL_STATES or task.state in {
+                TaskState.PAUSED,
+                TaskState.INTERRUPTED,
+            }:
+                raise BrokerRPCError(
+                    "Approval is no longer available.", code="approval_unavailable"
+                )
+            approvals = {
+                approval.operation_id: approval
+                for approval in self.broker.store.list_approvals(request.task_id)
+                if approval.operation_id in required_ids
+            }
+            if len(approvals) == len(required_ids):
+                if any(
+                    approval.status
+                    in {
+                        ApprovalStatus.REJECTED,
+                        ApprovalStatus.CANCELLED,
+                        ApprovalStatus.EXPIRED,
+                    }
+                    for approval in approvals.values()
+                ):
+                    operation = self.broker.store.get_operation(request.operation_id)
+                    if operation.state is OperationState.PREPARED:
+                        self.broker.store.transition_operation(
+                            request.operation_id,
+                            OperationState.FAILED,
+                            result={"code": "approval_rejected"},
+                            expected_state=OperationState.PREPARED,
+                        )
+                    raise BrokerRPCError(
+                        "Tool approval was rejected.", code="approval_rejected"
+                    )
+                if all(
+                    approval.status is ApprovalStatus.APPROVED
+                    and approval.lease is not None
+                    for approval in approvals.values()
+                ):
+                    main = approvals[request.operation_id]
+                    network = (
+                        approvals.get(required_ids[1])
+                        if len(required_ids) > 1
+                        else None
+                    )
+                    main_lease = main.lease
+                    if main_lease is None:
+                        raise BrokerRPCError(
+                            "Approved operation is missing its lease.",
+                            code="approval_unavailable",
+                        )
+                    return (
+                        main_lease.lease_id,
+                        network.lease.lease_id if network and network.lease else None,
+                    )
+            await asyncio.sleep(0.05)
 
 
 class BrokerRPCClient:

--- a/server/coding_worker/opencode_provider.py
+++ b/server/coding_worker/opencode_provider.py
@@ -30,6 +30,7 @@ from .provider import (
 
 
 OPENCODE_VERSION = "1.18.9"
+TOOL_BROKER_MCP_NAME = "modelmirror-tool-broker"
 DIRECT_TOOL_NAMES = frozenset(
     {
         "bash",
@@ -143,6 +144,7 @@ class OpenCodeProvider(CodingAgentProvider):
             raise OpenCodeProviderError("Workspace is unavailable.", code="workspace_unavailable")
         handle = await self._server_factory(request, workspace, route)
         try:
+            await self._wait_for_tool_broker(handle)
             response = await handle.client.post(
                 self._url("/session", workspace),
                 json={
@@ -296,10 +298,13 @@ class OpenCodeProvider(CodingAgentProvider):
         }
         mcp: dict[str, Any] = {}
         if self._tool_broker_command is not None:
-            permission["modelmirror-tool-broker_*"] = "allow"
-            mcp["modelmirror-tool-broker"] = {
+            permission[f"{TOOL_BROKER_MCP_NAME}_*"] = "allow"
+            mcp[TOOL_BROKER_MCP_NAME] = {
                 "type": "local",
                 "command": list(self._tool_broker_command),
+                "environment": {
+                    "PYTHONPATH": str(Path(__file__).resolve().parent.parent),
+                },
                 "enabled": True,
                 "timeout": 310_000,
             }
@@ -473,8 +478,37 @@ class OpenCodeProvider(CodingAgentProvider):
     def _prompt_tools(self) -> dict[str, bool]:
         tools = {name: False for name in DIRECT_TOOL_NAMES}
         if self._tool_broker_command is not None:
-            tools["modelmirror-tool-broker_*"] = True
+            tools[f"{TOOL_BROKER_MCP_NAME}_*"] = True
         return tools
+
+    async def _wait_for_tool_broker(self, handle: OpenCodeServerHandle) -> None:
+        if self._tool_broker_command is None:
+            return
+        deadline = asyncio.get_running_loop().time() + 15.0
+        while asyncio.get_running_loop().time() < deadline:
+            try:
+                status_response = await handle.client.get(
+                    self._url("/mcp", handle.workspace), timeout=2.0
+                )
+                status_response.raise_for_status()
+                statuses = status_response.json()
+                broker_status = (
+                    statuses.get(TOOL_BROKER_MCP_NAME)
+                    if isinstance(statuses, dict)
+                    else None
+                )
+                if (
+                    isinstance(broker_status, dict)
+                    and broker_status.get("status") == "connected"
+                ):
+                    return
+            except (httpx.HTTPError, ValueError):
+                pass
+            await asyncio.sleep(0.1)
+        raise OpenCodeProviderError(
+            "Tool Broker MCP failed to become ready.",
+            code="tool_broker_unavailable",
+        )
 
     @staticmethod
     def _url(path: str, workspace: Path) -> str:

--- a/server/coding_worker/source_adapters.py
+++ b/server/coding_worker/source_adapters.py
@@ -495,7 +495,7 @@ class HostSnapshotWorkspaceSourceAdapter:
             archive_sha256 = transfer.get("archive_sha256")
             if (
                 not isinstance(project, dict)
-                or project.get("id") != source.source_id
+                or project.get("project_id") != source.source_id
                 or project.get("head") != source.revision
                 or not isinstance(project.get("name"), str)
                 or not isinstance(project.get("branch"), str)

--- a/server/coding_worker/tool_broker.py
+++ b/server/coding_worker/tool_broker.py
@@ -291,7 +291,14 @@ class ToolBroker:
         request: dict[str, Any],
         network_lease_id: str | None,
     ) -> CapabilityLease | None:
-        readonly = {"list_files", "read_file", "search_text", "diff", "service_status"}
+        readonly = {
+            "list_files",
+            "read_file",
+            "search_text",
+            "diff",
+            "list_acceptance_checks",
+            "service_status",
+        }
         if tool_name in readonly:
             return None
         if tool_name in {
@@ -414,12 +421,33 @@ class ToolBroker:
         if tool_name == "diff":
             value = self.workspace_broker.diff(workspace_id, max_bytes=self.max_output_bytes)
             return {"diff": value.decode("utf-8", errors="replace")}
+        if tool_name == "list_acceptance_checks":
+            task = self.store.get_task(task_id)
+            return {
+                "checks": [
+                    {
+                        "check_id": check.check_id,
+                        "label": check.label,
+                        "kind": check.kind,
+                        "required": check.required,
+                    }
+                    for check in task.spec.acceptance.required_checks
+                ]
+            }
         if tool_name == "write_file":
             return self._write_file(workspace_id, arguments)
         if tool_name == "delete_file":
             return self._delete_file(workspace_id, arguments)
         if tool_name == "run_check":
             check_id = str(arguments.get("check_id", ""))
+            task = self.store.get_task(task_id)
+            if check_id not in {
+                check.check_id for check in task.spec.acceptance.required_checks
+            }:
+                raise ToolBrokerError(
+                    "Check is not in the task acceptance contract.",
+                    code="check_not_allowed",
+                )
             check = self.frozen_checks.get(check_id)
             if check is None:
                 raise ToolBrokerError("Check is not registered.", code="check_not_found")

--- a/server/coding_worker/workspace.py
+++ b/server/coding_worker/workspace.py
@@ -405,7 +405,7 @@ class WorkspaceBroker:
         text: bool = True,
     ) -> str | bytes:
         result = subprocess.run(
-            ["git", *args],
+            ["git", "-c", f"safe.directory={repository}", *args],
             cwd=repository,
             env=env,
             stdin=subprocess.DEVNULL,

--- a/server/tests/test_coding_applier_engine.py
+++ b/server/tests/test_coding_applier_engine.py
@@ -117,6 +117,24 @@ def test_apply_is_atomic_and_idempotent(
     assert staging.exists() is False
 
 
+def test_health_uses_source_path_part_ordering(
+    roots: tuple[Path, Path, Path],
+) -> None:
+    source, target, staging = roots
+    for root in (source, target):
+        nested = root / "experiments/matrix/third-party/gdunit4"
+        nested.mkdir(parents=True)
+        (nested / "LICENSE").write_text("license\n", encoding="utf-8")
+        (root / "experiments/matrix/third-party/gdunit4.lock.json").write_text(
+            "{}\n",
+            encoding="utf-8",
+        )
+
+    engine = CodingApplierEngine(source, target, staging)
+
+    assert engine.health()["available"] is True
+
+
 def test_apply_and_revert_support_delete_and_move(
     roots: tuple[Path, Path, Path],
 ) -> None:

--- a/server/tests/test_coding_worker_broker_rpc.py
+++ b/server/tests/test_coding_worker_broker_rpc.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import hashlib
 from pathlib import Path
 
@@ -12,16 +13,29 @@ from server.coding_worker.contracts import (
     AcceptanceCheck,
     AcceptanceContract,
     Origin,
+    PolicyProfile,
     TaskSpec,
     TaskState,
     WorkspaceSource,
 )
 from server.coding_worker.store import CodingWorkerStore
-from server.coding_worker.tool_broker import ToolBroker
+from server.coding_worker.tool_broker import FrozenCheck, ToolBroker
 from server.coding_worker.workspace import InMemoryWorkspaceSourceAdapter, WorkspaceBroker
 
 
-async def _rpc(tmp_path: Path) -> tuple[BrokerRPCServer, str, str]:
+class _Executor:
+    calls: list[tuple[str, ...]]
+
+    def __init__(self) -> None:
+        self.calls = []
+
+    async def run_process(self, **kwargs: object) -> dict[str, object]:
+        argv = tuple(str(item) for item in kwargs["argv"])  # type: ignore[index]
+        self.calls.append(argv)
+        return {"exit_code": 0, "output": "approved\n"}
+
+
+async def _rpc(tmp_path: Path) -> tuple[BrokerRPCServer, str, str, _Executor]:
     source = WorkspaceSource(kind="manifest", source_id="rpc", revision="h0")
     workspace = WorkspaceBroker(
         tmp_path / "workspace",
@@ -43,20 +57,29 @@ async def _rpc(tmp_path: Path) -> tuple[BrokerRPCServer, str, str]:
                 ),
             ),
             model_route="coding/default",
+            policy_profile=PolicyProfile.DEVELOP,
         )
     )
     store.transition(task.task_id, TaskState.PREPARING)
     store.transition(task.task_id, TaskState.RUNNING, workspace_id=prepared.workspace_id)
-    server = BrokerRPCServer(ToolBroker(store=store, workspace_broker=workspace))
+    executor = _Executor()
+    server = BrokerRPCServer(
+        ToolBroker(
+            store=store,
+            workspace_broker=workspace,
+            frozen_checks={"check": FrozenCheck(check_id="check", argv=("python", "-V"))},
+            executor=executor,
+        )
+    )
     endpoint = await server.start_tcp_for_tests()
-    return server, task.task_id, endpoint
+    return server, task.task_id, endpoint, executor
 
 
 @pytest.mark.asyncio
 async def test_rpc_is_task_token_bound_and_returns_provider_neutral_result(
     tmp_path: Path,
 ) -> None:
-    server, task_id, endpoint = await _rpc(tmp_path)
+    server, task_id, endpoint, _ = await _rpc(tmp_path)
     token = server.register_task(task_id)
     client = BrokerRPCClient(endpoint, token=token, task_id=task_id)
     result = await client.call(
@@ -74,7 +97,7 @@ async def test_rpc_is_task_token_bound_and_returns_provider_neutral_result(
 
 @pytest.mark.asyncio
 async def test_rpc_rejects_wrong_token_without_executing_operation(tmp_path: Path) -> None:
-    server, task_id, endpoint = await _rpc(tmp_path)
+    server, task_id, endpoint, _ = await _rpc(tmp_path)
     server.register_task(task_id)
     attacker = BrokerRPCClient(endpoint, token="x" * 48, task_id=task_id)
     with pytest.raises(BrokerRPCError) as denied:
@@ -101,6 +124,7 @@ async def test_mcp_exposes_only_modelmirror_broker_tools() -> None:
         "workspace_diff",
         "write_file",
         "delete_file",
+        "list_acceptance_checks",
         "run_check",
         "run_command",
         "install_dependencies",
@@ -112,6 +136,16 @@ async def test_mcp_exposes_only_modelmirror_broker_tools() -> None:
     write = next(tool for tool in tools if tool.name == "write_file")
     assert set(write.inputSchema["required"]) == {"operation_id", "path", "content"}
     assert "content_sha256" not in write.inputSchema["properties"]
+    command = next(tool for tool in tools if tool.name == "run_command")
+    assert set(command.inputSchema["required"]) == {"operation_id", "argv"}
+    assert "lease_id" not in command.inputSchema["properties"]
+    install = next(tool for tool in tools if tool.name == "install_dependencies")
+    assert set(install.inputSchema["required"]) == {"operation_id"}
+    assert "lease_id" not in install.inputSchema["properties"]
+    assert "network_lease_id" not in install.inputSchema["properties"]
+    service = next(tool for tool in tools if tool.name == "start_service")
+    assert set(service.inputSchema["required"]) == {"operation_id", "argv"}
+    assert "lease_id" not in service.inputSchema["properties"]
 
 
 @pytest.mark.asyncio
@@ -141,3 +175,93 @@ async def test_mcp_computes_write_digest_inside_trusted_adapter() -> None:
             "network_lease_id": None,
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_rpc_waits_for_exact_approval_and_executes_same_operation_once(
+    tmp_path: Path,
+) -> None:
+    server, task_id, endpoint, executor = await _rpc(tmp_path)
+    client = BrokerRPCClient(
+        endpoint, token=server.register_task(task_id), task_id=task_id
+    )
+    pending = asyncio.create_task(
+        client.call(
+            operation_id="rpc-command",
+            tool_name="run_command",
+            arguments={"argv": ["python", "-m", "pytest"], "timeout_seconds": 30},
+        )
+    )
+    for _ in range(100):
+        approvals = server.broker.store.list_approvals(task_id)
+        if approvals:
+            break
+        await asyncio.sleep(0.01)
+    assert len(approvals) == 1
+    assert server.broker.store.get_task(task_id).state is TaskState.WAITING_APPROVAL
+    decided = server.broker.store.decide_approval(approvals[0].approval_id, approved=True)
+    assert decided.lease is not None
+    server.broker.store.transition(
+        task_id, TaskState.RUNNING, expected_state=TaskState.WAITING_APPROVAL
+    )
+    result = await asyncio.wait_for(pending, timeout=2)
+    assert result["state"] == "completed"
+    assert result["data"]["output"] == "approved\n"
+    assert executor.calls == [("python", "-m", "pytest")]
+    await server.close()
+
+
+@pytest.mark.asyncio
+async def test_rpc_rejected_approval_never_reaches_executor(tmp_path: Path) -> None:
+    server, task_id, endpoint, executor = await _rpc(tmp_path)
+    client = BrokerRPCClient(
+        endpoint, token=server.register_task(task_id), task_id=task_id
+    )
+    pending = asyncio.create_task(
+        client.call(
+            operation_id="rpc-rejected",
+            tool_name="run_command",
+            arguments={"argv": ["python", "-V"]},
+        )
+    )
+    for _ in range(100):
+        approvals = server.broker.store.list_approvals(task_id)
+        if approvals:
+            break
+        await asyncio.sleep(0.01)
+    assert len(approvals) == 1
+    server.broker.store.decide_approval(approvals[0].approval_id, approved=False)
+    server.broker.store.transition(
+        task_id, TaskState.RUNNING, expected_state=TaskState.WAITING_APPROVAL
+    )
+    with pytest.raises(BrokerRPCError) as rejected:
+        await asyncio.wait_for(pending, timeout=2)
+    assert rejected.value.code == "approval_rejected"
+    assert executor.calls == []
+    assert server.broker.store.get_operation("rpc-rejected").state.value == "failed"
+    await server.close()
+
+
+@pytest.mark.asyncio
+async def test_rpc_lists_and_enforces_task_acceptance_checks(tmp_path: Path) -> None:
+    server, task_id, endpoint, executor = await _rpc(tmp_path)
+    client = BrokerRPCClient(
+        endpoint, token=server.register_task(task_id), task_id=task_id
+    )
+    listed = await client.call(
+        operation_id="rpc-checks", tool_name="list_acceptance_checks", arguments={}
+    )
+    assert listed["data"] == {
+        "checks": [
+            {"check_id": "check", "label": "check", "kind": "command", "required": True}
+        ]
+    }
+    with pytest.raises(BrokerRPCError) as denied:
+        await client.call(
+            operation_id="rpc-other-check",
+            tool_name="run_check",
+            arguments={"check_id": "other"},
+        )
+    assert denied.value.code == "check_not_allowed"
+    assert executor.calls == []
+    await server.close()

--- a/server/tests/test_coding_worker_broker_rpc.py
+++ b/server/tests/test_coding_worker_broker_rpc.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 from pathlib import Path
 
 import pytest
@@ -109,6 +110,34 @@ async def test_mcp_exposes_only_modelmirror_broker_tools() -> None:
         "stop_service",
     }
     write = next(tool for tool in tools if tool.name == "write_file")
-    assert {"operation_id", "path", "content", "content_sha256"}.issubset(
-        write.inputSchema["required"]
+    assert set(write.inputSchema["required"]) == {"operation_id", "path", "content"}
+    assert "content_sha256" not in write.inputSchema["properties"]
+
+
+@pytest.mark.asyncio
+async def test_mcp_computes_write_digest_inside_trusted_adapter() -> None:
+    calls: list[dict[str, object]] = []
+
+    class RecordingClient:
+        async def call(self, **kwargs: object) -> dict[str, object]:
+            calls.append(kwargs)
+            return {"ok": True}
+
+    content = "discount = 0.0\n"
+    await build_server(RecordingClient()).call_tool(
+        "write_file",
+        {"operation_id": "write-discount", "path": "pricing.py", "content": content},
     )
+    assert calls == [
+        {
+            "operation_id": "write-discount",
+            "tool_name": "write_file",
+            "arguments": {
+                "path": "pricing.py",
+                "content": content,
+                "content_sha256": hashlib.sha256(content.encode("utf-8")).hexdigest(),
+            },
+            "lease_id": None,
+            "network_lease_id": None,
+        }
+    ]

--- a/server/tests/test_coding_worker_opencode.py
+++ b/server/tests/test_coding_worker_opencode.py
@@ -22,6 +22,7 @@ from server.coding_worker.opencode_provider import (
     OpenCodeProvider,
     OpenCodeRoute,
     OpenCodeServerHandle,
+    TOOL_BROKER_MCP_NAME,
 )
 from server.coding_worker.store import CodingWorkerStore
 from server.coding_worker.tool_broker import ToolBroker
@@ -60,12 +61,68 @@ def test_config_disables_direct_tools_plugins_sharing_and_supplier_surface(tmp_p
     permission = config["permission"]
     assert permission["*"] == "deny"
     assert permission["modelmirror-tool-broker_*"] == "allow"
+    assert Path(
+        config["mcp"][TOOL_BROKER_MCP_NAME]["environment"]["PYTHONPATH"]
+    ).name == "server"
     assert config["plugin"] == [] and config["share"] == "disabled"
     assert config["instructions"] == []
     assert config["provider"]["modelmirror"]["options"]["apiKey"] == (
         "{env:CODING_WORKER_ROUTE_KEY}"
     )
     assert all(provider._prompt_tools()[name] is False for name in DIRECT_TOOL_NAMES)
+
+
+@pytest.mark.asyncio
+async def test_open_waits_for_connected_broker_before_creating_session(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    calls = {"mcp": 0, "session": 0}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/mcp":
+            calls["mcp"] += 1
+            status = "connecting" if calls["mcp"] == 1 else "connected"
+            return httpx.Response(
+                200,
+                json={TOOL_BROKER_MCP_NAME: {"status": status}},
+            )
+        if request.url.path == "/session" and request.method == "POST":
+            calls["session"] += 1
+            return httpx.Response(200, json={"id": "ses_ready"})
+        return httpx.Response(404)
+
+    async def factory(
+        request: ProviderOpenRequest, resolved: Path, route: OpenCodeRoute
+    ) -> OpenCodeServerHandle:
+        client = httpx.AsyncClient(
+            base_url="http://127.0.0.1:4096",
+            transport=httpx.MockTransport(handler),
+        )
+
+        async def close() -> None:
+            await client.aclose()
+
+        return OpenCodeServerHandle(
+            task_id=request.task_id,
+            workspace=resolved,
+            state_root=tmp_path / "state",
+            client=client,
+            close_callback=close,
+        )
+
+    provider = OpenCodeProvider(
+        workspace_resolver=lambda _workspace_id: workspace,
+        runtime_root=tmp_path / "runtime",
+        routes={"coding/default": _route()},
+        tool_broker_command=("python", "-m", "coding_worker.broker_mcp"),
+        server_factory=factory,
+    )
+    session = await provider.open(_request())
+    assert session.session_id == "ses_ready"
+    assert calls == {"mcp": 2, "session": 1}
+    await provider.close(session)
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_coding_worker_source_adapters.py
+++ b/server/tests/test_coding_worker_source_adapters.py
@@ -127,7 +127,7 @@ async def test_host_snapshot_adapter_requests_imports_and_releases_exact_transfe
     files = {"README.md": b"hello\n", "src/app.py": b"print('ok')\n"}
     lease = _lease("host_git", files)
     project = {
-        "id": lease["project_id"],
+        "project_id": lease["project_id"],
         "name": "中文 Host Project",
         "branch": "feature/v14",
         "head": lease["head"],
@@ -221,7 +221,7 @@ async def test_project_snapshot_adapter_rejects_changed_fingerprint_and_releases
     )
 
     project = {
-        "id": lease["project_id"],
+        "project_id": lease["project_id"],
         "name": "Host Project",
         "branch": "feature/v14",
         "head": lease["head"],

--- a/server/tests/test_coding_worker_workspace.py
+++ b/server/tests/test_coding_worker_workspace.py
@@ -117,6 +117,30 @@ async def test_workspace_tree_detects_links_and_diff_uses_private_index(tmp_path
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(
+    os.name == "nt" or not hasattr(os, "geteuid") or os.geteuid() != 0,
+    reason="requires Linux root to reproduce the sidecar ownership boundary",
+)
+async def test_diff_accepts_worker_owned_synthetic_repository(tmp_path: Path) -> None:
+    source = _source()
+    broker = WorkspaceBroker(
+        tmp_path / "control",
+        {
+            "manifest": InMemoryWorkspaceSourceAdapter(
+                {(source.source_id, source.revision): {"tracked.txt": b"old\n"}}
+            )
+        },
+        id_key=b"o" * 32,
+        slot_roots={"slot-a": tmp_path / "slot-a"},
+        slot_owner=(65532, 65532),
+    )
+    record = await broker.prepare(source, slot_id="slot-a")
+    (broker.repository_path(record.workspace_id) / "tracked.txt").write_bytes(b"new\n")
+
+    assert b"tracked.txt" in broker.diff(record.workspace_id)
+
+
+@pytest.mark.asyncio
 async def test_dedicated_slots_keep_workspace_files_in_separate_roots(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## 变更摘要

这是 V14 三层 PR 链之后的第四层实机验收修复，基线为 #130 的 `codex/coding-worker-v14-integration`。

- 补齐 Worker 本地项目选择、Host Snapshot 标识、合成仓库 Diff 与跨平台路径排序。
- 恢复 OpenCode 到 ModelMirror Tool Broker 的文件写入代理。
- 修复命令审批闭环：模型只提交 operation ID 与精确 argv；Broker 创建审批并在服务端等待一次性/任务级租约，批准后只执行原 operation，拒绝时零执行。
- 新增任务级冻结验收检查发现接口，并拒绝运行契约外 check ID。

## 根因

原 MCP `run_command` 把 `lease_id` 暴露给模型，但审批只会在没有 lease 时由 Tool Broker 创建，模型只能猜测无效租约，导致 Python 任务所有命令稳定失败为 `lease_unavailable`。Provider 同时不知道当前任务的冻结检查 ID，可能猜出 `check_not_found`。

## 验收证据

实机共享栈任务 `task_6ed3b5d802a04dd3bdc8522243a1c51a`：

1. `initial-tests` 请求精确 `python -m pytest -q`，一次性批准后真实观察到 `19.99 != 0.0`。
2. Worker 仅修改 `calculator.py` 的 100% 折扣返回值。
3. `retest-after-fix` 使用新 operation ID 再次请求同命令并独立批准，6 项测试通过。
4. Harness 冻结 `python-pytest` 再次通过，任务进入 `completed`，Evidence 与 Diff 可下载。

## 自动门禁

- 实际 PR 分支 Coding Worker：102 passed。
- Broker RPC + Tool Broker：18 passed。
- Agent Workspace：44 passed。
- 全部 Coding：725 passed，9 skipped。
- 前端：31 files / 145 tests passed；production build passed。
- 后端全量：2441 passed，21 skipped；两个初始失败均已隔离复核通过：既有 Base64 尾字符不稳定节点、容器 Node 20 不支持直接导入 TS（宿主 Node 24 通过）。
- `py_compile`、`git diff --check`、新增行敏感信息扫描通过。
- 六个定向提交与共享栈验收版本 `range-diff` 全部一致。

## PR 依赖

`#122 (Kernel) -> #125 (Execution) -> #130 (Integration) -> 本 PR`

本 PR 保持 Draft，待下层 PR 按序合并或重定基线后再转 Ready。