### PR TITLE
fix: 修复 MCP smoke SDK 收集冲突

### DIFF
--- a/server/sandbox_sidecar/smoke_file_artifacts.py
+++ b/server/sandbox_sidecar/smoke_file_artifacts.py
@@ -15,10 +15,11 @@ import tempfile
 import threading
 import time
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from mcp import ClientSession, StdioServerParameters
-from mcp.client.stdio import stdio_client
+if TYPE_CHECKING:
+    from mcp.client.session import ClientSession
+    from mcp.client.stdio import StdioServerParameters
 
 from .file_artifacts import (
     PANDOC_VERSION,
@@ -27,6 +28,15 @@ from .file_artifacts import (
     WAVE18A_TOOL_NAMES,
 )
 from .file_mcp import opaque_file_id
+
+
+def _load_mcp_stdio() -> tuple[Any, Any, Any]:
+    """Load the official SDK only inside isolated runtime smoke paths."""
+
+    from mcp.client.session import ClientSession
+    from mcp.client.stdio import StdioServerParameters, stdio_client
+
+    return ClientSession, StdioServerParameters, stdio_client
 
 
 BLOCKED_TOOL = {
@@ -183,6 +193,9 @@ async def _call_ok(session: ClientSession, name: str, arguments: dict[str, Any])
 
 
 async def _one_round(adapter_id: str, root: Path, round_number: int) -> dict[str, bytes]:
+    client_session_type, stdio_parameters_type, stdio_client_runtime = (
+        _load_mcp_stdio()
+    )
     workspace_id = "mcpws_" + hashlib.sha256(
         f"{adapter_id}:{round_number}".encode()
     ).hexdigest()[:32]
@@ -200,7 +213,7 @@ async def _one_round(adapter_id: str, root: Path, round_number: int) -> dict[str
     )
     env = _base_env(root, workspace_id)
     env["MCP_FILE_ADAPTER_ID"] = adapter_id
-    params = StdioServerParameters(
+    params = stdio_parameters_type(
         command=sys.executable,
         args=[
             "-m",
@@ -214,8 +227,8 @@ async def _one_round(adapter_id: str, root: Path, round_number: int) -> dict[str
         env=env,
         cwd=Path(env["TMPDIR"]),
     )
-    async with stdio_client(params) as (read_stream, write_stream):
-        async with ClientSession(read_stream, write_stream) as session:
+    async with stdio_client_runtime(params) as (read_stream, write_stream):
+        async with client_session_type(read_stream, write_stream) as session:
             await session.initialize()
             listed = await session.list_tools()
             if {tool.name for tool in listed.tools} != set(WAVE18A_TOOL_NAMES[adapter_id]):
@@ -419,6 +432,9 @@ def _pandoc_process_count() -> int:
 
 
 async def _timeout_probe(root: Path) -> None:
+    client_session_type, stdio_parameters_type, stdio_client_runtime = (
+        _load_mcp_stdio()
+    )
     adapter_id = "vivekvells-mcp-pandoc"
     workspace_id = "mcpws_" + "e" * 32
     input_root = root / "inputs" / workspace_id
@@ -431,7 +447,7 @@ async def _timeout_probe(root: Path) -> None:
     )
     proxy_env = _base_env(root, workspace_id)
     proxy_env["MCP_FILES_SOCKET_PATH"] = str(socket_path)
-    params = StdioServerParameters(
+    params = stdio_parameters_type(
         command=sys.executable,
         args=["-m", "sandbox_sidecar.smoke_file_artifacts", "--proxy", adapter_id],
         env=proxy_env,
@@ -439,8 +455,8 @@ async def _timeout_probe(root: Path) -> None:
     )
     started = time.monotonic()
     try:
-        async with stdio_client(params) as (read_stream, write_stream):
-            async with ClientSession(read_stream, write_stream) as session:
+        async with stdio_client_runtime(params) as (read_stream, write_stream):
+            async with client_session_type(read_stream, write_stream) as session:
                 await session.initialize()
                 try:
                     await asyncio.wait_for(

--- a/server/sandbox_sidecar/smoke_file_code_index.py
+++ b/server/sandbox_sidecar/smoke_file_code_index.py
@@ -16,10 +16,11 @@ import threading
 import time
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from mcp import ClientSession, StdioServerParameters
-from mcp.client.stdio import stdio_client
+if TYPE_CHECKING:
+    from mcp.client.session import ClientSession
+    from mcp.client.stdio import StdioServerParameters
 
 from .file_code_index import (
     GOGRAPH_ADAPTER_ID,
@@ -31,6 +32,15 @@ from .file_code_index import (
     WAVE20_TOOL_NAMES,
 )
 from .smoke_file_artifacts import _base_env, _start_file_server, _stop_process
+
+
+def _load_mcp_stdio() -> tuple[Any, Any, Any]:
+    """Load the official SDK only inside isolated runtime smoke paths."""
+
+    from mcp.client.session import ClientSession
+    from mcp.client.stdio import StdioServerParameters, stdio_client
+
+    return ClientSession, StdioServerParameters, stdio_client
 
 
 def _digest(tools: list[Any]) -> str:
@@ -240,6 +250,9 @@ async def _call_ok(
 
 
 async def _one_round(root: Path, round_number: int) -> dict[str, Any]:
+    client_session_type, stdio_parameters_type, stdio_client_runtime = (
+        _load_mcp_stdio()
+    )
     workspace_id = "mcpws_" + hashlib.sha256(
         f"wave20:{round_number}".encode("utf-8")
     ).hexdigest()[:32]
@@ -256,15 +269,15 @@ async def _one_round(root: Path, round_number: int) -> dict[str, Any]:
     )
     env = _base_env(root, workspace_id)
     env["MCP_FILES_SOCKET_PATH"] = str(socket_path)
-    params = StdioServerParameters(
+    params = stdio_parameters_type(
         command=sys.executable,
         args=["-m", "sandbox_sidecar.smoke_file_code_index", "--proxy"],
         env=env,
         cwd=Path(env["TMPDIR"]),
     )
     try:
-        async with stdio_client(params) as (read_stream, write_stream):
-            async with ClientSession(read_stream, write_stream) as session:
+        async with stdio_client_runtime(params) as (read_stream, write_stream):
+            async with client_session_type(read_stream, write_stream) as session:
                 await session.initialize()
                 listed = await session.list_tools()
                 if {tool.name for tool in listed.tools} != set(

--- a/server/sandbox_sidecar/smoke_public_adapters.py
+++ b/server/sandbox_sidecar/smoke_public_adapters.py
@@ -12,13 +12,23 @@ import sys
 import threading
 import time
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlsplit
 
-from mcp import ClientSession, StdioServerParameters
-from mcp.client.stdio import stdio_client
+if TYPE_CHECKING:
+    from mcp.client.session import ClientSession
+    from mcp.client.stdio import StdioServerParameters
 
 from .public_mcp import ADAPTER_TOOL_NAMES, BUILDERS, PUBLIC_SCHEMA_SHA256
+
+
+def _load_mcp_stdio() -> tuple[Any, Any, Any]:
+    """Load the official SDK only inside isolated runtime smoke paths."""
+
+    from mcp.client.session import ClientSession
+    from mcp.client.stdio import StdioServerParameters, stdio_client
+
+    return ClientSession, StdioServerParameters, stdio_client
 
 
 WAVE16A_ADAPTERS = frozenset(
@@ -201,7 +211,8 @@ async def _call(
 
 
 def _parameters(socket_path: Path, adapter_id: str) -> StdioServerParameters:
-    return StdioServerParameters(
+    _, stdio_parameters_type, _ = _load_mcp_stdio()
+    return stdio_parameters_type(
         command=sys.executable,
         args=[
             "-m",
@@ -236,8 +247,9 @@ async def _blocked_tool_is_denied(
 
 
 async def runtime_adapter(socket_path: Path, adapter_id: str) -> None:
-    async with stdio_client(_parameters(socket_path, adapter_id)) as streams:
-        async with ClientSession(*streams) as session:
+    client_session_type, _, stdio_client_runtime = _load_mcp_stdio()
+    async with stdio_client_runtime(_parameters(socket_path, adapter_id)) as streams:
+        async with client_session_type(*streams) as session:
             await session.initialize()
             listed = await session.list_tools()
             names = {tool.name for tool in listed.tools}
@@ -478,8 +490,9 @@ async def runtime_adapter(socket_path: Path, adapter_id: str) -> None:
 
 async def cancellation_timeout_probe(socket_path: Path, adapter_id: str) -> None:
     tool_name, arguments = TIMEOUT_TOOL_PROBES[adapter_id]
-    async with stdio_client(_parameters(socket_path, adapter_id)) as streams:
-        async with ClientSession(*streams) as session:
+    client_session_type, _, stdio_client_runtime = _load_mcp_stdio()
+    async with stdio_client_runtime(_parameters(socket_path, adapter_id)) as streams:
+        async with client_session_type(*streams) as session:
             await session.initialize()
             try:
                 await asyncio.wait_for(

--- a/server/tests/test_mcp_public_adapters.py
+++ b/server/tests/test_mcp_public_adapters.py
@@ -5,6 +5,9 @@ import base64
 import hashlib
 import json
 import socket
+import subprocess
+import sys
+import textwrap
 from pathlib import Path
 from typing import Any
 
@@ -71,6 +74,50 @@ from server.sandbox_sidecar.safe_http import (
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_smoke_modules_do_not_import_sdk_during_pytest_collection() -> None:
+    script = textwrap.dedent(
+        f"""
+        import importlib
+        import sys
+        from pathlib import Path
+
+        project_root = Path({str(PROJECT_ROOT)!r})
+        sys.path.insert(0, str(project_root / "server"))
+        for module_name in (
+            "server.sandbox_sidecar.smoke_public_adapters",
+            "server.sandbox_sidecar.smoke_file_artifacts",
+            "server.sandbox_sidecar.smoke_file_code_index",
+        ):
+            module = importlib.import_module(module_name)
+            for runtime_name in (
+                "ClientSession",
+                "StdioServerParameters",
+                "stdio_client",
+            ):
+                if hasattr(module, runtime_name):
+                    raise SystemExit(
+                        f"{{module_name}} eagerly imported {{runtime_name}}"
+                    )
+            client_session, stdio_parameters, stdio_client = module._load_mcp_stdio()
+            if client_session.__module__ != "mcp.client.session":
+                raise SystemExit(f"{{module_name}} loaded the wrong ClientSession")
+            if stdio_parameters.__module__ != "mcp.client.stdio":
+                raise SystemExit(f"{{module_name}} loaded the wrong stdio parameters")
+            if stdio_client.__module__ != "mcp.client.stdio":
+                raise SystemExit(f"{{module_name}} loaded the wrong stdio client")
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
 
 
 def test_public_url_policy_rejects_ssrf_primitives() -> None:


### PR DESCRIPTION
## 变更说明

- 将三个 MCP sidecar smoke 模块对官方 `mcp` SDK 的导入延迟到隔离 smoke 实际执行阶段。
- 避免 pytest 收集期间因仓库内 `server/mcp` 包遮蔽官方 SDK 顶层导出而触发 `ImportError`。
- 新增回归测试，模拟 CI 的 `server/` 优先搜索路径，并验证运行阶段仍加载官方 `ClientSession`、`StdioServerParameters` 和 `stdio_client`。

## 根因

`server/main.py` 会将 `server/` 放到 `sys.path` 前部。完整后端套件先导入 `server.main` 后，三个 smoke 测试模块在收集期执行 `from mcp import ClientSession`，此时 `mcp` 解析为仓库内 `server/mcp/__init__.py`，而不是官方 SDK 的顶层包，导致 Backend quality 在收集期失败。

## 影响

- 不修改生产 API、适配器策略或执行行为。
- 真实 smoke 执行时仍从官方 SDK 的深层模块加载客户端类型，并继续执行 initialize、tools/list 与 Schema 校验。

## 验证

- 原失败的三个测试模块：`37 passed, 2 skipped`
- Workflow contract：`4 passed`
- 完整后端 CI 命令：`2729 passed, 29 skipped`
- 前端 typecheck：通过
- 前端测试：`40 files / 186 tests passed`
- 前端生产构建：通过
- Windows Project Host：`86 passed, 1 skipped`
- `docker compose config --quiet`：通过
- `git diff --check`：通过

## 范围

仅包含 Gate 0 后端 CI 修复；不含 Wave 23 及后续适配器变更，不重建共享栈。
