### PR TITLE
V15 PR B: Provider portability and Claude isolation

### DIFF
--- a/docker-compose.coding-worker-v15-claude.yml
+++ b/docker-compose.coding-worker-v15-claude.yml
@@ -1,0 +1,40 @@
+services:
+  server:
+    environment:
+      CODING_WORKER_CLAUDE_ENABLED: ${CODING_WORKER_CLAUDE_ENABLED:-false}
+      CODING_WORKER_MODEL_ROUTES: coding/default,coding/quality
+      CODING_WORKER_ROUTE_SLOTS_JSON: '{"coding/default":["slot-a"],"coding/quality":["slot-b"]}'
+
+  coding-worker-provider-b:
+    image: modelmirror-coding-worker-claude-v15:local
+    build:
+      context: .
+      dockerfile: server/coding_worker/Dockerfile.claude
+    depends_on: !reset {}
+    networks: !override
+      - coding_worker_claude
+    environment: !override
+      CODING_WORKER_PROVIDER_SOCKET: /run/modelmirror-coding/provider.sock
+      CODING_WORKER_SIDECAR_TOKEN: ${CODING_WORKER_SLOT_B_TOKEN:?set a random V15 slot B token}
+      CODING_WORKER_PROVIDER_KIND: claude-code
+      CODING_WORKER_ROUTE_ID: coding/quality
+      CODING_WORKER_MODEL_ID: ${CODING_WORKER_CLAUDE_MODEL_ID:?set the controlled Claude model id}
+      CODING_WORKER_CLAUDE_SECRET_PATH: /run/secrets/modelmirror_claude_api_key
+    volumes: !override
+      - coding_worker_provider_b:/run/modelmirror-coding
+      - coding_worker_broker:/run/modelmirror-coding-broker:ro
+    secrets: !override
+      - source: coding_worker_claude_api_key
+        target: modelmirror_claude_api_key
+        uid: "65532"
+        gid: "65532"
+        mode: 0400
+
+secrets:
+  coding_worker_claude_api_key:
+    file: ${CODING_WORKER_CLAUDE_SECRET_FILE:?set an absolute Claude API key secret file}
+
+networks:
+  coding_worker_claude:
+    driver: bridge
+    internal: true

--- a/docker-compose.coding-worker-v15-claude.yml
+++ b/docker-compose.coding-worker-v15-claude.yml
@@ -20,6 +20,7 @@ services:
       CODING_WORKER_ROUTE_ID: coding/quality
       CODING_WORKER_MODEL_ID: ${CODING_WORKER_CLAUDE_MODEL_ID:?set the controlled Claude model id}
       CODING_WORKER_CLAUDE_SECRET_PATH: /run/secrets/modelmirror_claude_api_key
+      CODING_WORKER_PROVIDER_PROXY_URL: http://provider:${CODING_WORKER_CLAUDE_PROXY_TOKEN:?set a random URL-safe Claude proxy token}@coding-worker-claude-egress:8081
     volumes: !override
       - coding_worker_provider_b:/run/modelmirror-coding
       - coding_worker_broker:/run/modelmirror-coding-broker:ro
@@ -30,6 +31,32 @@ services:
         gid: "65532"
         mode: 0400
 
+  coding-worker-claude-egress:
+    image: modelmirror-coding-worker-claude-v15:local
+    build:
+      context: .
+      dockerfile: server/coding_worker/Dockerfile.claude
+    container_name: modelmirror-coding-worker-claude-egress
+    command: ["python", "-m", "coding_worker.egress_proxy"]
+    networks:
+      - coding_worker_claude
+      - coding_worker_claude_egress
+    user: "65532:65532"
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    pids_limit: 64
+    mem_limit: 128m
+    cpus: 0.5
+    tmpfs:
+      - /tmp:rw,nosuid,noexec,size=8m,uid=65532,gid=65532,mode=0700
+    environment:
+      CODING_WORKER_PROVIDER_EGRESS_TOKEN: ${CODING_WORKER_CLAUDE_PROXY_TOKEN:?set a random URL-safe Claude proxy token}
+      CODING_WORKER_PROVIDER_NETWORK_DOMAINS: api.anthropic.com
+    restart: unless-stopped
+
 secrets:
   coding_worker_claude_api_key:
     file: ${CODING_WORKER_CLAUDE_SECRET_FILE:?set an absolute Claude API key secret file}
@@ -38,3 +65,5 @@ networks:
   coding_worker_claude:
     driver: bridge
     internal: true
+  coding_worker_claude_egress:
+    driver: bridge

--- a/docs/tasks/CODING_WORKER_V15.md
+++ b/docs/tasks/CODING_WORKER_V15.md
@@ -41,7 +41,7 @@
 
 ## 当前进度（2026-08-11）
 
-PR A 的实现与自动门禁已完成，尚未进行真实 Provider/人工验收，也未开始 PR B、PR C：
+PR A 已作为 Draft PR #151 发布；PR B 的实现与自动门禁已完成，尚未进行真实 Provider/人工验收，也未开始 PR C：
 
 - 契约与文件工具：`d0e955b`、`50d933e`、`29c135b`。
 - Shell 执行、审批、changeset 与查询：`ad831ac`、`0a56605`、`45df707`。
@@ -58,6 +58,27 @@ PR A 实际自动验证：
 - `git diff --check` 通过；提交文件数门禁通过。
 
 上述结果只证明 PR A 的自动化边界，不等同于 OpenCode/Claude 双引擎真实任务、逐组件重启或 v13 Host 写回人工验收。PR A 发布后仍须按顺序完成 PR B、PR C，并在人工验收通过前保持 V15 非 Ready。
+
+PR B 实现提交：
+
+- Provider 私有契约 v2 与 route 固定：`59b4bf9`、`ae337ee`。
+- Claude Code Provider 与 Sidecar：`01512d0`、`6544878`。
+- Claude secret、网络和部署隔离：`f6bf8a5`、`23b9fc1`。
+- 完成回执对账与 Fake/OpenCode/Claude conformance：`b70d0e4`、`c040d60`。
+- 以上 8 个实现提交均不超过五个文件；PR B 以 PR A 的 `cdad6da` 为基线。
+
+PR B 实际自动验证：
+
+- Linux 无网络只读源码环境全部 Worker：142 passed、5 skipped、1 条框架告警。
+- Windows 全部 Worker：132 passed、12 skipped、3 项 V14 snapshot reader 的 `mtime_ns` 漂移失败；同样 3 项已在 PR A 工作树精确复现。
+- Agent Workspace：44 passed；Coding：765 passed、14 skipped。
+- 后端全量：2615 passed、27 skipped、6 failed、6 warnings。5 项为 PR A 已记录的 Agency Worker 测试镜像缺少构建产物；另 1 项为当前 `modelmirror-server` 镜像 Node 20 无法直接导入 `.ts`，已在 PR A 基线用相同镜像精确复现。该结果不是全绿，两个基线问题均未在 PR B 跨范围修复。
+- 前端 TypeScript 检查通过；35 个测试文件、169 项测试全部通过；production build 成功，仅有既有大 chunk 告警。
+- 变更 Python 文件 `py_compile` 通过；合并 V14/V15 overlay 的 Compose `config --quiet` 通过。
+- Claude 镜像使用固定包 `@anthropic-ai/claude-code@2.1.89` 及 SHA512 完整性门禁；最终镜像无网络只读探针返回 `2.1.89 (Claude Code)`，运行用户为 `65532`。
+- 有效 Compose 配置确认 Claude Provider 不继承 route key、gateway base URL 或 Workspace 挂载；Provider 只接内部网络和受控 socket/secret，独立代理只允许 `api.anthropic.com:443`。
+
+上述 PR B 证据证明契约、隔离、恢复对账和镜像构造，不等同于使用真实 Anthropic 凭据完成任务。真实 OpenCode/Claude 双任务、逐组件重启和 v13 Host 写回仍属于 PR C 后的人工验收，完成前 V15 保持非 Ready。
 
 ## 开关与回退
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -29,6 +29,15 @@ CODING_WORKER_MAX_ACTIVE_TASKS=2
 CODING_WORKER_RETENTION_SECONDS=604800
 CODING_WORKER_NETWORK_ENABLED=false
 CODING_WORKER_MODEL_ROUTES=coding/default
+# V15 Provider portability remains opt-in. The Claude secret is a host-side
+# regular file referenced by the dedicated Compose overlay; never put its value
+# in this env file or mount it into the Server/Executor containers.
+CODING_WORKER_V15_ENABLED=false
+CODING_WORKER_SHELL_ENABLED=false
+CODING_WORKER_CODE_INTELLIGENCE_ENABLED=false
+CODING_WORKER_CLAUDE_ENABLED=false
+CODING_WORKER_CLAUDE_MODEL_ID=
+CODING_WORKER_CLAUDE_SECRET_FILE=
 
 # 图片识别与生成使用实时能力目录；关闭后保留静态条目但隐藏交互入口。
 MULTIMODAL_IMAGE_ANALYSIS_ENABLED=true

--- a/server/THIRD_PARTY_NOTICES.md
+++ b/server/THIRD_PARTY_NOTICES.md
@@ -218,3 +218,18 @@ and separate evaluation and installation gates. It excludes the
 upstream evaluator, graders, result viewer, description optimizer, packaging
 scripts and Claude-specific execution paths. Anthropic does not endorse
 ModelMirror; this notice uses the project name only to identify provenance.
+
+## Claude Code command-line runtime
+
+The optional V15 Claude Provider image contains the unmodified
+`@anthropic-ai/claude-code` npm package, pinned to version `2.1.89` and verified
+against its npm registry SHA-512 integrity value during the image build.
+
+- Copyright: Copyright Anthropic PBC. All rights reserved.
+- Package: <https://www.npmjs.com/package/@anthropic-ai/claude-code/v/2.1.89>
+- Legal terms: <https://code.claude.com/docs/en/legal-and-compliance>
+- Packaged notice: `/usr/local/lib/node_modules/@anthropic-ai/claude-code/LICENSE.md`
+
+Use of Claude Code and Anthropic services remains subject to Anthropic's legal
+agreements. The package is isolated in the optional Provider sidecar and is not
+linked into ModelMirror application code.

--- a/server/coding_worker/Dockerfile.claude
+++ b/server/coding_worker/Dockerfile.claude
@@ -1,0 +1,38 @@
+FROM node:22-bookworm-slim AS claude_runtime
+
+ARG CLAUDE_CODE_VERSION=2.1.89
+ARG CLAUDE_CODE_INTEGRITY=sha512-etjihHqVxj1RjS5Zu/o+rv3ojn1N7AWzfgIOCSSSncfyb4qJn9J677scj0LHIxtwzjgU7j1qAedXlXKxgkFG2w==
+
+RUN npm pack "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" --pack-destination /tmp \
+    && node -e "const fs=require('fs');const crypto=require('crypto');const p='/tmp/anthropic-ai-claude-code-${CLAUDE_CODE_VERSION}.tgz';const actual='sha512-'+crypto.createHash('sha512').update(fs.readFileSync(p)).digest('base64');if(actual!=='${CLAUDE_CODE_INTEGRITY}'){throw new Error('Claude Code package integrity mismatch')}" \
+    && npm install --global "/tmp/anthropic-ai-claude-code-${CLAUDE_CODE_VERSION}.tgz" \
+    && test "$(claude --version | awk '{print $1}')" = "${CLAUDE_CODE_VERSION}"
+
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    CODING_WORKER_RUNTIME_ROOT=/worker-runtime
+
+COPY --from=claude_runtime /usr/local/bin/node /usr/local/bin/node
+COPY --from=claude_runtime /usr/local/lib/node_modules /usr/local/lib/node_modules
+
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -s ../lib/node_modules/@anthropic-ai/claude-code/cli.js /usr/local/bin/claude \
+    && groupadd --gid 65532 coding \
+    && useradd --uid 65532 --gid 65532 --home-dir /home/coding --no-create-home coding \
+    && mkdir -p /opt/modelmirror /home/coding /worker-runtime /run/modelmirror-coding \
+    && chown -R 65532:65532 /home/coding /worker-runtime /run/modelmirror-coding
+
+WORKDIR /opt/modelmirror
+COPY server/requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir --retries 5 --timeout 120 -r /tmp/requirements.txt
+
+COPY server/coding_worker ./coding_worker
+COPY server/THIRD_PARTY_NOTICES.md /usr/share/doc/modelmirror-coding/THIRD_PARTY_NOTICES.md
+
+USER 65532:65532
+
+CMD ["python", "-m", "coding_worker.sidecar"]

--- a/server/coding_worker/claude_provider.py
+++ b/server/coding_worker/claude_provider.py
@@ -565,9 +565,17 @@ class ClaudeCodeProvider(CodingAgentProvider):
                     code="provider_credential_unavailable",
                     failure_kind=ProviderFailureKind.AUTHENTICATION,
                 )
-            value = os.read(descriptor, MAX_SECRET_BYTES + 1).decode("utf-8").strip()
+            encoded = os.read(descriptor, MAX_SECRET_BYTES + 1)
         finally:
             os.close(descriptor)
+        try:
+            value = encoded.decode("utf-8").strip()
+        except UnicodeError as exc:
+            raise ClaudeCodeProviderError(
+                "Claude credential is invalid.",
+                code="provider_credential_unavailable",
+                failure_kind=ProviderFailureKind.AUTHENTICATION,
+            ) from exc
         if not value or len(value.encode("utf-8")) > MAX_SECRET_BYTES:
             raise ClaudeCodeProviderError(
                 "Claude credential is invalid.",

--- a/server/coding_worker/claude_provider.py
+++ b/server/coding_worker/claude_provider.py
@@ -1,0 +1,640 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import os
+import secrets
+import signal
+import stat
+import uuid
+from collections.abc import AsyncIterator, Callable, Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from pydantic import Field
+
+from .contracts import StrictModel
+from .provider import (
+    CodingAgentProvider,
+    ProviderCapabilities,
+    ProviderCheckpoint,
+    ProviderCheckpointCompatibility,
+    ProviderEvent,
+    ProviderEventKind,
+    ProviderFailureKind,
+    ProviderOpenRequest,
+    ProviderSession,
+    ProviderUsage,
+)
+
+
+CLAUDE_CODE_VERSION = "2.1.89"
+CLAUDE_MCP_NAME = "modelmirror-tool-broker"
+MAX_SECRET_BYTES = 16 * 1024
+MAX_STDERR_BYTES = 16 * 1024
+CLAUDE_BUILTIN_TOOLS = (
+    "Bash",
+    "Edit",
+    "Write",
+    "Read",
+    "Glob",
+    "Grep",
+    "WebFetch",
+    "WebSearch",
+    "Skill",
+    "Task",
+    "NotebookEdit",
+)
+
+
+class ClaudeCodeProviderError(RuntimeError):
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str,
+        failure_kind: ProviderFailureKind = ProviderFailureKind.UNAVAILABLE,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.failure_kind = failure_kind
+
+
+class ClaudeCodeRoute(StrictModel):
+    route_id: str
+    model_id: str = Field(min_length=1, max_length=128)
+    max_budget_usd: float = Field(default=20.0, gt=0, le=1_000)
+
+
+@dataclass(slots=True)
+class ClaudeSessionHandle:
+    request: ProviderOpenRequest
+    route: ClaudeCodeRoute
+    state_root: Path
+    home: Path
+    settings_path: Path
+    mcp_path: Path
+    session_id: str
+    revoke_broker: Callable[[], None]
+    resumed_once: bool = False
+    active_process: asyncio.subprocess.Process | None = None
+    public_context: list[str] = field(default_factory=list)
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+
+class ClaudeCodeProvider(CodingAgentProvider):
+    """Claude Code 2.1.89 adapter with no Workspace mount or public frames."""
+
+    def __init__(
+        self,
+        *,
+        runtime_root: Path,
+        routes: Mapping[str, ClaudeCodeRoute],
+        secret_path: Path,
+        command_prefix: tuple[str, ...] = ("/usr/local/bin/claude",),
+        tool_broker_command: tuple[str, ...] = (
+            "python",
+            "-m",
+            "coding_worker.broker_mcp",
+        ),
+        provider_proxy_url: str | None = None,
+    ) -> None:
+        if not command_prefix or not tool_broker_command:
+            raise ValueError("Claude provider commands cannot be empty")
+        self._runtime_root = Path(runtime_root)
+        self._routes = dict(routes)
+        self._secret_path = Path(secret_path)
+        self._command_prefix = command_prefix
+        self._tool_broker_command = tool_broker_command
+        self._provider_proxy_url = provider_proxy_url
+        self._broker_bindings: dict[str, tuple[str, str]] = {}
+        self._handles: dict[str, ClaudeSessionHandle] = {}
+        self._lock = asyncio.Lock()
+
+    def bind_broker(self, task_id: str, endpoint: str, token: str) -> None:
+        if not (
+            endpoint.startswith("unix:") or endpoint.startswith("tcp:127.0.0.1:")
+        ) or len(token) < 32:
+            raise ClaudeCodeProviderError(
+                "Tool Broker binding is invalid.", code="tool_broker_unavailable"
+            )
+        existing = self._broker_bindings.get(task_id)
+        if existing is not None and existing != (endpoint, token):
+            raise ClaudeCodeProviderError(
+                "Tool Broker binding changed.", code="tool_broker_binding_changed"
+            )
+        self._broker_bindings[task_id] = (endpoint, token)
+
+    def unbind_broker(self, task_id: str) -> None:
+        self._broker_bindings.pop(task_id, None)
+
+    async def capabilities(self) -> ProviderCapabilities:
+        return ProviderCapabilities(
+            supports_streaming=True,
+            supports_cancel=True,
+            supports_checkpoint=True,
+            supports_restore=True,
+            supports_steering=True,
+            supports_usage=True,
+        )
+
+    async def open(self, request: ProviderOpenRequest) -> ProviderSession:
+        route = self._require_route(request.model_route)
+        binding = self._broker_bindings.get(request.task_id)
+        if binding is None:
+            raise ClaudeCodeProviderError(
+                "Tool Broker binding is missing.", code="tool_broker_unavailable"
+            )
+        self._validate_secret_file()
+        session_id = str(uuid.uuid4())
+        state_root = self._runtime_root / request.task_id / session_id
+        state_root.mkdir(parents=True, exist_ok=False, mode=0o700)
+        home = state_root / "home"
+        home.mkdir(mode=0o700)
+        settings_path = state_root / "settings.json"
+        mcp_path = state_root / "mcp.json"
+        endpoint, token = binding
+        self._write_private_json(
+            settings_path, self.build_settings(request.tool_allowlist)
+        )
+        self._write_private_json(
+            mcp_path,
+            self.build_mcp_config(
+                task_id=request.task_id,
+                endpoint=endpoint,
+                token=token,
+            ),
+        )
+        handle = ClaudeSessionHandle(
+            request=request,
+            route=route,
+            state_root=state_root,
+            home=home,
+            settings_path=settings_path,
+            mcp_path=mcp_path,
+            session_id=session_id,
+            revoke_broker=lambda: self.unbind_broker(request.task_id),
+        )
+        async with self._lock:
+            if session_id in self._handles:
+                raise ClaudeCodeProviderError(
+                    "Claude session collision.", code="provider_invalid_response"
+                )
+            self._handles[session_id] = handle
+        return ProviderSession(
+            session_id=session_id,
+            task_id=request.task_id,
+            provider_capabilities=await self.capabilities(),
+        )
+
+    async def message(
+        self, session: ProviderSession, text: str
+    ) -> AsyncIterator[ProviderEvent]:
+        if not text.strip():
+            raise ValueError("provider message cannot be blank")
+        handle = self._require_session(session)
+        async with handle.lock:
+            if handle.active_process is not None:
+                raise ClaudeCodeProviderError(
+                    "Claude session is busy.", code="provider_session_busy"
+                )
+            api_key = self._read_secret()
+            command = self.build_command(handle)
+            environment = self.build_environment(handle, api_key=api_key)
+            process: asyncio.subprocess.Process | None = None
+            output_bytes = 0
+            saw_terminal = False
+            try:
+                process = await asyncio.create_subprocess_exec(
+                    *command,
+                    cwd=handle.state_root,
+                    env=environment,
+                    stdin=asyncio.subprocess.PIPE,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    start_new_session=True,
+                )
+                handle.active_process = process
+                if process.stdin is None or process.stdout is None:
+                    raise ClaudeCodeProviderError(
+                        "Claude stream is unavailable.",
+                        code="provider_unavailable",
+                    )
+                frame = self.build_input_frame(session.session_id, text)
+                process.stdin.write(
+                    json.dumps(frame, ensure_ascii=False, separators=(",", ":")).encode(
+                        "utf-8"
+                    )
+                    + b"\n"
+                )
+                await process.stdin.drain()
+                process.stdin.close()
+                with contextlib.suppress(Exception):
+                    await process.stdin.wait_closed()
+                async with asyncio.timeout(handle.request.budget.max_seconds):
+                    while line := await process.stdout.readline():
+                        output_bytes += len(line)
+                        if output_bytes > handle.request.budget.max_output_bytes:
+                            await _stop_process(process)
+                            yield self._failure_event(ProviderFailureKind.BUDGET)
+                            return
+                        events = self.map_stream_frame(line, session.session_id)
+                        for event in events:
+                            if event.kind is ProviderEventKind.MESSAGE:
+                                value = event.data.get("text")
+                                if isinstance(value, str) and value:
+                                    handle.public_context.append(value[:16_384])
+                                    if len(handle.public_context) > 64:
+                                        del handle.public_context[:-64]
+                            yield event
+                            if event.kind in {
+                                ProviderEventKind.TURN_COMPLETED,
+                                ProviderEventKind.CANCELLED,
+                                ProviderEventKind.FAILED,
+                            }:
+                                saw_terminal = True
+                    return_code = await process.wait()
+                if not saw_terminal:
+                    yield self._failure_event(
+                        ProviderFailureKind.INTERRUPTED
+                        if return_code == 0
+                        else ProviderFailureKind.UNAVAILABLE
+                    )
+            except TimeoutError:
+                if process is not None:
+                    await _stop_process(process)
+                yield self._failure_event(ProviderFailureKind.BUDGET)
+            except OSError as exc:
+                raise ClaudeCodeProviderError(
+                    "Claude process failed to start.", code="provider_unavailable"
+                ) from exc
+            finally:
+                if process is not None and process.returncode is None:
+                    await _stop_process(process)
+                if process is not None and process.stderr is not None:
+                    with contextlib.suppress(Exception):
+                        await asyncio.wait_for(
+                            process.stderr.read(MAX_STDERR_BYTES), timeout=0.2
+                        )
+                handle.active_process = None
+                handle.resumed_once = True
+
+    async def cancel(self, session: ProviderSession) -> bool:
+        handle = self._require_session(session)
+        process = handle.active_process
+        if process is None or process.returncode is not None:
+            return False
+        await _stop_process(process)
+        return True
+
+    async def checkpoint(self, session: ProviderSession) -> ProviderCheckpoint:
+        handle = self._require_session(session)
+        public_text = "".join(handle.public_context)
+        return ProviderCheckpoint(
+            checkpoint_id=f"checkpoint_{secrets.token_hex(16)}",
+            compatibility=ProviderCheckpointCompatibility(
+                provider_family="claude-code",
+                provider_version=CLAUDE_CODE_VERSION,
+                task_id=session.task_id,
+                workspace_tree_hash=handle.request.workspace_tree_hash,
+            ),
+            payload={
+                "task_id": session.task_id,
+                "public_output": public_text[-32_768:],
+            },
+        )
+
+    async def restore(
+        self, request: ProviderOpenRequest, checkpoint: ProviderCheckpoint
+    ) -> ProviderSession:
+        compatibility = checkpoint.compatibility
+        if (
+            compatibility is None
+            or compatibility.provider_family != "claude-code"
+            or compatibility.provider_version != CLAUDE_CODE_VERSION
+            or compatibility.task_id != request.task_id
+            or compatibility.workspace_tree_hash != request.workspace_tree_hash
+            or checkpoint.payload.get("task_id") != request.task_id
+            or not isinstance(checkpoint.payload.get("public_output", ""), str)
+        ):
+            raise ClaudeCodeProviderError(
+                "Claude checkpoint binding is invalid.", code="checkpoint_invalid"
+            )
+        return await self.open(request)
+
+    async def close(self, session: ProviderSession) -> None:
+        async with self._lock:
+            handle = self._handles.pop(session.session_id, None)
+        if handle is None:
+            return
+        if handle.active_process is not None:
+            await _stop_process(handle.active_process)
+        handle.revoke_broker()
+
+    def build_settings(self, tool_allowlist: tuple[str, ...]) -> dict[str, Any]:
+        allowed = [self._claude_tool_name(name) for name in tool_allowlist]
+        return {
+            "permissions": {
+                "allow": allowed,
+                "deny": list(CLAUDE_BUILTIN_TOOLS),
+                "defaultMode": "dontAsk",
+                "disableBypassPermissionsMode": "disable",
+            },
+            "disableAllHooks": True,
+            "enabledPlugins": {},
+            "strictKnownMarketplaces": [],
+            "allowManagedPermissionRulesOnly": True,
+            "allowManagedHooksOnly": True,
+        }
+
+    def build_mcp_config(
+        self, *, task_id: str, endpoint: str, token: str
+    ) -> dict[str, Any]:
+        return {
+            "mcpServers": {
+                CLAUDE_MCP_NAME: {
+                    "type": "stdio",
+                    "command": self._tool_broker_command[0],
+                    "args": list(self._tool_broker_command[1:]),
+                    "env": {
+                        "CODING_WORKER_BROKER_ENDPOINT": endpoint,
+                        "CODING_WORKER_BROKER_TOKEN": token,
+                        "CODING_WORKER_TASK_ID": task_id,
+                        "PYTHONPATH": str(Path(__file__).resolve().parent.parent),
+                    },
+                }
+            }
+        }
+
+    def build_command(self, handle: ClaudeSessionHandle) -> tuple[str, ...]:
+        allowed = ",".join(
+            self._claude_tool_name(name)
+            for name in handle.request.tool_allowlist
+        )
+        command = [
+            *self._command_prefix,
+            "--print",
+            "--input-format",
+            "stream-json",
+            "--output-format",
+            "stream-json",
+            "--verbose",
+            "--bare",
+            "--strict-mcp-config",
+            "--mcp-config",
+            str(handle.mcp_path),
+            "--settings",
+            str(handle.settings_path),
+            "--tools",
+            "",
+            "--allowedTools",
+            allowed,
+            "--disallowedTools",
+            ",".join(CLAUDE_BUILTIN_TOOLS),
+            "--disable-slash-commands",
+            "--no-chrome",
+            "--permission-mode",
+            "dontAsk",
+            "--model",
+            handle.route.model_id,
+            "--max-budget-usd",
+            f"{handle.route.max_budget_usd:.6f}",
+        ]
+        if handle.resumed_once:
+            command.extend(("--resume", handle.session_id))
+        else:
+            command.extend(("--session-id", handle.session_id))
+        return tuple(command)
+
+    def build_environment(
+        self, handle: ClaudeSessionHandle, *, api_key: str
+    ) -> dict[str, str]:
+        environment = {
+            "PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"),
+            "HOME": str(handle.home),
+            "TMPDIR": str(handle.state_root),
+            "ANTHROPIC_API_KEY": api_key,
+            "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+            "CLAUDE_CODE_DISABLE_OFFICIAL_MARKETPLACE_AUTOINSTALL": "1",
+            "CLAUDE_CODE_DONT_INHERIT_ENV": "1",
+            "DISABLE_AUTOUPDATER": "1",
+            "DISABLE_ERROR_REPORTING": "1",
+            "DISABLE_PLUGIN_AUTOLOAD": "1",
+            "DISABLE_TELEMETRY": "1",
+        }
+        if self._provider_proxy_url is not None:
+            environment["HTTPS_PROXY"] = self._provider_proxy_url
+            environment["HTTP_PROXY"] = self._provider_proxy_url
+        return environment
+
+    @staticmethod
+    def build_input_frame(session_id: str, text: str) -> dict[str, Any]:
+        return {
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [{"type": "text", "text": text}],
+            },
+            "parent_tool_use_id": None,
+            "session_id": session_id,
+        }
+
+    @staticmethod
+    def map_stream_frame(
+        encoded: bytes, session_id: str
+    ) -> tuple[ProviderEvent, ...]:
+        if len(encoded) > 1_048_576:
+            return ()
+        try:
+            value = json.loads(encoded)
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return ()
+        if not isinstance(value, dict):
+            return ()
+        frame_session = value.get("session_id")
+        if frame_session is not None and frame_session != session_id:
+            return ()
+        frame_type = value.get("type")
+        if frame_type == "assistant":
+            message = value.get("message")
+            content = message.get("content") if isinstance(message, dict) else None
+            text = "".join(
+                item.get("text", "")
+                for item in content
+                if isinstance(item, dict)
+                and item.get("type") == "text"
+                and isinstance(item.get("text"), str)
+            ) if isinstance(content, list) else ""
+            events: list[ProviderEvent] = []
+            if text:
+                events.append(
+                    ProviderEvent(
+                        kind=ProviderEventKind.MESSAGE,
+                        data={"text": text[:1_048_576]},
+                    )
+                )
+            usage = _usage_from_mapping(
+                message.get("usage") if isinstance(message, dict) else None,
+                cost=None,
+            )
+            if usage is not None:
+                events.append(_usage_event(usage))
+            return tuple(events)
+        if frame_type == "result":
+            usage = _usage_from_mapping(
+                value.get("usage"), cost=value.get("total_cost_usd")
+            )
+            events = [_usage_event(usage)] if usage is not None else []
+            if value.get("is_error") is True:
+                subtype = value.get("subtype")
+                failure = (
+                    ProviderFailureKind.BUDGET
+                    if subtype in {"error_max_budget_usd", "error_max_turns"}
+                    else ProviderFailureKind.UNAVAILABLE
+                )
+                events.append(ClaudeCodeProvider._failure_event(failure))
+            else:
+                events.append(ProviderEvent(kind=ProviderEventKind.TURN_COMPLETED))
+            return tuple(events)
+        return ()
+
+    @staticmethod
+    def _failure_event(kind: ProviderFailureKind) -> ProviderEvent:
+        return ProviderEvent(
+            kind=ProviderEventKind.FAILED,
+            data={"failure_kind": kind.value},
+        )
+
+    @staticmethod
+    def _claude_tool_name(tool_name: str) -> str:
+        return f"mcp__{CLAUDE_MCP_NAME}__{tool_name}"
+
+    def _require_route(self, route_id: str) -> ClaudeCodeRoute:
+        route = self._routes.get(route_id)
+        if route is None or route.route_id != route_id:
+            raise ClaudeCodeProviderError(
+                "Model route is unavailable.", code="model_route_unavailable"
+            )
+        return route
+
+    def _require_session(self, session: ProviderSession) -> ClaudeSessionHandle:
+        handle = self._handles.get(session.session_id)
+        if handle is None or handle.request.task_id != session.task_id:
+            raise ClaudeCodeProviderError(
+                "Provider session was not found.", code="session_not_found"
+            )
+        return handle
+
+    def _validate_secret_file(self) -> os.stat_result:
+        try:
+            metadata = self._secret_path.lstat()
+        except OSError as exc:
+            raise ClaudeCodeProviderError(
+                "Claude credential is unavailable.",
+                code="provider_credential_unavailable",
+                failure_kind=ProviderFailureKind.AUTHENTICATION,
+            ) from exc
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or self._secret_path.is_symlink()
+            or metadata.st_nlink != 1
+            or metadata.st_size <= 0
+            or metadata.st_size > MAX_SECRET_BYTES
+        ):
+            raise ClaudeCodeProviderError(
+                "Claude credential is unsafe.",
+                code="provider_credential_unavailable",
+                failure_kind=ProviderFailureKind.AUTHENTICATION,
+            )
+        return metadata
+
+    def _read_secret(self) -> str:
+        expected = self._validate_secret_file()
+        descriptor = os.open(self._secret_path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+        try:
+            actual = os.fstat(descriptor)
+            if (actual.st_dev, actual.st_ino, actual.st_size) != (
+                expected.st_dev,
+                expected.st_ino,
+                expected.st_size,
+            ):
+                raise ClaudeCodeProviderError(
+                    "Claude credential changed.",
+                    code="provider_credential_unavailable",
+                    failure_kind=ProviderFailureKind.AUTHENTICATION,
+                )
+            value = os.read(descriptor, MAX_SECRET_BYTES + 1).decode("utf-8").strip()
+        finally:
+            os.close(descriptor)
+        if not value or len(value.encode("utf-8")) > MAX_SECRET_BYTES:
+            raise ClaudeCodeProviderError(
+                "Claude credential is invalid.",
+                code="provider_credential_unavailable",
+                failure_kind=ProviderFailureKind.AUTHENTICATION,
+            )
+        return value
+
+    @staticmethod
+    def _write_private_json(path: Path, value: dict[str, Any]) -> None:
+        encoded = json.dumps(value, ensure_ascii=False, separators=(",", ":")).encode(
+            "utf-8"
+        )
+        descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        try:
+            os.write(descriptor, encoded)
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+
+
+def _usage_from_mapping(value: Any, *, cost: Any) -> ProviderUsage | None:
+    if not isinstance(value, dict):
+        return None
+    return ProviderUsage(
+        input_tokens=_nonnegative_int(value.get("input_tokens")),
+        output_tokens=_nonnegative_int(value.get("output_tokens")),
+        cache_read_tokens=_nonnegative_int(value.get("cache_read_input_tokens")),
+        cache_write_tokens=_nonnegative_int(value.get("cache_creation_input_tokens")),
+        cost_microusd=(
+            round(float(cost) * 1_000_000)
+            if isinstance(cost, (int, float)) and cost >= 0
+            else None
+        ),
+    )
+
+
+def _usage_event(usage: ProviderUsage) -> ProviderEvent:
+    return ProviderEvent(
+        kind=ProviderEventKind.USAGE,
+        data={"usage": usage.model_dump(mode="json")},
+    )
+
+
+def _nonnegative_int(value: Any) -> int:
+    return (
+        value
+        if isinstance(value, int) and not isinstance(value, bool) and value >= 0
+        else 0
+    )
+
+
+async def _stop_process(process: asyncio.subprocess.Process) -> None:
+    if process.returncode is not None:
+        return
+    with contextlib.suppress(ProcessLookupError):
+        if os.name == "posix":
+            os.killpg(process.pid, signal.SIGTERM)
+        else:
+            process.terminate()
+    try:
+        await asyncio.wait_for(process.wait(), timeout=3.0)
+    except TimeoutError:
+        with contextlib.suppress(ProcessLookupError):
+            if os.name == "posix":
+                os.killpg(process.pid, signal.SIGKILL)
+            else:
+                process.kill()
+        with contextlib.suppress(Exception):
+            await process.wait()

--- a/server/coding_worker/egress_proxy.py
+++ b/server/coding_worker/egress_proxy.py
@@ -3,19 +3,61 @@ from __future__ import annotations
 import asyncio
 import base64
 import contextlib
+import hmac
 import ipaddress
 import os
+import re
 import socket
 
 from .network_policy import EgressPolicy, NetworkPolicyError
 
 
 MAX_HEADER_BYTES = 16 * 1024
+PROVIDER_TOKEN = re.compile(r"^[A-Za-z0-9._~-]{32,256}$")
+
+
+class ProviderEgressPolicy:
+    """Authenticates one Provider sidecar to an exact API domain set."""
+
+    def __init__(self, *, token: str, allowed_domains: tuple[str, ...]) -> None:
+        if PROVIDER_TOKEN.fullmatch(token) is None:
+            raise NetworkPolicyError(
+                "Provider proxy token is invalid.", code="network_grant_key_invalid"
+            )
+        self._token = token
+        self.allowed_domains = frozenset(
+            EgressPolicy._normalize_domain(domain) for domain in allowed_domains
+        )
+        if not self.allowed_domains:
+            raise NetworkPolicyError(
+                "Provider domains are unavailable.", code="network_domain_not_allowed"
+            )
+
+    def validate(self, token: str, *, domain: str) -> None:
+        normalized = EgressPolicy._normalize_domain(domain)
+        if not hmac.compare_digest(token, self._token):
+            raise NetworkPolicyError(
+                "Provider proxy authorization is invalid.",
+                code="network_grant_invalid",
+            )
+        if normalized not in self.allowed_domains:
+            raise NetworkPolicyError(
+                "Provider destination is not allowed.",
+                code="network_domain_not_allowed",
+            )
 
 
 class EgressProxy:
-    def __init__(self, policy: EgressPolicy) -> None:
+    def __init__(
+        self,
+        policy: EgressPolicy | None = None,
+        *,
+        provider_policy: ProviderEgressPolicy | None = None,
+    ) -> None:
+        if (policy is None) == (provider_policy is None):
+            raise ValueError("exactly one proxy policy is required")
         self.policy = policy
+        self.provider_policy = provider_policy
 
     async def handle(
         self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
@@ -38,10 +80,24 @@ class EgressProxy:
             )
             if not authorization.startswith("Basic "):
                 raise NetworkPolicyError("Proxy authorization is required.", code="network_grant_invalid")
-            username, token = base64.b64decode(authorization[6:]).decode("utf-8").split(":", 1)
-            if username != "grant":
-                raise NetworkPolicyError("Proxy authorization is invalid.", code="network_grant_invalid")
-            self.policy.validate_grant(token, domain=domain)
+            try:
+                username, token = (
+                    base64.b64decode(authorization[6:], validate=True)
+                    .decode("utf-8")
+                    .split(":", 1)
+                )
+            except (ValueError, UnicodeError) as exc:
+                raise NetworkPolicyError(
+                    "Proxy authorization is invalid.", code="network_grant_invalid"
+                ) from exc
+            if username == "grant" and self.policy is not None:
+                self.policy.validate_grant(token, domain=domain)
+            elif username == "provider" and self.provider_policy is not None:
+                self.provider_policy.validate(token, domain=domain)
+            else:
+                raise NetworkPolicyError(
+                    "Proxy authorization is invalid.", code="network_grant_invalid"
+                )
             addresses = await asyncio.get_running_loop().getaddrinfo(
                 domain, 443, type=socket.SOCK_STREAM
             )
@@ -84,15 +140,34 @@ class EgressProxy:
 
 
 async def run() -> None:
-    key = os.environ.get("CODING_WORKER_EGRESS_GRANT_KEY", "")
-    domains = tuple(
-        item.strip().lower()
-        for item in os.environ.get("CODING_WORKER_NETWORK_DOMAINS", "").split(",")
-        if item.strip()
+    provider_token = os.environ.get("CODING_WORKER_PROVIDER_EGRESS_TOKEN", "")
+    if provider_token:
+        domains = tuple(
+            item.strip().lower()
+            for item in os.environ.get(
+                "CODING_WORKER_PROVIDER_NETWORK_DOMAINS", ""
+            ).split(",")
+            if item.strip()
+        )
+        proxy = EgressProxy(
+            provider_policy=ProviderEgressPolicy(
+                token=provider_token, allowed_domains=domains
+            )
+        )
+        port = 8081
+    else:
+        key = os.environ.get("CODING_WORKER_EGRESS_GRANT_KEY", "")
+        domains = tuple(
+            item.strip().lower()
+            for item in os.environ.get("CODING_WORKER_NETWORK_DOMAINS", "").split(",")
+            if item.strip()
+        )
+        policy = EgressPolicy(enabled=True, allowed_domains=domains, grant_key=key)
+        proxy = EgressProxy(policy)
+        port = 8080
+    server = await asyncio.start_server(
+        proxy.handle, "0.0.0.0", port, limit=MAX_HEADER_BYTES
     )
-    policy = EgressPolicy(enabled=True, allowed_domains=domains, grant_key=key)
-    proxy = EgressProxy(policy)
-    server = await asyncio.start_server(proxy.handle, "0.0.0.0", 8080, limit=MAX_HEADER_BYTES)
     async with server:
         await server.serve_forever()
 

--- a/server/coding_worker/opencode_provider.py
+++ b/server/coding_worker/opencode_provider.py
@@ -22,10 +22,13 @@ from .provider import (
     CodingAgentProvider,
     ProviderCapabilities,
     ProviderCheckpoint,
+    ProviderCheckpointCompatibility,
     ProviderEvent,
     ProviderEventKind,
     ProviderOpenRequest,
     ProviderSession,
+    PROVIDER_TOOL_NAMES,
+    ProviderUsage,
 )
 
 
@@ -203,7 +206,7 @@ class OpenCodeProvider(CodingAgentProvider):
                         "modelID": route.model_id,
                     },
                     "agent": "modelmirror-worker",
-                    "tools": self._prompt_tools(),
+                    "tools": self._prompt_tools(request.tool_allowlist),
                     "parts": [{"type": "text", "text": text}],
                 },
             )
@@ -257,6 +260,12 @@ class OpenCodeProvider(CodingAgentProvider):
         public_text = "".join(self._public_context.get(session.session_id, ()))
         return ProviderCheckpoint(
             checkpoint_id=f"checkpoint_{secrets.token_hex(16)}",
+            compatibility=ProviderCheckpointCompatibility(
+                provider_family="opencode",
+                provider_version=OPENCODE_VERSION,
+                task_id=request.task_id,
+                workspace_tree_hash=request.workspace_tree_hash,
+            ),
             payload={
                 "engine": "opencode-1.18.9",
                 "task_id": request.task_id,
@@ -267,10 +276,21 @@ class OpenCodeProvider(CodingAgentProvider):
     async def restore(
         self, request: ProviderOpenRequest, checkpoint: ProviderCheckpoint
     ) -> ProviderSession:
+        compatibility = checkpoint.compatibility
         if (
             checkpoint.payload.get("engine") != "opencode-1.18.9"
             or checkpoint.payload.get("task_id") != request.task_id
             or not isinstance(checkpoint.payload.get("public_output", ""), str)
+            or (
+                compatibility is not None
+                and (
+                    compatibility.provider_family != "opencode"
+                    or compatibility.provider_version != OPENCODE_VERSION
+                    or compatibility.task_id != request.task_id
+                    or compatibility.workspace_tree_hash
+                    != request.workspace_tree_hash
+                )
+            )
         ):
             raise OpenCodeProviderError(
                 "OpenCode checkpoint binding is invalid.", code="checkpoint_invalid"
@@ -289,7 +309,11 @@ class OpenCodeProvider(CodingAgentProvider):
         if handle is not None:
             await handle.close()
 
-    def build_config(self, route: OpenCodeRoute) -> dict[str, Any]:
+    def build_config(
+        self,
+        route: OpenCodeRoute,
+        tool_allowlist: tuple[str, ...] = PROVIDER_TOOL_NAMES,
+    ) -> dict[str, Any]:
         permission: dict[str, str] = {
             "*": "deny",
             "external_directory": "deny",
@@ -298,7 +322,8 @@ class OpenCodeProvider(CodingAgentProvider):
         }
         mcp: dict[str, Any] = {}
         if self._tool_broker_command is not None:
-            permission[f"{TOOL_BROKER_MCP_NAME}_*"] = "allow"
+            for tool_name in tool_allowlist:
+                permission[f"{TOOL_BROKER_MCP_NAME}_{tool_name}"] = "allow"
             mcp[TOOL_BROKER_MCP_NAME] = {
                 "type": "local",
                 "command": list(self._tool_broker_command),
@@ -364,7 +389,9 @@ class OpenCodeProvider(CodingAgentProvider):
             "XDG_STATE_HOME": str(home / ".local/state"),
             "XDG_CACHE_HOME": str(home / ".cache"),
             "OPENCODE_CONFIG_CONTENT": json.dumps(
-                self.build_config(route), ensure_ascii=False, separators=(",", ":")
+                self.build_config(route, request.tool_allowlist),
+                ensure_ascii=False,
+                separators=(",", ":"),
             ),
             "OPENCODE_DISABLE_PROJECT_CONFIG": "1",
             "OPENCODE_PURE": "1",
@@ -475,10 +502,17 @@ class OpenCodeProvider(CodingAgentProvider):
             raise OpenCodeProviderError("Provider session was not found.", code="session_not_found")
         return handle, request
 
-    def _prompt_tools(self) -> dict[str, bool]:
+    def _prompt_tools(
+        self, tool_allowlist: tuple[str, ...] = PROVIDER_TOOL_NAMES
+    ) -> dict[str, bool]:
         tools = {name: False for name in DIRECT_TOOL_NAMES}
         if self._tool_broker_command is not None:
-            tools[f"{TOOL_BROKER_MCP_NAME}_*"] = True
+            tools.update(
+                {
+                    f"{TOOL_BROKER_MCP_NAME}_{tool_name}": True
+                    for tool_name in tool_allowlist
+                }
+            )
         return tools
 
     async def _wait_for_tool_broker(self, handle: OpenCodeServerHandle) -> None:
@@ -531,6 +565,31 @@ class OpenCodeProvider(CodingAgentProvider):
                 text = delta if isinstance(delta, str) else part.get("text")
             if isinstance(text, str) and text:
                 return ProviderEvent(kind=ProviderEventKind.MESSAGE, data={"text": text})
+        if event_type == "message.updated":
+            info = properties.get("info")
+            tokens = info.get("tokens") if isinstance(info, dict) else None
+            if isinstance(tokens, dict):
+                cache = tokens.get("cache")
+                cost = info.get("cost")
+                usage = ProviderUsage(
+                    input_tokens=_nonnegative_int(tokens.get("input")),
+                    output_tokens=_nonnegative_int(tokens.get("output")),
+                    cache_read_tokens=_nonnegative_int(
+                        cache.get("read") if isinstance(cache, dict) else None
+                    ),
+                    cache_write_tokens=_nonnegative_int(
+                        cache.get("write") if isinstance(cache, dict) else None
+                    ),
+                    cost_microusd=(
+                        round(float(cost) * 1_000_000)
+                        if isinstance(cost, (int, float)) and cost >= 0
+                        else None
+                    ),
+                )
+                return ProviderEvent(
+                    kind=ProviderEventKind.USAGE,
+                    data={"usage": usage.model_dump(mode="json")},
+                )
         if event_type in {"permission.asked", "permission.updated"}:
             return ProviderEvent(
                 kind=ProviderEventKind.APPROVAL_REQUIRED,
@@ -543,6 +602,14 @@ class OpenCodeProvider(CodingAgentProvider):
         if event_type in {"session.error", "message.error"}:
             return ProviderEvent(kind=ProviderEventKind.FAILED, data={"error": "provider_failed"})
         return None
+
+
+def _nonnegative_int(value: Any) -> int:
+    return (
+        value
+        if isinstance(value, int) and not isinstance(value, bool) and value >= 0
+        else 0
+    )
 
 
 async def _iter_sse_json(response: httpx.Response) -> AsyncIterator[dict[str, Any]]:

--- a/server/coding_worker/provider.py
+++ b/server/coding_worker/provider.py
@@ -183,16 +183,19 @@ class FakeCodingAgentProvider:
         self._block = block
         self._cancelled: set[str] = set()
         self._closed: set[str] = set()
+        self._requests: dict[str, ProviderOpenRequest] = {}
 
     async def capabilities(self) -> ProviderCapabilities:
         return ProviderCapabilities(supports_checkpoint=True, supports_restore=True)
 
     async def open(self, request: ProviderOpenRequest) -> ProviderSession:
-        return ProviderSession(
+        session = ProviderSession(
             session_id=f"fake_{uuid.uuid4().hex}",
             task_id=request.task_id,
             provider_capabilities=await self.capabilities(),
         )
+        self._requests[session.session_id] = request
+        return session
 
     async def message(
         self, session: ProviderSession, text: str
@@ -215,12 +218,16 @@ class FakeCodingAgentProvider:
         return True
 
     async def checkpoint(self, session: ProviderSession) -> ProviderCheckpoint:
+        request = self._requests.get(session.session_id)
+        if request is None or request.task_id != session.task_id:
+            raise ValueError("invalid session")
         return ProviderCheckpoint(
             checkpoint_id=f"checkpoint_{uuid.uuid4().hex}",
             compatibility=ProviderCheckpointCompatibility(
                 provider_family="fake",
                 provider_version="1",
                 task_id=session.task_id,
+                workspace_tree_hash=request.workspace_tree_hash,
             ),
             payload={"fake_session": session.session_id},
         )
@@ -235,8 +242,7 @@ class FakeCodingAgentProvider:
             compatibility.provider_family != "fake"
             or compatibility.provider_version != "1"
             or compatibility.task_id != request.task_id
-            or compatibility.workspace_tree_hash
-            not in {None, request.workspace_tree_hash}
+            or compatibility.workspace_tree_hash != request.workspace_tree_hash
         ):
             raise ValueError("incompatible checkpoint")
         return await self.open(request)
@@ -244,3 +250,4 @@ class FakeCodingAgentProvider:
     async def close(self, session: ProviderSession) -> None:
         self._closed.add(session.session_id)
         self._cancelled.discard(session.session_id)
+        self._requests.pop(session.session_id, None)

--- a/server/coding_worker/provider.py
+++ b/server/coding_worker/provider.py
@@ -4,11 +4,44 @@ import asyncio
 import uuid
 from collections.abc import AsyncIterator, Sequence
 from enum import StrEnum
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, ClassVar, Protocol, runtime_checkable
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from .contracts import PolicyProfile, SAFE_ID, StrictModel, TaskBudget
+
+
+PROVIDER_CONTRACT_VERSION = 2
+PROVIDER_CHECKPOINT_FORMAT_VERSION = 2
+PROVIDER_TOOL_NAMES = (
+    "list_files",
+    "read_file",
+    "read_file_range",
+    "glob_files",
+    "search_text",
+    "search_regex",
+    "workspace_diff",
+    "code_symbols",
+    "code_definition",
+    "code_references",
+    "code_hover",
+    "code_diagnostics",
+    "write_file",
+    "delete_file",
+    "apply_changeset",
+    "list_acceptance_checks",
+    "run_check",
+    "run_command",
+    "run_shell",
+    "install_dependencies",
+    "start_service",
+    "service_status",
+    "service_input",
+    "stop_service",
+)
+INSPECT_PROVIDER_TOOLS = PROVIDER_TOOL_NAMES[:12] + (
+    "list_acceptance_checks",
+)
 
 
 class ProviderEventKind(StrEnum):
@@ -22,23 +55,71 @@ class ProviderEventKind(StrEnum):
     TURN_COMPLETED = "turn_completed"
     CANCELLED = "cancelled"
     FAILED = "failed"
+    USAGE = "usage"
+
+
+class ProviderFailureKind(StrEnum):
+    UNAVAILABLE = "unavailable"
+    AUTHENTICATION = "authentication"
+    RATE_LIMITED = "rate_limited"
+    INVALID_RESPONSE = "invalid_response"
+    POLICY = "policy"
+    BUDGET = "budget"
+    INTERRUPTED = "interrupted"
+
+
+class ProviderUsage(StrictModel):
+    input_tokens: int = Field(default=0, ge=0)
+    output_tokens: int = Field(default=0, ge=0)
+    cache_read_tokens: int = Field(default=0, ge=0)
+    cache_write_tokens: int = Field(default=0, ge=0)
+    cost_microusd: int | None = Field(default=None, ge=0)
+
+
+class ProviderCheckpointCompatibility(StrictModel):
+    contract_version: int = PROVIDER_CONTRACT_VERSION
+    format_version: int = PROVIDER_CHECKPOINT_FORMAT_VERSION
+    provider_family: str = Field(pattern=r"^[a-z][a-z0-9-]{1,31}$")
+    provider_version: str = Field(min_length=1, max_length=64)
+    task_id: str
+    workspace_tree_hash: str | None = Field(
+        default=None, pattern=r"^[0-9a-f]{64}$"
+    )
 
 
 class ProviderCapabilities(StrictModel):
+    contract_version: int = PROVIDER_CONTRACT_VERSION
     supports_streaming: bool = True
     supports_cancel: bool = True
     supports_checkpoint: bool = False
     supports_restore: bool = False
     supports_steering: bool = True
+    supports_usage: bool = True
+    tool_names: tuple[str, ...] = PROVIDER_TOOL_NAMES
 
 
 class ProviderOpenRequest(StrictModel):
+    _VALID_TOOLS: ClassVar[frozenset[str]] = frozenset(PROVIDER_TOOL_NAMES)
+
     task_id: str
     workspace_id: str
     objective: str = Field(min_length=1, max_length=1_048_576)
     model_route: str
     policy_profile: PolicyProfile
     budget: TaskBudget
+    workspace_tree_hash: str | None = Field(
+        default=None, pattern=r"^[0-9a-f]{64}$"
+    )
+    tool_allowlist: tuple[str, ...] = PROVIDER_TOOL_NAMES
+
+    @field_validator("tool_allowlist")
+    @classmethod
+    def _validate_tool_allowlist(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        if len(value) != len(set(value)) or any(
+            tool not in cls._VALID_TOOLS for tool in value
+        ):
+            raise ValueError("provider tool allowlist is invalid")
+        return value
 
 
 class ProviderSession(StrictModel):
@@ -54,7 +135,14 @@ class ProviderEvent(StrictModel):
 
 class ProviderCheckpoint(StrictModel):
     checkpoint_id: str
+    compatibility: ProviderCheckpointCompatibility | None = None
     payload: dict[str, Any] = Field(default_factory=dict)
+
+
+def provider_tools_for_policy(policy: PolicyProfile) -> tuple[str, ...]:
+    if policy is PolicyProfile.INSPECT:
+        return INSPECT_PROVIDER_TOOLS
+    return PROVIDER_TOOL_NAMES
 
 
 @runtime_checkable
@@ -129,6 +217,11 @@ class FakeCodingAgentProvider:
     async def checkpoint(self, session: ProviderSession) -> ProviderCheckpoint:
         return ProviderCheckpoint(
             checkpoint_id=f"checkpoint_{uuid.uuid4().hex}",
+            compatibility=ProviderCheckpointCompatibility(
+                provider_family="fake",
+                provider_version="1",
+                task_id=session.task_id,
+            ),
             payload={"fake_session": session.session_id},
         )
 
@@ -137,6 +230,15 @@ class FakeCodingAgentProvider:
     ) -> ProviderSession:
         if SAFE_ID.fullmatch(checkpoint.checkpoint_id) is None:
             raise ValueError("invalid checkpoint")
+        compatibility = checkpoint.compatibility
+        if compatibility is not None and (
+            compatibility.provider_family != "fake"
+            or compatibility.provider_version != "1"
+            or compatibility.task_id != request.task_id
+            or compatibility.workspace_tree_hash
+            not in {None, request.workspace_tree_hash}
+        ):
+            raise ValueError("incompatible checkpoint")
         return await self.open(request)
 
     async def close(self, session: ProviderSession) -> None:

--- a/server/coding_worker/runtime.py
+++ b/server/coding_worker/runtime.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import json
 import os
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 
 from .broker_rpc import BrokerRPCServer
@@ -49,6 +50,7 @@ class CodingWorkerRuntime:
         network_grant_key: bytes | str | None = None,
         sidecar_uid: int = 65532,
         sidecar_gid: int = 65532,
+        route_slots: Mapping[str, Sequence[str]] | None = None,
     ) -> None:
         if (
             set(slot_roots) != set(provider_endpoints)
@@ -118,6 +120,7 @@ class CodingWorkerRuntime:
             harness_runner=self.harness,
             max_active_tasks=max_active_tasks,
             tool_broker=self.tool_broker,
+            route_slots=route_slots,
         )
         self.broker_socket_path = broker_socket_path
         self.sidecar_gid = sidecar_gid
@@ -237,6 +240,7 @@ def build_runtime_from_environment() -> CodingWorkerRuntime:
         "slot-a": os.getenv("CODING_WORKER_SLOT_A_TOKEN", ""),
         "slot-b": os.getenv("CODING_WORKER_SLOT_B_TOKEN", ""),
     }
+    route_slots = _route_slots_from_environment(tuple(slot_roots))
     executor_endpoints = {
         "slot-a": os.getenv(
             "CODING_WORKER_EXECUTOR_A_ENDPOINT",
@@ -339,4 +343,45 @@ def build_runtime_from_environment() -> CodingWorkerRuntime:
         network_domains=domains,
         egress_proxy_url=os.getenv("CODING_WORKER_EGRESS_PROXY_URL") or None,
         network_grant_key=os.getenv("CODING_WORKER_EGRESS_GRANT_KEY") or None,
+        route_slots=route_slots,
     )
+
+
+def _route_slots_from_environment(
+    slot_ids: tuple[str, ...]
+) -> dict[str, tuple[str, ...]] | None:
+    encoded = os.getenv("CODING_WORKER_ROUTE_SLOTS_JSON", "").strip()
+    if not encoded:
+        return None
+    try:
+        value = json.loads(encoded)
+    except json.JSONDecodeError as exc:
+        raise CodingWorkerRuntimeError(
+            "Worker route catalog is invalid.", code="coding_worker_config_invalid"
+        ) from exc
+    if not isinstance(value, dict):
+        raise CodingWorkerRuntimeError(
+            "Worker route catalog is invalid.", code="coding_worker_config_invalid"
+        )
+    allowed_slots = set(slot_ids)
+    result: dict[str, tuple[str, ...]] = {}
+    for route_id, raw_slots in value.items():
+        if (
+            not isinstance(route_id, str)
+            or not route_id
+            or not isinstance(raw_slots, list)
+            or not raw_slots
+            or any(not isinstance(slot, str) for slot in raw_slots)
+        ):
+            raise CodingWorkerRuntimeError(
+                "Worker route catalog is invalid.",
+                code="coding_worker_config_invalid",
+            )
+        slots = tuple(dict.fromkeys(raw_slots))
+        if not set(slots).issubset(allowed_slots):
+            raise CodingWorkerRuntimeError(
+                "Worker route catalog is invalid.",
+                code="coding_worker_config_invalid",
+            )
+        result[route_id] = slots
+    return result

--- a/server/coding_worker/service.py
+++ b/server/coding_worker/service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
 
 from .contracts import (
     EvidenceStatus,
@@ -40,6 +40,7 @@ class CodingWorkerService:
         harness_runner: HarnessRunner | None = None,
         max_active_tasks: int = 2,
         tool_broker: ToolBroker | None = None,
+        route_slots: Mapping[str, Sequence[str]] | None = None,
     ) -> None:
         if not 1 <= max_active_tasks <= 16:
             raise ValueError("active task capacity is outside the allowed range")
@@ -49,6 +50,23 @@ class CodingWorkerService:
         self.harness_runner = harness_runner
         self.max_active_tasks = max_active_tasks
         self.tool_broker = tool_broker
+        self._route_slots = (
+            {
+                route_id: tuple(dict.fromkeys(slot_ids))
+                for route_id, slot_ids in route_slots.items()
+            }
+            if route_slots is not None
+            else None
+        )
+        if self._route_slots is not None:
+            known_slots = set(self.workspace_broker.slot_ids)
+            if any(
+                not route_id
+                or not slot_ids
+                or not set(slot_ids).issubset(known_slots)
+                for route_id, slot_ids in self._route_slots.items()
+            ):
+                raise ValueError("provider route slot configuration is invalid")
         self._active: dict[str, asyncio.Task[None]] = {}
         self._task_slots: dict[str, str] = {}
         self._sessions: dict[str, ProviderSession] = {}
@@ -97,6 +115,10 @@ class CodingWorkerService:
         self._started = False
 
     async def create_task(self, origin: Origin, request: TaskCreateRequest) -> TaskRecord:
+        if self._route_slots is not None and request.model_route not in self._route_slots:
+            raise WorkerConflictError(
+                "Model route is unavailable.", code="model_route_unavailable"
+            )
         frozen_checks = getattr(self.tool_broker, "frozen_checks", None)
         if isinstance(frozen_checks, Mapping):
             unknown = [
@@ -241,6 +263,16 @@ class CodingWorkerService:
         if not available:
             return None
         for record in queued:
+            route_slots = self._allowed_slots(record.spec.model_route)
+            if route_slots is None:
+                with contextlib.suppress(WorkerConflictError):
+                    self.store.transition(
+                        record.task_id,
+                        TaskState.BLOCKED,
+                        reason="model_route_unavailable",
+                        expected_state=TaskState.QUEUED,
+                    )
+                continue
             required_slot: str | None = None
             if record.workspace_id is not None:
                 try:
@@ -249,12 +281,35 @@ class CodingWorkerService:
                     )
                 except WorkspaceError:
                     # Let the runner persist the precise workspace failure.
-                    required_slot = available[0]
+                    required_slot = next(
+                        (slot for slot in route_slots if slot in available), None
+                    )
+                if required_slot is None:
+                    continue
+                if required_slot not in route_slots:
+                    with contextlib.suppress(WorkerConflictError):
+                        self.store.transition(
+                            record.task_id,
+                            TaskState.BLOCKED,
+                            reason="provider_binding_changed",
+                            expected_state=TaskState.QUEUED,
+                        )
+                    continue
             if required_slot is None:
-                return record, available[0]
+                selected = next(
+                    (slot for slot in route_slots if slot in available), None
+                )
+                if selected is not None:
+                    return record, selected
+                continue
             if required_slot in available:
                 return record, required_slot
         return None
+
+    def _allowed_slots(self, model_route: str) -> tuple[str, ...] | None:
+        if self._route_slots is None:
+            return self.workspace_broker.slot_ids
+        return self._route_slots.get(model_route)
 
     def _task_finished(self, task_id: str, _task: asyncio.Task[None]) -> None:
         self._active.pop(task_id, None)

--- a/server/coding_worker/service.py
+++ b/server/coding_worker/service.py
@@ -349,7 +349,18 @@ class CodingWorkerService:
             resume_context: dict[str, object] | None = None
             completed_turns = 0
             checkpoint = self.store.latest_checkpoint(task_id)
-            if checkpoint is not None:
+            uncheckpointed_turns = self._uncheckpointed_completed_turns(task_id)
+            if uncheckpointed_turns:
+                current_tree_hash = self.workspace_broker.current_tree_hash(
+                    workspace.workspace_id
+                )
+                resume_phase = "testing"
+                completed_turns = uncheckpointed_turns
+                resume_context = self._context_summary(
+                    task_id, tree_hash=current_tree_hash, public_output=""
+                )
+                session = await self.provider.open(request)
+            elif checkpoint is not None:
                 current_tree_hash = self.workspace_broker.current_tree_hash(
                     workspace.workspace_id
                 )
@@ -429,6 +440,34 @@ class CodingWorkerService:
             if session is not None:
                 with contextlib.suppress(Exception):
                     await self.provider.close(session)
+
+    def _uncheckpointed_completed_turns(self, task_id: str) -> int:
+        cursor = 0
+        completed_turns = 0
+        last_completed_sequence = 0
+        last_checkpoint_sequence = 0
+        while True:
+            events = self.store.list_events(task_id, after=cursor, limit=1000)
+            if not events:
+                break
+            for event in events:
+                if (
+                    event.type == "provider_event"
+                    and event.payload.get("kind")
+                    == ProviderEventKind.TURN_COMPLETED.value
+                ):
+                    completed_turns += 1
+                    last_completed_sequence = event.sequence
+                elif event.type == "checkpoint_created":
+                    last_checkpoint_sequence = event.sequence
+            cursor = events[-1].sequence
+            if len(events) < 1000:
+                break
+        return (
+            completed_turns
+            if last_completed_sequence > last_checkpoint_sequence
+            else 0
+        )
 
     async def _drive_session(
         self,

--- a/server/coding_worker/service.py
+++ b/server/coding_worker/service.py
@@ -21,6 +21,7 @@ from .provider import (
     ProviderEventKind,
     ProviderOpenRequest,
     ProviderSession,
+    provider_tools_for_policy,
 )
 from .store import CodingWorkerStore, WorkerConflictError
 from .tool_broker import ToolBroker, ToolBrokerError
@@ -284,6 +285,10 @@ class CodingWorkerService:
                 model_route=task.spec.model_route,
                 policy_profile=task.spec.policy_profile,
                 budget=task.spec.budget,
+                workspace_tree_hash=self.workspace_broker.current_tree_hash(
+                    workspace.workspace_id
+                ),
+                tool_allowlist=provider_tools_for_policy(task.spec.policy_profile),
             )
             resume_phase: str | None = None
             resume_context: dict[str, object] | None = None

--- a/server/coding_worker/sidecar.py
+++ b/server/coding_worker/sidecar.py
@@ -8,6 +8,7 @@ from collections.abc import Awaitable, Callable
 from pathlib import Path
 
 from .contracts import SAFE_ID
+from .claude_provider import ClaudeCodeProvider, ClaudeCodeRoute
 from .opencode_provider import OpenCodeProvider, OpenCodeRoute
 from .provider_rpc import ProviderRPCServer
 from .executor import ExecutorRPCServer, SidecarExecutor
@@ -61,19 +62,7 @@ async def run() -> None:
         await executor_server.start_unix(socket_path)
         await _wait_for_stop(executor_server.close)
         return
-    route_id = os.getenv("CODING_WORKER_ROUTE_ID", "coding/default").strip()
-    route = OpenCodeRoute(
-        route_id=route_id,
-        model_id=_required_environment("CODING_WORKER_MODEL_ID"),
-        base_url=_required_environment("CODING_WORKER_MODEL_BASE_URL"),
-        api_key=_required_environment("CODING_WORKER_ROUTE_KEY"),
-    )
-    provider = OpenCodeProvider(
-        workspace_resolver=_workspace_resolver(workspace_root),
-        runtime_root=runtime_root,
-        routes={route_id: route},
-        tool_broker_command=("python", "-m", "coding_worker.broker_mcp"),
-    )
+    provider = _provider_from_environment(workspace_root, runtime_root)
     server = ProviderRPCServer(
         provider,
         token=_required_environment("CODING_WORKER_SIDECAR_TOKEN"),
@@ -82,6 +71,38 @@ async def run() -> None:
     )
     await server.start_unix(socket_path)
     await _wait_for_stop(server.close)
+
+
+def _provider_from_environment(
+    workspace_root: Path, runtime_root: Path
+) -> OpenCodeProvider | ClaudeCodeProvider:
+    provider_kind = os.getenv("CODING_WORKER_PROVIDER_KIND", "opencode").strip()
+    route_id = os.getenv("CODING_WORKER_ROUTE_ID", "coding/default").strip()
+    model_id = _required_environment("CODING_WORKER_MODEL_ID")
+    command = ("python", "-m", "coding_worker.broker_mcp")
+    if provider_kind == "claude-code":
+        route = ClaudeCodeRoute(route_id=route_id, model_id=model_id)
+        return ClaudeCodeProvider(
+            runtime_root=runtime_root,
+            routes={route_id: route},
+            secret_path=Path(_required_environment("CODING_WORKER_CLAUDE_SECRET_PATH")),
+            tool_broker_command=command,
+            provider_proxy_url=os.getenv("CODING_WORKER_PROVIDER_PROXY_URL") or None,
+        )
+    if provider_kind != "opencode":
+        raise RuntimeError("CODING_WORKER_PROVIDER_KIND is invalid")
+    route = OpenCodeRoute(
+        route_id=route_id,
+        model_id=model_id,
+        base_url=_required_environment("CODING_WORKER_MODEL_BASE_URL"),
+        api_key=_required_environment("CODING_WORKER_ROUTE_KEY"),
+    )
+    return OpenCodeProvider(
+        workspace_resolver=_workspace_resolver(workspace_root),
+        runtime_root=runtime_root,
+        routes={route_id: route},
+        tool_broker_command=command,
+    )
 
 
 async def _wait_for_stop(close: Callable[[], Awaitable[None]]) -> None:

--- a/server/tests/test_coding_worker_claude.py
+++ b/server/tests/test_coding_worker_claude.py
@@ -20,6 +20,7 @@ from server.coding_worker.provider import (
     ProviderEventKind,
     ProviderOpenRequest,
 )
+from server.coding_worker.sidecar import _provider_from_environment
 
 
 def _request() -> ProviderOpenRequest:
@@ -70,6 +71,25 @@ def test_managed_settings_and_command_disable_builtin_surfaces(tmp_path: Path) -
         "mcp__modelmirror-tool-broker__apply_changeset",
         "mcp__modelmirror-tool-broker__run_shell",
     ]
+
+
+def test_sidecar_selects_claude_without_gateway_key_or_workspace_resolver(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    secret = tmp_path / "secret"
+    secret.write_text("secret", encoding="utf-8")
+    monkeypatch.setenv("CODING_WORKER_PROVIDER_KIND", "claude-code")
+    monkeypatch.setenv("CODING_WORKER_ROUTE_ID", "coding/quality")
+    monkeypatch.setenv("CODING_WORKER_MODEL_ID", "claude-test-model")
+    monkeypatch.setenv("CODING_WORKER_CLAUDE_SECRET_PATH", str(secret))
+    monkeypatch.delenv("CODING_WORKER_MODEL_BASE_URL", raising=False)
+    monkeypatch.delenv("CODING_WORKER_ROUTE_KEY", raising=False)
+
+    provider = _provider_from_environment(
+        tmp_path / "unused-workspace", tmp_path / "runtime"
+    )
+    assert isinstance(provider, ClaudeCodeProvider)
+    assert "secret" not in repr(provider)
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_coding_worker_claude.py
+++ b/server/tests/test_coding_worker_claude.py
@@ -215,3 +215,22 @@ async def test_secret_symlink_is_rejected_before_process_start(tmp_path: Path) -
     with pytest.raises(ClaudeCodeProviderError) as caught:
         await provider.open(_request())
     assert caught.value.code == "provider_credential_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_non_utf8_secret_is_an_authentication_failure(tmp_path: Path) -> None:
+    secret = tmp_path / "invalid-secret"
+    secret.write_bytes(b"\xff\xfe")
+    provider = ClaudeCodeProvider(
+        runtime_root=tmp_path / "runtime",
+        routes={"coding/quality": _route()},
+        secret_path=secret,
+        command_prefix=("must-not-start",),
+    )
+    provider.bind_broker("task-claude", "unix:/run/broker.sock", "b" * 48)
+    session = await provider.open(_request())
+    with pytest.raises(ClaudeCodeProviderError) as caught:
+        _ = [event async for event in provider.message(session, "continue")]
+    assert caught.value.code == "provider_credential_unavailable"
+    assert caught.value.failure_kind.value == "authentication"
+    await provider.close(session)

--- a/server/tests/test_coding_worker_claude.py
+++ b/server/tests/test_coding_worker_claude.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from server.coding_worker.claude_provider import (
+    CLAUDE_BUILTIN_TOOLS,
+    CLAUDE_CODE_VERSION,
+    ClaudeCodeProvider,
+    ClaudeCodeProviderError,
+    ClaudeCodeRoute,
+)
+from server.coding_worker.contracts import PolicyProfile, TaskBudget
+from server.coding_worker.provider import (
+    ProviderCheckpointCompatibility,
+    ProviderEventKind,
+    ProviderOpenRequest,
+)
+
+
+def _request() -> ProviderOpenRequest:
+    return ProviderOpenRequest(
+        task_id="task-claude",
+        workspace_id="workspace-claude",
+        objective="Inspect and fix the project.",
+        model_route="coding/quality",
+        policy_profile=PolicyProfile.DEVELOP,
+        budget=TaskBudget(max_seconds=60, max_output_bytes=1024 * 1024),
+        workspace_tree_hash="a" * 64,
+        tool_allowlist=("read_file", "apply_changeset", "run_shell"),
+    )
+
+
+def _route() -> ClaudeCodeRoute:
+    return ClaudeCodeRoute(
+        route_id="coding/quality",
+        model_id="claude-test-model",
+        max_budget_usd=3.5,
+    )
+
+
+def _provider(tmp_path: Path, *, command_prefix: tuple[str, ...]) -> ClaudeCodeProvider:
+    secret = tmp_path / "claude-api-key"
+    secret.write_text("test-secret-value\n", encoding="utf-8")
+    secret.chmod(0o600)
+    provider = ClaudeCodeProvider(
+        runtime_root=tmp_path / "runtime",
+        routes={"coding/quality": _route()},
+        secret_path=secret,
+        command_prefix=command_prefix,
+        tool_broker_command=(sys.executable, "-m", "coding_worker.broker_mcp"),
+    )
+    provider.bind_broker("task-claude", "unix:/run/broker.sock", "b" * 48)
+    return provider
+
+
+def test_managed_settings_and_command_disable_builtin_surfaces(tmp_path: Path) -> None:
+    provider = _provider(tmp_path, command_prefix=("claude",))
+    settings = provider.build_settings(_request().tool_allowlist)
+    assert settings["disableAllHooks"] is True
+    assert settings["enabledPlugins"] == {}
+    assert settings["strictKnownMarketplaces"] == []
+    assert settings["permissions"]["deny"] == list(CLAUDE_BUILTIN_TOOLS)
+    assert settings["permissions"]["allow"] == [
+        "mcp__modelmirror-tool-broker__read_file",
+        "mcp__modelmirror-tool-broker__apply_changeset",
+        "mcp__modelmirror-tool-broker__run_shell",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_headless_stream_maps_only_neutral_events_and_private_checkpoint(
+    tmp_path: Path,
+) -> None:
+    script = tmp_path / "fake_claude.py"
+    script.write_text(
+        """
+import json
+import os
+import sys
+
+args = sys.argv[1:]
+assert '--print' in args
+assert args[args.index('--input-format') + 1] == 'stream-json'
+assert args[args.index('--output-format') + 1] == 'stream-json'
+assert args[args.index('--tools') + 1] == ''
+assert '--strict-mcp-config' in args and '--bare' in args
+assert os.environ['ANTHROPIC_API_KEY'] == 'test-secret-value'
+frame = json.loads(sys.stdin.readline())
+session = frame['session_id']
+assert frame['type'] == 'user'
+assert ('--session-id' in args) != ('--resume' in args)
+text = 'resumed' if '--resume' in args else 'done'
+print(json.dumps({
+    'type': 'assistant',
+    'session_id': session,
+    'message': {
+        'content': [{'type': 'text', 'text': text}],
+        'usage': {'input_tokens': 10, 'output_tokens': 4},
+    },
+}))
+print(json.dumps({
+    'type': 'result',
+    'session_id': session,
+    'is_error': False,
+    'usage': {
+        'input_tokens': 10,
+        'output_tokens': 4,
+        'cache_read_input_tokens': 2,
+        'cache_creation_input_tokens': 1,
+    },
+    'total_cost_usd': 0.002,
+    'supplier_frame': 'must-not-leak',
+}))
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    provider = _provider(
+        tmp_path, command_prefix=(sys.executable, str(script))
+    )
+    session = await provider.open(_request())
+
+    events = [event async for event in provider.message(session, "continue")]
+    assert [event.kind for event in events] == [
+        ProviderEventKind.MESSAGE,
+        ProviderEventKind.USAGE,
+        ProviderEventKind.USAGE,
+        ProviderEventKind.TURN_COMPLETED,
+    ]
+    assert events[0].data == {"text": "done"}
+    assert all("supplier" not in json.dumps(event.data) for event in events)
+    resumed_events = [
+        event async for event in provider.message(session, "continue again")
+    ]
+    assert resumed_events[0].data == {"text": "resumed"}
+    assert resumed_events[-1].kind is ProviderEventKind.TURN_COMPLETED
+    checkpoint = await provider.checkpoint(session)
+    assert checkpoint.compatibility is not None
+    assert checkpoint.compatibility.provider_family == "claude-code"
+    assert checkpoint.compatibility.provider_version == CLAUDE_CODE_VERSION
+    assert checkpoint.compatibility.workspace_tree_hash == "a" * 64
+    assert checkpoint.payload == {
+        "task_id": "task-claude",
+        "public_output": "doneresumed",
+    }
+    assert "session" not in checkpoint.payload
+
+    await provider.close(session)
+    provider.bind_broker("task-claude", "unix:/run/broker.sock", "b" * 48)
+    restored = await provider.restore(_request(), checkpoint)
+    await provider.close(restored)
+
+
+@pytest.mark.asyncio
+async def test_restore_rejects_provider_version_or_tree_change(tmp_path: Path) -> None:
+    provider = _provider(tmp_path, command_prefix=("claude",))
+    session = await provider.open(_request())
+    checkpoint = await provider.checkpoint(session)
+    assert checkpoint.compatibility is not None
+    incompatible = checkpoint.model_copy(
+        update={
+            "compatibility": ProviderCheckpointCompatibility(
+                provider_family="claude-code",
+                provider_version="2.1.90",
+                task_id="task-claude",
+                workspace_tree_hash="a" * 64,
+            )
+        }
+    )
+    with pytest.raises(ClaudeCodeProviderError) as caught:
+        await provider.restore(_request(), incompatible)
+    assert caught.value.code == "checkpoint_invalid"
+    await provider.close(session)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="requires POSIX symlink semantics")
+@pytest.mark.asyncio
+async def test_secret_symlink_is_rejected_before_process_start(tmp_path: Path) -> None:
+    target = tmp_path / "target-secret"
+    target.write_text("outside-secret", encoding="utf-8")
+    link = tmp_path / "secret-link"
+    link.symlink_to(target)
+    provider = ClaudeCodeProvider(
+        runtime_root=tmp_path / "runtime",
+        routes={"coding/quality": _route()},
+        secret_path=link,
+        command_prefix=("claude",),
+    )
+    provider.bind_broker("task-claude", "unix:/run/broker.sock", "b" * 48)
+    with pytest.raises(ClaudeCodeProviderError) as caught:
+        await provider.open(_request())
+    assert caught.value.code == "provider_credential_unavailable"

--- a/server/tests/test_coding_worker_deployment.py
+++ b/server/tests/test_coding_worker_deployment.py
@@ -78,3 +78,12 @@ def test_v15_claude_provider_has_a_pinned_private_image_and_secret_only_mount() 
     assert ".ssh" not in provider
     assert "internal: true" in compose
     assert "CODING_WORKER_ROUTE_SLOTS_JSON" in compose
+    assert "coding-worker-claude-egress:" in compose
+    assert "CODING_WORKER_PROVIDER_NETWORK_DOMAINS: api.anthropic.com" in compose
+    assert "CODING_WORKER_PROVIDER_EGRESS_TOKEN" in compose
+    assert "CODING_WORKER_PROVIDER_PROXY_URL: http://provider:" in provider
+    proxy = compose.split("\n  coding-worker-claude-egress:", 1)[1].split(
+        "secrets:", 1
+    )[0]
+    assert "modelmirror_claude_api_key" not in proxy
+    assert "coding_worker_provider_b" not in proxy

--- a/server/tests/test_coding_worker_deployment.py
+++ b/server/tests/test_coding_worker_deployment.py
@@ -47,3 +47,34 @@ def test_v14_sidecar_is_non_root_and_has_no_host_control_mounts() -> None:
     assert "coding-worker-network" in compose
     assert 'command: ["python", "-m", "coding_worker.egress_proxy"]' in compose
     assert "CODING_WORKER_EGRESS_GRANT_KEY: ${CODING_WORKER_EGRESS_GRANT_KEY:-}" in compose
+
+
+def test_v15_claude_provider_has_a_pinned_private_image_and_secret_only_mount() -> None:
+    root = Path(__file__).parents[2]
+    dockerfile = (root / "server/coding_worker/Dockerfile.claude").read_text()
+    compose = (root / "docker-compose.coding-worker-v15-claude.yml").read_text()
+
+    assert "CLAUDE_CODE_VERSION=2.1.89" in dockerfile
+    assert "CLAUDE_CODE_INTEGRITY=sha512-" in dockerfile
+    assert "Claude Code package integrity mismatch" in dockerfile
+    assert 'test "$(claude --version | awk' in dockerfile
+    assert "USER 65532:65532" in dockerfile
+    assert 'CMD ["python", "-m", "coding_worker.sidecar"]' in dockerfile
+    assert "git " not in dockerfile
+    assert "ripgrep" not in dockerfile
+
+    provider = compose.split("coding-worker-provider-b:", 1)[1].split(
+        "secrets:", 1
+    )[0]
+    assert "CODING_WORKER_PROVIDER_KIND: claude-code" in provider
+    assert "CODING_WORKER_ROUTE_ID: coding/quality" in provider
+    assert "CODING_WORKER_CLAUDE_SECRET_PATH: /run/secrets/" in provider
+    assert "coding_worker_provider_b:/run/modelmirror-coding" in provider
+    assert "coding_worker_broker:/run/modelmirror-coding-broker:ro" in provider
+    assert "coding_worker_slot_b:/worker-data" not in provider
+    assert "CODING_WORKER_ROUTE_KEY" not in provider
+    assert "CODING_WORKER_MODEL_BASE_URL" not in provider
+    assert "docker.sock" not in provider
+    assert ".ssh" not in provider
+    assert "internal: true" in compose
+    assert "CODING_WORKER_ROUTE_SLOTS_JSON" in compose

--- a/server/tests/test_coding_worker_network.py
+++ b/server/tests/test_coding_worker_network.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from server.coding_worker.contracts import CapabilityLease
+from server.coding_worker.egress_proxy import ProviderEgressPolicy
 from server.coding_worker.network_policy import EgressPolicy, NetworkPolicyError
 
 
@@ -149,3 +150,27 @@ def test_signed_proxy_grant_is_exact_task_domain_purpose_and_ttl() -> None:
     tampered = token[:-1] + ("a" if token[-1] != "a" else "b")
     with pytest.raises(NetworkPolicyError):
         policy.validate_grant(tampered, domain="registry.npmjs.org")
+
+
+def test_provider_proxy_is_exact_token_and_anthropic_api_domain() -> None:
+    policy = ProviderEgressPolicy(
+        token="p" * 48, allowed_domains=("api.anthropic.com",)
+    )
+    policy.validate("p" * 48, domain="API.ANTHROPIC.COM.")
+
+    with pytest.raises(NetworkPolicyError) as wrong_token:
+        policy.validate("q" * 48, domain="api.anthropic.com")
+    assert wrong_token.value.code == "network_grant_invalid"
+    with pytest.raises(NetworkPolicyError) as wrong_domain:
+        policy.validate("p" * 48, domain="console.anthropic.com")
+    assert wrong_domain.value.code == "network_domain_not_allowed"
+
+
+@pytest.mark.parametrize(
+    "token",
+    ["short", "p" * 31 + ":" + "p" * 16, "p" * 31 + " " + "p" * 16],
+)
+def test_provider_proxy_token_is_url_safe_and_bounded(token: str) -> None:
+    with pytest.raises(NetworkPolicyError) as invalid:
+        ProviderEgressPolicy(token=token, allowed_domains=("api.anthropic.com",))
+    assert invalid.value.code == "network_grant_key_invalid"

--- a/server/tests/test_coding_worker_opencode.py
+++ b/server/tests/test_coding_worker_opencode.py
@@ -60,7 +60,8 @@ def test_config_disables_direct_tools_plugins_sharing_and_supplier_surface(tmp_p
     config = provider.build_config(_route())
     permission = config["permission"]
     assert permission["*"] == "deny"
-    assert permission["modelmirror-tool-broker_*"] == "allow"
+    assert "modelmirror-tool-broker_*" not in permission
+    assert permission["modelmirror-tool-broker_read_file"] == "allow"
     assert Path(
         config["mcp"][TOOL_BROKER_MCP_NAME]["environment"]["PYTHONPATH"]
     ).name == "server"
@@ -70,6 +71,7 @@ def test_config_disables_direct_tools_plugins_sharing_and_supplier_surface(tmp_p
         "{env:CODING_WORKER_ROUTE_KEY}"
     )
     assert all(provider._prompt_tools()[name] is False for name in DIRECT_TOOL_NAMES)
+    assert provider._prompt_tools()["modelmirror-tool-broker_read_file"] is True
 
 
 @pytest.mark.asyncio
@@ -199,6 +201,9 @@ async def test_headless_adapter_maps_events_cancel_and_checkpoint_without_public
         "task_id": "task-01",
         "public_output": "done",
     }
+    assert checkpoint.compatibility is not None
+    assert checkpoint.compatibility.provider_family == "opencode"
+    assert checkpoint.compatibility.provider_version == "1.18.9"
     assert "http" not in checkpoint.payload and "port" not in checkpoint.payload
     assert "session" not in checkpoint.payload and "messages" not in checkpoint.payload
     await provider.close(session)
@@ -262,6 +267,37 @@ def test_raw_permission_frame_never_enters_provider_neutral_event() -> None:
     assert event is not None
     assert event.kind is ProviderEventKind.APPROVAL_REQUIRED
     assert event.data == {"capability": "provider_permission"}
+
+
+def test_raw_usage_frame_maps_to_provider_neutral_usage() -> None:
+    event = OpenCodeProvider._map_event(
+        {
+            "type": "message.updated",
+            "properties": {
+                "sessionID": "ses_test",
+                "info": {
+                    "tokens": {
+                        "input": 12,
+                        "output": 7,
+                        "cache": {"read": 4, "write": 2},
+                    },
+                    "cost": 0.00125,
+                    "supplier": "must-not-leak",
+                },
+            },
+        },
+        "ses_test",
+    )
+    assert event is not None and event.kind is ProviderEventKind.USAGE
+    assert event.data == {
+        "usage": {
+            "input_tokens": 12,
+            "output_tokens": 7,
+            "cache_read_tokens": 4,
+            "cache_write_tokens": 2,
+            "cost_microusd": 1250,
+        }
+    }
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_coding_worker_provider_conformance.py
+++ b/server/tests/test_coding_worker_provider_conformance.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import json
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from server.coding_worker.claude_provider import (
+    ClaudeCodeProvider,
+    ClaudeCodeProviderError,
+    ClaudeCodeRoute,
+)
+from server.coding_worker.contracts import PolicyProfile, TaskBudget
+from server.coding_worker.opencode_provider import (
+    OpenCodeProvider,
+    OpenCodeProviderError,
+    OpenCodeRoute,
+    OpenCodeServerHandle,
+)
+from server.coding_worker.provider import (
+    CodingAgentProvider,
+    FakeCodingAgentProvider,
+    PROVIDER_CHECKPOINT_FORMAT_VERSION,
+    PROVIDER_CONTRACT_VERSION,
+    ProviderEventKind,
+    ProviderOpenRequest,
+)
+
+
+def _request(route_id: str) -> ProviderOpenRequest:
+    return ProviderOpenRequest(
+        task_id="task-conformance",
+        workspace_id="workspace-conformance",
+        objective="Inspect and fix the project.",
+        model_route=route_id,
+        policy_profile=PolicyProfile.DEVELOP,
+        budget=TaskBudget(max_seconds=60, max_output_bytes=1024 * 1024),
+        workspace_tree_hash="a" * 64,
+        tool_allowlist=("read_file",),
+    )
+
+
+def _fake_provider(_tmp_path: Path) -> tuple[CodingAgentProvider, ProviderOpenRequest]:
+    return FakeCodingAgentProvider(), _request("coding/default")
+
+
+def _opencode_provider(
+    tmp_path: Path,
+) -> tuple[CodingAgentProvider, ProviderOpenRequest]:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    state: dict[str, Any] = {"counter": 0, "session_id": ""}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/session" and request.method == "POST":
+            state["counter"] += 1
+            state["session_id"] = f"ses_conformance_{state['counter']}"
+            return httpx.Response(200, json={"id": state["session_id"]})
+        if request.url.path == "/event":
+            body = (
+                "data: "
+                + json.dumps(
+                    {
+                        "type": "session.idle",
+                        "properties": {"sessionID": state["session_id"]},
+                    }
+                )
+                + "\n\n"
+            )
+            return httpx.Response(
+                200, text=body, headers={"content-type": "text/event-stream"}
+            )
+        if request.url.path.endswith("/prompt_async"):
+            return httpx.Response(204)
+        if request.url.path == "/mcp":
+            return httpx.Response(200, json={})
+        return httpx.Response(404)
+
+    async def factory(
+        request: ProviderOpenRequest, resolved: Path, route: OpenCodeRoute
+    ) -> OpenCodeServerHandle:
+        assert request.task_id == "task-conformance"
+        assert resolved == workspace.resolve()
+        assert route.route_id == "coding/default"
+        client = httpx.AsyncClient(
+            base_url="http://127.0.0.1:4096",
+            transport=httpx.MockTransport(handler),
+        )
+
+        async def close() -> None:
+            await client.aclose()
+
+        return OpenCodeServerHandle(
+            task_id=request.task_id,
+            workspace=resolved,
+            state_root=tmp_path / "opencode-state",
+            client=client,
+            close_callback=close,
+        )
+
+    route = OpenCodeRoute(
+        route_id="coding/default",
+        model_id="test-model",
+        base_url="http://new-api:3000/v1",
+        api_key="test-route-key",
+    )
+    return (
+        OpenCodeProvider(
+            workspace_resolver=lambda _workspace_id: workspace,
+            runtime_root=tmp_path / "runtime",
+            routes={route.route_id: route},
+            server_factory=factory,
+        ),
+        _request(route.route_id),
+    )
+
+
+def _claude_provider(
+    tmp_path: Path,
+) -> tuple[CodingAgentProvider, ProviderOpenRequest]:
+    script = tmp_path / "fake_claude.py"
+    script.write_text(
+        """
+import json
+import sys
+frame = json.loads(sys.stdin.readline())
+print(json.dumps({
+    'type': 'result',
+    'session_id': frame['session_id'],
+    'is_error': False,
+    'usage': {'input_tokens': 1, 'output_tokens': 1},
+}))
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    secret = tmp_path / "claude-secret"
+    secret.write_text("test-secret", encoding="utf-8")
+    route = ClaudeCodeRoute(
+        route_id="coding/quality", model_id="claude-test-model"
+    )
+    provider = ClaudeCodeProvider(
+        runtime_root=tmp_path / "claude-runtime",
+        routes={route.route_id: route},
+        secret_path=secret,
+        command_prefix=(sys.executable, str(script)),
+    )
+    provider.bind_broker(
+        "task-conformance", "unix:/run/broker.sock", "b" * 48
+    )
+    return provider, _request(route.route_id)
+
+
+ProviderFactory = Callable[
+    [Path], tuple[CodingAgentProvider, ProviderOpenRequest]
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "factory", [_fake_provider, _opencode_provider, _claude_provider]
+)
+async def test_provider_v2_conformance(
+    factory: ProviderFactory, tmp_path: Path
+) -> None:
+    provider, request = factory(tmp_path)
+    capabilities = await provider.capabilities()
+    assert capabilities.contract_version == PROVIDER_CONTRACT_VERSION
+    assert capabilities.supports_streaming is True
+    assert capabilities.supports_checkpoint is True
+    assert capabilities.supports_restore is True
+
+    session = await provider.open(request)
+    events = [event async for event in provider.message(session, "continue")]
+    assert events[-1].kind is ProviderEventKind.TURN_COMPLETED
+    assert all("supplier" not in json.dumps(event.data) for event in events)
+    checkpoint = await provider.checkpoint(session)
+    compatibility = checkpoint.compatibility
+    assert compatibility is not None
+    assert compatibility.contract_version == PROVIDER_CONTRACT_VERSION
+    assert compatibility.format_version == PROVIDER_CHECKPOINT_FORMAT_VERSION
+    assert compatibility.task_id == request.task_id
+    assert compatibility.workspace_tree_hash == request.workspace_tree_hash
+    await provider.close(session)
+
+    if isinstance(provider, ClaudeCodeProvider):
+        provider.bind_broker(
+            "task-conformance", "unix:/run/broker.sock", "b" * 48
+        )
+    restored = await provider.restore(request, checkpoint)
+    await provider.close(restored)
+
+    changed = request.model_copy(update={"workspace_tree_hash": "b" * 64})
+    if isinstance(provider, ClaudeCodeProvider):
+        provider.bind_broker(
+            "task-conformance", "unix:/run/broker.sock", "b" * 48
+        )
+    with pytest.raises(
+        (ValueError, OpenCodeProviderError, ClaudeCodeProviderError)
+    ):
+        await provider.restore(changed, checkpoint)

--- a/server/tests/test_coding_worker_runtime.py
+++ b/server/tests/test_coding_worker_runtime.py
@@ -15,7 +15,11 @@ from server.coding_worker.contracts import (
 )
 from server.coding_worker.provider import FakeCodingAgentProvider
 from server.coding_worker.provider_rpc import ProviderRPCServer
-from server.coding_worker.runtime import CodingWorkerRuntime
+from server.coding_worker.runtime import (
+    CodingWorkerRuntime,
+    CodingWorkerRuntimeError,
+    _route_slots_from_environment,
+)
 from server.coding_worker.tool_broker import FrozenCheck
 from server.coding_worker.workspace import InMemoryWorkspaceSourceAdapter
 
@@ -92,3 +96,24 @@ async def test_runtime_connects_two_dedicated_provider_slots(tmp_path: Path) -> 
     await runtime.close()
     for server in servers.values():
         await server.close()
+
+
+def test_route_slot_catalog_is_strict_and_provider_neutral(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "CODING_WORKER_ROUTE_SLOTS_JSON",
+        '{"coding/default":["slot-a"],"coding/quality":["slot-b"]}',
+    )
+    assert _route_slots_from_environment(("slot-a", "slot-b")) == {
+        "coding/default": ("slot-a",),
+        "coding/quality": ("slot-b",),
+    }
+
+    monkeypatch.setenv(
+        "CODING_WORKER_ROUTE_SLOTS_JSON",
+        '{"coding/quality":["missing-slot"]}',
+    )
+    with pytest.raises(CodingWorkerRuntimeError) as caught:
+        _route_slots_from_environment(("slot-a", "slot-b"))
+    assert caught.value.code == "coding_worker_config_invalid"

--- a/server/tests/test_coding_worker_service.py
+++ b/server/tests/test_coding_worker_service.py
@@ -98,6 +98,16 @@ class _RestoreTrackingProvider(FakeCodingAgentProvider):
         return await super().restore(request, checkpoint)
 
 
+class _OpenTrackingProvider(FakeCodingAgentProvider):
+    def __init__(self) -> None:
+        super().__init__()
+        self.open_request: ProviderOpenRequest | None = None
+
+    async def open(self, request: ProviderOpenRequest) -> ProviderSession:
+        self.open_request = request
+        return await super().open(request)
+
+
 def _service_with_harness(
     tmp_path: Path, provider: FakeCodingAgentProvider
 ) -> tuple[CodingWorkerService, ToolBroker]:
@@ -202,6 +212,26 @@ async def test_model_stop_cannot_complete_without_acceptance_runner(tmp_path: Pa
     terminal = await service.wait_for(task.task_id, lambda item: item.state is TaskState.BLOCKED)
     assert terminal.state is not TaskState.COMPLETED
     assert [event.type for event in service.store.list_events(task.task_id)].count("task_state") >= 3
+    await service.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_provider_request_binds_tree_and_policy_tool_allowlist(
+    tmp_path: Path,
+) -> None:
+    provider = _OpenTrackingProvider()
+    service = _service(tmp_path, provider)
+    task = await service.create_task(
+        Origin(module="test", object_id="provider-contract"),
+        _request("provider-contract"),
+    )
+    await service.wait_for(task.task_id, lambda item: item.state is TaskState.BLOCKED)
+
+    request = provider.open_request
+    assert request is not None and len(request.workspace_tree_hash or "") == 64
+    assert "read_file" in request.tool_allowlist
+    assert "write_file" not in request.tool_allowlist
+    assert "run_shell" not in request.tool_allowlist
     await service.shutdown()
 
 

--- a/server/tests/test_coding_worker_service.py
+++ b/server/tests/test_coding_worker_service.py
@@ -312,6 +312,78 @@ async def test_dedicated_slots_queue_third_task_and_resume_on_original_slot(
 
 
 @pytest.mark.asyncio
+async def test_route_catalog_pins_tasks_to_provider_slots(tmp_path: Path) -> None:
+    blocker = asyncio.Event()
+    store = CodingWorkerStore(tmp_path / "control", master_key=Fernet.generate_key())
+    broker = WorkspaceBroker(
+        tmp_path / "control",
+        {
+            "manifest": InMemoryWorkspaceSourceAdapter(
+                {("source-01", "revision-01"): {"main.py": b"print('ok')\n"}}
+            )
+        },
+        id_key=b"r" * 32,
+        slot_roots={
+            "slot-a": tmp_path / "slot-a",
+            "slot-b": tmp_path / "slot-b",
+        },
+    )
+    service = CodingWorkerService(
+        store=store,
+        workspace_broker=broker,
+        provider=FakeCodingAgentProvider(block=blocker),
+        max_active_tasks=2,
+        route_slots={
+            "coding/default": ("slot-a",),
+            "coding/quality": ("slot-b",),
+        },
+    )
+    origin = Origin(module="test", object_id="route-slots")
+    default_task = await service.create_task(origin, _request("route-default"))
+    quality_task = await service.create_task(
+        origin,
+        _request("route-quality").model_copy(
+            update={"model_route": "coding/quality"}
+        ),
+    )
+    queued_default = await service.create_task(
+        origin, _request("route-default-queued")
+    )
+
+    for task in (default_task, quality_task):
+        await service.wait_for(task.task_id, lambda item: item.state is TaskState.RUNNING)
+    assert broker.workspace_slot(
+        store.get_task(default_task.task_id).workspace_id or ""
+    ) == "slot-a"
+    assert broker.workspace_slot(
+        store.get_task(quality_task.task_id).workspace_id or ""
+    ) == "slot-b"
+    assert store.get_task(queued_default.task_id).state is TaskState.QUEUED
+
+    await service.pause(quality_task.task_id)
+    await asyncio.sleep(0.05)
+    assert store.get_task(queued_default.task_id).state is TaskState.QUEUED
+    await service.cancel(default_task.task_id)
+    await service.wait_for(
+        queued_default.task_id, lambda item: item.state is TaskState.RUNNING
+    )
+    assert broker.workspace_slot(
+        store.get_task(queued_default.task_id).workspace_id or ""
+    ) == "slot-a"
+
+    with pytest.raises(WorkerConflictError) as unavailable:
+        await service.create_task(
+            origin,
+            _request("route-unknown").model_copy(
+                update={"model_route": "coding/unknown"}
+            ),
+        )
+    assert unavailable.value.code == "model_route_unavailable"
+    await service.cancel(queued_default.task_id)
+    await service.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_failed_acceptance_is_repaired_and_retested_before_completion(
     tmp_path: Path,
 ) -> None:

--- a/server/tests/test_coding_worker_service.py
+++ b/server/tests/test_coding_worker_service.py
@@ -108,6 +108,29 @@ class _OpenTrackingProvider(FakeCodingAgentProvider):
         return await super().open(request)
 
 
+class _LostTurnReceiptProvider(FakeCodingAgentProvider):
+    def __init__(self) -> None:
+        super().__init__()
+        self.message_count = 0
+        self.checkpoint_count = 0
+        self.repair: Callable[[], Awaitable[None]] | None = None
+
+    async def message(
+        self, session: ProviderSession, text: str
+    ) -> AsyncIterator[ProviderEvent]:
+        self.message_count += 1
+        if self.message_count == 1 and self.repair is not None:
+            await self.repair()
+        async for event in super().message(session, text):
+            yield event
+
+    async def checkpoint(self, session: ProviderSession) -> ProviderCheckpoint:
+        self.checkpoint_count += 1
+        if self.checkpoint_count == 1:
+            raise OSError("simulated provider receipt loss")
+        return await super().checkpoint(session)
+
+
 def _service_with_harness(
     tmp_path: Path, provider: FakeCodingAgentProvider
 ) -> tuple[CodingWorkerService, ToolBroker]:
@@ -535,4 +558,50 @@ async def test_resume_rejects_workspace_changed_after_checkpoint(tmp_path: Path)
     )
     assert blocked.reason == "checkpoint_workspace_changed"
     assert provider.restore_count == 0
+    await service.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_completed_provider_turn_is_reconciled_before_any_replay(
+    tmp_path: Path,
+) -> None:
+    provider = _LostTurnReceiptProvider()
+    service, broker = _service_with_harness(tmp_path, provider)
+    request = _request("lost-turn-receipt").model_copy(
+        update={"policy_profile": PolicyProfile.DEVELOP}
+    )
+    task = await service.create_task(
+        Origin(module="test", object_id="lost-turn-receipt"), request
+    )
+
+    async def repair() -> None:
+        content = "print('reconciled')\n"
+        await broker.execute(
+            task_id=task.task_id,
+            operation_id="lost-turn-write",
+            tool_name="write_file",
+            arguments={
+                "path": "main.py",
+                "content": content,
+                "content_sha256": hashlib.sha256(content.encode()).hexdigest(),
+            },
+        )
+
+    provider.repair = repair
+    blocked = await service.wait_for(
+        task.task_id,
+        lambda item: item.state is TaskState.BLOCKED,
+    )
+    assert blocked.reason == "checkpoint_failed"
+    assert service.store.latest_checkpoint(task.task_id) is None
+    assert provider.message_count == 1
+
+    await service.resume(task.task_id)
+    completed = await service.wait_for(
+        task.task_id,
+        lambda item: item.state is TaskState.COMPLETED,
+    )
+    assert completed.reason is None
+    assert provider.message_count == 1
+    assert service.store.get_operation("lost-turn-write").state.value == "completed"
     await service.shutdown()


### PR DESCRIPTION
## Summary
- add Provider private contract v2 and provider-neutral conformance for Fake, OpenCode, and Claude
- add a fixed Claude Code 2.1.89 sidecar with secret, network, route, and checkpoint isolation
- reconcile lost completion receipts without replaying provider or tool side effects

## Automated evidence
- Coding Worker (Linux/no-network): 142 passed, 5 skipped
- Agent Workspace: 44 passed
- Coding: 765 passed, 14 skipped
- Frontend: typecheck; 35 files / 169 tests; production build
- Python compile and combined V14/V15 Compose config passed
- Claude image probe: CLI 2.1.89, uid 65532, provider/proxy isolation assertions passed

## Known baseline failures
- Windows Worker: 3 V14 snapshot mtime failures reproduced on PR A
- Full backend: 2615 passed, 27 skipped, 6 baseline failures reproduced on PR A (5 Agency build artifacts; 1 Node 20 TypeScript import)

## Remaining acceptance
- real OpenCode and Claude tasks, component restart matrix, and v13 Host writeback remain manual acceptance after PR C
- V15 remains disabled and not Ready

Base: PR A branch `codex/coding-worker-v15-tooling` (#151).