### PR TITLE
feature: 完成 V15 Worker Console 与模块 SDK

### DIFF
--- a/client/src/components/CodingWorkerConsole.test.tsx
+++ b/client/src/components/CodingWorkerConsole.test.tsx
@@ -7,9 +7,12 @@ const api = vi.hoisted(() => ({
   getCodingWorkerStatus: vi.fn(),
   listCodingWorkerTasks: vi.fn(),
   getCodingWorkerTask: vi.fn(),
+  getCodingWorkerChangeset: vi.fn(),
+  getCodingWorkerDiagnostics: vi.fn(),
   handoffCodingWorkerTask: vi.fn(),
   listCodingWorkerApprovals: vi.fn(),
   listCodingWorkerEvidence: vi.fn(),
+  listCodingWorkerOperationOutput: vi.fn(),
   listCodingWorkerArtifacts: vi.fn(),
   listCodingWorkerTree: vi.fn(),
   readCodingWorkerDiff: vi.fn(),
@@ -64,7 +67,7 @@ beforeEach(() => {
   Object.values(api).forEach((mock) => "mockReset" in mock && mock.mockReset());
   Object.values(projectApi).forEach((mock) => "mockReset" in mock && mock.mockReset());
   api.codingWorkerArtifactUrl.mockImplementation((taskId: string, artifactId: string) => `/artifact/${taskId}/${artifactId}`);
-  api.getCodingWorkerStatus.mockResolvedValue({ enabled: true, available: true, version: "v1", max_active_tasks: 2, retention_seconds: 604800, network_enabled: false, acceptance_checks: ["python-pytest", "react-build"], reason: null });
+  api.getCodingWorkerStatus.mockResolvedValue({ enabled: true, available: true, version: "v1", max_active_tasks: 2, retention_seconds: 604800, network_enabled: false, acceptance_checks: ["python-pytest", "react-build"], reason: null, capabilities: { api_version: "v1", task_runtime: true, professional_file_tools: true, shell: true, operation_output: true, changesets: true, code_intelligence: true } });
   api.listCodingWorkerTasks.mockResolvedValue([task]);
   api.getCodingWorkerTask.mockResolvedValue(task);
   api.listCodingWorkerApprovals.mockResolvedValue([{ approval_id: "approval_1234567890abcdef1234567890abcdef", task_id: task.task_id, operation_id: "operation_1", capability: "command", status: "pending", request: { command: "pytest" }, lease: null, created_at: 1, decided_at: null }]);
@@ -72,6 +75,9 @@ beforeEach(() => {
   api.listCodingWorkerArtifacts.mockResolvedValue([]);
   api.listCodingWorkerTree.mockResolvedValue({ workspace_id: task.workspace_id, tree_hash: "a".repeat(64), entries: [{ entry_id: "entry_1", name: "app.py", display_path: "src/app.py", kind: "file", size: 12, sha256: "b".repeat(64) }] });
   api.readCodingWorkerDiff.mockResolvedValue("diff --git a/src/app.py b/src/app.py");
+  api.listCodingWorkerOperationOutput.mockResolvedValue([]);
+  api.getCodingWorkerChangeset.mockRejectedValue(new Error("not a changeset"));
+  api.getCodingWorkerDiagnostics.mockRejectedValue(new Error("not diagnostics"));
   api.connectCodingWorkerEvents.mockReturnValue(() => undefined);
   api.decideCodingWorkerApproval.mockResolvedValue({});
   projectApi.getCodingProjects.mockResolvedValue({
@@ -136,6 +142,82 @@ describe("CodingWorkerConsole", () => {
     render(<CodingWorkerConsole context="agent" />);
     expect((await screen.findAllByText("修复失败测试并生成证据")).length).toBe(2);
     expect(screen.queryByText("宿主写回")).not.toBeInTheDocument();
+  });
+
+  it("shows public plans, exact shell approval, replayed output, changesets and diagnostics", async () => {
+    api.listCodingWorkerApprovals.mockResolvedValue([{
+      approval_id: "approval_1234567890abcdef1234567890abcdef",
+      task_id: task.task_id,
+      operation_id: "operation_shell_1",
+      capability: "shell",
+      status: "pending",
+      request: {
+        operation_id: "operation_shell_1",
+        script_sha256: "c".repeat(64),
+        cwd: "src",
+        mode: "mutate",
+        timeout_seconds: 120,
+        network_scope_sha256: null,
+      },
+      lease: null,
+      created_at: 1,
+      decided_at: null,
+    }]);
+    api.listCodingWorkerOperationOutput.mockResolvedValue([{
+      task_id: task.task_id,
+      operation_id: "operation_shell_1",
+      sequence: 3,
+      stream: "stderr",
+      text: "pytest failed\n",
+      created_at: 2,
+      truncated: false,
+    }]);
+    api.getCodingWorkerChangeset.mockResolvedValue({
+      changeset_id: "changeset_1234567890abcdef1234567890abcdef",
+      task_id: task.task_id,
+      operation_id: "operation_shell_1",
+      base_tree_hash: "a".repeat(64),
+      result_tree_hash: "d".repeat(64),
+      state: "applied",
+      entries: [{ entry_id: "entry_1", kind: "modify", display_path: "src/app.py", destination_display_path: null, preimage_sha256: "b".repeat(64), postimage_sha256: "d".repeat(64), binary: false }],
+      artifact_id: null,
+      created_at: 2,
+      updated_at: 3,
+    });
+    api.getCodingWorkerDiagnostics.mockResolvedValue({
+      task_id: task.task_id,
+      operation_id: "operation_shell_1",
+      entry_id: "entry_1",
+      language: "python",
+      workspace_tree_hash: "d".repeat(64),
+      current_tree_hash: "d".repeat(64),
+      stale: false,
+      diagnostics: [{ diagnostic_id: "diagnostic_1", task_id: task.task_id, entry_id: "entry_1", workspace_tree_hash: "d".repeat(64), range: { start: { line: 4, character: 2 }, end: { line: 4, character: 8 } }, severity: "error", code: "reportGeneralTypeIssues", message: "返回类型不匹配", created_at: 3 }],
+    });
+    api.connectCodingWorkerEvents.mockImplementation((_taskId, _after, handlers) => {
+      queueMicrotask(() => {
+        handlers.onEvent({ sequence: 1, task_id: task.task_id, type: "provider_event", payload: { kind: "plan", data: { summary: "先复现失败，再修复并复测。" } }, created_at: 1 });
+        handlers.onEvent({ sequence: 2, task_id: task.task_id, type: "tool_operation", payload: { operation_id: "operation_shell_1", state: "completed" }, created_at: 2 });
+      });
+      return () => undefined;
+    });
+
+    const user = userEvent.setup();
+    render(<CodingWorkerConsole context="agent" />);
+
+    expect(await screen.findByText("先复现失败，再修复并复测。")).toBeInTheDocument();
+    await user.click(screen.getByRole("tab", { name: "证据" }));
+    expect(await screen.findByText("Shell 单次审批")).toBeInTheDocument();
+    expect(screen.getByText("c".repeat(64))).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "本任务批准" })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("tab", { name: "终端" }));
+    expect(await screen.findByText("pytest failed", { exact: false })).toBeInTheDocument();
+    await user.click(screen.getByRole("tab", { name: "变更" }));
+    expect(await screen.findByText("src/app.py")).toBeInTheDocument();
+    await user.click(screen.getByRole("tab", { name: "诊断" }));
+    expect(await screen.findByText("返回类型不匹配")).toBeInTheDocument();
+    expect(screen.getByText("5:3 · reportGeneralTypeIssues")).toBeInTheDocument();
   });
 
   it("hands a completed Host Snapshot task to the v13 confirmation chain", async () => {

--- a/client/src/components/CodingWorkerConsole.tsx
+++ b/client/src/components/CodingWorkerConsole.tsx
@@ -18,9 +18,12 @@ import {
 import type {
   CodingWorkerApproval,
   CodingWorkerArtifact,
+  CodingWorkerChangeset,
+  CodingWorkerDiagnosticsSnapshot,
   CodingWorkerEntry,
   CodingWorkerEvent,
   CodingWorkerEvidence,
+  CodingWorkerOperationOutputChunk,
   CodingWorkerStatus,
   CodingWorkerTask,
   CodingWorkerTaskSpec,
@@ -31,12 +34,15 @@ import {
   connectCodingWorkerEvents,
   createCodingWorkerTask,
   decideCodingWorkerApproval,
+  getCodingWorkerChangeset,
+  getCodingWorkerDiagnostics,
   getCodingWorkerTask,
   getCodingWorkerStatus,
   handoffCodingWorkerTask,
   listCodingWorkerApprovals,
   listCodingWorkerArtifacts,
   listCodingWorkerEvidence,
+  listCodingWorkerOperationOutput,
   listCodingWorkerTasks,
   listCodingWorkerTree,
   readCodingWorkerDiff,
@@ -53,7 +59,7 @@ import {
 } from "../utils/codingApi";
 
 type ConsoleContext = "coding" | "agent";
-type InspectorTab = "files" | "diff" | "evidence" | "terminal";
+type InspectorTab = "files" | "diff" | "changesets" | "diagnostics" | "evidence" | "terminal";
 
 const terminalStates = new Set([
   "completed", "blocked", "failed", "cancelled", "budget_limited", "expired",
@@ -76,6 +82,27 @@ function payloadText(event: CodingWorkerEvent) {
   return typeof value === "string" ? value : null;
 }
 
+function publicPlanText(event: CodingWorkerEvent) {
+  if (event.type !== "provider_event" || event.payload.kind !== "plan") return null;
+  const data = event.payload.data;
+  if (typeof data === "string") return data;
+  if (!data || typeof data !== "object") return null;
+  const record = data as Record<string, unknown>;
+  const value = [record.summary, record.message, record.text].find((item) => typeof item === "string");
+  return typeof value === "string" ? value : JSON.stringify(record);
+}
+
+function approvalField(request: Record<string, unknown>, key: string) {
+  const value = request[key];
+  return typeof value === "string" || typeof value === "number" ? String(value) : "未请求";
+}
+
+function outputTone(stream: CodingWorkerOperationOutputChunk["stream"]) {
+  if (stream === "stderr") return "text-rose-200";
+  if (stream === "system") return "text-amber-200";
+  return "text-slate-200";
+}
+
 interface CodingWorkerConsoleProps {
   context: ConsoleContext;
   onCodingHandoff?: (result: CodingWorkerHandoffResult) => void;
@@ -91,6 +118,10 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
   const [artifacts, setArtifacts] = useState<CodingWorkerArtifact[]>([]);
   const [entries, setEntries] = useState<CodingWorkerEntry[]>([]);
   const [treeHash, setTreeHash] = useState("");
+  const [operationOutputs, setOperationOutputs] = useState<Record<string, CodingWorkerOperationOutputChunk[]>>({});
+  const [changesets, setChangesets] = useState<CodingWorkerChangeset[]>([]);
+  const [diagnostics, setDiagnostics] = useState<CodingWorkerDiagnosticsSnapshot[]>([]);
+  const [inspectorLoading, setInspectorLoading] = useState(false);
   const [preview, setPreview] = useState<{ path: string; content: string } | null>(null);
   const [diff, setDiff] = useState("");
   const [tab, setTab] = useState<InspectorTab>("files");
@@ -112,6 +143,18 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
   const selectedTask = useMemo(
     () => tasks.find((task) => task.task_id === selectedTaskId) ?? null,
     [selectedTaskId, tasks],
+  );
+  const operationIds = useMemo(() => {
+    const ids = new Set<string>();
+    events.forEach((event) => {
+      const operationId = event.payload.operation_id;
+      if (typeof operationId === "string" && operationId.length <= 128) ids.add(operationId);
+    });
+    return [...ids].slice(-32);
+  }, [events]);
+  const latestPlan = useMemo(
+    () => events.map(publicPlanText).filter((item): item is string => Boolean(item)).at(-1) ?? null,
+    [events],
   );
 
   const refreshCodingProjects = useCallback(async (preferredId?: string, selectNew = false) => {
@@ -238,12 +281,16 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
     if (!selectedTaskId) {
       setEvents([]); setApprovals([]); setEvidence([]); setArtifacts([]);
       setEntries([]); setPreview(null); setDiff(""); setTreeHash("");
+      setOperationOutputs({}); setChangesets([]); setDiagnostics([]);
       return;
     }
     let active = true;
     let cursor = 0;
     setEvents([]);
     setPreview(null);
+    setOperationOutputs({});
+    setChangesets([]);
+    setDiagnostics([]);
     setTransportWarning(false);
     void refreshTaskPanels(selectedTaskId).catch((caught) => {
       if (active) setError(errorMessage(caught, "任务详情加载失败"));
@@ -260,6 +307,35 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
     });
     return () => { active = false; disconnect(); };
   }, [refreshTaskPanels, selectedTaskId]);
+
+  useEffect(() => {
+    if (!selectedTaskId || operationIds.length === 0) return;
+    let active = true;
+    const loadStructuredInspector = async () => {
+      setInspectorLoading(true);
+      try {
+        if (tab === "terminal" && status?.capabilities.operation_output) {
+          const values = await Promise.all(operationIds.map(async (operationId) => [
+            operationId,
+            await listCodingWorkerOperationOutput(selectedTaskId, operationId).catch(() => []),
+          ] as const));
+          if (active) setOperationOutputs(Object.fromEntries(values));
+        } else if (tab === "changesets" && status?.capabilities.changesets) {
+          const values = await Promise.all(operationIds.map((operationId) =>
+            getCodingWorkerChangeset(selectedTaskId, operationId).catch(() => null)));
+          if (active) setChangesets(values.filter((item): item is CodingWorkerChangeset => item !== null));
+        } else if (tab === "diagnostics" && status?.capabilities.code_intelligence) {
+          const values = await Promise.all(operationIds.map((operationId) =>
+            getCodingWorkerDiagnostics(selectedTaskId, operationId).catch(() => null)));
+          if (active) setDiagnostics(values.filter((item): item is CodingWorkerDiagnosticsSnapshot => item !== null));
+        }
+      } finally {
+        if (active) setInspectorLoading(false);
+      }
+    };
+    void loadStructuredInspector();
+    return () => { active = false; };
+  }, [operationIds, selectedTaskId, status?.capabilities, tab]);
 
   const run = useCallback(async (operation: () => Promise<unknown>) => {
     if (operationRef.current) return;
@@ -383,6 +459,19 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
         <div className="min-w-0">
           <h1 className="text-xl font-semibold text-white">Coding Worker</h1>
           <p className="mt-1 text-sm text-slate-300">两个隔离槽位，任务证据与 Diff 可在重启后继续读取。</p>
+          <div className="mt-2 flex flex-wrap gap-1.5" aria-label="Worker 通用能力">
+            {([
+              ["专业文件", status.capabilities.professional_file_tools],
+              ["Shell", status.capabilities.shell],
+              ["终端补发", status.capabilities.operation_output],
+              ["原子变更", status.capabilities.changesets],
+              ["代码诊断", status.capabilities.code_intelligence],
+            ] as const).map(([label, available]) => (
+              <span key={label} className={`rounded-full px-2.5 py-1 text-xs ${available ? "bg-cyan-300/10 text-cyan-100" : "bg-white/5 text-slate-500"}`}>
+                {label} · {available ? "可用" : "关闭"}
+              </span>
+            ))}
+          </div>
         </div>
         <button type="button" onClick={() => setShowCreate((value) => !value)} className="inline-flex min-h-11 items-center gap-2 rounded-lg bg-cyan-400 px-4 text-sm font-semibold text-slate-950 transition hover:bg-cyan-300 disabled:opacity-50" disabled={busy}>
           <Plus className="h-4 w-4" aria-hidden="true" />创建任务
@@ -477,6 +566,16 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
                 <ul className="mt-2 space-y-1 text-sm text-slate-300">{selectedTask.spec.acceptance.required_checks.map((check) => <li key={check.check_id}>• {check.label} <code className="break-all text-xs text-slate-400">{check.check_id}</code></li>)}</ul>
               </section>
 
+              {latestPlan && (
+                <section className="border-b border-white/10 py-3" aria-labelledby="worker-plan-heading">
+                  <div className="flex items-center justify-between gap-3">
+                    <h2 id="worker-plan-heading" className="text-sm font-semibold text-white">当前公开计划</h2>
+                    <span className="text-xs text-slate-500">Provider 中立</span>
+                  </div>
+                  <p className="mt-2 max-w-[72ch] whitespace-pre-wrap break-words text-sm leading-6 text-slate-300">{latestPlan}</p>
+                </section>
+              )}
+
               <section className="min-h-0 flex-1 overflow-y-auto py-3" aria-label="任务事件" aria-live="polite">
                 {events.length === 0 ? <p className="text-sm text-slate-400">等待 Worker 事件。公开事件只包含计划、状态和工具摘要。</p> : events.map((event) => (
                   <article key={event.sequence} className="mb-3 flex gap-3"><span className="mt-1 h-2 w-2 shrink-0 rounded-full bg-cyan-300" aria-hidden="true" /><div className="min-w-0"><p className="text-xs font-medium text-slate-400">{event.type} · #{event.sequence}</p><p className="mt-1 whitespace-pre-wrap break-words text-sm text-slate-200">{payloadText(event) ?? JSON.stringify(event.payload)}</p></div></article>
@@ -493,13 +592,48 @@ export default function CodingWorkerConsole({ context, onCodingHandoff }: Coding
 
         <aside className="min-w-0 border-t border-white/10 pt-3 xl:border-l xl:border-t-0 xl:pl-3 xl:pt-0" aria-label="任务检查器">
           <div className="flex overflow-x-auto border-b border-white/10" role="tablist">
-            {([ ["files", FolderTree, "文件"], ["diff", GitCompareArrows, "Diff"], ["evidence", ShieldCheck, "证据"], ["terminal", TerminalSquare, "终端"] ] as const).map(([value, Icon, label]) => <button key={value} type="button" role="tab" aria-selected={tab === value} onClick={() => setTab(value)} className={`inline-flex min-h-11 items-center gap-1 px-3 text-sm ${tab === value ? "border-b-2 border-cyan-300 text-white" : "text-slate-400"}`}><Icon className="h-4 w-4" />{label}</button>)}
+            {([ ["files", FolderTree, "文件"], ["diff", GitCompareArrows, "Diff"], ["changesets", GitCompareArrows, "变更"], ["diagnostics", CircleAlert, "诊断"], ["evidence", ShieldCheck, "证据"], ["terminal", TerminalSquare, "终端"] ] as const).map(([value, Icon, label]) => <button key={value} type="button" role="tab" aria-selected={tab === value} onClick={() => setTab(value)} className={`inline-flex min-h-11 items-center gap-1 px-3 text-sm ${tab === value ? "border-b-2 border-cyan-300 text-white" : "text-slate-400"}`}><Icon className="h-4 w-4" />{label}</button>)}
           </div>
           <div className="max-h-[46rem] overflow-auto py-3 text-sm">
             {tab === "files" && <div><p className="mb-2 break-all text-xs text-slate-400">tree {treeHash || "尚未创建"}</p>{preview ? <div><button type="button" className="mb-2 min-h-11 text-cyan-200" onClick={() => setPreview(null)}>返回文件树</button><p className="mb-2 break-all text-slate-300">{preview.path}</p><pre className="overflow-auto whitespace-pre-wrap break-words rounded-lg bg-slate-950/80 p-3 text-xs text-slate-200">{preview.content}</pre></div> : <ul className="space-y-1">{entries.map((entry) => <li key={entry.entry_id}><button type="button" disabled={entry.kind !== "file" || busy} onClick={() => void openEntry(entry)} className="flex min-h-10 w-full items-center gap-2 rounded-md px-2 text-left text-slate-300 hover:bg-white/5 disabled:cursor-default"><FileCode2 className="h-4 w-4 shrink-0" /><span className="min-w-0 break-all">{entry.display_path}</span></button></li>)}</ul>}</div>}
             {tab === "diff" && <pre className="overflow-auto whitespace-pre-wrap break-words rounded-lg bg-slate-950/80 p-3 text-xs text-slate-200">{diff || "工作区还没有变更。"}</pre>}
-            {tab === "evidence" && <div className="space-y-4"><section><h3 className="font-semibold text-white">审批</h3>{approvals.filter((item) => item.status === "pending").map((item) => <div key={item.approval_id} className="mt-2 rounded-lg bg-amber-300/10 p-3"><p className="text-amber-100">{item.capability}</p><p className="mt-1 break-words text-xs text-slate-300">{JSON.stringify(item.request)}</p><div className="mt-3 flex flex-wrap gap-2"><button type="button" disabled={busy} onClick={() => void decide(item.approval_id, "approve_once")} className="min-h-11 rounded-lg bg-cyan-400 px-3 font-semibold text-slate-950">批准一次</button><button type="button" disabled={busy} onClick={() => void decide(item.approval_id, "approve_task")} className="min-h-11 rounded-lg border border-cyan-300/40 px-3 text-cyan-100">本任务批准</button><button type="button" disabled={busy} onClick={() => void decide(item.approval_id, "reject")} className="min-h-11 rounded-lg border border-white/15 px-3 text-slate-200">拒绝</button></div></div>)}</section><section><h3 className="font-semibold text-white">检查证据</h3><ul className="mt-2 space-y-2">{evidence.map((item) => <li key={item.evidence_id} className="rounded-lg bg-white/5 p-3"><span className={item.status === "passed" ? "text-emerald-300" : item.status === "failed" ? "text-rose-300" : "text-amber-300"}>{item.status}</span><span className="ml-2 break-all text-slate-200">{item.check_id}</span><span className="mt-1 block text-xs text-slate-400">exit {item.exit_code}</span></li>)}</ul></section><section><h3 className="font-semibold text-white">Artifacts</h3><ul className="mt-2 space-y-1">{artifacts.map((item) => <li key={item.artifact_id}><a className="block min-h-10 break-all rounded-md px-2 py-2 text-cyan-200 hover:bg-white/5" href={codingWorkerArtifactUrl(item.task_id, item.artifact_id)}>{item.artifact_id} · {item.media_type}</a></li>)}</ul></section></div>}
-            {tab === "terminal" && <div><p className="mb-2 text-xs text-slate-400">命令归属和输出只来自 Tool Broker 公开事件。</p><pre className="overflow-auto whitespace-pre-wrap break-words rounded-lg bg-slate-950/80 p-3 text-xs text-slate-200">{events.filter((event) => event.type === "tool_operation" || event.type === "provider_event").map((event) => `#${event.sequence} ${event.type}\n${payloadText(event) ?? JSON.stringify(event.payload)}`).join("\n\n") || "尚无工具输出。"}</pre></div>}
+            {tab === "changesets" && (
+              <div className="space-y-3" aria-busy={inspectorLoading}>
+                {!status.capabilities.changesets ? <p className="text-slate-400">原子 changeset 当前关闭。</p> : null}
+                {status.capabilities.changesets && changesets.length === 0 ? <p className="text-slate-400">{inspectorLoading ? "正在读取变更记录。" : "尚无 changeset。"}</p> : null}
+                {changesets.map((changeset) => (
+                  <section key={changeset.changeset_id} className="rounded-lg bg-white/5 p-3">
+                    <div className="flex flex-wrap items-center justify-between gap-2"><h3 className="break-all font-semibold text-white">{changeset.changeset_id}</h3><span className={changeset.state === "applied" ? "text-emerald-300" : "text-amber-200"}>{changeset.state}</span></div>
+                    <p className="mt-1 break-all text-xs text-slate-400">operation {changeset.operation_id}</p>
+                    <p className="mt-1 break-all text-xs text-slate-500">tree {changeset.base_tree_hash.slice(0, 12)} → {changeset.result_tree_hash?.slice(0, 12) ?? "未发布"}</p>
+                    <ul className="mt-3 space-y-2">{changeset.entries.map((entry) => <li key={`${changeset.changeset_id}-${entry.entry_id}`} className="break-all text-slate-200"><span className="mr-2 rounded bg-slate-800 px-1.5 py-0.5 text-xs text-cyan-100">{entry.kind}</span>{entry.display_path}{entry.destination_display_path ? ` → ${entry.destination_display_path}` : ""}{entry.binary ? <span className="ml-2 text-xs text-amber-200">二进制</span> : null}</li>)}</ul>
+                    {changeset.artifact_id ? <a className="mt-3 block min-h-11 break-all py-2 text-cyan-200" href={codingWorkerArtifactUrl(changeset.task_id, changeset.artifact_id)}>下载 changeset Artifact</a> : null}
+                  </section>
+                ))}
+              </div>
+            )}
+            {tab === "diagnostics" && (
+              <div className="space-y-3" aria-busy={inspectorLoading}>
+                {!status.capabilities.code_intelligence ? <p className="text-slate-400">代码诊断当前关闭。</p> : null}
+                {status.capabilities.code_intelligence && diagnostics.length === 0 ? <p className="text-slate-400">{inspectorLoading ? "正在读取诊断。" : "尚无诊断结果。"}</p> : null}
+                {diagnostics.map((snapshot) => (
+                  <section key={snapshot.operation_id} className="rounded-lg bg-white/5 p-3">
+                    <div className="flex flex-wrap items-center justify-between gap-2"><h3 className="break-all font-semibold text-white">{entries.find((entry) => entry.entry_id === snapshot.entry_id)?.display_path ?? snapshot.entry_id}</h3><span className="text-xs text-slate-400">{snapshot.language}</span></div>
+                    {snapshot.stale ? <p className="mt-2 rounded-md bg-amber-300/10 px-2 py-1.5 text-xs text-amber-100" role="status">工作区已改变，此诊断仅作历史证据。</p> : null}
+                    <ul className="mt-3 space-y-2">{snapshot.diagnostics.map((item) => <li key={item.diagnostic_id} className="break-words text-slate-200"><span className={item.severity === "error" ? "text-rose-300" : item.severity === "warning" ? "text-amber-200" : "text-cyan-200"}>{item.severity}</span><span className="ml-2 text-xs text-slate-500">{item.range.start.line + 1}:{item.range.start.character + 1}{item.code ? ` · ${item.code}` : ""}</span><p className="mt-1 leading-5">{item.message}</p></li>)}</ul>
+                  </section>
+                ))}
+              </div>
+            )}
+            {tab === "evidence" && <div className="space-y-4"><section><h3 className="font-semibold text-white">审批</h3>{approvals.filter((item) => item.status === "pending").map((item) => <div key={item.approval_id} className="mt-2 rounded-lg bg-amber-300/10 p-3"><div className="flex flex-wrap items-center justify-between gap-2"><p className="text-amber-100">{item.capability === "shell" ? "Shell 单次审批" : item.capability}</p><code className="break-all text-xs text-slate-400">{item.operation_id}</code></div>{item.capability === "shell" ? <dl className="mt-3 grid grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-2 text-xs"><dt className="text-slate-400">模式</dt><dd className="break-all text-slate-200">{approvalField(item.request, "mode")}</dd><dt className="text-slate-400">工作目录</dt><dd className="break-all text-slate-200">{approvalField(item.request, "cwd")}</dd><dt className="text-slate-400">超时</dt><dd className="break-all text-slate-200">{approvalField(item.request, "timeout_seconds")} 秒</dd><dt className="text-slate-400">脚本摘要</dt><dd className="break-all font-mono text-slate-200">{approvalField(item.request, "script_sha256")}</dd><dt className="text-slate-400">网络范围</dt><dd className="break-all font-mono text-slate-200">{approvalField(item.request, "network_scope_sha256")}</dd></dl> : <p className="mt-1 break-words text-xs text-slate-300">{JSON.stringify(item.request)}</p>}<div className="mt-3 flex flex-wrap gap-2"><button type="button" disabled={busy} onClick={() => void decide(item.approval_id, "approve_once")} className="min-h-11 rounded-lg bg-cyan-400 px-3 font-semibold text-slate-950">批准一次</button>{item.capability !== "shell" ? <button type="button" disabled={busy} onClick={() => void decide(item.approval_id, "approve_task")} className="min-h-11 rounded-lg border border-cyan-300/40 px-3 text-cyan-100">本任务批准</button> : null}<button type="button" disabled={busy} onClick={() => void decide(item.approval_id, "reject")} className="min-h-11 rounded-lg border border-white/15 px-3 text-slate-200">拒绝</button></div></div>)}</section><section><h3 className="font-semibold text-white">检查证据</h3><ul className="mt-2 space-y-2">{evidence.map((item) => <li key={item.evidence_id} className="rounded-lg bg-white/5 p-3"><span className={item.status === "passed" ? "text-emerald-300" : item.status === "failed" ? "text-rose-300" : "text-amber-300"}>{item.status}</span><span className="ml-2 break-all text-slate-200">{item.check_id}</span><span className="mt-1 block text-xs text-slate-400">exit {item.exit_code}</span></li>)}</ul></section><section><h3 className="font-semibold text-white">Artifacts</h3><ul className="mt-2 space-y-1">{artifacts.map((item) => <li key={item.artifact_id}><a className="block min-h-11 break-all rounded-md px-2 py-2.5 text-cyan-200 hover:bg-white/5" href={codingWorkerArtifactUrl(item.task_id, item.artifact_id)}>{item.artifact_id} · {item.media_type}</a></li>)}</ul></section></div>}
+            {tab === "terminal" && (
+              <div aria-busy={inspectorLoading}>
+                <p className="mb-2 text-xs text-slate-400">输出按 operation 归属并从持久事件补发；刷新页面不会丢失已归档片段。</p>
+                {!status.capabilities.operation_output ? <p className="text-slate-400">终端补发当前关闭。</p> : null}
+                {status.capabilities.operation_output && Object.values(operationOutputs).every((items) => items.length === 0) ? <p className="text-slate-400">{inspectorLoading ? "正在补发终端输出。" : "尚无命令输出。"}</p> : null}
+                <div className="space-y-3">{Object.entries(operationOutputs).filter(([, chunks]) => chunks.length > 0).map(([operationId, chunks]) => <section key={operationId} className="overflow-hidden rounded-lg bg-slate-950/80"><h3 className="border-b border-white/10 px-3 py-2 break-all text-xs font-semibold text-cyan-100">{operationId}</h3><pre className="max-h-80 overflow-auto whitespace-pre-wrap break-words p-3 text-xs">{chunks.map((chunk) => <span key={chunk.sequence} className={outputTone(chunk.stream)}>{chunk.text}{chunk.truncated ? "\n[输出已截断]\n" : ""}</span>)}</pre></section>)}</div>
+              </div>
+            )}
           </div>
           {context === "coding" && selectedTask && <section className="mt-3 border-t border-white/10 pt-3"><div className="flex items-center gap-2"><GitCompareArrows className="h-4 w-4 text-cyan-300" /><h3 className="font-semibold text-white">宿主写回</h3></div><p className="mt-1 text-xs text-slate-400">完成后继续使用 v13 的应用、提交、撤销和发布确认链。Worker 不直接写用户仓库。</p>{selectedTask.state === "completed" && selectedTask.spec.workspace_source.kind === "host_snapshot" ? <button type="button" onClick={() => void handoffToWriteback()} disabled={busy} className="mt-3 min-h-11 w-full rounded-lg bg-cyan-400 px-3 text-sm font-semibold text-slate-950 transition hover:bg-cyan-300 disabled:opacity-50">进入 v13 写回确认</button> : <p className="mt-3 text-xs text-slate-500">Host Snapshot 任务通过全部必需检查后，才会开放写回确认。</p>}<div className="mt-3 flex flex-wrap gap-2" aria-label="Coding 领域动作"><span className="rounded-full bg-white/5 px-3 py-1 text-xs text-slate-300">应用</span><span className="rounded-full bg-white/5 px-3 py-1 text-xs text-slate-300">提交</span><span className="rounded-full bg-white/5 px-3 py-1 text-xs text-slate-300">撤销</span><span className="rounded-full bg-white/5 px-3 py-1 text-xs text-slate-300">发布</span></div></section>}
         </aside>

--- a/client/src/types/codingWorker.ts
+++ b/client/src/types/codingWorker.ts
@@ -79,6 +79,16 @@ export interface CodingWorkerEvent {
   created_at: number;
 }
 
+export interface CodingWorkerCapabilities {
+  api_version: "v1";
+  task_runtime: boolean;
+  professional_file_tools: boolean;
+  shell: boolean;
+  operation_output: boolean;
+  changesets: boolean;
+  code_intelligence: boolean;
+}
+
 export interface CodingWorkerStatus {
   enabled: boolean;
   available: boolean;
@@ -88,6 +98,7 @@ export interface CodingWorkerStatus {
   network_enabled: boolean;
   acceptance_checks: string[];
   reason: string | null;
+  capabilities: CodingWorkerCapabilities;
 }
 
 export interface CodingWorkerApproval {
@@ -135,4 +146,70 @@ export interface CodingWorkerEntry {
   kind: string;
   size: number;
   sha256: string | null;
+}
+
+export interface CodingWorkerOperationOutputChunk {
+  task_id: string;
+  operation_id: string;
+  sequence: number;
+  stream: "stdout" | "stderr" | "system";
+  text: string;
+  created_at: number;
+  truncated: boolean;
+}
+
+export interface CodingWorkerChangesetEntry {
+  entry_id: string;
+  kind: "add" | "modify" | "delete" | "move";
+  display_path: string;
+  destination_display_path: string | null;
+  preimage_sha256: string | null;
+  postimage_sha256: string | null;
+  binary: boolean;
+}
+
+export interface CodingWorkerChangeset {
+  changeset_id: string;
+  task_id: string;
+  operation_id: string;
+  base_tree_hash: string;
+  result_tree_hash: string | null;
+  state: "prepared" | "applied" | "conflict" | "rejected" | "unknown";
+  entries: CodingWorkerChangesetEntry[];
+  artifact_id: string | null;
+  created_at: number;
+  updated_at: number;
+}
+
+export interface CodingWorkerCodePosition {
+  line: number;
+  character: number;
+}
+
+export interface CodingWorkerCodeRange {
+  start: CodingWorkerCodePosition;
+  end: CodingWorkerCodePosition;
+}
+
+export interface CodingWorkerDiagnostic {
+  diagnostic_id: string;
+  task_id: string;
+  entry_id: string;
+  workspace_tree_hash: string;
+  range: CodingWorkerCodeRange;
+  severity: "error" | "warning" | "information" | "hint";
+  code: string | null;
+  message: string;
+  created_at: number;
+}
+
+export interface CodingWorkerDiagnosticsSnapshot {
+  task_id: string;
+  operation_id: string;
+  entry_id: string;
+  language: "python" | "typescript" | "typescriptreact" | "javascript" | "javascriptreact";
+  workspace_tree_hash: string;
+  current_tree_hash: string;
+  stale: boolean;
+  diagnostics: CodingWorkerDiagnostic[];
 }

--- a/client/src/utils/codingWorkerApi.ts
+++ b/client/src/utils/codingWorkerApi.ts
@@ -1,9 +1,12 @@
 import type {
   CodingWorkerApproval,
   CodingWorkerArtifact,
+  CodingWorkerChangeset,
+  CodingWorkerDiagnosticsSnapshot,
   CodingWorkerEntry,
   CodingWorkerEvent,
   CodingWorkerEvidence,
+  CodingWorkerOperationOutputChunk,
   CodingWorkerStatus,
   CodingWorkerTask,
   CodingWorkerTaskSpec,
@@ -59,7 +62,7 @@ const taskEventTypes = [
   "approval_requested", "approval_decided", "tool_operation",
   "artifact_created", "evidence_recorded", "evidence_invalidated",
   "checkpoint_created", "acceptance_evaluated", "acceptance_retry",
-  "task_pinned", "task_unpinned",
+  "task_pinned", "task_unpinned", "operation_output",
 ] as const;
 
 export const getCodingWorkerStatus = () => request<CodingWorkerStatus>(API_ROOT);
@@ -129,6 +132,26 @@ export async function listCodingWorkerArtifacts(taskId: string) {
     `${API_ROOT}/tasks/${encodeURIComponent(taskId)}/artifacts`,
   )).artifacts;
 }
+
+export async function listCodingWorkerOperationOutput(
+  taskId: string,
+  operationId: string,
+  after = 0,
+) {
+  return (await request<{ chunks: CodingWorkerOperationOutputChunk[] }>(
+    `${API_ROOT}/tasks/${encodeURIComponent(taskId)}/operations/${encodeURIComponent(operationId)}/output?after=${Math.max(0, after)}`,
+  )).chunks;
+}
+
+export const getCodingWorkerChangeset = (taskId: string, operationId: string) =>
+  request<CodingWorkerChangeset>(
+    `${API_ROOT}/tasks/${encodeURIComponent(taskId)}/changesets/${encodeURIComponent(operationId)}`,
+  );
+
+export const getCodingWorkerDiagnostics = (taskId: string, operationId: string) =>
+  request<CodingWorkerDiagnosticsSnapshot>(
+    `${API_ROOT}/tasks/${encodeURIComponent(taskId)}/diagnostics/${encodeURIComponent(operationId)}`,
+  );
 
 export async function listCodingWorkerTree(taskId: string) {
   return request<{ workspace_id: string; tree_hash: string; entries: CodingWorkerEntry[] }>(

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -331,3 +331,31 @@ flowchart LR
 - `host_snapshot` 在任务真正出队时才向 Windows Helper 请求一次性快照并导入 Project Source；Server 始终不获得宿主物理路径。完成后仅能显式交给现有 v13 写回链，Worker 本身不写用户仓库。
 
 `/coding` 和 `/agents/workbench` 使用同一个 Worker Console。前者保留 v13 apply/commit/undo/publish 领域动作；后者只显示通用任务、文件、Diff、审批、Evidence、Artifact 与终端语义。下游 Skill/MCP 创建、AI 应用、3D 引擎和用户开发模块只注册来源、上下文和验收适配器，不向 Worker 内核加入领域逻辑。
+
+## V15 专业执行与双引擎边界
+
+V15 保持 `/api/coding-worker/v1`、`TaskSpec` 和 V14 Workspace/Store 不变，在 Tool Broker 与
+Provider 私有层补充专业执行能力：
+
+- 文件修改使用带 preimage hash 的统一 changeset；多文件 Patch、移动或删除任一项冲突时整批
+  失败。Shell `mutate` 只在退出码为零且真实 Workspace tree CAS 未变化时发布，`inspect` 的
+  任何文件变化均丢弃。完整输出进入 Artifact，公共事件只保存有界、可补发的顺序片段。
+- Shell 批准只绑定一个 operation ID、脚本摘要、相对 cwd、模式、超时和网络范围，不存在
+  “本任务全部批准”。后台服务、冻结检查和 Shell 共享任务进程归属，但不共享批准租约。
+- Pyright 与 TypeScript Language Server 固定在 Executor 镜像内。symbols、definition、
+  references、hover 与 diagnostics 均绑定 task、entry ID 和 tree hash；树变化后旧诊断失效，
+  重启只重建 LSP，不恢复旧进程。
+- Provider 私有契约 v2 统一 Fake、OpenCode 与 Claude 的 capability、工具 allowlist、usage、
+  checkpoint compatibility 和错误分类。任务创建时固定内部 Provider；不可用时进入
+  `interrupted`，不跨引擎迁移 checkpoint，也不自动换供应商。
+- Claude Code 固定为 `2.1.89`，运行在独立、无 Workspace 挂载的 Provider sidecar。内建
+  Bash、文件、Web、Skill、插件、hooks、marketplace 与更新检查关闭；仅能调用
+  ModelMirror MCP Broker。凭据只以只读 secret 文件进入 Claude sidecar，并仅在启动子进程
+  时注入；Executor、Store、日志、Artifact 和公共 API 不接收它。
+- 平台内部 route catalog 把 `coding/default`、`coding/quality` 等通用路由固定到执行槽和
+  Provider。浏览器、模块与公共 SSE 仍看不到供应商名、端口、原始帧、session ID 或凭据状态。
+
+共享 Console 只查询公共 capability、公开计划、operation output、changeset 与 diagnostics，
+并展示精确 Shell 批准字段；它不获得 Provider 控制权。模块 SDK 对每次读取、steering、暂停、
+恢复和取消都复核服务端 `origin(module, business_object)`，跨模块任务 ID 在副作用前拒绝。
+模块仍不能注册 Provider、工具进程、密钥或任意 MCP Server；领域适配继续位于调用模块。

--- a/docs/CODING_AGENT_INTEGRATION.md
+++ b/docs/CODING_AGENT_INTEGRATION.md
@@ -742,3 +742,28 @@ V14 的公共入口是版本化 `/api/coding-worker/v1`。OpenCode、ACP、sidec
 `/coding` 与 `/agents/workbench` 的新会话可渐进使用同一 `CodingWorkerConsole`；已有活动会话仍走 legacy。Coding 场景中的 completed `host_snapshot` 任务可调用 `POST /api/coding/worker-tasks/{task_id}/handoff`，把严格 UTF-8 文本 Diff 交给 v13 Recovery，然后由用户确认 apply/commit/undo/publish。二进制变更、未通过验收、Workspace 变化或 Host 身份变化均不得进入写回。
 
 模型停止输出不代表完成。服务端先进入 `testing`，Harness Runner 运行冻结检查并写 Evidence Ledger；只有全部必需检查对当前 tree hash 为 passed，任务才进入 `completed`。运行中命令在重启时停止，任务标记 `interrupted`；resume 只恢复确定 checkpoint，不恢复旧进程或盲重放未知 operation ID。
+
+## V15 专业工具与模块控制
+
+V15 不改变 TaskSpec，也不允许调用方选择供应商。它在同一版本化 API 上增加只读查询：
+
+| 接口 | 用途 |
+| --- | --- |
+| `GET /tasks/{task_id}/operations/{operation_id}/output?after=` | 按序补发有界 Shell/检查输出；完整输出从绑定 Artifact 下载 |
+| `GET /tasks/{task_id}/changesets/{operation_id}` | 读取原子发布结果、preimage/tree CAS 与文件摘要 |
+| `GET /tasks/{task_id}/diagnostics/{operation_id}` | 读取绑定 entry ID 与 tree hash 的代码诊断；旧树结果标记失效 |
+
+公共 capability 只说明 `shell`、`changesets`、`code_intelligence` 等中立能力。内部 route catalog
+在任务创建时固定 Provider 与兼容版本；公共 API、SSE 和 Console 不返回 Claude/OpenCode 名称、
+原始帧、端口、session ID、secret 或真实端点。Provider 完成但回执丢失时先按 checkpoint/operation
+对账，不重新执行工具副作用。
+
+共享 `CodingWorkerConsole` 展示公开计划、实时终端、changeset、diagnostics、Evidence 与精确
+Shell 批准。Shell 批准包含 operation ID、脚本摘要、相对 cwd、模式、timeout 和网络范围；Shell
+不允许 task-scope lease。Coding 场景仍可在任务 completed 后进入 v13 handoff；通用 Agent 场景不
+显示 apply、commit、undo 或 publish。
+
+模块侧 `CodingWorkerClient` 的所有任务读取和生命周期操作都需要服务端 origin。跨模块或业务对象
+任务 ID 在读取事件或产生副作用前拒绝。模块可以注册 source、context、acceptance 和通用 route
+allowlist，不能控制 Provider、Tool Broker、Shell/LSP 进程、secret 或任意 MCP Server。旧 V14 任务
+继续按兼容默认值读取与恢复，不迁移 Provider checkpoint。

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -592,3 +592,46 @@ docker compose -f docker-compose.yml -f docker-compose.coding-project-host.yml -
 验收至少包括：两个任务并行、第三个排队；失败检查后的自动修复与复测；审批拒绝/过期；SSE 断线补发；Server、两个 Provider/Executor 逐个重启；Host Snapshot 经过 v13 写回。真实 OpenCode、Windows Helper 和用户项目写回必须单列人工结果，不能用 Fake Provider 或 Compose `config` 代替。
 
 回退只需设置 `CODING_WORKER_V14_ENABLED=false` 并重建 Server，使新会话回到 legacy。不要删除 `coding_worker_state`、slot Workspace 卷、v13 Recovery 或 Agent Workspace 数据；已有任务保持可审计，已有宿主副作用不会自动撤销。
+
+## Coding Worker V15 部署
+
+V15 在 V14 overlay 之后可选加载 `docker-compose.coding-worker-v15-claude.yml`。以下开关默认
+全部关闭；前三项写入绝对 `MODELMIRROR_DATA_ROOT` 对应的 `server/.env`，单独设置浏览器参数
+或 TaskSpec 不能开启能力：
+
+```dotenv
+CODING_WORKER_V15_ENABLED=false
+CODING_WORKER_SHELL_ENABLED=false
+CODING_WORKER_CODE_INTELLIGENCE_ENABLED=false
+```
+
+Claude overlay 的值用于 Compose 插值，必须由部署脚本/宿主环境或 Compose project `.env`
+显式提供；Server 的 `env_file` 不会替代这些插值：
+
+```dotenv
+CODING_WORKER_CLAUDE_ENABLED=false
+CODING_WORKER_CLAUDE_MODEL_ID=<controlled-model-id>
+CODING_WORKER_CLAUDE_SECRET_FILE=C:\\absolute\\path\\claude-api-key.secret
+CODING_WORKER_CLAUDE_PROXY_TOKEN=<random-url-safe-token>
+```
+
+Claude secret 文件不得放入仓库或数据导出；sidecar 只接受普通、非链接、单硬链接的只读文件。
+缺少或不安全的 secret 只禁用相应内部路由，不影响 OpenCode、Fake、legacy 或已有 V14 任务。
+Claude Provider 不挂载 Workspace、Docker socket、宿主目录或 Server 密钥；独立出口代理只允许
+`api.anthropic.com:443`，Executor 仍无模型网络。`CODING_WORKER_CLAUDE_MODEL_ID` 是部署者控制
+的内部映射，不进入公共 TaskSpec。
+
+只展开最终配置而不启动服务：
+
+```powershell
+docker compose -f docker-compose.yml `
+  -f docker-compose.coding-worker-v14.yml `
+  -f docker-compose.coding-worker-v15-claude.yml `
+  -p modelmirror --profile coding config --quiet
+```
+
+重建、真实 secret、真实双引擎任务和逐组件重启必须在用户确认的共享栈窗口执行。自动测试、
+镜像版本探针或 Compose 展开不等同于真实 Claude/OpenCode 验收。回退时先关闭
+`CODING_WORKER_CLAUDE_ENABLED`，再按需关闭 code intelligence、Shell 与 V15 总开关并停止接收
+新 V15 任务；不要删除 V14 Store、Workspace、Evidence、v13 Recovery 或 Agent Workspace 数据。
+已开始的任务必须进入明确的 `interrupted`/终态，未知 operation 只能对账，不能重放。

--- a/docs/HARNESS_ENGINEERING.md
+++ b/docs/HARNESS_ENGINEERING.md
@@ -405,3 +405,24 @@ curl http://localhost:5173/models
 49. **共享 Console 必须区分展示与能力。** `/coding` 和 `/agents/workbench` 可复用任务、对话、文件、
     Diff、审批、Evidence、Artifact 与终端组件；只有 Coding 上下文展示 v13 领域动作。开关关闭、Provider
     不可用或 legacy 活动会话存在时必须清晰降级，不能把 Mock/静态状态误报为真实引擎就绪。
+50. **专业文件修改必须以 preimage 与 tree CAS 整批发布。** unified patch、移动、删除和批量修改的每个
+    输入都要绑定旧内容；任一冲突时全部保持旧状态。Shell `mutate` 还必须满足 exit 0 与真实 Workspace
+    tree 未变化，`inspect` 永不发布文件变化；超限或策略外产物只进入 Artifact。
+51. **Shell 没有任务级永久批准。** 每次批准必须精确绑定 operation ID、脚本摘要、相对 cwd、模式、
+    timeout 和网络范围。修改脚本、重复批准、过期批准或把服务/检查租约复用于 Shell 都必须拒绝；未知
+    结果按原 operation ID 对账，不能换 ID 重跑。
+52. **代码智能结果是树版本证据，不是长期事实。** symbols、definition、references、hover 和 diagnostics
+    必须绑定 task、entry ID 与 tree hash。任何 Workspace 变化立即使旧结果失效；LSP 重启只能重新索引，
+    不能恢复旧进程、旧诊断或读取另一个任务的 Workspace。
+53. **Provider 可移植不等于 Provider 可见。** 公共 route 只表达平台质量档；供应商、版本、端口、原始帧、
+    session ID 与凭据只存在于加密私有绑定。任务只允许原 Provider、兼容版本和相同 tree 恢复；不得自动
+    跨引擎迁移或把缺少 Claude secret 扩大为 OpenCode/legacy 故障。
+54. **真实 Provider 内建工具必须保持关闭。** OpenCode 与 Claude 都只能经 ModelMirror Tool Broker 读写、
+    执行或联网。Claude secret 只进入独立 Provider 子进程，Provider 不挂 Workspace，Executor 不接收模型
+    凭据；conformance Mock 或 CLI `--version` 不能替代真实双引擎任务验收。
+55. **模块控制必须持续复核 origin。** SDK 的查询、事件、message、pause、resume 与 cancel 都要匹配
+    `origin(module, business_object)`，不能只在创建时校验。模块可登记来源、上下文和验收适配器，但不能
+    注册 Provider、Shell/LSP 进程、secret 或任意 MCP Server。
+56. **Console 展示的输出必须可补发且有界。** operation output 按序号重连，完整内容从受限 Artifact 获取；
+    大输出、长路径和 diagnostics 不得阻塞主线程或破坏移动端。精确 Shell 批准要可键盘操作、带明确焦点
+    与状态反馈，Coding 领域动作仍只在 Coding 上下文出现。

--- a/docs/tasks/CODING_WORKER_V15.md
+++ b/docs/tasks/CODING_WORKER_V15.md
@@ -41,7 +41,8 @@
 
 ## 当前进度（2026-08-11）
 
-PR A 已作为 Draft PR #151 发布；PR B 的实现与自动门禁已完成，尚未进行真实 Provider/人工验收，也未开始 PR C：
+PR A 已作为 Draft PR #151 发布，PR B 已作为 Draft PR #155 发布；PR C 的实现与自动门禁也已完成，
+尚未进行真实 Provider、共享栈或 v13 写回人工验收：
 
 - 契约与文件工具：`d0e955b`、`50d933e`、`29c135b`。
 - Shell 执行、审批、changeset 与查询：`ad831ac`、`0a56605`、`45df707`。
@@ -79,6 +80,30 @@ PR B 实际自动验证：
 - 有效 Compose 配置确认 Claude Provider 不继承 route key、gateway base URL 或 Workspace 挂载；Provider 只接内部网络和受控 socket/secret，独立代理只允许 `api.anthropic.com:443`。
 
 上述 PR B 证据证明契约、隔离、恢复对账和镜像构造，不等同于使用真实 Anthropic 凭据完成任务。真实 OpenCode/Claude 双任务、逐组件重启和 v13 Host 写回仍属于 PR C 后的人工验收，完成前 V15 保持非 Ready。
+
+PR C 实现提交：
+
+- 共享 Console 的中立 capability、公开计划、operation output、changeset、diagnostics 与精确 Shell
+  批准：`d553877`。
+- 持续复核 `origin(module, business_object)` 的模块任务查询、事件、steering 与生命周期控制：
+  `201602d`。
+- 两个实现提交分别修改 4 个和 2 个文件，均未扩大公共 TaskSpec，也未新增依赖。
+
+PR C 实际自动验证：
+
+- Linux 无网络只读源码环境全部 Worker：145 passed、5 skipped、1 条既有框架告警。
+- Agent Workspace：44 passed；全部 Coding：768 passed、14 skipped、1 条既有框架告警。
+- 后端全量：2617 passed、27 skipped、7 failed、6 warnings。5 项仍为 Agency Worker 测试镜像缺少
+  构建产物，1 项仍为 Node 20 无法直接导入 `.ts`；二者已在 PR B 基线复现。另 1 项 Host Apply
+  同内容替换身份测试在本次全量中波动失败，但同一 PR C 的 Coding 全量已通过，随后在 PR C 与
+  PR B 基线分别精确复跑均为 1 passed；未把该波动写成全绿或跨范围修改。
+- 前端 TypeScript 检查通过；35 个测试文件、170 项测试全部通过；production build 成功，仅有
+  既有大 chunk 告警。
+- 变更 Python 文件 `py_compile` 通过；V14 与 V15 Claude overlay 合并后的 Compose
+  `config --quiet` 通过；`git diff --check` 通过。
+
+上述 PR C 证据证明公共 Console、模块 origin 隔离和受影响回归，不等同于真实双引擎任务、
+逐组件重启、网络/依赖 lease 或 v13 Host 写回。PR C 必须保持 Draft，人工验收通过前 V15 非 Ready。
 
 ## 开关与回退
 

--- a/server/coding_worker/sdk.py
+++ b/server/coding_worker/sdk.py
@@ -7,6 +7,7 @@ from .contracts import (
     Origin,
     TaskCreateRequest,
     TaskRecord,
+    WorkerEvent,
 )
 from .runtime import register_frozen_check, register_workspace_source_adapter
 from .service import CodingWorkerService
@@ -75,6 +76,68 @@ class CodingWorkerModuleClient:
         return await self.service.create_task(
             Origin(module=self.module, object_id=business_object_id), request
         )
+
+    def get_task(self, *, business_object_id: str, task_id: str) -> TaskRecord:
+        """Return one task only when its immutable origin belongs to this module."""
+
+        return self._require_owned_task(business_object_id, task_id)
+
+    def list_events(
+        self,
+        *,
+        business_object_id: str,
+        task_id: str,
+        after: int = 0,
+        limit: int = 500,
+    ) -> tuple[WorkerEvent, ...]:
+        """Read provider-neutral public events without exposing provider sessions."""
+
+        self._require_owned_task(business_object_id, task_id)
+        if after < 0 or limit < 1 or limit > 1000:
+            raise CodingWorkerSDKError(
+                "Event cursor is invalid.", code="worker_event_cursor_invalid"
+            )
+        return tuple(self.service.store.list_events(task_id, after=after, limit=limit))
+
+    async def append_message(
+        self, *, business_object_id: str, task_id: str, message: str
+    ) -> TaskRecord:
+        self._require_owned_task(business_object_id, task_id)
+        if not message.strip() or len(message) > 1_048_576:
+            raise CodingWorkerSDKError(
+                "Worker message is invalid.", code="worker_message_invalid"
+            )
+        return await self.service.append_message(task_id, message)
+
+    async def pause_task(
+        self, *, business_object_id: str, task_id: str
+    ) -> TaskRecord:
+        self._require_owned_task(business_object_id, task_id)
+        return await self.service.pause(task_id)
+
+    async def resume_task(
+        self, *, business_object_id: str, task_id: str
+    ) -> TaskRecord:
+        self._require_owned_task(business_object_id, task_id)
+        return await self.service.resume(task_id)
+
+    async def cancel_task(
+        self, *, business_object_id: str, task_id: str
+    ) -> TaskRecord:
+        self._require_owned_task(business_object_id, task_id)
+        return await self.service.cancel(task_id)
+
+    def _require_owned_task(
+        self, business_object_id: str, task_id: str
+    ) -> TaskRecord:
+        task = self.service.store.get_task(task_id)
+        expected = Origin(module=self.module, object_id=business_object_id)
+        if task.spec.origin != expected:
+            raise CodingWorkerSDKError(
+                "Worker task is not available to this module.",
+                code="worker_task_not_owned",
+            )
+        return task
 
     def _validate_context(self, references: tuple[ContextReference, ...]) -> None:
         for reference in references:

--- a/server/tests/test_coding_worker_sdk.py
+++ b/server/tests/test_coding_worker_sdk.py
@@ -54,6 +54,17 @@ def _request() -> TaskCreateRequest:
     )
 
 
+def _other_client(client: CodingWorkerModuleClient) -> CodingWorkerModuleClient:
+    return CodingWorkerModuleClient(
+        module="mcp-creator",
+        service=client.service,
+        source_kinds=client.source_kinds,
+        check_ids=client.check_ids,
+        model_routes=client.model_routes,
+        context_validators=client.context_validators,
+    )
+
+
 @pytest.mark.asyncio
 async def test_module_client_owns_origin_and_preserves_idempotency(tmp_path: Path) -> None:
     client = _client(tmp_path)
@@ -85,3 +96,65 @@ async def test_module_client_rejects_unregistered_execution_inputs(
     with pytest.raises(CodingWorkerSDKError) as raised:
         await client.create_task(business_object_id="skill_01", request=request)
     assert raised.value.code == expected
+
+
+@pytest.mark.asyncio
+async def test_module_client_reads_and_controls_only_its_own_origin(tmp_path: Path) -> None:
+    client = _client(tmp_path)
+    task = await client.create_task(business_object_id="skill_01", request=_request())
+    client.service.store.append_event(task.task_id, "plan", {"summary": "public"})
+
+    assert client.get_task(
+        business_object_id="skill_01", task_id=task.task_id
+    ).task_id == task.task_id
+    assert [event.type for event in client.list_events(
+        business_object_id="skill_01", task_id=task.task_id
+    )][-1] == "plan"
+
+    foreign = _other_client(client)
+    for action in (
+        lambda: foreign.get_task(
+            business_object_id="mcp_01", task_id=task.task_id
+        ),
+        lambda: foreign.list_events(
+            business_object_id="mcp_01", task_id=task.task_id
+        ),
+    ):
+        with pytest.raises(CodingWorkerSDKError) as raised:
+            action()
+        assert raised.value.code == "worker_task_not_owned"
+
+    with pytest.raises(CodingWorkerSDKError) as raised:
+        await foreign.cancel_task(
+            business_object_id="mcp_01", task_id=task.task_id
+        )
+    assert raised.value.code == "worker_task_not_owned"
+
+
+@pytest.mark.asyncio
+async def test_module_client_bounds_public_event_and_message_inputs(tmp_path: Path) -> None:
+    client = _client(tmp_path)
+    task = await client.create_task(business_object_id="skill_01", request=_request())
+
+    with pytest.raises(CodingWorkerSDKError) as cursor:
+        client.list_events(
+            business_object_id="skill_01", task_id=task.task_id, limit=1001
+        )
+    assert cursor.value.code == "worker_event_cursor_invalid"
+
+    with pytest.raises(CodingWorkerSDKError) as message:
+        await client.append_message(
+            business_object_id="skill_01", task_id=task.task_id, message="   "
+        )
+    assert message.value.code == "worker_message_invalid"
+
+
+def test_module_sdk_has_no_provider_tool_or_secret_registration_surface() -> None:
+    forbidden = {
+        "register_provider",
+        "register_tool",
+        "register_process",
+        "register_secret",
+        "register_mcp_server",
+    }
+    assert forbidden.isdisjoint(vars(CodingWorkerModuleClient))


### PR DESCRIPTION
## 摘要
- 共享 Coding Worker Console 展示供应商中立 capability、公开计划、可补发 operation output、changeset、diagnostics 与精确 Shell 审批。
- 模块 SDK 对查询、事件、steering、pause/resume/cancel 持续校验 `origin(module, business_object)`，跨模块任务在副作用前拒绝。
- 更新 V15 架构、部署、Harness、接口与任务卡；所有 V15 开关默认关闭，真实双引擎与 v13 写回仍待人工验收。

## 自动验证
- Coding Worker：145 passed, 5 skipped
- Agent Workspace：44 passed
- Coding：768 passed, 14 skipped
- 前端：typecheck；35 files / 170 tests；production build
- Compose：V14 + V15 Claude overlay `config --quiet`
- Python `py_compile`、`git diff --check`、每提交不超过 5 文件、敏感/禁止产物扫描通过

后端全量为 2617 passed, 27 skipped, 7 failed, 6 warnings，不宣称全绿：5 项为 Agency Worker 测试镜像缺少构建产物，1 项为 Node 20 不能直接导入 TypeScript，均为已确认基线；另 1 项 Host Apply 文件身份测试仅在全量中波动失败，同一 PR C Coding 全量通过，且 PR C/PR B 基线精确复跑均通过。

## 发布边界
Draft。未重建共享栈，未使用真实 Claude/OpenCode 完成双任务，未执行逐组件重启或 v13 Host 写回人工验收；这些通过前 V15 不标记 Ready。