### PR TITLE
feature: 接入本地 Skill 安装与激活门

### DIFF
--- a/server/skills/api.py
+++ b/server/skills/api.py
@@ -162,7 +162,13 @@ def get_skill_manager() -> SkillManager:
 
     global _skill_manager
     if _skill_manager is None:
-        _skill_manager = SkillManager()
+        # Resolve the process-wide import Store lazily to avoid duplicate
+        # in-memory projections of the same immutable receipt index.
+        from .local_import_api import get_skill_local_import_store
+
+        _skill_manager = SkillManager(
+            local_import_store=get_skill_local_import_store()
+        )
     return _skill_manager
 
 
@@ -337,7 +343,7 @@ def _payload_from_skill(skill: InstalledSkill) -> SkillPayload:
 
 
 def _trust_projection(skill: InstalledSkill) -> dict[str, object]:
-    if skill.source_kind != "git":
+    if skill.source_kind not in {"git", "local_import"}:
         return {
             "trust_router_eligible": True,
             "trust_activation_status": "not_applicable",
@@ -347,9 +353,9 @@ def _trust_projection(skill: InstalledSkill) -> dict[str, object]:
             "trust_reason_codes": [],
         }
     try:
-        decision = get_skill_manager().trust_service.activation_decision(
-            skill,
-            environment=None,
+        decision = get_skill_manager().trust_activation_decision(
+            skill.skill_id,
+            runtime_environment=None,
             check_runtime=False,
         ).to_dict()
     except SkillTrustError as exc:
@@ -633,25 +639,10 @@ async def acknowledge_installed_skill(
 ) -> SkillPayload:
     try:
         manager = get_skill_manager()
-        skill = await asyncio.to_thread(manager.get_installed_skill, skill_id)
-        expected = payload.expected_trust_fingerprint.lower()
-        if (
-            skill.source_kind != "git"
-            or skill.trust_state != "receipt_matched"
-            or skill.trust_fingerprint != expected
-        ):
-            raise SkillTrustError(
-                "Installed Skill trust receipt changed. Reload before confirming.",
-                code="skill_trust_candidate_stale",
-                details={
-                    "skillId": skill.skill_id,
-                    "trustFingerprint": skill.trust_fingerprint,
-                },
-            )
-        await asyncio.to_thread(
-            manager.trust_service.acknowledge,
-            skill_id=skill.skill_id,
-            trust_fingerprint=expected,
+        skill = await asyncio.to_thread(
+            manager.acknowledge_trust,
+            skill_id,
+            expected_trust_fingerprint=payload.expected_trust_fingerprint,
             confirmed=payload.confirmed,
         )
         return _payload_from_skill(skill)
@@ -698,13 +689,29 @@ async def uninstall_skill(skill_id: str) -> dict[str, bool]:
             repaired = await asyncio.to_thread(
                 get_skill_draft_store().mark_uninstalled_skill, skill_id
             )
-            if repaired is None:
+            local_repaired = []
+            if manager.local_import_store is not None:
+                local_repaired = await asyncio.to_thread(
+                    manager.local_import_store.mark_uninstalled_skill, skill_id
+                )
+            if repaired is None and not local_repaired:
                 raise
+            if local_repaired:
+                await asyncio.to_thread(manager.trust_service.revoke, skill_id)
             return {"ok": True}
         if installed_before and installed_before.source_kind == "workspace_draft":
             await asyncio.to_thread(
                 get_skill_draft_store().mark_uninstalled_skill, skill_id
             )
+        if (
+            installed_before
+            and installed_before.source_kind == "local_import"
+            and manager.local_import_store is not None
+        ):
+            await asyncio.to_thread(
+                manager.local_import_store.mark_uninstalled_skill, skill_id
+            )
+            await asyncio.to_thread(manager.trust_service.revoke, skill_id)
         return {"ok": True}
     except SkillNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc

--- a/server/skills/finder.py
+++ b/server/skills/finder.py
@@ -316,6 +316,21 @@ class SkillFinder:
         for order, skill in enumerate(installed):
             if _source_key(skill.repo_url, skill.sub_path) in catalog_sources:
                 continue
+            trust = None
+            if str(getattr(skill, "source_kind", "")) == "local_import":
+                trust = {
+                    "receiptId": getattr(skill, "trust_receipt_id", None),
+                    "trustFingerprint": getattr(skill, "trust_fingerprint", None),
+                    "riskLevel": getattr(skill, "trust_risk_level", None),
+                    "trustStatus": getattr(skill, "trust_status", None),
+                    "installPolicy": getattr(skill, "trust_install_policy", None),
+                    "compatibilityStatus": getattr(
+                        skill, "trust_compatibility_status", None
+                    ),
+                    "routerEligible": bool(
+                        getattr(skill, "trust_router_eligible", False)
+                    ),
+                }
             payload = {
                 "candidateId": f"installed:{skill.skill_id}",
                 "sourceType": "installed",
@@ -344,6 +359,8 @@ class SkillFinder:
                     "sourceKind": skill.source_kind,
                 },
             }
+            if trust is not None:
+                payload["trust"] = trust
             dynamic.append(
                 {
                     **payload,
@@ -451,11 +468,21 @@ class SkillFinder:
                 )
                 or (
                     candidate.get("sourceType") == "installed"
-                    and str(
-                        ((candidate.get("installedSource") or {}).get("sourceKind"))
-                        or "git"
+                    and (
+                        (
+                            str(
+                                ((candidate.get("installedSource") or {}).get("sourceKind"))
+                                or "git"
+                            )
+                            == "local_import"
+                            and bool((candidate.get("trust") or {}).get("routerEligible"))
+                        )
+                        or str(
+                            ((candidate.get("installedSource") or {}).get("sourceKind"))
+                            or "git"
+                        )
+                        in {"workspace_draft", "plugin"}
                     )
-                    != "git"
                 )
             ]
         prepared: list[dict[str, Any]] = []

--- a/server/skills/local_import.py
+++ b/server/skills/local_import.py
@@ -15,7 +15,7 @@ import uuid
 import zipfile
 from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
-from typing import Any, Iterable, Literal, Mapping, Sequence
+from typing import Any, Callable, Iterable, Literal, Mapping, Sequence, TypeVar
 
 from .package_validation import (
     SkillPackageIssue,
@@ -54,6 +54,7 @@ ImportState = Literal[
     "stale",
 ]
 TransportKind = Literal["zip", "folder"]
+_InstallResult = TypeVar("_InstallResult")
 
 _LOCAL_ID_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 _DRIVE_RE = re.compile(r"^[A-Za-z]:")
@@ -1077,6 +1078,130 @@ class SkillLocalImportStore:
             files = self._read_package_unlocked(record.package_digest)
             self._verify_package_unlocked(record, files)
             return self.packages_root / record.package_digest
+
+    def install_current(
+        self,
+        import_id: str,
+        *,
+        expected_revision: int,
+        expected_package_digest: str,
+        expected_trust_fingerprint: str,
+        installer: Callable[[LocalSkillImport, Path], _InstallResult],
+    ) -> tuple[LocalSkillImport, _InstallResult]:
+        """Install one frozen import and persist its projection atomically.
+
+        The installer runs while the import record is locked so a rescan cannot
+        replace the receipt between final verification and installation.  If
+        the Store write fails after the filesystem transaction, retrying the
+        same request is safe because the manager installation is idempotent.
+        """
+
+        clean_digest = str(expected_package_digest or "").casefold()
+        clean_fingerprint = str(expected_trust_fingerprint or "").casefold()
+        with self._lock:
+            self._ensure_available(mutation=True)
+            current = self._records.get(str(import_id))
+            if current is None:
+                raise SkillLocalImportNotFoundError(
+                    "Local Skill import was not found.", code="skill_import_not_found"
+                )
+            if (
+                current.revision != expected_revision
+                or current.package_digest != clean_digest
+                or current.trust_fingerprint != clean_fingerprint
+            ):
+                raise SkillLocalImportConflictError(
+                    "Local Skill import changed. Reload before installing.",
+                    code="skill_import_stale",
+                )
+            if current.state in {
+                "blocked",
+                "failed",
+                "archived",
+                "stale",
+                "superseded",
+            }:
+                raise SkillLocalImportConflictError(
+                    "This local Skill import is not installable.",
+                    code=(
+                        "skill_import_blocked"
+                        if current.state == "blocked"
+                        else "skill_import_stale"
+                    ),
+                )
+            if not current.local_skill_id or not current.trust_receipt:
+                raise SkillLocalImportConflictError(
+                    "This local Skill import is missing a stable Skill ID or trust receipt.",
+                    code="skill_import_stale",
+                )
+            files = self._read_package_unlocked(clean_digest)
+            self._verify_package_unlocked(current, files)
+            package_dir = self.packages_root / clean_digest
+            result = installer(copy.deepcopy(current), package_dir)
+            now = time.time()
+            records = dict(self._records)
+            for other_id, other in list(records.items()):
+                if (
+                    other_id != current.import_id
+                    and other.installed_skill_id == current.local_skill_id
+                    and other.state == "installed"
+                ):
+                    superseded = copy.deepcopy(other)
+                    superseded.revision += 1
+                    superseded.state = "superseded"
+                    superseded.installed_skill_id = None
+                    superseded.updated_at = now
+                    records[other_id] = superseded
+            updated = copy.deepcopy(current)
+            if updated.state != "installed" or updated.installed_skill_id != current.local_skill_id:
+                updated.revision += 1
+            updated.state = "installed"
+            updated.installed_skill_id = current.local_skill_id
+            updated.error_code = None
+            updated.updated_at = now
+            records[current.import_id] = updated
+            self._save_records_unlocked(records)
+            self._records = records
+            return copy.deepcopy(updated), result
+
+    def mark_uninstalled_skill(self, skill_id: str) -> list[LocalSkillImport]:
+        """Clear installed projections after the global package is removed."""
+
+        clean_skill_id = _validate_local_skill_id(skill_id)
+        if clean_skill_id is None:
+            return []
+        with self._lock:
+            # Disabling imports must not strand an already-installed package.
+            self._ensure_available()
+            records = dict(self._records)
+            changed: list[LocalSkillImport] = []
+            now = time.time()
+            for import_id, item in list(records.items()):
+                if item.installed_skill_id != clean_skill_id:
+                    continue
+                updated = copy.deepcopy(item)
+                updated.revision += 1
+                updated.installed_skill_id = None
+                policy = str(
+                    (updated.trust_receipt or {}).get("installPolicy") or "block"
+                )
+                updated.state = (
+                    "ready"
+                    if policy == "allow"
+                    else "confirmation_required"
+                    if policy == "confirm"
+                    else "blocked"
+                )
+                updated.error_code = (
+                    "skill_import_blocked" if updated.state == "blocked" else None
+                )
+                updated.updated_at = now
+                records[import_id] = updated
+                changed.append(copy.deepcopy(updated))
+            if changed:
+                self._save_records_unlocked(records)
+                self._records = records
+            return changed
 
     def preview_file(self, import_id: str, path: str) -> str:
         clean_path = _normalize_path(path)

--- a/server/skills/local_import_api.py
+++ b/server/skills/local_import_api.py
@@ -16,6 +16,8 @@ from .local_import import (
     SkillLocalImportStorageError,
     SkillLocalImportStore,
 )
+from .skill_manager import SkillInstallError, SkillManagerError, SkillValidationError
+from .trust_service import SkillTrustError
 from .trust_scanner import (
     MAX_TRUST_FILE_BYTES,
     MAX_TRUST_FILES,
@@ -55,6 +57,27 @@ class LocalImportRescanRequest(BaseModel):
         pattern=r"^[0-9a-fA-F]{64}$",
     )
     expected_trust_fingerprint: str = Field(
+        min_length=64,
+        max_length=64,
+        pattern=r"^[0-9a-fA-F]{64}$",
+    )
+
+
+class LocalImportInstallRequest(BaseModel):
+    expected_revision: int = Field(ge=1)
+    expected_package_digest: str = Field(
+        min_length=64,
+        max_length=64,
+        pattern=r"^[0-9a-fA-F]{64}$",
+    )
+    expected_trust_fingerprint: str = Field(
+        min_length=64,
+        max_length=64,
+        pattern=r"^[0-9a-fA-F]{64}$",
+    )
+    confirmed: bool = False
+    expected_installed_digest: str | None = Field(
+        default=None,
         min_length=64,
         max_length=64,
         pattern=r"^[0-9a-fA-F]{64}$",
@@ -104,6 +127,34 @@ def _raise_import_error(exc: SkillLocalImportError) -> None:
     raise HTTPException(
         status_code=status,
         detail={"code": exc.code, "message": str(exc), "details": exc.details},
+    ) from exc
+
+
+def _raise_install_error(exc: Exception) -> None:
+    fallback_code = (
+        "skill_import_storage_unavailable"
+        if isinstance(exc, (SkillInstallError, SkillManagerError))
+        and not isinstance(exc, SkillValidationError)
+        else "skill_import_scan_failed"
+    )
+    code = str(getattr(exc, "code", "") or fallback_code)
+    details = dict(getattr(exc, "details", {}) or {})
+    if code in {
+        "skill_import_stale",
+        "skill_import_replace_required",
+        "skill_import_package_mismatch",
+        "skill_import_ack_required",
+        "skill_trust_ack_required",
+        "skill_trust_candidate_stale",
+    }:
+        status = 409
+    elif code in {"skill_import_storage_unavailable", "skill_trust_index_unavailable"}:
+        status = 503
+    else:
+        status = 400 if isinstance(exc, (SkillValidationError, SkillTrustError)) else 500
+    raise HTTPException(
+        status_code=status,
+        detail={"code": code, "message": str(exc), "details": details},
     ) from exc
 
 
@@ -220,9 +271,32 @@ async def get_local_import(import_id: str) -> dict[str, Any]:
     store = get_skill_local_import_store()
     _require_enabled(store)
     try:
-        return _serialize(await asyncio.to_thread(store.require, import_id))
+        record = await asyncio.to_thread(store.require, import_id)
+        payload = _serialize(record)
+        if (
+            record.package_digest
+            and record.file_manifest
+            and record.state not in {"blocked", "failed", "archived"}
+        ):
+            from .api import get_skill_manager
+
+            manager = get_skill_manager()
+            manager.local_import_store = store
+            package_dir = await asyncio.to_thread(
+                store.package_directory, import_id
+            )
+            payload["replacementPreview"] = await asyncio.to_thread(
+                manager.describe_local_import_replacement,
+                record=record,
+                package_dir=package_dir,
+            )
+        else:
+            payload["replacementPreview"] = None
+        return payload
     except SkillLocalImportError as exc:
         _raise_import_error(exc)
+    except (SkillValidationError, SkillManagerError) as exc:
+        _raise_install_error(exc)
 
 
 @router.get("/{import_id}/file")
@@ -257,6 +331,51 @@ async def rescan_local_import(
         return _serialize(record)
     except SkillLocalImportError as exc:
         _raise_import_error(exc)
+
+
+@router.post("/{import_id}/install")
+async def install_local_import(
+    import_id: str,
+    payload: LocalImportInstallRequest,
+) -> dict[str, Any]:
+    store = get_skill_local_import_store()
+    _require_enabled(store)
+    try:
+        # Imported lazily so the existing /api/skills manager remains the one
+        # authoritative installed-package registry.
+        from .api import _payload_from_skill, get_skill_manager
+
+        manager = get_skill_manager()
+        manager.local_import_store = store
+
+        updated, installed = await asyncio.to_thread(
+            manager.install_local_import_current,
+            import_id,
+            expected_revision=payload.expected_revision,
+            expected_package_digest=payload.expected_package_digest,
+            expected_trust_fingerprint=payload.expected_trust_fingerprint,
+            confirmed=payload.confirmed,
+            expected_installed_digest=payload.expected_installed_digest,
+        )
+        if str((updated.trust_receipt or {}).get("installPolicy") or "") == "confirm":
+            installed = await asyncio.to_thread(
+                manager.acknowledge_trust,
+                installed.skill_id,
+                expected_trust_fingerprint=payload.expected_trust_fingerprint,
+                confirmed=payload.confirmed,
+            )
+        return {
+            "import": _serialize(updated),
+            "installed": _payload_from_skill(installed).model_dump(mode="json"),
+        }
+    except SkillLocalImportError as exc:
+        _raise_import_error(exc)
+    except (SkillValidationError, SkillTrustError, SkillInstallError, SkillManagerError) as exc:
+        _raise_install_error(exc)
+    except (OSError, ValueError) as exc:
+        _raise_install_error(
+            SkillInstallError("Local Skill installation storage is unavailable.")
+        )
 
 
 @router.delete("/{import_id}")

--- a/server/skills/skill_manager.py
+++ b/server/skills/skill_manager.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import difflib
 import hashlib
 import json
 import os
@@ -16,12 +17,31 @@ from typing import Any, Literal, Mapping
 from urllib.parse import urlparse
 
 from .draft_store import SkillDraftValidationError, WorkspaceSkillDraftStore
+from .local_import import LocalSkillImport, SkillLocalImportError, SkillLocalImportStore
 from .package_validation import compute_package_digest
 from .trust_service import (
     SkillRuntimeEnvironment,
     SkillTrustError,
     SkillTrustService,
 )
+
+
+_REPLACE_DIFF_FILE_CHARS = 8 * 1024
+_REPLACE_DIFF_TOTAL_CHARS = 128 * 1024
+_REPLACE_CHANGE_LIMIT = 500
+_PASSIVE_BINARY_SUFFIXES = {
+    ".gif",
+    ".jpeg",
+    ".jpg",
+    ".mp3",
+    ".mp4",
+    ".pdf",
+    ".png",
+    ".wav",
+    ".webp",
+    ".woff",
+    ".woff2",
+}
 
 
 class SkillManagerError(Exception):
@@ -74,6 +94,7 @@ class InstalledSkill:
     trust_status: str | None = None
     trust_install_policy: str | None = None
     trust_compatibility_status: str | None = None
+    trust_router_eligible: bool = False
     trust_package_digest: str | None = None
     trust_directory_tree_sha: str | None = None
     trust_verified_at: float | None = None
@@ -101,6 +122,7 @@ class SkillInstallReceipt:
     installed_metadata: dict[str, object]
     created_at: float
     previous_content_digest: str | None = None
+    source_kind: Literal["workspace_draft", "local_import"] = "workspace_draft"
 
 
 class SkillManager:
@@ -119,6 +141,7 @@ class SkillManager:
         allow_local_repos: bool = False,
         git_timeout_seconds: int = 30,
         trust_service: SkillTrustService | None = None,
+        local_import_store: SkillLocalImportStore | None = None,
     ) -> None:
         package_dir = Path(__file__).resolve().parent
         self.installed_dir = Path(
@@ -133,6 +156,7 @@ class SkillManager:
         self.git_timeout_seconds = git_timeout_seconds
         self.metadata_path = self.installed_dir / "installed.json"
         self.trust_service = trust_service or SkillTrustService()
+        self.local_import_store = local_import_store
         self._lock = threading.RLock()
         self._trust_reconciled = False
 
@@ -439,6 +463,439 @@ class SkillManager:
                     raise SkillInstallError("Workspace Skill metadata was not created.")
                 return metadata
 
+    def install_local_import(
+        self,
+        *,
+        record: LocalSkillImport,
+        package_dir: Path,
+        confirmed: bool = False,
+        expected_installed_digest: str | None = None,
+    ) -> InstalledSkill:
+        """Install or explicitly replace one immutable local import package."""
+
+        if (
+            not record.local_skill_id
+            or not record.package_digest
+            or not record.trust_receipt
+        ):
+            raise SkillValidationError(
+                "Local Skill import is incomplete.", code="skill_import_stale"
+            )
+        skill_id = self._validate_skill_id(record.local_skill_id)
+        expected_previous = (
+            str(expected_installed_digest or "").strip().casefold() or None
+        )
+        if expected_previous is not None and not re.fullmatch(
+            r"[a-f0-9]{64}", expected_previous
+        ):
+            raise SkillValidationError(
+                "Expected installed digest is invalid.",
+                code="skill_import_package_mismatch",
+            )
+        try:
+            local_receipt = self.trust_service.validate_local_receipt(
+                record.trust_receipt,
+                import_id=record.import_id,
+                import_revision=record.content_revision,
+                package_digest=record.package_digest,
+            )
+            self.trust_service.local_import_decision(
+                local_receipt,
+                skill_id=skill_id,
+                import_id=record.import_id,
+                import_revision=record.content_revision,
+                package_digest=record.package_digest,
+                ephemeral_trust_fingerprint=(
+                    record.trust_fingerprint if confirmed else None
+                ),
+                environment=None,
+            )
+        except SkillTrustError as exc:
+            raise SkillValidationError(
+                str(exc), code=exc.code, details=exc.details
+            ) from exc
+        actual_source_digest = self.trust_service.compute_directory_digest(
+            package_dir
+        )
+        if actual_source_digest != record.package_digest:
+            raise SkillValidationError(
+                "Local Skill package no longer matches its import receipt.",
+                code="skill_import_package_mismatch",
+            )
+        trust_metadata = self.trust_service.receipt_metadata(
+            local_receipt, verified_at=time.time()
+        )
+
+        with self._lock:
+            self._ensure_dirs()
+            installed = self._read_metadata()
+            self._recover_install_receipt(
+                skill_id,
+                source_kind="local_import",
+                source_id=record.import_id,
+            )
+            installed = self._read_metadata()
+            target_dir = self._safe_skill_dir(skill_id)
+            previous_record = installed.get(skill_id)
+            previous_metadata = (
+                self._installed_skill_from_record(previous_record)
+                if previous_record is not None
+                else None
+            )
+            previous_content_digest = ""
+            if target_dir.exists() and previous_record is None:
+                raise SkillInstallError(
+                    "Local Skill target exists without installed metadata."
+                )
+            if previous_metadata is not None:
+                if previous_metadata.source_kind != "local_import":
+                    raise SkillValidationError(
+                        "A local import cannot replace a Skill from another source.",
+                        code="skill_import_replace_required",
+                    )
+                try:
+                    current_package_dir = self._resolve_package_directory(
+                        skill_id, previous_record or {}
+                    )
+                    previous_content_digest = self._directory_content_digest(
+                        current_package_dir
+                    )
+                except SkillNotFoundError:
+                    previous_content_digest = ""
+                if (
+                    previous_content_digest != previous_metadata.content_digest
+                    or not previous_content_digest
+                ):
+                    raise SkillValidationError(
+                        "Installed local Skill bytes no longer match metadata.",
+                        code="skill_import_package_mismatch",
+                    )
+                if previous_content_digest == record.package_digest:
+                    metadata = self._parse_skill_metadata(
+                        skill_id,
+                        f"local-import://{record.import_id}",
+                        "",
+                        current_package_dir / "SKILL.md",
+                        source_kind="local_import",
+                        source_id=record.import_id,
+                        source_revision=record.content_revision,
+                        content_digest=record.package_digest,
+                        trust_metadata=trust_metadata,
+                    )
+                    installed[skill_id] = asdict(metadata)
+                    self._write_metadata(installed)
+                    return metadata
+                if expected_previous is None:
+                    raise SkillValidationError(
+                        "Installing this import would replace a different local package.",
+                        code="skill_import_replace_required",
+                        details={
+                            "skillId": skill_id,
+                            "installedDigest": previous_content_digest,
+                            "newDigest": record.package_digest,
+                        },
+                    )
+                if expected_previous != previous_content_digest:
+                    raise SkillValidationError(
+                        "Installed local Skill changed. Reload before replacing it.",
+                        code="skill_import_package_mismatch",
+                    )
+            elif expected_previous is not None:
+                raise SkillValidationError(
+                    "The local Skill to replace is no longer installed.",
+                    code="skill_import_package_mismatch",
+                )
+
+            transaction_id = uuid.uuid4().hex
+            staging_dir = self.installed_dir / f".{skill_id}.staging-{transaction_id}"
+            backup_dir = self.installed_dir / f".{skill_id}.backup-{transaction_id}"
+            metadata: InstalledSkill | None = None
+            receipt: SkillInstallReceipt | None = None
+            swapped = False
+            metadata_write_attempted = False
+            try:
+                shutil.copytree(package_dir, staging_dir, symlinks=True)
+                if self.trust_service.compute_directory_digest(staging_dir) != record.package_digest:
+                    raise SkillValidationError(
+                        "Local Skill package changed while it was being installed.",
+                        code="skill_import_package_mismatch",
+                    )
+                metadata = self._parse_skill_metadata(
+                    skill_id,
+                    f"local-import://{record.import_id}",
+                    "",
+                    staging_dir / "SKILL.md",
+                    source_kind="local_import",
+                    source_id=record.import_id,
+                    source_revision=record.content_revision,
+                    content_digest=record.package_digest,
+                    trust_metadata=trust_metadata,
+                )
+                receipt = SkillInstallReceipt(
+                    version=1,
+                    transaction_id=transaction_id,
+                    phase="prepared",
+                    skill_id=skill_id,
+                    source_id=record.import_id,
+                    source_revision=record.content_revision,
+                    content_digest=record.package_digest,
+                    package_subpath="",
+                    staging_name=staging_dir.name,
+                    backup_name=backup_dir.name,
+                    previous_metadata=(
+                        dict(previous_record) if previous_record is not None else None
+                    ),
+                    installed_metadata=asdict(metadata),
+                    created_at=time.time(),
+                    previous_content_digest=previous_content_digest or None,
+                    source_kind="local_import",
+                )
+                self._write_install_receipt(receipt)
+                if target_dir.exists():
+                    target_dir.rename(backup_dir)
+                staging_dir.rename(target_dir)
+                swapped = True
+                self._write_install_receipt(replace(receipt, phase="swapped"))
+                installed[skill_id] = asdict(metadata)
+                metadata_write_attempted = True
+                self._write_metadata(installed)
+                self._write_install_receipt(replace(receipt, phase="committed"))
+            except Exception:
+                rollback_error: Exception | None = None
+                try:
+                    if backup_dir.exists():
+                        self._remove_directory_if_present(target_dir)
+                        backup_dir.rename(target_dir)
+                    elif (swapped or previous_record is None) and target_dir.exists():
+                        self._remove_directory_if_present(target_dir)
+                    if metadata_write_attempted:
+                        restored = self._read_metadata()
+                        if previous_record is None:
+                            restored.pop(skill_id, None)
+                        else:
+                            restored[skill_id] = dict(previous_record)
+                        self._write_metadata(restored)
+                    self._remove_directory_if_present(staging_dir)
+                    self._remove_directory_if_present(backup_dir)
+                    self._receipt_path(skill_id).unlink(missing_ok=True)
+                except Exception as exc:
+                    rollback_error = exc
+                if rollback_error is not None:
+                    raise SkillInstallError(
+                        "Local Skill installation failed and rollback is incomplete; "
+                        "retry the same installation to recover."
+                    ) from rollback_error
+                raise
+            else:
+                try:
+                    self._remove_directory_if_present(backup_dir)
+                    self._remove_directory_if_present(staging_dir)
+                    self._receipt_path(skill_id).unlink(missing_ok=True)
+                except Exception as exc:
+                    raise SkillInstallError(
+                        "Local Skill was installed, but transaction cleanup is incomplete; "
+                        "retry the same installation to recover."
+                    ) from exc
+                if metadata is None:
+                    raise SkillInstallError("Local Skill metadata was not created.")
+                return metadata
+
+    def install_local_import_current(
+        self,
+        import_id: str,
+        *,
+        expected_revision: int,
+        expected_package_digest: str,
+        expected_trust_fingerprint: str,
+        confirmed: bool = False,
+        expected_installed_digest: str | None = None,
+    ) -> tuple[LocalSkillImport, InstalledSkill]:
+        """Install a frozen import while preserving a single lock order.
+
+        Runtime activation acquires the manager lock before consulting the
+        import Store. Installation must use the same manager-to-Store order so
+        concurrent activation, rescan, and replacement cannot deadlock.
+        """
+
+        if self.local_import_store is None:
+            raise SkillValidationError(
+                "Local Skill import storage is unavailable.",
+                code="skill_import_storage_unavailable",
+            )
+        with self._lock:
+            return self.local_import_store.install_current(
+                import_id,
+                expected_revision=expected_revision,
+                expected_package_digest=expected_package_digest,
+                expected_trust_fingerprint=expected_trust_fingerprint,
+                installer=lambda frozen, package_dir: self.install_local_import(
+                    record=frozen,
+                    package_dir=package_dir,
+                    confirmed=confirmed,
+                    expected_installed_digest=expected_installed_digest,
+                ),
+            )
+
+    def describe_local_import_replacement(
+        self,
+        *,
+        record: LocalSkillImport,
+        package_dir: Path,
+    ) -> dict[str, Any] | None:
+        """Return a bounded, read-only replacement preview for the console."""
+
+        if not record.local_skill_id or not record.package_digest:
+            return None
+        skill_id = self._validate_skill_id(record.local_skill_id)
+        if (
+            self.trust_service.compute_directory_digest(package_dir)
+            != record.package_digest
+        ):
+            raise SkillValidationError(
+                "Local Skill package no longer matches its import receipt.",
+                code="skill_import_package_mismatch",
+            )
+        with self._lock:
+            installed = self._read_metadata()
+            previous_record = installed.get(skill_id)
+            if previous_record is None:
+                return None
+            previous = self._installed_skill_from_record(previous_record)
+            base = {
+                "skillId": skill_id,
+                "sourceKind": previous.source_kind,
+                "installedDigest": previous.content_digest,
+                "newDigest": record.package_digest,
+            }
+            if previous.source_kind != "local_import":
+                return {
+                    **base,
+                    "required": False,
+                    "allowed": False,
+                    "errorCode": "skill_import_replace_required",
+                    "changes": [],
+                    "changesTruncated": False,
+                    "diffTruncated": False,
+                }
+            try:
+                previous_dir = self._resolve_package_directory(
+                    skill_id, previous_record
+                )
+                actual_previous_digest = self._directory_content_digest(previous_dir)
+            except SkillManagerError:
+                return {
+                    **base,
+                    "required": True,
+                    "allowed": False,
+                    "errorCode": "skill_import_package_mismatch",
+                    "changes": [],
+                    "changesTruncated": False,
+                    "diffTruncated": False,
+                }
+            if actual_previous_digest != previous.content_digest:
+                return {
+                    **base,
+                    "required": True,
+                    "allowed": False,
+                    "errorCode": "skill_import_package_mismatch",
+                    "changes": [],
+                    "changesTruncated": False,
+                    "diffTruncated": False,
+                }
+            old_files = self._package_bytes(previous_dir)
+            new_files = self._package_bytes(package_dir)
+            return {
+                **base,
+                "required": actual_previous_digest != record.package_digest,
+                "allowed": True,
+                "errorCode": None,
+                **self._replacement_changes(old_files, new_files),
+            }
+
+    @staticmethod
+    def _package_bytes(package_dir: Path) -> dict[str, bytes]:
+        files: dict[str, bytes] = {}
+        for path in sorted(package_dir.rglob("*")):
+            if path.is_symlink():
+                raise SkillValidationError(
+                    "Skill package contains an unsafe link.",
+                    code="skill_import_package_mismatch",
+                )
+            if path.is_file():
+                files[path.relative_to(package_dir).as_posix()] = path.read_bytes()
+        return files
+
+    @staticmethod
+    def _replacement_changes(
+        old_files: Mapping[str, bytes],
+        new_files: Mapping[str, bytes],
+    ) -> dict[str, Any]:
+        changes: list[dict[str, Any]] = []
+        diff_chars = 0
+        diff_truncated = False
+        all_paths = sorted(set(old_files) | set(new_files))
+        for path in all_paths:
+            old = old_files.get(path)
+            new = new_files.get(path)
+            if old == new:
+                continue
+            status = "added" if old is None else "removed" if new is None else "changed"
+            old_bytes = old or b""
+            new_bytes = new or b""
+            suffix = Path(path).suffix.casefold()
+            is_binary = suffix in _PASSIVE_BINARY_SUFFIXES
+            old_text: str | None = None
+            new_text: str | None = None
+            if not is_binary:
+                try:
+                    old_text = old_bytes.decode("utf-8", errors="strict")
+                    new_text = new_bytes.decode("utf-8", errors="strict")
+                except UnicodeDecodeError:
+                    is_binary = True
+            change: dict[str, Any] = {
+                "path": path,
+                "status": status,
+                "kind": "binary" if is_binary else "text",
+                "oldSizeBytes": len(old_bytes) if old is not None else None,
+                "newSizeBytes": len(new_bytes) if new is not None else None,
+                "oldSha256": hashlib.sha256(old_bytes).hexdigest()
+                if old is not None
+                else None,
+                "newSha256": hashlib.sha256(new_bytes).hexdigest()
+                if new is not None
+                else None,
+            }
+            if not is_binary and old_text is not None and new_text is not None:
+                raw_diff = "\n".join(
+                    difflib.unified_diff(
+                        old_text.splitlines(),
+                        new_text.splitlines(),
+                        fromfile=f"installed/{path}",
+                        tofile=f"import/{path}",
+                        lineterm="",
+                    )
+                )
+                remaining = max(0, _REPLACE_DIFF_TOTAL_CHARS - diff_chars)
+                allowed = min(_REPLACE_DIFF_FILE_CHARS, remaining)
+                if len(raw_diff) > allowed:
+                    diff_truncated = True
+                if allowed:
+                    change["diff"] = raw_diff[:allowed]
+                    change["diffTruncated"] = len(raw_diff) > allowed
+                    diff_chars += min(len(raw_diff), allowed)
+                else:
+                    change["diff"] = ""
+                    change["diffTruncated"] = bool(raw_diff)
+            changes.append(change)
+        changes_truncated = len(changes) > _REPLACE_CHANGE_LIMIT
+        if changes_truncated:
+            changes = changes[:_REPLACE_CHANGE_LIMIT]
+        return {
+            "changes": changes,
+            "changesTruncated": changes_truncated,
+            "diffTruncated": diff_truncated or changes_truncated,
+        }
+
     def install_plugin_skill(
         self,
         *,
@@ -611,6 +1068,51 @@ class SkillManager:
     ) -> InstalledSkill:
         """Apply the final server-side third-party activation gate."""
 
+        try:
+            normalized_skill_id = self._validate_skill_id(skill_id)
+            with self._lock:
+                installed = self._read_metadata()
+                record = installed.get(normalized_skill_id)
+                if record is None:
+                    raise SkillNotFoundError(
+                        f"Skill '{normalized_skill_id}' is not installed"
+                    )
+                if self._reconcile_skill_trust_metadata_unlocked(
+                    normalized_skill_id, record
+                ):
+                    self._write_metadata(installed)
+                item = self._installed_skill_from_record(record)
+                local_receipt = (
+                    self._resolve_local_import_receipt_unlocked(item)
+                    if item.source_kind == "local_import"
+                    and self.trust_service.mode != "off"
+                    else None
+                )
+            self.trust_service.activation_decision(
+                item,
+                environment=runtime_environment,
+                ephemeral_authorizations=ephemeral_authorizations,
+                check_runtime=check_runtime,
+                local_receipt=local_receipt,
+            )
+        except (SkillTrustError, SkillLocalImportError) as exc:
+            raise SkillValidationError(
+                str(exc),
+                code=str(getattr(exc, "code", "") or "skill_trust_receipt_missing"),
+                details=dict(getattr(exc, "details", {}) or {}),
+            ) from exc
+        return item
+
+    def trust_activation_decision(
+        self,
+        skill_id: str,
+        *,
+        runtime_environment: SkillRuntimeEnvironment | None = None,
+        ephemeral_authorizations: Mapping[str, str] | None = None,
+        check_runtime: bool = True,
+    ):
+        """Return the server-authoritative activation decision for UI projection."""
+
         normalized_skill_id = self._validate_skill_id(skill_id)
         with self._lock:
             installed = self._read_metadata()
@@ -624,17 +1126,67 @@ class SkillManager:
             ):
                 self._write_metadata(installed)
             item = self._installed_skill_from_record(record)
-        try:
-            self.trust_service.activation_decision(
-                item,
-                environment=runtime_environment,
-                ephemeral_authorizations=ephemeral_authorizations,
-                check_runtime=check_runtime,
+            local_receipt = (
+                self._resolve_local_import_receipt_unlocked(item)
+                if item.source_kind == "local_import"
+                and self.trust_service.mode != "off"
+                else None
             )
-        except SkillTrustError as exc:
-            raise SkillValidationError(
-                str(exc), code=exc.code, details=exc.details
-            ) from exc
+        return self.trust_service.activation_decision(
+            item,
+            environment=runtime_environment,
+            ephemeral_authorizations=ephemeral_authorizations,
+            check_runtime=check_runtime,
+            local_receipt=local_receipt,
+        )
+
+    def acknowledge_trust(
+        self,
+        skill_id: str,
+        *,
+        expected_trust_fingerprint: str,
+        confirmed: bool,
+    ) -> InstalledSkill:
+        """Persist one exact Git or local-import acknowledgement."""
+
+        normalized_skill_id = self._validate_skill_id(skill_id)
+        expected = str(expected_trust_fingerprint or "").casefold()
+        with self._lock:
+            installed = self._read_metadata()
+            record = installed.get(normalized_skill_id)
+            if record is None:
+                raise SkillNotFoundError(
+                    f"Skill '{normalized_skill_id}' is not installed"
+                )
+            if self._reconcile_skill_trust_metadata_unlocked(
+                normalized_skill_id, record
+            ):
+                self._write_metadata(installed)
+            item = self._installed_skill_from_record(record)
+            if (
+                item.source_kind not in {"git", "local_import"}
+                or item.trust_state != "receipt_matched"
+                or item.trust_fingerprint != expected
+            ):
+                raise SkillTrustError(
+                    "Installed Skill trust receipt changed. Reload before confirming.",
+                    code="skill_trust_candidate_stale",
+                    details={
+                        "skillId": item.skill_id,
+                        "trustFingerprint": item.trust_fingerprint,
+                    },
+                )
+            local_receipt = (
+                self._resolve_local_import_receipt_unlocked(item)
+                if item.source_kind == "local_import"
+                else None
+            )
+        self.trust_service.acknowledge(
+            skill_id=item.skill_id,
+            trust_fingerprint=expected,
+            confirmed=confirmed,
+            receipt=local_receipt,
+        )
         return item
 
     @staticmethod
@@ -726,6 +1278,7 @@ class SkillManager:
             trust_compatibility_status=_optional_string(
                 record.get("trust_compatibility_status")
             ),
+            trust_router_eligible=bool(record.get("trust_router_eligible", False)),
             trust_package_digest=_optional_string(
                 record.get("trust_package_digest")
             ),
@@ -761,23 +1314,87 @@ class SkillManager:
         record: dict[str, object],
     ) -> bool:
         item = self._installed_skill_from_record(record)
-        if item.source_kind != "git" or self.trust_service.mode == "off":
+        if self.trust_service.mode == "off":
             return False
         package_dir: Path | None
         try:
             package_dir = self._resolve_package_directory(skill_id, record)
         except SkillManagerError:
             package_dir = None
-        trust_metadata = self.trust_service.reconcile_metadata(
-            record=record,
-            package_dir=package_dir,
-        )
+        if item.source_kind == "local_import":
+            try:
+                receipt = self._resolve_local_import_receipt_unlocked(
+                    item, package_dir=package_dir
+                )
+                trust_metadata = self.trust_service.receipt_metadata(
+                    receipt, verified_at=item.trust_verified_at or time.time()
+                )
+            except (SkillLocalImportError, SkillTrustError, ValueError):
+                trust_metadata = self.trust_service.unverified_metadata()
+        elif item.source_kind == "git":
+            trust_metadata = self.trust_service.reconcile_metadata(
+                record=record,
+                package_dir=package_dir,
+            )
+        else:
+            return False
         if not any(
             record.get(key) != value for key, value in trust_metadata.items()
         ):
             return False
         record.update(trust_metadata)
         return True
+
+    def _resolve_local_import_receipt_unlocked(
+        self,
+        item: InstalledSkill,
+        *,
+        package_dir: Path | None = None,
+    ) -> dict[str, Any]:
+        if self.local_import_store is None or item.source_kind != "local_import":
+            raise SkillTrustError(
+                "Local Skill trust receipt is unavailable.",
+                code="skill_trust_receipt_missing",
+            )
+        import_id = str(item.source_id or "")
+        try:
+            record = self.local_import_store.require(import_id)
+        except SkillLocalImportError as exc:
+            raise SkillTrustError(
+                "Local Skill trust receipt is unavailable.",
+                code="skill_trust_receipt_missing",
+            ) from exc
+        if (
+            record.content_revision != item.source_revision
+            or record.package_digest != item.content_digest
+            or record.installed_skill_id != item.skill_id
+        ):
+            raise SkillTrustError(
+                "Installed local Skill no longer matches its import receipt.",
+                code="skill_trust_receipt_missing",
+            )
+        resolved_package = package_dir
+        if resolved_package is None:
+            metadata = self._read_metadata().get(item.skill_id)
+            if metadata is None:
+                raise SkillTrustError(
+                    "Installed local Skill metadata is unavailable.",
+                    code="skill_trust_receipt_missing",
+                )
+            resolved_package = self._resolve_package_directory(
+                item.skill_id, metadata
+            )
+        if self._directory_content_digest(resolved_package) != item.content_digest:
+            raise SkillTrustError(
+                "Installed local Skill bytes no longer match its import receipt.",
+                code="skill_trust_package_mismatch",
+            )
+        return self.trust_service.validate_local_receipt(
+            record.trust_receipt,
+            import_id=record.import_id,
+            import_revision=record.content_revision,
+            package_digest=record.package_digest,
+        )
 
     def _resolve_package_directory(
         self, skill_id: str, record: dict[str, object]
@@ -857,6 +1474,7 @@ class SkillManager:
             receipt.version != 1
             or receipt.skill_id != skill_id
             or receipt.phase not in {"prepared", "swapped", "committed"}
+            or receipt.source_kind not in {"workspace_draft", "local_import"}
             or not re.fullmatch(r"[a-f0-9]{32}", receipt.transaction_id)
             or not re.fullmatch(r"[a-f0-9]{64}", receipt.content_digest)
             or (
@@ -891,7 +1509,7 @@ class SkillManager:
         )
         if (
             installed_item.skill_id != receipt.skill_id
-            or installed_item.source_kind != "workspace_draft"
+            or installed_item.source_kind != receipt.source_kind
             or installed_item.source_id != receipt.source_id
             or installed_item.source_revision != receipt.source_revision
             or installed_item.content_digest != receipt.content_digest
@@ -911,12 +1529,25 @@ class SkillManager:
     def _recover_workspace_install_receipt(
         self, skill_id: str, draft_id: str
     ) -> None:
+        self._recover_install_receipt(
+            skill_id,
+            source_kind="workspace_draft",
+            source_id=draft_id,
+        )
+
+    def _recover_install_receipt(
+        self,
+        skill_id: str,
+        *,
+        source_kind: Literal["workspace_draft", "local_import"],
+        source_id: str,
+    ) -> None:
         receipt = self._read_install_receipt(skill_id)
         if receipt is None:
             return
-        if receipt.source_id != draft_id:
+        if receipt.source_kind != source_kind or receipt.source_id != source_id:
             raise SkillInstallError(
-                "Workspace Skill install receipt belongs to another draft."
+                "Skill install receipt belongs to another immutable source."
             )
         target_dir = self._safe_skill_dir(skill_id)
         staging_dir = self._transaction_dir(
@@ -1141,6 +1772,9 @@ class SkillManager:
             ),
             trust_compatibility_status=_optional_string(
                 trust_values.get("trust_compatibility_status")
+            ),
+            trust_router_eligible=bool(
+                trust_values.get("trust_router_eligible", False)
             ),
             trust_package_digest=_optional_string(
                 trust_values.get("trust_package_digest")

--- a/server/skills/trust_service.py
+++ b/server/skills/trust_service.py
@@ -352,24 +352,137 @@ class SkillTrustService:
         trust_fingerprint: str,
         confirmed: bool,
         actor_kind: str = "local_console",
+        receipt: Mapping[str, Any] | None = None,
     ) -> SkillTrustAcknowledgement:
         if not confirmed:
             raise SkillTrustError(
                 "Skill trust acknowledgement requires explicit confirmation.",
                 code="skill_trust_ack_required",
             )
-        receipt = self.receipt_by_fingerprint(trust_fingerprint)
-        if receipt["installPolicy"] != "confirm":
+        resolved_receipt = (
+            self.validate_local_receipt(receipt)
+            if receipt is not None
+            else self.receipt_by_fingerprint(trust_fingerprint)
+        )
+        if resolved_receipt["trustFingerprint"] != trust_fingerprint.casefold():
+            raise SkillTrustError(
+                "Skill trust receipt changed. Reload before confirming.",
+                code="skill_trust_candidate_stale",
+            )
+        if resolved_receipt["installPolicy"] != "confirm":
             raise SkillTrustError(
                 "This Skill receipt cannot be acknowledged.",
                 code="skill_trust_policy_blocked",
             )
         return self.acknowledgements.acknowledge(
             skill_id=skill_id,
-            receipt_id=receipt["receiptId"],
-            trust_fingerprint=receipt["trustFingerprint"],
+            receipt_id=resolved_receipt["receiptId"],
+            trust_fingerprint=resolved_receipt["trustFingerprint"],
             actor_kind=actor_kind,
         )
+
+    @staticmethod
+    def validate_local_receipt(
+        receipt: Mapping[str, Any] | None,
+        *,
+        import_id: str | None = None,
+        import_revision: int | None = None,
+        package_digest: str | None = None,
+    ) -> dict[str, Any]:
+        """Validate a detached local-import receipt without the catalog index."""
+
+        if not isinstance(receipt, Mapping):
+            raise SkillTrustError(
+                "Local Skill trust receipt is unavailable.",
+                code="skill_trust_receipt_missing",
+            )
+        clean = json.loads(json.dumps(dict(receipt), ensure_ascii=False))
+        try:
+            _receipt_id(str(clean.get("receiptId") or ""))
+            fingerprint = _sha256(
+                str(clean.get("trustFingerprint") or ""), "trust fingerprint"
+            )
+            if sha256_json(
+                {key: value for key, value in clean.items() if key != "trustFingerprint"}
+            ) != fingerprint:
+                raise ValueError("fingerprint mismatch")
+            source = clean.get("source")
+            if not isinstance(source, dict) or source.get("kind") != "local_import":
+                raise ValueError("source mismatch")
+            if not re.fullmatch(
+                r"skillimport_[0-9a-f]{32}", str(source.get("importId") or "")
+            ):
+                raise ValueError("invalid import ID")
+            source_revision = source.get("importRevision")
+            if (
+                not isinstance(source_revision, int)
+                or isinstance(source_revision, bool)
+                or source_revision < 1
+            ):
+                raise ValueError("invalid import revision")
+            if source.get("transportKind") not in {"zip", "folder"}:
+                raise ValueError("invalid transport")
+            _sha256(str(source.get("transportDigest") or ""), "transport digest")
+            receipt_digest = _sha256(
+                str(clean.get("packageDigest") or ""), "package digest"
+            )
+            if clean.get("riskLevel") not in {"low", "medium", "high", "critical"}:
+                raise ValueError("invalid risk")
+            if clean.get("installPolicy") not in {"allow", "confirm", "block"}:
+                raise ValueError("invalid install policy")
+            if clean.get("trustStatus") not in {"verified", "conditional", "blocked"}:
+                raise ValueError("invalid trust status")
+            if clean.get("compatibilityStatus") not in {
+                "portable",
+                "conditional",
+                "unsupported",
+            }:
+                raise ValueError("invalid compatibility status")
+            if not isinstance(clean.get("routerEligible"), bool):
+                raise ValueError("invalid Router eligibility")
+            if import_id is not None and source.get("importId") != import_id:
+                raise ValueError("import ID mismatch")
+            if import_revision is not None and source_revision != import_revision:
+                raise ValueError("import revision mismatch")
+            if package_digest is not None and receipt_digest != package_digest.casefold():
+                raise ValueError("package digest mismatch")
+        except (TypeError, ValueError, SkillTrustError) as exc:
+            if isinstance(exc, SkillTrustError):
+                raise
+            raise SkillTrustError(
+                "Local Skill trust receipt is invalid.",
+                code="skill_trust_receipt_missing",
+            ) from exc
+        return clean
+
+    def local_import_decision(
+        self,
+        receipt: Mapping[str, Any] | None,
+        *,
+        skill_id: str | None,
+        import_id: str | None = None,
+        import_revision: int | None = None,
+        package_digest: str | None = None,
+        ephemeral_trust_fingerprint: str | None = None,
+        environment: SkillRuntimeEnvironment | None = None,
+    ) -> SkillTrustDecision:
+        if self.mode == "off":
+            return self._off_decision()
+        clean = self.validate_local_receipt(
+            receipt,
+            import_id=import_id,
+            import_revision=import_revision,
+            package_digest=package_digest,
+        )
+        decision = self._evaluate_receipt(
+            clean,
+            skill_id=skill_id,
+            ephemeral_trust_fingerprint=ephemeral_trust_fingerprint,
+            allow_pending_confirmation=False,
+            environment=environment,
+        )
+        self._raise_if_denied(decision)
+        return decision
 
     def revoke(self, skill_id: str) -> bool:
         return self.acknowledgements.revoke(skill_id)
@@ -541,11 +654,46 @@ class SkillTrustService:
         environment: SkillRuntimeEnvironment | None,
         ephemeral_authorizations: Mapping[str, str] | None = None,
         check_runtime: bool = True,
+        local_receipt: Mapping[str, Any] | None = None,
     ) -> SkillTrustDecision:
-        if str(getattr(installed_skill, "source_kind", "git")) != "git":
-            return self._off_decision(trust_status="not_applicable")
+        source_kind = str(getattr(installed_skill, "source_kind", "git"))
         if self.mode == "off":
             return self._off_decision()
+        if source_kind == "local_import":
+            skill_id = str(getattr(installed_skill, "skill_id", "") or "")
+            ephemeral = dict(ephemeral_authorizations or {}).get(skill_id)
+            clean = self.validate_local_receipt(
+                local_receipt,
+                import_id=str(getattr(installed_skill, "source_id", "") or ""),
+                import_revision=getattr(installed_skill, "source_revision", None),
+                package_digest=str(
+                    getattr(installed_skill, "content_digest", "") or ""
+                ),
+            )
+            state_matches = bool(
+                getattr(installed_skill, "trust_state", "") == "receipt_matched"
+                and getattr(installed_skill, "trust_receipt_id", None)
+                == clean["receiptId"]
+                and getattr(installed_skill, "trust_fingerprint", None)
+                == clean["trustFingerprint"]
+                and getattr(installed_skill, "trust_package_digest", None)
+                == clean["packageDigest"]
+            )
+            if not state_matches:
+                decision = self._missing_decision("skill_trust_receipt_missing")
+                self._raise_if_denied(decision)
+                return decision
+            decision = self._evaluate_receipt(
+                clean,
+                skill_id=skill_id,
+                ephemeral_trust_fingerprint=ephemeral,
+                allow_pending_confirmation=False,
+                environment=environment if check_runtime else None,
+            )
+            self._raise_if_denied(decision)
+            return decision
+        if source_kind != "git":
+            return self._off_decision(trust_status="not_applicable")
         source_ref = str(getattr(installed_skill, "source_ref", "") or "")
         try:
             receipt = self.resolve_source(
@@ -679,6 +827,7 @@ class SkillTrustService:
             "trust_status": receipt.get("trustStatus"),
             "trust_install_policy": receipt.get("installPolicy"),
             "trust_compatibility_status": receipt.get("compatibilityStatus"),
+            "trust_router_eligible": bool(receipt.get("routerEligible", False)),
             "trust_package_digest": receipt.get("packageDigest"),
             "trust_directory_tree_sha": receipt.get("directoryTreeSha"),
             "trust_verified_at": verified_at,
@@ -694,6 +843,7 @@ class SkillTrustService:
             "trust_status": "unknown",
             "trust_install_policy": "block",
             "trust_compatibility_status": "unsupported",
+            "trust_router_eligible": False,
             "trust_package_digest": None,
             "trust_directory_tree_sha": None,
             "trust_verified_at": None,
@@ -1095,7 +1245,10 @@ def _sha256(value: str, label: str) -> str:
 
 def _receipt_id(value: str) -> str:
     normalized = str(value or "").strip()
-    if not re.fullmatch(r"skill-trust-[0-9a-f]{24}", normalized):
+    if not re.fullmatch(
+        r"(?:skill-trust-[0-9a-f]{24}|trust_local_[0-9a-f]{32})",
+        normalized,
+    ):
         raise SkillTrustError(
             "Skill trust receipt id is invalid.",
             code="skill_trust_receipt_missing",

--- a/server/tests/test_skill_finder.py
+++ b/server/tests/test_skill_finder.py
@@ -113,6 +113,71 @@ def test_installed_only_skill_can_be_found_and_resolved() -> None:
     assert resolved["installSource"] is None
 
 
+def test_local_import_router_candidate_is_bound_to_trust_fingerprint() -> None:
+    eligible = InstalledSkill(
+        skill_id="local-audit",
+        name="本地审计报告",
+        description="整理本地审计记录并生成报告",
+        repo_url="local-import://skillimport_" + "a" * 32,
+        sub_path="",
+        installed_at=1_700_000_000.0,
+        source_kind="local_import",
+        source_id="skillimport_" + "a" * 32,
+        source_revision=1,
+        content_digest="b" * 64,
+        trust_state="receipt_matched",
+        trust_receipt_id="trust_local_" + "c" * 32,
+        trust_fingerprint="d" * 64,
+        trust_risk_level="medium",
+        trust_status="conditional",
+        trust_install_policy="confirm",
+        trust_compatibility_status="conditional",
+        trust_router_eligible=True,
+        trust_package_digest="b" * 64,
+    )
+    excluded = InstalledSkill(
+        **{
+            **eligible.__dict__,
+            "skill_id": "local-obfuscated",
+            "name": "本地混淆脚本",
+            "repo_url": "local-import://skillimport_" + "e" * 32,
+            "source_id": "skillimport_" + "e" * 32,
+            "trust_fingerprint": "f" * 64,
+            "trust_router_eligible": False,
+        }
+    )
+    finder = SkillFinder(
+        index_path=INDEX_PATH,
+        skill_manager=StubSkillManager([eligible, excluded]),
+    )
+
+    routed = finder.find("本地审计报告", router_eligible_only=True)
+    match = next(
+        item
+        for item in routed["results"]
+        if item["candidateId"] == "installed:local-audit"
+    )
+    assert match["trust"]["trustFingerprint"] == "d" * 64
+    assert match["trust"]["routerEligible"] is True
+    assert "installed:local-obfuscated" not in {
+        item["candidateId"]
+        for item in finder.find("本地混淆脚本", router_eligible_only=True)["results"]
+    }
+
+    changed = InstalledSkill(
+        **{**eligible.__dict__, "trust_fingerprint": "1" * 64}
+    )
+    changed_candidate = next(
+        item
+        for item in SkillFinder(
+            index_path=INDEX_PATH,
+            skill_manager=StubSkillManager([changed]),
+        ).candidates()
+        if item["candidateId"] == "installed:local-audit"
+    )
+    assert changed_candidate["candidateFingerprint"] != match["candidateFingerprint"]
+
+
 def test_catalog_candidate_reports_exact_stale_and_missing_install_state() -> None:
     base = SkillFinder(index_path=INDEX_PATH, skill_manager=StubSkillManager())
     candidate = base._load_index()["candidates"][0]

--- a/server/tests/test_skill_local_import_api.py
+++ b/server/tests/test_skill_local_import_api.py
@@ -9,8 +9,15 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from skills.api import router as skills_router
+from skills.api import set_skill_manager_for_tests
 from skills.local_import import SkillLocalImportStore
-from skills.local_import_api import configure_skill_local_import, router
+from skills.local_import_api import (
+    configure_skill_local_import,
+    router as import_router,
+)
+from skills.skill_manager import SkillManager
+from skills.trust_service import SkillTrustAcknowledgementStore, SkillTrustService
 
 
 def _markdown(name: str = "upload-example") -> bytes:
@@ -34,12 +41,26 @@ def _zip(files: dict[str, bytes]) -> bytes:
 @pytest.fixture()
 def app_client(tmp_path: Path):
     store = SkillLocalImportStore(tmp_path / "imports", enabled=True)
+    manager = SkillManager(
+        installed_dir=tmp_path / "installed",
+        tmp_dir=tmp_path / "skill-tmp",
+        local_import_store=store,
+        trust_service=SkillTrustService(
+            mode="enforce",
+            acknowledgement_store=SkillTrustAcknowledgementStore(
+                path=tmp_path / "trust-acknowledgements.json"
+            ),
+        ),
+    )
     configure_skill_local_import(store)
+    set_skill_manager_for_tests(manager)
     app = FastAPI()
-    app.include_router(router)
+    app.include_router(import_router)
+    app.include_router(skills_router)
     with TestClient(app) as client:
-        yield client, store
+        yield client, store, manager
     configure_skill_local_import(None)
+    set_skill_manager_for_tests(None)
 
 
 def test_status_is_readable_while_disabled(tmp_path: Path) -> None:
@@ -47,7 +68,7 @@ def test_status_is_readable_while_disabled(tmp_path: Path) -> None:
         SkillLocalImportStore(tmp_path / "imports", enabled=False)
     )
     app = FastAPI()
-    app.include_router(router)
+    app.include_router(import_router)
     with TestClient(app) as client:
         status = client.get("/api/skills/imports/status")
         listing = client.get("/api/skills/imports")
@@ -61,7 +82,7 @@ def test_status_is_readable_while_disabled(tmp_path: Path) -> None:
 
 
 def test_zip_upload_detail_preview_rescan_and_delete(app_client) -> None:
-    client, _store = app_client
+    client, _store, _manager = app_client
     response = client.post(
         "/api/skills/imports",
         data={"transport_kind": "zip"},
@@ -129,7 +150,7 @@ def test_zip_upload_detail_preview_rescan_and_delete(app_client) -> None:
 
 
 def test_folder_upload_uses_server_validated_path_manifest(app_client) -> None:
-    client, _store = app_client
+    client, _store, _manager = app_client
     response = client.post(
         "/api/skills/imports",
         data={
@@ -160,7 +181,7 @@ def test_folder_upload_uses_server_validated_path_manifest(app_client) -> None:
 
 
 def test_folder_manifest_mismatch_and_traversal_are_structured(app_client) -> None:
-    client, _store = app_client
+    client, _store, _manager = app_client
     mismatch = client.post(
         "/api/skills/imports",
         data={"transport_kind": "folder", "paths_json": json.dumps([])},
@@ -182,7 +203,7 @@ def test_folder_manifest_mismatch_and_traversal_are_structured(app_client) -> No
 
 
 def test_wrong_optimistic_receipt_returns_structured_conflict(app_client) -> None:
-    client, _store = app_client
+    client, _store, _manager = app_client
     created = client.post(
         "/api/skills/imports",
         data={"transport_kind": "zip"},
@@ -209,7 +230,7 @@ def test_wrong_optimistic_receipt_returns_structured_conflict(app_client) -> Non
 
 
 def test_blocked_upload_does_not_echo_or_retain_secret(app_client) -> None:
-    client, store = app_client
+    client, store, _manager = app_client
     secret = "sk-" + "apiuploadexampletoken123456789012345"
     response = client.post(
         "/api/skills/imports",
@@ -232,3 +253,203 @@ def test_blocked_upload_does_not_echo_or_retain_secret(app_client) -> None:
     assert payload["fileManifest"] == []
     assert secret not in response.text
     assert not (store.packages_root / payload["packageDigest"]).exists()
+
+
+def test_install_endpoint_persists_projection_and_confirmation(app_client) -> None:
+    client, store, manager = app_client
+    created = client.post(
+        "/api/skills/imports",
+        data={
+            "transport_kind": "folder",
+            "paths_json": json.dumps(["SKILL.md", "scripts/check.py"]),
+        },
+        files=[
+            (
+                "files",
+                (
+                    "SKILL.md",
+                    _markdown("local-script").replace(
+                        b"1. Read the input.",
+                        b"1. Run `python scripts/check.py`.",
+                    ),
+                    "text/markdown",
+                ),
+            ),
+            ("files", ("check.py", b"print('ok')\n", "text/x-python")),
+        ],
+    ).json()
+
+    pending = client.post(
+        f"/api/skills/imports/{created['importId']}/install",
+        json={
+            "expected_revision": created["revision"],
+            "expected_package_digest": created["packageDigest"],
+            "expected_trust_fingerprint": created["trustFingerprint"],
+            "confirmed": False,
+        },
+    )
+    assert pending.status_code == 409
+    assert pending.json()["detail"]["code"] == "skill_trust_ack_required"
+
+    installed = client.post(
+        f"/api/skills/imports/{created['importId']}/install",
+        json={
+            "expected_revision": created["revision"],
+            "expected_package_digest": created["packageDigest"],
+            "expected_trust_fingerprint": created["trustFingerprint"],
+            "confirmed": True,
+        },
+    )
+    assert installed.status_code == 200, installed.text
+    payload = installed.json()
+    assert payload["import"]["state"] == "installed"
+    assert payload["installed"]["source_kind"] == "local_import"
+    assert payload["installed"]["trust_activation_allowed"] is True
+    assert manager.trust_service.acknowledgements.is_acknowledged(
+        "local-script", created["trustFingerprint"]
+    )
+    assert store.require(created["importId"]).installed_skill_id == "local-script"
+
+
+def test_uninstall_retry_repairs_import_projection_and_revokes_ack(app_client) -> None:
+    client, store, manager = app_client
+    created = client.post(
+        "/api/skills/imports",
+        data={
+            "transport_kind": "folder",
+            "paths_json": json.dumps(["SKILL.md", "scripts/check.py"]),
+        },
+        files=[
+            (
+                "files",
+                (
+                    "SKILL.md",
+                    _markdown("local-uninstall-retry").replace(
+                        b"1. Read the input.",
+                        b"1. Run `python scripts/check.py`.",
+                    ),
+                    "text/markdown",
+                ),
+            ),
+            ("files", ("check.py", b"print('ok')\n", "text/x-python")),
+        ],
+    ).json()
+    installed = client.post(
+        f"/api/skills/imports/{created['importId']}/install",
+        json={
+            "expected_revision": created["revision"],
+            "expected_package_digest": created["packageDigest"],
+            "expected_trust_fingerprint": created["trustFingerprint"],
+            "confirmed": True,
+        },
+    )
+    assert installed.status_code == 200, installed.text
+    skill_id = installed.json()["installed"]["skill_id"]
+    assert manager.trust_service.acknowledgements.is_acknowledged(
+        skill_id, created["trustFingerprint"]
+    )
+
+    # Simulate a request interrupted after global files were removed but
+    # before the Import Store projection and acknowledgement were cleared.
+    manager.uninstall_skill(skill_id)
+    retried = client.delete(f"/api/skills/{skill_id}")
+
+    assert retried.status_code == 200, retried.text
+    current = store.require(created["importId"])
+    assert current.installed_skill_id is None
+    assert current.state == "confirmation_required"
+    assert not manager.trust_service.acknowledgements.is_acknowledged(
+        skill_id, created["trustFingerprint"]
+    )
+
+
+def test_install_endpoint_requires_explicit_replace_digest(app_client) -> None:
+    client, _store, _manager = app_client
+
+    def upload(body: bytes) -> dict:
+        return client.post(
+            "/api/skills/imports",
+            data={
+                "transport_kind": "folder",
+                "paths_json": json.dumps(["SKILL.md"]),
+            },
+            files=[("files", ("SKILL.md", body, "text/markdown"))],
+        ).json()
+
+    first = upload(_markdown("local-replace"))
+    first_install = client.post(
+        f"/api/skills/imports/{first['importId']}/install",
+        json={
+            "expected_revision": first["revision"],
+            "expected_package_digest": first["packageDigest"],
+            "expected_trust_fingerprint": first["trustFingerprint"],
+        },
+    ).json()
+    second = upload(
+        _markdown("local-replace").replace(b"Return the result", b"Return the revised result")
+    )
+    preview = client.get(f"/api/skills/imports/{second['importId']}")
+    assert preview.status_code == 200, preview.text
+    replacement = preview.json()["replacementPreview"]
+    assert replacement["required"] is True
+    assert replacement["allowed"] is True
+    changed = next(
+        item for item in replacement["changes"] if item["path"] == "SKILL.md"
+    )
+    assert changed["kind"] == "text"
+    assert "revised result" in changed["diff"]
+
+    required = client.post(
+        f"/api/skills/imports/{second['importId']}/install",
+        json={
+            "expected_revision": second["revision"],
+            "expected_package_digest": second["packageDigest"],
+            "expected_trust_fingerprint": second["trustFingerprint"],
+        },
+    )
+    assert required.status_code == 409
+    assert required.json()["detail"]["code"] == "skill_import_replace_required"
+
+    replaced = client.post(
+        f"/api/skills/imports/{second['importId']}/install",
+        json={
+            "expected_revision": second["revision"],
+            "expected_package_digest": second["packageDigest"],
+            "expected_trust_fingerprint": second["trustFingerprint"],
+            "expected_installed_digest": first_install["installed"]["content_digest"],
+        },
+    )
+    assert replaced.status_code == 200, replaced.text
+    assert replaced.json()["installed"]["content_digest"] == second["packageDigest"]
+
+
+def test_install_storage_failure_uses_stable_service_error(
+    app_client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    client, _store, manager = app_client
+    created = client.post(
+        "/api/skills/imports",
+        data={
+            "transport_kind": "folder",
+            "paths_json": json.dumps(["SKILL.md"]),
+        },
+        files=[
+            ("files", ("SKILL.md", _markdown("local-storage-failure"), "text/markdown"))
+        ],
+    ).json()
+
+    def fail_metadata(_payload):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(manager, "_write_metadata", fail_metadata)
+    response = client.post(
+        f"/api/skills/imports/{created['importId']}/install",
+        json={
+            "expected_revision": created["revision"],
+            "expected_package_digest": created["packageDigest"],
+            "expected_trust_fingerprint": created["trustFingerprint"],
+        },
+    )
+
+    assert response.status_code == 503
+    assert response.json()["detail"]["code"] == "skill_import_storage_unavailable"

--- a/server/tests/test_skill_local_import_install.py
+++ b/server/tests/test_skill_local_import_install.py
@@ -1,0 +1,474 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from skills.finder import SkillFinder
+from skills.local_import import SkillLocalImportError, SkillLocalImportStore
+from skills.skill_manager import InstalledSkill, SkillManager, SkillValidationError
+from skills.trust_service import (
+    SkillRuntimeEnvironment,
+    SkillTrustAcknowledgementStore,
+    SkillTrustService,
+)
+from xpert_runtime.sandbox_store import SandboxWorkspace
+from xpert_runtime.sandbox_toolset import (
+    SKILL_STAGE_MAX_FILE_BYTES,
+    SKILL_STAGE_MAX_FILES,
+    SKILL_STAGE_MAX_TOTAL_BYTES,
+    SandboxToolsetProvider,
+)
+from xpert_runtime.toolset import RuntimeToolCall, RuntimeToolError
+
+
+ROOT = Path(__file__).resolve().parents[2]
+RUNTIME_INDEX = ROOT / "server" / "skills" / "data" / "skill_runtime_index.json"
+
+
+def _markdown(name: str, body: str = "1. Read the input.\n2. Return the result.") -> bytes:
+    return (
+        "---\n"
+        f"name: {name}\n"
+        "description: Use this local Skill for a bounded deterministic task.\n"
+        "---\n\n"
+        "## Workflow\n\n"
+        f"{body}\n"
+    ).encode()
+
+
+def _manager(tmp_path: Path, store: SkillLocalImportStore) -> SkillManager:
+    trust = SkillTrustService(
+        mode="enforce",
+        acknowledgement_store=SkillTrustAcknowledgementStore(
+            path=tmp_path / "trust-acknowledgements.json"
+        ),
+    )
+    return SkillManager(
+        installed_dir=tmp_path / "installed",
+        tmp_dir=tmp_path / "tmp",
+        trust_service=trust,
+        local_import_store=store,
+    )
+
+
+def _install(
+    store: SkillLocalImportStore,
+    manager: SkillManager,
+    record,
+    *,
+    confirmed: bool = False,
+    expected_installed_digest: str | None = None,
+):
+    return manager.install_local_import_current(
+        record.import_id,
+        expected_revision=record.revision,
+        expected_package_digest=record.package_digest,
+        expected_trust_fingerprint=record.trust_fingerprint,
+        confirmed=confirmed,
+        expected_installed_digest=expected_installed_digest,
+    )
+
+
+def test_low_risk_local_import_install_is_idempotent_and_activatable(
+    tmp_path: Path,
+) -> None:
+    store = SkillLocalImportStore(tmp_path / "imports", enabled=True)
+    record = store.create_from_folder(
+        [("SKILL.md", _markdown("local-report"))]
+    )
+    manager = _manager(tmp_path, store)
+
+    installed_record, installed = _install(store, manager, record)
+    replay_record, replayed = _install(store, manager, installed_record)
+
+    assert installed_record.state == "installed"
+    assert installed.source_kind == "local_import"
+    assert installed.source_id == record.import_id
+    assert installed.source_revision == record.content_revision
+    assert installed.content_digest == record.package_digest
+    assert installed.trust_state == "receipt_matched"
+    assert replay_record.revision == installed_record.revision
+    assert replayed.content_digest == installed.content_digest
+    assert manager.require_activation("local-report").skill_id == "local-report"
+
+    manager.trust_service.mode = "off"
+    manager.local_import_store = None
+    assert manager.require_activation("local-report").skill_id == "local-report"
+
+
+def test_confirmed_script_install_still_requires_persistent_activation_ack(
+    tmp_path: Path,
+) -> None:
+    store = SkillLocalImportStore(tmp_path / "imports", enabled=True)
+    record = store.create_from_folder(
+        [
+            (
+                "SKILL.md",
+                _markdown(
+                    "local-script",
+                    "1. Run `python scripts/check.py`.\n2. Return the output.",
+                ),
+            ),
+            ("scripts/check.py", b"print('ok')\n"),
+        ]
+    )
+    manager = _manager(tmp_path, store)
+
+    with pytest.raises(SkillValidationError) as error:
+        _install(store, manager, record)
+    assert error.value.code == "skill_trust_ack_required"
+
+    installed_record, installed = _install(store, manager, record, confirmed=True)
+    with pytest.raises(SkillValidationError) as activation_error:
+        manager.require_activation(
+            installed.skill_id,
+            runtime_environment=SkillRuntimeEnvironment.installation_baseline(),
+        )
+    assert activation_error.value.code == "skill_trust_ack_required"
+
+    manager.trust_service.acknowledge(
+        skill_id=installed.skill_id,
+        trust_fingerprint=installed_record.trust_fingerprint,
+        confirmed=True,
+        receipt=installed_record.trust_receipt,
+    )
+    assert (
+        manager.require_activation(
+            installed.skill_id,
+            runtime_environment=SkillRuntimeEnvironment.installation_baseline(),
+        ).skill_id
+        == "local-script"
+    )
+
+
+def test_replacement_is_explicit_and_supersedes_previous_import(
+    tmp_path: Path,
+) -> None:
+    store = SkillLocalImportStore(tmp_path / "imports", enabled=True)
+    first = store.create_from_folder(
+        [("SKILL.md", _markdown("local-report", "1. Return version one."))]
+    )
+    manager = _manager(tmp_path, store)
+    first_installed_record, first_installed = _install(store, manager, first)
+    second = store.create_from_folder(
+        [("SKILL.md", _markdown("local-report", "1. Return version two."))]
+    )
+
+    with pytest.raises(SkillValidationError) as error:
+        _install(store, manager, second)
+    assert error.value.code == "skill_import_replace_required"
+
+    second_record, second_installed = _install(
+        store,
+        manager,
+        second,
+        expected_installed_digest=first_installed.content_digest,
+    )
+
+    assert second_record.state == "installed"
+    assert second_installed.skill_id == first_installed.skill_id
+    assert second_installed.content_digest == second.package_digest
+    assert store.require(first.import_id).state == "superseded"
+    assert store.require(first.import_id).installed_skill_id is None
+    assert first_installed_record.installed_skill_id == "local-report"
+    with pytest.raises(SkillLocalImportError) as superseded:
+        _install(
+            store,
+            manager,
+            store.require(first.import_id),
+            expected_installed_digest=second_installed.content_digest,
+        )
+    assert superseded.value.code == "skill_import_stale"
+
+
+def test_local_import_cannot_replace_another_source(tmp_path: Path) -> None:
+    store = SkillLocalImportStore(tmp_path / "imports", enabled=True)
+    record = store.create_from_folder(
+        [("SKILL.md", _markdown("shared-skill", "1. Return the local version."))]
+    )
+    manager = _manager(tmp_path, store)
+    target = manager.installed_dir / "shared-skill"
+    target.mkdir(parents=True)
+    (target / "SKILL.md").write_bytes(
+        _markdown("shared-skill", "1. Return the workspace version.")
+    )
+    foreign = InstalledSkill(
+        skill_id="shared-skill",
+        name="Shared Skill",
+        description="Existing non-import Skill.",
+        repo_url="workspace://draft/workspace-draft",
+        sub_path="",
+        installed_at=1_700_000_000.0,
+        source_kind="workspace_draft",
+        source_id="workspace-draft",
+        source_revision=1,
+        content_digest=manager._directory_content_digest(target),
+    )
+    manager._write_metadata({foreign.skill_id: asdict(foreign)})
+
+    with pytest.raises(SkillValidationError) as error:
+        _install(store, manager, record)
+
+    assert error.value.code == "skill_import_replace_required"
+    assert "workspace version" in manager.get_skill_content("shared-skill")
+
+
+def test_replacement_preview_keeps_binary_content_out_of_diff(tmp_path: Path) -> None:
+    store = SkillLocalImportStore(tmp_path / "imports", enabled=True)
+    markdown = _markdown(
+        "local-binary-preview",
+        "1. Copy `assets/template.pdf`.\n2. Return the rendered document.",
+    )
+    first = store.create_from_folder(
+        [
+            ("SKILL.md", markdown),
+            ("assets/template.pdf", b"%PDF-1.4\nfirst\n%%EOF\n"),
+        ]
+    )
+    manager = _manager(tmp_path, store)
+    _install(store, manager, first, confirmed=True)
+    second = store.create_from_folder(
+        [
+            ("SKILL.md", markdown),
+            ("assets/template.pdf", b"%PDF-1.4\nsecond\n%%EOF\n"),
+        ]
+    )
+
+    preview = manager.describe_local_import_replacement(
+        record=second,
+        package_dir=store.package_directory(second.import_id),
+    )
+
+    assert preview is not None
+    assert preview["required"] is True
+    changed = next(
+        item for item in preview["changes"] if item["path"] == "assets/template.pdf"
+    )
+    assert changed["kind"] == "binary"
+    assert "diff" not in changed
+    assert changed["oldSha256"] != changed["newSha256"]
+
+
+def test_uninstall_projection_is_retry_safe(tmp_path: Path) -> None:
+    store = SkillLocalImportStore(tmp_path / "imports", enabled=True)
+    record = store.create_from_folder(
+        [("SKILL.md", _markdown("local-uninstall"))]
+    )
+    manager = _manager(tmp_path, store)
+    installed_record, installed = _install(store, manager, record)
+
+    manager.uninstall_skill(installed.skill_id)
+    changed = store.mark_uninstalled_skill(installed.skill_id)
+    replay = store.mark_uninstalled_skill(installed.skill_id)
+
+    assert [item.import_id for item in changed] == [installed_record.import_id]
+    current = store.require(installed_record.import_id)
+    assert current.installed_skill_id is None
+    assert current.state == "ready"
+    assert replay == []
+
+
+def test_router_uses_exact_local_receipt_and_acknowledgement(tmp_path: Path) -> None:
+    store = SkillLocalImportStore(tmp_path / "imports", enabled=True)
+    record = store.create_from_folder(
+        [
+            (
+                "SKILL.md",
+                _markdown(
+                    "local-router-script-unique",
+                    "1. Run `python scripts/check.py`.\n2. Return the output.",
+                ),
+            ),
+            ("scripts/check.py", b"print('router-ok')\n"),
+        ]
+    )
+    assert record.trust_receipt["routerEligible"] is True
+    manager = _manager(tmp_path, store)
+    installed_record, installed = _install(store, manager, record, confirmed=True)
+    manager.acknowledge_trust(
+        installed.skill_id,
+        expected_trust_fingerprint=installed_record.trust_fingerprint,
+        confirmed=True,
+    )
+    provider = SandboxToolsetProvider(
+        SimpleNamespace(workspace_root=tmp_path / "workspaces"),
+        SimpleNamespace(request=AsyncMock(return_value={"ok": True})),
+        skill_manager=manager,
+        skill_finder=SkillFinder(index_path=RUNTIME_INDEX, skill_manager=manager),
+    )
+    call = RuntimeToolCall(
+        "skill_find",
+        {"need": "local router script unique"},
+        metadata={
+            "task_id": "task",
+            "run_id": "run",
+            "node_id": "node",
+            "skills_config": {"catalog_search": True},
+            "skill_runtime_environment": {
+                "tool_names": ["skill_read", "skill_stage", "sandbox_shell"],
+                "tool_providers": ["skill", "sandbox"],
+            },
+            "sandbox_config": {"allowed_commands": ["python", "python3"]},
+        },
+    )
+
+    found = json.loads(provider._skill_find(call).output)
+    candidate = next(
+        item
+        for item in found["results"]
+        if item["candidateId"] == f"installed:{installed.skill_id}"
+    )
+    assert candidate["trust"]["trustFingerprint"] == record.trust_fingerprint
+    assert candidate["trustActionable"] is True
+
+    manager.trust_service.revoke(installed.skill_id)
+    revoked = json.loads(provider._skill_find(call).output)
+    denied = next(
+        item
+        for item in revoked["results"]
+        if item["candidateId"] == f"installed:{installed.skill_id}"
+    )
+    assert denied["trustActionable"] is False
+    assert denied["trustDecision"]["errorCode"] == "skill_trust_ack_required"
+
+
+def test_failed_metadata_replace_restores_previous_package(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = SkillLocalImportStore(tmp_path / "imports", enabled=True)
+    first = store.create_from_folder(
+        [("SKILL.md", _markdown("local-report", "1. Return version one."))]
+    )
+    manager = _manager(tmp_path, store)
+    _, first_installed = _install(store, manager, first)
+    second = store.create_from_folder(
+        [("SKILL.md", _markdown("local-report", "1. Return version two."))]
+    )
+    original_write = manager._write_metadata
+    calls = 0
+
+    def fail_first_replace(payload):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise OSError("disk full")
+        return original_write(payload)
+
+    monkeypatch.setattr(manager, "_write_metadata", fail_first_replace)
+    with pytest.raises(OSError, match="disk full"):
+        _install(
+            store,
+            manager,
+            second,
+            expected_installed_digest=first_installed.content_digest,
+        )
+
+    restored = json.loads(manager.metadata_path.read_text(encoding="utf-8"))["skills"]
+    assert restored["local-report"]["content_digest"] == first_installed.content_digest
+    assert (
+        manager.get_skill_content("local-report").find("version one")
+        >= 0
+    )
+    assert store.require(second.import_id).state != "installed"
+
+
+def test_store_projection_failure_is_safe_to_retry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = SkillLocalImportStore(tmp_path / "imports", enabled=True)
+    record = store.create_from_folder(
+        [("SKILL.md", _markdown("local-store-retry"))]
+    )
+    manager = _manager(tmp_path, store)
+    original_save = store._save_records_unlocked
+    calls = 0
+
+    def fail_projection_once(records):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise OSError("disk full")
+        return original_save(records)
+
+    monkeypatch.setattr(store, "_save_records_unlocked", fail_projection_once)
+    with pytest.raises(OSError, match="disk full"):
+        _install(store, manager, record)
+
+    assert manager.get_skill_content("local-store-retry")
+    assert store.require(record.import_id).state == "ready"
+    with pytest.raises(SkillValidationError) as activation_error:
+        manager.require_activation("local-store-retry")
+    assert activation_error.value.code == "skill_trust_receipt_missing"
+
+    retried_record, retried = _install(store, manager, record)
+    assert retried_record.state == "installed"
+    assert retried.content_digest == record.package_digest
+    assert manager.require_activation(retried.skill_id).skill_id == retried.skill_id
+
+
+@pytest.mark.asyncio
+async def test_skill_stage_preflights_package_and_workspace_before_writes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    assert SKILL_STAGE_MAX_FILES == 500
+    assert SKILL_STAGE_MAX_FILE_BYTES == 10 * 1024 * 1024
+    assert SKILL_STAGE_MAX_TOTAL_BYTES == 50 * 1024 * 1024
+    package = tmp_path / "package"
+    package.mkdir()
+    (package / "SKILL.md").write_text("# Local\n", encoding="utf-8")
+    (package / "asset.bin").write_bytes(b"x" * 12)
+    workspace_root = tmp_path / "workspaces"
+    workspace = SandboxWorkspace(
+        workspace_id="ws_local",
+        scope_type="workflow",
+        scope_id="task:node",
+        node_id="node",
+        quota_bytes=1024,
+    )
+    client = SimpleNamespace(request=AsyncMock(return_value={"ok": True}))
+    manager = SimpleNamespace(
+        list_installed_skills=lambda: [SimpleNamespace(skill_id="local-stage")],
+        get_skill_directory=lambda _skill_id: package,
+        require_activation=lambda *_args, **_kwargs: None,
+    )
+    provider = SandboxToolsetProvider(
+        SimpleNamespace(workspace_root=workspace_root),
+        client,
+        skill_manager=manager,
+    )
+    call = RuntimeToolCall(
+        "skill_stage",
+        {"skill_id": "local-stage"},
+        metadata={
+            "task_id": "task",
+            "node_id": "node",
+            "skills_config": {"skill_ids": ["local-stage"]},
+        },
+    )
+
+    monkeypatch.setattr(
+        "xpert_runtime.sandbox_toolset.SKILL_STAGE_MAX_FILE_BYTES", 10
+    )
+    with pytest.raises(RuntimeToolError) as too_large:
+        await provider._skill_stage(workspace, call)
+    assert too_large.value.code == "skill_runtime_incompatible"
+    client.request.assert_not_awaited()
+
+    monkeypatch.setattr(
+        "xpert_runtime.sandbox_toolset.SKILL_STAGE_MAX_FILE_BYTES", 20
+    )
+    workspace.quota_bytes = 15
+    with pytest.raises(RuntimeToolError) as quota:
+        await provider._skill_stage(workspace, call)
+    assert quota.value.code == "skill_runtime_incompatible"
+    client.request.assert_not_awaited()
+
+    workspace.quota_bytes = 1024
+    result = await provider._skill_stage(workspace, call)
+    assert result.metadata["file_count"] == 2
+    assert client.request.await_count == 2

--- a/server/xpert_runtime/sandbox_toolset.py
+++ b/server/xpert_runtime/sandbox_toolset.py
@@ -50,6 +50,9 @@ SKILL_TOOL_NAMES = {
     "skill_enable",
     "skill_install",
 }
+SKILL_STAGE_MAX_FILES = 500
+SKILL_STAGE_MAX_FILE_BYTES = 10 * 1024 * 1024
+SKILL_STAGE_MAX_TOTAL_BYTES = 50 * 1024 * 1024
 
 
 class SandboxToolsetProvider:
@@ -624,9 +627,37 @@ class SandboxToolsetProvider:
                     if installed_skill_id
                     else None
                 )
-                if installed_item is not None and str(
+                source_kind = str(
                     getattr(installed_item, "source_kind", "git")
-                ) != "git":
+                ) if installed_item is not None else "git"
+                if installed_item is not None and source_kind == "local_import":
+                    try:
+                        resolver = getattr(
+                            self.skill_manager, "trust_activation_decision", None
+                        )
+                        if not callable(resolver):
+                            raise RuntimeToolError(
+                                call.tool_name,
+                                "Local Skill trust receipt is unavailable.",
+                                code="skill_trust_receipt_missing",
+                            )
+                        decision = resolver(
+                            installed_skill_id,
+                            runtime_environment=self._trust_environment(call),
+                        ).to_dict()
+                    except RuntimeToolError:
+                        raise
+                    except Exception as exc:
+                        code = str(
+                            getattr(exc, "code", "")
+                            or "skill_trust_receipt_missing"
+                        )
+                        raise RuntimeToolError(
+                            call.tool_name,
+                            str(exc),
+                            code=code,
+                        ) from exc
+                elif installed_item is not None and source_kind != "git":
                     decision = {
                         "mode": getattr(self.trust_service, "mode", "off"),
                         "allowed": True,
@@ -808,18 +839,69 @@ class SandboxToolsetProvider:
         self._require_enabled_skill(call, skill_id)
         root = self.skill_manager.get_skill_directory(skill_id)
         operation_base = self._operation_id(call)
-        files: list[str] = []
+        package_files: list[tuple[Path, Path, bytes]] = []
         total = 0
         for path in sorted(root.rglob("*")):
-            if path.is_symlink() or not path.is_file() or ".git" in path.parts:
+            if path.is_symlink():
+                raise RuntimeToolError(
+                    call.tool_name,
+                    "Skill package contains an unsafe link.",
+                    code="skill_runtime_incompatible",
+                )
+            if not path.is_file() or ".git" in path.parts:
                 continue
             relative = path.relative_to(root)
             content = path.read_bytes()
-            if len(content) > 2 * 1024 * 1024:
-                raise RuntimeToolError(call.tool_name, "Skill contains a file larger than 2 MB.", code="skill_file_too_large")
+            if len(content) > SKILL_STAGE_MAX_FILE_BYTES:
+                raise RuntimeToolError(
+                    call.tool_name,
+                    "Skill contains a file larger than 10 MiB.",
+                    code="skill_runtime_incompatible",
+                )
             total += len(content)
-            if total > 10 * 1024 * 1024 or len(files) >= 200:
-                raise RuntimeToolError(call.tool_name, "Skill package exceeds the staging limit.", code="skill_package_too_large")
+            package_files.append((path, relative, content))
+            if (
+                total > SKILL_STAGE_MAX_TOTAL_BYTES
+                or len(package_files) > SKILL_STAGE_MAX_FILES
+            ):
+                raise RuntimeToolError(
+                    call.tool_name,
+                    "Skill package exceeds the 500-file or 50 MiB staging limit.",
+                    code="skill_runtime_incompatible",
+                )
+        workspace_root = (self.store.workspace_root / workspace.workspace_id).resolve()
+        store_root = self.store.workspace_root.resolve()
+        if workspace_root.parent != store_root:
+            raise RuntimeToolError(
+                call.tool_name,
+                "Sandbox workspace path is invalid.",
+                code="skill_runtime_incompatible",
+            )
+        current_usage = 0
+        replaced_usage = 0
+        target_prefix = workspace_root / "skills" / skill_id
+        if workspace_root.exists():
+            for existing in workspace_root.rglob("*"):
+                if existing.is_symlink():
+                    continue
+                if existing.is_file():
+                    size = existing.stat().st_size
+                    current_usage += size
+                    try:
+                        existing.relative_to(target_prefix)
+                    except ValueError:
+                        pass
+                    else:
+                        replaced_usage += size
+        projected_usage = current_usage - replaced_usage + total
+        if projected_usage > workspace.quota_bytes:
+            raise RuntimeToolError(
+                call.tool_name,
+                "Sandbox quota is insufficient to stage this Skill package.",
+                code="skill_runtime_incompatible",
+            )
+        files: list[str] = []
+        for _source, relative, content in package_files:
             destination = f"skills/{skill_id}/{relative.as_posix()}"
             await self.client.request(
                 {
@@ -977,11 +1059,14 @@ class SandboxToolsetProvider:
                 require_router_eligible=True,
                 environment=self._trust_environment(call),
             )
-        except SkillTrustError as exc:
+        except Exception as exc:
+            code = str(
+                getattr(exc, "code", "") or "skill_trust_receipt_missing"
+            )
             raise RuntimeToolError(
                 call.tool_name,
                 str(exc),
-                code=exc.code,
+                code=code,
             ) from exc
         return decision.to_dict()
 


### PR DESCRIPTION
## 变更摘要

- 为 `local_import` 来源增加原子安装、同摘要幂等和显式替换事务。
- 将本地信任凭据、精确指纹授权和撤销接入聊天、工作流、Skill Read/Stage/Enable 与 Finder 激活门。
- Router 仅返回当前凭据明确允许自动调用的本地 Skill，不提供任意本地路径安装能力。
- 将 `skill_stage` 上限统一为 500 文件、单文件 10 MiB、包总计 50 MiB，并在写入前完成配额预检。
- 修复卸载、重试、Store 写盘中断后的安装投影与授权一致性。

## 设计边界

- 仅扩展 PR #161 已建立的本地导入与信任基础，不改变 Git、Workspace Creator、插件或内置 Skill 的来源合同。
- 不修改 Sandbox sidecar 协议或镜像。
- 本批无前端变更；正式导入工作台和默认启用留给串行 PR3。
- 本地导入仍不代表行为认证，也不会绕过精确凭据与运行兼容性检查。

## 验证

- Python 语法检查：通过。
- 本地导入、信任、Finder、Runtime Router：`78 passed, 1 deselected`。
- Sandbox staging 与信任扫描/索引：`36 passed`。
- 主应用 Skill 集成：`7 passed`，仅既有 FastAPI `on_event` 弃用警告。
- `git diff --check`：通过。
- 独立临时预览器：`/api/health`、`/api/skills/imports/status`、`/docs` 均通过，用户已确认验收。

唯一 deselected 为现有 `modelmirror-server` 镜像 Node 20 无法直接加载 TypeScript 金标的环境限制，不是本变更失败。

## 回退

- 关闭本地导入开关可停止新的本地导入操作。
- `SKILL_TRUST_GATE_MODE=off` 保留既有紧急回退语义。
- 安装替换继续使用 staging/backup/receipt 事务，失败恢复旧目录与元数据。