### PR TITLE
feature: 重构 Chat 对话优先极简壳

### DIFF
--- a/client/src/components/AdvancedParamsPanel.tsx
+++ b/client/src/components/AdvancedParamsPanel.tsx
@@ -13,6 +13,7 @@ interface AdvancedParamsPanelProps {
   onChange: (params: ChatAdvancedParams) => void;
   onReset: () => void;
   onToggle: () => void;
+  embedded?: boolean;
 }
 
 function numberInputClass() {
@@ -69,35 +70,35 @@ export default function AdvancedParamsPanel({
   onChange,
   onReset,
   onToggle,
+  embedded = false,
 }: AdvancedParamsPanelProps) {
   return (
-    <div className="border-b border-white/10 bg-ink-950/36 px-4 py-3 sm:px-5">
-      <div className="flex flex-wrap items-center justify-between gap-3">
+    <div className={embedded ? "px-5 py-4" : "border-b border-white/10 bg-ink-950/36 px-4 py-3 sm:px-5"}>
+      {!embedded ? <div className="flex flex-wrap items-center justify-between gap-3">
         <button
           aria-expanded={isOpen}
           className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.055] px-3 py-1.5 text-xs font-semibold text-slate-200 transition hover:border-hire-300/40 hover:bg-hire-300/10 hover:text-hire-100"
           onClick={onToggle}
           type="button"
         >
-          <span>⚙️</span>
           高级参数
-          <span className={`transition ${isOpen ? "rotate-180" : ""}`}>⌄</span>
+          <span aria-hidden className={`transition ${isOpen ? "rotate-180" : ""}`}>⌄</span>
         </button>
         <p className="text-xs text-slate-400">
           当前：温度 {params.temperature}，Top P {params.topP}，最大 {params.maxTokens}
         </p>
-      </div>
+      </div> : null}
 
       <div
         className={`grid transition-all duration-200 ${
-          isOpen ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0"
+          embedded || isOpen ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0"
         }`}
       >
         <div className="overflow-hidden">
-          <div className="mt-3 grid gap-3 lg:grid-cols-2">
+          <div className={`${embedded ? "" : "mt-3"} grid gap-3 lg:grid-cols-2`}>
             <SliderRow
               description="越高越有创意，越低越保守。"
-              label="🌡️ Temperature（温度）"
+              label="Temperature（温度）"
               max={2}
               min={0}
               onChange={(temperature) => onChange({ ...params, temperature })}
@@ -106,7 +107,7 @@ export default function AdvancedParamsPanel({
             />
             <SliderRow
               description="控制候选词采样范围，1.0 表示不额外收窄。"
-              label="🎯 Top P（核采样）"
+              label="Top P（核采样）"
               max={1}
               min={0}
               onChange={(topP) => onChange({ ...params, topP })}
@@ -116,7 +117,7 @@ export default function AdvancedParamsPanel({
 
             <label className="rounded-lg border border-white/10 bg-white/[0.04] p-3">
               <span className="text-sm font-semibold text-white">
-                📏 Max Tokens（最大输出长度）
+                Max Tokens（最大输出长度）
               </span>
               <input
                 className={`${numberInputClass()} mt-2`}
@@ -141,7 +142,7 @@ export default function AdvancedParamsPanel({
 
             <label className="rounded-lg border border-white/10 bg-white/[0.04] p-3">
               <span className="text-sm font-semibold text-white">
-                🧭 Seed（随机种子）
+                Seed（随机种子）
               </span>
               <input
                 className={`${numberInputClass()} mt-2`}
@@ -156,7 +157,7 @@ export default function AdvancedParamsPanel({
 
             <label className="rounded-lg border border-white/10 bg-white/[0.04] p-3 lg:col-span-2">
               <span className="text-sm font-semibold text-white">
-                ⛔ Stop Sequences（停止序列）
+                Stop Sequences（停止序列）
               </span>
               <input
                 className={`${numberInputClass()} mt-2`}

--- a/client/src/components/ChatFileComposer.tsx
+++ b/client/src/components/ChatFileComposer.tsx
@@ -176,6 +176,7 @@ interface ChatFileComposerProps {
   resetVersion: number;
   discardVersion: number;
   injectedFile?: PreparedChatFile | null;
+  hideTrigger?: boolean;
   onError: (message: string) => void;
   onStateChange: (state: ChatFileComposerState) => void;
 }
@@ -346,6 +347,7 @@ export default function ChatFileComposer({
   resetVersion,
   discardVersion,
   injectedFile,
+  hideTrigger = false,
   onError,
   onStateChange,
 }: ChatFileComposerProps) {
@@ -870,6 +872,18 @@ export default function ChatFileComposer({
             : mediaBlockedReason ??
               `上传 ${acceptedFormats.map((format) => formatFileFormatLabel(format.format_id)).join("、")}`;
 
+  useEffect(() => {
+    const openPicker = () => {
+      if (entryDisabled) {
+        onError(entryTitle);
+        return;
+      }
+      inputRef.current?.click();
+    };
+    window.addEventListener("modelmirror:open-chat-file", openPicker);
+    return () => window.removeEventListener("modelmirror:open-chat-file", openPicker);
+  }, [entryDisabled, entryTitle, onError]);
+
   const acceptValue = Array.from(
     new Set(
       acceptedFormats.flatMap((format) => [
@@ -919,7 +933,7 @@ export default function ChatFileComposer({
           }}
         />
       ) : null}
-      <button
+      {!hideTrigger ? <button
         aria-label="添加文件"
         className="min-h-11 rounded-full border border-white/10 bg-white/[0.06] px-3 text-xs font-semibold text-slate-200 transition hover:border-brand-300/40 hover:bg-brand-300/10 hover:text-brand-100 focus:outline-none focus:ring-4 focus:ring-brand-300/10 disabled:cursor-not-allowed disabled:opacity-45"
         disabled={entryDisabled}
@@ -941,7 +955,7 @@ export default function ChatFileComposer({
           : capabilityState === "unavailable"
             ? "文件不可用"
             : "文件"}
-      </button>
+      </button> : null}
 
       {items.length > 0 ? (
         <div

--- a/client/src/components/ChatVisualAnalysisPanel.tsx
+++ b/client/src/components/ChatVisualAnalysisPanel.tsx
@@ -60,7 +60,9 @@ interface ChatVisualAnalysisPanelProps {
   knowledgeBases: Array<{ id: string; name: string }>;
   resetVersion: number;
   discardVersion: number;
+  hideTrigger?: boolean;
   onError: (message: string) => void;
+  onCapabilityChange?: (state: "loading" | "ready" | "disabled") => void;
   onStateChange: (state: ChatVisualAnalysisState) => void;
 }
 
@@ -174,7 +176,9 @@ export default function ChatVisualAnalysisPanel({
   knowledgeBases,
   resetVersion,
   discardVersion,
+  hideTrigger = false,
   onError,
+  onCapabilityChange,
   onStateChange,
 }: ChatVisualAnalysisPanelProps) {
   const titleId = useId();
@@ -213,6 +217,10 @@ export default function ChatVisualAnalysisPanel({
   );
   const hasVisionTarget = targets.some((target) => target.mode === "vision");
   const fileAccept = hasVisionTarget ? ACCEPT : ".pdf";
+
+  useEffect(() => {
+    onCapabilityChange?.(capability);
+  }, [capability, onCapabilityChange]);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -750,7 +758,7 @@ export default function ChatVisualAnalysisPanel({
 
   return (
     <>
-      <button
+      {!hideTrigger ? <button
         aria-controls={open ? titleId : undefined}
         aria-expanded={open}
         className="min-h-11 rounded-full border border-cyan-300/25 bg-cyan-300/10 px-3 text-xs font-semibold text-cyan-100 disabled:cursor-not-allowed disabled:opacity-50"
@@ -761,7 +769,7 @@ export default function ChatVisualAnalysisPanel({
         type="button"
       >
         视觉/OCR{asset ? " · 1" : ""}
-      </button>
+      </button> : null}
       {panel}
     </>
   );

--- a/client/src/components/PromptSidebar.tsx
+++ b/client/src/components/PromptSidebar.tsx
@@ -51,10 +51,12 @@ function interviewCategoryName(name: string) {
 
 function PromptCard({
   prompt,
+  variant,
   onFillPrompt,
   onSendPrompt,
 }: {
   prompt: PromptItem;
+  variant: "prompt" | "question";
   onFillPrompt: (content: string) => void;
   onSendPrompt: (content: string) => void;
 }) {
@@ -79,26 +81,29 @@ function PromptCard({
           onClick={() => onFillPrompt(prompt.content)}
           type="button"
         >
-          备题
+          {variant === "question" ? "备题" : "填入"}
         </button>
         <button
           className="rounded-full bg-brand-300 px-2.5 py-1 text-xs font-semibold text-ink-950 transition hover:bg-brand-200 hover:shadow-neon"
           onClick={() => onSendPrompt(prompt.content)}
           type="button"
         >
-          开问
+          {variant === "question" ? "开问" : "发送"}
         </button>
       </div>
     </article>
   );
 }
 
-function SidebarContent({
+export function PromptLibraryContent({
   superPromptMode,
+  variant = "question",
   onSuperPromptModeChange,
   onFillPrompt,
   onSendPrompt,
-}: Omit<PromptSidebarProps, "isOpen" | "onToggleOpen">) {
+}: Omit<PromptSidebarProps, "isOpen" | "onToggleOpen"> & {
+  variant?: "prompt" | "question";
+}) {
   const [openCategoryIds, setOpenCategoryIds] = useState<string[]>([
     categories[0]?.id ?? "",
   ]);
@@ -124,10 +129,12 @@ function SidebarContent({
     <div className="flex h-full flex-col">
       <div className="border-b border-white/10 bg-[linear-gradient(120deg,rgba(36,217,255,0.10),transparent_56%)] p-4">
         <p className="text-sm font-semibold text-white">
-          {recruitmentTheme.promptPanelTitle}
+          {variant === "question" ? recruitmentTheme.promptPanelTitle : "提示库"}
         </p>
         <p className="mt-1 text-xs leading-5 text-slate-400">
-          {categories.length} 个题库，{promptCount} 道面试题
+          {variant === "question"
+            ? `${categories.length} 个题库，${promptCount} 道面试题`
+            : `${categories.length} 个分类，${promptCount} 条可复用提示`}
         </p>
 
         <button
@@ -142,10 +149,12 @@ function SidebarContent({
         >
           <span>
             <span className="block text-sm font-semibold">
-              {recruitmentTheme.superPromptTitle}
+              {variant === "question" ? recruitmentTheme.superPromptTitle : "增强提示模式"}
             </span>
             <span className="mt-0.5 block text-xs opacity-75">
-              {recruitmentTheme.superPromptDescription}
+              {variant === "question"
+                ? recruitmentTheme.superPromptDescription
+                : "使用更严格的提示结构组织下一轮请求"}
             </span>
           </span>
           <span
@@ -184,7 +193,9 @@ function SidebarContent({
                         {categoryMark(category.name)}
                       </span>
                       <span className="truncate">
-                        {interviewCategoryName(category.name)}
+                        {variant === "question"
+                          ? interviewCategoryName(category.name)
+                          : category.name}
                       </span>
                     </span>
                     <span className="mt-0.5 block text-xs text-slate-400">
@@ -215,6 +226,7 @@ function SidebarContent({
                           onFillPrompt={onFillPrompt}
                           onSendPrompt={onSendPrompt}
                           prompt={prompt}
+                          variant={variant}
                         />
                       ))}
                     </div>
@@ -257,7 +269,7 @@ export default function PromptSidebar({
             isOpen ? "opacity-100" : "pointer-events-none opacity-0"
           }`}
         >
-          <SidebarContent
+          <PromptLibraryContent
             onFillPrompt={onFillPrompt}
             onSendPrompt={onSendPrompt}
             onSuperPromptModeChange={onSuperPromptModeChange}
@@ -296,7 +308,7 @@ export default function PromptSidebar({
           </button>
         </div>
         <div className="h-[72vh]">
-          <SidebarContent
+          <PromptLibraryContent
             onFillPrompt={onFillPrompt}
             onSendPrompt={onSendPrompt}
             onSuperPromptModeChange={onSuperPromptModeChange}

--- a/client/src/components/chat/ChatConversationChrome.test.tsx
+++ b/client/src/components/chat/ChatConversationChrome.test.tsx
@@ -1,0 +1,112 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { FileText, Wrench } from "lucide-react";
+import { createRef } from "react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import {
+  ChatActionMenu,
+  ChatActiveContextBar,
+  ChatCompactHeader,
+  ChatOverlayDrawer,
+  type ChatActionDescriptor,
+} from "./ChatConversationChrome";
+
+describe("ChatConversationChrome", () => {
+  it.each([
+    ["direct", "直接对话"],
+    ["auto", "智能调度"],
+    ["expert", "专家模式"],
+  ] as const)("renders the %s compact header", (mode, label) => {
+    render(
+      <MemoryRouter>
+        <ChatCompactHeader
+          backTo="/models"
+          mode={mode}
+          modelLabel="GPT-5.6 Luna"
+          onOpenPrompt={vi.fn()}
+          onOpenSettings={vi.fn()}
+          promptLabel={mode === "expert" ? "题库" : "提示库"}
+          promptTriggerRef={createRef<HTMLButtonElement>()}
+          settingsTriggerRef={createRef<HTMLButtonElement>()}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("GPT-5.6 Luna")).toBeInTheDocument();
+    expect(screen.getByText(label)).toBeInTheDocument();
+    expect(screen.getByRole("banner").firstElementChild).toHaveClass("h-16");
+  });
+
+  it("groups actions, keeps blocked reasons visible, and restores trigger focus on Escape", () => {
+    const triggerRef = createRef<HTMLButtonElement>();
+    const onOpenChange = vi.fn();
+    const actions: ChatActionDescriptor[] = [
+      {
+        id: "file",
+        group: "content",
+        label: "文件",
+        description: "上传文件",
+        icon: FileText,
+        onSelect: vi.fn(),
+      },
+      {
+        id: "mcp",
+        group: "tools",
+        label: "MCP 工具",
+        description: "调用工具",
+        icon: Wrench,
+        status: "blocked",
+        blockedReason: "智能调度暂不支持 MCP。",
+      },
+    ];
+
+    render(
+      <ChatActionMenu
+        actions={actions}
+        onOpenChange={onOpenChange}
+        open
+        triggerRef={triggerRef}
+      />,
+    );
+
+    expect(screen.getByText("添加内容")).toBeInTheDocument();
+    expect(screen.getByText("工具")).toBeInTheDocument();
+    expect(screen.getByText("智能调度暂不支持 MCP。")).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("removes an active context without duplicating attachment UI", () => {
+    const onRemove = vi.fn();
+    render(
+      <ChatActiveContextBar
+        contexts={[{ id: "kb", label: "资料库 · 产品文档", onRemove }]}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "移除 资料库 · 产品文档" }));
+    expect(onRemove).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes the single overlay with Escape and returns focus", () => {
+    const triggerRef = createRef<HTMLButtonElement>();
+    const onClose = vi.fn();
+    render(
+      <>
+        <button ref={triggerRef} type="button">打开设置</button>
+        <ChatOverlayDrawer
+          onClose={onClose}
+          open
+          title="对话设置"
+          triggerRef={triggerRef}
+        >
+          <button type="button">抽屉操作</button>
+        </ChatOverlayDrawer>
+      </>,
+    );
+
+    const dialog = screen.getByRole("dialog", { name: "对话设置" });
+    expect(within(dialog).getByRole("button", { name: "抽屉操作" })).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/components/chat/ChatConversationChrome.tsx
+++ b/client/src/components/chat/ChatConversationChrome.tsx
@@ -1,0 +1,405 @@
+import {
+  type ComponentType,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type ReactNode,
+  type RefObject,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+} from "react";
+import { createPortal } from "react-dom";
+import {
+  ArrowLeft,
+  BookOpenText,
+  ChevronRight,
+  Plus,
+  Settings,
+  X,
+} from "lucide-react";
+import { Link } from "react-router-dom";
+
+export type ChatShellMode = "direct" | "auto" | "expert";
+
+export type ChatActionGroup = "content" | "context" | "tools" | "voice";
+
+export interface ChatActionDescriptor {
+  id: string;
+  group: ChatActionGroup;
+  label: string;
+  description: string;
+  icon: ComponentType<{ className?: string; "aria-hidden"?: boolean }>;
+  status?: "available" | "active" | "blocked";
+  blockedReason?: string;
+  count?: number;
+  onSelect?: () => void;
+  control?: ReactNode;
+}
+
+export interface ChatActiveContext {
+  id: string;
+  label: string;
+  detail?: string;
+  onRemove: () => void;
+  disabled?: boolean;
+}
+
+const ACTION_GROUP_LABELS: Record<ChatActionGroup, string> = {
+  content: "添加内容",
+  context: "添加上下文",
+  tools: "工具",
+  voice: "语音",
+};
+
+const ACTION_GROUP_ORDER: ChatActionGroup[] = ["content", "context", "tools", "voice"];
+
+function focusableElements(root: HTMLElement) {
+  return Array.from(
+    root.querySelectorAll<HTMLElement>(
+      'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    ),
+  );
+}
+
+export function ChatCompactHeader({
+  mode,
+  modelLabel,
+  providerLabel,
+  expertDepartment,
+  backTo,
+  promptLabel,
+  promptTriggerRef,
+  settingsTriggerRef,
+  onOpenPrompt,
+  onOpenSettings,
+  onExitExpert,
+  disabled,
+}: {
+  mode: ChatShellMode;
+  modelLabel: string;
+  providerLabel?: string;
+  expertDepartment?: string;
+  backTo: string;
+  promptLabel: string;
+  promptTriggerRef: RefObject<HTMLButtonElement | null>;
+  settingsTriggerRef: RefObject<HTMLButtonElement | null>;
+  onOpenPrompt: () => void;
+  onOpenSettings: () => void;
+  onExitExpert?: () => void;
+  disabled?: boolean;
+}) {
+  const modeLabel = mode === "expert" ? "专家模式" : mode === "auto" ? "智能调度" : "直接对话";
+
+  return (
+    <header className="sticky top-0 z-40 border-b border-white/10 bg-ink-950/95 backdrop-blur-xl">
+      <div className="mx-auto flex h-16 w-full max-w-[1200px] items-center gap-3 px-3 sm:px-5">
+        <Link
+          aria-label="返回"
+          className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-full text-slate-300 transition hover:bg-white/[0.07] hover:text-white focus:outline-none focus:ring-4 focus:ring-brand-300/15"
+          to={backTo}
+        >
+          <ArrowLeft aria-hidden className="h-5 w-5" />
+        </Link>
+        <Link
+          className="hidden shrink-0 items-center gap-2 text-sm font-semibold text-white transition hover:text-brand-100 sm:inline-flex"
+          to="/models"
+        >
+          <img alt="" className="h-7 w-7 rounded-md object-cover" src="/logo.png" />
+          <span>ModelMirror</span>
+        </Link>
+        <div className="min-w-0 flex-1 text-center">
+          <p className="truncate text-sm font-semibold text-white">{modelLabel}</p>
+          <p className="mt-0.5 flex items-center justify-center gap-1.5 truncate text-[11px] text-slate-400">
+            <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-300" />
+            <span className="truncate">
+              {modeLabel}
+              {expertDepartment ? ` · ${expertDepartment}` : providerLabel ? ` · ${providerLabel}` : ""}
+            </span>
+          </p>
+        </div>
+        {mode === "expert" && onExitExpert ? (
+          <button
+            aria-label="退出专家模式"
+            className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-full text-xs font-semibold text-slate-300 transition hover:bg-white/[0.07] hover:text-white disabled:opacity-50 md:w-auto md:px-3"
+            disabled={disabled}
+            onClick={onExitExpert}
+            type="button"
+          >
+            <X aria-hidden className="h-4 w-4 md:hidden" />
+            <span className="hidden md:inline">退出专家</span>
+          </button>
+        ) : null}
+        <button
+          aria-label={promptLabel}
+          className="inline-flex h-11 shrink-0 items-center gap-2 rounded-full px-3 text-xs font-semibold text-slate-300 transition hover:bg-white/[0.07] hover:text-white focus:outline-none focus:ring-4 focus:ring-brand-300/15"
+          onClick={onOpenPrompt}
+          ref={promptTriggerRef}
+          type="button"
+        >
+          <BookOpenText aria-hidden className="h-4 w-4" />
+          <span className="hidden sm:inline">{promptLabel}</span>
+        </button>
+        <button
+          aria-label="打开对话设置"
+          className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-full text-slate-300 transition hover:bg-white/[0.07] hover:text-white focus:outline-none focus:ring-4 focus:ring-brand-300/15"
+          onClick={onOpenSettings}
+          ref={settingsTriggerRef}
+          type="button"
+        >
+          <Settings aria-hidden className="h-5 w-5" />
+        </button>
+      </div>
+    </header>
+  );
+}
+
+export function ChatActionMenu({
+  open,
+  actions,
+  triggerRef,
+  onOpenChange,
+}: {
+  open: boolean;
+  actions: ChatActionDescriptor[];
+  triggerRef: RefObject<HTMLButtonElement | null>;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const menuId = useId();
+  const menuRef = useRef<HTMLDivElement>(null);
+  const groupedActions = useMemo(
+    () =>
+      ACTION_GROUP_ORDER.map((group) => ({
+        group,
+        actions: actions.filter((action) => action.group === group),
+      })).filter((entry) => entry.actions.length > 0),
+    [actions],
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (event: PointerEvent) => {
+      const target = event.target as Node;
+      if (menuRef.current?.contains(target) || triggerRef.current?.contains(target)) return;
+      onOpenChange(false);
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onOpenChange(false);
+        window.requestAnimationFrame(() => triggerRef.current?.focus());
+      }
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    document.addEventListener("keydown", onKeyDown);
+    window.requestAnimationFrame(() => focusableElements(menuRef.current ?? document.body)[0]?.focus());
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [onOpenChange, open, triggerRef]);
+
+  function onMenuKeyDown(event: ReactKeyboardEvent<HTMLDivElement>) {
+    if (event.key !== "ArrowDown" && event.key !== "ArrowUp") return;
+    const items = focusableElements(event.currentTarget);
+    const currentIndex = items.indexOf(document.activeElement as HTMLElement);
+    const delta = event.key === "ArrowDown" ? 1 : -1;
+    const nextIndex = currentIndex < 0 ? 0 : (currentIndex + delta + items.length) % items.length;
+    event.preventDefault();
+    items[nextIndex]?.focus();
+  }
+
+  return (
+    <div className="relative shrink-0">
+      <button
+        aria-controls={menuId}
+        aria-expanded={open}
+        aria-label="添加内容与工具"
+        className={`inline-flex h-11 w-11 items-center justify-center rounded-full border transition focus:outline-none focus:ring-4 focus:ring-brand-300/15 ${
+          open
+            ? "border-brand-300/45 bg-brand-300/15 text-brand-100"
+            : "border-white/10 bg-white/[0.055] text-slate-300 hover:border-white/20 hover:bg-white/[0.09] hover:text-white"
+        }`}
+        onClick={() => onOpenChange(!open)}
+        ref={triggerRef}
+        type="button"
+      >
+        <Plus aria-hidden className={`h-5 w-5 transition ${open ? "rotate-45" : ""}`} />
+      </button>
+      {open ? <div
+        aria-label="对话功能"
+        className="absolute bottom-[calc(100%+0.75rem)] left-0 z-50 w-[min(22rem,calc(100vw-2rem))] origin-bottom-left overflow-hidden rounded-2xl border border-white/10 bg-surface-900 p-2 shadow-panel"
+        id={menuId}
+        onKeyDown={onMenuKeyDown}
+        ref={menuRef}
+        role="menu"
+      >
+        <div className="max-h-[min(62vh,34rem)] overflow-y-auto [scrollbar-width:thin]">
+          {groupedActions.map((entry, groupIndex) => (
+            <section className={groupIndex > 0 ? "mt-2 border-t border-white/10 pt-2" : ""} key={entry.group}>
+              <p className="px-3 pb-1 pt-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-slate-500">
+                {ACTION_GROUP_LABELS[entry.group]}
+              </p>
+              <div className="space-y-1">
+                {entry.actions.map((action) => {
+                  const Icon = action.icon;
+                  const blocked = action.status === "blocked";
+                  return action.control ? (
+                    <div className="rounded-xl px-3 py-2" key={action.id}>
+                      <div className="mb-2 flex items-start gap-3">
+                        <Icon aria-hidden className="mt-0.5 h-5 w-5 shrink-0 text-slate-400" />
+                        <div className="min-w-0">
+                          <p className="text-sm font-semibold text-slate-100">{action.label}</p>
+                          <p className="mt-0.5 text-xs leading-5 text-slate-400">{action.description}</p>
+                        </div>
+                      </div>
+                      {action.control}
+                    </div>
+                  ) : (
+                    <button
+                      className="group flex min-h-14 w-full items-start gap-3 rounded-xl px-3 py-2.5 text-left transition hover:bg-white/[0.06] focus:outline-none focus:ring-2 focus:ring-brand-300/25 disabled:cursor-not-allowed disabled:opacity-60"
+                      disabled={blocked}
+                      key={action.id}
+                      onClick={() => {
+                        action.onSelect?.();
+                        onOpenChange(false);
+                      }}
+                      role="menuitem"
+                      title={blocked ? action.blockedReason : undefined}
+                      type="button"
+                    >
+                      <span className={`mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg ${action.status === "active" ? "bg-brand-300/15 text-brand-100" : "bg-white/[0.055] text-slate-300"}`}>
+                        <Icon aria-hidden className="h-4 w-4" />
+                      </span>
+                      <span className="min-w-0 flex-1">
+                        <span className="flex items-center gap-2 text-sm font-semibold text-slate-100">
+                          {action.label}
+                          {action.count ? <span className="rounded-full bg-brand-300/15 px-2 py-0.5 text-[10px] text-brand-100">{action.count}</span> : null}
+                        </span>
+                        <span className={`mt-0.5 block text-xs leading-5 ${blocked ? "text-amber-200/80" : "text-slate-400"}`}>
+                          {blocked ? action.blockedReason ?? action.description : action.description}
+                        </span>
+                      </span>
+                      {!blocked ? <ChevronRight aria-hidden className="mt-2 h-4 w-4 shrink-0 text-slate-600 transition group-hover:text-slate-300" /> : null}
+                    </button>
+                  );
+                })}
+              </div>
+            </section>
+          ))}
+        </div>
+      </div> : null}
+    </div>
+  );
+}
+
+export function ChatActiveContextBar({ contexts }: { contexts: ChatActiveContext[] }) {
+  if (contexts.length === 0) return null;
+  return (
+    <div aria-label="已启用的对话上下文" className="flex gap-2 overflow-x-auto px-1 pb-2 [scrollbar-width:thin]">
+      {contexts.map((context) => (
+        <span className="inline-flex min-h-9 shrink-0 items-center gap-2 rounded-full border border-brand-300/25 bg-brand-300/[0.08] pl-3 pr-1.5 text-xs font-semibold text-brand-50" key={context.id} title={context.detail}>
+          <span className="max-w-48 truncate">{context.label}</span>
+          <button
+            aria-label={`移除 ${context.label}`}
+            className="inline-flex h-8 w-8 items-center justify-center rounded-full text-brand-100 transition hover:bg-brand-300/15 hover:text-white focus:outline-none focus:ring-2 focus:ring-brand-300/25 disabled:opacity-50"
+            disabled={context.disabled}
+            onClick={context.onRemove}
+            type="button"
+          >
+            <X aria-hidden className="h-3.5 w-3.5" />
+          </button>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+export function ChatOverlayDrawer({
+  open,
+  title,
+  description,
+  triggerRef,
+  children,
+  onClose,
+}: {
+  open: boolean;
+  title: string;
+  description?: string;
+  triggerRef: RefObject<HTMLElement | null>;
+  children: ReactNode;
+  onClose: () => void;
+}) {
+  const titleId = useId();
+  const drawerRef = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+        window.requestAnimationFrame(() => triggerRef.current?.focus());
+        return;
+      }
+      if (event.key !== "Tab" || !drawerRef.current) return;
+      const items = focusableElements(drawerRef.current);
+      if (items.length === 0) return;
+      const first = items[0];
+      const last = items[items.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+    document.addEventListener("keydown", onKeyDown);
+    window.requestAnimationFrame(() => focusableElements(drawerRef.current ?? document.body)[0]?.focus());
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [onClose, open, triggerRef]);
+
+  if (typeof document === "undefined") return null;
+
+  return createPortal(
+    <div aria-hidden={!open} className={`fixed inset-0 z-[80] transition duration-200 motion-reduce:transition-none ${open ? "pointer-events-auto opacity-100" : "pointer-events-none opacity-0"}`}>
+      <button
+        aria-label="关闭覆盖层"
+        className="absolute inset-0 cursor-default bg-ink-950/68 backdrop-blur-[2px]"
+        onClick={() => {
+          onClose();
+          window.requestAnimationFrame(() => triggerRef.current?.focus());
+        }}
+        tabIndex={-1}
+        type="button"
+      />
+      <aside
+        aria-labelledby={titleId}
+        aria-modal="true"
+        className={`absolute inset-x-0 bottom-0 flex max-h-[86dvh] flex-col overflow-hidden rounded-t-3xl border border-white/10 bg-surface-900 shadow-panel transition-transform duration-200 motion-reduce:transition-none sm:inset-y-0 sm:left-auto sm:right-0 sm:max-h-none sm:w-[min(30rem,92vw)] sm:rounded-none sm:rounded-l-2xl ${open ? "translate-y-0 sm:translate-x-0" : "translate-y-full sm:translate-x-full sm:translate-y-0"}`}
+        ref={drawerRef}
+        role="dialog"
+      >
+        <div className="flex min-h-16 items-center justify-between gap-4 border-b border-white/10 px-5 py-3">
+          <div className="min-w-0">
+            <h2 className="truncate text-base font-semibold text-white" id={titleId}>{title}</h2>
+            {description ? <p className="mt-0.5 text-xs text-slate-400">{description}</p> : null}
+          </div>
+          <button
+            aria-label={`关闭${title}`}
+            className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-full text-slate-300 transition hover:bg-white/[0.07] hover:text-white focus:outline-none focus:ring-4 focus:ring-brand-300/15"
+            onClick={() => {
+              onClose();
+              window.requestAnimationFrame(() => triggerRef.current?.focus());
+            }}
+            type="button"
+          >
+            <X aria-hidden className="h-5 w-5" />
+          </button>
+        </div>
+        <div className="min-h-0 flex-1 overflow-y-auto [scrollbar-width:thin]">{children}</div>
+      </aside>
+    </div>,
+    document.body,
+  );
+}

--- a/client/src/pages/ChatPage.layout.test.ts
+++ b/client/src/pages/ChatPage.layout.test.ts
@@ -1,13 +1,17 @@
 import { describe, expect, it } from "vitest";
-import { CHAT_HEADER_POSITION_CLASSES } from "./ChatPage";
+import {
+  CHAT_COMPOSER_COLUMN_CLASSES,
+  CHAT_MESSAGE_COLUMN_CLASSES,
+  CHAT_SHELL_HEADER_CLASSES,
+} from "./ChatPage";
 
 const BREAKPOINTS: Record<string, number> = {
   md: 768,
   lg: 1024,
 };
 
-function activePositionClasses(viewportWidth: number) {
-  return CHAT_HEADER_POSITION_CLASSES.split(/\s+/).flatMap((token) => {
+function activePositionClasses(classNames: string, viewportWidth: number) {
+  return classNames.split(/\s+/).flatMap((token) => {
     const [prefix, className] = token.includes(":")
       ? token.split(":", 2)
       : [null, token];
@@ -16,16 +20,13 @@ function activePositionClasses(viewportWidth: number) {
   });
 }
 
-describe("ChatPage responsive interview header", () => {
-  it("keeps the 390px chat input clear while preserving desktop sticky behavior", () => {
-    expect(activePositionClasses(390)).not.toContain("sticky");
-    expect(activePositionClasses(390)).not.toContain("top-4");
-
-    expect(activePositionClasses(768)).toEqual(
-      expect.arrayContaining(["sticky", "top-4"]),
+describe("ChatPage conversation-first shell", () => {
+  it("keeps one compact header and bounded message/composer columns at every viewport", () => {
+    expect(activePositionClasses(CHAT_SHELL_HEADER_CLASSES, 390)).toEqual(
+      expect.arrayContaining(["sticky", "top-0", "h-16"]),
     );
-    expect(activePositionClasses(1024)).toEqual(
-      expect.arrayContaining(["sticky", "top-4", "top-24"]),
-    );
+    expect(CHAT_MESSAGE_COLUMN_CLASSES).toContain("max-w-[920px]");
+    expect(CHAT_COMPOSER_COLUMN_CLASSES).toContain("max-w-[1000px]");
+    expect(CHAT_SHELL_HEADER_CLASSES).not.toContain("top-24");
   });
 });

--- a/client/src/pages/ChatPage.tsx
+++ b/client/src/pages/ChatPage.tsx
@@ -11,6 +11,18 @@ import {
 import ReactMarkdown from "react-markdown";
 import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom";
 import remarkGfm from "remark-gfm";
+import {
+  AudioLines,
+  Database,
+  FileOutput as FileOutputIcon,
+  FileText,
+  Image as ImageIcon,
+  Radio,
+  ScanText,
+  Sparkles,
+  Video,
+  Wrench,
+} from "lucide-react";
 import AdvancedParamsPanel, {
   type ChatAdvancedParams,
 } from "../components/AdvancedParamsPanel";
@@ -41,7 +53,7 @@ import {
   federationFallbackModelId,
   federationRouteId,
 } from "../components/FederationRouterCard";
-import PromptSidebar from "../components/PromptSidebar";
+import { PromptLibraryContent } from "../components/PromptSidebar";
 import RealtimeVoiceWorkspace from "../components/RealtimeVoiceWorkspace";
 import ResourceNav from "../components/ResourceNav";
 import SpeechWorkspace from "../components/SpeechWorkspace";
@@ -70,7 +82,6 @@ import {
   type FileOutputReuseConfirmation,
 } from "../data/fileOutputs";
 import { models } from "../data/models";
-import { recruitmentTheme } from "../theme/recruitmentTheme";
 import { compressImage } from "../utils/compressImage";
 import {
   downloadImage,
@@ -102,6 +113,15 @@ import {
   speechVoiceLabel,
 } from "../utils/speechAudio";
 import { StreamingMp3Session } from "../utils/streamingAudio";
+import {
+  ChatActionMenu,
+  ChatActiveContextBar,
+  ChatCompactHeader,
+  ChatOverlayDrawer,
+  type ChatActionDescriptor,
+  type ChatActiveContext,
+  type ChatShellMode,
+} from "../components/chat/ChatConversationChrome";
 
 const WorldGenerationPanel = lazy(() =>
   import("../components/world/WorldGenerationPanel").then((module) => ({
@@ -112,8 +132,9 @@ const WorldGenerationPanel = lazy(() =>
 const TTS_MODEL_SESSION_KEY = "modelmirror-chat-tts-model";
 const TTS_VOICE_SESSION_KEY = "modelmirror-chat-tts-voice";
 
-export const CHAT_HEADER_POSITION_CLASSES =
-  "md:sticky md:top-4 lg:top-24";
+export const CHAT_SHELL_HEADER_CLASSES = "sticky top-0 h-16";
+export const CHAT_MESSAGE_COLUMN_CLASSES = "mx-auto w-full max-w-[920px]";
+export const CHAT_COMPOSER_COLUMN_CLASSES = "mx-auto w-full max-w-[1000px]";
 
 interface UploadedImage {
   id: string;
@@ -967,6 +988,7 @@ const MessageBubble = memo(function MessageBubble({
   onOutputsChange,
   onOutputReuse,
   onRead,
+  assistantLabel,
 }: {
   message: ChatMessage;
   isSending: boolean;
@@ -980,6 +1002,7 @@ const MessageBubble = memo(function MessageBubble({
     confirmation: FileOutputReuseConfirmation,
   ) => void | Promise<void>;
   onRead: (message: ChatMessage) => void;
+  assistantLabel: string;
 }) {
   const isUser = message.role === "user";
   const { text: cleanedContent, images: extractedImages } = useMemo(
@@ -990,10 +1013,10 @@ const MessageBubble = memo(function MessageBubble({
   return (
     <div className={`flex ${isUser ? "justify-end" : "justify-start"}`}>
       <div
-        className={`max-w-[88%] px-4 py-3 text-sm leading-6 shadow-prism sm:max-w-[76%] ${
+        className={`text-sm leading-6 ${
           isUser
-            ? "rounded-lg rounded-br-sm bg-brand-300 text-ink-950 shadow-neon"
-            : "rounded-lg rounded-bl-sm border border-white/10 bg-surface-850/90 text-slate-100"
+            ? "max-w-[88%] rounded-2xl rounded-br-md bg-brand-300 px-4 py-3 text-ink-950 shadow-neon sm:max-w-[76%]"
+            : "w-full max-w-full py-3 text-slate-100"
         }`}
       >
         <p
@@ -1001,7 +1024,7 @@ const MessageBubble = memo(function MessageBubble({
             isUser ? "text-ink-800" : "text-hire-200"
           }`}
         >
-          {isUser ? "面试官说" : "候选人说"}
+          {isUser ? "你" : assistantLabel}
         </p>
         {message.images && message.images.length > 0 ? (
           <div className="mb-3 flex flex-wrap gap-2">
@@ -1316,6 +1339,9 @@ function ChatConversationPage() {
       busy: false,
       allConfirmed: false,
     });
+  const [visualAnalysisCapability, setVisualAnalysisCapability] = useState<
+    "loading" | "ready" | "disabled"
+  >("loading");
   const [visualAnalysisResetVersion, setVisualAnalysisResetVersion] = useState(0);
   const [visualAnalysisDiscardVersion, setVisualAnalysisDiscardVersion] = useState(0);
   const [chatFileScope, setChatFileScope] = useState(() => ({
@@ -1373,11 +1399,9 @@ function ChatConversationPage() {
   const [isDraggingImage, setIsDraggingImage] = useState(false);
   const [error, setError] = useState("");
   const [lightboxImage, setLightboxImage] = useState<LightboxItem | null>(null);
-  const [promptSidebarOpen, setPromptSidebarOpen] = useState(false);
+  const [topOverlay, setTopOverlay] = useState<"prompt" | "settings" | null>(null);
+  const [composerMenuOpen, setComposerMenuOpen] = useState(false);
   const [superPromptMode, setSuperPromptMode] = useState(false);
-  const [advancedParamsOpen, setAdvancedParamsOpen] = useState(
-    () => searchParams.get("advanced") === "1",
-  );
   const [advancedParams, setAdvancedParams] = useState<ChatAdvancedParams>(() =>
     defaultAdvancedParams(),
   );
@@ -1423,6 +1447,9 @@ function ChatConversationPage() {
   const scrollRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const messageInputRef = useRef<HTMLTextAreaElement>(null);
+  const actionMenuTriggerRef = useRef<HTMLButtonElement>(null);
+  const promptTriggerRef = useRef<HTMLButtonElement>(null);
+  const settingsTriggerRef = useRef<HTMLButtonElement>(null);
   const autoFollowStreamRef = useRef(true);
   const streamingAudioSessionsRef = useRef(
     new Map<string, StreamingMp3Session>(),
@@ -1828,12 +1855,6 @@ function ChatConversationPage() {
     },
     [decodedModelId],
   );
-
-  useEffect(() => {
-    if (window.matchMedia("(min-width: 1024px)").matches) {
-      setPromptSidebarOpen(true);
-    }
-  }, []);
 
   useEffect(() => {
     void loadKnowledgeBases();
@@ -3507,6 +3528,228 @@ function ChatConversationPage() {
     : isFederationRoute
     ? "智能路由功能正在紧锣密鼓开发中，当前将使用默认模型为您服务。"
     : agentInterview?.expertise ?? model.description;
+  const shellMode: ChatShellMode = agentInterview
+    ? "expert"
+    : isOmniAutoRoute || isFederationRoute
+      ? "auto"
+      : "direct";
+  const promptLabel = agentInterview ? "题库" : "提示库";
+  const selectedKnowledgeBase = knowledgeBases.find(
+    (item) => item.id === selectedKnowledgeBaseId,
+  );
+  const selectedSkill = installedSkills.find(
+    (item) => item.skill_id === selectedSkillId,
+  );
+  const activeContexts: ChatActiveContext[] = [
+    ...(selectedKnowledgeBase
+      ? [
+          {
+            id: "knowledge-base",
+            label: `资料库 · ${selectedKnowledgeBase.name}`,
+            detail: "回答会基于资料库并附引用",
+            onRemove: () => setSelectedKnowledgeBaseId(""),
+            disabled: isSending,
+          },
+        ]
+      : []),
+    ...(selectedSkill
+      ? [
+          {
+            id: "skill",
+            label: `Skill · ${selectedSkill.name}`,
+            onRemove: () => void handleSkillSelection(""),
+            disabled: isSending,
+          },
+        ]
+      : []),
+    ...(runtimeToolsEnabled
+      ? [
+          {
+            id: "mcp",
+            label: "MCP 工具",
+            detail: runtimeToolNames.trim() || "使用当前白名单",
+            onRemove: () => setRuntimeToolsEnabled(false),
+            disabled: isSending,
+          },
+        ]
+      : []),
+    ...(chatOutputEnabled
+      ? [
+          {
+            id: "file-output",
+            label: "文件输出 · 本轮",
+            onRemove: () => setChatOutputEnabled(false),
+            disabled: isSending,
+          },
+        ]
+      : []),
+  ];
+  const contentBusy =
+    isSending ||
+    isPreparingVideo ||
+    isUploadingImage ||
+    chatFileState.busy ||
+    visualAnalysisState.busy;
+  const imageBlockedReason =
+    chatOutputEnabled
+      ? "文件输出模式开启时不能同时添加图片。"
+      : audioComposerOpen || videoComposerOpen || reusedDirectMedia
+        ? "本轮已有音视频输入，请先移除后再添加图片。"
+        : chatFileState.count > 0 || visualAnalysisState.count > 0
+          ? "本轮已有文件输入，请先移除后再添加图片。"
+          : "";
+  const audioBlockedReason =
+    chatOutputEnabled || uploadedImages.length > 0 || videoComposerOpen || reusedDirectMedia || chatFileState.count > 0 || visualAnalysisState.count > 0
+      ? "本轮已有互斥的文件、图片、视频或输出模式。"
+      : "";
+  const videoBlockedReason = !chatVideoEnabled
+    ? "当前环境未启用视频输入。"
+    : chatOutputEnabled || uploadedImages.length > 0 || audioComposerOpen || reusedDirectMedia || chatFileState.count > 0 || visualAnalysisState.count > 0
+      ? "本轮已有互斥的文件、图片、音频或输出模式。"
+      : "";
+  const visualCapabilityBlockedReason =
+    visualAnalysisCapability === "loading"
+      ? "正在读取视觉/OCR 能力。"
+      : visualAnalysisCapability === "disabled"
+        ? "视觉/OCR 功能未启用或没有实时可调用目标。"
+        : "";
+  const visualBlockedReason = visualCapabilityBlockedReason || visualAnalysisBlockedReason || (chatOutputEnabled ? "文件输出模式开启时不能同时使用视觉/OCR。" : "");
+  const chatActions: ChatActionDescriptor[] = [
+    {
+      id: "file",
+      group: "content",
+      label: "文件",
+      description: "上传并预览，逐个确认后才用于本轮",
+      icon: FileText,
+      count: chatFileState.count || undefined,
+      status: contentBusy || Boolean(chatFileMediaBlockedReason) || chatOutputEnabled ? "blocked" : chatFileState.count > 0 ? "active" : "available",
+      blockedReason: chatFileMediaBlockedReason || (chatOutputEnabled ? "文件输出模式开启时不能同时添加输入文件。" : "当前正在处理内容，请稍候。"),
+      onSelect: () => window.dispatchEvent(new CustomEvent("modelmirror:open-chat-file")),
+    },
+    {
+      id: "visual-analysis",
+      group: "content",
+      label: "视觉 / OCR",
+      description: "一次性识别扫描 PDF 或图片，预览确认后使用",
+      icon: ScanText,
+      count: visualAnalysisState.count || undefined,
+      status: contentBusy || Boolean(visualBlockedReason) ? "blocked" : visualAnalysisState.count > 0 ? "active" : "available",
+      blockedReason: visualBlockedReason || "当前正在处理内容，请稍候。",
+      onSelect: () => window.dispatchEvent(new CustomEvent("modelmirror:open-chat-visual-analysis")),
+    },
+    {
+      id: "image",
+      group: "content",
+      label: "图片",
+      description: supportsImageInput ? "添加图片到本轮消息" : "当前模型会按既有辅助能力校验处理",
+      icon: ImageIcon,
+      count: uploadedImages.length || undefined,
+      status: contentBusy || Boolean(imageBlockedReason) ? "blocked" : uploadedImages.length > 0 ? "active" : "available",
+      blockedReason: imageBlockedReason || "当前正在处理内容，请稍候。",
+      onSelect: () => fileInputRef.current?.click(),
+    },
+    {
+      id: "audio",
+      group: "content",
+      label: "音频",
+      description: "上传音频、转写或按模型能力直接发送",
+      icon: AudioLines,
+      status: contentBusy || Boolean(audioBlockedReason) ? "blocked" : audioComposerOpen ? "active" : "available",
+      blockedReason: audioBlockedReason || "当前正在处理内容，请稍候。",
+      onSelect: () => openAudioComposer("upload"),
+    },
+    {
+      id: "video",
+      group: "content",
+      label: "视频",
+      description: "按当前视频能力用于本轮",
+      icon: Video,
+      status: contentBusy || Boolean(videoBlockedReason) ? "blocked" : videoComposerOpen ? "active" : "available",
+      blockedReason: videoBlockedReason || "当前正在处理内容，请稍候。",
+      onSelect: openVideoComposer,
+    },
+    {
+      id: "knowledge-base",
+      group: "context",
+      label: "知识库",
+      description: isOmniAutoRoute ? "智能调度暂不组合知识库" : "选择资料库，回答将附带引用",
+      icon: Database,
+      control: (
+        <select
+          aria-label="选择知识库"
+          className="min-h-11 w-full rounded-xl border border-white/10 bg-ink-950/85 px-3 text-sm text-white outline-none focus:border-brand-300/45"
+          disabled={isSending || isLoadingKnowledgeBases || isOmniAutoRoute}
+          onChange={(event) => {
+            setSelectedKnowledgeBaseId(event.target.value);
+            if (event.target.value) setNativeAudioEnabled(false);
+          }}
+          value={selectedKnowledgeBaseId}
+        >
+          <option value="">不使用知识库</option>
+          {knowledgeBases.map((kb) => (
+            <option key={kb.id} value={kb.id}>{kb.name}（{kb.document_count} 份文档）</option>
+          ))}
+        </select>
+      ),
+    },
+    {
+      id: "skill",
+      group: "context",
+      label: "Skill",
+      description: "为本轮加入一个已安装 Skill",
+      icon: Sparkles,
+      control: (
+        <select
+          aria-label="选择 Skill"
+          className="min-h-11 w-full rounded-xl border border-white/10 bg-ink-950/85 px-3 text-sm text-white outline-none focus:border-brand-300/45"
+          disabled={isSending || isLoadingSkills}
+          onChange={(event) => void handleSkillSelection(event.target.value)}
+          value={selectedSkillId}
+        >
+          <option value="">不使用 Skill</option>
+          {installedSkills.map((skill) => (
+            <option key={skill.skill_id} value={skill.skill_id}>{skill.name}</option>
+          ))}
+        </select>
+      ),
+    },
+    {
+      id: "mcp",
+      group: "tools",
+      label: "MCP 工具",
+      description: "按白名单让模型调用已注册工具",
+      icon: Wrench,
+      status: isOmniAutoRoute ? "blocked" : runtimeToolsEnabled ? "active" : "available",
+      blockedReason: "智能调度暂不与本地 MCP 工具循环组合使用。",
+      onSelect: () => setRuntimeToolsEnabled((current) => !current),
+    },
+    {
+      id: "file-output",
+      group: "tools",
+      label: "文件输出",
+      description: "仅本轮允许精确模型调用受限文件生成工具",
+      icon: FileOutputIcon,
+      status: !chatOutputCapabilities || Boolean(chatOutputBlockedReason) ? "blocked" : chatOutputEnabled ? "active" : "available",
+      blockedReason: chatOutputBlockedReason || "文件输出能力当前未启用。",
+      onSelect: () => {
+        setChatOutputEnabled((current) => !current);
+        setError("");
+      },
+    },
+    {
+      id: "realtime-voice",
+      group: "voice",
+      label: "实时语音",
+      description: "进入连续语音通话，与单轮麦克风转写分开",
+      icon: Radio,
+      status: realtimeVoiceProfile?.interaction_status === "ready" ? "available" : "blocked",
+      blockedReason: realtimeVoiceProfile?.status_reason || "当前没有可调用的实时语音模型。",
+      onSelect: () => {
+        if (!realtimeVoiceProfile) return;
+        navigate(`/chat/${encodeURIComponent(realtimeVoiceProfile.model_id)}?operation=realtime_voice`);
+      },
+    },
+  ];
 
   if (model?.worldModel) {
     return (
@@ -3550,281 +3793,37 @@ function ChatConversationPage() {
   }
 
   return (
-    <main className="museum-grid min-h-screen pb-24 pt-5 text-slate-100 lg:pt-24">
-      <ResourceNav activeResource={agentInterview ? "agents" : "models"} />
-      <div className="mx-auto flex min-h-screen w-full max-w-[1540px] flex-col px-4 py-5 sm:px-6 lg:px-8">
-        <header
-          className={`${CHAT_HEADER_POSITION_CLASSES} z-30 border-y border-hire-300/20 bg-ink-950/72 px-0 py-4 backdrop-blur-2xl md:flex md:items-center md:justify-between md:gap-6`}
-        >
-          <div>
-            <BrandLogo className="mb-4 lg:hidden" />
-            <Link
-              className="inline-flex items-center rounded-full border border-white/10 bg-white/[0.05] px-3 py-1.5 text-sm font-medium text-slate-300 transition hover:border-brand-300/30 hover:bg-brand-300/10 hover:text-brand-100"
-              to={agentInterview ? "/agents" : "/models"}
-            >
-              {agentInterview ? "返回 AI 人才市场" : "返回招聘会现场"}
-            </Link>
-            <div className="mt-3 flex flex-wrap items-center gap-3">
-              <span className="inline-flex items-center gap-2 rounded-full border border-emerald-300/30 bg-emerald-300/10 px-3 py-1.5 text-xs font-semibold text-emerald-100">
-                <span className="h-2 w-2 animate-pulse rounded-full bg-emerald-300" />
-                面试中
-              </span>
-              <span className="rounded-full border border-hire-300/30 bg-hire-300/10 px-3 py-1.5 text-xs font-semibold text-hire-100">
-                {agentInterview ? "专家已入场" : "候选人已入场"}
-              </span>
-              {agentInterview ? (
-                <>
-                  <span className="rounded-full border border-brand-300/30 bg-brand-300/10 px-3 py-1.5 text-xs font-semibold text-brand-100">
-                    {agentInterview.department}
-                  </span>
-                  <button
-                    className="rounded-full border border-white/15 bg-white/[0.055] px-3 py-1.5 text-xs font-semibold text-slate-200 transition hover:border-brand-300/45 hover:bg-brand-300/10 hover:text-brand-100 disabled:cursor-not-allowed disabled:opacity-50"
-                    disabled={isSending}
-                    onClick={exitAgentInterview}
-                    title={
-                      isSending
-                        ? "请等待当前回答完成后再退出专家模式"
-                        : "清空当前专家对话，继续直接与所选模型聊天"
-                    }
-                    type="button"
-                  >
-                    退出专家模式
-                  </button>
-                </>
-              ) : null}
-              {isOmniAutoRoute ? (
-                <span className="rounded-full border border-brand-300/30 bg-brand-300/10 px-3 py-1.5 text-xs font-semibold text-brand-100">
-                  智能调度 · {decodedModelId}
-                </span>
-              ) : isFederationRoute ? (
-                <span className="rounded-full border border-hire-300/30 bg-hire-300/10 px-3 py-1.5 text-xs font-semibold text-hire-100">
-                  默认模型代班：{model.name}
-                </span>
-              ) : null}
-            </div>
-            <h1 className="mt-3 text-2xl font-semibold tracking-normal text-white sm:text-4xl">
-              面试进行中：与 {displayCandidateName} 交谈
-            </h1>
-            <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-300">
-              {displayCandidateDescription}
-            </p>
-            {isFederationRoute && !isOmniAutoRoute ? (
-              <div className="mt-4 rounded-lg border border-hire-300/25 bg-hire-300/10 px-4 py-3 text-sm leading-6 text-hire-50">
-                智能路由功能正在紧锣密鼓开发中，当前将使用默认模型为您服务。
-              </div>
-            ) : null}
-          </div>
+    <main className="museum-grid flex h-[100dvh] min-h-0 flex-col overflow-hidden text-slate-100">
+      <ChatCompactHeader
+        backTo={agentInterview ? "/agents" : "/models"}
+        disabled={isSending}
+        expertDepartment={agentInterview?.department}
+        mode={shellMode}
+        modelLabel={displayCandidateName}
+        onExitExpert={agentInterview ? exitAgentInterview : undefined}
+        onOpenPrompt={() => {
+          setComposerMenuOpen(false);
+          setTopOverlay("prompt");
+        }}
+        onOpenSettings={() => {
+          setComposerMenuOpen(false);
+          setTopOverlay("settings");
+        }}
+        promptLabel={promptLabel}
+        promptTriggerRef={promptTriggerRef}
+        providerLabel={providerName}
+        settingsTriggerRef={settingsTriggerRef}
+      />
+      <div className="flex min-h-0 w-full flex-1 flex-col">
 
-          {(agentDefaultModelNotice || modelSwitchNotice) ? (
-            <div className="mt-4 space-y-3 md:mt-0">
-              {agentDefaultModelNotice ? (
-                <div className="rounded-lg border border-brand-300/25 bg-brand-300/10 px-4 py-3 text-sm leading-6 text-brand-50">
-                  {agentDefaultModelNotice}
-                </div>
-              ) : null}
-              {modelSwitchNotice ? (
-                <div className="flex items-start justify-between gap-4 rounded-lg border border-amber-300/25 bg-amber-300/10 px-4 py-3 text-sm leading-6 text-amber-50">
-                  <span>{modelSwitchNotice}</span>
-                  <button
-                    className="shrink-0 rounded-full border border-amber-200/30 px-2 py-0.5 text-xs font-semibold transition hover:bg-amber-200/10"
-                    onClick={() => setModelSwitchNotice("")}
-                    type="button"
-                  >
-                    知道了
-                  </button>
-                </div>
-              ) : null}
-            </div>
-          ) : null}
+        <div className="flex min-h-0 min-w-0 flex-1 justify-center">
 
-          <div className="mt-4 flex flex-wrap items-center gap-2 text-xs text-slate-300 md:mt-0 md:justify-end">
-            {isOmniAutoRoute ? (
-              <span className="rounded-full border border-hire-300/25 bg-hire-300/10 px-3 py-1.5 font-semibold text-hire-50">
-                调用 {decodedModelId}
-              </span>
-            ) : (
-              <label className="flex items-center gap-2 rounded-full border border-hire-300/25 bg-hire-300/10 px-3 py-1.5 text-hire-50">
-                <span className="font-semibold">当前使用模型</span>
-                <select
-                  className="max-w-[220px] bg-transparent text-xs font-semibold text-white outline-none"
-                  onChange={(event) => handleModelChange(event.target.value)}
-                  value={model.id}
-                >
-                  {models.map((item) => (
-                    <option
-                      className="bg-slate-950 text-white"
-                      key={item.id}
-                      value={item.id}
-                    >
-                      {item.name}
-                    </option>
-                  ))}
-                </select>
-              </label>
-            )}
-            <span className="rounded-full border border-white/10 bg-white/[0.06] px-3 py-1.5">
-              {providerName}
-            </span>
-            <span className="rounded-full border border-white/10 bg-white/[0.06] px-3 py-1.5">
-              上下文 {model.context_length.toLocaleString("zh-CN")}
-            </span>
-            <span
-              className={`rounded-full border px-3 py-1.5 ${
-                supportsImageInput
-                  ? "border-brand-300/30 bg-brand-300/10 text-brand-100"
-                  : "border-white/10 bg-white/[0.06] text-slate-300"
-              }`}
-            >
-              {supportsImageInput
-                ? "支持图片输入"
-                : imageAnalysisModelIds === null && !omniRouteSupportsImage
-                  ? "正在核实图片能力"
-                  : "仅文本输入"}
-            </span>
-          </div>
-        </header>
-
-        <div className="grid min-w-0 flex-1 gap-5 py-5 lg:grid-cols-[280px_minmax(0,1fr)] xl:grid-cols-[300px_minmax(0,1fr)]">
-          <aside className="surface-panel rounded-lg p-5 lg:sticky lg:top-36 lg:h-[calc(100vh-11rem)]">
-            <p className="text-sm font-semibold text-white">候选人档案</p>
-            <p className="mt-2 text-sm leading-6 text-slate-300">
-              {agentInterview
-                ? "这场面试会带上智能体的完整岗位人设。刷新页面后会重新开始。"
-                : "当前对话只在本页会话中保留。刷新页面后会重新开始。"}
-            </p>
-            {isOmniAutoRoute ? (
-              <div className="mt-5 space-y-3 rounded-lg border border-brand-300/20 bg-brand-300/[0.065] p-3">
-                <div>
-                  <p className="text-xs font-semibold text-brand-100">路由控制</p>
-                  <p className="mt-1 text-xs leading-5 text-slate-400">
-                    设置只作用于本次智能调度会话。
-                  </p>
-                </div>
-                <label className="block text-xs font-semibold text-slate-300">
-                  调度模式
-                  <select
-                    className="mt-1 w-full rounded-lg border border-white/10 bg-ink-950/85 px-3 py-2 text-xs text-white outline-none transition focus:border-brand-300/50 focus:ring-4 focus:ring-brand-300/10"
-                    disabled={isSending}
-                    onChange={(event) =>
-                      setRoutingMode(
-                        event.target.value as
-                          | "fast"
-                          | "balanced"
-                          | "quality"
-                          | "cheap"
-                          | "reliable"
-                          | "offline",
-                      )
-                    }
-                    value={routingMode}
-                  >
-                    <option value="balanced">均衡</option>
-                    <option value="fast">速度优先</option>
-                    <option value="quality">质量优先</option>
-                    <option value="cheap">成本优先</option>
-                    <option value="reliable">稳定优先</option>
-                    <option value="offline">离线优先</option>
-                  </select>
-                </label>
-                <label className="block text-xs font-semibold text-slate-300">
-                  单次预算上限（USD，可选）
-                  <input
-                    className="mt-1 w-full rounded-lg border border-white/10 bg-ink-950/85 px-3 py-2 text-xs text-white outline-none transition placeholder:text-slate-400 focus:border-brand-300/50 focus:ring-4 focus:ring-brand-300/10"
-                    disabled={isSending}
-                    inputMode="decimal"
-                    max="1000"
-                    min="0.000001"
-                    onChange={(event) => setRoutingBudget(event.target.value)}
-                    placeholder="例如 0.05"
-                    step="0.000001"
-                    type="number"
-                    value={routingBudget}
-                  />
-                </label>
-                <label className="block text-xs font-semibold text-slate-300">
-                  超预算处理
-                  <select
-                    className="mt-1 w-full rounded-lg border border-white/10 bg-ink-950/85 px-3 py-2 text-xs text-white outline-none transition focus:border-brand-300/50 focus:ring-4 focus:ring-brand-300/10"
-                    disabled={isSending || !routingBudget.trim()}
-                    onChange={(event) =>
-                      setRoutingBudgetFallback(
-                        event.target.value as "strict" | "cheapest",
-                      )
-                    }
-                    value={routingBudgetFallback}
-                  >
-                    <option value="cheapest">改用最低成本候选</option>
-                    <option value="strict">严格拒绝并返回 402</option>
-                  </select>
-                </label>
-                <label className="block text-xs font-semibold text-slate-300">
-                  上下文优化
-                  <select
-                    className="mt-1 w-full rounded-lg border border-white/10 bg-ink-950/85 px-3 py-2 text-xs text-white outline-none transition focus:border-brand-300/50 focus:ring-4 focus:ring-brand-300/10"
-                    disabled={isSending}
-                    onChange={(event) =>
-                      setCompressionMode(
-                        event.target.value as
-                          | "auto"
-                          | "off"
-                          | "standard"
-                          | "strong",
-                      )
-                    }
-                    value={compressionMode}
-                  >
-                    <option value="auto">自动推荐</option>
-                    <option value="off">关闭</option>
-                    <option value="standard">标准</option>
-                    <option value="strong">强力</option>
-                  </select>
-                </label>
-              </div>
-            ) : null}
-            {isOmniAutoRoute || model.pricing_status === "dynamic" ? (
-              <div className="mt-4 rounded-lg border border-white/10 bg-white/[0.045] p-3 text-sm">
-                <p className="text-xs text-slate-400">结算方式</p>
-                <p className="mt-1 font-semibold text-white">
-                  {isOmniAutoRoute
-                    ? "按实际路由模型计费"
-                    : "按实际路由或组合调用计费"}
-                </p>
-                <p className="mt-1 text-xs leading-5 text-slate-500">
-                  最终费用以网关结算和回答下方的调用回执为准。
-                </p>
-              </div>
-            ) : (
-              <div className="mt-5 grid grid-cols-2 gap-3 text-sm lg:grid-cols-1">
-                <div className="rounded-lg border border-white/10 bg-white/[0.045] p-3">
-                  <p className="text-xs text-slate-400">输入薪资</p>
-                  <p className="mt-1 font-semibold text-white">
-                    ¥{model.price_cny.input.toFixed(2)}
-                  </p>
-                </div>
-                <div className="rounded-lg border border-white/10 bg-white/[0.045] p-3">
-                  <p className="text-xs text-slate-400">输出薪资</p>
-                  <p className="mt-1 font-semibold text-white">
-                    ¥{model.price_cny.output.toFixed(2)}
-                  </p>
-                </div>
-              </div>
-            )}
-            <div className="mt-4 rounded-lg border border-white/10 bg-[linear-gradient(135deg,rgba(36,217,255,0.10),rgba(124,58,237,0.08))] p-3">
-              <p className="text-xs text-slate-400">输入模态</p>
-              <p className="mt-2 text-sm font-semibold text-white">
-                {model.input_modalities
-                  .map((modality) => modalityLabels[modality] ?? modality)
-                  .join(" / ")}
-              </p>
-            </div>
-          </aside>
-
-          <div className="flex min-w-0 gap-5 overflow-hidden">
+          <div className="flex min-h-0 w-full max-w-[1000px] min-w-0 overflow-hidden px-2 sm:px-4">
             <section
-              className={`relative flex min-h-[560px] min-w-0 basis-0 flex-1 flex-col overflow-hidden rounded-lg border bg-surface-900/80 shadow-prism backdrop-blur-xl transition lg:h-[calc(100vh-11rem)] lg:min-h-[560px] ${
+              className={`relative flex min-h-0 min-w-0 basis-0 flex-1 flex-col overflow-hidden border-x bg-ink-950/38 transition ${
                 isDraggingImage
                   ? "border-brand-300/70 ring-4 ring-brand-300/10"
-                  : "border-white/10"
+                  : "border-white/[0.07]"
               }`}
               ref={chatSectionRef}
               onDragLeave={() => setIsDraggingImage(false)}
@@ -3841,7 +3840,7 @@ function ChatConversationPage() {
               ) : null}
 
               <div
-                className="flex-1 overflow-y-auto px-4 py-5 sm:px-6"
+                className="flex-1 overflow-y-auto px-3 py-5 sm:px-8"
                 onScroll={(event) => {
                   const viewport = event.currentTarget;
                   autoFollowStreamRef.current =
@@ -3853,7 +3852,7 @@ function ChatConversationPage() {
                 ref={messageViewportRef}
               >
                 {recoveredOutputs.length > 0 ? (
-                  <div className="mb-5">
+                  <div className={`${CHAT_MESSAGE_COLUMN_CLASSES} mb-5`}>
                     <FileOutputTray
                       modelId={outputModelId}
                       onChange={setRecoveredOutputs}
@@ -3866,7 +3865,7 @@ function ChatConversationPage() {
                   </div>
                 ) : null}
                 {messages.length === 0 ? (
-                  <div className="flex h-full min-h-[260px] flex-col items-center justify-start pt-20 text-center sm:justify-center sm:pt-0">
+                  <div className={`${CHAT_MESSAGE_COLUMN_CLASSES} flex h-full min-h-[260px] flex-col items-center justify-start pt-20 text-center sm:justify-center sm:pt-0`}>
                     <img
                       alt="模镜"
                       className="h-16 w-16 rounded-lg object-cover shadow-neon"
@@ -3874,12 +3873,12 @@ function ChatConversationPage() {
                     />
                     <h2 className="mt-5 text-xl font-semibold text-white">
                       {isOmniAutoRoute
-                        ? "智能调度员已就绪"
+                        ? "智能调度已就绪"
                         : isFederationRoute
                         ? "智能路由调度员正在候场..."
                         : agentInterview
-                        ? `正在等待 ${agentInterview.agentName} 入场...`
-                        : recruitmentTheme.interviewWaiting}
+                        ? `${agentInterview.agentName} 已就绪`
+                        : "开始一段新对话"}
                     </h2>
                     <p className="mt-2 max-w-md text-sm leading-6 text-slate-400">
                       {isOmniAutoRoute
@@ -3887,15 +3886,16 @@ function ChatConversationPage() {
                         : isFederationRoute
                         ? "先由默认模型代班回答。后续路由上线后，会自动按任务挑选更合适的候选人。"
                         : agentInterview
-                        ? "向这位 AI 专家描述你的任务，系统会自动带上他的完整简历和工作方式。"
-                        : "输入问题，上传图片，或从右侧面试题库抽一道题开场。"}
+                        ? "描述你的任务；专家身份与工作方式会在本次对话中保持。"
+                        : "直接输入问题，或通过加号添加文件、上下文与工具。"}
                     </p>
                   </div>
                 ) : (
-                  <div className="space-y-5">
+                  <div className={`${CHAT_MESSAGE_COLUMN_CLASSES} space-y-6`}>
                     {messages.map((message) => (
                       <MessageBubble
                         canRead={Boolean(ttsProfile)}
+                        assistantLabel={displayCandidateName}
                         currentScopeId={chatFileScopeId}
                         isSending={isSending}
                         key={message.id}
@@ -3926,6 +3926,30 @@ function ChatConversationPage() {
                 )}
               </div>
 
+              {agentDefaultModelNotice || modelSwitchNotice ? (
+                <div className="border-t border-white/10 px-3 py-2 sm:px-6">
+                  <div className="mx-auto flex w-full max-w-[920px] flex-col gap-2">
+                    {agentDefaultModelNotice ? (
+                      <div className="rounded-xl border border-brand-300/20 bg-brand-300/[0.08] px-3 py-2 text-xs leading-5 text-brand-50">
+                        {agentDefaultModelNotice}
+                      </div>
+                    ) : null}
+                    {modelSwitchNotice ? (
+                      <div className="flex items-start justify-between gap-3 rounded-xl border border-amber-300/20 bg-amber-300/[0.08] px-3 py-2 text-xs leading-5 text-amber-50">
+                        <span>{modelSwitchNotice}</span>
+                        <button
+                          className="min-h-8 shrink-0 rounded-full px-2 font-semibold transition hover:bg-amber-200/10"
+                          onClick={() => setModelSwitchNotice("")}
+                          type="button"
+                        >
+                          知道了
+                        </button>
+                      </div>
+                    ) : null}
+                  </div>
+                </div>
+              ) : null}
+
               {error ? (
                 <div className="flex flex-col gap-3 border-t border-rose-300/20 bg-rose-400/10 px-4 py-3 text-sm text-rose-100 sm:flex-row sm:items-center sm:justify-between sm:px-6">
                   <span>{error}</span>
@@ -3939,389 +3963,7 @@ function ChatConversationPage() {
                 </div>
               ) : null}
 
-              <AdvancedParamsPanel
-                isOpen={advancedParamsOpen}
-                maxTokenLimit={maxTokenLimit}
-                onChange={handleAdvancedParamsChange}
-                onReset={resetAdvancedParams}
-                onToggle={() => setAdvancedParamsOpen((current) => !current)}
-                params={advancedParams}
-              />
-
-              <div className="border-t border-white/10 bg-ink-950/40 p-4 sm:p-5">
-                <div className="mb-3 flex flex-col gap-2 rounded-lg border border-white/10 bg-white/[0.045] px-3 py-3 sm:flex-row sm:items-center sm:justify-between">
-                  <label className="flex flex-1 flex-col gap-2 text-xs font-semibold text-slate-300 sm:flex-row sm:items-center">
-                    <span className="shrink-0 text-hire-100">知识库</span>
-                    <select
-                      className="min-w-0 flex-1 rounded-full border border-white/10 bg-ink-950/80 px-3 py-2 text-xs font-semibold text-white outline-none transition focus:border-hire-300/50 focus:ring-4 focus:ring-hire-300/10"
-                      disabled={
-                        isSending ||
-                        isLoadingKnowledgeBases ||
-                        isOmniAutoRoute
-                      }
-                      onChange={(event) => {
-                        setSelectedKnowledgeBaseId(event.target.value);
-                        if (event.target.value) setNativeAudioEnabled(false);
-                      }}
-                      value={selectedKnowledgeBaseId}
-                    >
-                      <option value="">
-                        {isOmniAutoRoute
-                          ? "智能调度暂不组合知识库"
-                          : "不使用知识库，直接面试"}
-                      </option>
-                      {knowledgeBases.map((kb) => (
-                        <option className="bg-slate-950 text-white" key={kb.id} value={kb.id}>
-                          {kb.name}（{kb.document_count} 份文档）
-                        </option>
-                      ))}
-                    </select>
-                  </label>
-                  <label className="flex flex-1 flex-col gap-2 text-xs font-semibold text-slate-300 sm:flex-row sm:items-center">
-                    <span className="shrink-0 text-brand-100">Skill</span>
-                    <select
-                      className="min-w-0 flex-1 rounded-full border border-white/10 bg-ink-950/80 px-3 py-2 text-xs font-semibold text-white outline-none transition focus:border-brand-300/50 focus:ring-4 focus:ring-brand-300/10"
-                      disabled={isSending || isLoadingSkills}
-                      onChange={(event) => void handleSkillSelection(event.target.value)}
-                      value={selectedSkillId}
-                    >
-                      <option value="">不使用 Skill，普通面试</option>
-                      {installedSkills.map((skill) => (
-                        <option
-                          className="bg-slate-950 text-white"
-                          key={skill.skill_id}
-                          value={skill.skill_id}
-                        >
-                          {skill.name}
-                        </option>
-                      ))}
-                    </select>
-                  </label>
-                  <div className="flex items-center justify-between gap-3 sm:justify-end">
-                    <span className="text-xs text-slate-500">
-                      {selectedKnowledgeBaseId
-                        ? "回答会基于资料库并附引用"
-                        : "可在 /rag 上传资料后选择"}
-                    </span>
-                    <button
-                      className="rounded-full border border-white/10 px-3 py-1.5 text-xs font-semibold text-slate-300 transition hover:border-hire-300/30 hover:bg-hire-300/10 hover:text-hire-100"
-                      disabled={isLoadingKnowledgeBases}
-                      onClick={() => void loadKnowledgeBases()}
-                      type="button"
-                    >
-                      {isLoadingKnowledgeBases ? "刷新中" : "刷新"}
-                    </button>
-                  </div>
-                </div>
-                <div className="mb-3 rounded-lg border border-white/10 bg-white/[0.045] px-3 py-3">
-                  <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                    <div>
-                      <p className="text-xs font-semibold text-cyan-100">
-                        Runtime 工具模式 Beta
-                      </p>
-                      <p className="mt-1 text-xs leading-5 text-slate-400">
-                        {isOmniAutoRoute
-                          ? "智能调度暂不与本地 MCP 工具循环组合使用。"
-                          : "开启后，聊天会按 JSON 决策调用已注册 MCP 工具；默认关闭。"}
-                      </p>
-                    </div>
-                    <label className="flex items-center gap-2 text-xs font-semibold text-slate-200">
-                      <input
-                        checked={runtimeToolsEnabled}
-                        className="h-4 w-4 rounded border-white/20 bg-ink-950 text-cyan-300 focus:ring-cyan-300/30"
-                        disabled={isSending || isOmniAutoRoute}
-                        onChange={(event) => {
-                          setRuntimeToolsEnabled(event.target.checked);
-                          if (event.target.checked) {
-                            setNativeAudioEnabled(false);
-                          }
-                        }}
-                        type="checkbox"
-                      />
-                      启用 MCP 工具
-                    </label>
-                  </div>
-                  {runtimeToolsEnabled ? (
-                    <div className="mt-3 grid gap-3 lg:grid-cols-[1fr_140px]">
-                      <label className="flex flex-col gap-1 text-xs font-semibold text-slate-300">
-                        工具白名单
-                        <input
-                          className="rounded-lg border border-white/10 bg-ink-950/80 px-3 py-2 text-xs text-white outline-none transition placeholder:text-slate-500 focus:border-cyan-300/50 focus:ring-4 focus:ring-cyan-300/10"
-                          disabled={isSending}
-                          onChange={(event) => setRuntimeToolNames(event.target.value)}
-                          placeholder="fetch, search；留空代表全部已注册工具"
-                          value={runtimeToolNames}
-                        />
-                      </label>
-                      <label className="flex flex-col gap-1 text-xs font-semibold text-slate-300">
-                        最大循环
-                        <input
-                          className="rounded-lg border border-white/10 bg-ink-950/80 px-3 py-2 text-xs text-white outline-none transition focus:border-cyan-300/50 focus:ring-4 focus:ring-cyan-300/10"
-                          disabled={isSending}
-                          max={20}
-                          min={1}
-                          onChange={(event) =>
-                            setRuntimeMaxToolIterations(event.target.value)
-                          }
-                          type="number"
-                          value={runtimeMaxToolIterations}
-                        />
-                      </label>
-                      <label className="flex flex-col gap-1 text-xs font-semibold text-slate-300 lg:col-span-2">
-                        补充约束
-                        <textarea
-                          className="min-h-20 resize-none rounded-lg border border-white/10 bg-ink-950/80 px-3 py-2 text-xs leading-5 text-white outline-none transition placeholder:text-slate-500 focus:border-cyan-300/50 focus:ring-4 focus:ring-cyan-300/10"
-                          disabled={isSending}
-                          onChange={(event) =>
-                            setRuntimePromptSuffix(event.target.value)
-                          }
-                          placeholder="例如：工具结果不足时直接说明，不要猜测。"
-                          value={runtimePromptSuffix}
-                        />
-                      </label>
-                    </div>
-                  ) : null}
-                </div>
-                {runtimeToolsEnabled &&
-                (runtimeMeta || runtimeObservation || runtimeObservationError) ? (
-                  <div className="mb-3 rounded-lg border border-cyan-300/15 bg-cyan-300/[0.055] px-3 py-3">
-                    <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                      <div>
-                        <p className="text-xs font-semibold text-cyan-100">
-                          运行观测 Beta
-                        </p>
-                        <p className="mt-1 text-xs leading-5 text-slate-400">
-                          run {shortRuntimeId(runtimeMeta?.runId)} · task{" "}
-                          {shortRuntimeId(runtimeMeta?.taskId)}
-                        </p>
-                      </div>
-                      <button
-                        className="rounded-full border border-cyan-300/20 px-3 py-1.5 text-xs font-semibold text-cyan-100 transition hover:border-cyan-300/45 hover:bg-cyan-300/10 disabled:cursor-not-allowed disabled:opacity-60"
-                        disabled={runtimeObservationLoading || !runtimeMeta}
-                        onClick={() => void loadRuntimeObservation()}
-                        type="button"
-                      >
-                        {runtimeObservationLoading ? "加载中" : "刷新观测"}
-                      </button>
-                    </div>
-                    {runtimeObservationError ? (
-                      <p className="mt-3 rounded-lg border border-rose-300/20 bg-rose-400/10 px-3 py-2 text-xs text-rose-100">
-                        {runtimeObservationError}
-                      </p>
-                    ) : null}
-                    {runtimeObservation ? (
-                      <div className="mt-3 grid gap-3 xl:grid-cols-3">
-                        <div className="rounded-lg border border-white/10 bg-ink-950/55 p-3">
-                          <p className="text-[11px] font-semibold text-slate-400">
-                            Run 状态
-                          </p>
-                          <p className="mt-1 text-sm font-semibold text-white">
-                            {runtimeObservation.run?.status ?? "unknown"}
-                          </p>
-                          {runtimeObservation.run?.error ? (
-                            <p className="mt-1 truncate text-xs leading-5 text-rose-100">
-                              {runtimeObservation.run.error}
-                            </p>
-                          ) : (
-                            <p className="mt-1 text-xs leading-5 text-slate-400">
-                              事件 {runtimeObservation.eventCount} 条，审计{" "}
-                              {runtimeObservation.auditCount} 条。
-                            </p>
-                          )}
-                        </div>
-                        <div className="rounded-lg border border-white/10 bg-ink-950/55 p-3">
-                          <p className="text-[11px] font-semibold text-slate-400">
-                            Checkpoint
-                          </p>
-                          <div className="mt-2 space-y-2">
-                            {runtimeObservation.checkpoints.slice(0, 4).map((item) => (
-                              <div key={item.checkpoint_id}>
-                                <p className="truncate text-xs font-semibold text-slate-100">
-                                  {item.event_type}
-                                </p>
-                                <p className="truncate text-[11px] text-slate-400">
-                                  {formatRuntimeTimestamp(item.created_at)}
-                                  {item.summary ? ` · ${item.summary}` : ""}
-                                </p>
-                              </div>
-                            ))}
-                            {runtimeObservation.checkpoints.length === 0 ? (
-                              <p className="text-xs text-slate-500">暂无 checkpoint。</p>
-                            ) : null}
-                          </div>
-                        </div>
-                        <div className="rounded-lg border border-white/10 bg-ink-950/55 p-3">
-                          <p className="text-[11px] font-semibold text-slate-400">
-                            Tool 事件 / 审计
-                          </p>
-                          <div className="mt-2 space-y-2">
-                            {runtimeObservation.auditRecords.slice(0, 3).map((item) => (
-                              <div key={item.record_id}>
-                                <p className="truncate text-xs font-semibold text-slate-100">
-                                  {item.tool_name} · {item.status}
-                                </p>
-                                <p className="truncate text-[11px] text-slate-400">
-                                  {item.duration_ms != null
-                                    ? `${item.duration_ms.toFixed(0)}ms`
-                                    : "无耗时"}
-                                  {item.output_length != null
-                                    ? ` · ${item.output_length} chars`
-                                    : ""}
-                                  {item.error ? ` · ${item.error}` : ""}
-                                </p>
-                              </div>
-                            ))}
-                            {runtimeObservation.auditRecords.length === 0 ? (
-                              <p className="text-xs text-slate-500">
-                                暂无工具审计记录。
-                              </p>
-                            ) : null}
-                          </div>
-                        </div>
-                      </div>
-                    ) : null}
-                  </div>
-                ) : null}
-                {ttsProfile || nativeAudioAvailable ? (
-                  <div className="mb-3 flex flex-wrap items-center gap-x-4 gap-y-2 border-y border-white/10 px-1 py-2.5 text-xs">
-                    <span className="font-semibold text-cyan-100">语音回答</span>
-                    {nativeAudioAvailable ? (
-                      <label className="inline-flex items-center gap-2 font-semibold text-slate-200">
-                        <input
-                          checked={nativeAudioEnabled}
-                          className="h-4 w-4 rounded border-white/20 bg-ink-950 text-cyan-300 focus:ring-cyan-300/30"
-                          disabled={
-                            isSending ||
-                            Boolean(selectedKnowledgeBaseId) ||
-                            runtimeToolsEnabled
-                          }
-                          onChange={(event) =>
-                            setNativeAudioEnabled(event.target.checked)
-                          }
-                          type="checkbox"
-                        />
-                        原生语音回答
-                      </label>
-                    ) : null}
-                    {nativeAudioEnabled && nativeAudioProfile ? (
-                      <label className="inline-flex items-center gap-2 text-slate-300">
-                        声线
-                        <select
-                          className="rounded-full border border-white/10 bg-ink-950/80 px-2.5 py-1.5 text-xs font-semibold text-white outline-none focus:border-cyan-300/45"
-                          disabled={isSending}
-                          onChange={(event) =>
-                            setNativeAudioVoice(event.target.value)
-                          }
-                          value={nativeAudioVoice}
-                        >
-                          {nativeAudioProfile.voices.map((voice) => (
-                            <option key={voice} value={voice}>
-                              {voice}
-                            </option>
-                          ))}
-                        </select>
-                      </label>
-                    ) : null}
-                    {ttsProfile ? (
-                      <>
-                        <label className="inline-flex items-center gap-2 text-slate-300">
-                          朗读模型
-                          <select
-                            aria-label="朗读模型"
-                            className="max-w-52 rounded-full border border-white/10 bg-ink-950/80 px-2.5 py-1.5 text-xs font-semibold text-white outline-none focus:border-cyan-300/45"
-                            disabled={isSending}
-                            onChange={(event) => {
-                              const nextModelId = event.target.value;
-                              setTtsModelId(nextModelId);
-                              window.sessionStorage.setItem(
-                                TTS_MODEL_SESSION_KEY,
-                                nextModelId,
-                              );
-                            }}
-                            value={ttsProfile.model_id}
-                          >
-                            {ttsProfiles.map((profile) => (
-                              <option
-                                key={profile.model_id}
-                                value={profile.model_id}
-                              >
-                                {profile.display_name}
-                              </option>
-                            ))}
-                          </select>
-                        </label>
-                        <label className="inline-flex items-center gap-2 text-slate-300">
-                          声线
-                          <select
-                            aria-label="朗读声线"
-                            className="max-w-44 rounded-full border border-white/10 bg-ink-950/80 px-2.5 py-1.5 text-xs font-semibold text-white outline-none focus:border-cyan-300/45"
-                            disabled={isSending}
-                            onChange={(event) => {
-                              const nextVoice = event.target.value;
-                              setTtsVoice(nextVoice);
-                              window.sessionStorage.setItem(
-                                TTS_VOICE_SESSION_KEY,
-                                nextVoice,
-                              );
-                            }}
-                            value={ttsVoice}
-                          >
-                            {ttsProfile.voices.map((voice) => (
-                              <option key={voice} value={voice}>
-                                {speechVoiceLabel(voice)}
-                              </option>
-                            ))}
-                          </select>
-                        </label>
-                        <label className="inline-flex items-center gap-2 font-semibold text-slate-200">
-                          <input
-                            checked={autoReadEnabled}
-                            className="h-4 w-4 rounded border-white/20 bg-ink-950 text-cyan-300 focus:ring-cyan-300/30"
-                            disabled={isSending}
-                            onChange={(event) => {
-                              if (
-                                event.target.checked &&
-                                !autoReadConfirmedRef.current
-                              ) {
-                                setAutoReadConfirmationOpen(true);
-                                return;
-                              }
-                              setAutoReadEnabled(event.target.checked);
-                            }}
-                            type="checkbox"
-                          />
-                          自动朗读后续回答
-                        </label>
-                      </>
-                    ) : null}
-                    <span className="text-slate-500">
-                      默认关闭；原生语音开启时不会重复调用辅助朗读。
-                    </span>
-                    {autoReadConfirmationOpen ? (
-                      <span className="flex basis-full flex-wrap items-center gap-2 rounded-md bg-amber-300/[0.08] px-3 py-2 text-amber-100">
-                        每次文字回答后会额外调用一次语音模型，可能产生费用。
-                        <button
-                          className="rounded-full bg-amber-200 px-3 py-1 font-semibold text-ink-950"
-                          onClick={() => {
-                            autoReadConfirmedRef.current = true;
-                            setAutoReadEnabled(true);
-                            setAutoReadConfirmationOpen(false);
-                          }}
-                          type="button"
-                        >
-                          确认开启
-                        </button>
-                        <button
-                          className="rounded-full border border-amber-200/30 px-3 py-1 font-semibold"
-                          onClick={() => setAutoReadConfirmationOpen(false)}
-                          type="button"
-                        >
-                          取消
-                        </button>
-                      </span>
-                    ) : null}
-                  </div>
-                ) : null}
+              <div className={`${CHAT_COMPOSER_COLUMN_CLASSES} border-t border-white/10 bg-ink-950/72 p-3 sm:p-4`}>
                 <div
                   className={`rounded-lg border p-2 transition ${
                     superPromptMode
@@ -4408,122 +4050,108 @@ function ChatConversationPage() {
                     </div>
                   ) : null}
 
+                  <ChatFileComposer
+                    disabled={
+                      isSending ||
+                      isPreparingVideo ||
+                      isUploadingImage ||
+                      chatOutputEnabled ||
+                      visualAnalysisState.count > 0
+                    }
+                    discardVersion={chatFileDiscardVersion}
+                    drawerHost={messageViewportRef.current}
+                    hideTrigger
+                    injectedFile={injectedOutputFile}
+                    inputBoundary={messageInputRef.current}
+                    isAutoRoute={isOmniAutoRoute}
+                    knowledgeBaseSelected={Boolean(selectedKnowledgeBaseId)}
+                    mediaBlockedReason={chatFileMediaBlockedReason}
+                    modelId={isOmniAutoRoute ? decodedModelId : model.id}
+                    onError={setError}
+                    onStateChange={handleChatFileStateChange}
+                    resetVersion={chatFileResetVersion}
+                    scopeId={chatFileScopeId}
+                  />
+                  <ChatVisualAnalysisPanel
+                    blockedReason={visualAnalysisBlockedReason}
+                    disabled={
+                      isSending ||
+                      isPreparingVideo ||
+                      isUploadingImage ||
+                      chatOutputEnabled
+                    }
+                    discardVersion={visualAnalysisDiscardVersion}
+                    drawerHost={messageViewportRef.current}
+                    hideTrigger
+                    inputBoundary={messageInputRef.current}
+                    knowledgeBases={knowledgeBases.map((item) => ({
+                      id: item.id,
+                      name: item.name,
+                    }))}
+                    modelId={isOmniAutoRoute ? decodedModelId : model.id}
+                    onCapabilityChange={setVisualAnalysisCapability}
+                    onError={setError}
+                    onStateChange={setVisualAnalysisState}
+                    resetVersion={visualAnalysisResetVersion}
+                    scopeId={chatFileScopeId}
+                  />
+                  <input
+                    accept="image/png,image/jpeg,image/jpg,image/gif,image/webp"
+                    className="hidden"
+                    multiple
+                    onChange={(event) => {
+                      void addImageFiles(Array.from(event.target.files ?? []));
+                      event.target.value = "";
+                    }}
+                    ref={fileInputRef}
+                    type="file"
+                  />
+                  <ChatActiveContextBar contexts={activeContexts} />
+
                   <textarea
                     className="max-h-44 min-h-24 w-full resize-none bg-transparent px-3 py-2 text-sm leading-6 text-white outline-none placeholder:text-slate-500"
                     disabled={isSending}
                     onChange={(event) => setInput(event.target.value)}
                     onKeyDown={handleKeyDown}
                     onPaste={handlePaste}
-                    placeholder={recruitmentTheme.chatPlaceholder}
+                    placeholder={agentInterview ? "向专家描述任务…" : "给当前模型发送消息…"}
                     ref={messageInputRef}
                     value={input}
                   />
 
-                  <div className="flex flex-col gap-3 px-2 pb-1 sm:flex-row sm:items-center sm:justify-between">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <ChatFileComposer
-                        disabled={
-                          isSending ||
-                          isPreparingVideo ||
-                          isUploadingImage ||
-                          chatOutputEnabled ||
-                          visualAnalysisState.count > 0
-                        }
-                        discardVersion={chatFileDiscardVersion}
-                        drawerHost={messageViewportRef.current}
-                        injectedFile={injectedOutputFile}
-                        inputBoundary={messageInputRef.current}
-                        isAutoRoute={isOmniAutoRoute}
-                        knowledgeBaseSelected={Boolean(selectedKnowledgeBaseId)}
-                        mediaBlockedReason={chatFileMediaBlockedReason}
-                        modelId={isOmniAutoRoute ? decodedModelId : model.id}
-                        onError={setError}
-                        onStateChange={handleChatFileStateChange}
-                        resetVersion={chatFileResetVersion}
-                        scopeId={chatFileScopeId}
-                      />
-                      <ChatVisualAnalysisPanel
-                        blockedReason={visualAnalysisBlockedReason}
-                        disabled={
-                          isSending ||
-                          isPreparingVideo ||
-                          isUploadingImage ||
-                          chatOutputEnabled
-                        }
-                        discardVersion={visualAnalysisDiscardVersion}
-                        drawerHost={messageViewportRef.current}
-                        inputBoundary={messageInputRef.current}
-                        knowledgeBases={knowledgeBases.map((item) => ({
-                          id: item.id,
-                          name: item.name,
-                        }))}
-                        modelId={isOmniAutoRoute ? decodedModelId : model.id}
-                        onError={setError}
-                        onStateChange={setVisualAnalysisState}
-                        resetVersion={visualAnalysisResetVersion}
-                        scopeId={chatFileScopeId}
-                      />
-                      <button
-                        aria-checked={chatOutputEnabled}
-                        className={`min-h-11 rounded-full border px-3 text-xs font-semibold transition focus:outline-none focus:ring-4 focus:ring-cyan-300/10 disabled:cursor-not-allowed disabled:opacity-45 ${
-                          chatOutputEnabled
-                            ? "border-cyan-300/50 bg-cyan-300/15 text-cyan-50"
-                            : "border-white/10 bg-white/[0.06] text-slate-200 hover:border-cyan-300/40 hover:bg-cyan-300/10 hover:text-cyan-100"
-                        }`}
-                        disabled={isSending || Boolean(chatOutputBlockedReason)}
-                        onClick={() => {
-                          setChatOutputEnabled((current) => !current);
-                          setError("");
-                        }}
-                        role="switch"
-                        title={
-                          chatOutputBlockedReason ||
-                          "仅允许当前精确模型在本轮调用受限文件生成工具；不会调用 shell 或任意路径。"
-                        }
-                        type="button"
-                      >
-                        {chatOutputCapabilities
-                          ? chatOutputEnabled
-                            ? "生成文件 · 本轮已允许"
-                            : "生成文件 · 仅本轮"
-                          : "文件输出未启用"}
-                      </button>
-                      <input
-                        accept="image/png,image/jpeg,image/jpg,image/gif,image/webp"
-                        className="hidden"
-                        multiple
-                        onChange={(event) => {
-                          void addImageFiles(Array.from(event.target.files ?? []));
-                          event.target.value = "";
-                        }}
-                        ref={fileInputRef}
-                        type="file"
-                      />
-                      <button
-                        className="rounded-full border border-white/10 bg-white/[0.06] px-3 py-2 text-xs font-semibold text-slate-200 transition hover:border-brand-300/40 hover:bg-brand-300/10 hover:text-brand-100 disabled:cursor-not-allowed disabled:opacity-50"
-                        disabled={
-                          isSending ||
-                          isUploadingImage ||
-                          chatOutputEnabled ||
-                          audioComposerOpen ||
-                          videoComposerOpen ||
-                          Boolean(reusedDirectMedia) ||
-                          chatFileState.count > 0 ||
-                          visualAnalysisState.count > 0
-                        }
-                        onClick={() => fileInputRef.current?.click()}
-                        title="上传图片"
-                        type="button"
-                      >
-                        图片
-                      </button>
-                      <button
-                        className={`rounded-full border px-3 py-2 text-xs font-semibold transition disabled:cursor-not-allowed disabled:opacity-50 ${
-                          audioComposerOpen &&
-                          audioComposerSource === "upload"
-                            ? "border-brand-300/45 bg-brand-300/12 text-brand-100"
-                            : "border-white/10 bg-white/[0.06] text-slate-200 hover:border-brand-300/40 hover:bg-brand-300/10 hover:text-brand-100"
-                        }`}
+
+                  <div className="flex items-center gap-2 px-1 pb-1 pt-1">
+                    <ChatActionMenu
+                      actions={chatActions}
+                      onOpenChange={setComposerMenuOpen}
+                      open={composerMenuOpen}
+                      triggerRef={actionMenuTriggerRef}
+                    />
+                    {isOmniAutoRoute ? (
+                      <span className="inline-flex min-h-11 min-w-0 flex-1 items-center rounded-full border border-white/10 bg-white/[0.045] px-4 text-xs font-semibold text-slate-200 sm:max-w-64">
+                        <span className="truncate">{displayCandidateName}</span>
+                      </span>
+                    ) : (
+                      <label className="min-w-0 flex-1 sm:max-w-64">
+                        <span className="sr-only">切换当前模型</span>
+                        <select
+                          className="min-h-11 w-full truncate rounded-full border border-white/10 bg-white/[0.045] px-4 text-xs font-semibold text-white outline-none transition hover:border-white/20 focus:border-brand-300/45 focus:ring-4 focus:ring-brand-300/10"
+                          disabled={isSending}
+                          onChange={(event) => handleModelChange(event.target.value)}
+                          value={model.id}
+                        >
+                          {models.map((item) => (
+                            <option className="bg-slate-950 text-white" key={item.id} value={item.id}>
+                              {item.name}
+                            </option>
+                          ))}
+                        </select>
+                      </label>
+                    )}
+                    {chatAudioFeatures?.microphone_enabled ? (
+                      <QuickTranscriptionControl
+                        currentModelId={isOmniAutoRoute ? decodedModelId : model.id}
+                        directBlockedReason={directAudioBlockedReason}
                         disabled={
                           isSending ||
                           isUploadingImage ||
@@ -4534,155 +4162,332 @@ function ChatConversationPage() {
                           chatFileState.count > 0 ||
                           visualAnalysisState.count > 0
                         }
-                        onClick={() => openAudioComposer("upload")}
-                        type="button"
-                      >
-                        音频
-                      </button>
-                      {chatVideoEnabled ? (
-                        <button
-                          className={`rounded-full border px-3 py-2 text-xs font-semibold transition disabled:cursor-not-allowed disabled:opacity-50 ${
-                            videoComposerOpen
-                              ? "border-brand-300/45 bg-brand-300/12 text-brand-100"
-                              : "border-white/10 bg-white/[0.06] text-slate-200 hover:border-brand-300/40 hover:bg-brand-300/10 hover:text-brand-100"
-                          }`}
-                          disabled={
-                            isSending ||
-                            isPreparingVideo ||
-                            isUploadingImage ||
-                            chatOutputEnabled ||
-                            uploadedImages.length > 0 ||
-                            audioComposerOpen ||
-                            Boolean(reusedDirectMedia) ||
-                            chatFileState.count > 0 ||
-                            visualAnalysisState.count > 0
-                          }
-                          onClick={openVideoComposer}
-                          type="button"
-                        >
-                          视频
-                        </button>
-                      ) : null}
-                      {chatAudioFeatures?.microphone_enabled ? (
-                        <QuickTranscriptionControl
-                          currentModelId={
-                            isOmniAutoRoute ? decodedModelId : model.id
-                          }
-                          directBlockedReason={directAudioBlockedReason}
-                          disabled={
-                            isSending ||
-                            isUploadingImage ||
-                            chatOutputEnabled ||
-                            uploadedImages.length > 0 ||
-                            videoComposerOpen ||
-                            Boolean(reusedDirectMedia) ||
-                            chatFileState.count > 0 ||
-                            visualAnalysisState.count > 0
-                          }
-                          enabled
-                          isAutoRoute={isOmniAutoRoute}
-                          onError={setError}
-                          onSendDirectAudio={sendDirectAudio}
-                          onTranscript={fillQuickTranscript}
-                        />
-                      ) : null}
-                      {realtimeVoiceProfile ? (
-                        <Link
-                          className={`inline-flex items-center rounded-full border px-3 py-2 text-xs font-semibold transition ${
-                            realtimeVoiceProfile.interaction_status === "ready"
-                              ? "border-cyan-300/35 bg-cyan-300/10 text-cyan-100 hover:border-cyan-300/60 hover:bg-cyan-300/15"
-                              : "border-white/10 bg-white/[0.045] text-slate-400 hover:border-white/20 hover:text-slate-200"
-                          }`}
-                          title={
-                            realtimeVoiceProfile.status_reason ??
-                            "进入连续语音通话，区别于单轮麦克风转写"
-                          }
-                          to={`/chat/${encodeURIComponent(
-                            realtimeVoiceProfile.model_id,
-                          )}?operation=realtime_voice`}
-                        >
-                          实时语音
-                        </Link>
-                      ) : null}
-                      <p className="text-xs text-slate-400">
-                        {visualAnalysisState.busy
-                          ? "视觉/OCR 正在处理；不会自动重试"
-                          : visualAnalysisState.count > 0
-                            ? visualAnalysisState.allConfirmed
-                              ? "识别结果已确认，可用于本轮发送"
-                              : "请在视觉/OCR 面板预览并选择用途"
-                        : chatFileState.busy
-                          ? "正在本地提取文件内容..."
-                          : chatFileState.count > 0
-                            ? chatFileState.allConfirmed
-                              ? `已确认 ${chatFileState.count} 个文件，可发送`
-                              : "请打开文件预览并逐个确认"
-                        : isUploadingImage
-                          ? "正在压缩图片..."
-                          : isPreparingVideo
-                            ? videoSelection?.mode === "assist"
-                              ? "正在生成视频理解摘要..."
-                              : "正在上传并理解视频..."
-                          : reusedDirectMedia
-                            ? `复用${reusedDirectMedia.kind === "audio" ? "音频" : "视频"}已加入本轮，尚未发送`
-                          : audioComposerOpen
-                            ? "语音只在本页临时处理"
-                            : videoComposerOpen
-                              ? "视频只参与本轮，刷新后不会保留"
-                          : supportsImageInput
-                            ? chatAudioFeatures?.microphone_enabled
-                              ? chatVideoEnabled
-                                ? "可上传图片、音频、视频或使用麦克风"
-                                : "麦克风可直接转成文字"
-                              : chatVideoEnabled
-                                ? "可上传图片、音频或视频"
-                                : "可上传图片或音频"
-                            : chatAudioFeatures?.microphone_enabled
-                              ? chatVideoEnabled
-                                ? "可上传音频、视频或使用麦克风"
-                                : "麦克风可直接转成文字"
-                              : chatVideoEnabled
-                                ? "可上传音频或视频"
-                                : "可上传音频"}
-                      </p>
-                    </div>
+                        enabled
+                        isAutoRoute={isOmniAutoRoute}
+                        onError={setError}
+                        onSendDirectAudio={sendDirectAudio}
+                        onTranscript={fillQuickTranscript}
+                      />
+                    ) : null}
                     <button
-                      className="rounded-full bg-brand-300 px-5 py-2 text-sm font-semibold text-ink-950 shadow-neon transition hover:bg-brand-200 active:scale-[0.98] disabled:cursor-not-allowed disabled:bg-white/10 disabled:text-slate-500 disabled:shadow-none"
+                      aria-label="发送消息"
+                      className="inline-flex h-11 min-w-11 shrink-0 items-center justify-center rounded-full bg-brand-300 px-4 text-sm font-semibold text-ink-950 shadow-neon transition hover:bg-brand-200 active:scale-[0.98] disabled:cursor-not-allowed disabled:bg-white/10 disabled:text-slate-500 disabled:shadow-none"
                       disabled={!canSend}
-                      onClick={() =>
-                        void (
-                          videoSelection
-                            ? sendSelectedVideo()
-                            : sendMessage()
-                        )
-                      }
+                      onClick={() => void (videoSelection ? sendSelectedVideo() : sendMessage())}
                       type="button"
                     >
-                      {isPreparingVideo
-                        ? "理解视频中"
-                        : isSending
-                          ? "发送中"
-                          : "发送"}
+                      {isPreparingVideo ? "处理中" : isSending ? "发送中" : "发送"}
                     </button>
                   </div>
                 </div>
               </div>
             </section>
 
-            <PromptSidebar
-              isOpen={promptSidebarOpen}
-              onFillPrompt={(content) => {
-                setInput(content);
-                setError("");
-              }}
-              onSendPrompt={(content) => void sendMessage(content)}
-              onSuperPromptModeChange={setSuperPromptMode}
-              onToggleOpen={() => setPromptSidebarOpen((current) => !current)}
-              superPromptMode={superPromptMode}
-            />
           </div>
         </div>
       </div>
+
+      <ChatOverlayDrawer
+        description={agentInterview ? "选择一道题填入或直接发送" : "选择提示填入输入框或直接发送"}
+        onClose={() => setTopOverlay(null)}
+        open={topOverlay === "prompt"}
+        title={promptLabel}
+        triggerRef={promptTriggerRef}
+      >
+        <PromptLibraryContent
+          onFillPrompt={(content) => {
+            setInput(content);
+            setError("");
+            setTopOverlay(null);
+            window.requestAnimationFrame(() => messageInputRef.current?.focus());
+          }}
+          onSendPrompt={(content) => {
+            setTopOverlay(null);
+            void sendMessage(content);
+          }}
+          onSuperPromptModeChange={setSuperPromptMode}
+          superPromptMode={superPromptMode}
+          variant={agentInterview ? "question" : "prompt"}
+        />
+      </ChatOverlayDrawer>
+
+      <ChatOverlayDrawer
+        description="模型、路由、工具与语音设置"
+        onClose={() => setTopOverlay(null)}
+        open={topOverlay === "settings"}
+        title="对话设置"
+        triggerRef={settingsTriggerRef}
+      >
+        <div className="divide-y divide-white/10">
+          <section className="p-5">
+            <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-500">当前模型</p>
+            <h3 className="mt-2 text-base font-semibold text-white">{displayCandidateName}</h3>
+            <p className="mt-1 text-sm leading-6 text-slate-400">{displayCandidateDescription}</p>
+            <dl className="mt-4 grid grid-cols-2 gap-3 text-xs">
+              <div className="rounded-xl border border-white/10 bg-white/[0.035] p-3">
+                <dt className="text-slate-500">服务</dt>
+                <dd className="mt-1 font-semibold text-slate-100">{providerName}</dd>
+              </div>
+              <div className="rounded-xl border border-white/10 bg-white/[0.035] p-3">
+                <dt className="text-slate-500">上下文</dt>
+                <dd className="mt-1 font-semibold text-slate-100">{model.context_length.toLocaleString("zh-CN")}</dd>
+              </div>
+              <div className="rounded-xl border border-white/10 bg-white/[0.035] p-3">
+                <dt className="text-slate-500">输入模态</dt>
+                <dd className="mt-1 font-semibold text-slate-100">
+                  {model.input_modalities.map((modality) => modalityLabels[modality] ?? modality).join(" / ")}
+                </dd>
+              </div>
+              <div className="rounded-xl border border-white/10 bg-white/[0.035] p-3">
+                <dt className="text-slate-500">价格</dt>
+                <dd className="mt-1 font-semibold text-slate-100">
+                  {isOmniAutoRoute || model.pricing_status === "dynamic"
+                    ? "按实际调用"
+                    : `¥${model.price_cny.input.toFixed(2)} / ¥${model.price_cny.output.toFixed(2)}`}
+                </dd>
+              </div>
+            </dl>
+          </section>
+
+          {isOmniAutoRoute ? (
+            <section className="space-y-4 p-5">
+              <div>
+                <h3 className="text-sm font-semibold text-white">智能调度与预算</h3>
+                <p className="mt-1 text-xs leading-5 text-slate-400">设置只作用于当前调度会话，不自动切换你的输入能力。</p>
+              </div>
+              <label className="block text-xs font-semibold text-slate-300">
+                调度模式
+                <select
+                  className="mt-2 min-h-11 w-full rounded-xl border border-white/10 bg-ink-950/85 px-3 text-sm text-white outline-none focus:border-brand-300/45"
+                  disabled={isSending}
+                  onChange={(event) => setRoutingMode(event.target.value as typeof routingMode)}
+                  value={routingMode}
+                >
+                  <option value="balanced">均衡</option>
+                  <option value="fast">速度优先</option>
+                  <option value="quality">质量优先</option>
+                  <option value="cheap">成本优先</option>
+                  <option value="reliable">稳定优先</option>
+                  <option value="offline">离线优先</option>
+                </select>
+              </label>
+              <label className="block text-xs font-semibold text-slate-300">
+                单次预算上限（USD，可选）
+                <input
+                  className="mt-2 min-h-11 w-full rounded-xl border border-white/10 bg-ink-950/85 px-3 text-sm text-white outline-none placeholder:text-slate-500 focus:border-brand-300/45"
+                  disabled={isSending}
+                  inputMode="decimal"
+                  min="0.000001"
+                  onChange={(event) => setRoutingBudget(event.target.value)}
+                  placeholder="例如 0.05"
+                  type="number"
+                  value={routingBudget}
+                />
+              </label>
+              <label className="block text-xs font-semibold text-slate-300">
+                超预算处理
+                <select
+                  className="mt-2 min-h-11 w-full rounded-xl border border-white/10 bg-ink-950/85 px-3 text-sm text-white outline-none focus:border-brand-300/45"
+                  disabled={isSending || !routingBudget.trim()}
+                  onChange={(event) => setRoutingBudgetFallback(event.target.value as typeof routingBudgetFallback)}
+                  value={routingBudgetFallback}
+                >
+                  <option value="cheapest">改用最低成本候选</option>
+                  <option value="strict">严格拒绝并返回 402</option>
+                </select>
+              </label>
+              <label className="block text-xs font-semibold text-slate-300">
+                上下文优化
+                <select
+                  className="mt-2 min-h-11 w-full rounded-xl border border-white/10 bg-ink-950/85 px-3 text-sm text-white outline-none focus:border-brand-300/45"
+                  disabled={isSending}
+                  onChange={(event) => setCompressionMode(event.target.value as typeof compressionMode)}
+                  value={compressionMode}
+                >
+                  <option value="auto">自动推荐</option>
+                  <option value="off">关闭</option>
+                  <option value="standard">标准</option>
+                  <option value="strong">强力</option>
+                </select>
+              </label>
+            </section>
+          ) : null}
+
+          <section>
+            <div className="px-5 pt-5">
+              <h3 className="text-sm font-semibold text-white">高级参数</h3>
+              <p className="mt-1 text-xs text-slate-400">继续按模型保存在现有本地设置中。</p>
+            </div>
+            <AdvancedParamsPanel
+              embedded
+              isOpen
+              maxTokenLimit={maxTokenLimit}
+              onChange={handleAdvancedParamsChange}
+              onReset={resetAdvancedParams}
+              onToggle={() => undefined}
+              params={advancedParams}
+            />
+          </section>
+
+          <section className="space-y-4 p-5">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h3 className="text-sm font-semibold text-white">MCP 工具</h3>
+                <p className="mt-1 text-xs leading-5 text-slate-400">仅调用白名单内已注册工具，默认关闭。</p>
+              </div>
+              <label className="inline-flex min-h-11 items-center gap-2 text-xs font-semibold text-slate-200">
+                <input
+                  checked={runtimeToolsEnabled}
+                  className="h-4 w-4"
+                  disabled={isSending || isOmniAutoRoute}
+                  onChange={(event) => setRuntimeToolsEnabled(event.target.checked)}
+                  type="checkbox"
+                />
+                启用
+              </label>
+            </div>
+            {runtimeToolsEnabled ? (
+              <div className="space-y-3">
+                <label className="block text-xs font-semibold text-slate-300">
+                  工具白名单
+                  <input
+                    className="mt-2 min-h-11 w-full rounded-xl border border-white/10 bg-ink-950/85 px-3 text-sm text-white outline-none focus:border-brand-300/45"
+                    disabled={isSending}
+                    onChange={(event) => setRuntimeToolNames(event.target.value)}
+                    placeholder="多个名称用逗号分隔；留空使用当前可用工具"
+                    value={runtimeToolNames}
+                  />
+                </label>
+                <label className="block text-xs font-semibold text-slate-300">
+                  最大循环次数
+                  <input
+                    className="mt-2 min-h-11 w-full rounded-xl border border-white/10 bg-ink-950/85 px-3 text-sm text-white outline-none focus:border-brand-300/45"
+                    disabled={isSending}
+                    max="12"
+                    min="1"
+                    onChange={(event) => setRuntimeMaxToolIterations(event.target.value)}
+                    type="number"
+                    value={runtimeMaxToolIterations}
+                  />
+                </label>
+                <label className="block text-xs font-semibold text-slate-300">
+                  补充约束
+                  <textarea
+                    className="mt-2 min-h-24 w-full resize-y rounded-xl border border-white/10 bg-ink-950/85 p-3 text-sm text-white outline-none focus:border-brand-300/45"
+                    disabled={isSending}
+                    maxLength={2000}
+                    onChange={(event) => setRuntimePromptSuffix(event.target.value)}
+                    value={runtimePromptSuffix}
+                  />
+                </label>
+              </div>
+            ) : null}
+          </section>
+
+          {ttsProfile || nativeAudioAvailable ? (
+            <section className="space-y-4 p-5">
+              <div>
+                <h3 className="text-sm font-semibold text-white">回答语音</h3>
+                <p className="mt-1 text-xs leading-5 text-slate-400">默认关闭；原生语音开启时不会重复调用辅助朗读。</p>
+              </div>
+              {nativeAudioAvailable ? (
+                <label className="flex min-h-11 items-center justify-between gap-3 text-sm text-slate-200">
+                  原生语音回答
+                  <input
+                    checked={nativeAudioEnabled}
+                    className="h-4 w-4"
+                    disabled={isSending || Boolean(selectedKnowledgeBaseId) || runtimeToolsEnabled}
+                    onChange={(event) => setNativeAudioEnabled(event.target.checked)}
+                    type="checkbox"
+                  />
+                </label>
+              ) : null}
+              {nativeAudioEnabled && nativeAudioProfile ? (
+                <label className="block text-xs font-semibold text-slate-300">
+                  原生声线
+                  <select
+                    className="mt-2 min-h-11 w-full rounded-xl border border-white/10 bg-ink-950/85 px-3 text-sm text-white"
+                    disabled={isSending}
+                    onChange={(event) => setNativeAudioVoice(event.target.value)}
+                    value={nativeAudioVoice}
+                  >
+                    {nativeAudioProfile.voices.map((voice) => <option key={voice} value={voice}>{voice}</option>)}
+                  </select>
+                </label>
+              ) : null}
+              {ttsProfile ? (
+                <>
+                  <label className="block text-xs font-semibold text-slate-300">
+                    辅助朗读模型
+                    <select
+                      className="mt-2 min-h-11 w-full rounded-xl border border-white/10 bg-ink-950/85 px-3 text-sm text-white"
+                      disabled={isSending}
+                      onChange={(event) => {
+                        setTtsModelId(event.target.value);
+                        window.sessionStorage.setItem(TTS_MODEL_SESSION_KEY, event.target.value);
+                      }}
+                      value={ttsProfile.model_id}
+                    >
+                      {ttsProfiles.map((profile) => <option key={profile.model_id} value={profile.model_id}>{profile.display_name}</option>)}
+                    </select>
+                  </label>
+                  <label className="block text-xs font-semibold text-slate-300">
+                    辅助朗读声线
+                    <select
+                      className="mt-2 min-h-11 w-full rounded-xl border border-white/10 bg-ink-950/85 px-3 text-sm text-white"
+                      disabled={isSending}
+                      onChange={(event) => {
+                        setTtsVoice(event.target.value);
+                        window.sessionStorage.setItem(TTS_VOICE_SESSION_KEY, event.target.value);
+                      }}
+                      value={ttsVoice}
+                    >
+                      {ttsProfile.voices.map((voice) => <option key={voice} value={voice}>{speechVoiceLabel(voice)}</option>)}
+                    </select>
+                  </label>
+                  <label className="flex min-h-11 items-center justify-between gap-3 text-sm text-slate-200">
+                    自动朗读后续回答
+                    <input
+                      checked={autoReadEnabled}
+                      className="h-4 w-4"
+                      disabled={isSending}
+                      onChange={(event) => {
+                        if (event.target.checked && !autoReadConfirmedRef.current) {
+                          setAutoReadConfirmationOpen(true);
+                          return;
+                        }
+                        setAutoReadEnabled(event.target.checked);
+                      }}
+                      type="checkbox"
+                    />
+                  </label>
+                  {autoReadConfirmationOpen ? (
+                    <div className="rounded-xl border border-amber-300/20 bg-amber-300/[0.08] p-3 text-xs leading-5 text-amber-100">
+                      每次文字回答后会额外调用一次语音模型，可能产生费用。
+                      <div className="mt-3 flex gap-2">
+                        <button
+                          className="min-h-11 rounded-full bg-amber-200 px-4 font-semibold text-ink-950"
+                          onClick={() => {
+                            autoReadConfirmedRef.current = true;
+                            setAutoReadEnabled(true);
+                            setAutoReadConfirmationOpen(false);
+                          }}
+                          type="button"
+                        >确认开启</button>
+                        <button
+                          className="min-h-11 rounded-full border border-amber-200/30 px-4 font-semibold"
+                          onClick={() => setAutoReadConfirmationOpen(false)}
+                          type="button"
+                        >取消</button>
+                      </div>
+                    </div>
+                  ) : null}
+                </>
+              ) : null}
+            </section>
+          ) : null}
+        </div>
+      </ChatOverlayDrawer>
 
       {lightboxImage ? (
         <div

--- a/design-qa.md
+++ b/design-qa.md
@@ -1,0 +1,27 @@
+# Design QA
+
+Result: passed
+
+## Visual baseline
+
+- Reference: candidate 1, `exec-223c13ba-84a7-4cc9-ba69-ea7a6053b44e.png`.
+- Preserved ModelMirror's existing dark brand palette and typography while matching the reference hierarchy: compact header, centered conversation, one bottom composer, and one progressive-disclosure action menu.
+- Removed the persistent profile rail, question-bank rail, wide introduction block, advanced-parameter block, and capability button wall from the conversation viewport.
+
+## Browser checks
+
+- `1440 x 900`: no persistent left or right rails; the 920 px message column is primary; the 1000 px composer is fully visible with bottom clearance.
+- `390 x 844`: no horizontal overflow; the textarea remains fully visible; the action menu remains inside the viewport; the settings and prompt drawers use the mobile bottom-sheet layout.
+- User messages remain right-aligned bubbles; assistant messages render as open left-aligned content.
+- Closing the action menu removes it from the accessibility tree. Escape, outside click, and explicit close restore focus to the invoking control.
+- Only one top-level overlay can be open at a time.
+
+## Behavioral checks
+
+- Existing file, visual/OCR, image, audio, video, realtime voice, knowledge-base, Skill, MCP, and file-output flows are triggered through the unified menu without changing their request or confirmation contracts.
+- Unavailable actions remain visible with their stable blocking reason.
+- Existing Chat SSE and file-output tests passed without protocol changes.
+
+## Known non-blocking note
+
+- The production bundle retains the repository's existing large-chunk warning; this redesign does not add a dependency or a new route.


### PR DESCRIPTION
## 变更说明

- 将 `/chat` 改为对话优先的极简壳：64px 紧凑页头、居中消息流和底部统一输入框。
- 将文件、视觉/OCR、图片、音频、视频、知识库、Skill、MCP、文件输出及实时语音统一收进单一 `+` 菜单。
- 将高级参数、路由预算、语音/MCP 设置和提示库/题库迁移到响应式覆盖抽屉。
- 移除常驻候选人档案、宽幅介绍、左右侧栏和能力按钮墙，但保留全部既有能力、服务端确认与清理语义。
- 普通聊天改为中性文案；Auto/OmniRoute 与专家模式继续使用同一壳层并显示紧凑状态。
- 增加键盘、焦点恢复、单覆盖层、禁用原因及 390×844/1440×900 布局回归。

## 原因与影响

随着文件、视觉、媒体、RAG、Skill、MCP 和输出能力持续增加，原 Chat 页面把大量控制常驻在消息区域周围，显著挤压正文与输入空间。本次通过渐进披露恢复“消息与输入优先”的信息层级，同时不修改后端 API、ChatRequest、SSE 事件、文件确认协议或 URL 路由。

## 验证

- `npm.cmd test -- --run`：36 files / 175 tests passed
- `npm.cmd run build`：通过（仅仓库既有的大 chunk 警告）
- `git diff --check origin/main...HEAD`：通过
- 独立 15178 预览完成 1440×900 与 390×844 视觉/交互 QA
- 未触碰共享 5173/8000

## 回退

恢复旧 Chat 展示组件即可；服务端、数据库和聊天协议无需回滚。
