### PR TITLE
feature: 添加 Benchmark 驱动的 RAG 策略自动调优闭环

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -703,6 +703,28 @@ Office 自动化是高风险客户端副作用路径。修改 `server/xpert_runt
 - Router API、metadata、日志和前端不得返回完整文档、物理路径、embedding、Prompt、模型隐藏推理或密钥。
 - 修改该路径至少运行 `test_rag_strategy_router.py`、RAG Pipeline/Graph/Integration 回归、前端生产构建和敏感信息扫描。
 
+### RAG Strategy Auto Tuner 护栏
+
+- 调优必须固定 V2 知识版本、来源快照和已发布 Evaluation Set Version；不得跟随活动指针或可编辑评测草稿漂移。
+- 标准 Catalog Pack 必须标记为 `regression_guard`，只能用于引擎回归，禁止作为正式调优胜者和候选版本物化的唯一证据。
+- 正式检索调优至少需要 30 条正样例；threshold 调优至少需要 12 条已审核、语料近邻的困难负例。证据不足必须禁用对应维度，不得用小样本比例伪装成稳定门禁。
+- Threshold 选择必须同时报告 Recall、nDCG 和困难负例误召回；不得恢复“Recall 绝对优先”或仅凭全局 score 分位数选择阈值。质量回退与误召回改善边界必须固定、可测试。
+- 检索候选必须按生效字段生成语义 checksum。模式无关权重、关闭状态下的 Rerank 字段及相同实际排序不得重复占用 trial、finalist 或胜者名额。
+- 生成调优证据时，数量门槛不替代人工审核；生成的无答案题必须逐题批准并重新校准后，才能计入困难负例资格。
+- 跨分块调优必须使用稳定 `source_block` Gold。只有 chunk Gold 时只能比较检索参数，不得伪装成跨分块证据。
+- 分块候选必须记录不含正文的真实索引指纹和固定探针排序指纹；名义配置不同但真实结果一致时，非基线分块候选不得自动胜出。
+- 优化集用于 threshold 和候选选择，Holdout 只用于 finalist 门禁。不得读取 Holdout 后修改 Gold、候选或阈值。
+- Holdout finalist 必须使用固定验证计划：每题重复查询后先按 case 取中位延迟，再聚合 P95；配对 bootstrap 和分层重采样只能使用固定 Holdout，不得混入优化集。统计摘要必须持久化且不得包含 query 或正文。
+- Promotion Gate 与有效改善只是必要条件；配对质量区间未证明非退化时不得物化候选。宽置信区间必须按证据不足展示，不得通过放宽文案伪装为成功。
+- Hash Embedding 下 Vector/Hybrid 不得自动胜出。Rerank 必须由用户明确授权并固定 Provider、模型和调用预算。
+- trial namespace 不得出现在普通版本列表、不得激活，终态必须清理。物化胜者必须重新构建为普通 `promotion_required` 版本并完成全量评测。
+- Tuner 不得修改 Pipeline Draft、Processor、Vision、Embedding Profile 或活动索引；无有效改善必须返回 `no_improvement`。
+- 普通 Evaluation 保持原最大 K 语义；Tuner 搜索与最终复跑必须显式遵守候选 Retrieval Profile 的 Top-K。
+- 调整检索评分、阈值、候选去重、排名、门禁或物化逻辑时，必须运行 03D known-winner 与 already-optimal control；禁止修改夹具 Gold 以迎合当前实现。
+- 与基线完全相同的 Chunker + Retrieval Profile 必须标记为 `baseline_equivalent`，不得因延迟噪声或缓存顺序成为自动胜者。
+- RunRegistry、API、metadata 和日志只记录版本、配置、指标、耗时与安全错误摘要，不得包含问题全集、正文、路径、embedding、Rerank 原始输出或密钥。
+- 修改该路径至少运行 `test_rag_strategy_tuner.py`、Router、Evaluation、Pipeline 回归、全量后端测试和前端生产构建。
+
 ### 自编写高风险路径
 
 - `xpert_authoring` 与 `skill_creator` 只能创建提案，不得加入发布、安装、删除或直接覆盖工具。

--- a/client/src/components/RagStrategyTunerPanel.tsx
+++ b/client/src/components/RagStrategyTunerPanel.tsx
@@ -1,0 +1,459 @@
+import {
+  AlertTriangle,
+  CheckCircle2,
+  ExternalLink,
+  LoaderCircle,
+  Play,
+  RefreshCw,
+  SlidersHorizontal,
+  Square,
+  X,
+} from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+
+type Objective = "balanced" | "quality" | "low_latency";
+
+interface PipelineVersion {
+  version_id: string;
+  version: number;
+  status: string;
+  active: boolean;
+  chunk_count: number;
+}
+
+interface EvaluationSet {
+  eval_set_id: string;
+  name: string;
+  latest_version?: number | null;
+}
+
+interface EvaluationSetVersion {
+  version_id: string;
+  version: number;
+  cases: unknown[];
+  checksum: string;
+}
+
+interface Recommendation {
+  recommendation_id: string;
+  state: string;
+  created_at: number;
+}
+
+interface Metrics {
+  recall_at_5?: number;
+  mrr_at_10?: number;
+  ndcg_at_10?: number;
+  citation_coverage?: number;
+  no_result_accuracy?: number;
+  p95_latency_ms?: number;
+}
+
+interface Finalist {
+  candidate_id: string;
+  retrieval: { mode: string; top_k: number; score_threshold: number; vector_weight?: number };
+  holdout_metrics: Metrics;
+  cost: { chunk_count: number; estimated_index_bytes: number; size_is_estimated: boolean };
+  promotion_gate: { passed: boolean };
+  improvement: { effective: boolean };
+  rerank_call_count: number;
+  threshold_selection_reason?: string | null;
+  statistical_validation?: {
+    validation_version: string;
+    passed: boolean;
+    quality_delta?: number;
+    confidence_level?: number;
+    confidence_interval?: { lower: number; upper: number };
+    stable_resample_count?: number;
+    required_stable_resamples?: number;
+    query_repetitions?: number;
+  };
+}
+
+interface TuningRun {
+  run_id: string;
+  status: string;
+  stage: string;
+  progress: number;
+  warnings: string[];
+  finalists: Finalist[];
+  pareto_front: string[];
+  final_version_id?: string | null;
+  evaluation_run_id?: string | null;
+  winner?: (Finalist & { materialized_version_id?: string }) | null;
+  no_improvement_reason?: "optimization_gate" | "holdout_gate" | "statistical_gate" | "full_evaluation_gate" | null;
+  optimization_gate_summary?: {
+    evaluated_count?: number;
+    passed_count?: number;
+    eligible_count?: number;
+    failed_check_counts?: Record<string, number>;
+  };
+  chunk_sensitivity?: {
+    status: "sufficient" | "insufficient" | "not_measured" | "not_applicable";
+    probe_count: number;
+    unique_realized_outcomes: number;
+  };
+  retrieval_deduplication?: {
+    candidate_count: number;
+    unique_semantic_outcomes: number;
+    duplicate_count: number;
+  };
+  statistical_summary?: {
+    evaluated_finalist_count: number;
+    statistically_non_degrading_count: number;
+    eligible_count: number;
+    query_repetitions: number;
+    resample_count: number;
+    confidence_level: number;
+  };
+  error?: string | null;
+}
+
+interface TuningReadiness {
+  status: "ready" | "report_only" | "insufficient_data";
+  benchmark_role: "unclassified" | "regression_guard" | "strategy_tuning" | "promotion_evidence";
+  selection_eligible: boolean;
+  evidence_strength: string;
+  counts: {
+    total: number;
+    positive: number;
+    no_result: number;
+    reviewed_hard_negative: number;
+  };
+  dimensions: {
+    retrieval: { eligible: boolean };
+    threshold: { eligible: boolean };
+    chunking: { eligible: boolean; sensitivity_probe_required: boolean };
+  };
+  checks: Array<{
+    check_id: string;
+    passed: boolean;
+    severity: string;
+    actual: unknown;
+    required: unknown;
+    message: string;
+  }>;
+  blockers: string[];
+  warnings: string[];
+}
+
+interface Preflight {
+  snapshot_hash: string;
+  eval_case_count: number;
+  chunk_tuning_available: boolean;
+  threshold_tuning_available: boolean;
+  benchmark_role: TuningReadiness["benchmark_role"];
+  selection_eligible: boolean;
+  tuning_readiness: TuningReadiness;
+  retrieval_only: boolean;
+  embedding_degraded: boolean;
+  rerank_available: boolean;
+  warnings: string[];
+}
+
+interface Props {
+  kbId: string;
+  open: boolean;
+  onClose: () => void;
+  onCompleted: () => Promise<void> | void;
+}
+
+const ACTIVE_STATUSES = new Set([
+  "queued",
+  "profiling",
+  "searching",
+  "building",
+  "evaluating",
+  "materializing",
+  "validating",
+]);
+
+function errorMessage(value: unknown, fallback: string) {
+  if (!value || typeof value !== "object") return fallback;
+  const detail = (value as { detail?: unknown }).detail;
+  return typeof detail === "string" ? detail : fallback;
+}
+
+function percent(value?: number) {
+  return value == null ? "-" : `${(value * 100).toFixed(1)}%`;
+}
+
+function confidenceInterval(item: Finalist) {
+  const interval = item.statistical_validation?.confidence_interval;
+  if (!interval) return "-";
+  return `${(interval.lower * 100).toFixed(1)}% ~ ${(interval.upper * 100).toFixed(1)}%`;
+}
+
+function statusLabel(status: string) {
+  const labels: Record<string, string> = {
+    queued: "排队中",
+    profiling: "固定快照",
+    searching: "检索搜索",
+    building: "构建 Trial",
+    evaluating: "Holdout 验证",
+    materializing: "物化胜者",
+    validating: "完整评测",
+    completed: "已完成",
+    no_improvement: "无有效改善",
+    failed: "失败",
+    cancelled: "已取消",
+  };
+  return labels[status] || status;
+}
+
+function readinessLabel(status: TuningReadiness["status"]) {
+  if (status === "ready") return "可进入调优";
+  if (status === "report_only") return "仅回归报告";
+  return "证据不足";
+}
+
+function benchmarkRoleLabel(role: TuningReadiness["benchmark_role"]) {
+  const labels: Record<TuningReadiness["benchmark_role"], string> = {
+    unclassified: "未分类",
+    regression_guard: "回归护栏",
+    strategy_tuning: "策略调优",
+    promotion_evidence: "推广证据",
+  };
+  return labels[role];
+}
+
+function chunkSensitivityLabel(status: NonNullable<TuningRun["chunk_sensitivity"]>["status"]) {
+  const labels: Record<NonNullable<TuningRun["chunk_sensitivity"]>["status"], string> = {
+    sufficient: "候选产生可区分结果",
+    insufficient: "候选等价，已降级为仅检索",
+    not_measured: "探针不足",
+    not_applicable: "不适用",
+  };
+  return labels[status];
+}
+
+export default function RagStrategyTunerPanel({ kbId, open, onClose, onCompleted }: Props) {
+  const [versions, setVersions] = useState<PipelineVersion[]>([]);
+  const [sets, setSets] = useState<EvaluationSet[]>([]);
+  const [evaluationVersions, setEvaluationVersions] = useState<EvaluationSetVersion[]>([]);
+  const [recommendations, setRecommendations] = useState<Recommendation[]>([]);
+  const [baseVersionId, setBaseVersionId] = useState("");
+  const [evalSetId, setEvalSetId] = useState("");
+  const [evalVersion, setEvalVersion] = useState("");
+  const [recommendationId, setRecommendationId] = useState("");
+  const [objective, setObjective] = useState<Objective>("balanced");
+  const [enableRerank, setEnableRerank] = useState(false);
+  const [preflight, setPreflight] = useState<Preflight | null>(null);
+  const [run, setRun] = useState<TuningRun | null>(null);
+  const [busy, setBusy] = useState<"load" | "preflight" | "start" | "cancel" | "retry" | "">("");
+  const [error, setError] = useState("");
+
+  const load = useCallback(async () => {
+    setBusy("load");
+    setError("");
+    try {
+      const [versionResponse, setResponse, recommendationResponse] = await Promise.all([
+        fetch(`/api/rag/pipeline/versions?kb_id=${encodeURIComponent(kbId)}`),
+        fetch(`/api/rag/evaluation-sets?kb_id=${encodeURIComponent(kbId)}`),
+        fetch(`/api/rag/strategy-router/recommendations?kb_id=${encodeURIComponent(kbId)}`),
+      ]);
+      if (!versionResponse.ok || !setResponse.ok) throw new Error("调优资源加载失败。");
+      const nextVersions = ((await versionResponse.json()) as { versions: PipelineVersion[] }).versions || [];
+      const nextSets = ((await setResponse.json()) as { evaluation_sets: EvaluationSet[] }).evaluation_sets || [];
+      setVersions(nextVersions.filter((item) => item.status === "ready" || item.status === "active"));
+      setSets(nextSets.filter((item) => Number(item.latest_version || 0) > 0));
+      setBaseVersionId((current) => current || nextVersions.find((item) => item.active)?.version_id || nextVersions[0]?.version_id || "");
+      setEvalSetId((current) => current || nextSets.find((item) => Number(item.latest_version || 0) > 0)?.eval_set_id || "");
+      if (recommendationResponse.ok) {
+        const nextRecommendations = ((await recommendationResponse.json()) as { recommendations: Recommendation[] }).recommendations || [];
+        setRecommendations(nextRecommendations.filter((item) => item.state === "ready" || item.state === "applied"));
+      }
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "调优资源加载失败。");
+    } finally {
+      setBusy("");
+    }
+  }, [kbId]);
+
+  const loadSetVersions = useCallback(async () => {
+    if (!evalSetId) {
+      setEvaluationVersions([]);
+      setEvalVersion("");
+      return;
+    }
+    const response = await fetch(`/api/rag/evaluation-sets/${encodeURIComponent(evalSetId)}/versions`);
+    if (!response.ok) return;
+    const values = ((await response.json()) as { versions: EvaluationSetVersion[] }).versions || [];
+    setEvaluationVersions(values);
+    setEvalVersion((current) => current || String(values[0]?.version || ""));
+  }, [evalSetId]);
+
+  useEffect(() => { if (open) void load(); }, [load, open]);
+  useEffect(() => { if (open) void loadSetVersions(); }, [loadSetVersions, open]);
+  useEffect(() => {
+    setPreflight(null);
+  }, [baseVersionId, evalSetId, evalVersion, recommendationId, objective, enableRerank]);
+
+  useEffect(() => {
+    if (!run || !ACTIVE_STATUSES.has(run.status)) return undefined;
+    const timer = window.setInterval(async () => {
+      const response = await fetch(`/api/rag/strategy-tuner/runs/${encodeURIComponent(run.run_id)}`);
+      if (!response.ok) return;
+      const next = (await response.json()) as TuningRun;
+      setRun(next);
+      if (!ACTIVE_STATUSES.has(next.status) && next.status === "completed") await onCompleted();
+    }, 1800);
+    return () => window.clearInterval(timer);
+  }, [onCompleted, run]);
+
+  function requestBody() {
+    return {
+      kb_id: kbId,
+      base_version_id: baseVersionId,
+      eval_set_id: evalSetId,
+      eval_set_version: Number(evalVersion),
+      recommendation_id: recommendationId || null,
+      objective,
+      seed: 42,
+      max_chunk_indexes: 4,
+      max_retrieval_trials: 24,
+      max_finalists: 3,
+      enable_rerank: enableRerank,
+      rerank_provider: "auto",
+    };
+  }
+
+  async function runPreflight() {
+    setBusy("preflight");
+    setError("");
+    try {
+      const response = await fetch("/api/rag/strategy-tuner/preflight", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(requestBody()),
+      });
+      const payload = await response.json().catch(() => null);
+      if (!response.ok) throw new Error(errorMessage(payload, "调优预检失败。"));
+      setPreflight(payload as Preflight);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "调优预检失败。");
+    } finally {
+      setBusy("");
+    }
+  }
+
+  async function startRun() {
+    setBusy("start");
+    setError("");
+    try {
+      const response = await fetch("/api/rag/strategy-tuner/runs", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(requestBody()),
+      });
+      const payload = await response.json().catch(() => null);
+      if (!response.ok) throw new Error(errorMessage(payload, "调优任务创建失败。"));
+      setRun(payload as TuningRun);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "调优任务创建失败。");
+    } finally {
+      setBusy("");
+    }
+  }
+
+  async function cancelRun() {
+    if (!run) return;
+    setBusy("cancel");
+    const response = await fetch(`/api/rag/strategy-tuner/runs/${encodeURIComponent(run.run_id)}/cancel`, { method: "POST" });
+    if (response.ok) setRun((await response.json()) as TuningRun);
+    else setError(errorMessage(await response.json().catch(() => null), "取消失败。"));
+    setBusy("");
+  }
+
+  async function retryRun() {
+    if (!run) return;
+    setBusy("retry");
+    setError("");
+    const response = await fetch(
+      `/api/rag/strategy-tuner/runs/${encodeURIComponent(run.run_id)}/retry`,
+      { method: "POST" },
+    );
+    const payload = await response.json().catch(() => null);
+    if (response.ok) setRun(payload as TuningRun);
+    else setError(errorMessage(payload, "重试失败。"));
+    setBusy("");
+  }
+
+  if (!open) return null;
+  const canPreflight = Boolean(baseVersionId && evalSetId && evalVersion);
+  const active = Boolean(run && ACTIVE_STATUSES.has(run.status));
+
+  return (
+    <div className="fixed inset-0 z-50 flex justify-end bg-surface-950/70" role="dialog" aria-modal="true" aria-label="RAG 评测调优">
+      <button className="absolute inset-0 cursor-default" aria-label="关闭评测调优" onClick={onClose} type="button" />
+      <aside className="relative flex h-full w-full max-w-[720px] flex-col border-l border-white/10 bg-surface-950 shadow-2xl">
+        <header className="flex items-start justify-between gap-4 border-b border-white/10 px-5 py-4">
+          <div className="flex min-w-0 gap-3">
+            <span className="grid h-9 w-9 shrink-0 place-items-center rounded-md bg-emerald-300/10 text-emerald-200"><SlidersHorizontal size={18} /></span>
+            <div><h2 className="text-base font-semibold text-white">Benchmark 驱动的策略调优</h2><p className="mt-1 text-xs leading-5 text-slate-400">固定知识与 Gold 快照，搜索分块和检索参数；胜者仍需显式推广。</p></div>
+          </div>
+          <button className="grid h-9 w-9 place-items-center rounded-md text-slate-400 hover:bg-white/[0.06] hover:text-white" onClick={onClose} title="关闭" type="button"><X size={18} /></button>
+        </header>
+
+        <div className="flex-1 overflow-y-auto">
+          <section className="border-b border-white/10 px-5 py-5">
+            <div className="grid gap-3 sm:grid-cols-2">
+              <Select label="固定知识版本" value={baseVersionId} onChange={setBaseVersionId} options={versions.map((item) => ({ value: item.version_id, label: `v${item.version}${item.active ? " · active" : ""} · ${item.chunk_count} chunks` }))} />
+              <Select label="已发布评测集" value={evalSetId} onChange={(value) => { setEvalSetId(value); setEvalVersion(""); }} options={sets.map((item) => ({ value: item.eval_set_id, label: `${item.name} · v${item.latest_version}` }))} />
+              <Select label="评测版本" value={evalVersion} onChange={setEvalVersion} options={evaluationVersions.map((item) => ({ value: String(item.version), label: `v${item.version} · ${item.cases.length} cases` }))} />
+              <Select label="Router 推荐（可选）" value={recommendationId} onChange={setRecommendationId} options={[{ value: "", label: "仅使用当前配置与规则邻域" }, ...recommendations.map((item) => ({ value: item.recommendation_id, label: `${item.state} · ${new Date(item.created_at * 1000).toLocaleString("zh-CN", { hour12: false })}` }))]} />
+            </div>
+            <div className="mt-4 grid grid-cols-3 gap-2" role="group" aria-label="调优目标">
+              {([['balanced', '均衡'], ['quality', '质量优先'], ['low_latency', '低延迟']] as Array<[Objective, string]>).map(([value, label]) => <button className={`rounded-md border px-3 py-2 text-xs font-semibold ${objective === value ? "border-emerald-300/45 bg-emerald-300/10 text-emerald-50" : "border-white/10 text-slate-300 hover:bg-white/[0.05]"}`} key={value} onClick={() => setObjective(value)} type="button">{label}</button>)}
+            </div>
+            <label className="mt-4 flex items-start gap-3 border-t border-white/10 pt-4 text-xs leading-5 text-slate-300"><input checked={enableRerank} className="mt-1 h-4 w-4 accent-emerald-300" onChange={(event) => setEnableRerank(event.target.checked)} type="checkbox" /><span><strong className="block text-slate-100">显式授权 finalist Rerank 实测</strong>默认关闭；最多对两个非 Rerank finalist 调用已配置 Provider。</span></label>
+            <div className="mt-4 flex gap-2">
+              <button className="inline-flex flex-1 items-center justify-center gap-2 rounded-md border border-white/10 px-3 py-2 text-sm font-semibold text-slate-200 hover:bg-white/[0.06] disabled:opacity-45" disabled={!canPreflight || Boolean(busy) || active} onClick={() => void runPreflight()} type="button">{busy === "preflight" ? <LoaderCircle className="animate-spin" size={15} /> : <RefreshCw size={15} />}运行预检</button>
+              <button className="inline-flex flex-1 items-center justify-center gap-2 rounded-md bg-emerald-300 px-3 py-2 text-sm font-bold text-surface-950 hover:bg-emerald-200 disabled:opacity-45" disabled={!preflight?.selection_eligible || Boolean(busy) || active} onClick={() => void startRun()} type="button"><Play size={15} />开始调优</button>
+            </div>
+            <p className="mt-2 text-[10px] leading-4 text-slate-500">均衡预算：最多 4 个分块索引、24 组检索参数和 3 个 finalist。不会修改 Draft 或活动索引。</p>
+          </section>
+
+          {preflight ? <section className="border-b border-white/10 px-5 py-5">
+            <div className="flex items-center justify-between gap-3">
+              <h3 className="text-sm font-semibold text-white">调优资格与固定快照</h3>
+              <span className={`px-2 py-1 text-[11px] font-semibold ${preflight.selection_eligible ? "bg-emerald-300/10 text-emerald-200" : "bg-amber-300/10 text-amber-100"}`}>{readinessLabel(preflight.tuning_readiness.status)}</span>
+            </div>
+            <p className="mt-2 text-xs leading-5 text-slate-400">评测角色：{benchmarkRoleLabel(preflight.benchmark_role)}。标准回归 Pack 只能验证引擎一致性，不能单独选择调优胜者。</p>
+            <div className="mt-4 grid grid-cols-2 gap-x-6 gap-y-3 sm:grid-cols-4">
+              <Metric label="正样例" value={`${preflight.tuning_readiness.counts.positive}/30`} />
+              <Metric label="困难负例" value={`${preflight.tuning_readiness.counts.reviewed_hard_negative}/12`} />
+              <Metric label="分块搜索" value={preflight.chunk_tuning_available ? "探针后可用" : "仅检索"} />
+              <Metric label="阈值搜索" value={preflight.threshold_tuning_available ? "可用" : "固定基线"} />
+              <Metric label="Embedding" value={preflight.embedding_degraded ? "Hash 降级" : "真实向量"} />
+              <Metric label="Rerank" value={preflight.rerank_available ? "可用" : "不可用"} />
+            </div>
+            {preflight.tuning_readiness.checks.filter((item) => !item.passed).map((item) => <p className={`mt-3 flex gap-2 text-xs leading-5 ${item.severity === "blocker" ? "text-rose-100" : "text-amber-100"}`} key={item.check_id}><AlertTriangle className="mt-0.5 shrink-0" size={14} />{item.message}</p>)}
+          </section> : null}
+
+          {run ? <section className="px-5 py-5"><div className="flex items-center justify-between gap-3"><div><h3 className="text-sm font-semibold text-white">调优运行</h3><p className="mt-1 font-mono text-[10px] text-slate-500">{run.run_id}</p></div><span className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${run.status === "completed" ? "bg-emerald-300/10 text-emerald-200" : run.status === "failed" ? "bg-rose-300/10 text-rose-200" : "bg-cyan-300/10 text-cyan-200"}`}>{statusLabel(run.status)}</span></div><div className="mt-4 h-2 overflow-hidden rounded-full bg-white/[0.06]"><div className="h-full bg-emerald-300 transition-[width]" style={{ width: `${Math.max(2, run.progress)}%` }} /></div><p className="mt-2 text-xs text-slate-400">{run.stage} · {run.progress}%</p>
+            {active ? <button className="mt-4 inline-flex items-center gap-2 rounded-md border border-rose-300/25 px-3 py-2 text-xs font-semibold text-rose-100 hover:bg-rose-300/10 disabled:opacity-45" disabled={busy === "cancel"} onClick={() => void cancelRun()} type="button"><Square size={13} />取消后续搜索</button> : null}
+            {run.status === "failed" || run.status === "cancelled" ? <button className="mt-4 inline-flex items-center gap-2 rounded-md border border-white/10 px-3 py-2 text-xs font-semibold text-slate-100 hover:bg-white/[0.06] disabled:opacity-45" disabled={busy === "retry"} onClick={() => void retryRun()} type="button">{busy === "retry" ? <LoaderCircle className="animate-spin" size={13} /> : <RefreshCw size={13} />}重新开始搜索</button> : null}
+            {run.error ? <p className="mt-4 rounded-md bg-rose-300/10 px-3 py-2 text-xs leading-5 text-rose-100">{run.error}</p> : null}
+            {run.chunk_sensitivity?.status ? <p className="mt-4 text-xs leading-5 text-slate-400">分块敏感性：{chunkSensitivityLabel(run.chunk_sensitivity.status)} · {run.chunk_sensitivity.unique_realized_outcomes}/{run.chunk_sensitivity.probe_count} 个真实结果指纹。</p> : null}
+            {run.retrieval_deduplication?.candidate_count ? <p className="mt-2 text-xs leading-5 text-slate-400">检索语义去重：{run.retrieval_deduplication.unique_semantic_outcomes}/{run.retrieval_deduplication.candidate_count} 个独立结果，排除 {run.retrieval_deduplication.duplicate_count} 个等价候选。</p> : null}
+            {run.statistical_summary ? <p className="mt-2 text-xs leading-5 text-slate-400">稳健验证：固定 Holdout 内 {run.statistical_summary.resample_count} 组分层重采样，每题查询 {run.statistical_summary.query_repetitions} 次后取中位延迟；{run.statistical_summary.statistically_non_degrading_count}/{run.statistical_summary.evaluated_finalist_count} 个 finalist 通过统计非退化门禁。</p> : null}
+            {run.status === "no_improvement" ? <p className="mt-4 rounded-md bg-amber-300/10 px-3 py-2 text-xs leading-5 text-amber-100">{run.no_improvement_reason === "optimization_gate" ? `优化集上没有候选通过当前质量门禁，因此未进入 Holdout、也未生成候选版本。已检查 ${run.optimization_gate_summary?.evaluated_count ?? 0} 个配置。` : run.no_improvement_reason === "statistical_gate" ? "候选在单点指标上达到改善，但配对重采样的质量区间无法证明其稳定非退化，因此未生成版本。" : run.evaluation_run_id ? "Holdout 胜者已生成候选版本，但未通过完整评测集复核，因此不可推广；可查看下方候选与评测证据。" : "固定 Holdout 上没有候选同时通过质量门禁并达到有效改善阈值，因此未生成版本。"}</p> : null}
+            {run.finalists.length ? <div className="mt-5 overflow-x-auto border-t border-white/10 pt-4"><table className="w-full min-w-[820px] text-left text-xs"><thead className="text-slate-500"><tr><th className="pb-2 font-semibold">配置</th><th className="pb-2 font-semibold">nDCG@10</th><th className="pb-2 font-semibold">Recall@5</th><th className="pb-2 font-semibold">No-result</th><th className="pb-2 font-semibold">稳健 P95</th><th className="pb-2 font-semibold">质量差异 90% CI</th><th className="pb-2 font-semibold">门禁</th></tr></thead><tbody>{run.finalists.map((item) => <tr className="border-t border-white/[0.07] text-slate-300" key={item.candidate_id}><td className="py-3"><span className="font-semibold text-white">{item.retrieval.mode}</span><span className="ml-2 text-slate-500">K={item.retrieval.top_k} · T={item.retrieval.score_threshold.toFixed(3)}</span>{item.threshold_selection_reason === "hard_negative_false_positive_improved" ? <span className="ml-2 text-emerald-200">负样例 Pareto</span> : null}</td><td className="py-3">{percent(item.holdout_metrics.ndcg_at_10)}</td><td className="py-3">{percent(item.holdout_metrics.recall_at_5)}</td><td className="py-3">{percent(item.holdout_metrics.no_result_accuracy)}</td><td className="py-3">{item.holdout_metrics.p95_latency_ms?.toFixed(1) ?? "-"} ms</td><td className="py-3"><span className={item.statistical_validation?.passed ? "text-emerald-200" : "text-amber-100"}>{confidenceInterval(item)}</span><span className="mt-1 block text-[10px] text-slate-500">稳定 {item.statistical_validation?.stable_resample_count ?? 0}/{item.statistical_validation?.required_stable_resamples ?? 0}</span></td><td className="py-3">{item.promotion_gate.passed && item.improvement.effective && item.statistical_validation?.passed ? <span className="text-emerald-200">可晋级</span> : <span className="text-slate-500">未通过</span>}</td></tr>)}</tbody></table></div> : null}
+            {run.status === "completed" && run.final_version_id ? <div className="mt-5 flex gap-3 border-t border-white/10 pt-4"><CheckCircle2 className="mt-0.5 shrink-0 text-emerald-300" size={18} /><div><p className="text-sm font-semibold text-white">候选版本已物化并通过完整评测</p><p className="mt-1 text-xs leading-5 text-slate-400">版本仍为 promotion_required，活动索引没有变化。</p><Link className="mt-3 inline-flex items-center gap-2 text-xs font-semibold text-emerald-200 hover:text-emerald-100" to={`/rag/${encodeURIComponent(kbId)}/evaluation`}>查看 Evaluation 与推广入口<ExternalLink size={13} /></Link></div></div> : null}
+          </section> : null}
+        </div>
+        {error ? <div className="border-t border-rose-300/20 bg-rose-300/10 px-5 py-3 text-xs leading-5 text-rose-100" aria-live="polite">{error}</div> : null}
+      </aside>
+    </div>
+  );
+}
+
+function Select({ label, value, onChange, options }: { label: string; value: string; onChange: (value: string) => void; options: Array<{ value: string; label: string }> }) {
+  return <label className="text-xs font-semibold text-slate-300">{label}<select className="mt-2 w-full rounded-md border border-white/10 bg-surface-950 px-3 py-2 text-sm font-normal text-white" onChange={(event) => onChange(event.target.value)} value={value}><option value="">请选择</option>{options.map((item) => <option key={`${item.value}-${item.label}`} value={item.value}>{item.label}</option>)}</select></label>;
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return <div><p className="text-[10px] font-semibold uppercase text-slate-500">{label}</p><p className="mt-1 text-sm font-semibold text-slate-100">{value}</p></div>;
+}

--- a/client/src/components/evaluations/KnowledgeBenchmarkGenerator.tsx
+++ b/client/src/components/evaluations/KnowledgeBenchmarkGenerator.tsx
@@ -81,6 +81,7 @@ export default function KnowledgeBenchmarkGenerator({
   const [versionId, setVersionId] = useState("");
   const [documentIds, setDocumentIds] = useState<string[]>([]);
   const [generatorModelId, setGeneratorModelId] = useState(models[0]?.id ?? "");
+  const [generationPurpose, setGenerationPurpose] = useState<"general" | "strategy_tuning">("general");
   const [caseCount, setCaseCount] = useState(12);
   const [noResultCount, setNoResultCount] = useState(0);
   const [seed, setSeed] = useState(0);
@@ -143,6 +144,7 @@ export default function KnowledgeBenchmarkGenerator({
         postJson({
           target: target(),
           generator_model_id: generatorModelId,
+          generation_purpose: generationPurpose,
           case_count: caseCount,
           no_result_count: noResultCount,
           locales,
@@ -175,9 +177,13 @@ export default function KnowledgeBenchmarkGenerator({
     ));
   }
 
-  const maxNoResult = Math.min(5, Math.floor(caseCount / 5));
+  const tuningMode = generationPurpose === "strategy_tuning";
+  const maxNoResult = tuningMode ? Math.max(0, Math.min(20, caseCount - 30)) : Math.min(5, Math.floor(caseCount / 5));
+  const generationCountsValid = tuningMode
+    ? caseCount - noResultCount >= 30 && (noResultCount === 0 || noResultCount >= 12)
+    : caseCount <= 30 && noResultCount <= maxNoResult;
   const canGenerate = Boolean(
-    versionId && generatorModelId && coverage.length && preflight?.valid && !busy,
+    versionId && generatorModelId && coverage.length && preflight?.valid && generationCountsValid && !busy,
   );
 
   return (
@@ -208,6 +214,17 @@ export default function KnowledgeBenchmarkGenerator({
       </div>
 
       <div className="mt-4">
+        <span className="text-xs font-semibold text-slate-300">生成用途</span>
+        <div className="mt-2 inline-flex rounded-md border border-white/10 bg-surface-950 p-1">
+          <button className={`rounded px-3 py-2 text-xs ${!tuningMode ? "bg-white/10 text-white" : "text-slate-400"}`} onClick={() => { setGenerationPurpose("general"); setCaseCount(12); setNoResultCount(0); }} type="button">常规评测</button>
+          <button className={`rounded px-3 py-2 text-xs ${tuningMode ? "bg-cyan-300 text-surface-950" : "text-slate-400"}`} onClick={() => { setGenerationPurpose("strategy_tuning"); setCaseCount(42); setNoResultCount(12); }} type="button">策略调优证据</button>
+        </div>
+        <p className="mt-2 text-[11px] leading-5 text-slate-500">
+          {tuningMode ? "生成至少 30 个正样例和 12 个语料近邻负样例；负样例逐题确认并重新校准后，阈值调优才会解锁。" : "适合日常检索回归；保持 6–30 条和最多 5 条无答案题的兼容限制。"}
+        </p>
+      </div>
+
+      <div className="mt-4">
         <div className="flex items-center justify-between gap-3"><span className="text-xs font-semibold text-slate-300">文档范围</span><button className="text-xs text-cyan-100" onClick={() => setDocumentIds([])} type="button">全部文档</button></div>
         <div className="mt-2 grid max-h-36 gap-2 overflow-y-auto sm:grid-cols-2 xl:grid-cols-3">
           {documents.map((document) => <label className="flex items-center gap-2 rounded-md border border-white/10 px-3 py-2 text-xs text-slate-300" key={document.id}><input checked={documentIds.includes(document.id)} onChange={(event) => setDocumentIds((current) => event.target.checked ? [...current, document.id] : current.filter((item) => item !== document.id))} type="checkbox" /><span className="truncate">{document.filename}</span></label>)}
@@ -216,7 +233,7 @@ export default function KnowledgeBenchmarkGenerator({
       </div>
 
       <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-        <label className="text-xs text-slate-400">用例数<input className="mt-1 h-9 w-full rounded-md border border-white/10 bg-surface-950 px-3 text-sm text-white" max={30} min={6} onChange={(event) => { const value = Number(event.target.value); setCaseCount(value); setNoResultCount((current) => Math.min(current, Math.min(5, Math.floor(value / 5)))); }} type="number" value={caseCount} /></label>
+        <label className="text-xs text-slate-400">用例数<input className="mt-1 h-9 w-full rounded-md border border-white/10 bg-surface-950 px-3 text-sm text-white" max={tuningMode ? 60 : 30} min={tuningMode ? 30 : 6} onChange={(event) => { const value = Number(event.target.value); setCaseCount(value); setNoResultCount((current) => Math.min(current, tuningMode ? Math.min(20, Math.max(0, value - 30)) : Math.min(5, Math.floor(value / 5)))); }} type="number" value={caseCount} /></label>
         <label className="text-xs text-slate-400">无答案题<input className="mt-1 h-9 w-full rounded-md border border-white/10 bg-surface-950 px-3 text-sm text-white" max={maxNoResult} min={0} onChange={(event) => setNoResultCount(Number(event.target.value))} type="number" value={noResultCount} /></label>
         <label className="text-xs text-slate-400">Seed<input className="mt-1 h-9 w-full rounded-md border border-white/10 bg-surface-950 px-3 text-sm text-white" min={0} onChange={(event) => setSeed(Number(event.target.value))} type="number" value={seed} /></label>
         <div className="text-xs text-slate-400">语言<div className="mt-1 flex h-9 items-center gap-3 rounded-md border border-white/10 bg-surface-950 px-3">{["zh-CN", "en-US"].map((locale) => <label className="flex items-center gap-1" key={locale}><input checked={locales.includes(locale)} onChange={(event) => setLocales((current) => event.target.checked ? [...current, locale] : current.filter((item) => item !== locale))} type="checkbox" />{locale}</label>)}</div></div>

--- a/client/src/pages/KnowledgePipelineCanvasPage.tsx
+++ b/client/src/pages/KnowledgePipelineCanvasPage.tsx
@@ -17,10 +17,11 @@ import {
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Route } from "lucide-react";
+import { Route, SlidersHorizontal } from "lucide-react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import PageContainer from "../components/PageContainer";
 import RagStrategyRouterPanel from "../components/RagStrategyRouterPanel";
+import RagStrategyTunerPanel from "../components/RagStrategyTunerPanel";
 import {
   DEFAULT_EMBEDDING_MODEL_ID,
   embeddingModelOptions,
@@ -299,6 +300,7 @@ export default function KnowledgePipelineCanvasPage() {
   const [workbenchTab, setWorkbenchTab] = useState<"config" | "preview" | "run">("config");
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [strategyOpen, setStrategyOpen] = useState(false);
+  const [strategyTunerOpen, setStrategyTunerOpen] = useState(false);
   const [selectedDocumentId, setSelectedDocumentId] = useState("");
   const [preview, setPreview] = useState<NodePreview | null>(null);
   const [jobs, setJobs] = useState<PipelineJob[]>([]);
@@ -598,6 +600,7 @@ export default function KnowledgePipelineCanvasPage() {
           <div className="flex flex-wrap items-center gap-2">
             <Link className="rounded-lg border border-emerald-300/25 bg-emerald-300/10 px-3 py-2 text-sm font-semibold text-emerald-100 hover:bg-emerald-300/15" to={`/rag/${encodeURIComponent(kbId)}/evaluation`}>质量评估</Link>
             <button className="inline-flex items-center gap-2 rounded-lg border border-cyan-300/25 bg-cyan-300/10 px-3 py-2 text-sm font-semibold text-cyan-100 hover:bg-cyan-300/15" onClick={() => setStrategyOpen(true)} type="button"><Route size={15} />策略路由</button>
+            <button className="inline-flex items-center gap-2 rounded-lg border border-emerald-300/25 bg-emerald-300/10 px-3 py-2 text-sm font-semibold text-emerald-100 hover:bg-emerald-300/15" onClick={() => setStrategyTunerOpen(true)} type="button"><SlidersHorizontal size={15} />评测调优</button>
             <button className="rounded-lg border border-white/10 bg-white/[0.05] px-3 py-2 text-sm font-semibold text-slate-200 hover:bg-white/[0.09] disabled:opacity-50" disabled={Boolean(busy)} onClick={() => void validateGraph()} type="button">校验</button>
             <button className="rounded-lg border border-hire-300/25 bg-hire-300/10 px-3 py-2 text-sm font-semibold text-hire-100 hover:bg-hire-300/15 disabled:opacity-50" disabled={Boolean(busy)} onClick={() => void saveGraph()} type="button">保存草稿</button>
             <button className="rounded-lg bg-hire-300 px-4 py-2 text-sm font-bold text-surface-950 hover:bg-hire-200 disabled:opacity-50" disabled={Boolean(busy) || documents.length === 0} onClick={() => void executeGraph()} type="button">执行流水线</button>
@@ -698,6 +701,7 @@ export default function KnowledgePipelineCanvasPage() {
         ) : null}
       </div>
       <RagStrategyRouterPanel kbId={kbId} onApplied={loadPage} onClose={() => setStrategyOpen(false)} open={strategyOpen} />
+      <RagStrategyTunerPanel kbId={kbId} onCompleted={loadRuns} onClose={() => setStrategyTunerOpen(false)} open={strategyTunerOpen} />
     </PageContainer>
   );
 }

--- a/docs/RAG_INTEGRATION.md
+++ b/docs/RAG_INTEGRATION.md
@@ -2,12 +2,73 @@
 
 本文件说明模镜本地 RAG 模块的架构、API、扩展方式和测试方法。该模块位于 `server/rag/`，前端入口为 `/rag`，聊天页可选择知识库进行检索增强问答。
 
-最后更新日期：2026-08-09
+最后更新日期：2026-08-11
 
 > **当前状态：** `/rag` 是 ModelMirror 本地主路径。知识流水线已支持候选版本、
 > 人工激活/回滚、Processor、可选视觉理解、向量 + FTS5 双索引、检索评测和
 > Promotion Gate。下方按日期保留的段落是增量记录；较早段落中的“planned”
 > 只代表当时状态。
+
+## 2026-08-10 增量：Benchmark 驱动的 RAG Strategy Auto Tuner
+
+Strategy Router 的规则推荐现在可以进入第二阶段的固定证据调优。Tuner 固定一个
+`ready / active` V2 知识版本、一个已发布 Evaluation Set Version、Router rules 和
+完整来源快照，按固定 seed 将 Gold 分成优化集与 Holdout。预检先执行
+`RAG Strategy Tuning Readiness V1`：标准 Catalog Pack 标记为 `regression_guard`，
+只能做引擎回归，不能单独选择调优胜者；正式检索调优至少需要 30 条正样例。
+
+Threshold 调优额外要求至少 12 条已审核的语料近邻困难负例；证据不足时阈值固定为
+基线值。跨分块比较必须有稳定 `source_block` Gold，并覆盖稀疏、单块密集和多块密集
+问题。多个名义分块方案若产生相同真实索引统计和排序指纹，会自动降级为仅检索调优，
+避免把等价分块误判为改进。
+
+默认均衡预算最多构建 4 个分块索引、比较 24 组检索参数并保留 3 个 finalist。搜索
+覆盖 Full-text、Vector、Hybrid、Top-K、Hybrid 权重和从优化集分数确定性产生的 threshold；
+Hash Embedding 下 Vector/Hybrid 不得自动胜出。Rerank 默认关闭，只有用户明确授权且
+Provider 就绪时才对最多两个 finalist 实测。
+
+`RAG Strategy Tuner V4` 保留 V3 的阈值 Pareto 与语义去重，并增加重复统计验证。V3
+不再以 Recall 的词典序独占阈值选择：它在优化集上构建
+Recall@5、nDCG@10 与困难负例 false-positive rate 的非支配前沿；只有在 Recall 和
+nDCG 各自最多回退 0.02 时，才允许用更高阈值换取至少 0.01 的误召回改善，否则保留
+基线阈值。不同模式下不生效的权重和已关闭 Rerank 字段不再形成重复配置；实际索引、
+排序和有效检索语义均相同时，重复候选不能占用 finalist 或胜者名额。
+
+知识库定向生成器新增“策略调优证据”模式，允许 30–60 条用例。检索调优至少保留
+30 条正样例；需要 threshold 调优时，默认生成 42 条，其中 12 条是语料近邻无答案题。
+这些负样例仍为 `pending`，必须逐题确认并重新校准后才能满足调优资格。
+
+中间 trial 使用隔离 namespace，不可激活，也不会出现在普通版本列表。搜索通过当前
+Evaluation Gate、Pareto 排名及质量/延迟/索引规模有效改善门槛后，才按胜者精确配置重建
+普通 `ready` 版本。该版本固定 `origin.kind=rag_strategy_tuner` 与
+`promotion_required=true`，并在完整评测集上重新比较基线；活动索引始终不自动切换。
+
+运行由文件型 Store 与后台 Coordinator 持久化；进程恢复复用已完成 trial、Holdout 和
+Rerank 结果，显式 Retry 则清空失效搜索进度后重新开始。RunRegistry 仅记录版本、候选
+数量、阶段、耗时与错误摘要，不保存问题、正文、路径、embedding 或密钥。
+
+03C 将 finalist 验证升级为固定 Holdout 内的重复统计：每题查询 3 次，先取每题中位延迟，
+再聚合平均值和 P95；同时进行 3 组固定 seed 的分层重采样与 1,000 次确定性配对
+bootstrap，报告 case-weighted 质量差异的 90% 区间。区间下界不得低于 `-0.02`，且至少
+2/3 重采样不得越过该退化边界。该门禁只证明在固定 Gold 下未观察到明显退化，不能把
+宽区间解释为等价或全局最优。验证计划、基线和 finalist 的安全统计会持久化，重启不会
+重复已完成的 Holdout 查询。优化集的单次延迟只作诊断，不会在稳健 Holdout 前淘汰候选。
+
+接口：
+
+```text
+GET  /api/rag/strategy-tuner/capabilities
+POST /api/rag/strategy-tuner/preflight
+GET  /api/rag/strategy-tuner/runs?kb_id=&status=
+POST /api/rag/strategy-tuner/runs
+GET  /api/rag/strategy-tuner/runs/{run_id}
+POST /api/rag/strategy-tuner/runs/{run_id}/cancel
+POST /api/rag/strategy-tuner/runs/{run_id}/retry
+```
+
+该报告只证明特定语料与固定 Gold 下的相对结果，不宣称存在通用最优 RAG 策略。
+当前资格层、阈值 Pareto、语义去重、重复分层验证和稳健延迟已经阻断已知无效证据；
+真实 known-winner 端到端夹具仍属于下一调优可靠性轮次。
 
 ## 2026-08-10 增量：可解释 RAG Strategy Router V1
 

--- a/docs/RAG_STRATEGY_RESEARCH.md
+++ b/docs/RAG_STRATEGY_RESEARCH.md
@@ -251,3 +251,162 @@ Phase B should begin only if the user accepts these four decisions:
 `RAG Strategy Rules V1` is therefore the fixed rule source for Router V1. Any
 rule change must update its evidence classification, counterexample and local
 experiment reference before production behavior changes.
+
+## 11. Benchmark Auto Tuner authorization and evidence boundary
+
+Follow-up decision recorded on 2026-08-10: after Router V1 was accepted and
+merged, the bounded Auto Tuner round was authorized. This does not revise the
+Rules V1 evidence or turn any heuristic into a universal default. It adds a
+target-specific empirical stage with these boundaries:
+
+- fix one immutable V2 source snapshot and one published Evaluation Set Version;
+- use the optimization split for threshold/candidate selection and reserve Holdout
+  for finalist comparison;
+- keep Processor, Vision and Embedding profiles unchanged;
+- isolate and clean trial indexes, and never expose them as activatable versions;
+- materialize only a candidate that passes the existing Evaluation Gate and an
+  explicit quality, latency or index-size improvement threshold;
+- rerun the full evaluation set on the materialized version;
+- leave the result `promotion_required` for explicit human promotion.
+
+The resulting ranking is evidence for that corpus, Gold distribution, provider
+state and fixed run budget. It must not be cited as proof of a generally optimal
+chunking or retrieval strategy.
+
+## 12. Auto Tuner qualification audit and corrective boundary
+
+The first Auto Tuner acceptance round did not produce a trustworthy promoted
+candidate. Repeated runs exposed a system-level mismatch rather than one isolated
+threshold bug:
+
+- the synthetic catalog pack was designed as an engine regression guard but was
+  used as winner-selection evidence;
+- 34 answerable and 6 obvious out-of-domain no-result cases made the Holdout
+  no-result gate too coarse and unstable;
+- several nominally different chunk profiles produced the same realized chunk
+  count and retrieval ranking, so the benchmark could not distinguish chunking;
+- threshold selection optimized Recall first, while very small negative slices
+  made abstention evidence effectively all-or-nothing;
+- single-run latency was noisy enough to create false cost improvements.
+
+The corrective implementation therefore starts with evidence qualification, not
+with a wider parameter grid. Evaluation versions now carry one of four roles:
+`unclassified`, `regression_guard`, `strategy_tuning`, or `promotion_evidence`.
+Catalog regression packs remain runnable in the Evaluation workspace but cannot
+start a formal tuning run or materialize a winner.
+
+`RAG Strategy Tuning Readiness V1` requires at least 30 answerable cases before
+retrieval selection. Threshold tuning additionally requires at least 12 reviewed,
+corpus-near hard negatives. Cross-chunk tuning additionally requires stable
+source-block Gold plus sparse, single-dense, and multi-dense evidence coverage.
+Missing evidence disables only the affected dimension when safe; it is never
+silently treated as passing evidence.
+
+Chunk trials also record a content-free realized-index fingerprint and a ranked
+result fingerprint under one fixed probe retrieval profile. If multiple nominal
+profiles yield one realized outcome, non-baseline chunk candidates lose automatic
+winner eligibility and the run continues as retrieval-only tuning. These hashes
+contain IDs and counts, not document text or queries.
+
+## 13. Auto Tuner 03B: threshold Pareto and semantic search space
+
+03B corrects the two search-space defects isolated by the qualification audit.
+Threshold selection now builds a non-dominated frontier over Recall@5, nDCG@10,
+and hard-negative false-positive rate. A non-zero threshold is selected only when
+it reduces false positives by at least `0.01` while keeping Recall and nDCG within
+`0.02` of the zero-threshold profile. If no such point exists, the baseline
+threshold is retained. Thresholds remain profile- and corpus-specific because
+FTS confidence, vector similarity, and normalized RRF scores are not portable.
+
+Retrieval candidates are now normalized by effective semantics. Full-text and
+vector modes ignore inactive Hybrid weights; disabled Rerank ignores provider,
+model, and top-N fields. After execution, candidates with the same realized-index,
+ranking, and effective retrieval fingerprints cannot consume another winner slot.
+The report exposes both nominal candidate count and unique semantic outcomes.
+
+Targeted knowledge generation now has an explicit `strategy_tuning` purpose. It
+can create 30-60 cases and defaults to 30 answerable cases plus 12 corpus-near
+negative cases when threshold evidence is requested. Generated negatives remain
+pending until a human reviews them and calibration is rerun; quantity alone never
+confers tuning eligibility.
+
+Real known-winner end-to-end fixtures remain intentionally separate. Until that
+round passes, Auto Tuner output is corpus-specific comparative evidence rather
+than proof of a generally reliable strategy optimizer.
+
+## 14. Auto Tuner 03C: repeated Holdout evidence and robust latency
+
+03C keeps the original optimization/Holdout boundary and does not expand the
+search space. The fixed Holdout is evaluated with three queries per case. Each
+case latency is reduced to its median before the run reports average and P95,
+so a single cold start or scheduler spike cannot create a false latency win.
+The optimization split still filters quality and execution errors, but its
+single-query latency is diagnostic only and cannot reject a candidate before
+the repeated Holdout measurement.
+
+Finalist quality is compared to the baseline by case. Answerable cases use
+nDCG@10 and approved no-result cases use no-result accuracy. Three deterministic
+stratified bootstrap views are sampled only from the fixed Holdout; optimization
+cases are never admitted. A deterministic 1,000-sample paired bootstrap then
+reports a 90% confidence interval for the case-weighted quality delta.
+
+The statistical gate is deliberately a non-degradation gate, not a universal
+significance claim. Its lower confidence bound must remain within `-0.02`, and
+at least two of the three stratified resamples must do the same. A candidate must
+still pass the existing Promotion Gate and effective quality/cost improvement
+rule. The baseline summary, validation plan checksum, per-case metric summaries,
+and finalist intervals are persisted without queries or document text, allowing
+restart recovery without repeating completed Holdout calls.
+
+Small Holdouts still produce wide intervals; that is evidence uncertainty rather
+than a software error. 03D must add real known-winner fixtures to prove that the
+complete system can recover expected winners under controlled perturbations.
+
+## 15. Auto Tuner 03D: known-winner system proof
+
+03D adds a project-owned, versioned synthetic fixture at
+`server/tests/fixtures/rag_strategy_tuner_known_winners.json`. It is not a product
+benchmark and must not be used to claim universal retrieval quality. Its purpose
+is narrower: prove that the complete tuner can recover a known intervention and
+can abstain when the same intervention is already present.
+
+The `threshold_recovery` scenario uses the real FTS5 index and ModelMirror lexical
+confidence contract. Positive queries match every required policy term, while
+approved corpus-near negatives share the policy identifier but contain absent
+requirements. With the baseline threshold at zero, both groups are recalled.
+The expected winner is therefore known before the run: a non-zero threshold above
+the observed negative ceiling must preserve the stable source-block Gold, restore
+no-result accuracy, pass repeated Holdout validation, materialize a normal ready
+version, and leave the active version unchanged.
+
+The `already_optimal_control` scenario rebuilds the same immutable corpus with
+that safe threshold already fixed in the base version. A candidate whose chunker
+and retrieval profile are exactly equal to the base is marked
+`baseline_equivalent` before Holdout. It cannot become a winner because of timing
+noise, and the run must finish `no_improvement` without creating a version.
+
+Both scenarios execute the real upload, parser, pipeline job, vector/FTS build,
+query, optimization split, repeated Holdout, paired statistical gate, materialized
+pipeline job and full Evaluation Gate path. They do not monkeypatch search results
+or metrics. The fixture and capability contract are fixed as
+`rag-strategy-known-winner-v1`; changing scoring or selection logic requires the
+same fixture to pass without rewriting its Gold to match the new behavior.
+
+### Verified and unverified boundary
+
+Verified by 03D:
+
+- a real full-text threshold defect is recovered end to end;
+- hard-negative improvement survives fixed Holdout and full-set validation;
+- the winner becomes `promotion_required` and is never auto-activated;
+- an already-optimal equivalent profile cannot manufacture a latency-only win.
+
+Not yet proved by this fixture:
+
+- a known winner between Recursive and Parent-child chunking;
+- Vector or Hybrid selection with a real semantic embedding provider;
+- Rerank quality/cost selection;
+- transfer of any selected threshold to another corpus or retrieval mode.
+
+Those remain separate evidence tasks. Absence of those fixtures must be shown as
+an unverified boundary, not inferred from the threshold proof.

--- a/docs/XPERT_ALIGNMENT.md
+++ b/docs/XPERT_ALIGNMENT.md
@@ -21,6 +21,11 @@ Xpert 功能扩张已在
 多租户、远程市场、动态插件、更多 Provider 和 UI 像素对齐均进入延期清单。
 下一项功能增量固定为 `EVOAGENTX-META-PLANNER-01`。
 
+知识能力的冻结后维护增量已补齐可解释 Strategy Router 与 Benchmark Auto Tuner。
+它们复用既有 Pipeline、Evaluation Gate 和 Promotion，不改变 Xpert Runtime 协议：Router
+只更新草稿；Tuner 只生成 `promotion_required` 候选，活动索引仍由人工显式推广。完整
+执行契约见 [RAG_INTEGRATION.md](./RAG_INTEGRATION.md)。
+
 ## 2026-07-23 增量：XPERT-PLUGIN-PROMPT-03
 
 Xpert 冻结前最后一轮功能增量已进入真实闭环：

--- a/docs/XPERT_KNOWLEDGE.md
+++ b/docs/XPERT_KNOWLEDGE.md
@@ -1,10 +1,25 @@
 # Xpert Knowledge Pipeline Runtime
 
-最后更新日期：2026-07-16
+最后更新日期：2026-08-11
 
 ## 目标
 
 Knowledge Pipeline 把安全草稿配置推进为可恢复的本地索引构建任务，同时保持现有上传和查询入口兼容。核心契约是：**构建候选、隔离预览、人工激活、随时回滚**。
+
+## Strategy Router 与 Auto Tuner
+
+- Router V1 使用经审阅的确定性规则和聚合语料画像，只把 Chunker/Retrieval 建议写入草稿。
+- Auto Tuner 固定知识版本、来源、评测版本与规则版本，在隔离 trial namespace 中搜索并验证参数。
+- 调优前必须通过 `RAG Strategy Tuning Readiness V1`：Catalog 标准 Pack 仅作回归护栏；正式检索选择至少需要 30 条正样例，阈值搜索另需 12 条已审核语料近邻困难负例。
+- `RAG Strategy Tuner V4` 保留 V3 的 Recall/nDCG/困难负例误召回 Pareto 和语义去重，并增加重复 Holdout 与配对统计；不安全的阈值改善会保留基线。
+- 定向 Gold 生成器的“策略调优证据”模式可生成 30–60 条用例，默认 30 条正样例与 12 条待审核困难负例；审核和重新校准仍是解锁 threshold 调优的必要条件。
+- 跨分块证据除了稳定 `source_block` Gold，还必须覆盖稀疏、单块密集和多块密集问题；真实索引与排序指纹无差异时自动退化为仅检索调优。
+- Processor、Vision 与 Embedding Profile 在本轮调优中固定，不参与候选变化。
+- 只有通过 Holdout、Evaluation Gate、Pareto 与有效改善门槛的胜者才会物化为普通候选版本。
+- Holdout finalist 每题重复检索 3 次并使用中位延迟；质量差异以固定 Holdout 内的 3 组分层重采样和 1,000 次配对 bootstrap 形成 90% 区间，统计非退化失败时禁止物化。
+- 物化版本始终是 `promotion_required`；完整评测通过后仍需用户显式 Promote，绝不自动激活。
+- 调优运行的直接检索和最终复跑都遵守候选 Profile 的 Top-K；普通 Evaluation API 保持既有最大 K 评测语义。
+- trial 索引不可激活、不可见于普通版本列表，终态后清理；持久 Coordinator 在重启后复用已完成工作。
 
 ## 数据模型
 

--- a/server/benchmarks/api.py
+++ b/server/benchmarks/api.py
@@ -166,6 +166,12 @@ async def get_capabilities() -> dict[str, Any]:
             "target_kind": "knowledge_version",
             "case_count": {"default": 12, "min": 6, "max": 30},
             "no_result_count": {"default": 0, "max": 5, "max_ratio": 0.2},
+            "strategy_tuning": {
+                "case_count": {"default": 42, "min": 30, "max": 60},
+                "minimum_positive_cases": 30,
+                "no_result_count": {"default": 12, "disabled": 0, "min": 12, "max": 20},
+                "negative_review_required": True,
+            },
             "max_evidence_units": 40,
             "max_evidence_chars": 48_000,
         }

--- a/server/benchmarks/executor.py
+++ b/server/benchmarks/executor.py
@@ -715,7 +715,7 @@ class BenchmarkJobExecutor:
             system,
             user,
             0.2,
-            12_000,
+            16_000 if int(request.get("case_count") or 12) > 30 else 12_000,
         )
         attempts = [{
             "attempt": "initial",
@@ -755,7 +755,7 @@ class BenchmarkJobExecutor:
                 repair_system,
                 repair_user,
                 0.0,
-                12_000,
+                16_000 if int(request.get("case_count") or 12) > 30 else 12_000,
             )
             attempts.append({
                 "attempt": "repair",
@@ -789,6 +789,9 @@ class BenchmarkJobExecutor:
             cases=generated["cases"],
             provenance={
                 "generator": "modelmirror-targeted-rag-benchmark-v1",
+                "generation_purpose": str(
+                    request.get("generation_purpose") or "general"
+                ),
                 "generation_job_id": job["job_id"],
                 "generator_model_id": str(request.get("generator_model_id") or "")[:300],
                 "target_reference": copy.deepcopy(reference),
@@ -807,6 +810,9 @@ class BenchmarkJobExecutor:
                 "available": list(context["available_coverage"]),
                 "locales": list(request.get("locales") or ["zh-CN", "en-US"]),
                 "targeting": copy.deepcopy(generated.get("targeting") or []),
+                "generation_purpose": str(
+                    request.get("generation_purpose") or "general"
+                ),
             },
             calibration={
                 "status": "pending",
@@ -821,6 +827,9 @@ class BenchmarkJobExecutor:
             status="validating",
             generation={
                 "case_count": len(generated["cases"]),
+                "generation_purpose": str(
+                    request.get("generation_purpose") or "general"
+                ),
                 "repair_used": repair_used,
                 "attempt_diagnostics": copy.deepcopy(attempts),
                 "assumptions": generated["assumptions"],

--- a/server/benchmarks/models.py
+++ b/server/benchmarks/models.py
@@ -101,7 +101,8 @@ class BenchmarkTargetRequest(BaseModel):
 class BenchmarkGenerationRequest(BaseModel):
     target: BenchmarkTargetRequest
     generator_model_id: str = Field(min_length=1, max_length=300)
-    case_count: int = Field(default=12, ge=6, le=30)
+    generation_purpose: Literal["general", "strategy_tuning"] = "general"
+    case_count: int = Field(default=12, ge=6, le=60)
     locales: list[Literal["zh-CN", "en-US"]] = Field(
         default_factory=lambda: ["zh-CN", "en-US"],
         min_length=1,
@@ -112,18 +113,36 @@ class BenchmarkGenerationRequest(BaseModel):
         default_factory=list,
         max_length=20,
     )
-    no_result_count: int = Field(default=0, ge=0, le=5)
+    no_result_count: int = Field(default=0, ge=0, le=20)
     seed: int = Field(default=0, ge=0, le=2_147_483_647)
 
     @model_validator(mode="after")
     def validate_no_result_count(self) -> "BenchmarkGenerationRequest":
-        limit = min(5, self.case_count // 5)
-        if self.no_result_count > limit:
-            raise ValueError(
-                f"no_result_count cannot exceed {limit} for {self.case_count} cases."
-            )
         if self.target.kind != "knowledge_version" and self.no_result_count:
             raise ValueError("no_result_count is only supported for knowledge targets.")
+        if self.generation_purpose == "strategy_tuning":
+            if self.target.kind != "knowledge_version":
+                raise ValueError(
+                    "strategy_tuning generation is only supported for knowledge targets."
+                )
+            positive_count = self.case_count - self.no_result_count
+            if positive_count < 30:
+                raise ValueError(
+                    "strategy_tuning generation requires at least 30 answerable cases."
+                )
+            if self.no_result_count and self.no_result_count < 12:
+                raise ValueError(
+                    "strategy_tuning threshold evidence requires either 0 or at least 12 "
+                    "hard-negative cases."
+                )
+        else:
+            if self.case_count > 30:
+                raise ValueError("general generation cannot exceed 30 cases.")
+            limit = min(5, self.case_count // 5)
+            if self.no_result_count > limit:
+                raise ValueError(
+                    f"no_result_count cannot exceed {limit} for {self.case_count} cases."
+                )
         return self
 
 
@@ -145,4 +164,3 @@ class BenchmarkCalibrationRequest(BaseModel):
     dataset_id: str = Field(min_length=1, max_length=200)
     dataset_revision: int = Field(ge=1)
     target: BenchmarkTargetRequest | None = None
-

--- a/server/main.py
+++ b/server/main.py
@@ -43,20 +43,24 @@ try:
     from server.rag.api import (
         configure_evaluation_executor,
         configure_pipeline_executor,
+        configure_strategy_tuner,
         get_evaluation_executor,
         get_evaluation_store as get_rag_evaluation_store,
         get_pipeline_executor,
         get_rag_service,
+        get_strategy_tuner,
         router as rag_router,
     )
 except ModuleNotFoundError:
     from rag.api import (
         configure_evaluation_executor,
         configure_pipeline_executor,
+        configure_strategy_tuner,
         get_evaluation_executor,
         get_evaluation_store as get_rag_evaluation_store,
         get_pipeline_executor,
         get_rag_service,
+        get_strategy_tuner,
         router as rag_router,
     )
 
@@ -1127,6 +1131,7 @@ workflow_execution_store = WorkflowExecutionStore(
 configure_runtime_approvals(runtime_approval_store, workflow_execution_store)
 knowledge_pipeline_executor = configure_pipeline_executor(run_registry=run_registry)
 knowledge_evaluation_executor = configure_evaluation_executor(run_registry=run_registry)
+rag_strategy_tuner = configure_strategy_tuner(run_registry=run_registry)
 handoff_executor: HandoffExecutor | None = None
 goal_coordinator: GoalCoordinator | None = None
 approval_coordinator: ApprovalCoordinator | None = None
@@ -15994,6 +15999,7 @@ async def start_mcp_ttl_cleanup() -> None:
         logger.warning("Toolset auto-start failed: %s", warning)
     get_pipeline_executor().start()
     get_evaluation_executor().start()
+    get_strategy_tuner().start()
     get_xpert_evaluation_executor().start()
     start_skill_creator_evaluation_runtime()
     get_benchmark_job_executor().start()
@@ -16014,6 +16020,7 @@ async def start_mcp_ttl_cleanup() -> None:
 async def shutdown_mcp_sessions() -> None:
     await get_pipeline_executor().stop()
     await get_evaluation_executor().stop()
+    await get_strategy_tuner().stop()
     await get_benchmark_job_executor().stop()
     await get_xpert_evolution_executor().stop()
     await get_xpert_evaluation_executor().stop()

--- a/server/rag/api.py
+++ b/server/rag/api.py
@@ -54,6 +54,15 @@ from .strategy_router import (
     RagStrategyStateError,
     RagStrategyValidationError,
 )
+from .strategy_tuner import (
+    RUNNING_STATUSES as STRATEGY_TUNER_RUNNING_STATUSES,
+    TERMINAL_STATUSES as STRATEGY_TUNER_TERMINAL_STATUSES,
+    RagStrategyTuner,
+    RagStrategyTuningNotFoundError,
+    RagStrategyTuningStateError,
+    RagStrategyTuningStore,
+    RagStrategyTuningValidationError,
+)
 
 
 MAX_UPLOAD_BYTES = 10 * 1024 * 1024
@@ -63,6 +72,8 @@ _rag_service: RagService | None = None
 _pipeline_executor: KnowledgePipelineExecutor | None = None
 _evaluation_store: KnowledgeEvaluationStore | None = None
 _evaluation_executor: KnowledgeEvaluationExecutor | None = None
+_strategy_tuning_store: RagStrategyTuningStore | None = None
+_strategy_tuner: RagStrategyTuner | None = None
 
 
 class KnowledgeBaseCreateRequest(BaseModel):
@@ -358,6 +369,22 @@ class RagStrategyApplyRequest(BaseModel):
     expected_draft_version: int = Field(ge=1)
     profile_id: str = Field(default="primary", min_length=1, max_length=80)
     confirm_low_confidence: bool = False
+
+
+class RagStrategyTuningRequest(BaseModel):
+    kb_id: str = Field(min_length=1, max_length=160)
+    base_version_id: str = Field(min_length=1, max_length=200)
+    eval_set_id: str = Field(min_length=1, max_length=200)
+    eval_set_version: int = Field(ge=1)
+    recommendation_id: str | None = Field(default=None, max_length=200)
+    objective: Literal["balanced", "quality", "low_latency"] = "balanced"
+    seed: int = Field(default=42, ge=0, le=2_147_483_647)
+    max_chunk_indexes: int = Field(default=4, ge=1, le=4)
+    max_retrieval_trials: int = Field(default=24, ge=1, le=24)
+    max_finalists: int = Field(default=3, ge=1, le=3)
+    enable_rerank: bool = False
+    rerank_provider: Literal["auto", "api", "llm"] = "auto"
+    rerank_model: str = Field(default="", max_length=200)
 
 
 class PipelineGraphNodePayload(BaseModel):
@@ -689,6 +716,9 @@ class EvaluationSetCreateRequest(BaseModel):
     kb_id: str = Field(min_length=1, max_length=160)
     name: str = Field(min_length=1, max_length=160)
     description: str = Field(default="", max_length=1000)
+    benchmark_role: Literal[
+        "unclassified", "regression_guard", "strategy_tuning", "promotion_evidence"
+    ] = "unclassified"
 
 
 class EvaluationSetUpdateRequest(BaseModel):
@@ -696,6 +726,9 @@ class EvaluationSetUpdateRequest(BaseModel):
     name: str | None = Field(default=None, min_length=1, max_length=160)
     description: str | None = Field(default=None, max_length=1000)
     status: str | None = None
+    benchmark_role: Literal[
+        "unclassified", "regression_guard", "strategy_tuning", "promotion_evidence"
+    ] | None = None
 
 
 class EvaluationSetPublishRequest(BaseModel):
@@ -769,10 +802,13 @@ def set_rag_service_for_tests(service: RagService | None) -> None:
     """Replace the global RAG service in tests."""
 
     global _rag_service, _pipeline_executor, _evaluation_store, _evaluation_executor
+    global _strategy_tuning_store, _strategy_tuner
     _rag_service = service
     _pipeline_executor = None
     _evaluation_store = None
     _evaluation_executor = None
+    _strategy_tuning_store = None
+    _strategy_tuner = None
 
 
 def configure_pipeline_executor(*, run_registry: Any | None = None) -> KnowledgePipelineExecutor:
@@ -830,6 +866,46 @@ def get_evaluation_executor() -> KnowledgeEvaluationExecutor:
 def set_evaluation_executor_for_tests(executor: KnowledgeEvaluationExecutor | None) -> None:
     global _evaluation_executor
     _evaluation_executor = executor
+
+
+def get_strategy_tuning_store() -> RagStrategyTuningStore:
+    global _strategy_tuning_store
+    if _strategy_tuning_store is None:
+        _strategy_tuning_store = RagStrategyTuningStore(
+            get_rag_service().storage_dir / "strategy_tuning_runs.json"
+        )
+    return _strategy_tuning_store
+
+
+def configure_strategy_tuner(*, run_registry: Any | None = None) -> RagStrategyTuner:
+    global _strategy_tuner
+    _strategy_tuner = RagStrategyTuner(
+        get_rag_service(),
+        get_strategy_tuning_store(),
+        get_evaluation_store(),
+        get_pipeline_executor(),
+        get_evaluation_executor(),
+        run_registry=run_registry,
+    )
+    return _strategy_tuner
+
+
+def get_strategy_tuner() -> RagStrategyTuner:
+    global _strategy_tuner
+    if _strategy_tuner is None:
+        _strategy_tuner = RagStrategyTuner(
+            get_rag_service(),
+            get_strategy_tuning_store(),
+            get_evaluation_store(),
+            get_pipeline_executor(),
+            get_evaluation_executor(),
+        )
+    return _strategy_tuner
+
+
+def set_strategy_tuner_for_tests(tuner: RagStrategyTuner | None) -> None:
+    global _strategy_tuner
+    _strategy_tuner = tuner
 
 
 def _require_knowledge_base(kb_id: str) -> None:
@@ -918,6 +994,90 @@ async def apply_strategy_router_recommendation(
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     except (RagStrategyStateError, RagStrategyValidationError) as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.get("/strategy-tuner/capabilities")
+async def get_strategy_tuner_capabilities() -> dict[str, Any]:
+    return get_strategy_tuner().capabilities()
+
+
+@router.post("/strategy-tuner/preflight")
+async def preflight_strategy_tuner(payload: RagStrategyTuningRequest) -> dict[str, Any]:
+    try:
+        return get_strategy_tuner().preflight(payload.model_dump())
+    except (
+        KnowledgeBaseNotFoundError,
+        PipelineJobNotFoundError,
+        PipelineVersionNotFoundError,
+    ) as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except (EvaluationSetNotFoundError, RagStrategyRecommendationNotFoundError) as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except (RagStrategyTuningValidationError, PipelineJobStateError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.get("/strategy-tuner/runs")
+async def list_strategy_tuner_runs(
+    kb_id: str | None = None,
+    status: str | None = None,
+    limit: int = 50,
+) -> dict[str, Any]:
+    valid = STRATEGY_TUNER_RUNNING_STATUSES | STRATEGY_TUNER_TERMINAL_STATUSES
+    if status is not None and status not in valid:
+        raise HTTPException(status_code=400, detail="Invalid strategy tuning status.")
+    runs = get_strategy_tuning_store().list_runs(
+        kb_id=kb_id, status=status, limit=limit
+    )
+    return {"runs": runs, "run_count": len(runs)}
+
+
+@router.post("/strategy-tuner/runs", status_code=202)
+async def create_strategy_tuner_run(payload: RagStrategyTuningRequest) -> dict[str, Any]:
+    try:
+        return get_strategy_tuner().create_run(payload.model_dump())
+    except (
+        KnowledgeBaseNotFoundError,
+        PipelineJobNotFoundError,
+        PipelineVersionNotFoundError,
+    ) as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except (EvaluationSetNotFoundError, RagStrategyRecommendationNotFoundError) as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except (RagStrategyTuningValidationError, PipelineJobStateError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.get("/strategy-tuner/runs/{run_id}")
+async def get_strategy_tuner_run(run_id: str) -> dict[str, Any]:
+    try:
+        return get_strategy_tuning_store().get_run(run_id)
+    except RagStrategyTuningNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.post("/strategy-tuner/runs/{run_id}/cancel")
+async def cancel_strategy_tuner_run(run_id: str) -> dict[str, Any]:
+    try:
+        run = get_strategy_tuning_store().request_cancel(run_id)
+        get_strategy_tuner().notify()
+        return run
+    except RagStrategyTuningNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except RagStrategyTuningStateError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+
+@router.post("/strategy-tuner/runs/{run_id}/retry")
+async def retry_strategy_tuner_run(run_id: str) -> dict[str, Any]:
+    try:
+        run = get_strategy_tuning_store().retry(run_id)
+        get_strategy_tuner().notify()
+        return run
+    except RagStrategyTuningNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except RagStrategyTuningStateError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
 
 
 @router.post("/knowledge_bases", response_model=KnowledgeBasePayload)
@@ -1643,6 +1803,7 @@ async def create_evaluation_set(payload: EvaluationSetCreateRequest) -> dict[str
         payload.kb_id,
         payload.name,
         payload.description,
+        benchmark_role=payload.benchmark_role,
     )
 
 
@@ -1666,6 +1827,7 @@ async def update_evaluation_set(
             name=payload.name,
             description=payload.description,
             status=payload.status,
+            benchmark_role=payload.benchmark_role,
         )
     except EvaluationSetNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
@@ -2078,6 +2240,8 @@ async def activate_pipeline_version(
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except EvaluationPromotionError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except PipelineJobStateError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
 
 
 @router.post("/pipeline/versions/{version_id}/promote", response_model=PipelineVersionPayload)
@@ -2109,6 +2273,8 @@ async def promote_pipeline_version(
     except PipelineVersionNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except EvaluationPromotionError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except PipelineJobStateError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
 
 

--- a/server/rag/evaluation.py
+++ b/server/rag/evaluation.py
@@ -9,6 +9,8 @@ import uuid
 from pathlib import Path
 from typing import Any
 
+from .strategy_tuning_qualification import normalize_benchmark_role
+
 
 class EvaluationError(RuntimeError):
     """Base error for knowledge evaluation operations."""
@@ -208,6 +210,11 @@ def aggregate_target_metrics(
             )
             if completed
             else 1.0,
+            "positive_no_result_rate": round(
+                sum(1 for item in positive if item.get("no_result")) / len(positive), 6
+            )
+            if positive
+            else 0.0,
             "warning_rate": round(
                 sum(1 for item in completed if int(item.get("warning_count", 0)) > 0)
                 / len(completed),
@@ -304,15 +311,17 @@ def evaluate_promotion_gate(
             float(effective["max_citation_hit_regression"]),
             "Citation hit-rate regression must stay within tolerance.",
         )
-        no_result_increase = float(candidate.get("no_result_rate", 0.0)) - float(
-            baseline.get("no_result_rate", 0.0)
+        no_result_increase = float(
+            candidate.get("positive_no_result_rate", candidate.get("no_result_rate", 0.0))
+        ) - float(
+            baseline.get("positive_no_result_rate", baseline.get("no_result_rate", 0.0))
         )
         add_check(
             "max_no_result_increase",
             no_result_increase <= float(effective["max_no_result_increase"]),
             no_result_increase,
             float(effective["max_no_result_increase"]),
-            "No-result rate increase must stay within tolerance.",
+            "Positive-case no-result rate increase must stay within tolerance.",
         )
         baseline_p95 = float(baseline.get("p95_latency_ms", 0.0))
         candidate_p95 = float(candidate.get("p95_latency_ms", 0.0))
@@ -351,6 +360,7 @@ class KnowledgeEvaluationStore:
         provenance: dict[str, Any] | None = None,
         coverage: dict[str, Any] | None = None,
         calibration: dict[str, Any] | None = None,
+        benchmark_role: str | None = None,
     ) -> dict[str, Any]:
         clean_name = name.strip()
         if not clean_name:
@@ -369,6 +379,11 @@ class KnowledgeEvaluationStore:
             "provenance": _copy(provenance or {}),
             "coverage": _copy(coverage or {}),
             "calibration": _copy(calibration or {}),
+            "benchmark_role": normalize_benchmark_role(
+                benchmark_role,
+                origin=str(origin or "manual"),
+                catalog_ref=catalog_ref,
+            ),
             "latest_version": None,
             "created_at": now,
             "updated_at": now,
@@ -389,6 +404,7 @@ class KnowledgeEvaluationStore:
         provenance: dict[str, Any],
         coverage: dict[str, Any],
         calibration: dict[str, Any],
+        benchmark_role: str = "strategy_tuning",
     ) -> dict[str, Any]:
         clean_name = name.strip()
         if not clean_name:
@@ -410,6 +426,10 @@ class KnowledgeEvaluationStore:
             "provenance": _copy(provenance),
             "coverage": _copy(coverage),
             "calibration": _copy(calibration),
+            "benchmark_role": normalize_benchmark_role(
+                benchmark_role,
+                origin="generated",
+            ),
             "latest_version": None,
             "created_at": now,
             "updated_at": now,
@@ -501,6 +521,11 @@ class KnowledgeEvaluationStore:
                 "provenance": _copy(item.get("provenance") or {}),
                 "coverage": _copy(item.get("coverage") or {}),
                 "calibration": _copy(item.get("calibration") or {}),
+                "benchmark_role": normalize_benchmark_role(
+                    item.get("benchmark_role"),
+                    origin=str(item.get("origin") or "manual"),
+                    catalog_ref=dict(item.get("catalog_ref") or {}),
+                ),
                 "release_notes": str(release_notes or "")[:1000],
                 "checksum": _checksum({"cases": cases, "coverage": item.get("coverage") or {}}),
                 "published_at": now,
@@ -531,7 +556,7 @@ class KnowledgeEvaluationStore:
         data = self._read()
         self._set_or_raise(data, eval_set_id)
         items = [
-            _copy(version)
+            self._version_payload(version)
             for version in data["versions"].values()
             if version.get("eval_set_id") == eval_set_id
         ]
@@ -552,7 +577,7 @@ class KnowledgeEvaluationStore:
         )
         if not isinstance(item, dict):
             raise EvaluationSetNotFoundError("Knowledge evaluation set version not found.")
-        return _copy(item)
+        return self._version_payload(item)
 
     def update_set(
         self,
@@ -562,6 +587,7 @@ class KnowledgeEvaluationStore:
         name: str | None = None,
         description: str | None = None,
         status: str | None = None,
+        benchmark_role: str | None = None,
     ) -> dict[str, Any]:
         with self._lock:
             data = self._read_unlocked()
@@ -578,9 +604,15 @@ class KnowledgeEvaluationStore:
                 if status not in {"active", "archived"}:
                     raise ValueError("Evaluation set status must be active or archived.")
                 item["status"] = status
+            if benchmark_role is not None:
+                item["benchmark_role"] = normalize_benchmark_role(
+                    benchmark_role,
+                    origin=str(item.get("origin") or "manual"),
+                    catalog_ref=dict(item.get("catalog_ref") or {}),
+                )
             self._touch_set(item)
             self._write_unlocked(data)
-            return _copy(item)
+            return self._set_payload(item)
 
     def add_cases(
         self,
@@ -655,8 +687,25 @@ class KnowledgeEvaluationStore:
         ks: list[int],
         gate_policy: dict[str, Any],
         evaluation_set_version: dict[str, Any] | None = None,
+        case_ids: list[str] | None = None,
     ) -> dict[str, Any]:
         now = time.time()
+        snapshot = _copy(evaluation_set_version or evaluation_set)
+        if case_ids is not None:
+            requested = list(dict.fromkeys(str(item) for item in case_ids if str(item)))
+            by_id = {
+                str(case.get("case_id") or ""): case
+                for case in snapshot.get("cases", [])
+                if isinstance(case, dict)
+            }
+            missing = [case_id for case_id in requested if case_id not in by_id]
+            if missing:
+                raise EvaluationStateError(
+                    f"Evaluation case is unavailable in the fixed snapshot: {missing[0]}"
+                )
+            snapshot["cases"] = [_copy(by_id[case_id]) for case_id in requested]
+            if not snapshot["cases"]:
+                raise EvaluationStateError("Evaluation case subset cannot be empty.")
         run = {
             "run_id": f"evalrun_{uuid.uuid4().hex}",
             "kb_id": evaluation_set["kb_id"],
@@ -672,7 +721,10 @@ class KnowledgeEvaluationStore:
                 if evaluation_set_version is not None
                 else None
             ),
-            "eval_set_snapshot": _copy(evaluation_set_version or evaluation_set),
+            "eval_set_snapshot": snapshot,
+            "case_ids": [
+                str(case.get("case_id") or "") for case in snapshot.get("cases", [])
+            ],
             "targets": _copy(targets),
             "baseline_version_id": baseline_version_id,
             "ks": sorted(set(ks)),
@@ -939,11 +991,25 @@ class KnowledgeEvaluationStore:
         payload.setdefault("coverage", {})
         payload.setdefault("calibration", {})
         payload.setdefault("latest_version", None)
+        payload["benchmark_role"] = normalize_benchmark_role(
+            payload.get("benchmark_role"),
+            origin=str(payload.get("origin") or "manual"),
+            catalog_ref=dict(payload.get("catalog_ref") or {}),
+        )
         for case in payload.get("cases", []):
             if isinstance(case, dict):
                 case.setdefault("expected_no_result", False)
                 case.setdefault("review_status", "not_required")
                 case.setdefault("targeting", {})
+        return payload
+
+    def _version_payload(self, item: dict[str, Any]) -> dict[str, Any]:
+        payload = _copy(item)
+        payload["benchmark_role"] = normalize_benchmark_role(
+            payload.get("benchmark_role"),
+            origin=str(payload.get("origin") or "manual"),
+            catalog_ref=dict(payload.get("catalog_ref") or {}),
+        )
         return payload
 
     def _check_revision(self, item: dict[str, Any], expected_revision: int) -> None:

--- a/server/rag/evaluation_executor.py
+++ b/server/rag/evaluation_executor.py
@@ -89,6 +89,15 @@ class KnowledgeEvaluationExecutor:
             max_k = max(run["ks"])
             for target in run["targets"]:
                 target_id = str(target["target_id"])
+                target_top_k = max_k
+                if bool(target.get("respect_profile_top_k")):
+                    target_top_k = max(
+                        1,
+                        min(
+                            int((target.get("retrieval") or {}).get("top_k") or max_k),
+                            max_k,
+                        ),
+                    )
                 for case in run["eval_set_snapshot"]["cases"]:
                     case_id = str(case["case_id"])
                     current = self.store.get_run(run_id)
@@ -104,8 +113,11 @@ class KnowledgeEvaluationExecutor:
                         retrieval = await self.service.query_pipeline_version(
                             str(target["version_id"]),
                             str(case["query"]),
-                            top_k=max_k,
-                            retrieval=dict(target.get("retrieval") or {}),
+                            top_k=target_top_k,
+                            retrieval={
+                                **dict(target.get("retrieval") or {}),
+                                "top_k": target_top_k,
+                            },
                             generate_answer=False,
                         )
                         case_result = evaluate_retrieval_case(

--- a/server/rag/lexical_store.py
+++ b/server/rag/lexical_store.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 import re
 import sqlite3
 import threading
@@ -124,7 +125,8 @@ class SqliteLexicalStore:
         with self._lock, self._connect() as connection:
             rows = connection.execute(
                 """
-                SELECT c.*, bm25(rag_chunks_fts) AS lexical_rank
+                SELECT c.*, rag_chunks_fts.tokens AS search_tokens,
+                       bm25(rag_chunks_fts) AS lexical_rank
                 FROM rag_chunks_fts
                 JOIN rag_chunks c ON c.chunk_id = rag_chunks_fts.chunk_id
                 WHERE rag_chunks_fts MATCH ? AND rag_chunks_fts.namespace = ?
@@ -133,6 +135,9 @@ class SqliteLexicalStore:
                 """,
                 (expression, namespace, top_k),
             ).fetchall()
+            confidence_weights = _lexical_confidence_weights(
+                connection, namespace, query
+            )
         return [
             LexicalSearchResult(
                 chunk_id=str(row["chunk_id"]),
@@ -140,7 +145,11 @@ class SqliteLexicalStore:
                 doc_id=str(row["doc_id"]),
                 document_name=str(row["document_name"]),
                 text=str(row["text"]),
-                score=round(1.0 / (1.0 + index), 6),
+                score=_lexical_confidence(
+                    str(row["search_tokens"] or ""),
+                    confidence_weights,
+                    fallback_rank=index + 1,
+                ),
                 rank=index + 1,
                 parent_chunk_id=str(row["parent_chunk_id"]) if row["parent_chunk_id"] else None,
                 parent_text=str(row["parent_text"]) if row["parent_text"] else None,
@@ -257,3 +266,61 @@ def tokenize_for_search(text: str) -> str:
 def build_fts_query(text: str) -> str:
     tokens = tokenize_for_search(text).split()
     return " OR ".join(f'"{token.replace(chr(34), chr(34) * 2)}"' for token in tokens[:64])
+
+
+def _lexical_confidence_weights(
+    connection: sqlite3.Connection,
+    namespace: str,
+    query: str,
+) -> dict[str, float]:
+    tokens = [
+        token
+        for token in tokenize_for_search(query).split()[:64]
+        if _is_significant_confidence_token(token)
+    ]
+    if not tokens:
+        return {}
+    total_chunks = int(
+        connection.execute(
+            "SELECT COUNT(*) FROM rag_chunks WHERE namespace = ?", (namespace,)
+        ).fetchone()[0]
+    )
+    weights: dict[str, float] = {}
+    for token in dict.fromkeys(tokens):
+        expression = f'"{token.replace(chr(34), chr(34) * 2)}"'
+        document_frequency = int(
+            connection.execute(
+                """
+                SELECT COUNT(*) FROM rag_chunks_fts
+                WHERE rag_chunks_fts MATCH ? AND namespace = ?
+                """,
+                (expression, namespace),
+            ).fetchone()[0]
+        )
+        weights[token] = math.log(
+            (total_chunks + 1) / (document_frequency + 1)
+        ) + 1.0
+    return weights
+
+
+def _lexical_confidence(
+    indexed_tokens: str,
+    weights: dict[str, float],
+    *,
+    fallback_rank: int,
+) -> float:
+    if not weights:
+        return round(1.0 / max(1, fallback_rank), 6)
+    indexed = set(indexed_tokens.split())
+    total_weight = sum(weights.values())
+    matched_weight = sum(
+        weight for token, weight in weights.items() if token in indexed
+    )
+    return round(matched_weight / total_weight if total_weight else 0.0, 6)
+
+
+def _is_significant_confidence_token(token: str) -> bool:
+    is_cjk = bool(token) and all("\u3400" <= char <= "\u9fff" for char in token)
+    if is_cjk:
+        return len(token) == 2
+    return len(token) >= 2

--- a/server/rag/rag_service.py
+++ b/server/rag/rag_service.py
@@ -2515,6 +2515,192 @@ class RagService:
             self._write_metadata_unlocked(metadata)
             return self.pipeline_job_payload(job)
 
+    def create_strategy_tuning_pipeline_job(
+        self,
+        kb_id: str,
+        *,
+        base_version_id: str,
+        chunker_profile: dict[str, Any],
+        retrieval_profile: dict[str, Any],
+        tuning_run_id: str,
+        trial: bool,
+    ) -> dict[str, Any]:
+        """Create an isolated tuning job from one immutable version snapshot.
+
+        This deliberately does not reuse the editable draft path. Only chunking
+        and retrieval fields may differ from the fixed base version.
+        """
+
+        with self._metadata_lock:
+            metadata = self._read_metadata_unlocked()
+            self._ensure_kb_exists(metadata, kb_id)
+            base_version = metadata["pipeline_versions"].get(base_version_id)
+            if (
+                not isinstance(base_version, dict)
+                or base_version.get("kb_id") != kb_id
+                or base_version.get("status") not in {"ready", "active"}
+            ):
+                raise PipelineVersionNotFoundError(
+                    "A ready or active base knowledge version is required for tuning."
+                )
+            if int(base_version.get("index_schema_version") or 1) < 2:
+                raise PipelineDraftValidationError(
+                    "RAG strategy tuning requires an index schema v2 base version."
+                )
+            base_job = metadata["pipeline_jobs"].get(str(base_version.get("job_id") or ""))
+            if not isinstance(base_job, dict) or not base_job.get("sources"):
+                raise PipelineJobNotFoundError(
+                    "Base knowledge pipeline source snapshot is unavailable."
+                )
+
+            config_snapshot = json.loads(json.dumps(base_job.get("config_snapshot") or {}))
+            stages = config_snapshot.get("stages")
+            if not isinstance(stages, dict):
+                raise PipelineDraftValidationError(
+                    "Base knowledge pipeline configuration snapshot is unavailable."
+                )
+            if not isinstance(chunker_profile, dict) or not isinstance(retrieval_profile, dict):
+                raise PipelineDraftValidationError(
+                    "Tuning chunker and retrieval profiles must be objects."
+                )
+            stages["stage_chunker"] = self._validated_pipeline_stage_config(
+                "stage_chunker",
+                dict(stages.get("stage_chunker") or {}),
+                chunker_profile,
+            )
+            try:
+                config_snapshot["retrieval_profile"] = RetrievalConfig.from_mapping(
+                    retrieval_profile,
+                    base=RetrievalConfig.from_mapping(
+                        config_snapshot.get("retrieval_profile")
+                        if isinstance(config_snapshot.get("retrieval_profile"), dict)
+                        else None
+                    ),
+                ).payload()
+            except ValueError as exc:
+                raise PipelineDraftValidationError(str(exc)) from exc
+            processor_profile = json.loads(
+                json.dumps(stages.get("stage_processor") or {})
+            )
+            vision_profile = json.loads(
+                json.dumps(stages.get("stage_image_understanding") or {})
+            )
+            config_snapshot["processor_profile"] = processor_profile
+            config_snapshot["vision_profile"] = vision_profile
+
+            job_id = f"kpjob_{uuid.uuid4().hex}"
+            source_dir = self.pipeline_sources_dir / job_id
+            source_dir.mkdir(parents=True, exist_ok=True)
+            manifest: list[dict[str, Any]] = []
+            try:
+                for index, source in enumerate(base_job.get("sources", [])):
+                    if not isinstance(source, dict):
+                        continue
+                    source_id = str(source.get("source_id") or "")
+                    source_path = self.storage_dir / str(source.get("snapshot_key") or "")
+                    if not source_id or not source_path.is_file():
+                        raise DocumentNotFoundError(
+                            "Base knowledge pipeline source snapshot is unavailable."
+                        )
+                    snapshot = source_dir / f"base_{index}{(source_path.suffix or '.txt').lower()}"
+                    shutil.copyfile(source_path, snapshot)
+                    copied = json.loads(json.dumps(source))
+                    copied["snapshot_key"] = snapshot.relative_to(self.storage_dir).as_posix()
+                    copied["content_hash"] = self._file_sha256(snapshot)
+                    manifest.append(copied)
+                if not manifest:
+                    raise PipelineDraftValidationError(
+                        "A strategy tuning job requires a reusable source snapshot."
+                    )
+            except Exception:
+                shutil.rmtree(source_dir, ignore_errors=True)
+                raise
+
+            reserved_numbers = [
+                int(item.get("version", 0))
+                for item in metadata["pipeline_versions"].values()
+                if item.get("kb_id") == kb_id
+            ] + [
+                int(item.get("candidate_version", 0))
+                for item in metadata["pipeline_jobs"].values()
+                if item.get("kb_id") == kb_id
+            ]
+            candidate_version = max(reserved_numbers, default=0) + 1
+            candidate_version_id = f"kpv_{uuid.uuid4().hex}"
+            now = time.time()
+            processor_hash = self._mapping_sha256(processor_profile)
+            vision_hash = self._mapping_sha256(vision_profile)
+            document_results = [
+                {
+                    "source_id": str(source["source_id"]),
+                    "filename": str(source["filename"]),
+                    "status": "pending",
+                    "content_hash": str(source["content_hash"]),
+                    "processor_config_hash": processor_hash,
+                    "vision_config_hash": vision_hash,
+                    "attempt": 0,
+                    "block_count": 0,
+                    "generated_count": 0,
+                    "chunk_count": 0,
+                    "qa_count": 0,
+                    "summary_count": 0,
+                    "warnings": [],
+                    "error": None,
+                    "duration_ms": None,
+                    "vision_status": "pending" if vision_profile.get("enabled") else "skipped",
+                    "vision_page_count": 0,
+                    "vision_selected_page_count": 0,
+                    "vision_processed_page_count": 0,
+                    "vision_failed_page_count": 0,
+                    "vision_block_count": 0,
+                    "vision_warnings": [],
+                    "vision_error": None,
+                    "vision_artifact_key": (
+                        self.pipeline_vision_dir / job_id / f"source_{index}.json"
+                    ).relative_to(self.storage_dir).as_posix(),
+                    "artifact_key": (
+                        self.pipeline_processed_dir / job_id / f"source_{index}.json"
+                    ).relative_to(self.storage_dir).as_posix(),
+                }
+                for index, source in enumerate(manifest)
+            ]
+            origin = {
+                "kind": "rag_strategy_tuner_trial" if trial else "rag_strategy_tuner",
+                "promotion_required": True,
+                "source_run_id": str(tuning_run_id)[:200],
+            }
+            job = {
+                "job_id": job_id,
+                "kb_id": kb_id,
+                "draft_id": str(base_version.get("draft_id") or base_job.get("draft_id") or ""),
+                "draft_version": int(base_version.get("draft_version") or base_job.get("draft_version") or 1),
+                "graph_id": str(config_snapshot.get("graph_id") or base_job.get("graph_id") or ""),
+                "graph_revision": int(config_snapshot.get("graph_revision") or base_job.get("graph_revision") or 1),
+                "config_snapshot": config_snapshot,
+                "origin": origin,
+                "base_version_id": base_version_id,
+                "sources": manifest,
+                "document_results": document_results,
+                "status": "queued",
+                "stages": self._new_pipeline_job_stages(),
+                "candidate_version_id": candidate_version_id,
+                "candidate_version": candidate_version,
+                "candidate_namespace": f"{kb_id}::{candidate_version_id}",
+                "run_id": None,
+                "attempt": 0,
+                "cancel_requested": False,
+                "error": None,
+                "warnings": [],
+                "processor_error": None,
+                "created_at": now,
+                "updated_at": now,
+                "started_at": None,
+                "completed_at": None,
+            }
+            metadata["pipeline_jobs"][job_id] = job
+            self._write_metadata_unlocked(metadata)
+            return self.pipeline_job_payload(job)
+
     def list_pipeline_jobs(
         self,
         *,
@@ -3273,6 +3459,8 @@ class RagService:
             self.pipeline_version_payload(item, active_id=active_id)
             for item in metadata["pipeline_versions"].values()
             if item.get("kb_id") == kb_id
+            and str((item.get("origin") or {}).get("kind") or "")
+            != "rag_strategy_tuner_trial"
         ]
         items.sort(key=lambda item: int(item["version"]), reverse=True)
         return items
@@ -3305,6 +3493,10 @@ class RagService:
             version = metadata["pipeline_versions"].get(version_id)
             if not isinstance(version, dict):
                 raise PipelineVersionNotFoundError("Knowledge pipeline version not found.")
+            if str((version.get("origin") or {}).get("kind") or "") == "rag_strategy_tuner_trial":
+                raise PipelineJobStateError(
+                    "Strategy tuning trial versions cannot be activated."
+                )
             kb_id = str(version["kb_id"])
             self._ensure_kb_exists(metadata, kb_id)
             previous_id = metadata["pipeline_active_versions"].get(kb_id)
@@ -3316,6 +3508,117 @@ class RagService:
             metadata["knowledge_bases"][kb_id]["updated_at"] = time.time()
             self._write_metadata_unlocked(metadata)
             return self.pipeline_version_payload(version, active_id=version_id)
+
+    def pipeline_version_cost_summary(self, version_id: str) -> dict[str, Any]:
+        """Return deterministic, explicitly estimated index cost metadata."""
+
+        version = self.get_pipeline_version(version_id)
+        chunk_count = max(0, int(version.get("chunk_count") or 0))
+        embedding_profile = version.get("embedding_profile") or {}
+        dimension = max(1, int(embedding_profile.get("dimension") or 1))
+        estimated_vector_bytes = chunk_count * dimension * 4
+        estimated_lexical_bytes = chunk_count * 256
+        job = self.get_pipeline_job(str(version.get("job_id") or ""))
+        started_at = job.get("started_at")
+        completed_at = job.get("completed_at")
+        build_duration_ms = None
+        if isinstance(started_at, (int, float)) and isinstance(completed_at, (int, float)):
+            build_duration_ms = max(0.0, round((completed_at - started_at) * 1000, 2))
+        return {
+            "chunk_count": chunk_count,
+            "embedding_dimension": dimension,
+            "estimated_vector_bytes": estimated_vector_bytes,
+            "estimated_lexical_bytes": estimated_lexical_bytes,
+            "estimated_index_bytes": estimated_vector_bytes + estimated_lexical_bytes,
+            "build_duration_ms": build_duration_ms,
+            "size_is_estimated": True,
+        }
+
+    def cleanup_strategy_tuning_trial_version(self, version_id: str) -> None:
+        """Remove an isolated tuning trial after its safe statistics are persisted."""
+
+        with self._metadata_lock:
+            metadata = self._read_metadata_unlocked()
+            version = metadata["pipeline_versions"].get(version_id)
+            if not isinstance(version, dict):
+                return
+            if str((version.get("origin") or {}).get("kind") or "") != "rag_strategy_tuner_trial":
+                raise PipelineJobStateError(
+                    "Only strategy tuning trial versions can be cleaned up here."
+                )
+            if metadata["pipeline_active_versions"].get(str(version.get("kb_id") or "")) == version_id:
+                raise PipelineJobStateError("An active knowledge version cannot be cleaned up.")
+            job_id = str(version.get("job_id") or "")
+            namespace = str(version.get("namespace") or "")
+            job = metadata["pipeline_jobs"].get(job_id)
+            if isinstance(job, dict) and str(job.get("status") or "") not in {
+                "succeeded",
+                "failed",
+                "cancelled",
+            }:
+                raise PipelineJobStateError(
+                    "A running strategy tuning trial cannot be cleaned up."
+                )
+
+        if namespace:
+            self.vector_store.delete_knowledge_base(namespace)
+            self.lexical_store.delete_namespace(namespace)
+        for path in (
+            self.pipeline_sources_dir / job_id,
+            self.pipeline_processed_dir / job_id,
+            self.pipeline_vision_dir / job_id,
+        ):
+            if path.exists():
+                shutil.rmtree(path)
+
+        with self._metadata_lock:
+            metadata = self._read_metadata_unlocked()
+            current = metadata["pipeline_versions"].get(version_id)
+            if isinstance(current, dict):
+                metadata["pipeline_versions"].pop(version_id, None)
+                metadata["pipeline_jobs"].pop(job_id, None)
+                self._write_metadata_unlocked(metadata)
+
+    def cleanup_strategy_tuning_trial_job(self, job_id: str) -> None:
+        """Remove a terminal trial job that did not publish a version."""
+
+        with self._metadata_lock:
+            metadata = self._read_metadata_unlocked()
+            job = metadata["pipeline_jobs"].get(job_id)
+            if not isinstance(job, dict):
+                return
+            if str((job.get("origin") or {}).get("kind") or "") != "rag_strategy_tuner_trial":
+                raise PipelineJobStateError(
+                    "Only strategy tuning trial jobs can be cleaned up here."
+                )
+            if str(job.get("status") or "") not in {"succeeded", "failed", "cancelled"}:
+                raise PipelineJobStateError(
+                    "A running strategy tuning trial cannot be cleaned up."
+                )
+            version_id = str(job.get("candidate_version_id") or "")
+            if isinstance(metadata["pipeline_versions"].get(version_id), dict):
+                pass
+            else:
+                namespace = str(job.get("candidate_namespace") or "")
+                version_id = ""
+
+        if version_id:
+            self.cleanup_strategy_tuning_trial_version(version_id)
+            return
+        if namespace:
+            self.vector_store.delete_knowledge_base(namespace)
+            self.lexical_store.delete_namespace(namespace)
+        for path in (
+            self.pipeline_sources_dir / job_id,
+            self.pipeline_processed_dir / job_id,
+            self.pipeline_vision_dir / job_id,
+        ):
+            if path.exists():
+                shutil.rmtree(path)
+        with self._metadata_lock:
+            metadata = self._read_metadata_unlocked()
+            metadata["pipeline_jobs"].pop(job_id, None)
+            self._write_metadata_unlocked(metadata)
 
     async def query_pipeline_version(
         self,
@@ -4333,7 +4636,7 @@ class RagService:
         vector_candidates = [self._candidate_from_vector(item) for item in vector_results]
         lexical_candidates = [self._candidate_from_lexical(item) for item in lexical_results]
         effective_config = config
-        if config.mode == "fulltext" and not lexical_candidates:
+        if config.mode == "fulltext" and not lexical_candidates and not lexical_ready:
             effective_config = RetrievalConfig.from_mapping(
                 {**config.payload(), "mode": "vector", "rerank_enabled": config.rerank_enabled}
             )

--- a/server/rag/retrieval.py
+++ b/server/rag/retrieval.py
@@ -135,7 +135,9 @@ def fuse_rankings(
     if config.mode == "fulltext":
         for item in fulltext_items:
             item.fused_score = max(0.0, min(1.0, float(item.fulltext_score or 0.0)))
-        return sorted(fulltext_items, key=lambda item: (-item.fused_score, item.chunk_id))
+        # The lexical store already orders by BM25. Confidence is used for
+        # thresholding and must not replace the proven lexical rank order.
+        return fulltext_items
 
     by_id: dict[str, RetrievalCandidate] = {}
     raw_scores: dict[str, float] = {}

--- a/server/rag/strategy_tuner.py
+++ b/server/rag/strategy_tuner.py
@@ -1,0 +1,2234 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import random
+import statistics
+import threading
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+from .evaluation import (
+    KnowledgeEvaluationStore,
+    aggregate_target_metrics,
+    evaluate_promotion_gate,
+    evaluate_retrieval_case,
+)
+from .evaluation_executor import KnowledgeEvaluationExecutor
+from .pipeline_executor import KnowledgePipelineExecutor
+from .rag_service import RagService
+from .retrieval import RetrievalConfig
+from .strategy_router import RULES_VERSION, RagStrategyService
+from .strategy_tuning_qualification import (
+    assess_chunk_sensitivity,
+    build_tuning_readiness,
+    ranking_fingerprint,
+    realized_index_fingerprint,
+)
+
+
+TUNER_VERSION = "rag-strategy-tuner-v4"
+VALIDATION_VERSION = "rag-strategy-validation-v1"
+KNOWN_WINNER_FIXTURE_VERSION = "rag-strategy-known-winner-v1"
+VALIDATION_RESAMPLE_COUNT = 3
+VALIDATION_QUERY_REPETITIONS = 3
+VALIDATION_BOOTSTRAP_SAMPLES = 1000
+VALIDATION_CONFIDENCE_LEVEL = 0.90
+VALIDATION_MAX_REGRESSION = 0.02
+RUNNING_STATUSES = {
+    "queued",
+    "profiling",
+    "searching",
+    "building",
+    "evaluating",
+    "materializing",
+    "validating",
+}
+TERMINAL_STATUSES = {"completed", "no_improvement", "failed", "cancelled"}
+OBJECTIVES = {"balanced", "quality", "low_latency"}
+
+
+class RagStrategyTuningError(RuntimeError):
+    pass
+
+
+class RagStrategyTuningNotFoundError(RagStrategyTuningError):
+    pass
+
+
+class RagStrategyTuningStateError(RagStrategyTuningError):
+    pass
+
+
+class RagStrategyTuningValidationError(ValueError):
+    pass
+
+
+class _TuningCancelled(RuntimeError):
+    pass
+
+
+def _copy(value: Any) -> Any:
+    return json.loads(json.dumps(value))
+
+
+def _checksum(value: Any) -> str:
+    encoded = json.dumps(
+        value, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+class RagStrategyTuningStore:
+    """Atomic, restart-safe state for bounded strategy tuning runs."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.RLock()
+
+    def create_run(self, request: dict[str, Any], snapshot: dict[str, Any]) -> dict[str, Any]:
+        now = time.time()
+        run = {
+            "run_id": f"ragtune_{uuid.uuid4().hex}",
+            "version": TUNER_VERSION,
+            "kb_id": str(request["kb_id"]),
+            "status": "queued",
+            "progress": 0,
+            "stage": "queued",
+            "request": _copy(request),
+            "snapshot": _copy(snapshot),
+            "case_split": {},
+            "validation_plan": {},
+            "validation_baseline": {},
+            "statistical_summary": {},
+            "candidates": [],
+            "pareto_front": [],
+            "finalists": [],
+            "trial_indexes": [],
+            "trial_version_ids": [],
+            "pipeline_job_ids": [],
+            "evaluation_run_id": None,
+            "final_version_id": None,
+            "winner": None,
+            "no_improvement_reason": None,
+            "optimization_baseline_metrics": {},
+            "optimization_gate_summary": {},
+            "chunk_sensitivity": {},
+            "retrieval_deduplication": {},
+            "cancel_requested": False,
+            "warnings": list(snapshot.get("warnings") or []),
+            "error": None,
+            "created_at": now,
+            "updated_at": now,
+            "started_at": None,
+            "completed_at": None,
+        }
+        with self._lock:
+            data = self._read_unlocked()
+            data["runs"][run["run_id"]] = run
+            self._write_unlocked(data)
+        return self.payload(run)
+
+    def get_run(self, run_id: str) -> dict[str, Any]:
+        run = self._read()["runs"].get(run_id)
+        if not isinstance(run, dict):
+            raise RagStrategyTuningNotFoundError("RAG strategy tuning run not found.")
+        return self.payload(run)
+
+    def list_runs(
+        self, *, kb_id: str | None = None, status: str | None = None, limit: int = 50
+    ) -> list[dict[str, Any]]:
+        items = list(self._read()["runs"].values())
+        if kb_id:
+            items = [item for item in items if item.get("kb_id") == kb_id]
+        if status:
+            items = [item for item in items if item.get("status") == status]
+        items.sort(key=lambda item: float(item.get("created_at") or 0), reverse=True)
+        return [self.payload(item, detail=False) for item in items[: max(1, min(limit, 100))]]
+
+    def claim_next_run(self) -> dict[str, Any] | None:
+        with self._lock:
+            data = self._read_unlocked()
+            queued = [item for item in data["runs"].values() if item.get("status") == "queued"]
+            if not queued:
+                return None
+            queued.sort(key=lambda item: float(item.get("created_at") or 0))
+            run = queued[0]
+            run.update(
+                {
+                    "status": "profiling",
+                    "stage": "profiling",
+                    "progress": max(1, int(run.get("progress") or 0)),
+                    "started_at": run.get("started_at") or time.time(),
+                    "updated_at": time.time(),
+                }
+            )
+            self._write_unlocked(data)
+            return _copy(run)
+
+    def recover_runs(self) -> int:
+        recovered = 0
+        with self._lock:
+            data = self._read_unlocked()
+            for run in data["runs"].values():
+                if run.get("status") in RUNNING_STATUSES - {"queued"}:
+                    run["status"] = "queued"
+                    run["stage"] = "recovery"
+                    run["updated_at"] = time.time()
+                    recovered += 1
+            if recovered:
+                self._write_unlocked(data)
+        return recovered
+
+    def update(self, run_id: str, **values: Any) -> dict[str, Any]:
+        with self._lock:
+            data = self._read_unlocked()
+            run = data["runs"].get(run_id)
+            if not isinstance(run, dict):
+                raise RagStrategyTuningNotFoundError("RAG strategy tuning run not found.")
+            run.update(_copy(values))
+            run["updated_at"] = time.time()
+            self._write_unlocked(data)
+            return self.payload(run)
+
+    def request_cancel(self, run_id: str) -> dict[str, Any]:
+        run = self.get_run(run_id)
+        if run["status"] not in RUNNING_STATUSES:
+            raise RagStrategyTuningStateError("Only active tuning runs can be cancelled.")
+        values: dict[str, Any] = {"cancel_requested": True}
+        if run["status"] == "queued":
+            values.update(status="cancelled", stage="cancelled", completed_at=time.time())
+        return self.update(run_id, **values)
+
+    def retry(self, run_id: str) -> dict[str, Any]:
+        run = self.get_run(run_id)
+        if run["status"] not in {"failed", "cancelled"}:
+            raise RagStrategyTuningStateError("Only failed or cancelled tuning runs can be retried.")
+        return self.update(
+            run_id,
+            status="queued",
+            stage="queued",
+            progress=0,
+            cancel_requested=False,
+            error=None,
+            completed_at=None,
+            case_split={},
+            validation_plan={},
+            validation_baseline={},
+            statistical_summary={},
+            candidates=[],
+            finalists=[],
+            pareto_front=[],
+            trial_indexes=[],
+            trial_version_ids=[],
+            pipeline_job_ids=[],
+            evaluation_run_id=None,
+            final_version_id=None,
+            winner=None,
+            no_improvement_reason=None,
+            optimization_baseline_metrics={},
+            optimization_gate_summary={},
+            chunk_sensitivity={},
+            retrieval_deduplication={},
+        )
+
+    def cancelled(self, run_id: str) -> bool:
+        return bool(self.get_run(run_id).get("cancel_requested"))
+
+    def payload(self, run: dict[str, Any], *, detail: bool = True) -> dict[str, Any]:
+        payload = _copy(run)
+        if not detail:
+            payload.pop("snapshot", None)
+            payload.pop("candidates", None)
+            payload.pop("finalists", None)
+            payload.pop("pareto_front", None)
+        return payload
+
+    def _read(self) -> dict[str, Any]:
+        with self._lock:
+            return self._read_unlocked()
+
+    def _read_unlocked(self) -> dict[str, Any]:
+        if not self.path.exists():
+            return {"version": TUNER_VERSION, "runs": {}}
+        try:
+            raw = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            raw = {}
+        return {
+            "version": TUNER_VERSION,
+            "runs": raw.get("runs") if isinstance(raw.get("runs"), dict) else {},
+        }
+
+    def _write_unlocked(self, data: dict[str, Any]) -> None:
+        temporary = self.path.with_suffix(f"{self.path.suffix}.{uuid.uuid4().hex}.tmp")
+        temporary.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+        os.replace(temporary, self.path)
+
+
+def stratified_split(cases: list[dict[str, Any]], seed: int) -> dict[str, Any]:
+    buckets: dict[str, list[dict[str, Any]]] = {}
+    for case in cases:
+        tags = case.get("tags") or []
+        key = f"{bool(case.get('expected_no_result'))}:{str(tags[0]) if tags else 'default'}"
+        buckets.setdefault(key, []).append(case)
+    optimization: list[str] = []
+    holdout: list[str] = []
+    for key in sorted(buckets):
+        ordered = sorted(
+            buckets[key],
+            key=lambda case: hashlib.sha256(
+                f"{seed}:{case.get('case_id')}".encode("utf-8")
+            ).hexdigest(),
+        )
+        holdout_count = max(1, round(len(ordered) / 3))
+        holdout.extend(str(case["case_id"]) for case in ordered[:holdout_count])
+        optimization.extend(str(case["case_id"]) for case in ordered[holdout_count:])
+    target_holdout = min(4, len(cases) - 1)
+    if len(holdout) < target_holdout:
+        move = optimization[: target_holdout - len(holdout)]
+        holdout.extend(move)
+        optimization = [case_id for case_id in optimization if case_id not in move]
+    return {
+        "seed": seed,
+        "optimization_case_ids": sorted(optimization),
+        "holdout_case_ids": sorted(holdout),
+    }
+
+
+def _case_stratum(case: dict[str, Any]) -> str:
+    tags = case.get("tags") or []
+    return f"{bool(case.get('expected_no_result'))}:{str(tags[0]) if tags else 'default'}"
+
+
+def repeated_validation_plan(
+    cases: list[dict[str, Any]],
+    holdout_case_ids: list[str],
+    seed: int,
+    *,
+    resample_count: int = VALIDATION_RESAMPLE_COUNT,
+) -> dict[str, Any]:
+    """Create deterministic stratified bootstrap samples inside the fixed Holdout.
+
+    Optimization cases are never admitted into these samples. Sampling with
+    replacement gives several paired views of a small immutable Holdout without
+    leaking its results back into candidate generation.
+    """
+
+    allowed = {str(item) for item in holdout_case_ids}
+    buckets: dict[str, list[str]] = {}
+    for case in cases:
+        case_id = str(case.get("case_id") or "")
+        if case_id in allowed:
+            buckets.setdefault(_case_stratum(case), []).append(case_id)
+    for values in buckets.values():
+        values.sort()
+    resamples: list[dict[str, Any]] = []
+    for index in range(max(1, resample_count)):
+        sample_seed = int(seed) + (index + 1) * 1009
+        rng = random.Random(sample_seed)
+        sample_ids: list[str] = []
+        for key in sorted(buckets):
+            values = buckets[key]
+            sample_ids.extend(rng.choice(values) for _ in range(len(values)))
+        resamples.append(
+            {
+                "index": index + 1,
+                "seed": sample_seed,
+                "case_ids": sample_ids,
+            }
+        )
+    payload = {
+        "validation_version": VALIDATION_VERSION,
+        "seed": int(seed),
+        "holdout_case_ids": sorted(allowed),
+        "strata": {key: len(values) for key, values in sorted(buckets.items())},
+        "resamples": resamples,
+        "query_repetitions": VALIDATION_QUERY_REPETITIONS,
+        "bootstrap_samples": VALIDATION_BOOTSTRAP_SAMPLES,
+        "confidence_level": VALIDATION_CONFIDENCE_LEVEL,
+        "max_quality_regression": VALIDATION_MAX_REGRESSION,
+    }
+    payload["checksum"] = _checksum(payload)
+    return payload
+
+
+def _percentile(values: list[float], fraction: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(float(item) for item in values)
+    if len(ordered) == 1:
+        return ordered[0]
+    position = max(0.0, min(1.0, fraction)) * (len(ordered) - 1)
+    lower = int(position)
+    upper = min(len(ordered) - 1, lower + 1)
+    weight = position - lower
+    return ordered[lower] * (1 - weight) + ordered[upper] * weight
+
+
+def summarize_repeated_case_results(
+    case_results: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for result in case_results:
+        grouped.setdefault(str(result.get("case_id") or ""), []).append(result)
+    summaries: list[dict[str, Any]] = []
+    for case_id in sorted(grouped):
+        values = grouped[case_id]
+        completed = [item for item in values if item.get("status") == "completed"]
+        metric_names = sorted(
+            {
+                str(name)
+                for item in completed
+                for name in (item.get("metrics") or {}).keys()
+            }
+        )
+        latencies = [float(item.get("latency_ms") or 0) for item in values]
+        no_result_votes = sum(1 for item in completed if item.get("no_result"))
+        summary = {
+            "case_id": case_id,
+            "status": "completed" if len(completed) == len(values) else "failed",
+            "metrics": {
+                name: round(
+                    sum(float((item.get("metrics") or {}).get(name) or 0) for item in completed)
+                    / len(completed),
+                    6,
+                )
+                for name in metric_names
+            }
+            if completed
+            else {},
+            "latency_ms": round(statistics.median(latencies), 3) if latencies else 0.0,
+            "expected_no_result": bool(values[0].get("expected_no_result")),
+            "stratum": str(
+                values[0].get("stratum")
+                or ("no_result" if values[0].get("expected_no_result") else "answerable")
+            ),
+            "no_result": bool(completed) and no_result_votes * 2 >= len(completed),
+            "warning_count": sum(int(item.get("warning_count") or 0) for item in values),
+            "repeat_count": len(values),
+            "completed_repeat_count": len(completed),
+        }
+        if len(completed) != len(values):
+            summary["error"] = next(
+                (str(item.get("error") or "")[:240] for item in values if item.get("status") == "failed"),
+                "Repeated validation query failed.",
+            )
+        summaries.append(summary)
+    return summaries
+
+
+def _case_quality_score(summary: dict[str, Any]) -> float:
+    metrics = summary.get("metrics") or {}
+    if summary.get("expected_no_result"):
+        return float(metrics.get("no_result_accuracy") or 0)
+    return float(metrics.get("ndcg_at_10") or 0)
+
+
+def paired_statistical_validation(
+    baseline: dict[str, Any],
+    candidate: dict[str, Any],
+    plan: dict[str, Any],
+) -> dict[str, Any]:
+    """Return deterministic paired quality evidence for one fixed Holdout."""
+
+    baseline_by_id = {
+        str(item.get("case_id") or ""): item
+        for item in baseline.get("case_summaries") or []
+    }
+    candidate_by_id = {
+        str(item.get("case_id") or ""): item
+        for item in candidate.get("case_summaries") or []
+    }
+    expected_ids = [str(item) for item in plan.get("holdout_case_ids") or []]
+    missing = [
+        case_id
+        for case_id in expected_ids
+        if case_id not in baseline_by_id or case_id not in candidate_by_id
+    ]
+    failed = [
+        case_id
+        for case_id in expected_ids
+        if case_id in baseline_by_id
+        and case_id in candidate_by_id
+        and (
+            baseline_by_id[case_id].get("status") != "completed"
+            or candidate_by_id[case_id].get("status") != "completed"
+        )
+    ]
+    if missing or failed or not expected_ids:
+        return {
+            "validation_version": VALIDATION_VERSION,
+            "status": "insufficient",
+            "passed": False,
+            "missing_case_ids": missing,
+            "failed_case_ids": failed,
+            "reason": "paired_holdout_results_incomplete",
+        }
+
+    deltas = {
+        case_id: _case_quality_score(candidate_by_id[case_id])
+        - _case_quality_score(baseline_by_id[case_id])
+        for case_id in expected_ids
+    }
+    point_delta = sum(deltas.values()) / len(deltas)
+    resample_deltas: list[float] = []
+    for resample in plan.get("resamples") or []:
+        ids = [str(item) for item in resample.get("case_ids") or [] if str(item) in deltas]
+        if ids:
+            resample_deltas.append(sum(deltas[item] for item in ids) / len(ids))
+
+    cases_by_stratum: dict[str, list[str]] = {}
+    for case_id in expected_ids:
+        summary = baseline_by_id[case_id]
+        key = str(
+            summary.get("stratum")
+            or ("no_result" if summary.get("expected_no_result") else "answerable")
+        )
+        cases_by_stratum.setdefault(key, []).append(case_id)
+    rng = random.Random(int(plan.get("seed") or 0) + 7919)
+    bootstrap_deltas: list[float] = []
+    for _ in range(int(plan.get("bootstrap_samples") or VALIDATION_BOOTSTRAP_SAMPLES)):
+        sampled: list[str] = []
+        for key in sorted(cases_by_stratum):
+            values = cases_by_stratum[key]
+            sampled.extend(rng.choice(values) for _ in range(len(values)))
+        bootstrap_deltas.append(sum(deltas[item] for item in sampled) / len(sampled))
+    confidence = float(plan.get("confidence_level") or VALIDATION_CONFIDENCE_LEVEL)
+    tail = (1.0 - confidence) / 2.0
+    lower = _percentile(bootstrap_deltas, tail)
+    upper = _percentile(bootstrap_deltas, 1.0 - tail)
+    max_regression = float(
+        plan.get("max_quality_regression") or VALIDATION_MAX_REGRESSION
+    )
+    required_stable = max(1, (len(resample_deltas) * 2 + 2) // 3)
+    stable_count = sum(1 for value in resample_deltas if value >= -max_regression)
+    passed = lower >= -max_regression and stable_count >= required_stable
+    return {
+        "validation_version": VALIDATION_VERSION,
+        "status": "completed",
+        "passed": passed,
+        "primary_metric": "case_weighted_ndcg_or_no_result_accuracy",
+        "quality_delta": round(point_delta, 6),
+        "confidence_level": confidence,
+        "confidence_interval": {
+            "lower": round(lower, 6),
+            "upper": round(upper, 6),
+        },
+        "bootstrap_samples": len(bootstrap_deltas),
+        "resample_deltas": [round(item, 6) for item in resample_deltas],
+        "stable_resample_count": stable_count,
+        "required_stable_resamples": required_stable,
+        "max_quality_regression": max_regression,
+        "quality_improvement_confident": bool(point_delta >= 0.01 and lower >= 0),
+        "holdout_case_count": len(expected_ids),
+        "query_repetitions": int(plan.get("query_repetitions") or 1),
+        "baseline_p95_latency_ms": float(
+            (baseline.get("metrics") or {}).get("p95_latency_ms") or 0
+        ),
+        "candidate_p95_latency_ms": float(
+            (candidate.get("metrics") or {}).get("p95_latency_ms") or 0
+        ),
+    }
+
+
+def retrieval_candidates(base: dict[str, Any], *, degraded: bool) -> list[dict[str, Any]]:
+    values: list[dict[str, Any]] = []
+    modes = ["fulltext"] if degraded else ["fulltext", "vector", "hybrid"]
+    for mode in modes:
+        weights = [0.5] if mode != "hybrid" else [0.3, 0.5, 0.7]
+        for top_k in (5, 10):
+            for vector_weight in weights:
+                values.append(
+                    RetrievalConfig.from_mapping(
+                        {
+                            "mode": mode,
+                            "top_k": top_k,
+                            "vector_weight": vector_weight,
+                            "fulltext_weight": 1 - vector_weight,
+                            "score_threshold": 0,
+                            "candidate_multiplier": 4,
+                            "rerank_enabled": False,
+                            "rerank_provider": "none",
+                            "rerank_top_n": top_k,
+                        }
+                    ).payload()
+                )
+    values.insert(0, RetrievalConfig.from_mapping(base).payload())
+    deduped: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for value in values:
+        checksum = retrieval_semantic_checksum(value)
+        if checksum not in seen:
+            seen.add(checksum)
+            deduped.append(value)
+    return deduped
+
+
+def retrieval_semantic_payload(value: dict[str, Any]) -> dict[str, Any]:
+    """Return only fields that can change retrieval behavior for this mode."""
+
+    config = RetrievalConfig.from_mapping(value).payload()
+    payload: dict[str, Any] = {
+        "mode": config["mode"],
+        "top_k": int(config["top_k"]),
+        "score_threshold": round(float(config["score_threshold"]), 6),
+        "candidate_multiplier": int(config["candidate_multiplier"]),
+        "rerank_enabled": bool(config["rerank_enabled"]),
+    }
+    if config["mode"] == "hybrid":
+        payload["vector_weight"] = round(float(config["vector_weight"]), 6)
+        payload["fulltext_weight"] = round(float(config["fulltext_weight"]), 6)
+    if config["rerank_enabled"]:
+        payload.update(
+            {
+                "rerank_provider": str(config["rerank_provider"]),
+                "rerank_model": str(config["rerank_model"]),
+                "rerank_top_n": int(config["rerank_top_n"]),
+            }
+        )
+    return payload
+
+
+def retrieval_semantic_checksum(value: dict[str, Any]) -> str:
+    return _checksum(retrieval_semantic_payload(value))
+
+
+def chunker_candidates(snapshot: dict[str, Any]) -> list[dict[str, Any]]:
+    base = _copy(snapshot["base_chunker"])
+    values = [base]
+    recommendation = snapshot.get("router_recommendation") or {}
+    for profile in recommendation.get("profiles") or []:
+        if isinstance(profile, dict) and isinstance(profile.get("chunker"), dict):
+            values.append(_copy(profile["chunker"]))
+    strategy = str(base.get("strategy") or "recursive_character")
+    if strategy == "parent_child":
+        parent = int(base.get("parent_chunk_size") or 1800)
+        child = int(base.get("child_chunk_size") or 450)
+        for ratio in (0.75, 1.25):
+            candidate = _copy(base)
+            candidate["parent_chunk_size"] = max(400, min(4000, round(parent * ratio)))
+            candidate["child_chunk_size"] = max(100, min(2000, round(child * ratio)))
+            candidate["parent_chunk_overlap"] = min(
+                int(candidate["parent_chunk_size"] * 0.1), candidate["parent_chunk_size"] - 1
+            )
+            candidate["child_chunk_overlap"] = min(
+                int(candidate["child_chunk_size"] * 0.1), candidate["child_chunk_size"] - 1
+            )
+            values.append(candidate)
+    else:
+        size = int(base.get("chunk_size") or 700)
+        for ratio in (0.7, 1.3):
+            candidate = _copy(base)
+            candidate["chunk_size"] = max(100, min(4000, round(size * ratio)))
+            candidate["chunk_overlap"] = min(
+                int(candidate["chunk_size"] * 0.1), candidate["chunk_size"] - 1
+            )
+            values.append(candidate)
+    deduped: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for value in values:
+        checksum = _checksum(value)
+        if checksum not in seen:
+            seen.add(checksum)
+            deduped.append(value)
+    return deduped[:4]
+
+
+def calibrate_threshold(result: dict[str, Any], retrieval: dict[str, Any]) -> dict[str, Any]:
+    cases_by_id = {str(case["case_id"]): case for case in result["cases"]}
+    thresholds = _threshold_candidates(result, retrieval, cases_by_id=cases_by_id)
+    points: list[dict[str, Any]] = []
+    for threshold in thresholds:
+        rescored: list[dict[str, Any]] = []
+        for case_result in result["case_results"]:
+            case = cases_by_id[str(case_result["case_id"])]
+            ranking = [
+                item
+                for item in case_result.get("ranking") or []
+                if float(item.get("score") or 0) >= threshold
+            ]
+            sources = [
+                {
+                    "chunk_id": item.get("chunk_id"),
+                    "document_id": item.get("document_id"),
+                    "source_document_id": item.get("document_id"),
+                    "document_name": item.get("document_name"),
+                    "source_block_id": item.get("source_block_id"),
+                    "page_number": item.get("page_number"),
+                    "score": item.get("score"),
+                }
+                for item in ranking
+            ]
+            rescored.append(
+                evaluate_retrieval_case(
+                    sources,
+                    list(case.get("expected_refs") or []),
+                    ks=[1, 3, 5, 10],
+                    latency_ms=float(case_result.get("latency_ms") or 0),
+                    expected_no_result=bool(case.get("expected_no_result")),
+                )
+            )
+        metrics = aggregate_target_metrics(rescored, ks=[1, 3, 5, 10])
+        points.append({"threshold": threshold, "metrics": metrics})
+
+    baseline_threshold = round(float(retrieval.get("score_threshold") or 0), 6)
+    baseline = min(points, key=lambda item: abs(float(item["threshold"]) - baseline_threshold))
+    baseline_metrics = dict(baseline["metrics"])
+    pareto = _threshold_pareto_front(points)
+    admissible = [
+        item
+        for item in pareto
+        if float((item.get("metrics") or {}).get("recall_at_5") or 0)
+        >= float(baseline_metrics.get("recall_at_5") or 0) - 0.02
+        and float((item.get("metrics") or {}).get("ndcg_at_10") or 0)
+        >= float(baseline_metrics.get("ndcg_at_10") or 0) - 0.02
+        and float((item.get("metrics") or {}).get("false_positive_rate") or 0)
+        <= float(baseline_metrics.get("false_positive_rate") or 0)
+    ]
+    improved = [
+        item
+        for item in admissible
+        if float((item.get("metrics") or {}).get("false_positive_rate") or 0)
+        <= float(baseline_metrics.get("false_positive_rate") or 0) - 0.01
+    ]
+    if improved:
+        selected = min(
+            improved,
+            key=lambda item: (
+                float((item.get("metrics") or {}).get("false_positive_rate") or 0),
+                -float((item.get("metrics") or {}).get("recall_at_5") or 0),
+                -float((item.get("metrics") or {}).get("ndcg_at_10") or 0),
+                float(item["threshold"]),
+            ),
+        )
+        selection_reason = "hard_negative_false_positive_improved"
+    else:
+        selected = baseline
+        selection_reason = "baseline_preserved_no_safe_negative_improvement"
+    threshold = float(selected["threshold"])
+    metrics = dict(selected["metrics"])
+    return {
+        "retrieval": {**_copy(retrieval), "score_threshold": threshold},
+        "metrics": metrics,
+        "threshold_candidates": thresholds,
+        "threshold_front": [
+            {
+                "threshold": float(item["threshold"]),
+                "recall_at_5": float((item.get("metrics") or {}).get("recall_at_5") or 0),
+                "ndcg_at_10": float((item.get("metrics") or {}).get("ndcg_at_10") or 0),
+                "no_result_accuracy": float(
+                    (item.get("metrics") or {}).get("no_result_accuracy") or 0
+                ),
+                "false_positive_rate": float(
+                    (item.get("metrics") or {}).get("false_positive_rate") or 0
+                ),
+            }
+            for item in pareto
+        ],
+        "threshold_selection_reason": selection_reason,
+    }
+
+
+def _threshold_candidates(
+    result: dict[str, Any],
+    retrieval: dict[str, Any],
+    *,
+    cases_by_id: dict[str, dict[str, Any]],
+) -> list[float]:
+    negative_top_scores: list[float] = []
+    positive_scores: list[float] = []
+    all_scores: list[float] = []
+    for case_result in result.get("case_results") or []:
+        case = cases_by_id.get(str(case_result.get("case_id") or ""), {})
+        ranking = [
+            item
+            for item in case_result.get("ranking") or []
+            if item.get("score") is not None
+        ]
+        scores = [round(float(item.get("score") or 0), 6) for item in ranking]
+        all_scores.extend(scores)
+        if case.get("expected_no_result"):
+            if scores:
+                negative_top_scores.append(max(scores))
+        else:
+            positive_scores.extend(scores[:5])
+
+    thresholds = {
+        0.0,
+        round(float(retrieval.get("score_threshold") or 0), 6),
+    }
+    for values, add_epsilon in (
+        (sorted(negative_top_scores), True),
+        (sorted(positive_scores), False),
+        (sorted(all_scores), True),
+    ):
+        if not values:
+            continue
+        for fraction in (0.0, 0.5, 1.0):
+            observed = values[min(len(values) - 1, round((len(values) - 1) * fraction))]
+            thresholds.add(
+                min(1.0, max(0.0, round(observed + (0.000001 if add_epsilon else 0), 6)))
+            )
+    ordered = sorted(thresholds)
+    if len(ordered) <= 8:
+        return ordered
+    selected = [ordered[0], ordered[-1]]
+    for fraction in (0.2, 0.4, 0.6, 0.8):
+        selected.append(ordered[round((len(ordered) - 1) * fraction)])
+    current = round(float(retrieval.get("score_threshold") or 0), 6)
+    selected.append(current)
+    return sorted(set(selected))[:8]
+
+
+def _threshold_pareto_front(points: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    front: list[dict[str, Any]] = []
+    for point in points:
+        metrics = point.get("metrics") or {}
+        dominated = False
+        for other in points:
+            if other is point:
+                continue
+            other_metrics = other.get("metrics") or {}
+            at_least_as_good = (
+                float(other_metrics.get("recall_at_5") or 0)
+                >= float(metrics.get("recall_at_5") or 0)
+                and float(other_metrics.get("ndcg_at_10") or 0)
+                >= float(metrics.get("ndcg_at_10") or 0)
+                and float(other_metrics.get("false_positive_rate") or 0)
+                <= float(metrics.get("false_positive_rate") or 0)
+            )
+            strictly_better = (
+                float(other_metrics.get("recall_at_5") or 0)
+                > float(metrics.get("recall_at_5") or 0)
+                or float(other_metrics.get("ndcg_at_10") or 0)
+                > float(metrics.get("ndcg_at_10") or 0)
+                or float(other_metrics.get("false_positive_rate") or 0)
+                < float(metrics.get("false_positive_rate") or 0)
+            )
+            if at_least_as_good and strictly_better:
+                dominated = True
+                break
+        if not dominated:
+            front.append(point)
+    return sorted(front, key=lambda item: float(item["threshold"]))
+
+
+def mark_semantic_duplicate_candidates(
+    candidates: list[dict[str, Any]],
+) -> dict[str, Any]:
+    representatives: dict[str, str] = {}
+    duplicate_ids: list[str] = []
+    for candidate in candidates:
+        semantic_key = _checksum(
+            {
+                "realized_index": candidate.get("realized_index_fingerprint"),
+                "ranking": candidate.get("ranking_fingerprint"),
+                "retrieval": retrieval_semantic_payload(
+                    dict(candidate.get("retrieval") or {})
+                ),
+            }
+        )
+        candidate["semantic_outcome_checksum"] = semantic_key
+        representative_id = representatives.get(semantic_key)
+        if representative_id:
+            if candidate.get("automatic_winner_eligible", True):
+                candidate["automatic_winner_eligible"] = False
+                candidate["ineligible_reason"] = "semantic_duplicate"
+            candidate["duplicate_of_candidate_id"] = representative_id
+            duplicate_ids.append(str(candidate.get("candidate_id") or ""))
+        else:
+            representatives[semantic_key] = str(candidate.get("candidate_id") or "")
+    return {
+        "candidate_count": len(candidates),
+        "unique_semantic_outcomes": len(representatives),
+        "duplicate_count": len(duplicate_ids),
+        "duplicate_candidate_ids": duplicate_ids,
+    }
+
+
+def rank_key(metrics: dict[str, Any], cost: dict[str, Any], objective: str) -> tuple[Any, ...]:
+    quality = (
+        -float(metrics.get("ndcg_at_10") or 0),
+        -float(metrics.get("recall_at_5") or 0),
+        -float(metrics.get("mrr_at_10") or 0),
+        -float(metrics.get("citation_coverage") or 0),
+        -float(metrics.get("no_result_accuracy") or 0),
+    )
+    latency = float(metrics.get("p95_latency_ms") or 0)
+    size = int(cost.get("estimated_index_bytes") or 0)
+    build = float(cost.get("build_duration_ms") or 0)
+    checksum = str(cost.get("checksum") or "")
+    if objective == "quality":
+        return (*quality, latency, size, build, checksum)
+    if objective == "low_latency":
+        return (latency, size, build, *quality, checksum)
+    return (quality[0], latency, size, build, *quality[1:], checksum)
+
+
+def pareto_front(candidates: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    front: list[dict[str, Any]] = []
+    for candidate in candidates:
+        metrics = candidate.get("holdout_metrics") or {}
+        cost = candidate.get("cost") or {}
+        dominated = False
+        for other in candidates:
+            if other is candidate:
+                continue
+            other_metrics = other.get("holdout_metrics") or {}
+            other_cost = other.get("cost") or {}
+            no_worse = (
+                float(other_metrics.get("ndcg_at_10") or 0)
+                >= float(metrics.get("ndcg_at_10") or 0)
+                and float(other_metrics.get("p95_latency_ms") or 0)
+                <= float(metrics.get("p95_latency_ms") or 0)
+                and int(other_cost.get("estimated_index_bytes") or 0)
+                <= int(cost.get("estimated_index_bytes") or 0)
+            )
+            better = (
+                float(other_metrics.get("ndcg_at_10") or 0)
+                > float(metrics.get("ndcg_at_10") or 0)
+                or float(other_metrics.get("p95_latency_ms") or 0)
+                < float(metrics.get("p95_latency_ms") or 0)
+                or int(other_cost.get("estimated_index_bytes") or 0)
+                < int(cost.get("estimated_index_bytes") or 0)
+            )
+            if no_worse and better:
+                dominated = True
+                break
+        if not dominated:
+            front.append(candidate)
+    return front
+
+
+def improvement_summary(
+    baseline_metrics: dict[str, Any],
+    candidate_metrics: dict[str, Any],
+    baseline_cost: dict[str, Any],
+    candidate_cost: dict[str, Any],
+) -> dict[str, Any]:
+    quality_delta = float(candidate_metrics.get("ndcg_at_10") or 0) - float(
+        baseline_metrics.get("ndcg_at_10") or 0
+    )
+    no_result_accuracy_delta = float(
+        candidate_metrics.get("no_result_accuracy") or 0
+    ) - float(baseline_metrics.get("no_result_accuracy") or 0)
+    baseline_p95 = float(baseline_metrics.get("p95_latency_ms") or 0)
+    candidate_p95 = float(candidate_metrics.get("p95_latency_ms") or 0)
+    latency_ratio = (baseline_p95 - candidate_p95) / baseline_p95 if baseline_p95 else 0.0
+    baseline_size = int(baseline_cost.get("estimated_index_bytes") or 0)
+    candidate_size = int(candidate_cost.get("estimated_index_bytes") or 0)
+    size_ratio = (baseline_size - candidate_size) / baseline_size if baseline_size else 0.0
+    baseline_chunks = int(baseline_cost.get("chunk_count") or 0)
+    candidate_chunks = int(candidate_cost.get("chunk_count") or 0)
+    chunk_ratio = (
+        (baseline_chunks - candidate_chunks) / baseline_chunks if baseline_chunks else 0.0
+    )
+    return {
+        "quality_delta": round(quality_delta, 6),
+        "no_result_accuracy_delta": round(no_result_accuracy_delta, 6),
+        "p95_reduction_ratio": round(latency_ratio, 6),
+        "index_size_reduction_ratio": round(size_ratio, 6),
+        "chunk_reduction_ratio": round(chunk_ratio, 6),
+        "effective": bool(
+            quality_delta >= 0.01
+            or no_result_accuracy_delta >= 0.01
+            or latency_ratio >= 0.1
+            or size_ratio >= 0.1
+            or chunk_ratio >= 0.1
+        ),
+    }
+
+
+def apply_optimization_gate(
+    candidates: list[dict[str, Any]],
+    *,
+    baseline_metrics: dict[str, Any],
+    baseline_cost: dict[str, Any],
+    policy: dict[str, Any],
+    objective: str,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], dict[str, Any]]:
+    """Apply the knowledge gate before candidates consume Holdout budget."""
+
+    evaluated: list[dict[str, Any]] = []
+    eligible: list[dict[str, Any]] = []
+    failed_checks: dict[str, int] = {}
+    for candidate in candidates:
+        item = _copy(candidate)
+        metrics = dict(item.get("optimization_metrics") or {})
+        gate_metrics = {
+            **metrics,
+            # Search trials query each optimization case once. A single P95 is
+            # diagnostic only; latency gating is deferred to repeated Holdout.
+            "p95_latency_ms": float(baseline_metrics.get("p95_latency_ms") or 0),
+        }
+        gate = evaluate_promotion_gate(
+            gate_metrics,
+            baseline=baseline_metrics,
+            policy=policy,
+        )
+        gate["latency_evidence"] = "deferred_to_repeated_holdout"
+        item["optimization_gate"] = gate
+        item["optimization_improvement"] = improvement_summary(
+            baseline_metrics,
+            metrics,
+            baseline_cost,
+            dict(item.get("cost") or {}),
+        )
+        evaluated.append(item)
+        if not gate.get("passed"):
+            for check in gate.get("checks") or []:
+                if not check.get("passed"):
+                    check_id = str(check.get("id") or "unknown")
+                    failed_checks[check_id] = failed_checks.get(check_id, 0) + 1
+            continue
+        if item.get("automatic_winner_eligible"):
+            eligible.append(item)
+
+    eligible.sort(
+        key=lambda item: rank_key(
+            item["optimization_metrics"], item["cost"], objective
+        )
+    )
+    summary = {
+        "evaluated_count": len(evaluated),
+        "passed_count": sum(
+            1 for item in evaluated if item.get("optimization_gate", {}).get("passed")
+        ),
+        "eligible_count": len(eligible),
+        "failed_check_counts": dict(sorted(failed_checks.items())),
+    }
+    return evaluated, eligible, summary
+
+
+class RagStrategyTuner:
+    """Deterministic bounded search over fixed RAG and evaluation snapshots."""
+
+    def __init__(
+        self,
+        service: RagService,
+        store: RagStrategyTuningStore,
+        evaluation_store: KnowledgeEvaluationStore,
+        pipeline_executor: KnowledgePipelineExecutor,
+        evaluation_executor: KnowledgeEvaluationExecutor,
+        *,
+        run_registry: Any | None = None,
+        poll_interval: float = 0.5,
+    ) -> None:
+        self.service = service
+        self.store = store
+        self.evaluation_store = evaluation_store
+        self.pipeline_executor = pipeline_executor
+        self.evaluation_executor = evaluation_executor
+        self.run_registry = run_registry
+        self.poll_interval = max(0.1, poll_interval)
+        self._wake = asyncio.Event()
+        self._task: asyncio.Task[None] | None = None
+        self._stopping = False
+
+    def capabilities(self) -> dict[str, Any]:
+        rerank = self.service.reranker.capabilities()
+        return {
+            "version": TUNER_VERSION,
+            "rules_version": RULES_VERSION,
+            "objectives": sorted(OBJECTIVES),
+            "limits": {
+                "max_chunk_indexes": 4,
+                "max_retrieval_trials": 24,
+                "max_finalists": 3,
+                "minimum_evaluation_cases": 12,
+                "minimum_positive_cases": 30,
+                "minimum_reviewed_hard_negatives": 12,
+            },
+            "validation": {
+                "version": VALIDATION_VERSION,
+                "resample_count": VALIDATION_RESAMPLE_COUNT,
+                "query_repetitions": VALIDATION_QUERY_REPETITIONS,
+                "bootstrap_samples": VALIDATION_BOOTSTRAP_SAMPLES,
+                "confidence_level": VALIDATION_CONFIDENCE_LEVEL,
+                "max_quality_regression": VALIDATION_MAX_REGRESSION,
+                "latency_aggregation": "median_per_case_then_p95",
+                "known_winner_fixture_version": KNOWN_WINNER_FIXTURE_VERSION,
+                "known_winner_scenarios": [
+                    "threshold_recovery",
+                    "already_optimal_control",
+                ],
+            },
+            "tunable": [
+                "chunker",
+                "retrieval_mode",
+                "top_k",
+                "hybrid_weight",
+                "score_threshold",
+                "rerank_finalists",
+            ],
+            "fixed": ["processor", "vision", "embedding"],
+            "rerank_available": bool(
+                rerank.get("api_configured") or rerank.get("llm_configured")
+            ),
+        }
+
+    def preflight(self, request: dict[str, Any]) -> dict[str, Any]:
+        normalized = self._normalize_request(request)
+        kb_id = normalized["kb_id"]
+        base_version_id = normalized["base_version_id"]
+        base = self.service.get_pipeline_version(base_version_id)
+        if base.get("kb_id") != kb_id or base.get("status") not in {"ready", "active"}:
+            raise RagStrategyTuningValidationError(
+                "The base version must be a ready or active version in the selected knowledge base."
+            )
+        if int(base.get("index_schema_version") or 1) < 2:
+            raise RagStrategyTuningValidationError("Strategy tuning requires a V2 index.")
+        base_job = self.service.get_pipeline_job(str(base.get("job_id") or ""))
+        if not base_job.get("sources"):
+            raise RagStrategyTuningValidationError("The base source snapshot is unavailable.")
+        evaluation_set = self.evaluation_store.get_set(normalized["eval_set_id"])
+        evaluation_version = self.evaluation_store.get_set_version(
+            normalized["eval_set_id"], normalized["eval_set_version"]
+        )
+        cases = list(evaluation_version.get("cases") or [])
+        if evaluation_set.get("kb_id") != kb_id or evaluation_version.get("kb_id") != kb_id:
+            raise RagStrategyTuningValidationError(
+                "The published evaluation set must belong to the selected knowledge base."
+            )
+        readiness = build_tuning_readiness(
+            evaluation_version,
+            target_version_id=base_version_id,
+        )
+        positive = [case for case in cases if not case.get("expected_no_result")]
+        stable_blocks = bool(positive) and all(
+            all(
+                str(ref.get("match_mode") or "") == "source_block"
+                and bool(ref.get("source_block_id"))
+                for ref in case.get("expected_refs") or []
+            )
+            for case in positive
+        )
+        warnings: list[str] = list(readiness.get("warnings") or [])
+        if readiness.get("blockers"):
+            warnings.extend(str(item) for item in readiness["blockers"])
+        if not stable_blocks:
+            warnings.append(
+                "Some positive cases lack stable source-block Gold; tuning is limited to retrieval parameters."
+            )
+        embedding = dict(base.get("embedding_profile") or {})
+        degraded_embedding = bool(embedding.get("degraded")) or str(
+            embedding.get("provider") or ""
+        ) == "hash"
+        if degraded_embedding:
+            warnings.append(
+                "The fixed version uses hash embedding; vector and hybrid trials cannot win automatically."
+            )
+        rerank = self.service.reranker.capabilities()
+        rerank_available = bool(
+            rerank.get("api_configured") or rerank.get("llm_configured")
+        )
+        if normalized["enable_rerank"] and not rerank_available:
+            raise RagStrategyTuningValidationError(
+                "Rerank was requested but no rerank provider is configured."
+            )
+        recommendation = None
+        if normalized["recommendation_id"]:
+            recommendation = RagStrategyService(self.service).get_recommendation(
+                normalized["recommendation_id"]
+            )
+            if recommendation.get("kb_id") != kb_id:
+                raise RagStrategyTuningValidationError(
+                    "The Router recommendation belongs to another knowledge base."
+                )
+            if recommendation.get("state") not in {"ready", "applied"}:
+                raise RagStrategyTuningValidationError(
+                    "The Router recommendation is stale or unavailable."
+                )
+        source_snapshot = [
+            {
+                "source_id": str(item.get("source_id") or ""),
+                "document_id": str(item.get("document_id") or ""),
+                "content_hash": str(item.get("content_hash") or ""),
+            }
+            for item in base_job.get("sources") or []
+            if isinstance(item, dict)
+        ]
+        snapshot = {
+            "kb_id": kb_id,
+            "base_version_id": base_version_id,
+            "base_version": int(base.get("version") or 0),
+            "base_job_id": str(base.get("job_id") or ""),
+            "source_snapshot_hash": _checksum(source_snapshot),
+            "eval_set_id": normalized["eval_set_id"],
+            "eval_set_version": normalized["eval_set_version"],
+            "eval_set_version_id": str(evaluation_version.get("version_id") or ""),
+            "eval_case_count": len(cases),
+            "eval_checksum": str(evaluation_version.get("checksum") or _checksum(cases)),
+            "benchmark_role": str(readiness.get("benchmark_role") or "unclassified"),
+            "tuning_readiness": readiness,
+            "selection_eligible": bool(readiness.get("selection_eligible")),
+            "rules_version": RULES_VERSION,
+            "router_recommendation": recommendation,
+            "chunk_tuning_available": bool(
+                (readiness.get("dimensions") or {}).get("chunking", {}).get("eligible")
+            ),
+            "threshold_tuning_available": bool(
+                (readiness.get("dimensions") or {}).get("threshold", {}).get("eligible")
+            ),
+            "retrieval_only": not bool(
+                (readiness.get("dimensions") or {}).get("chunking", {}).get("eligible")
+            ),
+            "embedding_degraded": degraded_embedding,
+            "rerank_available": rerank_available,
+            "processor_profile": _copy(base.get("processor_profile") or {}),
+            "vision_profile": _copy(base.get("vision_profile") or {}),
+            "embedding_profile": embedding,
+            "base_chunker": _copy(
+                (base_job.get("config_snapshot") or {})
+                .get("stages", {})
+                .get("stage_chunker", {})
+            ),
+            "base_retrieval": _copy(base.get("retrieval_profile") or {}),
+            "warnings": warnings,
+        }
+        snapshot["snapshot_hash"] = _checksum(
+            {key: value for key, value in snapshot.items() if key != "router_recommendation"}
+        )
+        return snapshot
+
+    def create_run(self, request: dict[str, Any]) -> dict[str, Any]:
+        normalized = self._normalize_request(request)
+        snapshot = self.preflight(normalized)
+        if not snapshot.get("selection_eligible"):
+            readiness = dict(snapshot.get("tuning_readiness") or {})
+            reasons = [str(item) for item in readiness.get("blockers") or []]
+            detail = " ".join(reasons[:3]) or "The evaluation evidence is not tuning-ready."
+            raise RagStrategyTuningValidationError(detail)
+        run = self.store.create_run(normalized, snapshot)
+        self.notify()
+        return run
+
+    def start(self) -> None:
+        if self._task is not None and not self._task.done():
+            return
+        self._stopping = False
+        self.store.recover_runs()
+        self._task = asyncio.create_task(self._worker(), name="rag-strategy-tuner")
+        self._wake.set()
+
+    async def stop(self) -> None:
+        self._stopping = True
+        self._wake.set()
+        if self._task is not None:
+            await self._task
+        self._task = None
+
+    def notify(self) -> None:
+        self._wake.set()
+
+    async def run_once(self) -> bool:
+        run = self.store.claim_next_run()
+        if run is None:
+            return False
+        await self._execute(run)
+        return True
+
+    async def _worker(self) -> None:
+        while not self._stopping:
+            processed = await self.run_once()
+            if processed:
+                continue
+            self._wake.clear()
+            try:
+                await asyncio.wait_for(self._wake.wait(), timeout=self.poll_interval)
+            except TimeoutError:
+                pass
+
+    def _normalize_request(self, request: dict[str, Any]) -> dict[str, Any]:
+        objective = str(request.get("objective") or "balanced")
+        if objective not in OBJECTIVES:
+            raise RagStrategyTuningValidationError("Unknown tuning objective.")
+        max_indexes = int(request.get("max_chunk_indexes") or 4)
+        max_trials = int(request.get("max_retrieval_trials") or 24)
+        max_finalists = int(request.get("max_finalists") or 3)
+        if not 1 <= max_indexes <= 4:
+            raise RagStrategyTuningValidationError("max_chunk_indexes must be 1-4.")
+        if not 1 <= max_trials <= 24:
+            raise RagStrategyTuningValidationError("max_retrieval_trials must be 1-24.")
+        if not 1 <= max_finalists <= 3:
+            raise RagStrategyTuningValidationError("max_finalists must be 1-3.")
+        normalized = {
+            "kb_id": str(request.get("kb_id") or ""),
+            "base_version_id": str(request.get("base_version_id") or ""),
+            "eval_set_id": str(request.get("eval_set_id") or ""),
+            "eval_set_version": int(request.get("eval_set_version") or 0),
+            "recommendation_id": str(request.get("recommendation_id") or "") or None,
+            "objective": objective,
+            "seed": int(request.get("seed") or 42),
+            "max_chunk_indexes": max_indexes,
+            "max_retrieval_trials": max_trials,
+            "max_finalists": max_finalists,
+            "enable_rerank": bool(request.get("enable_rerank", False)),
+            "rerank_provider": str(request.get("rerank_provider") or "auto"),
+            "rerank_model": str(request.get("rerank_model") or "")[:200],
+        }
+        if not normalized["kb_id"] or not normalized["base_version_id"]:
+            raise RagStrategyTuningValidationError("Knowledge base and base version are required.")
+        if not normalized["eval_set_id"] or normalized["eval_set_version"] < 1:
+            raise RagStrategyTuningValidationError(
+                "A published evaluation set version is required."
+            )
+        return normalized
+
+    async def _execute(self, run: dict[str, Any]) -> None:
+        run_id = str(run["run_id"])
+        trial_versions: list[str] = list(run.get("trial_version_ids") or [])
+        registry_id = await self._ensure_registry_run(run)
+        try:
+            await self._checkpoint(
+                registry_id,
+                "rag_strategy_tuning.started",
+                "RAG strategy tuning started",
+                {
+                    "tuning_run_id": run_id,
+                    "kb_id": str(run["kb_id"]),
+                    "objective": str((run.get("request") or {}).get("objective") or "balanced"),
+                },
+            )
+            self._raise_if_cancelled(run_id)
+            snapshot = self.preflight(dict(run["request"]))
+            if snapshot["snapshot_hash"] != run["snapshot"]["snapshot_hash"]:
+                raise RagStrategyTuningStateError(
+                    "The fixed source or evaluation snapshot is no longer available."
+                )
+            search = await self._search(run_id, run["request"], snapshot, trial_versions)
+            await self._checkpoint(
+                registry_id,
+                "rag_strategy_tuning.search_completed",
+                "RAG strategy search completed",
+                {
+                    "tuning_run_id": run_id,
+                    "candidate_count": len(self.store.get_run(run_id).get("candidates") or []),
+                    "finalist_count": len(self.store.get_run(run_id).get("finalists") or []),
+                    "eligible_count": len(search.get("eligible") or []),
+                },
+            )
+            if not search["eligible"]:
+                self.store.update(
+                    run_id,
+                    status="no_improvement",
+                    stage="completed",
+                    progress=100,
+                    completed_at=time.time(),
+                    winner=None,
+                )
+                await self._finish_registry(
+                    registry_id,
+                    "completed",
+                    metadata={"tuning_run_id": run_id, "outcome": "no_improvement"},
+                )
+                return
+            materialized = await self._materialize(
+                run_id, run["request"], snapshot, search["eligible"][0]
+            )
+            completed = self.store.get_run(run_id)
+            if not materialized:
+                await self._checkpoint(
+                    registry_id,
+                    "rag_strategy_tuning.no_improvement",
+                    "The materialized candidate did not pass full evaluation",
+                    {
+                        "tuning_run_id": run_id,
+                        "final_version_id": str(completed.get("final_version_id") or ""),
+                        "evaluation_run_id": str(completed.get("evaluation_run_id") or ""),
+                    },
+                )
+                await self._finish_registry(
+                    registry_id,
+                    "completed",
+                    metadata={
+                        "tuning_run_id": run_id,
+                        "outcome": "no_improvement",
+                        "final_version_id": str(completed.get("final_version_id") or ""),
+                    },
+                )
+                return
+            await self._checkpoint(
+                registry_id,
+                "rag_strategy_tuning.completed",
+                "RAG strategy candidate materialized",
+                {
+                    "tuning_run_id": run_id,
+                    "final_version_id": str(completed.get("final_version_id") or ""),
+                    "evaluation_run_id": str(completed.get("evaluation_run_id") or ""),
+                },
+            )
+            await self._finish_registry(
+                registry_id,
+                "completed",
+                metadata={
+                    "tuning_run_id": run_id,
+                    "final_version_id": str(completed.get("final_version_id") or ""),
+                },
+            )
+        except asyncio.CancelledError:
+            raise
+        except _TuningCancelled:
+            await self._cancel_trial_jobs(run_id)
+            self.store.update(
+                run_id,
+                status="cancelled",
+                stage="cancelled",
+                completed_at=time.time(),
+            )
+            await self._finish_registry(
+                registry_id,
+                "cancelled",
+                metadata={"tuning_run_id": run_id},
+            )
+        except Exception as exc:
+            safe_error = self.service._safe_pipeline_error(exc)
+            self.store.update(
+                run_id,
+                status="failed",
+                stage="failed",
+                error=safe_error,
+                completed_at=time.time(),
+            )
+            await self._checkpoint(
+                registry_id,
+                "rag_strategy_tuning.failed",
+                "RAG strategy tuning failed",
+                {"tuning_run_id": run_id, "error": safe_error[:300]},
+                severity="error",
+            )
+            await self._finish_registry(
+                registry_id,
+                "failed",
+                error=safe_error,
+                metadata={"tuning_run_id": run_id},
+            )
+        finally:
+            known = [
+                *trial_versions,
+                *self.store.get_run(run_id).get("trial_version_ids", []),
+            ]
+            for version_id in list(dict.fromkeys(known)):
+                try:
+                    self.service.cleanup_strategy_tuning_trial_version(version_id)
+                except Exception:
+                    pass
+            for job_id in self.store.get_run(run_id).get("pipeline_job_ids", []):
+                try:
+                    self.service.cleanup_strategy_tuning_trial_job(str(job_id))
+                except Exception:
+                    pass
+
+    async def _search(
+        self,
+        run_id: str,
+        request: dict[str, Any],
+        snapshot: dict[str, Any],
+        trial_versions: list[str],
+    ) -> dict[str, Any]:
+        evaluation_version = self.evaluation_store.get_set_version(
+            snapshot["eval_set_id"], snapshot["eval_set_version"]
+        )
+        cases = list(evaluation_version.get("cases") or [])
+        split = stratified_split(cases, int(request["seed"]))
+        validation_plan = repeated_validation_plan(
+            cases,
+            list(split["holdout_case_ids"]),
+            int(request["seed"]),
+        )
+        self.store.update(
+            run_id,
+            status="searching",
+            stage="retrieval_search",
+            progress=8,
+            case_split=split,
+            validation_plan=validation_plan,
+        )
+        optimization_ids = set(split["optimization_case_ids"])
+        holdout_ids = set(split["holdout_case_ids"])
+        optimization_cases = [case for case in cases if case["case_id"] in optimization_ids]
+        holdout_cases = [case for case in cases if case["case_id"] in holdout_ids]
+        retrieval_profiles = retrieval_candidates(
+            snapshot["base_retrieval"], degraded=bool(snapshot["embedding_degraded"])
+        )
+        if snapshot.get("threshold_tuning_available"):
+            retrieval_profiles = [
+                {**profile, "score_threshold": 0.0}
+                for profile in retrieval_profiles
+            ]
+        else:
+            fixed_threshold = float(
+                (snapshot.get("base_retrieval") or {}).get("score_threshold") or 0
+            )
+            retrieval_profiles = [
+                {**profile, "score_threshold": fixed_threshold}
+                for profile in retrieval_profiles
+            ]
+        chunkers = chunker_candidates(snapshot)
+        if snapshot["retrieval_only"]:
+            chunkers = chunkers[:1]
+        max_indexes = int(request["max_chunk_indexes"])
+        max_trials = int(request["max_retrieval_trials"])
+        current_run = self.store.get_run(run_id)
+        candidates: list[dict[str, Any]] = list(current_run.get("candidates") or [])
+        candidate_cache = {
+            str(item.get("search_profile_checksum") or ""): item
+            for item in candidates
+            if item.get("search_profile_checksum")
+        }
+        trial_cache = {
+            str(item.get("chunker_checksum") or ""): item
+            for item in current_run.get("trial_indexes") or []
+            if item.get("chunker_checksum")
+        }
+        baseline_cost = self.service.pipeline_version_cost_summary(
+            snapshot["base_version_id"]
+        )
+        baseline_candidate_checksum = _checksum(
+            {
+                "chunker": snapshot["base_chunker"],
+                "retrieval": snapshot["base_retrieval"],
+            }
+        )
+        probe_retrieval_checksum = retrieval_semantic_checksum(retrieval_profiles[0])
+        base_chunker_checksum = _checksum(snapshot["base_chunker"])
+        for chunk_index, chunker in enumerate(chunkers[:max_indexes]):
+            self._raise_if_cancelled(run_id)
+            chunker_checksum = _checksum(chunker)
+            if chunk_index == 0:
+                version_id = snapshot["base_version_id"]
+                cost = baseline_cost
+                index_job_id = str(snapshot["base_job_id"])
+            else:
+                cached_trial = trial_cache.get(chunker_checksum)
+                version_id = ""
+                cost: dict[str, Any] = {}
+                if cached_trial:
+                    try:
+                        cached_version = self.service.get_pipeline_version(
+                            str(cached_trial["version_id"])
+                        )
+                        if str((cached_version.get("origin") or {}).get("kind") or "") == "rag_strategy_tuner_trial":
+                            version_id = str(cached_version["version_id"])
+                            cost = dict(cached_trial.get("cost") or {})
+                            index_job_id = str(cached_trial.get("job_id") or "")
+                    except Exception:
+                        version_id = ""
+                if not version_id:
+                    self.store.update(
+                        run_id,
+                        status="building",
+                        stage="building_trial_index",
+                        progress=min(55, 12 + chunk_index * 10),
+                    )
+                    job = self.service.create_strategy_tuning_pipeline_job(
+                        snapshot["kb_id"],
+                        base_version_id=snapshot["base_version_id"],
+                        chunker_profile=chunker,
+                        retrieval_profile=retrieval_profiles[0],
+                        tuning_run_id=run_id,
+                        trial=True,
+                    )
+                    self._append_run_value(run_id, "pipeline_job_ids", job["job_id"])
+                    self.pipeline_executor.notify()
+                    version_id = await self._wait_for_pipeline(job["job_id"], run_id)
+                    cost = self.service.pipeline_version_cost_summary(version_id)
+                    index_job_id = str(job["job_id"])
+                    cached_trial = {
+                        "chunker_checksum": chunker_checksum,
+                        "version_id": version_id,
+                        "job_id": str(job["job_id"]),
+                        "cost": cost,
+                    }
+                    trial_cache[chunker_checksum] = cached_trial
+                    self._upsert_run_item(
+                        run_id,
+                        "trial_indexes",
+                        cached_trial,
+                        identity_key="chunker_checksum",
+                    )
+                trial_versions.append(version_id)
+                self._append_run_value(run_id, "trial_version_ids", version_id)
+                if not cost:
+                    cost = self.service.pipeline_version_cost_summary(version_id)
+            index_job = self.service.get_pipeline_job(index_job_id)
+            index_fingerprint = realized_index_fingerprint(
+                chunker=chunker,
+                cost=cost,
+                document_results=list(index_job.get("document_results") or []),
+            )
+            for retrieval in retrieval_profiles:
+                if len(candidates) >= max_trials:
+                    break
+                search_profile_checksum = _checksum(
+                    {
+                        "version_id": version_id,
+                        "retrieval": retrieval_semantic_payload(retrieval),
+                    }
+                )
+                if search_profile_checksum in candidate_cache:
+                    continue
+                result = await self._evaluate_profile(
+                    version_id, retrieval, optimization_cases
+                )
+                retrieval_input_checksum = retrieval_semantic_checksum(retrieval)
+                calibrated = (
+                    calibrate_threshold(result, retrieval)
+                    if snapshot.get("threshold_tuning_available")
+                    else {
+                        "retrieval": _copy(retrieval),
+                        "threshold_candidates": [
+                            float(retrieval.get("score_threshold") or 0)
+                        ],
+                        "metrics": _copy(result["metrics"]),
+                    }
+                )
+                candidate = {
+                    "candidate_id": f"ragtc_{uuid.uuid4().hex}",
+                    "chunker": _copy(chunker),
+                    "retrieval": calibrated["retrieval"],
+                    "threshold_candidates": calibrated["threshold_candidates"],
+                    "threshold_front": calibrated.get("threshold_front") or [],
+                    "threshold_selection_reason": calibrated.get(
+                        "threshold_selection_reason"
+                    ),
+                    "version_id": version_id,
+                    "trial_version": chunk_index > 0,
+                    "optimization_metrics": calibrated["metrics"],
+                    "cost": {**cost, "checksum": _checksum(cost)},
+                    "checksum": _checksum(
+                        {"chunker": chunker, "retrieval": calibrated["retrieval"]}
+                    ),
+                    "search_profile_checksum": search_profile_checksum,
+                    "chunker_checksum": chunker_checksum,
+                    "realized_index_fingerprint": index_fingerprint,
+                    "retrieval_input_checksum": retrieval_input_checksum,
+                    "ranking_fingerprint": ranking_fingerprint(
+                        list(result.get("case_results") or [])
+                    ),
+                    "rerank_call_count": 0,
+                    "automatic_winner_eligible": not (
+                        snapshot["embedding_degraded"]
+                        and calibrated["retrieval"]["mode"] in {"vector", "hybrid"}
+                    ),
+                }
+                if not candidate["automatic_winner_eligible"]:
+                    candidate["ineligible_reason"] = "hash_embedding"
+                elif candidate["checksum"] == baseline_candidate_checksum:
+                    candidate["automatic_winner_eligible"] = False
+                    candidate["ineligible_reason"] = "baseline_equivalent"
+                candidates.append(candidate)
+                candidate_cache[search_profile_checksum] = candidate
+                self.store.update(run_id, candidates=candidates)
+            if len(candidates) >= max_trials:
+                break
+        chunk_sensitivity = assess_chunk_sensitivity(
+            candidates,
+            probe_retrieval_checksum=probe_retrieval_checksum,
+            enabled=bool(snapshot.get("chunk_tuning_available")),
+        )
+        if chunk_sensitivity["status"] == "insufficient":
+            for candidate in candidates:
+                if str(candidate.get("chunker_checksum") or "") == base_chunker_checksum:
+                    continue
+                candidate["automatic_winner_eligible"] = False
+                candidate["ineligible_reason"] = "chunk_insensitive"
+        retrieval_deduplication = mark_semantic_duplicate_candidates(candidates)
+        self.store.update(
+            run_id,
+            candidates=candidates,
+            chunk_sensitivity=chunk_sensitivity,
+            retrieval_deduplication=retrieval_deduplication,
+        )
+        gate_policy = self.evaluation_store.get_gate_policy(snapshot["kb_id"])
+        optimization_baseline = await self._evaluate_profile(
+            snapshot["base_version_id"],
+            snapshot["base_retrieval"],
+            optimization_cases,
+        )
+        candidates, ranked_training, optimization_gate_summary = apply_optimization_gate(
+            candidates,
+            baseline_metrics=optimization_baseline["metrics"],
+            baseline_cost=baseline_cost,
+            policy=gate_policy,
+            objective=request["objective"],
+        )
+        self.store.update(
+            run_id,
+            candidates=candidates,
+            optimization_baseline_metrics=optimization_baseline["metrics"],
+            optimization_gate_summary=optimization_gate_summary,
+            no_improvement_reason=None if ranked_training else "optimization_gate",
+        )
+        if not ranked_training:
+            return {
+                "eligible": [],
+                "baseline_metrics": optimization_baseline["metrics"],
+            }
+        self.store.update(
+            run_id,
+            status="evaluating",
+            stage="holdout_evaluation",
+            progress=62,
+        )
+        baseline_validation_checksum = _checksum(
+            {
+                "validation_plan": validation_plan["checksum"],
+                "version_id": snapshot["base_version_id"],
+                "retrieval": retrieval_semantic_payload(snapshot["base_retrieval"]),
+            }
+        )
+        stored_baseline = dict(
+            self.store.get_run(run_id).get("validation_baseline") or {}
+        )
+        if (
+            stored_baseline.get("validation_version") == VALIDATION_VERSION
+            and stored_baseline.get("checksum") == baseline_validation_checksum
+        ):
+            baseline = stored_baseline
+        else:
+            evaluated_baseline = await self._evaluate_profile(
+                snapshot["base_version_id"],
+                snapshot["base_retrieval"],
+                holdout_cases,
+                repetitions=VALIDATION_QUERY_REPETITIONS,
+            )
+            baseline = {
+                "validation_version": VALIDATION_VERSION,
+                "checksum": baseline_validation_checksum,
+                "metrics": evaluated_baseline["metrics"],
+                "case_summaries": evaluated_baseline["case_summaries"],
+            }
+            self.store.update(run_id, validation_baseline=baseline)
+        stored_finalists = list(self.store.get_run(run_id).get("finalists") or [])
+        finalist_cache = {
+            str(item.get("checksum") or ""): item
+            for item in stored_finalists
+            if item.get("checksum")
+        }
+        finalists: list[dict[str, Any]] = []
+        for candidate in ranked_training[: int(request["max_finalists"])]:
+            finalist = finalist_cache.get(str(candidate.get("checksum") or ""))
+            if finalist is not None and (
+                (finalist.get("statistical_validation") or {}).get(
+                    "validation_version"
+                )
+                != VALIDATION_VERSION
+                or finalist.get("validation_plan_checksum")
+                != validation_plan["checksum"]
+            ):
+                finalist = None
+            if finalist is None:
+                result = await self._evaluate_profile(
+                    candidate["version_id"],
+                    candidate["retrieval"],
+                    holdout_cases,
+                    repetitions=VALIDATION_QUERY_REPETITIONS,
+                )
+                finalist = _copy(candidate)
+                finalist["holdout_metrics"] = result["metrics"]
+                finalist["validation_plan_checksum"] = validation_plan["checksum"]
+                finalist["statistical_validation"] = paired_statistical_validation(
+                    baseline, result, validation_plan
+                )
+                finalist["promotion_gate"] = evaluate_promotion_gate(
+                    result["metrics"], baseline=baseline["metrics"], policy=gate_policy
+                )
+                finalist["improvement"] = improvement_summary(
+                    baseline["metrics"], result["metrics"], baseline_cost, finalist["cost"]
+                )
+                finalist_cache[str(finalist["checksum"])] = finalist
+                stored_finalists = [
+                    item
+                    for item in stored_finalists
+                    if str(item.get("checksum") or "") != str(finalist["checksum"])
+                ]
+                stored_finalists.append(finalist)
+                self.store.update(run_id, finalists=stored_finalists)
+            finalists.append(finalist)
+        if request.get("enable_rerank") and finalists:
+            reranked: list[dict[str, Any]] = []
+            for candidate in finalists[:2]:
+                retrieval = {
+                    **candidate["retrieval"],
+                    "rerank_enabled": True,
+                    "rerank_provider": str(request.get("rerank_provider") or "auto"),
+                    "rerank_model": str(request.get("rerank_model") or ""),
+                    "rerank_top_n": int(candidate["retrieval"]["top_k"]),
+                }
+                rerank_checksum = _checksum(
+                    {"chunker": candidate["chunker"], "retrieval": retrieval}
+                )
+                reranked_candidate = finalist_cache.get(rerank_checksum)
+                if reranked_candidate is not None and (
+                    (reranked_candidate.get("statistical_validation") or {}).get(
+                        "validation_version"
+                    )
+                    != VALIDATION_VERSION
+                    or reranked_candidate.get("validation_plan_checksum")
+                    != validation_plan["checksum"]
+                ):
+                    reranked_candidate = None
+                if reranked_candidate is None:
+                    result = await self._evaluate_profile(
+                        candidate["version_id"],
+                        retrieval,
+                        holdout_cases,
+                        repetitions=VALIDATION_QUERY_REPETITIONS,
+                    )
+                    reranked_candidate = {
+                        **_copy(candidate),
+                        "candidate_id": f"ragtc_{uuid.uuid4().hex}",
+                        "retrieval": retrieval,
+                        "checksum": rerank_checksum,
+                        "holdout_metrics": result["metrics"],
+                        "rerank_call_count": len(holdout_cases)
+                        * VALIDATION_QUERY_REPETITIONS,
+                        "validation_plan_checksum": validation_plan["checksum"],
+                    }
+                    reranked_candidate[
+                        "statistical_validation"
+                    ] = paired_statistical_validation(
+                        baseline, result, validation_plan
+                    )
+                    reranked_candidate["promotion_gate"] = evaluate_promotion_gate(
+                        result["metrics"], baseline=baseline["metrics"], policy=gate_policy
+                    )
+                    reranked_candidate["improvement"] = improvement_summary(
+                        baseline["metrics"], result["metrics"], baseline_cost, candidate["cost"]
+                    )
+                    finalist_cache[rerank_checksum] = reranked_candidate
+                    stored_finalists = [
+                        item
+                        for item in stored_finalists
+                        if str(item.get("checksum") or "") != rerank_checksum
+                    ]
+                    stored_finalists.append(reranked_candidate)
+                    self.store.update(run_id, finalists=stored_finalists)
+                reranked.append(reranked_candidate)
+            finalists.extend(reranked)
+        front = pareto_front(finalists)
+        eligible = [
+            item
+            for item in front
+            if item.get("promotion_gate", {}).get("passed")
+            and item.get("improvement", {}).get("effective")
+            and item.get("statistical_validation", {}).get("passed")
+        ]
+        eligible.sort(
+            key=lambda item: rank_key(
+                item["holdout_metrics"], item["cost"], request["objective"]
+            )
+        )
+        if eligible:
+            no_improvement_reason = None
+        elif any(
+            item.get("promotion_gate", {}).get("passed")
+            and item.get("improvement", {}).get("effective")
+            and not item.get("statistical_validation", {}).get("passed")
+            for item in front
+        ):
+            no_improvement_reason = "statistical_gate"
+        else:
+            no_improvement_reason = "holdout_gate"
+        self.store.update(
+            run_id,
+            progress=78,
+            finalists=finalists,
+            pareto_front=[item["candidate_id"] for item in front],
+            no_improvement_reason=no_improvement_reason,
+            statistical_summary={
+                "validation_version": VALIDATION_VERSION,
+                "evaluated_finalist_count": len(finalists),
+                "statistically_non_degrading_count": sum(
+                    1
+                    for item in finalists
+                    if item.get("statistical_validation", {}).get("passed")
+                ),
+                "eligible_count": len(eligible),
+                "query_repetitions": VALIDATION_QUERY_REPETITIONS,
+                "resample_count": len(validation_plan.get("resamples") or []),
+                "confidence_level": VALIDATION_CONFIDENCE_LEVEL,
+            },
+        )
+        return {
+            "eligible": eligible,
+            "baseline_metrics": baseline["metrics"],
+            "evaluation_version": evaluation_version,
+        }
+
+    async def _materialize(
+        self,
+        run_id: str,
+        request: dict[str, Any],
+        snapshot: dict[str, Any],
+        winner: dict[str, Any],
+    ) -> bool:
+        if not (winner.get("statistical_validation") or {}).get("passed"):
+            raise RagStrategyTuningStateError(
+                "The winner lacks a passing paired Holdout validation report."
+            )
+        self.store.update(
+            run_id,
+            status="materializing",
+            stage="materializing_winner",
+            progress=82,
+            winner=winner,
+        )
+        current = self.store.get_run(run_id)
+        final_version_id = str(current.get("final_version_id") or "")
+        if final_version_id:
+            version = self.service.get_pipeline_version(final_version_id)
+            origin = version.get("origin") or {}
+            if (
+                str(origin.get("kind") or "") != "rag_strategy_tuner"
+                or str(origin.get("source_run_id") or "") != run_id
+            ):
+                raise RagStrategyTuningStateError(
+                    "The persisted materialized version does not belong to this tuner run."
+                )
+        else:
+            materialization_job: dict[str, Any] | None = None
+            for job_id in current.get("pipeline_job_ids") or []:
+                try:
+                    candidate_job = self.service.get_pipeline_job(str(job_id))
+                except Exception:
+                    continue
+                origin = candidate_job.get("origin") or {}
+                if (
+                    str(origin.get("kind") or "") == "rag_strategy_tuner"
+                    and str(origin.get("source_run_id") or "") == run_id
+                ):
+                    materialization_job = candidate_job
+                    break
+            if materialization_job is None:
+                materialization_job = self.service.create_strategy_tuning_pipeline_job(
+                    snapshot["kb_id"],
+                    base_version_id=snapshot["base_version_id"],
+                    chunker_profile=winner["chunker"],
+                    retrieval_profile=winner["retrieval"],
+                    tuning_run_id=run_id,
+                    trial=False,
+                )
+                self._append_run_value(
+                    run_id, "pipeline_job_ids", str(materialization_job["job_id"])
+                )
+                self.pipeline_executor.notify()
+            final_version_id = await self._wait_for_pipeline(
+                str(materialization_job["job_id"]), run_id
+            )
+        self.store.update(
+            run_id,
+            status="validating",
+            stage="full_evaluation",
+            progress=90,
+            final_version_id=final_version_id,
+        )
+        evaluation_version = self.evaluation_store.get_set_version(
+            snapshot["eval_set_id"], snapshot["eval_set_version"]
+        )
+        evaluation_set = self.evaluation_store.get_set(snapshot["eval_set_id"])
+        current = self.store.get_run(run_id)
+        evaluation_run_id = str(current.get("evaluation_run_id") or "")
+        if evaluation_run_id:
+            official_run = self.evaluation_store.get_run(evaluation_run_id)
+            target_versions = {
+                str(item.get("version_id") or "")
+                for item in official_run.get("targets") or []
+                if isinstance(item, dict)
+            }
+            if (
+                str(official_run.get("eval_set_id") or "") != snapshot["eval_set_id"]
+                or int(official_run.get("eval_set_version") or 0)
+                != int(snapshot["eval_set_version"])
+                or target_versions
+                != {snapshot["base_version_id"], final_version_id}
+            ):
+                raise RagStrategyTuningStateError(
+                    "The persisted evaluation run does not match this tuner snapshot."
+                )
+        else:
+            official_run = self.evaluation_store.create_run(
+                evaluation_set=evaluation_set,
+                evaluation_set_version=evaluation_version,
+                targets=[
+                    {
+                        "target_id": f"target_{snapshot['base_version_id']}",
+                        "version_id": snapshot["base_version_id"],
+                        "label": "Fixed baseline",
+                        "retrieval": snapshot["base_retrieval"],
+                        "respect_profile_top_k": True,
+                    },
+                    {
+                        "target_id": f"target_{final_version_id}",
+                        "version_id": final_version_id,
+                        "label": "Strategy tuner candidate",
+                        "retrieval": winner["retrieval"],
+                        "respect_profile_top_k": True,
+                    },
+                ],
+                baseline_version_id=snapshot["base_version_id"],
+                ks=[1, 3, 5, 10],
+                gate_policy=self.evaluation_store.get_gate_policy(snapshot["kb_id"]),
+            )
+            evaluation_run_id = str(official_run["run_id"])
+            self.store.update(run_id, evaluation_run_id=evaluation_run_id)
+            self.evaluation_executor.notify()
+        completed_evaluation = await self._wait_for_evaluation(
+            evaluation_run_id, run_id
+        )
+        final_target = next(
+            (
+                item
+                for item in completed_evaluation.get("target_results", [])
+                if item.get("version_id") == final_version_id
+            ),
+            None,
+        )
+        if not isinstance(final_target, dict) or not final_target.get(
+            "promotion_gate", {}
+        ).get("passed"):
+            self.store.update(
+                run_id,
+                status="no_improvement",
+                stage="completed",
+                progress=100,
+                completed_at=time.time(),
+                no_improvement_reason="full_evaluation_gate",
+                winner={
+                    **winner,
+                    "materialized_version_id": final_version_id,
+                    "full_evaluation_metrics": _copy(
+                        final_target.get("metrics") if isinstance(final_target, dict) else {}
+                    ),
+                    "full_evaluation_gate": _copy(
+                        final_target.get("promotion_gate")
+                        if isinstance(final_target, dict)
+                        else {}
+                    ),
+                },
+            )
+            return False
+        self.store.update(
+            run_id,
+            status="completed",
+            stage="completed",
+            progress=100,
+            completed_at=time.time(),
+            no_improvement_reason=None,
+            winner={**winner, "materialized_version_id": final_version_id},
+        )
+        return True
+
+    async def _evaluate_profile(
+        self,
+        version_id: str,
+        retrieval: dict[str, Any],
+        cases: list[dict[str, Any]],
+        *,
+        repetitions: int = 1,
+    ) -> dict[str, Any]:
+        results: list[dict[str, Any]] = []
+        top_k = max(1, min(int(retrieval.get("top_k") or 5), 50))
+        for case in cases:
+            for repeat_index in range(max(1, min(int(repetitions), 5))):
+                started = time.perf_counter()
+                try:
+                    response = await self.service.query_pipeline_version(
+                        version_id,
+                        str(case["query"]),
+                        top_k=top_k,
+                        retrieval={**retrieval, "top_k": top_k},
+                        generate_answer=False,
+                    )
+                    result = evaluate_retrieval_case(
+                        list(response.get("sources") or []),
+                        list(case.get("expected_refs") or []),
+                        ks=[1, 3, 5, 10],
+                        latency_ms=(time.perf_counter() - started) * 1000,
+                        warnings=list(response.get("warnings") or []),
+                        expected_no_result=bool(case.get("expected_no_result")),
+                    )
+                except Exception as exc:
+                    result = {
+                        "status": "failed",
+                        "metrics": {},
+                        "ranking": [],
+                        "latency_ms": round(
+                            (time.perf_counter() - started) * 1000, 3
+                        ),
+                        "expected_no_result": bool(case.get("expected_no_result")),
+                        "error": self.service._safe_pipeline_error(exc),
+                    }
+                result["case_id"] = str(case["case_id"])
+                result["repeat_index"] = repeat_index
+                result["stratum"] = _case_stratum(case)
+                results.append(result)
+        case_summaries = summarize_repeated_case_results(results)
+        return {
+            "metrics": {
+                **aggregate_target_metrics(case_summaries, ks=[1, 3, 5, 10]),
+                "execution_count": len(results),
+                "query_repetitions": max(1, min(int(repetitions), 5)),
+                "latency_aggregation": "median_per_case_then_p95",
+            },
+            "case_results": results,
+            "case_summaries": case_summaries,
+            "cases": _copy(cases),
+        }
+
+    async def _wait_for_pipeline(self, job_id: str, run_id: str) -> str:
+        deadline = time.monotonic() + 1800
+        while time.monotonic() < deadline:
+            self._raise_if_cancelled(run_id)
+            job = self.service.get_pipeline_job(job_id)
+            status = str(job.get("status") or "")
+            if status == "succeeded":
+                return str(job["candidate_version_id"])
+            if status in {"failed", "cancelled"}:
+                raise RagStrategyTuningStateError(
+                    str(job.get("error") or f"Pipeline trial {status}.")
+                )
+            if self.pipeline_executor._task is None:
+                await self.pipeline_executor.run_once()
+            else:
+                await asyncio.sleep(self.poll_interval)
+        raise RagStrategyTuningStateError("Pipeline trial timed out.")
+
+    async def _wait_for_evaluation(self, evaluation_run_id: str, run_id: str) -> dict[str, Any]:
+        deadline = time.monotonic() + 1800
+        while time.monotonic() < deadline:
+            self._raise_if_cancelled(run_id)
+            evaluation = self.evaluation_store.get_run(evaluation_run_id)
+            status = str(evaluation.get("status") or "")
+            if status == "succeeded":
+                return evaluation
+            if status in {"failed", "cancelled"}:
+                raise RagStrategyTuningStateError(
+                    str(evaluation.get("error") or f"Evaluation {status}.")
+                )
+            if self.evaluation_executor._task is None:
+                await self.evaluation_executor.run_once()
+            else:
+                await asyncio.sleep(self.poll_interval)
+        raise RagStrategyTuningStateError("Full evaluation timed out.")
+
+    def _raise_if_cancelled(self, run_id: str) -> None:
+        if self.store.cancelled(run_id):
+            raise _TuningCancelled()
+
+    def _append_run_value(self, run_id: str, key: str, value: str) -> None:
+        current = self.store.get_run(run_id)
+        values = [str(item) for item in current.get(key, [])]
+        if value not in values:
+            values.append(value)
+            self.store.update(run_id, **{key: values})
+
+    def _upsert_run_item(
+        self,
+        run_id: str,
+        key: str,
+        value: dict[str, Any],
+        *,
+        identity_key: str,
+    ) -> None:
+        current = self.store.get_run(run_id)
+        items = [dict(item) for item in current.get(key, []) if isinstance(item, dict)]
+        identity = str(value.get(identity_key) or "")
+        items = [item for item in items if str(item.get(identity_key) or "") != identity]
+        items.append(_copy(value))
+        self.store.update(run_id, **{key: items})
+
+    async def _ensure_registry_run(self, run: dict[str, Any]) -> str | None:
+        if self.run_registry is None:
+            return None
+        existing_id = str(run.get("run_registry_id") or "")
+        if existing_id and await self.run_registry.get_run(existing_id) is not None:
+            await self.run_registry.update_run(existing_id, status="running")
+            return existing_id
+        registry_run = await self.run_registry.create_run(
+            "rag_strategy_tuning",
+            f"RAG strategy tuning: {run['kb_id']}",
+            status="running",
+            source_id=str(run["run_id"]),
+            metadata={
+                "tuning_run_id": str(run["run_id"]),
+                "kb_id": str(run["kb_id"]),
+                "base_version_id": str((run.get("request") or {}).get("base_version_id") or ""),
+                "eval_set_id": str((run.get("request") or {}).get("eval_set_id") or ""),
+            },
+        )
+        self.store.update(str(run["run_id"]), run_registry_id=registry_run.run_id)
+        return registry_run.run_id
+
+    async def _checkpoint(
+        self,
+        run_id: str | None,
+        event_type: str,
+        title: str,
+        metadata: dict[str, Any],
+        *,
+        severity: str = "info",
+    ) -> None:
+        if self.run_registry is None or not run_id:
+            return
+        await self.run_registry.record_checkpoint(
+            run_id,
+            event_type=event_type,
+            title=title,
+            severity=severity,
+            metadata=metadata,
+        )
+
+    async def _finish_registry(
+        self,
+        run_id: str | None,
+        status: str,
+        error: str | None = None,
+        *,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        if self.run_registry is None or not run_id:
+            return
+        await self.run_registry.update_run(
+            run_id,
+            status=status,
+            error=error,
+            metadata=metadata,
+        )
+
+    async def _cancel_trial_jobs(self, run_id: str) -> None:
+        job_ids = self.store.get_run(run_id).get("pipeline_job_ids", [])
+        pending: list[str] = []
+        for job_id in job_ids:
+            try:
+                job = self.service.get_pipeline_job(str(job_id))
+                if str((job.get("origin") or {}).get("kind") or "") != "rag_strategy_tuner_trial":
+                    continue
+                if job.get("status") in {"queued", "running"}:
+                    self.service.request_pipeline_job_cancel(str(job_id))
+                    pending.append(str(job_id))
+            except Exception:
+                continue
+        if not pending:
+            return
+        self.pipeline_executor.notify()
+        deadline = time.monotonic() + 30
+        while pending and time.monotonic() < deadline:
+            remaining: list[str] = []
+            for job_id in pending:
+                try:
+                    status = str(self.service.get_pipeline_job(job_id).get("status") or "")
+                    if status not in {"succeeded", "failed", "cancelled"}:
+                        remaining.append(job_id)
+                except Exception:
+                    pass
+            pending = remaining
+            if pending:
+                await asyncio.sleep(self.poll_interval)

--- a/server/rag/strategy_tuning_qualification.py
+++ b/server/rag/strategy_tuning_qualification.py
@@ -1,0 +1,379 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import Counter
+from typing import Any
+
+
+READINESS_VERSION = "rag-strategy-tuning-readiness-v1"
+BENCHMARK_ROLES = {
+    "unclassified",
+    "regression_guard",
+    "strategy_tuning",
+    "promotion_evidence",
+}
+MIN_TOTAL_CASES = 12
+MIN_POSITIVE_CASES = 30
+MIN_HARD_NEGATIVES = 12
+MIN_DENSITY_CASES = {
+    "sparse": 6,
+    "single_dense": 4,
+    "multi_dense": 4,
+}
+
+
+def normalize_benchmark_role(
+    value: Any,
+    *,
+    origin: str = "manual",
+    catalog_ref: dict[str, Any] | None = None,
+) -> str:
+    role = str(value or "").strip().lower()
+    if role:
+        if role not in BENCHMARK_ROLES:
+            raise ValueError("Unknown knowledge evaluation benchmark role.")
+        return role
+    if origin == "benchmark_catalog":
+        return "regression_guard"
+    if origin == "generated":
+        return "strategy_tuning"
+    return "unclassified"
+
+
+def benchmark_role_for(value: dict[str, Any]) -> str:
+    return normalize_benchmark_role(
+        value.get("benchmark_role"),
+        origin=str(value.get("origin") or "manual"),
+        catalog_ref=dict(value.get("catalog_ref") or {}),
+    )
+
+
+def build_tuning_readiness(
+    evaluation_version: dict[str, Any],
+    *,
+    target_version_id: str | None = None,
+) -> dict[str, Any]:
+    cases = [item for item in evaluation_version.get("cases") or [] if isinstance(item, dict)]
+    role = benchmark_role_for(evaluation_version)
+    positive = [item for item in cases if not item.get("expected_no_result")]
+    negatives = [item for item in cases if item.get("expected_no_result")]
+    reviewed_negatives = [
+        item for item in negatives if str(item.get("review_status") or "pending") == "approved"
+    ]
+    hard_negatives = [item for item in reviewed_negatives if _is_hard_negative(item)]
+    stable_positive = [item for item in positive if _has_stable_gold(item)]
+    density = Counter(_density_bucket(item) for item in positive)
+    query_types = Counter(_query_type(item) for item in cases)
+    calibration = dict(evaluation_version.get("calibration") or {})
+    calibration_status = str(calibration.get("status") or "pending")
+    origin = str(evaluation_version.get("origin") or "manual")
+    provenance = dict(evaluation_version.get("provenance") or {})
+    target_reference = dict(provenance.get("target_reference") or {})
+    calibration_reference = dict(calibration.get("target_reference") or {})
+    declared_target_version = str(
+        provenance.get("pipeline_version_id")
+        or target_reference.get("pipeline_version_id")
+        or calibration_reference.get("pipeline_version_id")
+        or ""
+    )
+
+    checks: list[dict[str, Any]] = []
+
+    def add_check(
+        check_id: str,
+        *,
+        passed: bool,
+        severity: str,
+        actual: Any,
+        required: Any,
+        message: str,
+    ) -> None:
+        checks.append(
+            {
+                "check_id": check_id,
+                "passed": bool(passed),
+                "severity": severity,
+                "actual": actual,
+                "required": required,
+                "message": message,
+            }
+        )
+
+    add_check(
+        "selection_role",
+        passed=role in {"strategy_tuning", "promotion_evidence"},
+        severity="blocker",
+        actual=role,
+        required=["strategy_tuning", "promotion_evidence"],
+        message=(
+            "Regression packs verify engine consistency and cannot select a tuning winner."
+            if role == "regression_guard"
+            else "The evaluation version must declare a tuning or promotion evidence role."
+        ),
+    )
+    add_check(
+        "minimum_total_cases",
+        passed=len(cases) >= MIN_TOTAL_CASES,
+        severity="blocker",
+        actual=len(cases),
+        required=MIN_TOTAL_CASES,
+        message="A tuning run needs enough cases for a separate validation slice.",
+    )
+    add_check(
+        "minimum_positive_cases",
+        passed=len(positive) >= MIN_POSITIVE_CASES,
+        severity="blocker",
+        actual=len(positive),
+        required=MIN_POSITIVE_CASES,
+        message="Strategy selection requires at least 30 answerable cases.",
+    )
+    if target_version_id and origin == "generated":
+        add_check(
+            "target_version_snapshot",
+            passed=declared_target_version == target_version_id,
+            severity="blocker",
+            actual=declared_target_version or None,
+            required=target_version_id,
+            message=(
+                "Generated tuning evidence must target the fixed knowledge version exactly."
+            ),
+        )
+    add_check(
+        "stable_source_block_gold",
+        passed=bool(positive) and len(stable_positive) == len(positive),
+        severity="dimension",
+        actual=len(stable_positive),
+        required=len(positive),
+        message="Cross-chunk comparison requires source-block Gold for every answerable case.",
+    )
+    add_check(
+        "reviewed_hard_negatives",
+        passed=len(hard_negatives) >= MIN_HARD_NEGATIVES,
+        severity="dimension",
+        actual=len(hard_negatives),
+        required=MIN_HARD_NEGATIVES,
+        message=(
+            "Threshold tuning needs at least 12 reviewed corpus-near hard negatives; "
+            "otherwise score_threshold remains fixed."
+        ),
+    )
+    for bucket, minimum in MIN_DENSITY_CASES.items():
+        add_check(
+            f"density_{bucket}",
+            passed=int(density.get(bucket, 0)) >= minimum,
+            severity="dimension",
+            actual=int(density.get(bucket, 0)),
+            required=minimum,
+            message=f"Chunk tuning needs {minimum} {bucket.replace('_', ' ')} evidence cases.",
+        )
+    add_check(
+        "calibration_status",
+        passed=calibration_status in {"calibrated", "warning"},
+        severity="blocker" if origin == "generated" else "warning",
+        actual=calibration_status,
+        required=["calibrated", "warning"],
+        message="A calibrated targeted set provides stronger evidence than an uncalibrated draft.",
+    )
+
+    blockers = [item["message"] for item in checks if item["severity"] == "blocker" and not item["passed"]]
+    warnings = [item["message"] for item in checks if item["severity"] != "blocker" and not item["passed"]]
+    retrieval_ready = not blockers
+    stable_gold_ready = bool(positive) and len(stable_positive) == len(positive)
+    density_ready = all(
+        int(density.get(bucket, 0)) >= minimum
+        for bucket, minimum in MIN_DENSITY_CASES.items()
+    )
+    threshold_ready = retrieval_ready and len(hard_negatives) >= MIN_HARD_NEGATIVES
+    chunk_ready = retrieval_ready and stable_gold_ready and density_ready
+    if retrieval_ready:
+        status = "ready"
+        evidence_strength = "qualified" if threshold_ready and chunk_ready else "limited"
+    elif role == "regression_guard":
+        status = "report_only"
+        evidence_strength = "regression_only"
+    else:
+        status = "insufficient_data"
+        evidence_strength = "insufficient"
+
+    payload = {
+        "version": READINESS_VERSION,
+        "status": status,
+        "benchmark_role": role,
+        "selection_eligible": retrieval_ready,
+        "evidence_strength": evidence_strength,
+        "counts": {
+            "total": len(cases),
+            "positive": len(positive),
+            "no_result": len(negatives),
+            "reviewed_no_result": len(reviewed_negatives),
+            "reviewed_hard_negative": len(hard_negatives),
+            "stable_source_block_positive": len(stable_positive),
+        },
+        "target": {
+            "declared_pipeline_version_id": declared_target_version or None,
+            "fixed_pipeline_version_id": target_version_id,
+        },
+        "coverage": {
+            "density": dict(sorted(density.items())),
+            "query_types": dict(sorted(query_types.items())),
+        },
+        "dimensions": {
+            "retrieval": {"eligible": retrieval_ready},
+            "threshold": {"eligible": threshold_ready},
+            "chunking": {
+                "eligible": chunk_ready,
+                "sensitivity_probe_required": chunk_ready,
+            },
+        },
+        "checks": checks,
+        "blockers": blockers,
+        "warnings": warnings,
+    }
+    payload["checksum"] = hashlib.sha256(
+        json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode(
+            "utf-8"
+        )
+    ).hexdigest()
+    return payload
+
+
+def realized_index_fingerprint(
+    *,
+    chunker: dict[str, Any],
+    cost: dict[str, Any],
+    document_results: list[dict[str, Any]] | None = None,
+) -> str:
+    per_document = [
+        {
+            "source_id": str(item.get("source_id") or ""),
+            "chunk_count": int(item.get("chunk_count") or 0),
+            "block_count": int(item.get("block_count") or 0),
+        }
+        for item in document_results or []
+        if isinstance(item, dict)
+    ]
+    per_document.sort(key=lambda item: item["source_id"])
+    payload = {
+        "strategy": str(chunker.get("strategy") or ""),
+        "chunk_count": int(cost.get("chunk_count") or 0),
+        "per_document": per_document,
+    }
+    return hashlib.sha256(
+        json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode(
+            "utf-8"
+        )
+    ).hexdigest()
+
+
+def ranking_fingerprint(case_results: list[dict[str, Any]]) -> str:
+    payload = []
+    for item in case_results:
+        sources = []
+        for source in item.get("ranking") or item.get("sources") or []:
+            if not isinstance(source, dict):
+                continue
+            sources.append(
+                str(
+                    source.get("chunk_id")
+                    or source.get("source_block_id")
+                    or source.get("document_id")
+                    or ""
+                )
+            )
+        payload.append({"case_id": str(item.get("case_id") or ""), "sources": sources})
+    payload.sort(key=lambda item: item["case_id"])
+    return hashlib.sha256(
+        json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode(
+            "utf-8"
+        )
+    ).hexdigest()
+
+
+def assess_chunk_sensitivity(
+    candidates: list[dict[str, Any]],
+    *,
+    probe_retrieval_checksum: str,
+    enabled: bool,
+) -> dict[str, Any]:
+    probes = [
+        item
+        for item in candidates
+        if str(item.get("retrieval_input_checksum") or "")
+        == probe_retrieval_checksum
+    ]
+    realized_pairs = {
+        (
+            str(item.get("realized_index_fingerprint") or ""),
+            str(item.get("ranking_fingerprint") or ""),
+        )
+        for item in probes
+        if item.get("realized_index_fingerprint") and item.get("ranking_fingerprint")
+    }
+    if enabled and len(probes) >= 2:
+        status = "sufficient" if len(realized_pairs) >= 2 else "insufficient"
+    elif enabled:
+        status = "not_measured"
+    else:
+        status = "not_applicable"
+    return {
+        "status": status,
+        "probe_count": len(probes),
+        "unique_realized_outcomes": len(realized_pairs),
+        "retrieval_checksum": probe_retrieval_checksum,
+    }
+
+
+def _has_stable_gold(case: dict[str, Any]) -> bool:
+    refs = [item for item in case.get("expected_refs") or [] if isinstance(item, dict)]
+    return bool(refs) and all(
+        str(item.get("match_mode") or "") == "source_block"
+        and bool(item.get("source_block_id"))
+        for item in refs
+    )
+
+
+def _query_type(case: dict[str, Any]) -> str:
+    targeting = case.get("targeting") if isinstance(case.get("targeting"), dict) else {}
+    query_type = str(targeting.get("query_type") or "").strip().lower()
+    if query_type:
+        return query_type
+    for tag in case.get("tags") or []:
+        value = str(tag).strip().lower()
+        if value in {
+            "factual_lookup",
+            "fact",
+            "paraphrase",
+            "section_context",
+            "parent_child",
+            "cross_language",
+            "multi_evidence",
+            "confusable_content",
+            "no_result",
+        }:
+            return value
+    return "unclassified"
+
+
+def _density_bucket(case: dict[str, Any]) -> str:
+    query_type = _query_type(case)
+    reference_count = len(case.get("expected_refs") or [])
+    if reference_count >= 2 or query_type == "multi_evidence":
+        return "multi_dense"
+    if query_type in {"section_context", "parent_child", "confusable_content"}:
+        return "single_dense"
+    return "sparse"
+
+
+def _is_hard_negative(case: dict[str, Any]) -> bool:
+    if not case.get("expected_no_result"):
+        return False
+    targeting = case.get("targeting") if isinstance(case.get("targeting"), dict) else {}
+    tags = {str(item).strip().lower() for item in case.get("tags") or []}
+    query_type = str(targeting.get("query_type") or "").strip().lower()
+    has_context = bool(targeting.get("context_evidence_ids"))
+    return bool(
+        query_type in {"no_result", "confusable_content", "corpus_near"}
+        and (has_context or targeting.get("blueprint_id"))
+        or tags.intersection({"hard_negative", "corpus_near", "near_miss", "confusable"})
+    )

--- a/server/tests/fixtures/rag_strategy_tuner_known_winners.json
+++ b/server/tests/fixtures/rag_strategy_tuner_known_winners.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": 1,
+  "fixture_version": "rag-strategy-known-winner-v1",
+  "source": "ModelMirror project-owned synthetic fixture",
+  "license": "ModelMirror repository license",
+  "scenarios": [
+    {
+      "scenario_id": "threshold_recovery",
+      "description": "Full-text OR recall returns corpus-near hard negatives below exact positive matches. A safe non-zero threshold must preserve the Gold block and reject the negatives.",
+      "document_name": "orbit-control-policy.md",
+      "document_content": "# Orbit control policy\n\nControl MM-2042 requires an owner, a reviewer, and a dated audit record. Every audit record uses the cobalt ledger and quartz seal. Emergency exceptions expire after seven days.\n",
+      "positive_queries": [
+        "MM-2042 owner reviewer audit",
+        "Control MM-2042 dated audit record",
+        "MM-2042 cobalt ledger quartz seal"
+      ],
+      "hard_negative_queries": [
+        "MM-2042 biometric escrow",
+        "MM-2042 satellite custody",
+        "MM-2042 quantum notarization"
+      ],
+      "positive_case_count": 30,
+      "hard_negative_case_count": 12,
+      "expected_outcome": "completed",
+      "expected_winner": {
+        "retrieval_mode": "fulltext",
+        "score_threshold": "greater_than_zero",
+        "minimum_no_result_accuracy_delta": 0.5,
+        "promotion_required": true
+      }
+    },
+    {
+      "scenario_id": "already_optimal_control",
+      "inherits": "threshold_recovery",
+      "description": "The base version already uses the safe threshold discovered from the same fixed evidence. The tuner must not manufacture a winner from an equivalent profile.",
+      "baseline_threshold": "observed_hard_negative_max_plus_epsilon",
+      "expected_outcome": "no_improvement",
+      "expected_final_version": null
+    }
+  ]
+}

--- a/server/tests/test_rag_benchmark_generator.py
+++ b/server/tests/test_rag_benchmark_generator.py
@@ -11,11 +11,74 @@ import server.benchmarks.api as benchmark_api
 import server.rag.api as rag_api
 from server.benchmarks.executor import BenchmarkJobExecutor
 from server.benchmarks.knowledge_generation import KnowledgeBenchmarkGenerationService
+from server.benchmarks.models import BenchmarkGenerationRequest
 from server.benchmarks.service import BenchmarkGenerationError
 from server.benchmarks.store import BenchmarkJobStore
 from server.main import app
 from server.rag.evaluation import EvaluationStateError, KnowledgeEvaluationStore
 from server.rag.vector_store import StoredVectorChunk
+
+
+def test_strategy_tuning_generation_supports_qualified_positive_and_negative_counts() -> None:
+    request = BenchmarkGenerationRequest.model_validate(
+        {
+            "target": {
+                "kind": "knowledge_version",
+                "kb_id": "kb_target",
+                "pipeline_version_id": "pipeline_v2",
+            },
+            "generator_model_id": "test-model",
+            "generation_purpose": "strategy_tuning",
+            "case_count": 42,
+            "no_result_count": 12,
+        }
+    )
+
+    assert request.case_count - request.no_result_count == 30
+    assert request.no_result_count == 12
+
+
+@pytest.mark.parametrize(
+    ("case_count", "no_result_count", "message"),
+    [
+        (41, 12, "at least 30 answerable cases"),
+        (35, 5, "either 0 or at least 12 hard-negative cases"),
+    ],
+)
+def test_strategy_tuning_generation_rejects_unqualified_counts(
+    case_count: int,
+    no_result_count: int,
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        BenchmarkGenerationRequest.model_validate(
+            {
+                "target": {
+                    "kind": "knowledge_version",
+                    "kb_id": "kb_target",
+                    "pipeline_version_id": "pipeline_v2",
+                },
+                "generator_model_id": "test-model",
+                "generation_purpose": "strategy_tuning",
+                "case_count": case_count,
+                "no_result_count": no_result_count,
+            }
+        )
+
+
+def test_general_generation_preserves_legacy_limits() -> None:
+    with pytest.raises(ValueError, match="general generation cannot exceed 30 cases"):
+        BenchmarkGenerationRequest.model_validate(
+            {
+                "target": {
+                    "kind": "knowledge_version",
+                    "kb_id": "kb_target",
+                    "pipeline_version_id": "pipeline_v2",
+                },
+                "generator_model_id": "test-model",
+                "case_count": 31,
+            }
+        )
 
 
 class _VectorStore:

--- a/server/tests/test_rag_evaluation.py
+++ b/server/tests/test_rag_evaluation.py
@@ -187,6 +187,42 @@ def test_source_block_and_no_result_metrics_are_aggregated_separately() -> None:
     assert aggregate["false_positive_rate"] == 0.5
 
 
+def test_promotion_gate_does_not_penalize_correct_no_result_abstention() -> None:
+    positive = evaluate_retrieval_case(
+        [{"chunk_id": "answer", "source_document_id": "doc-a", "score": 0.9}],
+        [{"document_id": "doc-a"}],
+        ks=[1, 5, 10],
+    )
+    noisy_no_result = evaluate_retrieval_case(
+        [{"chunk_id": "noise", "source_document_id": "doc-z", "score": 0.1}],
+        [],
+        ks=[1, 5, 10],
+        expected_no_result=True,
+    )
+    correct_no_result = evaluate_retrieval_case(
+        [],
+        [],
+        ks=[1, 5, 10],
+        expected_no_result=True,
+    )
+    baseline = aggregate_target_metrics([positive, noisy_no_result], ks=[1, 5, 10])
+    candidate = aggregate_target_metrics([positive, correct_no_result], ks=[1, 5, 10])
+
+    gate = evaluate_promotion_gate(
+        candidate,
+        baseline=baseline,
+        policy={
+            "min_recall_at_5": 1.0,
+            "min_no_result_accuracy": 1.0,
+            "max_no_result_increase": 0.0,
+        },
+    )
+
+    assert baseline["positive_no_result_rate"] == 0.0
+    assert candidate["positive_no_result_rate"] == 0.0
+    assert gate["passed"] is True
+
+
 def test_evaluation_store_persists_revisions_runs_and_recovery(tmp_path: Path) -> None:
     path = tmp_path / "evaluations.json"
     store = KnowledgeEvaluationStore(path)
@@ -258,6 +294,8 @@ def test_evaluation_set_versions_are_immutable_and_pin_run_snapshot(tmp_path: Pa
         expected_revision=draft["revision"],
         release_notes="v1",
     )
+    assert draft["benchmark_role"] == "regression_guard"
+    assert version["benchmark_role"] == "regression_guard"
     changed = store.update_case(
         draft["eval_set_id"],
         draft["cases"][0]["case_id"],

--- a/server/tests/test_rag_retrieval_v2.py
+++ b/server/tests/test_rag_retrieval_v2.py
@@ -94,6 +94,39 @@ def test_sqlite_fts5_indexes_mixed_chinese_and_english(tmp_path: Path) -> None:
     assert store.query("other", "蓝鲸", 5) == []
 
 
+def test_sqlite_fts5_uses_query_confidence_without_reordering_bm25(
+    tmp_path: Path,
+) -> None:
+    store = SqliteLexicalStore(tmp_path / "lexical-confidence.sqlite3")
+    store.add_chunks(
+        [
+            LexicalChunk(
+                chunk_id="exact",
+                namespace="kb-v2",
+                doc_id="d1",
+                document_name="warranty.md",
+                text="ZEP-91 quantum battery warranty lasts eighteen months.",
+                chunk_index=0,
+            ),
+            LexicalChunk(
+                chunk_id="generic",
+                namespace="kb-v2",
+                doc_id="d2",
+                document_name="policy.md",
+                text="The policy defines a standard warranty period.",
+                chunk_index=1,
+            ),
+        ]
+    )
+
+    exact = store.query("kb-v2", "ZEP-91 quantum battery warranty", 5)
+    weak = store.query("kb-v2", "VTX-88 satellite warranty window", 5)
+
+    assert exact[0].chunk_id == "exact"
+    assert exact[0].score > weak[0].score
+    assert weak[0].score < 1.0
+
+
 def test_sqlite_fts5_migrates_old_source_schema_with_optional_defaults(
     tmp_path: Path,
 ) -> None:

--- a/server/tests/test_rag_strategy_tuner.py
+++ b/server/tests/test_rag_strategy_tuner.py
@@ -1,0 +1,1284 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from server.main import app
+from server.rag.api import (
+    set_evaluation_executor_for_tests,
+    set_pipeline_executor_for_tests,
+    set_rag_service_for_tests,
+    set_strategy_tuner_for_tests,
+)
+from server.rag.embedder import EmbeddingClient
+from server.rag.evaluation import KnowledgeEvaluationStore
+from server.rag.evaluation_executor import KnowledgeEvaluationExecutor
+from server.rag.pipeline_executor import KnowledgePipelineExecutor
+from server.rag.rag_service import PipelineJobStateError, RagService
+from server.rag.strategy_tuner import (
+    KNOWN_WINNER_FIXTURE_VERSION,
+    RagStrategyTuner,
+    RagStrategyTuningStore,
+    apply_optimization_gate,
+    calibrate_threshold,
+    improvement_summary,
+    mark_semantic_duplicate_candidates,
+    paired_statistical_validation,
+    repeated_validation_plan,
+    retrieval_candidates,
+    retrieval_semantic_checksum,
+    stratified_split,
+    summarize_repeated_case_results,
+)
+from server.rag.vector_store import LocalJsonVectorStore
+from server.xpert_runtime.run_registry import RunRegistry
+
+
+KNOWN_WINNER_FIXTURE_PATH = (
+    Path(__file__).parent / "fixtures" / "rag_strategy_tuner_known_winners.json"
+)
+
+
+def _known_winner_fixture(scenario_id: str) -> dict:
+    payload = json.loads(KNOWN_WINNER_FIXTURE_PATH.read_text(encoding="utf-8"))
+    assert payload["fixture_version"] == KNOWN_WINNER_FIXTURE_VERSION
+    scenarios = {
+        str(item["scenario_id"]): item for item in payload.get("scenarios") or []
+    }
+    scenario = dict(scenarios[scenario_id])
+    inherited = str(scenario.get("inherits") or "")
+    if inherited:
+        scenario = {**dict(scenarios[inherited]), **scenario}
+    return scenario
+
+
+@pytest_asyncio.fixture
+async def tuning_runtime(tmp_path: Path):
+    service = RagService(
+        storage_dir=tmp_path / "rag-storage",
+        uploads_dir=tmp_path / "rag-uploads",
+        embedder=EmbeddingClient(api_key="", dimension=64),
+        vector_store=LocalJsonVectorStore(tmp_path / "rag-storage" / "vectors.json"),
+        llm_enabled=False,
+    )
+    pipeline_executor = KnowledgePipelineExecutor(service, poll_interval=0.01)
+    evaluation_store = KnowledgeEvaluationStore(service.storage_dir / "evaluations.json")
+    evaluation_executor = KnowledgeEvaluationExecutor(
+        service, evaluation_store, poll_interval=0.01
+    )
+    run_registry = RunRegistry()
+    tuning_store = RagStrategyTuningStore(service.storage_dir / "strategy_tuning_runs.json")
+    tuner = RagStrategyTuner(
+        service,
+        tuning_store,
+        evaluation_store,
+        pipeline_executor,
+        evaluation_executor,
+        run_registry=run_registry,
+        poll_interval=0.01,
+    )
+    set_rag_service_for_tests(service)
+    set_pipeline_executor_for_tests(pipeline_executor)
+    set_evaluation_executor_for_tests(evaluation_executor)
+    set_strategy_tuner_for_tests(tuner)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        yield client, service, pipeline_executor, evaluation_store, tuner
+    set_strategy_tuner_for_tests(None)
+    set_evaluation_executor_for_tests(None)
+    set_pipeline_executor_for_tests(None)
+    set_rag_service_for_tests(None)
+
+
+async def _base_version(
+    service: RagService, executor: KnowledgePipelineExecutor
+) -> tuple[str, str, str]:
+    kb = service.create_knowledge_base("strategy tuner")
+    document = await service.upload_document(
+        kb["id"],
+        "policy.md",
+        (
+            "# Control policy\n\n"
+            "Control MM-2042 requires an owner, a reviewer, and a dated audit record.\n\n"
+            "# Exceptions\n\nEmergency exceptions expire after seven days.\n"
+        ).encode("utf-8"),
+    )
+    draft = service.get_pipeline_draft(kb["id"])
+    job = service.create_pipeline_job(
+        kb["id"],
+        draft_version=draft["version"],
+        source_document_ids=[document["id"]],
+    )
+    assert await executor.run_once() is True
+    completed = service.get_pipeline_job(job["job_id"])
+    assert completed["status"] == "succeeded"
+    return kb["id"], document["id"], completed["candidate_version_id"]
+
+
+def _published_set(
+    store: KnowledgeEvaluationStore,
+    kb_id: str,
+    *,
+    stable_blocks: bool = True,
+    qualified: bool = False,
+) -> tuple[str, int]:
+    evaluation_set = store.create_set(
+        kb_id,
+        "Tuning Gold",
+        "fixed benchmark",
+        benchmark_role="strategy_tuning" if qualified else "unclassified",
+    )
+    cases = []
+    for index in range(30 if qualified else 12):
+        reference = {
+            "document_id": "doc-fixed",
+            "chunk_id": f"chunk-{index}",
+            "relevance": 3,
+        }
+        if stable_blocks:
+            reference.update(
+                {
+                    "source_block_id": f"block-{index}",
+                    "match_mode": "source_block",
+                }
+            )
+        cases.append(
+            {
+                "query": f"What does control MM-2042 require? Case {index}",
+                "expected_refs": [reference],
+                "tags": ["fact" if index % 2 else "paraphrase"],
+            }
+        )
+    if qualified:
+        cases.extend(
+            {
+                "query": f"Which similar control is not defined? Case {index}",
+                "expected_refs": [],
+                "expected_no_result": True,
+                "review_status": "approved",
+                "tags": ["hard_negative", "corpus_near"],
+                "targeting": {
+                    "blueprint_id": f"negative-{index}",
+                    "query_type": "no_result",
+                    "context_evidence_ids": [f"evidence-{index}"],
+                },
+            }
+            for index in range(12)
+        )
+    updated = store.add_cases(
+        evaluation_set["eval_set_id"],
+        expected_revision=evaluation_set["revision"],
+        cases=cases,
+    )
+    version = store.publish_set(
+        evaluation_set["eval_set_id"], expected_revision=updated["revision"]
+    )
+    return evaluation_set["eval_set_id"], int(version["version"])
+
+
+async def _published_set_for_version(
+    service: RagService,
+    store: KnowledgeEvaluationStore,
+    kb_id: str,
+    version_id: str,
+) -> tuple[str, int]:
+    retrieval = await service.query_pipeline_version(
+        version_id,
+        "control MM-2042 owner reviewer dated audit record",
+        top_k=5,
+        retrieval={"mode": "fulltext", "top_k": 5},
+        generate_answer=False,
+    )
+    source = retrieval["sources"][0]
+    document_id = str(
+        source.get("source_document_id")
+        or source.get("document_id")
+        or source.get("doc_id")
+    )
+    source_block_id = str(source.get("source_block_id") or "")
+    assert document_id
+    assert source_block_id
+    evaluation_set = store.create_set(
+        kb_id,
+        "Executable tuning Gold",
+        benchmark_role="strategy_tuning",
+    )
+    updated = store.add_cases(
+        evaluation_set["eval_set_id"],
+        expected_revision=evaluation_set["revision"],
+        cases=[
+            {
+                "query": "What evidence is required for control MM-2042?",
+                "expected_refs": [
+                    {
+                        "document_id": document_id,
+                        "source_block_id": source_block_id,
+                        "match_mode": "source_block",
+                        "relevance": 3,
+                    }
+                ],
+                "tags": ["fact" if index % 2 else "paraphrase"],
+            }
+            for index in range(30)
+        ]
+        + [
+            {
+                "query": f"Which neighboring control is absent? Case {index}",
+                "expected_refs": [],
+                "expected_no_result": True,
+                "review_status": "approved",
+                "tags": ["hard_negative", "corpus_near"],
+                "targeting": {
+                    "blueprint_id": f"negative-{index}",
+                    "query_type": "no_result",
+                    "context_evidence_ids": [f"evidence-{index}"],
+                },
+            }
+            for index in range(12)
+        ],
+    )
+    version = store.publish_set(
+        evaluation_set["eval_set_id"], expected_revision=updated["revision"]
+    )
+    return evaluation_set["eval_set_id"], int(version["version"])
+
+
+async def _known_winner_base_version(
+    service: RagService,
+    executor: KnowledgePipelineExecutor,
+    scenario: dict,
+) -> tuple[str, str, str]:
+    kb = service.create_knowledge_base("strategy tuner known winner")
+    document = await service.upload_document(
+        kb["id"],
+        str(scenario["document_name"]),
+        str(scenario["document_content"]).encode("utf-8"),
+    )
+    draft = service.update_pipeline_draft(
+        kb["id"],
+        {},
+        retrieval_profile={
+            "mode": "fulltext",
+            "top_k": 5,
+            "score_threshold": 0,
+            "rerank_enabled": False,
+            "rerank_provider": "none",
+        },
+    )
+    job = service.create_pipeline_job(
+        kb["id"],
+        draft_version=draft["version"],
+        source_document_ids=[document["id"]],
+    )
+    assert await executor.run_once() is True
+    completed = service.get_pipeline_job(job["job_id"])
+    assert completed["status"] == "succeeded"
+    return kb["id"], document["id"], str(completed["candidate_version_id"])
+
+
+async def _rebuild_known_winner_base(
+    service: RagService,
+    executor: KnowledgePipelineExecutor,
+    kb_id: str,
+    document_id: str,
+    *,
+    score_threshold: float,
+) -> str:
+    draft = service.update_pipeline_draft(
+        kb_id,
+        {},
+        retrieval_profile={
+            "mode": "fulltext",
+            "top_k": 5,
+            "score_threshold": score_threshold,
+            "rerank_enabled": False,
+            "rerank_provider": "none",
+        },
+    )
+    job = service.create_pipeline_job(
+        kb_id,
+        draft_version=draft["version"],
+        source_document_ids=[document_id],
+    )
+    assert await executor.run_once() is True
+    completed = service.get_pipeline_job(job["job_id"])
+    assert completed["status"] == "succeeded"
+    return str(completed["candidate_version_id"])
+
+
+async def _known_winner_score_boundary(
+    service: RagService,
+    version_id: str,
+    scenario: dict,
+) -> tuple[float, float]:
+    async def top_score(query: str) -> float:
+        response = await service.query_pipeline_version(
+            version_id,
+            query,
+            top_k=5,
+            retrieval={"mode": "fulltext", "top_k": 5, "score_threshold": 0},
+            generate_answer=False,
+        )
+        assert response["sources"], query
+        return float(response["sources"][0]["score"])
+
+    positive_scores = [
+        await top_score(str(query)) for query in scenario["positive_queries"]
+    ]
+    negative_scores = [
+        await top_score(str(query)) for query in scenario["hard_negative_queries"]
+    ]
+    positive_floor = min(positive_scores)
+    negative_ceiling = max(negative_scores)
+    assert positive_floor > negative_ceiling
+    return positive_floor, negative_ceiling
+
+
+async def _known_winner_evaluation_set(
+    service: RagService,
+    store: KnowledgeEvaluationStore,
+    kb_id: str,
+    version_id: str,
+    scenario: dict,
+) -> tuple[str, int]:
+    source_block_ids: set[str] = set()
+    document_id = ""
+    for query in scenario["positive_queries"]:
+        response = await service.query_pipeline_version(
+            version_id,
+            str(query),
+            top_k=5,
+            retrieval={"mode": "fulltext", "top_k": 5, "score_threshold": 0},
+            generate_answer=False,
+        )
+        assert response["sources"], query
+        source = response["sources"][0]
+        document_id = str(
+            source.get("source_document_id")
+            or source.get("document_id")
+            or source.get("doc_id")
+        )
+        source_block_ids.add(str(source.get("source_block_id") or ""))
+    assert document_id
+    assert len(source_block_ids) == 1
+    source_block_id = source_block_ids.pop()
+    assert source_block_id
+
+    evaluation_set = store.create_set(
+        kb_id,
+        f"Known winner: {scenario['scenario_id']}",
+        "Project-owned deterministic strategy tuner fixture",
+        benchmark_role="strategy_tuning",
+    )
+    positive_queries = list(scenario["positive_queries"])
+    negative_queries = list(scenario["hard_negative_queries"])
+    positive_count = int(scenario["positive_case_count"])
+    negative_count = int(scenario["hard_negative_case_count"])
+    cases = [
+        {
+            "query": str(positive_queries[index % len(positive_queries)]),
+            "expected_refs": [
+                {
+                    "document_id": document_id,
+                    "source_block_id": source_block_id,
+                    "match_mode": "source_block",
+                    "relevance": 3,
+                }
+            ],
+            "tags": ["fact" if index % 2 else "paraphrase"],
+        }
+        for index in range(positive_count)
+    ]
+    cases.extend(
+        {
+            "query": str(negative_queries[index % len(negative_queries)]),
+            "expected_refs": [],
+            "expected_no_result": True,
+            "review_status": "approved",
+            "tags": ["hard_negative", "corpus_near"],
+            "targeting": {
+                "blueprint_id": f"known-negative-{index}",
+                "query_type": "no_result",
+                "context_evidence_ids": [source_block_id],
+            },
+        }
+        for index in range(negative_count)
+    )
+    updated = store.add_cases(
+        evaluation_set["eval_set_id"],
+        expected_revision=evaluation_set["revision"],
+        cases=cases,
+    )
+    published = store.publish_set(
+        evaluation_set["eval_set_id"], expected_revision=updated["revision"]
+    )
+    return evaluation_set["eval_set_id"], int(published["version"])
+
+
+def test_tuning_store_recovers_inflight_and_preserves_terminal_runs(tmp_path: Path) -> None:
+    store = RagStrategyTuningStore(tmp_path / "runs.json")
+    queued = store.create_run(
+        {"kb_id": "kb-a"}, {"snapshot_hash": "hash", "warnings": []}
+    )
+    claimed = store.claim_next_run()
+    assert claimed is not None and claimed["status"] == "profiling"
+    store.update(
+        queued["run_id"],
+        validation_plan={"checksum": "plan"},
+        validation_baseline={"checksum": "baseline"},
+    )
+    terminal = store.create_run(
+        {"kb_id": "kb-a"}, {"snapshot_hash": "hash-2", "warnings": []}
+    )
+    store.update(terminal["run_id"], status="completed", completed_at=1.0)
+
+    reloaded = RagStrategyTuningStore(tmp_path / "runs.json")
+    assert reloaded.recover_runs() == 1
+    assert reloaded.get_run(queued["run_id"])["status"] == "queued"
+    assert reloaded.get_run(queued["run_id"])["validation_plan"]["checksum"] == "plan"
+    assert (
+        reloaded.get_run(queued["run_id"])["validation_baseline"]["checksum"]
+        == "baseline"
+    )
+    assert reloaded.get_run(terminal["run_id"])["status"] == "completed"
+
+
+def test_explicit_retry_discards_stale_trial_progress(tmp_path: Path) -> None:
+    store = RagStrategyTuningStore(tmp_path / "runs.json")
+    run = store.create_run(
+        {"kb_id": "kb-a"}, {"snapshot_hash": "hash", "warnings": []}
+    )
+    store.update(
+        run["run_id"],
+        status="failed",
+        candidates=[{"candidate_id": "old"}],
+        finalists=[{"candidate_id": "old-finalist"}],
+        trial_indexes=[{"chunker_checksum": "old"}],
+        trial_version_ids=["version-old"],
+        pipeline_job_ids=["job-old"],
+        final_version_id="version-final",
+        validation_plan={"checksum": "old-plan"},
+        validation_baseline={"checksum": "old-baseline"},
+        statistical_summary={"eligible_count": 1},
+    )
+
+    retried = store.retry(run["run_id"])
+
+    assert retried["status"] == "queued"
+    assert retried["candidates"] == []
+    assert retried["finalists"] == []
+    assert retried["trial_indexes"] == []
+    assert retried["pipeline_job_ids"] == []
+    assert retried["final_version_id"] is None
+    assert retried["validation_plan"] == {}
+    assert retried["validation_baseline"] == {}
+    assert retried["statistical_summary"] == {}
+
+
+@pytest.mark.asyncio
+async def test_evaluation_executor_can_respect_fixed_profile_top_k(tmp_path: Path) -> None:
+    class RecordingService:
+        def __init__(self) -> None:
+            self.top_ks: list[int] = []
+
+        async def query_pipeline_version(self, _version_id, _query, *, top_k, **_kwargs):
+            self.top_ks.append(int(top_k))
+            return {"sources": [], "warnings": []}
+
+        @staticmethod
+        def _safe_pipeline_error(exc: Exception) -> str:
+            return str(exc)
+
+    service = RecordingService()
+    store = KnowledgeEvaluationStore(tmp_path / "evaluations.json")
+    dataset = store.create_set("kb-a", "Top-K contract")
+    dataset = store.add_cases(
+        dataset["eval_set_id"],
+        expected_revision=dataset["revision"],
+        cases=[
+            {
+                "query": "Which source is expected?",
+                "expected_refs": [{"document_id": "doc-a"}],
+            }
+        ],
+    )
+    version = store.publish_set(
+        dataset["eval_set_id"], expected_revision=dataset["revision"]
+    )
+    store.create_run(
+        evaluation_set=dataset,
+        evaluation_set_version=version,
+        targets=[
+            {
+                "target_id": "fixed-profile",
+                "version_id": "v1",
+                "retrieval": {"top_k": 5},
+                "respect_profile_top_k": True,
+            },
+            {
+                "target_id": "legacy-evaluation",
+                "version_id": "v2",
+                "retrieval": {"top_k": 5},
+            },
+        ],
+        baseline_version_id=None,
+        ks=[1, 5, 10],
+        gate_policy=store.get_gate_policy("kb-a"),
+    )
+    executor = KnowledgeEvaluationExecutor(service, store, poll_interval=0.01)
+
+    assert await executor.run_once() is True
+    assert service.top_ks == [5, 10]
+
+
+def test_split_and_hash_retrieval_candidates_are_deterministic() -> None:
+    cases = [
+        {
+            "case_id": f"case-{index}",
+            "expected_no_result": index % 5 == 0,
+            "tags": ["fact" if index % 2 else "context"],
+        }
+        for index in range(18)
+    ]
+    first = stratified_split(cases, 42)
+    second = stratified_split(cases, 42)
+    assert first == second
+    assert set(first["optimization_case_ids"]).isdisjoint(first["holdout_case_ids"])
+    assert len(first["holdout_case_ids"]) >= 4
+
+    profiles = retrieval_candidates({"mode": "hybrid", "top_k": 5}, degraded=True)
+    assert profiles[0]["mode"] == "hybrid"
+    assert all(item["mode"] == "fulltext" for item in profiles[1:])
+
+
+def test_repeated_validation_plan_stays_inside_fixed_holdout() -> None:
+    cases = [
+        {
+            "case_id": f"case-{index}",
+            "expected_no_result": index >= 8,
+            "tags": ["fact" if index % 2 else "context"],
+        }
+        for index in range(12)
+    ]
+    holdout = ["case-1", "case-2", "case-4", "case-8", "case-10"]
+
+    first = repeated_validation_plan(cases, holdout, 42)
+    second = repeated_validation_plan(cases, holdout, 42)
+
+    assert first == second
+    assert len(first["resamples"]) == 3
+    assert first["query_repetitions"] == 3
+    for resample in first["resamples"]:
+        assert len(resample["case_ids"]) == len(holdout)
+        assert set(resample["case_ids"]) <= set(holdout)
+
+
+def test_repeated_case_summary_uses_per_case_median_latency() -> None:
+    results = [
+        {
+            "case_id": "case-a",
+            "status": "completed",
+            "metrics": {"ndcg_at_10": value},
+            "latency_ms": latency,
+            "expected_no_result": False,
+            "no_result": False,
+        }
+        for value, latency in ((1.0, 10), (0.8, 1000), (1.0, 12))
+    ]
+
+    summary = summarize_repeated_case_results(results)[0]
+
+    assert summary["latency_ms"] == 12
+    assert summary["metrics"]["ndcg_at_10"] == pytest.approx(0.933333, abs=1e-6)
+    assert summary["repeat_count"] == 3
+
+
+def test_paired_bootstrap_gate_accepts_stable_gain_and_rejects_regression() -> None:
+    cases = [
+        {
+            "case_id": f"case-{index}",
+            "expected_no_result": index >= 8,
+            "tags": ["fact" if index % 2 else "context"],
+        }
+        for index in range(12)
+    ]
+    holdout = [str(item["case_id"]) for item in cases]
+    plan = repeated_validation_plan(cases, holdout, 7)
+
+    def result(delta: float) -> dict:
+        return {
+            "metrics": {"p95_latency_ms": 10},
+            "case_summaries": [
+                {
+                    "case_id": case["case_id"],
+                    "status": "completed",
+                    "expected_no_result": case["expected_no_result"],
+                    "metrics": {
+                        (
+                            "no_result_accuracy"
+                            if case["expected_no_result"]
+                            else "ndcg_at_10"
+                        ): 0.7 + delta
+                    },
+                }
+                for case in cases
+            ],
+        }
+
+    baseline = result(0)
+    improved = paired_statistical_validation(baseline, result(0.1), plan)
+    regressed = paired_statistical_validation(baseline, result(-0.05), plan)
+
+    assert improved["passed"] is True
+    assert improved["quality_improvement_confident"] is True
+    assert improved["confidence_interval"]["lower"] == pytest.approx(0.1)
+    assert regressed["passed"] is False
+    assert regressed["confidence_interval"]["upper"] == pytest.approx(-0.05)
+
+
+def test_retrieval_semantic_checksum_ignores_inactive_mode_fields() -> None:
+    first = {
+        "mode": "fulltext",
+        "top_k": 5,
+        "score_threshold": 0,
+        "candidate_multiplier": 4,
+        "vector_weight": 0.9,
+        "fulltext_weight": 0.1,
+        "rerank_enabled": False,
+        "rerank_provider": "llm",
+        "rerank_model": "unused-model",
+        "rerank_top_n": 20,
+    }
+    second = {
+        **first,
+        "vector_weight": 0.1,
+        "fulltext_weight": 0.9,
+        "rerank_provider": "api",
+        "rerank_model": "another-unused-model",
+        "rerank_top_n": 2,
+    }
+
+    assert retrieval_semantic_checksum(first) == retrieval_semantic_checksum(second)
+
+
+def test_semantic_outcome_duplicates_cannot_consume_winner_slots() -> None:
+    candidates = [
+        {
+            "candidate_id": "candidate-a",
+            "retrieval": {"mode": "fulltext", "top_k": 5},
+            "realized_index_fingerprint": "same-index",
+            "ranking_fingerprint": "same-ranking",
+            "automatic_winner_eligible": True,
+        },
+        {
+            "candidate_id": "candidate-b",
+            "retrieval": {
+                "mode": "fulltext",
+                "top_k": 5,
+                "vector_weight": 0.1,
+                "fulltext_weight": 0.9,
+            },
+            "realized_index_fingerprint": "same-index",
+            "ranking_fingerprint": "same-ranking",
+            "automatic_winner_eligible": True,
+        },
+    ]
+
+    summary = mark_semantic_duplicate_candidates(candidates)
+
+    assert summary["unique_semantic_outcomes"] == 1
+    assert summary["duplicate_count"] == 1
+    assert candidates[1]["automatic_winner_eligible"] is False
+    assert candidates[1]["ineligible_reason"] == "semantic_duplicate"
+    assert candidates[1]["duplicate_of_candidate_id"] == "candidate-a"
+
+
+def test_no_result_accuracy_counts_as_effective_quality_improvement() -> None:
+    improvement = improvement_summary(
+        {"ndcg_at_10": 0.9, "no_result_accuracy": 0.0, "p95_latency_ms": 10},
+        {"ndcg_at_10": 0.9, "no_result_accuracy": 0.8, "p95_latency_ms": 10},
+        {"estimated_index_bytes": 1000, "chunk_count": 10},
+        {"estimated_index_bytes": 1000, "chunk_count": 10},
+    )
+
+    assert improvement["no_result_accuracy_delta"] == 0.8
+    assert improvement["effective"] is True
+
+
+def test_optimization_gate_filters_candidates_before_holdout() -> None:
+    baseline_metrics = {
+        "recall_at_5": 1.0,
+        "mrr_at_10": 0.8,
+        "ndcg_at_10": 0.8,
+        "citation_hit_rate": 0.5,
+        "citation_coverage": 1.0,
+        "no_result_accuracy": 0.5,
+        "positive_no_result_rate": 0.0,
+        "p95_latency_ms": 20.0,
+        "error_count": 0,
+    }
+    common = {
+        "cost": {"chunk_count": 10, "estimated_index_bytes": 1000},
+        "automatic_winner_eligible": True,
+    }
+    candidates = [
+        {
+            **common,
+            "candidate_id": "fails-no-result",
+            "optimization_metrics": {
+                **baseline_metrics,
+                "no_result_accuracy": 0.5,
+            },
+        },
+        {
+            **common,
+            "candidate_id": "passes-gate",
+            "optimization_metrics": {
+                **baseline_metrics,
+                "no_result_accuracy": 1.0,
+            },
+        },
+    ]
+
+    evaluated, eligible, summary = apply_optimization_gate(
+        candidates,
+        baseline_metrics=baseline_metrics,
+        baseline_cost=common["cost"],
+        policy={"min_recall_at_5": 0.7, "min_no_result_accuracy": 0.8},
+        objective="balanced",
+    )
+
+    assert [item["candidate_id"] for item in eligible] == ["passes-gate"]
+    assert evaluated[0]["optimization_gate"]["passed"] is False
+    assert evaluated[1]["optimization_gate"]["passed"] is True
+    assert summary == {
+        "evaluated_count": 2,
+        "passed_count": 1,
+        "eligible_count": 1,
+        "failed_check_counts": {"min_no_result_accuracy": 1},
+    }
+
+
+def test_threshold_calibration_preserves_recall_before_improving_abstention() -> None:
+    positive_scores = [0.4, 0.3, 0.2, 0.15]
+    no_result_scores = [0.05, 0.05, 0.05, 0.2]
+    cases = [
+        {
+            "case_id": f"positive-{index}",
+            "expected_refs": [{"document_id": f"doc-{index}"}],
+            "expected_no_result": False,
+        }
+        for index in range(len(positive_scores))
+    ] + [
+        {
+            "case_id": f"no-result-{index}",
+            "expected_refs": [],
+            "expected_no_result": True,
+        }
+        for index in range(len(no_result_scores))
+    ]
+    case_results = [
+        {
+            "case_id": f"positive-{index}",
+            "ranking": [
+                {
+                    "chunk_id": f"chunk-{index}",
+                    "document_id": f"doc-{index}",
+                    "document_name": f"doc-{index}.md",
+                    "score": score,
+                }
+            ]
+            + (
+                [
+                    {
+                        "chunk_id": "low-confidence-noise",
+                        "document_id": "noise-doc",
+                        "document_name": "noise.md",
+                        "score": 0.1,
+                    }
+                ]
+                if index == 0
+                else []
+            ),
+            "latency_ms": 1,
+        }
+        for index, score in enumerate(positive_scores)
+    ] + [
+        {
+            "case_id": f"no-result-{index}",
+            "ranking": [
+                {
+                    "chunk_id": f"noise-{index}",
+                    "document_id": f"noise-doc-{index}",
+                    "document_name": f"noise-{index}.md",
+                    "score": score,
+                }
+            ],
+            "latency_ms": 1,
+        }
+        for index, score in enumerate(no_result_scores)
+    ]
+
+    calibrated = calibrate_threshold(
+        {"cases": cases, "case_results": case_results},
+        {"mode": "fulltext", "top_k": 10, "score_threshold": 0},
+    )
+
+    assert len(calibrated["threshold_candidates"]) <= 8
+    assert calibrated["retrieval"]["score_threshold"] > 0
+    assert calibrated["metrics"]["recall_at_5"] == 1.0
+    assert calibrated["metrics"]["no_result_accuracy"] == 0.75
+    assert calibrated["threshold_selection_reason"] == "hard_negative_false_positive_improved"
+    assert calibrated["threshold_front"]
+
+
+def test_threshold_calibration_keeps_baseline_when_abstention_costs_recall() -> None:
+    cases = [
+        {
+            "case_id": "positive",
+            "expected_refs": [{"document_id": "doc-positive"}],
+            "expected_no_result": False,
+        },
+        {
+            "case_id": "negative",
+            "expected_refs": [],
+            "expected_no_result": True,
+        },
+    ]
+    case_results = [
+        {
+            "case_id": "positive",
+            "ranking": [{"document_id": "doc-positive", "score": 0.1}],
+            "latency_ms": 1,
+        },
+        {
+            "case_id": "negative",
+            "ranking": [{"document_id": "noise", "score": 0.2}],
+            "latency_ms": 1,
+        },
+    ]
+
+    calibrated = calibrate_threshold(
+        {"cases": cases, "case_results": case_results},
+        {"mode": "fulltext", "top_k": 10, "score_threshold": 0},
+    )
+
+    assert calibrated["retrieval"]["score_threshold"] == 0
+    assert calibrated["threshold_selection_reason"] == (
+        "baseline_preserved_no_safe_negative_improvement"
+    )
+
+
+@pytest.mark.asyncio
+async def test_preflight_degrades_chunk_tuning_and_hides_sensitive_snapshot(
+    tuning_runtime,
+) -> None:
+    client, service, executor, evaluation_store, _ = tuning_runtime
+    kb_id, _, version_id = await _base_version(service, executor)
+    eval_set_id, eval_version = _published_set(
+        evaluation_store, kb_id, stable_blocks=False
+    )
+    response = await client.post(
+        "/api/rag/strategy-tuner/preflight",
+        json={
+            "kb_id": kb_id,
+            "base_version_id": version_id,
+            "eval_set_id": eval_set_id,
+            "eval_set_version": eval_version,
+        },
+    )
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["retrieval_only"] is True
+    assert payload["selection_eligible"] is False
+    assert payload["tuning_readiness"]["status"] == "insufficient_data"
+    assert payload["embedding_degraded"] is True
+    assert payload["eval_case_count"] == 12
+    serialized = response.text
+    assert "snapshot_key" not in serialized
+    assert "stored_path" not in serialized
+    assert "OPENROUTER_API_KEY" not in serialized
+
+
+@pytest.mark.asyncio
+async def test_strategy_tuner_rejects_report_only_evaluation_evidence(
+    tuning_runtime,
+) -> None:
+    client, service, executor, evaluation_store, _ = tuning_runtime
+    kb_id, _, version_id = await _base_version(service, executor)
+    eval_set_id, eval_version = _published_set(evaluation_store, kb_id)
+
+    response = await client.post(
+        "/api/rag/strategy-tuner/runs",
+        json={
+            "kb_id": kb_id,
+            "base_version_id": version_id,
+            "eval_set_id": eval_set_id,
+            "eval_set_version": eval_version,
+        },
+    )
+
+    assert response.status_code == 400
+    assert "at least 30 answerable cases" in response.text
+
+
+@pytest.mark.asyncio
+async def test_strategy_tuner_api_lists_cancels_and_retries_queued_run(
+    tuning_runtime,
+) -> None:
+    client, service, executor, evaluation_store, _ = tuning_runtime
+    kb_id, _, version_id = await _base_version(service, executor)
+    eval_set_id, eval_version = _published_set(
+        evaluation_store, kb_id, qualified=True
+    )
+    payload = {
+        "kb_id": kb_id,
+        "base_version_id": version_id,
+        "eval_set_id": eval_set_id,
+        "eval_set_version": eval_version,
+    }
+    created_response = await client.post(
+        "/api/rag/strategy-tuner/runs", json=payload
+    )
+    assert created_response.status_code == 202, created_response.text
+    created = created_response.json()
+    assert created["status"] == "queued"
+
+    listed = await client.get(
+        f"/api/rag/strategy-tuner/runs?kb_id={kb_id}&status=queued"
+    )
+    assert listed.status_code == 200
+    assert [item["run_id"] for item in listed.json()["runs"]] == [created["run_id"]]
+
+    cancelled = await client.post(
+        f"/api/rag/strategy-tuner/runs/{created['run_id']}/cancel"
+    )
+    assert cancelled.status_code == 200
+    assert cancelled.json()["status"] == "cancelled"
+    retried = await client.post(
+        f"/api/rag/strategy-tuner/runs/{created['run_id']}/retry"
+    )
+    assert retried.status_code == 200
+    assert retried.json()["status"] == "queued"
+
+
+def test_optimization_gate_defers_single_query_latency_to_holdout() -> None:
+    baseline = {
+        "recall_at_5": 1.0,
+        "mrr_at_10": 1.0,
+        "citation_hit_rate": 1.0,
+        "citation_coverage": 1.0,
+        "no_result_accuracy": 1.0,
+        "positive_no_result_rate": 0.0,
+        "p95_latency_ms": 10.0,
+        "error_count": 0,
+    }
+    candidate = {
+        "candidate_id": "cold-start-outlier",
+        "optimization_metrics": {**baseline, "p95_latency_ms": 5000.0},
+        "cost": {"chunk_count": 10, "estimated_index_bytes": 1000},
+        "automatic_winner_eligible": True,
+    }
+
+    evaluated, eligible, _ = apply_optimization_gate(
+        [candidate],
+        baseline_metrics=baseline,
+        baseline_cost=candidate["cost"],
+        policy={"max_p95_latency_ratio": 1.1},
+        objective="balanced",
+    )
+
+    assert [item["candidate_id"] for item in eligible] == ["cold-start-outlier"]
+    assert evaluated[0]["optimization_gate"]["latency_evidence"] == (
+        "deferred_to_repeated_holdout"
+    )
+
+
+@pytest.mark.asyncio
+async def test_trial_version_is_hidden_unactivatable_and_cleanup_preserves_draft(
+    tuning_runtime,
+) -> None:
+    _, service, executor, _, _ = tuning_runtime
+    kb_id, _, base_version_id = await _base_version(service, executor)
+    base = service.get_pipeline_version(base_version_id)
+    base_job = service.get_pipeline_job(base["job_id"])
+    base_chunker = base_job["config_snapshot"]["stages"]["stage_chunker"]
+    changed_chunker = {**base_chunker, "chunk_size": 500, "chunk_overlap": 50}
+    draft_before = service.get_pipeline_draft(kb_id)
+    trial = service.create_strategy_tuning_pipeline_job(
+        kb_id,
+        base_version_id=base_version_id,
+        chunker_profile=changed_chunker,
+        retrieval_profile={"mode": "fulltext", "top_k": 10},
+        tuning_run_id="ragtune-test",
+        trial=True,
+    )
+    assert await executor.run_once() is True
+    trial_version_id = trial["candidate_version_id"]
+    trial_version = service.get_pipeline_version(trial_version_id)
+    assert trial_version["origin"]["kind"] == "rag_strategy_tuner_trial"
+    assert all(
+        item["version_id"] != trial_version_id
+        for item in service.list_pipeline_versions(kb_id)
+    )
+    with pytest.raises(PipelineJobStateError):
+        service.activate_pipeline_version(trial_version_id)
+    assert service.get_pipeline_draft(kb_id) == draft_before
+
+    service.cleanup_strategy_tuning_trial_version(trial_version_id)
+    assert trial["job_id"] not in service._read_metadata()["pipeline_jobs"]
+
+
+@pytest.mark.asyncio
+async def test_holdout_profile_uses_three_queries_and_case_level_latency(
+    tuning_runtime,
+) -> None:
+    _, service, executor, _, tuner = tuning_runtime
+    kb_id, _, version_id = await _base_version(service, executor)
+    version = service.get_pipeline_version(version_id)
+
+    result = await tuner._evaluate_profile(
+        version_id,
+        dict(version["retrieval_profile"]),
+        [
+            {
+                "case_id": "repeat-case",
+                "query": "Which policy applies?",
+                "expected_refs": [],
+                "expected_no_result": True,
+            }
+        ],
+        repetitions=3,
+    )
+
+    assert result["metrics"]["case_count"] == 1
+    assert result["metrics"]["execution_count"] == 3
+    assert result["metrics"]["query_repetitions"] == 3
+    assert result["metrics"]["latency_aggregation"] == "median_per_case_then_p95"
+    assert result["case_summaries"][0]["repeat_count"] == 3
+
+
+@pytest.mark.asyncio
+async def test_tuner_materializes_ready_candidate_without_switching_active_version(
+    tuning_runtime,
+    monkeypatch,
+) -> None:
+    _, service, executor, evaluation_store, tuner = tuning_runtime
+    kb_id, _, base_version_id = await _base_version(service, executor)
+    service.activate_pipeline_version(base_version_id)
+    eval_set_id, eval_version = await _published_set_for_version(
+        service, evaluation_store, kb_id, base_version_id
+    )
+    request = {
+        "kb_id": kb_id,
+        "base_version_id": base_version_id,
+        "eval_set_id": eval_set_id,
+        "eval_set_version": eval_version,
+        "objective": "balanced",
+    }
+    created = tuner.create_run(request)
+    stored = tuner.store.get_run(created["run_id"])
+    winner = {
+        "candidate_id": "forced-safe-winner",
+        "chunker": stored["snapshot"]["base_chunker"],
+        "retrieval": {
+            **stored["snapshot"]["base_retrieval"],
+            "mode": "fulltext",
+            "top_k": 5,
+            "rerank_enabled": False,
+            "rerank_provider": "none",
+        },
+        "optimization_metrics": {},
+        "holdout_metrics": {},
+        "promotion_gate": {"passed": True},
+        "improvement": {"effective": True},
+        "statistical_validation": {
+            "validation_version": "rag-strategy-validation-v1",
+            "passed": True,
+        },
+        "cost": {},
+        "checksum": "forced-safe-winner",
+    }
+
+    async def fixed_search(*_args, **_kwargs):
+        return {"eligible": [winner], "baseline_metrics": {}}
+
+    monkeypatch.setattr(tuner, "_search", fixed_search)
+    assert await tuner.run_once() is True
+
+    completed = tuner.store.get_run(created["run_id"])
+    assert completed["status"] == "completed", completed
+    final_version = service.get_pipeline_version(completed["final_version_id"])
+    assert final_version["status"] == "ready"
+    assert final_version["promotion_required"] is True
+    assert final_version["origin"]["kind"] == "rag_strategy_tuner"
+    assert service.get_active_pipeline_version(kb_id)["version_id"] == base_version_id
+    evaluation = evaluation_store.get_run(completed["evaluation_run_id"])
+    assert evaluation["status"] == "succeeded"
+    candidate_result = next(
+        item
+        for item in evaluation["target_results"]
+        if item["version_id"] == final_version["version_id"]
+    )
+    assert candidate_result["promotion_gate"]["passed"] is True
+
+    registry_run = await tuner.run_registry.get_run(completed["run_registry_id"])
+    assert registry_run is not None and registry_run.status == "completed"
+    checkpoints = await tuner.run_registry.list_checkpoints(registry_run.run_id)
+    serialized = str([item.metadata for item in checkpoints])
+    assert "MM-2042" not in serialized
+    assert "control policy" not in serialized.lower()
+
+    version_ids_before = {
+        item["version_id"] for item in service.list_pipeline_versions(kb_id)
+    }
+    evaluation_run_id = completed["evaluation_run_id"]
+    await tuner._materialize(
+        completed["run_id"], completed["request"], completed["snapshot"], winner
+    )
+    resumed = tuner.store.get_run(completed["run_id"])
+    assert resumed["final_version_id"] == final_version["version_id"]
+    assert resumed["evaluation_run_id"] == evaluation_run_id
+    assert {
+        item["version_id"] for item in service.list_pipeline_versions(kb_id)
+    } == version_ids_before
+
+
+def test_known_winner_fixture_contract_is_versioned_and_project_owned() -> None:
+    payload = json.loads(KNOWN_WINNER_FIXTURE_PATH.read_text(encoding="utf-8"))
+
+    assert payload["schema_version"] == 1
+    assert payload["fixture_version"] == KNOWN_WINNER_FIXTURE_VERSION
+    assert payload["source"] == "ModelMirror project-owned synthetic fixture"
+    assert {item["scenario_id"] for item in payload["scenarios"]} == {
+        "threshold_recovery",
+        "already_optimal_control",
+    }
+
+
+@pytest.mark.asyncio
+async def test_known_winner_threshold_recovery_runs_real_search_and_materializes(
+    tuning_runtime,
+) -> None:
+    _, service, executor, evaluation_store, tuner = tuning_runtime
+    scenario = _known_winner_fixture("threshold_recovery")
+    kb_id, _, base_version_id = await _known_winner_base_version(
+        service, executor, scenario
+    )
+    service.activate_pipeline_version(base_version_id)
+    _, negative_ceiling = await _known_winner_score_boundary(
+        service, base_version_id, scenario
+    )
+    eval_set_id, eval_version = await _known_winner_evaluation_set(
+        service, evaluation_store, kb_id, base_version_id, scenario
+    )
+
+    created = tuner.create_run(
+        {
+            "kb_id": kb_id,
+            "base_version_id": base_version_id,
+            "eval_set_id": eval_set_id,
+            "eval_set_version": eval_version,
+            "objective": "quality",
+            "max_chunk_indexes": 1,
+            "max_retrieval_trials": 1,
+            "max_finalists": 1,
+            "seed": 42,
+        }
+    )
+    assert await tuner.run_once() is True
+
+    completed = tuner.store.get_run(created["run_id"])
+    assert completed["status"] == scenario["expected_outcome"], completed
+    winner = completed["winner"]
+    assert winner["retrieval"]["mode"] == "fulltext"
+    assert float(winner["retrieval"]["score_threshold"]) > negative_ceiling
+    assert winner["threshold_selection_reason"] == (
+        "hard_negative_false_positive_improved"
+    )
+    assert float(winner["improvement"]["no_result_accuracy_delta"]) >= float(
+        scenario["expected_winner"]["minimum_no_result_accuracy_delta"]
+    )
+    assert winner["statistical_validation"]["passed"] is True
+
+    final_version = service.get_pipeline_version(completed["final_version_id"])
+    assert final_version["status"] == "ready"
+    assert final_version["promotion_required"] is True
+    assert float(final_version["retrieval_profile"]["score_threshold"]) > 0
+    assert service.get_active_pipeline_version(kb_id)["version_id"] == base_version_id
+    evaluation = evaluation_store.get_run(completed["evaluation_run_id"])
+    assert evaluation["status"] == "succeeded"
+    candidate_result = next(
+        item
+        for item in evaluation["target_results"]
+        if item["version_id"] == final_version["version_id"]
+    )
+    assert candidate_result["promotion_gate"]["passed"] is True
+
+
+@pytest.mark.asyncio
+async def test_known_winner_already_optimal_control_does_not_invent_winner(
+    tuning_runtime,
+) -> None:
+    _, service, executor, evaluation_store, tuner = tuning_runtime
+    scenario = _known_winner_fixture("already_optimal_control")
+    kb_id, document_id, calibration_version_id = await _known_winner_base_version(
+        service, executor, scenario
+    )
+    _, negative_ceiling = await _known_winner_score_boundary(
+        service, calibration_version_id, scenario
+    )
+    safe_threshold = round(negative_ceiling + 0.000001, 6)
+    base_version_id = await _rebuild_known_winner_base(
+        service,
+        executor,
+        kb_id,
+        document_id,
+        score_threshold=safe_threshold,
+    )
+    service.activate_pipeline_version(base_version_id)
+    eval_set_id, eval_version = await _known_winner_evaluation_set(
+        service, evaluation_store, kb_id, base_version_id, scenario
+    )
+
+    created = tuner.create_run(
+        {
+            "kb_id": kb_id,
+            "base_version_id": base_version_id,
+            "eval_set_id": eval_set_id,
+            "eval_set_version": eval_version,
+            "objective": "quality",
+            "max_chunk_indexes": 1,
+            "max_retrieval_trials": 1,
+            "max_finalists": 1,
+            "seed": 42,
+        }
+    )
+    assert await tuner.run_once() is True
+
+    completed = tuner.store.get_run(created["run_id"])
+    assert completed["status"] == scenario["expected_outcome"], completed
+    assert completed.get("final_version_id") is None
+    assert completed.get("winner") is None
+    assert completed["no_improvement_reason"] == "optimization_gate"
+    assert len(completed["candidates"]) == 1
+    assert completed["candidates"][0]["automatic_winner_eligible"] is False
+    assert completed["candidates"][0]["ineligible_reason"] == "baseline_equivalent"
+    assert service.get_active_pipeline_version(kb_id)["version_id"] == base_version_id
+
+
+def test_tuner_capabilities_publish_known_winner_evidence_version(
+    tuning_runtime,
+) -> None:
+    _, _, _, _, tuner = tuning_runtime
+
+    validation = tuner.capabilities()["validation"]
+    assert validation["known_winner_fixture_version"] == KNOWN_WINNER_FIXTURE_VERSION
+    assert validation["known_winner_scenarios"] == [
+        "threshold_recovery",
+        "already_optimal_control",
+    ]

--- a/server/tests/test_rag_strategy_tuning_qualification.py
+++ b/server/tests/test_rag_strategy_tuning_qualification.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+from server.rag.strategy_tuning_qualification import (
+    assess_chunk_sensitivity,
+    build_tuning_readiness,
+    ranking_fingerprint,
+    realized_index_fingerprint,
+)
+
+
+def _case(
+    index: int,
+    *,
+    query_type: str,
+    expected_no_result: bool = False,
+    review_status: str = "not_required",
+    reference_count: int = 1,
+) -> dict:
+    refs = []
+    if not expected_no_result:
+        refs = [
+            {
+                "document_id": "doc-a",
+                "chunk_id": f"chunk-{index}-{ref_index}",
+                "source_block_id": f"block-{index}-{ref_index}",
+                "match_mode": "source_block",
+            }
+            for ref_index in range(reference_count)
+        ]
+    return {
+        "case_id": f"case-{index}",
+        "query": f"query {index}",
+        "expected_refs": refs,
+        "expected_no_result": expected_no_result,
+        "review_status": review_status,
+        "tags": [query_type],
+        "targeting": {
+            "blueprint_id": f"blueprint-{index}",
+            "query_type": query_type,
+            "context_evidence_ids": [f"evidence-{index}"] if expected_no_result else [],
+        },
+    }
+
+
+def _qualified_cases() -> list[dict]:
+    cases = []
+    cases.extend(
+        _case(index, query_type="factual_lookup") for index in range(8)
+    )
+    cases.extend(
+        _case(index + 8, query_type="paraphrase") for index in range(6)
+    )
+    cases.extend(
+        _case(index + 14, query_type="section_context") for index in range(8)
+    )
+    cases.extend(
+        _case(
+            index + 22,
+            query_type="multi_evidence",
+            reference_count=2,
+        )
+        for index in range(8)
+    )
+    cases.extend(
+        _case(
+            index + 30,
+            query_type="no_result",
+            expected_no_result=True,
+            review_status="approved",
+            reference_count=0,
+        )
+        for index in range(12)
+    )
+    return cases
+
+
+def test_catalog_pack_is_report_only_even_with_enough_cases() -> None:
+    readiness = build_tuning_readiness(
+        {
+            "origin": "benchmark_catalog",
+            "catalog_ref": {"pack_id": "modelmirror-rag-foundation-bilingual-v1"},
+            "cases": _qualified_cases(),
+            "calibration": {"status": "calibrated"},
+        }
+    )
+
+    assert readiness["benchmark_role"] == "regression_guard"
+    assert readiness["status"] == "report_only"
+    assert readiness["selection_eligible"] is False
+    assert any(item["check_id"] == "selection_role" for item in readiness["checks"])
+
+
+def test_targeted_benchmark_qualifies_each_search_dimension() -> None:
+    readiness = build_tuning_readiness(
+        {
+            "origin": "generated",
+            "benchmark_role": "strategy_tuning",
+            "cases": _qualified_cases(),
+            "calibration": {"status": "calibrated"},
+        }
+    )
+
+    assert readiness["status"] == "ready"
+    assert readiness["selection_eligible"] is True
+    assert readiness["dimensions"]["retrieval"]["eligible"] is True
+    assert readiness["dimensions"]["threshold"]["eligible"] is True
+    assert readiness["dimensions"]["chunking"]["eligible"] is True
+    assert readiness["counts"]["reviewed_hard_negative"] == 12
+    assert readiness["coverage"]["density"] == {
+        "multi_dense": 8,
+        "single_dense": 8,
+        "sparse": 14,
+    }
+
+
+def test_small_targeted_set_is_insufficient_and_does_not_enable_threshold() -> None:
+    readiness = build_tuning_readiness(
+        {
+            "origin": "generated",
+            "cases": _qualified_cases()[:12],
+            "calibration": {"status": "calibrated"},
+        }
+    )
+
+    assert readiness["status"] == "insufficient_data"
+    assert readiness["selection_eligible"] is False
+    assert readiness["dimensions"]["threshold"]["eligible"] is False
+    assert readiness["counts"]["positive"] == 12
+
+
+def test_generated_tuning_evidence_must_match_fixed_knowledge_version() -> None:
+    readiness = build_tuning_readiness(
+        {
+            "origin": "generated",
+            "benchmark_role": "strategy_tuning",
+            "provenance": {"pipeline_version_id": "version-old"},
+            "cases": _qualified_cases(),
+            "calibration": {"status": "calibrated"},
+        },
+        target_version_id="version-current",
+    )
+
+    assert readiness["selection_eligible"] is False
+    assert any(
+        item["check_id"] == "target_version_snapshot" and not item["passed"]
+        for item in readiness["checks"]
+    )
+
+
+def test_realized_and_ranking_fingerprints_ignore_sensitive_content() -> None:
+    first = realized_index_fingerprint(
+        chunker={"strategy": "recursive_character", "chunk_size": 400},
+        cost={"chunk_count": 12},
+        document_results=[
+            {"source_id": "source-a", "chunk_count": 12, "block_count": 4}
+        ],
+    )
+    second = realized_index_fingerprint(
+        chunker={"strategy": "recursive_character", "chunk_size": 900},
+        cost={"chunk_count": 12},
+        document_results=[
+            {"source_id": "source-a", "chunk_count": 12, "block_count": 4}
+        ],
+    )
+    changed = realized_index_fingerprint(
+        chunker={"strategy": "parent_child"},
+        cost={"chunk_count": 18},
+        document_results=[
+            {"source_id": "source-a", "chunk_count": 18, "block_count": 4}
+        ],
+    )
+
+    assert first == second
+    assert changed != first
+    assert ranking_fingerprint(
+        [{"case_id": "case-a", "sources": [{"chunk_id": "chunk-a", "text": "secret"}]}]
+    ) == ranking_fingerprint(
+        [{"case_id": "case-a", "sources": [{"chunk_id": "chunk-a", "text": "other"}]}]
+    )
+
+
+def test_chunk_sensitivity_requires_distinct_realized_or_ranking_outcomes() -> None:
+    candidates = [
+        {
+            "retrieval_input_checksum": "probe",
+            "realized_index_fingerprint": "same-index",
+            "ranking_fingerprint": "same-ranking",
+        },
+        {
+            "retrieval_input_checksum": "probe",
+            "realized_index_fingerprint": "same-index",
+            "ranking_fingerprint": "same-ranking",
+        },
+    ]
+    insufficient = assess_chunk_sensitivity(
+        candidates,
+        probe_retrieval_checksum="probe",
+        enabled=True,
+    )
+    assert insufficient["status"] == "insufficient"
+    assert insufficient["unique_realized_outcomes"] == 1
+
+    candidates[1]["ranking_fingerprint"] = "different-ranking"
+    sufficient = assess_chunk_sensitivity(
+        candidates,
+        probe_retrieval_checksum="probe",
+        enabled=True,
+    )
+    assert sufficient["status"] == "sufficient"
+    assert sufficient["unique_realized_outcomes"] == 2


### PR DESCRIPTION
## Summary
- 新增 Benchmark 驱动的 RAG Strategy Auto Tuner，固定知识版本、评测版本、语料快照与 Router 规则版本。
- 补齐调优资格判定、检索/分块候选搜索、Holdout 验证、Pareto 排名、重复稳健性验证与候选版本物化。
- 将标准回归 Pack 限定为回归护栏；仅具备充分正样例、已审核困难负例和密集证据的策略调优集可选择胜者。
- 在知识流水线中提供调优配置、资格说明、候选证据、成本对比和 Promotion 入口。

## Acceptance Evidence
- 独立预览器真实验收已跑通阈值调优：困难负例误召回改善 1.0，统计复核通过，生成 `ready` 候选版本，原活动版本保持不变。
- 最近 15 分钟 backend/frontend 日志未发现 ERROR、CRITICAL、Traceback 或 5xx。
- 聚焦测试：60 passed, 4 warnings。
- 全量后端：2568 passed, 22 skipped, 1 unrelated failure。
- 前端生产构建通过；涉及后端模块 py_compile 通过；敏感信息与排除文件扫描通过。

## Known Baseline Issue
全量测试唯一失败为 `test_skill_finder.py::test_python_and_typescript_matcher_keep_the_same_golden_order`。测试镜像使用 Node 20，无法直接 import `.ts`（`ERR_UNKNOWN_FILE_EXTENSION`）；宿主 Node 24 对同一文件导入成功。该问题与本 PR 的 RAG 改动无交集。

## Safety And Compatibility
- 调优不修改 Pipeline Draft 或活动索引；胜者仅物化为 `promotion_required` 的 ready 版本。
- Hash Embedding 降级时不允许 Vector/Hybrid 自动胜出；Rerank 必须显式可用和授权。
- 未提交 `.env`、API key、RAG/Runtime Store、索引数据库、构建产物或 APK。