### PR TITLE
feature: 刷新 OpenRouter 模型并适配 Seedance 2.5

### DIFF
--- a/client/src/components/VideoGenerationWorkspace.tsx
+++ b/client/src/components/VideoGenerationWorkspace.tsx
@@ -8,6 +8,7 @@ import {
 } from "react";
 import { Link } from "react-router-dom";
 import type { Model } from "../data/models";
+import { estimateVideoCost } from "../utils/videoCostEstimate";
 import BrandLogo from "./BrandLogo";
 import ResourceNav from "./ResourceNav";
 
@@ -44,6 +45,7 @@ interface VideoModelProfile {
   operation: "analyze_video" | "generate_video";
   supported_resolutions: string[];
   supported_aspect_ratios: string[];
+  supported_sizes: string[];
   supported_durations: number[];
   supported_frame_types: ("first_frame" | "last_frame")[];
   supports_first_frame: boolean;
@@ -213,72 +215,10 @@ function resolutionRank(value: string) {
   return match ? Number(match[1]) : Number.MAX_SAFE_INTEGER;
 }
 
-function pricingNumber(profile: VideoModelProfile, key: string) {
-  const raw = profile.pricing_skus[key];
-  if (raw === undefined) return null;
-  const value = Number(raw);
-  return Number.isFinite(value) && value >= 0 ? value : null;
-}
-
-function estimatedCost(
-  profile: VideoModelProfile,
-  {
-    duration,
-    resolution,
-    generateAudio,
-    imageInputCount,
-  }: {
-    duration: number | null;
-    resolution: string;
-    generateAudio: boolean;
-    imageInputCount: number;
-  },
-) {
-  if (duration === null || !resolution) return null;
-  const resolutionKey = resolution.toLowerCase();
-  const mode = imageInputCount > 0 ? "image_to_video" : "text_to_video";
-  const dollarKeys = [
-    generateAudio
-      ? `duration_seconds_with_audio_${resolutionKey}`
-      : `duration_seconds_without_audio_${resolutionKey}`,
-    `${mode}_duration_seconds_${resolutionKey}`,
-    `duration_seconds_${resolutionKey}`,
-    generateAudio
-      ? "duration_seconds_with_audio"
-      : "duration_seconds_without_audio",
-    `${mode}_duration_seconds`,
-    "duration_seconds",
-  ];
-  let perSecond: number | null = null;
-  for (const key of dollarKeys) {
-    const value = pricingNumber(profile, key);
-    if (value !== null) {
-      perSecond = value;
-      break;
-    }
-  }
-  if (perSecond === null) {
-    const cents =
-      pricingNumber(
-        profile,
-        `cents_per_video_output_second_${resolutionKey}`,
-      ) ??
-      pricingNumber(profile, `cents_per_second_output_${resolutionKey}`) ??
-      pricingNumber(profile, "cents_per_video_output_second") ??
-      pricingNumber(profile, "cents_per_second_output");
-    if (cents !== null) perSecond = cents / 100;
-  }
-  if (perSecond === null) return null;
-  const imageInputCents =
-    imageInputCount > 0
-      ? (pricingNumber(profile, "cents_per_image_input") ?? 0)
-      : 0;
-  return perSecond * duration + (imageInputCents * imageInputCount) / 100;
-}
-
 function defaultResolution(
   profile: VideoModelProfile,
   duration: number | null,
+  aspectRatio: string,
 ) {
   const ranked = [...profile.supported_resolutions].sort(
     (left, right) => resolutionRank(left) - resolutionRank(right),
@@ -286,9 +226,10 @@ function defaultResolution(
   const priced = ranked
     .map((resolution) => ({
       resolution,
-      cost: estimatedCost(profile, {
+      cost: estimateVideoCost(profile, {
         duration,
         resolution,
+        aspectRatio,
         generateAudio: false,
         imageInputCount: 0,
       }),
@@ -479,6 +420,11 @@ export default function VideoGenerationWorkspace({
         (left, right) => left - right,
       );
       const fallbackDuration = sortedDurations[0] ?? null;
+      const fallbackAspectRatio = nextProfile.supported_aspect_ratios.includes(
+        "16:9",
+      )
+        ? "16:9"
+        : (nextProfile.supported_aspect_ratios[0] ?? "");
       setDuration((current) =>
         current !== null &&
         nextProfile.supported_durations.includes(current)
@@ -488,14 +434,16 @@ export default function VideoGenerationWorkspace({
       setResolution((current) =>
         nextProfile.supported_resolutions.includes(current)
           ? current
-          : defaultResolution(nextProfile, fallbackDuration),
+          : defaultResolution(
+              nextProfile,
+              fallbackDuration,
+              fallbackAspectRatio,
+            ),
       );
       setAspectRatio((current) =>
         nextProfile.supported_aspect_ratios.includes(current)
           ? current
-          : nextProfile.supported_aspect_ratios.includes("16:9")
-            ? "16:9"
-            : (nextProfile.supported_aspect_ratios[0] ?? ""),
+          : fallbackAspectRatio,
       );
 
       const supportsFirst =
@@ -850,9 +798,10 @@ export default function VideoGenerationWorkspace({
     catalogStale && enhancedInputsSelected;
 
   const estimate = profile
-    ? estimatedCost(profile, {
+    ? estimateVideoCost(profile, {
         duration,
         resolution,
+        aspectRatio,
         generateAudio,
         imageInputCount,
       })

--- a/client/src/data/models.refresh.test.ts
+++ b/client/src/data/models.refresh.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { models } from "./models";
+
+const middleModelIds = [
+  "sakana/sakana-namazu",
+  "upstage/solar-pro4",
+  "meta/muse-glimmer-30b",
+  "inclusionai/ling-3.0-tiny:free",
+];
+
+describe("OpenRouter 2026-08-11 model refresh", () => {
+  it("places Seedance 2.5 at the former GPT-4o Mini TTS slot", () => {
+    expect(models[11]?.id).toBe("bytedance/seedance-2.5");
+    expect(models[12]?.id).toBe("gpt-4o-mini-tts");
+  });
+
+  it("keeps the four general models in the catalog middle", () => {
+    const lowerBound = Math.floor(models.length * 0.25);
+    const upperBound = Math.ceil(models.length * 0.75);
+
+    for (const modelId of middleModelIds) {
+      const matches = models.filter((model) => model.id === modelId);
+      expect(matches).toHaveLength(1);
+      const index = models.findIndex((model) => model.id === modelId);
+      expect(index).toBeGreaterThan(lowerBound);
+      expect(index).toBeLessThan(upperBound);
+    }
+  });
+});

--- a/client/src/data/models.ts
+++ b/client/src/data/models.ts
@@ -1,6 +1,7 @@
 ﻿// Merged with OpenRouter model catalog on 2026-08-06T08:31:09.233Z.
 // Refreshed with entries published through 2026-08-05T23:51:37.000Z.
 // Source: https://openrouter.ai/api/v1/models?output_modalities=all&sort=newest
+// Supplemental OpenRouter refresh: 2026-08-11 (five newly listed models).
 // Prices are stored as USD per 1M tokens and CNY per 1M tokens.
 export const USD_TO_CNY = 6.77;
 
@@ -125,6 +126,148 @@ interface RawCatalogModel {
 }
 
 const rawCatalogModels: RawCatalogModel[] = [
+  {
+    id: "bytedance/seedance-2.5",
+    canonical_slug: "bytedance/seedance-2.5-20260807",
+    name: "ByteDance: Seedance 2.5",
+    raw_description:
+      "Seedance 2.5 is a video generation model from ByteDance. It is suited for long-form storytelling, multimodal reference-based generation, video editing, and video extension. It supports first-frame and first-and-last-frame control.",
+    context_length: 0,
+    pricing: { input: 10.7, output: 10.7 },
+    input_modalities: ["text", "image"],
+    output_modalities: ["video"],
+    tokenizer: "Other",
+    supported_parameters: [
+      "duration",
+      "resolution",
+      "aspect_ratio",
+      "frame_images",
+      "input_references",
+      "generate_audio",
+      "seed",
+    ],
+    created: 1786141253,
+    expiration_date: null,
+    model_author: "ByteDance",
+  },
+  {
+    id: "sakana/sakana-namazu",
+    canonical_slug: "sakana/namazu-20260811",
+    name: "Sakana: Sakana Namazu",
+    raw_description:
+      "Sakana Namazu is a Japanese-specialized reasoning model from Sakana AI, based on Kimi K2.6 with additional training for Japanese language and business contexts. It is suited for Japanese instruction following and business work.",
+    context_length: 262144,
+    pricing: { input: 0.95, output: 4 },
+    input_modalities: ["text", "image", "file"],
+    output_modalities: ["text"],
+    tokenizer: "Other",
+    supported_parameters: [
+      "include_reasoning",
+      "reasoning",
+      "reasoning_effort",
+      "structured_outputs",
+      "tool_choice",
+      "tools",
+      "web_search_options",
+    ],
+    created: 1786410129,
+    expiration_date: null,
+    model_author: "Sakana",
+  },
+  {
+    id: "upstage/solar-pro4",
+    canonical_slug: "upstage/solar-pro4-20260810",
+    name: "Upstage: Solar Pro 4",
+    raw_description:
+      "Solar Pro 4 is a large language model from Upstage. It is suited for agentic workflows, office productivity, document-intensive work, and coding.",
+    context_length: 524288,
+    pricing: { input: 0.03, output: 0.12 },
+    input_modalities: ["text"],
+    output_modalities: ["text"],
+    tokenizer: "Other",
+    supported_parameters: [
+      "frequency_penalty",
+      "include_reasoning",
+      "max_tokens",
+      "presence_penalty",
+      "reasoning",
+      "response_format",
+      "structured_outputs",
+      "temperature",
+      "tool_choice",
+      "tools",
+      "top_p",
+    ],
+    created: 1786371636,
+    expiration_date: null,
+    model_author: "Upstage",
+  },
+  {
+    id: "meta/muse-glimmer-30b",
+    canonical_slug: "meta/muse-glimmer-30b-20260810",
+    name: "Meta: Muse Glimmer 30B",
+    raw_description:
+      "Muse Glimmer 30B is a dense, open-weight multimodal model from Meta Superintelligence Labs, distilled from Muse Spark and optimized for autonomous agents on consumer hardware. It is suited for long-horizon agent work.",
+    context_length: 131072,
+    pricing: { input: 0.35, output: 1.5 },
+    input_modalities: ["text", "image"],
+    output_modalities: ["text"],
+    tokenizer: "Other",
+    supported_parameters: [
+      "frequency_penalty",
+      "include_reasoning",
+      "logit_bias",
+      "max_tokens",
+      "min_p",
+      "presence_penalty",
+      "reasoning",
+      "reasoning_effort",
+      "repetition_penalty",
+      "response_format",
+      "stop",
+      "structured_outputs",
+      "temperature",
+      "tool_choice",
+      "tools",
+      "top_k",
+      "top_p",
+    ],
+    created: 1786302394,
+    expiration_date: null,
+    model_author: "Meta",
+  },
+  {
+    id: "inclusionai/ling-3.0-tiny:free",
+    canonical_slug: "inclusionai/ling-3.0-tiny-20260806",
+    name: "inclusionAI: Ling 3.0 Tiny (free)",
+    raw_description:
+      "Ling 3.0 Tiny is a mixture-of-experts model from InclusionAI, with 1.3B active parameters out of 7.9B total. It is designed for responsive agents, instruction following, and multi-turn conversations.",
+    context_length: 262144,
+    pricing: { input: 0, output: 0 },
+    input_modalities: ["text"],
+    output_modalities: ["text"],
+    tokenizer: "Other",
+    supported_parameters: [
+      "frequency_penalty",
+      "include_reasoning",
+      "logprobs",
+      "max_tokens",
+      "presence_penalty",
+      "reasoning",
+      "repetition_penalty",
+      "seed",
+      "stop",
+      "temperature",
+      "tool_choice",
+      "tools",
+      "top_k",
+      "top_logprobs",
+      "top_p",
+    ],
+    created: 1786034890,
+    expiration_date: null,
+    model_author: "InclusionAI",
+  },
   {
     "id": "openai/gpt-transcribe",
     "canonical_slug": "openai/gpt-transcribe-20260805",
@@ -18141,6 +18284,7 @@ const VERIFIED_SPEECH_MODEL_IDS = new Set([
 
 const VERIFIED_VIDEO_MODEL_IDS = new Set([
   "bytedance/seedance-2.0",
+  "bytedance/seedance-2.5",
   "runway/aleph-2",
   "runway/gen-4.5",
 ]);
@@ -18524,14 +18668,43 @@ const sortedCatalogModels = [...rawCatalogModels]
   .sort(catalogSort)
   .map(enrichModel);
 
+const SEEDANCE_2_5_MODEL_ID = "bytedance/seedance-2.5";
+const MID_CATALOG_MODEL_IDS = [
+  "sakana/sakana-namazu",
+  "upstage/solar-pro4",
+  "meta/muse-glimmer-30b",
+  "inclusionai/ling-3.0-tiny:free",
+];
+const reservedCatalogModelIds = new Set([
+  SEEDANCE_2_5_MODEL_ID,
+  ...MID_CATALOG_MODEL_IDS,
+]);
+const seedance25Model = sortedCatalogModels.find(
+  (model) => model.id === SEEDANCE_2_5_MODEL_ID,
+);
+const midCatalogModels = MID_CATALOG_MODEL_IDS.map((modelId) =>
+  sortedCatalogModels.find((model) => model.id === modelId),
+).filter((model): model is Model => Boolean(model));
+const normallyOrderedCatalogModels = sortedCatalogModels.filter(
+  (model) => !reservedCatalogModelIds.has(model.id),
+);
+
 // The homepage reserves two spotlight cards plus three desktop gallery rows for
 // broadly useful catalog models before showing direct OpenAI audio models.
 const REALTIME_MODEL_INSERT_INDEX = 11;
 
-const assembledModels: Model[] = [
-  ...sortedCatalogModels.slice(0, REALTIME_MODEL_INSERT_INDEX),
+const primaryCatalogModels: Model[] = [
+  ...normallyOrderedCatalogModels.slice(0, REALTIME_MODEL_INSERT_INDEX),
+  ...(seedance25Model ? [seedance25Model] : []),
   ...DIRECT_OPENAI_AUDIO_MODELS,
-  ...sortedCatalogModels.slice(REALTIME_MODEL_INSERT_INDEX),
+  ...normallyOrderedCatalogModels.slice(REALTIME_MODEL_INSERT_INDEX),
+];
+const catalogMidpoint = Math.floor(primaryCatalogModels.length / 2);
+
+const assembledModels: Model[] = [
+  ...primaryCatalogModels.slice(0, catalogMidpoint),
+  ...midCatalogModels,
+  ...primaryCatalogModels.slice(catalogMidpoint),
   worldModelEntry,
 ];
 

--- a/client/src/utils/videoCostEstimate.test.ts
+++ b/client/src/utils/videoCostEstimate.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { estimateVideoCost } from "./videoCostEstimate";
+
+const seedance25Profile = {
+  supported_resolutions: ["480p", "720p"],
+  supported_aspect_ratios: ["16:9", "4:3", "1:1", "3:4", "9:16", "21:9"],
+  supported_sizes: [
+    "854x480",
+    "752x560",
+    "640x640",
+    "560x752",
+    "480x854",
+    "992x432",
+    "1280x720",
+    "1112x834",
+    "960x960",
+    "834x1112",
+    "720x1280",
+    "1470x630",
+  ],
+  pricing_skus: {
+    video_tokens: "0.0000107",
+    video_tokens_without_audio: "0.0000107",
+    video_tokens_with_video_input: "0.0000064",
+  },
+};
+
+describe("estimateVideoCost", () => {
+  it("estimates Seedance 2.5 from its selected size and video-token rate", () => {
+    const estimate = estimateVideoCost(seedance25Profile, {
+      duration: 4,
+      resolution: "480p",
+      aspectRatio: "16:9",
+      generateAudio: false,
+      imageInputCount: 0,
+    });
+
+    expect(estimate).toBeCloseTo(0.411201, 6);
+  });
+
+  it("keeps existing per-second pricing ahead of the video-token fallback", () => {
+    const estimate = estimateVideoCost(
+      {
+        supported_resolutions: ["720p"],
+        supported_aspect_ratios: ["16:9"],
+        supported_sizes: ["1280x720"],
+        pricing_skus: {
+          duration_seconds_without_audio_720p: "0.25",
+          video_tokens: "0.0000107",
+        },
+      },
+      {
+        duration: 4,
+        resolution: "720p",
+        aspectRatio: "16:9",
+        generateAudio: false,
+        imageInputCount: 1,
+      },
+    );
+
+    expect(estimate).toBe(1);
+  });
+
+  it("does not guess a video-token estimate without a matching catalog size", () => {
+    const estimate = estimateVideoCost(seedance25Profile, {
+      duration: 4,
+      resolution: "720p",
+      aspectRatio: "2:1",
+      generateAudio: false,
+      imageInputCount: 0,
+    });
+
+    expect(estimate).toBeNull();
+  });
+});

--- a/client/src/utils/videoCostEstimate.ts
+++ b/client/src/utils/videoCostEstimate.ts
@@ -1,0 +1,108 @@
+export interface VideoPricingProfile {
+  supported_resolutions: string[];
+  supported_aspect_ratios: string[];
+  supported_sizes: string[];
+  pricing_skus: Record<string, string>;
+}
+
+export interface VideoCostSelection {
+  duration: number | null;
+  resolution: string;
+  aspectRatio: string;
+  generateAudio: boolean;
+  imageInputCount: number;
+}
+
+function pricingNumber(profile: VideoPricingProfile, key: string) {
+  const raw = profile.pricing_skus[key];
+  if (raw === undefined) return null;
+  const value = Number(raw);
+  return Number.isFinite(value) && value >= 0 ? value : null;
+}
+
+function selectedDimensions(
+  profile: VideoPricingProfile,
+  resolution: string,
+  aspectRatio: string,
+) {
+  const resolutionIndex = profile.supported_resolutions.indexOf(resolution);
+  const aspectRatioIndex = profile.supported_aspect_ratios.indexOf(aspectRatio);
+  if (resolutionIndex < 0 || aspectRatioIndex < 0) return null;
+
+  // OpenRouter returns sizes in resolution-major, aspect-ratio-minor order.
+  const size =
+    profile.supported_sizes[
+      resolutionIndex * profile.supported_aspect_ratios.length +
+        aspectRatioIndex
+    ];
+  const match = size?.trim().toLowerCase().match(/^(\d+)x(\d+)$/);
+  if (!match) return null;
+  const width = Number(match[1]);
+  const height = Number(match[2]);
+  return width > 0 && height > 0 ? { width, height } : null;
+}
+
+export function estimateVideoCost(
+  profile: VideoPricingProfile,
+  {
+    duration,
+    resolution,
+    aspectRatio,
+    generateAudio,
+    imageInputCount,
+  }: VideoCostSelection,
+) {
+  if (duration === null || duration <= 0 || !resolution) return null;
+  const resolutionKey = resolution.toLowerCase();
+  const mode = imageInputCount > 0 ? "image_to_video" : "text_to_video";
+  const dollarKeys = [
+    generateAudio
+      ? `duration_seconds_with_audio_${resolutionKey}`
+      : `duration_seconds_without_audio_${resolutionKey}`,
+    `${mode}_duration_seconds_${resolutionKey}`,
+    `duration_seconds_${resolutionKey}`,
+    generateAudio
+      ? "duration_seconds_with_audio"
+      : "duration_seconds_without_audio",
+    `${mode}_duration_seconds`,
+    "duration_seconds",
+  ];
+  let perSecond: number | null = null;
+  for (const key of dollarKeys) {
+    const value = pricingNumber(profile, key);
+    if (value !== null) {
+      perSecond = value;
+      break;
+    }
+  }
+  if (perSecond === null) {
+    const cents =
+      pricingNumber(
+        profile,
+        `cents_per_video_output_second_${resolutionKey}`,
+      ) ??
+      pricingNumber(profile, `cents_per_second_output_${resolutionKey}`) ??
+      pricingNumber(profile, "cents_per_video_output_second") ??
+      pricingNumber(profile, "cents_per_second_output");
+    if (cents !== null) perSecond = cents / 100;
+  }
+  if (perSecond !== null) {
+    const imageInputCents =
+      imageInputCount > 0
+        ? (pricingNumber(profile, "cents_per_image_input") ?? 0)
+        : 0;
+    return perSecond * duration + (imageInputCents * imageInputCount) / 100;
+  }
+
+  const dimensions = selectedDimensions(profile, resolution, aspectRatio);
+  const videoTokenRate =
+    (generateAudio
+      ? pricingNumber(profile, "video_tokens")
+      : pricingNumber(profile, "video_tokens_without_audio")) ??
+    pricingNumber(profile, "video_tokens");
+  if (!dimensions || videoTokenRate === null) return null;
+
+  const videoTokens =
+    (dimensions.width * dimensions.height * duration * 24) / 1024;
+  return videoTokens * videoTokenRate;
+}

--- a/server/multimodal/video_catalog.py
+++ b/server/multimodal/video_catalog.py
@@ -47,6 +47,8 @@ VERIFIED_VIDEO_GENERATION_MODELS = frozenset(
         "kwaivgi/kling-video-o1",
         "bytedance/seedance-1-5-pro",
         "bytedance/seedance-2.0-fast",
+        # 2026-08-11：复用统一异步视频链路，首尾帧、本地参考图与费用估算已适配。
+        "bytedance/seedance-2.5",
         # 2026-08-06 人工验收：最低规格生成、轮询、播放与下载闭环通过。
         # Veo Lite 的受控高级参数也已完成验收。
         "google/veo-3.1-lite",
@@ -86,6 +88,7 @@ class VideoModelProfile(BaseModel):
     )
     supported_resolutions: list[str] = Field(default_factory=list)
     supported_aspect_ratios: list[str] = Field(default_factory=list)
+    supported_sizes: list[str] = Field(default_factory=list)
     supported_durations: list[int] = Field(default_factory=list)
     supported_frame_types: list[
         Literal["first_frame", "last_frame"]
@@ -110,6 +113,7 @@ class VideoModelProfile(BaseModel):
 
 REFERENCE_IMAGE_AUDIT: dict[str, int] = {
     "bytedance/seedance-2.0-fast": 3,
+    "bytedance/seedance-2.5": 3,
 }
 
 PROVIDER_OPTION_AUDIT: dict[
@@ -317,6 +321,9 @@ class VideoCatalogService:
                         ),
                         supported_aspect_ratios=self._strings(
                             item.get("supported_aspect_ratios")
+                        ),
+                        supported_sizes=self._strings(
+                            item.get("supported_sizes")
                         ),
                         supported_durations=self._integers(
                             item.get("supported_durations")

--- a/server/tests/test_multimodal_video_catalog.py
+++ b/server/tests/test_multimodal_video_catalog.py
@@ -53,6 +53,10 @@ def test_verified_video_registry_contains_batch_g_acceptance() -> None:
     } <= VERIFIED_VIDEO_GENERATION_MODELS
 
 
+def test_verified_video_registry_contains_seedance_25_refresh() -> None:
+    assert "bytedance/seedance-2.5" in VERIFIED_VIDEO_GENERATION_MODELS
+
+
 def openrouter_service(tmp_path: Path) -> ModelRouterService:
     repository = SQLiteRouterRepository(tmp_path)
     connection = repository.create_connection(
@@ -115,6 +119,12 @@ async def test_video_catalog_normalizes_analysis_and_generation_models(
                             "id": "google/veo-3.1-lite",
                             "supported_resolutions": ["720p", "1080p"],
                             "supported_aspect_ratios": ["16:9", "9:16"],
+                            "supported_sizes": [
+                                "1280x720",
+                                "720x1280",
+                                "1920x1080",
+                                "1080x1920",
+                            ],
                             "supported_durations": [5, 8],
                             "supported_frame_images": [
                                 "first_frame",
@@ -233,6 +243,12 @@ async def test_video_catalog_normalizes_analysis_and_generation_models(
     assert analysis.operation_readiness[0].availability_status == "available"
     assert generation.model_id == "google/veo-3.1-lite"
     assert generation.supported_resolutions == ["720p", "1080p"]
+    assert generation.supported_sizes == [
+        "1280x720",
+        "720x1280",
+        "1920x1080",
+        "1080x1920",
+    ]
     assert generation.supported_durations == [5, 8]
     assert generation.supports_first_frame is True
     assert generation.supported_frame_types == [


### PR DESCRIPTION
## 改动摘要

- 从 OpenRouter 最新目录补充 5 个尚未收录的模型：
  - `sakana/sakana-namazu`
  - `upstage/solar-pro4`
  - `meta/muse-glimmer-30b`
  - `inclusionai/ling-3.0-tiny:free`
  - `bytedance/seedance-2.5`
- 将四个通用模型稳定放在模型目录中段。
- 将 Seedance 2.5 放在首页第五行原 `OpenAI: GPT-4o Mini TTS` 位置，TTS 顺延。
- Seedance 2.5 复用 PR #142 的统一异步视频生成工作区和 multipart 本地图片链路，支持首帧、尾帧和最多 3 张参考图。
- 删除 Seedance 专用协议、固定轮询次数和专用 ZDR 提交确认文案，保持与现有视频生成模型一致。
- 将 OpenRouter `supported_sizes` 传入前端，并按照 video-token 计价补充动态费用估算；默认 4 秒 / 480p / 16:9 约为 $0.4112。

## 基线与兼容性

- 初始实现严格基于 PR #142 合并提交 `fbbcfa504c`。
- 创建 PR 前已重放到最新 `main`：`6d7bdb26d6`（包含 PR #143）。
- PR #142 仍位于当前分支祖先链中。
- PR #143 未修改本 PR 涉及的模型目录、统一视频工作区或视频目录文件；重放过程无冲突。

## 验证

- `npm.cmd run test:run -- src/utils/videoCostEstimate.test.ts src/data/models.refresh.test.ts`
  - 2 files / 5 tests passed
- `python -m pytest server/tests/test_multimodal_video_catalog.py server/tests/test_multimodal_video_jobs.py -q`（在 `modelmirror-server:latest` 容器中）
  - 31 tests passed
- `npm.cmd run build`
  - TypeScript 与 Vite 生产构建通过
- `git diff --check origin/main...HEAD`
  - 通过
- 应用内预览器人工检查：
  - 首页第五行顺序正确
  - 本地首帧文件可选择并进入图生视频状态
  - 费用估算显示 $0.4112
  - 页面控制台无错误

## 未验证边界

- 未点击付费提交按钮，未产生 OpenRouter 视频生成费用。
- 尚未执行 Seedance 2.5 的真实供应商最低规格生成、轮询、播放与下载验收。
- 依赖锁文件未变更；构建仍保留现有大 chunk 警告。
