### PR TITLE
merge: 收口完整 V14 Coding Worker

### DIFF
--- a/client/src/components/CodingWorkerConsole.test.tsx
+++ b/client/src/components/CodingWorkerConsole.test.tsx
@@ -7,6 +7,7 @@ const api = vi.hoisted(() => ({
   getCodingWorkerStatus: vi.fn(),
   listCodingWorkerTasks: vi.fn(),
   getCodingWorkerTask: vi.fn(),
+  handoffCodingWorkerTask: vi.fn(),
   listCodingWorkerApprovals: vi.fn(),
   listCodingWorkerEvidence: vi.fn(),
   listCodingWorkerArtifacts: vi.fn(),
@@ -87,5 +88,26 @@ describe("CodingWorkerConsole", () => {
     render(<CodingWorkerConsole context="agent" />);
     expect((await screen.findAllByText("修复失败测试并生成证据")).length).toBe(2);
     expect(screen.queryByText("宿主写回")).not.toBeInTheDocument();
+  });
+
+  it("hands a completed Host Snapshot task to the v13 confirmation chain", async () => {
+    const completed = { ...task, state: "completed" as const };
+    api.listCodingWorkerTasks.mockResolvedValue([completed]);
+    api.getCodingWorkerTask.mockResolvedValue(completed);
+    api.handoffCodingWorkerTask.mockResolvedValue({
+      id: "session_1234567890abcdef1234567890abcdef",
+      status: "ready",
+      project: { id: "hostgit_1234567890abcdef1234567890abcdef" },
+      revision: 1,
+      task_id: task.task_id,
+    });
+    const onCodingHandoff = vi.fn();
+    const user = userEvent.setup();
+    render(<CodingWorkerConsole context="coding" onCodingHandoff={onCodingHandoff} />);
+
+    await user.click(await screen.findByRole("button", { name: "进入 v13 写回确认" }));
+
+    await waitFor(() => expect(api.handoffCodingWorkerTask).toHaveBeenCalledWith(task.task_id));
+    expect(onCodingHandoff).toHaveBeenCalledWith(expect.objectContaining({ revision: 1 }));
   });
 });

--- a/client/src/components/CodingWorkerConsole.test.tsx
+++ b/client/src/components/CodingWorkerConsole.test.tsx
@@ -24,6 +24,15 @@ const api = vi.hoisted(() => ({
 
 vi.mock("../utils/codingWorkerApi", () => api);
 
+const projectApi = vi.hoisted(() => ({
+  createCodingProjectSelection: vi.fn(),
+  getCodingProjectSelection: vi.fn(),
+  getCodingProjects: vi.fn(),
+  getCodingWorkerHostSource: vi.fn(),
+}));
+
+vi.mock("../utils/codingApi", () => projectApi);
+
 const task = {
   task_id: "task_1234567890abcdef1234567890abcdef",
   spec: {
@@ -53,6 +62,7 @@ const task = {
 
 beforeEach(() => {
   Object.values(api).forEach((mock) => "mockReset" in mock && mock.mockReset());
+  Object.values(projectApi).forEach((mock) => "mockReset" in mock && mock.mockReset());
   api.codingWorkerArtifactUrl.mockImplementation((taskId: string, artifactId: string) => `/artifact/${taskId}/${artifactId}`);
   api.getCodingWorkerStatus.mockResolvedValue({ enabled: true, available: true, version: "v1", max_active_tasks: 2, retention_seconds: 604800, network_enabled: false, acceptance_checks: ["python-pytest", "react-build"], reason: null });
   api.listCodingWorkerTasks.mockResolvedValue([task]);
@@ -64,6 +74,44 @@ beforeEach(() => {
   api.readCodingWorkerDiff.mockResolvedValue("diff --git a/src/app.py b/src/app.py");
   api.connectCodingWorkerEvents.mockReturnValue(() => undefined);
   api.decideCodingWorkerApproval.mockResolvedValue({});
+  projectApi.getCodingProjects.mockResolvedValue({
+    enabled: true,
+    configured: true,
+    available: true,
+    selection: true,
+    default_project_id: "modelmirror",
+    max_projects: 50,
+    projects: [{
+      id: "hostgit_existing",
+      name: "现有项目",
+      kind: "host_git",
+      state: "available",
+      reason: null,
+      branch: "main",
+      head: "a".repeat(40),
+      features: {
+        chat: true,
+        draft: true,
+        diff: true,
+        download: true,
+        recovery: true,
+        verification: true,
+        apply: true,
+        commit: true,
+        publish: false,
+        commands: true,
+      },
+      writeback_reason: null,
+    }],
+  });
+  projectApi.getCodingWorkerHostSource.mockImplementation(async (projectId: string) => ({
+    source_id: projectId,
+    name: "已授权项目",
+    branch: "main",
+    revision: projectId === "hostgit_python_sample"
+      ? "c8c27a695d3a6562b5ff8fe3df28548ecc388df4"
+      : "b".repeat(40),
+  }));
 });
 
 describe("CodingWorkerConsole", () => {
@@ -109,5 +157,109 @@ describe("CodingWorkerConsole", () => {
 
     await waitFor(() => expect(api.handoffCodingWorkerTask).toHaveBeenCalledWith(task.task_id));
     expect(onCodingHandoff).toHaveBeenCalledWith(expect.objectContaining({ revision: 1 }));
+  });
+
+  it("requests a Helper folder selection and binds the returned project revision", async () => {
+    const newProject = {
+      id: "hostgit_python_sample",
+      name: "Python 折扣样例",
+      kind: "host_git",
+      state: "available",
+      reason: null,
+      branch: "main",
+      head: "c8c27a695d3a6562b5ff8fe3df28548ecc388df4",
+      features: {
+        chat: true,
+        draft: true,
+        diff: true,
+        download: true,
+        recovery: true,
+        verification: true,
+        apply: true,
+        commit: true,
+        publish: false,
+        commands: true,
+      },
+      writeback_reason: null,
+    } as const;
+    projectApi.createCodingProjectSelection.mockResolvedValue({
+      request_id: "selection_1",
+      status: "completed",
+      project_id: newProject.id,
+      error: null,
+      expires_at: 100,
+    });
+    projectApi.getCodingProjects
+      .mockResolvedValueOnce(await projectApi.getCodingProjects())
+      .mockResolvedValueOnce({
+        enabled: true,
+        configured: true,
+        available: true,
+        selection: true,
+        default_project_id: "modelmirror",
+        max_projects: 50,
+        projects: [newProject],
+      });
+
+    const user = userEvent.setup();
+    render(<CodingWorkerConsole context="coding" />);
+    await user.click(await screen.findByRole("button", { name: "创建任务" }));
+    await user.click(screen.getByRole("button", { name: "添加本地项目" }));
+
+    await waitFor(() => expect(screen.getByLabelText("本地项目")).toHaveValue(newProject.id));
+    expect(screen.getByLabelText("基准 revision")).toHaveValue(newProject.head);
+    expect(projectApi.createCodingProjectSelection).toHaveBeenCalledTimes(1);
+  });
+
+  it("recovers a project registered after the selection request expires", async () => {
+    const lateProject = {
+      id: "hostgit_late_sample",
+      name: "延迟返回样例",
+      kind: "host_git",
+      state: "available",
+      reason: null,
+      branch: "main",
+      head: "b".repeat(40),
+      features: {
+        chat: true,
+        draft: true,
+        diff: true,
+        download: true,
+        recovery: true,
+        verification: true,
+        apply: true,
+        commit: true,
+        publish: false,
+        commands: true,
+      },
+      writeback_reason: null,
+    } as const;
+    projectApi.createCodingProjectSelection.mockResolvedValue({
+      request_id: "selection_late",
+      status: "expired",
+      project_id: null,
+      error: "project_selection_expired",
+      expires_at: 100,
+    });
+    projectApi.getCodingProjects
+      .mockResolvedValueOnce(await projectApi.getCodingProjects())
+      .mockResolvedValueOnce({
+        enabled: true,
+        configured: true,
+        available: true,
+        selection: true,
+        default_project_id: "modelmirror",
+        max_projects: 50,
+        projects: [lateProject],
+      });
+
+    const user = userEvent.setup();
+    render(<CodingWorkerConsole context="coding" />);
+    await user.click(await screen.findByRole("button", { name: "创建任务" }));
+    await user.click(screen.getByRole("button", { name: "添加本地项目" }));
+
+    await waitFor(() => expect(screen.getByLabelText("本地项目")).toHaveValue(lateProject.id));
+    expect(screen.getByLabelText("基准 revision")).toHaveValue(lateProject.head);
+    expect(screen.queryByText("选择请求已超时", { exact: false })).not.toBeInTheDocument();
   });
 });

--- a/client/src/components/CodingWorkerConsole.test.tsx
+++ b/client/src/components/CodingWorkerConsole.test.tsx
@@ -32,7 +32,7 @@ const task = {
     workspace_source: { kind: "host_snapshot", source_id: "source_1", revision: "rev_1" },
     acceptance: {
       contract_id: "contract_1",
-      required_checks: [{ check_id: "tests", kind: "command", label: "运行测试" }],
+      required_checks: [{ check_id: "tests", kind: "command", label: "运行测试", required: true }],
       required_artifacts: [],
     },
     policy_profile: "develop",

--- a/client/src/components/CodingWorkerConsole.test.tsx
+++ b/client/src/components/CodingWorkerConsole.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import CodingWorkerConsole from "./CodingWorkerConsole";
+
+const api = vi.hoisted(() => ({
+  getCodingWorkerStatus: vi.fn(),
+  listCodingWorkerTasks: vi.fn(),
+  getCodingWorkerTask: vi.fn(),
+  listCodingWorkerApprovals: vi.fn(),
+  listCodingWorkerEvidence: vi.fn(),
+  listCodingWorkerArtifacts: vi.fn(),
+  listCodingWorkerTree: vi.fn(),
+  readCodingWorkerDiff: vi.fn(),
+  connectCodingWorkerEvents: vi.fn(),
+  decideCodingWorkerApproval: vi.fn(),
+  changeCodingWorkerTask: vi.fn(),
+  createCodingWorkerTask: vi.fn(),
+  readCodingWorkerEntry: vi.fn(),
+  sendCodingWorkerMessage: vi.fn(),
+  codingWorkerArtifactUrl: vi.fn((taskId: string, artifactId: string) => `/artifact/${taskId}/${artifactId}`),
+}));
+
+vi.mock("../utils/codingWorkerApi", () => api);
+
+const task = {
+  task_id: "task_1234567890abcdef1234567890abcdef",
+  spec: {
+    client_task_id: "console_1234567890abcdef1234567890abcdef",
+    origin: { module: "worker-console", object_id: "local-user" },
+    objective: "修复失败测试并生成证据",
+    workspace_source: { kind: "host_snapshot", source_id: "source_1", revision: "rev_1" },
+    acceptance: {
+      contract_id: "contract_1",
+      required_checks: [{ check_id: "tests", kind: "command", label: "运行测试" }],
+      required_artifacts: [],
+    },
+    policy_profile: "develop",
+    model_route: "coding/default",
+    budget: { max_seconds: 3600, max_turns: 64, max_tool_calls: 512, max_output_bytes: 8_388_608 },
+    context_refs: [],
+  },
+  state: "waiting_approval",
+  workspace_id: "workspace_1234567890abcdef1234567890abcdef",
+  created_at: 1,
+  updated_at: 2,
+  expires_at: 100,
+  pinned: false,
+  last_event_sequence: 1,
+  reason: null,
+} as const;
+
+beforeEach(() => {
+  Object.values(api).forEach((mock) => "mockReset" in mock && mock.mockReset());
+  api.codingWorkerArtifactUrl.mockImplementation((taskId: string, artifactId: string) => `/artifact/${taskId}/${artifactId}`);
+  api.getCodingWorkerStatus.mockResolvedValue({ enabled: true, available: true, version: "v1", max_active_tasks: 2, retention_seconds: 604800, network_enabled: false, reason: null });
+  api.listCodingWorkerTasks.mockResolvedValue([task]);
+  api.getCodingWorkerTask.mockResolvedValue(task);
+  api.listCodingWorkerApprovals.mockResolvedValue([{ approval_id: "approval_1234567890abcdef1234567890abcdef", task_id: task.task_id, operation_id: "operation_1", capability: "command", status: "pending", request: { command: "pytest" }, lease: null, created_at: 1, decided_at: null }]);
+  api.listCodingWorkerEvidence.mockResolvedValue([{ evidence_id: "evidence_1", task_id: task.task_id, check_id: "tests", operation_id: "operation_1", workspace_tree_hash: "a".repeat(64), status: "failed", exit_code: 1, artifact_id: "artifact_1", created_at: 2 }]);
+  api.listCodingWorkerArtifacts.mockResolvedValue([]);
+  api.listCodingWorkerTree.mockResolvedValue({ workspace_id: task.workspace_id, tree_hash: "a".repeat(64), entries: [{ entry_id: "entry_1", name: "app.py", display_path: "src/app.py", kind: "file", size: 12, sha256: "b".repeat(64) }] });
+  api.readCodingWorkerDiff.mockResolvedValue("diff --git a/src/app.py b/src/app.py");
+  api.connectCodingWorkerEvents.mockReturnValue(() => undefined);
+  api.decideCodingWorkerApproval.mockResolvedValue({});
+});
+
+describe("CodingWorkerConsole", () => {
+  it("shows task state, workspace, approval and Coding writeback boundary", async () => {
+    const user = userEvent.setup();
+    render(<CodingWorkerConsole context="coding" />);
+
+    expect((await screen.findAllByText("修复失败测试并生成证据")).length).toBe(2);
+    expect(screen.getByText("宿主写回")).toBeInTheDocument();
+    expect(await screen.findByText("src/app.py")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("tab", { name: "证据" }));
+    await user.click(await screen.findByRole("button", { name: "批准一次" }));
+    await waitFor(() => expect(api.decideCodingWorkerApproval).toHaveBeenCalledWith(
+      task.task_id,
+      "approval_1234567890abcdef1234567890abcdef",
+      "approve_once",
+    ));
+  });
+
+  it("keeps domain writeback controls out of the generic Agent context", async () => {
+    render(<CodingWorkerConsole context="agent" />);
+    expect((await screen.findAllByText("修复失败测试并生成证据")).length).toBe(2);
+    expect(screen.queryByText("宿主写回")).not.toBeInTheDocument();
+  });
+});

--- a/client/src/components/CodingWorkerConsole.test.tsx
+++ b/client/src/components/CodingWorkerConsole.test.tsx
@@ -54,7 +54,7 @@ const task = {
 beforeEach(() => {
   Object.values(api).forEach((mock) => "mockReset" in mock && mock.mockReset());
   api.codingWorkerArtifactUrl.mockImplementation((taskId: string, artifactId: string) => `/artifact/${taskId}/${artifactId}`);
-  api.getCodingWorkerStatus.mockResolvedValue({ enabled: true, available: true, version: "v1", max_active_tasks: 2, retention_seconds: 604800, network_enabled: false, reason: null });
+  api.getCodingWorkerStatus.mockResolvedValue({ enabled: true, available: true, version: "v1", max_active_tasks: 2, retention_seconds: 604800, network_enabled: false, acceptance_checks: ["python-pytest", "react-build"], reason: null });
   api.listCodingWorkerTasks.mockResolvedValue([task]);
   api.getCodingWorkerTask.mockResolvedValue(task);
   api.listCodingWorkerApprovals.mockResolvedValue([{ approval_id: "approval_1234567890abcdef1234567890abcdef", task_id: task.task_id, operation_id: "operation_1", capability: "command", status: "pending", request: { command: "pytest" }, lease: null, created_at: 1, decided_at: null }]);

--- a/client/src/components/CodingWorkerConsole.tsx
+++ b/client/src/components/CodingWorkerConsole.tsx
@@ -3,6 +3,7 @@ import {
   CheckCircle2,
   CircleAlert,
   FileCode2,
+  FolderPlus,
   FolderTree,
   GitCompareArrows,
   MessageSquareText,
@@ -43,6 +44,13 @@ import {
   sendCodingWorkerMessage,
   type CodingWorkerHandoffResult,
 } from "../utils/codingWorkerApi";
+import type { CodingProjectSelection, CodingProjectSummary } from "../types/coding";
+import {
+  createCodingProjectSelection,
+  getCodingProjectSelection,
+  getCodingProjects,
+  getCodingWorkerHostSource,
+} from "../utils/codingApi";
 
 type ConsoleContext = "coding" | "agent";
 type InspectorTab = "files" | "diff" | "evidence" | "terminal";
@@ -92,16 +100,51 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
   const [sourceId, setSourceId] = useState("");
   const [revision, setRevision] = useState("");
   const [checkId, setCheckId] = useState("");
+  const [codingProjects, setCodingProjects] = useState<CodingProjectSummary[]>([]);
+  const [selection, setSelection] = useState<CodingProjectSelection | null>(null);
   const [busy, setBusy] = useState(false);
   const [loading, setLoading] = useState(true);
   const [transportWarning, setTransportWarning] = useState(false);
   const [error, setError] = useState("");
   const operationRef = useRef(false);
+  const selectionProjectIdsRef = useRef<Set<string>>(new Set());
 
   const selectedTask = useMemo(
     () => tasks.find((task) => task.task_id === selectedTaskId) ?? null,
     [selectedTaskId, tasks],
   );
+
+  const refreshCodingProjects = useCallback(async (preferredId?: string, selectNew = false) => {
+    if (context !== "coding") return null;
+    const response = await getCodingProjects();
+    const hostProjects = response.projects.filter((project) => project.kind === "host_git");
+    setCodingProjects(hostProjects);
+    const preferred = hostProjects.find(
+      (project) => project.id === preferredId && project.state === "available" && project.head,
+    );
+    const newlyAdded = selectNew
+      ? hostProjects.filter(
+        (project) => !selectionProjectIdsRef.current.has(project.id)
+          && project.state === "available"
+          && project.head,
+      )
+      : [];
+    const selected = preferred ?? (newlyAdded.length === 1 ? newlyAdded[0] : undefined);
+    if (selected?.head) {
+      const binding = await getCodingWorkerHostSource(selected.id);
+      if (
+        binding.source_id !== selected.id
+        || binding.branch !== selected.branch
+        || !binding.revision.startsWith(selected.head)
+      ) {
+        throw new Error("本地项目基准已改变，请刷新后重新选择。");
+      }
+      setSourceId(binding.source_id);
+      setRevision(binding.revision);
+      return selected.id;
+    }
+    return null;
+  }, [context]);
 
   const refreshTasks = useCallback(async (preferredId?: string) => {
     const next = await listCodingWorkerTasks();
@@ -148,6 +191,48 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
       .finally(() => { if (active) setLoading(false); });
     return () => { active = false; };
   }, [refreshTasks]);
+
+  useEffect(() => {
+    if (context !== "coding") return;
+    void refreshCodingProjects().catch((caught) => {
+      setError(errorMessage(caught, "本地项目列表加载失败"));
+    });
+  }, [context, refreshCodingProjects]);
+
+  useEffect(() => {
+    if (!selection || !["pending", "dispatched"].includes(selection.status)) return;
+    let active = true;
+    let timer = 0;
+    const poll = async () => {
+      try {
+        const next = await getCodingProjectSelection(selection.request_id);
+        if (!active) return;
+        setSelection(next);
+        if (next.status === "completed" && next.project_id) {
+          await refreshCodingProjects(next.project_id);
+          return;
+        }
+        if (next.status === "failed" || next.status === "expired") {
+          const recoveredProjectId = await refreshCodingProjects(undefined, true);
+          if (recoveredProjectId) return;
+          setError(next.error === "project_selection_cancelled"
+            ? "已取消选择，本地项目列表没有变化。"
+            : next.status === "expired"
+              ? "选择请求已超时；若 Helper 已完成授权，请从本地项目列表中选择该项目。"
+              : "没有添加项目，请重新选择一个干净的 Git 仓库。");
+          return;
+        }
+        timer = window.setTimeout(() => void poll(), 800);
+      } catch (caught) {
+        if (active) setError(errorMessage(caught, "本地项目选择失败"));
+      }
+    };
+    timer = window.setTimeout(() => void poll(), 500);
+    return () => {
+      active = false;
+      window.clearTimeout(timer);
+    };
+  }, [refreshCodingProjects, selection]);
 
   useEffect(() => {
     if (!selectedTaskId) {
@@ -209,6 +294,42 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
     const task = await createCodingWorkerTask(spec);
     await refreshTasks(task.task_id);
     setShowCreate(false); setObjective(""); setSourceId(""); setRevision(""); setCheckId("");
+  });
+
+  const addCodingProject = () => run(async () => {
+    selectionProjectIdsRef.current = new Set(codingProjects.map((project) => project.id));
+    const next = await createCodingProjectSelection();
+    setSelection(next);
+    if (next.status === "completed" && next.project_id) {
+      await refreshCodingProjects(next.project_id);
+    } else if (next.status === "failed" || next.status === "expired") {
+      const recoveredProjectId = await refreshCodingProjects(undefined, true);
+      if (recoveredProjectId) return;
+      setError(next.error === "project_selection_cancelled"
+        ? "已取消选择，本地项目列表没有变化。"
+        : next.status === "expired"
+          ? "选择请求已超时；若 Helper 已完成授权，请从本地项目列表中选择该项目。"
+          : "没有添加项目，请重新选择一个干净的 Git 仓库。");
+    }
+  });
+
+  const selectCodingProject = (projectId: string) => run(async () => {
+    const project = codingProjects.find((item) => item.id === projectId);
+    if (!project || project.state !== "available" || !project.head) {
+      setSourceId("");
+      setRevision("");
+      return;
+    }
+    const binding = await getCodingWorkerHostSource(project.id);
+    if (
+      binding.source_id !== project.id
+      || binding.branch !== project.branch
+      || !binding.revision.startsWith(project.head)
+    ) {
+      throw new Error("本地项目基准已改变，请刷新后重新选择。");
+    }
+    setSourceId(binding.source_id);
+    setRevision(binding.revision);
   });
 
   const submitMessage = () => run(async () => {
@@ -273,8 +394,47 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
           <label className="md:col-span-2 xl:col-span-2 text-sm text-slate-200">任务目标
             <textarea value={objective} onChange={(event) => setObjective(event.target.value)} className="mt-1 min-h-24 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 py-2 text-white" maxLength={1_048_576} />
           </label>
-          <label className="text-sm text-slate-200">不透明来源 ID<input value={sourceId} onChange={(event) => setSourceId(event.target.value)} className="mt-1 min-h-11 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 text-white" /></label>
-          <label className="text-sm text-slate-200">基准 revision<input value={revision} onChange={(event) => setRevision(event.target.value)} className="mt-1 min-h-11 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 text-white" /></label>
+          {context === "coding" ? (
+            <div className="text-sm text-slate-200">
+              <label htmlFor="worker-host-project">本地项目</label>
+              <select
+                id="worker-host-project"
+                value={sourceId}
+                onChange={(event) => void selectCodingProject(event.target.value)}
+                className="mt-1 min-h-11 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 text-white outline-none focus:border-cyan-300/70 focus:ring-4 focus:ring-cyan-300/10"
+              >
+                <option value="">选择已授权项目</option>
+                {codingProjects.map((project) => (
+                  <option
+                    key={project.id}
+                    value={project.id}
+                    disabled={project.state !== "available" || !project.head}
+                  >
+                    {project.name}{project.branch ? ` · ${project.branch}` : ""}
+                    {project.head ? ` · ${project.head.slice(0, 12)}` : ""}
+                    {project.state !== "available" ? " · 当前不可用" : ""}
+                  </option>
+                ))}
+              </select>
+              <button
+                type="button"
+                onClick={() => void addCodingProject()}
+                disabled={busy || selection?.status === "pending" || selection?.status === "dispatched"}
+                className="mt-2 inline-flex min-h-11 w-full items-center justify-center gap-2 rounded-lg border border-cyan-300/35 px-3 text-sm font-semibold text-cyan-100 transition hover:bg-cyan-300/10 focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-cyan-300/20 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <FolderPlus className="h-4 w-4" aria-hidden="true" />
+                {selection?.status === "pending" || selection?.status === "dispatched"
+                  ? "等待 Helper 选择"
+                  : "添加本地项目"}
+              </button>
+              <p className="mt-2 text-xs leading-5 text-slate-400">
+                点击后在 Helper 弹出的窗口中选择干净的 Git 仓库，物理路径不会发送到 Server。
+              </p>
+            </div>
+          ) : (
+            <label className="text-sm text-slate-200">不透明来源 ID<input value={sourceId} onChange={(event) => setSourceId(event.target.value)} className="mt-1 min-h-11 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 text-white" /></label>
+          )}
+          <label className="text-sm text-slate-200">基准 revision<input value={revision} onChange={(event) => setRevision(event.target.value)} readOnly={context === "coding"} className="mt-1 min-h-11 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 text-white read-only:text-slate-300" /></label>
           <label className="text-sm text-slate-200">冻结验收检查<select value={checkId} onChange={(event) => setCheckId(event.target.value)} disabled={!status.acceptance_checks.length} className="mt-1 min-h-11 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 text-white disabled:opacity-60">{status.acceptance_checks.map((item) => <option key={item} value={item}>{item}</option>)}</select></label>
           <div className="flex items-end md:col-span-2 xl:col-span-5"><button type="submit" disabled={busy || !checkId} className="min-h-11 rounded-lg bg-cyan-400 px-5 text-sm font-semibold text-slate-950 disabled:opacity-50">提交到队列</button></div>
         </form>

--- a/client/src/components/CodingWorkerConsole.tsx
+++ b/client/src/components/CodingWorkerConsole.tsx
@@ -189,7 +189,7 @@ export default function CodingWorkerConsole({ context }: CodingWorkerConsoleProp
       workspace_source: { kind: context === "coding" ? "host_snapshot" : "builtin", source_id: sourceId.trim(), revision: revision.trim() },
       acceptance: {
         contract_id: `contract_${suffix}`,
-        required_checks: [{ check_id: checkId.trim(), kind: "command", label: "必需检查" }],
+        required_checks: [{ check_id: checkId.trim(), kind: "command", label: "必需检查", required: true }],
         required_artifacts: [],
       },
       policy_profile: "develop",

--- a/client/src/components/CodingWorkerConsole.tsx
+++ b/client/src/components/CodingWorkerConsole.tsx
@@ -32,6 +32,7 @@ import {
   decideCodingWorkerApproval,
   getCodingWorkerTask,
   getCodingWorkerStatus,
+  handoffCodingWorkerTask,
   listCodingWorkerApprovals,
   listCodingWorkerArtifacts,
   listCodingWorkerEvidence,
@@ -40,6 +41,7 @@ import {
   readCodingWorkerDiff,
   readCodingWorkerEntry,
   sendCodingWorkerMessage,
+  type CodingWorkerHandoffResult,
 } from "../utils/codingWorkerApi";
 
 type ConsoleContext = "coding" | "agent";
@@ -68,9 +70,10 @@ function payloadText(event: CodingWorkerEvent) {
 
 interface CodingWorkerConsoleProps {
   context: ConsoleContext;
+  onCodingHandoff?: (result: CodingWorkerHandoffResult) => void;
 }
 
-export default function CodingWorkerConsole({ context }: CodingWorkerConsoleProps) {
+export default function CodingWorkerConsole({ context, onCodingHandoff }: CodingWorkerConsoleProps) {
   const [status, setStatus] = useState<CodingWorkerStatus | null>(null);
   const [tasks, setTasks] = useState<CodingWorkerTask[]>([]);
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
@@ -227,6 +230,12 @@ export default function CodingWorkerConsole({ context }: CodingWorkerConsoleProp
     setPreview({ path: entry.display_path, content });
   });
 
+  const handoffToWriteback = () => run(async () => {
+    if (!selectedTask || selectedTask.state !== "completed") return;
+    const result = await handoffCodingWorkerTask(selectedTask.task_id);
+    onCodingHandoff?.(result);
+  });
+
   if (loading) return <div className="min-h-[60vh] animate-pulse rounded-xl bg-white/5" aria-label="正在加载 Coding Worker" />;
 
   if (!status?.enabled || !status.available) {
@@ -326,7 +335,7 @@ export default function CodingWorkerConsole({ context }: CodingWorkerConsoleProp
             {tab === "evidence" && <div className="space-y-4"><section><h3 className="font-semibold text-white">审批</h3>{approvals.filter((item) => item.status === "pending").map((item) => <div key={item.approval_id} className="mt-2 rounded-lg bg-amber-300/10 p-3"><p className="text-amber-100">{item.capability}</p><p className="mt-1 break-words text-xs text-slate-300">{JSON.stringify(item.request)}</p><div className="mt-3 flex flex-wrap gap-2"><button type="button" disabled={busy} onClick={() => void decide(item.approval_id, "approve_once")} className="min-h-11 rounded-lg bg-cyan-400 px-3 font-semibold text-slate-950">批准一次</button><button type="button" disabled={busy} onClick={() => void decide(item.approval_id, "approve_task")} className="min-h-11 rounded-lg border border-cyan-300/40 px-3 text-cyan-100">本任务批准</button><button type="button" disabled={busy} onClick={() => void decide(item.approval_id, "reject")} className="min-h-11 rounded-lg border border-white/15 px-3 text-slate-200">拒绝</button></div></div>)}</section><section><h3 className="font-semibold text-white">检查证据</h3><ul className="mt-2 space-y-2">{evidence.map((item) => <li key={item.evidence_id} className="rounded-lg bg-white/5 p-3"><span className={item.status === "passed" ? "text-emerald-300" : item.status === "failed" ? "text-rose-300" : "text-amber-300"}>{item.status}</span><span className="ml-2 break-all text-slate-200">{item.check_id}</span><span className="mt-1 block text-xs text-slate-400">exit {item.exit_code}</span></li>)}</ul></section><section><h3 className="font-semibold text-white">Artifacts</h3><ul className="mt-2 space-y-1">{artifacts.map((item) => <li key={item.artifact_id}><a className="block min-h-10 break-all rounded-md px-2 py-2 text-cyan-200 hover:bg-white/5" href={codingWorkerArtifactUrl(item.task_id, item.artifact_id)}>{item.artifact_id} · {item.media_type}</a></li>)}</ul></section></div>}
             {tab === "terminal" && <div><p className="mb-2 text-xs text-slate-400">命令归属和输出只来自 Tool Broker 公开事件。</p><pre className="overflow-auto whitespace-pre-wrap break-words rounded-lg bg-slate-950/80 p-3 text-xs text-slate-200">{events.filter((event) => event.type === "tool_operation" || event.type === "provider_event").map((event) => `#${event.sequence} ${event.type}\n${payloadText(event) ?? JSON.stringify(event.payload)}`).join("\n\n") || "尚无工具输出。"}</pre></div>}
           </div>
-          {context === "coding" && selectedTask && <section className="mt-3 border-t border-white/10 pt-3"><div className="flex items-center gap-2"><GitCompareArrows className="h-4 w-4 text-cyan-300" /><h3 className="font-semibold text-white">宿主写回</h3></div><p className="mt-1 text-xs text-slate-400">完成后继续使用 v13 的应用、提交、撤销和发布确认链。Worker 不直接写用户仓库。</p><div className="mt-3 flex flex-wrap gap-2" aria-label="Coding 领域动作"><span className="rounded-full bg-white/5 px-3 py-1 text-xs text-slate-300">应用</span><span className="rounded-full bg-white/5 px-3 py-1 text-xs text-slate-300">提交</span><span className="rounded-full bg-white/5 px-3 py-1 text-xs text-slate-300">撤销</span><span className="rounded-full bg-white/5 px-3 py-1 text-xs text-slate-300">发布</span></div></section>}
+          {context === "coding" && selectedTask && <section className="mt-3 border-t border-white/10 pt-3"><div className="flex items-center gap-2"><GitCompareArrows className="h-4 w-4 text-cyan-300" /><h3 className="font-semibold text-white">宿主写回</h3></div><p className="mt-1 text-xs text-slate-400">完成后继续使用 v13 的应用、提交、撤销和发布确认链。Worker 不直接写用户仓库。</p>{selectedTask.state === "completed" && selectedTask.spec.workspace_source.kind === "host_snapshot" ? <button type="button" onClick={() => void handoffToWriteback()} disabled={busy} className="mt-3 min-h-11 w-full rounded-lg bg-cyan-400 px-3 text-sm font-semibold text-slate-950 transition hover:bg-cyan-300 disabled:opacity-50">进入 v13 写回确认</button> : <p className="mt-3 text-xs text-slate-500">Host Snapshot 任务通过全部必需检查后，才会开放写回确认。</p>}<div className="mt-3 flex flex-wrap gap-2" aria-label="Coding 领域动作"><span className="rounded-full bg-white/5 px-3 py-1 text-xs text-slate-300">应用</span><span className="rounded-full bg-white/5 px-3 py-1 text-xs text-slate-300">提交</span><span className="rounded-full bg-white/5 px-3 py-1 text-xs text-slate-300">撤销</span><span className="rounded-full bg-white/5 px-3 py-1 text-xs text-slate-300">发布</span></div></section>}
         </aside>
       </div>
     </div>

--- a/client/src/components/CodingWorkerConsole.tsx
+++ b/client/src/components/CodingWorkerConsole.tsx
@@ -137,7 +137,13 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
     let active = true;
     setLoading(true);
     void Promise.all([getCodingWorkerStatus(), refreshTasks()])
-      .then(([nextStatus]) => { if (active) setStatus(nextStatus); })
+      .then(([nextStatus]) => {
+        if (!active) return;
+        setStatus(nextStatus);
+        setCheckId((current) => nextStatus.acceptance_checks.includes(current)
+          ? current
+          : nextStatus.acceptance_checks[0] ?? "");
+      })
       .catch((caught) => { if (active) setError(errorMessage(caught, "Coding Worker 加载失败")); })
       .finally(() => { if (active) setLoading(false); });
     return () => { active = false; };
@@ -269,8 +275,8 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
           </label>
           <label className="text-sm text-slate-200">不透明来源 ID<input value={sourceId} onChange={(event) => setSourceId(event.target.value)} className="mt-1 min-h-11 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 text-white" /></label>
           <label className="text-sm text-slate-200">基准 revision<input value={revision} onChange={(event) => setRevision(event.target.value)} className="mt-1 min-h-11 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 text-white" /></label>
-          <label className="text-sm text-slate-200">必需检查 ID<input value={checkId} onChange={(event) => setCheckId(event.target.value)} className="mt-1 min-h-11 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 text-white" /></label>
-          <div className="flex items-end md:col-span-2 xl:col-span-5"><button type="submit" disabled={busy} className="min-h-11 rounded-lg bg-cyan-400 px-5 text-sm font-semibold text-slate-950 disabled:opacity-50">提交到队列</button></div>
+          <label className="text-sm text-slate-200">冻结验收检查<select value={checkId} onChange={(event) => setCheckId(event.target.value)} disabled={!status.acceptance_checks.length} className="mt-1 min-h-11 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 text-white disabled:opacity-60">{status.acceptance_checks.map((item) => <option key={item} value={item}>{item}</option>)}</select></label>
+          <div className="flex items-end md:col-span-2 xl:col-span-5"><button type="submit" disabled={busy || !checkId} className="min-h-11 rounded-lg bg-cyan-400 px-5 text-sm font-semibold text-slate-950 disabled:opacity-50">提交到队列</button></div>
         </form>
       )}
 

--- a/client/src/components/CodingWorkerConsole.tsx
+++ b/client/src/components/CodingWorkerConsole.tsx
@@ -1,0 +1,334 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  CheckCircle2,
+  CircleAlert,
+  FileCode2,
+  FolderTree,
+  GitCompareArrows,
+  MessageSquareText,
+  Pause,
+  Pin,
+  Play,
+  Plus,
+  ShieldCheck,
+  Square,
+  TerminalSquare,
+} from "lucide-react";
+import type {
+  CodingWorkerApproval,
+  CodingWorkerArtifact,
+  CodingWorkerEntry,
+  CodingWorkerEvent,
+  CodingWorkerEvidence,
+  CodingWorkerStatus,
+  CodingWorkerTask,
+  CodingWorkerTaskSpec,
+} from "../types/codingWorker";
+import {
+  changeCodingWorkerTask,
+  codingWorkerArtifactUrl,
+  connectCodingWorkerEvents,
+  createCodingWorkerTask,
+  decideCodingWorkerApproval,
+  getCodingWorkerTask,
+  getCodingWorkerStatus,
+  listCodingWorkerApprovals,
+  listCodingWorkerArtifacts,
+  listCodingWorkerEvidence,
+  listCodingWorkerTasks,
+  listCodingWorkerTree,
+  readCodingWorkerDiff,
+  readCodingWorkerEntry,
+  sendCodingWorkerMessage,
+} from "../utils/codingWorkerApi";
+
+type ConsoleContext = "coding" | "agent";
+type InspectorTab = "files" | "diff" | "evidence" | "terminal";
+
+const terminalStates = new Set([
+  "completed", "blocked", "failed", "cancelled", "budget_limited", "expired",
+]);
+
+const stateCopy: Record<string, string> = {
+  queued: "排队中", preparing: "准备工作区", running: "执行中",
+  waiting_approval: "等待批准", paused: "已暂停", testing: "运行验收",
+  interrupted: "已中断", completed: "已完成", blocked: "已阻塞",
+  failed: "失败", cancelled: "已取消", budget_limited: "预算已用完", expired: "已过期",
+};
+
+function errorMessage(error: unknown, fallback: string) {
+  return error instanceof Error ? error.message : fallback;
+}
+
+function payloadText(event: CodingWorkerEvent) {
+  const candidates = [event.payload.message, event.payload.text, event.payload.summary, event.payload.output];
+  const value = candidates.find((item) => typeof item === "string");
+  return typeof value === "string" ? value : null;
+}
+
+interface CodingWorkerConsoleProps {
+  context: ConsoleContext;
+}
+
+export default function CodingWorkerConsole({ context }: CodingWorkerConsoleProps) {
+  const [status, setStatus] = useState<CodingWorkerStatus | null>(null);
+  const [tasks, setTasks] = useState<CodingWorkerTask[]>([]);
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+  const [events, setEvents] = useState<CodingWorkerEvent[]>([]);
+  const [approvals, setApprovals] = useState<CodingWorkerApproval[]>([]);
+  const [evidence, setEvidence] = useState<CodingWorkerEvidence[]>([]);
+  const [artifacts, setArtifacts] = useState<CodingWorkerArtifact[]>([]);
+  const [entries, setEntries] = useState<CodingWorkerEntry[]>([]);
+  const [treeHash, setTreeHash] = useState("");
+  const [preview, setPreview] = useState<{ path: string; content: string } | null>(null);
+  const [diff, setDiff] = useState("");
+  const [tab, setTab] = useState<InspectorTab>("files");
+  const [message, setMessage] = useState("");
+  const [showCreate, setShowCreate] = useState(false);
+  const [objective, setObjective] = useState("");
+  const [sourceId, setSourceId] = useState("");
+  const [revision, setRevision] = useState("");
+  const [checkId, setCheckId] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [transportWarning, setTransportWarning] = useState(false);
+  const [error, setError] = useState("");
+  const operationRef = useRef(false);
+
+  const selectedTask = useMemo(
+    () => tasks.find((task) => task.task_id === selectedTaskId) ?? null,
+    [selectedTaskId, tasks],
+  );
+
+  const refreshTasks = useCallback(async (preferredId?: string) => {
+    const next = await listCodingWorkerTasks();
+    setTasks(next);
+    setSelectedTaskId((current) => {
+      const candidate = preferredId ?? current;
+      return candidate && next.some((task) => task.task_id === candidate)
+        ? candidate
+        : next[0]?.task_id ?? null;
+    });
+    return next;
+  }, []);
+
+  const refreshTaskPanels = useCallback(async (taskId: string) => {
+    const [task, approvalItems, evidenceItems, artifactItems, tree, nextDiff] = await Promise.all([
+      getCodingWorkerTask(taskId),
+      listCodingWorkerApprovals(taskId),
+      listCodingWorkerEvidence(taskId),
+      listCodingWorkerArtifacts(taskId),
+      listCodingWorkerTree(taskId).catch(() => null),
+      readCodingWorkerDiff(taskId).catch(() => ""),
+    ]);
+    setTasks((current) => current.map((item) => item.task_id === taskId ? task : item));
+    setApprovals(approvalItems);
+    setEvidence(evidenceItems);
+    setArtifacts(artifactItems);
+    setEntries(tree?.entries ?? []);
+    setTreeHash(tree?.tree_hash ?? "");
+    setDiff(nextDiff);
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    void Promise.all([getCodingWorkerStatus(), refreshTasks()])
+      .then(([nextStatus]) => { if (active) setStatus(nextStatus); })
+      .catch((caught) => { if (active) setError(errorMessage(caught, "Coding Worker 加载失败")); })
+      .finally(() => { if (active) setLoading(false); });
+    return () => { active = false; };
+  }, [refreshTasks]);
+
+  useEffect(() => {
+    if (!selectedTaskId) {
+      setEvents([]); setApprovals([]); setEvidence([]); setArtifacts([]);
+      setEntries([]); setPreview(null); setDiff(""); setTreeHash("");
+      return;
+    }
+    let active = true;
+    let cursor = 0;
+    setEvents([]);
+    setPreview(null);
+    setTransportWarning(false);
+    void refreshTaskPanels(selectedTaskId).catch((caught) => {
+      if (active) setError(errorMessage(caught, "任务详情加载失败"));
+    });
+    const disconnect = connectCodingWorkerEvents(selectedTaskId, cursor, {
+      onEvent: (event) => {
+        if (!active || event.sequence <= cursor) return;
+        cursor = event.sequence;
+        setEvents((current) => [...current, event].slice(-400));
+        setTransportWarning(false);
+        void refreshTaskPanels(selectedTaskId).catch(() => setTransportWarning(true));
+      },
+      onTransportError: () => { if (active) setTransportWarning(true); },
+    });
+    return () => { active = false; disconnect(); };
+  }, [refreshTaskPanels, selectedTaskId]);
+
+  const run = useCallback(async (operation: () => Promise<unknown>) => {
+    if (operationRef.current) return;
+    operationRef.current = true;
+    setBusy(true);
+    setError("");
+    try { await operation(); }
+    catch (caught) { setError(errorMessage(caught, "操作失败")); }
+    finally { operationRef.current = false; setBusy(false); }
+  }, []);
+
+  const createTask = () => run(async () => {
+    if (!objective.trim() || !sourceId.trim() || !revision.trim() || !checkId.trim()) {
+      setError("请填写目标、来源 ID、基准 revision 和必需检查 ID。");
+      return;
+    }
+    const suffix = crypto.randomUUID().replaceAll("-", "");
+    const spec: CodingWorkerTaskSpec = {
+      client_task_id: `console_${suffix}`,
+      objective: objective.trim(),
+      workspace_source: { kind: context === "coding" ? "host_snapshot" : "builtin", source_id: sourceId.trim(), revision: revision.trim() },
+      acceptance: {
+        contract_id: `contract_${suffix}`,
+        required_checks: [{ check_id: checkId.trim(), kind: "command", label: "必需检查" }],
+        required_artifacts: [],
+      },
+      policy_profile: "develop",
+      model_route: "coding/default",
+      budget: { max_seconds: 3600, max_turns: 64, max_tool_calls: 512, max_output_bytes: 8 * 1024 * 1024 },
+      context_refs: [],
+    };
+    const task = await createCodingWorkerTask(spec);
+    await refreshTasks(task.task_id);
+    setShowCreate(false); setObjective(""); setSourceId(""); setRevision(""); setCheckId("");
+  });
+
+  const submitMessage = () => run(async () => {
+    if (!selectedTask || !message.trim()) return;
+    await sendCodingWorkerMessage(selectedTask.task_id, message.trim());
+    setMessage("");
+    await refreshTaskPanels(selectedTask.task_id);
+  });
+
+  const taskAction = (action: "pause" | "resume" | "cancel" | "pin" | "unpin") => run(async () => {
+    if (!selectedTask) return;
+    const task = await changeCodingWorkerTask(selectedTask.task_id, action);
+    setTasks((current) => current.map((item) => item.task_id === task.task_id ? task : item));
+  });
+
+  const decide = (approvalId: string, decision: "approve_once" | "approve_task" | "reject") => run(async () => {
+    if (!selectedTask) return;
+    await decideCodingWorkerApproval(selectedTask.task_id, approvalId, decision);
+    await refreshTaskPanels(selectedTask.task_id);
+  });
+
+  const openEntry = (entry: CodingWorkerEntry) => run(async () => {
+    if (!selectedTask || entry.kind !== "file") return;
+    const content = await readCodingWorkerEntry(selectedTask.task_id, entry.entry_id);
+    setPreview({ path: entry.display_path, content });
+  });
+
+  if (loading) return <div className="min-h-[60vh] animate-pulse rounded-xl bg-white/5" aria-label="正在加载 Coding Worker" />;
+
+  if (!status?.enabled || !status.available) {
+    return (
+      <section className="mx-auto max-w-3xl px-4 py-20 text-center" role="status">
+        <CircleAlert className="mx-auto h-9 w-9 text-amber-300" aria-hidden="true" />
+        <h1 className="mt-4 text-xl font-semibold text-white">Coding Worker 尚未启用</h1>
+        <p className="mx-auto mt-2 max-w-[65ch] text-sm text-slate-300">
+          管理员启用 CODING_WORKER_V14_ENABLED 后，新任务会进入统一 Worker。已有会话继续使用原执行面。
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <div className="mx-auto flex min-h-[calc(100vh-5rem)] max-w-[1800px] flex-col gap-3 px-3 py-4 lg:px-5">
+      <header className="flex flex-wrap items-center justify-between gap-3 border-b border-white/10 pb-3">
+        <div className="min-w-0">
+          <h1 className="text-xl font-semibold text-white">Coding Worker</h1>
+          <p className="mt-1 text-sm text-slate-300">两个隔离槽位，任务证据与 Diff 可在重启后继续读取。</p>
+        </div>
+        <button type="button" onClick={() => setShowCreate((value) => !value)} className="inline-flex min-h-11 items-center gap-2 rounded-lg bg-cyan-400 px-4 text-sm font-semibold text-slate-950 transition hover:bg-cyan-300 disabled:opacity-50" disabled={busy}>
+          <Plus className="h-4 w-4" aria-hidden="true" />创建任务
+        </button>
+      </header>
+
+      {showCreate && (
+        <form className="grid gap-3 border-b border-white/10 pb-4 md:grid-cols-2 xl:grid-cols-5" onSubmit={(event) => { event.preventDefault(); void createTask(); }}>
+          <label className="md:col-span-2 xl:col-span-2 text-sm text-slate-200">任务目标
+            <textarea value={objective} onChange={(event) => setObjective(event.target.value)} className="mt-1 min-h-24 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 py-2 text-white" maxLength={1_048_576} />
+          </label>
+          <label className="text-sm text-slate-200">不透明来源 ID<input value={sourceId} onChange={(event) => setSourceId(event.target.value)} className="mt-1 min-h-11 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 text-white" /></label>
+          <label className="text-sm text-slate-200">基准 revision<input value={revision} onChange={(event) => setRevision(event.target.value)} className="mt-1 min-h-11 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 text-white" /></label>
+          <label className="text-sm text-slate-200">必需检查 ID<input value={checkId} onChange={(event) => setCheckId(event.target.value)} className="mt-1 min-h-11 w-full rounded-lg border border-white/15 bg-slate-950/70 px-3 text-white" /></label>
+          <div className="flex items-end md:col-span-2 xl:col-span-5"><button type="submit" disabled={busy} className="min-h-11 rounded-lg bg-cyan-400 px-5 text-sm font-semibold text-slate-950 disabled:opacity-50">提交到队列</button></div>
+        </form>
+      )}
+
+      {error && <div className="rounded-lg bg-rose-500/15 px-4 py-3 text-sm text-rose-100" role="alert">{error}</div>}
+      {transportWarning && <div className="rounded-lg bg-amber-400/10 px-4 py-3 text-sm text-amber-100" role="status">事件连接已中断，任务状态仍可从持久存储恢复。</div>}
+
+      <div className="grid min-h-0 flex-1 gap-3 lg:grid-cols-[16rem_minmax(0,1fr)] xl:grid-cols-[16rem_minmax(0,1fr)_26rem]">
+        <aside className="min-h-0 border-r border-white/10 pr-3" aria-label="Worker 任务列表">
+          <div className="mb-2 flex items-center justify-between"><h2 className="text-sm font-semibold text-slate-200">任务</h2><span className="text-xs text-slate-400">{tasks.length}</span></div>
+          <div className="flex max-h-[38vh] flex-col gap-1 overflow-y-auto lg:max-h-[calc(100vh-11rem)]">
+            {tasks.length === 0 && <p className="rounded-lg bg-white/5 p-3 text-sm text-slate-300">还没有任务。先从受控来源创建一个任务。</p>}
+            {tasks.map((task) => (
+              <button key={task.task_id} type="button" onClick={() => setSelectedTaskId(task.task_id)} className={`min-h-14 rounded-lg px-3 py-2 text-left transition ${task.task_id === selectedTaskId ? "bg-cyan-400/15 text-white" : "text-slate-300 hover:bg-white/5"}`}>
+                <span className="block truncate text-sm font-medium">{task.spec.objective}</span>
+                <span className="mt-1 flex items-center justify-between gap-2 text-xs text-slate-400"><span>{stateCopy[task.state] ?? task.state}</span><span>{task.spec.origin.module}</span></span>
+              </button>
+            ))}
+          </div>
+        </aside>
+
+        <main className="min-w-0">
+          {!selectedTask ? (
+            <div className="flex min-h-80 items-center justify-center text-sm text-slate-400">选择任务后查看目标、计划和运行事件。</div>
+          ) : (
+            <div className="flex h-full min-h-[32rem] flex-col">
+              <div className="flex flex-wrap items-start justify-between gap-3 border-b border-white/10 pb-3">
+                <div className="min-w-0"><p className="break-words text-lg font-semibold text-white">{selectedTask.spec.objective}</p><p className="mt-1 break-all text-xs text-slate-400">{selectedTask.task_id} · {stateCopy[selectedTask.state] ?? selectedTask.state}</p></div>
+                <div className="flex flex-wrap gap-2">
+                  {selectedTask.state === "running" || selectedTask.state === "testing" ? <button type="button" onClick={() => void taskAction("pause")} disabled={busy} className="inline-flex min-h-11 items-center gap-1 rounded-lg border border-white/15 px-3 text-sm text-slate-200"><Pause className="h-4 w-4" />暂停</button> : null}
+                  {selectedTask.state === "paused" || selectedTask.state === "interrupted" ? <button type="button" onClick={() => void taskAction("resume")} disabled={busy} className="inline-flex min-h-11 items-center gap-1 rounded-lg border border-cyan-300/40 px-3 text-sm text-cyan-100"><Play className="h-4 w-4" />继续</button> : null}
+                  {!terminalStates.has(selectedTask.state) && <button type="button" onClick={() => void taskAction("cancel")} disabled={busy} className="inline-flex min-h-11 items-center gap-1 rounded-lg border border-white/15 px-3 text-sm text-slate-200"><Square className="h-4 w-4" />取消</button>}
+                  <button type="button" onClick={() => void taskAction(selectedTask.pinned ? "unpin" : "pin")} disabled={busy} aria-pressed={selectedTask.pinned} className="inline-flex min-h-11 items-center gap-1 rounded-lg border border-white/15 px-3 text-sm text-slate-200"><Pin className="h-4 w-4" />{selectedTask.pinned ? "取消固定" : "固定"}</button>
+                </div>
+              </div>
+
+              <section className="mt-3 border-b border-white/10 pb-3" aria-labelledby="goal-heading">
+                <div className="flex items-center gap-2"><CheckCircle2 className="h-4 w-4 text-cyan-300" /><h2 id="goal-heading" className="text-sm font-semibold text-white">目标与验收</h2></div>
+                <ul className="mt-2 space-y-1 text-sm text-slate-300">{selectedTask.spec.acceptance.required_checks.map((check) => <li key={check.check_id}>• {check.label} <code className="break-all text-xs text-slate-400">{check.check_id}</code></li>)}</ul>
+              </section>
+
+              <section className="min-h-0 flex-1 overflow-y-auto py-3" aria-label="任务事件" aria-live="polite">
+                {events.length === 0 ? <p className="text-sm text-slate-400">等待 Worker 事件。公开事件只包含计划、状态和工具摘要。</p> : events.map((event) => (
+                  <article key={event.sequence} className="mb-3 flex gap-3"><span className="mt-1 h-2 w-2 shrink-0 rounded-full bg-cyan-300" aria-hidden="true" /><div className="min-w-0"><p className="text-xs font-medium text-slate-400">{event.type} · #{event.sequence}</p><p className="mt-1 whitespace-pre-wrap break-words text-sm text-slate-200">{payloadText(event) ?? JSON.stringify(event.payload)}</p></div></article>
+                ))}
+              </section>
+
+              <form className="border-t border-white/10 pt-3" onSubmit={(event) => { event.preventDefault(); void submitMessage(); }}>
+                <label className="sr-only" htmlFor="worker-message">追加指令</label>
+                <div className="flex gap-2"><textarea id="worker-message" value={message} onChange={(event) => setMessage(event.target.value)} disabled={busy || terminalStates.has(selectedTask.state)} placeholder="追加指令或运行中 steering" className="min-h-12 flex-1 resize-y rounded-lg border border-white/15 bg-slate-950/70 px-3 py-2 text-sm text-white placeholder:text-slate-400 disabled:opacity-60" /><button type="submit" disabled={busy || !message.trim() || terminalStates.has(selectedTask.state)} className="min-h-12 rounded-lg bg-cyan-400 px-4 text-sm font-semibold text-slate-950 disabled:opacity-50">发送指令</button></div>
+              </form>
+            </div>
+          )}
+        </main>
+
+        <aside className="min-w-0 border-t border-white/10 pt-3 xl:border-l xl:border-t-0 xl:pl-3 xl:pt-0" aria-label="任务检查器">
+          <div className="flex overflow-x-auto border-b border-white/10" role="tablist">
+            {([ ["files", FolderTree, "文件"], ["diff", GitCompareArrows, "Diff"], ["evidence", ShieldCheck, "证据"], ["terminal", TerminalSquare, "终端"] ] as const).map(([value, Icon, label]) => <button key={value} type="button" role="tab" aria-selected={tab === value} onClick={() => setTab(value)} className={`inline-flex min-h-11 items-center gap-1 px-3 text-sm ${tab === value ? "border-b-2 border-cyan-300 text-white" : "text-slate-400"}`}><Icon className="h-4 w-4" />{label}</button>)}
+          </div>
+          <div className="max-h-[46rem] overflow-auto py-3 text-sm">
+            {tab === "files" && <div><p className="mb-2 break-all text-xs text-slate-400">tree {treeHash || "尚未创建"}</p>{preview ? <div><button type="button" className="mb-2 min-h-11 text-cyan-200" onClick={() => setPreview(null)}>返回文件树</button><p className="mb-2 break-all text-slate-300">{preview.path}</p><pre className="overflow-auto whitespace-pre-wrap break-words rounded-lg bg-slate-950/80 p-3 text-xs text-slate-200">{preview.content}</pre></div> : <ul className="space-y-1">{entries.map((entry) => <li key={entry.entry_id}><button type="button" disabled={entry.kind !== "file" || busy} onClick={() => void openEntry(entry)} className="flex min-h-10 w-full items-center gap-2 rounded-md px-2 text-left text-slate-300 hover:bg-white/5 disabled:cursor-default"><FileCode2 className="h-4 w-4 shrink-0" /><span className="min-w-0 break-all">{entry.display_path}</span></button></li>)}</ul>}</div>}
+            {tab === "diff" && <pre className="overflow-auto whitespace-pre-wrap break-words rounded-lg bg-slate-950/80 p-3 text-xs text-slate-200">{diff || "工作区还没有变更。"}</pre>}
+            {tab === "evidence" && <div className="space-y-4"><section><h3 className="font-semibold text-white">审批</h3>{approvals.filter((item) => item.status === "pending").map((item) => <div key={item.approval_id} className="mt-2 rounded-lg bg-amber-300/10 p-3"><p className="text-amber-100">{item.capability}</p><p className="mt-1 break-words text-xs text-slate-300">{JSON.stringify(item.request)}</p><div className="mt-3 flex flex-wrap gap-2"><button type="button" disabled={busy} onClick={() => void decide(item.approval_id, "approve_once")} className="min-h-11 rounded-lg bg-cyan-400 px-3 font-semibold text-slate-950">批准一次</button><button type="button" disabled={busy} onClick={() => void decide(item.approval_id, "approve_task")} className="min-h-11 rounded-lg border border-cyan-300/40 px-3 text-cyan-100">本任务批准</button><button type="button" disabled={busy} onClick={() => void decide(item.approval_id, "reject")} className="min-h-11 rounded-lg border border-white/15 px-3 text-slate-200">拒绝</button></div></div>)}</section><section><h3 className="font-semibold text-white">检查证据</h3><ul className="mt-2 space-y-2">{evidence.map((item) => <li key={item.evidence_id} className="rounded-lg bg-white/5 p-3"><span className={item.status === "passed" ? "text-emerald-300" : item.status === "failed" ? "text-rose-300" : "text-amber-300"}>{item.status}</span><span className="ml-2 break-all text-slate-200">{item.check_id}</span><span className="mt-1 block text-xs text-slate-400">exit {item.exit_code}</span></li>)}</ul></section><section><h3 className="font-semibold text-white">Artifacts</h3><ul className="mt-2 space-y-1">{artifacts.map((item) => <li key={item.artifact_id}><a className="block min-h-10 break-all rounded-md px-2 py-2 text-cyan-200 hover:bg-white/5" href={codingWorkerArtifactUrl(item.task_id, item.artifact_id)}>{item.artifact_id} · {item.media_type}</a></li>)}</ul></section></div>}
+            {tab === "terminal" && <div><p className="mb-2 text-xs text-slate-400">命令归属和输出只来自 Tool Broker 公开事件。</p><pre className="overflow-auto whitespace-pre-wrap break-words rounded-lg bg-slate-950/80 p-3 text-xs text-slate-200">{events.filter((event) => event.type === "tool_operation" || event.type === "provider_event").map((event) => `#${event.sequence} ${event.type}\n${payloadText(event) ?? JSON.stringify(event.payload)}`).join("\n\n") || "尚无工具输出。"}</pre></div>}
+          </div>
+          {context === "coding" && selectedTask && <section className="mt-3 border-t border-white/10 pt-3"><div className="flex items-center gap-2"><GitCompareArrows className="h-4 w-4 text-cyan-300" /><h3 className="font-semibold text-white">宿主写回</h3></div><p className="mt-1 text-xs text-slate-400">完成后继续使用 v13 的应用、提交、撤销和发布确认链。Worker 不直接写用户仓库。</p><div className="mt-3 flex flex-wrap gap-2" aria-label="Coding 领域动作"><span className="rounded-full bg-white/5 px-3 py-1 text-xs text-slate-300">应用</span><span className="rounded-full bg-white/5 px-3 py-1 text-xs text-slate-300">提交</span><span className="rounded-full bg-white/5 px-3 py-1 text-xs text-slate-300">撤销</span><span className="rounded-full bg-white/5 px-3 py-1 text-xs text-slate-300">发布</span></div></section>}
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/AgentWorkbenchPage.test.tsx
+++ b/client/src/pages/AgentWorkbenchPage.test.tsx
@@ -481,6 +481,8 @@ describe("AgentWorkbenchPage", () => {
 
     expect(await screen.findByText("Agent 工作区已关闭")).toBeVisible();
     expect(screen.getByRole("button", { name: "一句话创建 Agent" })).toBeDisabled();
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenNthCalledWith(1, "/api/coding-worker/v1", undefined);
+    expect(fetchMock).toHaveBeenNthCalledWith(2, "/api/agent-workspace/status", undefined);
   });
 });

--- a/client/src/pages/AgentWorkbenchPage.tsx
+++ b/client/src/pages/AgentWorkbenchPage.tsx
@@ -15,6 +15,7 @@ import { Link } from "react-router-dom";
 import ConversationPanel from "../components/agent-workspace/ConversationPanel";
 import SessionSidebar from "../components/agent-workspace/SessionSidebar";
 import WorkspacePanel from "../components/agent-workspace/WorkspacePanel";
+import CodingWorkerConsole from "../components/CodingWorkerConsole";
 import PageContainer from "../components/PageContainer";
 import { useModelPreference } from "../context/ModelPreferenceContext";
 import {
@@ -54,6 +55,7 @@ import {
   stopAgentTask,
   updateAgentSessionApprovalMode,
 } from "../utils/agentWorkspaceApi";
+import { getCodingWorkerStatus } from "../utils/codingWorkerApi";
 
 interface WorkspacePreview {
   path: string;
@@ -75,7 +77,7 @@ const refreshEventTypes = new Set([
 
 const workspaceEventTypes = new Set(["tool_output", "completed", "agent_generated"]);
 
-export default function AgentWorkbenchPage() {
+function LegacyAgentWorkbenchPage() {
   const { preferredModelId, setPreferredModelId } = useModelPreference();
   const [enabled, setEnabled] = useState(true);
   const [loading, setLoading] = useState(true);
@@ -718,4 +720,28 @@ export default function AgentWorkbenchPage() {
       ) : null}
     </PageContainer>
   );
+}
+
+export default function AgentWorkbenchPage() {
+  const [surface, setSurface] = useState<"loading" | "legacy" | "worker">("loading");
+
+  useEffect(() => {
+    let active = true;
+    void getCodingWorkerStatus()
+      .then(async (status) => {
+        if (!status.enabled || !status.available) return "legacy" as const;
+        const legacySessions = await listAgentSessions();
+        return legacySessions.length === 0 ? "worker" as const : "legacy" as const;
+      })
+      .then((nextSurface) => { if (active) setSurface(nextSurface); })
+      .catch(() => { if (active) setSurface("legacy"); });
+    return () => { active = false; };
+  }, []);
+
+  if (surface === "loading") {
+    return <div className="mx-auto mt-10 min-h-[60vh] max-w-7xl animate-pulse rounded-xl bg-white/5" aria-label="正在选择 Agent 执行面" />;
+  }
+  return surface === "worker"
+    ? <CodingWorkerConsole context="agent" />
+    : <LegacyAgentWorkbenchPage />;
 }

--- a/client/src/pages/CodingPage.tsx
+++ b/client/src/pages/CodingPage.tsx
@@ -2885,6 +2885,12 @@ export default function CodingPage() {
     return <div className="mx-auto mt-10 min-h-[60vh] max-w-7xl animate-pulse rounded-xl bg-white/5" aria-label="正在选择 Coding 执行面" />;
   }
   return surface === "worker"
-    ? <CodingWorkerConsole context="coding" />
+    ? <CodingWorkerConsole
+        context="coding"
+        onCodingHandoff={(result) => {
+          storeCodingSession(result.id, 0, result.project.id);
+          setSurface("legacy");
+        }}
+      />
     : <LegacyCodingPage />;
 }

--- a/client/src/pages/CodingPage.tsx
+++ b/client/src/pages/CodingPage.tsx
@@ -30,6 +30,7 @@ import CodingRecoveryCard, {
   type CodingRecoveryAction,
 } from "../components/CodingRecoveryCard";
 import PageContainer from "../components/PageContainer";
+import CodingWorkerConsole from "../components/CodingWorkerConsole";
 import type {
   CodingApplyResult,
   CodingCapabilities,
@@ -81,6 +82,7 @@ import {
   undoCodingCommit,
   validateCodingChanges,
 } from "../utils/codingApi";
+import { getCodingWorkerStatus } from "../utils/codingWorkerApi";
 
 type RunState = "idle" | "starting" | "running" | "stopping" | "error";
 type CapabilityState = "loading" | "ready" | "error";
@@ -465,7 +467,7 @@ function CodingCommandConfirmation({
   );
 }
 
-export default function CodingPage() {
+function LegacyCodingPage() {
   const restoredSessionRef = useRef<StoredCodingSession | null>(
     readStoredCodingSession(),
   );
@@ -2860,4 +2862,29 @@ export default function CodingPage() {
       </div>
     </PageContainer>
   );
+}
+
+export default function CodingPage() {
+  const hasLegacySession = readStoredCodingSession() !== null;
+  const [surface, setSurface] = useState<"loading" | "legacy" | "worker">(
+    hasLegacySession ? "legacy" : "loading",
+  );
+
+  useEffect(() => {
+    if (hasLegacySession) return;
+    let active = true;
+    void Promise.all([getCodingWorkerStatus(), getCodingRecovery()])
+      .then(([status, recovery]) => {
+        if (active) setSurface(status.enabled && status.available && !recovery.pending ? "worker" : "legacy");
+      })
+      .catch(() => { if (active) setSurface("legacy"); });
+    return () => { active = false; };
+  }, [hasLegacySession]);
+
+  if (surface === "loading") {
+    return <div className="mx-auto mt-10 min-h-[60vh] max-w-7xl animate-pulse rounded-xl bg-white/5" aria-label="正在选择 Coding 执行面" />;
+  }
+  return surface === "worker"
+    ? <CodingWorkerConsole context="coding" />
+    : <LegacyCodingPage />;
 }

--- a/client/src/types/codingWorker.ts
+++ b/client/src/types/codingWorker.ts
@@ -52,7 +52,9 @@ export interface CodingWorkerTaskSpec {
 
 export interface CodingWorkerTask {
   task_id: string;
-  spec: CodingWorkerTaskSpec & { origin: { module: string; object_id: string } };
+  spec: Omit<CodingWorkerTaskSpec, "origin"> & {
+    origin: { module: string; object_id: string };
+  };
   state: CodingWorkerTaskState;
   workspace_id: string | null;
   created_at: number;
@@ -79,4 +81,51 @@ export interface CodingWorkerStatus {
   retention_seconds: number;
   network_enabled: boolean;
   reason: string | null;
+}
+
+export interface CodingWorkerApproval {
+  approval_id: string;
+  task_id: string;
+  operation_id: string;
+  capability: string;
+  status: "pending" | "approved" | "rejected" | "cancelled" | "expired";
+  request: Record<string, unknown>;
+  lease: {
+    lease_id: string;
+    expires_at: number;
+    operation_limit: number;
+  } | null;
+  created_at: number;
+  decided_at: number | null;
+}
+
+export interface CodingWorkerEvidence {
+  evidence_id: string;
+  task_id: string;
+  check_id: string;
+  operation_id: string;
+  workspace_tree_hash: string;
+  status: "passed" | "failed" | "invalidated";
+  exit_code: number;
+  artifact_id: string;
+  created_at: number;
+}
+
+export interface CodingWorkerArtifact {
+  artifact_id: string;
+  task_id: string;
+  media_type: string;
+  sha256: string;
+  size: number;
+  metadata: Record<string, unknown>;
+  created_at: number;
+}
+
+export interface CodingWorkerEntry {
+  entry_id: string;
+  name: string;
+  display_path: string;
+  kind: string;
+  size: number;
+  sha256: string | null;
 }

--- a/client/src/types/codingWorker.ts
+++ b/client/src/types/codingWorker.ts
@@ -1,0 +1,82 @@
+export type CodingWorkerTaskState =
+  | "queued"
+  | "preparing"
+  | "running"
+  | "waiting_approval"
+  | "paused"
+  | "testing"
+  | "interrupted"
+  | "completed"
+  | "blocked"
+  | "failed"
+  | "cancelled"
+  | "budget_limited"
+  | "expired";
+
+export type CodingWorkerPolicyProfile = "inspect" | "develop" | "develop_networked";
+
+export interface CodingWorkerSource {
+  kind: "builtin" | "manifest" | "host_snapshot";
+  source_id: string;
+  revision: string;
+}
+
+export interface CodingWorkerAcceptanceCheck {
+  check_id: string;
+  kind: "command" | "artifact" | "policy";
+  label: string;
+}
+
+export interface CodingWorkerAcceptanceContract {
+  contract_id: string;
+  required_checks: CodingWorkerAcceptanceCheck[];
+  required_artifacts: Array<{ artifact_id: string; label: string }>;
+}
+
+export interface CodingWorkerTaskSpec {
+  client_task_id: string;
+  objective: string;
+  workspace_source: CodingWorkerSource;
+  acceptance: CodingWorkerAcceptanceContract;
+  policy_profile: CodingWorkerPolicyProfile;
+  model_route: string;
+  budget: {
+    max_seconds: number;
+    max_turns: number;
+    max_tool_calls: number;
+    max_output_bytes: number;
+  };
+  context_refs: Array<{ ref_id: string; kind: "artifact" | "resource" | "file" | "image" }>;
+  origin?: never;
+}
+
+export interface CodingWorkerTask {
+  task_id: string;
+  spec: CodingWorkerTaskSpec & { origin: { module: string; object_id: string } };
+  state: CodingWorkerTaskState;
+  workspace_id: string | null;
+  created_at: number;
+  updated_at: number;
+  expires_at: number;
+  pinned: boolean;
+  last_event_sequence: number;
+  reason: string | null;
+}
+
+export interface CodingWorkerEvent {
+  sequence: number;
+  task_id: string;
+  type: string;
+  payload: Record<string, unknown>;
+  created_at: number;
+}
+
+export interface CodingWorkerStatus {
+  enabled: boolean;
+  available: boolean;
+  version: "v1";
+  max_active_tasks: number;
+  retention_seconds: number;
+  network_enabled: boolean;
+  reason: string | null;
+}

--- a/client/src/types/codingWorker.ts
+++ b/client/src/types/codingWorker.ts
@@ -86,6 +86,7 @@ export interface CodingWorkerStatus {
   max_active_tasks: number;
   retention_seconds: number;
   network_enabled: boolean;
+  acceptance_checks: string[];
   reason: string | null;
 }
 

--- a/client/src/types/codingWorker.ts
+++ b/client/src/types/codingWorker.ts
@@ -23,14 +23,20 @@ export interface CodingWorkerSource {
 
 export interface CodingWorkerAcceptanceCheck {
   check_id: string;
-  kind: "command" | "artifact" | "policy";
+  kind: "command" | "diff" | "artifact" | "custom";
   label: string;
+  required: true;
 }
 
 export interface CodingWorkerAcceptanceContract {
   contract_id: string;
   required_checks: CodingWorkerAcceptanceCheck[];
-  required_artifacts: Array<{ artifact_id: string; label: string }>;
+  required_artifacts: Array<{
+    artifact_id: string;
+    media_type: string;
+    label: string;
+    required: true;
+  }>;
 }
 
 export interface CodingWorkerTaskSpec {

--- a/client/src/utils/codingApi.ts
+++ b/client/src/utils/codingApi.ts
@@ -87,6 +87,15 @@ export function getCodingProjects() {
   return requestJson<CodingProjectsResponse>("/api/coding/projects");
 }
 
+export function getCodingWorkerHostSource(projectId: string) {
+  return requestJson<{
+    source_id: string;
+    name: string;
+    branch: string;
+    revision: string;
+  }>(`/api/coding/worker-sources/${encodeURIComponent(projectId)}`);
+}
+
 export function getCodingProjectHost() {
   return requestJson<CodingProjectHostStatus>("/api/coding/project-host");
 }

--- a/client/src/utils/codingWorkerApi.ts
+++ b/client/src/utils/codingWorkerApi.ts
@@ -11,6 +11,14 @@ import type {
 
 const API_ROOT = "/api/coding-worker/v1";
 
+export interface CodingWorkerHandoffResult {
+  id: string;
+  status: string;
+  project: { id: string; [key: string]: unknown };
+  revision: number;
+  task_id: string;
+}
+
 export class CodingWorkerApiError extends Error {
   status: number;
   code: string | null;
@@ -69,6 +77,12 @@ export const createCodingWorkerTask = (spec: CodingWorkerTaskSpec) =>
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(spec),
   });
+
+export const handoffCodingWorkerTask = (taskId: string) =>
+  request<CodingWorkerHandoffResult>(
+    `/api/coding/worker-tasks/${encodeURIComponent(taskId)}/handoff`,
+    { method: "POST" },
+  );
 
 export const sendCodingWorkerMessage = (taskId: string, message: string) =>
   request<CodingWorkerTask>(`${API_ROOT}/tasks/${encodeURIComponent(taskId)}/messages`, {

--- a/client/src/utils/codingWorkerApi.ts
+++ b/client/src/utils/codingWorkerApi.ts
@@ -1,0 +1,161 @@
+import type {
+  CodingWorkerApproval,
+  CodingWorkerArtifact,
+  CodingWorkerEntry,
+  CodingWorkerEvent,
+  CodingWorkerEvidence,
+  CodingWorkerStatus,
+  CodingWorkerTask,
+  CodingWorkerTaskSpec,
+} from "../types/codingWorker";
+
+const API_ROOT = "/api/coding-worker/v1";
+
+export class CodingWorkerApiError extends Error {
+  status: number;
+  code: string | null;
+
+  constructor(message: string, status: number, code: string | null = null) {
+    super(message);
+    this.name = "CodingWorkerApiError";
+    this.status = status;
+    this.code = code;
+  }
+}
+
+async function request<T>(url: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(url, init);
+  const payload = await response.json().catch(() => null);
+  if (!response.ok) {
+    const detail = payload && typeof payload === "object" && "detail" in payload
+      ? (payload as { detail?: unknown }).detail
+      : null;
+    const structured = detail && typeof detail === "object"
+      ? detail as { code?: unknown; message?: unknown }
+      : null;
+    throw new CodingWorkerApiError(
+      typeof structured?.message === "string"
+        ? structured.message
+        : typeof detail === "string"
+          ? detail
+          : `Coding Worker 请求失败（${response.status}）`,
+      response.status,
+      typeof structured?.code === "string" ? structured.code : null,
+    );
+  }
+  return payload as T;
+}
+
+const taskEventTypes = [
+  "task_created", "task_state", "provider_event", "steering_queued",
+  "approval_requested", "approval_decided", "tool_operation",
+  "artifact_created", "evidence_recorded", "evidence_invalidated",
+  "checkpoint_created", "acceptance_evaluated", "acceptance_retry",
+  "task_pinned", "task_unpinned",
+] as const;
+
+export const getCodingWorkerStatus = () => request<CodingWorkerStatus>(API_ROOT);
+
+export async function listCodingWorkerTasks() {
+  return (await request<{ tasks: CodingWorkerTask[] }>(`${API_ROOT}/tasks`)).tasks;
+}
+
+export const getCodingWorkerTask = (taskId: string) =>
+  request<CodingWorkerTask>(`${API_ROOT}/tasks/${encodeURIComponent(taskId)}`);
+
+export const createCodingWorkerTask = (spec: CodingWorkerTaskSpec) =>
+  request<CodingWorkerTask>(`${API_ROOT}/tasks`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(spec),
+  });
+
+export const sendCodingWorkerMessage = (taskId: string, message: string) =>
+  request<CodingWorkerTask>(`${API_ROOT}/tasks/${encodeURIComponent(taskId)}/messages`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ message }),
+  });
+
+export const changeCodingWorkerTask = (
+  taskId: string,
+  action: "pause" | "resume" | "cancel" | "pin" | "unpin",
+) => request<CodingWorkerTask>(
+  `${API_ROOT}/tasks/${encodeURIComponent(taskId)}/${action === "unpin" ? "pin" : action}`,
+  { method: action === "unpin" ? "DELETE" : "POST" },
+);
+
+export async function listCodingWorkerApprovals(taskId: string) {
+  return (await request<{ approvals: CodingWorkerApproval[] }>(
+    `${API_ROOT}/tasks/${encodeURIComponent(taskId)}/approvals`,
+  )).approvals;
+}
+
+export const decideCodingWorkerApproval = (
+  taskId: string,
+  approvalId: string,
+  decision: "approve_once" | "approve_task" | "reject",
+) => request<CodingWorkerApproval>(
+  `${API_ROOT}/tasks/${encodeURIComponent(taskId)}/approvals`,
+  {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ approval_id: approvalId, decision, ttl_seconds: 900 }),
+  },
+);
+
+export async function listCodingWorkerEvidence(taskId: string) {
+  return (await request<{ evidence: CodingWorkerEvidence[] }>(
+    `${API_ROOT}/tasks/${encodeURIComponent(taskId)}/evidence`,
+  )).evidence;
+}
+
+export async function listCodingWorkerArtifacts(taskId: string) {
+  return (await request<{ artifacts: CodingWorkerArtifact[] }>(
+    `${API_ROOT}/tasks/${encodeURIComponent(taskId)}/artifacts`,
+  )).artifacts;
+}
+
+export async function listCodingWorkerTree(taskId: string) {
+  return request<{ workspace_id: string; tree_hash: string; entries: CodingWorkerEntry[] }>(
+    `${API_ROOT}/tasks/${encodeURIComponent(taskId)}/workspace/tree`,
+  );
+}
+
+async function requestText(url: string) {
+  const response = await fetch(url);
+  if (!response.ok) throw new CodingWorkerApiError(`内容读取失败（${response.status}）`, response.status);
+  return response.text();
+}
+
+export const readCodingWorkerEntry = (taskId: string, entryId: string) =>
+  requestText(`${API_ROOT}/tasks/${encodeURIComponent(taskId)}/workspace/entries/${encodeURIComponent(entryId)}`);
+
+export const readCodingWorkerDiff = (taskId: string) =>
+  requestText(`${API_ROOT}/tasks/${encodeURIComponent(taskId)}/workspace/diff`);
+
+export const codingWorkerArtifactUrl = (taskId: string, artifactId: string) =>
+  `${API_ROOT}/tasks/${encodeURIComponent(taskId)}/artifacts/${encodeURIComponent(artifactId)}`;
+
+export function connectCodingWorkerEvents(
+  taskId: string,
+  after: number,
+  handlers: { onEvent: (event: CodingWorkerEvent) => void; onTransportError: () => void },
+) {
+  const source = new EventSource(
+    `${API_ROOT}/tasks/${encodeURIComponent(taskId)}/events?after=${Math.max(0, after)}`,
+  );
+  const receive = (message: MessageEvent<string>) => {
+    try {
+      const event = JSON.parse(message.data) as CodingWorkerEvent;
+      if (!Number.isFinite(event.sequence) || typeof event.type !== "string") throw new Error("invalid event");
+      handlers.onEvent(event);
+    } catch {
+      source.close();
+      handlers.onTransportError();
+    }
+  };
+  taskEventTypes.forEach((type) => source.addEventListener(type, receive as EventListener));
+  source.onerror = handlers.onTransportError;
+  return () => source.close();
+}

--- a/docker-compose.coding-worker-v14.yml
+++ b/docker-compose.coding-worker-v14.yml
@@ -21,6 +21,9 @@ services:
       CODING_WORKER_EGRESS_PROXY_URL: http://coding-worker-egress:8080
       CODING_WORKER_EGRESS_GRANT_KEY: ${CODING_WORKER_EGRESS_GRANT_KEY:-}
       CODING_WORKER_PROJECT_SNAPSHOT_ROOT: /project-snapshots
+      CODING_WORKER_BUILTIN_SOURCE_ROOT: /builtin-source
+      CODING_WORKER_BUILTIN_SOURCE_ID: modelmirror
+      CODING_WORKER_BUILTIN_REVISION: ${CODING_WORKER_BUILTIN_REVISION:?set the full ModelMirror source commit}
     volumes:
       - coding_worker_state:/var/lib/modelmirror/coding-worker
       - coding_worker_slot_a:/worker-slots/slot-a
@@ -31,6 +34,12 @@ services:
       - coding_worker_executor_b:/run/modelmirror-coding-executor-b
       - coding_worker_broker:/run/modelmirror-coding-broker
       - coding_project_snapshot:/project-snapshots:ro
+      - type: bind
+        source: ${CODING_IMPLEMENTATION_WORKTREE:?set the absolute ModelMirror implementation worktree}
+        target: /builtin-source
+        read_only: true
+        bind:
+          create_host_path: false
 
   coding-worker-provider-a:
     image: modelmirror-coding-worker-v14:local

--- a/docker-compose.coding-worker-v14.yml
+++ b/docker-compose.coding-worker-v14.yml
@@ -13,6 +13,9 @@ services:
       CODING_WORKER_MAX_ACTIVE_TASKS: ${CODING_WORKER_MAX_ACTIVE_TASKS:-2}
       CODING_WORKER_RETENTION_SECONDS: ${CODING_WORKER_RETENTION_SECONDS:-604800}
       CODING_WORKER_NETWORK_ENABLED: ${CODING_WORKER_NETWORK_ENABLED:-false}
+      CODING_WORKER_NETWORK_DOMAINS: ${CODING_WORKER_NETWORK_DOMAINS:-registry.npmjs.org}
+      CODING_WORKER_EGRESS_PROXY_URL: http://coding-worker-egress:8080
+      CODING_WORKER_EGRESS_GRANT_KEY: ${CODING_WORKER_EGRESS_GRANT_KEY:-}
     volumes:
       - coding_worker_state:/var/lib/modelmirror/coding-worker
       - coding_worker_slot_a:/worker-slots/slot-a
@@ -81,6 +84,34 @@ services:
       - coding_worker_provider_b:/run/modelmirror-coding
       - coding_worker_broker:/run/modelmirror-coding-broker:ro
 
+  coding-worker-egress:
+    profiles:
+      - coding-worker-network
+    image: modelmirror-coding-worker-v14:local
+    build:
+      context: .
+      dockerfile: server/coding_worker/Dockerfile.v14
+    container_name: modelmirror-coding-worker-egress
+    command: ["python", "-m", "coding_worker.egress_proxy"]
+    networks:
+      - coding_internal
+      - coding_worker_egress
+    user: "65532:65532"
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    pids_limit: 64
+    mem_limit: 128m
+    cpus: 0.5
+    tmpfs:
+      - /tmp:rw,nosuid,noexec,size=8m,uid=65532,gid=65532,mode=0700
+    environment:
+      CODING_WORKER_EGRESS_GRANT_KEY: ${CODING_WORKER_EGRESS_GRANT_KEY:-}
+      CODING_WORKER_NETWORK_DOMAINS: ${CODING_WORKER_NETWORK_DOMAINS:-registry.npmjs.org}
+    restart: unless-stopped
+
 volumes:
   coding_worker_state:
   coding_worker_slot_a:
@@ -88,3 +119,7 @@ volumes:
   coding_worker_provider_a:
   coding_worker_provider_b:
   coding_worker_broker:
+
+networks:
+  coding_worker_egress:
+    driver: bridge

--- a/docker-compose.coding-worker-v14.yml
+++ b/docker-compose.coding-worker-v14.yml
@@ -20,6 +20,7 @@ services:
       CODING_WORKER_NETWORK_DOMAINS: ${CODING_WORKER_NETWORK_DOMAINS:-registry.npmjs.org}
       CODING_WORKER_EGRESS_PROXY_URL: http://coding-worker-egress:8080
       CODING_WORKER_EGRESS_GRANT_KEY: ${CODING_WORKER_EGRESS_GRANT_KEY:-}
+      CODING_WORKER_PROJECT_SNAPSHOT_ROOT: /project-snapshots
     volumes:
       - coding_worker_state:/var/lib/modelmirror/coding-worker
       - coding_worker_slot_a:/worker-slots/slot-a
@@ -29,6 +30,7 @@ services:
       - coding_worker_executor_a:/run/modelmirror-coding-executor-a
       - coding_worker_executor_b:/run/modelmirror-coding-executor-b
       - coding_worker_broker:/run/modelmirror-coding-broker
+      - coding_project_snapshot:/project-snapshots:ro
 
   coding-worker-provider-a:
     image: modelmirror-coding-worker-v14:local
@@ -167,6 +169,7 @@ services:
     restart: unless-stopped
 
 volumes:
+  coding_project_snapshot:
   coding_worker_state:
   coding_worker_slot_a:
   coding_worker_slot_b:

--- a/docker-compose.coding-worker-v14.yml
+++ b/docker-compose.coding-worker-v14.yml
@@ -108,7 +108,7 @@ services:
       dockerfile: server/coding_worker/Dockerfile.v14
     container_name: modelmirror-coding-worker-slot-a
     networks:
-      - coding_internal
+      - coding_worker_tools
     user: "65532:65532"
     read_only: true
     cap_drop:
@@ -159,7 +159,7 @@ services:
     container_name: modelmirror-coding-worker-egress
     command: ["python", "-m", "coding_worker.egress_proxy"]
     networks:
-      - coding_internal
+      - coding_worker_tools
       - coding_worker_egress
     user: "65532:65532"
     read_only: true
@@ -189,5 +189,8 @@ volumes:
   coding_worker_broker:
 
 networks:
+  coding_worker_tools:
+    driver: bridge
+    internal: true
   coding_worker_egress:
     driver: bridge

--- a/docker-compose.coding-worker-v14.yml
+++ b/docker-compose.coding-worker-v14.yml
@@ -1,0 +1,90 @@
+services:
+  server:
+    environment:
+      CODING_WORKER_V14_ENABLED: ${CODING_WORKER_V14_ENABLED:-false}
+      CODING_WORKER_STATE_ROOT: /var/lib/modelmirror/coding-worker
+      CODING_WORKER_SLOT_A_ROOT: /worker-slots/slot-a
+      CODING_WORKER_SLOT_B_ROOT: /worker-slots/slot-b
+      CODING_WORKER_SLOT_A_ENDPOINT: unix:/run/modelmirror-coding-slot-a/provider.sock
+      CODING_WORKER_SLOT_B_ENDPOINT: unix:/run/modelmirror-coding-slot-b/provider.sock
+      CODING_WORKER_SLOT_A_TOKEN: ${CODING_WORKER_SLOT_A_TOKEN:?set a random V14 slot A token}
+      CODING_WORKER_SLOT_B_TOKEN: ${CODING_WORKER_SLOT_B_TOKEN:?set a random V14 slot B token}
+      CODING_WORKER_BROKER_SOCKET: /run/modelmirror-coding-broker/broker.sock
+      CODING_WORKER_MAX_ACTIVE_TASKS: ${CODING_WORKER_MAX_ACTIVE_TASKS:-2}
+      CODING_WORKER_RETENTION_SECONDS: ${CODING_WORKER_RETENTION_SECONDS:-604800}
+      CODING_WORKER_NETWORK_ENABLED: ${CODING_WORKER_NETWORK_ENABLED:-false}
+    volumes:
+      - coding_worker_state:/var/lib/modelmirror/coding-worker
+      - coding_worker_slot_a:/worker-slots/slot-a
+      - coding_worker_slot_b:/worker-slots/slot-b
+      - coding_worker_provider_a:/run/modelmirror-coding-slot-a
+      - coding_worker_provider_b:/run/modelmirror-coding-slot-b
+      - coding_worker_broker:/run/modelmirror-coding-broker
+
+  coding-worker-slot-a:
+    image: modelmirror-coding-worker-v14:local
+    build:
+      context: .
+      dockerfile: server/coding_worker/Dockerfile.v14
+    container_name: modelmirror-coding-worker-slot-a
+    depends_on:
+      new-api:
+        condition: service_healthy
+    networks:
+      - coding_internal
+    user: "65532:65532"
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    pids_limit: 192
+    mem_limit: 2g
+    cpus: 2.0
+    tmpfs:
+      - /tmp:rw,nosuid,size=256m,uid=65532,gid=65532,mode=0700
+      - /home/coding:rw,nosuid,size=128m,uid=65532,gid=65532,mode=0700
+      - /worker-runtime:rw,nosuid,size=512m,uid=65532,gid=65532,mode=0700
+    environment:
+      CODING_WORKER_PROVIDER_SOCKET: /run/modelmirror-coding/provider.sock
+      CODING_WORKER_SIDECAR_TOKEN: ${CODING_WORKER_SLOT_A_TOKEN:?set a random V14 slot A token}
+      CODING_WORKER_ROUTE_ID: coding/default
+      CODING_WORKER_MODEL_ID: ${CODING_WORKER_MODEL_ID:?set the controlled V14 model id}
+      CODING_WORKER_MODEL_BASE_URL: ${CODING_WORKER_MODEL_BASE_URL:-http://new-api:3000/v1}
+      CODING_WORKER_ROUTE_KEY: ${CODING_WORKER_ROUTE_KEY:?set a dedicated V14 route key}
+    volumes:
+      - coding_worker_slot_a:/worker-data
+      - coding_worker_provider_a:/run/modelmirror-coding
+      - coding_worker_broker:/run/modelmirror-coding-broker:ro
+    restart: unless-stopped
+    stop_grace_period: 10s
+    healthcheck:
+      test: ["CMD", "python", "-c", "import json,os,socket; s=socket.socket(socket.AF_UNIX); s.connect('/run/modelmirror-coding/provider.sock'); s.sendall((json.dumps({'token':os.environ['CODING_WORKER_SIDECAR_TOKEN'],'action':'capabilities','payload':{}})+'\\n').encode()); assert json.loads(s.recv(65536))['ok']"]
+      interval: 10s
+      timeout: 5s
+      retries: 8
+      start_period: 30s
+
+  coding-worker-slot-b:
+    extends:
+      service: coding-worker-slot-a
+    container_name: modelmirror-coding-worker-slot-b
+    environment:
+      CODING_WORKER_PROVIDER_SOCKET: /run/modelmirror-coding/provider.sock
+      CODING_WORKER_SIDECAR_TOKEN: ${CODING_WORKER_SLOT_B_TOKEN:?set a random V14 slot B token}
+      CODING_WORKER_ROUTE_ID: coding/default
+      CODING_WORKER_MODEL_ID: ${CODING_WORKER_MODEL_ID:?set the controlled V14 model id}
+      CODING_WORKER_MODEL_BASE_URL: ${CODING_WORKER_MODEL_BASE_URL:-http://new-api:3000/v1}
+      CODING_WORKER_ROUTE_KEY: ${CODING_WORKER_ROUTE_KEY:?set a dedicated V14 route key}
+    volumes:
+      - coding_worker_slot_b:/worker-data
+      - coding_worker_provider_b:/run/modelmirror-coding
+      - coding_worker_broker:/run/modelmirror-coding-broker:ro
+
+volumes:
+  coding_worker_state:
+  coding_worker_slot_a:
+  coding_worker_slot_b:
+  coding_worker_provider_a:
+  coding_worker_provider_b:
+  coding_worker_broker:

--- a/docker-compose.coding-worker-v14.yml
+++ b/docker-compose.coding-worker-v14.yml
@@ -9,6 +9,10 @@ services:
       CODING_WORKER_SLOT_B_ENDPOINT: unix:/run/modelmirror-coding-slot-b/provider.sock
       CODING_WORKER_SLOT_A_TOKEN: ${CODING_WORKER_SLOT_A_TOKEN:?set a random V14 slot A token}
       CODING_WORKER_SLOT_B_TOKEN: ${CODING_WORKER_SLOT_B_TOKEN:?set a random V14 slot B token}
+      CODING_WORKER_EXECUTOR_A_ENDPOINT: unix:/run/modelmirror-coding-executor-a/executor.sock
+      CODING_WORKER_EXECUTOR_B_ENDPOINT: unix:/run/modelmirror-coding-executor-b/executor.sock
+      CODING_WORKER_EXECUTOR_A_TOKEN: ${CODING_WORKER_EXECUTOR_A_TOKEN:?set a random V14 executor A token}
+      CODING_WORKER_EXECUTOR_B_TOKEN: ${CODING_WORKER_EXECUTOR_B_TOKEN:?set a random V14 executor B token}
       CODING_WORKER_BROKER_SOCKET: /run/modelmirror-coding-broker/broker.sock
       CODING_WORKER_MAX_ACTIVE_TASKS: ${CODING_WORKER_MAX_ACTIVE_TASKS:-2}
       CODING_WORKER_RETENTION_SECONDS: ${CODING_WORKER_RETENTION_SECONDS:-604800}
@@ -22,14 +26,16 @@ services:
       - coding_worker_slot_b:/worker-slots/slot-b
       - coding_worker_provider_a:/run/modelmirror-coding-slot-a
       - coding_worker_provider_b:/run/modelmirror-coding-slot-b
+      - coding_worker_executor_a:/run/modelmirror-coding-executor-a
+      - coding_worker_executor_b:/run/modelmirror-coding-executor-b
       - coding_worker_broker:/run/modelmirror-coding-broker
 
-  coding-worker-slot-a:
+  coding-worker-provider-a:
     image: modelmirror-coding-worker-v14:local
     build:
       context: .
       dockerfile: server/coding_worker/Dockerfile.v14
-    container_name: modelmirror-coding-worker-slot-a
+    container_name: modelmirror-coding-worker-provider-a
     depends_on:
       new-api:
         condition: service_healthy
@@ -56,7 +62,7 @@ services:
       CODING_WORKER_MODEL_BASE_URL: ${CODING_WORKER_MODEL_BASE_URL:-http://new-api:3000/v1}
       CODING_WORKER_ROUTE_KEY: ${CODING_WORKER_ROUTE_KEY:?set a dedicated V14 route key}
     volumes:
-      - coding_worker_slot_a:/worker-data
+      - coding_worker_slot_a:/worker-data:ro
       - coding_worker_provider_a:/run/modelmirror-coding
       - coding_worker_broker:/run/modelmirror-coding-broker:ro
     restart: unless-stopped
@@ -68,10 +74,10 @@ services:
       retries: 8
       start_period: 30s
 
-  coding-worker-slot-b:
+  coding-worker-provider-b:
     extends:
-      service: coding-worker-slot-a
-    container_name: modelmirror-coding-worker-slot-b
+      service: coding-worker-provider-a
+    container_name: modelmirror-coding-worker-provider-b
     environment:
       CODING_WORKER_PROVIDER_SOCKET: /run/modelmirror-coding/provider.sock
       CODING_WORKER_SIDECAR_TOKEN: ${CODING_WORKER_SLOT_B_TOKEN:?set a random V14 slot B token}
@@ -80,9 +86,57 @@ services:
       CODING_WORKER_MODEL_BASE_URL: ${CODING_WORKER_MODEL_BASE_URL:-http://new-api:3000/v1}
       CODING_WORKER_ROUTE_KEY: ${CODING_WORKER_ROUTE_KEY:?set a dedicated V14 route key}
     volumes:
-      - coding_worker_slot_b:/worker-data
+      - coding_worker_slot_b:/worker-data:ro
       - coding_worker_provider_b:/run/modelmirror-coding
       - coding_worker_broker:/run/modelmirror-coding-broker:ro
+
+  coding-worker-slot-a:
+    image: modelmirror-coding-worker-v14:local
+    build:
+      context: .
+      dockerfile: server/coding_worker/Dockerfile.v14
+    container_name: modelmirror-coding-worker-slot-a
+    networks:
+      - coding_internal
+    user: "65532:65532"
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    pids_limit: 192
+    mem_limit: 2g
+    cpus: 2.0
+    tmpfs:
+      - /tmp:rw,nosuid,size=256m,uid=65532,gid=65532,mode=0700
+      - /worker-runtime:rw,nosuid,size=512m,uid=65532,gid=65532,mode=0700
+    environment:
+      CODING_WORKER_MODE: executor
+      CODING_WORKER_PROVIDER_SOCKET: /run/modelmirror-coding/executor.sock
+      CODING_WORKER_EXECUTOR_TOKEN: ${CODING_WORKER_EXECUTOR_A_TOKEN:?set a random V14 executor A token}
+    volumes:
+      - coding_worker_slot_a:/worker-data
+      - coding_worker_executor_a:/run/modelmirror-coding
+    restart: unless-stopped
+    stop_grace_period: 10s
+    healthcheck:
+      test: ["CMD", "python", "-c", "import json,os,socket; s=socket.socket(socket.AF_UNIX); s.connect('/run/modelmirror-coding/executor.sock'); s.sendall((json.dumps({'token':os.environ['CODING_WORKER_EXECUTOR_TOKEN'],'action':'bind_task','payload':{'task_id':'healthcheck','workspace_id':'healthcheck'}})+'\\n').encode()); assert json.loads(s.recv(65536))['error']['code']=='executor_failed'"]
+      interval: 10s
+      timeout: 5s
+      retries: 8
+      start_period: 20s
+
+  coding-worker-slot-b:
+    extends:
+      service: coding-worker-slot-a
+    container_name: modelmirror-coding-worker-slot-b
+    environment:
+      CODING_WORKER_MODE: executor
+      CODING_WORKER_PROVIDER_SOCKET: /run/modelmirror-coding/executor.sock
+      CODING_WORKER_EXECUTOR_TOKEN: ${CODING_WORKER_EXECUTOR_B_TOKEN:?set a random V14 executor B token}
+    volumes:
+      - coding_worker_slot_b:/worker-data
+      - coding_worker_executor_b:/run/modelmirror-coding
 
   coding-worker-egress:
     profiles:
@@ -118,6 +172,8 @@ volumes:
   coding_worker_slot_b:
   coding_worker_provider_a:
   coding_worker_provider_b:
+  coding_worker_executor_a:
+  coding_worker_executor_b:
   coding_worker_broker:
 
 networks:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -37,7 +37,7 @@ Dify 不再承载 `/workflow` 或 `/rag` 主路径。仓库仍保留
 | DuckDB | Data X 项目隔离分析。 |
 | Browser / Sandbox sidecar | 受控浏览器和无网络沙箱执行。 |
 | OmniRoute sidecar | 可选兼容、诊断和紧急回退；不是普通用户控制面。 |
-| OpenCode + 最小 ACP Worker | 实验性代码问答与修改草稿执行面；单实例、默认关闭。 |
+| Coding Worker V14 | 供应商中立的持久任务控制面；双槽、默认关闭，OpenCode 1.18.9 为首个内部 Provider，ACP 为回退。 |
 | Coding Project Source | 无网络的受控项目清单与单槽 Git HEAD 快照服务；只有它可读取清单 `CODING_PROJECTS_ROOT`。 |
 | Coding Project Writer | 对清单中逐项目授权的无远程本地克隆执行原子写入、撤销、本地提交与对账。 |
 | Windows Project Host v2 | 在用户电脑上保存项目路径并执行受控原子写入、当前分支本地提交和精确对账；Server 只看到不透明项目 ID。 |
@@ -288,3 +288,38 @@ flowchart LR
   远端合并、目录操作、多 Agent、分布式
   Worker 或生产多租户。
 - Dify 代理属于 legacy compatibility；除非形成新的产品决策，不恢复为主路由。
+
+## V14 通用 Coding Worker
+
+V14 将新的平台级代码任务放入 `server/coding_worker/`，不再把任务控制、工具执行和验收继续堆进 `coding_runtime/api.py`。现有 Coding Runtime 与 Agent Workspace 的活动会话保持 legacy；新会话仅在 `CODING_WORKER_V14_ENABLED=true` 且 Worker 健康时渐进转发。
+
+```mermaid
+flowchart LR
+  MODULE["平台模块 / 浏览器"] --> API["/api/coding-worker/v1"]
+  API --> STORE["加密 Worker Store + Event Log"]
+  API --> SCHED["双槽调度器"]
+  SOURCE["builtin / manifest / host_snapshot"] --> WS["任务独立合成 Git H0"]
+  SCHED --> PA["Provider A"]
+  SCHED --> PB["Provider B"]
+  PA --> BROKER["Tool Broker"]
+  PB --> BROKER
+  BROKER --> EA["Executor A"]
+  BROKER --> EB["Executor B"]
+  EA -. "批准的网络租约" .-> EGRESS["allowlisted egress proxy"]
+  EB -. "批准的网络租约" .-> EGRESS
+  WS --> EVIDENCE["Harness Runner + Evidence Ledger"]
+  EVIDENCE --> CONSOLE["共享 Worker Console"]
+  CONSOLE -. "完成的 Host Snapshot" .-> V13["v13 写回确认链"]
+```
+
+核心边界：
+
+- `TaskSpec.origin` 由 Server 写入；浏览器和模块不能传物理路径、环境变量、remote URL、凭据、供应商名或原始执行端点。
+- 每个任务使用独立 Workspace、事件、审批、进程、Artifact 与 checkpoint；两个固定槽可并行，第三个任务持久排队。
+- Provider 与 Executor 分离。Provider 只连接受控模型网络；Executor 只连接内部 `coding_worker_tools` 网络，无法直接访问 Server/newAPI。网络租约只能经独立 egress proxy 生效。
+- OpenCode 1.18.9 的端口、认证和原始帧属于 Provider 私有实现；公共契约只包含 capability、open、message、event stream、cancel、checkpoint、restore、close。
+- 必需检查由后端冻结并绑定 Workspace tree hash。模型停止调用工具只进入验收阶段；全部必需 Evidence 通过后才能 `completed`，树变化会使旧证据失效。
+- 重启不会恢复旧进程或重放未知副作用。只恢复与当前 tree hash 匹配的确定 checkpoint；其余任务进入 `interrupted`，等待显式 resume。
+- `host_snapshot` 在任务真正出队时才向 Windows Helper 请求一次性快照并导入 Project Source；Server 始终不获得宿主物理路径。完成后仅能显式交给现有 v13 写回链，Worker 本身不写用户仓库。
+
+`/coding` 和 `/agents/workbench` 使用同一个 Worker Console。前者保留 v13 apply/commit/undo/publish 领域动作；后者只显示通用任务、文件、Diff、审批、Evidence、Artifact 与终端语义。下游 Skill/MCP 创建、AI 应用、3D 引擎和用户开发模块只注册来源、上下文和验收适配器，不向 Worker 内核加入领域逻辑。

--- a/docs/CODING_AGENT_INTEGRATION.md
+++ b/docs/CODING_AGENT_INTEGRATION.md
@@ -702,3 +702,43 @@ docker compose -p modelmirror --profile coding stop coding-runtime
 恢复 SQLite 是 Coding 专用、可选的单槽存储，不迁移其他业务数据库。需要整轮
 回退时，省略恢复 overlay 并按独立提交逆序撤销；已有外部文件和本地提交不会被
 自动删除。
+
+## V14 平台 Coding Worker 契约
+
+V14 的公共入口是版本化 `/api/coding-worker/v1`。OpenCode、ACP、sidecar socket、端口和 session ID 均为内部实现，不进入浏览器或模块契约。
+
+| 接口 | 用途 |
+| --- | --- |
+| `GET /api/coding-worker/v1` | 功能开关、并发、保留期与可选择的冻结检查 ID |
+| `POST /api/coding-worker/v1/tasks` | 使用 `client_task_id` 幂等创建任务；`origin` 由 Server 写入 |
+| `GET /tasks`、`GET /tasks/{id}` | 列表与任务状态 |
+| `GET /tasks/{id}/events?after=` | 可补发事件流；断线后从最后 event ID 继续 |
+| `POST /tasks/{id}/messages` | 追加指令或运行中 steering |
+| `GET/POST /tasks/{id}/approvals` | 查询和签发一次性或任务级能力租约 |
+| `POST /tasks/{id}/pause|resume|cancel|pin` | 显式生命周期控制 |
+| `GET /tasks/{id}/workspace/tree` | 获取 opaque `entry_id` 文件树 |
+| `GET /tasks/{id}/workspace/entries/{entry_id}` | 受限文本预览 |
+| `GET /tasks/{id}/workspace/diff` | 当前合成 Git 基线 Diff |
+| `GET /tasks/{id}/evidence` | 绑定当前 tree hash 的必需检查证据 |
+| `GET /tasks/{id}/artifacts/{artifact_id}` | 下载任务绑定 Artifact |
+| `GET /tasks/{id}/services/{service_id}/preview/{path}` | 短期安全预览 |
+
+`TaskSpec` 固定包含调用方幂等键、Server origin、目标、opaque Workspace 来源与 revision、冻结 AcceptanceContract、policy profile、平台模型路由、低于系统上限的预算和受控 context refs。浏览器或模块提交物理路径、环境变量、供应商名、remote URL、凭据或原始执行端点时必须拒绝。
+
+模块集成使用 `server/coding_worker/sdk.py`：
+
+- 模块可注册 `builtin`、`manifest`、`host_snapshot` 范围内的来源适配器、上下文和冻结检查；
+- 模块只能通过内部客户端创建/查询/steer 任务，不能直接取得 Provider、Executor、进程或权限对象；
+- AcceptanceContract 创建后不可删除或降级；当前公开基础检查为 `python-compile`、`python-pytest`、`react-test`、`react-build`；
+- 新增 Skill/MCP 创建、AI 应用或 3D 引擎适配时，只增加模块侧来源、上下文与验收，不修改 Worker 内核的领域逻辑。
+
+来源语义：
+
+- `builtin` 从部署时固定的只读 ModelMirror source commit 构造合成 Git `H0`；
+- `manifest` 复用 Project Source 单槽快照，模块只持 opaque project/revision；
+- `host_snapshot` 在任务出队后惰性请求 v13 Windows Helper 快照，复核 project/head/fingerprint，导入完成即释放租约；
+- 每个任务的 Workspace、进程、事件、审批、checkpoint、Evidence 和 Artifact 按 `task_id` 隔离，二进制 Diff 只记录身份与元数据。
+
+`/coding` 与 `/agents/workbench` 的新会话可渐进使用同一 `CodingWorkerConsole`；已有活动会话仍走 legacy。Coding 场景中的 completed `host_snapshot` 任务可调用 `POST /api/coding/worker-tasks/{task_id}/handoff`，把严格 UTF-8 文本 Diff 交给 v13 Recovery，然后由用户确认 apply/commit/undo/publish。二进制变更、未通过验收、Workspace 变化或 Host 身份变化均不得进入写回。
+
+模型停止输出不代表完成。服务端先进入 `testing`，Harness Runner 运行冻结检查并写 Evidence Ledger；只有全部必需检查对当前 tree hash 为 passed，任务才进入 `completed`。运行中命令在重启时停止，任务标记 `interrupted`；resume 只恢复确定 checkpoint，不恢复旧进程或盲重放未知 operation ID。

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -550,3 +550,45 @@ curl http://localhost:5173/studio
 - 可选 profile 故障不得通过删除核心数据解决。
 
 legacy `/api/dify/*` 健康只表示兼容代理配置状态，不是平台健康门禁。
+
+## Coding Worker V14 部署
+
+V14 默认关闭，使用独立 overlay `docker-compose.coding-worker-v14.yml`。它增加两个 Provider、两个单槽 Executor、持久 Store/Workspace 卷，以及可选的网络 egress proxy；不替换 v13 Project Host、Coding Recovery 或 Agent Workspace 数据。
+
+在绝对 `MODELMIRROR_DATA_ROOT` 对应的 `server/.env` 中设置以下值，不要把真实值提交到仓库：
+
+```dotenv
+CODING_WORKER_V14_ENABLED=false
+CODING_WORKER_MAX_ACTIVE_TASKS=2
+CODING_WORKER_RETENTION_SECONDS=604800
+CODING_WORKER_NETWORK_ENABLED=false
+CODING_WORKER_SLOT_A_TOKEN=<random>
+CODING_WORKER_SLOT_B_TOKEN=<random>
+CODING_WORKER_EXECUTOR_A_TOKEN=<random>
+CODING_WORKER_EXECUTOR_B_TOKEN=<random>
+CODING_WORKER_MODEL_ID=<controlled-model-id>
+CODING_WORKER_ROUTE_KEY=<dedicated-route-key>
+CODING_WORKER_BUILTIN_REVISION=<full-source-commit>
+```
+
+`CODING_WORKER_MODEL_BASE_URL` 默认使用 `http://new-api:3000/v1`。若启用 `develop_networked`，还必须显式设置 `CODING_WORKER_NETWORK_ENABLED=true`、随机 `CODING_WORKER_EGRESS_GRANT_KEY` 和最小 `CODING_WORKER_NETWORK_DOMAINS`，并加载 `coding-worker-network` profile。不要把模型网关密钥复用为 slot、executor 或 egress token。
+
+只做配置展开检查、不启动服务：
+
+```powershell
+docker compose -f docker-compose.yml -f docker-compose.coding-worker-v14.yml -p modelmirror --profile coding config --quiet
+```
+
+Host Snapshot 场景还需按既有顺序加载 Project Host overlay；若同时启用清单项目，继续遵守 project-source/full compatibility overlay 的顺序。`CODING_IMPLEMENTATION_WORKTREE` 必须是当前验收 HEAD 的绝对只读来源，`CODING_WORKER_BUILTIN_REVISION` 必须是同一完整 commit。
+
+只有在用户确认共享栈独占窗口、最新主线和正式环境变量后，才可执行重建：
+
+```powershell
+docker compose -f docker-compose.yml -f docker-compose.coding-project-host.yml -f docker-compose.coding-worker-v14.yml -p modelmirror --profile coding up -d --build --force-recreate server coding-worker-provider-a coding-worker-provider-b coding-worker-slot-a coding-worker-slot-b
+```
+
+网络默认保持关闭；需要依赖下载时再追加 `--profile coding-worker-network`，批准结束后关闭 profile。Provider 在 `coding_internal` 访问受控模型网关，Executor 仅在内部 `coding_worker_tools`；只有 egress proxy 同时加入工具网络和外部网络。
+
+验收至少包括：两个任务并行、第三个排队；失败检查后的自动修复与复测；审批拒绝/过期；SSE 断线补发；Server、两个 Provider/Executor 逐个重启；Host Snapshot 经过 v13 写回。真实 OpenCode、Windows Helper 和用户项目写回必须单列人工结果，不能用 Fake Provider 或 Compose `config` 代替。
+
+回退只需设置 `CODING_WORKER_V14_ENABLED=false` 并重建 Server，使新会话回到 legacy。不要删除 `coding_worker_state`、slot Workspace 卷、v13 Recovery 或 Agent Workspace 数据；已有任务保持可审计，已有宿主副作用不会自动撤销。

--- a/docs/HARNESS_ENGINEERING.md
+++ b/docs/HARNESS_ENGINEERING.md
@@ -381,3 +381,27 @@ curl http://localhost:5173/models
     任何 build/up/recreate 前都要取得用户确认的独占窗口；若 `origin/main` 前进，应在新验收
     集成工作树定向引入批次并 range-diff。人工验收后还要再次核对主线、全 Diff、敏感信息
     和禁止产物，才允许 push 或 PR。
+42. **通用 Coding Worker 只接受供应商中立任务。** 模块只能提交目标、opaque 来源、上下文引用、
+    冻结验收 ID 和低于系统上限的预算；`origin` 由 Server 写入。物理路径、环境变量、remote URL、
+    凭据、供应商名和原始执行端点不得进入 `TaskSpec`。领域适配放在调用模块，不进入 Worker 内核。
+43. **Provider、Executor 与网络出口必须分层隔离。** Provider 可以访问受控模型网络，但不能直接执行
+    Workspace 命令；Executor 只能加入内部工具网络，不能访问 Server/newAPI。网络动作必须经绑定任务、
+    用途、域名和 TTL 的租约以及独立 egress proxy；IP 字面量、私网和重定向越界保持拒绝。
+44. **任务完成由冻结验收和当前树证据决定。** 模型停止调用工具只进入 `testing`。必需检查的 argv、
+    timeout 和交付物由后端注册，Agent 与调用模块不能删除、替换或降级；Workspace tree hash 改变后旧
+    Evidence 必须失效，未全部通过不得进入 `completed`。
+45. **双槽任务和进程必须按任务归属。** 两个任务可并行，第三个持久排队；取消、输入、输出、服务、
+    审批和 Artifact 都要绑定 `task_id` 与 slot。取消一个任务不得终止另一个任务的进程，也不得把其
+    Workspace、事件或 Artifact 读给另一个调用方。
+46. **恢复只重放控制意图，不重放未知副作用。** Server 或 Worker 重启后，运行中进程停止并把任务
+    标记 `interrupted`。只有 provider checkpoint 与当前 tree hash 精确匹配才可由显式 resume 恢复；
+    副作用工具使用稳定 operation ID，未知结果先 reconcile，禁止换 ID 盲重放。
+47. **来源租约应尽可能晚取得并及时释放。** `host_snapshot` 只在任务真正出队时请求 Windows Helper，
+    导入并校验 project/head/fingerprint 后立即释放 Project Source 租约；排队任务不能占用单槽快照。
+    Server、Provider、Executor 和模型始终只看 opaque ID 或隔离 Workspace，不得获得宿主物理路径。
+48. **宿主写回继续由 v13 执行。** Worker 在合成 Git H0 内生成 Diff，不在用户仓库原地运行。只有
+    completed、必需检查通过且仍绑定原 Host Snapshot 的文本变更，才可由用户显式交给 v13
+    apply/commit/undo/publish 链；Worker 不新增第二套宿主写事务。
+49. **共享 Console 必须区分展示与能力。** `/coding` 和 `/agents/workbench` 可复用任务、对话、文件、
+    Diff、审批、Evidence、Artifact 与终端组件；只有 Coding 上下文展示 v13 领域动作。开关关闭、Provider
+    不可用或 legacy 活动会话存在时必须清晰降级，不能把 Mock/静态状态误报为真实引擎就绪。

--- a/docs/tasks/CODING_WORKER_V14.md
+++ b/docs/tasks/CODING_WORKER_V14.md
@@ -27,8 +27,44 @@ V14 不在宿主仓库原地执行，不开放 Git remote/push、自动 PR、任
 
 关闭 `CODING_WORKER_V14_ENABLED` 后，新任务继续走 legacy；不得删除 Worker Store、Workspace、Coding Recovery 或 Agent Workspace 数据。已有活动 legacy 会话不迁移。
 
-## PR A 当前接口
+## 顺序 PR 状态
 
-`/api/coding-worker/v1` 默认关闭。Kernel 阶段提供任务幂等创建、状态、SSE 事件补发、消息、暂停/继续/取消/pin，以及用 opaque `entry_id` 读取的 Workspace tree、文本预览与 Diff。`origin` 始终由 Server 写入；模型路由必须命中 `CODING_WORKER_MODEL_ROUTES`。
+| PR | 范围 | 当前状态 |
+| --- | --- | --- |
+| PR A `#122` | 契约、加密任务 Store、事件补发、Workspace Broker、双槽调度与 Fake Provider | 已完成并作为后续堆叠基线 |
+| PR B `#125` | OpenCode Provider、Tool Broker、审批/网络/服务租约、Evidence Ledger、checkpoint 恢复 | 已完成并作为 PR C 基线 |
+| PR C `#130` | 模块 SDK、共享 Console、三类来源、冻结验收、v13 写回桥、部署与文档 | Draft；自动门禁尚未全部完成 |
 
-PR A 使用 Fake Provider 验证状态机，模型停止后只进入 `testing` 并以 `acceptance_runner_pending` 阻断，绝不伪造完成。OpenCode、Tool Broker、Harness Runner 和 legacy 转发在后续顺序 PR 接入；未配置真实 Provider 时即使误开开关，API 也返回 503，而不会回退到未隔离执行。
+每个实现提交继续限制在不超过五个文件。PR C 不迁移已有活动 legacy 会话；只有新会话在开关开启且 Worker 可用时进入 V14。
+
+## 当前公共能力
+
+`/api/coding-worker/v1` 默认关闭，提供：
+
+- 幂等创建与查询任务、SSE 事件补发、消息 steering、审批、暂停、继续、取消、pin 和删除；
+- 使用 opaque `entry_id` 的 Workspace tree、文本预览、Diff、Evidence、Artifact 与安全预览；
+- `builtin`、`manifest`、`host_snapshot` 三种受控来源；来源适配器和冻结检查只能由 Server 模块注册；
+- 两个固定任务槽；第三个任务持久排队，重启后的运行中任务进入 `interrupted`；
+- 供应商中立的 Provider 契约。首个真实实现固定为 OpenCode 1.18.9，ACP 保留回退，公共 API 不暴露两者；
+- 通过 Tool Broker 执行文件、命令、服务与网络动作。Executor 默认只在内部工具网络，只有带批准租约且启用专用 profile 时才经 egress proxy 访问允许域名；
+- 后端冻结的 `python-compile`、`python-pytest`、`react-test`、`react-build` 检查。调用方只能选择公开 ID，不能改写 argv 或降低验收；
+- `/coding` 与 `/agents/workbench` 共用 Worker Console；Coding 场景中的已完成 `host_snapshot` 任务可显式转入 v13 apply/commit/undo/publish 确认链。
+
+## 当前自动验证证据
+
+- V14 Worker 17 个专项文件：`96 passed`；
+- Project Host API：`19 passed`；
+- 前端：`29` 个文件、`134 passed`；
+- 前端 production build 通过，`CodingPage` gzip `37.60 kB`；
+- V14 Compose 组合 `config --quiet` 与部署静态测试通过；
+- 分支已推送至 Draft PR `#130`。
+
+这些结果不等同于完整发布验收。全部 Coding + Agent Workspace、后端全量、真实 OpenCode headless、真实 Windows Helper、共享栈重建和用户项目写回仍须分别完成并记录。
+
+## 发布与人工验收门禁
+
+1. 运行新增专项、全部 Agent Workspace、全部 Coding、后端全量、前端测试/build、Compose config、敏感信息与禁止产物扫描。
+2. 在独立临时环境验证真实 OpenCode 1.18.9、两个任务并行、第三个排队、失败后自动修复复测、SSE 补发与逐个重启。
+3. 取得用户确认的共享栈独占窗口后，重新 fetch 最新主线、核对堆叠 PR 和环境变量，再重建；不得停止仍在运行的独立预览器。
+4. 使用用户明确选择的测试项目验证 Host Snapshot → Worker → v13 apply/commit/undo；真实写入前再次确认项目、分支与 Diff。
+5. 只有以上证据齐全且人工验收通过，PR C 才可由 Draft 转为 Ready。

--- a/docs/tasks/CODING_WORKER_V14.md
+++ b/docs/tasks/CODING_WORKER_V14.md
@@ -55,17 +55,19 @@ V14 不在宿主仓库原地执行，不开放 Git remote/push、自动 PR、任
 - V14 Worker 17 个专项文件：`96 passed`；
 - Project Host API：`19 passed`；
 - 全部 Coding + Agent Workspace：`762 passed, 9 skipped`；
-- 后端全量：`2131 passed, 21 skipped, 1 failed`。唯一失败是现有 `modelmirror-server`
+- 本地后端全量：`2131 passed, 21 skipped, 1 failed`。唯一失败是陈旧 `modelmirror-server`
   测试镜像内 Node `20.20.2` 无法直接导入 TypeScript；该节点及数据未被 PR C 修改，使用本机
-  Node `24.18.0` 单独复跑为 `1 passed`，因此记录为测试镜像环境门禁而非绿色全量；
+  Node `24.18.0` 单独复跑为 `1 passed`；GitHub 当前 HEAD 的 `Backend quality` 已通过；
 - 前端：`29` 个文件、`134 passed`；
 - 前端 production build 通过，`CodingPage` gzip `37.60 kB`；
 - V14 Compose 组合 `config --quiet` 与部署静态测试通过；
 - 真实 Worker 镜像中的 OpenCode `1.18.9` 已在非 root、只读根、无网络、无宿主端口的
   临时容器中完成 Basic Auth `serve` 与 `/global/health` 冒烟；这不等同于带真实模型的修复循环；
+- GitHub 当前 HEAD 的 `Backend quality`、`Frontend quality`、`Windows Project Host` 与
+  `readiness` 均通过；
 - 分支已推送至 Draft PR `#130`。
 
-这些结果不等同于完整发布验收。后端全量仍需在支持 TypeScript strip 的正式 Node 镜像复跑；真实 OpenCode 模型任务循环、真实 Windows Helper、共享栈重建和用户项目写回仍须分别完成并记录。
+这些结果不等同于完整发布验收。真实 OpenCode 模型任务循环、真实 Windows Helper、共享栈重建和用户项目写回仍须分别完成并记录。
 
 ## 发布与人工验收门禁
 

--- a/docs/tasks/CODING_WORKER_V14.md
+++ b/docs/tasks/CODING_WORKER_V14.md
@@ -61,9 +61,11 @@ V14 不在宿主仓库原地执行，不开放 Git remote/push、自动 PR、任
 - 前端：`29` 个文件、`134 passed`；
 - 前端 production build 通过，`CodingPage` gzip `37.60 kB`；
 - V14 Compose 组合 `config --quiet` 与部署静态测试通过；
+- 真实 Worker 镜像中的 OpenCode `1.18.9` 已在非 root、只读根、无网络、无宿主端口的
+  临时容器中完成 Basic Auth `serve` 与 `/global/health` 冒烟；这不等同于带真实模型的修复循环；
 - 分支已推送至 Draft PR `#130`。
 
-这些结果不等同于完整发布验收。后端全量仍需在支持 TypeScript strip 的正式 Node 镜像复跑；真实 OpenCode headless、真实 Windows Helper、共享栈重建和用户项目写回仍须分别完成并记录。
+这些结果不等同于完整发布验收。后端全量仍需在支持 TypeScript strip 的正式 Node 镜像复跑；真实 OpenCode 模型任务循环、真实 Windows Helper、共享栈重建和用户项目写回仍须分别完成并记录。
 
 ## 发布与人工验收门禁
 

--- a/docs/tasks/CODING_WORKER_V14.md
+++ b/docs/tasks/CODING_WORKER_V14.md
@@ -54,12 +54,16 @@ V14 不在宿主仓库原地执行，不开放 Git remote/push、自动 PR、任
 
 - V14 Worker 17 个专项文件：`96 passed`；
 - Project Host API：`19 passed`；
+- 全部 Coding + Agent Workspace：`762 passed, 9 skipped`；
+- 后端全量：`2131 passed, 21 skipped, 1 failed`。唯一失败是现有 `modelmirror-server`
+  测试镜像内 Node `20.20.2` 无法直接导入 TypeScript；该节点及数据未被 PR C 修改，使用本机
+  Node `24.18.0` 单独复跑为 `1 passed`，因此记录为测试镜像环境门禁而非绿色全量；
 - 前端：`29` 个文件、`134 passed`；
 - 前端 production build 通过，`CodingPage` gzip `37.60 kB`；
 - V14 Compose 组合 `config --quiet` 与部署静态测试通过；
 - 分支已推送至 Draft PR `#130`。
 
-这些结果不等同于完整发布验收。全部 Coding + Agent Workspace、后端全量、真实 OpenCode headless、真实 Windows Helper、共享栈重建和用户项目写回仍须分别完成并记录。
+这些结果不等同于完整发布验收。后端全量仍需在支持 TypeScript strip 的正式 Node 镜像复跑；真实 OpenCode headless、真实 Windows Helper、共享栈重建和用户项目写回仍须分别完成并记录。
 
 ## 发布与人工验收门禁
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -49,6 +49,7 @@ COPY multimodal ./multimodal
 COPY model_router ./model_router
 COPY context_engine ./context_engine
 COPY coding_runtime ./coding_runtime
+COPY coding_worker ./coding_worker
 
 EXPOSE 8000
 

--- a/server/coding_applier/engine.py
+++ b/server/coding_applier/engine.py
@@ -10,7 +10,7 @@ import tempfile
 import threading
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 from server.coding_runtime.apply_models import (
     APPLY_ID_PATTERN,
@@ -548,7 +548,7 @@ class CodingApplierEngine:
                     entries.add(("file", relative))
                     file_hashes.append((relative, content_hash))
                     next_cache[relative] = (signature, content_hash)
-            file_hashes.sort()
+            file_hashes.sort(key=lambda item: PurePosixPath(item[0]).parts)
             for relative, content_hash in file_hashes:
                 size = next_cache[relative][0][0]
                 digest.update(relative.encode("utf-8"))

--- a/server/coding_runtime/api.py
+++ b/server/coding_runtime/api.py
@@ -5242,6 +5242,18 @@ async def coding_projects(response: Response) -> dict[str, Any]:
     return await get_coding_service().project_catalog()
 
 
+@router.get("/worker-sources/{project_id}")
+async def coding_worker_source(project_id: str, response: Response) -> dict[str, str]:
+    response.headers["Cache-Control"] = "no-store"
+    service = get_coding_service()
+    if service.project_host is None:
+        raise _http_error(status.HTTP_503_SERVICE_UNAVAILABLE, "project_host_unavailable")
+    try:
+        return service.project_host.worker_source(project_id)
+    except ProjectHostError as exc:
+        raise _project_host_http_error(exc) from exc
+
+
 @router.get("/recovery")
 async def coding_recovery_status(response: Response) -> dict[str, Any]:
     response.headers["Cache-Control"] = "no-store"

--- a/server/coding_runtime/api.py
+++ b/server/coding_runtime/api.py
@@ -1318,6 +1318,149 @@ class CodingService:
                 self._sessions[session_id] = record
             return record
 
+    async def adopt_worker_patch(
+        self,
+        *,
+        project_id: str,
+        expected_head: str,
+        patch: str,
+        paths: list[str],
+    ) -> CodingApiSession:
+        """Import a completed V14 patch into the existing v13 writeback chain."""
+
+        async with self._create_lock:
+            return await self._adopt_worker_patch_locked(
+                project_id=project_id,
+                expected_head=expected_head,
+                patch=patch,
+                paths=paths,
+            )
+
+    async def _adopt_worker_patch_locked(
+        self,
+        *,
+        project_id: str,
+        expected_head: str,
+        patch: str,
+        paths: list[str],
+    ) -> CodingApiSession:
+        if "GIT binary patch" in patch or "Binary files " in patch:
+            raise _http_error(
+                status.HTTP_409_CONFLICT, "worker_writeback_patch_unsupported"
+            )
+
+        await self._require_available()
+        if self.mode != "draft":
+            raise _http_error(status.HTTP_409_CONFLICT, "draft_unavailable")
+        if not self.recovery_enabled or self.recovery_store is None:
+            raise _http_error(
+                status.HTTP_503_SERVICE_UNAVAILABLE,
+                self.recovery_reason or "recovery_unavailable",
+            )
+        safe_patch = _safe_diff(patch)
+        safe_paths = _diff_paths(safe_patch)
+        if not safe_patch or safe_paths != paths:
+            raise _http_error(
+                status.HTTP_409_CONFLICT, "worker_writeback_patch_unsupported"
+            )
+        await self.cleanup_expired()
+        if await self._load_recovery_record() is not None:
+            raise _http_error(status.HTTP_409_CONFLICT, "recovery_pending")
+        async with self._lock:
+            if self._sessions:
+                raise _http_error(status.HTTP_409_CONFLICT, "concurrency_limit")
+
+        source: dict[str, Any] | None = None
+        try:
+            source, project = await self._acquire_host_project(
+                project_id,
+                expected_head=expected_head,
+            )
+            fingerprint = source.get("fingerprint")
+            if (
+                not isinstance(fingerprint, str)
+                or SNAPSHOT_FINGERPRINT_PATTERN.fullmatch(fingerprint) is None
+            ):
+                raise _http_error(
+                    status.HTTP_503_SERVICE_UNAVAILABLE,
+                    "invalid_project_source_response",
+                )
+            result = await self.worker.restore_session(
+                revision=1,
+                patch=safe_patch,
+                paths=safe_paths,
+                snapshot_fingerprint=fingerprint,
+                verification=None,
+                source=source,
+            )
+        except CodingWorkerError as exc:
+            await self._release_project_source(source)
+            raise _worker_http_error(exc) from exc
+        except Exception:
+            await self._release_project_source(source)
+            raise
+
+        session_id = result.get("session_id")
+        event_data = result.get("event")
+        restored_changes = _public_changes(result.get("changes"))
+        if (
+            not isinstance(session_id, str)
+            or SAFE_IDENTIFIER.fullmatch(session_id) is None
+            or result.get("mode") != self.mode
+            or not isinstance(event_data, dict)
+            or not _worker_project_matches(result.get("project"), project)
+            or restored_changes["revision"] != 1
+            or [item["path"] for item in restored_changes["files"]] != safe_paths
+            or restored_changes["can_download"] is not True
+        ):
+            if isinstance(session_id, str) and session_id:
+                await self._close_worker_session_and_release(
+                    session_id, source, required=False
+                )
+            else:
+                await self._release_project_source(source)
+            raise _http_error(
+                status.HTTP_503_SERVICE_UNAVAILABLE, "invalid_worker_response"
+            )
+        record = CodingApiSession(
+            session_id=session_id,
+            worker_session_id=session_id,
+            project=project,
+            project_source=source,
+        )
+        initial = _event_from_payload(event_data)
+        if (
+            initial.kind is not CodingEventKind.SESSION_STARTED
+            or initial.seq != 1
+            or initial.session_id != session_id
+        ):
+            await self._close_worker_session_and_release(
+                session_id, source, required=False
+            )
+            raise _http_error(
+                status.HTTP_503_SERVICE_UNAVAILABLE, "invalid_worker_response"
+            )
+        await self._append_event(record, initial)
+        try:
+            persisted = await self._persist_recovery(record, required=True)
+            if not persisted:
+                raise _http_error(
+                    status.HTTP_503_SERVICE_UNAVAILABLE,
+                    "recovery_storage_unavailable",
+                )
+            async with self._lock:
+                if self._sessions:
+                    raise _http_error(
+                        status.HTTP_409_CONFLICT, "concurrency_limit"
+                    )
+                self._sessions[session_id] = record
+        except Exception:
+            await self._close_worker_session_and_release(
+                session_id, source, required=False
+            )
+            raise
+        return record
+
     async def _acquire_host_project(
         self,
         project_id: str,
@@ -5152,6 +5295,76 @@ async def create_coding_session(
         "status": record.state,
         "project": record.project,
     }
+
+
+@router.post(
+    "/worker-tasks/{task_id}/handoff",
+    status_code=status.HTTP_201_CREATED,
+)
+async def handoff_coding_worker_task(task_id: str) -> dict[str, Any]:
+    try:
+        try:
+            from server.coding_worker.api import get_coding_worker_service
+            from server.coding_worker.contracts import TaskState
+        except ModuleNotFoundError:
+            from coding_worker.api import get_coding_worker_service
+            from coding_worker.contracts import TaskState
+
+        worker_service = get_coding_worker_service()
+        task = worker_service.store.get_task(task_id)
+        if (
+            task.state is not TaskState.COMPLETED
+            or task.workspace_id is None
+            or task.spec.workspace_source.kind != "host_snapshot"
+        ):
+            raise _http_error(
+                status.HTTP_409_CONFLICT, "worker_task_not_writeback_ready"
+            )
+        if (
+            worker_service.harness_runner is None
+            or not worker_service.harness_runner.acceptance_satisfied(task_id)
+        ):
+            raise _http_error(
+                status.HTTP_409_CONFLICT, "worker_acceptance_invalidated"
+            )
+        patch_bytes = worker_service.workspace_broker.diff(task.workspace_id)
+        try:
+            patch = patch_bytes.decode("utf-8", errors="strict")
+        except UnicodeDecodeError as exc:
+            raise _http_error(
+                status.HTTP_409_CONFLICT, "worker_writeback_patch_unsupported"
+            ) from exc
+        if not worker_service.harness_runner.acceptance_satisfied(task_id):
+            raise _http_error(
+                status.HTTP_409_CONFLICT, "worker_acceptance_invalidated"
+            )
+        paths = _diff_paths(patch)
+        if not paths:
+            raise _http_error(status.HTTP_409_CONFLICT, "draft_is_empty")
+        record = await get_coding_service().adopt_worker_patch(
+            project_id=task.spec.workspace_source.source_id,
+            expected_head=task.spec.workspace_source.revision,
+            patch=patch,
+            paths=paths,
+        )
+        changes = await get_coding_service().changes(record.session_id)
+        return {
+            "id": record.session_id,
+            "status": record.state,
+            "project": record.project,
+            "revision": changes["revision"],
+            "task_id": task_id,
+        }
+    except HTTPException:
+        raise
+    except Exception as exc:
+        code = getattr(exc, "code", "worker_handoff_failed")
+        http_status = (
+            status.HTTP_404_NOT_FOUND
+            if code in {"task_not_found", "workspace_not_found"}
+            else status.HTTP_409_CONFLICT
+        )
+        raise _http_error(http_status, _safe_code(code)) from exc
 
 
 @router.post(

--- a/server/coding_runtime/project_host_api.py
+++ b/server/coding_runtime/project_host_api.py
@@ -173,6 +173,20 @@ class ProjectHostRuntime:
             project.to_public_dict(host_online=host.status == "online")
         )
 
+    def worker_source(self, project_id: str) -> dict[str, str]:
+        project = self.store.require_project(project_id)
+        host = self.store.require_host(project.host_id)
+        if host.status != "online":
+            raise ProjectHostError("project_host_offline")
+        if project.state != "available":
+            raise ProjectHostError(project.reason or "project_changed")
+        return {
+            "source_id": project.project_id,
+            "name": project.name,
+            "branch": project.branch,
+            "revision": project.head,
+        }
+
     def check_project(self, project_id: str, head: str, branch: str | None) -> dict[str, Any]:
         project = self.store.require_project(project_id)
         host = self.store.require_host(project.host_id)

--- a/server/coding_worker/Dockerfile.v14
+++ b/server/coding_worker/Dockerfile.v14
@@ -1,0 +1,41 @@
+FROM node:22-bookworm-slim AS opencode_runtime
+
+ARG OPENCODE_VERSION=1.18.9
+ARG OPENCODE_INTEGRITY=sha512-tqvu/hJ26c2dBj/V/uTHaQI3bMSpLck0hIgGXO2z7b11s5mYfnaq+K1CBjsg8Pp6EirfzwUYGzi85K/SvOgkKg==
+
+RUN npm pack "opencode-ai@${OPENCODE_VERSION}" --pack-destination /tmp \
+    && node -e "const fs=require('fs');const crypto=require('crypto');const p='/tmp/opencode-ai-${OPENCODE_VERSION}.tgz';const actual='sha512-'+crypto.createHash('sha512').update(fs.readFileSync(p)).digest('base64');if(actual!=='${OPENCODE_INTEGRITY}'){throw new Error('OpenCode package integrity mismatch')}" \
+    && npm install --global "/tmp/opencode-ai-${OPENCODE_VERSION}.tgz" \
+    && test "$(opencode --version)" = "${OPENCODE_VERSION}"
+
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    CODING_WORKER_SLOT_ROOT=/worker-data \
+    CODING_WORKER_RUNTIME_ROOT=/worker-runtime
+
+COPY --from=opencode_runtime /usr/local/bin/node /usr/local/bin/node
+COPY --from=opencode_runtime /usr/local/lib/node_modules /usr/local/lib/node_modules
+
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends ca-certificates git ripgrep \
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+    && ln -s ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx \
+    && ln -s ../lib/node_modules/opencode-ai/bin/opencode.exe /usr/local/bin/opencode \
+    && groupadd --gid 65532 coding \
+    && useradd --uid 65532 --gid 65532 --home-dir /home/coding --no-create-home coding \
+    && mkdir -p /opt/modelmirror /home/coding /worker-data /worker-runtime /run/modelmirror-coding \
+    && chown -R 65532:65532 /home/coding /worker-data /worker-runtime /run/modelmirror-coding
+
+WORKDIR /opt/modelmirror
+COPY server/requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir --retries 5 --timeout 120 -r /tmp/requirements.txt
+
+COPY server/coding_worker ./coding_worker
+COPY server/THIRD_PARTY_NOTICES.md /usr/share/doc/modelmirror-coding/THIRD_PARTY_NOTICES.md
+
+USER 65532:65532
+
+CMD ["python", "-m", "coding_worker.sidecar"]

--- a/server/coding_worker/__init__.py
+++ b/server/coding_worker/__init__.py
@@ -14,6 +14,7 @@ from .contracts import (
     WorkspaceSource,
 )
 from .provider import CodingAgentProvider, FakeCodingAgentProvider
+from .evidence import HarnessRunner
 from .opencode_provider import OpenCodeProvider
 from .service import CodingWorkerService
 from .store import CodingWorkerStore
@@ -27,6 +28,7 @@ __all__ = [
     "CodingWorkerService",
     "CodingWorkerStore",
     "FrozenCheck",
+    "HarnessRunner",
     "ToolBroker",
     "ToolBrokerError",
     "ToolResult",

--- a/server/coding_worker/__init__.py
+++ b/server/coding_worker/__init__.py
@@ -15,6 +15,7 @@ from .contracts import (
 )
 from .provider import CodingAgentProvider, FakeCodingAgentProvider
 from .evidence import HarnessRunner
+from .network_policy import EgressPolicy, NetworkPolicyError
 from .opencode_provider import OpenCodeProvider
 from .service import CodingWorkerService
 from .store import CodingWorkerStore
@@ -29,6 +30,8 @@ __all__ = [
     "CodingWorkerStore",
     "FrozenCheck",
     "HarnessRunner",
+    "EgressPolicy",
+    "NetworkPolicyError",
     "ToolBroker",
     "ToolBrokerError",
     "ToolResult",

--- a/server/coding_worker/__init__.py
+++ b/server/coding_worker/__init__.py
@@ -16,6 +16,7 @@ from .contracts import (
 from .provider import CodingAgentProvider, FakeCodingAgentProvider
 from .evidence import HarnessRunner
 from .network_policy import EgressPolicy, NetworkPolicyError
+from .process_manager import BackgroundProcessManager, ManagedProcess, ProcessManagerError
 from .opencode_provider import OpenCodeProvider
 from .service import CodingWorkerService
 from .store import CodingWorkerStore
@@ -32,6 +33,9 @@ __all__ = [
     "HarnessRunner",
     "EgressPolicy",
     "NetworkPolicyError",
+    "BackgroundProcessManager",
+    "ManagedProcess",
+    "ProcessManagerError",
     "ToolBroker",
     "ToolBrokerError",
     "ToolResult",

--- a/server/coding_worker/__init__.py
+++ b/server/coding_worker/__init__.py
@@ -17,6 +17,7 @@ from .provider import CodingAgentProvider, FakeCodingAgentProvider
 from .opencode_provider import OpenCodeProvider
 from .service import CodingWorkerService
 from .store import CodingWorkerStore
+from .tool_broker import FrozenCheck, ToolBroker, ToolBrokerError, ToolResult
 from .workspace import WorkspaceBroker
 
 __all__ = [
@@ -25,6 +26,10 @@ __all__ = [
     "CodingAgentProvider",
     "CodingWorkerService",
     "CodingWorkerStore",
+    "FrozenCheck",
+    "ToolBroker",
+    "ToolBrokerError",
+    "ToolResult",
     "ContextReference",
     "FakeCodingAgentProvider",
     "OpenCodeProvider",

--- a/server/coding_worker/__init__.py
+++ b/server/coding_worker/__init__.py
@@ -14,6 +14,7 @@ from .contracts import (
     WorkspaceSource,
 )
 from .provider import CodingAgentProvider, FakeCodingAgentProvider
+from .opencode_provider import OpenCodeProvider
 from .service import CodingWorkerService
 from .store import CodingWorkerStore
 from .workspace import WorkspaceBroker
@@ -26,6 +27,7 @@ __all__ = [
     "CodingWorkerStore",
     "ContextReference",
     "FakeCodingAgentProvider",
+    "OpenCodeProvider",
     "Origin",
     "PolicyProfile",
     "TaskBudget",

--- a/server/coding_worker/__init__.py
+++ b/server/coding_worker/__init__.py
@@ -17,6 +17,7 @@ from .provider import CodingAgentProvider, FakeCodingAgentProvider
 from .evidence import HarnessRunner
 from .network_policy import EgressPolicy, NetworkPolicyError
 from .process_manager import BackgroundProcessManager, ManagedProcess, ProcessManagerError
+from .broker_rpc import BrokerRPCClient, BrokerRPCError, BrokerRPCServer
 from .opencode_provider import OpenCodeProvider
 from .service import CodingWorkerService
 from .store import CodingWorkerStore
@@ -36,6 +37,9 @@ __all__ = [
     "BackgroundProcessManager",
     "ManagedProcess",
     "ProcessManagerError",
+    "BrokerRPCClient",
+    "BrokerRPCError",
+    "BrokerRPCServer",
     "ToolBroker",
     "ToolBrokerError",
     "ToolResult",

--- a/server/coding_worker/api.py
+++ b/server/coding_worker/api.py
@@ -5,13 +5,21 @@ import json
 import os
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from typing import Any
+from typing import Any, Literal
 
 from fastapi import APIRouter, HTTPException, Query, Request, Response
 from fastapi.responses import StreamingResponse
 from pydantic import Field
 
-from .contracts import Origin, StrictModel, TaskCreateRequest, TaskRecord, TERMINAL_STATES
+from .contracts import (
+    Origin,
+    StrictModel,
+    TaskCreateRequest,
+    TaskRecord,
+    TaskState,
+    TERMINAL_STATES,
+    WorkerApproval,
+)
 from .service import CodingWorkerService
 from .store import WorkerConflictError, WorkerNotFoundError, WorkerStoreError
 from .workspace import WorkspaceError
@@ -19,6 +27,12 @@ from .workspace import WorkspaceError
 
 class TaskMessageRequest(StrictModel):
     message: str = Field(min_length=1, max_length=1_048_576)
+
+
+class ApprovalDecisionRequest(StrictModel):
+    approval_id: str = Field(pattern=r"^approval_[a-f0-9]{32}$")
+    decision: Literal["approve_once", "approve_task", "reject"]
+    ttl_seconds: int = Field(default=900, ge=30, le=3600)
 
 
 _service: CodingWorkerService | None = None
@@ -177,6 +191,41 @@ async def task_events(
 async def append_task_message(task_id: str, payload: TaskMessageRequest) -> TaskRecord:
     try:
         return await get_coding_worker_service().append_message(task_id, payload.message)
+    except Exception as exc:
+        _raise_worker_error(exc)
+
+
+@router.get("/tasks/{task_id}/approvals", response_model=dict[str, list[WorkerApproval]])
+async def task_approvals(task_id: str) -> dict[str, list[WorkerApproval]]:
+    try:
+        return {"approvals": get_coding_worker_service().store.list_approvals(task_id)}
+    except Exception as exc:
+        _raise_worker_error(exc)
+
+
+@router.post("/tasks/{task_id}/approvals", response_model=WorkerApproval)
+async def decide_task_approval(
+    task_id: str, payload: ApprovalDecisionRequest
+) -> WorkerApproval:
+    service = get_coding_worker_service()
+    try:
+        approval = service.store.get_approval(payload.approval_id)
+        if approval.task_id != task_id:
+            raise WorkerNotFoundError("Approval was not found.", code="approval_not_found")
+        decided = service.store.decide_approval(
+            payload.approval_id,
+            approved=payload.decision != "reject",
+            task_scope=payload.decision == "approve_task",
+            ttl_seconds=payload.ttl_seconds,
+        )
+        task = service.store.get_task(task_id)
+        if task.state is TaskState.WAITING_APPROVAL:
+            service.store.transition(
+                task_id,
+                TaskState.RUNNING,
+                expected_state=TaskState.WAITING_APPROVAL,
+            )
+        return decided
     except Exception as exc:
         _raise_worker_error(exc)
 

--- a/server/coding_worker/api.py
+++ b/server/coding_worker/api.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+from pathlib import PurePosixPath
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Any, Literal
 
 from fastapi import APIRouter, HTTPException, Query, Request, Response
 from fastapi.responses import StreamingResponse
+import httpx
 from pydantic import Field
 
 from .contracts import (
@@ -412,6 +414,89 @@ async def workspace_diff(task_id: str) -> Response:
         )
     except Exception as exc:
         _raise_worker_error(exc)
+
+
+@router.get("/tasks/{task_id}/services/{service_id}/preview/{preview_path:path}")
+async def service_preview(
+    task_id: str,
+    service_id: str,
+    preview_path: str,
+    request: Request,
+) -> Response:
+    service, task = _task_workspace(task_id)
+    try:
+        if service.tool_broker is None or service.tool_broker.executor is None:
+            raise WorkerConflictError(
+                "Preview service is unavailable.", code="preview_unavailable"
+            )
+        path = PurePosixPath(preview_path or ".")
+        if "\\" in preview_path or any(part == ".." for part in path.parts):
+            raise WorkerConflictError(
+                "Preview path is invalid.", code="preview_path_invalid"
+            )
+        result = await service.tool_broker.executor.service_status(
+            task_id=task_id,
+            workspace_id=task.workspace_id,
+            service_id=service_id,
+        )
+        port = result.get("preview_port")
+        if result.get("state") != "running" or isinstance(port, bool) or not isinstance(port, int):
+            raise WorkerConflictError(
+                "Preview service is not running.", code="preview_unavailable"
+            )
+        slot_id = service.workspace_broker.workspace_slot(task.workspace_id)
+        host = os.getenv(
+            f"CODING_WORKER_{slot_id.replace('-', '_').upper()}_PREVIEW_HOST",
+            f"coding-worker-{slot_id}",
+        )
+        query = request.url.query
+        upstream = await _fetch_preview(
+            f"http://{host}:{port}/{preview_path}" + (f"?{query}" if query else "")
+        )
+        if 300 <= upstream.status_code < 400:
+            raise WorkerConflictError(
+                "Preview redirects are not allowed.", code="preview_redirect_denied"
+            )
+        return Response(
+            upstream.content,
+            status_code=upstream.status_code,
+            media_type=upstream.headers.get("content-type", "application/octet-stream"),
+            headers={
+                "Cache-Control": "no-store",
+                "Content-Security-Policy": "sandbox allow-scripts allow-forms; default-src 'self' data: blob:; connect-src 'self'; frame-ancestors 'self'",
+                "X-Content-Type-Options": "nosniff",
+            },
+        )
+    except Exception as exc:
+        _raise_worker_error(exc)
+
+
+async def _fetch_preview(url: str) -> httpx.Response:
+    async with httpx.AsyncClient(
+        timeout=httpx.Timeout(15.0, connect=3.0),
+        follow_redirects=False,
+        trust_env=False,
+    ) as client:
+        request = client.build_request("GET", url)
+        response = await client.send(request, stream=True)
+        try:
+            chunks: list[bytes] = []
+            size = 0
+            async for chunk in response.aiter_bytes(64 * 1024):
+                size += len(chunk)
+                if size > 4 * 1024 * 1024:
+                    raise WorkerConflictError(
+                        "Preview response is too large.",
+                        code="preview_response_too_large",
+                    )
+                chunks.append(chunk)
+            return httpx.Response(
+                response.status_code,
+                headers=response.headers,
+                content=b"".join(chunks),
+            )
+        finally:
+            await response.aclose()
 
 
 def _task_workspace(task_id: str) -> tuple[CodingWorkerService, TaskRecord]:

--- a/server/coding_worker/api.py
+++ b/server/coding_worker/api.py
@@ -148,7 +148,7 @@ async def coding_worker_status() -> dict[str, Any]:
         "retention_seconds": (
             _service.store.retention_seconds if _service is not None else 604800
         ),
-        "network_enabled": False,
+        "network_enabled": _runtime.network_enabled if _runtime is not None else False,
         "reason": _startup_error,
     }
 

--- a/server/coding_worker/api.py
+++ b/server/coding_worker/api.py
@@ -151,6 +151,11 @@ async def coding_worker_status() -> dict[str, Any]:
             _service.store.retention_seconds if _service is not None else 604800
         ),
         "network_enabled": _runtime.network_enabled if _runtime is not None else False,
+        "acceptance_checks": (
+            sorted(_service.tool_broker.frozen_checks)
+            if _service is not None and _service.tool_broker is not None
+            else []
+        ),
         "reason": _startup_error,
     }
 

--- a/server/coding_worker/api.py
+++ b/server/coding_worker/api.py
@@ -23,6 +23,7 @@ from .contracts import (
     WorkerEvidence,
 )
 from .service import CodingWorkerService
+from .runtime import CodingWorkerRuntime, build_runtime_from_environment
 from .store import WorkerConflictError, WorkerNotFoundError, WorkerStoreError
 from .workspace import WorkspaceError
 
@@ -39,14 +40,32 @@ class ApprovalDecisionRequest(StrictModel):
 
 _service: CodingWorkerService | None = None
 _enabled_override: bool | None = None
+_runtime: CodingWorkerRuntime | None = None
+_startup_error: str | None = None
 _CONSOLE_ORIGIN = Origin(module="worker-console", object_id="local-user")
 
 
 @asynccontextmanager
 async def _lifespan(_app: object) -> AsyncIterator[None]:
-    yield
-    if _service is not None:
-        await _service.shutdown()
+    global _service, _runtime, _startup_error
+    if is_coding_worker_enabled() and _service is None:
+        try:
+            _runtime = build_runtime_from_environment()
+            _service = await _runtime.start()
+            _startup_error = None
+        except Exception as exc:
+            _startup_error = getattr(
+                exc, "code", "coding_worker_provider_unavailable"
+            )
+    try:
+        yield
+    finally:
+        if _runtime is not None:
+            await _runtime.close()
+            _runtime = None
+            _service = None
+        elif _service is not None:
+            await _service.shutdown()
 
 
 router = APIRouter(
@@ -70,9 +89,10 @@ def is_coding_worker_enabled() -> bool:
 def configure_coding_worker_for_tests(
     service: CodingWorkerService | None, *, enabled: bool | None = None
 ) -> None:
-    global _service, _enabled_override
+    global _service, _enabled_override, _startup_error
     _service = service
     _enabled_override = enabled
+    _startup_error = None
 
 
 def get_coding_worker_service() -> CodingWorkerService:
@@ -82,7 +102,8 @@ def get_coding_worker_service() -> CodingWorkerService:
             status_code=503,
             detail={
                 "code": "coding_worker_provider_unavailable",
-                "message": "The V14 Worker provider is not configured yet.",
+                "message": "The V14 Worker provider is unavailable.",
+                "reason": _startup_error,
             },
         )
     return _service
@@ -128,6 +149,7 @@ async def coding_worker_status() -> dict[str, Any]:
             _service.store.retention_seconds if _service is not None else 604800
         ),
         "network_enabled": False,
+        "reason": _startup_error,
     }
 
 

--- a/server/coding_worker/api.py
+++ b/server/coding_worker/api.py
@@ -19,6 +19,8 @@ from .contracts import (
     TaskState,
     TERMINAL_STATES,
     WorkerApproval,
+    WorkerArtifact,
+    WorkerEvidence,
 )
 from .service import CodingWorkerService
 from .store import WorkerConflictError, WorkerNotFoundError, WorkerStoreError
@@ -226,6 +228,64 @@ async def decide_task_approval(
                 expected_state=TaskState.WAITING_APPROVAL,
             )
         return decided
+    except Exception as exc:
+        _raise_worker_error(exc)
+
+
+@router.get(
+    "/tasks/{task_id}/evidence", response_model=dict[str, list[WorkerEvidence]]
+)
+async def task_evidence(task_id: str) -> dict[str, list[WorkerEvidence]]:
+    service = get_coding_worker_service()
+    try:
+        task = service.store.get_task(task_id)
+        tree_hash = (
+            service.workspace_broker.current_tree_hash(task.workspace_id)
+            if task.workspace_id is not None
+            else None
+        )
+        return {
+            "evidence": service.store.list_evidence(
+                task_id, current_tree_hash=tree_hash
+            )
+        }
+    except Exception as exc:
+        _raise_worker_error(exc)
+
+
+@router.get(
+    "/tasks/{task_id}/artifacts", response_model=dict[str, list[WorkerArtifact]]
+)
+async def task_artifacts(task_id: str) -> dict[str, list[WorkerArtifact]]:
+    try:
+        return {"artifacts": get_coding_worker_service().store.list_artifacts(task_id)}
+    except Exception as exc:
+        _raise_worker_error(exc)
+
+
+@router.get("/tasks/{task_id}/artifacts/{artifact_id}")
+async def task_artifact(task_id: str, artifact_id: str) -> Response:
+    service = get_coding_worker_service()
+    try:
+        artifact = next(
+            (
+                item
+                for item in service.store.list_artifacts(task_id)
+                if item.artifact_id == artifact_id
+            ),
+            None,
+        )
+        if artifact is None:
+            raise WorkerNotFoundError("Artifact was not found.", code="artifact_not_found")
+        content = service.store.read_artifact(artifact_id, task_id=task_id)
+        return Response(
+            content,
+            media_type=artifact.media_type,
+            headers={
+                "Cache-Control": "no-store",
+                "Content-Disposition": f'attachment; filename="{artifact_id}.bin"',
+            },
+        )
     except Exception as exc:
         _raise_worker_error(exc)
 

--- a/server/coding_worker/broker_mcp.py
+++ b/server/coding_worker/broker_mcp.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import os
+import uuid
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from .broker_rpc import BrokerRPCClient
+
+
+def build_server(client: BrokerRPCClient) -> FastMCP:
+    mcp = FastMCP("ModelMirror Coding Worker Tools")
+
+    async def call(
+        tool_name: str,
+        arguments: dict[str, Any],
+        *,
+        operation_id: str | None = None,
+        lease_id: str | None = None,
+        network_lease_id: str | None = None,
+    ) -> dict[str, Any]:
+        return await client.call(
+            operation_id=operation_id or f"inspect_{uuid.uuid4().hex}",
+            tool_name=tool_name,
+            arguments=arguments,
+            lease_id=lease_id,
+            network_lease_id=network_lease_id,
+        )
+
+    @mcp.tool()
+    async def list_files() -> dict[str, Any]:
+        """List task workspace entries using opaque, workspace-relative identities."""
+        return await call("list_files", {})
+
+    @mcp.tool()
+    async def read_file(path: str) -> dict[str, Any]:
+        """Read one workspace-relative text file or return binary metadata."""
+        return await call("read_file", {"path": path})
+
+    @mcp.tool()
+    async def search_text(query: str) -> dict[str, Any]:
+        """Search text inside the current task workspace."""
+        return await call("search_text", {"query": query})
+
+    @mcp.tool()
+    async def workspace_diff() -> dict[str, Any]:
+        """Return the current synthetic-H0 Git diff."""
+        return await call("diff", {})
+
+    @mcp.tool()
+    async def write_file(
+        operation_id: str, path: str, content: str, content_sha256: str
+    ) -> dict[str, Any]:
+        """Atomically write UTF-8 text using a stable operation id and content digest."""
+        return await call(
+            "write_file",
+            {"path": path, "content": content, "content_sha256": content_sha256},
+            operation_id=operation_id,
+        )
+
+    @mcp.tool()
+    async def delete_file(
+        operation_id: str, path: str, expected_sha256: str
+    ) -> dict[str, Any]:
+        """Delete an unchanged workspace file using a stable operation id."""
+        return await call(
+            "delete_file",
+            {"path": path, "expected_sha256": expected_sha256},
+            operation_id=operation_id,
+        )
+
+    @mcp.tool()
+    async def run_check(check_id: str) -> dict[str, Any]:
+        """Run one immutable server-defined acceptance check."""
+        return await call("run_check", {"check_id": check_id})
+
+    @mcp.tool()
+    async def run_command(
+        operation_id: str,
+        argv: list[str],
+        lease_id: str,
+        timeout_seconds: int = 300,
+    ) -> dict[str, Any]:
+        """Run an argv-only command after an exact command lease is approved."""
+        return await call(
+            "run_command",
+            {"argv": argv, "timeout_seconds": timeout_seconds},
+            operation_id=operation_id,
+            lease_id=lease_id,
+        )
+
+    @mcp.tool()
+    async def install_dependencies(
+        operation_id: str, lease_id: str, network_lease_id: str
+    ) -> dict[str, Any]:
+        """Run frozen npm-ci through the approved egress lease and proxy."""
+        return await call(
+            "install_dependencies",
+            {"manager": "npm", "action": "ci"},
+            operation_id=operation_id,
+            lease_id=lease_id,
+            network_lease_id=network_lease_id,
+        )
+
+    @mcp.tool()
+    async def start_service(
+        operation_id: str,
+        argv: list[str],
+        lease_id: str,
+        ttl_seconds: int = 900,
+    ) -> dict[str, Any]:
+        """Start one approved task-owned background service."""
+        return await call(
+            "start_service",
+            {"argv": argv, "ttl_seconds": ttl_seconds},
+            operation_id=operation_id,
+            lease_id=lease_id,
+        )
+
+    @mcp.tool()
+    async def service_status(service_id: str) -> dict[str, Any]:
+        """Read task-owned service state without exposing its process id."""
+        return await call("service_status", {"service_id": service_id})
+
+    @mcp.tool()
+    async def service_input(
+        operation_id: str, service_id: str, data: str
+    ) -> dict[str, Any]:
+        """Send bounded input to a task-owned service."""
+        return await call(
+            "service_input",
+            {"service_id": service_id, "data": data},
+            operation_id=operation_id,
+        )
+
+    @mcp.tool()
+    async def stop_service(operation_id: str, service_id: str) -> dict[str, Any]:
+        """Send Ctrl-C to a task-owned service and archive its output."""
+        return await call(
+            "stop_service",
+            {"service_id": service_id},
+            operation_id=operation_id,
+        )
+
+    return mcp
+
+
+def main() -> None:
+    endpoint = os.environ.get("CODING_WORKER_BROKER_ENDPOINT", "")
+    token = os.environ.get("CODING_WORKER_BROKER_TOKEN", "")
+    task_id = os.environ.get("CODING_WORKER_TASK_ID", "")
+    if not endpoint or not token or not task_id:
+        raise SystemExit("Coding Worker broker binding is unavailable")
+    build_server(BrokerRPCClient(endpoint, token=token, task_id=task_id)).run()
+
+
+if __name__ == "__main__":
+    main()

--- a/server/coding_worker/broker_mcp.py
+++ b/server/coding_worker/broker_mcp.py
@@ -109,11 +109,16 @@ def build_server(client: BrokerRPCClient) -> FastMCP:
         argv: list[str],
         lease_id: str,
         ttl_seconds: int = 900,
+        preview_port: int | None = None,
     ) -> dict[str, Any]:
         """Start one approved task-owned background service."""
         return await call(
             "start_service",
-            {"argv": argv, "ttl_seconds": ttl_seconds},
+            {
+                "argv": argv,
+                "ttl_seconds": ttl_seconds,
+                "preview_port": preview_port,
+            },
             operation_id=operation_id,
             lease_id=lease_id,
         )

--- a/server/coding_worker/broker_mcp.py
+++ b/server/coding_worker/broker_mcp.py
@@ -71,47 +71,45 @@ def build_server(client: BrokerRPCClient) -> FastMCP:
         )
 
     @mcp.tool()
+    async def list_acceptance_checks() -> dict[str, Any]:
+        """List the immutable acceptance checks allowed for this task."""
+        return await call("list_acceptance_checks", {})
+
+    @mcp.tool()
     async def run_check(check_id: str) -> dict[str, Any]:
-        """Run one immutable server-defined acceptance check."""
+        """Run one check returned by list_acceptance_checks."""
         return await call("run_check", {"check_id": check_id})
 
     @mcp.tool()
     async def run_command(
         operation_id: str,
         argv: list[str],
-        lease_id: str,
         timeout_seconds: int = 300,
     ) -> dict[str, Any]:
-        """Run an argv-only command after an exact command lease is approved."""
+        """Request approval, then run one exact argv-only command."""
         return await call(
             "run_command",
             {"argv": argv, "timeout_seconds": timeout_seconds},
             operation_id=operation_id,
-            lease_id=lease_id,
         )
 
     @mcp.tool()
-    async def install_dependencies(
-        operation_id: str, lease_id: str, network_lease_id: str
-    ) -> dict[str, Any]:
-        """Run frozen npm-ci through the approved egress lease and proxy."""
+    async def install_dependencies(operation_id: str) -> dict[str, Any]:
+        """Request approval, then run frozen npm-ci through controlled egress."""
         return await call(
             "install_dependencies",
             {"manager": "npm", "action": "ci"},
             operation_id=operation_id,
-            lease_id=lease_id,
-            network_lease_id=network_lease_id,
         )
 
     @mcp.tool()
     async def start_service(
         operation_id: str,
         argv: list[str],
-        lease_id: str,
         ttl_seconds: int = 900,
         preview_port: int | None = None,
     ) -> dict[str, Any]:
-        """Start one approved task-owned background service."""
+        """Request approval, then start one task-owned background service."""
         return await call(
             "start_service",
             {
@@ -120,7 +118,6 @@ def build_server(client: BrokerRPCClient) -> FastMCP:
                 "preview_port": preview_port,
             },
             operation_id=operation_id,
-            lease_id=lease_id,
         )
 
     @mcp.tool()

--- a/server/coding_worker/broker_mcp.py
+++ b/server/coding_worker/broker_mcp.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import os
 import uuid
 from typing import Any
@@ -49,10 +50,9 @@ def build_server(client: BrokerRPCClient) -> FastMCP:
         return await call("diff", {})
 
     @mcp.tool()
-    async def write_file(
-        operation_id: str, path: str, content: str, content_sha256: str
-    ) -> dict[str, Any]:
-        """Atomically write UTF-8 text using a stable operation id and content digest."""
+    async def write_file(operation_id: str, path: str, content: str) -> dict[str, Any]:
+        """Atomically write UTF-8 text using a stable operation id."""
+        content_sha256 = hashlib.sha256(content.encode("utf-8")).hexdigest()
         return await call(
             "write_file",
             {"path": path, "content": content, "content_sha256": content_sha256},

--- a/server/coding_worker/broker_rpc.py
+++ b/server/coding_worker/broker_rpc.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import secrets
+from pathlib import Path
+from typing import Any
+
+from pydantic import Field
+
+from .contracts import StrictModel
+from .tool_broker import ToolBroker, ToolBrokerError
+
+
+MAX_RPC_BYTES = 1024 * 1024
+
+
+class BrokerRPCError(RuntimeError):
+    def __init__(self, message: str, *, code: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+class BrokerRPCRequest(StrictModel):
+    token: str = Field(min_length=32, max_length=256)
+    task_id: str
+    operation_id: str
+    tool_name: str
+    arguments: dict[str, Any] = Field(default_factory=dict)
+    lease_id: str | None = None
+    network_lease_id: str | None = None
+
+
+class BrokerRPCServer:
+    """Authenticated internal RPC boundary used by the task-local MCP process."""
+
+    def __init__(self, broker: ToolBroker) -> None:
+        self.broker = broker
+        self._tokens: dict[str, str] = {}
+        self._server: asyncio.AbstractServer | None = None
+        self.endpoint: str | None = None
+
+    def register_task(self, task_id: str) -> str:
+        self.broker.store.get_task(task_id)
+        token = secrets.token_urlsafe(48)
+        self._tokens[task_id] = token
+        return token
+
+    def revoke_task(self, task_id: str) -> None:
+        self._tokens.pop(task_id, None)
+
+    async def start_unix(self, socket_path: Path) -> str:
+        if self._server is not None:
+            raise RuntimeError("broker RPC server is already running")
+        socket_path = Path(socket_path)
+        socket_path.parent.mkdir(parents=True, exist_ok=True)
+        socket_path.unlink(missing_ok=True)
+        self._server = await asyncio.start_unix_server(
+            self._handle, path=str(socket_path), limit=MAX_RPC_BYTES
+        )
+        socket_path.chmod(0o600)
+        self.endpoint = f"unix:{socket_path}"
+        return self.endpoint
+
+    async def start_tcp_for_tests(self) -> str:
+        if self._server is not None:
+            raise RuntimeError("broker RPC server is already running")
+        self._server = await asyncio.start_server(
+            self._handle, "127.0.0.1", 0, limit=MAX_RPC_BYTES
+        )
+        address = self._server.sockets[0].getsockname()
+        self.endpoint = f"tcp:127.0.0.1:{address[1]}"
+        return self.endpoint
+
+    async def close(self) -> None:
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+        self._server = None
+        self.endpoint = None
+        self._tokens.clear()
+
+    async def _handle(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        response: dict[str, Any]
+        try:
+            raw = await reader.readline()
+            if not raw or len(raw) > MAX_RPC_BYTES or not raw.endswith(b"\n"):
+                raise BrokerRPCError("Broker request is invalid.", code="broker_request_invalid")
+            request = BrokerRPCRequest.model_validate_json(raw)
+            expected = self._tokens.get(request.task_id)
+            if expected is None or not secrets.compare_digest(expected, request.token):
+                raise BrokerRPCError("Broker authentication failed.", code="broker_unauthorized")
+            result = await self.broker.execute(
+                task_id=request.task_id,
+                operation_id=request.operation_id,
+                tool_name=request.tool_name,
+                arguments=request.arguments,
+                lease_id=request.lease_id,
+                network_lease_id=request.network_lease_id,
+            )
+            response = {"ok": True, "result": result.model_dump(mode="json")}
+        except Exception as exc:
+            response = {
+                "ok": False,
+                "error": {
+                    "code": getattr(exc, "code", "broker_failed"),
+                    "message": str(exc)
+                    if isinstance(exc, (BrokerRPCError, ToolBrokerError))
+                    else "Broker request failed.",
+                },
+            }
+        encoded = json.dumps(response, separators=(",", ":")).encode("utf-8") + b"\n"
+        if len(encoded) > MAX_RPC_BYTES:
+            encoded = b'{"ok":false,"error":{"code":"broker_response_too_large","message":"Broker response is too large."}}\n'
+        writer.write(encoded)
+        await writer.drain()
+        writer.close()
+        await writer.wait_closed()
+
+
+class BrokerRPCClient:
+    def __init__(self, endpoint: str, *, token: str, task_id: str) -> None:
+        self.endpoint = endpoint
+        self.token = token
+        self.task_id = task_id
+
+    async def call(
+        self,
+        *,
+        operation_id: str,
+        tool_name: str,
+        arguments: dict[str, Any],
+        lease_id: str | None = None,
+        network_lease_id: str | None = None,
+    ) -> dict[str, Any]:
+        reader, writer = await self._connect()
+        request = BrokerRPCRequest(
+            token=self.token,
+            task_id=self.task_id,
+            operation_id=operation_id,
+            tool_name=tool_name,
+            arguments=arguments,
+            lease_id=lease_id,
+            network_lease_id=network_lease_id,
+        )
+        writer.write(request.model_dump_json().encode("utf-8") + b"\n")
+        await writer.drain()
+        raw = await reader.readline()
+        writer.close()
+        await writer.wait_closed()
+        if not raw or len(raw) > MAX_RPC_BYTES:
+            raise BrokerRPCError("Broker response is invalid.", code="broker_invalid_response")
+        value = json.loads(raw)
+        if not isinstance(value, dict) or not isinstance(value.get("ok"), bool):
+            raise BrokerRPCError("Broker response is invalid.", code="broker_invalid_response")
+        if not value["ok"]:
+            error = value.get("error")
+            code = error.get("code") if isinstance(error, dict) else "broker_failed"
+            message = error.get("message") if isinstance(error, dict) else "Broker request failed."
+            raise BrokerRPCError(str(message), code=str(code))
+        result = value.get("result")
+        if not isinstance(result, dict):
+            raise BrokerRPCError("Broker response is invalid.", code="broker_invalid_response")
+        return result
+
+    async def _connect(self) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+        if self.endpoint.startswith("unix:"):
+            return await asyncio.open_unix_connection(
+                self.endpoint.removeprefix("unix:"), limit=MAX_RPC_BYTES
+            )
+        if self.endpoint.startswith("tcp:127.0.0.1:"):
+            port = int(self.endpoint.rsplit(":", 1)[1])
+            return await asyncio.open_connection("127.0.0.1", port, limit=MAX_RPC_BYTES)
+        raise BrokerRPCError("Broker endpoint is invalid.", code="broker_endpoint_invalid")

--- a/server/coding_worker/broker_rpc.py
+++ b/server/coding_worker/broker_rpc.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import os
 import secrets
@@ -9,8 +10,14 @@ from typing import Any
 
 from pydantic import Field
 
-from .contracts import StrictModel
-from .tool_broker import ToolBroker, ToolBrokerError
+from .contracts import (
+    ApprovalStatus,
+    OperationState,
+    StrictModel,
+    TaskState,
+    TERMINAL_STATES,
+)
+from .tool_broker import ToolBroker, ToolBrokerError, ToolResult
 
 
 MAX_RPC_BYTES = 1024 * 1024
@@ -96,14 +103,7 @@ class BrokerRPCServer:
             expected = self._tokens.get(request.task_id)
             if expected is None or not secrets.compare_digest(expected, request.token):
                 raise BrokerRPCError("Broker authentication failed.", code="broker_unauthorized")
-            result = await self.broker.execute(
-                task_id=request.task_id,
-                operation_id=request.operation_id,
-                tool_name=request.tool_name,
-                arguments=request.arguments,
-                lease_id=request.lease_id,
-                network_lease_id=request.network_lease_id,
-            )
+            result = await self._execute(request)
             response = {"ok": True, "result": result.model_dump(mode="json")}
         except Exception as exc:
             response = {
@@ -122,6 +122,96 @@ class BrokerRPCServer:
         await writer.drain()
         writer.close()
         await writer.wait_closed()
+
+    async def _execute(self, request: BrokerRPCRequest) -> ToolResult:
+        try:
+            return await self.broker.execute(
+                task_id=request.task_id,
+                operation_id=request.operation_id,
+                tool_name=request.tool_name,
+                arguments=request.arguments,
+                lease_id=request.lease_id,
+                network_lease_id=request.network_lease_id,
+            )
+        except ToolBrokerError as exc:
+            if exc.code != "approval_required" or request.lease_id is not None:
+                raise
+        lease_id, network_lease_id = await self._wait_for_approval(request)
+        return await self.broker.execute(
+            task_id=request.task_id,
+            operation_id=request.operation_id,
+            tool_name=request.tool_name,
+            arguments=request.arguments,
+            lease_id=lease_id,
+            network_lease_id=network_lease_id,
+        )
+
+    async def _wait_for_approval(
+        self, request: BrokerRPCRequest
+    ) -> tuple[str, str | None]:
+        required_ids = [request.operation_id]
+        if request.tool_name == "install_dependencies":
+            required_ids.append(
+                "network_"
+                + hashlib.sha256(request.operation_id.encode("utf-8")).hexdigest()[:32]
+            )
+        while True:
+            task = self.broker.store.get_task(request.task_id)
+            if task.state in TERMINAL_STATES or task.state in {
+                TaskState.PAUSED,
+                TaskState.INTERRUPTED,
+            }:
+                raise BrokerRPCError(
+                    "Approval is no longer available.", code="approval_unavailable"
+                )
+            approvals = {
+                approval.operation_id: approval
+                for approval in self.broker.store.list_approvals(request.task_id)
+                if approval.operation_id in required_ids
+            }
+            if len(approvals) == len(required_ids):
+                if any(
+                    approval.status
+                    in {
+                        ApprovalStatus.REJECTED,
+                        ApprovalStatus.CANCELLED,
+                        ApprovalStatus.EXPIRED,
+                    }
+                    for approval in approvals.values()
+                ):
+                    operation = self.broker.store.get_operation(request.operation_id)
+                    if operation.state is OperationState.PREPARED:
+                        self.broker.store.transition_operation(
+                            request.operation_id,
+                            OperationState.FAILED,
+                            result={"code": "approval_rejected"},
+                            expected_state=OperationState.PREPARED,
+                        )
+                    raise BrokerRPCError(
+                        "Tool approval was rejected.", code="approval_rejected"
+                    )
+                if all(
+                    approval.status is ApprovalStatus.APPROVED
+                    and approval.lease is not None
+                    for approval in approvals.values()
+                ):
+                    main = approvals[request.operation_id]
+                    network = (
+                        approvals.get(required_ids[1])
+                        if len(required_ids) > 1
+                        else None
+                    )
+                    main_lease = main.lease
+                    if main_lease is None:
+                        raise BrokerRPCError(
+                            "Approved operation is missing its lease.",
+                            code="approval_unavailable",
+                        )
+                    return (
+                        main_lease.lease_id,
+                        network.lease.lease_id if network and network.lease else None,
+                    )
+            await asyncio.sleep(0.05)
 
 
 class BrokerRPCClient:

--- a/server/coding_worker/broker_rpc.py
+++ b/server/coding_worker/broker_rpc.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import secrets
 from pathlib import Path
 from typing import Any
@@ -49,7 +50,7 @@ class BrokerRPCServer:
     def revoke_task(self, task_id: str) -> None:
         self._tokens.pop(task_id, None)
 
-    async def start_unix(self, socket_path: Path) -> str:
+    async def start_unix(self, socket_path: Path, *, group_id: int | None = None) -> str:
         if self._server is not None:
             raise RuntimeError("broker RPC server is already running")
         socket_path = Path(socket_path)
@@ -59,6 +60,9 @@ class BrokerRPCServer:
             self._handle, path=str(socket_path), limit=MAX_RPC_BYTES
         )
         socket_path.chmod(0o600)
+        if group_id is not None and hasattr(os, "chown"):
+            os.chown(socket_path, -1, group_id)
+            socket_path.chmod(0o660)
         self.endpoint = f"unix:{socket_path}"
         return self.endpoint
 

--- a/server/coding_worker/contracts.py
+++ b/server/coding_worker/contracts.py
@@ -351,6 +351,24 @@ class WorkerArtifact(StrictModel):
     created_at: float
 
 
+class EvidenceStatus(StrEnum):
+    PASSED = "passed"
+    FAILED = "failed"
+    INVALIDATED = "invalidated"
+
+
+class WorkerEvidence(StrictModel):
+    evidence_id: str
+    task_id: str
+    check_id: str
+    operation_id: str
+    workspace_tree_hash: str = Field(pattern=r"^[a-f0-9]{64}$")
+    status: EvidenceStatus
+    exit_code: int
+    artifact_id: str
+    created_at: float
+
+
 class OperationState(StrEnum):
     PREPARED = "prepared"
     RUNNING = "running"

--- a/server/coding_worker/contracts.py
+++ b/server/coding_worker/contracts.py
@@ -91,6 +91,7 @@ _TRANSITIONS: dict[TaskState, frozenset[TaskState]] = {
         {
             TaskState.RUNNING,
             TaskState.WAITING_APPROVAL,
+            TaskState.PAUSED,
             TaskState.INTERRUPTED,
             TaskState.COMPLETED,
             TaskState.BLOCKED,

--- a/server/coding_worker/contracts.py
+++ b/server/coding_worker/contracts.py
@@ -279,7 +279,7 @@ class TaskRecord(StrictModel):
     spec: TaskSpec
     state: TaskState
     workspace_id: str | None = None
-    provider_session_id: str | None = None
+    provider_session_id: str | None = Field(default=None, exclude=True, repr=False)
     created_at: float
     updated_at: float
     expires_at: float

--- a/server/coding_worker/contracts.py
+++ b/server/coding_worker/contracts.py
@@ -11,6 +11,9 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 SAFE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$")
 SAFE_ROUTE = re.compile(r"^[a-z0-9][a-z0-9._/-]{0,127}$")
 TERMINAL_STATES: frozenset["TaskState"]
+CapabilityName = Literal[
+    "workspace_write", "command", "dependency_install", "service", "network"
+]
 
 
 class StrictModel(BaseModel):
@@ -255,9 +258,7 @@ class TaskSpec(TaskCreateRequest):
 class CapabilityLease(StrictModel):
     lease_id: str
     task_id: str
-    capability: Literal[
-        "workspace_write", "command", "dependency_install", "service", "network"
-    ]
+    capability: CapabilityName
     scope: dict[str, Any] = Field(default_factory=dict)
     issued_at: float
     expires_at: float
@@ -324,7 +325,7 @@ class WorkerApproval(StrictModel):
     approval_id: str
     task_id: str
     operation_id: str
-    capability: str
+    capability: CapabilityName
     status: ApprovalStatus
     request: dict[str, Any] = Field(default_factory=dict)
     lease: CapabilityLease | None = None
@@ -348,3 +349,23 @@ class WorkerArtifact(StrictModel):
     size: int = Field(ge=0)
     metadata: dict[str, Any] = Field(default_factory=dict)
     created_at: float
+
+
+class OperationState(StrEnum):
+    PREPARED = "prepared"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    UNKNOWN = "unknown"
+
+
+class WorkerOperation(StrictModel):
+    operation_id: str
+    task_id: str
+    tool_name: str
+    intent_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    state: OperationState
+    request: dict[str, Any]
+    result: dict[str, Any] | None = None
+    created_at: float
+    updated_at: float

--- a/server/coding_worker/egress_proxy.py
+++ b/server/coding_worker/egress_proxy.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import contextlib
+import ipaddress
+import os
+import socket
+
+from .network_policy import EgressPolicy, NetworkPolicyError
+
+
+MAX_HEADER_BYTES = 16 * 1024
+
+
+class EgressProxy:
+    def __init__(self, policy: EgressPolicy) -> None:
+        self.policy = policy
+
+    async def handle(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        upstream_writer: asyncio.StreamWriter | None = None
+        try:
+            header = await asyncio.wait_for(reader.readuntil(b"\r\n\r\n"), timeout=5)
+            if len(header) > MAX_HEADER_BYTES:
+                raise NetworkPolicyError("Proxy header is too large.", code="network_request_invalid")
+            lines = header.decode("iso-8859-1").split("\r\n")
+            method, authority, version = lines[0].split(" ", 2)
+            if method != "CONNECT" or version != "HTTP/1.1" or authority.count(":") != 1:
+                raise NetworkPolicyError("Only HTTPS CONNECT is allowed.", code="network_request_invalid")
+            domain, port = authority.rsplit(":", 1)
+            if port != "443":
+                raise NetworkPolicyError("Only HTTPS port 443 is allowed.", code="network_request_invalid")
+            authorization = next(
+                (line.split(":", 1)[1].strip() for line in lines[1:] if line.lower().startswith("proxy-authorization:")),
+                "",
+            )
+            if not authorization.startswith("Basic "):
+                raise NetworkPolicyError("Proxy authorization is required.", code="network_grant_invalid")
+            username, token = base64.b64decode(authorization[6:]).decode("utf-8").split(":", 1)
+            if username != "grant":
+                raise NetworkPolicyError("Proxy authorization is invalid.", code="network_grant_invalid")
+            self.policy.validate_grant(token, domain=domain)
+            addresses = await asyncio.get_running_loop().getaddrinfo(
+                domain, 443, type=socket.SOCK_STREAM
+            )
+            selected: str | None = None
+            for _family, _type, _protocol, _name, address in addresses:
+                candidate = str(address[0])
+                if not ipaddress.ip_address(candidate).is_global:
+                    raise NetworkPolicyError("Private destination is denied.", code="network_private_address_denied")
+                selected = selected or candidate
+            if selected is None:
+                raise NetworkPolicyError("Destination could not be resolved.", code="network_resolution_required")
+            upstream_reader, upstream_writer = await asyncio.open_connection(selected, 443)
+            writer.write(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+            await writer.drain()
+            await asyncio.gather(
+                self._relay(reader, upstream_writer),
+                self._relay(upstream_reader, writer),
+            )
+        except Exception:
+            if not writer.is_closing():
+                writer.write(b"HTTP/1.1 403 Forbidden\r\nConnection: close\r\n\r\n")
+                with contextlib.suppress(Exception):
+                    await writer.drain()
+        finally:
+            if upstream_writer is not None:
+                upstream_writer.close()
+                with contextlib.suppress(Exception):
+                    await upstream_writer.wait_closed()
+            writer.close()
+            with contextlib.suppress(Exception):
+                await writer.wait_closed()
+
+    @staticmethod
+    async def _relay(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        while data := await reader.read(64 * 1024):
+            writer.write(data)
+            await writer.drain()
+        with contextlib.suppress(Exception):
+            writer.write_eof()
+
+
+async def run() -> None:
+    key = os.environ.get("CODING_WORKER_EGRESS_GRANT_KEY", "")
+    domains = tuple(
+        item.strip().lower()
+        for item in os.environ.get("CODING_WORKER_NETWORK_DOMAINS", "").split(",")
+        if item.strip()
+    )
+    policy = EgressPolicy(enabled=True, allowed_domains=domains, grant_key=key)
+    proxy = EgressProxy(policy)
+    server = await asyncio.start_server(proxy.handle, "0.0.0.0", 8080, limit=MAX_HEADER_BYTES)
+    async with server:
+        await server.serve_forever()
+
+
+if __name__ == "__main__":
+    asyncio.run(run())

--- a/server/coding_worker/evidence.py
+++ b/server/coding_worker/evidence.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import hashlib
+
+from .contracts import EvidenceStatus, WorkerEvidence
+from .store import CodingWorkerStore
+from .tool_broker import ToolBroker, ToolBrokerError
+from .workspace import WorkspaceBroker
+
+
+class HarnessRunner:
+    """Runs the immutable server-side acceptance contract and records evidence."""
+
+    def __init__(
+        self,
+        *,
+        store: CodingWorkerStore,
+        workspace_broker: WorkspaceBroker,
+        tool_broker: ToolBroker,
+    ) -> None:
+        self.store = store
+        self.workspace_broker = workspace_broker
+        self.tool_broker = tool_broker
+
+    async def run_required_checks(self, task_id: str) -> tuple[WorkerEvidence, ...]:
+        task = self.store.get_task(task_id)
+        if task.workspace_id is None:
+            raise ToolBrokerError("Task workspace is unavailable.", code="workspace_unavailable")
+        results: list[WorkerEvidence] = []
+        for check in task.spec.acceptance.required_checks:
+            before = self.workspace_broker.current_tree_hash(task.workspace_id)
+            operation_id = self._operation_id(task_id, check.check_id, before)
+            if check.kind == "command":
+                result = await self.tool_broker.execute(
+                    task_id=task_id,
+                    operation_id=operation_id,
+                    tool_name="run_check",
+                    arguments={"check_id": check.check_id},
+                )
+                exit_code = int(result.data["exit_code"])
+                output = str(result.data.get("output", "")).encode("utf-8")
+            elif check.kind == "diff":
+                output = self.workspace_broker.diff(task.workspace_id)
+                exit_code = 0 if output else 1
+            else:
+                output = f"Unsupported acceptance check kind: {check.kind}\n".encode()
+                exit_code = 2
+            after = self.workspace_broker.current_tree_hash(task.workspace_id)
+            if after != before:
+                raise ToolBrokerError(
+                    "Workspace changed while acceptance was running.",
+                    code="acceptance_workspace_changed",
+                )
+            artifact = self.store.create_artifact(
+                task_id=task_id,
+                media_type="text/plain; charset=utf-8",
+                content=output,
+                metadata={"check_id": check.check_id, "workspace_tree_hash": before},
+            )
+            results.append(
+                self.store.record_evidence(
+                    task_id=task_id,
+                    check_id=check.check_id,
+                    operation_id=operation_id,
+                    workspace_tree_hash=before,
+                    exit_code=exit_code,
+                    artifact_id=artifact.artifact_id,
+                )
+            )
+        return tuple(results)
+
+    def acceptance_satisfied(self, task_id: str) -> bool:
+        task = self.store.get_task(task_id)
+        if task.workspace_id is None:
+            return False
+        tree_hash = self.workspace_broker.current_tree_hash(task.workspace_id)
+        evidence = self.store.list_evidence(task_id, current_tree_hash=tree_hash)
+        latest: dict[str, WorkerEvidence] = {}
+        for item in evidence:
+            latest[item.check_id] = item
+        if any(
+            latest.get(check.check_id) is None
+            or latest[check.check_id].status is not EvidenceStatus.PASSED
+            for check in task.spec.acceptance.required_checks
+        ):
+            return False
+        artifacts = self.store.list_artifacts(task_id)
+        requirement_ids = {
+            str(item.metadata.get("requirement_id"))
+            for item in artifacts
+            if item.metadata.get("workspace_tree_hash") == tree_hash
+        }
+        return all(
+            requirement.artifact_id in requirement_ids
+            for requirement in task.spec.acceptance.required_artifacts
+        )
+
+    @staticmethod
+    def _operation_id(task_id: str, check_id: str, tree_hash: str) -> str:
+        digest = hashlib.sha256(f"{task_id}\0{check_id}\0{tree_hash}".encode()).hexdigest()
+        return f"acceptance_{digest[:32]}"

--- a/server/coding_worker/executor.py
+++ b/server/coding_worker/executor.py
@@ -127,7 +127,14 @@ class SidecarExecutor:
             process = await asyncio.create_subprocess_exec(
                 *argv,
                 cwd=self._workspace_resolver(workspace_id),
-                env=self._environment(self._workspace_resolver(workspace_id)),
+                env=self._environment(
+                    self._workspace_resolver(workspace_id),
+                    (
+                        {"HOST": "0.0.0.0", "PORT": str(preview_port)}
+                        if preview_port is not None
+                        else None
+                    ),
+                ),
                 stdin=asyncio.subprocess.PIPE,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,

--- a/server/coding_worker/executor.py
+++ b/server/coding_worker/executor.py
@@ -26,6 +26,7 @@ class _Service:
     started_at: float
     expires_at: float
     output: bytearray
+    preview_port: int | None = None
     state: str = "running"
     exit_code: int | None = None
     reason: str | None = None
@@ -105,9 +106,14 @@ class SidecarExecutor:
         workspace_id: str,
         argv: Sequence[str],
         ttl_seconds: int,
+        preview_port: int | None = None,
     ) -> dict[str, object]:
         if not 1 <= ttl_seconds <= 3600:
             raise SidecarExecutionError("Service TTL is invalid.", code="service_ttl_invalid")
+        if preview_port is not None and not 1024 <= preview_port <= 65535:
+            raise SidecarExecutionError(
+                "Preview port is invalid.", code="service_preview_invalid"
+            )
         async with self._lock:
             active = sum(
                 service.task_id == task_id and service.state == "running"
@@ -134,6 +140,7 @@ class SidecarExecutor:
                 started_at=now,
                 expires_at=now + ttl_seconds,
                 output=bytearray(),
+                preview_port=preview_port,
             )
             self._services[service.service_id] = service
             service.monitor = asyncio.create_task(self._monitor(service, ttl_seconds))
@@ -246,6 +253,7 @@ class SidecarExecutor:
             "expires_at": service.expires_at,
             "exit_code": service.exit_code,
             "reason": service.reason,
+            "preview_port": service.preview_port,
         }
         if include_output and service.state != "running":
             result["output"] = bytes(service.output).decode("utf-8", errors="replace")

--- a/server/coding_worker/executor.py
+++ b/server/coding_worker/executor.py
@@ -1,0 +1,286 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import shutil
+import signal
+import time
+import uuid
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+
+class SidecarExecutionError(RuntimeError):
+    def __init__(self, message: str, *, code: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+@dataclass(slots=True)
+class _Service:
+    service_id: str
+    task_id: str
+    process: asyncio.subprocess.Process
+    started_at: float
+    expires_at: float
+    output: bytearray
+    state: str = "running"
+    exit_code: int | None = None
+    reason: str | None = None
+    monitor: asyncio.Task[None] | None = None
+
+
+class SidecarExecutor:
+    """Runs task commands inside one non-root slot sidecar."""
+
+    def __init__(
+        self,
+        workspace_resolver: Callable[[str], Path],
+        *,
+        runtime_root: Path,
+        max_output_bytes: int = 2 * 1024 * 1024,
+        max_services_per_task: int = 4,
+    ) -> None:
+        self._workspace_resolver = workspace_resolver
+        self._runtime_root = Path(runtime_root)
+        self._max_output_bytes = max_output_bytes
+        self._max_services_per_task = max_services_per_task
+        self._services: dict[str, _Service] = {}
+        self._lock = asyncio.Lock()
+
+    async def run_process(
+        self,
+        *,
+        workspace_id: str,
+        argv: Sequence[str],
+        timeout_seconds: int,
+        isolated: bool,
+        environment_overrides: Mapping[str, str] | None = None,
+    ) -> dict[str, object]:
+        repository = self._workspace_resolver(workspace_id)
+        execution_root: Path | None = None
+        execution_repository = repository
+        try:
+            if isolated:
+                execution_root = self._runtime_root / "checks" / f"run_{uuid.uuid4().hex}"
+                execution_root.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copytree(repository, execution_root, ignore=shutil.ignore_patterns(".git"))
+                execution_repository = execution_root
+            process = await asyncio.create_subprocess_exec(
+                *argv,
+                cwd=execution_repository,
+                env=self._environment(execution_repository, environment_overrides),
+                stdin=asyncio.subprocess.DEVNULL,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+                start_new_session=os.name != "nt",
+            )
+            try:
+                output = await asyncio.wait_for(
+                    self._collect(process), timeout=timeout_seconds
+                )
+            except TimeoutError:
+                process.kill()
+                await process.wait()
+                raise SidecarExecutionError("Command timed out.", code="command_timeout")
+            except asyncio.CancelledError:
+                process.kill()
+                await process.wait()
+                raise
+            return {
+                "argv": list(argv),
+                "exit_code": int(process.returncode or 0),
+                "output": output.decode("utf-8", errors="replace"),
+            }
+        finally:
+            if execution_root is not None:
+                shutil.rmtree(execution_root, ignore_errors=True)
+
+    async def start_service(
+        self,
+        *,
+        task_id: str,
+        workspace_id: str,
+        argv: Sequence[str],
+        ttl_seconds: int,
+    ) -> dict[str, object]:
+        if not 1 <= ttl_seconds <= 3600:
+            raise SidecarExecutionError("Service TTL is invalid.", code="service_ttl_invalid")
+        async with self._lock:
+            active = sum(
+                service.task_id == task_id and service.state == "running"
+                for service in self._services.values()
+            )
+            if active >= self._max_services_per_task:
+                raise SidecarExecutionError(
+                    "Task service capacity is exhausted.", code="service_capacity_exhausted"
+                )
+            now = time.time()
+            process = await asyncio.create_subprocess_exec(
+                *argv,
+                cwd=self._workspace_resolver(workspace_id),
+                env=self._environment(self._workspace_resolver(workspace_id)),
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+                start_new_session=os.name != "nt",
+            )
+            service = _Service(
+                service_id=f"service_{uuid.uuid4().hex}",
+                task_id=task_id,
+                process=process,
+                started_at=now,
+                expires_at=now + ttl_seconds,
+                output=bytearray(),
+            )
+            self._services[service.service_id] = service
+            service.monitor = asyncio.create_task(self._monitor(service, ttl_seconds))
+            return self._service_result(service, include_output=False)
+
+    def service_status(self, *, task_id: str, service_id: str) -> dict[str, object]:
+        return self._service_result(self._require_service(task_id, service_id), include_output=True)
+
+    async def service_input(self, *, task_id: str, service_id: str, data: str) -> None:
+        if not data or len(data.encode("utf-8")) > 64 * 1024:
+            raise SidecarExecutionError("Service input is invalid.", code="service_input_invalid")
+        service = self._require_service(task_id, service_id)
+        if service.state != "running" or service.process.stdin is None:
+            raise SidecarExecutionError("Service is not running.", code="service_not_running")
+        service.process.stdin.write(data.encode("utf-8"))
+        await service.process.stdin.drain()
+
+    async def stop_service(self, *, task_id: str, service_id: str) -> dict[str, object]:
+        service = self._require_service(task_id, service_id)
+        if service.state == "running":
+            service.reason = "user_interrupted"
+            await self._interrupt(service.process)
+            if service.monitor is not None:
+                await service.monitor
+        return self._service_result(service, include_output=True)
+
+    async def stop_task(self, task_id: str) -> None:
+        services = [
+            service
+            for service in self._services.values()
+            if service.task_id == task_id and service.state == "running"
+        ]
+        for service in services:
+            service.reason = "task_closed"
+            await self._interrupt(service.process)
+        await asyncio.gather(
+            *(service.monitor for service in services if service.monitor is not None),
+            return_exceptions=True,
+        )
+
+    async def _monitor(self, service: _Service, ttl_seconds: int) -> None:
+        drain = asyncio.create_task(self._drain(service))
+        try:
+            try:
+                await asyncio.wait_for(service.process.wait(), timeout=ttl_seconds)
+            except TimeoutError:
+                service.reason = "service_ttl_expired"
+                await self._interrupt(service.process)
+            await drain
+        finally:
+            if not drain.done():
+                drain.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await drain
+            service.exit_code = service.process.returncode
+            if service.reason is not None:
+                service.state = "stopped"
+            elif service.exit_code == 0:
+                service.state = "completed"
+            else:
+                service.state = "failed"
+                service.reason = "service_exited"
+
+    async def _drain(self, service: _Service) -> None:
+        if service.process.stdout is None:
+            return
+        while True:
+            chunk = await service.process.stdout.read(64 * 1024)
+            if not chunk:
+                return
+            if len(service.output) + len(chunk) > self._max_output_bytes:
+                remaining = self._max_output_bytes - len(service.output)
+                service.output.extend(chunk[: max(remaining, 0)])
+                service.reason = "service_output_limit"
+                service.process.kill()
+                return
+            service.output.extend(chunk)
+
+    async def _collect(self, process: asyncio.subprocess.Process) -> bytes:
+        if process.stdout is None:
+            raise SidecarExecutionError("Command output is unavailable.", code="command_failed")
+        output = bytearray()
+        while True:
+            chunk = await process.stdout.read(64 * 1024)
+            if not chunk:
+                break
+            output.extend(chunk)
+            if len(output) > self._max_output_bytes:
+                process.kill()
+                await process.wait()
+                raise SidecarExecutionError(
+                    "Command output is too large.", code="tool_output_too_large"
+                )
+        await process.wait()
+        return bytes(output)
+
+    def _require_service(self, task_id: str, service_id: str) -> _Service:
+        service = self._services.get(service_id)
+        if service is None or service.task_id != task_id:
+            raise SidecarExecutionError("Service was not found.", code="service_not_found")
+        return service
+
+    @staticmethod
+    def _service_result(service: _Service, *, include_output: bool) -> dict[str, object]:
+        result: dict[str, object] = {
+            "service_id": service.service_id,
+            "task_id": service.task_id,
+            "state": service.state,
+            "started_at": service.started_at,
+            "expires_at": service.expires_at,
+            "exit_code": service.exit_code,
+            "reason": service.reason,
+        }
+        if include_output and service.state != "running":
+            result["output"] = bytes(service.output).decode("utf-8", errors="replace")
+        return result
+
+    @staticmethod
+    async def _interrupt(process: asyncio.subprocess.Process) -> None:
+        if process.returncode is not None:
+            return
+        with contextlib.suppress(ProcessLookupError):
+            if os.name == "nt":
+                process.terminate()
+            else:
+                os.killpg(process.pid, signal.SIGINT)
+        try:
+            await asyncio.wait_for(process.wait(), timeout=2)
+        except TimeoutError:
+            process.kill()
+            await process.wait()
+
+    @staticmethod
+    def _environment(
+        repository: Path, overrides: Mapping[str, str] | None = None
+    ) -> dict[str, str]:
+        home = repository.parent / "home"
+        home.mkdir(exist_ok=True)
+        environment = {
+            "HOME": str(home),
+            "LANG": "C.UTF-8",
+            "LC_ALL": "C.UTF-8",
+            "PATH": "/usr/local/bin:/usr/bin:/bin",
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_TERMINAL_PROMPT": "0",
+            "GIT_NO_LAZY_FETCH": "1",
+            "GIT_NO_REPLACE_OBJECTS": "1",
+        }
+        environment.update(overrides or {})
+        return environment

--- a/server/coding_worker/executor.py
+++ b/server/coding_worker/executor.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import json
 import os
+import secrets
 import shutil
 import signal
 import time
@@ -10,12 +12,22 @@ import uuid
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
+
+from .contracts import SAFE_ID
+
+
+MAX_EXECUTOR_RPC_BYTES = 8 * 1024 * 1024
 
 
 class SidecarExecutionError(RuntimeError):
     def __init__(self, message: str, *, code: str) -> None:
         super().__init__(message)
         self.code = code
+
+
+class ExecutorRPCError(SidecarExecutionError):
+    pass
 
 
 @dataclass(slots=True)
@@ -299,3 +311,210 @@ class SidecarExecutor:
         }
         environment.update(overrides or {})
         return environment
+
+
+class ExecutorRPCServer:
+    """Credential-free command host for one fixed workspace slot."""
+
+    def __init__(self, executor: SidecarExecutor, *, token: str) -> None:
+        if len(token) < 32:
+            raise ValueError("executor RPC token is too short")
+        self.executor = executor
+        self._token = token
+        self._server: asyncio.AbstractServer | None = None
+        self.endpoint: str | None = None
+        self._task_id: str | None = None
+        self._workspace_id: str | None = None
+
+    async def start_unix(self, socket_path: Path) -> str:
+        socket_path = Path(socket_path)
+        socket_path.parent.mkdir(parents=True, exist_ok=True)
+        socket_path.unlink(missing_ok=True)
+        self._server = await asyncio.start_unix_server(
+            self._handle, path=str(socket_path), limit=MAX_EXECUTOR_RPC_BYTES
+        )
+        socket_path.chmod(0o660)
+        self.endpoint = f"unix:{socket_path}"
+        return self.endpoint
+
+    async def start_tcp_for_tests(self) -> str:
+        self._server = await asyncio.start_server(
+            self._handle, "127.0.0.1", 0, limit=MAX_EXECUTOR_RPC_BYTES
+        )
+        address = self._server.sockets[0].getsockname()
+        self.endpoint = f"tcp:127.0.0.1:{address[1]}"
+        return self.endpoint
+
+    async def close(self) -> None:
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+        if self._task_id is not None:
+            await self.executor.stop_task(self._task_id)
+        self._server = None
+        self.endpoint = None
+        self._task_id = None
+        self._workspace_id = None
+
+    async def _handle(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        try:
+            raw = await reader.readline()
+            if not raw or len(raw) > MAX_EXECUTOR_RPC_BYTES or not raw.endswith(b"\n"):
+                raise ExecutorRPCError("Executor request is invalid.", code="executor_request_invalid")
+            value = json.loads(raw)
+            token = value.get("token") if isinstance(value, dict) else None
+            action = value.get("action") if isinstance(value, dict) else None
+            payload = value.get("payload") if isinstance(value, dict) else None
+            if not isinstance(token, str) or not secrets.compare_digest(token, self._token):
+                raise ExecutorRPCError("Executor authentication failed.", code="executor_unauthorized")
+            if not isinstance(action, str) or not isinstance(payload, dict):
+                raise ExecutorRPCError("Executor request is invalid.", code="executor_request_invalid")
+            result = await self._dispatch(action, payload)
+            response = {"ok": True, "result": result}
+        except Exception as exc:
+            response = {
+                "ok": False,
+                "error": {
+                    "code": getattr(exc, "code", "executor_failed"),
+                    "message": str(exc)
+                    if isinstance(exc, (ExecutorRPCError, SidecarExecutionError, ValueError))
+                    else "Executor request failed.",
+                },
+            }
+        encoded = json.dumps(response, separators=(",", ":")).encode() + b"\n"
+        writer.write(encoded)
+        await writer.drain()
+        writer.close()
+        with contextlib.suppress(Exception):
+            await writer.wait_closed()
+
+    async def _dispatch(self, action: str, payload: dict[str, Any]) -> dict[str, Any]:
+        task_id = str(payload.get("task_id", ""))
+        workspace_id = str(payload.get("workspace_id", ""))
+        if action == "bind_task":
+            if SAFE_ID.fullmatch(task_id) is None or SAFE_ID.fullmatch(workspace_id) is None:
+                raise ExecutorRPCError("Executor binding is invalid.", code="executor_binding_invalid")
+            if self._task_id not in {None, task_id} or self._workspace_id not in {
+                None,
+                workspace_id,
+            }:
+                raise ExecutorRPCError("Executor slot is busy.", code="executor_slot_busy")
+            self.executor._workspace_resolver(workspace_id)
+            self._task_id, self._workspace_id = task_id, workspace_id
+            return {"bound": True}
+        if action == "close_task":
+            self._require_binding(task_id, workspace_id)
+            await self.executor.stop_task(task_id)
+            self._task_id = self._workspace_id = None
+            return {"closed": True}
+        self._require_binding(task_id, workspace_id)
+        if action == "execute_process":
+            return await self.executor.run_process(
+                workspace_id=workspace_id,
+                argv=tuple(payload.get("argv", ())),
+                timeout_seconds=int(payload.get("timeout_seconds", 0)),
+                isolated=payload.get("isolated") is True,
+                environment_overrides=payload.get("environment_overrides"),
+            )
+        if action == "start_service":
+            return await self.executor.start_service(
+                task_id=task_id,
+                workspace_id=workspace_id,
+                argv=tuple(payload.get("argv", ())),
+                ttl_seconds=int(payload.get("ttl_seconds", 0)),
+                preview_port=(
+                    int(payload["preview_port"])
+                    if payload.get("preview_port") is not None
+                    else None
+                ),
+            )
+        if action == "service_status":
+            return self.executor.service_status(
+                task_id=task_id, service_id=str(payload.get("service_id", ""))
+            )
+        if action == "service_input":
+            await self.executor.service_input(
+                task_id=task_id,
+                service_id=str(payload.get("service_id", "")),
+                data=str(payload.get("data", "")),
+            )
+            return {"accepted": True}
+        if action == "stop_service":
+            return await self.executor.stop_service(
+                task_id=task_id, service_id=str(payload.get("service_id", ""))
+            )
+        raise ExecutorRPCError("Executor action is invalid.", code="executor_request_invalid")
+
+    def _require_binding(self, task_id: str, workspace_id: str) -> None:
+        if self._task_id != task_id or self._workspace_id != workspace_id:
+            raise ExecutorRPCError("Executor task is not bound.", code="executor_binding_invalid")
+
+
+class ExecutorSidecarClientPool:
+    """Routes task commands to the credential-free executor for a fixed slot."""
+
+    def __init__(
+        self,
+        *,
+        endpoints: Mapping[str, str],
+        tokens: Mapping[str, str],
+        workspace_slot_resolver: Callable[[str], str],
+    ) -> None:
+        if set(endpoints) != set(tokens) or not endpoints:
+            raise ValueError("executor sidecar bindings are incomplete")
+        self._endpoints = dict(endpoints)
+        self._tokens = dict(tokens)
+        self._workspace_slot_resolver = workspace_slot_resolver
+
+    async def bind_task(self, task_id: str, workspace_id: str) -> None:
+        await self._workspace_call(workspace_id, "bind_task", {"task_id": task_id, "workspace_id": workspace_id})
+
+    async def close_task(self, task_id: str, workspace_id: str) -> None:
+        await self._workspace_call(workspace_id, "close_task", {"task_id": task_id, "workspace_id": workspace_id})
+
+    async def run_process(self, *, task_id: str, workspace_id: str, argv: Sequence[str], timeout_seconds: int, isolated: bool, environment_overrides: Mapping[str, str] | None = None) -> dict[str, Any]:
+        return await self._workspace_call(workspace_id, "execute_process", {"task_id": task_id, "workspace_id": workspace_id, "argv": list(argv), "timeout_seconds": timeout_seconds, "isolated": isolated, "environment_overrides": dict(environment_overrides or {})})
+
+    async def start_service(self, *, task_id: str, workspace_id: str, argv: Sequence[str], ttl_seconds: int, preview_port: int | None = None) -> dict[str, Any]:
+        return await self._workspace_call(workspace_id, "start_service", {"task_id": task_id, "workspace_id": workspace_id, "argv": list(argv), "ttl_seconds": ttl_seconds, "preview_port": preview_port})
+
+    async def service_status(self, *, task_id: str, workspace_id: str, service_id: str) -> dict[str, Any]:
+        return await self._workspace_call(workspace_id, "service_status", {"task_id": task_id, "workspace_id": workspace_id, "service_id": service_id})
+
+    async def service_input(self, *, task_id: str, workspace_id: str, service_id: str, data: str) -> dict[str, Any]:
+        return await self._workspace_call(workspace_id, "service_input", {"task_id": task_id, "workspace_id": workspace_id, "service_id": service_id, "data": data})
+
+    async def stop_service(self, *, task_id: str, workspace_id: str, service_id: str) -> dict[str, Any]:
+        return await self._workspace_call(workspace_id, "stop_service", {"task_id": task_id, "workspace_id": workspace_id, "service_id": service_id})
+
+    async def _workspace_call(self, workspace_id: str, action: str, payload: dict[str, Any]) -> dict[str, Any]:
+        slot_id = self._workspace_slot_resolver(workspace_id)
+        endpoint = self._endpoints.get(slot_id)
+        token = self._tokens.get(slot_id)
+        if endpoint is None or token is None:
+            raise ExecutorRPCError("Executor slot is unavailable.", code="executor_unavailable")
+        if endpoint.startswith("unix:"):
+            reader, writer = await asyncio.open_unix_connection(endpoint[5:])
+        elif endpoint.startswith("tcp:127.0.0.1:"):
+            reader, writer = await asyncio.open_connection("127.0.0.1", int(endpoint.rsplit(":", 1)[1]))
+        else:
+            raise ExecutorRPCError("Executor endpoint is invalid.", code="executor_unavailable")
+        try:
+            request = json.dumps({"token": token, "action": action, "payload": payload}, separators=(",", ":")).encode() + b"\n"
+            writer.write(request)
+            await writer.drain()
+            raw = await reader.readline()
+            value = json.loads(raw)
+            if not isinstance(value, dict) or value.get("ok") is not True:
+                error = value.get("error", {}) if isinstance(value, dict) else {}
+                raise ExecutorRPCError(str(error.get("message", "Executor request failed.")), code=str(error.get("code", "executor_failed")))
+            result = value.get("result")
+            if not isinstance(result, dict):
+                raise ExecutorRPCError("Executor response is invalid.", code="executor_invalid_response")
+            return result
+        finally:
+            writer.close()
+            with contextlib.suppress(Exception):
+                await writer.wait_closed()

--- a/server/coding_worker/network_policy.py
+++ b/server/coding_worker/network_policy.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
 import ipaddress
+import base64
+import hashlib
+import hmac
+import json
+import secrets
 import re
 import time
 from collections.abc import Callable, Iterable
-from urllib.parse import urlsplit
+from urllib.parse import quote, urlsplit
 
 from .contracts import CapabilityLease
 
@@ -27,12 +32,94 @@ class EgressPolicy:
         enabled: bool = False,
         allowed_domains: Iterable[str] = (),
         clock: Callable[[], float] = time.time,
+        grant_key: bytes | str | None = None,
     ) -> None:
         self.enabled = enabled
         self.allowed_domains = frozenset(
             self._normalize_domain(domain) for domain in allowed_domains
         )
         self._clock = clock
+        self._grant_key = (
+            grant_key.encode("utf-8") if isinstance(grant_key, str) else grant_key
+        )
+        if self.enabled and (self._grant_key is None or len(self._grant_key) < 32):
+            raise NetworkPolicyError(
+                "Egress grant key is unavailable.", code="network_grant_key_invalid"
+            )
+
+    def proxy_url(
+        self,
+        *,
+        base_url: str,
+        lease: CapabilityLease,
+        task_id: str,
+        purpose: str,
+    ) -> str:
+        self.validate_lease_scope(
+            lease=lease,
+            domains=tuple(str(item) for item in lease.scope.get("domains", ())),
+            purpose=purpose,
+        )
+        payload = {
+            "task_id": task_id,
+            "domains": lease.scope["domains"],
+            "purpose": purpose,
+            "expires_at": lease.expires_at,
+            "nonce": secrets.token_hex(16),
+        }
+        encoded = self._encode_payload(payload)
+        assert self._grant_key is not None
+        signature = hmac.new(self._grant_key, encoded, hashlib.sha256).digest()
+        token = self._urlsafe(encoded) + "." + self._urlsafe(signature)
+        parsed = urlsplit(base_url)
+        if parsed.scheme != "http" or parsed.hostname is None:
+            raise NetworkPolicyError(
+                "Egress proxy is invalid.", code="network_proxy_invalid"
+            )
+        authority = parsed.hostname
+        if parsed.port is not None:
+            authority += f":{parsed.port}"
+        return f"http://grant:{quote(token, safe='')}@{authority}"
+
+    def validate_grant(self, token: str, *, domain: str) -> dict[str, object]:
+        self._require_enabled()
+        try:
+            payload_part, signature_part = token.split(".", 1)
+            encoded = self._urlsafe_decode(payload_part)
+            signature = self._urlsafe_decode(signature_part)
+        except (ValueError, UnicodeError) as exc:
+            raise NetworkPolicyError(
+                "Egress grant is invalid.", code="network_grant_invalid"
+            ) from exc
+        assert self._grant_key is not None
+        expected = hmac.new(self._grant_key, encoded, hashlib.sha256).digest()
+        if not hmac.compare_digest(expected, signature):
+            raise NetworkPolicyError(
+                "Egress grant is invalid.", code="network_grant_invalid"
+            )
+        try:
+            payload = json.loads(encoded)
+        except (json.JSONDecodeError, UnicodeError) as exc:
+            raise NetworkPolicyError(
+                "Egress grant is invalid.", code="network_grant_invalid"
+            ) from exc
+        normalized = self._normalize_domain(domain)
+        if (
+            not isinstance(payload, dict)
+            or not isinstance(payload.get("task_id"), str)
+            or not isinstance(payload.get("purpose"), str)
+            or not isinstance(payload.get("domains"), list)
+            or normalized not in payload["domains"]
+            or normalized not in self.allowed_domains
+            or not isinstance(payload.get("expires_at"), (int, float))
+            or isinstance(payload.get("expires_at"), bool)
+            or float(payload["expires_at"]) <= self._clock()
+        ):
+            raise NetworkPolicyError(
+                "Egress grant does not match the destination.",
+                code="network_grant_invalid",
+            )
+        return payload
 
     def approval_scope(self, *, domains: Iterable[str], purpose: str) -> dict[str, object]:
         self._require_enabled()
@@ -121,6 +208,18 @@ class EgressPolicy:
     def _require_enabled(self) -> None:
         if not self.enabled:
             raise NetworkPolicyError("Worker network access is disabled.", code="network_disabled")
+
+    @staticmethod
+    def _encode_payload(value: dict[str, object]) -> bytes:
+        return json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+    @staticmethod
+    def _urlsafe(value: bytes) -> str:
+        return base64.urlsafe_b64encode(value).decode("ascii").rstrip("=")
+
+    @staticmethod
+    def _urlsafe_decode(value: str) -> bytes:
+        return base64.urlsafe_b64decode(value + "=" * (-len(value) % 4))
 
     @staticmethod
     def _normalize_domain(value: str) -> str:

--- a/server/coding_worker/network_policy.py
+++ b/server/coding_worker/network_policy.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import ipaddress
+import re
+import time
+from collections.abc import Callable, Iterable
+from urllib.parse import urlsplit
+
+from .contracts import CapabilityLease
+
+
+PURPOSE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$")
+
+
+class NetworkPolicyError(RuntimeError):
+    def __init__(self, message: str, *, code: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+class EgressPolicy:
+    """Validates a task-scoped HTTPS egress lease before a proxy opens a socket."""
+
+    def __init__(
+        self,
+        *,
+        enabled: bool = False,
+        allowed_domains: Iterable[str] = (),
+        clock: Callable[[], float] = time.time,
+    ) -> None:
+        self.enabled = enabled
+        self.allowed_domains = frozenset(
+            self._normalize_domain(domain) for domain in allowed_domains
+        )
+        self._clock = clock
+
+    def approval_scope(self, *, domains: Iterable[str], purpose: str) -> dict[str, object]:
+        self._require_enabled()
+        if PURPOSE.fullmatch(purpose) is None:
+            raise NetworkPolicyError("Network purpose is invalid.", code="network_scope_invalid")
+        normalized = tuple(dict.fromkeys(self._normalize_domain(item) for item in domains))
+        if not normalized or any(item not in self.allowed_domains for item in normalized):
+            raise NetworkPolicyError(
+                "Requested domains are outside the deployment allowlist.",
+                code="network_domain_not_allowed",
+            )
+        return {"domains": list(normalized), "purpose": purpose}
+
+    def authorize(
+        self,
+        *,
+        url: str,
+        lease: CapabilityLease,
+        purpose: str,
+        resolved_addresses: Iterable[str],
+    ) -> str:
+        self._require_enabled()
+        if lease.capability != "network" or lease.expires_at <= self._clock():
+            raise NetworkPolicyError("Network lease is unavailable.", code="network_lease_invalid")
+        if lease.scope.get("purpose") != purpose:
+            raise NetworkPolicyError("Network purpose does not match the lease.", code="network_scope_invalid")
+        parsed = urlsplit(url)
+        if (
+            parsed.scheme.lower() != "https"
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.hostname is None
+            or parsed.port not in {None, 443}
+        ):
+            raise NetworkPolicyError(
+                "Only credential-free HTTPS destinations are permitted.",
+                code="network_url_not_allowed",
+            )
+        host = self._normalize_domain(parsed.hostname)
+        leased_domains = lease.scope.get("domains")
+        if (
+            not isinstance(leased_domains, list)
+            or host not in leased_domains
+            or host not in self.allowed_domains
+        ):
+            raise NetworkPolicyError(
+                "Destination is outside the task lease.", code="network_domain_not_allowed"
+            )
+        addresses = tuple(resolved_addresses)
+        if not addresses:
+            raise NetworkPolicyError(
+                "Destination must be resolved by the egress proxy.", code="network_resolution_required"
+            )
+        for value in addresses:
+            try:
+                address = ipaddress.ip_address(value)
+            except ValueError as exc:
+                raise NetworkPolicyError(
+                    "Destination resolution is invalid.", code="network_resolution_invalid"
+                ) from exc
+            if not address.is_global:
+                raise NetworkPolicyError(
+                    "Private and non-global destinations are forbidden.",
+                    code="network_private_address_denied",
+                )
+        return host
+
+    def _require_enabled(self) -> None:
+        if not self.enabled:
+            raise NetworkPolicyError("Worker network access is disabled.", code="network_disabled")
+
+    @staticmethod
+    def _normalize_domain(value: str) -> str:
+        candidate = value.strip().lower().rstrip(".")
+        try:
+            ipaddress.ip_address(candidate)
+        except ValueError:
+            pass
+        else:
+            raise NetworkPolicyError(
+                "IP literal destinations are forbidden.", code="network_ip_literal_denied"
+            )
+        try:
+            ascii_domain = candidate.encode("idna").decode("ascii")
+        except UnicodeError as exc:
+            raise NetworkPolicyError("Domain is invalid.", code="network_domain_invalid") from exc
+        labels = ascii_domain.split(".")
+        if (
+            len(labels) < 2
+            or any(not label or len(label) > 63 for label in labels)
+            or any(label.startswith("-") or label.endswith("-") for label in labels)
+            or any(re.fullmatch(r"[a-z0-9-]+", label) is None for label in labels)
+            or ascii_domain.endswith((".local", ".localhost", ".internal"))
+        ):
+            raise NetworkPolicyError("Domain is invalid.", code="network_domain_invalid")
+        return ascii_domain

--- a/server/coding_worker/network_policy.py
+++ b/server/coding_worker/network_policy.py
@@ -100,6 +100,24 @@ class EgressPolicy:
                 )
         return host
 
+    def validate_lease_scope(
+        self,
+        *,
+        lease: CapabilityLease,
+        domains: Iterable[str],
+        purpose: str,
+    ) -> None:
+        expected = self.approval_scope(domains=domains, purpose=purpose)
+        if (
+            lease.capability != "network"
+            or lease.expires_at <= self._clock()
+            or lease.scope != expected
+        ):
+            raise NetworkPolicyError(
+                "Network lease does not match the requested purpose.",
+                code="network_lease_invalid",
+            )
+
     def _require_enabled(self) -> None:
         if not self.enabled:
             raise NetworkPolicyError("Worker network access is disabled.", code="network_disabled")

--- a/server/coding_worker/opencode_provider.py
+++ b/server/coding_worker/opencode_provider.py
@@ -16,6 +16,7 @@ from urllib.parse import quote
 import httpx
 from pydantic import Field
 
+from .broker_rpc import BrokerRPCServer
 from .contracts import PolicyProfile, StrictModel
 from .provider import (
     CodingAgentProvider,
@@ -88,13 +89,19 @@ class OpenCodeProvider(CodingAgentProvider):
         routes: Mapping[str, OpenCodeRoute],
         executable: str = "/usr/local/bin/opencode",
         tool_broker_command: tuple[str, ...] | None = None,
+        broker_rpc: BrokerRPCServer | None = None,
         server_factory: ServerFactory | None = None,
     ) -> None:
         self._workspace_resolver = workspace_resolver
         self._runtime_root = Path(runtime_root)
         self._routes = dict(routes)
         self._executable = executable
-        self._tool_broker_command = tool_broker_command
+        self._broker_rpc = broker_rpc
+        self._tool_broker_command = tool_broker_command or (
+            ("python", "-m", "coding_worker.broker_mcp")
+            if broker_rpc is not None
+            else None
+        )
         self._server_factory = server_factory or self._launch_server
         self._handles: dict[str, OpenCodeServerHandle] = {}
         self._requests: dict[str, ProviderOpenRequest] = {}
@@ -353,6 +360,7 @@ class OpenCodeProvider(CodingAgentProvider):
         home.mkdir(exist_ok=True)
         password = secrets.token_urlsafe(32)
         port = _unused_loopback_port()
+        broker_environment, revoke_broker = self._broker_environment(request.task_id)
         environment = {
             "PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"),
             "HOME": str(home),
@@ -373,20 +381,25 @@ class OpenCodeProvider(CodingAgentProvider):
             "CODING_WORKER_ROUTE_KEY": route.api_key,
             "NO_PROXY": "127.0.0.1,localhost,new-api",
             "no_proxy": "127.0.0.1,localhost,new-api",
+            **broker_environment,
         }
-        process = await asyncio.create_subprocess_exec(
-            self._executable,
-            "serve",
-            "--hostname",
-            "127.0.0.1",
-            "--port",
-            str(port),
-            cwd=workspace,
-            env=environment,
-            stdin=asyncio.subprocess.DEVNULL,
-            stdout=asyncio.subprocess.DEVNULL,
-            stderr=asyncio.subprocess.DEVNULL,
-        )
+        try:
+            process = await asyncio.create_subprocess_exec(
+                self._executable,
+                "serve",
+                "--hostname",
+                "127.0.0.1",
+                "--port",
+                str(port),
+                cwd=workspace,
+                env=environment,
+                stdin=asyncio.subprocess.DEVNULL,
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+        except Exception:
+            revoke_broker()
+            raise
         auth = base64.b64encode(f"opencode:{password}".encode()).decode("ascii")
         client = httpx.AsyncClient(
             base_url=f"http://127.0.0.1:{port}",
@@ -406,11 +419,13 @@ class OpenCodeProvider(CodingAgentProvider):
         except Exception:
             await client.aclose()
             await _stop_process(process)
+            revoke_broker()
             raise
 
         async def close() -> None:
             await client.aclose()
             await _stop_process(process)
+            revoke_broker()
 
         return OpenCodeServerHandle(
             task_id=request.task_id,
@@ -419,6 +434,29 @@ class OpenCodeProvider(CodingAgentProvider):
             client=client,
             close_callback=close,
         )
+
+    def _broker_environment(self, task_id: str) -> tuple[dict[str, str], Callable[[], None]]:
+        if self._broker_rpc is None:
+            return {}, lambda: None
+        endpoint = self._broker_rpc.endpoint
+        if endpoint is None:
+            raise OpenCodeProviderError(
+                "Tool Broker RPC is unavailable.", code="tool_broker_unavailable"
+            )
+        token = self._broker_rpc.register_task(task_id)
+        revoked = False
+
+        def revoke() -> None:
+            nonlocal revoked
+            if not revoked:
+                self._broker_rpc.revoke_task(task_id)
+                revoked = True
+
+        return {
+            "CODING_WORKER_BROKER_ENDPOINT": endpoint,
+            "CODING_WORKER_BROKER_TOKEN": token,
+            "CODING_WORKER_TASK_ID": task_id,
+        }, revoke
 
     def _require_route(self, route_id: str) -> OpenCodeRoute:
         route = self._routes.get(route_id)

--- a/server/coding_worker/opencode_provider.py
+++ b/server/coding_worker/opencode_provider.py
@@ -105,6 +105,7 @@ class OpenCodeProvider(CodingAgentProvider):
         self._server_factory = server_factory or self._launch_server
         self._handles: dict[str, OpenCodeServerHandle] = {}
         self._requests: dict[str, ProviderOpenRequest] = {}
+        self._public_context: dict[str, list[str]] = {}
         self._broker_bindings: dict[str, tuple[str, str]] = {}
         self._lock = asyncio.Lock()
 
@@ -171,6 +172,7 @@ class OpenCodeProvider(CodingAgentProvider):
                 )
             self._handles[session_id] = handle
             self._requests[session_id] = request
+            self._public_context[session_id] = []
         return ProviderSession(
             session_id=session_id,
             task_id=request.task_id,
@@ -208,6 +210,13 @@ class OpenCodeProvider(CodingAgentProvider):
                 mapped = self._map_event(payload, session.session_id)
                 if mapped is None:
                     continue
+                if mapped.kind is ProviderEventKind.MESSAGE:
+                    text_part = mapped.data.get("text")
+                    if isinstance(text_part, str) and text_part:
+                        public = self._public_context.setdefault(session.session_id, [])
+                        public.append(text_part[:16_384])
+                        if len(public) > 64:
+                            del public[:-64]
                 yield mapped
                 if mapped.kind in {
                     ProviderEventKind.TURN_COMPLETED,
@@ -242,77 +251,39 @@ class OpenCodeProvider(CodingAgentProvider):
         return value is True
 
     async def checkpoint(self, session: ProviderSession) -> ProviderCheckpoint:
-        handle, request = self._require_session(session)
-        try:
-            session_response, messages_response = await asyncio.gather(
-                handle.client.get(
-                    self._url(f"/session/{quote(session.session_id)}", handle.workspace)
-                ),
-                handle.client.get(
-                    self._url(
-                        f"/session/{quote(session.session_id)}/message", handle.workspace
-                    )
-                ),
-            )
-            session_response.raise_for_status()
-            messages_response.raise_for_status()
-        except httpx.HTTPError as exc:
-            raise OpenCodeProviderError(
-                "OpenCode checkpoint failed.", code="provider_unavailable"
-            ) from exc
+        _handle, request = self._require_session(session)
+        public_text = "".join(self._public_context.get(session.session_id, ()))
         return ProviderCheckpoint(
             checkpoint_id=f"checkpoint_{secrets.token_hex(16)}",
             payload={
                 "engine": "opencode-1.18.9",
-                "session_id": session.session_id,
                 "task_id": request.task_id,
-                "session": session_response.json(),
-                "messages": messages_response.json(),
+                "public_output": public_text[-32_768:],
             },
         )
 
     async def restore(
         self, request: ProviderOpenRequest, checkpoint: ProviderCheckpoint
     ) -> ProviderSession:
-        session_id = checkpoint.payload.get("session_id")
         if (
             checkpoint.payload.get("engine") != "opencode-1.18.9"
             or checkpoint.payload.get("task_id") != request.task_id
-            or not isinstance(session_id, str)
-            or not session_id.startswith("ses")
+            or not isinstance(checkpoint.payload.get("public_output", ""), str)
         ):
             raise OpenCodeProviderError(
                 "OpenCode checkpoint binding is invalid.", code="checkpoint_invalid"
             )
-        route = self._require_route(request.model_route)
-        workspace = self._workspace_resolver(request.workspace_id).resolve()
-        handle = await self._server_factory(request, workspace, route)
-        try:
-            response = await handle.client.get(
-                self._url(f"/session/{quote(session_id)}", workspace)
-            )
-            response.raise_for_status()
-            payload = response.json()
-            if not isinstance(payload, dict) or payload.get("id") != session_id:
-                raise OpenCodeProviderError(
-                    "OpenCode checkpoint is unavailable.", code="checkpoint_unavailable"
-                )
-        except Exception:
-            await handle.close()
-            raise
-        async with self._lock:
-            self._handles[session_id] = handle
-            self._requests[session_id] = request
-        return ProviderSession(
-            session_id=session_id,
-            task_id=request.task_id,
-            provider_capabilities=await self.capabilities(),
-        )
+        # A provider process is never resurrected. Restore opens a fresh, pinned
+        # engine session; the control plane supplies the public checkpoint
+        # summary in the next message. Raw vendor frames and hidden reasoning
+        # are intentionally absent from the durable checkpoint.
+        return await self.open(request)
 
     async def close(self, session: ProviderSession) -> None:
         async with self._lock:
             handle = self._handles.pop(session.session_id, None)
             self._requests.pop(session.session_id, None)
+            self._public_context.pop(session.session_id, None)
         if handle is not None:
             await handle.close()
 

--- a/server/coding_worker/opencode_provider.py
+++ b/server/coding_worker/opencode_provider.py
@@ -1,0 +1,539 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import contextlib
+import json
+import os
+import secrets
+import socket
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+from pydantic import Field
+
+from .contracts import PolicyProfile, StrictModel
+from .provider import (
+    CodingAgentProvider,
+    ProviderCapabilities,
+    ProviderCheckpoint,
+    ProviderEvent,
+    ProviderEventKind,
+    ProviderOpenRequest,
+    ProviderSession,
+)
+
+
+OPENCODE_VERSION = "1.18.9"
+DIRECT_TOOL_NAMES = frozenset(
+    {
+        "bash",
+        "edit",
+        "write",
+        "patch",
+        "webfetch",
+        "websearch",
+        "skill",
+        "task",
+        "question",
+        "todowrite",
+    }
+)
+
+
+class OpenCodeProviderError(RuntimeError):
+    def __init__(self, message: str, *, code: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+class OpenCodeRoute(StrictModel):
+    route_id: str
+    model_id: str
+    base_url: str
+    api_key: str = Field(min_length=1, repr=False, exclude=True)
+    context_tokens: int = Field(default=128_000, ge=8_192, le=2_000_000)
+    output_tokens: int = Field(default=32_000, ge=1_024, le=262_144)
+
+
+@dataclass(slots=True)
+class OpenCodeServerHandle:
+    task_id: str
+    workspace: Path
+    state_root: Path
+    client: httpx.AsyncClient
+    close_callback: Callable[[], Awaitable[None]]
+
+    async def close(self) -> None:
+        await self.close_callback()
+
+
+ServerFactory = Callable[
+    [ProviderOpenRequest, Path, OpenCodeRoute], Awaitable[OpenCodeServerHandle]
+]
+
+
+class OpenCodeProvider(CodingAgentProvider):
+    """OpenCode 1.18.9 headless adapter; raw HTTP details remain private."""
+
+    def __init__(
+        self,
+        *,
+        workspace_resolver: Callable[[str], Path],
+        runtime_root: Path,
+        routes: Mapping[str, OpenCodeRoute],
+        executable: str = "/usr/local/bin/opencode",
+        tool_broker_command: tuple[str, ...] | None = None,
+        server_factory: ServerFactory | None = None,
+    ) -> None:
+        self._workspace_resolver = workspace_resolver
+        self._runtime_root = Path(runtime_root)
+        self._routes = dict(routes)
+        self._executable = executable
+        self._tool_broker_command = tool_broker_command
+        self._server_factory = server_factory or self._launch_server
+        self._handles: dict[str, OpenCodeServerHandle] = {}
+        self._requests: dict[str, ProviderOpenRequest] = {}
+        self._lock = asyncio.Lock()
+
+    async def capabilities(self) -> ProviderCapabilities:
+        return ProviderCapabilities(
+            supports_streaming=True,
+            supports_cancel=True,
+            supports_checkpoint=True,
+            supports_restore=True,
+            supports_steering=True,
+        )
+
+    async def open(self, request: ProviderOpenRequest) -> ProviderSession:
+        route = self._require_route(request.model_route)
+        workspace = self._workspace_resolver(request.workspace_id).resolve()
+        if not workspace.is_dir() or workspace.is_symlink():
+            raise OpenCodeProviderError("Workspace is unavailable.", code="workspace_unavailable")
+        handle = await self._server_factory(request, workspace, route)
+        try:
+            response = await handle.client.post(
+                self._url("/session", workspace),
+                json={
+                    "title": f"ModelMirror {request.task_id}",
+                    "agent": "modelmirror-worker",
+                    "model": {
+                        "providerID": "modelmirror",
+                        "id": route.model_id,
+                    },
+                },
+            )
+            response.raise_for_status()
+            payload = response.json()
+            session_id = payload.get("id") if isinstance(payload, dict) else None
+            if not isinstance(session_id, str) or not session_id.startswith("ses"):
+                raise OpenCodeProviderError(
+                    "OpenCode returned an invalid session.", code="provider_invalid_response"
+                )
+        except Exception:
+            await handle.close()
+            raise
+        async with self._lock:
+            if session_id in self._handles:
+                await handle.close()
+                raise OpenCodeProviderError(
+                    "OpenCode session collision.", code="provider_invalid_response"
+                )
+            self._handles[session_id] = handle
+            self._requests[session_id] = request
+        return ProviderSession(
+            session_id=session_id,
+            task_id=request.task_id,
+            provider_capabilities=await self.capabilities(),
+        )
+
+    async def message(
+        self, session: ProviderSession, text: str
+    ) -> AsyncIterator[ProviderEvent]:
+        if not text.strip():
+            raise ValueError("provider message cannot be blank")
+        handle, request = self._require_session(session)
+        route = self._require_route(request.model_route)
+        event_response: httpx.Response | None = None
+        try:
+            event_request = handle.client.build_request(
+                "GET", self._url("/event", handle.workspace)
+            )
+            event_response = await handle.client.send(event_request, stream=True)
+            event_response.raise_for_status()
+            prompt = await handle.client.post(
+                self._url(f"/session/{quote(session.session_id)}/prompt_async", handle.workspace),
+                json={
+                    "model": {
+                        "providerID": "modelmirror",
+                        "modelID": route.model_id,
+                    },
+                    "agent": "modelmirror-worker",
+                    "tools": self._prompt_tools(),
+                    "parts": [{"type": "text", "text": text}],
+                },
+            )
+            prompt.raise_for_status()
+            async for payload in _iter_sse_json(event_response):
+                mapped = self._map_event(payload, session.session_id)
+                if mapped is None:
+                    continue
+                yield mapped
+                if mapped.kind in {
+                    ProviderEventKind.TURN_COMPLETED,
+                    ProviderEventKind.CANCELLED,
+                    ProviderEventKind.FAILED,
+                }:
+                    return
+            raise OpenCodeProviderError(
+                "OpenCode event stream ended before a terminal event.",
+                code="provider_stream_ended",
+            )
+        except httpx.HTTPError as exc:
+            raise OpenCodeProviderError(
+                "OpenCode request failed.", code="provider_unavailable"
+            ) from exc
+        finally:
+            if event_response is not None:
+                await event_response.aclose()
+
+    async def cancel(self, session: ProviderSession) -> bool:
+        handle, _request = self._require_session(session)
+        try:
+            response = await handle.client.post(
+                self._url(f"/session/{quote(session.session_id)}/abort", handle.workspace)
+            )
+            response.raise_for_status()
+            value = response.json()
+        except httpx.HTTPError as exc:
+            raise OpenCodeProviderError(
+                "OpenCode cancel failed.", code="provider_unavailable"
+            ) from exc
+        return value is True
+
+    async def checkpoint(self, session: ProviderSession) -> ProviderCheckpoint:
+        handle, request = self._require_session(session)
+        try:
+            session_response, messages_response = await asyncio.gather(
+                handle.client.get(
+                    self._url(f"/session/{quote(session.session_id)}", handle.workspace)
+                ),
+                handle.client.get(
+                    self._url(
+                        f"/session/{quote(session.session_id)}/message", handle.workspace
+                    )
+                ),
+            )
+            session_response.raise_for_status()
+            messages_response.raise_for_status()
+        except httpx.HTTPError as exc:
+            raise OpenCodeProviderError(
+                "OpenCode checkpoint failed.", code="provider_unavailable"
+            ) from exc
+        return ProviderCheckpoint(
+            checkpoint_id=f"checkpoint_{secrets.token_hex(16)}",
+            payload={
+                "engine": "opencode-1.18.9",
+                "session_id": session.session_id,
+                "task_id": request.task_id,
+                "session": session_response.json(),
+                "messages": messages_response.json(),
+            },
+        )
+
+    async def restore(
+        self, request: ProviderOpenRequest, checkpoint: ProviderCheckpoint
+    ) -> ProviderSession:
+        session_id = checkpoint.payload.get("session_id")
+        if (
+            checkpoint.payload.get("engine") != "opencode-1.18.9"
+            or checkpoint.payload.get("task_id") != request.task_id
+            or not isinstance(session_id, str)
+            or not session_id.startswith("ses")
+        ):
+            raise OpenCodeProviderError(
+                "OpenCode checkpoint binding is invalid.", code="checkpoint_invalid"
+            )
+        route = self._require_route(request.model_route)
+        workspace = self._workspace_resolver(request.workspace_id).resolve()
+        handle = await self._server_factory(request, workspace, route)
+        try:
+            response = await handle.client.get(
+                self._url(f"/session/{quote(session_id)}", workspace)
+            )
+            response.raise_for_status()
+            payload = response.json()
+            if not isinstance(payload, dict) or payload.get("id") != session_id:
+                raise OpenCodeProviderError(
+                    "OpenCode checkpoint is unavailable.", code="checkpoint_unavailable"
+                )
+        except Exception:
+            await handle.close()
+            raise
+        async with self._lock:
+            self._handles[session_id] = handle
+            self._requests[session_id] = request
+        return ProviderSession(
+            session_id=session_id,
+            task_id=request.task_id,
+            provider_capabilities=await self.capabilities(),
+        )
+
+    async def close(self, session: ProviderSession) -> None:
+        async with self._lock:
+            handle = self._handles.pop(session.session_id, None)
+            self._requests.pop(session.session_id, None)
+        if handle is not None:
+            await handle.close()
+
+    def build_config(self, route: OpenCodeRoute) -> dict[str, Any]:
+        permission: dict[str, str] = {
+            "*": "deny",
+            "external_directory": "deny",
+            "doom_loop": "deny",
+            "question": "deny",
+        }
+        mcp: dict[str, Any] = {}
+        if self._tool_broker_command is not None:
+            permission["modelmirror-tool-broker_*"] = "allow"
+            mcp["modelmirror-tool-broker"] = {
+                "type": "local",
+                "command": list(self._tool_broker_command),
+                "enabled": True,
+                "timeout": 310_000,
+            }
+        return {
+            "$schema": "https://opencode.ai/config.json",
+            "model": f"modelmirror/{route.model_id}",
+            "default_agent": "modelmirror-worker",
+            "agent": {
+                "modelmirror-worker": {
+                    "description": "ModelMirror provider-neutral coding worker",
+                    "mode": "primary",
+                    "permission": permission,
+                }
+            },
+            "permission": permission,
+            "provider": {
+                "modelmirror": {
+                    "npm": "@ai-sdk/openai-compatible",
+                    "name": "ModelMirror Internal Gateway",
+                    "options": {
+                        "baseURL": route.base_url,
+                        "apiKey": "{env:CODING_WORKER_ROUTE_KEY}",
+                    },
+                    "models": {
+                        route.model_id: {
+                            "name": "ModelMirror controlled model route",
+                            "limit": {
+                                "context": route.context_tokens,
+                                "output": route.output_tokens,
+                            },
+                        }
+                    },
+                }
+            },
+            "plugin": [],
+            "mcp": mcp,
+            "instructions": [],
+            "share": "disabled",
+            "autoupdate": False,
+        }
+
+    async def _launch_server(
+        self, request: ProviderOpenRequest, workspace: Path, route: OpenCodeRoute
+    ) -> OpenCodeServerHandle:
+        state_root = self._runtime_root / request.task_id
+        state_root.mkdir(parents=True, exist_ok=True)
+        home = state_root / "home"
+        home.mkdir(exist_ok=True)
+        password = secrets.token_urlsafe(32)
+        port = _unused_loopback_port()
+        environment = {
+            "PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"),
+            "HOME": str(home),
+            "XDG_CONFIG_HOME": str(home / ".config"),
+            "XDG_DATA_HOME": str(home / ".local/share"),
+            "XDG_STATE_HOME": str(home / ".local/state"),
+            "XDG_CACHE_HOME": str(home / ".cache"),
+            "OPENCODE_CONFIG_CONTENT": json.dumps(
+                self.build_config(route), ensure_ascii=False, separators=(",", ":")
+            ),
+            "OPENCODE_DISABLE_PROJECT_CONFIG": "1",
+            "OPENCODE_PURE": "1",
+            "OPENCODE_DISABLE_AUTOUPDATE": "1",
+            "OPENCODE_DISABLE_AUTOCOMPACT": "1",
+            "OPENCODE_DISABLE_MODELS_FETCH": "1",
+            "OPENCODE_AUTH_CONTENT": "{}",
+            "OPENCODE_SERVER_PASSWORD": password,
+            "CODING_WORKER_ROUTE_KEY": route.api_key,
+            "NO_PROXY": "127.0.0.1,localhost,new-api",
+            "no_proxy": "127.0.0.1,localhost,new-api",
+        }
+        process = await asyncio.create_subprocess_exec(
+            self._executable,
+            "serve",
+            "--hostname",
+            "127.0.0.1",
+            "--port",
+            str(port),
+            cwd=workspace,
+            env=environment,
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        auth = base64.b64encode(f"opencode:{password}".encode()).decode("ascii")
+        client = httpx.AsyncClient(
+            base_url=f"http://127.0.0.1:{port}",
+            headers={"Authorization": f"Basic {auth}"},
+            timeout=httpx.Timeout(120.0, connect=5.0),
+            trust_env=False,
+        )
+        try:
+            await _wait_for_server(client, process)
+            health = await client.get("/global/health")
+            health.raise_for_status()
+            payload = health.json()
+            if payload != {"healthy": True, "version": OPENCODE_VERSION}:
+                raise OpenCodeProviderError(
+                    "OpenCode version is not the pinned version.", code="provider_version_mismatch"
+                )
+        except Exception:
+            await client.aclose()
+            await _stop_process(process)
+            raise
+
+        async def close() -> None:
+            await client.aclose()
+            await _stop_process(process)
+
+        return OpenCodeServerHandle(
+            task_id=request.task_id,
+            workspace=workspace,
+            state_root=state_root,
+            client=client,
+            close_callback=close,
+        )
+
+    def _require_route(self, route_id: str) -> OpenCodeRoute:
+        route = self._routes.get(route_id)
+        if route is None or route.route_id != route_id:
+            raise OpenCodeProviderError("Model route is unavailable.", code="model_route_unavailable")
+        return route
+
+    def _require_session(
+        self, session: ProviderSession
+    ) -> tuple[OpenCodeServerHandle, ProviderOpenRequest]:
+        handle = self._handles.get(session.session_id)
+        request = self._requests.get(session.session_id)
+        if handle is None or request is None or request.task_id != session.task_id:
+            raise OpenCodeProviderError("Provider session was not found.", code="session_not_found")
+        return handle, request
+
+    def _prompt_tools(self) -> dict[str, bool]:
+        tools = {name: False for name in DIRECT_TOOL_NAMES}
+        if self._tool_broker_command is not None:
+            tools["modelmirror-tool-broker_*"] = True
+        return tools
+
+    @staticmethod
+    def _url(path: str, workspace: Path) -> str:
+        return f"{path}?directory={quote(str(workspace), safe='')}"
+
+    @staticmethod
+    def _map_event(payload: dict[str, Any], session_id: str) -> ProviderEvent | None:
+        event_type = payload.get("type")
+        properties = payload.get("properties")
+        if not isinstance(event_type, str) or not isinstance(properties, dict):
+            return None
+        event_session = properties.get("sessionID") or properties.get("sessionId")
+        if event_session is not None and event_session != session_id:
+            return None
+        if event_type in {"message.part.updated", "message.part.delta"}:
+            part = properties.get("part")
+            delta = properties.get("delta")
+            text = None
+            if isinstance(part, dict) and part.get("type") == "text":
+                text = delta if isinstance(delta, str) else part.get("text")
+            if isinstance(text, str) and text:
+                return ProviderEvent(kind=ProviderEventKind.MESSAGE, data={"text": text})
+        if event_type in {"permission.asked", "permission.updated"}:
+            return ProviderEvent(
+                kind=ProviderEventKind.APPROVAL_REQUIRED,
+                data={"request": properties},
+            )
+        if event_type in {"session.idle", "session.completed"}:
+            return ProviderEvent(kind=ProviderEventKind.TURN_COMPLETED)
+        if event_type in {"session.aborted", "session.cancelled"}:
+            return ProviderEvent(kind=ProviderEventKind.CANCELLED)
+        if event_type in {"session.error", "message.error"}:
+            return ProviderEvent(kind=ProviderEventKind.FAILED, data={"error": "provider_failed"})
+        return None
+
+
+async def _iter_sse_json(response: httpx.Response) -> AsyncIterator[dict[str, Any]]:
+    data_lines: list[str] = []
+    async for line in response.aiter_lines():
+        if not line:
+            if data_lines:
+                try:
+                    value = json.loads("\n".join(data_lines))
+                except json.JSONDecodeError:
+                    value = None
+                if isinstance(value, dict):
+                    yield value
+                data_lines.clear()
+            continue
+        if line.startswith("data:"):
+            data_lines.append(line[5:].lstrip())
+    if data_lines:
+        try:
+            value = json.loads("\n".join(data_lines))
+        except json.JSONDecodeError:
+            return
+        if isinstance(value, dict):
+            yield value
+
+
+async def _wait_for_server(
+    client: httpx.AsyncClient,
+    process: asyncio.subprocess.Process,
+    *,
+    timeout: float = 10.0,
+) -> None:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        if process.returncode is not None:
+            raise OpenCodeProviderError("OpenCode exited during startup.", code="provider_unavailable")
+        try:
+            response = await client.get("/global/health", timeout=0.25)
+            if response.status_code == 200:
+                return
+        except httpx.HTTPError:
+            pass
+        await asyncio.sleep(0.05)
+    raise OpenCodeProviderError("OpenCode startup timed out.", code="provider_unavailable")
+
+
+async def _stop_process(process: asyncio.subprocess.Process) -> None:
+    if process.returncode is not None:
+        return
+    with contextlib.suppress(ProcessLookupError):
+        process.terminate()
+    try:
+        await asyncio.wait_for(process.wait(), timeout=5.0)
+    except TimeoutError:
+        with contextlib.suppress(ProcessLookupError):
+            process.kill()
+        await process.wait()
+
+
+def _unused_loopback_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as candidate:
+        candidate.bind(("127.0.0.1", 0))
+        return int(candidate.getsockname()[1])

--- a/server/coding_worker/opencode_provider.py
+++ b/server/coding_worker/opencode_provider.py
@@ -30,6 +30,7 @@ from .provider import (
 
 
 OPENCODE_VERSION = "1.18.9"
+TOOL_BROKER_MCP_NAME = "modelmirror-tool-broker"
 DIRECT_TOOL_NAMES = frozenset(
     {
         "bash",
@@ -143,6 +144,7 @@ class OpenCodeProvider(CodingAgentProvider):
             raise OpenCodeProviderError("Workspace is unavailable.", code="workspace_unavailable")
         handle = await self._server_factory(request, workspace, route)
         try:
+            await self._wait_for_tool_broker(handle)
             response = await handle.client.post(
                 self._url("/session", workspace),
                 json={
@@ -296,10 +298,13 @@ class OpenCodeProvider(CodingAgentProvider):
         }
         mcp: dict[str, Any] = {}
         if self._tool_broker_command is not None:
-            permission["modelmirror-tool-broker_*"] = "allow"
-            mcp["modelmirror-tool-broker"] = {
+            permission[f"{TOOL_BROKER_MCP_NAME}_*"] = "allow"
+            mcp[TOOL_BROKER_MCP_NAME] = {
                 "type": "local",
                 "command": list(self._tool_broker_command),
+                "environment": {
+                    "PYTHONPATH": str(Path(__file__).resolve().parent.parent),
+                },
                 "enabled": True,
                 "timeout": 310_000,
             }
@@ -473,8 +478,37 @@ class OpenCodeProvider(CodingAgentProvider):
     def _prompt_tools(self) -> dict[str, bool]:
         tools = {name: False for name in DIRECT_TOOL_NAMES}
         if self._tool_broker_command is not None:
-            tools["modelmirror-tool-broker_*"] = True
+            tools[f"{TOOL_BROKER_MCP_NAME}_*"] = True
         return tools
+
+    async def _wait_for_tool_broker(self, handle: OpenCodeServerHandle) -> None:
+        if self._tool_broker_command is None:
+            return
+        deadline = asyncio.get_running_loop().time() + 15.0
+        while asyncio.get_running_loop().time() < deadline:
+            try:
+                status_response = await handle.client.get(
+                    self._url("/mcp", handle.workspace), timeout=2.0
+                )
+                status_response.raise_for_status()
+                statuses = status_response.json()
+                broker_status = (
+                    statuses.get(TOOL_BROKER_MCP_NAME)
+                    if isinstance(statuses, dict)
+                    else None
+                )
+                if (
+                    isinstance(broker_status, dict)
+                    and broker_status.get("status") == "connected"
+                ):
+                    return
+            except (httpx.HTTPError, ValueError):
+                pass
+            await asyncio.sleep(0.1)
+        raise OpenCodeProviderError(
+            "Tool Broker MCP failed to become ready.",
+            code="tool_broker_unavailable",
+        )
 
     @staticmethod
     def _url(path: str, workspace: Path) -> str:

--- a/server/coding_worker/opencode_provider.py
+++ b/server/coding_worker/opencode_provider.py
@@ -105,7 +105,26 @@ class OpenCodeProvider(CodingAgentProvider):
         self._server_factory = server_factory or self._launch_server
         self._handles: dict[str, OpenCodeServerHandle] = {}
         self._requests: dict[str, ProviderOpenRequest] = {}
+        self._broker_bindings: dict[str, tuple[str, str]] = {}
         self._lock = asyncio.Lock()
+
+    def bind_broker(self, task_id: str, endpoint: str, token: str) -> None:
+        if not (
+            endpoint.startswith("unix:")
+            or endpoint.startswith("tcp:127.0.0.1:")
+        ) or len(token) < 32:
+            raise OpenCodeProviderError(
+                "Tool Broker binding is invalid.", code="tool_broker_unavailable"
+            )
+        existing = self._broker_bindings.get(task_id)
+        if existing is not None and existing != (endpoint, token):
+            raise OpenCodeProviderError(
+                "Tool Broker binding changed.", code="tool_broker_binding_changed"
+            )
+        self._broker_bindings[task_id] = (endpoint, token)
+
+    def unbind_broker(self, task_id: str) -> None:
+        self._broker_bindings.pop(task_id, None)
 
     async def capabilities(self) -> ProviderCapabilities:
         return ProviderCapabilities(
@@ -436,20 +455,27 @@ class OpenCodeProvider(CodingAgentProvider):
         )
 
     def _broker_environment(self, task_id: str) -> tuple[dict[str, str], Callable[[], None]]:
-        if self._broker_rpc is None:
-            return {}, lambda: None
-        endpoint = self._broker_rpc.endpoint
-        if endpoint is None:
-            raise OpenCodeProviderError(
-                "Tool Broker RPC is unavailable.", code="tool_broker_unavailable"
-            )
-        token = self._broker_rpc.register_task(task_id)
+        if self._broker_rpc is not None:
+            endpoint = self._broker_rpc.endpoint
+            if endpoint is None:
+                raise OpenCodeProviderError(
+                    "Tool Broker RPC is unavailable.", code="tool_broker_unavailable"
+                )
+            token = self._broker_rpc.register_task(task_id)
+        else:
+            binding = self._broker_bindings.get(task_id)
+            if binding is None:
+                return {}, lambda: None
+            endpoint, token = binding
         revoked = False
 
         def revoke() -> None:
             nonlocal revoked
             if not revoked:
-                self._broker_rpc.revoke_task(task_id)
+                if self._broker_rpc is not None:
+                    self._broker_rpc.revoke_task(task_id)
+                else:
+                    self.unbind_broker(task_id)
                 revoked = True
 
         return {

--- a/server/coding_worker/opencode_provider.py
+++ b/server/coding_worker/opencode_provider.py
@@ -465,7 +465,7 @@ class OpenCodeProvider(CodingAgentProvider):
         if event_type in {"permission.asked", "permission.updated"}:
             return ProviderEvent(
                 kind=ProviderEventKind.APPROVAL_REQUIRED,
-                data={"request": properties},
+                data={"capability": "provider_permission"},
             )
         if event_type in {"session.idle", "session.completed"}:
             return ProviderEvent(kind=ProviderEventKind.TURN_COMPLETED)

--- a/server/coding_worker/process_manager.py
+++ b/server/coding_worker/process_manager.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import signal
+import subprocess
+import time
+import uuid
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Literal
+
+from pydantic import Field
+
+from .contracts import StrictModel
+from .store import CodingWorkerStore, WorkerNotFoundError
+from .workspace import WorkspaceBroker
+
+
+class ProcessManagerError(RuntimeError):
+    def __init__(self, message: str, *, code: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+class ManagedProcess(StrictModel):
+    service_id: str
+    task_id: str
+    state: Literal["running", "completed", "failed", "stopped"]
+    started_at: float
+    expires_at: float
+    exit_code: int | None = None
+    output_artifact_id: str | None = None
+    reason: str | None = None
+
+
+@dataclass(slots=True)
+class _LiveProcess:
+    record: ManagedProcess
+    process: asyncio.subprocess.Process
+    output: bytearray
+    monitor: asyncio.Task[None] | None = None
+    reason: str | None = None
+
+
+class BackgroundProcessManager:
+    """Owns task processes and archives bounded output; it never exposes a PID."""
+
+    def __init__(
+        self,
+        *,
+        store: CodingWorkerStore,
+        workspace_broker: WorkspaceBroker,
+        environment_factory: Callable[[str], Mapping[str, str]],
+        max_processes_per_task: int = 4,
+        max_output_bytes: int = 2 * 1024 * 1024,
+        clock: Callable[[], float] = time.time,
+    ) -> None:
+        if not 1 <= max_processes_per_task <= 16:
+            raise ValueError("process capacity is invalid")
+        if not 1024 <= max_output_bytes <= 16 * 1024 * 1024:
+            raise ValueError("process output limit is invalid")
+        self.store = store
+        self.workspace_broker = workspace_broker
+        self.environment_factory = environment_factory
+        self.max_processes_per_task = max_processes_per_task
+        self.max_output_bytes = max_output_bytes
+        self._clock = clock
+        self._processes: dict[str, _LiveProcess] = {}
+        self._lock = asyncio.Lock()
+
+    async def start(
+        self,
+        *,
+        task_id: str,
+        workspace_id: str,
+        argv: Sequence[str],
+        ttl_seconds: int,
+    ) -> ManagedProcess:
+        if not 1 <= ttl_seconds <= 3600:
+            raise ProcessManagerError("Service TTL is invalid.", code="service_ttl_invalid")
+        async with self._lock:
+            active = sum(
+                item.record.task_id == task_id and item.record.state == "running"
+                for item in self._processes.values()
+            )
+            if active >= self.max_processes_per_task:
+                raise ProcessManagerError(
+                    "Task service capacity is exhausted.", code="service_capacity_exhausted"
+                )
+            now = self._clock()
+            service_id = f"service_{uuid.uuid4().hex}"
+            kwargs: dict[str, object] = {}
+            if os.name == "nt":
+                kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+            else:
+                kwargs["start_new_session"] = True
+            process = await asyncio.create_subprocess_exec(
+                *argv,
+                cwd=self.workspace_broker.repository_path(workspace_id),
+                env=dict(self.environment_factory(workspace_id)),
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+                **kwargs,
+            )
+            live = _LiveProcess(
+                record=ManagedProcess(
+                    service_id=service_id,
+                    task_id=task_id,
+                    state="running",
+                    started_at=now,
+                    expires_at=now + ttl_seconds,
+                ),
+                process=process,
+                output=bytearray(),
+            )
+            self._processes[service_id] = live
+            live.monitor = asyncio.create_task(
+                self._monitor(live, ttl_seconds), name=f"worker-service-{service_id}"
+            )
+            self.store.append_event(task_id, "service_started", {"service_id": service_id})
+            return live.record
+
+    async def send_input(self, *, task_id: str, service_id: str, data: bytes) -> None:
+        if not data or len(data) > 64 * 1024:
+            raise ProcessManagerError("Service input is invalid.", code="service_input_invalid")
+        live = self._require(task_id, service_id)
+        if live.process.stdin is None or live.record.state != "running":
+            raise ProcessManagerError("Service is not running.", code="service_not_running")
+        live.process.stdin.write(data)
+        await live.process.stdin.drain()
+
+    async def interrupt(self, *, task_id: str, service_id: str) -> ManagedProcess:
+        live = self._require(task_id, service_id)
+        if live.record.state != "running":
+            return live.record
+        live.reason = "user_interrupted"
+        await self._interrupt_process(live.process)
+        if live.monitor is not None:
+            await live.monitor
+        return live.record
+
+    def status(self, *, task_id: str, service_id: str) -> ManagedProcess:
+        return self._require(task_id, service_id).record
+
+    def list(self, task_id: str) -> tuple[ManagedProcess, ...]:
+        self.store.get_task(task_id)
+        return tuple(
+            item.record for item in self._processes.values() if item.record.task_id == task_id
+        )
+
+    async def shutdown(self) -> None:
+        running = [item for item in self._processes.values() if item.record.state == "running"]
+        for item in running:
+            item.reason = "manager_shutdown"
+            await self._interrupt_process(item.process)
+        await asyncio.gather(
+            *(item.monitor for item in running if item.monitor is not None),
+            return_exceptions=True,
+        )
+
+    async def _monitor(self, live: _LiveProcess, ttl_seconds: int) -> None:
+        drain = asyncio.create_task(self._drain_output(live))
+        try:
+            try:
+                await asyncio.wait_for(live.process.wait(), timeout=ttl_seconds)
+            except TimeoutError:
+                live.reason = "service_ttl_expired"
+                await self._interrupt_process(live.process)
+            await drain
+        finally:
+            if not drain.done():
+                drain.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await drain
+            exit_code = live.process.returncode
+            reason = live.reason
+            state: Literal["completed", "failed", "stopped"]
+            if reason is not None:
+                state = "stopped"
+            elif exit_code == 0:
+                state = "completed"
+            else:
+                state = "failed"
+                reason = "service_exited"
+            artifact = self.store.create_artifact(
+                task_id=live.record.task_id,
+                media_type="text/plain; charset=utf-8",
+                content=bytes(live.output),
+                metadata={"service_id": live.record.service_id, "reason": reason},
+            )
+            live.record = live.record.model_copy(
+                update={
+                    "state": state,
+                    "exit_code": exit_code,
+                    "output_artifact_id": artifact.artifact_id,
+                    "reason": reason,
+                }
+            )
+            self.store.append_event(
+                live.record.task_id,
+                "service_stopped",
+                {
+                    "service_id": live.record.service_id,
+                    "state": state,
+                    "artifact_id": artifact.artifact_id,
+                    "reason": reason,
+                },
+            )
+
+    async def _drain_output(self, live: _LiveProcess) -> None:
+        if live.process.stdout is None:
+            return
+        while True:
+            chunk = await live.process.stdout.read(64 * 1024)
+            if not chunk:
+                return
+            if len(live.output) + len(chunk) > self.max_output_bytes:
+                remaining = self.max_output_bytes - len(live.output)
+                if remaining > 0:
+                    live.output.extend(chunk[:remaining])
+                live.reason = "service_output_limit"
+                with contextlib.suppress(ProcessLookupError):
+                    live.process.kill()
+                return
+            live.output.extend(chunk)
+
+    @staticmethod
+    async def _interrupt_process(process: asyncio.subprocess.Process) -> None:
+        if process.returncode is not None:
+            return
+        with contextlib.suppress(ProcessLookupError):
+            if os.name == "nt":
+                process.send_signal(signal.CTRL_BREAK_EVENT)
+            else:
+                os.killpg(process.pid, signal.SIGINT)
+        try:
+            await asyncio.wait_for(process.wait(), timeout=2.0)
+        except TimeoutError:
+            with contextlib.suppress(ProcessLookupError):
+                process.kill()
+            await process.wait()
+
+    def _require(self, task_id: str, service_id: str) -> _LiveProcess:
+        item = self._processes.get(service_id)
+        if item is None or item.record.task_id != task_id:
+            raise WorkerNotFoundError("Service was not found.", code="service_not_found")
+        return item

--- a/server/coding_worker/provider_rpc.py
+++ b/server/coding_worker/provider_rpc.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import secrets
 from collections.abc import AsyncIterator, Callable, Mapping, Sequence
@@ -60,6 +61,7 @@ class ProviderRPCServer:
         self.endpoint: str | None = None
         self._active_task_id: str | None = None
         self._lock = asyncio.Lock()
+        self._connections: dict[asyncio.Task[None], asyncio.StreamWriter] = {}
 
     async def start_unix(self, socket_path: Path) -> str:
         if self._server is not None:
@@ -87,13 +89,23 @@ class ProviderRPCServer:
     async def close(self) -> None:
         if self._server is not None:
             self._server.close()
-            await self._server.wait_closed()
+        connections = tuple(self._connections.items())
+        for task, writer in connections:
+            writer.close()
+            task.cancel()
+        if connections:
+            await asyncio.wait(tuple(task for task, _writer in connections), timeout=2)
+        if self._server is not None:
+            await asyncio.wait_for(self._server.wait_closed(), timeout=2)
         self._server = None
         self.endpoint = None
 
     async def _handle(
         self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
     ) -> None:
+        current = asyncio.current_task()
+        if current is not None:
+            self._connections[current] = writer
         try:
             request = await self._read_request(reader)
             if request.action == "message":
@@ -125,7 +137,10 @@ class ProviderRPCServer:
             )
         finally:
             writer.close()
-            await writer.wait_closed()
+            with contextlib.suppress(Exception):
+                await asyncio.wait_for(writer.wait_closed(), timeout=1)
+            if current is not None:
+                self._connections.pop(current, None)
 
     async def _dispatch(self, request: ProviderRPCRequest) -> dict[str, Any]:
         if request.action == "capabilities":

--- a/server/coding_worker/provider_rpc.py
+++ b/server/coding_worker/provider_rpc.py
@@ -20,7 +20,7 @@ from .provider import (
     ProviderOpenRequest,
     ProviderSession,
 )
-from .executor import SidecarExecutor
+from .executor import ExecutorSidecarClientPool, SidecarExecutor
 
 
 MAX_PROVIDER_RPC_BYTES = 8 * 1024 * 1024
@@ -283,6 +283,7 @@ class ProviderSidecarClientPool(CodingAgentProvider):
         tokens: Mapping[str, str],
         workspace_slot_resolver: Callable[[str], str],
         broker_rpc: BrokerRPCServer,
+        executor_pool: ExecutorSidecarClientPool | None = None,
     ) -> None:
         if set(endpoints) != set(tokens) or not endpoints:
             raise ValueError("provider sidecar bindings are incomplete")
@@ -290,7 +291,8 @@ class ProviderSidecarClientPool(CodingAgentProvider):
         self._tokens = dict(tokens)
         self._workspace_slot_resolver = workspace_slot_resolver
         self._broker_rpc = broker_rpc
-        self._sessions: dict[str, tuple[str, str]] = {}
+        self._executor_pool = executor_pool
+        self._sessions: dict[str, tuple[str, str, str]] = {}
 
     async def capabilities(self) -> ProviderCapabilities:
         values = [
@@ -324,6 +326,14 @@ class ProviderSidecarClientPool(CodingAgentProvider):
                 "Provider slot is unavailable.", code="provider_unavailable"
             )
         broker_token = self._broker_rpc.register_task(request.task_id)
+        if self._executor_pool is not None:
+            try:
+                await self._executor_pool.bind_task(
+                    request.task_id, request.workspace_id
+                )
+            except Exception:
+                self._broker_rpc.revoke_task(request.task_id)
+                raise
         payload: dict[str, Any] = {
             "request": request.model_dump(mode="json"),
             "broker_endpoint": broker_endpoint,
@@ -339,13 +349,22 @@ class ProviderSidecarClientPool(CodingAgentProvider):
             )
         except Exception:
             self._broker_rpc.revoke_task(request.task_id)
+            if self._executor_pool is not None:
+                with contextlib.suppress(Exception):
+                    await self._executor_pool.close_task(
+                        request.task_id, request.workspace_id
+                    )
             raise
         if session.task_id != request.task_id:
             self._broker_rpc.revoke_task(request.task_id)
             raise ProviderRPCError(
                 "Provider session binding is invalid.", code="provider_invalid_response"
             )
-        self._sessions[session.session_id] = (slot_id, session.task_id)
+        self._sessions[session.session_id] = (
+            slot_id,
+            session.task_id,
+            request.workspace_id,
+        )
         return session
 
     async def message(
@@ -399,6 +418,9 @@ class ProviderSidecarClientPool(CodingAgentProvider):
                 slot_id, "close", {"session": session.model_dump(mode="json")}
             )
         finally:
+            if self._executor_pool is not None:
+                with contextlib.suppress(Exception):
+                    await self._executor_pool.close_task(session.task_id, binding[2])
             self._broker_rpc.revoke_task(session.task_id)
 
     async def run_process(
@@ -411,6 +433,15 @@ class ProviderSidecarClientPool(CodingAgentProvider):
         isolated: bool,
         environment_overrides: Mapping[str, str] | None = None,
     ) -> dict[str, Any]:
+        if self._executor_pool is not None:
+            return await self._executor_pool.run_process(
+                task_id=task_id,
+                workspace_id=workspace_id,
+                argv=argv,
+                timeout_seconds=timeout_seconds,
+                isolated=isolated,
+                environment_overrides=environment_overrides,
+            )
         return await self._workspace_call(
             workspace_id,
             "execute_process",
@@ -433,6 +464,14 @@ class ProviderSidecarClientPool(CodingAgentProvider):
         ttl_seconds: int,
         preview_port: int | None = None,
     ) -> dict[str, Any]:
+        if self._executor_pool is not None:
+            return await self._executor_pool.start_service(
+                task_id=task_id,
+                workspace_id=workspace_id,
+                argv=argv,
+                ttl_seconds=ttl_seconds,
+                preview_port=preview_port,
+            )
         return await self._workspace_call(
             workspace_id,
             "start_service",
@@ -446,12 +485,18 @@ class ProviderSidecarClientPool(CodingAgentProvider):
         )
 
     async def service_status(self, *, task_id: str, workspace_id: str, service_id: str) -> dict[str, Any]:
+        if self._executor_pool is not None:
+            return await self._executor_pool.service_status(task_id=task_id, workspace_id=workspace_id, service_id=service_id)
         return await self._workspace_call(workspace_id, "service_status", {"task_id": task_id, "service_id": service_id})
 
     async def service_input(self, *, task_id: str, workspace_id: str, service_id: str, data: str) -> dict[str, Any]:
+        if self._executor_pool is not None:
+            return await self._executor_pool.service_input(task_id=task_id, workspace_id=workspace_id, service_id=service_id, data=data)
         return await self._workspace_call(workspace_id, "service_input", {"task_id": task_id, "service_id": service_id, "data": data})
 
     async def stop_service(self, *, task_id: str, workspace_id: str, service_id: str) -> dict[str, Any]:
+        if self._executor_pool is not None:
+            return await self._executor_pool.stop_service(task_id=task_id, workspace_id=workspace_id, service_id=service_id)
         return await self._workspace_call(workspace_id, "stop_service", {"task_id": task_id, "service_id": service_id})
 
     async def _workspace_call(self, workspace_id: str, action: str, payload: dict[str, Any]) -> dict[str, Any]:

--- a/server/coding_worker/provider_rpc.py
+++ b/server/coding_worker/provider_rpc.py
@@ -1,0 +1,409 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import secrets
+from collections.abc import AsyncIterator, Callable, Mapping
+from pathlib import Path
+from typing import Any
+
+from pydantic import Field
+
+from .broker_rpc import BrokerRPCServer
+from .contracts import StrictModel
+from .provider import (
+    CodingAgentProvider,
+    ProviderCapabilities,
+    ProviderCheckpoint,
+    ProviderEvent,
+    ProviderOpenRequest,
+    ProviderSession,
+)
+
+
+MAX_PROVIDER_RPC_BYTES = 8 * 1024 * 1024
+
+
+class ProviderRPCError(RuntimeError):
+    def __init__(self, message: str, *, code: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+class ProviderRPCRequest(StrictModel):
+    token: str = Field(min_length=32, max_length=256)
+    action: str = Field(pattern=r"^[a-z_]{1,32}$")
+    payload: dict[str, Any] = Field(default_factory=dict)
+
+
+class ProviderRPCServer:
+    """Single-slot provider host. Only provider-neutral frames cross this boundary."""
+
+    def __init__(
+        self,
+        provider: CodingAgentProvider,
+        *,
+        token: str,
+        bind_broker: Callable[[str, str, str], None] | None = None,
+        unbind_broker: Callable[[str], None] | None = None,
+    ) -> None:
+        if len(token) < 32:
+            raise ValueError("provider RPC token is too short")
+        self.provider = provider
+        self._token = token
+        self._bind_broker = bind_broker
+        self._unbind_broker = unbind_broker
+        self._server: asyncio.AbstractServer | None = None
+        self.endpoint: str | None = None
+        self._active_task_id: str | None = None
+        self._lock = asyncio.Lock()
+
+    async def start_unix(self, socket_path: Path) -> str:
+        if self._server is not None:
+            raise RuntimeError("provider RPC server is already running")
+        socket_path = Path(socket_path)
+        socket_path.parent.mkdir(parents=True, exist_ok=True)
+        socket_path.unlink(missing_ok=True)
+        self._server = await asyncio.start_unix_server(
+            self._handle, path=str(socket_path), limit=MAX_PROVIDER_RPC_BYTES
+        )
+        socket_path.chmod(0o660)
+        self.endpoint = f"unix:{socket_path}"
+        return self.endpoint
+
+    async def start_tcp_for_tests(self) -> str:
+        if self._server is not None:
+            raise RuntimeError("provider RPC server is already running")
+        self._server = await asyncio.start_server(
+            self._handle, "127.0.0.1", 0, limit=MAX_PROVIDER_RPC_BYTES
+        )
+        address = self._server.sockets[0].getsockname()
+        self.endpoint = f"tcp:127.0.0.1:{address[1]}"
+        return self.endpoint
+
+    async def close(self) -> None:
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+        self._server = None
+        self.endpoint = None
+
+    async def _handle(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        try:
+            request = await self._read_request(reader)
+            if request.action == "message":
+                session = ProviderSession.model_validate(request.payload.get("session"))
+                text = request.payload.get("text")
+                if not isinstance(text, str):
+                    raise ProviderRPCError(
+                        "Provider message is invalid.", code="provider_request_invalid"
+                    )
+                self._require_active(session.task_id)
+                async for event in self.provider.message(session, text):
+                    await self._write(writer, {"ok": True, "event": event.model_dump(mode="json")})
+                await self._write(writer, {"ok": True, "done": True})
+                return
+            result = await self._dispatch(request)
+            await self._write(writer, {"ok": True, "result": result})
+        except Exception as exc:
+            await self._write(
+                writer,
+                {
+                    "ok": False,
+                    "error": {
+                        "code": getattr(exc, "code", "provider_failed"),
+                        "message": str(exc)
+                        if isinstance(exc, (ProviderRPCError, ValueError))
+                        else "Provider request failed.",
+                    },
+                },
+            )
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+    async def _dispatch(self, request: ProviderRPCRequest) -> dict[str, Any]:
+        if request.action == "capabilities":
+            return (await self.provider.capabilities()).model_dump(mode="json")
+        if request.action in {"open", "restore"}:
+            opened = ProviderOpenRequest.model_validate(request.payload.get("request"))
+            broker_endpoint = request.payload.get("broker_endpoint")
+            broker_token = request.payload.get("broker_token")
+            if not isinstance(broker_endpoint, str) or not isinstance(broker_token, str):
+                raise ProviderRPCError(
+                    "Tool Broker binding is missing.", code="tool_broker_unavailable"
+                )
+            async with self._lock:
+                if self._active_task_id not in {None, opened.task_id}:
+                    raise ProviderRPCError(
+                        "Provider slot is busy.", code="provider_slot_busy"
+                    )
+                if self._bind_broker is not None:
+                    self._bind_broker(opened.task_id, broker_endpoint, broker_token)
+                try:
+                    if request.action == "restore":
+                        checkpoint = ProviderCheckpoint.model_validate(
+                            request.payload.get("checkpoint")
+                        )
+                        session = await self.provider.restore(opened, checkpoint)
+                    else:
+                        session = await self.provider.open(opened)
+                except Exception:
+                    if self._unbind_broker is not None:
+                        self._unbind_broker(opened.task_id)
+                    raise
+                self._active_task_id = opened.task_id
+                return session.model_dump(mode="json")
+        session = ProviderSession.model_validate(request.payload.get("session"))
+        self._require_active(session.task_id)
+        if request.action == "cancel":
+            return {"cancelled": await self.provider.cancel(session)}
+        if request.action == "checkpoint":
+            return (await self.provider.checkpoint(session)).model_dump(mode="json")
+        if request.action == "close":
+            await self.provider.close(session)
+            async with self._lock:
+                if self._active_task_id == session.task_id:
+                    self._active_task_id = None
+                if self._unbind_broker is not None:
+                    self._unbind_broker(session.task_id)
+            return {"closed": True}
+        raise ProviderRPCError(
+            "Provider action is invalid.", code="provider_request_invalid"
+        )
+
+    def _require_active(self, task_id: str) -> None:
+        if self._active_task_id != task_id:
+            raise ProviderRPCError(
+                "Provider session was not found.", code="session_not_found"
+            )
+
+    async def _read_request(self, reader: asyncio.StreamReader) -> ProviderRPCRequest:
+        raw = await reader.readline()
+        if not raw or len(raw) > MAX_PROVIDER_RPC_BYTES or not raw.endswith(b"\n"):
+            raise ProviderRPCError(
+                "Provider request is invalid.", code="provider_request_invalid"
+            )
+        request = ProviderRPCRequest.model_validate_json(raw)
+        if not secrets.compare_digest(request.token, self._token):
+            raise ProviderRPCError(
+                "Provider authentication failed.", code="provider_unauthorized"
+            )
+        return request
+
+    @staticmethod
+    async def _write(writer: asyncio.StreamWriter, value: dict[str, Any]) -> None:
+        encoded = json.dumps(value, separators=(",", ":")).encode("utf-8") + b"\n"
+        if len(encoded) > MAX_PROVIDER_RPC_BYTES:
+            encoded = b'{"ok":false,"error":{"code":"provider_response_too_large","message":"Provider response is too large."}}\n'
+        writer.write(encoded)
+        await writer.drain()
+
+
+class ProviderSidecarClientPool(CodingAgentProvider):
+    """Routes each workspace to its fixed provider sidecar slot."""
+
+    def __init__(
+        self,
+        *,
+        endpoints: Mapping[str, str],
+        tokens: Mapping[str, str],
+        workspace_slot_resolver: Callable[[str], str],
+        broker_rpc: BrokerRPCServer,
+    ) -> None:
+        if set(endpoints) != set(tokens) or not endpoints:
+            raise ValueError("provider sidecar bindings are incomplete")
+        self._endpoints = dict(endpoints)
+        self._tokens = dict(tokens)
+        self._workspace_slot_resolver = workspace_slot_resolver
+        self._broker_rpc = broker_rpc
+        self._sessions: dict[str, tuple[str, str]] = {}
+
+    async def capabilities(self) -> ProviderCapabilities:
+        values = [
+            ProviderCapabilities.model_validate(
+                await self._call(slot_id, "capabilities", {})
+            )
+            for slot_id in self._endpoints
+        ]
+        first = values[0]
+        if any(value != first for value in values[1:]):
+            raise ProviderRPCError(
+                "Provider slot capabilities differ.", code="provider_capability_mismatch"
+            )
+        return first
+
+    async def open(self, request: ProviderOpenRequest) -> ProviderSession:
+        return await self._open_or_restore(request, None)
+
+    async def restore(
+        self, request: ProviderOpenRequest, checkpoint: ProviderCheckpoint
+    ) -> ProviderSession:
+        return await self._open_or_restore(request, checkpoint)
+
+    async def _open_or_restore(
+        self, request: ProviderOpenRequest, checkpoint: ProviderCheckpoint | None
+    ) -> ProviderSession:
+        slot_id = self._workspace_slot_resolver(request.workspace_id)
+        broker_endpoint = self._broker_rpc.endpoint
+        if slot_id not in self._endpoints or broker_endpoint is None:
+            raise ProviderRPCError(
+                "Provider slot is unavailable.", code="provider_unavailable"
+            )
+        broker_token = self._broker_rpc.register_task(request.task_id)
+        payload: dict[str, Any] = {
+            "request": request.model_dump(mode="json"),
+            "broker_endpoint": broker_endpoint,
+            "broker_token": broker_token,
+        }
+        action = "open"
+        if checkpoint is not None:
+            action = "restore"
+            payload["checkpoint"] = checkpoint.model_dump(mode="json")
+        try:
+            session = ProviderSession.model_validate(
+                await self._call(slot_id, action, payload)
+            )
+        except Exception:
+            self._broker_rpc.revoke_task(request.task_id)
+            raise
+        if session.task_id != request.task_id:
+            self._broker_rpc.revoke_task(request.task_id)
+            raise ProviderRPCError(
+                "Provider session binding is invalid.", code="provider_invalid_response"
+            )
+        self._sessions[session.session_id] = (slot_id, session.task_id)
+        return session
+
+    async def message(
+        self, session: ProviderSession, text: str
+    ) -> AsyncIterator[ProviderEvent]:
+        slot_id = self._require_session(session)
+        reader, writer = await self._connect(slot_id)
+        await self._send(
+            writer,
+            "message",
+            {"session": session.model_dump(mode="json"), "text": text},
+            slot_id,
+        )
+        try:
+            while True:
+                value = await self._read(reader)
+                if value.get("done") is True:
+                    return
+                event = value.get("event")
+                if not isinstance(event, dict):
+                    raise ProviderRPCError(
+                        "Provider stream is invalid.", code="provider_invalid_response"
+                    )
+                yield ProviderEvent.model_validate(event)
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+    async def cancel(self, session: ProviderSession) -> bool:
+        slot_id = self._require_session(session)
+        result = await self._call(
+            slot_id, "cancel", {"session": session.model_dump(mode="json")}
+        )
+        return result.get("cancelled") is True
+
+    async def checkpoint(self, session: ProviderSession) -> ProviderCheckpoint:
+        slot_id = self._require_session(session)
+        return ProviderCheckpoint.model_validate(
+            await self._call(
+                slot_id, "checkpoint", {"session": session.model_dump(mode="json")}
+            )
+        )
+
+    async def close(self, session: ProviderSession) -> None:
+        binding = self._sessions.pop(session.session_id, None)
+        if binding is None or binding[1] != session.task_id:
+            return
+        slot_id = binding[0]
+        try:
+            await self._call(
+                slot_id, "close", {"session": session.model_dump(mode="json")}
+            )
+        finally:
+            self._broker_rpc.revoke_task(session.task_id)
+
+    def _require_session(self, session: ProviderSession) -> str:
+        binding = self._sessions.get(session.session_id)
+        if binding is None or binding[1] != session.task_id:
+            raise ProviderRPCError(
+                "Provider session was not found.", code="session_not_found"
+            )
+        return binding[0]
+
+    async def _call(
+        self, slot_id: str, action: str, payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        reader, writer = await self._connect(slot_id)
+        await self._send(writer, action, payload, slot_id)
+        try:
+            value = await self._read(reader)
+            result = value.get("result")
+            if not isinstance(result, dict):
+                raise ProviderRPCError(
+                    "Provider response is invalid.", code="provider_invalid_response"
+                )
+            return result
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+    async def _send(
+        self,
+        writer: asyncio.StreamWriter,
+        action: str,
+        payload: dict[str, Any],
+        slot_id: str,
+    ) -> None:
+        request = ProviderRPCRequest(
+            token=self._tokens[slot_id], action=action, payload=payload
+        )
+        encoded = request.model_dump_json().encode("utf-8") + b"\n"
+        if len(encoded) > MAX_PROVIDER_RPC_BYTES:
+            raise ProviderRPCError(
+                "Provider request is too large.", code="provider_request_too_large"
+            )
+        writer.write(encoded)
+        await writer.drain()
+
+    async def _connect(
+        self, slot_id: str
+    ) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+        endpoint = self._endpoints[slot_id]
+        if endpoint.startswith("unix:"):
+            return await asyncio.open_unix_connection(
+                endpoint.removeprefix("unix:"), limit=MAX_PROVIDER_RPC_BYTES
+            )
+        if endpoint.startswith("tcp:127.0.0.1:"):
+            return await asyncio.open_connection(
+                "127.0.0.1", int(endpoint.rsplit(":", 1)[1]), limit=MAX_PROVIDER_RPC_BYTES
+            )
+        raise ProviderRPCError(
+            "Provider endpoint is invalid.", code="provider_endpoint_invalid"
+        )
+
+    @staticmethod
+    async def _read(reader: asyncio.StreamReader) -> dict[str, Any]:
+        raw = await reader.readline()
+        if not raw or len(raw) > MAX_PROVIDER_RPC_BYTES:
+            raise ProviderRPCError(
+                "Provider response is invalid.", code="provider_invalid_response"
+            )
+        value = json.loads(raw)
+        if not isinstance(value, dict) or value.get("ok") is not True:
+            error = value.get("error") if isinstance(value, dict) else None
+            code = error.get("code") if isinstance(error, dict) else "provider_failed"
+            message = (
+                error.get("message")
+                if isinstance(error, dict)
+                else "Provider request failed."
+            )
+            raise ProviderRPCError(str(message), code=str(code))
+        return value

--- a/server/coding_worker/provider_rpc.py
+++ b/server/coding_worker/provider_rpc.py
@@ -163,6 +163,11 @@ class ProviderRPCServer:
                 workspace_id=str(request.payload.get("workspace_id", "")),
                 argv=tuple(request.payload.get("argv", ())),
                 ttl_seconds=int(request.payload.get("ttl_seconds", 0)),
+                preview_port=(
+                    int(request.payload["preview_port"])
+                    if request.payload.get("preview_port") is not None
+                    else None
+                ),
             )
         if request.action == "service_status":
             self._require_active(str(request.payload.get("task_id", "")))
@@ -420,12 +425,24 @@ class ProviderSidecarClientPool(CodingAgentProvider):
         )
 
     async def start_service(
-        self, *, task_id: str, workspace_id: str, argv: Sequence[str], ttl_seconds: int
+        self,
+        *,
+        task_id: str,
+        workspace_id: str,
+        argv: Sequence[str],
+        ttl_seconds: int,
+        preview_port: int | None = None,
     ) -> dict[str, Any]:
         return await self._workspace_call(
             workspace_id,
             "start_service",
-            {"task_id": task_id, "workspace_id": workspace_id, "argv": list(argv), "ttl_seconds": ttl_seconds},
+            {
+                "task_id": task_id,
+                "workspace_id": workspace_id,
+                "argv": list(argv),
+                "ttl_seconds": ttl_seconds,
+                "preview_port": preview_port,
+            },
         )
 
     async def service_status(self, *, task_id: str, workspace_id: str, service_id: str) -> dict[str, Any]:

--- a/server/coding_worker/provider_rpc.py
+++ b/server/coding_worker/provider_rpc.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import secrets
-from collections.abc import AsyncIterator, Callable, Mapping
+from collections.abc import AsyncIterator, Callable, Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
@@ -19,6 +19,7 @@ from .provider import (
     ProviderOpenRequest,
     ProviderSession,
 )
+from .executor import SidecarExecutor
 
 
 MAX_PROVIDER_RPC_BYTES = 8 * 1024 * 1024
@@ -46,6 +47,7 @@ class ProviderRPCServer:
         token: str,
         bind_broker: Callable[[str, str, str], None] | None = None,
         unbind_broker: Callable[[str], None] | None = None,
+        executor: SidecarExecutor | None = None,
     ) -> None:
         if len(token) < 32:
             raise ValueError("provider RPC token is too short")
@@ -53,6 +55,7 @@ class ProviderRPCServer:
         self._token = token
         self._bind_broker = bind_broker
         self._unbind_broker = unbind_broker
+        self._executor = executor
         self._server: asyncio.AbstractServer | None = None
         self.endpoint: str | None = None
         self._active_task_id: str | None = None
@@ -127,6 +130,45 @@ class ProviderRPCServer:
     async def _dispatch(self, request: ProviderRPCRequest) -> dict[str, Any]:
         if request.action == "capabilities":
             return (await self.provider.capabilities()).model_dump(mode="json")
+        if request.action == "execute_process":
+            executor = self._require_executor()
+            self._require_active(str(request.payload.get("task_id", "")))
+            return await executor.run_process(
+                workspace_id=str(request.payload.get("workspace_id", "")),
+                argv=tuple(request.payload.get("argv", ())),
+                timeout_seconds=int(request.payload.get("timeout_seconds", 0)),
+                isolated=request.payload.get("isolated") is True,
+                environment_overrides=request.payload.get("environment_overrides"),
+            )
+        if request.action == "start_service":
+            executor = self._require_executor()
+            self._require_active(str(request.payload.get("task_id", "")))
+            return await executor.start_service(
+                task_id=str(request.payload.get("task_id", "")),
+                workspace_id=str(request.payload.get("workspace_id", "")),
+                argv=tuple(request.payload.get("argv", ())),
+                ttl_seconds=int(request.payload.get("ttl_seconds", 0)),
+            )
+        if request.action == "service_status":
+            self._require_active(str(request.payload.get("task_id", "")))
+            return self._require_executor().service_status(
+                task_id=str(request.payload.get("task_id", "")),
+                service_id=str(request.payload.get("service_id", "")),
+            )
+        if request.action == "service_input":
+            self._require_active(str(request.payload.get("task_id", "")))
+            await self._require_executor().service_input(
+                task_id=str(request.payload.get("task_id", "")),
+                service_id=str(request.payload.get("service_id", "")),
+                data=str(request.payload.get("data", "")),
+            )
+            return {"accepted": True}
+        if request.action == "stop_service":
+            self._require_active(str(request.payload.get("task_id", "")))
+            return await self._require_executor().stop_service(
+                task_id=str(request.payload.get("task_id", "")),
+                service_id=str(request.payload.get("service_id", "")),
+            )
         if request.action in {"open", "restore"}:
             opened = ProviderOpenRequest.model_validate(request.payload.get("request"))
             broker_endpoint = request.payload.get("broker_endpoint")
@@ -164,6 +206,8 @@ class ProviderRPCServer:
             return (await self.provider.checkpoint(session)).model_dump(mode="json")
         if request.action == "close":
             await self.provider.close(session)
+            if self._executor is not None:
+                await self._executor.stop_task(session.task_id)
             async with self._lock:
                 if self._active_task_id == session.task_id:
                     self._active_task_id = None
@@ -173,6 +217,13 @@ class ProviderRPCServer:
         raise ProviderRPCError(
             "Provider action is invalid.", code="provider_request_invalid"
         )
+
+    def _require_executor(self) -> SidecarExecutor:
+        if self._executor is None:
+            raise ProviderRPCError(
+                "Provider executor is unavailable.", code="executor_unavailable"
+            )
+        return self._executor
 
     def _require_active(self, task_id: str) -> None:
         if self._active_task_id != task_id:
@@ -329,6 +380,53 @@ class ProviderSidecarClientPool(CodingAgentProvider):
             )
         finally:
             self._broker_rpc.revoke_task(session.task_id)
+
+    async def run_process(
+        self,
+        *,
+        task_id: str,
+        workspace_id: str,
+        argv: Sequence[str],
+        timeout_seconds: int,
+        isolated: bool,
+        environment_overrides: Mapping[str, str] | None = None,
+    ) -> dict[str, Any]:
+        return await self._workspace_call(
+            workspace_id,
+            "execute_process",
+            {
+                "task_id": task_id,
+                "workspace_id": workspace_id,
+                "argv": list(argv),
+                "timeout_seconds": timeout_seconds,
+                "isolated": isolated,
+                "environment_overrides": dict(environment_overrides or {}),
+            },
+        )
+
+    async def start_service(
+        self, *, task_id: str, workspace_id: str, argv: Sequence[str], ttl_seconds: int
+    ) -> dict[str, Any]:
+        return await self._workspace_call(
+            workspace_id,
+            "start_service",
+            {"task_id": task_id, "workspace_id": workspace_id, "argv": list(argv), "ttl_seconds": ttl_seconds},
+        )
+
+    async def service_status(self, *, task_id: str, workspace_id: str, service_id: str) -> dict[str, Any]:
+        return await self._workspace_call(workspace_id, "service_status", {"task_id": task_id, "service_id": service_id})
+
+    async def service_input(self, *, task_id: str, workspace_id: str, service_id: str, data: str) -> dict[str, Any]:
+        return await self._workspace_call(workspace_id, "service_input", {"task_id": task_id, "service_id": service_id, "data": data})
+
+    async def stop_service(self, *, task_id: str, workspace_id: str, service_id: str) -> dict[str, Any]:
+        return await self._workspace_call(workspace_id, "stop_service", {"task_id": task_id, "service_id": service_id})
+
+    async def _workspace_call(self, workspace_id: str, action: str, payload: dict[str, Any]) -> dict[str, Any]:
+        slot_id = self._workspace_slot_resolver(workspace_id)
+        if slot_id not in self._endpoints:
+            raise ProviderRPCError("Provider slot is unavailable.", code="provider_unavailable")
+        return await self._call(slot_id, action, payload)
 
     def _require_session(self, session: ProviderSession) -> str:
         binding = self._sessions.get(session.session_id)

--- a/server/coding_worker/runtime.py
+++ b/server/coding_worker/runtime.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from pathlib import Path
+
+from .broker_rpc import BrokerRPCServer
+from .evidence import HarnessRunner
+from .network_policy import EgressPolicy
+from .provider_rpc import ProviderSidecarClientPool
+from .service import CodingWorkerService
+from .store import CodingWorkerStore, DEFAULT_RETENTION_SECONDS
+from .tool_broker import FrozenCheck, ToolBroker
+from .workspace import WorkspaceBroker, WorkspaceSourceAdapter
+
+
+class CodingWorkerRuntimeError(RuntimeError):
+    def __init__(self, message: str, *, code: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+class CodingWorkerRuntime:
+    """Production lifecycle for the store, broker and two fixed sidecars."""
+
+    def __init__(
+        self,
+        *,
+        storage_root: Path,
+        slot_roots: Mapping[str, Path],
+        source_adapters: Mapping[str, WorkspaceSourceAdapter],
+        frozen_checks: Mapping[str, FrozenCheck],
+        provider_endpoints: Mapping[str, str],
+        provider_tokens: Mapping[str, str],
+        broker_socket_path: Path | None,
+        retention_seconds: int = DEFAULT_RETENTION_SECONDS,
+        max_active_tasks: int = 2,
+        network_enabled: bool = False,
+        network_domains: tuple[str, ...] = (),
+        egress_proxy_url: str | None = None,
+        sidecar_uid: int = 65532,
+        sidecar_gid: int = 65532,
+    ) -> None:
+        if (
+            set(slot_roots) != set(provider_endpoints)
+            or set(slot_roots) != set(provider_tokens)
+        ):
+            raise CodingWorkerRuntimeError(
+                "Worker slot configuration is incomplete.",
+                code="coding_worker_config_invalid",
+            )
+        storage_root = Path(storage_root)
+        self.store = CodingWorkerStore(
+            storage_root, retention_seconds=retention_seconds
+        )
+        self.workspace_broker = WorkspaceBroker(
+            storage_root,
+            source_adapters,
+            id_key=self._workspace_key(storage_root),
+            slot_roots=slot_roots,
+            slot_owner=(sidecar_uid, sidecar_gid),
+        )
+        self.tool_broker = ToolBroker(
+            store=self.store,
+            workspace_broker=self.workspace_broker,
+            frozen_checks=frozen_checks,
+            egress_policy=EgressPolicy(
+                enabled=network_enabled, allowed_domains=network_domains
+            ),
+            egress_proxy_url=egress_proxy_url,
+        )
+        self.broker_rpc = BrokerRPCServer(self.tool_broker)
+        self.provider = ProviderSidecarClientPool(
+            endpoints=provider_endpoints,
+            tokens=provider_tokens,
+            workspace_slot_resolver=self.workspace_broker.workspace_slot,
+            broker_rpc=self.broker_rpc,
+        )
+        self.tool_broker.executor = self.provider
+        self.harness = HarnessRunner(
+            store=self.store,
+            workspace_broker=self.workspace_broker,
+            tool_broker=self.tool_broker,
+        )
+        self.service = CodingWorkerService(
+            store=self.store,
+            workspace_broker=self.workspace_broker,
+            provider=self.provider,
+            harness_runner=self.harness,
+            max_active_tasks=max_active_tasks,
+        )
+        self.broker_socket_path = broker_socket_path
+        self.sidecar_gid = sidecar_gid
+        self.network_enabled = network_enabled
+        self._started = False
+
+    async def start(self) -> CodingWorkerService:
+        if self._started:
+            return self.service
+        if self.broker_socket_path is None:
+            await self.broker_rpc.start_tcp_for_tests()
+        else:
+            await self.broker_rpc.start_unix(
+                self.broker_socket_path, group_id=self.sidecar_gid
+            )
+        await self.service.start()
+        self._started = True
+        return self.service
+
+    async def close(self) -> None:
+        if not self._started:
+            return
+        await self.service.shutdown()
+        await self.broker_rpc.close()
+        self._started = False
+
+    @staticmethod
+    def _workspace_key(storage_root: Path) -> bytes:
+        path = storage_root / "workspace-id.key"
+        if path.exists():
+            value = path.read_bytes()
+            if len(value) != 32:
+                raise CodingWorkerRuntimeError(
+                    "Workspace key is invalid.", code="coding_worker_key_invalid"
+                )
+            return value
+        value = os.urandom(32)
+        descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(value)
+            handle.flush()
+            os.fsync(handle.fileno())
+        return value
+
+
+_SOURCE_ADAPTERS: dict[str, WorkspaceSourceAdapter] = {}
+_FROZEN_CHECKS: dict[str, FrozenCheck] = {}
+
+
+def register_workspace_source_adapter(
+    kind: str, adapter: WorkspaceSourceAdapter
+) -> None:
+    if kind in _SOURCE_ADAPTERS and _SOURCE_ADAPTERS[kind] is not adapter:
+        raise CodingWorkerRuntimeError(
+            "Workspace source adapter is already registered.",
+            code="coding_worker_adapter_conflict",
+        )
+    _SOURCE_ADAPTERS[kind] = adapter
+
+
+def register_frozen_check(check: FrozenCheck) -> None:
+    existing = _FROZEN_CHECKS.get(check.check_id)
+    if existing is not None and existing != check:
+        raise CodingWorkerRuntimeError(
+            "Frozen check is already registered.",
+            code="coding_worker_check_conflict",
+        )
+    _FROZEN_CHECKS[check.check_id] = check
+
+
+def build_runtime_from_environment() -> CodingWorkerRuntime:
+    root = Path(
+        os.getenv("CODING_WORKER_STATE_ROOT", "/var/lib/modelmirror/coding-worker")
+    )
+    slot_roots = {
+        "slot-a": Path(
+            os.getenv("CODING_WORKER_SLOT_A_ROOT", "/worker-slots/slot-a")
+        ),
+        "slot-b": Path(
+            os.getenv("CODING_WORKER_SLOT_B_ROOT", "/worker-slots/slot-b")
+        ),
+    }
+    endpoints = {
+        "slot-a": os.getenv(
+            "CODING_WORKER_SLOT_A_ENDPOINT",
+            "unix:/run/modelmirror-coding-slot-a/provider.sock",
+        ),
+        "slot-b": os.getenv(
+            "CODING_WORKER_SLOT_B_ENDPOINT",
+            "unix:/run/modelmirror-coding-slot-b/provider.sock",
+        ),
+    }
+    tokens = {
+        "slot-a": os.getenv("CODING_WORKER_SLOT_A_TOKEN", ""),
+        "slot-b": os.getenv("CODING_WORKER_SLOT_B_TOKEN", ""),
+    }
+    if any(len(value) < 32 for value in tokens.values()):
+        raise CodingWorkerRuntimeError(
+            "Worker sidecar tokens are missing.",
+            code="coding_worker_config_invalid",
+        )
+    network_enabled = os.getenv(
+        "CODING_WORKER_NETWORK_ENABLED", "false"
+    ).lower() in {"1", "true", "yes", "on"}
+    domains = tuple(
+        value.strip().lower()
+        for value in os.getenv("CODING_WORKER_NETWORK_DOMAINS", "").split(",")
+        if value.strip()
+    )
+    return CodingWorkerRuntime(
+        storage_root=root,
+        slot_roots=slot_roots,
+        source_adapters=_SOURCE_ADAPTERS,
+        frozen_checks=_FROZEN_CHECKS,
+        provider_endpoints=endpoints,
+        provider_tokens=tokens,
+        broker_socket_path=Path(
+            os.getenv(
+                "CODING_WORKER_BROKER_SOCKET",
+                "/run/modelmirror-coding-broker/broker.sock",
+            )
+        ),
+        retention_seconds=int(
+            os.getenv(
+                "CODING_WORKER_RETENTION_SECONDS", str(DEFAULT_RETENTION_SECONDS)
+            )
+        ),
+        max_active_tasks=int(os.getenv("CODING_WORKER_MAX_ACTIVE_TASKS", "2")),
+        network_enabled=network_enabled,
+        network_domains=domains,
+        egress_proxy_url=os.getenv("CODING_WORKER_EGRESS_PROXY_URL") or None,
+    )

--- a/server/coding_worker/runtime.py
+++ b/server/coding_worker/runtime.py
@@ -91,6 +91,7 @@ class CodingWorkerRuntime:
             provider=self.provider,
             harness_runner=self.harness,
             max_active_tasks=max_active_tasks,
+            tool_broker=self.tool_broker,
         )
         self.broker_socket_path = broker_socket_path
         self.sidecar_gid = sidecar_gid

--- a/server/coding_worker/runtime.py
+++ b/server/coding_worker/runtime.py
@@ -165,6 +165,27 @@ class CodingWorkerRuntime:
 
 _SOURCE_ADAPTERS: dict[str, WorkspaceSourceAdapter] = {}
 _FROZEN_CHECKS: dict[str, FrozenCheck] = {}
+_DEFAULT_FROZEN_CHECKS = {
+    "python-compile": FrozenCheck(
+        check_id="python-compile",
+        argv=("python", "-m", "compileall", "-q", "."),
+    ),
+    "python-pytest": FrozenCheck(
+        check_id="python-pytest",
+        argv=("python", "-m", "pytest", "-q"),
+        timeout_seconds=900,
+    ),
+    "react-test": FrozenCheck(
+        check_id="react-test",
+        argv=("npm", "test", "--", "--run"),
+        timeout_seconds=900,
+    ),
+    "react-build": FrozenCheck(
+        check_id="react-build",
+        argv=("npm", "run", "build"),
+        timeout_seconds=900,
+    ),
+}
 
 
 def register_workspace_source_adapter(
@@ -179,7 +200,9 @@ def register_workspace_source_adapter(
 
 
 def register_frozen_check(check: FrozenCheck) -> None:
-    existing = _FROZEN_CHECKS.get(check.check_id)
+    existing = _DEFAULT_FROZEN_CHECKS.get(check.check_id) or _FROZEN_CHECKS.get(
+        check.check_id
+    )
     if existing is not None and existing != check:
         raise CodingWorkerRuntimeError(
             "Frozen check is already registered.",
@@ -295,7 +318,7 @@ def build_runtime_from_environment() -> CodingWorkerRuntime:
         storage_root=root,
         slot_roots=slot_roots,
         source_adapters=source_adapters,
-        frozen_checks=_FROZEN_CHECKS,
+        frozen_checks={**_DEFAULT_FROZEN_CHECKS, **_FROZEN_CHECKS},
         provider_endpoints=endpoints,
         provider_tokens=tokens,
         executor_endpoints=executor_endpoints,

--- a/server/coding_worker/runtime.py
+++ b/server/coding_worker/runtime.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from .broker_rpc import BrokerRPCServer
 from .evidence import HarnessRunner
+from .executor import ExecutorSidecarClientPool
 from .network_policy import EgressPolicy
 from .provider_rpc import ProviderSidecarClientPool
 from .service import CodingWorkerService
@@ -32,6 +33,8 @@ class CodingWorkerRuntime:
         frozen_checks: Mapping[str, FrozenCheck],
         provider_endpoints: Mapping[str, str],
         provider_tokens: Mapping[str, str],
+        executor_endpoints: Mapping[str, str] | None = None,
+        executor_tokens: Mapping[str, str] | None = None,
         broker_socket_path: Path | None,
         retention_seconds: int = DEFAULT_RETENTION_SECONDS,
         max_active_tasks: int = 2,
@@ -73,11 +76,29 @@ class CodingWorkerRuntime:
             egress_proxy_url=egress_proxy_url,
         )
         self.broker_rpc = BrokerRPCServer(self.tool_broker)
+        executor_pool = None
+        if executor_endpoints is not None or executor_tokens is not None:
+            if (
+                executor_endpoints is None
+                or executor_tokens is None
+                or set(slot_roots) != set(executor_endpoints)
+                or set(slot_roots) != set(executor_tokens)
+            ):
+                raise CodingWorkerRuntimeError(
+                    "Worker executor configuration is incomplete.",
+                    code="coding_worker_config_invalid",
+                )
+            executor_pool = ExecutorSidecarClientPool(
+                endpoints=executor_endpoints,
+                tokens=executor_tokens,
+                workspace_slot_resolver=self.workspace_broker.workspace_slot,
+            )
         self.provider = ProviderSidecarClientPool(
             endpoints=provider_endpoints,
             tokens=provider_tokens,
             workspace_slot_resolver=self.workspace_broker.workspace_slot,
             broker_rpc=self.broker_rpc,
+            executor_pool=executor_pool,
         )
         self.tool_broker.executor = self.provider
         self.harness = HarnessRunner(
@@ -188,7 +209,21 @@ def build_runtime_from_environment() -> CodingWorkerRuntime:
         "slot-a": os.getenv("CODING_WORKER_SLOT_A_TOKEN", ""),
         "slot-b": os.getenv("CODING_WORKER_SLOT_B_TOKEN", ""),
     }
-    if any(len(value) < 32 for value in tokens.values()):
+    executor_endpoints = {
+        "slot-a": os.getenv(
+            "CODING_WORKER_EXECUTOR_A_ENDPOINT",
+            "unix:/run/modelmirror-coding-executor-a/executor.sock",
+        ),
+        "slot-b": os.getenv(
+            "CODING_WORKER_EXECUTOR_B_ENDPOINT",
+            "unix:/run/modelmirror-coding-executor-b/executor.sock",
+        ),
+    }
+    executor_tokens = {
+        "slot-a": os.getenv("CODING_WORKER_EXECUTOR_A_TOKEN", ""),
+        "slot-b": os.getenv("CODING_WORKER_EXECUTOR_B_TOKEN", ""),
+    }
+    if any(len(value) < 32 for value in (*tokens.values(), *executor_tokens.values())):
         raise CodingWorkerRuntimeError(
             "Worker sidecar tokens are missing.",
             code="coding_worker_config_invalid",
@@ -208,6 +243,8 @@ def build_runtime_from_environment() -> CodingWorkerRuntime:
         frozen_checks=_FROZEN_CHECKS,
         provider_endpoints=endpoints,
         provider_tokens=tokens,
+        executor_endpoints=executor_endpoints,
+        executor_tokens=executor_tokens,
         broker_socket_path=Path(
             os.getenv(
                 "CODING_WORKER_BROKER_SOCKET",

--- a/server/coding_worker/runtime.py
+++ b/server/coding_worker/runtime.py
@@ -38,6 +38,7 @@ class CodingWorkerRuntime:
         network_enabled: bool = False,
         network_domains: tuple[str, ...] = (),
         egress_proxy_url: str | None = None,
+        network_grant_key: bytes | str | None = None,
         sidecar_uid: int = 65532,
         sidecar_gid: int = 65532,
     ) -> None:
@@ -65,7 +66,9 @@ class CodingWorkerRuntime:
             workspace_broker=self.workspace_broker,
             frozen_checks=frozen_checks,
             egress_policy=EgressPolicy(
-                enabled=network_enabled, allowed_domains=network_domains
+                enabled=network_enabled,
+                allowed_domains=network_domains,
+                grant_key=network_grant_key,
             ),
             egress_proxy_url=egress_proxy_url,
         )
@@ -219,4 +222,5 @@ def build_runtime_from_environment() -> CodingWorkerRuntime:
         network_enabled=network_enabled,
         network_domains=domains,
         egress_proxy_url=os.getenv("CODING_WORKER_EGRESS_PROXY_URL") or None,
+        network_grant_key=os.getenv("CODING_WORKER_EGRESS_GRANT_KEY") or None,
     )

--- a/server/coding_worker/runtime.py
+++ b/server/coding_worker/runtime.py
@@ -15,6 +15,7 @@ from .tool_broker import FrozenCheck, ToolBroker
 from .workspace import WorkspaceBroker, WorkspaceSourceAdapter
 from .source_adapters import (
     BuiltinGitWorkspaceSourceAdapter,
+    HostSnapshotWorkspaceSourceAdapter,
     ProjectSnapshotWorkspaceSourceAdapter,
 )
 
@@ -265,12 +266,31 @@ def build_runtime_from_environment() -> CodingWorkerRuntime:
             )
         except ModuleNotFoundError:
             from coding_runtime.project_source_client import CodingProjectSourceClient
+        project_source_client = CodingProjectSourceClient(project_source_socket)
         project_adapter = ProjectSnapshotWorkspaceSourceAdapter(
-            CodingProjectSourceClient(project_source_socket),
+            project_source_client,
             Path(os.getenv("CODING_WORKER_PROJECT_SNAPSHOT_ROOT", "/project-snapshots")),
         )
         source_adapters.setdefault("manifest", project_adapter)
-        source_adapters.setdefault("host_snapshot", project_adapter)
+        try:
+            from server.coding_runtime.api import get_coding_service
+        except ModuleNotFoundError:
+            from coding_runtime.api import get_coding_service
+        coding_service = get_coding_service()
+        if coding_service.project_host is not None:
+            source_adapters.setdefault(
+                "host_snapshot",
+                HostSnapshotWorkspaceSourceAdapter(
+                    coding_service.project_host,
+                    project_source_client,
+                    Path(
+                        os.getenv(
+                            "CODING_WORKER_PROJECT_SNAPSHOT_ROOT",
+                            "/project-snapshots",
+                        )
+                    ),
+                ),
+            )
     return CodingWorkerRuntime(
         storage_root=root,
         slot_roots=slot_roots,

--- a/server/coding_worker/runtime.py
+++ b/server/coding_worker/runtime.py
@@ -13,7 +13,10 @@ from .service import CodingWorkerService
 from .store import CodingWorkerStore, DEFAULT_RETENTION_SECONDS
 from .tool_broker import FrozenCheck, ToolBroker
 from .workspace import WorkspaceBroker, WorkspaceSourceAdapter
-from .source_adapters import ProjectSnapshotWorkspaceSourceAdapter
+from .source_adapters import (
+    BuiltinGitWorkspaceSourceAdapter,
+    ProjectSnapshotWorkspaceSourceAdapter,
+)
 
 
 class CodingWorkerRuntimeError(RuntimeError):
@@ -238,6 +241,22 @@ def build_runtime_from_environment() -> CodingWorkerRuntime:
         if value.strip()
     )
     source_adapters = dict(_SOURCE_ADAPTERS)
+    builtin_root = os.getenv("CODING_WORKER_BUILTIN_SOURCE_ROOT")
+    builtin_revision = os.getenv("CODING_WORKER_BUILTIN_REVISION")
+    if bool(builtin_root) != bool(builtin_revision):
+        raise CodingWorkerRuntimeError(
+            "Builtin Worker source configuration is incomplete.",
+            code="coding_worker_config_invalid",
+        )
+    if builtin_root and builtin_revision:
+        source_adapters.setdefault(
+            "builtin",
+            BuiltinGitWorkspaceSourceAdapter(
+                Path(builtin_root),
+                source_id=os.getenv("CODING_WORKER_BUILTIN_SOURCE_ID", "modelmirror"),
+                revision=builtin_revision,
+            ),
+        )
     project_source_socket = os.getenv("CODING_PROJECT_SOURCE_SOCKET_PATH")
     if project_source_socket:
         try:

--- a/server/coding_worker/runtime.py
+++ b/server/coding_worker/runtime.py
@@ -13,6 +13,7 @@ from .service import CodingWorkerService
 from .store import CodingWorkerStore, DEFAULT_RETENTION_SECONDS
 from .tool_broker import FrozenCheck, ToolBroker
 from .workspace import WorkspaceBroker, WorkspaceSourceAdapter
+from .source_adapters import ProjectSnapshotWorkspaceSourceAdapter
 
 
 class CodingWorkerRuntimeError(RuntimeError):
@@ -236,10 +237,25 @@ def build_runtime_from_environment() -> CodingWorkerRuntime:
         for value in os.getenv("CODING_WORKER_NETWORK_DOMAINS", "").split(",")
         if value.strip()
     )
+    source_adapters = dict(_SOURCE_ADAPTERS)
+    project_source_socket = os.getenv("CODING_PROJECT_SOURCE_SOCKET_PATH")
+    if project_source_socket:
+        try:
+            from server.coding_runtime.project_source_client import (
+                CodingProjectSourceClient,
+            )
+        except ModuleNotFoundError:
+            from coding_runtime.project_source_client import CodingProjectSourceClient
+        project_adapter = ProjectSnapshotWorkspaceSourceAdapter(
+            CodingProjectSourceClient(project_source_socket),
+            Path(os.getenv("CODING_WORKER_PROJECT_SNAPSHOT_ROOT", "/project-snapshots")),
+        )
+        source_adapters.setdefault("manifest", project_adapter)
+        source_adapters.setdefault("host_snapshot", project_adapter)
     return CodingWorkerRuntime(
         storage_root=root,
         slot_roots=slot_roots,
-        source_adapters=_SOURCE_ADAPTERS,
+        source_adapters=source_adapters,
         frozen_checks=_FROZEN_CHECKS,
         provider_endpoints=endpoints,
         provider_tokens=tokens,

--- a/server/coding_worker/sdk.py
+++ b/server/coding_worker/sdk.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+
+from .contracts import (
+    ContextReference,
+    Origin,
+    TaskCreateRequest,
+    TaskRecord,
+)
+from .runtime import register_frozen_check, register_workspace_source_adapter
+from .service import CodingWorkerService
+from .tool_broker import FrozenCheck
+from .workspace import WorkspaceSourceAdapter
+
+
+class CodingWorkerSDKError(RuntimeError):
+    def __init__(self, message: str, *, code: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+ContextValidator = Callable[[str], bool]
+
+
+class CodingWorkerModuleClient:
+    """Trusted module boundary for creating provider-neutral Worker tasks.
+
+    The client fixes the module identity and allowlists source, context, check,
+    and model route identifiers. It deliberately exposes no provider, process,
+    environment, network endpoint, credential, or physical path controls.
+    """
+
+    def __init__(
+        self,
+        *,
+        module: str,
+        service: CodingWorkerService,
+        source_kinds: frozenset[str],
+        check_ids: frozenset[str],
+        model_routes: frozenset[str],
+        context_validators: Mapping[str, ContextValidator] | None = None,
+    ) -> None:
+        if not module or not source_kinds or not check_ids or not model_routes:
+            raise ValueError("coding worker module policy is incomplete")
+        self.module = module
+        self.service = service
+        self.source_kinds = source_kinds
+        self.check_ids = check_ids
+        self.model_routes = model_routes
+        self.context_validators = dict(context_validators or {})
+
+    async def create_task(
+        self, *, business_object_id: str, request: TaskCreateRequest
+    ) -> TaskRecord:
+        if request.workspace_source.kind not in self.source_kinds:
+            raise CodingWorkerSDKError(
+                "Workspace source is not registered for this module.",
+                code="worker_source_not_registered",
+            )
+        required_checks = {
+            item.check_id for item in request.acceptance.required_checks
+        }
+        if not required_checks.issubset(self.check_ids):
+            raise CodingWorkerSDKError(
+                "Acceptance check is not registered for this module.",
+                code="worker_acceptance_not_registered",
+            )
+        if request.model_route not in self.model_routes:
+            raise CodingWorkerSDKError(
+                "Model route is not registered for this module.",
+                code="worker_model_route_not_registered",
+            )
+        self._validate_context(request.context_refs)
+        return await self.service.create_task(
+            Origin(module=self.module, object_id=business_object_id), request
+        )
+
+    def _validate_context(self, references: tuple[ContextReference, ...]) -> None:
+        for reference in references:
+            validator = self.context_validators.get(reference.kind)
+            if validator is None or not validator(reference.ref_id):
+                raise CodingWorkerSDKError(
+                    "Context reference is not registered for this module.",
+                    code="worker_context_not_registered",
+                )
+
+
+def register_module_source(kind: str, adapter: WorkspaceSourceAdapter) -> None:
+    """Register a trusted opaque source adapter; paths stay inside the adapter."""
+
+    register_workspace_source_adapter(kind, adapter)
+
+
+def register_module_acceptance(check: FrozenCheck) -> None:
+    """Register a deployment-frozen check, never a caller supplied command."""
+
+    register_frozen_check(check)

--- a/server/coding_worker/service.py
+++ b/server/coding_worker/service.py
@@ -273,6 +273,7 @@ class CodingWorkerService:
                 budget=task.spec.budget,
             )
             resume_phase: str | None = None
+            resume_context: dict[str, object] | None = None
             completed_turns = 0
             checkpoint = self.store.latest_checkpoint(task_id)
             if checkpoint is not None:
@@ -293,6 +294,11 @@ class CodingWorkerService:
                     )
                     resume_phase = str(checkpoint.payload["phase"])
                     completed_turns = int(checkpoint.payload["completed_turns"])
+                    raw_context = checkpoint.payload.get("context_summary")
+                    if raw_context is not None:
+                        if not isinstance(raw_context, dict):
+                            raise TypeError("context summary is invalid")
+                        resume_context = raw_context
                 except (KeyError, TypeError, ValueError) as exc:
                     raise WorkerConflictError(
                         "Checkpoint payload is invalid.", code="checkpoint_invalid"
@@ -318,6 +324,7 @@ class CodingWorkerService:
                 task,
                 session,
                 resume_phase=resume_phase,
+                resume_context=resume_context,
                 completed_turns=completed_turns,
             )
         except TimeoutError:
@@ -356,6 +363,7 @@ class CodingWorkerService:
         session: ProviderSession,
         *,
         resume_phase: str | None,
+        resume_context: dict[str, object] | None,
         completed_turns: int,
     ) -> None:
         task_id = task.task_id
@@ -366,7 +374,7 @@ class CodingWorkerService:
                 feedback = await self._evaluate_acceptance(task, turns)
                 if feedback is None:
                     return
-                message = feedback
+                message = self._restored_context_message(resume_context, feedback)
             while True:
                 turns += 1
                 turn_completed = False
@@ -406,6 +414,13 @@ class CodingWorkerService:
                             "phase": "testing",
                             "completed_turns": turns,
                             "provider": provider_checkpoint.model_dump(mode="json"),
+                            "context_summary": self._context_summary(
+                                task_id,
+                                tree_hash=tree_hash,
+                                public_output=str(
+                                    provider_checkpoint.payload.get("public_output", "")
+                                ),
+                            ),
                         },
                     )
                 except Exception:
@@ -420,6 +435,65 @@ class CodingWorkerService:
                 if feedback is None:
                     return
                 message = feedback
+
+    def _context_summary(
+        self, task_id: str, *, tree_hash: str, public_output: str
+    ) -> dict[str, object]:
+        task = self.store.get_task(task_id)
+        latest: dict[str, WorkerEvidence] = {}
+        for item in self.store.list_evidence(task_id, current_tree_hash=tree_hash):
+            latest[item.check_id] = item
+        failures = [
+            {
+                "check_id": item.check_id,
+                "evidence_id": item.evidence_id,
+                "artifact_id": item.artifact_id,
+                "exit_code": item.exit_code,
+            }
+            for item in latest.values()
+            if item.status is EvidenceStatus.FAILED
+        ]
+        return {
+            "version": 1,
+            "objective": task.spec.objective,
+            "required_checks": [
+                item.check_id for item in task.spec.acceptance.required_checks
+            ],
+            "required_artifacts": [
+                item.artifact_id for item in task.spec.acceptance.required_artifacts
+            ],
+            "state": task.state.value,
+            "workspace_tree_hash": tree_hash,
+            "failure_evidence": failures,
+            "public_output": public_output[-16_384:],
+            "next_step": "run_required_acceptance",
+        }
+
+    @staticmethod
+    def _restored_context_message(
+        summary: dict[str, object] | None, feedback: str
+    ) -> str:
+        if summary is None:
+            return feedback
+        objective = summary.get("objective")
+        checks = summary.get("required_checks")
+        if not isinstance(objective, str) or not isinstance(checks, list) or not all(
+            isinstance(item, str) for item in checks
+        ):
+            raise WorkerConflictError(
+                "Checkpoint context is invalid.", code="checkpoint_invalid"
+            )
+        public_output = summary.get("public_output")
+        prior = public_output if isinstance(public_output, str) else ""
+        text = (
+            "Restored public task context. Hidden reasoning and raw provider frames were "
+            "not persisted.\n"
+            f"Objective: {objective}\n"
+            f"Required checks: {', '.join(checks)}\n"
+        )
+        if prior:
+            text += f"Last public provider output:\n{prior}\n"
+        return (text + feedback)[:32_768]
 
     async def _evaluate_acceptance(self, task: TaskRecord, turns: int) -> str | None:
         task_id = task.task_id

--- a/server/coding_worker/service.py
+++ b/server/coding_worker/service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 
 from .contracts import (
     EvidenceStatus,
@@ -96,12 +96,13 @@ class CodingWorkerService:
         self._started = False
 
     async def create_task(self, origin: Origin, request: TaskCreateRequest) -> TaskRecord:
-        if self.tool_broker is not None:
+        frozen_checks = getattr(self.tool_broker, "frozen_checks", None)
+        if isinstance(frozen_checks, Mapping):
             unknown = [
                 check.check_id
                 for check in request.acceptance.required_checks
                 if check.kind == "command"
-                and check.check_id not in self.tool_broker.frozen_checks
+                and check.check_id not in frozen_checks
             ]
             if unknown:
                 raise WorkerConflictError(

--- a/server/coding_worker/service.py
+++ b/server/coding_worker/service.py
@@ -23,7 +23,7 @@ from .provider import (
     ProviderSession,
 )
 from .store import CodingWorkerStore, WorkerConflictError
-from .tool_broker import ToolBrokerError
+from .tool_broker import ToolBroker, ToolBrokerError
 from .workspace import WorkspaceBroker, WorkspaceError
 
 
@@ -38,6 +38,7 @@ class CodingWorkerService:
         provider: CodingAgentProvider,
         harness_runner: HarnessRunner | None = None,
         max_active_tasks: int = 2,
+        tool_broker: ToolBroker | None = None,
     ) -> None:
         if not 1 <= max_active_tasks <= 16:
             raise ValueError("active task capacity is outside the allowed range")
@@ -46,6 +47,7 @@ class CodingWorkerService:
         self.provider = provider
         self.harness_runner = harness_runner
         self.max_active_tasks = max_active_tasks
+        self.tool_broker = tool_broker
         self._active: dict[str, asyncio.Task[None]] = {}
         self._task_slots: dict[str, str] = {}
         self._sessions: dict[str, ProviderSession] = {}

--- a/server/coding_worker/service.py
+++ b/server/coding_worker/service.py
@@ -96,6 +96,18 @@ class CodingWorkerService:
         self._started = False
 
     async def create_task(self, origin: Origin, request: TaskCreateRequest) -> TaskRecord:
+        if self.tool_broker is not None:
+            unknown = [
+                check.check_id
+                for check in request.acceptance.required_checks
+                if check.kind == "command"
+                and check.check_id not in self.tool_broker.frozen_checks
+            ]
+            if unknown:
+                raise WorkerConflictError(
+                    "Acceptance check is not registered.",
+                    code="worker_acceptance_not_registered",
+                )
         await self.start()
         spec = TaskSpec(**request.model_dump(), origin=origin)
         task = self.store.create_task(spec)

--- a/server/coding_worker/service.py
+++ b/server/coding_worker/service.py
@@ -5,13 +5,16 @@ import contextlib
 from collections.abc import Callable
 
 from .contracts import (
+    EvidenceStatus,
     Origin,
     TaskCreateRequest,
     TaskRecord,
     TaskSpec,
     TaskState,
     TERMINAL_STATES,
+    WorkerEvidence,
 )
+from .evidence import HarnessRunner
 from .provider import (
     CodingAgentProvider,
     ProviderEventKind,
@@ -19,6 +22,7 @@ from .provider import (
     ProviderSession,
 )
 from .store import CodingWorkerStore, WorkerConflictError
+from .tool_broker import ToolBrokerError
 from .workspace import WorkspaceBroker, WorkspaceError
 
 
@@ -31,6 +35,7 @@ class CodingWorkerService:
         store: CodingWorkerStore,
         workspace_broker: WorkspaceBroker,
         provider: CodingAgentProvider,
+        harness_runner: HarnessRunner | None = None,
         max_active_tasks: int = 2,
     ) -> None:
         if not 1 <= max_active_tasks <= 16:
@@ -38,6 +43,7 @@ class CodingWorkerService:
         self.store = store
         self.workspace_broker = workspace_broker
         self.provider = provider
+        self.harness_runner = harness_runner
         self.max_active_tasks = max_active_tasks
         self._active: dict[str, asyncio.Task[None]] = {}
         self._sessions: dict[str, ProviderSession] = {}
@@ -226,35 +232,13 @@ class CodingWorkerService:
             )
             if not self.store.list_messages(task_id):
                 self.store.append_message(task_id, role="user", content=task.spec.objective)
-            terminal = False
-            async for event in self.provider.message(session, task.spec.objective):
-                self.store.append_event(
-                    task_id,
-                    "provider_event",
-                    {"kind": event.kind.value, "data": event.data},
-                )
-                if event.kind is ProviderEventKind.TURN_COMPLETED:
-                    self.store.transition(task_id, TaskState.TESTING)
+            await self._drive_session(task, session)
+        except TimeoutError:
+            current = self.store.get_task(task_id)
+            if current.state not in TERMINAL_STATES:
+                with contextlib.suppress(WorkerConflictError):
                     self.store.transition(
-                        task_id,
-                        TaskState.BLOCKED,
-                        reason="acceptance_runner_pending",
-                    )
-                    terminal = True
-                    break
-                if event.kind is ProviderEventKind.CANCELLED:
-                    self.store.transition(task_id, TaskState.CANCELLED, reason="provider_cancelled")
-                    terminal = True
-                    break
-                if event.kind is ProviderEventKind.FAILED:
-                    self.store.transition(task_id, TaskState.FAILED, reason="provider_failed")
-                    terminal = True
-                    break
-            if not terminal:
-                current = self.store.get_task(task_id)
-                if current.state not in TERMINAL_STATES:
-                    self.store.transition(
-                        task_id, TaskState.INTERRUPTED, reason="provider_stream_ended"
+                        task_id, TaskState.BUDGET_LIMITED, reason="time_budget_exhausted"
                     )
         except asyncio.CancelledError:
             current = self.store.get_task(task_id)
@@ -278,3 +262,130 @@ class CodingWorkerService:
             if session is not None:
                 with contextlib.suppress(Exception):
                     await self.provider.close(session)
+
+    async def _drive_session(self, task: TaskRecord, session: ProviderSession) -> None:
+        task_id = task.task_id
+        message = task.spec.objective
+        turns = 0
+        async with asyncio.timeout(task.spec.budget.max_seconds):
+            while True:
+                turns += 1
+                turn_completed = False
+                async for event in self.provider.message(session, message):
+                    self.store.append_event(
+                        task_id,
+                        "provider_event",
+                        {"kind": event.kind.value, "data": event.data},
+                    )
+                    if event.kind is ProviderEventKind.TURN_COMPLETED:
+                        turn_completed = True
+                        break
+                    if event.kind is ProviderEventKind.CANCELLED:
+                        self.store.transition(
+                            task_id, TaskState.CANCELLED, reason="provider_cancelled"
+                        )
+                        return
+                    if event.kind is ProviderEventKind.FAILED:
+                        self.store.transition(task_id, TaskState.FAILED, reason="provider_failed")
+                        return
+                if not turn_completed:
+                    current = self.store.get_task(task_id)
+                    if current.state not in TERMINAL_STATES:
+                        self.store.transition(
+                            task_id, TaskState.INTERRUPTED, reason="provider_stream_ended"
+                        )
+                    return
+
+                self.store.transition(
+                    task_id, TaskState.TESTING, expected_state=TaskState.RUNNING
+                )
+                if self.harness_runner is None:
+                    self.store.transition(
+                        task_id,
+                        TaskState.BLOCKED,
+                        reason="acceptance_runner_pending",
+                        expected_state=TaskState.TESTING,
+                    )
+                    return
+                try:
+                    evidence = await self.harness_runner.run_required_checks(task_id)
+                except ToolBrokerError as exc:
+                    self.store.transition(
+                        task_id,
+                        TaskState.BLOCKED,
+                        reason=exc.code,
+                        expected_state=TaskState.TESTING,
+                    )
+                    return
+                self.store.append_event(
+                    task_id,
+                    "acceptance_evaluated",
+                    {
+                        "turn": turns,
+                        "evidence": [
+                            {
+                                "check_id": item.check_id,
+                                "status": item.status.value,
+                                "artifact_id": item.artifact_id,
+                            }
+                            for item in evidence
+                        ],
+                    },
+                )
+                if self.harness_runner.acceptance_satisfied(task_id):
+                    self.store.transition(
+                        task_id,
+                        TaskState.COMPLETED,
+                        expected_state=TaskState.TESTING,
+                    )
+                    return
+                if turns >= task.spec.budget.max_turns:
+                    self.store.transition(
+                        task_id,
+                        TaskState.BUDGET_LIMITED,
+                        reason="turn_budget_exhausted",
+                        expected_state=TaskState.TESTING,
+                    )
+                    return
+                message = self._acceptance_feedback(task_id, evidence)
+                self.store.append_message(task_id, role="system", content=message)
+                self.store.append_event(task_id, "acceptance_retry", {"turn": turns + 1})
+                self.store.transition(
+                    task_id,
+                    TaskState.RUNNING,
+                    reason="acceptance_failed",
+                    expected_state=TaskState.TESTING,
+                )
+
+    def _acceptance_feedback(
+        self, task_id: str, evidence: tuple[WorkerEvidence, ...]
+    ) -> str:
+        task = self.store.get_task(task_id)
+        lines = [
+            "Required acceptance checks are not yet satisfied.",
+            "Fix the workspace without weakening or rewriting the acceptance contract, "
+            "then finish the turn for an exact retest.",
+        ]
+        for item in evidence:
+            if item.status is EvidenceStatus.PASSED:
+                continue
+            output = self.store.read_artifact(item.artifact_id, task_id=task_id)
+            excerpt = output.decode("utf-8", errors="replace")[:4000]
+            lines.append(
+                f"\nCheck {item.check_id} failed with exit code {item.exit_code}:\n{excerpt}"
+            )
+        current_hash = self.workspace_broker.current_tree_hash(task.workspace_id or "")
+        artifacts = self.store.list_artifacts(task_id)
+        supplied = {
+            str(item.metadata.get("requirement_id"))
+            for item in artifacts
+            if item.metadata.get("workspace_tree_hash") == current_hash
+        }
+        missing = [
+            item.artifact_id
+            for item in task.spec.acceptance.required_artifacts
+            if item.artifact_id not in supplied
+        ]
+        if missing:
+            lines.append("\nMissing required artifacts: " + ", ".join(missing))
+        return "\n".join(lines)[:16_384]

--- a/server/coding_worker/service.py
+++ b/server/coding_worker/service.py
@@ -17,6 +17,7 @@ from .contracts import (
 from .evidence import HarnessRunner
 from .provider import (
     CodingAgentProvider,
+    ProviderCheckpoint,
     ProviderEventKind,
     ProviderOpenRequest,
     ProviderSession,
@@ -221,7 +222,38 @@ class CodingWorkerService:
                 policy_profile=task.spec.policy_profile,
                 budget=task.spec.budget,
             )
-            session = await self.provider.open(request)
+            resume_phase: str | None = None
+            completed_turns = 0
+            checkpoint = self.store.latest_checkpoint(task_id)
+            if checkpoint is not None:
+                current_tree_hash = self.workspace_broker.current_tree_hash(
+                    workspace.workspace_id
+                )
+                if checkpoint.workspace_tree_hash != current_tree_hash:
+                    self.store.transition(
+                        task_id,
+                        TaskState.BLOCKED,
+                        reason="checkpoint_workspace_changed",
+                        expected_state=TaskState.PREPARING,
+                    )
+                    return
+                try:
+                    provider_checkpoint = ProviderCheckpoint.model_validate(
+                        checkpoint.payload["provider"]
+                    )
+                    resume_phase = str(checkpoint.payload["phase"])
+                    completed_turns = int(checkpoint.payload["completed_turns"])
+                except (KeyError, TypeError, ValueError) as exc:
+                    raise WorkerConflictError(
+                        "Checkpoint payload is invalid.", code="checkpoint_invalid"
+                    ) from exc
+                if resume_phase != "testing" or completed_turns < 1:
+                    raise WorkerConflictError(
+                        "Checkpoint phase is invalid.", code="checkpoint_invalid"
+                    )
+                session = await self.provider.restore(request, provider_checkpoint)
+            else:
+                session = await self.provider.open(request)
             self._sessions[task_id] = session
             self.store.transition(
                 task_id,
@@ -232,7 +264,12 @@ class CodingWorkerService:
             )
             if not self.store.list_messages(task_id):
                 self.store.append_message(task_id, role="user", content=task.spec.objective)
-            await self._drive_session(task, session)
+            await self._drive_session(
+                task,
+                session,
+                resume_phase=resume_phase,
+                completed_turns=completed_turns,
+            )
         except TimeoutError:
             current = self.store.get_task(task_id)
             if current.state not in TERMINAL_STATES:
@@ -263,11 +300,23 @@ class CodingWorkerService:
                 with contextlib.suppress(Exception):
                     await self.provider.close(session)
 
-    async def _drive_session(self, task: TaskRecord, session: ProviderSession) -> None:
+    async def _drive_session(
+        self,
+        task: TaskRecord,
+        session: ProviderSession,
+        *,
+        resume_phase: str | None,
+        completed_turns: int,
+    ) -> None:
         task_id = task.task_id
         message = task.spec.objective
-        turns = 0
+        turns = completed_turns
         async with asyncio.timeout(task.spec.budget.max_seconds):
+            if resume_phase == "testing":
+                feedback = await self._evaluate_acceptance(task, turns)
+                if feedback is None:
+                    return
+                message = feedback
             while True:
                 turns += 1
                 turn_completed = False
@@ -295,67 +344,96 @@ class CodingWorkerService:
                             task_id, TaskState.INTERRUPTED, reason="provider_stream_ended"
                         )
                     return
-
-                self.store.transition(
-                    task_id, TaskState.TESTING, expected_state=TaskState.RUNNING
-                )
-                if self.harness_runner is None:
-                    self.store.transition(
-                        task_id,
-                        TaskState.BLOCKED,
-                        reason="acceptance_runner_pending",
-                        expected_state=TaskState.TESTING,
-                    )
-                    return
                 try:
-                    evidence = await self.harness_runner.run_required_checks(task_id)
-                except ToolBrokerError as exc:
+                    provider_checkpoint = await self.provider.checkpoint(session)
+                    tree_hash = self.workspace_broker.current_tree_hash(
+                        self.store.get_task(task_id).workspace_id or ""
+                    )
+                    self.store.create_checkpoint(
+                        task_id=task_id,
+                        workspace_tree_hash=tree_hash,
+                        payload={
+                            "phase": "testing",
+                            "completed_turns": turns,
+                            "provider": provider_checkpoint.model_dump(mode="json"),
+                        },
+                    )
+                except Exception:
                     self.store.transition(
                         task_id,
                         TaskState.BLOCKED,
-                        reason=exc.code,
-                        expected_state=TaskState.TESTING,
+                        reason="checkpoint_failed",
+                        expected_state=TaskState.RUNNING,
                     )
                     return
-                self.store.append_event(
-                    task_id,
-                    "acceptance_evaluated",
+                feedback = await self._evaluate_acceptance(task, turns)
+                if feedback is None:
+                    return
+                message = feedback
+
+    async def _evaluate_acceptance(self, task: TaskRecord, turns: int) -> str | None:
+        task_id = task.task_id
+        self.store.transition(
+            task_id, TaskState.TESTING, expected_state=TaskState.RUNNING
+        )
+        if self.harness_runner is None:
+            self.store.transition(
+                task_id,
+                TaskState.BLOCKED,
+                reason="acceptance_runner_pending",
+                expected_state=TaskState.TESTING,
+            )
+            return None
+        try:
+            evidence = await self.harness_runner.run_required_checks(task_id)
+        except ToolBrokerError as exc:
+            self.store.transition(
+                task_id,
+                TaskState.BLOCKED,
+                reason=exc.code,
+                expected_state=TaskState.TESTING,
+            )
+            return None
+        self.store.append_event(
+            task_id,
+            "acceptance_evaluated",
+            {
+                "turn": turns,
+                "evidence": [
                     {
-                        "turn": turns,
-                        "evidence": [
-                            {
-                                "check_id": item.check_id,
-                                "status": item.status.value,
-                                "artifact_id": item.artifact_id,
-                            }
-                            for item in evidence
-                        ],
-                    },
-                )
-                if self.harness_runner.acceptance_satisfied(task_id):
-                    self.store.transition(
-                        task_id,
-                        TaskState.COMPLETED,
-                        expected_state=TaskState.TESTING,
-                    )
-                    return
-                if turns >= task.spec.budget.max_turns:
-                    self.store.transition(
-                        task_id,
-                        TaskState.BUDGET_LIMITED,
-                        reason="turn_budget_exhausted",
-                        expected_state=TaskState.TESTING,
-                    )
-                    return
-                message = self._acceptance_feedback(task_id, evidence)
-                self.store.append_message(task_id, role="system", content=message)
-                self.store.append_event(task_id, "acceptance_retry", {"turn": turns + 1})
-                self.store.transition(
-                    task_id,
-                    TaskState.RUNNING,
-                    reason="acceptance_failed",
-                    expected_state=TaskState.TESTING,
-                )
+                        "check_id": item.check_id,
+                        "status": item.status.value,
+                        "artifact_id": item.artifact_id,
+                    }
+                    for item in evidence
+                ],
+            },
+        )
+        if self.harness_runner.acceptance_satisfied(task_id):
+            self.store.transition(
+                task_id,
+                TaskState.COMPLETED,
+                expected_state=TaskState.TESTING,
+            )
+            return None
+        if turns >= task.spec.budget.max_turns:
+            self.store.transition(
+                task_id,
+                TaskState.BUDGET_LIMITED,
+                reason="turn_budget_exhausted",
+                expected_state=TaskState.TESTING,
+            )
+            return None
+        message = self._acceptance_feedback(task_id, evidence)
+        self.store.append_message(task_id, role="system", content=message)
+        self.store.append_event(task_id, "acceptance_retry", {"turn": turns + 1})
+        self.store.transition(
+            task_id,
+            TaskState.RUNNING,
+            reason="acceptance_failed",
+            expected_state=TaskState.TESTING,
+        )
+        return message
 
     def _acceptance_feedback(
         self, task_id: str, evidence: tuple[WorkerEvidence, ...]

--- a/server/coding_worker/service.py
+++ b/server/coding_worker/service.py
@@ -47,6 +47,7 @@ class CodingWorkerService:
         self.harness_runner = harness_runner
         self.max_active_tasks = max_active_tasks
         self._active: dict[str, asyncio.Task[None]] = {}
+        self._task_slots: dict[str, str] = {}
         self._sessions: dict[str, ProviderSession] = {}
         self._wake = asyncio.Event()
         self._scheduler: asyncio.Task[None] | None = None
@@ -87,6 +88,7 @@ class CodingWorkerService:
             with contextlib.suppress(asyncio.CancelledError):
                 await self._scheduler
         self._active.clear()
+        self._task_slots.clear()
         self._sessions.clear()
         self._scheduler = None
         self._started = False
@@ -176,11 +178,17 @@ class CodingWorkerService:
         while True:
             await self._wake.wait()
             self._wake.clear()
-            while not self._closing and len(self._active) < self.max_active_tasks:
-                queued = self.store.list_queued_tasks(limit=1)
-                if not queued:
+            capacity = min(
+                self.max_active_tasks,
+                len(self.workspace_broker.slot_ids)
+                if self.workspace_broker.dedicated_slots
+                else self.max_active_tasks,
+            )
+            while not self._closing and len(self._active) < capacity:
+                selected = self._select_queued_task()
+                if selected is None:
                     break
-                record = queued[0]
+                record, slot_id = selected
                 try:
                     self.store.transition(
                         record.task_id,
@@ -189,8 +197,11 @@ class CodingWorkerService:
                     )
                 except WorkerConflictError:
                     continue
+                if slot_id is not None:
+                    self._task_slots[record.task_id] = slot_id
                 runner = asyncio.create_task(
-                    self._run_task(record.task_id), name=f"coding-worker-{record.task_id}"
+                    self._run_task(record.task_id, slot_id=slot_id),
+                    name=f"coding-worker-{record.task_id}",
                 )
                 self._active[record.task_id] = runner
                 runner.add_done_callback(
@@ -199,21 +210,58 @@ class CodingWorkerService:
                     )
                 )
 
+    def _select_queued_task(self) -> tuple[TaskRecord, str | None] | None:
+        queued = self.store.list_queued_tasks(limit=128)
+        if not queued:
+            return None
+        if not self.workspace_broker.dedicated_slots:
+            return queued[0], None
+        occupied = set(self._task_slots.values())
+        available = [
+            slot_id
+            for slot_id in self.workspace_broker.slot_ids
+            if slot_id not in occupied
+        ]
+        if not available:
+            return None
+        for record in queued:
+            required_slot: str | None = None
+            if record.workspace_id is not None:
+                try:
+                    required_slot = self.workspace_broker.workspace_slot(
+                        record.workspace_id
+                    )
+                except WorkspaceError:
+                    # Let the runner persist the precise workspace failure.
+                    required_slot = available[0]
+            if required_slot is None:
+                return record, available[0]
+            if required_slot in available:
+                return record, required_slot
+        return None
+
     def _task_finished(self, task_id: str, _task: asyncio.Task[None]) -> None:
         self._active.pop(task_id, None)
+        self._task_slots.pop(task_id, None)
         self._sessions.pop(task_id, None)
         if not self._closing:
             self._wake.set()
 
-    async def _run_task(self, task_id: str) -> None:
+    async def _run_task(self, task_id: str, *, slot_id: str | None = None) -> None:
         session: ProviderSession | None = None
         try:
             task = self.store.get_task(task_id)
             workspace = (
                 self.workspace_broker.get(task.workspace_id)
                 if task.workspace_id is not None
-                else await self.workspace_broker.prepare(task.spec.workspace_source)
+                else await self.workspace_broker.prepare(
+                    task.spec.workspace_source, slot_id=slot_id
+                )
             )
+            if slot_id is not None and workspace.slot_id != slot_id:
+                raise WorkspaceError(
+                    "Workspace slot binding changed.", code="workspace_slot_changed"
+                )
             request = ProviderOpenRequest(
                 task_id=task_id,
                 workspace_id=workspace.workspace_id,

--- a/server/coding_worker/sidecar.py
+++ b/server/coding_worker/sidecar.py
@@ -4,12 +4,13 @@ import asyncio
 import contextlib
 import os
 import signal
+from collections.abc import Awaitable, Callable
 from pathlib import Path
 
 from .contracts import SAFE_ID
 from .opencode_provider import OpenCodeProvider, OpenCodeRoute
 from .provider_rpc import ProviderRPCServer
-from .executor import SidecarExecutor
+from .executor import ExecutorRPCServer, SidecarExecutor
 
 
 def _required_environment(name: str) -> str:
@@ -50,6 +51,16 @@ async def run() -> None:
     runtime_root = Path(
         os.getenv("CODING_WORKER_RUNTIME_ROOT", "/worker-runtime")
     ).resolve()
+    if os.getenv("CODING_WORKER_MODE", "provider").strip() == "executor":
+        executor = SidecarExecutor(
+            _workspace_resolver(workspace_root), runtime_root=runtime_root
+        )
+        executor_server = ExecutorRPCServer(
+            executor, token=_required_environment("CODING_WORKER_EXECUTOR_TOKEN")
+        )
+        await executor_server.start_unix(socket_path)
+        await _wait_for_stop(executor_server.close)
+        return
     route_id = os.getenv("CODING_WORKER_ROUTE_ID", "coding/default").strip()
     route = OpenCodeRoute(
         route_id=route_id,
@@ -63,17 +74,17 @@ async def run() -> None:
         routes={route_id: route},
         tool_broker_command=("python", "-m", "coding_worker.broker_mcp"),
     )
-    executor = SidecarExecutor(
-        _workspace_resolver(workspace_root), runtime_root=runtime_root
-    )
     server = ProviderRPCServer(
         provider,
         token=_required_environment("CODING_WORKER_SIDECAR_TOKEN"),
         bind_broker=provider.bind_broker,
         unbind_broker=provider.unbind_broker,
-        executor=executor,
     )
     await server.start_unix(socket_path)
+    await _wait_for_stop(server.close)
+
+
+async def _wait_for_stop(close: Callable[[], Awaitable[None]]) -> None:
     stop = asyncio.Event()
     loop = asyncio.get_running_loop()
     for signal_name in (signal.SIGINT, signal.SIGTERM):
@@ -82,7 +93,7 @@ async def run() -> None:
     try:
         await stop.wait()
     finally:
-        await server.close()
+        await close()
 
 
 def main() -> None:

--- a/server/coding_worker/sidecar.py
+++ b/server/coding_worker/sidecar.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from .contracts import SAFE_ID
 from .opencode_provider import OpenCodeProvider, OpenCodeRoute
 from .provider_rpc import ProviderRPCServer
+from .executor import SidecarExecutor
 
 
 def _required_environment(name: str) -> str:
@@ -62,11 +63,15 @@ async def run() -> None:
         routes={route_id: route},
         tool_broker_command=("python", "-m", "coding_worker.broker_mcp"),
     )
+    executor = SidecarExecutor(
+        _workspace_resolver(workspace_root), runtime_root=runtime_root
+    )
     server = ProviderRPCServer(
         provider,
         token=_required_environment("CODING_WORKER_SIDECAR_TOKEN"),
         bind_broker=provider.bind_broker,
         unbind_broker=provider.unbind_broker,
+        executor=executor,
     )
     await server.start_unix(socket_path)
     stop = asyncio.Event()

--- a/server/coding_worker/sidecar.py
+++ b/server/coding_worker/sidecar.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import signal
+from pathlib import Path
+
+from .contracts import SAFE_ID
+from .opencode_provider import OpenCodeProvider, OpenCodeRoute
+from .provider_rpc import ProviderRPCServer
+
+
+def _required_environment(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise RuntimeError(f"{name} is required")
+    return value
+
+
+def _workspace_resolver(root: Path):
+    resolved_root = root.resolve()
+
+    def resolve(workspace_id: str) -> Path:
+        if SAFE_ID.fullmatch(workspace_id) is None:
+            raise ValueError("workspace id is invalid")
+        candidate = resolved_root / "workspaces" / workspace_id / "repo"
+        resolved = candidate.resolve(strict=True)
+        if (
+            not resolved.is_relative_to(resolved_root)
+            or not resolved.is_dir()
+            or candidate.is_symlink()
+        ):
+            raise ValueError("workspace is unavailable")
+        return resolved
+
+    return resolve
+
+
+async def run() -> None:
+    socket_path = Path(
+        os.getenv(
+            "CODING_WORKER_PROVIDER_SOCKET", "/run/modelmirror-coding/provider.sock"
+        )
+    )
+    workspace_root = Path(
+        os.getenv("CODING_WORKER_SLOT_ROOT", "/worker-data")
+    ).resolve()
+    runtime_root = Path(
+        os.getenv("CODING_WORKER_RUNTIME_ROOT", "/worker-runtime")
+    ).resolve()
+    route_id = os.getenv("CODING_WORKER_ROUTE_ID", "coding/default").strip()
+    route = OpenCodeRoute(
+        route_id=route_id,
+        model_id=_required_environment("CODING_WORKER_MODEL_ID"),
+        base_url=_required_environment("CODING_WORKER_MODEL_BASE_URL"),
+        api_key=_required_environment("CODING_WORKER_ROUTE_KEY"),
+    )
+    provider = OpenCodeProvider(
+        workspace_resolver=_workspace_resolver(workspace_root),
+        runtime_root=runtime_root,
+        routes={route_id: route},
+        tool_broker_command=("python", "-m", "coding_worker.broker_mcp"),
+    )
+    server = ProviderRPCServer(
+        provider,
+        token=_required_environment("CODING_WORKER_SIDECAR_TOKEN"),
+        bind_broker=provider.bind_broker,
+        unbind_broker=provider.unbind_broker,
+    )
+    await server.start_unix(socket_path)
+    stop = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    for signal_name in (signal.SIGINT, signal.SIGTERM):
+        with contextlib.suppress(NotImplementedError):
+            loop.add_signal_handler(signal_name, stop.set)
+    try:
+        await stop.wait()
+    finally:
+        await server.close()
+
+
+def main() -> None:
+    asyncio.run(run())
+
+
+if __name__ == "__main__":
+    main()

--- a/server/coding_worker/source_adapters.py
+++ b/server/coding_worker/source_adapters.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import os
+import re
 import stat
+import subprocess
 from pathlib import Path, PurePosixPath
 from typing import Any, Protocol
 
@@ -24,6 +26,223 @@ class ProjectSnapshotClient(Protocol):
     ) -> dict[str, Any]: ...
 
     async def release(self, project_id: str, lease_id: str) -> bool: ...
+
+
+_DANGEROUS_CONFIG = re.compile(
+    r"^(?:include(?:if)?\.|filter\.|credential\.|url\.|diff\..*\.textconv$|"
+    r"core\.worktree$|core\.excludesfile$|extensions\.(?:worktreeconfig|partialclone|refstorage)$|"
+    r"remote\..*\.(?:promisor|partialclonefilter)$)",
+    re.IGNORECASE,
+)
+
+
+class BuiltinGitWorkspaceSourceAdapter:
+    """Read tracked blobs from one deployment-fixed ModelMirror revision."""
+
+    def __init__(self, root: Path, *, source_id: str, revision: str) -> None:
+        self._root = Path(root)
+        self._source_id = source_id
+        self._revision = revision.lower()
+        if re.fullmatch(r"[a-f0-9]{40}", self._revision) is None:
+            raise ValueError("builtin revision must be a full commit id")
+
+    async def acquire(self, source: WorkspaceSource) -> SourceSnapshot:
+        if (
+            source.kind != "builtin"
+            or source.source_id != self._source_id
+            or source.revision != self._revision
+        ):
+            raise WorkspaceError(
+                "Builtin source is not registered at this revision.",
+                code="source_not_found",
+            )
+        return await asyncio.to_thread(self._read_revision, source)
+
+    def _read_revision(self, source: WorkspaceSource) -> SourceSnapshot:
+        try:
+            root_metadata = self._root.lstat()
+            git_metadata = (self._root / ".git").lstat()
+        except OSError as exc:
+            raise WorkspaceError(
+                "Builtin source is unavailable.", code="source_not_found"
+            ) from exc
+        if (
+            not stat.S_ISDIR(root_metadata.st_mode)
+            or stat.S_ISLNK(root_metadata.st_mode)
+            or stat.S_ISLNK(git_metadata.st_mode)
+            or not (
+                stat.S_ISDIR(git_metadata.st_mode)
+                or stat.S_ISREG(git_metadata.st_mode)
+            )
+        ):
+            raise WorkspaceError(
+                "Builtin source repository is unsafe.",
+                code="source_snapshot_unsafe",
+            )
+        config = self._git("config", "--local", "--no-includes", "--name-only", "--list")
+        names = config.stdout.decode("utf-8", errors="strict").splitlines()
+        if any(_DANGEROUS_CONFIG.search(name.strip()) for name in names):
+            raise WorkspaceError(
+                "Builtin source configuration is unsafe.",
+                code="source_snapshot_unsafe",
+            )
+        resolved = self._git("rev-parse", "--verify", f"{self._revision}^{{commit}}")
+        if resolved.stdout.decode("ascii", errors="strict").strip().lower() != self._revision:
+            raise WorkspaceError(
+                "Builtin revision changed.", code="source_revision_changed"
+            )
+        tree = self._git("ls-tree", "-r", "-z", "-l", self._revision)
+        if len(tree.stdout) > 16 * 1024 * 1024:
+            raise WorkspaceError(
+                "Builtin tree metadata is too large.", code="source_limit_exceeded"
+            )
+        entries: list[tuple[str, str, int, bool]] = []
+        total_bytes = 0
+        for raw in tree.stdout.split(b"\0"):
+            if not raw:
+                continue
+            try:
+                header, encoded_path = raw.split(b"\t", 1)
+                mode, object_type, object_id, encoded_size = header.split()
+                relative = encoded_path.decode("utf-8", errors="strict")
+                size = int(encoded_size)
+            except (ValueError, UnicodeError) as exc:
+                raise WorkspaceError(
+                    "Builtin tree is invalid.", code="source_snapshot_unsafe"
+                ) from exc
+            pure = PurePosixPath(relative)
+            if (
+                object_type != b"blob"
+                or mode not in {b"100644", b"100755"}
+                or pure.is_absolute()
+                or ".." in pure.parts
+                or not pure.parts
+                or pure.parts[0] == ".git"
+                or size < 0
+                or size > MAX_SOURCE_FILE_BYTES
+            ):
+                raise WorkspaceError(
+                    "Builtin tree contains an unsupported entry.",
+                    code="source_snapshot_unsafe",
+                )
+            total_bytes += size
+            if len(entries) >= MAX_SOURCE_FILES or total_bytes > MAX_SOURCE_BYTES:
+                raise WorkspaceError(
+                    "Builtin tree exceeds Worker limits.",
+                    code="source_limit_exceeded",
+                )
+            entries.append(
+                (
+                    relative,
+                    object_id.decode("ascii", errors="strict"),
+                    size,
+                    mode == b"100755",
+                )
+            )
+        contents = self._read_blobs(entries)
+        return SourceSnapshot(
+            source=source,
+            files=tuple(
+                SourceFile(path=path, content=content, executable=executable)
+                for (path, _object_id, _size, executable), content in zip(
+                    entries, contents, strict=True
+                )
+            ),
+        )
+
+    def _read_blobs(
+        self, entries: list[tuple[str, str, int, bool]]
+    ) -> list[bytes]:
+        command = self._git_command("cat-file", "--batch")
+        try:
+            process = subprocess.Popen(
+                command,
+                cwd=self._root,
+                env=self._git_environment(),
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+        except OSError as exc:
+            raise WorkspaceError(
+                "Builtin object reader is unavailable.", code="source_not_found"
+            ) from exc
+        assert process.stdin is not None and process.stdout is not None
+        result: list[bytes] = []
+        try:
+            for _path, object_id, expected_size, _executable in entries:
+                process.stdin.write(object_id.encode("ascii") + b"\n")
+                process.stdin.flush()
+                header = process.stdout.readline()
+                parts = header.rstrip(b"\n").split(b" ")
+                if (
+                    len(parts) != 3
+                    or parts[0].decode("ascii", errors="strict") != object_id
+                    or parts[1] != b"blob"
+                    or int(parts[2]) != expected_size
+                ):
+                    raise WorkspaceError(
+                        "Builtin object response is invalid.",
+                        code="source_revision_changed",
+                    )
+                content = process.stdout.read(expected_size)
+                if len(content) != expected_size or process.stdout.read(1) != b"\n":
+                    raise WorkspaceError(
+                        "Builtin object response is truncated.",
+                        code="source_revision_changed",
+                    )
+                result.append(content)
+            process.stdin.close()
+            if process.wait(timeout=15) != 0:
+                raise WorkspaceError(
+                    "Builtin object reader failed.", code="source_revision_changed"
+                )
+            return result
+        except Exception:
+            process.kill()
+            process.wait(timeout=5)
+            raise
+
+    def _git(self, *args: str) -> subprocess.CompletedProcess[bytes]:
+        try:
+            return subprocess.run(
+                self._git_command(*args),
+                cwd=self._root,
+                env=self._git_environment(),
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=True,
+                timeout=20,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            raise WorkspaceError(
+                "Builtin repository could not be inspected.",
+                code="source_snapshot_unsafe",
+            ) from exc
+
+    def _git_command(self, *args: str) -> list[str]:
+        null = os.devnull
+        return [
+            "git", "-c", f"core.hooksPath={null}", "-c", f"core.attributesFile={null}",
+            "-c", f"core.excludesFile={null}", "-c", "credential.helper=", "-c", "protocol.file.allow=never",
+            "-c", "protocol.ext.allow=never", *args,
+        ]
+
+    @staticmethod
+    def _git_environment() -> dict[str, str]:
+        keep = {key: value for key, value in os.environ.items() if key.upper() in {"PATH", "SYSTEMROOT", "WINDIR"}}
+        return {
+            **keep,
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_TERMINAL_PROMPT": "0",
+            "GIT_ASKPASS": "",
+            "GIT_SSH_COMMAND": "false",
+            "GIT_NO_LAZY_FETCH": "1",
+            "GIT_NO_REPLACE_OBJECTS": "1",
+            "GIT_OPTIONAL_LOCKS": "0",
+        }
 
 
 class ProjectSnapshotWorkspaceSourceAdapter:

--- a/server/coding_worker/source_adapters.py
+++ b/server/coding_worker/source_adapters.py
@@ -27,6 +27,30 @@ class ProjectSnapshotClient(Protocol):
 
     async def release(self, project_id: str, lease_id: str) -> bool: ...
 
+    async def import_uploaded(
+        self,
+        *,
+        upload_id: str,
+        archive_sha256: str,
+        project_id: str,
+        name: str,
+        branch: str,
+        head: str,
+    ) -> dict[str, Any]: ...
+
+
+class ProjectHostSnapshotClient(Protocol):
+    async def request_snapshot(
+        self,
+        project_id: str,
+        *,
+        expected_head: str | None = None,
+        expected_branch: str | None = None,
+        managed_operation_id: str | None = None,
+    ) -> dict[str, Any]: ...
+
+    def finish_transfer(self, transfer_id: str) -> None: ...
+
 
 _DANGEROUS_CONFIG = re.compile(
     r"^(?:include(?:if)?\.|filter\.|credential\.|url\.|diff\..*\.textconv$|"
@@ -252,7 +276,7 @@ class ProjectSnapshotWorkspaceSourceAdapter:
     snapshot volume and Project Source socket stay behind this trusted adapter.
     """
 
-    _KINDS = {"manifest": "local_clone", "host_snapshot": "host_git"}
+    _KINDS = {"manifest": "local_clone"}
 
     def __init__(self, client: ProjectSnapshotClient, snapshot_root: Path) -> None:
         self._client = client
@@ -267,6 +291,15 @@ class ProjectSnapshotWorkspaceSourceAdapter:
         lease = await self._client.acquire(
             source.source_id, expected_head=source.revision
         )
+        return await self.consume_lease(source, lease, expected_kind=expected_kind)
+
+    async def consume_lease(
+        self,
+        source: WorkspaceSource,
+        lease: dict[str, Any],
+        *,
+        expected_kind: str,
+    ) -> SourceSnapshot:
         lease_id = lease.get("lease_id")
         if (
             lease.get("kind") != expected_kind
@@ -424,3 +457,75 @@ class ProjectSnapshotWorkspaceSourceAdapter:
                 for relative, content, executable in records
             ),
         )
+
+
+class HostSnapshotWorkspaceSourceAdapter:
+    """Lazily transfer one exact Windows Helper snapshot into the Worker.
+
+    Queued tasks do not occupy the single Project Source lease. The physical
+    path remains in the Helper; this adapter sees only the opaque project id,
+    revision, transfer metadata, and the fixed Project Source snapshot mount.
+    """
+
+    def __init__(
+        self,
+        host: ProjectHostSnapshotClient,
+        project_source: ProjectSnapshotClient,
+        snapshot_root: Path,
+    ) -> None:
+        self._host = host
+        self._project_source = project_source
+        self._reader = ProjectSnapshotWorkspaceSourceAdapter(
+            project_source, snapshot_root
+        )
+
+    async def acquire(self, source: WorkspaceSource) -> SourceSnapshot:
+        if source.kind != "host_snapshot":
+            raise WorkspaceError(
+                "Workspace source kind is unsupported.", code="source_not_found"
+            )
+        transfer_id: str | None = None
+        try:
+            transfer = await self._host.request_snapshot(
+                source.source_id,
+                expected_head=source.revision,
+            )
+            project = transfer.get("project")
+            transfer_id = transfer.get("upload_id")
+            archive_sha256 = transfer.get("archive_sha256")
+            if (
+                not isinstance(project, dict)
+                or project.get("id") != source.source_id
+                or project.get("head") != source.revision
+                or not isinstance(project.get("name"), str)
+                or not isinstance(project.get("branch"), str)
+                or not isinstance(transfer_id, str)
+                or re.fullmatch(r"[a-f0-9]{32}", transfer_id) is None
+                or not isinstance(archive_sha256, str)
+                or re.fullmatch(r"[a-f0-9]{64}", archive_sha256) is None
+            ):
+                raise WorkspaceError(
+                    "Host snapshot response is inconsistent.",
+                    code="source_revision_changed",
+                )
+            lease = await self._project_source.import_uploaded(
+                upload_id=transfer_id,
+                archive_sha256=archive_sha256,
+                project_id=source.source_id,
+                name=project["name"],
+                branch=project["branch"],
+                head=source.revision,
+            )
+            return await self._reader.consume_lease(
+                source, lease, expected_kind="host_git"
+            )
+        except WorkspaceError:
+            raise
+        except Exception as exc:
+            raise WorkspaceError(
+                "Host snapshot is unavailable.",
+                code=str(getattr(exc, "code", "source_unavailable")),
+            ) from exc
+        finally:
+            if transfer_id is not None:
+                self._host.finish_transfer(transfer_id)

--- a/server/coding_worker/source_adapters.py
+++ b/server/coding_worker/source_adapters.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import os
+import stat
+from pathlib import Path, PurePosixPath
+from typing import Any, Protocol
+
+from .contracts import WorkspaceSource
+from .workspace import (
+    MAX_SOURCE_BYTES,
+    MAX_SOURCE_FILE_BYTES,
+    MAX_SOURCE_FILES,
+    SourceFile,
+    SourceSnapshot,
+    WorkspaceError,
+)
+
+
+class ProjectSnapshotClient(Protocol):
+    async def acquire(
+        self, project_id: str, *, expected_head: str | None = None
+    ) -> dict[str, Any]: ...
+
+    async def release(self, project_id: str, lease_id: str) -> bool: ...
+
+
+class ProjectSnapshotWorkspaceSourceAdapter:
+    """Copy one exact Project Source lease into a Worker-owned snapshot.
+
+    The caller supplies only opaque project and revision identifiers. The fixed
+    snapshot volume and Project Source socket stay behind this trusted adapter.
+    """
+
+    _KINDS = {"manifest": "local_clone", "host_snapshot": "host_git"}
+
+    def __init__(self, client: ProjectSnapshotClient, snapshot_root: Path) -> None:
+        self._client = client
+        self._snapshot_root = Path(snapshot_root)
+
+    async def acquire(self, source: WorkspaceSource) -> SourceSnapshot:
+        expected_kind = self._KINDS.get(source.kind)
+        if expected_kind is None:
+            raise WorkspaceError(
+                "Workspace source kind is unsupported.", code="source_not_found"
+            )
+        lease = await self._client.acquire(
+            source.source_id, expected_head=source.revision
+        )
+        lease_id = lease.get("lease_id")
+        if (
+            lease.get("kind") != expected_kind
+            or lease.get("project_id") != source.source_id
+            or lease.get("head") != source.revision
+            or not isinstance(lease_id, str)
+        ):
+            await self._release(source.source_id, lease_id)
+            raise WorkspaceError(
+                "Project source lease is inconsistent.",
+                code="source_revision_changed",
+            )
+
+        snapshot: SourceSnapshot | None = None
+        failure: BaseException | None = None
+        try:
+            snapshot = await asyncio.to_thread(self._read_snapshot, source, lease)
+        except BaseException as exc:
+            failure = exc
+        released = await self._release(source.source_id, lease_id)
+        if not released:
+            raise WorkspaceError(
+                "Project source lease could not be released.",
+                code="source_release_failed",
+            ) from failure
+        if failure is not None:
+            raise failure
+        assert snapshot is not None
+        return snapshot
+
+    async def _release(self, project_id: str, lease_id: object) -> bool:
+        if not isinstance(lease_id, str):
+            return False
+        try:
+            return await self._client.release(project_id, lease_id)
+        except Exception as exc:
+            raise WorkspaceError(
+                "Project source lease could not be released.",
+                code="source_release_failed",
+            ) from exc
+
+    def _read_snapshot(
+        self, source: WorkspaceSource, lease: dict[str, Any]
+    ) -> SourceSnapshot:
+        root = self._snapshot_root / "current" / "workspace"
+        try:
+            root_stat = root.lstat()
+        except OSError as exc:
+            raise WorkspaceError(
+                "Project snapshot is unavailable.", code="source_not_found"
+            ) from exc
+        if not stat.S_ISDIR(root_stat.st_mode) or stat.S_ISLNK(root_stat.st_mode):
+            raise WorkspaceError(
+                "Project snapshot is unsafe.", code="source_snapshot_unsafe"
+            )
+
+        records: list[tuple[str, bytes, bool]] = []
+        total_bytes = 0
+        stack = [root]
+        while stack:
+            directory = stack.pop()
+            try:
+                children = sorted(os.scandir(directory), key=lambda item: item.name)
+            except OSError as exc:
+                raise WorkspaceError(
+                    "Project snapshot is unavailable.", code="source_not_found"
+                ) from exc
+            for child in children:
+                path = Path(child.path)
+                try:
+                    metadata = child.stat(follow_symlinks=False)
+                except OSError as exc:
+                    raise WorkspaceError(
+                        "Project snapshot changed while reading.",
+                        code="source_revision_changed",
+                    ) from exc
+                relative = path.relative_to(root).as_posix()
+                pure = PurePosixPath(relative)
+                if (
+                    not relative
+                    or pure.is_absolute()
+                    or ".." in pure.parts
+                    or pure.parts[0] == ".git"
+                ):
+                    raise WorkspaceError(
+                        "Project snapshot contains an unsafe path.",
+                        code="source_snapshot_unsafe",
+                    )
+                if stat.S_ISLNK(metadata.st_mode):
+                    raise WorkspaceError(
+                        "Project snapshot contains a link.",
+                        code="source_snapshot_unsafe",
+                    )
+                if stat.S_ISDIR(metadata.st_mode):
+                    stack.append(path)
+                    continue
+                if not stat.S_ISREG(metadata.st_mode):
+                    raise WorkspaceError(
+                        "Project snapshot contains an unsupported entry.",
+                        code="source_snapshot_unsafe",
+                    )
+                if metadata.st_size > MAX_SOURCE_FILE_BYTES:
+                    raise WorkspaceError(
+                        "Project snapshot file is too large.",
+                        code="source_file_limit_exceeded",
+                    )
+                try:
+                    content = path.read_bytes()
+                    after = path.stat(follow_symlinks=False)
+                except OSError as exc:
+                    raise WorkspaceError(
+                        "Project snapshot changed while reading.",
+                        code="source_revision_changed",
+                    ) from exc
+                if (
+                    len(content) != metadata.st_size
+                    or (metadata.st_dev, metadata.st_ino, metadata.st_mtime_ns)
+                    != (after.st_dev, after.st_ino, after.st_mtime_ns)
+                ):
+                    raise WorkspaceError(
+                        "Project snapshot changed while reading.",
+                        code="source_revision_changed",
+                    )
+                total_bytes += len(content)
+                if len(records) >= MAX_SOURCE_FILES or total_bytes > MAX_SOURCE_BYTES:
+                    raise WorkspaceError(
+                        "Project snapshot exceeds Worker limits.",
+                        code="source_limit_exceeded",
+                    )
+                records.append(
+                    (relative, content, bool(metadata.st_mode & stat.S_IXUSR))
+                )
+
+        records.sort(key=lambda item: item[0])
+        fingerprint = hashlib.sha256()
+        for relative, content, _executable in records:
+            fingerprint.update(relative.encode("utf-8"))
+            fingerprint.update(b"\0")
+            fingerprint.update(str(len(content)).encode("ascii"))
+            fingerprint.update(b"\0")
+            fingerprint.update(hashlib.sha256(content).digest())
+        if (
+            lease.get("file_count") != len(records)
+            or lease.get("total_bytes") != total_bytes
+            or lease.get("fingerprint") != fingerprint.hexdigest()
+        ):
+            raise WorkspaceError(
+                "Project snapshot does not match its lease.",
+                code="source_revision_changed",
+            )
+        return SourceSnapshot(
+            source=source,
+            files=tuple(
+                SourceFile(path=relative, content=content, executable=executable)
+                for relative, content, executable in records
+            ),
+        )

--- a/server/coding_worker/source_adapters.py
+++ b/server/coding_worker/source_adapters.py
@@ -495,7 +495,7 @@ class HostSnapshotWorkspaceSourceAdapter:
             archive_sha256 = transfer.get("archive_sha256")
             if (
                 not isinstance(project, dict)
-                or project.get("id") != source.source_id
+                or project.get("project_id") != source.source_id
                 or project.get("head") != source.revision
                 or not isinstance(project.get("name"), str)
                 or not isinstance(project.get("branch"), str)

--- a/server/coding_worker/store.py
+++ b/server/coding_worker/store.py
@@ -10,13 +10,19 @@ from pathlib import Path
 from typing import Any
 
 from .contracts import (
+    ApprovalStatus,
+    CapabilityName,
+    CapabilityLease,
+    OperationState,
     TERMINAL_STATES,
     Origin,
     TaskRecord,
     TaskSpec,
     TaskState,
     WorkerEvent,
+    WorkerApproval,
     WorkerMessage,
+    WorkerOperation,
     require_transition,
 )
 from .crypto import WorkerCryptoError, WorkerEncryptedCodec
@@ -74,6 +80,7 @@ class CodingWorkerStore:
         self.workspaces_root.mkdir(parents=True, exist_ok=True)
         self._initialize()
         self.mark_inflight_interrupted()
+        self.mark_inflight_operations_unknown()
 
     def create_task(self, spec: TaskSpec) -> TaskRecord:
         now = self._now()
@@ -320,6 +327,330 @@ class CodingWorkerStore:
             )
         return self.get_task(task_id)
 
+    def create_approval(
+        self,
+        *,
+        task_id: str,
+        operation_id: str,
+        capability: CapabilityName,
+        request: dict[str, Any],
+    ) -> WorkerApproval:
+        now = self._now()
+        approval_id = f"approval_{uuid.uuid4().hex}"
+        encrypted_request = self._codec.encrypt(request)
+        with self._lock, self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            self._require_task_row(connection, task_id)
+            existing = connection.execute(
+                "SELECT * FROM worker_approvals WHERE operation_id = ?",
+                (operation_id,),
+            ).fetchone()
+            if existing is not None:
+                approval = self._approval(existing)
+                if (
+                    approval.task_id != task_id
+                    or approval.capability != capability
+                    or approval.request != request
+                ):
+                    raise WorkerConflictError(
+                        "Approval operation id is bound to another intent.",
+                        code="approval_intent_conflict",
+                    )
+                return approval
+            connection.execute(
+                """
+                INSERT INTO worker_approvals (
+                    approval_id, task_id, operation_id, capability, status,
+                    request_ciphertext, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    approval_id,
+                    task_id,
+                    operation_id,
+                    capability,
+                    ApprovalStatus.PENDING.value,
+                    encrypted_request,
+                    now,
+                ),
+            )
+            self._append_event_locked(
+                connection,
+                task_id=task_id,
+                event_type="approval_requested",
+                payload={"approval_id": approval_id, "capability": capability},
+                created_at=now,
+            )
+        return self.get_approval(approval_id)
+
+    def get_approval(self, approval_id: str) -> WorkerApproval:
+        with self._connect() as connection:
+            row = connection.execute(
+                "SELECT * FROM worker_approvals WHERE approval_id = ?", (approval_id,)
+            ).fetchone()
+        if row is None:
+            raise WorkerNotFoundError("Approval was not found.", code="approval_not_found")
+        return self._approval(row)
+
+    def list_approvals(self, task_id: str) -> list[WorkerApproval]:
+        with self._connect() as connection:
+            self._require_task_row(connection, task_id)
+            rows = connection.execute(
+                "SELECT * FROM worker_approvals WHERE task_id = ? ORDER BY created_at",
+                (task_id,),
+            ).fetchall()
+        return [self._approval(row) for row in rows]
+
+    def decide_approval(
+        self,
+        approval_id: str,
+        *,
+        approved: bool,
+        task_scope: bool = False,
+        ttl_seconds: int = 900,
+    ) -> WorkerApproval:
+        if isinstance(ttl_seconds, bool) or not 30 <= ttl_seconds <= 3600:
+            raise ValueError("approval ttl is outside the allowed range")
+        now = self._now()
+        with self._lock, self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            row = connection.execute(
+                "SELECT * FROM worker_approvals WHERE approval_id = ?", (approval_id,)
+            ).fetchone()
+            if row is None:
+                raise WorkerNotFoundError("Approval was not found.", code="approval_not_found")
+            if row["status"] != ApprovalStatus.PENDING.value:
+                raise WorkerConflictError(
+                    "Approval has already been decided.", code="approval_already_decided"
+                )
+            lease: CapabilityLease | None = None
+            status = ApprovalStatus.APPROVED if approved else ApprovalStatus.REJECTED
+            if approved:
+                task_row = self._require_task_row(connection, str(row["task_id"]))
+                lease = CapabilityLease(
+                    lease_id=f"lease_{uuid.uuid4().hex}",
+                    task_id=str(row["task_id"]),
+                    capability=str(row["capability"]),  # type: ignore[arg-type]
+                    scope=self._decrypt_dict(row["request_ciphertext"]),
+                    issued_at=now,
+                    expires_at=min(now + ttl_seconds, float(task_row["expires_at"])),
+                    operation_limit=1024 if task_scope else 1,
+                )
+                connection.execute(
+                    """
+                    INSERT INTO worker_leases (
+                        lease_id, task_id, capability, scope_ciphertext,
+                        issued_at, expires_at, remaining_operations
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        lease.lease_id,
+                        lease.task_id,
+                        lease.capability,
+                        self._codec.encrypt(lease.scope),
+                        lease.issued_at,
+                        lease.expires_at,
+                        lease.operation_limit,
+                    ),
+                )
+            connection.execute(
+                """
+                UPDATE worker_approvals SET status = ?, lease_ciphertext = ?, decided_at = ?
+                WHERE approval_id = ?
+                """,
+                (
+                    status.value,
+                    self._codec.encrypt(lease.model_dump(mode="json")) if lease else None,
+                    now,
+                    approval_id,
+                ),
+            )
+            self._append_event_locked(
+                connection,
+                task_id=str(row["task_id"]),
+                event_type="approval_decided",
+                payload={"approval_id": approval_id, "status": status.value},
+                created_at=now,
+            )
+        return self.get_approval(approval_id)
+
+    def consume_lease(
+        self, lease_id: str, *, task_id: str, capability: CapabilityName
+    ) -> CapabilityLease:
+        now = self._now()
+        with self._lock, self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            row = connection.execute(
+                "SELECT * FROM worker_leases WHERE lease_id = ?", (lease_id,)
+            ).fetchone()
+            if (
+                row is None
+                or row["task_id"] != task_id
+                or row["capability"] != capability
+                or float(row["expires_at"]) <= now
+                or int(row["remaining_operations"]) <= 0
+            ):
+                raise WorkerConflictError(
+                    "Capability lease is unavailable.", code="lease_unavailable"
+                )
+            remaining = int(row["remaining_operations"]) - 1
+            connection.execute(
+                "UPDATE worker_leases SET remaining_operations = ? WHERE lease_id = ?",
+                (remaining, lease_id),
+            )
+            return CapabilityLease(
+                lease_id=lease_id,
+                task_id=task_id,
+                capability=capability,  # type: ignore[arg-type]
+                scope=self._decrypt_dict(row["scope_ciphertext"]),
+                issued_at=float(row["issued_at"]),
+                expires_at=float(row["expires_at"]),
+                operation_limit=remaining + 1,
+            )
+
+    def create_operation(
+        self,
+        *,
+        task_id: str,
+        operation_id: str,
+        tool_name: str,
+        intent_sha256: str,
+        request: dict[str, Any],
+    ) -> WorkerOperation:
+        now = self._now()
+        with self._lock, self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            self._require_task_row(connection, task_id)
+            existing = connection.execute(
+                "SELECT * FROM worker_operations WHERE operation_id = ?", (operation_id,)
+            ).fetchone()
+            if existing is not None:
+                operation = self._operation(existing)
+                if (
+                    operation.task_id != task_id
+                    or operation.tool_name != tool_name
+                    or operation.intent_sha256 != intent_sha256
+                    or operation.request != request
+                ):
+                    raise WorkerConflictError(
+                        "Tool operation id is bound to another intent.",
+                        code="operation_intent_conflict",
+                    )
+                return operation
+            connection.execute(
+                """
+                INSERT INTO worker_operations (
+                    operation_id, task_id, tool_name, intent_sha256, state,
+                    request_ciphertext, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    operation_id,
+                    task_id,
+                    tool_name,
+                    intent_sha256,
+                    OperationState.PREPARED.value,
+                    self._codec.encrypt(request),
+                    now,
+                    now,
+                ),
+            )
+        return self.get_operation(operation_id)
+
+    def get_operation(self, operation_id: str) -> WorkerOperation:
+        with self._connect() as connection:
+            row = connection.execute(
+                "SELECT * FROM worker_operations WHERE operation_id = ?", (operation_id,)
+            ).fetchone()
+        if row is None:
+            raise WorkerNotFoundError("Tool operation was not found.", code="operation_not_found")
+        return self._operation(row)
+
+    def transition_operation(
+        self,
+        operation_id: str,
+        target: OperationState,
+        *,
+        result: dict[str, Any] | None = None,
+        expected_state: OperationState | None = None,
+    ) -> WorkerOperation:
+        now = self._now()
+        with self._lock, self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            row = connection.execute(
+                "SELECT * FROM worker_operations WHERE operation_id = ?", (operation_id,)
+            ).fetchone()
+            if row is None:
+                raise WorkerNotFoundError("Tool operation was not found.", code="operation_not_found")
+            current = OperationState(row["state"])
+            if expected_state is not None and current is not expected_state:
+                raise WorkerConflictError(
+                    "Tool operation state changed.", code="operation_state_conflict"
+                )
+            allowed = {
+                OperationState.PREPARED: {OperationState.RUNNING, OperationState.FAILED},
+                OperationState.RUNNING: {
+                    OperationState.COMPLETED,
+                    OperationState.FAILED,
+                    OperationState.UNKNOWN,
+                },
+                OperationState.UNKNOWN: {
+                    OperationState.COMPLETED,
+                    OperationState.FAILED,
+                },
+                OperationState.COMPLETED: set(),
+                OperationState.FAILED: set(),
+            }
+            if current is not target and target not in allowed[current]:
+                raise WorkerConflictError(
+                    "Tool operation transition is invalid.", code="operation_state_conflict"
+                )
+            connection.execute(
+                """
+                UPDATE worker_operations SET state = ?, result_ciphertext = ?, updated_at = ?
+                WHERE operation_id = ?
+                """,
+                (
+                    target.value,
+                    self._codec.encrypt(result) if result is not None else row["result_ciphertext"],
+                    now,
+                    operation_id,
+                ),
+            )
+            self._append_event_locked(
+                connection,
+                task_id=str(row["task_id"]),
+                event_type="tool_operation",
+                payload={"operation_id": operation_id, "state": target.value},
+                created_at=now,
+            )
+        return self.get_operation(operation_id)
+
+    def mark_inflight_operations_unknown(self) -> int:
+        now = self._now()
+        with self._lock, self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            rows = connection.execute(
+                "SELECT operation_id, task_id FROM worker_operations WHERE state = ?",
+                (OperationState.RUNNING.value,),
+            ).fetchall()
+            for row in rows:
+                connection.execute(
+                    "UPDATE worker_operations SET state = ?, updated_at = ? WHERE operation_id = ?",
+                    (OperationState.UNKNOWN.value, now, row["operation_id"]),
+                )
+                self._append_event_locked(
+                    connection,
+                    task_id=str(row["task_id"]),
+                    event_type="tool_operation",
+                    payload={
+                        "operation_id": str(row["operation_id"]),
+                        "state": OperationState.UNKNOWN.value,
+                    },
+                    created_at=now,
+                )
+        return len(rows)
+
     def delete_task(self, task_id: str) -> bool:
         with self._lock, self._connect() as connection:
             row = self._require_task_row(connection, task_id)
@@ -432,6 +763,44 @@ class CodingWorkerStore:
                     UNIQUE(task_id, sequence),
                     FOREIGN KEY(task_id) REFERENCES worker_tasks(task_id) ON DELETE CASCADE
                 );
+                CREATE TABLE IF NOT EXISTS worker_approvals (
+                    approval_id TEXT PRIMARY KEY,
+                    task_id TEXT NOT NULL,
+                    operation_id TEXT NOT NULL UNIQUE,
+                    capability TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    request_ciphertext TEXT NOT NULL,
+                    lease_ciphertext TEXT,
+                    created_at REAL NOT NULL,
+                    decided_at REAL,
+                    FOREIGN KEY(task_id) REFERENCES worker_tasks(task_id) ON DELETE CASCADE
+                );
+                CREATE INDEX IF NOT EXISTS idx_worker_approvals_task
+                    ON worker_approvals(task_id, created_at);
+                CREATE TABLE IF NOT EXISTS worker_leases (
+                    lease_id TEXT PRIMARY KEY,
+                    task_id TEXT NOT NULL,
+                    capability TEXT NOT NULL,
+                    scope_ciphertext TEXT NOT NULL,
+                    issued_at REAL NOT NULL,
+                    expires_at REAL NOT NULL,
+                    remaining_operations INTEGER NOT NULL,
+                    FOREIGN KEY(task_id) REFERENCES worker_tasks(task_id) ON DELETE CASCADE
+                );
+                CREATE TABLE IF NOT EXISTS worker_operations (
+                    operation_id TEXT PRIMARY KEY,
+                    task_id TEXT NOT NULL,
+                    tool_name TEXT NOT NULL,
+                    intent_sha256 TEXT NOT NULL,
+                    state TEXT NOT NULL,
+                    request_ciphertext TEXT NOT NULL,
+                    result_ciphertext TEXT,
+                    created_at REAL NOT NULL,
+                    updated_at REAL NOT NULL,
+                    FOREIGN KEY(task_id) REFERENCES worker_tasks(task_id) ON DELETE CASCADE
+                );
+                CREATE INDEX IF NOT EXISTS idx_worker_operations_task
+                    ON worker_operations(task_id, created_at);
                 """
             )
 
@@ -486,6 +855,55 @@ class CodingWorkerStore:
             (task_id, event_type, self._codec.encrypt(payload), created_at),
         )
         return int(cursor.lastrowid)
+
+    def _approval(self, row: sqlite3.Row) -> WorkerApproval:
+        try:
+            lease_value = (
+                self._codec.decrypt(str(row["lease_ciphertext"]))
+                if row["lease_ciphertext"] is not None
+                else None
+            )
+            lease = CapabilityLease.model_validate(lease_value) if lease_value else None
+            return WorkerApproval(
+                approval_id=str(row["approval_id"]),
+                task_id=str(row["task_id"]),
+                operation_id=str(row["operation_id"]),
+                capability=str(row["capability"]),
+                status=ApprovalStatus(row["status"]),
+                request=self._decrypt_dict(row["request_ciphertext"]),
+                lease=lease,
+                created_at=float(row["created_at"]),
+                decided_at=(
+                    float(row["decided_at"]) if row["decided_at"] is not None else None
+                ),
+            )
+        except (WorkerCryptoError, ValueError) as exc:
+            raise WorkerStoreError(
+                "Worker approval data is corrupt.", code="worker_data_corrupt"
+            ) from exc
+
+    def _operation(self, row: sqlite3.Row) -> WorkerOperation:
+        try:
+            result = (
+                self._decrypt_dict(row["result_ciphertext"])
+                if row["result_ciphertext"] is not None
+                else None
+            )
+            return WorkerOperation(
+                operation_id=str(row["operation_id"]),
+                task_id=str(row["task_id"]),
+                tool_name=str(row["tool_name"]),
+                intent_sha256=str(row["intent_sha256"]),
+                state=OperationState(row["state"]),
+                request=self._decrypt_dict(row["request_ciphertext"]),
+                result=result,
+                created_at=float(row["created_at"]),
+                updated_at=float(row["updated_at"]),
+            )
+        except (WorkerCryptoError, ValueError) as exc:
+            raise WorkerStoreError(
+                "Worker operation data is corrupt.", code="worker_data_corrupt"
+            ) from exc
 
     @staticmethod
     def _require_task_row(connection: sqlite3.Connection, task_id: str) -> sqlite3.Row:

--- a/server/coding_worker/store.py
+++ b/server/coding_worker/store.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import base64
+import hashlib
 import math
 import sqlite3
 import threading
@@ -12,6 +14,7 @@ from typing import Any
 from .contracts import (
     ApprovalStatus,
     CapabilityName,
+    EvidenceStatus,
     CapabilityLease,
     OperationState,
     TERMINAL_STATES,
@@ -20,6 +23,8 @@ from .contracts import (
     TaskSpec,
     TaskState,
     WorkerEvent,
+    WorkerEvidence,
+    WorkerArtifact,
     WorkerApproval,
     WorkerMessage,
     WorkerOperation,
@@ -651,6 +656,183 @@ class CodingWorkerStore:
                 )
         return len(rows)
 
+    def create_artifact(
+        self,
+        *,
+        task_id: str,
+        media_type: str,
+        content: bytes,
+        metadata: dict[str, Any] | None = None,
+    ) -> WorkerArtifact:
+        if not media_type or len(media_type) > 120:
+            raise ValueError("artifact media type is invalid")
+        if len(content) > 16 * 1024 * 1024:
+            raise ValueError("artifact is too large")
+        now = self._now()
+        artifact_id = f"artifact_{uuid.uuid4().hex}"
+        digest = hashlib.sha256(content).hexdigest()
+        with self._lock, self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            self._require_task_row(connection, task_id)
+            connection.execute(
+                """
+                INSERT INTO worker_artifacts (
+                    artifact_id, task_id, media_type, sha256, size,
+                    metadata_ciphertext, content_ciphertext, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    artifact_id,
+                    task_id,
+                    media_type,
+                    digest,
+                    len(content),
+                    self._codec.encrypt(metadata or {}),
+                    self._codec.encrypt({"base64": base64.b64encode(content).decode("ascii")}),
+                    now,
+                ),
+            )
+            self._append_event_locked(
+                connection,
+                task_id=task_id,
+                event_type="artifact_created",
+                payload={"artifact_id": artifact_id, "media_type": media_type},
+                created_at=now,
+            )
+        return self.get_artifact(artifact_id)
+
+    def get_artifact(self, artifact_id: str) -> WorkerArtifact:
+        with self._connect() as connection:
+            row = connection.execute(
+                "SELECT * FROM worker_artifacts WHERE artifact_id = ?", (artifact_id,)
+            ).fetchone()
+        if row is None:
+            raise WorkerNotFoundError("Artifact was not found.", code="artifact_not_found")
+        return self._artifact(row)
+
+    def list_artifacts(self, task_id: str) -> list[WorkerArtifact]:
+        with self._connect() as connection:
+            self._require_task_row(connection, task_id)
+            rows = connection.execute(
+                "SELECT * FROM worker_artifacts WHERE task_id = ? ORDER BY created_at",
+                (task_id,),
+            ).fetchall()
+        return [self._artifact(row) for row in rows]
+
+    def read_artifact(self, artifact_id: str, *, task_id: str) -> bytes:
+        with self._connect() as connection:
+            row = connection.execute(
+                "SELECT * FROM worker_artifacts WHERE artifact_id = ? AND task_id = ?",
+                (artifact_id, task_id),
+            ).fetchone()
+        if row is None:
+            raise WorkerNotFoundError("Artifact was not found.", code="artifact_not_found")
+        try:
+            value = self._decrypt_dict(row["content_ciphertext"])
+            content = base64.b64decode(str(value["base64"]), validate=True)
+        except (KeyError, ValueError, WorkerCryptoError) as exc:
+            raise WorkerStoreError(
+                "Worker artifact data is corrupt.", code="worker_data_corrupt"
+            ) from exc
+        if (
+            len(content) != int(row["size"])
+            or hashlib.sha256(content).hexdigest() != str(row["sha256"])
+        ):
+            raise WorkerStoreError(
+                "Worker artifact data is corrupt.", code="worker_data_corrupt"
+            )
+        return content
+
+    def record_evidence(
+        self,
+        *,
+        task_id: str,
+        check_id: str,
+        operation_id: str,
+        workspace_tree_hash: str,
+        exit_code: int,
+        artifact_id: str,
+    ) -> WorkerEvidence:
+        now = self._now()
+        evidence_id = f"evidence_{uuid.uuid4().hex}"
+        status = EvidenceStatus.PASSED if exit_code == 0 else EvidenceStatus.FAILED
+        with self._lock, self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            task = self._task(self._require_task_row(connection, task_id), connection)
+            if check_id not in {item.check_id for item in task.spec.acceptance.required_checks}:
+                raise WorkerConflictError(
+                    "Evidence check is not in the acceptance contract.",
+                    code="acceptance_check_unknown",
+                )
+            artifact = connection.execute(
+                "SELECT task_id FROM worker_artifacts WHERE artifact_id = ?", (artifact_id,)
+            ).fetchone()
+            if artifact is None or str(artifact["task_id"]) != task_id:
+                raise WorkerConflictError(
+                    "Evidence artifact is not bound to this task.",
+                    code="artifact_binding_conflict",
+                )
+            connection.execute(
+                """
+                INSERT INTO worker_evidence (
+                    evidence_id, task_id, check_id, operation_id,
+                    workspace_tree_hash, status, exit_code, artifact_id, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    evidence_id,
+                    task_id,
+                    check_id,
+                    operation_id,
+                    workspace_tree_hash,
+                    status.value,
+                    exit_code,
+                    artifact_id,
+                    now,
+                ),
+            )
+            self._append_event_locked(
+                connection,
+                task_id=task_id,
+                event_type="evidence_recorded",
+                payload={
+                    "evidence_id": evidence_id,
+                    "check_id": check_id,
+                    "status": status.value,
+                    "workspace_tree_hash": workspace_tree_hash,
+                },
+                created_at=now,
+            )
+        return self.get_evidence(evidence_id)
+
+    def get_evidence(self, evidence_id: str) -> WorkerEvidence:
+        with self._connect() as connection:
+            row = connection.execute(
+                "SELECT * FROM worker_evidence WHERE evidence_id = ?", (evidence_id,)
+            ).fetchone()
+        if row is None:
+            raise WorkerNotFoundError("Evidence was not found.", code="evidence_not_found")
+        return self._evidence(row)
+
+    def list_evidence(
+        self, task_id: str, *, current_tree_hash: str | None = None
+    ) -> list[WorkerEvidence]:
+        with self._connect() as connection:
+            self._require_task_row(connection, task_id)
+            rows = connection.execute(
+                "SELECT * FROM worker_evidence WHERE task_id = ? ORDER BY created_at",
+                (task_id,),
+            ).fetchall()
+        evidence = [self._evidence(row) for row in rows]
+        if current_tree_hash is None:
+            return evidence
+        return [
+            item.model_copy(update={"status": EvidenceStatus.INVALIDATED})
+            if item.workspace_tree_hash != current_tree_hash
+            else item
+            for item in evidence
+        ]
+
     def delete_task(self, task_id: str) -> bool:
         with self._lock, self._connect() as connection:
             row = self._require_task_row(connection, task_id)
@@ -801,6 +983,34 @@ class CodingWorkerStore:
                 );
                 CREATE INDEX IF NOT EXISTS idx_worker_operations_task
                     ON worker_operations(task_id, created_at);
+                CREATE TABLE IF NOT EXISTS worker_artifacts (
+                    artifact_id TEXT PRIMARY KEY,
+                    task_id TEXT NOT NULL,
+                    media_type TEXT NOT NULL,
+                    sha256 TEXT NOT NULL,
+                    size INTEGER NOT NULL,
+                    metadata_ciphertext TEXT NOT NULL,
+                    content_ciphertext TEXT NOT NULL,
+                    created_at REAL NOT NULL,
+                    FOREIGN KEY(task_id) REFERENCES worker_tasks(task_id) ON DELETE CASCADE
+                );
+                CREATE INDEX IF NOT EXISTS idx_worker_artifacts_task
+                    ON worker_artifacts(task_id, created_at);
+                CREATE TABLE IF NOT EXISTS worker_evidence (
+                    evidence_id TEXT PRIMARY KEY,
+                    task_id TEXT NOT NULL,
+                    check_id TEXT NOT NULL,
+                    operation_id TEXT NOT NULL,
+                    workspace_tree_hash TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    exit_code INTEGER NOT NULL,
+                    artifact_id TEXT NOT NULL,
+                    created_at REAL NOT NULL,
+                    FOREIGN KEY(task_id) REFERENCES worker_tasks(task_id) ON DELETE CASCADE,
+                    FOREIGN KEY(artifact_id) REFERENCES worker_artifacts(artifact_id) ON DELETE CASCADE
+                );
+                CREATE INDEX IF NOT EXISTS idx_worker_evidence_task
+                    ON worker_evidence(task_id, check_id, created_at);
                 """
             )
 
@@ -903,6 +1113,41 @@ class CodingWorkerStore:
         except (WorkerCryptoError, ValueError) as exc:
             raise WorkerStoreError(
                 "Worker operation data is corrupt.", code="worker_data_corrupt"
+            ) from exc
+
+    def _artifact(self, row: sqlite3.Row) -> WorkerArtifact:
+        try:
+            return WorkerArtifact(
+                artifact_id=str(row["artifact_id"]),
+                task_id=str(row["task_id"]),
+                media_type=str(row["media_type"]),
+                sha256=str(row["sha256"]),
+                size=int(row["size"]),
+                metadata=self._decrypt_dict(row["metadata_ciphertext"]),
+                created_at=float(row["created_at"]),
+            )
+        except (WorkerCryptoError, ValueError) as exc:
+            raise WorkerStoreError(
+                "Worker artifact data is corrupt.", code="worker_data_corrupt"
+            ) from exc
+
+    @staticmethod
+    def _evidence(row: sqlite3.Row) -> WorkerEvidence:
+        try:
+            return WorkerEvidence(
+                evidence_id=str(row["evidence_id"]),
+                task_id=str(row["task_id"]),
+                check_id=str(row["check_id"]),
+                operation_id=str(row["operation_id"]),
+                workspace_tree_hash=str(row["workspace_tree_hash"]),
+                status=EvidenceStatus(row["status"]),
+                exit_code=int(row["exit_code"]),
+                artifact_id=str(row["artifact_id"]),
+                created_at=float(row["created_at"]),
+            )
+        except ValueError as exc:
+            raise WorkerStoreError(
+                "Worker evidence data is corrupt.", code="worker_data_corrupt"
             ) from exc
 
     @staticmethod

--- a/server/coding_worker/store.py
+++ b/server/coding_worker/store.py
@@ -26,6 +26,7 @@ from .contracts import (
     WorkerEvidence,
     WorkerArtifact,
     WorkerApproval,
+    WorkerCheckpoint,
     WorkerMessage,
     WorkerOperation,
     require_transition,
@@ -710,6 +711,63 @@ class CodingWorkerStore:
             raise WorkerNotFoundError("Artifact was not found.", code="artifact_not_found")
         return self._artifact(row)
 
+    def create_checkpoint(
+        self,
+        *,
+        task_id: str,
+        workspace_tree_hash: str,
+        payload: dict[str, Any],
+    ) -> WorkerCheckpoint:
+        now = self._now()
+        checkpoint = WorkerCheckpoint(
+            checkpoint_id=f"checkpoint_{uuid.uuid4().hex}",
+            task_id=task_id,
+            workspace_tree_hash=workspace_tree_hash,
+            payload=payload,
+            created_at=now,
+        )
+        with self._lock, self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            self._require_task_row(connection, task_id)
+            connection.execute(
+                """
+                INSERT INTO worker_checkpoints (
+                    checkpoint_id, task_id, workspace_tree_hash,
+                    payload_ciphertext, created_at
+                ) VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    checkpoint.checkpoint_id,
+                    task_id,
+                    workspace_tree_hash,
+                    self._codec.encrypt(payload),
+                    now,
+                ),
+            )
+            self._append_event_locked(
+                connection,
+                task_id=task_id,
+                event_type="checkpoint_created",
+                payload={
+                    "checkpoint_id": checkpoint.checkpoint_id,
+                    "workspace_tree_hash": workspace_tree_hash,
+                },
+                created_at=now,
+            )
+        return checkpoint
+
+    def latest_checkpoint(self, task_id: str) -> WorkerCheckpoint | None:
+        with self._connect() as connection:
+            self._require_task_row(connection, task_id)
+            row = connection.execute(
+                """
+                SELECT * FROM worker_checkpoints
+                WHERE task_id = ? ORDER BY created_at DESC, checkpoint_id DESC LIMIT 1
+                """,
+                (task_id,),
+            ).fetchone()
+        return self._checkpoint(row) if row is not None else None
+
     def list_artifacts(self, task_id: str) -> list[WorkerArtifact]:
         with self._connect() as connection:
             self._require_task_row(connection, task_id)
@@ -1011,6 +1069,16 @@ class CodingWorkerStore:
                 );
                 CREATE INDEX IF NOT EXISTS idx_worker_evidence_task
                     ON worker_evidence(task_id, check_id, created_at);
+                CREATE TABLE IF NOT EXISTS worker_checkpoints (
+                    checkpoint_id TEXT PRIMARY KEY,
+                    task_id TEXT NOT NULL,
+                    workspace_tree_hash TEXT NOT NULL,
+                    payload_ciphertext TEXT NOT NULL,
+                    created_at REAL NOT NULL,
+                    FOREIGN KEY(task_id) REFERENCES worker_tasks(task_id) ON DELETE CASCADE
+                );
+                CREATE INDEX IF NOT EXISTS idx_worker_checkpoints_task
+                    ON worker_checkpoints(task_id, created_at);
                 """
             )
 
@@ -1129,6 +1197,20 @@ class CodingWorkerStore:
         except (WorkerCryptoError, ValueError) as exc:
             raise WorkerStoreError(
                 "Worker artifact data is corrupt.", code="worker_data_corrupt"
+            ) from exc
+
+    def _checkpoint(self, row: sqlite3.Row) -> WorkerCheckpoint:
+        try:
+            return WorkerCheckpoint(
+                checkpoint_id=str(row["checkpoint_id"]),
+                task_id=str(row["task_id"]),
+                workspace_tree_hash=str(row["workspace_tree_hash"]),
+                payload=self._decrypt_dict(row["payload_ciphertext"]),
+                created_at=float(row["created_at"]),
+            )
+        except (WorkerCryptoError, ValueError) as exc:
+            raise WorkerStoreError(
+                "Worker checkpoint data is corrupt.", code="worker_data_corrupt"
             ) from exc
 
     @staticmethod

--- a/server/coding_worker/tool_broker.py
+++ b/server/coding_worker/tool_broker.py
@@ -291,7 +291,14 @@ class ToolBroker:
         request: dict[str, Any],
         network_lease_id: str | None,
     ) -> CapabilityLease | None:
-        readonly = {"list_files", "read_file", "search_text", "diff", "service_status"}
+        readonly = {
+            "list_files",
+            "read_file",
+            "search_text",
+            "diff",
+            "list_acceptance_checks",
+            "service_status",
+        }
         if tool_name in readonly:
             return None
         if tool_name in {
@@ -414,12 +421,33 @@ class ToolBroker:
         if tool_name == "diff":
             value = self.workspace_broker.diff(workspace_id, max_bytes=self.max_output_bytes)
             return {"diff": value.decode("utf-8", errors="replace")}
+        if tool_name == "list_acceptance_checks":
+            task = self.store.get_task(task_id)
+            return {
+                "checks": [
+                    {
+                        "check_id": check.check_id,
+                        "label": check.label,
+                        "kind": check.kind,
+                        "required": check.required,
+                    }
+                    for check in task.spec.acceptance.required_checks
+                ]
+            }
         if tool_name == "write_file":
             return self._write_file(workspace_id, arguments)
         if tool_name == "delete_file":
             return self._delete_file(workspace_id, arguments)
         if tool_name == "run_check":
             check_id = str(arguments.get("check_id", ""))
+            task = self.store.get_task(task_id)
+            if check_id not in {
+                check.check_id for check in task.spec.acceptance.required_checks
+            }:
+                raise ToolBrokerError(
+                    "Check is not in the task acceptance contract.",
+                    code="check_not_allowed",
+                )
             check = self.frozen_checks.get(check_id)
             if check is None:
                 raise ToolBrokerError("Check is not registered.", code="check_not_found")

--- a/server/coding_worker/tool_broker.py
+++ b/server/coding_worker/tool_broker.py
@@ -12,7 +12,7 @@ from typing import Any
 
 from pydantic import Field
 
-from .contracts import CapabilityName, OperationState, PolicyProfile, StrictModel
+from .contracts import CapabilityName, OperationState, PolicyProfile, StrictModel, TaskState
 from .store import CodingWorkerStore, WorkerConflictError
 from .workspace import WorkspaceBroker, WorkspaceError
 
@@ -100,7 +100,6 @@ class ToolBroker:
             raise ToolBrokerError("Task workspace is unavailable.", code="workspace_unavailable")
         request = {
             "arguments": self._json_object(arguments),
-            "lease_id": lease_id,
             "workspace_id": task.workspace_id,
         }
         intent_sha256 = self._intent_sha256(tool_name, request)
@@ -125,7 +124,14 @@ class ToolBroker:
                 "Tool operation cannot be replayed.", code="operation_not_replayable"
             )
         try:
-            self._authorize(task.spec.policy_profile, tool_name, lease_id, task_id, request)
+            self._authorize(
+                task.spec.policy_profile,
+                tool_name,
+                lease_id,
+                task_id,
+                operation_id,
+                request,
+            )
             self.store.transition_operation(
                 operation_id,
                 OperationState.RUNNING,
@@ -152,7 +158,15 @@ class ToolBroker:
             asyncio.TimeoutError,
         ) as exc:
             current = self.store.get_operation(operation_id)
-            if current.state in {OperationState.PREPARED, OperationState.RUNNING}:
+            awaiting_approval = (
+                isinstance(exc, ToolBrokerError)
+                and exc.code == "approval_required"
+                and current.state is OperationState.PREPARED
+            )
+            if not awaiting_approval and current.state in {
+                OperationState.PREPARED,
+                OperationState.RUNNING,
+            }:
                 self.store.transition_operation(
                     operation_id,
                     OperationState.FAILED,
@@ -223,6 +237,7 @@ class ToolBroker:
         tool_name: str,
         lease_id: str | None,
         task_id: str,
+        operation_id: str,
         request: dict[str, Any],
     ) -> None:
         readonly = {"list_files", "read_file", "search_text", "diff"}
@@ -238,6 +253,15 @@ class ToolBroker:
         else:
             raise ToolBrokerError("Tool is not available.", code="tool_not_allowed")
         if lease_id is None:
+            self.store.create_approval(
+                task_id=task_id,
+                operation_id=operation_id,
+                capability=capability,
+                request=request["arguments"],
+            )
+            task = self.store.get_task(task_id)
+            if task.state is TaskState.RUNNING:
+                self.store.transition(task_id, TaskState.WAITING_APPROVAL)
             raise ToolBrokerError("Tool requires approval.", code="approval_required")
         lease = self.store.consume_lease(lease_id, task_id=task_id, capability=capability)
         requested_argv = request["arguments"].get("argv")

--- a/server/coding_worker/tool_broker.py
+++ b/server/coding_worker/tool_broker.py
@@ -10,7 +10,7 @@ import tempfile
 import uuid
 from collections.abc import Mapping, Sequence
 from pathlib import Path, PurePosixPath
-from typing import Any
+from typing import Any, Protocol
 from urllib.parse import urlsplit
 
 from pydantic import Field
@@ -67,6 +67,14 @@ class ToolResult(StrictModel):
     data: dict[str, Any] = Field(default_factory=dict)
 
 
+class ToolExecutor(Protocol):
+    async def run_process(self, *, task_id: str, workspace_id: str, argv: Sequence[str], timeout_seconds: int, isolated: bool, environment_overrides: Mapping[str, str] | None = None) -> dict[str, Any]: ...
+    async def start_service(self, *, task_id: str, workspace_id: str, argv: Sequence[str], ttl_seconds: int) -> dict[str, Any]: ...
+    async def service_status(self, *, task_id: str, workspace_id: str, service_id: str) -> dict[str, Any]: ...
+    async def service_input(self, *, task_id: str, workspace_id: str, service_id: str, data: str) -> dict[str, Any]: ...
+    async def stop_service(self, *, task_id: str, workspace_id: str, service_id: str) -> dict[str, Any]: ...
+
+
 class ToolBroker:
     """The sole side-effect boundary exposed to a coding provider.
 
@@ -84,6 +92,7 @@ class ToolBroker:
         egress_policy: EgressPolicy | None = None,
         egress_proxy_url: str | None = None,
         max_output_bytes: int = MAX_TOOL_OUTPUT_BYTES,
+        executor: ToolExecutor | None = None,
     ) -> None:
         if not 1024 <= max_output_bytes <= 16 * 1024 * 1024:
             raise ValueError("tool output limit is invalid")
@@ -94,6 +103,7 @@ class ToolBroker:
         self.egress_policy = egress_policy
         self.egress_proxy_url = self._validate_proxy_url(egress_proxy_url)
         self.max_output_bytes = max_output_bytes
+        self.executor = executor
 
     async def execute(
         self,
@@ -193,6 +203,18 @@ class ToolBroker:
             if isinstance(exc, ToolBrokerError):
                 raise
             raise ToolBrokerError("Tool operation failed.", code=getattr(exc, "code", "tool_failed")) from exc
+        except Exception as exc:
+            current = self.store.get_operation(operation_id)
+            if current.state in {OperationState.PREPARED, OperationState.RUNNING}:
+                self.store.transition_operation(
+                    operation_id,
+                    OperationState.FAILED,
+                    result={"code": getattr(exc, "code", "tool_failed")},
+                    expected_state=current.state,
+                )
+            raise ToolBrokerError(
+                "Tool operation failed.", code=getattr(exc, "code", "tool_failed")
+            ) from exc
 
     def reconcile(self, operation_id: str) -> ToolResult:
         operation = self.store.get_operation(operation_id)
@@ -387,6 +409,7 @@ class ToolBroker:
             if check is None:
                 raise ToolBrokerError("Check is not registered.", code="check_not_found")
             return await self._run_process(
+                task_id,
                 workspace_id,
                 check.argv,
                 check.timeout_seconds,
@@ -400,9 +423,8 @@ class ToolBroker:
                 raise ToolBrokerError("Command argv is invalid.", code="tool_input_invalid")
             if isinstance(timeout, bool) or not isinstance(timeout, int) or not 1 <= timeout <= 1800:
                 raise ToolBrokerError("Command timeout is invalid.", code="tool_input_invalid")
-            return await self._run_process(workspace_id, tuple(argv), timeout)
+            return await self._run_process(task_id, workspace_id, tuple(argv), timeout)
         if tool_name == "start_service":
-            manager = self._require_process_manager()
             argv = arguments.get("argv")
             ttl = arguments.get("ttl_seconds", 900)
             if (
@@ -412,7 +434,14 @@ class ToolBroker:
                 or not isinstance(ttl, int)
             ):
                 raise ToolBrokerError("Service input is invalid.", code="tool_input_invalid")
-            record = await manager.start(
+            if self.executor is not None:
+                return await self.executor.start_service(
+                    task_id=task_id,
+                    workspace_id=workspace_id,
+                    argv=self._validate_argv(argv),
+                    ttl_seconds=ttl,
+                )
+            record = await self._require_process_manager().start(
                 task_id=task_id,
                 workspace_id=workspace_id,
                 argv=self._validate_argv(argv),
@@ -420,6 +449,13 @@ class ToolBroker:
             )
             return record.model_dump(mode="json")
         if tool_name == "service_status":
+            if self.executor is not None:
+                result = await self.executor.service_status(
+                    task_id=task_id,
+                    workspace_id=workspace_id,
+                    service_id=str(arguments.get("service_id", "")),
+                )
+                return self._archive_service_output(task_id, result)
             record = self._require_process_manager().status(
                 task_id=task_id,
                 service_id=str(arguments.get("service_id", "")),
@@ -430,6 +466,13 @@ class ToolBroker:
             data = arguments.get("data")
             if not isinstance(data, str):
                 raise ToolBrokerError("Service input is invalid.", code="tool_input_invalid")
+            if self.executor is not None:
+                return await self.executor.service_input(
+                    task_id=task_id,
+                    workspace_id=workspace_id,
+                    service_id=service_id,
+                    data=data,
+                )
             await self._require_process_manager().send_input(
                 task_id=task_id,
                 service_id=service_id,
@@ -437,6 +480,13 @@ class ToolBroker:
             )
             return {"service_id": service_id, "accepted": True}
         if tool_name == "stop_service":
+            if self.executor is not None:
+                result = await self.executor.stop_service(
+                    task_id=task_id,
+                    workspace_id=workspace_id,
+                    service_id=str(arguments.get("service_id", "")),
+                )
+                return self._archive_service_output(task_id, result)
             record = await self._require_process_manager().interrupt(
                 task_id=task_id,
                 service_id=str(arguments.get("service_id", "")),
@@ -451,6 +501,7 @@ class ToolBroker:
             if self.egress_proxy_url is None:
                 raise ToolBrokerError("Egress proxy is unavailable.", code="network_disabled")
             result = await self._run_process(
+                task_id,
                 workspace_id,
                 ("npm", "ci", "--ignore-scripts", "--no-audit", "--no-fund"),
                 1800,
@@ -483,6 +534,30 @@ class ToolBroker:
         if self.process_manager is None:
             raise ToolBrokerError("Service manager is unavailable.", code="service_unavailable")
         return self.process_manager
+
+    def _archive_service_output(
+        self, task_id: str, result: dict[str, Any]
+    ) -> dict[str, Any]:
+        output = result.pop("output", None)
+        if not isinstance(output, str):
+            return result
+        service_id = str(result.get("service_id", ""))
+        existing = next(
+            (
+                item
+                for item in self.store.list_artifacts(task_id)
+                if item.metadata.get("kind") == "service_output"
+                and item.metadata.get("service_id") == service_id
+            ),
+            None,
+        )
+        artifact = existing or self.store.create_artifact(
+            task_id=task_id,
+            media_type="text/plain; charset=utf-8",
+            content=output.encode("utf-8"),
+            metadata={"kind": "service_output", "service_id": service_id},
+        )
+        return {**result, "output_artifact_id": artifact.artifact_id}
 
     def _require_egress_policy(self) -> EgressPolicy:
         if self.egress_policy is None:
@@ -532,6 +607,7 @@ class ToolBroker:
 
     async def _run_process(
         self,
+        task_id: str,
         workspace_id: str,
         argv: Sequence[str],
         timeout_seconds: int,
@@ -541,6 +617,15 @@ class ToolBroker:
         environment_overrides: Mapping[str, str] | None = None,
     ) -> dict[str, Any]:
         normalized = self._validate_argv(argv, trusted=trusted)
+        if self.executor is not None:
+            return await self.executor.run_process(
+                task_id=task_id,
+                workspace_id=workspace_id,
+                argv=normalized,
+                timeout_seconds=timeout_seconds,
+                isolated=isolated,
+                environment_overrides=environment_overrides,
+            )
         repository = self.workspace_broker.repository_path(workspace_id)
         execution_root: Path | None = None
         execution_repository = repository

--- a/server/coding_worker/tool_broker.py
+++ b/server/coding_worker/tool_broker.py
@@ -11,11 +11,13 @@ import uuid
 from collections.abc import Mapping, Sequence
 from pathlib import Path, PurePosixPath
 from typing import Any
+from urllib.parse import urlsplit
 
 from pydantic import Field
 
 from .contracts import CapabilityName, OperationState, PolicyProfile, StrictModel, TaskState
 from .process_manager import BackgroundProcessManager, ProcessManagerError
+from .network_policy import EgressPolicy, NetworkPolicyError
 from .store import CodingWorkerStore, WorkerConflictError
 from .workspace import WorkspaceBroker, WorkspaceError
 
@@ -79,6 +81,8 @@ class ToolBroker:
         workspace_broker: WorkspaceBroker,
         frozen_checks: Mapping[str, FrozenCheck] | None = None,
         process_manager: BackgroundProcessManager | None = None,
+        egress_policy: EgressPolicy | None = None,
+        egress_proxy_url: str | None = None,
         max_output_bytes: int = MAX_TOOL_OUTPUT_BYTES,
     ) -> None:
         if not 1024 <= max_output_bytes <= 16 * 1024 * 1024:
@@ -87,6 +91,8 @@ class ToolBroker:
         self.workspace_broker = workspace_broker
         self.frozen_checks = dict(frozen_checks or {})
         self.process_manager = process_manager
+        self.egress_policy = egress_policy
+        self.egress_proxy_url = self._validate_proxy_url(egress_proxy_url)
         self.max_output_bytes = max_output_bytes
 
     async def execute(
@@ -97,6 +103,7 @@ class ToolBroker:
         tool_name: str,
         arguments: Mapping[str, Any],
         lease_id: str | None = None,
+        network_lease_id: str | None = None,
     ) -> ToolResult:
         if SAFE_TOOL_NAME.fullmatch(tool_name) is None:
             raise ToolBrokerError("Tool name is invalid.", code="tool_not_allowed")
@@ -136,6 +143,7 @@ class ToolBroker:
                 task_id,
                 operation_id,
                 request,
+                network_lease_id,
             )
             self.store.transition_operation(
                 operation_id,
@@ -162,6 +170,7 @@ class ToolBroker:
             WorkerConflictError,
             WorkspaceError,
             ProcessManagerError,
+            NetworkPolicyError,
             OSError,
             asyncio.TimeoutError,
         ) as exc:
@@ -247,6 +256,7 @@ class ToolBroker:
         task_id: str,
         operation_id: str,
         request: dict[str, Any],
+        network_lease_id: str | None,
     ) -> None:
         readonly = {"list_files", "read_file", "search_text", "diff", "service_status"}
         if tool_name in readonly:
@@ -266,8 +276,21 @@ class ToolBroker:
             capability = "command"
         elif tool_name == "start_service":
             capability = "service"
+        elif tool_name == "install_dependencies":
+            if profile is not PolicyProfile.DEVELOP_NETWORKED:
+                raise ToolBrokerError(
+                    "Dependency installation requires networked development policy.",
+                    code="approval_required",
+                )
+            capability = "dependency_install"
         else:
             raise ToolBrokerError("Tool is not available.", code="tool_not_allowed")
+        network_scope: dict[str, object] | None = None
+        if tool_name == "install_dependencies":
+            policy = self._require_egress_policy()
+            network_scope = policy.approval_scope(
+                domains=("registry.npmjs.org",), purpose="dependency-install"
+            )
         if lease_id is None:
             self.store.create_approval(
                 task_id=task_id,
@@ -275,6 +298,17 @@ class ToolBroker:
                 capability=capability,
                 request=request["arguments"],
             )
+        if network_scope is not None and network_lease_id is None:
+            network_operation_id = "network_" + hashlib.sha256(
+                operation_id.encode("utf-8")
+            ).hexdigest()[:32]
+            self.store.create_approval(
+                task_id=task_id,
+                operation_id=network_operation_id,
+                capability="network",
+                request=network_scope,
+            )
+        if lease_id is None or (network_scope is not None and network_lease_id is None):
             task = self.store.get_task(task_id)
             if task.state is TaskState.RUNNING:
                 self.store.transition(task_id, TaskState.WAITING_APPROVAL)
@@ -282,6 +316,15 @@ class ToolBroker:
         lease = self.store.consume_lease(lease_id, task_id=task_id, capability=capability)
         if lease.scope != request["arguments"]:
             raise ToolBrokerError("Approval does not match the request.", code="lease_scope_mismatch")
+        if network_scope is not None:
+            network_lease = self.store.consume_lease(
+                str(network_lease_id), task_id=task_id, capability="network"
+            )
+            self._require_egress_policy().validate_lease_scope(
+                lease=network_lease,
+                domains=("registry.npmjs.org",),
+                purpose="dependency-install",
+            )
 
     async def _dispatch(
         self,
@@ -399,12 +442,52 @@ class ToolBroker:
                 service_id=str(arguments.get("service_id", "")),
             )
             return record.model_dump(mode="json")
+        if tool_name == "install_dependencies":
+            if arguments != {"manager": "npm", "action": "ci"}:
+                raise ToolBrokerError(
+                    "Only frozen npm lockfile installation is supported.",
+                    code="dependency_plan_invalid",
+                )
+            if self.egress_proxy_url is None:
+                raise ToolBrokerError("Egress proxy is unavailable.", code="network_disabled")
+            result = await self._run_process(
+                workspace_id,
+                ("npm", "ci", "--ignore-scripts", "--no-audit", "--no-fund"),
+                1800,
+                environment_overrides={
+                    "HTTPS_PROXY": self.egress_proxy_url,
+                    "HTTP_PROXY": self.egress_proxy_url,
+                    "NO_PROXY": "",
+                    "npm_config_registry": "https://registry.npmjs.org/",
+                    "npm_config_ignore_scripts": "true",
+                    "npm_config_audit": "false",
+                    "npm_config_fund": "false",
+                },
+            )
+            source = {
+                "manager": "npm",
+                "action": "ci",
+                "registry_domains": ["registry.npmjs.org"],
+                "exit_code": result["exit_code"],
+            }
+            artifact = self.store.create_artifact(
+                task_id=task_id,
+                media_type="application/json",
+                content=json.dumps(source, sort_keys=True, separators=(",", ":")).encode(),
+                metadata={"kind": "dependency_source"},
+            )
+            return {**result, "source_artifact_id": artifact.artifact_id}
         raise ToolBrokerError("Tool is not available.", code="tool_not_allowed")
 
     def _require_process_manager(self) -> BackgroundProcessManager:
         if self.process_manager is None:
             raise ToolBrokerError("Service manager is unavailable.", code="service_unavailable")
         return self.process_manager
+
+    def _require_egress_policy(self) -> EgressPolicy:
+        if self.egress_policy is None:
+            raise NetworkPolicyError("Worker network access is disabled.", code="network_disabled")
+        return self.egress_policy
 
     def _write_file(self, workspace_id: str, arguments: dict[str, Any]) -> dict[str, Any]:
         path = str(arguments.get("path", ""))
@@ -455,6 +538,7 @@ class ToolBroker:
         *,
         trusted: bool = False,
         isolated: bool = False,
+        environment_overrides: Mapping[str, str] | None = None,
     ) -> dict[str, Any]:
         normalized = self._validate_argv(argv, trusted=trusted)
         repository = self.workspace_broker.repository_path(workspace_id)
@@ -475,10 +559,12 @@ class ToolBroker:
                     ignore=shutil.ignore_patterns(".git"),
                 )
                 execution_repository = execution_root
+            environment = self._safe_environment(execution_repository)
+            environment.update(environment_overrides or {})
             process = await asyncio.create_subprocess_exec(
                 *normalized,
                 cwd=execution_repository,
-                env=self._safe_environment(execution_repository),
+                env=environment,
                 stdin=asyncio.subprocess.DEVNULL,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,
@@ -587,6 +673,23 @@ class ToolBroker:
             environment["SYSTEMROOT"] = os.environ.get("SYSTEMROOT", "C:\\Windows")
         Path(environment["HOME"]).mkdir(exist_ok=True)
         return environment
+
+    @staticmethod
+    def _validate_proxy_url(value: str | None) -> str | None:
+        if value is None:
+            return None
+        parsed = urlsplit(value)
+        if (
+            parsed.scheme != "http"
+            or parsed.hostname is None
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.path not in {"", "/"}
+            or parsed.query
+            or parsed.fragment
+        ):
+            raise ValueError("egress proxy URL is invalid")
+        return value.rstrip("/")
 
     @staticmethod
     def _intent_sha256(tool_name: str, request: dict[str, Any]) -> str:

--- a/server/coding_worker/tool_broker.py
+++ b/server/coding_worker/tool_broker.py
@@ -586,6 +586,7 @@ class ToolBroker:
                 handle.write(encoded)
                 handle.flush()
                 os.fsync(handle.fileno())
+            self.workspace_broker.apply_slot_owner(workspace_id, Path(temporary))
             os.replace(temporary, target)
         finally:
             try:
@@ -715,6 +716,7 @@ class ToolBroker:
                     raise ToolBrokerError("Workspace path changed.", code="workspace_changed")
             elif create_parents:
                 parent.mkdir()
+                self.workspace_broker.apply_slot_owner(workspace_id, parent)
             else:
                 raise ToolBrokerError("Workspace path was not found.", code="entry_not_found")
         target = parent / path.name

--- a/server/coding_worker/tool_broker.py
+++ b/server/coding_worker/tool_broker.py
@@ -1,0 +1,470 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import re
+import tempfile
+from collections.abc import Mapping, Sequence
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from pydantic import Field
+
+from .contracts import CapabilityName, OperationState, PolicyProfile, StrictModel
+from .store import CodingWorkerStore, WorkerConflictError
+from .workspace import WorkspaceBroker, WorkspaceError
+
+
+MAX_TOOL_OUTPUT_BYTES = 2 * 1024 * 1024
+MAX_WRITE_BYTES = 8 * 1024 * 1024
+SAFE_TOOL_NAME = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
+ALWAYS_DENIED_EXECUTABLES = frozenset(
+    {
+        "bash",
+        "cmd",
+        "curl",
+        "docker",
+        "mount",
+        "nc",
+        "netcat",
+        "powershell",
+        "pwsh",
+        "scp",
+        "sh",
+        "ssh",
+        "sudo",
+        "wget",
+    }
+)
+DENIED_GIT_SUBCOMMANDS = frozenset(
+    {"clone", "fetch", "ls-remote", "pull", "push", "remote", "submodule"}
+)
+
+
+class ToolBrokerError(RuntimeError):
+    def __init__(self, message: str, *, code: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+class FrozenCheck(StrictModel):
+    check_id: str = Field(pattern=r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$")
+    argv: tuple[str, ...] = Field(min_length=1, max_length=64)
+    timeout_seconds: int = Field(default=300, ge=1, le=1800)
+
+
+class ToolResult(StrictModel):
+    operation_id: str
+    tool_name: str
+    state: OperationState
+    data: dict[str, Any] = Field(default_factory=dict)
+
+
+class ToolBroker:
+    """The sole side-effect boundary exposed to a coding provider.
+
+    Requests contain only task/workspace-relative values. Commands are argv arrays,
+    never shell strings, and execute with a minimal credential-free environment.
+    """
+
+    def __init__(
+        self,
+        *,
+        store: CodingWorkerStore,
+        workspace_broker: WorkspaceBroker,
+        frozen_checks: Mapping[str, FrozenCheck] | None = None,
+        max_output_bytes: int = MAX_TOOL_OUTPUT_BYTES,
+    ) -> None:
+        if not 1024 <= max_output_bytes <= 16 * 1024 * 1024:
+            raise ValueError("tool output limit is invalid")
+        self.store = store
+        self.workspace_broker = workspace_broker
+        self.frozen_checks = dict(frozen_checks or {})
+        self.max_output_bytes = max_output_bytes
+
+    async def execute(
+        self,
+        *,
+        task_id: str,
+        operation_id: str,
+        tool_name: str,
+        arguments: Mapping[str, Any],
+        lease_id: str | None = None,
+    ) -> ToolResult:
+        if SAFE_TOOL_NAME.fullmatch(tool_name) is None:
+            raise ToolBrokerError("Tool name is invalid.", code="tool_not_allowed")
+        task = self.store.get_task(task_id)
+        if task.workspace_id is None:
+            raise ToolBrokerError("Task workspace is unavailable.", code="workspace_unavailable")
+        request = {
+            "arguments": self._json_object(arguments),
+            "lease_id": lease_id,
+            "workspace_id": task.workspace_id,
+        }
+        intent_sha256 = self._intent_sha256(tool_name, request)
+        operation = self.store.create_operation(
+            task_id=task_id,
+            operation_id=operation_id,
+            tool_name=tool_name,
+            intent_sha256=intent_sha256,
+            request=request,
+        )
+        if operation.state is OperationState.COMPLETED:
+            return ToolResult(
+                operation_id=operation_id,
+                tool_name=tool_name,
+                state=operation.state,
+                data=operation.result or {},
+            )
+        if operation.state is OperationState.UNKNOWN:
+            return self.reconcile(operation_id)
+        if operation.state is not OperationState.PREPARED:
+            raise ToolBrokerError(
+                "Tool operation cannot be replayed.", code="operation_not_replayable"
+            )
+        try:
+            self._authorize(task.spec.policy_profile, tool_name, lease_id, task_id, request)
+            self.store.transition_operation(
+                operation_id,
+                OperationState.RUNNING,
+                expected_state=OperationState.PREPARED,
+            )
+            data = await self._dispatch(task.workspace_id, tool_name, request["arguments"])
+            completed = self.store.transition_operation(
+                operation_id,
+                OperationState.COMPLETED,
+                result=data,
+                expected_state=OperationState.RUNNING,
+            )
+            return ToolResult(
+                operation_id=operation_id,
+                tool_name=tool_name,
+                state=completed.state,
+                data=completed.result or {},
+            )
+        except (
+            ToolBrokerError,
+            WorkerConflictError,
+            WorkspaceError,
+            OSError,
+            asyncio.TimeoutError,
+        ) as exc:
+            current = self.store.get_operation(operation_id)
+            if current.state in {OperationState.PREPARED, OperationState.RUNNING}:
+                self.store.transition_operation(
+                    operation_id,
+                    OperationState.FAILED,
+                    result={"code": getattr(exc, "code", "tool_failed")},
+                    expected_state=current.state,
+                )
+            if isinstance(exc, ToolBrokerError):
+                raise
+            raise ToolBrokerError("Tool operation failed.", code=getattr(exc, "code", "tool_failed")) from exc
+
+    def reconcile(self, operation_id: str) -> ToolResult:
+        operation = self.store.get_operation(operation_id)
+        if operation.state is OperationState.COMPLETED:
+            return ToolResult(
+                operation_id=operation_id,
+                tool_name=operation.tool_name,
+                state=operation.state,
+                data=operation.result or {},
+            )
+        if operation.state is not OperationState.UNKNOWN:
+            raise ToolBrokerError(
+                "Tool operation is not awaiting reconciliation.",
+                code="operation_not_reconcilable",
+            )
+        workspace_id = str(operation.request["workspace_id"])
+        arguments = self._json_object(operation.request["arguments"])
+        if operation.tool_name == "write_file":
+            target = self._target(workspace_id, str(arguments.get("path", "")))
+            expected = str(arguments.get("content_sha256", ""))
+            if target.is_file() and not target.is_symlink():
+                actual = hashlib.sha256(target.read_bytes()).hexdigest()
+                if actual == expected:
+                    resolved = self.store.transition_operation(
+                        operation_id,
+                        OperationState.COMPLETED,
+                        result={"path": str(arguments["path"]), "sha256": actual},
+                        expected_state=OperationState.UNKNOWN,
+                    )
+                    return ToolResult(
+                        operation_id=operation_id,
+                        tool_name=operation.tool_name,
+                        state=resolved.state,
+                        data=resolved.result or {},
+                    )
+        elif operation.tool_name == "delete_file":
+            target = self._target(workspace_id, str(arguments.get("path", "")))
+            if not target.exists() and not target.is_symlink():
+                resolved = self.store.transition_operation(
+                    operation_id,
+                    OperationState.COMPLETED,
+                    result={"path": str(arguments["path"]), "deleted": True},
+                    expected_state=OperationState.UNKNOWN,
+                )
+                return ToolResult(
+                    operation_id=operation_id,
+                    tool_name=operation.tool_name,
+                    state=resolved.state,
+                    data=resolved.result or {},
+                )
+        raise ToolBrokerError(
+            "Tool result is unknown and must not be replayed.",
+            code="operation_result_unknown",
+        )
+
+    def _authorize(
+        self,
+        profile: PolicyProfile,
+        tool_name: str,
+        lease_id: str | None,
+        task_id: str,
+        request: dict[str, Any],
+    ) -> None:
+        readonly = {"list_files", "read_file", "search_text", "diff"}
+        if tool_name in readonly:
+            return
+        if tool_name in {"write_file", "delete_file", "run_check"}:
+            if profile not in {PolicyProfile.DEVELOP, PolicyProfile.DEVELOP_NETWORKED}:
+                raise ToolBrokerError("Task policy is read-only.", code="approval_required")
+            return
+        capability: CapabilityName
+        if tool_name == "run_command":
+            capability = "command"
+        else:
+            raise ToolBrokerError("Tool is not available.", code="tool_not_allowed")
+        if lease_id is None:
+            raise ToolBrokerError("Tool requires approval.", code="approval_required")
+        lease = self.store.consume_lease(lease_id, task_id=task_id, capability=capability)
+        requested_argv = request["arguments"].get("argv")
+        if lease.scope.get("argv") != requested_argv:
+            raise ToolBrokerError("Approval does not match the command.", code="lease_scope_mismatch")
+
+    async def _dispatch(
+        self, workspace_id: str, tool_name: str, arguments: dict[str, Any]
+    ) -> dict[str, Any]:
+        if tool_name == "list_files":
+            return {
+                "entries": [
+                    entry.model_dump(mode="json")
+                    for entry in self.workspace_broker.tree(workspace_id)
+                ]
+            }
+        if tool_name == "read_file":
+            target = self._target(workspace_id, str(arguments.get("path", "")))
+            content = target.read_bytes()
+            if len(content) > self.max_output_bytes:
+                raise ToolBrokerError("File is too large.", code="tool_output_too_large")
+            try:
+                text = content.decode("utf-8")
+            except UnicodeDecodeError:
+                return {
+                    "path": str(arguments["path"]),
+                    "binary": True,
+                    "size": len(content),
+                    "sha256": hashlib.sha256(content).hexdigest(),
+                }
+            return {"path": str(arguments["path"]), "binary": False, "content": text}
+        if tool_name == "search_text":
+            needle = str(arguments.get("query", ""))
+            if not needle or len(needle) > 512:
+                raise ToolBrokerError("Search query is invalid.", code="tool_input_invalid")
+            matches: list[dict[str, Any]] = []
+            for entry in self.workspace_broker.tree(workspace_id):
+                if entry.kind != "file" or entry.size > 1024 * 1024:
+                    continue
+                target = self._target(workspace_id, entry.display_path)
+                try:
+                    lines = target.read_text(encoding="utf-8").splitlines()
+                except UnicodeDecodeError:
+                    continue
+                for number, line in enumerate(lines, 1):
+                    if needle in line:
+                        matches.append({"path": entry.display_path, "line": number, "text": line[:1000]})
+                        if len(matches) >= 1000:
+                            return {"matches": matches, "truncated": True}
+            return {"matches": matches, "truncated": False}
+        if tool_name == "diff":
+            value = self.workspace_broker.diff(workspace_id, max_bytes=self.max_output_bytes)
+            return {"diff": value.decode("utf-8", errors="replace")}
+        if tool_name == "write_file":
+            return self._write_file(workspace_id, arguments)
+        if tool_name == "delete_file":
+            return self._delete_file(workspace_id, arguments)
+        if tool_name == "run_check":
+            check_id = str(arguments.get("check_id", ""))
+            check = self.frozen_checks.get(check_id)
+            if check is None:
+                raise ToolBrokerError("Check is not registered.", code="check_not_found")
+            return await self._run_process(
+                workspace_id, check.argv, check.timeout_seconds, trusted=True
+            )
+        if tool_name == "run_command":
+            argv = arguments.get("argv")
+            timeout = arguments.get("timeout_seconds", 300)
+            if not isinstance(argv, list) or not all(isinstance(item, str) for item in argv):
+                raise ToolBrokerError("Command argv is invalid.", code="tool_input_invalid")
+            if isinstance(timeout, bool) or not isinstance(timeout, int) or not 1 <= timeout <= 1800:
+                raise ToolBrokerError("Command timeout is invalid.", code="tool_input_invalid")
+            return await self._run_process(workspace_id, tuple(argv), timeout)
+        raise ToolBrokerError("Tool is not available.", code="tool_not_allowed")
+
+    def _write_file(self, workspace_id: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        path = str(arguments.get("path", ""))
+        content = arguments.get("content")
+        expected = str(arguments.get("content_sha256", ""))
+        if not isinstance(content, str):
+            raise ToolBrokerError("File content must be text.", code="tool_input_invalid")
+        encoded = content.encode("utf-8")
+        actual = hashlib.sha256(encoded).hexdigest()
+        if len(encoded) > MAX_WRITE_BYTES or expected != actual:
+            raise ToolBrokerError("File content binding is invalid.", code="tool_input_invalid")
+        target = self._target(workspace_id, path, create_parents=True)
+        if target.exists() and (not target.is_file() or target.is_symlink()):
+            raise ToolBrokerError("Target is not a regular file.", code="workspace_changed")
+        repository = self.workspace_broker.repository_path(workspace_id)
+        stage_root = repository.parent / "broker-stage"
+        stage_root.mkdir(exist_ok=True)
+        fd, temporary = tempfile.mkstemp(prefix="write-", dir=stage_root)
+        try:
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(encoded)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary, target)
+        finally:
+            try:
+                os.unlink(temporary)
+            except FileNotFoundError:
+                pass
+        return {"path": path, "sha256": actual, "size": len(encoded)}
+
+    def _delete_file(self, workspace_id: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        path = str(arguments.get("path", ""))
+        target = self._target(workspace_id, path)
+        expected = str(arguments.get("expected_sha256", ""))
+        if not target.is_file() or target.is_symlink():
+            raise ToolBrokerError("Target is not a regular file.", code="workspace_changed")
+        if hashlib.sha256(target.read_bytes()).hexdigest() != expected:
+            raise ToolBrokerError("Target changed before deletion.", code="workspace_changed")
+        target.unlink()
+        return {"path": path, "deleted": True}
+
+    async def _run_process(
+        self,
+        workspace_id: str,
+        argv: Sequence[str],
+        timeout_seconds: int,
+        *,
+        trusted: bool = False,
+    ) -> dict[str, Any]:
+        normalized = self._validate_argv(argv, trusted=trusted)
+        repository = self.workspace_broker.repository_path(workspace_id)
+        process = await asyncio.create_subprocess_exec(
+            *normalized,
+            cwd=repository,
+            env=self._safe_environment(repository),
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+        try:
+            output, _ = await asyncio.wait_for(process.communicate(), timeout=timeout_seconds)
+        except asyncio.TimeoutError:
+            process.kill()
+            await process.wait()
+            raise ToolBrokerError("Command timed out.", code="command_timeout")
+        if len(output) > self.max_output_bytes:
+            raise ToolBrokerError("Command output is too large.", code="tool_output_too_large")
+        return {
+            "argv": list(normalized),
+            "exit_code": int(process.returncode or 0),
+            "output": output.decode("utf-8", errors="replace"),
+        }
+
+    def _target(self, workspace_id: str, value: str, *, create_parents: bool = False) -> Path:
+        path = PurePosixPath(value)
+        if (
+            not value
+            or "\\" in value
+            or path.is_absolute()
+            or any(part in {"", ".", "..", ".git"} for part in path.parts)
+        ):
+            raise ToolBrokerError("Workspace path is invalid.", code="workspace_path_invalid")
+        repository = self.workspace_broker.repository_path(workspace_id)
+        parent = repository
+        for part in path.parts[:-1]:
+            parent = parent / part
+            if parent.exists():
+                if not parent.is_dir() or parent.is_symlink():
+                    raise ToolBrokerError("Workspace path changed.", code="workspace_changed")
+            elif create_parents:
+                parent.mkdir()
+            else:
+                raise ToolBrokerError("Workspace path was not found.", code="entry_not_found")
+        target = parent / path.name
+        if target.parent.resolve() != parent.resolve() or repository not in target.parents:
+            raise ToolBrokerError("Workspace path escaped the task.", code="workspace_path_invalid")
+        return target
+
+    @staticmethod
+    def _validate_argv(argv: Sequence[str], *, trusted: bool = False) -> tuple[str, ...]:
+        if not argv or len(argv) > 64 or any(not item or "\x00" in item for item in argv):
+            raise ToolBrokerError("Command argv is invalid.", code="tool_input_invalid")
+        executable = Path(argv[0]).name.lower()
+        if executable.endswith(".exe"):
+            executable = executable[:-4]
+        if executable in ALWAYS_DENIED_EXECUTABLES or (
+            Path(argv[0]).is_absolute() and not trusted
+        ):
+            raise ToolBrokerError("Command is always denied.", code="command_denied")
+        if executable == "git" and len(argv) > 1 and argv[1].lower() in DENIED_GIT_SUBCOMMANDS:
+            raise ToolBrokerError("Git remote operations are denied.", code="command_denied")
+        for item in argv[1:]:
+            path = PurePosixPath(item.replace("\\", "/"))
+            if Path(item).is_absolute() or ".." in path.parts:
+                raise ToolBrokerError("Command contains a host path.", code="command_denied")
+        return tuple(argv)
+
+    @staticmethod
+    def _safe_environment(repository: Path) -> dict[str, str]:
+        environment = {
+            "HOME": str(repository.parent / "home"),
+            "LANG": "C.UTF-8",
+            "LC_ALL": "C.UTF-8",
+            "PATH": "/usr/local/bin:/usr/bin:/bin",
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_TERMINAL_PROMPT": "0",
+            "GIT_NO_LAZY_FETCH": "1",
+            "GIT_NO_REPLACE_OBJECTS": "1",
+        }
+        if os.name == "nt":
+            environment["PATH"] = os.environ.get("PATH", "")
+            environment["SYSTEMROOT"] = os.environ.get("SYSTEMROOT", "C:\\Windows")
+        Path(environment["HOME"]).mkdir(exist_ok=True)
+        return environment
+
+    @staticmethod
+    def _intent_sha256(tool_name: str, request: dict[str, Any]) -> str:
+        encoded = json.dumps(
+            {"tool": tool_name, "request": request},
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+    @staticmethod
+    def _json_object(value: Mapping[str, Any] | Any) -> dict[str, Any]:
+        try:
+            encoded = json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+            decoded = json.loads(encoded)
+        except (TypeError, ValueError) as exc:
+            raise ToolBrokerError("Tool input is not JSON.", code="tool_input_invalid") from exc
+        if not isinstance(decoded, dict):
+            raise ToolBrokerError("Tool input must be an object.", code="tool_input_invalid")
+        return decoded

--- a/server/coding_worker/tool_broker.py
+++ b/server/coding_worker/tool_broker.py
@@ -15,7 +15,14 @@ from urllib.parse import urlsplit
 
 from pydantic import Field
 
-from .contracts import CapabilityName, OperationState, PolicyProfile, StrictModel, TaskState
+from .contracts import (
+    CapabilityLease,
+    CapabilityName,
+    OperationState,
+    PolicyProfile,
+    StrictModel,
+    TaskState,
+)
 from .process_manager import BackgroundProcessManager, ProcessManagerError
 from .network_policy import EgressPolicy, NetworkPolicyError
 from .store import CodingWorkerStore, WorkerConflictError
@@ -146,7 +153,7 @@ class ToolBroker:
                 "Tool operation cannot be replayed.", code="operation_not_replayable"
             )
         try:
-            self._authorize(
+            network_lease = self._authorize(
                 task.spec.policy_profile,
                 tool_name,
                 lease_id,
@@ -161,7 +168,11 @@ class ToolBroker:
                 expected_state=OperationState.PREPARED,
             )
             data = await self._dispatch(
-                task_id, task.workspace_id, tool_name, request["arguments"]
+                task_id,
+                task.workspace_id,
+                tool_name,
+                request["arguments"],
+                network_lease=network_lease,
             )
             completed = self.store.transition_operation(
                 operation_id,
@@ -279,10 +290,10 @@ class ToolBroker:
         operation_id: str,
         request: dict[str, Any],
         network_lease_id: str | None,
-    ) -> None:
+    ) -> CapabilityLease | None:
         readonly = {"list_files", "read_file", "search_text", "diff", "service_status"}
         if tool_name in readonly:
-            return
+            return None
         if tool_name in {
             "write_file",
             "delete_file",
@@ -292,7 +303,7 @@ class ToolBroker:
         }:
             if profile not in {PolicyProfile.DEVELOP, PolicyProfile.DEVELOP_NETWORKED}:
                 raise ToolBrokerError("Task policy is read-only.", code="approval_required")
-            return
+            return None
         capability: CapabilityName
         if tool_name == "run_command":
             capability = "command"
@@ -338,15 +349,17 @@ class ToolBroker:
         lease = self.store.consume_lease(lease_id, task_id=task_id, capability=capability)
         if lease.scope != request["arguments"]:
             raise ToolBrokerError("Approval does not match the request.", code="lease_scope_mismatch")
+        consumed_network_lease: CapabilityLease | None = None
         if network_scope is not None:
-            network_lease = self.store.consume_lease(
+            consumed_network_lease = self.store.consume_lease(
                 str(network_lease_id), task_id=task_id, capability="network"
             )
             self._require_egress_policy().validate_lease_scope(
-                lease=network_lease,
+                lease=consumed_network_lease,
                 domains=("registry.npmjs.org",),
                 purpose="dependency-install",
             )
+        return consumed_network_lease
 
     async def _dispatch(
         self,
@@ -354,6 +367,8 @@ class ToolBroker:
         workspace_id: str,
         tool_name: str,
         arguments: dict[str, Any],
+        *,
+        network_lease: CapabilityLease | None,
     ) -> dict[str, Any]:
         if tool_name == "list_files":
             return {
@@ -500,14 +515,24 @@ class ToolBroker:
                 )
             if self.egress_proxy_url is None:
                 raise ToolBrokerError("Egress proxy is unavailable.", code="network_disabled")
+            if network_lease is None:
+                raise ToolBrokerError(
+                    "Network lease is unavailable.", code="network_lease_invalid"
+                )
+            authenticated_proxy = self._require_egress_policy().proxy_url(
+                base_url=self.egress_proxy_url,
+                lease=network_lease,
+                task_id=task_id,
+                purpose="dependency-install",
+            )
             result = await self._run_process(
                 task_id,
                 workspace_id,
                 ("npm", "ci", "--ignore-scripts", "--no-audit", "--no-fund"),
                 1800,
                 environment_overrides={
-                    "HTTPS_PROXY": self.egress_proxy_url,
-                    "HTTP_PROXY": self.egress_proxy_url,
+                    "HTTPS_PROXY": authenticated_proxy,
+                    "HTTP_PROXY": authenticated_proxy,
                     "NO_PROXY": "",
                     "npm_config_registry": "https://registry.npmjs.org/",
                     "npm_config_ignore_scripts": "true",

--- a/server/coding_worker/tool_broker.py
+++ b/server/coding_worker/tool_broker.py
@@ -421,17 +421,17 @@ class ToolBroker:
                 stderr=asyncio.subprocess.STDOUT,
             )
             try:
-                output, _ = await asyncio.wait_for(
-                    process.communicate(), timeout=timeout_seconds
+                output = await asyncio.wait_for(
+                    self._collect_bounded_output(process), timeout=timeout_seconds
                 )
             except asyncio.TimeoutError:
                 process.kill()
                 await process.wait()
                 raise ToolBrokerError("Command timed out.", code="command_timeout")
-            if len(output) > self.max_output_bytes:
-                raise ToolBrokerError(
-                    "Command output is too large.", code="tool_output_too_large"
-                )
+            except asyncio.CancelledError:
+                process.kill()
+                await process.wait()
+                raise
             return {
                 "argv": list(normalized),
                 "exit_code": int(process.returncode or 0),
@@ -440,6 +440,28 @@ class ToolBroker:
         finally:
             if execution_root is not None:
                 self.workspace_broker._remove_tree(execution_root)
+
+    async def _collect_bounded_output(
+        self, process: asyncio.subprocess.Process
+    ) -> bytes:
+        if process.stdout is None:
+            raise ToolBrokerError("Command output is unavailable.", code="command_failed")
+        chunks: list[bytes] = []
+        size = 0
+        while True:
+            chunk = await process.stdout.read(64 * 1024)
+            if not chunk:
+                break
+            size += len(chunk)
+            if size > self.max_output_bytes:
+                process.kill()
+                await process.wait()
+                raise ToolBrokerError(
+                    "Command output is too large.", code="tool_output_too_large"
+                )
+            chunks.append(chunk)
+        await process.wait()
+        return b"".join(chunks)
 
     def _target(self, workspace_id: str, value: str, *, create_parents: bool = False) -> Path:
         path = PurePosixPath(value)

--- a/server/coding_worker/tool_broker.py
+++ b/server/coding_worker/tool_broker.py
@@ -5,7 +5,9 @@ import hashlib
 import json
 import os
 import re
+import shutil
 import tempfile
+import uuid
 from collections.abc import Mapping, Sequence
 from pathlib import Path, PurePosixPath
 from typing import Any
@@ -325,7 +327,11 @@ class ToolBroker:
             if check is None:
                 raise ToolBrokerError("Check is not registered.", code="check_not_found")
             return await self._run_process(
-                workspace_id, check.argv, check.timeout_seconds, trusted=True
+                workspace_id,
+                check.argv,
+                check.timeout_seconds,
+                trusted=True,
+                isolated=True,
             )
         if tool_name == "run_command":
             argv = arguments.get("argv")
@@ -385,30 +391,55 @@ class ToolBroker:
         timeout_seconds: int,
         *,
         trusted: bool = False,
+        isolated: bool = False,
     ) -> dict[str, Any]:
         normalized = self._validate_argv(argv, trusted=trusted)
         repository = self.workspace_broker.repository_path(workspace_id)
-        process = await asyncio.create_subprocess_exec(
-            *normalized,
-            cwd=repository,
-            env=self._safe_environment(repository),
-            stdin=asyncio.subprocess.DEVNULL,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT,
-        )
+        execution_root: Path | None = None
+        execution_repository = repository
         try:
-            output, _ = await asyncio.wait_for(process.communicate(), timeout=timeout_seconds)
-        except asyncio.TimeoutError:
-            process.kill()
-            await process.wait()
-            raise ToolBrokerError("Command timed out.", code="command_timeout")
-        if len(output) > self.max_output_bytes:
-            raise ToolBrokerError("Command output is too large.", code="tool_output_too_large")
-        return {
-            "argv": list(normalized),
-            "exit_code": int(process.returncode or 0),
-            "output": output.decode("utf-8", errors="replace"),
-        }
+            if isolated:
+                self.workspace_broker.tree(workspace_id)
+                execution_root = (
+                    self.workspace_broker.root
+                    / "harness-runs"
+                    / f"run_{uuid.uuid4().hex}"
+                )
+                execution_root.parent.mkdir(exist_ok=True)
+                shutil.copytree(
+                    repository,
+                    execution_root,
+                    ignore=shutil.ignore_patterns(".git"),
+                )
+                execution_repository = execution_root
+            process = await asyncio.create_subprocess_exec(
+                *normalized,
+                cwd=execution_repository,
+                env=self._safe_environment(execution_repository),
+                stdin=asyncio.subprocess.DEVNULL,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+            )
+            try:
+                output, _ = await asyncio.wait_for(
+                    process.communicate(), timeout=timeout_seconds
+                )
+            except asyncio.TimeoutError:
+                process.kill()
+                await process.wait()
+                raise ToolBrokerError("Command timed out.", code="command_timeout")
+            if len(output) > self.max_output_bytes:
+                raise ToolBrokerError(
+                    "Command output is too large.", code="tool_output_too_large"
+                )
+            return {
+                "argv": list(normalized),
+                "exit_code": int(process.returncode or 0),
+                "output": output.decode("utf-8", errors="replace"),
+            }
+        finally:
+            if execution_root is not None:
+                self.workspace_broker._remove_tree(execution_root)
 
     def _target(self, workspace_id: str, value: str, *, create_parents: bool = False) -> Path:
         path = PurePosixPath(value)

--- a/server/coding_worker/tool_broker.py
+++ b/server/coding_worker/tool_broker.py
@@ -76,7 +76,7 @@ class ToolResult(StrictModel):
 
 class ToolExecutor(Protocol):
     async def run_process(self, *, task_id: str, workspace_id: str, argv: Sequence[str], timeout_seconds: int, isolated: bool, environment_overrides: Mapping[str, str] | None = None) -> dict[str, Any]: ...
-    async def start_service(self, *, task_id: str, workspace_id: str, argv: Sequence[str], ttl_seconds: int) -> dict[str, Any]: ...
+    async def start_service(self, *, task_id: str, workspace_id: str, argv: Sequence[str], ttl_seconds: int, preview_port: int | None = None) -> dict[str, Any]: ...
     async def service_status(self, *, task_id: str, workspace_id: str, service_id: str) -> dict[str, Any]: ...
     async def service_input(self, *, task_id: str, workspace_id: str, service_id: str, data: str) -> dict[str, Any]: ...
     async def stop_service(self, *, task_id: str, workspace_id: str, service_id: str) -> dict[str, Any]: ...
@@ -442,20 +442,36 @@ class ToolBroker:
         if tool_name == "start_service":
             argv = arguments.get("argv")
             ttl = arguments.get("ttl_seconds", 900)
+            preview_port = arguments.get("preview_port")
             if (
                 not isinstance(argv, list)
                 or not all(isinstance(item, str) for item in argv)
                 or isinstance(ttl, bool)
                 or not isinstance(ttl, int)
+                or (
+                    preview_port is not None
+                    and (
+                        isinstance(preview_port, bool)
+                        or not isinstance(preview_port, int)
+                        or not 1024 <= preview_port <= 65535
+                    )
+                )
             ):
                 raise ToolBrokerError("Service input is invalid.", code="tool_input_invalid")
             if self.executor is not None:
-                return await self.executor.start_service(
+                result = await self.executor.start_service(
                     task_id=task_id,
                     workspace_id=workspace_id,
                     argv=self._validate_argv(argv),
                     ttl_seconds=ttl,
+                    preview_port=preview_port,
                 )
+                if preview_port is not None:
+                    result["preview_url"] = (
+                        f"/api/coding-worker/v1/tasks/{task_id}/services/"
+                        f"{result['service_id']}/preview/"
+                    )
+                return result
             record = await self._require_process_manager().start(
                 task_id=task_id,
                 workspace_id=workspace_id,

--- a/server/coding_worker/tool_broker.py
+++ b/server/coding_worker/tool_broker.py
@@ -15,6 +15,7 @@ from typing import Any
 from pydantic import Field
 
 from .contracts import CapabilityName, OperationState, PolicyProfile, StrictModel, TaskState
+from .process_manager import BackgroundProcessManager, ProcessManagerError
 from .store import CodingWorkerStore, WorkerConflictError
 from .workspace import WorkspaceBroker, WorkspaceError
 
@@ -77,6 +78,7 @@ class ToolBroker:
         store: CodingWorkerStore,
         workspace_broker: WorkspaceBroker,
         frozen_checks: Mapping[str, FrozenCheck] | None = None,
+        process_manager: BackgroundProcessManager | None = None,
         max_output_bytes: int = MAX_TOOL_OUTPUT_BYTES,
     ) -> None:
         if not 1024 <= max_output_bytes <= 16 * 1024 * 1024:
@@ -84,6 +86,7 @@ class ToolBroker:
         self.store = store
         self.workspace_broker = workspace_broker
         self.frozen_checks = dict(frozen_checks or {})
+        self.process_manager = process_manager
         self.max_output_bytes = max_output_bytes
 
     async def execute(
@@ -139,7 +142,9 @@ class ToolBroker:
                 OperationState.RUNNING,
                 expected_state=OperationState.PREPARED,
             )
-            data = await self._dispatch(task.workspace_id, tool_name, request["arguments"])
+            data = await self._dispatch(
+                task_id, task.workspace_id, tool_name, request["arguments"]
+            )
             completed = self.store.transition_operation(
                 operation_id,
                 OperationState.COMPLETED,
@@ -156,6 +161,7 @@ class ToolBroker:
             ToolBrokerError,
             WorkerConflictError,
             WorkspaceError,
+            ProcessManagerError,
             OSError,
             asyncio.TimeoutError,
         ) as exc:
@@ -242,16 +248,24 @@ class ToolBroker:
         operation_id: str,
         request: dict[str, Any],
     ) -> None:
-        readonly = {"list_files", "read_file", "search_text", "diff"}
+        readonly = {"list_files", "read_file", "search_text", "diff", "service_status"}
         if tool_name in readonly:
             return
-        if tool_name in {"write_file", "delete_file", "run_check"}:
+        if tool_name in {
+            "write_file",
+            "delete_file",
+            "run_check",
+            "service_input",
+            "stop_service",
+        }:
             if profile not in {PolicyProfile.DEVELOP, PolicyProfile.DEVELOP_NETWORKED}:
                 raise ToolBrokerError("Task policy is read-only.", code="approval_required")
             return
         capability: CapabilityName
         if tool_name == "run_command":
             capability = "command"
+        elif tool_name == "start_service":
+            capability = "service"
         else:
             raise ToolBrokerError("Tool is not available.", code="tool_not_allowed")
         if lease_id is None:
@@ -266,12 +280,15 @@ class ToolBroker:
                 self.store.transition(task_id, TaskState.WAITING_APPROVAL)
             raise ToolBrokerError("Tool requires approval.", code="approval_required")
         lease = self.store.consume_lease(lease_id, task_id=task_id, capability=capability)
-        requested_argv = request["arguments"].get("argv")
-        if lease.scope.get("argv") != requested_argv:
-            raise ToolBrokerError("Approval does not match the command.", code="lease_scope_mismatch")
+        if lease.scope != request["arguments"]:
+            raise ToolBrokerError("Approval does not match the request.", code="lease_scope_mismatch")
 
     async def _dispatch(
-        self, workspace_id: str, tool_name: str, arguments: dict[str, Any]
+        self,
+        task_id: str,
+        workspace_id: str,
+        tool_name: str,
+        arguments: dict[str, Any],
     ) -> dict[str, Any]:
         if tool_name == "list_files":
             return {
@@ -341,7 +358,53 @@ class ToolBroker:
             if isinstance(timeout, bool) or not isinstance(timeout, int) or not 1 <= timeout <= 1800:
                 raise ToolBrokerError("Command timeout is invalid.", code="tool_input_invalid")
             return await self._run_process(workspace_id, tuple(argv), timeout)
+        if tool_name == "start_service":
+            manager = self._require_process_manager()
+            argv = arguments.get("argv")
+            ttl = arguments.get("ttl_seconds", 900)
+            if (
+                not isinstance(argv, list)
+                or not all(isinstance(item, str) for item in argv)
+                or isinstance(ttl, bool)
+                or not isinstance(ttl, int)
+            ):
+                raise ToolBrokerError("Service input is invalid.", code="tool_input_invalid")
+            record = await manager.start(
+                task_id=task_id,
+                workspace_id=workspace_id,
+                argv=self._validate_argv(argv),
+                ttl_seconds=ttl,
+            )
+            return record.model_dump(mode="json")
+        if tool_name == "service_status":
+            record = self._require_process_manager().status(
+                task_id=task_id,
+                service_id=str(arguments.get("service_id", "")),
+            )
+            return record.model_dump(mode="json")
+        if tool_name == "service_input":
+            service_id = str(arguments.get("service_id", ""))
+            data = arguments.get("data")
+            if not isinstance(data, str):
+                raise ToolBrokerError("Service input is invalid.", code="tool_input_invalid")
+            await self._require_process_manager().send_input(
+                task_id=task_id,
+                service_id=service_id,
+                data=data.encode("utf-8"),
+            )
+            return {"service_id": service_id, "accepted": True}
+        if tool_name == "stop_service":
+            record = await self._require_process_manager().interrupt(
+                task_id=task_id,
+                service_id=str(arguments.get("service_id", "")),
+            )
+            return record.model_dump(mode="json")
         raise ToolBrokerError("Tool is not available.", code="tool_not_allowed")
+
+    def _require_process_manager(self) -> BackgroundProcessManager:
+        if self.process_manager is None:
+            raise ToolBrokerError("Service manager is unavailable.", code="service_unavailable")
+        return self.process_manager
 
     def _write_file(self, workspace_id: str, arguments: dict[str, Any]) -> dict[str, Any]:
         path = str(arguments.get("path", ""))

--- a/server/coding_worker/workspace.py
+++ b/server/coding_worker/workspace.py
@@ -6,6 +6,7 @@ import json
 import os
 import re
 import shutil
+import stat
 import subprocess
 import tempfile
 import uuid
@@ -393,4 +394,20 @@ class WorkspaceBroker:
     @staticmethod
     def _remove_tree(path: Path) -> None:
         if path.exists():
-            shutil.rmtree(path)
+            root = path.resolve()
+
+            def remove_owned_readonly(
+                function: object, name: str, error: tuple[type[BaseException], BaseException, object]
+            ) -> None:
+                failure = error[1]
+                target = Path(name)
+                try:
+                    metadata = os.lstat(target)
+                    if stat.S_ISLNK(metadata.st_mode) or not target.resolve().is_relative_to(root):
+                        raise failure
+                    os.chmod(target, metadata.st_mode | stat.S_IWRITE)
+                    function(name)  # type: ignore[operator]
+                except Exception:
+                    raise failure
+
+            shutil.rmtree(path, onerror=remove_owned_readonly)

--- a/server/coding_worker/workspace.py
+++ b/server/coding_worker/workspace.py
@@ -44,6 +44,7 @@ class SourceSnapshot(StrictModel):
 
 class WorkspaceRecord(StrictModel):
     workspace_id: str
+    slot_id: str = "default"
     source: WorkspaceSource
     baseline_commit: str = Field(pattern=r"^[a-f0-9]{40}$")
     baseline_tree_hash: str = Field(pattern=r"^[a-f0-9]{64}$")
@@ -87,18 +88,37 @@ class WorkspaceBroker:
         adapters: Mapping[str, WorkspaceSourceAdapter],
         *,
         id_key: bytes,
+        slot_roots: Mapping[str, Path] | None = None,
     ) -> None:
         if len(id_key) < 32:
             raise ValueError("workspace id key is too short")
         self.root = Path(root).resolve()
-        self.workspaces_root = self.root / "workspaces"
-        self.staging_root = self.root / "workspace-staging"
+        self.dedicated_slots = slot_roots is not None
+        configured = slot_roots or {"default": self.root}
+        if not configured or any(
+            re.fullmatch(r"[a-z0-9][a-z0-9-]{0,31}", key) is None
+            for key in configured
+        ):
+            raise ValueError("workspace slot id is invalid")
+        self._slot_roots = {
+            key: Path(value).resolve() for key, value in configured.items()
+        }
+        first_root = next(iter(self._slot_roots.values()))
+        self.workspaces_root = first_root / "workspaces"
+        self.staging_root = first_root / "workspace-staging"
         self._adapters = dict(adapters)
         self._id_key = bytes(id_key)
-        self.workspaces_root.mkdir(parents=True, exist_ok=True)
-        self.staging_root.mkdir(parents=True, exist_ok=True)
+        for slot_root in self._slot_roots.values():
+            (slot_root / "workspaces").mkdir(parents=True, exist_ok=True)
+            (slot_root / "workspace-staging").mkdir(parents=True, exist_ok=True)
 
-    async def prepare(self, source: WorkspaceSource) -> WorkspaceRecord:
+    @property
+    def slot_ids(self) -> tuple[str, ...]:
+        return tuple(self._slot_roots)
+
+    async def prepare(
+        self, source: WorkspaceSource, *, slot_id: str | None = None
+    ) -> WorkspaceRecord:
         adapter = self._adapters.get(source.kind)
         if adapter is None:
             raise WorkspaceError("Workspace source kind is unavailable.", code="source_unavailable")
@@ -106,9 +126,15 @@ class WorkspaceBroker:
         if snapshot.source != source:
             raise WorkspaceError("Workspace source binding changed.", code="source_changed")
         normalized = self._validate_snapshot(snapshot.files)
+        selected_slot = slot_id or (None if self.dedicated_slots else "default")
+        slot_root = self._slot_roots.get(selected_slot or "")
+        if slot_root is None:
+            raise WorkspaceError(
+                "Workspace slot is unavailable.", code="workspace_slot_unavailable"
+            )
         workspace_id = f"workspace_{uuid.uuid4().hex}"
-        stage = self.staging_root / workspace_id
-        destination = self.workspaces_root / workspace_id
+        stage = slot_root / "workspace-staging" / workspace_id
+        destination = slot_root / "workspaces" / workspace_id
         if stage.exists() or destination.exists():
             raise WorkspaceError("Workspace id collision.", code="workspace_unavailable")
         repository = stage / "repo"
@@ -125,6 +151,7 @@ class WorkspaceBroker:
             total_bytes = sum(len(file.content) for _, file in normalized)
             metadata = WorkspaceRecord(
                 workspace_id=workspace_id,
+                slot_id=selected_slot or "",
                 source=source,
                 baseline_commit=baseline_commit,
                 baseline_tree_hash=baseline_tree_hash,
@@ -152,15 +179,22 @@ class WorkspaceBroker:
             ) from exc
 
     def get(self, workspace_id: str) -> WorkspaceRecord:
-        root = self._workspace_root(workspace_id)
+        slot_id, root = self._workspace_location(workspace_id)
         try:
             value = json.loads((root / "metadata.json").read_text(encoding="utf-8"))
             record = WorkspaceRecord.model_validate(value)
         except (OSError, json.JSONDecodeError, ValueError) as exc:
             raise WorkspaceError("Workspace metadata is invalid.", code="workspace_corrupt") from exc
-        if record.workspace_id != workspace_id or not (root / "repo").is_dir():
+        if (
+            record.workspace_id != workspace_id
+            or record.slot_id != slot_id
+            or not (root / "repo").is_dir()
+        ):
             raise WorkspaceError("Workspace metadata is invalid.", code="workspace_corrupt")
         return record
+
+    def workspace_slot(self, workspace_id: str) -> str:
+        return self._workspace_location(workspace_id)[0]
 
     def repository_path(self, workspace_id: str) -> Path:
         root = self._workspace_root(workspace_id)
@@ -255,12 +289,20 @@ class WorkspaceBroker:
         self._remove_tree(self._workspace_root(workspace_id))
 
     def _workspace_root(self, workspace_id: str) -> Path:
+        return self._workspace_location(workspace_id)[1]
+
+    def _workspace_location(self, workspace_id: str) -> tuple[str, Path]:
         if SAFE_WORKSPACE_ID.fullmatch(workspace_id) is None:
             raise WorkspaceError("Workspace id is invalid.", code="workspace_not_found")
-        candidate = self.workspaces_root / workspace_id
-        if not candidate.is_dir() or candidate.is_symlink():
+        matches = [
+            (slot_id, slot_root / "workspaces" / workspace_id)
+            for slot_id, slot_root in self._slot_roots.items()
+            if (slot_root / "workspaces" / workspace_id).is_dir()
+            and not (slot_root / "workspaces" / workspace_id).is_symlink()
+        ]
+        if len(matches) != 1:
             raise WorkspaceError("Workspace was not found.", code="workspace_not_found")
-        return candidate
+        return matches[0]
 
     @staticmethod
     def _validate_snapshot(files: Sequence[SourceFile]) -> list[tuple[PurePosixPath, SourceFile]]:

--- a/server/coding_worker/workspace.py
+++ b/server/coding_worker/workspace.py
@@ -199,6 +199,20 @@ class WorkspaceBroker:
     def workspace_slot(self, workspace_id: str) -> str:
         return self._workspace_location(workspace_id)[0]
 
+    def apply_slot_owner(self, workspace_id: str, path: Path) -> None:
+        if self._slot_owner is None or os.name == "nt":
+            return
+        workspace_root = self._workspace_root(workspace_id)
+        candidate = Path(path)
+        resolved = candidate.resolve(strict=True)
+        if not resolved.is_relative_to(workspace_root) or candidate.is_symlink():
+            raise WorkspaceError(
+                "Workspace ownership target is invalid.", code="workspace_changed"
+            )
+        uid, gid = self._slot_owner
+        os.chown(candidate, uid, gid)
+        candidate.chmod(0o770 if candidate.is_dir() else 0o660)
+
     def repository_path(self, workspace_id: str) -> Path:
         root = self._workspace_root(workspace_id)
         repository = root / "repo"

--- a/server/coding_worker/workspace.py
+++ b/server/coding_worker/workspace.py
@@ -405,7 +405,7 @@ class WorkspaceBroker:
         text: bool = True,
     ) -> str | bytes:
         result = subprocess.run(
-            ["git", *args],
+            ["git", "-c", f"safe.directory={repository}", *args],
             cwd=repository,
             env=env,
             stdin=subprocess.DEVNULL,

--- a/server/coding_worker/workspace.py
+++ b/server/coding_worker/workspace.py
@@ -89,6 +89,7 @@ class WorkspaceBroker:
         *,
         id_key: bytes,
         slot_roots: Mapping[str, Path] | None = None,
+        slot_owner: tuple[int, int] | None = None,
     ) -> None:
         if len(id_key) < 32:
             raise ValueError("workspace id key is too short")
@@ -103,6 +104,7 @@ class WorkspaceBroker:
         self._slot_roots = {
             key: Path(value).resolve() for key, value in configured.items()
         }
+        self._slot_owner = slot_owner
         first_root = next(iter(self._slot_roots.values()))
         self.workspaces_root = first_root / "workspaces"
         self.staging_root = first_root / "workspace-staging"
@@ -168,6 +170,7 @@ class WorkspaceBroker:
                 ).encode("utf-8"),
             )
             os.replace(stage, destination)
+            self._apply_slot_owner(destination)
             return self.get(workspace_id)
         except WorkspaceError:
             self._remove_tree(stage)
@@ -453,3 +456,15 @@ class WorkspaceBroker:
                     raise failure
 
             shutil.rmtree(path, onerror=remove_owned_readonly)
+
+    def _apply_slot_owner(self, root: Path) -> None:
+        if self._slot_owner is None or os.name == "nt":
+            return
+        uid, gid = self._slot_owner
+        for candidate in (root, *root.rglob("*")):
+            if candidate.is_symlink():
+                raise WorkspaceError(
+                    "Workspace contains a link.", code="workspace_link_detected"
+                )
+            os.chown(candidate, uid, gid)
+            candidate.chmod(0o770 if candidate.is_dir() else 0o660)

--- a/server/tests/test_coding_applier_engine.py
+++ b/server/tests/test_coding_applier_engine.py
@@ -117,6 +117,24 @@ def test_apply_is_atomic_and_idempotent(
     assert staging.exists() is False
 
 
+def test_health_uses_source_path_part_ordering(
+    roots: tuple[Path, Path, Path],
+) -> None:
+    source, target, staging = roots
+    for root in (source, target):
+        nested = root / "experiments/matrix/third-party/gdunit4"
+        nested.mkdir(parents=True)
+        (nested / "LICENSE").write_text("license\n", encoding="utf-8")
+        (root / "experiments/matrix/third-party/gdunit4.lock.json").write_text(
+            "{}\n",
+            encoding="utf-8",
+        )
+
+    engine = CodingApplierEngine(source, target, staging)
+
+    assert engine.health()["available"] is True
+
+
 def test_apply_and_revert_support_delete_and_move(
     roots: tuple[Path, Path, Path],
 ) -> None:

--- a/server/tests/test_coding_project_host_api.py
+++ b/server/tests/test_coding_project_host_api.py
@@ -5,11 +5,12 @@ import hashlib
 import json
 import time
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, AsyncIterator
 
 import httpx
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 
 from server.coding_runtime.api import (
     CodingService,
@@ -33,6 +34,8 @@ from server.coding_runtime.project_host_api import (
 )
 from server.coding_runtime.project_writer_client import ProjectWriterClientError
 from server.coding_runtime.projects import ProjectFeatures, ProjectKind
+from server.coding_worker.api import configure_coding_worker_for_tests
+from server.coding_worker.contracts import TaskState
 from server.coding_runtime.recovery import CodingRecoveryStore, RecoveryProjectContext
 from server.coding_runtime.worker import CodingWorkerError, CodingWorkerServer
 from server.tests.test_coding_runtime_api import FakeWorker
@@ -505,6 +508,111 @@ async def test_host_project_catalog_and_session_use_one_path_free_snapshot() -> 
     await service.shutdown()
     assert source.released == [(PROJECT_ID, "lease_host_k8r3_202608")]
     configure_coding_service(None)
+
+
+@pytest.mark.asyncio
+async def test_completed_worker_patch_enters_existing_host_recovery_chain(
+    tmp_path: Path,
+) -> None:
+    store = CodingRecoveryStore(tmp_path / "worker-handoff-recovery")
+    service, worker, source, host = _service(store)
+    patch = worker._diff_content()
+
+    record = await service.adopt_worker_patch(
+        project_id=PROJECT_ID,
+        expected_head=PROJECT_HEAD,
+        patch=patch,
+        paths=[worker.change_path],
+    )
+
+    assert record.project["kind"] == "host_git"
+    assert record.project_source == _lease()
+    assert worker.restore_calls == [
+        {
+            "revision": 1,
+            "patch": patch,
+            "paths": [worker.change_path],
+            "snapshot_fingerprint": PROJECT_FINGERPRINT,
+            "verification": None,
+            "source": _lease(),
+        }
+    ]
+    recovery = store.load()
+    assert recovery is not None
+    assert recovery.payload.patch == patch
+    context = store.load_project_context(recovery.recovery_id)
+    assert context is not None
+    assert context.project_id == PROJECT_ID
+    assert source.released == []
+    assert host.snapshot_calls == [(PROJECT_ID, PROJECT_HEAD, None, None)]
+
+
+@pytest.mark.asyncio
+async def test_worker_handoff_rejects_binary_patch_before_host_snapshot(
+    tmp_path: Path,
+) -> None:
+    service, worker, _source, host = _service(
+        CodingRecoveryStore(tmp_path / "binary-handoff-recovery")
+    )
+    patch = (
+        "diff --git a/image.png b/image.png\n"
+        "Binary files a/image.png and b/image.png differ\n"
+    )
+
+    with pytest.raises(HTTPException) as caught:
+        await service.adopt_worker_patch(
+            project_id=PROJECT_ID,
+            expected_head=PROJECT_HEAD,
+            patch=patch,
+            paths=["image.png"],
+        )
+
+    assert caught.value.status_code == 409
+    assert caught.value.detail["code"] == "worker_writeback_patch_unsupported"
+    assert worker.restore_calls == []
+    assert host.snapshot_calls == []
+
+
+@pytest.mark.asyncio
+async def test_completed_worker_task_handoff_route_uses_v13_recovery(
+    tmp_path: Path,
+) -> None:
+    store = CodingRecoveryStore(tmp_path / "worker-route-recovery")
+    service, worker, _source, _host = _service(store)
+    task_id = "task_" + "a" * 32
+    task = SimpleNamespace(
+        state=TaskState.COMPLETED,
+        workspace_id="workspace_" + "b" * 32,
+        spec=SimpleNamespace(
+            workspace_source=SimpleNamespace(
+                kind="host_snapshot",
+                source_id=PROJECT_ID,
+                revision=PROJECT_HEAD,
+            )
+        ),
+    )
+    worker_service = SimpleNamespace(
+        store=SimpleNamespace(get_task=lambda value: task if value == task_id else None),
+        harness_runner=SimpleNamespace(acceptance_satisfied=lambda value: value == task_id),
+        workspace_broker=SimpleNamespace(
+            diff=lambda value: worker._diff_content().encode("utf-8")
+        ),
+    )
+    configure_coding_worker_for_tests(worker_service, enabled=True)  # type: ignore[arg-type]
+    try:
+        async with _client(service) as client:
+            response = await client.post(f"/api/coding/worker-tasks/{task_id}/handoff")
+    finally:
+        configure_coding_worker_for_tests(None, enabled=None)
+        configure_coding_service(None)
+
+    assert response.status_code == 201, response.text
+    assert response.json()["task_id"] == task_id
+    assert response.json()["project"]["id"] == PROJECT_ID
+    assert response.json()["revision"] == 1
+    recovery = store.load()
+    assert recovery is not None
+    assert recovery.payload.patch == worker._diff_content()
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_coding_worker_api.py
+++ b/server/tests/test_coding_worker_api.py
@@ -93,6 +93,7 @@ def test_enabled_runtime_fails_closed_when_sidecar_tokens_are_missing(
 def test_create_is_idempotent_and_server_owns_origin(tmp_path: Path) -> None:
     client, _service = _client(tmp_path)
     with client:
+        assert client.get("/api/coding-worker/v1").json()["acceptance_checks"] == []
         first = client.post("/api/coding-worker/v1/tasks", json=_payload())
         second = client.post("/api/coding-worker/v1/tasks", json=_payload())
     assert first.status_code == 202

--- a/server/tests/test_coding_worker_api.py
+++ b/server/tests/test_coding_worker_api.py
@@ -163,3 +163,50 @@ def test_approval_endpoints_are_task_bound_and_single_decision(tmp_path: Path) -
             json={"approval_id": approval.approval_id, "decision": "reject"},
         )
         assert replay.status_code == 409
+
+
+def test_evidence_and_artifact_download_are_opaque_and_task_bound(
+    tmp_path: Path,
+) -> None:
+    client, service = _client(tmp_path)
+    with client:
+        first = client.post("/api/coding-worker/v1/tasks", json=_payload()).json()
+        second = client.post(
+            "/api/coding-worker/v1/tasks", json=_payload("api-task-02")
+        ).json()
+        task_id = first["task_id"]
+        asyncio.run(service.wait_for(task_id, lambda item: item.state.value == "blocked"))
+        workspace_id = service.store.get_task(task_id).workspace_id
+        tree_hash = service.workspace_broker.current_tree_hash(workspace_id)
+        artifact = service.store.create_artifact(
+            task_id=task_id,
+            media_type="text/plain; charset=utf-8",
+            content=b"2 passed in 0.10s\n",
+            metadata={"check_id": "pytest", "workspace_tree_hash": tree_hash},
+        )
+        evidence = service.store.record_evidence(
+            task_id=task_id,
+            check_id="pytest",
+            operation_id="api-evidence-operation",
+            workspace_tree_hash=tree_hash,
+            exit_code=0,
+            artifact_id=artifact.artifact_id,
+        )
+
+        listed = client.get(f"/api/coding-worker/v1/tasks/{task_id}/evidence")
+        assert listed.status_code == 200
+        assert listed.json()["evidence"][0]["evidence_id"] == evidence.evidence_id
+        artifacts = client.get(f"/api/coding-worker/v1/tasks/{task_id}/artifacts")
+        assert artifacts.status_code == 200
+        assert artifacts.json()["artifacts"][0]["artifact_id"] == artifact.artifact_id
+        download = client.get(
+            f"/api/coding-worker/v1/tasks/{task_id}/artifacts/{artifact.artifact_id}"
+        )
+        assert download.status_code == 200
+        assert download.content == b"2 passed in 0.10s\n"
+        assert download.headers["cache-control"] == "no-store"
+        assert "C:" not in download.headers["content-disposition"]
+        foreign = client.get(
+            f"/api/coding-worker/v1/tasks/{second['task_id']}/artifacts/{artifact.artifact_id}"
+        )
+        assert foreign.status_code == 404

--- a/server/tests/test_coding_worker_api.py
+++ b/server/tests/test_coding_worker_api.py
@@ -4,11 +4,14 @@ import asyncio
 from pathlib import Path
 
 import pytest
+import httpx
+from unittest.mock import AsyncMock
 from cryptography.fernet import Fernet
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from server.coding_worker.api import configure_coding_worker_for_tests, router
+import server.coding_worker.api as worker_api
 from server.coding_worker.provider import FakeCodingAgentProvider
 from server.coding_worker.service import CodingWorkerService
 from server.coding_worker.store import CodingWorkerStore
@@ -229,3 +232,40 @@ def test_evidence_and_artifact_download_are_opaque_and_task_bound(
             f"/api/coding-worker/v1/tasks/{second['task_id']}/artifacts/{artifact.artifact_id}"
         )
         assert foreign.status_code == 404
+
+
+def test_preview_proxy_uses_only_task_slot_and_registered_port(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    client, service = _client(tmp_path)
+    executor = AsyncMock()
+    service.tool_broker = AsyncMock()
+    service.tool_broker.executor = executor
+    with client:
+        task = client.post("/api/coding-worker/v1/tasks", json=_payload()).json()
+        task_id = task["task_id"]
+        asyncio.run(
+            service.wait_for(task_id, lambda item: item.workspace_id is not None)
+        )
+        executor.service_status.return_value = {
+            "service_id": "service_" + "a" * 32,
+            "task_id": task_id,
+            "state": "running",
+            "preview_port": 4173,
+        }
+        seen: list[str] = []
+
+        async def fetch(url: str) -> httpx.Response:
+            seen.append(url)
+            return httpx.Response(200, content=b"<h1>preview</h1>", headers={"content-type": "text/html"})
+
+        monkeypatch.setattr(worker_api, "_fetch_preview", fetch)
+        response = client.get(
+            f"/api/coding-worker/v1/tasks/{task_id}/services/"
+            f"service_{'a' * 32}/preview/app?mode=test"
+        )
+        assert response.status_code == 200
+        assert response.content == b"<h1>preview</h1>"
+        assert seen == ["http://coding-worker-default:4173/app?mode=test"]
+        assert response.headers["cache-control"] == "no-store"
+        assert "sandbox" in response.headers["content-security-policy"]

--- a/server/tests/test_coding_worker_api.py
+++ b/server/tests/test_coding_worker_api.py
@@ -127,3 +127,39 @@ def test_pin_unpin_and_delete_keep_active_task_safe(tmp_path: Path) -> None:
         assert client.delete(f"/api/coding-worker/v1/tasks/{task_id}").status_code == 409
         assert client.post(f"/api/coding-worker/v1/tasks/{task_id}/cancel").status_code == 200
         assert client.delete(f"/api/coding-worker/v1/tasks/{task_id}").status_code == 204
+
+
+def test_approval_endpoints_are_task_bound_and_single_decision(tmp_path: Path) -> None:
+    client, service = _client(tmp_path, blocked=True)
+    with client:
+        first = client.post("/api/coding-worker/v1/tasks", json=_payload()).json()
+        second = client.post(
+            "/api/coding-worker/v1/tasks", json=_payload("api-task-02")
+        ).json()
+        approval = service.store.create_approval(
+            task_id=first["task_id"],
+            operation_id="api-approval-operation",
+            capability="command",
+            request={"argv": ["python", "-m", "pytest"]},
+        )
+        listed = client.get(
+            f"/api/coding-worker/v1/tasks/{first['task_id']}/approvals"
+        )
+        assert listed.status_code == 200
+        assert listed.json()["approvals"][0]["approval_id"] == approval.approval_id
+        foreign = client.post(
+            f"/api/coding-worker/v1/tasks/{second['task_id']}/approvals",
+            json={"approval_id": approval.approval_id, "decision": "approve_once"},
+        )
+        assert foreign.status_code == 404
+        decided = client.post(
+            f"/api/coding-worker/v1/tasks/{first['task_id']}/approvals",
+            json={"approval_id": approval.approval_id, "decision": "approve_once"},
+        )
+        assert decided.status_code == 200
+        assert decided.json()["lease"]["operation_limit"] == 1
+        replay = client.post(
+            f"/api/coding-worker/v1/tasks/{first['task_id']}/approvals",
+            json={"approval_id": approval.approval_id, "decision": "reject"},
+        )
+        assert replay.status_code == 409

--- a/server/tests/test_coding_worker_api.py
+++ b/server/tests/test_coding_worker_api.py
@@ -68,6 +68,25 @@ def test_feature_flag_is_default_deny(monkeypatch: pytest.MonkeyPatch) -> None:
     assert client.post("/api/coding-worker/v1/tasks", json=_payload()).status_code == 404
 
 
+def test_enabled_runtime_fails_closed_when_sidecar_tokens_are_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CODING_WORKER_V14_ENABLED", "true")
+    monkeypatch.delenv("CODING_WORKER_SLOT_A_TOKEN", raising=False)
+    monkeypatch.delenv("CODING_WORKER_SLOT_B_TOKEN", raising=False)
+    configure_coding_worker_for_tests(None, enabled=None)
+    app = FastAPI()
+    app.include_router(router)
+    with TestClient(app) as client:
+        status = client.get("/api/coding-worker/v1").json()
+        assert status["enabled"] is True
+        assert status["available"] is False
+        assert status["reason"] == "coding_worker_config_invalid"
+        unavailable = client.post("/api/coding-worker/v1/tasks", json=_payload())
+        assert unavailable.status_code == 503
+        assert unavailable.json()["detail"]["reason"] == "coding_worker_config_invalid"
+
+
 def test_create_is_idempotent_and_server_owns_origin(tmp_path: Path) -> None:
     client, _service = _client(tmp_path)
     with client:

--- a/server/tests/test_coding_worker_approvals.py
+++ b/server/tests/test_coding_worker_approvals.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from cryptography.fernet import Fernet
+
+from server.coding_worker.contracts import (
+    AcceptanceCheck,
+    AcceptanceContract,
+    OperationState,
+    Origin,
+    TaskSpec,
+    WorkspaceSource,
+)
+from server.coding_worker.store import CodingWorkerStore, WorkerConflictError
+
+
+def _store(
+    tmp_path: Path,
+    *,
+    clock=lambda: 100.0,
+    key: bytes | None = None,
+) -> tuple[CodingWorkerStore, str]:
+    store = CodingWorkerStore(
+        tmp_path / "worker", master_key=key or Fernet.generate_key(), clock=clock
+    )
+    task = store.create_task(
+        TaskSpec(
+            client_task_id="client-01",
+            origin=Origin(module="test", object_id="one"),
+            objective="work",
+            workspace_source=WorkspaceSource(
+                kind="manifest", source_id="source-01", revision="revision-01"
+            ),
+            acceptance=AcceptanceContract(
+                contract_id="contract-01",
+                required_checks=(
+                    AcceptanceCheck(check_id="pytest", label="pytest", kind="command"),
+                ),
+            ),
+            model_route="coding/default",
+        )
+    )
+    return store, task.task_id
+
+
+def test_approval_is_durable_single_decision_and_once_lease_is_consumed(tmp_path: Path) -> None:
+    store, task_id = _store(tmp_path)
+    approval = store.create_approval(
+        task_id=task_id,
+        operation_id="operation-01",
+        capability="command",
+        request={"argv": ["python", "-m", "pytest"]},
+    )
+    same = store.create_approval(
+        task_id=task_id,
+        operation_id="operation-01",
+        capability="command",
+        request={"argv": ["python", "-m", "pytest"]},
+    )
+    assert same.approval_id == approval.approval_id
+    decided = store.decide_approval(approval.approval_id, approved=True)
+    assert decided.lease is not None and decided.lease.operation_limit == 1
+    store.consume_lease(
+        decided.lease.lease_id, task_id=task_id, capability="command"
+    )
+    with pytest.raises(WorkerConflictError) as spent:
+        store.consume_lease(
+            decided.lease.lease_id, task_id=task_id, capability="command"
+        )
+    assert spent.value.code == "lease_unavailable"
+    with pytest.raises(WorkerConflictError) as replay:
+        store.decide_approval(approval.approval_id, approved=False)
+    assert replay.value.code == "approval_already_decided"
+
+
+def test_task_lease_is_bound_to_task_capability_ttl_and_encrypted(tmp_path: Path) -> None:
+    now = [100.0]
+    store, task_id = _store(tmp_path, clock=lambda: now[0])
+    approval = store.create_approval(
+        task_id=task_id,
+        operation_id="operation-network",
+        capability="network",
+        request={"domains": ["registry.npmjs.org"], "purpose": "install"},
+    )
+    decided = store.decide_approval(
+        approval.approval_id, approved=True, task_scope=True, ttl_seconds=60
+    )
+    assert decided.lease is not None and decided.lease.operation_limit == 1024
+    with pytest.raises(WorkerConflictError):
+        store.consume_lease(
+            decided.lease.lease_id, task_id="task_other", capability="network"
+        )
+    now[0] = 161.0
+    with pytest.raises(WorkerConflictError):
+        store.consume_lease(
+            decided.lease.lease_id, task_id=task_id, capability="network"
+        )
+    raw = store.database_path.read_bytes()
+    assert b"registry.npmjs.org" not in raw and b"install" not in raw
+
+
+def test_running_operation_becomes_unknown_after_restart_and_cannot_blind_replay(
+    tmp_path: Path,
+) -> None:
+    key = Fernet.generate_key()
+    root = tmp_path / "worker"
+    store, task_id = _store(tmp_path, key=key)
+    operation = store.create_operation(
+        task_id=task_id,
+        operation_id="operation-write",
+        tool_name="write_file",
+        intent_sha256="a" * 64,
+        request={"path": "result.txt", "sha256": "b" * 64},
+    )
+    store.transition_operation(
+        operation.operation_id,
+        OperationState.RUNNING,
+        expected_state=OperationState.PREPARED,
+    )
+    restarted = CodingWorkerStore(root, master_key=key)
+    unknown = restarted.get_operation(operation.operation_id)
+    assert unknown.state is OperationState.UNKNOWN
+    with pytest.raises(WorkerConflictError):
+        store.transition_operation(
+            operation.operation_id,
+            OperationState.RUNNING,
+            expected_state=OperationState.PREPARED,
+        )
+
+
+def test_operation_id_binds_exact_intent_and_completed_result_is_idempotent(
+    tmp_path: Path,
+) -> None:
+    store, task_id = _store(tmp_path)
+    operation = store.create_operation(
+        task_id=task_id,
+        operation_id="operation-01",
+        tool_name="run_check",
+        intent_sha256="c" * 64,
+        request={"check_id": "pytest"},
+    )
+    with pytest.raises(WorkerConflictError) as conflict:
+        store.create_operation(
+            task_id=task_id,
+            operation_id="operation-01",
+            tool_name="run_check",
+            intent_sha256="d" * 64,
+            request={"check_id": "pytest"},
+        )
+    assert conflict.value.code == "operation_intent_conflict"
+    store.transition_operation(operation.operation_id, OperationState.RUNNING)
+    completed = store.transition_operation(
+        operation.operation_id,
+        OperationState.COMPLETED,
+        result={"exit_code": 0, "artifact_id": "artifact-01"},
+    )
+    assert completed.result == {"exit_code": 0, "artifact_id": "artifact-01"}

--- a/server/tests/test_coding_worker_broker_rpc.py
+++ b/server/tests/test_coding_worker_broker_rpc.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import hashlib
 from pathlib import Path
 
@@ -12,16 +13,29 @@ from server.coding_worker.contracts import (
     AcceptanceCheck,
     AcceptanceContract,
     Origin,
+    PolicyProfile,
     TaskSpec,
     TaskState,
     WorkspaceSource,
 )
 from server.coding_worker.store import CodingWorkerStore
-from server.coding_worker.tool_broker import ToolBroker
+from server.coding_worker.tool_broker import FrozenCheck, ToolBroker
 from server.coding_worker.workspace import InMemoryWorkspaceSourceAdapter, WorkspaceBroker
 
 
-async def _rpc(tmp_path: Path) -> tuple[BrokerRPCServer, str, str]:
+class _Executor:
+    calls: list[tuple[str, ...]]
+
+    def __init__(self) -> None:
+        self.calls = []
+
+    async def run_process(self, **kwargs: object) -> dict[str, object]:
+        argv = tuple(str(item) for item in kwargs["argv"])  # type: ignore[index]
+        self.calls.append(argv)
+        return {"exit_code": 0, "output": "approved\n"}
+
+
+async def _rpc(tmp_path: Path) -> tuple[BrokerRPCServer, str, str, _Executor]:
     source = WorkspaceSource(kind="manifest", source_id="rpc", revision="h0")
     workspace = WorkspaceBroker(
         tmp_path / "workspace",
@@ -43,20 +57,29 @@ async def _rpc(tmp_path: Path) -> tuple[BrokerRPCServer, str, str]:
                 ),
             ),
             model_route="coding/default",
+            policy_profile=PolicyProfile.DEVELOP,
         )
     )
     store.transition(task.task_id, TaskState.PREPARING)
     store.transition(task.task_id, TaskState.RUNNING, workspace_id=prepared.workspace_id)
-    server = BrokerRPCServer(ToolBroker(store=store, workspace_broker=workspace))
+    executor = _Executor()
+    server = BrokerRPCServer(
+        ToolBroker(
+            store=store,
+            workspace_broker=workspace,
+            frozen_checks={"check": FrozenCheck(check_id="check", argv=("python", "-V"))},
+            executor=executor,
+        )
+    )
     endpoint = await server.start_tcp_for_tests()
-    return server, task.task_id, endpoint
+    return server, task.task_id, endpoint, executor
 
 
 @pytest.mark.asyncio
 async def test_rpc_is_task_token_bound_and_returns_provider_neutral_result(
     tmp_path: Path,
 ) -> None:
-    server, task_id, endpoint = await _rpc(tmp_path)
+    server, task_id, endpoint, _ = await _rpc(tmp_path)
     token = server.register_task(task_id)
     client = BrokerRPCClient(endpoint, token=token, task_id=task_id)
     result = await client.call(
@@ -74,7 +97,7 @@ async def test_rpc_is_task_token_bound_and_returns_provider_neutral_result(
 
 @pytest.mark.asyncio
 async def test_rpc_rejects_wrong_token_without_executing_operation(tmp_path: Path) -> None:
-    server, task_id, endpoint = await _rpc(tmp_path)
+    server, task_id, endpoint, _ = await _rpc(tmp_path)
     server.register_task(task_id)
     attacker = BrokerRPCClient(endpoint, token="x" * 48, task_id=task_id)
     with pytest.raises(BrokerRPCError) as denied:
@@ -101,6 +124,7 @@ async def test_mcp_exposes_only_modelmirror_broker_tools() -> None:
         "workspace_diff",
         "write_file",
         "delete_file",
+        "list_acceptance_checks",
         "run_check",
         "run_command",
         "install_dependencies",
@@ -112,6 +136,16 @@ async def test_mcp_exposes_only_modelmirror_broker_tools() -> None:
     write = next(tool for tool in tools if tool.name == "write_file")
     assert set(write.inputSchema["required"]) == {"operation_id", "path", "content"}
     assert "content_sha256" not in write.inputSchema["properties"]
+    command = next(tool for tool in tools if tool.name == "run_command")
+    assert set(command.inputSchema["required"]) == {"operation_id", "argv"}
+    assert "lease_id" not in command.inputSchema["properties"]
+    install = next(tool for tool in tools if tool.name == "install_dependencies")
+    assert set(install.inputSchema["required"]) == {"operation_id"}
+    assert "lease_id" not in install.inputSchema["properties"]
+    assert "network_lease_id" not in install.inputSchema["properties"]
+    service = next(tool for tool in tools if tool.name == "start_service")
+    assert set(service.inputSchema["required"]) == {"operation_id", "argv"}
+    assert "lease_id" not in service.inputSchema["properties"]
 
 
 @pytest.mark.asyncio
@@ -141,3 +175,93 @@ async def test_mcp_computes_write_digest_inside_trusted_adapter() -> None:
             "network_lease_id": None,
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_rpc_waits_for_exact_approval_and_executes_same_operation_once(
+    tmp_path: Path,
+) -> None:
+    server, task_id, endpoint, executor = await _rpc(tmp_path)
+    client = BrokerRPCClient(
+        endpoint, token=server.register_task(task_id), task_id=task_id
+    )
+    pending = asyncio.create_task(
+        client.call(
+            operation_id="rpc-command",
+            tool_name="run_command",
+            arguments={"argv": ["python", "-m", "pytest"], "timeout_seconds": 30},
+        )
+    )
+    for _ in range(100):
+        approvals = server.broker.store.list_approvals(task_id)
+        if approvals:
+            break
+        await asyncio.sleep(0.01)
+    assert len(approvals) == 1
+    assert server.broker.store.get_task(task_id).state is TaskState.WAITING_APPROVAL
+    decided = server.broker.store.decide_approval(approvals[0].approval_id, approved=True)
+    assert decided.lease is not None
+    server.broker.store.transition(
+        task_id, TaskState.RUNNING, expected_state=TaskState.WAITING_APPROVAL
+    )
+    result = await asyncio.wait_for(pending, timeout=2)
+    assert result["state"] == "completed"
+    assert result["data"]["output"] == "approved\n"
+    assert executor.calls == [("python", "-m", "pytest")]
+    await server.close()
+
+
+@pytest.mark.asyncio
+async def test_rpc_rejected_approval_never_reaches_executor(tmp_path: Path) -> None:
+    server, task_id, endpoint, executor = await _rpc(tmp_path)
+    client = BrokerRPCClient(
+        endpoint, token=server.register_task(task_id), task_id=task_id
+    )
+    pending = asyncio.create_task(
+        client.call(
+            operation_id="rpc-rejected",
+            tool_name="run_command",
+            arguments={"argv": ["python", "-V"]},
+        )
+    )
+    for _ in range(100):
+        approvals = server.broker.store.list_approvals(task_id)
+        if approvals:
+            break
+        await asyncio.sleep(0.01)
+    assert len(approvals) == 1
+    server.broker.store.decide_approval(approvals[0].approval_id, approved=False)
+    server.broker.store.transition(
+        task_id, TaskState.RUNNING, expected_state=TaskState.WAITING_APPROVAL
+    )
+    with pytest.raises(BrokerRPCError) as rejected:
+        await asyncio.wait_for(pending, timeout=2)
+    assert rejected.value.code == "approval_rejected"
+    assert executor.calls == []
+    assert server.broker.store.get_operation("rpc-rejected").state.value == "failed"
+    await server.close()
+
+
+@pytest.mark.asyncio
+async def test_rpc_lists_and_enforces_task_acceptance_checks(tmp_path: Path) -> None:
+    server, task_id, endpoint, executor = await _rpc(tmp_path)
+    client = BrokerRPCClient(
+        endpoint, token=server.register_task(task_id), task_id=task_id
+    )
+    listed = await client.call(
+        operation_id="rpc-checks", tool_name="list_acceptance_checks", arguments={}
+    )
+    assert listed["data"] == {
+        "checks": [
+            {"check_id": "check", "label": "check", "kind": "command", "required": True}
+        ]
+    }
+    with pytest.raises(BrokerRPCError) as denied:
+        await client.call(
+            operation_id="rpc-other-check",
+            tool_name="run_check",
+            arguments={"check_id": "other"},
+        )
+    assert denied.value.code == "check_not_allowed"
+    assert executor.calls == []
+    await server.close()

--- a/server/tests/test_coding_worker_broker_rpc.py
+++ b/server/tests/test_coding_worker_broker_rpc.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 from pathlib import Path
 
 import pytest
@@ -109,6 +110,34 @@ async def test_mcp_exposes_only_modelmirror_broker_tools() -> None:
         "stop_service",
     }
     write = next(tool for tool in tools if tool.name == "write_file")
-    assert {"operation_id", "path", "content", "content_sha256"}.issubset(
-        write.inputSchema["required"]
+    assert set(write.inputSchema["required"]) == {"operation_id", "path", "content"}
+    assert "content_sha256" not in write.inputSchema["properties"]
+
+
+@pytest.mark.asyncio
+async def test_mcp_computes_write_digest_inside_trusted_adapter() -> None:
+    calls: list[dict[str, object]] = []
+
+    class RecordingClient:
+        async def call(self, **kwargs: object) -> dict[str, object]:
+            calls.append(kwargs)
+            return {"ok": True}
+
+    content = "discount = 0.0\n"
+    await build_server(RecordingClient()).call_tool(
+        "write_file",
+        {"operation_id": "write-discount", "path": "pricing.py", "content": content},
     )
+    assert calls == [
+        {
+            "operation_id": "write-discount",
+            "tool_name": "write_file",
+            "arguments": {
+                "path": "pricing.py",
+                "content": content,
+                "content_sha256": hashlib.sha256(content.encode("utf-8")).hexdigest(),
+            },
+            "lease_id": None,
+            "network_lease_id": None,
+        }
+    ]

--- a/server/tests/test_coding_worker_broker_rpc.py
+++ b/server/tests/test_coding_worker_broker_rpc.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from cryptography.fernet import Fernet
+
+from server.coding_worker.broker_rpc import BrokerRPCClient, BrokerRPCError, BrokerRPCServer
+from server.coding_worker.broker_mcp import build_server
+from server.coding_worker.contracts import (
+    AcceptanceCheck,
+    AcceptanceContract,
+    Origin,
+    TaskSpec,
+    TaskState,
+    WorkspaceSource,
+)
+from server.coding_worker.store import CodingWorkerStore
+from server.coding_worker.tool_broker import ToolBroker
+from server.coding_worker.workspace import InMemoryWorkspaceSourceAdapter, WorkspaceBroker
+
+
+async def _rpc(tmp_path: Path) -> tuple[BrokerRPCServer, str, str]:
+    source = WorkspaceSource(kind="manifest", source_id="rpc", revision="h0")
+    workspace = WorkspaceBroker(
+        tmp_path / "workspace",
+        {"manifest": InMemoryWorkspaceSourceAdapter({("rpc", "h0"): {"app.py": b"hello\n"}})},
+        id_key=b"r" * 32,
+    )
+    prepared = await workspace.prepare(source)
+    store = CodingWorkerStore(tmp_path / "store", master_key=Fernet.generate_key())
+    task = store.create_task(
+        TaskSpec(
+            client_task_id="rpc",
+            origin=Origin(module="tests", object_id="rpc"),
+            objective="inspect",
+            workspace_source=source,
+            acceptance=AcceptanceContract(
+                contract_id="contract",
+                required_checks=(
+                    AcceptanceCheck(check_id="check", label="check", kind="command"),
+                ),
+            ),
+            model_route="coding/default",
+        )
+    )
+    store.transition(task.task_id, TaskState.PREPARING)
+    store.transition(task.task_id, TaskState.RUNNING, workspace_id=prepared.workspace_id)
+    server = BrokerRPCServer(ToolBroker(store=store, workspace_broker=workspace))
+    endpoint = await server.start_tcp_for_tests()
+    return server, task.task_id, endpoint
+
+
+@pytest.mark.asyncio
+async def test_rpc_is_task_token_bound_and_returns_provider_neutral_result(
+    tmp_path: Path,
+) -> None:
+    server, task_id, endpoint = await _rpc(tmp_path)
+    token = server.register_task(task_id)
+    client = BrokerRPCClient(endpoint, token=token, task_id=task_id)
+    result = await client.call(
+        operation_id="rpc-list", tool_name="list_files", arguments={}
+    )
+    assert result["tool_name"] == "list_files"
+    assert result["data"]["entries"][0]["display_path"] == "app.py"
+    assert "workspace" not in result and "path" not in result
+    server.revoke_task(task_id)
+    with pytest.raises(BrokerRPCError) as revoked:
+        await client.call(operation_id="rpc-revoked", tool_name="list_files", arguments={})
+    assert revoked.value.code == "broker_unauthorized"
+    await server.close()
+
+
+@pytest.mark.asyncio
+async def test_rpc_rejects_wrong_token_without_executing_operation(tmp_path: Path) -> None:
+    server, task_id, endpoint = await _rpc(tmp_path)
+    server.register_task(task_id)
+    attacker = BrokerRPCClient(endpoint, token="x" * 48, task_id=task_id)
+    with pytest.raises(BrokerRPCError) as denied:
+        await attacker.call(
+            operation_id="rpc-attacker", tool_name="list_files", arguments={}
+        )
+    assert denied.value.code == "broker_unauthorized"
+    with pytest.raises(Exception):
+        server.broker.store.get_operation("rpc-attacker")
+    await server.close()
+
+
+@pytest.mark.asyncio
+async def test_mcp_exposes_only_modelmirror_broker_tools() -> None:
+    client = BrokerRPCClient(
+        "tcp:127.0.0.1:1", token="x" * 48, task_id="task_schema"
+    )
+    tools = await build_server(client).list_tools()
+    names = {tool.name for tool in tools}
+    assert names == {
+        "list_files",
+        "read_file",
+        "search_text",
+        "workspace_diff",
+        "write_file",
+        "delete_file",
+        "run_check",
+        "run_command",
+        "install_dependencies",
+        "start_service",
+        "service_status",
+        "service_input",
+        "stop_service",
+    }
+    write = next(tool for tool in tools if tool.name == "write_file")
+    assert {"operation_id", "path", "content", "content_sha256"}.issubset(
+        write.inputSchema["required"]
+    )

--- a/server/tests/test_coding_worker_deployment.py
+++ b/server/tests/test_coding_worker_deployment.py
@@ -9,15 +9,20 @@ def test_v14_sidecar_is_non_root_and_has_no_host_control_mounts() -> None:
     assert "USER 65532:65532" in dockerfile
     assert 'CMD ["python", "-m", "coding_worker.sidecar"]' in dockerfile
     assert "OPENCODE_VERSION=1.18.9" in dockerfile
+    assert "coding-worker-provider-a:" in compose
+    assert "coding-worker-provider-b:" in compose
     assert "coding-worker-slot-a:" in compose
     assert "coding-worker-slot-b:" in compose
     assert "CODING_WORKER_V14_ENABLED: ${CODING_WORKER_V14_ENABLED:-false}" in compose
     assert "/var/run/docker.sock" not in compose
     assert ".ssh" not in compose
     assert "network_mode: host" not in compose
-    assert compose.count('user: "65532:65532"') == 2  # slot B inherits slot A
+    assert compose.count('user: "65532:65532"') == 3  # provider/executor B inherit A
     assert ":/worker-data" in compose
     assert ":/run/modelmirror-coding-broker:ro" in compose
+    assert "CODING_WORKER_MODE: executor" in compose
+    assert "CODING_WORKER_ROUTE_KEY" not in compose.split("coding-worker-slot-a:", 1)[1].split("coding-worker-egress:", 1)[0]
+    assert "coding_worker_slot_a:/worker-data:ro" in compose
     assert "coding-worker-network" in compose
     assert 'command: ["python", "-m", "coding_worker.egress_proxy"]' in compose
     assert "CODING_WORKER_EGRESS_GRANT_KEY: ${CODING_WORKER_EGRESS_GRANT_KEY:-}" in compose

--- a/server/tests/test_coding_worker_deployment.py
+++ b/server/tests/test_coding_worker_deployment.py
@@ -4,8 +4,10 @@ from pathlib import Path
 def test_v14_sidecar_is_non_root_and_has_no_host_control_mounts() -> None:
     root = Path(__file__).parents[2]
     dockerfile = (root / "server/coding_worker/Dockerfile.v14").read_text()
+    server_dockerfile = (root / "server/Dockerfile").read_text()
     compose = (root / "docker-compose.coding-worker-v14.yml").read_text()
 
+    assert "COPY coding_worker ./coding_worker" in server_dockerfile
     assert "USER 65532:65532" in dockerfile
     assert 'CMD ["python", "-m", "coding_worker.sidecar"]' in dockerfile
     assert "OPENCODE_VERSION=1.18.9" in dockerfile

--- a/server/tests/test_coding_worker_deployment.py
+++ b/server/tests/test_coding_worker_deployment.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+
+def test_v14_sidecar_is_non_root_and_has_no_host_control_mounts() -> None:
+    root = Path(__file__).parents[2]
+    dockerfile = (root / "server/coding_worker/Dockerfile.v14").read_text()
+    compose = (root / "docker-compose.coding-worker-v14.yml").read_text()
+
+    assert "USER 65532:65532" in dockerfile
+    assert 'CMD ["python", "-m", "coding_worker.sidecar"]' in dockerfile
+    assert "OPENCODE_VERSION=1.18.9" in dockerfile
+    assert "coding-worker-slot-a:" in compose
+    assert "coding-worker-slot-b:" in compose
+    assert "CODING_WORKER_V14_ENABLED: ${CODING_WORKER_V14_ENABLED:-false}" in compose
+    assert "/var/run/docker.sock" not in compose
+    assert ".ssh" not in compose
+    assert "network_mode: host" not in compose
+    assert compose.count('user: "65532:65532"') == 1  # slot B inherits slot A
+    assert ":/worker-data" in compose
+    assert ":/run/modelmirror-coding-broker:ro" in compose

--- a/server/tests/test_coding_worker_deployment.py
+++ b/server/tests/test_coding_worker_deployment.py
@@ -25,6 +25,12 @@ def test_v14_sidecar_is_non_root_and_has_no_host_control_mounts() -> None:
     assert "CODING_WORKER_MODE: executor" in compose
     assert "CODING_WORKER_ROUTE_KEY" not in compose.split("coding-worker-slot-a:", 1)[1].split("coding-worker-egress:", 1)[0]
     assert "coding_worker_slot_a:/worker-data:ro" in compose
+    executor = compose.split("coding-worker-slot-a:", 1)[1].split(
+        "coding-worker-slot-b:", 1
+    )[0]
+    assert "coding_worker_tools" in executor
+    assert "coding_internal" not in executor
+    assert "coding_worker_tools:" in compose and "internal: true" in compose
     assert "coding-worker-network" in compose
     assert 'command: ["python", "-m", "coding_worker.egress_proxy"]' in compose
     assert "CODING_WORKER_EGRESS_GRANT_KEY: ${CODING_WORKER_EGRESS_GRANT_KEY:-}" in compose

--- a/server/tests/test_coding_worker_deployment.py
+++ b/server/tests/test_coding_worker_deployment.py
@@ -15,6 +15,9 @@ def test_v14_sidecar_is_non_root_and_has_no_host_control_mounts() -> None:
     assert "/var/run/docker.sock" not in compose
     assert ".ssh" not in compose
     assert "network_mode: host" not in compose
-    assert compose.count('user: "65532:65532"') == 1  # slot B inherits slot A
+    assert compose.count('user: "65532:65532"') == 2  # slot B inherits slot A
     assert ":/worker-data" in compose
     assert ":/run/modelmirror-coding-broker:ro" in compose
+    assert "coding-worker-network" in compose
+    assert 'command: ["python", "-m", "coding_worker.egress_proxy"]' in compose
+    assert "CODING_WORKER_EGRESS_GRANT_KEY: ${CODING_WORKER_EGRESS_GRANT_KEY:-}" in compose

--- a/server/tests/test_coding_worker_evidence.py
+++ b/server/tests/test_coding_worker_evidence.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import hashlib
+import sys
+from pathlib import Path
+
+import pytest
+from cryptography.fernet import Fernet
+
+from server.coding_worker.contracts import (
+    AcceptanceCheck,
+    AcceptanceContract,
+    EvidenceStatus,
+    Origin,
+    PolicyProfile,
+    TaskSpec,
+    TaskState,
+    WorkspaceSource,
+)
+from server.coding_worker.evidence import HarnessRunner
+from server.coding_worker.store import CodingWorkerStore, WorkerConflictError
+from server.coding_worker.tool_broker import FrozenCheck, ToolBroker
+from server.coding_worker.workspace import InMemoryWorkspaceSourceAdapter, WorkspaceBroker
+
+
+async def _harness(tmp_path: Path) -> tuple[HarnessRunner, CodingWorkerStore, ToolBroker, str, Path]:
+    source = WorkspaceSource(kind="manifest", source_id="evidence", revision="h0")
+    workspace = WorkspaceBroker(
+        tmp_path / "workspace",
+        {"manifest": InMemoryWorkspaceSourceAdapter({("evidence", "h0"): {"app.py": b"bad python\n"}})},
+        id_key=b"e" * 32,
+    )
+    prepared = await workspace.prepare(source)
+    store = CodingWorkerStore(tmp_path / "store", master_key=Fernet.generate_key())
+    task = store.create_task(
+        TaskSpec(
+            client_task_id="evidence-task",
+            origin=Origin(module="tests", object_id="evidence"),
+            objective="fix syntax",
+            workspace_source=source,
+            acceptance=AcceptanceContract(
+                contract_id="contract",
+                required_checks=(AcceptanceCheck(check_id="syntax", label="syntax", kind="command"),),
+            ),
+            policy_profile=PolicyProfile.DEVELOP,
+            model_route="coding/default",
+        )
+    )
+    store.transition(task.task_id, TaskState.PREPARING)
+    store.transition(task.task_id, TaskState.RUNNING, workspace_id=prepared.workspace_id)
+    broker = ToolBroker(
+        store=store,
+        workspace_broker=workspace,
+        frozen_checks={"syntax": FrozenCheck(check_id="syntax", argv=(sys.executable, "-m", "py_compile", "app.py"))},
+    )
+    return (
+        HarnessRunner(store=store, workspace_broker=workspace, tool_broker=broker),
+        store,
+        broker,
+        task.task_id,
+        workspace.repository_path(prepared.workspace_id),
+    )
+
+
+@pytest.mark.asyncio
+async def test_failed_check_blocks_completion_then_fix_and_retest_passes(tmp_path: Path) -> None:
+    harness, store, broker, task_id, repository = await _harness(tmp_path)
+    failed = await harness.run_required_checks(task_id)
+    assert failed[0].status is EvidenceStatus.FAILED
+    assert not harness.acceptance_satisfied(task_id)
+    content = "print('fixed')\n"
+    await broker.execute(
+        task_id=task_id,
+        operation_id="fix-file",
+        tool_name="write_file",
+        arguments={
+            "path": "app.py",
+            "content": content,
+            "content_sha256": hashlib.sha256(content.encode()).hexdigest(),
+        },
+    )
+    invalidated = store.list_evidence(
+        task_id,
+        current_tree_hash=harness.workspace_broker.current_tree_hash(store.get_task(task_id).workspace_id),
+    )
+    assert invalidated[0].status is EvidenceStatus.INVALIDATED
+    passed = await harness.run_required_checks(task_id)
+    assert passed[0].status is EvidenceStatus.PASSED
+    assert harness.acceptance_satisfied(task_id)
+    assert repository.joinpath("app.py").read_text() == content
+
+
+@pytest.mark.asyncio
+async def test_artifact_and_evidence_are_encrypted_and_task_bound(tmp_path: Path) -> None:
+    harness, store, _, task_id, _ = await _harness(tmp_path)
+    evidence = (await harness.run_required_checks(task_id))[0]
+    content = store.read_artifact(evidence.artifact_id, task_id=task_id)
+    assert b"SyntaxError" in content
+    raw = store.database_path.read_bytes()
+    assert b"SyntaxError" not in raw and b"bad python" not in raw
+    other = store.create_task(store.get_task(task_id).spec.model_copy(update={"client_task_id": "other"}))
+    with pytest.raises(Exception):
+        store.read_artifact(evidence.artifact_id, task_id=other.task_id)
+
+
+@pytest.mark.asyncio
+async def test_acceptance_contract_cannot_be_replaced_by_agent_evidence(tmp_path: Path) -> None:
+    harness, store, _, task_id, _ = await _harness(tmp_path)
+    artifact = store.create_artifact(
+        task_id=task_id,
+        media_type="text/plain",
+        content=b"pretend pass",
+        metadata={},
+    )
+    with pytest.raises(WorkerConflictError) as unknown:
+        store.record_evidence(
+            task_id=task_id,
+            check_id="agent-replaced-check",
+            operation_id="forged-operation",
+            workspace_tree_hash=harness.workspace_broker.current_tree_hash(store.get_task(task_id).workspace_id),
+            exit_code=0,
+            artifact_id=artifact.artifact_id,
+        )
+    assert unknown.value.code == "acceptance_check_unknown"
+    assert not harness.acceptance_satisfied(task_id)

--- a/server/tests/test_coding_worker_network.py
+++ b/server/tests/test_coding_worker_network.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import pytest
+
+from server.coding_worker.contracts import CapabilityLease
+from server.coding_worker.network_policy import EgressPolicy, NetworkPolicyError
+
+
+def _lease(scope: dict[str, object], *, expires_at: float = 200.0) -> CapabilityLease:
+    return CapabilityLease(
+        lease_id="lease_network",
+        task_id="task_network",
+        capability="network",
+        scope=scope,
+        issued_at=100.0,
+        expires_at=expires_at,
+    )
+
+
+def test_network_is_default_deny_and_scope_is_deployment_allowlisted() -> None:
+    disabled = EgressPolicy(allowed_domains={"registry.npmjs.org"})
+    with pytest.raises(NetworkPolicyError) as denied:
+        disabled.approval_scope(domains=["registry.npmjs.org"], purpose="npm-install")
+    assert denied.value.code == "network_disabled"
+
+    policy = EgressPolicy(enabled=True, allowed_domains={"registry.npmjs.org"})
+    assert policy.approval_scope(
+        domains=["REGISTRY.NPMJS.ORG."], purpose="npm-install"
+    ) == {"domains": ["registry.npmjs.org"], "purpose": "npm-install"}
+    with pytest.raises(NetworkPolicyError) as outside:
+        policy.approval_scope(domains=["example.com"], purpose="npm-install")
+    assert outside.value.code == "network_domain_not_allowed"
+
+
+@pytest.mark.parametrize(
+    "domain",
+    ["127.0.0.1", "::1", "localhost", "metadata.internal", "service.local"],
+)
+def test_ip_literals_and_local_names_are_rejected(domain: str) -> None:
+    with pytest.raises(NetworkPolicyError):
+        EgressPolicy(enabled=True, allowed_domains={domain})
+
+
+def test_https_destination_is_bound_to_task_purpose_dns_and_ttl() -> None:
+    policy = EgressPolicy(
+        enabled=True,
+        allowed_domains={"registry.npmjs.org", "cdn.example.com"},
+        clock=lambda: 150.0,
+    )
+    scope = policy.approval_scope(
+        domains=["registry.npmjs.org"], purpose="npm-install"
+    )
+    lease = _lease(scope)
+    assert (
+        policy.authorize(
+            url="https://registry.npmjs.org/package",
+            lease=lease,
+            purpose="npm-install",
+            resolved_addresses=["104.16.24.34"],
+        )
+        == "registry.npmjs.org"
+    )
+    with pytest.raises(NetworkPolicyError) as private:
+        policy.authorize(
+            url="https://registry.npmjs.org/package",
+            lease=lease,
+            purpose="npm-install",
+            resolved_addresses=["10.0.0.8"],
+        )
+    assert private.value.code == "network_private_address_denied"
+    with pytest.raises(NetworkPolicyError) as expired:
+        policy.authorize(
+            url="https://registry.npmjs.org/package",
+            lease=_lease(scope, expires_at=149.0),
+            purpose="npm-install",
+            resolved_addresses=["104.16.24.34"],
+        )
+    assert expired.value.code == "network_lease_invalid"
+
+
+def test_redirect_must_remain_inside_the_exact_lease_domain() -> None:
+    policy = EgressPolicy(
+        enabled=True,
+        allowed_domains={"registry.npmjs.org", "cdn.example.com"},
+        clock=lambda: 150.0,
+    )
+    lease = _lease(
+        policy.approval_scope(
+            domains=["registry.npmjs.org"], purpose="dependency-download"
+        )
+    )
+    with pytest.raises(NetworkPolicyError) as redirect:
+        policy.authorize(
+            url="https://cdn.example.com/package.tgz",
+            lease=lease,
+            purpose="dependency-download",
+            resolved_addresses=["93.184.216.34"],
+        )
+    assert redirect.value.code == "network_domain_not_allowed"
+
+
+def test_credentials_non_https_and_nonstandard_ports_are_rejected() -> None:
+    policy = EgressPolicy(
+        enabled=True, allowed_domains={"registry.npmjs.org"}, clock=lambda: 150.0
+    )
+    lease = _lease(
+        policy.approval_scope(domains=["registry.npmjs.org"], purpose="install")
+    )
+    for url in (
+        "http://registry.npmjs.org/a",
+        "https://user:secret@registry.npmjs.org/a",
+        "https://registry.npmjs.org:8443/a",
+    ):
+        with pytest.raises(NetworkPolicyError) as denied:
+            policy.authorize(
+                url=url,
+                lease=lease,
+                purpose="install",
+                resolved_addresses=["104.16.24.34"],
+            )
+        assert denied.value.code == "network_url_not_allowed"

--- a/server/tests/test_coding_worker_network.py
+++ b/server/tests/test_coding_worker_network.py
@@ -23,7 +23,7 @@ def test_network_is_default_deny_and_scope_is_deployment_allowlisted() -> None:
         disabled.approval_scope(domains=["registry.npmjs.org"], purpose="npm-install")
     assert denied.value.code == "network_disabled"
 
-    policy = EgressPolicy(enabled=True, allowed_domains={"registry.npmjs.org"})
+    policy = EgressPolicy(enabled=True, allowed_domains={"registry.npmjs.org"}, grant_key=b"k" * 32)
     assert policy.approval_scope(
         domains=["REGISTRY.NPMJS.ORG."], purpose="npm-install"
     ) == {"domains": ["registry.npmjs.org"], "purpose": "npm-install"}
@@ -46,6 +46,7 @@ def test_https_destination_is_bound_to_task_purpose_dns_and_ttl() -> None:
         enabled=True,
         allowed_domains={"registry.npmjs.org", "cdn.example.com"},
         clock=lambda: 150.0,
+        grant_key=b"k" * 32,
     )
     scope = policy.approval_scope(
         domains=["registry.npmjs.org"], purpose="npm-install"
@@ -83,6 +84,7 @@ def test_redirect_must_remain_inside_the_exact_lease_domain() -> None:
         enabled=True,
         allowed_domains={"registry.npmjs.org", "cdn.example.com"},
         clock=lambda: 150.0,
+        grant_key=b"k" * 32,
     )
     lease = _lease(
         policy.approval_scope(
@@ -101,7 +103,7 @@ def test_redirect_must_remain_inside_the_exact_lease_domain() -> None:
 
 def test_credentials_non_https_and_nonstandard_ports_are_rejected() -> None:
     policy = EgressPolicy(
-        enabled=True, allowed_domains={"registry.npmjs.org"}, clock=lambda: 150.0
+        enabled=True, allowed_domains={"registry.npmjs.org"}, clock=lambda: 150.0, grant_key=b"k" * 32
     )
     lease = _lease(
         policy.approval_scope(domains=["registry.npmjs.org"], purpose="install")
@@ -119,3 +121,31 @@ def test_credentials_non_https_and_nonstandard_ports_are_rejected() -> None:
                 resolved_addresses=["104.16.24.34"],
             )
         assert denied.value.code == "network_url_not_allowed"
+
+
+def test_signed_proxy_grant_is_exact_task_domain_purpose_and_ttl() -> None:
+    policy = EgressPolicy(
+        enabled=True,
+        allowed_domains={"registry.npmjs.org"},
+        clock=lambda: 150.0,
+        grant_key=b"g" * 32,
+    )
+    lease = _lease(
+        policy.approval_scope(
+            domains=["registry.npmjs.org"], purpose="dependency-install"
+        )
+    )
+    proxy_url = policy.proxy_url(
+        base_url="http://worker-egress:8080",
+        lease=lease,
+        task_id="task_network",
+        purpose="dependency-install",
+    )
+    token = proxy_url.split("grant:", 1)[1].split("@", 1)[0]
+    payload = policy.validate_grant(token, domain="registry.npmjs.org")
+    assert payload["task_id"] == "task_network"
+    with pytest.raises(NetworkPolicyError):
+        policy.validate_grant(token, domain="example.com")
+    tampered = token[:-1] + ("a" if token[-1] != "a" else "b")
+    with pytest.raises(NetworkPolicyError):
+        policy.validate_grant(tampered, domain="registry.npmjs.org")

--- a/server/tests/test_coding_worker_opencode.py
+++ b/server/tests/test_coding_worker_opencode.py
@@ -5,14 +5,27 @@ from pathlib import Path
 
 import httpx
 import pytest
+from cryptography.fernet import Fernet
 
-from server.coding_worker.contracts import TaskBudget
+from server.coding_worker.broker_rpc import BrokerRPCServer
+from server.coding_worker.contracts import (
+    AcceptanceCheck,
+    AcceptanceContract,
+    Origin,
+    TaskBudget,
+    TaskSpec,
+    TaskState,
+    WorkspaceSource,
+)
 from server.coding_worker.opencode_provider import (
     DIRECT_TOOL_NAMES,
     OpenCodeProvider,
     OpenCodeRoute,
     OpenCodeServerHandle,
 )
+from server.coding_worker.store import CodingWorkerStore
+from server.coding_worker.tool_broker import ToolBroker
+from server.coding_worker.workspace import InMemoryWorkspaceSourceAdapter, WorkspaceBroker
 from server.coding_worker.provider import ProviderEventKind, ProviderOpenRequest
 
 
@@ -184,3 +197,48 @@ def test_raw_permission_frame_never_enters_provider_neutral_event() -> None:
     assert event is not None
     assert event.kind is ProviderEventKind.APPROVAL_REQUIRED
     assert event.data == {"capability": "provider_permission"}
+
+
+@pytest.mark.asyncio
+async def test_provider_gives_mcp_only_a_revocable_task_broker_binding(
+    tmp_path: Path,
+) -> None:
+    source = WorkspaceSource(kind="manifest", source_id="broker", revision="h0")
+    workspace_broker = WorkspaceBroker(
+        tmp_path / "workspace-broker",
+        {"manifest": InMemoryWorkspaceSourceAdapter({("broker", "h0"): {"a.py": b""}})},
+        id_key=b"o" * 32,
+    )
+    prepared = await workspace_broker.prepare(source)
+    store = CodingWorkerStore(tmp_path / "store", master_key=Fernet.generate_key())
+    spec = TaskSpec(
+        client_task_id="broker-binding",
+        origin=Origin(module="tests", object_id="broker-binding"),
+        objective="inspect",
+        workspace_source=source,
+        acceptance=AcceptanceContract(
+            contract_id="contract",
+            required_checks=(
+                AcceptanceCheck(check_id="check", label="check", kind="command"),
+            ),
+        ),
+        model_route="coding/default",
+    )
+    task = store.create_task(spec)
+    store.transition(task.task_id, TaskState.PREPARING)
+    store.transition(task.task_id, TaskState.RUNNING, workspace_id=prepared.workspace_id)
+    rpc = BrokerRPCServer(ToolBroker(store=store, workspace_broker=workspace_broker))
+    await rpc.start_tcp_for_tests()
+    provider = OpenCodeProvider(
+        workspace_resolver=lambda _workspace_id: workspace,
+        runtime_root=tmp_path / "runtime",
+        routes={"coding/default": _route()},
+        broker_rpc=rpc,
+    )
+    environment, revoke = provider._broker_environment(task.task_id)
+    assert environment["CODING_WORKER_TASK_ID"] == task.task_id
+    assert "coding_worker.broker_mcp" in " ".join(provider._tool_broker_command or ())
+    assert "CODING_WORKER_ROUTE_KEY" not in environment
+    revoke()
+    assert task.task_id not in rpc._tokens
+    await rpc.close()

--- a/server/tests/test_coding_worker_opencode.py
+++ b/server/tests/test_coding_worker_opencode.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+from server.coding_worker.contracts import TaskBudget
+from server.coding_worker.opencode_provider import (
+    DIRECT_TOOL_NAMES,
+    OpenCodeProvider,
+    OpenCodeRoute,
+    OpenCodeServerHandle,
+)
+from server.coding_worker.provider import ProviderEventKind, ProviderOpenRequest
+
+
+def _request() -> ProviderOpenRequest:
+    return ProviderOpenRequest(
+        task_id="task-01",
+        workspace_id="workspace-01",
+        objective="Inspect and fix the project.",
+        model_route="coding/default",
+        policy_profile="develop",
+        budget=TaskBudget(),
+    )
+
+
+def _route() -> OpenCodeRoute:
+    return OpenCodeRoute(
+        route_id="coding/default",
+        model_id="test-model",
+        base_url="http://new-api:3000/v1",
+        api_key="ephemeral-route-key",
+    )
+
+
+def test_config_disables_direct_tools_plugins_sharing_and_supplier_surface(tmp_path: Path) -> None:
+    provider = OpenCodeProvider(
+        workspace_resolver=lambda _workspace_id: tmp_path,
+        runtime_root=tmp_path / "runtime",
+        routes={"coding/default": _route()},
+        tool_broker_command=("python", "-m", "coding_worker.tool_mcp"),
+    )
+    config = provider.build_config(_route())
+    permission = config["permission"]
+    assert permission["*"] == "deny"
+    assert permission["modelmirror-tool-broker_*"] == "allow"
+    assert config["plugin"] == [] and config["share"] == "disabled"
+    assert config["instructions"] == []
+    assert config["provider"]["modelmirror"]["options"]["apiKey"] == (
+        "{env:CODING_WORKER_ROUTE_KEY}"
+    )
+    assert all(provider._prompt_tools()[name] is False for name in DIRECT_TOOL_NAMES)
+
+
+@pytest.mark.asyncio
+async def test_headless_adapter_maps_events_cancel_and_checkpoint_without_public_frames(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    closed: list[bool] = []
+    state = {"session": {"id": "ses_test"}, "messages": []}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path == "/session" and request.method == "POST":
+            body = json.loads(request.content)
+            assert body["model"] == {"providerID": "modelmirror", "id": "test-model"}
+            return httpx.Response(200, json=state["session"])
+        if path == "/event":
+            content = (
+                'data: {"type":"message.part.updated","properties":{"sessionID":"ses_test","part":{"type":"text","text":"done"}}}\n\n'
+                'data: {"type":"session.idle","properties":{"sessionID":"ses_test"}}\n\n'
+            )
+            return httpx.Response(200, text=content, headers={"content-type": "text/event-stream"})
+        if path.endswith("/prompt_async"):
+            body = json.loads(request.content)
+            assert body["tools"]["bash"] is False
+            return httpx.Response(204)
+        if path.endswith("/abort"):
+            return httpx.Response(200, json=True)
+        if path.endswith("/message"):
+            return httpx.Response(200, json=state["messages"])
+        if path == "/session/ses_test":
+            return httpx.Response(200, json=state["session"])
+        return httpx.Response(404)
+
+    async def factory(
+        request: ProviderOpenRequest, resolved: Path, route: OpenCodeRoute
+    ) -> OpenCodeServerHandle:
+        assert request.task_id == "task-01" and resolved == workspace.resolve()
+        assert route.route_id == "coding/default"
+        client = httpx.AsyncClient(
+            base_url="http://127.0.0.1:4096",
+            transport=httpx.MockTransport(handler),
+        )
+
+        async def close() -> None:
+            closed.append(True)
+            await client.aclose()
+
+        return OpenCodeServerHandle(
+            task_id=request.task_id,
+            workspace=resolved,
+            state_root=tmp_path / "state",
+            client=client,
+            close_callback=close,
+        )
+
+    provider = OpenCodeProvider(
+        workspace_resolver=lambda _workspace_id: workspace,
+        runtime_root=tmp_path / "runtime",
+        routes={"coding/default": _route()},
+        server_factory=factory,
+    )
+    session = await provider.open(_request())
+    events = [event async for event in provider.message(session, "continue")]
+    assert [event.kind for event in events] == [
+        ProviderEventKind.MESSAGE,
+        ProviderEventKind.TURN_COMPLETED,
+    ]
+    assert await provider.cancel(session) is True
+    checkpoint = await provider.checkpoint(session)
+    assert checkpoint.payload["session_id"] == "ses_test"
+    assert "http" not in checkpoint.payload and "port" not in checkpoint.payload
+    await provider.close(session)
+    assert closed == [True]
+
+
+def test_provider_session_is_excluded_from_public_task_record() -> None:
+    from server.coding_worker.contracts import (
+        AcceptanceCheck,
+        AcceptanceContract,
+        Origin,
+        TaskRecord,
+        TaskSpec,
+        TaskState,
+        WorkspaceSource,
+    )
+
+    record = TaskRecord(
+        task_id="task-01",
+        spec=TaskSpec(
+            client_task_id="client-01",
+            origin=Origin(module="test", object_id="one"),
+            objective="work",
+            workspace_source=WorkspaceSource(
+                kind="manifest", source_id="source-01", revision="revision-01"
+            ),
+            acceptance=AcceptanceContract(
+                contract_id="contract-01",
+                required_checks=(
+                    AcceptanceCheck(check_id="check", label="check", kind="command"),
+                ),
+            ),
+            model_route="coding/default",
+        ),
+        state=TaskState.RUNNING,
+        provider_session_id="ses_private",
+        created_at=1,
+        updated_at=1,
+        expires_at=2,
+    )
+    assert record.provider_session_id == "ses_private"
+    assert "provider_session_id" not in record.model_dump(mode="json")

--- a/server/tests/test_coding_worker_opencode.py
+++ b/server/tests/test_coding_worker_opencode.py
@@ -137,10 +137,18 @@ async def test_headless_adapter_maps_events_cancel_and_checkpoint_without_public
     ]
     assert await provider.cancel(session) is True
     checkpoint = await provider.checkpoint(session)
-    assert checkpoint.payload["session_id"] == "ses_test"
+    assert checkpoint.payload == {
+        "engine": "opencode-1.18.9",
+        "task_id": "task-01",
+        "public_output": "done",
+    }
     assert "http" not in checkpoint.payload and "port" not in checkpoint.payload
+    assert "session" not in checkpoint.payload and "messages" not in checkpoint.payload
     await provider.close(session)
-    assert closed == [True]
+    restored = await provider.restore(_request(), checkpoint)
+    assert restored.task_id == session.task_id
+    await provider.close(restored)
+    assert closed == [True, True]
 
 
 def test_provider_session_is_excluded_from_public_task_record() -> None:

--- a/server/tests/test_coding_worker_opencode.py
+++ b/server/tests/test_coding_worker_opencode.py
@@ -22,6 +22,7 @@ from server.coding_worker.opencode_provider import (
     OpenCodeProvider,
     OpenCodeRoute,
     OpenCodeServerHandle,
+    TOOL_BROKER_MCP_NAME,
 )
 from server.coding_worker.store import CodingWorkerStore
 from server.coding_worker.tool_broker import ToolBroker
@@ -60,12 +61,68 @@ def test_config_disables_direct_tools_plugins_sharing_and_supplier_surface(tmp_p
     permission = config["permission"]
     assert permission["*"] == "deny"
     assert permission["modelmirror-tool-broker_*"] == "allow"
+    assert Path(
+        config["mcp"][TOOL_BROKER_MCP_NAME]["environment"]["PYTHONPATH"]
+    ).name == "server"
     assert config["plugin"] == [] and config["share"] == "disabled"
     assert config["instructions"] == []
     assert config["provider"]["modelmirror"]["options"]["apiKey"] == (
         "{env:CODING_WORKER_ROUTE_KEY}"
     )
     assert all(provider._prompt_tools()[name] is False for name in DIRECT_TOOL_NAMES)
+
+
+@pytest.mark.asyncio
+async def test_open_waits_for_connected_broker_before_creating_session(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    calls = {"mcp": 0, "session": 0}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/mcp":
+            calls["mcp"] += 1
+            status = "connecting" if calls["mcp"] == 1 else "connected"
+            return httpx.Response(
+                200,
+                json={TOOL_BROKER_MCP_NAME: {"status": status}},
+            )
+        if request.url.path == "/session" and request.method == "POST":
+            calls["session"] += 1
+            return httpx.Response(200, json={"id": "ses_ready"})
+        return httpx.Response(404)
+
+    async def factory(
+        request: ProviderOpenRequest, resolved: Path, route: OpenCodeRoute
+    ) -> OpenCodeServerHandle:
+        client = httpx.AsyncClient(
+            base_url="http://127.0.0.1:4096",
+            transport=httpx.MockTransport(handler),
+        )
+
+        async def close() -> None:
+            await client.aclose()
+
+        return OpenCodeServerHandle(
+            task_id=request.task_id,
+            workspace=resolved,
+            state_root=tmp_path / "state",
+            client=client,
+            close_callback=close,
+        )
+
+    provider = OpenCodeProvider(
+        workspace_resolver=lambda _workspace_id: workspace,
+        runtime_root=tmp_path / "runtime",
+        routes={"coding/default": _route()},
+        tool_broker_command=("python", "-m", "coding_worker.broker_mcp"),
+        server_factory=factory,
+    )
+    session = await provider.open(_request())
+    assert session.session_id == "ses_ready"
+    assert calls == {"mcp": 2, "session": 1}
+    await provider.close(session)
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_coding_worker_opencode.py
+++ b/server/tests/test_coding_worker_opencode.py
@@ -166,3 +166,21 @@ def test_provider_session_is_excluded_from_public_task_record() -> None:
     )
     assert record.provider_session_id == "ses_private"
     assert "provider_session_id" not in record.model_dump(mode="json")
+
+
+def test_raw_permission_frame_never_enters_provider_neutral_event() -> None:
+    event = OpenCodeProvider._map_event(
+        {
+            "type": "permission.asked",
+            "properties": {
+                "sessionID": "ses_test",
+                "path": "C:/private/project",
+                "port": 47123,
+                "vendorRequest": {"tool": "bash"},
+            },
+        },
+        "ses_test",
+    )
+    assert event is not None
+    assert event.kind is ProviderEventKind.APPROVAL_REQUIRED
+    assert event.data == {"capability": "provider_permission"}

--- a/server/tests/test_coding_worker_opencode.py
+++ b/server/tests/test_coding_worker_opencode.py
@@ -242,3 +242,21 @@ async def test_provider_gives_mcp_only_a_revocable_task_broker_binding(
     revoke()
     assert task.task_id not in rpc._tokens
     await rpc.close()
+
+
+def test_opencode_provider_accepts_sidecar_broker_binding(tmp_path: Path) -> None:
+    provider = OpenCodeProvider(
+        workspace_resolver=lambda _workspace_id: tmp_path,
+        runtime_root=tmp_path / "runtime",
+        routes={"coding/default": _route()},
+        tool_broker_command=("python", "-m", "coding_worker.broker_mcp"),
+    )
+    provider.bind_broker("task_sidecar", "unix:/run/broker.sock", "t" * 48)
+    environment, revoke = provider._broker_environment("task_sidecar")
+    assert environment == {
+        "CODING_WORKER_BROKER_ENDPOINT": "unix:/run/broker.sock",
+        "CODING_WORKER_BROKER_TOKEN": "t" * 48,
+        "CODING_WORKER_TASK_ID": "task_sidecar",
+    }
+    revoke()
+    assert "task_sidecar" not in provider._broker_bindings

--- a/server/tests/test_coding_worker_processes.py
+++ b/server/tests/test_coding_worker_processes.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from cryptography.fernet import Fernet
+
+from server.coding_worker.contracts import (
+    AcceptanceCheck,
+    AcceptanceContract,
+    Origin,
+    TaskSpec,
+    WorkspaceSource,
+)
+from server.coding_worker.process_manager import (
+    BackgroundProcessManager,
+    ProcessManagerError,
+)
+from server.coding_worker.store import CodingWorkerStore, WorkerNotFoundError
+from server.coding_worker.workspace import InMemoryWorkspaceSourceAdapter, WorkspaceBroker
+
+
+async def _manager(
+    tmp_path: Path, *, max_output_bytes: int = 4096
+) -> tuple[BackgroundProcessManager, CodingWorkerStore, str, str]:
+    source = WorkspaceSource(kind="manifest", source_id="process", revision="h0")
+    workspace = WorkspaceBroker(
+        tmp_path / "workspace",
+        {"manifest": InMemoryWorkspaceSourceAdapter({("process", "h0"): {"app.py": b""}})},
+        id_key=b"p" * 32,
+    )
+    prepared = await workspace.prepare(source)
+    store = CodingWorkerStore(tmp_path / "store", master_key=Fernet.generate_key())
+    task = store.create_task(
+        TaskSpec(
+            client_task_id="process-task",
+            origin=Origin(module="tests", object_id="process"),
+            objective="run service",
+            workspace_source=source,
+            acceptance=AcceptanceContract(
+                contract_id="contract",
+                required_checks=(
+                    AcceptanceCheck(check_id="check", label="check", kind="command"),
+                ),
+            ),
+            model_route="coding/default",
+        )
+    )
+
+    def environment(_workspace_id: str) -> dict[str, str]:
+        return {
+            "PATH": os.environ.get("PATH", ""),
+            "SYSTEMROOT": os.environ.get("SYSTEMROOT", "C:\\Windows"),
+            "PYTHONIOENCODING": "utf-8",
+        }
+
+    return (
+        BackgroundProcessManager(
+            store=store,
+            workspace_broker=workspace,
+            environment_factory=environment,
+            max_output_bytes=max_output_bytes,
+        ),
+        store,
+        task.task_id,
+        prepared.workspace_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_service_output_is_archived_without_exposing_pid(tmp_path: Path) -> None:
+    manager, store, task_id, workspace_id = await _manager(tmp_path)
+    started = await manager.start(
+        task_id=task_id,
+        workspace_id=workspace_id,
+        argv=(sys.executable, "-c", "print('ready')"),
+        ttl_seconds=30,
+    )
+    assert started.state == "running" and "pid" not in started.model_dump()
+    while manager.status(task_id=task_id, service_id=started.service_id).state == "running":
+        await asyncio.sleep(0.01)
+    completed = manager.status(task_id=task_id, service_id=started.service_id)
+    assert completed.state == "completed" and completed.output_artifact_id
+    assert store.read_artifact(completed.output_artifact_id, task_id=task_id) == b"ready\r\n"
+
+
+@pytest.mark.asyncio
+async def test_interrupt_and_lookup_are_task_bound(tmp_path: Path) -> None:
+    manager, store, task_id, workspace_id = await _manager(tmp_path)
+    other = store.create_task(
+        store.get_task(task_id).spec.model_copy(
+            update={"client_task_id": "other", "origin": Origin(module="tests", object_id="other")}
+        )
+    )
+    started = await manager.start(
+        task_id=task_id,
+        workspace_id=workspace_id,
+        argv=(sys.executable, "-c", "import time;print('up', flush=True);time.sleep(30)"),
+        ttl_seconds=60,
+    )
+    with pytest.raises(WorkerNotFoundError):
+        manager.status(task_id=other.task_id, service_id=started.service_id)
+    stopped = await manager.interrupt(task_id=task_id, service_id=started.service_id)
+    assert stopped.state == "stopped" and stopped.reason == "user_interrupted"
+    await manager.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_output_limit_stops_background_service_and_records_reason(tmp_path: Path) -> None:
+    manager, _, task_id, workspace_id = await _manager(tmp_path, max_output_bytes=1024)
+    started = await manager.start(
+        task_id=task_id,
+        workspace_id=workspace_id,
+        argv=(sys.executable, "-c", "print('x' * 5000)"),
+        ttl_seconds=30,
+    )
+    while manager.status(task_id=task_id, service_id=started.service_id).state == "running":
+        await asyncio.sleep(0.01)
+    stopped = manager.status(task_id=task_id, service_id=started.service_id)
+    assert stopped.state == "stopped" and stopped.reason == "service_output_limit"
+
+
+@pytest.mark.asyncio
+async def test_ttl_and_capacity_are_bounded(tmp_path: Path) -> None:
+    manager, _, task_id, workspace_id = await _manager(tmp_path)
+    manager.max_processes_per_task = 1
+    started = await manager.start(
+        task_id=task_id,
+        workspace_id=workspace_id,
+        argv=(sys.executable, "-c", "import time;time.sleep(30)"),
+        ttl_seconds=1,
+    )
+    with pytest.raises(ProcessManagerError) as capacity:
+        await manager.start(
+            task_id=task_id,
+            workspace_id=workspace_id,
+            argv=(sys.executable, "-c", "print('no')"),
+            ttl_seconds=30,
+        )
+    assert capacity.value.code == "service_capacity_exhausted"
+    while manager.status(task_id=task_id, service_id=started.service_id).state == "running":
+        await asyncio.sleep(0.02)
+    expired = manager.status(task_id=task_id, service_id=started.service_id)
+    assert expired.reason == "service_ttl_expired"

--- a/server/tests/test_coding_worker_processes.py
+++ b/server/tests/test_coding_worker_processes.py
@@ -84,7 +84,9 @@ async def test_service_output_is_archived_without_exposing_pid(tmp_path: Path) -
         await asyncio.sleep(0.01)
     completed = manager.status(task_id=task_id, service_id=started.service_id)
     assert completed.state == "completed" and completed.output_artifact_id
-    assert store.read_artifact(completed.output_artifact_id, task_id=task_id) == b"ready\r\n"
+    assert store.read_artifact(
+        completed.output_artifact_id, task_id=task_id
+    ).splitlines() == [b"ready"]
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_coding_worker_provider_rpc.py
+++ b/server/tests/test_coding_worker_provider_rpc.py
@@ -17,6 +17,12 @@ from server.coding_worker.provider_rpc import (
     ProviderRPCServer,
     ProviderSidecarClientPool,
 )
+from server.coding_worker.executor import (
+    ExecutorRPCError,
+    ExecutorRPCServer,
+    ExecutorSidecarClientPool,
+    SidecarExecutor,
+)
 from server.coding_worker.store import CodingWorkerStore
 from server.coding_worker.tool_broker import ToolBroker
 from server.coding_worker.workspace import WorkspaceBroker
@@ -116,3 +122,54 @@ async def test_provider_sidecar_rejects_wrong_token_and_second_active_task(
     await pool.close(first)
     await server.close()
     await broker_rpc.close()
+
+
+@pytest.mark.asyncio
+async def test_credential_free_executor_requires_exact_task_workspace_binding(
+    tmp_path: Path,
+) -> None:
+    repository = tmp_path / "slots" / "workspaces" / "workspace_one" / "repo"
+    repository.mkdir(parents=True)
+    (repository / "main.py").write_text("print('isolated')\n")
+    executor = SidecarExecutor(
+        lambda workspace_id: repository if workspace_id == "workspace_one" else tmp_path / "missing",
+        runtime_root=tmp_path / "runtime",
+    )
+    server = ExecutorRPCServer(executor, token="e" * 48)
+    endpoint = await server.start_tcp_for_tests()
+    pool = ExecutorSidecarClientPool(
+        endpoints={"slot-a": endpoint},
+        tokens={"slot-a": "e" * 48},
+        workspace_slot_resolver=lambda _workspace_id: "slot-a",
+    )
+    with pytest.raises(ExecutorRPCError) as unbound:
+        await pool.run_process(
+            task_id="task_one",
+            workspace_id="workspace_one",
+            argv=("python", "main.py"),
+            timeout_seconds=10,
+            isolated=False,
+        )
+    assert unbound.value.code == "executor_binding_invalid"
+    await pool.bind_task("task_one", "workspace_one")
+    result = await pool.run_process(
+        task_id="task_one",
+        workspace_id="workspace_one",
+        argv=("python", "main.py"),
+        timeout_seconds=10,
+        isolated=False,
+    )
+    assert result["exit_code"] == 0 and str(result["output"]).splitlines() == [
+        "isolated"
+    ]
+    with pytest.raises(ExecutorRPCError) as foreign:
+        await pool.run_process(
+            task_id="task_two",
+            workspace_id="workspace_one",
+            argv=("python", "main.py"),
+            timeout_seconds=10,
+            isolated=False,
+        )
+    assert foreign.value.code == "executor_binding_invalid"
+    await pool.close_task("task_one", "workspace_one")
+    await server.close()

--- a/server/tests/test_coding_worker_provider_rpc.py
+++ b/server/tests/test_coding_worker_provider_rpc.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from cryptography.fernet import Fernet
+
+from server.coding_worker.broker_rpc import BrokerRPCServer
+from server.coding_worker.contracts import PolicyProfile, TaskBudget
+from server.coding_worker.provider import (
+    FakeCodingAgentProvider,
+    ProviderEventKind,
+    ProviderOpenRequest,
+)
+from server.coding_worker.provider_rpc import (
+    ProviderRPCError,
+    ProviderRPCServer,
+    ProviderSidecarClientPool,
+)
+from server.coding_worker.store import CodingWorkerStore
+from server.coding_worker.tool_broker import ToolBroker
+from server.coding_worker.workspace import WorkspaceBroker
+
+
+def _request(task_id: str, workspace_id: str) -> ProviderOpenRequest:
+    return ProviderOpenRequest(
+        task_id=task_id,
+        workspace_id=workspace_id,
+        objective="Fix and test the project",
+        model_route="coding/default",
+        policy_profile=PolicyProfile.DEVELOP,
+        budget=TaskBudget(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_provider_sidecar_pool_streams_neutral_events_and_revokes_broker_token(
+    tmp_path: Path,
+) -> None:
+    store = CodingWorkerStore(tmp_path / "control", master_key=Fernet.generate_key())
+    workspace = WorkspaceBroker(tmp_path / "workspace", {}, id_key=b"w" * 32)
+    broker_rpc = BrokerRPCServer(ToolBroker(store=store, workspace_broker=workspace))
+    await broker_rpc.start_tcp_for_tests()
+    server = ProviderRPCServer(FakeCodingAgentProvider(), token="s" * 48)
+    endpoint = await server.start_tcp_for_tests()
+    pool = ProviderSidecarClientPool(
+        endpoints={"slot-a": endpoint},
+        tokens={"slot-a": "s" * 48},
+        workspace_slot_resolver=lambda _workspace_id: "slot-a",
+        broker_rpc=broker_rpc,
+    )
+    # Broker tokens bind to persisted tasks, just as the production service does.
+    from server.tests.test_coding_worker_service import _request as task_request
+    from server.coding_worker.contracts import Origin, TaskSpec
+
+    task_id = store.create_task(
+        TaskSpec(**task_request("rpc-task").model_dump(), origin=Origin(module="test", object_id="rpc"))
+    ).task_id
+    session = await pool.open(_request(task_id, "workspace_fake"))
+    events = [event async for event in pool.message(session, "continue")]
+    assert [event.kind for event in events] == [
+        ProviderEventKind.PLAN,
+        ProviderEventKind.TURN_COMPLETED,
+    ]
+    checkpoint = await pool.checkpoint(session)
+    assert checkpoint.payload["fake_session"] == session.session_id
+    assert task_id in broker_rpc._tokens
+    await pool.close(session)
+    assert task_id not in broker_rpc._tokens
+    await server.close()
+    await broker_rpc.close()
+
+
+@pytest.mark.asyncio
+async def test_provider_sidecar_rejects_wrong_token_and_second_active_task(
+    tmp_path: Path,
+) -> None:
+    store = CodingWorkerStore(tmp_path / "control", master_key=Fernet.generate_key())
+    workspace = WorkspaceBroker(tmp_path / "workspace", {}, id_key=b"x" * 32)
+    broker_rpc = BrokerRPCServer(ToolBroker(store=store, workspace_broker=workspace))
+    await broker_rpc.start_tcp_for_tests()
+    server = ProviderRPCServer(FakeCodingAgentProvider(), token="a" * 48)
+    endpoint = await server.start_tcp_for_tests()
+    bad = ProviderSidecarClientPool(
+        endpoints={"slot-a": endpoint},
+        tokens={"slot-a": "b" * 48},
+        workspace_slot_resolver=lambda _workspace_id: "slot-a",
+        broker_rpc=broker_rpc,
+    )
+    with pytest.raises(ProviderRPCError) as unauthorized:
+        await bad.capabilities()
+    assert unauthorized.value.code == "provider_unauthorized"
+
+    from server.tests.test_coding_worker_service import _request as task_request
+    from server.coding_worker.contracts import Origin, TaskSpec
+
+    task_ids = [
+        store.create_task(
+            TaskSpec(
+                **task_request(f"rpc-busy-{index}").model_dump(),
+                origin=Origin(module="test", object_id=f"rpc-{index}"),
+            )
+        ).task_id
+        for index in range(2)
+    ]
+    pool = ProviderSidecarClientPool(
+        endpoints={"slot-a": endpoint},
+        tokens={"slot-a": "a" * 48},
+        workspace_slot_resolver=lambda _workspace_id: "slot-a",
+        broker_rpc=broker_rpc,
+    )
+    first = await pool.open(_request(task_ids[0], "workspace_one"))
+    with pytest.raises(ProviderRPCError) as busy:
+        await pool.open(_request(task_ids[1], "workspace_two"))
+    assert busy.value.code == "provider_slot_busy"
+    await pool.close(first)
+    await server.close()
+    await broker_rpc.close()

--- a/server/tests/test_coding_worker_provider_rpc.py
+++ b/server/tests/test_coding_worker_provider_rpc.py
@@ -173,3 +173,60 @@ async def test_credential_free_executor_requires_exact_task_workspace_binding(
     assert foreign.value.code == "executor_binding_invalid"
     await pool.close_task("task_one", "workspace_one")
     await server.close()
+
+
+@pytest.mark.asyncio
+async def test_provider_pool_binds_and_closes_separate_executor(tmp_path: Path) -> None:
+    store = CodingWorkerStore(tmp_path / "control", master_key=Fernet.generate_key())
+    workspace = WorkspaceBroker(tmp_path / "workspace", {}, id_key=b"z" * 32)
+    broker_rpc = BrokerRPCServer(ToolBroker(store=store, workspace_broker=workspace))
+    await broker_rpc.start_tcp_for_tests()
+    provider_server = ProviderRPCServer(FakeCodingAgentProvider(), token="p" * 48)
+    provider_endpoint = await provider_server.start_tcp_for_tests()
+    repository = tmp_path / "repo"
+    repository.mkdir()
+    executor_server = ExecutorRPCServer(
+        SidecarExecutor(lambda _workspace_id: repository, runtime_root=tmp_path / "run"),
+        token="x" * 48,
+    )
+    executor_endpoint = await executor_server.start_tcp_for_tests()
+    executor_pool = ExecutorSidecarClientPool(
+        endpoints={"slot-a": executor_endpoint},
+        tokens={"slot-a": "x" * 48},
+        workspace_slot_resolver=lambda _workspace_id: "slot-a",
+    )
+    pool = ProviderSidecarClientPool(
+        endpoints={"slot-a": provider_endpoint},
+        tokens={"slot-a": "p" * 48},
+        workspace_slot_resolver=lambda _workspace_id: "slot-a",
+        broker_rpc=broker_rpc,
+        executor_pool=executor_pool,
+    )
+    from server.tests.test_coding_worker_service import _request as task_request
+    from server.coding_worker.contracts import Origin, TaskSpec
+
+    task_id = store.create_task(
+        TaskSpec(**task_request("split-slot").model_dump(), origin=Origin(module="test", object_id="split"))
+    ).task_id
+    session = await pool.open(_request(task_id, "workspace_split"))
+    result = await pool.run_process(
+        task_id=task_id,
+        workspace_id="workspace_split",
+        argv=("python", "-c", "print('executor-only')"),
+        timeout_seconds=10,
+        isolated=False,
+    )
+    assert result["exit_code"] == 0
+    await pool.close(session)
+    with pytest.raises(ExecutorRPCError) as closed:
+        await executor_pool.run_process(
+            task_id=task_id,
+            workspace_id="workspace_split",
+            argv=("python", "-c", "print('no')"),
+            timeout_seconds=10,
+            isolated=False,
+        )
+    assert closed.value.code == "executor_binding_invalid"
+    await provider_server.close()
+    await executor_server.close()
+    await broker_rpc.close()

--- a/server/tests/test_coding_worker_runtime.py
+++ b/server/tests/test_coding_worker_runtime.py
@@ -16,6 +16,7 @@ from server.coding_worker.contracts import (
 from server.coding_worker.provider import FakeCodingAgentProvider
 from server.coding_worker.provider_rpc import ProviderRPCServer
 from server.coding_worker.runtime import CodingWorkerRuntime
+from server.coding_worker.tool_broker import FrozenCheck
 from server.coding_worker.workspace import InMemoryWorkspaceSourceAdapter
 
 
@@ -42,7 +43,11 @@ async def test_runtime_connects_two_dedicated_provider_slots(tmp_path: Path) -> 
                 {("source", "h0"): {"main.py": b"print('ok')\n"}}
             )
         },
-        frozen_checks={},
+        frozen_checks={
+            "syntax": FrozenCheck(
+                check_id="syntax", argv=("python", "-m", "py_compile", "main.py")
+            )
+        },
         provider_endpoints=endpoints,
         provider_tokens={"slot-a": "a" * 48, "slot-b": "b" * 48},
         broker_socket_path=None,

--- a/server/tests/test_coding_worker_runtime.py
+++ b/server/tests/test_coding_worker_runtime.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from server.coding_worker.contracts import (
+    AcceptanceCheck,
+    AcceptanceContract,
+    Origin,
+    TaskCreateRequest,
+    TaskState,
+    WorkspaceSource,
+)
+from server.coding_worker.provider import FakeCodingAgentProvider
+from server.coding_worker.provider_rpc import ProviderRPCServer
+from server.coding_worker.runtime import CodingWorkerRuntime
+from server.coding_worker.workspace import InMemoryWorkspaceSourceAdapter
+
+
+@pytest.mark.asyncio
+async def test_runtime_connects_two_dedicated_provider_slots(tmp_path: Path) -> None:
+    blockers = {slot: asyncio.Event() for slot in ("slot-a", "slot-b")}
+    servers = {
+        slot: ProviderRPCServer(
+            FakeCodingAgentProvider(block=blockers[slot]), token=token
+        )
+        for slot, token in {"slot-a": "a" * 48, "slot-b": "b" * 48}.items()
+    }
+    endpoints = {
+        slot: await server.start_tcp_for_tests() for slot, server in servers.items()
+    }
+    runtime = CodingWorkerRuntime(
+        storage_root=tmp_path / "control",
+        slot_roots={
+            "slot-a": tmp_path / "slot-a",
+            "slot-b": tmp_path / "slot-b",
+        },
+        source_adapters={
+            "manifest": InMemoryWorkspaceSourceAdapter(
+                {("source", "h0"): {"main.py": b"print('ok')\n"}}
+            )
+        },
+        frozen_checks={},
+        provider_endpoints=endpoints,
+        provider_tokens={"slot-a": "a" * 48, "slot-b": "b" * 48},
+        broker_socket_path=None,
+        sidecar_uid=-1,
+        sidecar_gid=-1,
+    )
+    await runtime.start()
+    source = WorkspaceSource(kind="manifest", source_id="source", revision="h0")
+    tasks = [
+        await runtime.service.create_task(
+            Origin(module="test", object_id=str(index)),
+            TaskCreateRequest(
+                client_task_id=f"runtime-{index}",
+                objective="inspect",
+                workspace_source=source,
+                acceptance=AcceptanceContract(
+                    contract_id="syntax",
+                    required_checks=(
+                        AcceptanceCheck(
+                            check_id="syntax", label="syntax", kind="command"
+                        ),
+                    ),
+                ),
+                model_route="coding/default",
+            ),
+        )
+        for index in range(2)
+    ]
+    for task in tasks:
+        running = await runtime.service.wait_for(
+            task.task_id, lambda item: item.state is TaskState.RUNNING
+        )
+        assert running.workspace_id is not None
+    assert {
+        runtime.workspace_broker.workspace_slot(
+            runtime.store.get_task(task.task_id).workspace_id or ""
+        )
+        for task in tasks
+    } == {"slot-a", "slot-b"}
+    for task in tasks:
+        await runtime.service.cancel(task.task_id)
+    await runtime.close()
+    for server in servers.values():
+        await server.close()

--- a/server/tests/test_coding_worker_sdk.py
+++ b/server/tests/test_coding_worker_sdk.py
@@ -1,0 +1,87 @@
+from pathlib import Path
+
+import pytest
+from cryptography.fernet import Fernet
+
+from server.coding_worker.contracts import (
+    AcceptanceCheck,
+    AcceptanceContract,
+    ContextReference,
+    TaskCreateRequest,
+    WorkspaceSource,
+)
+from server.coding_worker.provider import FakeCodingAgentProvider
+from server.coding_worker.sdk import CodingWorkerModuleClient, CodingWorkerSDKError
+from server.coding_worker.service import CodingWorkerService
+from server.coding_worker.store import CodingWorkerStore
+from server.coding_worker.workspace import WorkspaceBroker
+
+
+def _client(tmp_path: Path) -> CodingWorkerModuleClient:
+    store = CodingWorkerStore(tmp_path / "store", master_key=Fernet.generate_key())
+    service = CodingWorkerService(
+        store=store,
+        workspace_broker=WorkspaceBroker(tmp_path / "work", {}, id_key=b"m" * 32),
+        provider=FakeCodingAgentProvider(),
+    )
+    return CodingWorkerModuleClient(
+        module="skill-creator",
+        service=service,
+        source_kinds=frozenset({"manifest"}),
+        check_ids=frozenset({"python-tests"}),
+        model_routes=frozenset({"coding/default"}),
+        context_validators={"artifact": lambda value: value == "artifact_context"},
+    )
+
+
+def _request() -> TaskCreateRequest:
+    return TaskCreateRequest(
+        client_task_id="module-task-01",
+        objective="Implement the requested module change.",
+        workspace_source=WorkspaceSource(
+            kind="manifest", source_id="source_01", revision="revision_01"
+        ),
+        acceptance=AcceptanceContract(
+            contract_id="contract_01",
+            required_checks=(
+                AcceptanceCheck(
+                    check_id="python-tests", label="Python tests", kind="command"
+                ),
+            ),
+        ),
+        model_route="coding/default",
+        context_refs=(ContextReference(ref_id="artifact_context", kind="artifact"),),
+    )
+
+
+@pytest.mark.asyncio
+async def test_module_client_owns_origin_and_preserves_idempotency(tmp_path: Path) -> None:
+    client = _client(tmp_path)
+    first = await client.create_task(business_object_id="skill_01", request=_request())
+    same = await client.create_task(business_object_id="skill_01", request=_request())
+    assert same.task_id == first.task_id
+    assert first.spec.origin.module == "skill-creator"
+    assert first.spec.origin.object_id == "skill_01"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("field", "expected"),
+    (("source", "worker_source_not_registered"), ("check", "worker_acceptance_not_registered"), ("route", "worker_model_route_not_registered"), ("context", "worker_context_not_registered")),
+)
+async def test_module_client_rejects_unregistered_execution_inputs(
+    tmp_path: Path, field: str, expected: str
+) -> None:
+    client = _client(tmp_path)
+    request = _request()
+    if field == "source":
+        request = request.model_copy(update={"workspace_source": request.workspace_source.model_copy(update={"kind": "host_git"})})
+    elif field == "check":
+        request = request.model_copy(update={"acceptance": AcceptanceContract(contract_id="other", required_checks=(AcceptanceCheck(check_id="shell", label="shell", kind="command"),))})
+    elif field == "route":
+        request = request.model_copy(update={"model_route": "coding/other"})
+    else:
+        request = request.model_copy(update={"context_refs": (ContextReference(ref_id="artifact_other", kind="artifact"),)})
+    with pytest.raises(CodingWorkerSDKError) as raised:
+        await client.create_task(business_object_id="skill_01", request=request)
+    assert raised.value.code == expected

--- a/server/tests/test_coding_worker_service.py
+++ b/server/tests/test_coding_worker_service.py
@@ -281,6 +281,13 @@ async def test_failed_acceptance_is_repaired_and_retested_before_completion(
     assert "Check pytest failed" in provider.messages[1]
     statuses = [item.status.value for item in service.store.list_evidence(task.task_id)]
     assert statuses[-1] == "passed"
+    checkpoint = service.store.latest_checkpoint(task.task_id)
+    assert checkpoint is not None
+    summary = checkpoint.payload["context_summary"]
+    assert summary["objective"] == "Complete repair"
+    assert summary["required_checks"] == ["pytest"]
+    assert summary["next_step"] == "run_required_acceptance"
+    assert "private" not in checkpoint.payload["provider"]
     await service.shutdown()
 
 

--- a/server/tests/test_coding_worker_service.py
+++ b/server/tests/test_coding_worker_service.py
@@ -16,6 +16,7 @@ from server.coding_worker.contracts import (
     PolicyProfile,
     TaskBudget,
     TaskCreateRequest,
+    TaskSpec,
     TaskState,
     WorkspaceSource,
 )
@@ -23,6 +24,8 @@ from server.coding_worker.evidence import HarnessRunner
 from server.coding_worker.provider import (
     FakeCodingAgentProvider,
     ProviderEvent,
+    ProviderCheckpoint,
+    ProviderOpenRequest,
     ProviderSession,
 )
 from server.coding_worker.service import CodingWorkerService
@@ -73,6 +76,26 @@ class _RepairingProvider(FakeCodingAgentProvider):
             await self.repair()
         async for event in super().message(session, text):
             yield event
+
+
+class _RestoreTrackingProvider(FakeCodingAgentProvider):
+    def __init__(self) -> None:
+        super().__init__()
+        self.restore_count = 0
+        self.message_count = 0
+
+    async def message(
+        self, session: ProviderSession, text: str
+    ) -> AsyncIterator[ProviderEvent]:
+        self.message_count += 1
+        async for event in super().message(session, text):
+            yield event
+
+    async def restore(
+        self, request: ProviderOpenRequest, checkpoint: ProviderCheckpoint
+    ) -> ProviderSession:
+        self.restore_count += 1
+        return await super().restore(request, checkpoint)
 
 
 def _service_with_harness(
@@ -223,4 +246,95 @@ async def test_required_check_failure_exhausts_turn_budget_without_completion(
     assert limited.reason == "turn_budget_exhausted"
     assert limited.state is not TaskState.COMPLETED
     assert len(service.store.list_evidence(task.task_id)) == 2
+    await service.shutdown()
+
+
+async def _checkpointed_task(
+    service: CodingWorkerService,
+    broker: ToolBroker,
+    *,
+    mutate_after_checkpoint: bool,
+) -> str:
+    request = _request("restore").model_copy(
+        update={"policy_profile": PolicyProfile.DEVELOP}
+    )
+    prepared = await service.workspace_broker.prepare(request.workspace_source)
+    task = service.store.create_task(
+        TaskSpec(**request.model_dump(), origin=Origin(module="test", object_id="restore"))
+    )
+    service.store.transition(task.task_id, TaskState.PREPARING)
+    service.store.transition(
+        task.task_id, TaskState.RUNNING, workspace_id=prepared.workspace_id
+    )
+    content = "print('checkpoint')\n"
+    await broker.execute(
+        task_id=task.task_id,
+        operation_id="checkpoint-write",
+        tool_name="write_file",
+        arguments={
+            "path": "main.py",
+            "content": content,
+            "content_sha256": hashlib.sha256(content.encode()).hexdigest(),
+        },
+    )
+    tree_hash = service.workspace_broker.current_tree_hash(prepared.workspace_id)
+    provider_checkpoint = ProviderCheckpoint(
+        checkpoint_id="checkpoint_provider",
+        payload={"private_context": "resume-only"},
+    )
+    service.store.create_checkpoint(
+        task_id=task.task_id,
+        workspace_tree_hash=tree_hash,
+        payload={
+            "phase": "testing",
+            "completed_turns": 1,
+            "provider": provider_checkpoint.model_dump(mode="json"),
+        },
+    )
+    if mutate_after_checkpoint:
+        changed = "print('changed after checkpoint')\n"
+        await broker.execute(
+            task_id=task.task_id,
+            operation_id="post-checkpoint-write",
+            tool_name="write_file",
+            arguments={
+                "path": "main.py",
+                "content": changed,
+                "content_sha256": hashlib.sha256(changed.encode()).hexdigest(),
+            },
+        )
+    service.store.transition(task.task_id, TaskState.INTERRUPTED)
+    return task.task_id
+
+
+@pytest.mark.asyncio
+async def test_explicit_resume_restores_exact_checkpoint_and_runs_acceptance_first(
+    tmp_path: Path,
+) -> None:
+    provider = _RestoreTrackingProvider()
+    service, broker = _service_with_harness(tmp_path, provider)
+    task_id = await _checkpointed_task(
+        service, broker, mutate_after_checkpoint=False
+    )
+    await service.resume(task_id)
+    completed = await service.wait_for(
+        task_id, lambda item: item.state is TaskState.COMPLETED
+    )
+    assert completed.reason is None
+    assert provider.restore_count == 1
+    assert provider.message_count == 0
+    await service.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_resume_rejects_workspace_changed_after_checkpoint(tmp_path: Path) -> None:
+    provider = _RestoreTrackingProvider()
+    service, broker = _service_with_harness(tmp_path, provider)
+    task_id = await _checkpointed_task(service, broker, mutate_after_checkpoint=True)
+    await service.resume(task_id)
+    blocked = await service.wait_for(
+        task_id, lambda item: item.state is TaskState.BLOCKED
+    )
+    assert blocked.reason == "checkpoint_workspace_changed"
+    assert provider.restore_count == 0
     await service.shutdown()

--- a/server/tests/test_coding_worker_service.py
+++ b/server/tests/test_coding_worker_service.py
@@ -193,6 +193,62 @@ async def test_shutdown_interrupts_without_replaying_and_resume_is_explicit(tmp_
 
 
 @pytest.mark.asyncio
+async def test_dedicated_slots_queue_third_task_and_resume_on_original_slot(
+    tmp_path: Path,
+) -> None:
+    blocker = asyncio.Event()
+    provider = FakeCodingAgentProvider(block=blocker)
+    store = CodingWorkerStore(tmp_path / "control", master_key=Fernet.generate_key())
+    broker = WorkspaceBroker(
+        tmp_path / "control",
+        {
+            "manifest": InMemoryWorkspaceSourceAdapter(
+                {("source-01", "revision-01"): {"main.py": b"print('ok')\n"}}
+            )
+        },
+        id_key=b"z" * 32,
+        slot_roots={
+            "slot-a": tmp_path / "slot-a",
+            "slot-b": tmp_path / "slot-b",
+        },
+    )
+    service = CodingWorkerService(
+        store=store,
+        workspace_broker=broker,
+        provider=provider,
+        max_active_tasks=2,
+    )
+    origin = Origin(module="test", object_id="dedicated-slots")
+    tasks = [
+        await service.create_task(origin, _request(f"slot-task-{index}"))
+        for index in range(3)
+    ]
+
+    for task in tasks[:2]:
+        await service.wait_for(task.task_id, lambda item: item.state is TaskState.RUNNING)
+    first_workspace = service.store.get_task(tasks[0].task_id).workspace_id
+    second_workspace = service.store.get_task(tasks[1].task_id).workspace_id
+    assert first_workspace is not None and second_workspace is not None
+    assert {
+        broker.workspace_slot(first_workspace),
+        broker.workspace_slot(second_workspace),
+    } == {"slot-a", "slot-b"}
+    original_slot = broker.workspace_slot(first_workspace)
+    assert service.store.get_task(tasks[2].task_id).state is TaskState.QUEUED
+
+    await service.pause(tasks[0].task_id)
+    await service.wait_for(tasks[2].task_id, lambda item: item.state is TaskState.RUNNING)
+    await service.pause(tasks[2].task_id)
+    await service.resume(tasks[0].task_id)
+    await service.wait_for(tasks[0].task_id, lambda item: item.state is TaskState.RUNNING)
+    assert broker.workspace_slot(first_workspace) == original_slot
+
+    await service.cancel(tasks[0].task_id)
+    await service.cancel(tasks[1].task_id)
+    await service.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_failed_acceptance_is_repaired_and_retested_before_completion(
     tmp_path: Path,
 ) -> None:

--- a/server/tests/test_coding_worker_service.py
+++ b/server/tests/test_coding_worker_service.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import sys
+from collections.abc import AsyncIterator, Awaitable, Callable
 from pathlib import Path
 
 import pytest
@@ -10,13 +13,21 @@ from server.coding_worker.contracts import (
     AcceptanceCheck,
     AcceptanceContract,
     Origin,
+    PolicyProfile,
+    TaskBudget,
     TaskCreateRequest,
     TaskState,
     WorkspaceSource,
 )
-from server.coding_worker.provider import FakeCodingAgentProvider
+from server.coding_worker.evidence import HarnessRunner
+from server.coding_worker.provider import (
+    FakeCodingAgentProvider,
+    ProviderEvent,
+    ProviderSession,
+)
 from server.coding_worker.service import CodingWorkerService
 from server.coding_worker.store import CodingWorkerStore
+from server.coding_worker.tool_broker import FrozenCheck, ToolBroker
 from server.coding_worker.workspace import InMemoryWorkspaceSourceAdapter, WorkspaceBroker
 
 
@@ -46,6 +57,59 @@ def _service(tmp_path: Path, provider: FakeCodingAgentProvider) -> CodingWorkerS
         tmp_path / "worker", {"manifest": adapter}, id_key=b"s" * 32
     )
     return CodingWorkerService(store=store, workspace_broker=broker, provider=provider)
+
+
+class _RepairingProvider(FakeCodingAgentProvider):
+    def __init__(self) -> None:
+        super().__init__()
+        self.messages: list[str] = []
+        self.repair: Callable[[], Awaitable[None]] | None = None
+
+    async def message(
+        self, session: ProviderSession, text: str
+    ) -> AsyncIterator[ProviderEvent]:
+        self.messages.append(text)
+        if len(self.messages) == 2 and self.repair is not None:
+            await self.repair()
+        async for event in super().message(session, text):
+            yield event
+
+
+def _service_with_harness(
+    tmp_path: Path, provider: FakeCodingAgentProvider
+) -> tuple[CodingWorkerService, ToolBroker]:
+    store = CodingWorkerStore(tmp_path / "worker", master_key=Fernet.generate_key())
+    workspace = WorkspaceBroker(
+        tmp_path / "worker",
+        {
+            "manifest": InMemoryWorkspaceSourceAdapter(
+                {("source-01", "revision-01"): {"main.py": b"bad python\n"}}
+            )
+        },
+        id_key=b"h" * 32,
+    )
+    broker = ToolBroker(
+        store=store,
+        workspace_broker=workspace,
+        frozen_checks={
+            "pytest": FrozenCheck(
+                check_id="pytest",
+                argv=(sys.executable, "-m", "py_compile", "main.py"),
+            )
+        },
+    )
+    harness = HarnessRunner(
+        store=store, workspace_broker=workspace, tool_broker=broker
+    )
+    return (
+        CodingWorkerService(
+            store=store,
+            workspace_broker=workspace,
+            provider=provider,
+            harness_runner=harness,
+        ),
+        broker,
+    )
 
 
 @pytest.mark.asyncio
@@ -102,4 +166,61 @@ async def test_shutdown_interrupts_without_replaying_and_resume_is_explicit(tmp_
     await service.wait_for(task.task_id, lambda item: item.state is TaskState.RUNNING)
     assert service.store.get_task(task.task_id).workspace_id == workspace_id
     await service.cancel(task.task_id)
+    await service.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_failed_acceptance_is_repaired_and_retested_before_completion(
+    tmp_path: Path,
+) -> None:
+    provider = _RepairingProvider()
+    service, broker = _service_with_harness(tmp_path, provider)
+    request = _request("repair").model_copy(
+        update={"policy_profile": PolicyProfile.DEVELOP}
+    )
+    task = await service.create_task(Origin(module="test", object_id="repair"), request)
+
+    async def repair() -> None:
+        content = "print('fixed')\n"
+        await broker.execute(
+            task_id=task.task_id,
+            operation_id="repair-main",
+            tool_name="write_file",
+            arguments={
+                "path": "main.py",
+                "content": content,
+                "content_sha256": hashlib.sha256(content.encode()).hexdigest(),
+            },
+        )
+
+    provider.repair = repair
+    completed = await service.wait_for(
+        task.task_id, lambda item: item.state is TaskState.COMPLETED
+    )
+    assert completed.reason is None
+    assert len(provider.messages) == 2
+    assert "Check pytest failed" in provider.messages[1]
+    statuses = [item.status.value for item in service.store.list_evidence(task.task_id)]
+    assert statuses[-1] == "passed"
+    await service.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_required_check_failure_exhausts_turn_budget_without_completion(
+    tmp_path: Path,
+) -> None:
+    service, _ = _service_with_harness(tmp_path, FakeCodingAgentProvider())
+    request = _request("budget").model_copy(
+        update={
+            "policy_profile": PolicyProfile.DEVELOP,
+            "budget": TaskBudget(max_turns=2),
+        }
+    )
+    task = await service.create_task(Origin(module="test", object_id="budget"), request)
+    limited = await service.wait_for(
+        task.task_id, lambda item: item.state is TaskState.BUDGET_LIMITED
+    )
+    assert limited.reason == "turn_budget_exhausted"
+    assert limited.state is not TaskState.COMPLETED
+    assert len(service.store.list_evidence(task.task_id)) == 2
     await service.shutdown()

--- a/server/tests/test_coding_worker_service.py
+++ b/server/tests/test_coding_worker_service.py
@@ -29,7 +29,7 @@ from server.coding_worker.provider import (
     ProviderSession,
 )
 from server.coding_worker.service import CodingWorkerService
-from server.coding_worker.store import CodingWorkerStore
+from server.coding_worker.store import CodingWorkerStore, WorkerConflictError
 from server.coding_worker.tool_broker import FrozenCheck, ToolBroker
 from server.coding_worker.workspace import InMemoryWorkspaceSourceAdapter, WorkspaceBroker
 
@@ -130,9 +130,42 @@ def _service_with_harness(
             workspace_broker=workspace,
             provider=provider,
             harness_runner=harness,
+            tool_broker=broker,
         ),
         broker,
     )
+
+
+@pytest.mark.asyncio
+async def test_unregistered_command_check_is_rejected_before_queue(
+    tmp_path: Path,
+) -> None:
+    service, _broker = _service_with_harness(
+        tmp_path, FakeCodingAgentProvider()
+    )
+    request = _request("unknown-check").model_copy(
+        update={
+            "acceptance": AcceptanceContract(
+                contract_id="unknown-contract",
+                required_checks=(
+                    AcceptanceCheck(
+                        check_id="caller-shell",
+                        label="Caller shell",
+                        kind="command",
+                    ),
+                ),
+            )
+        }
+    )
+
+    with pytest.raises(WorkerConflictError) as caught:
+        await service.create_task(
+            Origin(module="test", object_id="unknown-check"), request
+        )
+
+    assert caught.value.code == "worker_acceptance_not_registered"
+    assert service.store.list_tasks() == []
+    await service.shutdown()
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_coding_worker_source_adapters.py
+++ b/server/tests/test_coding_worker_source_adapters.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import hashlib
 from pathlib import Path
+import subprocess
 
 import pytest
 
 from server.coding_worker.contracts import WorkspaceSource
 from server.coding_worker.source_adapters import (
+    BuiltinGitWorkspaceSourceAdapter,
     ProjectSnapshotWorkspaceSourceAdapter,
 )
 from server.coding_worker.workspace import WorkspaceError
@@ -131,3 +133,57 @@ async def test_project_snapshot_adapter_fails_closed_when_release_is_uncertain(
         ).acquire(source)
 
     assert caught.value.code == "source_release_failed"
+
+
+def _git(root: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=root,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    ).stdout.strip()
+
+
+@pytest.mark.asyncio
+async def test_builtin_adapter_reads_only_tracked_blobs_from_exact_revision(
+    tmp_path: Path,
+) -> None:
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.name", "ModelMirror Test")
+    _git(tmp_path, "config", "user.email", "test@modelmirror.local")
+    (tmp_path / "app.py").write_text("print('tracked')\n", encoding="utf-8")
+    _git(tmp_path, "add", "app.py")
+    _git(tmp_path, "commit", "-m", "baseline")
+    revision = _git(tmp_path, "rev-parse", "HEAD")
+    (tmp_path / "secret.env").write_text("TOKEN=do-not-copy\n", encoding="utf-8")
+    source = WorkspaceSource(
+        kind="builtin", source_id="modelmirror", revision=revision
+    )
+
+    snapshot = await BuiltinGitWorkspaceSourceAdapter(
+        tmp_path, source_id="modelmirror", revision=revision
+    ).acquire(source)
+
+    assert [(item.path, item.content) for item in snapshot.files] == [
+        ("app.py", b"print('tracked')\n")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_builtin_adapter_rejects_unregistered_revision_before_reading(
+    tmp_path: Path,
+) -> None:
+    _git(tmp_path, "init")
+    source = WorkspaceSource(
+        kind="builtin", source_id="modelmirror", revision="b" * 40
+    )
+    adapter = BuiltinGitWorkspaceSourceAdapter(
+        tmp_path, source_id="modelmirror", revision="a" * 40
+    )
+
+    with pytest.raises(WorkspaceError) as caught:
+        await adapter.acquire(source)
+
+    assert caught.value.code == "source_not_found"

--- a/server/tests/test_coding_worker_source_adapters.py
+++ b/server/tests/test_coding_worker_source_adapters.py
@@ -127,7 +127,7 @@ async def test_host_snapshot_adapter_requests_imports_and_releases_exact_transfe
     files = {"README.md": b"hello\n", "src/app.py": b"print('ok')\n"}
     lease = _lease("host_git", files)
     project = {
-        "id": lease["project_id"],
+        "project_id": lease["project_id"],
         "name": "中文 Host Project",
         "branch": "feature/v14",
         "head": lease["head"],
@@ -221,7 +221,7 @@ async def test_project_snapshot_adapter_rejects_changed_fingerprint_and_releases
     )
 
     project = {
-        "id": lease["project_id"],
+        "project_id": lease["project_id"],
         "name": "Host Project",
         "branch": "feature/v14",
         "head": lease["head"],

--- a/server/tests/test_coding_worker_source_adapters.py
+++ b/server/tests/test_coding_worker_source_adapters.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from server.coding_worker.contracts import WorkspaceSource
+from server.coding_worker.source_adapters import (
+    ProjectSnapshotWorkspaceSourceAdapter,
+)
+from server.coding_worker.workspace import WorkspaceError
+
+
+class FakeProjectSource:
+    def __init__(self, lease: dict[str, object]) -> None:
+        self.lease = lease
+        self.acquired: list[tuple[str, str | None]] = []
+        self.released: list[tuple[str, str]] = []
+        self.release_result = True
+
+    async def acquire(
+        self, project_id: str, *, expected_head: str | None = None
+    ) -> dict[str, object]:
+        self.acquired.append((project_id, expected_head))
+        return dict(self.lease)
+
+    async def release(self, project_id: str, lease_id: str) -> bool:
+        self.released.append((project_id, lease_id))
+        return self.release_result
+
+
+def _fingerprint(files: dict[str, bytes]) -> str:
+    digest = hashlib.sha256()
+    for path, content in sorted(files.items()):
+        digest.update(path.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(str(len(content)).encode("ascii"))
+        digest.update(b"\0")
+        digest.update(hashlib.sha256(content).digest())
+    return digest.hexdigest()
+
+
+def _source_root(tmp_path: Path, files: dict[str, bytes]) -> Path:
+    workspace = tmp_path / "current" / "workspace"
+    workspace.mkdir(parents=True)
+    for relative, content in files.items():
+        target = workspace / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(content)
+    return tmp_path
+
+
+def _lease(kind: str, files: dict[str, bytes]) -> dict[str, object]:
+    return {
+        "kind": kind,
+        "lease_id": "lease_1",
+        "project_id": "hostgit_" + "1" * 32 if kind == "host_git" else "local-" + "1" * 24,
+        "head": "a" * 40,
+        "file_count": len(files),
+        "total_bytes": sum(map(len, files.values())),
+        "fingerprint": _fingerprint(files),
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("source_kind", "lease_kind"),
+    (("manifest", "local_clone"), ("host_snapshot", "host_git")),
+)
+async def test_project_snapshot_adapter_copies_exact_lease_and_releases(
+    tmp_path: Path, source_kind: str, lease_kind: str
+) -> None:
+    files = {"README.md": b"hello\n", "src/app.py": b"print('ok')\n"}
+    lease = _lease(lease_kind, files)
+    client = FakeProjectSource(lease)
+    source = WorkspaceSource(
+        kind=source_kind,
+        source_id=str(lease["project_id"]),
+        revision=str(lease["head"]),
+    )
+
+    snapshot = await ProjectSnapshotWorkspaceSourceAdapter(
+        client, _source_root(tmp_path, files)
+    ).acquire(source)
+
+    assert [(item.path, item.content) for item in snapshot.files] == sorted(files.items())
+    assert client.acquired == [(source.source_id, source.revision)]
+    assert client.released == [(source.source_id, "lease_1")]
+
+
+@pytest.mark.asyncio
+async def test_project_snapshot_adapter_rejects_changed_fingerprint_and_releases(
+    tmp_path: Path,
+) -> None:
+    files = {"README.md": b"changed\n"}
+    lease = _lease("host_git", {"README.md": b"original\n"})
+    client = FakeProjectSource(lease)
+    source = WorkspaceSource(
+        kind="host_snapshot",
+        source_id=str(lease["project_id"]),
+        revision=str(lease["head"]),
+    )
+
+    with pytest.raises(WorkspaceError, match="does not match") as caught:
+        await ProjectSnapshotWorkspaceSourceAdapter(
+            client, _source_root(tmp_path, files)
+        ).acquire(source)
+
+    assert caught.value.code == "source_revision_changed"
+    assert client.released == [(source.source_id, "lease_1")]
+
+
+@pytest.mark.asyncio
+async def test_project_snapshot_adapter_fails_closed_when_release_is_uncertain(
+    tmp_path: Path,
+) -> None:
+    files = {"README.md": b"hello\n"}
+    lease = _lease("local_clone", files)
+    client = FakeProjectSource(lease)
+    client.release_result = False
+    source = WorkspaceSource(
+        kind="manifest",
+        source_id=str(lease["project_id"]),
+        revision=str(lease["head"]),
+    )
+
+    with pytest.raises(WorkspaceError, match="released") as caught:
+        await ProjectSnapshotWorkspaceSourceAdapter(
+            client, _source_root(tmp_path, files)
+        ).acquire(source)
+
+    assert caught.value.code == "source_release_failed"

--- a/server/tests/test_coding_worker_source_adapters.py
+++ b/server/tests/test_coding_worker_source_adapters.py
@@ -199,6 +199,12 @@ def test_runtime_wires_host_snapshot_to_live_project_host(
         runtime.workspace_broker._adapters["manifest"],
         ProjectSnapshotWorkspaceSourceAdapter,
     )
+    assert set(runtime.tool_broker.frozen_checks) >= {
+        "python-compile",
+        "python-pytest",
+        "react-test",
+        "react-build",
+    }
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_coding_worker_source_adapters.py
+++ b/server/tests/test_coding_worker_source_adapters.py
@@ -3,15 +3,18 @@ from __future__ import annotations
 import hashlib
 from pathlib import Path
 import subprocess
+from types import SimpleNamespace
 
 import pytest
 
 from server.coding_worker.contracts import WorkspaceSource
 from server.coding_worker.source_adapters import (
     BuiltinGitWorkspaceSourceAdapter,
+    HostSnapshotWorkspaceSourceAdapter,
     ProjectSnapshotWorkspaceSourceAdapter,
 )
 from server.coding_worker.workspace import WorkspaceError
+from server.coding_worker.runtime import build_runtime_from_environment
 
 
 class FakeProjectSource:
@@ -20,6 +23,7 @@ class FakeProjectSource:
         self.acquired: list[tuple[str, str | None]] = []
         self.released: list[tuple[str, str]] = []
         self.release_result = True
+        self.imports: list[dict[str, str]] = []
 
     async def acquire(
         self, project_id: str, *, expected_head: str | None = None
@@ -30,6 +34,35 @@ class FakeProjectSource:
     async def release(self, project_id: str, lease_id: str) -> bool:
         self.released.append((project_id, lease_id))
         return self.release_result
+
+    async def import_uploaded(self, **payload: str) -> dict[str, object]:
+        self.imports.append(payload)
+        return dict(self.lease)
+
+
+class FakeProjectHost:
+    def __init__(self, project: dict[str, object]) -> None:
+        self.project = project
+        self.requests: list[tuple[str, str | None]] = []
+        self.finished: list[str] = []
+
+    async def request_snapshot(
+        self,
+        project_id: str,
+        *,
+        expected_head: str | None = None,
+        expected_branch: str | None = None,
+        managed_operation_id: str | None = None,
+    ) -> dict[str, object]:
+        self.requests.append((project_id, expected_head))
+        return {
+            "upload_id": "1" * 32,
+            "archive_sha256": "2" * 64,
+            "project": dict(self.project),
+        }
+
+    def finish_transfer(self, transfer_id: str) -> None:
+        self.finished.append(transfer_id)
 
 
 def _fingerprint(files: dict[str, bytes]) -> str:
@@ -66,18 +99,14 @@ def _lease(kind: str, files: dict[str, bytes]) -> dict[str, object]:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("source_kind", "lease_kind"),
-    (("manifest", "local_clone"), ("host_snapshot", "host_git")),
-)
 async def test_project_snapshot_adapter_copies_exact_lease_and_releases(
-    tmp_path: Path, source_kind: str, lease_kind: str
+    tmp_path: Path,
 ) -> None:
     files = {"README.md": b"hello\n", "src/app.py": b"print('ok')\n"}
-    lease = _lease(lease_kind, files)
+    lease = _lease("local_clone", files)
     client = FakeProjectSource(lease)
     source = WorkspaceSource(
-        kind=source_kind,
+        kind="manifest",
         source_id=str(lease["project_id"]),
         revision=str(lease["head"]),
     )
@@ -89,6 +118,87 @@ async def test_project_snapshot_adapter_copies_exact_lease_and_releases(
     assert [(item.path, item.content) for item in snapshot.files] == sorted(files.items())
     assert client.acquired == [(source.source_id, source.revision)]
     assert client.released == [(source.source_id, "lease_1")]
+
+
+@pytest.mark.asyncio
+async def test_host_snapshot_adapter_requests_imports_and_releases_exact_transfer(
+    tmp_path: Path,
+) -> None:
+    files = {"README.md": b"hello\n", "src/app.py": b"print('ok')\n"}
+    lease = _lease("host_git", files)
+    project = {
+        "id": lease["project_id"],
+        "name": "中文 Host Project",
+        "branch": "feature/v14",
+        "head": lease["head"],
+    }
+    client = FakeProjectSource(lease)
+    host = FakeProjectHost(project)
+    source = WorkspaceSource(
+        kind="host_snapshot",
+        source_id=str(lease["project_id"]),
+        revision=str(lease["head"]),
+    )
+
+    snapshot = await HostSnapshotWorkspaceSourceAdapter(
+        host, client, _source_root(tmp_path, files)
+    ).acquire(source)
+
+    assert [(item.path, item.content) for item in snapshot.files] == sorted(files.items())
+    assert host.requests == [(source.source_id, source.revision)]
+    assert client.acquired == []
+    assert client.imports == [
+        {
+            "upload_id": "1" * 32,
+            "archive_sha256": "2" * 64,
+            "project_id": source.source_id,
+            "name": "中文 Host Project",
+            "branch": "feature/v14",
+            "head": source.revision,
+        }
+    ]
+    assert client.released == [(source.source_id, "lease_1")]
+    assert host.finished == ["1" * 32]
+
+
+def test_runtime_wires_host_snapshot_to_live_project_host(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    host = FakeProjectHost({})
+    import server.coding_runtime.api as coding_api
+
+    monkeypatch.setattr(
+        coding_api,
+        "get_coding_service",
+        lambda: SimpleNamespace(project_host=host),
+    )
+    environment = {
+        "CODING_WORKER_STATE_ROOT": str(tmp_path / "state"),
+        "CODING_WORKER_SLOT_A_ROOT": str(tmp_path / "slot-a"),
+        "CODING_WORKER_SLOT_B_ROOT": str(tmp_path / "slot-b"),
+        "CODING_WORKER_SLOT_A_TOKEN": "a" * 32,
+        "CODING_WORKER_SLOT_B_TOKEN": "b" * 32,
+        "CODING_WORKER_EXECUTOR_A_TOKEN": "c" * 32,
+        "CODING_WORKER_EXECUTOR_B_TOKEN": "d" * 32,
+        "CODING_PROJECT_SOURCE_SOCKET_PATH": str(tmp_path / "source.sock"),
+        "CODING_WORKER_PROJECT_SNAPSHOT_ROOT": str(tmp_path / "snapshots"),
+        "CODING_WORKER_BROKER_SOCKET": str(tmp_path / "broker.sock"),
+    }
+    for key, value in environment.items():
+        monkeypatch.setenv(key, value)
+    monkeypatch.delenv("CODING_WORKER_BUILTIN_SOURCE_ROOT", raising=False)
+    monkeypatch.delenv("CODING_WORKER_BUILTIN_REVISION", raising=False)
+
+    runtime = build_runtime_from_environment()
+
+    assert isinstance(
+        runtime.workspace_broker._adapters["host_snapshot"],
+        HostSnapshotWorkspaceSourceAdapter,
+    )
+    assert isinstance(
+        runtime.workspace_broker._adapters["manifest"],
+        ProjectSnapshotWorkspaceSourceAdapter,
+    )
 
 
 @pytest.mark.asyncio
@@ -104,13 +214,21 @@ async def test_project_snapshot_adapter_rejects_changed_fingerprint_and_releases
         revision=str(lease["head"]),
     )
 
+    project = {
+        "id": lease["project_id"],
+        "name": "Host Project",
+        "branch": "feature/v14",
+        "head": lease["head"],
+    }
+    host = FakeProjectHost(project)
     with pytest.raises(WorkspaceError, match="does not match") as caught:
-        await ProjectSnapshotWorkspaceSourceAdapter(
-            client, _source_root(tmp_path, files)
+        await HostSnapshotWorkspaceSourceAdapter(
+            host, client, _source_root(tmp_path, files)
         ).acquire(source)
 
     assert caught.value.code == "source_revision_changed"
     assert client.released == [(source.source_id, "lease_1")]
+    assert host.finished == ["1" * 32]
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_coding_worker_store.py
+++ b/server/tests/test_coding_worker_store.py
@@ -107,6 +107,28 @@ def test_pin_retention_cleanup_and_immediate_delete(tmp_path: Path) -> None:
     assert store.delete_task(pinned.task_id) is True
 
 
+def test_checkpoint_is_encrypted_tree_bound_and_survives_restart(tmp_path: Path) -> None:
+    key = Fernet.generate_key()
+    root = tmp_path / "worker"
+    store = CodingWorkerStore(root, master_key=key)
+    task = store.create_task(_spec(client_task_id="checkpoint"))
+    checkpoint = store.create_checkpoint(
+        task_id=task.task_id,
+        workspace_tree_hash="a" * 64,
+        payload={
+            "phase": "testing",
+            "provider": {"checkpoint_id": "private-provider-session"},
+        },
+    )
+    assert b"private-provider-session" not in store.database_path.read_bytes()
+
+    restarted = CodingWorkerStore(root, master_key=key)
+    loaded = restarted.latest_checkpoint(task.task_id)
+    assert loaded == checkpoint
+    assert loaded is not None and loaded.workspace_tree_hash == "a" * 64
+    assert loaded.payload["phase"] == "testing"
+
+
 def test_existing_database_without_key_fails_closed(tmp_path: Path) -> None:
     root = tmp_path / "worker"
     store = CodingWorkerStore(root, master_key=Fernet.generate_key())

--- a/server/tests/test_coding_worker_tool_broker.py
+++ b/server/tests/test_coding_worker_tool_broker.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import sys
+from unittest.mock import AsyncMock
 from pathlib import Path
 
 import pytest
@@ -19,6 +20,7 @@ from server.coding_worker.contracts import (
 )
 from server.coding_worker.store import CodingWorkerStore
 from server.coding_worker.process_manager import BackgroundProcessManager
+from server.coding_worker.network_policy import EgressPolicy
 from server.coding_worker.tool_broker import FrozenCheck, ToolBroker, ToolBrokerError
 from server.coding_worker.workspace import InMemoryWorkspaceSourceAdapter, WorkspaceBroker
 
@@ -330,3 +332,65 @@ async def test_background_service_requires_exact_lease_and_remains_task_owned(
     )
     assert stopped.data["reason"] == "user_interrupted"
     await manager.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_dependency_install_requires_both_exact_leases_and_records_source(
+    tmp_path: Path,
+) -> None:
+    broker, store, task_id, _ = await _broker(
+        tmp_path, profile=PolicyProfile.DEVELOP_NETWORKED
+    )
+    broker.egress_policy = EgressPolicy(
+        enabled=True, allowed_domains={"registry.npmjs.org"}
+    )
+    broker.egress_proxy_url = "http://worker-egress:8080"
+    broker._run_process = AsyncMock(
+        return_value={"argv": ["npm", "ci"], "exit_code": 0, "output": "installed"}
+    )
+    arguments = {"manager": "npm", "action": "ci"}
+    with pytest.raises(ToolBrokerError) as approval_required:
+        await broker.execute(
+            task_id=task_id,
+            operation_id="dependency-install",
+            tool_name="install_dependencies",
+            arguments=arguments,
+        )
+    assert approval_required.value.code == "approval_required"
+    approvals = store.list_approvals(task_id)
+    assert {item.capability for item in approvals} == {"dependency_install", "network"}
+    decided = {
+        item.capability: store.decide_approval(item.approval_id, approved=True).lease
+        for item in approvals
+    }
+    store.transition(task_id, TaskState.RUNNING)
+    result = await broker.execute(
+        task_id=task_id,
+        operation_id="dependency-install",
+        tool_name="install_dependencies",
+        arguments=arguments,
+        lease_id=decided["dependency_install"].lease_id,
+        network_lease_id=decided["network"].lease_id,
+    )
+    assert result.data["exit_code"] == 0
+    source = store.read_artifact(result.data["source_artifact_id"], task_id=task_id)
+    assert b"registry.npmjs.org" in source and b"worker-egress" not in source
+    call = broker._run_process.await_args
+    assert call.kwargs["environment_overrides"]["HTTPS_PROXY"] == "http://worker-egress:8080"
+
+
+@pytest.mark.asyncio
+async def test_dependency_install_is_disabled_without_global_egress_policy(
+    tmp_path: Path,
+) -> None:
+    broker, _, task_id, _ = await _broker(
+        tmp_path, profile=PolicyProfile.DEVELOP_NETWORKED
+    )
+    with pytest.raises(ToolBrokerError) as disabled:
+        await broker.execute(
+            task_id=task_id,
+            operation_id="dependency-disabled",
+            tool_name="install_dependencies",
+            arguments={"manager": "npm", "action": "ci"},
+        )
+    assert disabled.value.code == "network_disabled"

--- a/server/tests/test_coding_worker_tool_broker.py
+++ b/server/tests/test_coding_worker_tool_broker.py
@@ -426,7 +426,9 @@ async def test_dependency_install_requires_both_exact_leases_and_records_source(
         tmp_path, profile=PolicyProfile.DEVELOP_NETWORKED
     )
     broker.egress_policy = EgressPolicy(
-        enabled=True, allowed_domains={"registry.npmjs.org"}
+        enabled=True,
+        allowed_domains={"registry.npmjs.org"},
+        grant_key=b"g" * 32,
     )
     broker.egress_proxy_url = "http://worker-egress:8080"
     broker._run_process = AsyncMock(
@@ -460,7 +462,8 @@ async def test_dependency_install_requires_both_exact_leases_and_records_source(
     source = store.read_artifact(result.data["source_artifact_id"], task_id=task_id)
     assert b"registry.npmjs.org" in source and b"worker-egress" not in source
     call = broker._run_process.await_args
-    assert call.kwargs["environment_overrides"]["HTTPS_PROXY"] == "http://worker-egress:8080"
+    proxy = call.kwargs["environment_overrides"]["HTTPS_PROXY"]
+    assert proxy.startswith("http://grant:") and proxy.endswith("@worker-egress:8080")
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_coding_worker_tool_broker.py
+++ b/server/tests/test_coding_worker_tool_broker.py
@@ -214,6 +214,30 @@ async def test_unknown_write_reconciles_but_command_never_replays(tmp_path: Path
 
 
 @pytest.mark.asyncio
+async def test_command_is_killed_while_output_limit_is_crossed(tmp_path: Path) -> None:
+    broker, store, task_id, _ = await _broker(tmp_path)
+    broker.max_output_bytes = 1024
+    argv = ["python", "-c", "print('x' * 5000)"]
+    approval = store.create_approval(
+        task_id=task_id,
+        operation_id="approve-large-output",
+        capability="command",
+        request={"argv": argv},
+    )
+    lease = store.decide_approval(approval.approval_id, approved=True).lease
+    assert lease is not None
+    with pytest.raises(ToolBrokerError) as too_large:
+        await broker.execute(
+            task_id=task_id,
+            operation_id="large-output",
+            tool_name="run_command",
+            arguments={"argv": argv},
+            lease_id=lease.lease_id,
+        )
+    assert too_large.value.code == "tool_output_too_large"
+
+
+@pytest.mark.asyncio
 async def test_missing_command_lease_creates_one_approval_and_same_operation_resumes(
     tmp_path: Path,
 ) -> None:

--- a/server/tests/test_coding_worker_tool_broker.py
+++ b/server/tests/test_coding_worker_tool_broker.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import sys
 from unittest.mock import AsyncMock
@@ -21,6 +22,7 @@ from server.coding_worker.contracts import (
 from server.coding_worker.store import CodingWorkerStore
 from server.coding_worker.process_manager import BackgroundProcessManager
 from server.coding_worker.network_policy import EgressPolicy
+from server.coding_worker.executor import SidecarExecutor
 from server.coding_worker.tool_broker import FrozenCheck, ToolBroker, ToolBrokerError
 from server.coding_worker.workspace import InMemoryWorkspaceSourceAdapter, WorkspaceBroker
 
@@ -100,6 +102,88 @@ async def test_develop_can_write_search_diff_and_run_frozen_check(tmp_path: Path
     )
     assert check.data["exit_code"] == 0
     assert repository.joinpath("app.py").read_text() == content
+
+
+@pytest.mark.asyncio
+async def test_command_execution_can_be_delegated_to_sidecar(tmp_path: Path) -> None:
+    broker, store, task_id, _ = await _broker(tmp_path)
+    executor = AsyncMock()
+    executor.run_process.return_value = {
+        "argv": ["python", "-V"],
+        "exit_code": 0,
+        "output": "Python sidecar",
+    }
+    broker.executor = executor
+    arguments = {"argv": ["python", "-V"], "timeout_seconds": 30}
+    approval = store.create_approval(
+        task_id=task_id,
+        operation_id="sidecar-command",
+        capability="command",
+        request=arguments,
+    )
+    lease = store.decide_approval(
+        approval.approval_id, approved=True, task_scope=False
+    ).lease
+    assert lease is not None
+    result = await broker.execute(
+        task_id=task_id,
+        operation_id="sidecar-command",
+        tool_name="run_command",
+        arguments=arguments,
+        lease_id=lease.lease_id,
+    )
+    assert result.data["output"] == "Python sidecar"
+    executor.run_process.assert_awaited_once()
+    executor.service_status.return_value = {
+        "service_id": "service_" + "a" * 32,
+        "task_id": task_id,
+        "state": "completed",
+        "output": "archived sidecar output",
+    }
+    status = await broker.execute(
+        task_id=task_id,
+        operation_id="sidecar-status",
+        tool_name="service_status",
+        arguments={"service_id": "service_" + "a" * 32},
+    )
+    assert "output" not in status.data
+    artifact_id = status.data["output_artifact_id"]
+    assert store.read_artifact(artifact_id, task_id=task_id) == b"archived sidecar output"
+
+
+@pytest.mark.asyncio
+async def test_sidecar_executor_owns_commands_and_background_services(
+    tmp_path: Path,
+) -> None:
+    repository = tmp_path / "slot" / "workspaces" / "workspace_one" / "repo"
+    repository.mkdir(parents=True)
+    executor = SidecarExecutor(
+        lambda _workspace_id: repository,
+        runtime_root=tmp_path / "slot" / "runtime",
+    )
+    command = await executor.run_process(
+        workspace_id="workspace_one",
+        argv=(sys.executable, "-c", "print('sidecar-command')"),
+        timeout_seconds=10,
+        isolated=False,
+    )
+    assert command["exit_code"] == 0
+    assert command["output"].strip() == "sidecar-command"
+    service = await executor.start_service(
+        task_id="task_sidecar",
+        workspace_id="workspace_one",
+        argv=(sys.executable, "-c", "print('sidecar-service')"),
+        ttl_seconds=10,
+    )
+    for _ in range(100):
+        status = executor.service_status(
+            task_id="task_sidecar", service_id=str(service["service_id"])
+        )
+        if status["state"] != "running":
+            break
+        await asyncio.sleep(0.01)
+    assert status["state"] == "completed"
+    assert str(status["output"]).strip() == "sidecar-service"
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_coding_worker_tool_broker.py
+++ b/server/tests/test_coding_worker_tool_broker.py
@@ -204,10 +204,39 @@ async def test_unknown_write_reconciles_but_command_never_replays(tmp_path: Path
         operation_id="unknown-command",
         tool_name="run_command",
         intent_sha256="f" * 64,
-        request={"arguments": {"argv": ["python", "-V"]}, "lease_id": "lease", "workspace_id": store.get_task(task_id).workspace_id},
+        request={"arguments": {"argv": ["python", "-V"]}, "workspace_id": store.get_task(task_id).workspace_id},
     )
     store.transition_operation(command.operation_id, OperationState.RUNNING)
     store.mark_inflight_operations_unknown()
     with pytest.raises(ToolBrokerError) as unknown:
         broker.reconcile(command.operation_id)
     assert unknown.value.code == "operation_result_unknown"
+
+
+@pytest.mark.asyncio
+async def test_missing_command_lease_creates_one_approval_and_same_operation_resumes(
+    tmp_path: Path,
+) -> None:
+    broker, store, task_id, _ = await _broker(tmp_path)
+    argv = ["python", "-c", "print('approved')"]
+    with pytest.raises(ToolBrokerError) as pending:
+        await broker.execute(
+            task_id=task_id,
+            operation_id="approval-command",
+            tool_name="run_command",
+            arguments={"argv": argv},
+        )
+    assert pending.value.code == "approval_required"
+    approvals = store.list_approvals(task_id)
+    assert len(approvals) == 1
+    decided = store.decide_approval(approvals[0].approval_id, approved=True)
+    assert decided.lease is not None
+    store.transition(task_id, TaskState.RUNNING)
+    result = await broker.execute(
+        task_id=task_id,
+        operation_id="approval-command",
+        tool_name="run_command",
+        arguments={"argv": argv},
+        lease_id=decided.lease.lease_id,
+    )
+    assert result.data["output"].strip() == "approved"

--- a/server/tests/test_coding_worker_tool_broker.py
+++ b/server/tests/test_coding_worker_tool_broker.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import hashlib
+import sys
+from pathlib import Path
+
+import pytest
+from cryptography.fernet import Fernet
+
+from server.coding_worker.contracts import (
+    AcceptanceCheck,
+    AcceptanceContract,
+    Origin,
+    PolicyProfile,
+    OperationState,
+    TaskSpec,
+    TaskState,
+    WorkspaceSource,
+)
+from server.coding_worker.store import CodingWorkerStore
+from server.coding_worker.tool_broker import FrozenCheck, ToolBroker, ToolBrokerError
+from server.coding_worker.workspace import InMemoryWorkspaceSourceAdapter, WorkspaceBroker
+
+
+async def _broker(
+    tmp_path: Path, *, profile: PolicyProfile = PolicyProfile.DEVELOP
+) -> tuple[ToolBroker, CodingWorkerStore, str, Path]:
+    source = WorkspaceSource(kind="manifest", source_id="source", revision="h0")
+    workspace = WorkspaceBroker(
+        tmp_path / "broker",
+        {"manifest": InMemoryWorkspaceSourceAdapter({("source", "h0"): {"app.py": b"print('old')\n"}})},
+        id_key=b"w" * 32,
+    )
+    prepared = await workspace.prepare(source)
+    store = CodingWorkerStore(tmp_path / "store", master_key=Fernet.generate_key())
+    task = store.create_task(
+        TaskSpec(
+            client_task_id="client",
+            origin=Origin(module="tests", object_id="broker"),
+            objective="change app",
+            workspace_source=source,
+            acceptance=AcceptanceContract(
+                contract_id="contract",
+                required_checks=(AcceptanceCheck(check_id="syntax", label="syntax", kind="command"),),
+            ),
+            policy_profile=profile,
+            model_route="coding/default",
+        )
+    )
+    store.transition(task.task_id, TaskState.PREPARING)
+    store.transition(task.task_id, TaskState.RUNNING, workspace_id=prepared.workspace_id)
+    broker = ToolBroker(
+        store=store,
+        workspace_broker=workspace,
+        frozen_checks={
+            "syntax": FrozenCheck(check_id="syntax", argv=(sys.executable, "-m", "py_compile", "app.py"))
+        },
+    )
+    return broker, store, task.task_id, workspace.repository_path(prepared.workspace_id)
+
+
+@pytest.mark.asyncio
+async def test_develop_can_write_search_diff_and_run_frozen_check(tmp_path: Path) -> None:
+    broker, _, task_id, repository = await _broker(tmp_path)
+    content = "print('new')\n"
+    digest = hashlib.sha256(content.encode()).hexdigest()
+    written = await broker.execute(
+        task_id=task_id,
+        operation_id="write-01",
+        tool_name="write_file",
+        arguments={"path": "app.py", "content": content, "content_sha256": digest},
+    )
+    assert written.data["sha256"] == digest
+    same = await broker.execute(
+        task_id=task_id,
+        operation_id="write-01",
+        tool_name="write_file",
+        arguments={"path": "app.py", "content": content, "content_sha256": digest},
+    )
+    assert same == written
+    search = await broker.execute(
+        task_id=task_id,
+        operation_id="search-01",
+        tool_name="search_text",
+        arguments={"query": "new"},
+    )
+    assert search.data["matches"][0]["path"] == "app.py"
+    diff = await broker.execute(
+        task_id=task_id, operation_id="diff-01", tool_name="diff", arguments={}
+    )
+    assert "+print('new')" in diff.data["diff"]
+    check = await broker.execute(
+        task_id=task_id,
+        operation_id="check-01",
+        tool_name="run_check",
+        arguments={"check_id": "syntax"},
+    )
+    assert check.data["exit_code"] == 0
+    assert repository.joinpath("app.py").read_text() == content
+
+
+@pytest.mark.asyncio
+async def test_inspect_policy_and_paths_fail_closed(tmp_path: Path) -> None:
+    broker, _, task_id, repository = await _broker(tmp_path, profile=PolicyProfile.INSPECT)
+    content = "bad\n"
+    with pytest.raises(ToolBrokerError) as readonly:
+        await broker.execute(
+            task_id=task_id,
+            operation_id="write-readonly",
+            tool_name="write_file",
+            arguments={
+                "path": "app.py",
+                "content": content,
+                "content_sha256": hashlib.sha256(content.encode()).hexdigest(),
+            },
+        )
+    assert readonly.value.code == "approval_required"
+    with pytest.raises(ToolBrokerError) as traversal:
+        await broker.execute(
+            task_id=task_id,
+            operation_id="read-traversal",
+            tool_name="read_file",
+            arguments={"path": "../secret"},
+        )
+    assert traversal.value.code == "workspace_path_invalid"
+    assert repository.joinpath("app.py").read_text() == "print('old')\n"
+
+
+@pytest.mark.asyncio
+async def test_command_requires_exact_once_lease_and_denies_shell_remote_and_environment(
+    tmp_path: Path,
+) -> None:
+    broker, store, task_id, _ = await _broker(tmp_path)
+    argv = ["python", "-c", "import os;print(os.getenv('LLM_GATEWAY_KEY'))"]
+    approval = store.create_approval(
+        task_id=task_id,
+        operation_id="approve-command",
+        capability="command",
+        request={"argv": argv},
+    )
+    lease = store.decide_approval(approval.approval_id, approved=True).lease
+    assert lease is not None
+    result = await broker.execute(
+        task_id=task_id,
+        operation_id="command-01",
+        tool_name="run_command",
+        arguments={"argv": argv},
+        lease_id=lease.lease_id,
+    )
+    assert result.data["output"].strip() == "None"
+    with pytest.raises(ToolBrokerError):
+        await broker.execute(
+            task_id=task_id,
+            operation_id="command-02",
+            tool_name="run_command",
+            arguments={"argv": argv},
+            lease_id=lease.lease_id,
+        )
+    for denied in (["sh", "-c", "id"], ["git", "push", "origin", "main"]):
+        approval = store.create_approval(
+            task_id=task_id,
+            operation_id=f"approve-{denied[0]}-{denied[1]}",
+            capability="command",
+            request={"argv": denied},
+        )
+        denied_lease = store.decide_approval(approval.approval_id, approved=True).lease
+        assert denied_lease is not None
+        with pytest.raises(ToolBrokerError) as error:
+            await broker.execute(
+                task_id=task_id,
+                operation_id=f"command-{denied[0]}-{denied[1]}",
+                tool_name="run_command",
+                arguments={"argv": denied},
+                lease_id=denied_lease.lease_id,
+            )
+        assert error.value.code == "command_denied"
+
+
+@pytest.mark.asyncio
+async def test_unknown_write_reconciles_but_command_never_replays(tmp_path: Path) -> None:
+    broker, store, task_id, repository = await _broker(tmp_path)
+    content = "print('reconciled')\n"
+    digest = hashlib.sha256(content.encode()).hexdigest()
+    request = {
+        "arguments": {"path": "app.py", "content": content, "content_sha256": digest},
+        "lease_id": None,
+        "workspace_id": store.get_task(task_id).workspace_id,
+    }
+    operation = store.create_operation(
+        task_id=task_id,
+        operation_id="unknown-write",
+        tool_name="write_file",
+        intent_sha256=broker._intent_sha256("write_file", request),
+        request=request,
+    )
+    store.transition_operation(operation.operation_id, OperationState.RUNNING)
+    repository.joinpath("app.py").write_bytes(content.encode("utf-8"))
+    store.mark_inflight_operations_unknown()
+    reconciled = broker.reconcile(operation.operation_id)
+    assert reconciled.state.value == "completed"
+
+    command = store.create_operation(
+        task_id=task_id,
+        operation_id="unknown-command",
+        tool_name="run_command",
+        intent_sha256="f" * 64,
+        request={"arguments": {"argv": ["python", "-V"]}, "lease_id": "lease", "workspace_id": store.get_task(task_id).workspace_id},
+    )
+    store.transition_operation(command.operation_id, OperationState.RUNNING)
+    store.mark_inflight_operations_unknown()
+    with pytest.raises(ToolBrokerError) as unknown:
+        broker.reconcile(command.operation_id)
+    assert unknown.value.code == "operation_result_unknown"

--- a/server/tests/test_coding_worker_tool_broker.py
+++ b/server/tests/test_coding_worker_tool_broker.py
@@ -174,6 +174,7 @@ async def test_sidecar_executor_owns_commands_and_background_services(
         workspace_id="workspace_one",
         argv=(sys.executable, "-c", "print('sidecar-service')"),
         ttl_seconds=10,
+        preview_port=4173,
     )
     for _ in range(100):
         status = executor.service_status(
@@ -184,6 +185,7 @@ async def test_sidecar_executor_owns_commands_and_background_services(
         await asyncio.sleep(0.01)
     assert status["state"] == "completed"
     assert str(status["output"]).strip() == "sidecar-service"
+    assert status["preview_port"] == 4173
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_coding_worker_tool_broker.py
+++ b/server/tests/test_coding_worker_tool_broker.py
@@ -18,6 +18,7 @@ from server.coding_worker.contracts import (
     WorkspaceSource,
 )
 from server.coding_worker.store import CodingWorkerStore
+from server.coding_worker.process_manager import BackgroundProcessManager
 from server.coding_worker.tool_broker import FrozenCheck, ToolBroker, ToolBrokerError
 from server.coding_worker.workspace import InMemoryWorkspaceSourceAdapter, WorkspaceBroker
 
@@ -264,3 +265,68 @@ async def test_missing_command_lease_creates_one_approval_and_same_operation_res
         lease_id=decided.lease.lease_id,
     )
     assert result.data["output"].strip() == "approved"
+
+
+@pytest.mark.asyncio
+async def test_background_service_requires_exact_lease_and_remains_task_owned(
+    tmp_path: Path,
+) -> None:
+    broker, store, task_id, _ = await _broker(tmp_path)
+    manager = BackgroundProcessManager(
+        store=store,
+        workspace_broker=broker.workspace_broker,
+        environment_factory=lambda workspace_id: broker._safe_environment(
+            broker.workspace_broker.repository_path(workspace_id)
+        ),
+    )
+    broker.process_manager = manager
+    arguments = {
+        "argv": [
+            "python",
+            "-c",
+            "import sys,time;print('ready',flush=True);"
+            "line=sys.stdin.readline();print(line,flush=True);time.sleep(30)",
+        ],
+        "ttl_seconds": 60,
+    }
+    with pytest.raises(ToolBrokerError) as approval_required:
+        await broker.execute(
+            task_id=task_id,
+            operation_id="start-service",
+            tool_name="start_service",
+            arguments=arguments,
+        )
+    assert approval_required.value.code == "approval_required"
+    approval = store.list_approvals(task_id)[-1]
+    lease = store.decide_approval(approval.approval_id, approved=True).lease
+    assert lease is not None
+    store.transition(task_id, TaskState.RUNNING)
+    started = await broker.execute(
+        task_id=task_id,
+        operation_id="start-service",
+        tool_name="start_service",
+        arguments=arguments,
+        lease_id=lease.lease_id,
+    )
+    service_id = str(started.data["service_id"])
+    await broker.execute(
+        task_id=task_id,
+        operation_id="service-input",
+        tool_name="service_input",
+        arguments={"service_id": service_id, "data": "hello\n"},
+    )
+    status = await broker.execute(
+        task_id=task_id,
+        operation_id="service-status",
+        tool_name="service_status",
+        arguments={"service_id": service_id},
+    )
+    assert status.data["task_id"] == task_id and "pid" not in status.data
+    stopped = await broker.execute(
+        task_id=task_id,
+        operation_id="service-stop",
+        tool_name="stop_service",
+        arguments={"service_id": service_id},
+    )
+    assert stopped.data["reason"] == "user_interrupted"
+    await manager.shutdown()

--- a/server/tests/test_coding_worker_workspace.py
+++ b/server/tests/test_coding_worker_workspace.py
@@ -114,3 +114,36 @@ async def test_workspace_tree_detects_links_and_diff_uses_private_index(tmp_path
         (repository / "unsafe-link").symlink_to(repository / "tracked.txt")
         with pytest.raises(WorkspaceError, match="link"):
             broker.tree(record.workspace_id)
+
+
+@pytest.mark.asyncio
+async def test_dedicated_slots_keep_workspace_files_in_separate_roots(
+    tmp_path: Path,
+) -> None:
+    source = _source()
+    broker = WorkspaceBroker(
+        tmp_path / "control",
+        {
+            "manifest": InMemoryWorkspaceSourceAdapter(
+                {(source.source_id, source.revision): {"main.py": b"print('ok')\n"}}
+            )
+        },
+        id_key=b"s" * 32,
+        slot_roots={
+            "slot-a": tmp_path / "slot-a",
+            "slot-b": tmp_path / "slot-b",
+        },
+    )
+
+    first = await broker.prepare(source, slot_id="slot-a")
+    second = await broker.prepare(source, slot_id="slot-b")
+
+    assert first.slot_id == "slot-a"
+    assert second.slot_id == "slot-b"
+    assert broker.workspace_slot(first.workspace_id) == "slot-a"
+    assert broker.workspace_slot(second.workspace_id) == "slot-b"
+    assert broker.repository_path(first.workspace_id).is_relative_to(tmp_path / "slot-a")
+    assert broker.repository_path(second.workspace_id).is_relative_to(tmp_path / "slot-b")
+    with pytest.raises(WorkspaceError) as raised:
+        await broker.prepare(source)
+    assert raised.value.code == "workspace_slot_unavailable"

--- a/server/tests/test_coding_worker_workspace.py
+++ b/server/tests/test_coding_worker_workspace.py
@@ -117,6 +117,30 @@ async def test_workspace_tree_detects_links_and_diff_uses_private_index(tmp_path
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(
+    os.name == "nt" or not hasattr(os, "geteuid") or os.geteuid() != 0,
+    reason="requires Linux root to reproduce the sidecar ownership boundary",
+)
+async def test_diff_accepts_worker_owned_synthetic_repository(tmp_path: Path) -> None:
+    source = _source()
+    broker = WorkspaceBroker(
+        tmp_path / "control",
+        {
+            "manifest": InMemoryWorkspaceSourceAdapter(
+                {(source.source_id, source.revision): {"tracked.txt": b"old\n"}}
+            )
+        },
+        id_key=b"o" * 32,
+        slot_roots={"slot-a": tmp_path / "slot-a"},
+        slot_owner=(65532, 65532),
+    )
+    record = await broker.prepare(source, slot_id="slot-a")
+    (broker.repository_path(record.workspace_id) / "tracked.txt").write_bytes(b"new\n")
+
+    assert b"tracked.txt" in broker.diff(record.workspace_id)
+
+
+@pytest.mark.asyncio
 async def test_dedicated_slots_keep_workspace_files_in_separate_roots(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## 变更

- 将完整 V14 Coding Worker 集成分支 `c166604` 合入最新 `main` 基线 `ad7e12a`。
- 保留主线新增的 Current-State / Target-State 架构说明，并并列加入 V14 Worker 架构。
- 为后续 V15 Tooling、双 Provider 与 Console 三组顺序 PR 建立唯一、可验证的主线基线。

## Patch 完整性

- 原 V14 相对共同基线变更 57 个路径。
- 收口分支相对 `main` 仍为相同 57 个路径；缺失 0，额外 0。
- 主线与 V14 仅在 `docs/ARCHITECTURE.md` 相交，冲突内容已并列保留。

## 验证

- Coding Worker：102 passed。
- Agent Workspace：44 passed。
- Coding 全量：725 passed，9 skipped。
- 后端全量：2442 passed，21 skipped；容器内仅 1 项 Node/TypeScript loader 环境失败，同一测试在主机 Node 24 单独复跑 1 passed。
- 前端：TypeScript 通过；Vitest 145 passed；Vite production build 通过。
- Compose：V14 基础拓扑与 `coding-worker-network` profile 均 `config --quiet` 通过。
- `git diff --check`、禁入产物和新增凭据模式扫描通过。

## 回退

- 本 PR 是单一 merge commit；未启用 V14 时现有 legacy 会话路径保持不变。
- 如需回退，可在主线按合并提交整体回退；不删除既有 Coding、Agent Workspace 或 v13 Recovery 数据。

## 后续

- 本 PR 合入 `main` 并记录新基线 SHA 后，V15 的 PR A/B/C 才开始；不会在当前分支混入 V15 功能。
