### PR TITLE
feature: 建立本地 Skill 安全导入基础

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ server/rag/uploads/
 server/skills/installed/
 server/skills/tmp/
 server/skills/storage/
+server/skills/imports/
 server/agent_workspace/storage/
 server/xperts/storage/
 server/plugins/storage/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -589,6 +589,8 @@ services:
       CHROMA_DB_PATH: /app/rag/storage/chroma_db
       SKILL_INSTALLED_DIR: /app/skills/installed
       SKILL_TMP_DIR: /app/skills/tmp
+      SKILL_LOCAL_IMPORT_ENABLED: ${SKILL_LOCAL_IMPORT_ENABLED:-false}
+      SKILL_LOCAL_IMPORT_STORAGE_DIR: /app/skills/imports
       AGENT_WORKSPACE_ENABLED: ${AGENT_WORKSPACE_ENABLED:-true}
       AGENT_APP_ENGINE_SHADOW_ENABLED: ${AGENT_APP_ENGINE_SHADOW_ENABLED:-false}
       AGENT_WORKSPACE_ROOT: /data/agent-workspace
@@ -635,6 +637,7 @@ services:
       - ${MODELMIRROR_DATA_ROOT:-.}/server/rag/storage:/app/rag/storage
       - ${MODELMIRROR_DATA_ROOT:-.}/server/rag/uploads:/app/rag/uploads
       - ${MODELMIRROR_DATA_ROOT:-.}/server/skills/installed:/app/skills/installed
+      - ${MODELMIRROR_DATA_ROOT:-.}/server/skills/imports:/app/skills/imports
       - agent_workspace_data:/data/agent-workspace
       - ${MODELMIRROR_DATA_ROOT:-.}/server/xperts/storage:/app/xperts/storage
       - ${MODELMIRROR_DATA_ROOT:-.}/server/xpert_runtime/storage:/app/xpert_runtime/storage

--- a/server/.env.example
+++ b/server/.env.example
@@ -19,6 +19,9 @@ SKILL_CREATOR_RESOURCE_AUTHORING_ENABLED=true
 # 第三方 Git Skill 信任门默认 enforce：确定恶意或不可安装内容会被阻断；
 # 其余风险需确认精确凭据，可疑项不进入 Agent Router。可切回 audit 或 off 即时回退。
 SKILL_TRUST_GATE_MODE=enforce
+# Local Skill ZIP/folder import remains disabled until the complete private-console experience ships.
+SKILL_LOCAL_IMPORT_ENABLED=false
+SKILL_LOCAL_IMPORT_STORAGE_DIR=./skills/imports
 # 可选运维覆盖；实时目录和前端默认选择不依赖这两个旧回退值。
 OPENROUTER_TEXT_FALLBACK_MODEL=deepseek/deepseek-chat
 OPENROUTER_VISION_FALLBACK_MODEL=qwen/qwen2.5-vl-72b-instruct

--- a/server/main.py
+++ b/server/main.py
@@ -165,6 +165,7 @@ try:
         get_skill_manager,
         router as skills_router,
     )
+    from server.skills.local_import_api import router as skill_local_import_router
     from server.skills.creator_api import (
         configure_skill_creator,
         configure_skill_creator_evaluation,
@@ -227,6 +228,7 @@ try:
     )
 except ModuleNotFoundError:
     from skills.api import get_skill_draft_store, get_skill_manager, router as skills_router
+    from skills.local_import_api import router as skill_local_import_router
     from skills.creator_api import (
         configure_skill_creator,
         configure_skill_creator_evaluation,
@@ -1010,6 +1012,7 @@ app.include_router(rag_router)
 app.include_router(datax_router)
 app.include_router(file_assets_router)
 app.include_router(skills_router)
+app.include_router(skill_local_import_router)
 app.include_router(skill_creator_router)
 app.include_router(agent_workspace_router)
 app.include_router(agent_upstream_router)

--- a/server/skills/local_import.py
+++ b/server/skills/local_import.py
@@ -1,0 +1,1248 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import io
+import json
+import os
+import re
+import shutil
+import stat
+import threading
+import time
+import unicodedata
+import uuid
+import zipfile
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import Any, Iterable, Literal, Mapping, Sequence
+
+from .package_validation import (
+    SkillPackageIssue,
+    _parse_skill_frontmatter,
+    _scan_credentials,
+    compute_skill_content_digest,
+)
+from .trust_scanner import (
+    MAX_TRUST_DIRECTORY_DEPTH,
+    MAX_TRUST_FILE_BYTES,
+    MAX_TRUST_FILES,
+    MAX_TRUST_PATH_CHARS,
+    MAX_TRUST_TOTAL_BYTES,
+    SKILL_TRUST_SCANNER_VERSION,
+    SkillTrustTreeEntry,
+    scan_local_skill_trust_receipt,
+    sha256_json,
+)
+
+
+LOCAL_IMPORT_STORE_VERSION = 1
+LOCAL_IMPORT_MAX_ARCHIVE_BYTES = 64 * 1024 * 1024
+LOCAL_IMPORT_MAX_ACTIVE = 100
+LOCAL_IMPORT_MAX_STORAGE_BYTES = 1024 * 1024 * 1024
+LOCAL_IMPORT_PREVIEW_BYTES = 256 * 1024
+
+ImportState = Literal[
+    "scanning",
+    "ready",
+    "confirmation_required",
+    "blocked",
+    "failed",
+    "installed",
+    "superseded",
+    "archived",
+    "stale",
+]
+TransportKind = Literal["zip", "folder"]
+
+_LOCAL_ID_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+_DRIVE_RE = re.compile(r"^[A-Za-z]:")
+_WINDOWS_RESERVED = frozenset(
+    {"con", "prn", "aux", "nul", "clock$"}
+    | {f"com{index}" for index in range(1, 10)}
+    | {f"lpt{index}" for index in range(1, 10)}
+)
+_ACTIVE_PREVIEW_SUFFIXES = {".html", ".htm", ".svg", ".xml"}
+_ALLOWED_ZIP_COMPRESSION = {zipfile.ZIP_STORED, zipfile.ZIP_DEFLATED}
+
+
+class SkillLocalImportError(Exception):
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str = "skill_import_invalid_transport",
+        details: Mapping[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.details = dict(details or {})
+
+
+class SkillLocalImportNotFoundError(SkillLocalImportError):
+    pass
+
+
+class SkillLocalImportConflictError(SkillLocalImportError):
+    pass
+
+
+class SkillLocalImportStorageError(SkillLocalImportError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class ImportedFile:
+    path: str
+    content: bytes
+    mode: str = "100644"
+
+
+@dataclass(slots=True)
+class LocalSkillImport:
+    import_id: str
+    revision: int
+    content_revision: int
+    state: ImportState
+    transport_kind: TransportKind
+    transport_digest: str
+    local_skill_id: str | None = None
+    declared_name: str | None = None
+    package_digest: str | None = None
+    trust_receipt: dict[str, Any] | None = None
+    file_manifest: list[dict[str, Any]] = field(default_factory=list)
+    ignored_entries: list[dict[str, Any]] = field(default_factory=list)
+    error_code: str | None = None
+    installed_skill_id: str | None = None
+    created_at: float = field(default_factory=time.time)
+    updated_at: float = field(default_factory=time.time)
+
+    @property
+    def trust_fingerprint(self) -> str | None:
+        if not self.trust_receipt:
+            return None
+        value = str(self.trust_receipt.get("trustFingerprint") or "")
+        return value or None
+
+    @property
+    def receipt_id(self) -> str | None:
+        if not self.trust_receipt:
+            return None
+        value = str(self.trust_receipt.get("receiptId") or "")
+        return value or None
+
+    def serialize(self, *, include_receipt: bool = True) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "version": LOCAL_IMPORT_STORE_VERSION,
+            "importId": self.import_id,
+            "revision": self.revision,
+            "contentRevision": self.content_revision,
+            "state": self.state,
+            "transportKind": self.transport_kind,
+            "transportDigest": self.transport_digest,
+            "localSkillId": self.local_skill_id,
+            "declaredName": self.declared_name,
+            "packageDigest": self.package_digest,
+            "receiptId": self.receipt_id,
+            "trustFingerprint": self.trust_fingerprint,
+            "fileManifest": copy.deepcopy(self.file_manifest),
+            "ignoredEntries": copy.deepcopy(self.ignored_entries),
+            "errorCode": self.error_code,
+            "installedSkillId": self.installed_skill_id,
+            "createdAt": self.created_at,
+            "updatedAt": self.updated_at,
+        }
+        if include_receipt:
+            payload["trustReceipt"] = copy.deepcopy(self.trust_receipt)
+        return payload
+
+
+def _validate_local_skill_id(value: str | None) -> str | None:
+    if value is None or not str(value).strip():
+        return None
+    clean = str(value).strip()
+    if len(clean) > 64 or not _LOCAL_ID_RE.fullmatch(clean):
+        raise SkillLocalImportError(
+            "Local Skill ID must be 1-64 characters of kebab-case text.",
+            code="skill_import_invalid_transport",
+        )
+    if clean.casefold() in _WINDOWS_RESERVED:
+        raise SkillLocalImportError(
+            "Local Skill ID is reserved on Windows.",
+            code="skill_import_invalid_transport",
+        )
+    credential_issues: list[SkillPackageIssue] = []
+    _scan_credentials(None, clean, credential_issues)
+    if credential_issues:
+        raise SkillLocalImportError(
+            "Local Skill ID contains credential-like material.",
+            code="skill_import_invalid_transport",
+        )
+    return clean
+
+
+def _normalize_path(raw_path: str) -> str:
+    if not isinstance(raw_path, str) or not raw_path or "\x00" in raw_path:
+        raise SkillLocalImportError(
+            "The upload contains an invalid path.", code="skill_import_path_unsafe"
+        )
+    candidate = unicodedata.normalize("NFC", raw_path.replace("\\", "/"))
+    if candidate.startswith("/") or _DRIVE_RE.match(candidate):
+        raise SkillLocalImportError(
+            "The upload contains an absolute path.", code="skill_import_path_unsafe"
+        )
+    parts = candidate.split("/")
+    if any(part in {"", ".", ".."} for part in parts):
+        raise SkillLocalImportError(
+            "The upload contains an unsafe relative path.", code="skill_import_path_unsafe"
+        )
+    if len(parts) > MAX_TRUST_DIRECTORY_DEPTH + 1 or len(candidate) > MAX_TRUST_PATH_CHARS:
+        raise SkillLocalImportError(
+            "The upload path exceeds the import limit.", code="skill_import_limit_exceeded"
+        )
+    for part in parts:
+        if any(ord(character) < 32 for character in part):
+            raise SkillLocalImportError(
+                "The upload path contains control characters.", code="skill_import_path_unsafe"
+            )
+        basename = part.rstrip(". ").split(".", 1)[0].casefold()
+        if part != part.rstrip(". ") or basename in _WINDOWS_RESERVED:
+            raise SkillLocalImportError(
+                "The upload path is unsafe on Windows.", code="skill_import_path_unsafe"
+            )
+    if any(part.casefold() == ".git" for part in parts):
+        raise SkillLocalImportError(
+            "Git metadata is not allowed in a local Skill import.",
+            code="skill_import_path_unsafe",
+        )
+    return PurePosixPath(*parts).as_posix()
+
+
+def _noise_reason(path: str) -> str | None:
+    parts = PurePosixPath(path).parts
+    if parts and parts[0] == "__MACOSX":
+        return "macos_metadata"
+    if parts and (parts[-1] == ".DS_Store" or parts[-1].startswith("._")):
+        return "macos_metadata"
+    return None
+
+
+def _strip_single_wrapper(files: Sequence[ImportedFile]) -> list[ImportedFile]:
+    by_path = {item.path: item for item in files}
+    if "SKILL.md" in by_path:
+        return list(files)
+    roots = {PurePosixPath(item.path).parts[0] for item in files}
+    if len(roots) != 1:
+        raise SkillLocalImportError(
+            "The upload contains multiple top-level Skill roots.",
+            code="skill_import_multiple_roots",
+        )
+    root = next(iter(roots))
+    prefix = f"{root}/"
+    stripped = [
+        ImportedFile(item.path[len(prefix) :], item.content, item.mode)
+        for item in files
+        if item.path.startswith(prefix)
+    ]
+    if not any(item.path == "SKILL.md" for item in stripped):
+        raise SkillLocalImportError(
+            "The upload does not contain one Skill root with SKILL.md.",
+            code="skill_import_multiple_roots",
+        )
+    return stripped
+
+
+def _validate_file_set(files: Sequence[ImportedFile]) -> list[ImportedFile]:
+    if not files:
+        raise SkillLocalImportError("The upload is empty.")
+    if len(files) > MAX_TRUST_FILES:
+        raise SkillLocalImportError(
+            "The upload exceeds the file-count limit.", code="skill_import_limit_exceeded"
+        )
+    total = sum(len(item.content) for item in files)
+    if total > MAX_TRUST_TOTAL_BYTES or any(
+        len(item.content) > MAX_TRUST_FILE_BYTES for item in files
+    ):
+        raise SkillLocalImportError(
+            "The upload exceeds the expanded-size limit.", code="skill_import_limit_exceeded"
+        )
+    seen: dict[str, str] = {}
+    paths: set[str] = set()
+    ordered: list[ImportedFile] = []
+    for item in sorted(files, key=lambda value: value.path.encode("utf-8", "surrogatepass")):
+        path = _normalize_path(item.path)
+        identity = unicodedata.normalize("NFC", path).casefold()
+        if identity in seen:
+            raise SkillLocalImportError(
+                "Upload paths collide after case and Unicode normalization.",
+                code="skill_import_path_unsafe",
+            )
+        seen[identity] = path
+        paths.add(path)
+        ordered.append(ImportedFile(path, bytes(item.content), item.mode))
+    for path in paths:
+        parts = PurePosixPath(path).parts
+        for index in range(1, len(parts)):
+            if PurePosixPath(*parts[:index]).as_posix() in paths:
+                raise SkillLocalImportError(
+                    "A package path cannot be both a file and a directory.",
+                    code="skill_import_path_unsafe",
+                )
+    if "SKILL.md" not in paths:
+        raise SkillLocalImportError(
+            "The upload does not contain SKILL.md.", code="skill_import_multiple_roots"
+        )
+    if any(path != "SKILL.md" and PurePosixPath(path).name == "SKILL.md" for path in paths):
+        raise SkillLocalImportError(
+            "The upload contains multiple Skill roots.",
+            code="skill_import_multiple_roots",
+        )
+    return ordered
+
+
+def normalize_folder_upload(
+    items: Sequence[tuple[str, bytes]],
+) -> tuple[list[ImportedFile], str, list[dict[str, Any]]]:
+    normalized: list[ImportedFile] = []
+    ignored_count = 0
+    transport_hasher = hashlib.sha256()
+    prepared = sorted(
+        ((_normalize_path(raw_path), bytes(content)) for raw_path, content in items),
+        key=lambda item: item[0].encode("utf-8", "surrogatepass"),
+    )
+    for path, raw in prepared:
+        transport_hasher.update(len(path.encode("utf-8")).to_bytes(4, "big"))
+        transport_hasher.update(path.encode("utf-8"))
+        transport_hasher.update(len(raw).to_bytes(8, "big"))
+        transport_hasher.update(raw)
+        if _noise_reason(path):
+            ignored_count += 1
+            continue
+        normalized.append(ImportedFile(path, raw))
+    normalized = _validate_file_set(_strip_single_wrapper(normalized))
+    ignored = ([{"reason": "macos_metadata", "count": ignored_count}] if ignored_count else [])
+    return normalized, transport_hasher.hexdigest(), ignored
+
+
+def normalize_zip_upload(
+    archive: bytes,
+) -> tuple[list[ImportedFile], str, list[dict[str, Any]]]:
+    raw_archive = bytes(archive)
+    if len(raw_archive) > LOCAL_IMPORT_MAX_ARCHIVE_BYTES:
+        raise SkillLocalImportError(
+            "The ZIP upload exceeds the compressed-size limit.",
+            code="skill_import_limit_exceeded",
+        )
+    imported: list[ImportedFile] = []
+    ignored_count = 0
+    actual_total = 0
+    try:
+        with zipfile.ZipFile(io.BytesIO(raw_archive), "r") as bundle:
+            if len(bundle.infolist()) > MAX_TRUST_FILES + 128:
+                raise SkillLocalImportError(
+                    "The ZIP contains too many entries.", code="skill_import_limit_exceeded"
+                )
+            for info in bundle.infolist():
+                if info.flag_bits & 0x1:
+                    raise SkillLocalImportError(
+                        "Encrypted ZIP entries are not supported.",
+                        code="skill_import_archive_encrypted",
+                    )
+                if info.compress_type not in _ALLOWED_ZIP_COMPRESSION:
+                    raise SkillLocalImportError(
+                        "The ZIP uses an unsupported compression method.",
+                        code="skill_import_archive_invalid",
+                    )
+                raw_name = info.filename.rstrip("/") if info.is_dir() else info.filename
+                if not raw_name:
+                    continue
+                path = _normalize_path(raw_name)
+                unix_mode = (info.external_attr >> 16) & 0xFFFF
+                file_type = stat.S_IFMT(unix_mode)
+                if info.is_dir():
+                    if file_type not in {0, stat.S_IFDIR}:
+                        raise SkillLocalImportError(
+                            "The ZIP contains an unsupported directory entry.",
+                            code="skill_import_archive_invalid",
+                        )
+                    continue
+                if file_type not in {0, stat.S_IFREG}:
+                    raise SkillLocalImportError(
+                        "Links and special files are not allowed in ZIP imports.",
+                        code="skill_import_path_unsafe",
+                    )
+                if info.file_size > MAX_TRUST_FILE_BYTES:
+                    raise SkillLocalImportError(
+                        "A ZIP entry exceeds the file-size limit.",
+                        code="skill_import_limit_exceeded",
+                    )
+                chunks: list[bytes] = []
+                file_size = 0
+                with bundle.open(info, "r") as source:
+                    while True:
+                        chunk = source.read(1024 * 1024)
+                        if not chunk:
+                            break
+                        file_size += len(chunk)
+                        actual_total += len(chunk)
+                        if file_size > MAX_TRUST_FILE_BYTES or actual_total > MAX_TRUST_TOTAL_BYTES:
+                            raise SkillLocalImportError(
+                                "The expanded ZIP exceeds the import limit.",
+                                code="skill_import_limit_exceeded",
+                            )
+                        chunks.append(chunk)
+                content = b"".join(chunks)
+                if len(content) != info.file_size:
+                    raise SkillLocalImportError(
+                        "A ZIP entry size does not match its metadata.",
+                        code="skill_import_archive_invalid",
+                    )
+                if _noise_reason(path):
+                    ignored_count += 1
+                    continue
+                mode = "100755" if unix_mode & 0o111 else "100644"
+                imported.append(ImportedFile(path, content, mode))
+    except SkillLocalImportError:
+        raise
+    except (OSError, RuntimeError, zipfile.BadZipFile, zipfile.LargeZipFile) as exc:
+        raise SkillLocalImportError(
+            "The ZIP upload is invalid.", code="skill_import_archive_invalid"
+        ) from exc
+    imported = _validate_file_set(_strip_single_wrapper(imported))
+    ignored = ([{"reason": "macos_metadata", "count": ignored_count}] if ignored_count else [])
+    return imported, hashlib.sha256(raw_archive).hexdigest(), ignored
+
+
+def _declared_name(files: Sequence[ImportedFile]) -> str | None:
+    markdown = next(item.content for item in files if item.path == "SKILL.md")
+    try:
+        text = markdown.decode("utf-8", errors="strict")
+    except UnicodeDecodeError:
+        return None
+    issues: list[SkillPackageIssue] = []
+    parsed = _parse_skill_frontmatter(text, issues)
+    if not isinstance(parsed, Mapping):
+        return None
+    value = parsed.get("name")
+    if not isinstance(value, str):
+        return None
+    clean = value.strip()
+    return clean if len(clean) <= 64 and _LOCAL_ID_RE.fullmatch(clean) else None
+
+
+def _tree_entries(files: Sequence[ImportedFile]) -> list[SkillTrustTreeEntry]:
+    return [
+        SkillTrustTreeEntry(
+            path=item.path,
+            mode=item.mode,
+            object_type="blob",
+            object_id=hashlib.sha1(item.content).hexdigest(),
+            size=len(item.content),
+            content=item.content,
+        )
+        for item in files
+    ]
+
+
+def _package_manifest(files: Sequence[ImportedFile]) -> list[dict[str, Any]]:
+    return [
+        {
+            "path": item.path,
+            "mode": item.mode,
+            "sizeBytes": len(item.content),
+            "sha256": hashlib.sha256(item.content).hexdigest(),
+        }
+        for item in files
+    ]
+
+
+class SkillLocalImportStore:
+    def __init__(
+        self,
+        storage_dir: str | os.PathLike[str] | None = None,
+        *,
+        enabled: bool | None = None,
+        max_active: int = LOCAL_IMPORT_MAX_ACTIVE,
+        max_storage_bytes: int = LOCAL_IMPORT_MAX_STORAGE_BYTES,
+    ) -> None:
+        default_dir = Path(__file__).resolve().parent / "imports"
+        self.root = Path(
+            storage_dir
+            or os.getenv("SKILL_LOCAL_IMPORT_STORAGE_DIR", "").strip()
+            or default_dir
+        ).resolve()
+        self.enabled = (
+            str(os.getenv("SKILL_LOCAL_IMPORT_ENABLED", "false")).strip().casefold()
+            in {"1", "true", "yes", "on"}
+            if enabled is None
+            else bool(enabled)
+        )
+        self.max_active = max(1, int(max_active))
+        self.max_storage_bytes = max(MAX_TRUST_TOTAL_BYTES, int(max_storage_bytes))
+        self.index_path = self.root / "imports.json"
+        self.packages_root = self.root / "packages"
+        self.tmp_root = self.root / "tmp"
+        self._lock = threading.RLock()
+        self._records: dict[str, LocalSkillImport] = {}
+        self._quarantine: list[dict[str, Any]] = []
+        self._load_error: str | None = None
+        self._load()
+        if self._load_error is None:
+            self._recover_temp_dirs()
+
+    def status(self) -> dict[str, Any]:
+        with self._lock:
+            return {
+                "enabled": self.enabled,
+                "available": self._load_error is None,
+                "version": LOCAL_IMPORT_STORE_VERSION,
+                "scannerVersion": SKILL_TRUST_SCANNER_VERSION,
+                "supportedTransports": ["zip", "folder"],
+                "limits": {
+                    "archiveBytes": LOCAL_IMPORT_MAX_ARCHIVE_BYTES,
+                    "fileCount": MAX_TRUST_FILES,
+                    "fileBytes": MAX_TRUST_FILE_BYTES,
+                    "expandedBytes": MAX_TRUST_TOTAL_BYTES,
+                    "storageBytes": self.max_storage_bytes,
+                    "activeImports": self.max_active,
+                },
+                "errorCode": self._load_error,
+            }
+
+    def _load(self) -> None:
+        if not self.index_path.exists():
+            return
+        try:
+            raw = self.index_path.read_bytes()
+            payload = json.loads(raw.decode("utf-8"))
+            if not isinstance(payload, Mapping) or payload.get("version") != LOCAL_IMPORT_STORE_VERSION:
+                raise ValueError("unsupported local import store")
+            records = payload.get("imports")
+            if not isinstance(records, list):
+                raise ValueError("invalid local import records")
+            stored_quarantine = payload.get("quarantine") or []
+            if not isinstance(stored_quarantine, list):
+                raise ValueError("invalid local import quarantine")
+            quarantine = []
+            for entry in stored_quarantine:
+                index_value = entry.get("index") if isinstance(entry, Mapping) else None
+                size_value = entry.get("sizeBytes") if isinstance(entry, Mapping) else None
+                if (
+                    not isinstance(entry, Mapping)
+                    or not isinstance(index_value, int)
+                    or isinstance(index_value, bool)
+                    or index_value < 0
+                    or not re.fullmatch(r"[0-9a-f]{64}", str(entry.get("sha256") or ""))
+                    or not isinstance(size_value, int)
+                    or isinstance(size_value, bool)
+                    or size_value < 0
+                ):
+                    raise ValueError("invalid local import quarantine entry")
+                quarantine.append(
+                    {
+                        "index": index_value,
+                        "sha256": str(entry["sha256"]),
+                        "sizeBytes": size_value,
+                    }
+                )
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError):
+            self._load_error = "skill_import_storage_unavailable"
+            return
+        decoded: dict[str, LocalSkillImport] = {}
+        for index, raw_record in enumerate(records):
+            try:
+                record = self._decode_record(raw_record)
+                if record.import_id in decoded:
+                    raise ValueError("duplicate import ID")
+                decoded[record.import_id] = record
+            except (TypeError, ValueError):
+                encoded = json.dumps(raw_record, sort_keys=True, ensure_ascii=False, default=str).encode("utf-8")
+                quarantine.append(
+                    {
+                        "index": index,
+                        "sha256": hashlib.sha256(encoded).hexdigest(),
+                        "sizeBytes": len(encoded),
+                    }
+                )
+        self._records = decoded
+        self._quarantine = quarantine
+
+    @staticmethod
+    def _decode_record(payload: Any) -> LocalSkillImport:
+        if not isinstance(payload, Mapping):
+            raise ValueError("record must be a mapping")
+        import_id = str(payload.get("importId") or "")
+        if not re.fullmatch(r"skillimport_[0-9a-f]{32}", import_id):
+            raise ValueError("invalid import ID")
+        revision = int(payload.get("revision") or 0)
+        content_revision = int(payload.get("contentRevision") or 0)
+        state = str(payload.get("state") or "")
+        transport_kind = str(payload.get("transportKind") or "")
+        transport_digest = str(payload.get("transportDigest") or "")
+        if revision < 1 or content_revision < 1 or content_revision > revision or state not in {
+            "scanning", "ready", "confirmation_required", "blocked", "failed",
+            "installed", "superseded", "archived", "stale",
+        }:
+            raise ValueError("invalid import state")
+        if transport_kind not in {"zip", "folder"} or not re.fullmatch(r"[0-9a-f]{64}", transport_digest):
+            raise ValueError("invalid import transport")
+        receipt = payload.get("trustReceipt")
+        if receipt is not None and not isinstance(receipt, Mapping):
+            raise ValueError("invalid trust receipt")
+        package_digest = str(payload.get("packageDigest") or "") or None
+        if package_digest is not None and not re.fullmatch(r"[0-9a-f]{64}", package_digest):
+            raise ValueError("invalid package digest")
+        if receipt is not None:
+            fingerprint = str(receipt.get("trustFingerprint") or "")
+            if not re.fullmatch(r"[0-9a-f]{64}", fingerprint) or sha256_json(
+                {key: value for key, value in receipt.items() if key != "trustFingerprint"}
+            ) != fingerprint:
+                raise ValueError("invalid trust receipt fingerprint")
+            source = receipt.get("source")
+            if (
+                not isinstance(source, Mapping)
+                or source.get("kind") != "local_import"
+                or source.get("importId") != import_id
+                or source.get("importRevision") != content_revision
+                or source.get("transportKind") != transport_kind
+                or source.get("transportDigest") != transport_digest
+                or receipt.get("packageDigest") != package_digest
+            ):
+                raise ValueError("local trust receipt does not match its import")
+        manifest = payload.get("fileManifest") or []
+        ignored = payload.get("ignoredEntries") or []
+        if not isinstance(manifest, list) or not isinstance(ignored, list):
+            raise ValueError("invalid import manifest")
+        for entry in manifest:
+            if not isinstance(entry, Mapping):
+                raise ValueError("invalid import manifest entry")
+            _normalize_path(str(entry.get("path") or ""))
+            if str(entry.get("mode") or "") not in {"100644", "100755"}:
+                raise ValueError("invalid import manifest mode")
+            if not re.fullmatch(r"[0-9a-f]{64}", str(entry.get("sha256") or "")):
+                raise ValueError("invalid import manifest digest")
+            if int(entry.get("sizeBytes") or -1) < 0:
+                raise ValueError("invalid import manifest size")
+        return LocalSkillImport(
+            import_id=import_id,
+            revision=revision,
+            content_revision=content_revision,
+            state=state,  # type: ignore[arg-type]
+            transport_kind=transport_kind,  # type: ignore[arg-type]
+            transport_digest=transport_digest,
+            local_skill_id=_validate_local_skill_id(payload.get("localSkillId")),
+            declared_name=_validate_local_skill_id(payload.get("declaredName")),
+            package_digest=package_digest,
+            trust_receipt=copy.deepcopy(dict(receipt)) if receipt else None,
+            file_manifest=copy.deepcopy(manifest),
+            ignored_entries=copy.deepcopy(ignored),
+            error_code=str(payload.get("errorCode") or "") or None,
+            installed_skill_id=str(payload.get("installedSkillId") or "") or None,
+            created_at=float(payload.get("createdAt") or 0.0),
+            updated_at=float(payload.get("updatedAt") or 0.0),
+        )
+
+    def _ensure_available(self, *, mutation: bool = False) -> None:
+        if self._load_error:
+            raise SkillLocalImportStorageError(
+                "Local Skill import storage is unavailable.",
+                code="skill_import_storage_unavailable",
+            )
+        if mutation and not self.enabled:
+            raise SkillLocalImportError(
+                "Local Skill import is disabled.", code="skill_import_disabled"
+            )
+
+    def _recover_temp_dirs(self) -> None:
+        try:
+            if self.tmp_root.is_symlink():
+                raise OSError("Local Skill import temp storage cannot be a link.")
+            if self.tmp_root.exists():
+                for child in self.tmp_root.iterdir():
+                    if child.is_symlink() or child.is_file():
+                        child.unlink(missing_ok=True)
+                    elif child.is_dir():
+                        shutil.rmtree(child)
+            if self.packages_root.is_symlink():
+                raise OSError("Local Skill package storage cannot be a link.")
+            referenced = {
+                item.package_digest
+                for item in self._records.values()
+                if item.package_digest and item.file_manifest
+            }
+            if self.packages_root.exists() and not self._quarantine:
+                for child in self.packages_root.iterdir():
+                    if (
+                        child.is_symlink()
+                        or not child.is_dir()
+                        or not re.fullmatch(r"[0-9a-f]{64}", child.name)
+                    ):
+                        raise OSError("Local Skill package storage contains an unsafe entry.")
+                    if child.name not in referenced:
+                        shutil.rmtree(child)
+            interrupted = {
+                import_id: item
+                for import_id, item in self._records.items()
+                if item.state == "scanning"
+            }
+            if interrupted:
+                now = time.time()
+                records = dict(self._records)
+                for import_id, item in interrupted.items():
+                    recovered = copy.deepcopy(item)
+                    recovered.revision += 1
+                    recovered.state = "failed"
+                    recovered.error_code = "skill_import_scan_failed"
+                    recovered.updated_at = now
+                    records[import_id] = recovered
+                self._save_records_unlocked(records)
+                self._records = records
+        except (OSError, SkillLocalImportStorageError):
+            self._load_error = "skill_import_storage_unavailable"
+
+    def _save_records_unlocked(self, records: Mapping[str, LocalSkillImport]) -> None:
+        self.root.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "version": LOCAL_IMPORT_STORE_VERSION,
+            "imports": [records[key].serialize(include_receipt=True) for key in sorted(records)],
+            "quarantine": copy.deepcopy(self._quarantine),
+        }
+        temp_path = self.index_path.with_suffix(".json.tmp")
+        encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        try:
+            with temp_path.open("wb") as handle:
+                handle.write(encoded)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temp_path, self.index_path)
+        except OSError as exc:
+            try:
+                temp_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+            raise SkillLocalImportStorageError(
+                "Local Skill import metadata could not be persisted.",
+                code="skill_import_storage_unavailable",
+            ) from exc
+
+    def _storage_bytes_unlocked(self) -> int:
+        if not self.root.exists():
+            return 0
+        return sum(
+            path.stat().st_size
+            for path in self.root.rglob("*")
+            if path.is_file()
+            and not path.is_symlink()
+            and path not in {self.index_path, self.index_path.with_suffix(".json.tmp")}
+        )
+
+    def list_imports(self, *, include_archived: bool = False) -> list[LocalSkillImport]:
+        with self._lock:
+            self._ensure_available()
+            records = [
+                copy.deepcopy(item)
+                for item in self._records.values()
+                if include_archived or item.state != "archived"
+            ]
+        return sorted(records, key=lambda item: (-item.updated_at, item.import_id))
+
+    def require(self, import_id: str) -> LocalSkillImport:
+        with self._lock:
+            self._ensure_available()
+            item = self._records.get(str(import_id))
+            if item is None:
+                raise SkillLocalImportNotFoundError(
+                    "Local Skill import was not found.", code="skill_import_not_found"
+                )
+            return copy.deepcopy(item)
+
+    def create_from_zip(
+        self,
+        archive: bytes,
+        *,
+        local_skill_id: str | None = None,
+    ) -> LocalSkillImport:
+        return self._create(
+            "zip",
+            lambda: normalize_zip_upload(archive),
+            local_skill_id=local_skill_id,
+            fallback_transport_digest=hashlib.sha256(bytes(archive)).hexdigest(),
+        )
+
+    def create_from_folder(
+        self,
+        items: Sequence[tuple[str, bytes]],
+        *,
+        local_skill_id: str | None = None,
+    ) -> LocalSkillImport:
+        fallback = hashlib.sha256()
+        for path, content in items:
+            fallback.update(str(path).encode("utf-8", errors="replace"))
+            fallback.update(bytes(content))
+        return self._create(
+            "folder",
+            lambda: normalize_folder_upload(items),
+            local_skill_id=local_skill_id,
+            fallback_transport_digest=fallback.hexdigest(),
+        )
+
+    def _create(
+        self,
+        transport_kind: TransportKind,
+        normalizer: Any,
+        *,
+        local_skill_id: str | None,
+        fallback_transport_digest: str,
+    ) -> LocalSkillImport:
+        clean_local_id = _validate_local_skill_id(local_skill_id)
+        import_id = "skillimport_" + uuid.uuid4().hex
+        now = time.time()
+        pending = LocalSkillImport(
+            import_id=import_id,
+            revision=1,
+            content_revision=1,
+            state="scanning",
+            transport_kind=transport_kind,
+            transport_digest=fallback_transport_digest,
+            local_skill_id=clean_local_id,
+            created_at=now,
+            updated_at=now,
+        )
+        with self._lock:
+            self._ensure_available(mutation=True)
+            active_count = sum(item.state != "archived" for item in self._records.values())
+            if active_count >= self.max_active:
+                raise SkillLocalImportError(
+                    "The local Skill import count limit has been reached.",
+                    code="skill_import_limit_exceeded",
+                )
+            records = dict(self._records)
+            records[import_id] = pending
+            self._save_records_unlocked(records)
+            self._records = records
+        try:
+            files, transport_digest, ignored = normalizer()
+            return self._publish_import(
+                import_id=import_id,
+                transport_kind=transport_kind,
+                transport_digest=transport_digest,
+                files=files,
+                ignored=ignored,
+                local_skill_id=clean_local_id,
+            )
+        except SkillLocalImportError as exc:
+            self._record_failure(
+                import_id,
+                transport_kind,
+                fallback_transport_digest,
+                exc.code,
+                clean_local_id,
+            )
+            raise
+        except Exception as exc:
+            self._record_failure(
+                import_id,
+                transport_kind,
+                fallback_transport_digest,
+                "skill_import_scan_failed",
+                clean_local_id,
+            )
+            raise SkillLocalImportError(
+                "The local Skill package could not be completely scanned.",
+                code="skill_import_scan_failed",
+            ) from exc
+
+    def _publish_import(
+        self,
+        *,
+        import_id: str,
+        transport_kind: TransportKind,
+        transport_digest: str,
+        files: Sequence[ImportedFile],
+        ignored: list[dict[str, Any]],
+        local_skill_id: str | None,
+    ) -> LocalSkillImport:
+        entries = _tree_entries(files)
+        receipt = scan_local_skill_trust_receipt(
+            import_id=import_id,
+            import_revision=1,
+            transport_kind=transport_kind,
+            transport_digest=transport_digest,
+            entries=entries,
+        )
+        package_digest = str(receipt.get("packageDigest") or "") or None
+        if package_digest is None:
+            raise SkillLocalImportError(
+                "The local Skill package could not be completely scanned.",
+                code="skill_import_scan_failed",
+            )
+        declared_name = _declared_name(files)
+        selected_id = local_skill_id or declared_name
+        policy = str(receipt.get("installPolicy") or "block")
+        state: ImportState = (
+            "blocked" if policy == "block" else "ready" if policy == "allow" else "confirmation_required"
+        )
+        keep_source = state != "blocked"
+        with self._lock:
+            self._ensure_available(mutation=True)
+            pending = self._records.get(import_id)
+            if pending is None or pending.state != "scanning":
+                raise SkillLocalImportConflictError(
+                    "Local Skill import state changed during scanning.",
+                    code="skill_import_stale",
+                )
+            duplicate = next(
+                (
+                    item
+                    for item in self._records.values()
+                    if item.import_id != import_id
+                    and item.package_digest == package_digest
+                    and item.state not in {"archived", "failed", "blocked"}
+                ),
+                None,
+            )
+            if duplicate is not None:
+                records = dict(self._records)
+                del records[import_id]
+                self._save_records_unlocked(records)
+                self._records = records
+                return copy.deepcopy(duplicate)
+            now = time.time()
+            record = LocalSkillImport(
+                import_id=import_id,
+                revision=pending.revision + 1,
+                content_revision=pending.content_revision,
+                state=state,
+                transport_kind=transport_kind,
+                transport_digest=transport_digest,
+                local_skill_id=selected_id if keep_source else None,
+                declared_name=declared_name if keep_source else None,
+                package_digest=package_digest,
+                trust_receipt=receipt,
+                file_manifest=_package_manifest(files) if keep_source else [],
+                ignored_entries=ignored,
+                error_code="skill_import_blocked" if state == "blocked" else None,
+                created_at=pending.created_at,
+                updated_at=now,
+            )
+            package_created = False
+            if keep_source:
+                package_bytes = sum(len(item.content) for item in files)
+                if self._storage_bytes_unlocked() + package_bytes > self.max_storage_bytes:
+                    raise SkillLocalImportError(
+                        "The local Skill import storage quota has been reached.",
+                        code="skill_import_limit_exceeded",
+                    )
+                package_created = self._write_package_unlocked(package_digest, files)
+            records = dict(self._records)
+            records[record.import_id] = record
+            try:
+                self._save_records_unlocked(records)
+            except Exception:
+                if package_created:
+                    shutil.rmtree(self.packages_root / package_digest, ignore_errors=True)
+                raise
+            self._records = records
+            return copy.deepcopy(record)
+
+    def _record_failure(
+        self,
+        import_id: str,
+        transport_kind: TransportKind,
+        transport_digest: str,
+        error_code: str,
+        local_skill_id: str | None,
+    ) -> None:
+        with self._lock:
+            if self._load_error:
+                return
+            now = time.time()
+            pending = self._records.get(import_id)
+            record = LocalSkillImport(
+                import_id=import_id,
+                revision=(pending.revision + 1) if pending else 1,
+                content_revision=pending.content_revision if pending else 1,
+                state="failed",
+                transport_kind=transport_kind,
+                transport_digest=transport_digest,
+                local_skill_id=local_skill_id,
+                error_code=error_code,
+                created_at=pending.created_at if pending else now,
+                updated_at=now,
+            )
+            records = dict(self._records)
+            records[import_id] = record
+            self._save_records_unlocked(records)
+            self._records = records
+
+    def _write_package_unlocked(
+        self, package_digest: str, files: Sequence[ImportedFile]
+    ) -> bool:
+        if self.packages_root.is_symlink() or self.tmp_root.is_symlink():
+            raise SkillLocalImportStorageError(
+                "Local Skill import storage cannot contain linked roots.",
+                code="skill_import_storage_unavailable",
+            )
+        destination = self.packages_root / package_digest
+        if destination.exists():
+            existing = self._read_package_unlocked(package_digest)
+            if compute_skill_content_digest(existing) != package_digest:
+                raise SkillLocalImportStorageError(
+                    "Stored local Skill bytes do not match their digest.",
+                    code="skill_import_storage_unavailable",
+                )
+            return False
+        self.tmp_root.mkdir(parents=True, exist_ok=True)
+        temp = self.tmp_root / (package_digest + "." + uuid.uuid4().hex)
+        temp.mkdir(parents=False, exist_ok=False)
+        try:
+            for item in files:
+                target = temp.joinpath(*PurePosixPath(item.path).parts)
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_bytes(item.content)
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            os.replace(temp, destination)
+            return True
+        except OSError as exc:
+            shutil.rmtree(temp, ignore_errors=True)
+            raise SkillLocalImportStorageError(
+                "The normalized local Skill package could not be persisted.",
+                code="skill_import_storage_unavailable",
+            ) from exc
+
+    def _read_package_unlocked(self, package_digest: str) -> dict[str, bytes]:
+        root = self.packages_root / package_digest
+        if self.packages_root.is_symlink() or root.is_symlink() or not root.is_dir():
+            raise SkillLocalImportStorageError(
+                "The normalized local Skill package is unavailable.",
+                code="skill_import_storage_unavailable",
+            )
+        files: dict[str, bytes] = {}
+        for path in sorted(root.rglob("*")):
+            if path.is_symlink():
+                raise SkillLocalImportStorageError(
+                    "Stored local Skill packages cannot contain links.",
+                    code="skill_import_storage_unavailable",
+                )
+            if path.is_file():
+                relative = path.relative_to(root).as_posix()
+                files[relative] = path.read_bytes()
+        return files
+
+    @staticmethod
+    def _verify_package_unlocked(
+        record: LocalSkillImport, files: Mapping[str, bytes]
+    ) -> None:
+        if (
+            not record.package_digest
+            or compute_skill_content_digest(files) != record.package_digest
+        ):
+            raise SkillLocalImportConflictError(
+                "Stored local Skill bytes no longer match the import.",
+                code="skill_import_package_mismatch",
+            )
+        manifest = {
+            str(entry.get("path") or ""): entry
+            for entry in record.file_manifest
+            if isinstance(entry, Mapping)
+        }
+        if set(manifest) != set(files):
+            raise SkillLocalImportConflictError(
+                "Stored local Skill files no longer match the import manifest.",
+                code="skill_import_package_mismatch",
+            )
+        for path, content in files.items():
+            entry = manifest[path]
+            if (
+                int(entry.get("sizeBytes") or -1) != len(content)
+                or str(entry.get("sha256") or "") != hashlib.sha256(content).hexdigest()
+            ):
+                raise SkillLocalImportConflictError(
+                    "Stored local Skill files no longer match the import manifest.",
+                    code="skill_import_package_mismatch",
+                )
+
+    def package_directory(self, import_id: str) -> Path:
+        with self._lock:
+            record = self.require(import_id)
+            if (
+                not record.package_digest
+                or not record.file_manifest
+                or record.state in {"blocked", "failed", "archived"}
+            ):
+                raise SkillLocalImportStorageError(
+                    "This import does not retain package bytes.",
+                    code="skill_import_storage_unavailable",
+                )
+            files = self._read_package_unlocked(record.package_digest)
+            self._verify_package_unlocked(record, files)
+            return self.packages_root / record.package_digest
+
+    def preview_file(self, import_id: str, path: str) -> str:
+        clean_path = _normalize_path(path)
+        if PurePosixPath(clean_path).suffix.casefold() in _ACTIVE_PREVIEW_SUFFIXES:
+            raise SkillLocalImportError(
+                "Active browser content is not available for preview.",
+                code="skill_import_invalid_transport",
+            )
+        with self._lock:
+            record = self.require(import_id)
+            if not record.package_digest or record.state in {"blocked", "failed", "archived"}:
+                raise SkillLocalImportStorageError(
+                    "This import does not retain package bytes.",
+                    code="skill_import_storage_unavailable",
+                )
+            files = self._read_package_unlocked(record.package_digest)
+            self._verify_package_unlocked(record, files)
+            content = files.get(clean_path)
+        if content is None:
+            raise SkillLocalImportNotFoundError(
+                "The imported Skill file was not found.", code="skill_import_not_found"
+            )
+        if len(content) > LOCAL_IMPORT_PREVIEW_BYTES:
+            raise SkillLocalImportError(
+                "The imported Skill file exceeds the preview limit.",
+                code="skill_import_limit_exceeded",
+            )
+        try:
+            return content.decode("utf-8", errors="strict")
+        except UnicodeDecodeError as exc:
+            raise SkillLocalImportError(
+                "Binary Skill resources cannot be previewed as text.",
+                code="skill_import_invalid_transport",
+            ) from exc
+
+    def rescan(
+        self,
+        import_id: str,
+        *,
+        expected_revision: int,
+        expected_package_digest: str,
+        expected_trust_fingerprint: str,
+    ) -> LocalSkillImport:
+        with self._lock:
+            self._ensure_available(mutation=True)
+            current = self._records.get(import_id)
+            if current is None:
+                raise SkillLocalImportNotFoundError(
+                    "Local Skill import was not found.", code="skill_import_not_found"
+                )
+            if (
+                current.revision != expected_revision
+                or current.package_digest != expected_package_digest.casefold()
+                or current.trust_fingerprint != expected_trust_fingerprint.casefold()
+            ):
+                raise SkillLocalImportConflictError(
+                    "Local Skill import changed. Reload before rescanning.",
+                    code="skill_import_stale",
+                )
+            raw_files = self._read_package_unlocked(expected_package_digest.casefold())
+            actual_digest = compute_skill_content_digest(raw_files)
+            if actual_digest != current.package_digest:
+                raise SkillLocalImportConflictError(
+                    "Stored local Skill bytes no longer match the import.",
+                    code="skill_import_package_mismatch",
+                )
+            entries = _tree_entries(
+                [
+                    ImportedFile(
+                        path,
+                        content,
+                        next(
+                            (
+                                str(entry.get("mode") or "100644")
+                                for entry in current.file_manifest
+                                if isinstance(entry, Mapping) and entry.get("path") == path
+                            ),
+                            "100644",
+                        ),
+                    )
+                    for path, content in raw_files.items()
+                ]
+            )
+            next_revision = current.revision + 1
+            next_content_revision = current.content_revision + 1
+            receipt = scan_local_skill_trust_receipt(
+                import_id=current.import_id,
+                import_revision=next_content_revision,
+                transport_kind=current.transport_kind,
+                transport_digest=current.transport_digest,
+                entries=entries,
+            )
+            policy = str(receipt.get("installPolicy") or "block")
+            state: ImportState = (
+                "blocked" if policy == "block" else "ready" if policy == "allow" else "confirmation_required"
+            )
+            updated = copy.deepcopy(current)
+            updated.revision = next_revision
+            updated.content_revision = next_content_revision
+            updated.state = state
+            updated.trust_receipt = receipt
+            updated.updated_at = time.time()
+            updated.error_code = "skill_import_blocked" if state == "blocked" else None
+            if state == "blocked":
+                updated.file_manifest = []
+            records = dict(self._records)
+            records[import_id] = updated
+            self._save_records_unlocked(records)
+            self._records = records
+            if state == "blocked":
+                shutil.rmtree(self.packages_root / expected_package_digest, ignore_errors=True)
+            return copy.deepcopy(updated)
+
+    def delete(
+        self,
+        import_id: str,
+        *,
+        expected_revision: int,
+        expected_package_digest: str | None,
+        expected_trust_fingerprint: str | None,
+    ) -> None:
+        with self._lock:
+            self._ensure_available(mutation=True)
+            current = self._records.get(import_id)
+            if current is None:
+                raise SkillLocalImportNotFoundError(
+                    "Local Skill import was not found.", code="skill_import_not_found"
+                )
+            if current.installed_skill_id or current.state == "installed":
+                raise SkillLocalImportConflictError(
+                    "Uninstall the local Skill before deleting its import.",
+                    code="skill_import_replace_required",
+                )
+            if (
+                current.revision != expected_revision
+                or current.package_digest != (expected_package_digest.casefold() if expected_package_digest else None)
+                or current.trust_fingerprint != (
+                    expected_trust_fingerprint.casefold() if expected_trust_fingerprint else None
+                )
+            ):
+                raise SkillLocalImportConflictError(
+                    "Local Skill import changed. Reload before deleting.",
+                    code="skill_import_stale",
+                )
+            records = dict(self._records)
+            del records[import_id]
+            self._save_records_unlocked(records)
+            self._records = records
+            if current.package_digest and not any(
+                item.package_digest == current.package_digest for item in records.values()
+            ):
+                shutil.rmtree(self.packages_root / current.package_digest, ignore_errors=True)
+
+
+__all__ = [
+    "LOCAL_IMPORT_MAX_ACTIVE",
+    "LOCAL_IMPORT_MAX_ARCHIVE_BYTES",
+    "LOCAL_IMPORT_MAX_STORAGE_BYTES",
+    "LOCAL_IMPORT_STORE_VERSION",
+    "ImportedFile",
+    "LocalSkillImport",
+    "SkillLocalImportConflictError",
+    "SkillLocalImportError",
+    "SkillLocalImportNotFoundError",
+    "SkillLocalImportStorageError",
+    "SkillLocalImportStore",
+    "normalize_folder_upload",
+    "normalize_zip_upload",
+]

--- a/server/skills/local_import_api.py
+++ b/server/skills/local_import_api.py
@@ -1,0 +1,286 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Annotated, Any, Literal
+
+from fastapi import APIRouter, File, Form, HTTPException, Query, UploadFile
+from pydantic import BaseModel, Field
+
+from .local_import import (
+    LOCAL_IMPORT_MAX_ARCHIVE_BYTES,
+    LocalSkillImport,
+    SkillLocalImportConflictError,
+    SkillLocalImportError,
+    SkillLocalImportNotFoundError,
+    SkillLocalImportStorageError,
+    SkillLocalImportStore,
+)
+from .trust_scanner import (
+    MAX_TRUST_FILE_BYTES,
+    MAX_TRUST_FILES,
+    MAX_TRUST_PATH_CHARS,
+    MAX_TRUST_TOTAL_BYTES,
+)
+
+
+router = APIRouter(prefix="/api/skills/imports", tags=["skill-imports"])
+_store: SkillLocalImportStore | None = None
+# A JSON array of 500 maximum-length paths plus syntax overhead remains bounded
+# without allowing an unbounded multipart form field.
+MAX_TRUST_PATH_CHARS_JSON = MAX_TRUST_FILES * (MAX_TRUST_PATH_CHARS + 4)
+
+
+class LocalImportMutationRequest(BaseModel):
+    expected_revision: int = Field(ge=1)
+    expected_package_digest: str | None = Field(
+        default=None,
+        min_length=64,
+        max_length=64,
+        pattern=r"^[0-9a-fA-F]{64}$",
+    )
+    expected_trust_fingerprint: str | None = Field(
+        default=None,
+        min_length=64,
+        max_length=64,
+        pattern=r"^[0-9a-fA-F]{64}$",
+    )
+
+
+class LocalImportRescanRequest(BaseModel):
+    expected_revision: int = Field(ge=1)
+    expected_package_digest: str = Field(
+        min_length=64,
+        max_length=64,
+        pattern=r"^[0-9a-fA-F]{64}$",
+    )
+    expected_trust_fingerprint: str = Field(
+        min_length=64,
+        max_length=64,
+        pattern=r"^[0-9a-fA-F]{64}$",
+    )
+
+
+def configure_skill_local_import(store: SkillLocalImportStore | None) -> None:
+    global _store
+    _store = store
+
+
+def get_skill_local_import_store() -> SkillLocalImportStore:
+    global _store
+    if _store is None:
+        _store = SkillLocalImportStore()
+    return _store
+
+
+def _require_enabled(store: SkillLocalImportStore) -> None:
+    if not store.enabled:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "code": "skill_import_disabled",
+                "message": "Local Skill import is disabled.",
+            },
+        )
+
+
+def _raise_import_error(exc: SkillLocalImportError) -> None:
+    if isinstance(exc, SkillLocalImportNotFoundError):
+        status = 404
+    elif isinstance(exc, SkillLocalImportStorageError):
+        status = 503
+    elif isinstance(exc, SkillLocalImportConflictError):
+        status = 409
+    elif exc.code == "skill_import_disabled":
+        status = 404
+    elif exc.code == "skill_import_limit_exceeded":
+        status = 413
+    elif exc.code in {"skill_import_stale", "skill_import_package_mismatch"}:
+        status = 409
+    elif exc.code == "skill_import_scan_failed":
+        status = 422
+    else:
+        status = 400
+    raise HTTPException(
+        status_code=status,
+        detail={"code": exc.code, "message": str(exc), "details": exc.details},
+    ) from exc
+
+
+def _serialize(record: LocalSkillImport, *, include_receipt: bool = True) -> dict[str, Any]:
+    return record.serialize(include_receipt=include_receipt)
+
+
+async def _read_bounded(upload: UploadFile, limit: int) -> bytes:
+    chunks: list[bytes] = []
+    total = 0
+    while True:
+        chunk = await upload.read(min(1024 * 1024, limit + 1 - total))
+        if not chunk:
+            break
+        total += len(chunk)
+        if total > limit:
+            raise SkillLocalImportError(
+                "The upload exceeds the request size limit.",
+                code="skill_import_limit_exceeded",
+            )
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+@router.get("/status")
+async def local_import_status() -> dict[str, Any]:
+    return get_skill_local_import_store().status()
+
+
+@router.post("")
+async def create_local_import(
+    transport_kind: Annotated[Literal["zip", "folder"], Form()],
+    local_skill_id: Annotated[str | None, Form(max_length=64)] = None,
+    paths_json: Annotated[str | None, Form(max_length=MAX_TRUST_PATH_CHARS_JSON)] = None,
+    archive: Annotated[UploadFile | None, File()] = None,
+    files: Annotated[list[UploadFile] | None, File()] = None,
+) -> dict[str, Any]:
+    store = get_skill_local_import_store()
+    _require_enabled(store)
+    try:
+        if transport_kind == "zip":
+            if archive is None or files or paths_json:
+                raise SkillLocalImportError(
+                    "ZIP import accepts exactly one archive upload.",
+                    code="skill_import_invalid_transport",
+                )
+            content = await _read_bounded(archive, LOCAL_IMPORT_MAX_ARCHIVE_BYTES)
+            record = await asyncio.to_thread(
+                store.create_from_zip, content, local_skill_id=local_skill_id
+            )
+            return _serialize(record)
+
+        if archive is not None or not files or paths_json is None:
+            raise SkillLocalImportError(
+                "Folder import requires a path manifest and matching file uploads.",
+                code="skill_import_invalid_transport",
+            )
+        try:
+            paths = json.loads(paths_json)
+        except json.JSONDecodeError as exc:
+            raise SkillLocalImportError(
+                "Folder import path manifest is invalid.",
+                code="skill_import_invalid_transport",
+            ) from exc
+        if (
+            not isinstance(paths, list)
+            or any(not isinstance(path, str) for path in paths)
+            or len(paths) != len(files)
+            or len(paths) > MAX_TRUST_FILES
+        ):
+            raise SkillLocalImportError(
+                "Folder import path manifest does not match the uploaded files.",
+                code="skill_import_invalid_transport",
+            )
+        items: list[tuple[str, bytes]] = []
+        total = 0
+        for path, upload in zip(paths, files, strict=True):
+            content = await _read_bounded(upload, MAX_TRUST_FILE_BYTES)
+            total += len(content)
+            if total > MAX_TRUST_TOTAL_BYTES:
+                raise SkillLocalImportError(
+                    "Folder import exceeds the expanded-size limit.",
+                    code="skill_import_limit_exceeded",
+                )
+            items.append((path, content))
+        record = await asyncio.to_thread(
+            store.create_from_folder, items, local_skill_id=local_skill_id
+        )
+        return _serialize(record)
+    except SkillLocalImportError as exc:
+        _raise_import_error(exc)
+
+
+@router.get("")
+async def list_local_imports(
+    include_archived: bool = Query(default=False),
+) -> dict[str, Any]:
+    store = get_skill_local_import_store()
+    _require_enabled(store)
+    try:
+        records = await asyncio.to_thread(
+            store.list_imports, include_archived=include_archived
+        )
+        return {
+            "imports": [_serialize(item, include_receipt=False) for item in records],
+            "total": len(records),
+        }
+    except SkillLocalImportError as exc:
+        _raise_import_error(exc)
+
+
+@router.get("/{import_id}")
+async def get_local_import(import_id: str) -> dict[str, Any]:
+    store = get_skill_local_import_store()
+    _require_enabled(store)
+    try:
+        return _serialize(await asyncio.to_thread(store.require, import_id))
+    except SkillLocalImportError as exc:
+        _raise_import_error(exc)
+
+
+@router.get("/{import_id}/file")
+async def preview_local_import_file(
+    import_id: str,
+    path: str = Query(min_length=1, max_length=240),
+) -> dict[str, str]:
+    store = get_skill_local_import_store()
+    _require_enabled(store)
+    try:
+        content = await asyncio.to_thread(store.preview_file, import_id, path)
+        return {"importId": import_id, "path": path, "content": content}
+    except SkillLocalImportError as exc:
+        _raise_import_error(exc)
+
+
+@router.post("/{import_id}/rescan")
+async def rescan_local_import(
+    import_id: str,
+    payload: LocalImportRescanRequest,
+) -> dict[str, Any]:
+    store = get_skill_local_import_store()
+    _require_enabled(store)
+    try:
+        record = await asyncio.to_thread(
+            store.rescan,
+            import_id,
+            expected_revision=payload.expected_revision,
+            expected_package_digest=payload.expected_package_digest,
+            expected_trust_fingerprint=payload.expected_trust_fingerprint,
+        )
+        return _serialize(record)
+    except SkillLocalImportError as exc:
+        _raise_import_error(exc)
+
+
+@router.delete("/{import_id}")
+async def delete_local_import(
+    import_id: str,
+    payload: LocalImportMutationRequest,
+) -> dict[str, bool]:
+    store = get_skill_local_import_store()
+    _require_enabled(store)
+    try:
+        await asyncio.to_thread(
+            store.delete,
+            import_id,
+            expected_revision=payload.expected_revision,
+            expected_package_digest=payload.expected_package_digest,
+            expected_trust_fingerprint=payload.expected_trust_fingerprint,
+        )
+        return {"ok": True}
+    except SkillLocalImportError as exc:
+        _raise_import_error(exc)
+
+
+__all__ = [
+    "configure_skill_local_import",
+    "get_skill_local_import_store",
+    "router",
+]

--- a/server/skills/trust_scanner.py
+++ b/server/skills/trust_scanner.py
@@ -794,6 +794,119 @@ def scan_skill_trust_receipt(
     return receipt_payload
 
 
+_LOCAL_IMPORT_HARD_BLOCK_CODES = {
+    "trust_archive_blocked",
+    "trust_executable_binary_blocked",
+    "trust_unknown_binary_blocked",
+}
+
+
+def scan_local_skill_trust_receipt(
+    *,
+    import_id: str,
+    import_revision: int,
+    transport_kind: Literal["zip", "folder"],
+    transport_digest: str,
+    entries: Sequence[SkillTrustTreeEntry],
+) -> dict[str, Any]:
+    """Scan an immutable local package without giving it synthetic Git trust.
+
+    The mature byte-tree scanner remains authoritative for content findings.
+    Synthetic Git evidence is used only while executing that scanner and is
+    removed before the local receipt is fingerprinted or persisted.
+    """
+
+    if not re.fullmatch(r"skillimport_[0-9a-f]{32}", import_id):
+        raise ValueError("Local Skill import ID is invalid.")
+    if not isinstance(import_revision, int) or isinstance(import_revision, bool) or import_revision < 1:
+        raise ValueError("Local Skill import revision is invalid.")
+    if transport_kind not in {"zip", "folder"}:
+        raise ValueError("Local Skill import transport kind is invalid.")
+    clean_transport_digest = str(transport_digest or "").casefold()
+    if not re.fullmatch(r"[0-9a-f]{64}", clean_transport_digest):
+        raise ValueError("Local Skill import transport digest is invalid.")
+
+    tree_payload = [
+        {
+            "path": entry.path,
+            "mode": entry.mode,
+            "objectType": entry.object_type,
+            "objectId": entry.object_id,
+            "size": entry.size,
+        }
+        for entry in sorted(
+            entries,
+            key=lambda item: item.path.encode("utf-8", "surrogatepass"),
+        )
+    ]
+    content_tree_digest = sha256_json(tree_payload)
+    synthetic_commit = hashlib.sha1(
+        f"{import_id}:{import_revision}:{clean_transport_digest}".encode("ascii")
+    ).hexdigest()
+    synthetic_tree = hashlib.sha1(content_tree_digest.encode("ascii")).hexdigest()
+    synthetic_root = "local-skill"
+    skill_markdown = next(
+        (
+            entry.content
+            for entry in entries
+            if entry.path == "SKILL.md" and entry.content is not None
+        ),
+        None,
+    )
+    if skill_markdown is not None:
+        try:
+            markdown_text = skill_markdown.decode("utf-8", errors="strict")
+        except UnicodeDecodeError:
+            markdown_text = ""
+        parsed_issues: list[SkillPackageIssue] = []
+        parsed_frontmatter = _parse_skill_frontmatter(markdown_text, parsed_issues)
+        declared_name = (
+            parsed_frontmatter.get("name")
+            if isinstance(parsed_frontmatter, Mapping)
+            else None
+        )
+        if (
+            isinstance(declared_name, str)
+            and re.fullmatch(r"[a-z0-9]+(?:-[a-z0-9]+)*", declared_name)
+            and len(declared_name) <= 64
+        ):
+            synthetic_root = declared_name
+    receipt = scan_skill_trust_receipt(
+        repo_url="https://local.invalid/modelmirror-skill-import",
+        sub_path=synthetic_root,
+        verified_commit=synthetic_commit,
+        directory_tree_sha=synthetic_tree,
+        entries=entries,
+    )
+
+    source = {
+        "kind": "local_import",
+        "importId": import_id,
+        "importRevision": import_revision,
+        "transportKind": transport_kind,
+        "transportDigest": clean_transport_digest,
+    }
+    receipt["receiptId"] = "trust_local_" + sha256_json(source)[:32]
+    receipt["source"] = source
+    receipt.pop("directoryTreeSha", None)
+    receipt["contentTreeDigest"] = content_tree_digest
+
+    finding_codes = {
+        str(finding.get("code") or "")
+        for finding in receipt.get("findings", ())
+        if isinstance(finding, Mapping)
+    }
+    if finding_codes.intersection(_LOCAL_IMPORT_HARD_BLOCK_CODES):
+        receipt["trustStatus"] = "blocked"
+        receipt["installPolicy"] = "block"
+        receipt["compatibilityStatus"] = "unsupported"
+        receipt["routerEligible"] = False
+
+    receipt.pop("trustFingerprint", None)
+    receipt["trustFingerprint"] = sha256_json(receipt)
+    return receipt
+
+
 def build_skill_trust_index(
     *,
     candidates: Sequence[Mapping[str, Any]],
@@ -931,6 +1044,7 @@ __all__ = [
     "build_skill_trust_summary",
     "catalog_fingerprint_for",
     "receipt_id_for",
+    "scan_local_skill_trust_receipt",
     "scan_skill_trust_receipt",
     "sha256_json",
     "source_key",

--- a/server/tests/test_skill_local_import.py
+++ b/server/tests/test_skill_local_import.py
@@ -1,0 +1,512 @@
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import shutil
+import stat
+import zipfile
+from pathlib import Path
+
+import pytest
+import skills.local_import as local_import
+
+from skills.local_import import (
+    SkillLocalImportConflictError,
+    SkillLocalImportError,
+    SkillLocalImportStorageError,
+    SkillLocalImportStore,
+    normalize_folder_upload,
+    normalize_zip_upload,
+)
+from skills.trust_scanner import SkillTrustTreeEntry, scan_local_skill_trust_receipt, sha256_json
+
+
+def _skill_markdown(
+    name: str = "local-example",
+    body: str = "## Workflow\n\n1. Read the input.\n2. Return the result.\n",
+) -> bytes:
+    return (
+        "---\n"
+        f"name: {name}\n"
+        "description: Use this local Skill for a bounded deterministic task.\n"
+        "---\n\n"
+        f"{body}"
+    ).encode()
+
+
+def _zip(files: dict[str, bytes], *, modes: dict[str, int] | None = None) -> bytes:
+    output = io.BytesIO()
+    with zipfile.ZipFile(output, "w", compression=zipfile.ZIP_DEFLATED) as bundle:
+        for path, content in files.items():
+            info = zipfile.ZipInfo(path)
+            info.compress_type = zipfile.ZIP_DEFLATED
+            if modes and path in modes:
+                info.create_system = 3
+                info.external_attr = modes[path] << 16
+            bundle.writestr(info, content)
+    return output.getvalue()
+
+
+def _entry(path: str, content: bytes) -> SkillTrustTreeEntry:
+    return SkillTrustTreeEntry(
+        path=path,
+        mode="100644",
+        object_type="blob",
+        object_id=hashlib.sha1(content).hexdigest(),
+        size=len(content),
+        content=content,
+    )
+
+
+def test_local_receipt_uses_local_source_without_changing_git_contract() -> None:
+    receipt = scan_local_skill_trust_receipt(
+        import_id="skillimport_" + "a" * 32,
+        import_revision=1,
+        transport_kind="folder",
+        transport_digest="b" * 64,
+        entries=[_entry("SKILL.md", _skill_markdown())],
+    )
+
+    assert receipt["source"] == {
+        "kind": "local_import",
+        "importId": "skillimport_" + "a" * 32,
+        "importRevision": 1,
+        "transportKind": "folder",
+        "transportDigest": "b" * 64,
+    }
+    assert "directoryTreeSha" not in receipt
+    assert len(receipt["contentTreeDigest"]) == 64
+    assert receipt["receiptId"].startswith("trust_local_")
+    assert sha256_json(
+        {key: value for key, value in receipt.items() if key != "trustFingerprint"}
+    ) == receipt["trustFingerprint"]
+    assert receipt["installPolicy"] == "allow"
+
+
+@pytest.mark.parametrize(
+    ("path", "content", "code"),
+    [
+        ("scripts/tool.zip", b"PK\x03\x04payload", "trust_archive_blocked"),
+        ("assets/tool.exe", b"MZpayload", "trust_executable_binary_blocked"),
+        ("assets/blob.dat", b"\x00\xffpayload", "trust_unknown_binary_blocked"),
+    ],
+)
+def test_local_uninspectable_payloads_are_hard_blocks(
+    path: str, content: bytes, code: str
+) -> None:
+    receipt = scan_local_skill_trust_receipt(
+        import_id="skillimport_" + "a" * 32,
+        import_revision=1,
+        transport_kind="folder",
+        transport_digest="b" * 64,
+        entries=[_entry("SKILL.md", _skill_markdown()), _entry(path, content)],
+    )
+
+    assert code in {finding["code"] for finding in receipt["findings"]}
+    assert receipt["trustStatus"] == "blocked"
+    assert receipt["installPolicy"] == "block"
+    assert receipt["routerEligible"] is False
+
+
+def test_local_script_policy_allows_valid_code_but_excludes_invalid_code_from_router() -> None:
+    markdown = _skill_markdown(
+        body="## Workflow\n\n1. Run `python scripts/tool.py`.\n2. Return its output.\n"
+    )
+    valid = scan_local_skill_trust_receipt(
+        import_id="skillimport_" + "a" * 32,
+        import_revision=1,
+        transport_kind="folder",
+        transport_digest="b" * 64,
+        entries=[_entry("SKILL.md", markdown), _entry("scripts/tool.py", b"print('ok')\n")],
+    )
+    invalid = scan_local_skill_trust_receipt(
+        import_id="skillimport_" + "b" * 32,
+        import_revision=1,
+        transport_kind="folder",
+        transport_digest="c" * 64,
+        entries=[_entry("SKILL.md", markdown), _entry("scripts/tool.py", b"value =\n")],
+    )
+
+    assert valid["installPolicy"] == "confirm"
+    assert valid["routerEligible"] is True
+    assert invalid["installPolicy"] == "confirm"
+    assert invalid["routerEligible"] is False
+
+
+def test_folder_normalization_is_order_independent_and_strips_one_wrapper() -> None:
+    first, first_digest, ignored = normalize_folder_upload(
+        [
+            ("package/references/guide.md", b"guide"),
+            ("package/.DS_Store", b"noise"),
+            ("package/SKILL.md", _skill_markdown()),
+        ]
+    )
+    second, second_digest, _ = normalize_folder_upload(
+        [
+            ("package/SKILL.md", _skill_markdown()),
+            ("package/.DS_Store", b"noise"),
+            ("package/references/guide.md", b"guide"),
+        ]
+    )
+
+    assert [item.path for item in first] == ["SKILL.md", "references/guide.md"]
+    assert [item.path for item in second] == ["SKILL.md", "references/guide.md"]
+    assert first_digest == second_digest
+    assert ignored == [{"reason": "macos_metadata", "count": 1}]
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "../SKILL.md",
+        "/absolute/SKILL.md",
+        "C:/Users/example/SKILL.md",
+        "package/.git/config",
+        "package/CON/file.md",
+        "package/references/item. ",
+    ],
+)
+def test_folder_rejects_unsafe_paths(path: str) -> None:
+    with pytest.raises(SkillLocalImportError) as error:
+        normalize_folder_upload([(path, _skill_markdown())])
+    assert error.value.code == "skill_import_path_unsafe"
+
+
+def test_folder_rejects_case_collisions_and_multiple_roots() -> None:
+    with pytest.raises(SkillLocalImportError, match="collide"):
+        normalize_folder_upload(
+            [
+                ("SKILL.md", _skill_markdown()),
+                ("References/Guide.md", b"one"),
+                ("references/guide.md", b"two"),
+            ]
+        )
+    with pytest.raises(SkillLocalImportError) as error:
+        normalize_folder_upload(
+            [("one/SKILL.md", _skill_markdown()), ("two/SKILL.md", _skill_markdown())]
+        )
+    assert error.value.code == "skill_import_multiple_roots"
+
+    with pytest.raises(SkillLocalImportError) as nested:
+        normalize_folder_upload(
+            [
+                ("SKILL.md", _skill_markdown()),
+                ("nested/SKILL.md", _skill_markdown(name="nested")),
+            ]
+        )
+    assert nested.value.code == "skill_import_multiple_roots"
+
+
+def test_zip_preserves_passive_binary_and_executable_mode() -> None:
+    archive = _zip(
+        {
+            "wrapper/SKILL.md": _skill_markdown(
+                body="## Workflow\n\n1. Run `python scripts/tool.py`.\n2. Use `assets/pixel.png`.\n"
+            ),
+            "wrapper/scripts/tool.py": b"print('ok')\n",
+            "wrapper/assets/pixel.png": b"\x89PNG\r\n\x1a\nrest",
+        },
+        modes={"wrapper/scripts/tool.py": stat.S_IFREG | 0o755},
+    )
+
+    files, digest, ignored = normalize_zip_upload(archive)
+
+    assert len(digest) == 64
+    assert ignored == []
+    assert {item.path for item in files} == {
+        "SKILL.md",
+        "scripts/tool.py",
+        "assets/pixel.png",
+    }
+    assert next(item for item in files if item.path == "scripts/tool.py").mode == "100755"
+
+
+def test_zip_rejects_symlink_and_bad_compression() -> None:
+    symlink = _zip(
+        {"SKILL.md": _skill_markdown(), "references/link": b"target"},
+        modes={"references/link": stat.S_IFLNK | 0o777},
+    )
+    with pytest.raises(SkillLocalImportError) as error:
+        normalize_zip_upload(symlink)
+    assert error.value.code == "skill_import_path_unsafe"
+
+    output = io.BytesIO()
+    with zipfile.ZipFile(output, "w", compression=zipfile.ZIP_BZIP2) as bundle:
+        bundle.writestr("SKILL.md", _skill_markdown())
+    with pytest.raises(SkillLocalImportError) as error:
+        normalize_zip_upload(output.getvalue())
+    assert error.value.code == "skill_import_archive_invalid"
+
+
+def test_zip_rejects_encrypted_entry_before_reading_content() -> None:
+    archive = bytearray(_zip({"SKILL.md": _skill_markdown()}))
+    central = archive.find(b"PK\x01\x02")
+    assert central >= 0
+    flags = int.from_bytes(archive[central + 8 : central + 10], "little") | 0x1
+    archive[central + 8 : central + 10] = flags.to_bytes(2, "little")
+
+    with pytest.raises(SkillLocalImportError) as exc_info:
+        normalize_zip_upload(bytes(archive))
+    assert exc_info.value.code == "skill_import_archive_encrypted"
+
+
+def test_store_publishes_immutable_package_and_deduplicates(tmp_path: Path) -> None:
+    store = SkillLocalImportStore(tmp_path / "imports", enabled=True)
+    items = [
+        ("local-example/SKILL.md", _skill_markdown()),
+        ("local-example/references/guide.md", b"# Guide\n"),
+    ]
+
+    created = store.create_from_folder(items)
+    duplicate = store.create_from_folder(list(reversed(items)))
+
+    assert created.state == "ready"
+    assert created.local_skill_id == "local-example"
+    assert duplicate.import_id == created.import_id
+    assert duplicate.package_digest == created.package_digest
+    assert store.package_directory(created.import_id).is_dir()
+    assert store.preview_file(created.import_id, "references/guide.md") == "# Guide\n"
+    assert len(store.list_imports()) == 1
+
+    reloaded = SkillLocalImportStore(tmp_path / "imports", enabled=True)
+    assert reloaded.require(created.import_id).serialize() == created.serialize()
+
+
+def test_store_keeps_passive_resources_but_purges_blocked_bytes(tmp_path: Path) -> None:
+    store = SkillLocalImportStore(tmp_path / "imports", enabled=True)
+    passive = store.create_from_folder(
+        [
+            ("SKILL.md", _skill_markdown()),
+            ("assets/pixel.png", b"\x89PNG\r\n\x1a\nrest"),
+        ]
+    )
+    assert passive.state == "confirmation_required"
+    assert store.package_directory(passive.import_id).joinpath("assets/pixel.png").read_bytes().startswith(b"\x89PNG")
+    with pytest.raises(SkillLocalImportError):
+        store.preview_file(passive.import_id, "assets/pixel.png")
+
+
+def test_blocked_import_retains_only_redacted_metadata(tmp_path: Path) -> None:
+    store = SkillLocalImportStore(tmp_path / "imports", enabled=True)
+    secret = "sk-" + "exampletoken12345678901234567890"
+    record = store.create_from_folder(
+        [("SKILL.md", _skill_markdown(body=f"## Workflow\n\n1. TOKEN={secret}\n"))]
+    )
+
+    assert record.state == "blocked"
+    assert record.file_manifest == []
+    assert record.local_skill_id is None
+    assert record.package_digest
+    assert not (store.packages_root / record.package_digest).exists()
+    assert secret not in json.dumps(record.serialize(), ensure_ascii=False)
+
+
+def test_hidden_env_secret_is_scanned_and_never_retained(tmp_path: Path) -> None:
+    store = SkillLocalImportStore(tmp_path / "imports", enabled=True)
+    secret = "sk-" + "hidden-local-secret-value-1234567890"
+    record = store.create_from_folder(
+        [("SKILL.md", _skill_markdown()), (".env", f"API_KEY={secret}\n".encode())]
+    )
+
+    assert record.state == "blocked"
+    assert record.file_manifest == []
+    assert record.package_digest
+    assert not (store.packages_root / record.package_digest).exists()
+    assert secret not in json.dumps(record.serialize(), ensure_ascii=False)
+
+
+def test_store_rescan_uses_optimistic_receipt_and_delete_cleans_bytes(tmp_path: Path) -> None:
+    store = SkillLocalImportStore(tmp_path / "imports", enabled=True)
+    record = store.create_from_folder([("SKILL.md", _skill_markdown())])
+
+    with pytest.raises(SkillLocalImportConflictError):
+        store.rescan(
+            record.import_id,
+            expected_revision=record.revision + 1,
+            expected_package_digest=record.package_digest or "",
+            expected_trust_fingerprint=record.trust_fingerprint or "",
+        )
+    rescanned = store.rescan(
+        record.import_id,
+        expected_revision=record.revision,
+        expected_package_digest=record.package_digest or "",
+        expected_trust_fingerprint=record.trust_fingerprint or "",
+    )
+    assert rescanned.revision == record.revision + 1
+    assert rescanned.package_digest == record.package_digest
+    assert rescanned.trust_fingerprint != record.trust_fingerprint
+
+    package_dir = store.package_directory(record.import_id)
+    store.delete(
+        record.import_id,
+        expected_revision=rescanned.revision,
+        expected_package_digest=rescanned.package_digest,
+        expected_trust_fingerprint=rescanned.trust_fingerprint,
+    )
+    assert not package_dir.exists()
+    assert store.list_imports() == []
+
+
+def test_top_level_corruption_fails_closed_without_overwrite(tmp_path: Path) -> None:
+    root = tmp_path / "imports"
+    root.mkdir()
+    index = root / "imports.json"
+    original = b"{not-json"
+    index.write_bytes(original)
+    store = SkillLocalImportStore(root, enabled=True)
+
+    assert store.status()["available"] is False
+    with pytest.raises(SkillLocalImportStorageError):
+        store.create_from_folder([("SKILL.md", _skill_markdown())])
+    assert index.read_bytes() == original
+
+
+def test_interrupted_scan_recovers_as_failed_without_source_bytes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "imports"
+    store = SkillLocalImportStore(root, enabled=True)
+
+    def interrupt(_items: object) -> object:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(local_import, "normalize_folder_upload", interrupt)
+    with pytest.raises(KeyboardInterrupt):
+        store.create_from_folder([("SKILL.md", _skill_markdown())])
+
+    recovered = SkillLocalImportStore(root, enabled=True).list_imports()
+    assert len(recovered) == 1
+    assert recovered[0].state == "failed"
+    assert recovered[0].revision == 2
+    assert recovered[0].error_code == "skill_import_scan_failed"
+    assert recovered[0].package_digest is None
+    assert not (root / "packages").exists()
+
+
+def test_startup_removes_unreferenced_published_package(tmp_path: Path) -> None:
+    root = tmp_path / "imports"
+    store = SkillLocalImportStore(root, enabled=True)
+    orphan = store.packages_root / ("a" * 64)
+    orphan.mkdir(parents=True)
+    (orphan / "SKILL.md").write_bytes(_skill_markdown())
+
+    reloaded = SkillLocalImportStore(root, enabled=True)
+
+    assert reloaded.status()["available"] is True
+    assert not orphan.exists()
+
+
+def test_preview_and_package_directory_fail_closed_after_disk_tamper(tmp_path: Path) -> None:
+    store = SkillLocalImportStore(tmp_path / "imports", enabled=True)
+    record = store.create_from_folder([("SKILL.md", _skill_markdown())])
+    package_root = store.packages_root / str(record.package_digest)
+    (package_root / "SKILL.md").write_bytes(_skill_markdown(name="tampered"))
+
+    for operation in (
+        lambda: store.package_directory(record.import_id),
+        lambda: store.preview_file(record.import_id, "SKILL.md"),
+    ):
+        with pytest.raises(SkillLocalImportConflictError) as exc_info:
+            operation()
+        assert exc_info.value.code == "skill_import_package_mismatch"
+
+
+def test_active_browser_content_is_not_returned_by_preview(tmp_path: Path) -> None:
+    store = SkillLocalImportStore(tmp_path / "imports", enabled=True)
+    record = store.create_from_folder(
+        [
+            ("SKILL.md", _skill_markdown(body="Use `assets/template.html`.")),
+            (
+                "assets/template.html",
+                b"<html><body><script>window.example = true</script></body></html>",
+            ),
+        ]
+    )
+
+    assert record.state == "confirmation_required"
+    with pytest.raises(SkillLocalImportError) as exc_info:
+        store.preview_file(record.import_id, "assets/template.html")
+    assert exc_info.value.code == "skill_import_invalid_transport"
+
+
+def test_stored_package_link_is_never_followed(tmp_path: Path) -> None:
+    store = SkillLocalImportStore(tmp_path / "imports", enabled=True)
+    record = store.create_from_folder([("SKILL.md", _skill_markdown())])
+    package_root = store.packages_root / str(record.package_digest)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "SKILL.md").write_bytes(_skill_markdown())
+    shutil.rmtree(package_root)
+    try:
+        package_root.symlink_to(outside, target_is_directory=True)
+    except OSError:
+        pytest.skip("Directory symlinks are unavailable in this environment.")
+
+    with pytest.raises(SkillLocalImportStorageError) as exc_info:
+        store.preview_file(record.import_id, "SKILL.md")
+    assert exc_info.value.code == "skill_import_storage_unavailable"
+
+
+def test_single_bad_record_is_quarantined_without_losing_valid_record(tmp_path: Path) -> None:
+    root = tmp_path / "imports"
+    store = SkillLocalImportStore(root, enabled=True)
+    valid = store.create_from_folder([("SKILL.md", _skill_markdown())])
+    payload = json.loads((root / "imports.json").read_text(encoding="utf-8"))
+    payload["imports"].append({"importId": "bad", "source": "secret payload omitted"})
+    (root / "imports.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    reloaded = SkillLocalImportStore(root, enabled=True)
+
+    assert reloaded.status()["available"] is True
+    assert [item.import_id for item in reloaded.list_imports()] == [valid.import_id]
+    assert reloaded._quarantine[0]["sizeBytes"] > 0
+    assert "source" not in reloaded._quarantine[0]
+
+    rescanned = reloaded.rescan(
+        valid.import_id,
+        expected_revision=valid.revision,
+        expected_package_digest=valid.package_digest or "",
+        expected_trust_fingerprint=valid.trust_fingerprint or "",
+    )
+    restarted = SkillLocalImportStore(root, enabled=True)
+    assert restarted.require(valid.import_id).revision == rescanned.revision
+    assert restarted._quarantine == reloaded._quarantine
+
+
+def test_tampered_trust_receipt_is_quarantined_on_load(tmp_path: Path) -> None:
+    root = tmp_path / "imports"
+    store = SkillLocalImportStore(root, enabled=True)
+    store.create_from_folder([("SKILL.md", _skill_markdown())])
+    payload = json.loads((root / "imports.json").read_text(encoding="utf-8"))
+    payload["imports"][0]["trustReceipt"]["riskLevel"] = "high"
+    (root / "imports.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    reloaded = SkillLocalImportStore(root, enabled=True)
+
+    assert reloaded.status()["available"] is True
+    assert reloaded.list_imports() == []
+    assert len(reloaded._quarantine) == 1
+    assert (store.packages_root / str(payload["imports"][0]["packageDigest"])).is_dir()
+
+
+def test_metadata_failure_rolls_back_new_package(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    store = SkillLocalImportStore(tmp_path / "imports", enabled=True)
+
+    def fail_save(_records: object) -> None:
+        raise SkillLocalImportStorageError(
+            "disk full", code="skill_import_storage_unavailable"
+        )
+
+    monkeypatch.setattr(store, "_save_records_unlocked", fail_save)
+    with pytest.raises(SkillLocalImportStorageError):
+        store.create_from_folder([("SKILL.md", _skill_markdown())])
+    assert not store.packages_root.exists() or not any(store.packages_root.iterdir())
+
+
+def test_disabled_store_keeps_status_readable_but_blocks_mutation(tmp_path: Path) -> None:
+    store = SkillLocalImportStore(tmp_path / "imports", enabled=False)
+    assert store.status()["enabled"] is False
+    with pytest.raises(SkillLocalImportError) as error:
+        store.create_from_zip(_zip({"SKILL.md": _skill_markdown()}))
+    assert error.value.code == "skill_import_disabled"

--- a/server/tests/test_skill_local_import_api.py
+++ b/server/tests/test_skill_local_import_api.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from skills.local_import import SkillLocalImportStore
+from skills.local_import_api import configure_skill_local_import, router
+
+
+def _markdown(name: str = "upload-example") -> bytes:
+    return (
+        "---\n"
+        f"name: {name}\n"
+        "description: Use this uploaded Skill for a bounded local task.\n"
+        "---\n\n"
+        "## Workflow\n\n1. Read the input.\n2. Return the result.\n"
+    ).encode()
+
+
+def _zip(files: dict[str, bytes]) -> bytes:
+    output = io.BytesIO()
+    with zipfile.ZipFile(output, "w", compression=zipfile.ZIP_DEFLATED) as bundle:
+        for path, content in files.items():
+            bundle.writestr(path, content)
+    return output.getvalue()
+
+
+@pytest.fixture()
+def app_client(tmp_path: Path):
+    store = SkillLocalImportStore(tmp_path / "imports", enabled=True)
+    configure_skill_local_import(store)
+    app = FastAPI()
+    app.include_router(router)
+    with TestClient(app) as client:
+        yield client, store
+    configure_skill_local_import(None)
+
+
+def test_status_is_readable_while_disabled(tmp_path: Path) -> None:
+    configure_skill_local_import(
+        SkillLocalImportStore(tmp_path / "imports", enabled=False)
+    )
+    app = FastAPI()
+    app.include_router(router)
+    with TestClient(app) as client:
+        status = client.get("/api/skills/imports/status")
+        listing = client.get("/api/skills/imports")
+    configure_skill_local_import(None)
+
+    assert status.status_code == 200
+    assert status.json()["enabled"] is False
+    assert status.json()["available"] is True
+    assert listing.status_code == 404
+    assert listing.json()["detail"]["code"] == "skill_import_disabled"
+
+
+def test_zip_upload_detail_preview_rescan_and_delete(app_client) -> None:
+    client, _store = app_client
+    response = client.post(
+        "/api/skills/imports",
+        data={"transport_kind": "zip"},
+        files={
+            "archive": (
+                "skill.zip",
+                _zip(
+                    {
+                        "wrapper/SKILL.md": _markdown(),
+                        "wrapper/references/guide.md": b"# Guide\n",
+                    }
+                ),
+                "application/zip",
+            )
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    created = response.json()
+    assert created["state"] == "ready"
+    assert created["transportKind"] == "zip"
+    assert created["localSkillId"] == "upload-example"
+    import_id = created["importId"]
+
+    listing = client.get("/api/skills/imports")
+    assert listing.status_code == 200
+    assert listing.json()["total"] == 1
+    assert "trustReceipt" not in listing.json()["imports"][0]
+
+    detail = client.get(f"/api/skills/imports/{import_id}")
+    assert detail.status_code == 200
+    assert detail.json()["trustReceipt"]["source"]["kind"] == "local_import"
+
+    preview = client.get(
+        f"/api/skills/imports/{import_id}/file",
+        params={"path": "references/guide.md"},
+    )
+    assert preview.status_code == 200
+    assert preview.json()["content"] == "# Guide\n"
+
+    rescan = client.post(
+        f"/api/skills/imports/{import_id}/rescan",
+        json={
+            "expected_revision": created["revision"],
+            "expected_package_digest": created["packageDigest"],
+            "expected_trust_fingerprint": created["trustFingerprint"],
+        },
+    )
+    assert rescan.status_code == 200
+    rescanned = rescan.json()
+    assert rescanned["revision"] == created["revision"] + 1
+
+    deleted = client.request(
+        "DELETE",
+        f"/api/skills/imports/{import_id}",
+        json={
+            "expected_revision": rescanned["revision"],
+            "expected_package_digest": rescanned["packageDigest"],
+            "expected_trust_fingerprint": rescanned["trustFingerprint"],
+        },
+    )
+    assert deleted.status_code == 200
+    assert deleted.json() == {"ok": True}
+    assert client.get(f"/api/skills/imports/{import_id}").status_code == 404
+
+
+def test_folder_upload_uses_server_validated_path_manifest(app_client) -> None:
+    client, _store = app_client
+    response = client.post(
+        "/api/skills/imports",
+        data={
+            "transport_kind": "folder",
+            "paths_json": json.dumps(
+                ["folder/SKILL.md", "folder/assets/pixel.png"]
+            ),
+        },
+        files=[
+            ("files", ("ignored-client-name.md", _markdown(), "text/markdown")),
+            ("files", ("ignored.png", b"\x89PNG\r\n\x1a\nrest", "image/png")),
+        ],
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["state"] == "confirmation_required"
+    assert {item["path"] for item in payload["fileManifest"]} == {
+        "SKILL.md",
+        "assets/pixel.png",
+    }
+    binary_preview = client.get(
+        f"/api/skills/imports/{payload['importId']}/file",
+        params={"path": "assets/pixel.png"},
+    )
+    assert binary_preview.status_code == 400
+    assert binary_preview.json()["detail"]["code"] == "skill_import_invalid_transport"
+
+
+def test_folder_manifest_mismatch_and_traversal_are_structured(app_client) -> None:
+    client, _store = app_client
+    mismatch = client.post(
+        "/api/skills/imports",
+        data={"transport_kind": "folder", "paths_json": json.dumps([])},
+        files=[("files", ("SKILL.md", _markdown(), "text/markdown"))],
+    )
+    assert mismatch.status_code == 400
+    assert mismatch.json()["detail"]["code"] == "skill_import_invalid_transport"
+
+    traversal = client.post(
+        "/api/skills/imports",
+        data={
+            "transport_kind": "folder",
+            "paths_json": json.dumps(["../SKILL.md"]),
+        },
+        files=[("files", ("SKILL.md", _markdown(), "text/markdown"))],
+    )
+    assert traversal.status_code == 400
+    assert traversal.json()["detail"]["code"] == "skill_import_path_unsafe"
+
+
+def test_wrong_optimistic_receipt_returns_structured_conflict(app_client) -> None:
+    client, _store = app_client
+    created = client.post(
+        "/api/skills/imports",
+        data={"transport_kind": "zip"},
+        files={
+            "archive": (
+                "skill.zip",
+                _zip({"SKILL.md": _markdown()}),
+                "application/zip",
+            )
+        },
+    ).json()
+
+    response = client.post(
+        f"/api/skills/imports/{created['importId']}/rescan",
+        json={
+            "expected_revision": created["revision"] + 1,
+            "expected_package_digest": created["packageDigest"],
+            "expected_trust_fingerprint": created["trustFingerprint"],
+        },
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"]["code"] == "skill_import_stale"
+
+
+def test_blocked_upload_does_not_echo_or_retain_secret(app_client) -> None:
+    client, store = app_client
+    secret = "sk-" + "apiuploadexampletoken123456789012345"
+    response = client.post(
+        "/api/skills/imports",
+        data={"transport_kind": "folder", "paths_json": json.dumps(["SKILL.md"])},
+        files=[
+            (
+                "files",
+                (
+                    "SKILL.md",
+                    _markdown().replace(b"1. Read the input.", f"1. TOKEN={secret}".encode()),
+                    "text/markdown",
+                ),
+            )
+        ],
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["state"] == "blocked"
+    assert payload["fileManifest"] == []
+    assert secret not in response.text
+    assert not (store.packages_root / payload["packageDigest"]).exists()


### PR DESCRIPTION
## 变更

- 增加本地 ZIP 与文件夹 Skill 的安全规范化、不可变存储和恢复机制。
- 复用第三方 Skill 字节树扫描器，生成绑定 import revision、transport digest 与 package digest 的本地信任凭据。
- 增加状态、上传、列表、详情、源码预览、重扫和删除 API。
- 默认保持 `SKILL_LOCAL_IMPORT_ENABLED=false`，并配置独立持久化目录。
- 合法 Python/JavaScript 需风险确认但可进入 Router；语法错误、可疑或不兼容脚本可安装确认但 Router 排除；秘密、无法审计二进制、嵌套归档和可执行文件阻断。

## 安全边界

- 不执行导入包脚本，不访问网络，不保留原始 ZIP。
- 拒绝路径穿越、链接、设备项、加密/异常 ZIP、大小写或 Unicode 冲突及超限内容。
- 单记录损坏隔离，顶层损坏失败关闭；中断扫描、临时目录、孤儿包和磁盘篡改均有恢复或阻断。
- 本 PR 不包含安装、替换、Runtime 激活或前端工作台；这些留给后续串行 PR。

## 验证

- 受影响范围：`97 passed, 1 deselected`。
- deselected 为既有 Python/TypeScript Finder 金标：server 镜像 Node 20 无法直接导入 `.ts`；使用宿主 Node 24 与容器 Python 独立计算的五组排序逐项一致。
- `python -m py_compile server/main.py server/skills/trust_scanner.py server/skills/local_import.py server/skills/local_import_api.py`
- `docker compose config --quiet`
- `git diff --check origin/main...HEAD`
- 高置信密钥、本机路径与临时预览端口扫描无命中。

## 回退

默认开关关闭；代码回退可直接 revert 本提交，不迁移或改写现有 Git、Creator、插件或内置 Skill 数据。