### PR TITLE
feature: 收口工作流 RAG 知识消费节点

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -520,6 +520,10 @@ MCP 原生集成属于后端进程管理和工具执行能力，开发时必须�
 - `required` Promotion Gate 必须校验评估运行成功、知识库与候选版本匹配、评估集 revision 仍为当前版本且门禁通过；`advisory` 模式保留人工激活兼容路径。
 - Knowledge Runtime Toolset 只能访问 `workflow_agent.knowledgeBaseIds` 显式声明的 1 至 5 个知识库。模型不得通过工具参数扩展作用域；`toolNames` 仍只过滤 MCP 工具。
 - `knowledge_search/get/cite/propose_write` 必须继续经过 Runtime middleware、tool policy、audit 和 checkpoint。工具输出与审计不得保存完整知识正文或写入提议正文。
+- Classic workflow 的知识分类只承载消费能力；数据源、Processor、分块、Embedding、索引、策略、评测和版本管理由 `/rag` 独占，不得以占位 stage 重新进入工作流节点库。
+- 新建 `knowledge_retrieval` 必须使用 `contractVersion=2` 并显式配置 `knowledgeBaseId`。节点只调用 `RagService.search_knowledge`，不得额外生成 RAG 回答；`result` 模式保留 typed object，`context` 模式返回纯文本。
+- `knowledge_citation` 仅用于旧图加载和执行兼容，不得重新进入节点库或 Planner。旧节点缺失知识库 ID 时，只能在恰有一个可用知识库时兼容；零个或多个必须 fail-closed。
+- 修改工作流知识消费至少运行 `test_workflow_knowledge_retrieval_v2.py`、`test_workflow_knowledge_citation_node.py`、`test_workflow_native_validate.py`、节点 registry 测试和前端构建。
 - 模型写入只能生成 `KnowledgeWriteProposal`，不得直接修改知识库。`/rag/:kbId/inbox` 是唯一正式审批入口；pending 编辑必须使用 revision 乐观并发。
 - 批准提议只能创建受管文档和候选 Pipeline Job，不得自动激活。提议候选必须标记 `promotion_required=true`，通过 Evaluation Gate 后才能由 `/promote` 切换活动版本。
 - 批准创建 Job 失败必须回滚受管文档并保持提议 pending；拒绝不得创建文档、Job 或候选版本。

--- a/client/src/components/workflow/NodePalette.test.ts
+++ b/client/src/components/workflow/NodePalette.test.ts
@@ -3,12 +3,24 @@ import { render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import NodePalette, { disabledPaletteItem } from "./NodePalette";
+import {
+  knowledgePipelineItems,
+  knowledgePipelinePlaceholders,
+} from "./workflowNodeRegistry";
 
 afterEach(() => {
   vi.unstubAllGlobals();
 });
 
 describe("NodePalette disabled workflow nodes", () => {
+  it("only exposes executable knowledge consumption nodes", () => {
+    expect(knowledgePipelineItems.map((item) => item.kind)).toEqual([
+      "knowledge_base",
+      "knowledge_retrieval",
+    ]);
+    expect(knowledgePipelinePlaceholders).toEqual([]);
+  });
+
   it("keeps a disabled node visible with its explicit reason", () => {
     const placeholder = disabledPaletteItem({
       kind: "document_extractor",

--- a/client/src/components/workflow/NodePalette.tsx
+++ b/client/src/components/workflow/NodePalette.tsx
@@ -425,14 +425,14 @@ export default function NodePalette() {
           <section className="space-y-2">
             <div>
               <h3 className="text-sm font-semibold text-slate-200">
-                引用与检索
+                知识消费
               </h3>
               <p className="mt-0.5 text-xs leading-5 text-slate-500">
-                当前先暴露可运行的 CitationAnchor 节点。
+                绑定知识库，或在控制流中检索其当前活动版本。
               </p>
             </div>
             {filteredKnowledgeItems.length === 0 ? (
-              <EmptyState>没有匹配的知识引用节点。</EmptyState>
+              <EmptyState>没有匹配的知识消费节点。</EmptyState>
             ) : (
               <div className="space-y-2">
                 {filteredKnowledgeItems.map((item) => (
@@ -442,25 +442,15 @@ export default function NodePalette() {
             )}
           </section>
 
-          <section className="space-y-2">
-            <div>
-              <h3 className="text-sm font-semibold text-slate-200">
-                流水线阶段
-              </h3>
-              <p className="mt-0.5 text-xs leading-5 text-slate-500">
-                智能体资源草稿入口，当前不会直接创建工作流节点。
-              </p>
-            </div>
-            {filteredKnowledgePlaceholders.length === 0 ? (
-              <EmptyState>没有匹配的知识流水线条目。</EmptyState>
-            ) : (
+          {filteredKnowledgePlaceholders.length > 0 ? (
+            <section className="space-y-2">
               <div className="space-y-2">
                 {filteredKnowledgePlaceholders.map((item) => (
                   <PlaceholderCard item={item} key={item.id} />
                 ))}
               </div>
-            )}
-          </section>
+            </section>
+          ) : null}
         </div>
       ) : null}
     </div>

--- a/client/src/components/workflow/WorkflowEditor.tsx
+++ b/client/src/components/workflow/WorkflowEditor.tsx
@@ -256,10 +256,13 @@ function createNodeData(
     return {
       kind,
       title: "知识检索",
-      description: "使用本地 RAG 资料库检索相关片段。",
+      description: "检索指定知识库的活动版本。",
+      contractVersion: 2,
+      knowledgeBaseId: "",
       queryVariable: "user_input",
-      top_k: "3",
-      outputVariable: "rag_context",
+      top_k: "5",
+      returnMode: "result",
+      outputVariable: "knowledge_result",
     };
   }
 
@@ -1590,23 +1593,9 @@ interface WorkflowResourceOption {
   middleware_count?: number;
 }
 
-function ResourceNodeConfig({
-  data,
-  update,
-}: {
-  data: WorkflowNodeData;
-  update: (patch: Partial<WorkflowNodeData>) => void;
-}) {
+function useWorkflowResourceOptions(resourceKind: string) {
   const [options, setOptions] = useState<WorkflowResourceOption[]>([]);
   const [loadError, setLoadError] = useState("");
-  const resourceKind =
-    data.kind === "external_xpert"
-      ? "external_xpert"
-      : data.kind === "toolset_resource"
-        ? "toolset"
-        : data.kind === "plugin_resource"
-          ? "plugin"
-          : "knowledge_base";
 
   useEffect(() => {
     let cancelled = false;
@@ -1635,6 +1624,26 @@ function ResourceNodeConfig({
       cancelled = true;
     };
   }, [resourceKind]);
+
+  return { loadError, options };
+}
+
+function ResourceNodeConfig({
+  data,
+  update,
+}: {
+  data: WorkflowNodeData;
+  update: (patch: Partial<WorkflowNodeData>) => void;
+}) {
+  const resourceKind =
+    data.kind === "external_xpert"
+      ? "external_xpert"
+      : data.kind === "toolset_resource"
+        ? "toolset"
+        : data.kind === "plugin_resource"
+          ? "plugin"
+          : "knowledge_base";
+  const { loadError, options } = useWorkflowResourceOptions(resourceKind);
 
   if (data.kind === "external_xpert") {
     return (
@@ -1965,6 +1974,154 @@ function ResourceNodeConfig({
         <p className="text-xs leading-5 text-amber-200">{loadError}</p>
       ) : null}
     </ConfigSection>
+  );
+}
+
+function KnowledgeBaseSelector({
+  allowLegacyEmpty = false,
+  onChange,
+  value,
+}: {
+  allowLegacyEmpty?: boolean;
+  onChange: (value: string) => void;
+  value: string;
+}) {
+  const { loadError, options } = useWorkflowResourceOptions("knowledge_base");
+  return (
+    <>
+      <select
+        className={textInputClass()}
+        onChange={(event) => onChange(event.target.value)}
+        value={value}
+      >
+        <option className="bg-slate-950" value="">
+          {allowLegacyEmpty ? "未固定（仅单知识库旧图兼容）" : "选择知识库"}
+        </option>
+        {options.map((item) => (
+          <option className="bg-slate-950" key={item.id} value={item.id}>
+            {item.name} · {item.active_version_id ? "活动索引可用" : "暂无活动索引"}
+          </option>
+        ))}
+      </select>
+      {loadError ? (
+        <p className="mt-2 text-xs leading-5 text-amber-200">{loadError}</p>
+      ) : null}
+    </>
+  );
+}
+
+function KnowledgeRetrievalNodeConfig({
+  data,
+  update,
+}: {
+  data: WorkflowNodeData;
+  update: (patch: Partial<WorkflowNodeData>) => void;
+}) {
+  const isLegacy = !data.contractVersion;
+  return (
+    <>
+      <div className="rounded-lg border border-cyan-300/25 bg-cyan-300/10 px-3 py-2 text-xs leading-5 text-cyan-50">
+        {isLegacy
+          ? "兼容旧版文本契约。保存现有工作流不会自动改变输出类型。"
+          : "V2 只执行活动知识版本检索；结果模式返回上下文、来源、CitationAnchor 与安全诊断。"}
+      </div>
+      <Field label="知识库">
+        <KnowledgeBaseSelector
+          allowLegacyEmpty={isLegacy}
+          onChange={(value) => update({ knowledgeBaseId: value })}
+          value={data.knowledgeBaseId ?? ""}
+        />
+      </Field>
+      <Field label="查询变量">
+        <input
+          className={textInputClass()}
+          onChange={(event) => update({ queryVariable: event.target.value })}
+          value={data.queryVariable ?? ""}
+        />
+      </Field>
+      <Field label="返回片段数 Top K">
+        <input
+          className={textInputClass()}
+          inputMode="numeric"
+          max={isLegacy ? 20 : 10}
+          min={1}
+          onChange={(event) => update({ top_k: event.target.value })}
+          type="number"
+          value={data.top_k ?? "5"}
+        />
+      </Field>
+      {!isLegacy ? (
+        <Field label="返回模式">
+          <select
+            className={textInputClass()}
+            onChange={(event) => update({ returnMode: event.target.value as "context" | "result" })}
+            value={data.returnMode ?? "result"}
+          >
+            <option className="bg-slate-950" value="result">
+              类型化结果（推荐）
+            </option>
+            <option className="bg-slate-950" value="context">
+              纯文本上下文
+            </option>
+          </select>
+        </Field>
+      ) : null}
+      <Field label="输出变量">
+        <input
+          className={textInputClass()}
+          onChange={(event) => update({ outputVariable: event.target.value })}
+          value={data.outputVariable ?? ""}
+        />
+      </Field>
+    </>
+  );
+}
+
+function LegacyKnowledgeCitationConfig({
+  data,
+  update,
+}: {
+  data: WorkflowNodeData;
+  update: (patch: Partial<WorkflowNodeData>) => void;
+}) {
+  return (
+    <>
+      <div className="rounded-lg border border-amber-300/25 bg-amber-300/10 px-3 py-2 text-xs leading-5 text-amber-50">
+        该节点已弃用，仅用于旧工作流兼容。新流程请使用知识检索 V2 的类型化结果。
+      </div>
+      <Field label="查询变量">
+        <input
+          className={textInputClass()}
+          onChange={(event) => update({ queryVariable: event.target.value })}
+          value={data.queryVariable ?? ""}
+        />
+      </Field>
+      <Field label="知识库">
+        <KnowledgeBaseSelector
+          allowLegacyEmpty
+          onChange={(value) => update({ knowledgeBaseId: value })}
+          value={data.knowledgeBaseId ?? ""}
+        />
+      </Field>
+      <Field label="返回引用数 Top K">
+        <input
+          className={textInputClass()}
+          inputMode="numeric"
+          max={10}
+          min={1}
+          onChange={(event) => update({ top_k: event.target.value })}
+          type="number"
+          value={data.top_k ?? "4"}
+        />
+      </Field>
+      <Field label="输出变量">
+        <input
+          className={textInputClass()}
+          onChange={(event) => update({ outputVariable: event.target.value })}
+          value={data.outputVariable ?? ""}
+        />
+      </Field>
+    </>
   );
 }
 
@@ -2469,72 +2626,11 @@ function NodeConfig({
       ) : null}
 
       {data.kind === "knowledge_retrieval" ? (
-        <>
-          <Field label="查询变量">
-            <input
-              className={textInputClass()}
-              onChange={(event) => update({ queryVariable: event.target.value })}
-              value={data.queryVariable ?? ""}
-            />
-          </Field>
-          <Field label="返回片段数 Top K">
-            <input
-              className={textInputClass()}
-              inputMode="numeric"
-              onChange={(event) => update({ top_k: event.target.value })}
-              type="number"
-              value={data.top_k ?? "3"}
-            />
-          </Field>
-          <Field label="输出变量">
-            <input
-              className={textInputClass()}
-              onChange={(event) => update({ outputVariable: event.target.value })}
-              value={data.outputVariable ?? ""}
-            />
-          </Field>
-        </>
+        <KnowledgeRetrievalNodeConfig data={data} update={update} />
       ) : null}
 
       {data.kind === "knowledge_citation" ? (
-        <>
-          <div className="rounded-lg border border-teal-300/25 bg-teal-300/10 px-3 py-2 text-xs leading-5 text-teal-50">
-            输出为 JSON 字符串，包含 citations 与 citation_count；不返回本地文件路径或向量内容。
-          </div>
-          <Field label="查询变量">
-            <input
-              className={textInputClass()}
-              onChange={(event) => update({ queryVariable: event.target.value })}
-              value={data.queryVariable ?? ""}
-            />
-          </Field>
-          <Field label="知识库 ID（可选）">
-            <input
-              className={textInputClass()}
-              onChange={(event) => update({ knowledgeBaseId: event.target.value })}
-              placeholder="留空时使用第一个知识库"
-              value={data.knowledgeBaseId ?? ""}
-            />
-          </Field>
-          <Field label="返回引用数 Top K">
-            <input
-              className={textInputClass()}
-              inputMode="numeric"
-              max={10}
-              min={1}
-              onChange={(event) => update({ top_k: event.target.value })}
-              type="number"
-              value={data.top_k ?? "4"}
-            />
-          </Field>
-          <Field label="输出变量">
-            <input
-              className={textInputClass()}
-              onChange={(event) => update({ outputVariable: event.target.value })}
-              value={data.outputVariable ?? ""}
-            />
-          </Field>
-        </>
+        <LegacyKnowledgeCitationConfig data={data} update={update} />
       ) : null}
 
       {data.kind === "document_extractor" ? (

--- a/client/src/components/workflow/workflowNodeRegistry.ts
+++ b/client/src/components/workflow/workflowNodeRegistry.ts
@@ -124,13 +124,6 @@ export const workflowPaletteSections: WorkflowPaletteSection[] = [
         tags: ["classifier", "question"],
       },
       {
-        kind: "knowledge_retrieval",
-        icon: "▥",
-        title: "知识检索",
-        description: "查询本地 RAG 资料库，把相关段落写入变量。",
-        tags: ["rag", "knowledge"],
-      },
-      {
         kind: "code",
         icon: "</>",
         title: "代码执行",
@@ -207,13 +200,6 @@ export const workflowPaletteSections: WorkflowPaletteSection[] = [
         title: "外部智能体",
         description: "将已发布智能体作为同步协作者工具绑定到工作流智能体。",
         tags: ["xpert", "expert", "resource", "binding"],
-      },
-      {
-        kind: "knowledge_base",
-        icon: "KB",
-        title: "知识库",
-        description: "将知识库的检索、原文和引用能力绑定到工作流智能体。",
-        tags: ["knowledge", "rag", "resource", "binding"],
       },
       {
         kind: "toolset_resource",
@@ -337,48 +323,22 @@ export const workflowPaletteSections: WorkflowPaletteSection[] = [
 
 export const knowledgePipelineItems: WorkflowPaletteItem[] = [
   {
-    kind: "knowledge_citation",
-    icon: "◇",
-    title: "知识引用锚点",
-    description: "查询本地 RAG，输出 CitationAnchor JSON。",
-    tags: ["citation", "rag", "knowledge-pipeline"],
+    kind: "knowledge_base",
+    icon: "KB",
+    title: "知识库",
+    description: "将一个知识库绑定到工作流智能体的只读知识工具。",
+    tags: ["knowledge", "rag", "resource", "binding"],
+  },
+  {
+    kind: "knowledge_retrieval",
+    icon: "▥",
+    title: "知识检索",
+    description: "检索指定知识库的活动版本并输出文本或类型化结果。",
+    tags: ["rag", "knowledge", "retrieval"],
   },
 ];
 
-export const knowledgePipelinePlaceholders: WorkflowPalettePlaceholder[] = [
-  {
-    id: "pipeline_source_default",
-    icon: "TXT",
-    title: "默认数据源",
-    description: "待接入：从知识流水线数据源读取文件。",
-    statusLabel: "待接入",
-    tags: ["source", "data"],
-  },
-  {
-    id: "pipeline_processor",
-    icon: "PX",
-    title: "处理器",
-    description: "待接入：清洗、解析和转换文档内容。",
-    statusLabel: "待接入",
-    tags: ["processor"],
-  },
-  {
-    id: "pipeline_splitter",
-    icon: "¶",
-    title: "分块器",
-    description: "待接入：递归字符、Markdown 或父子分块。",
-    statusLabel: "待接入",
-    tags: ["splitter", "chunk"],
-  },
-  {
-    id: "pipeline_vision",
-    icon: "眼",
-    title: "图像理解",
-    description: "待接入：视觉语言模型处理图片内容。",
-    statusLabel: "待接入",
-    tags: ["vision", "image"],
-  },
-];
+export const knowledgePipelinePlaceholders: WorkflowPalettePlaceholder[] = [];
 
 export function matchesWorkflowPaletteQuery(
   item: WorkflowPaletteItem | WorkflowPalettePlaceholder,

--- a/client/src/types/workflow.ts
+++ b/client/src/types/workflow.ts
@@ -79,6 +79,7 @@ export interface WorkflowNodeData extends Record<string, unknown> {
   schema?: string;
   queryVariable?: string;
   knowledgeBaseId?: string;
+  contractVersion?: number | string;
   toolsetId?: string;
   pluginId?: string;
   xpertId?: string;
@@ -90,7 +91,7 @@ export interface WorkflowNodeData extends Record<string, unknown> {
   filter?: Record<string, unknown>;
   sort?: Array<{ field: string; direction: "asc" | "desc" }>;
   limit?: number | string;
-  returnMode?: "list" | "first";
+  returnMode?: "list" | "first" | "context" | "result";
   valueBindings?: Record<string, unknown>;
   topK?: string;
   scoreThreshold?: string;

--- a/docs/RAG_INTEGRATION.md
+++ b/docs/RAG_INTEGRATION.md
@@ -348,9 +348,20 @@ disabled 占位。它已在 2026-07-15 升级为可选真实阶段，当前状�
 “图像与扫描 PDF 知识理解”为准。安全响应仍不返回本地文件绝对路径、完整
 chunk 文本、embedding、prompt 或密钥。
 
-## 2026-07-08 增量：Workflow CitationAnchor 节点
+## 2026-08-11 增量：Workflow RAG Consumption V2
 
-Classic workflow 已新增 `knowledge_citation` 节点，复用本地 RAG Knowledge Pipeline 的 citation 生成能力。节点读取 `queryVariable` 中的文本，使用可选 `knowledgeBaseId` 和 `top_k` 调用 `RagService.create_pipeline_citations(...)`，并把结果写入 `outputVariable`：
+Classic workflow 的知识节点已收口为 `knowledge_base` 与 `knowledge_retrieval`。`/rag` 继续独占数据源、Processor、分块、Embedding、索引、策略、评测和版本管理；工作流只消费活动版本，不创建 RAG Job 或知识版本。
+
+新建检索节点使用 `contractVersion=2`，必须显式选择 `knowledgeBaseId`，并直接调用 `RagService.search_knowledge(...)`，不生成额外回答：
+
+- `returnMode=result` 输出 typed object，包含实际知识库/活动版本、受限上下文、来源、CitationAnchor、Retrieval 诊断和 warnings。
+- `returnMode=context` 仅输出纯文本上下文，便于直接进入 Prompt。
+- 旧检索节点缺少版本字段时保持文本输出；缺失知识库 ID 时仅在恰有一个知识库时兼容。
+- `knowledge_citation` 从节点库和 Planner 隐藏，保留旧工作流加载与执行兼容。
+
+## 2026-07-08 增量：Workflow CitationAnchor 节点（历史）
+
+Classic workflow 曾新增 `knowledge_citation` 节点，复用本地 RAG Knowledge Pipeline 的 citation 生成能力。该节点现在只承担旧图兼容，新流程使用 `knowledge_retrieval` V2。
 
 ```json
 {"citations":[...],"citation_count":1}

--- a/docs/XPERT_ALIGNMENT.md
+++ b/docs/XPERT_ALIGNMENT.md
@@ -361,7 +361,7 @@ Evaluator、Prompt 候选和工作流结构候选顺序推进。MIT 代码只允
 ## 已实现基线
 
 - `/api/chat` 默认保持普通 SSE 聊天；显式启用 `tool_mode=mcp_tools` 时进入 Runtime Toolset 工具循环，登记 chat run、checkpoint、tool events 与审计摘要。
-- Classic workflow 已支持 `workflow_agent`、`agent_task`、`agent_handoff`、`handoff_router`、`knowledge_citation`、`mcp_tool`、`runtime_middleware` 等 Xpert 对齐节点。
+- Classic workflow 已支持 `workflow_agent`、`agent_task`、`agent_handoff`、`handoff_router`、`knowledge_base`、`knowledge_retrieval`、`mcp_tool`、`runtime_middleware` 等 Xpert 对齐节点；`knowledge_citation` 仅保留旧图兼容。
 - `/workflow` 节点库已从平铺数组收敛为前端 `workflowNodeRegistry`，按工作流、中间件、知识流水线 tab 和逻辑、转换、工具、记忆、其他等 Xpert 分类渲染；拖拽协议和运行语义不变。
 - `/workflow` 中 `agent` 与 `workflow_agent` 的右侧配置已对齐为 Xpert 式分区侧栏，包含节点、参数、提示词/模型、中间件、知识库、工具、运行策略、输出结构和记忆写入；其中高级区块当前只保存配置草稿。
 - `MCPToolsetProvider`、`CapabilityRegistry`、`run_tool_with_runtime` 已成为 MCP 工具调用主路径。
@@ -399,7 +399,7 @@ Evaluator、Prompt 候选和工作流结构候选顺序推进。MIT 代码只允
 目标：把 classic workflow 节点从散落的静态列表收敛为 Xpert 分类节点注册表。
 
 - `XPERT-WORKFLOW-PALETTE-01`：已完成第一版前端节点 registry，按逻辑、转换、工具、记忆、其他、中间件、知识流水线分类渲染节点库。
-- 当前边界：registry 先放前端本地；未实现的数据库、注释、知识流水线 stage 只显示禁用占位，不生成节点；拖拽 payload、validate、runner 和 SSE 协议保持不变。
+- 当前边界：registry 以后端 API 为主、前端 fallback 为辅。数据库、注释和 JSON 节点已由独立工作流数据轮次收尾；知识建设 stage 已从 classic workflow 节点库移除，由 `/rag` 独占。
 
 ### 阶段 3：智能体配置面板对齐
 
@@ -413,7 +413,7 @@ Evaluator、Prompt 候选和工作流结构候选顺序推进。MIT 代码只允
 目标：从当前 RAG 元数据视图推进到可视化知识流水线草稿。
 
 - `XPERT-KNOWLEDGE-PIPELINE-02`：已引入数据源、处理器、分块器、图像理解四类 stage 的只读草稿 API 与 `/rag` UI。
-- 当前边界：不迁移向量库，不改变 `/api/rag/query`，不执行真实图像理解；只新增可观测草稿层。
+- 当前边界：该历史阶段现已发展为 `/rag` 的可执行、版本化知识流水线；classic workflow 只通过知识库绑定与检索消费活动版本。
 
 ### 阶段 5：运行与工具运维收口
 

--- a/docs/XPERT_UI_REFERENCE.md
+++ b/docs/XPERT_UI_REFERENCE.md
@@ -79,7 +79,7 @@ Xpert “添加工作流”菜单按以下分类组织：
 
 ModelMirror 已有对应基础：`input`、`condition`、`iteration`、`list_operation`、`variable_aggregator`、`variable_assign`、`question_classifier`、`knowledge_retrieval`、`code`、`template_transform`、`mcp_tool`、`workflow_agent`、`agent_task`、`agent_handoff`、`handoff_router`、`knowledge_citation`、`output`。
 
-`XPERT-WORKFLOW-PALETTE-01` 已完成第一版本地映射：ModelMirror 在前端建立 `workflowNodeRegistry`，并让 `/workflow` 节点库以“工作流 / 中间件 / 知识流水线”三个 tab 呈现。工作流 tab 内按 Xpert 的逻辑、转换、工具、记忆、其他分类渲染；中间件 tab 继续读取 `/api/runtime/middleware-nodes`；知识流水线 tab 先暴露可运行的 `knowledge_citation`，并以禁用占位呈现数据源、处理器、分块器、图像理解等后续 stage。
+`XPERT-WORKFLOW-PALETTE-01` 已完成节点 registry 与分类渲染。当前知识流水线 tab 只展示 `knowledge_base` 与 `knowledge_retrieval`；数据源、处理器、分块器、Embedding、索引和评测由 `/rag` 独占，不再显示工作流占位。`knowledge_citation` 仅保留旧图兼容。
 
 `XPERT-WORKFLOW-REGISTRY-API-01` 已把“工作流 / 知识流水线”菜单元数据后端化为 `GET /api/workflow/node-registry`。前端仍保留本地 registry 作为 fallback；后端 registry 仅暴露概念、分类、标题、描述、图标、标签与禁用占位，不复制 Xpert 源码，也不改变节点执行语义。中间件菜单继续由现有 middleware registry 提供，避免两个 registry 在本轮混用职责。
 
@@ -87,7 +87,7 @@ ModelMirror 已有对应基础：`input`、`condition`、`iteration`、`list_ope
 
 - 普通工作流节点仍使用原有 `application/modelmirror-node = kind` 拖拽协议。
 - runtime middleware 仍使用现有 JSON payload，不改变 `WorkflowEditor` 解析逻辑。
-- 数据库、注释、JSON 序列化/反序列化、知识流水线 stage 等 Xpert 节点暂不创建真实节点，只显示“待接入”占位，避免用户拖入无法运行的节点。
+- 知识流水线建设 stage 不进入 classic workflow；工作流只保留知识库绑定、确定性检索，以及后续独立交付的通用视觉理解。
 - registry 先放在前端本地，后续如节点元数据继续扩张，再评估后端统一 registry API。
 
 ## 中间件菜单

--- a/docs/workflow-native-design.md
+++ b/docs/workflow-native-design.md
@@ -21,6 +21,8 @@
 
 > 2026-07-22 Resource Nodes：新增 `external_xpert` 与 `knowledge_base`。资源节点通过 `sourceHandle="expert-binding" -> targetHandle="expert"` 或 `sourceHandle="knowledge-binding" -> targetHandle="knowledge"` 绑定单个 `workflow_agent`，不参与控制流、变量可达性或节点调度。发布 Xpert 时外部专家解析为不可变版本；知识库继续读取活动索引。同步专家调用与异步 Handoff 是两套明确语义。
 
+> 2026-08-11 Workflow RAG Consumption V2：知识分类收口为 `knowledge_base` 与 `knowledge_retrieval`。数据源、Processor、分块、Embedding、索引、策略、评测和版本管理继续由 `/rag` 独占。新检索节点必须显式选择知识库，可返回纯文本上下文或 typed result；`knowledge_citation` 从新建入口和 Planner 隐藏，仅保留旧图兼容。
+
 > 2026-07-19 Office Automation：`office_automation` 可通过 middleware binding 绑定到 `workflow_agent`，复用 `wait_kind=client_tool` 的持久暂停和恢复语义。22 个 Word/Excel/PowerPoint 工具由用户主动绑定的 Office.js Task Pane 执行；绑定边不参与控制流，修改工具必须有 HITL 覆盖，公开 App/API 禁止该中间件。完整契约见 `docs/XPERT_OFFICE_AUTOMATION.md`。
 
 > 2026-07-19 File Memory Middleware：`xpert_file_memory` 可通过 middleware binding 绑定到 `workflow_agent`，提供索引、摘要 digest、正文选择和候选写回。绑定边不参与控制流；显式配置优先于旧 `memoryReadEnabled/memoryWriteEnabled` 字段。普通 Workflow 无 Xpert 上下文时安全跳过，公开 App 只允许显式开启的只读访问。完整契约见 `docs/XPERT_FILE_MEMORY.md`。
@@ -91,7 +93,7 @@
 | Xpert 分类 | Xpert 菜单示例 | ModelMirror 已有/对应节点 | 下一步 |
 | --- | --- | --- | --- |
 | 逻辑 | 触发器、路由、迭代、子流程、列表操作、变量聚合、变量赋值 | `input`、`condition`、`iteration`、`list_operation`、`variable_aggregator`、`variable_assign` | 用节点 registry 统一分类与元数据 |
-| 转换 | 问题分类器、知识检索、代码执行、模板、JSON 序列化、JSON 反序列化、回答 | `question_classifier`、`knowledge_retrieval`、`knowledge_citation`、`code`、`template_transform`、`output` | 补 JSON 序列化/反序列化节点前先统一 registry |
+| 转换 | 问题分类器、代码执行、模板、JSON 序列化、JSON 反序列化、回答 | `question_classifier`、`code`、`template_transform`、`json_serialize`、`json_deserialize`、`output` | 知识检索已归入知识消费分类 |
 | 工具 | HTTP、工具调用、智能体工作流、任务移交 | `http_request`、`mcp_tool`、`workflow_agent`、`agent_task`、`agent_handoff`、`handoff_router` | 继续收敛到 Runtime Toolset 与 RunRegistry |
 | 记忆 | 数据库 | 暂无完整数据库/记忆节点，仅有 RunRegistry 与 RAG 元数据 | 等工作空间资源与记忆模型稳定后推进 |
 | 其他 | 注释 | 暂无 | 作为 UI-only 节点，低优先级 |
@@ -102,7 +104,9 @@
 
 ### 知识流水线分类
 
-Xpert 知识流水线菜单按数据源、处理器、分块器、图像理解组织。ModelMirror 当前已有 RAG pipeline 元数据、`knowledge_citation` 节点、四段草稿、版本化执行，以及 Advanced RAG V2 的递归/父子分块、向量/FTS5 双索引和混合检索。工作流节点不直接保存检索实现细节，而是统一消费知识库 active version 固定 profile；候选失败或回滚不需要修改 workflow definition。
+工作流中的知识分类只展示知识消费节点。当前为 `knowledge_base` 资源绑定和 `knowledge_retrieval` 确定性检索；后续独立 PR 增加通用 `vision_understanding`。数据源、Processor、分块、Embedding、索引、检索策略、评测和版本管理属于 `/rag`，不得在 classic workflow 中复制实现或保留占位节点。
+
+`knowledge_retrieval` V2 读取指定知识库的活动版本并调用 `RagService.search_knowledge`，不额外生成回答。`returnMode=result` 输出上下文、受限来源、CitationAnchor、检索诊断和 warnings 的 typed object；`returnMode=context` 输出纯文本。活动版本切换仍由 RAG 指针控制，工作流定义无需改变。
 
 ### 对齐顺序
 
@@ -120,9 +124,9 @@ Xpert 知识流水线菜单按数据源、处理器、分块器、图像理解�
 
 - `工作流`：按逻辑、转换、工具、记忆、其他分组展示现有可运行节点。
 - `中间件`：继续从 `GET /api/runtime/middleware-nodes` 拉取 runtime middleware metadata，并保持现有 JSON 拖拽 payload。
-- `知识流水线`：classic workflow 暴露可运行的 `knowledge_citation` 节点；独立 `/rag/:kbId/pipeline` 画布负责数据源、视觉理解、处理器、分块器、Embedding 与索引执行，避免把两套节点协议混在一起。
+- `知识流水线`：classic workflow 暴露 `knowledge_base` 与 `knowledge_retrieval`；独立 `/rag/:kbId/pipeline` 画布负责数据源、视觉理解、处理器、分块器、Embedding、索引、策略和评测。
 
-本轮不新增后端节点类型，不修改 `NativeNodeKind`、validate、classic runner、SSE 协议或 React Flow 拖拽协议。数据库、注释、JSON 序列化/反序列化和知识流水线 stage 仅显示“待接入”占位，不会生成无法运行的画布节点。
+历史占位已收口：知识流水线 stage 不再显示在 classic workflow 节点库。`knowledge_citation` 仍属于 `SUPPORTED_NODE_KINDS` 以加载和运行旧图，但不再提供新建入口或 Planner 能力。
 
 ### 2026-07-09 增量：Xpert 式智能体配置侧栏
 
@@ -132,7 +136,7 @@ Xpert 知识流水线菜单按数据源、处理器、分块器、图像理解�
 
 - 继续复用现有 `agentMode`、`instruction`、`modelId`、`rolePrompt`、`taskInput`、`toolMode`、`toolNames`、`maxIterations`、`promptSuffix`、`outputVariable` 执行字段。
 - 新增 `disableOutput`、`enableFileUnderstanding`、`parallelToolCalls`、`retryOnFailure`、`fallbackModelId`、`exceptionHandling`、`outputSchemaMode`、`outputSchemaJson`、`memoryWriteEnabled`、`memoryWriteTarget`、`nodeParametersJson` 作为配置草稿字段。
-- 中间件与知识库区块当前只提示继续使用画布上的 `runtime_middleware`、`knowledge_retrieval`、`knowledge_citation` 节点，不做节点内嵌语义。
+- 中间件与知识库区块继续使用画布上的 `runtime_middleware`、`knowledge_base` 和 `knowledge_retrieval`；`knowledge_citation` 仅用于旧图加载与执行兼容。
 - 本轮不修改后端 validate、runner、RunRegistry、SSE 和拖拽协议；非 Agent 节点仍使用原有配置表单。
 
 > 2026-07-08 状态补充：Chat Toolset 运行观测进入最小闭环。`tool_mode=mcp_tools` 的聊天请求会登记 `chat` run，响应 header 返回 `X-ModelMirror-Runtime-Run-Id` / `X-ModelMirror-Runtime-Task-Id`；前端聊天页展示 run 状态、checkpoint、tool events 与 audit 摘要。普通聊天仍不创建 chat run，SSE wire format 不变。
@@ -724,9 +728,9 @@ Classic workflow 新增 handoff_router 节点，作为 workflow_agent -> Handoff
 
 因此 classic `/workflow` 的节点数据、validate API、拖拽协议和 SSE wire format 均保持不变。详细契约见 `docs/XPERT_GOALS.md`。
 
-## 2026-07-08 增量：Knowledge Citation 工作流节点
+## 2026-07-08 增量：Knowledge Citation 工作流节点（旧图兼容）
 
-Classic workflow 新增 `knowledge_citation` 节点，用于把本地 RAG Knowledge Pipeline 的 `CitationAnchor` 变成可拖拽、可配置、可运行、可观测的工作流能力。前端字段为 `queryVariable`、`knowledgeBaseId`、`top_k`、`outputVariable`；`knowledgeBaseId` 留空时使用第一个知识库，`top_k` 静态校验范围为 1-10。
+该历史节点把 CitationAnchor 写为 JSON 字符串。自 Workflow RAG Consumption V2 起，它不再出现在节点库或 Planner 中；旧图仍可加载和执行。显式 `knowledgeBaseId` 继续使用；缺失时只有恰好一个可用知识库才兼容执行，零个或多个知识库均 fail-closed。
 
 运行时读取 `variables[queryVariable]` 作为检索问题，调用 `RagService.create_pipeline_citations(kb_id, query_text, top_k=...)`，并将输出变量写成 JSON 字符串：
 
@@ -734,7 +738,7 @@ Classic workflow 新增 `knowledge_citation` 节点，用于把本地 RAG Knowle
 {"citations":[{"chunk_id":"...","document_name":"...","score":0.91,"snippet":"..."}],"citation_count":1}
 ```
 
-节点会登记 `knowledge_citation` 子 run，`parent_run_id` 指向 workflow run，并写入 `knowledge_citation.started/completed/failed` checkpoint。metadata 只保存知识库 ID、变量名、输出变量、引用数量等摘要，不返回本地文件路径、embedding、完整上传文件内容或密钥。该节点与既有 `knowledge_retrieval` 并存，不改变 `/api/rag/query`、聊天 RAG 或向量库行为。
+节点会登记 `knowledge_citation` 子 run，`parent_run_id` 指向 workflow run，并写入 `knowledge_citation.started/completed/failed` checkpoint。metadata 只保存知识库 ID、变量名、输出变量、引用数量等摘要，不返回本地文件路径、embedding、完整上传文件内容或密钥。新工作流统一使用 `knowledge_retrieval` V2 的 typed CitationAnchor。
 
 > 2026-07-10 Knowledge Pipeline draft config: `/rag` Pipeline Draft now supports safe saved config and preflight observation. Classic workflow `knowledge_citation` is unchanged; it still reads CitationAnchor summary JSON and does not execute draft config.
 

--- a/server/main.py
+++ b/server/main.py
@@ -435,10 +435,21 @@ except ModuleNotFoundError:
 
 try:
     from server.rag.document_parser import parse_document
-    from server.rag.rag_service import RagService
 except ModuleNotFoundError:
     from rag.document_parser import parse_document
-    from rag.rag_service import RagService
+
+try:
+    from server.xpert_runtime.workflow_knowledge import (
+        WorkflowKnowledgeContractError,
+        execute_workflow_knowledge_retrieval,
+        resolve_workflow_knowledge_base,
+    )
+except ModuleNotFoundError:
+    from xpert_runtime.workflow_knowledge import (
+        WorkflowKnowledgeContractError,
+        execute_workflow_knowledge_retrieval,
+        resolve_workflow_knowledge_base,
+    )
 
 try:
     from server.coding_runtime.api import router as coding_router
@@ -4294,6 +4305,16 @@ def workflow_document_extractor_root() -> Path:
 
 class WorkflowDocumentFatalError(RuntimeError):
     """Stable, path-free fatal error for document_extractor nodes."""
+
+    def __init__(self, node_id: str, error_code: str, safe_message: str) -> None:
+        super().__init__(safe_message)
+        self.node_id = node_id
+        self.error_code = error_code
+        self.safe_message = safe_message
+
+
+class WorkflowKnowledgeFatalError(RuntimeError):
+    """Stable, content-free fatal error for knowledge consumption nodes."""
 
     def __init__(self, node_id: str, error_code: str, safe_message: str) -> None:
         super().__init__(safe_message)
@@ -10005,6 +10026,7 @@ async def _run_workflow_response(
                         )
 
                 elif kind == "knowledge_retrieval":
+                    retrieval_run = None
                     try:
                         output_variable = str(
                             node.data.get("outputVariable") or "rag_context"
@@ -10017,53 +10039,161 @@ async def _run_workflow_response(
                             top_k = int(str(node.data.get("top_k") or "3"))
                         except ValueError:
                             top_k = 3
-                        top_k = max(1, min(top_k, 20))
-                        service = RagService(llm_enabled=False)
-                        knowledge_bases = service.list_knowledge_bases()
-                        if not knowledge_bases:
-                            output = ""
-                            variables[output_variable] = output
-                            yield sse_payload(
-                                {
-                                    "event": "error",
-                                    "node_id": node.id,
-                                    "message": "RAG 索引未就绪，尚无可查询知识库。",
-                                }
+                        contract_value = node.data.get("contractVersion")
+                        try:
+                            contract_version = (
+                                int(contract_value) if contract_value is not None else 1
                             )
-                        else:
-                            kb_id = str(knowledge_bases[0]["id"])
-                            result = await service.query(kb_id, query_text, top_k=top_k)
-                            sources = result.get("sources")
-                            if isinstance(sources, list):
-                                parts = [
-                                    str(source.get("text") or "")
-                                    for source in sources
-                                    if isinstance(source, dict) and source.get("text")
-                                ]
-                            else:
-                                parts = []
-                            output = "\n---\n".join(parts)
-                            variables[output_variable] = output
-                            yield sse_payload(
-                                {
-                                    "event": "node_delta",
-                                    "node_id": node.id,
-                                    "node_title": title,
-                                    "node_type": kind,
-                                    "output": output or "RAG 未返回相关片段。",
-                                    "variable": output_variable,
-                                }
+                        except (TypeError, ValueError) as exc:
+                            raise WorkflowKnowledgeContractError(
+                                "workflow_knowledge_contract_invalid",
+                                "Knowledge retrieval contractVersion is invalid.",
+                            ) from exc
+                        return_mode = str(
+                            node.data.get("returnMode")
+                            or ("result" if contract_version >= 2 else "context")
+                        ).strip()
+                        configured_kb_id = str(
+                            node.data.get("knowledgeBaseId") or ""
+                        ).strip()
+                        retrieval_run = await run_registry.create_run(
+                            "knowledge_retrieval",
+                            title,
+                            status="running",
+                            source_id=f"{task_id}:{node.id}",
+                            parent_run_id=workflow_run.run_id,
+                            metadata={
+                                "workflow_id": payload.workflow.id,
+                                "workflow_task_id": task_id,
+                                "node_id": node.id,
+                                "kb_id": configured_kb_id,
+                                "contract_version": contract_version,
+                                "return_mode": return_mode,
+                                "top_k": top_k,
+                                "output_variable": output_variable,
+                            },
+                        )
+                        await run_registry.record_checkpoint(
+                            retrieval_run.run_id,
+                            event_type="knowledge_retrieval.started",
+                            title="Knowledge retrieval started",
+                            summary=f"top_k={top_k}, return_mode={return_mode}",
+                            metadata={
+                                "node_id": node.id,
+                                "kb_id": configured_kb_id,
+                                "contract_version": contract_version,
+                                "return_mode": return_mode,
+                                "top_k": top_k,
+                            },
+                        )
+                        output, retrieval_metadata = (
+                            await execute_workflow_knowledge_retrieval(
+                                get_rag_service(),
+                                configured_kb_id=configured_kb_id,
+                                query=query_text,
+                                top_k=top_k,
+                                contract_version=contract_version,
+                                return_mode=return_mode,
                             )
-                    except Exception as exc:
-                        logger.warning("Workflow knowledge_retrieval node failed: %s", exc)
-                        variables[str(node.data.get("outputVariable") or "rag_context")] = ""
+                        )
+                        variables[output_variable] = output
+                        output_length = len(workflow_value_to_text(output))
+                        await run_registry.update_run(
+                            retrieval_run.run_id,
+                            status="completed",
+                            metadata={
+                                **retrieval_metadata,
+                                "output_length": output_length,
+                            },
+                        )
+                        await run_registry.record_checkpoint(
+                            retrieval_run.run_id,
+                            event_type="knowledge_retrieval.completed",
+                            title="Knowledge retrieval completed",
+                            summary=(
+                                f"hit_count={retrieval_metadata['hit_count']}, "
+                                f"output_length={output_length}"
+                            ),
+                            metadata={
+                                "node_id": node.id,
+                                **retrieval_metadata,
+                                "output_variable": output_variable,
+                                "output_length": output_length,
+                            },
+                        )
+                        display_output = (
+                            workflow_value_to_text(output)[:1_000]
+                            if isinstance(output, str)
+                            else (
+                                f"Retrieved {retrieval_metadata['hit_count']} source(s) "
+                                f"into {output_variable}."
+                            )
+                        )
                         yield sse_payload(
                             {
-                                "event": "error",
+                                "event": "node_delta",
                                 "node_id": node.id,
-                                "message": str(exc),
+                                "node_title": title,
+                                "node_type": kind,
+                                "output": display_output,
+                                "variable": output_variable,
+                                "run_id": retrieval_run.run_id,
+                                **retrieval_metadata,
                             }
                         )
+                    except WorkflowKnowledgeContractError as exc:
+                        if retrieval_run is not None:
+                            await run_registry.record_checkpoint(
+                                retrieval_run.run_id,
+                                event_type="knowledge_retrieval.failed",
+                                title="Knowledge retrieval failed",
+                                summary=exc.error_code,
+                                severity="error",
+                                metadata={
+                                    "node_id": node.id,
+                                    "error_code": exc.error_code,
+                                },
+                            )
+                            await run_registry.update_run(
+                                retrieval_run.run_id,
+                                status="failed",
+                                error=exc.safe_message,
+                            )
+                        raise WorkflowKnowledgeFatalError(
+                            node.id,
+                            exc.error_code,
+                            exc.safe_message,
+                        ) from None
+                    except Exception as exc:
+                        logger.warning(
+                            "Workflow knowledge_retrieval node failed: %s",
+                            type(exc).__name__,
+                        )
+                        if retrieval_run is not None:
+                            try:
+                                await run_registry.record_checkpoint(
+                                    retrieval_run.run_id,
+                                    event_type="knowledge_retrieval.failed",
+                                    title="Knowledge retrieval failed",
+                                    summary="workflow_knowledge_retrieval_failed",
+                                    severity="error",
+                                    metadata={"node_id": node.id},
+                                )
+                                await run_registry.update_run(
+                                    retrieval_run.run_id,
+                                    status="failed",
+                                    error="Knowledge retrieval failed.",
+                                )
+                            except Exception:
+                                logger.warning(
+                                    "Failed to update knowledge retrieval run",
+                                    exc_info=True,
+                                )
+                        raise WorkflowKnowledgeFatalError(
+                            node.id,
+                            "workflow_knowledge_retrieval_failed",
+                            "Knowledge retrieval failed.",
+                        ) from None
 
                 elif kind == "knowledge_citation":
                     output_variable = str(
@@ -10091,10 +10221,13 @@ async def _run_workflow_response(
                         top_k = max(1, min(top_k, 10))
 
                         service = get_rag_service()
-                        if not knowledge_base_id:
-                            knowledge_bases = service.list_knowledge_bases()
-                            if knowledge_bases:
-                                knowledge_base_id = str(knowledge_bases[0]["id"])
+                        knowledge_base_id, compatibility_warnings = (
+                            resolve_workflow_knowledge_base(
+                                service,
+                                knowledge_base_id,
+                                allow_legacy_fallback=True,
+                            )
+                        )
 
                         citation_run = await run_registry.create_run(
                             "knowledge_citation",
@@ -10112,6 +10245,7 @@ async def _run_workflow_response(
                                 "query_variable": query_variable,
                                 "output_variable": output_variable,
                                 "top_k": top_k,
+                                "warning_count": len(compatibility_warnings),
                             },
                         )
                         await run_registry.record_checkpoint(
@@ -10125,123 +10259,95 @@ async def _run_workflow_response(
                                 "query_variable": query_variable,
                                 "output_variable": output_variable,
                                 "top_k": top_k,
+                                "warning_count": len(compatibility_warnings),
                             },
                         )
-
-                        if not knowledge_base_id:
-                            variables[output_variable] = output
-                            await run_registry.update_run(
-                                citation_run.run_id,
-                                status="completed",
-                                metadata={"citation_count": 0},
-                            )
-                            await run_registry.record_checkpoint(
-                                citation_run.run_id,
-                                event_type="knowledge_citation.completed",
-                                title="Knowledge citation completed",
-                                summary="citation_count=0",
-                                metadata={
-                                    "node_id": node.id,
-                                    "citation_count": 0,
-                                },
-                            )
-                            yield sse_payload(
-                                {
-                                    "event": "error",
-                                    "node_id": node.id,
-                                    "message": "RAG 索引尚未就绪，暂无可查询知识库。",
-                                }
-                            )
-                            yield sse_payload(
-                                {
-                                    "event": "node_delta",
-                                    "node_id": node.id,
-                                    "node_title": title,
-                                    "node_type": kind,
-                                    "output": "未找到可查询知识库，已写入空 CitationAnchor JSON。",
-                                    "variable": output_variable,
-                                    "run_id": citation_run.run_id,
-                                    "citation_count": 0,
-                                }
-                            )
-                        else:
-                            citations = await service.create_pipeline_citations(
-                                knowledge_base_id,
-                                query_text,
-                                top_k=top_k,
-                            )
-                            payload_json = {
-                                "citations": citations,
-                                "citation_count": len(citations),
-                            }
-                            output = json.dumps(payload_json, ensure_ascii=False)
-                            variables[output_variable] = output
-                            await run_registry.update_run(
-                                citation_run.run_id,
-                                status="completed",
-                                metadata={
-                                    "kb_id": knowledge_base_id,
-                                    "citation_count": len(citations),
-                                    "output_length": len(output),
-                                },
-                            )
-                            await run_registry.record_checkpoint(
-                                citation_run.run_id,
-                                event_type="knowledge_citation.completed",
-                                title="Knowledge citation completed",
-                                summary=f"citation_count={len(citations)}",
-                                metadata={
-                                    "node_id": node.id,
-                                    "kb_id": knowledge_base_id,
-                                    "citation_count": len(citations),
-                                    "output_variable": output_variable,
-                                },
-                            )
-                            yield sse_payload(
-                                {
-                                    "event": "node_delta",
-                                    "node_id": node.id,
-                                    "node_title": title,
-                                    "node_type": kind,
-                                    "output": (
-                                        f"已生成 {len(citations)} 个 CitationAnchor，"
-                                        f"写入 {output_variable}。"
-                                    ),
-                                    "variable": output_variable,
-                                    "run_id": citation_run.run_id,
-                                    "citation_count": len(citations),
-                                }
-                            )
-                    except Exception as exc:
-                        logger.warning("Workflow knowledge_citation node failed: %s", exc)
+                        citations = await service.create_pipeline_citations(
+                            knowledge_base_id,
+                            query_text,
+                            top_k=top_k,
+                        )
+                        payload_json = {
+                            "citations": citations,
+                            "citation_count": len(citations),
+                        }
+                        output = json.dumps(payload_json, ensure_ascii=False)
                         variables[output_variable] = output
+                        await run_registry.update_run(
+                            citation_run.run_id,
+                            status="completed",
+                            metadata={
+                                "kb_id": knowledge_base_id,
+                                "citation_count": len(citations),
+                                "output_length": len(output),
+                                "warning_count": len(compatibility_warnings),
+                            },
+                        )
+                        await run_registry.record_checkpoint(
+                            citation_run.run_id,
+                            event_type="knowledge_citation.completed",
+                            title="Knowledge citation completed",
+                            summary=f"citation_count={len(citations)}",
+                            metadata={
+                                "node_id": node.id,
+                                "kb_id": knowledge_base_id,
+                                "citation_count": len(citations),
+                                "output_variable": output_variable,
+                                "warning_count": len(compatibility_warnings),
+                            },
+                        )
+                        yield sse_payload(
+                            {
+                                "event": "node_delta",
+                                "node_id": node.id,
+                                "node_title": title,
+                                "node_type": kind,
+                                "output": (
+                                    f"已生成 {len(citations)} 个 CitationAnchor，"
+                                    f"写入 {output_variable}。"
+                                ),
+                                "variable": output_variable,
+                                "run_id": citation_run.run_id,
+                                "citation_count": len(citations),
+                                "warning_count": len(compatibility_warnings),
+                            }
+                        )
+                    except WorkflowKnowledgeContractError as exc:
+                        raise WorkflowKnowledgeFatalError(
+                            node.id,
+                            exc.error_code,
+                            exc.safe_message,
+                        ) from None
+                    except Exception as exc:
+                        logger.warning(
+                            "Workflow knowledge_citation node failed: %s",
+                            type(exc).__name__,
+                        )
                         if citation_run is not None:
                             try:
                                 await run_registry.record_checkpoint(
                                     citation_run.run_id,
                                     event_type="knowledge_citation.failed",
                                     title="Knowledge citation failed",
-                                    summary=str(exc),
+                                    summary="workflow_knowledge_citation_failed",
                                     severity="error",
                                     metadata={"node_id": node.id},
                                 )
                                 await run_registry.update_run(
                                     citation_run.run_id,
                                     status="failed",
-                                    error=str(exc),
+                                    error="Knowledge citation failed.",
                                 )
                             except Exception:
                                 logger.warning(
                                     "Failed to update knowledge_citation run status",
                                     exc_info=True,
                                 )
-                        yield sse_payload(
-                            {
-                                "event": "error",
-                                "node_id": node.id,
-                                "message": str(exc),
-                            }
-                        )
+                        raise WorkflowKnowledgeFatalError(
+                            node.id,
+                            "workflow_knowledge_citation_failed",
+                            "Knowledge citation failed.",
+                        ) from None
 
                 elif kind == "document_extractor":
                     try:
@@ -13986,6 +14092,64 @@ async def _run_workflow_response(
                 )
             task_state["created_at"] = time.monotonic()
             yield sse_payload(pending_event)
+        except WorkflowKnowledgeFatalError as exc:
+            failure_error = f"{exc.error_code}: {exc.safe_message}"
+            logger.warning(
+                "Workflow knowledge node failed workflow=%s node=%s code=%s",
+                payload.workflow.id,
+                exc.node_id,
+                exc.error_code,
+            )
+            try:
+                await run_registry.update_run(
+                    workflow_run.run_id,
+                    status="failed",
+                    error=failure_error,
+                )
+                await run_registry.record_checkpoint(
+                    workflow_run.run_id,
+                    event_type="workflow.knowledge.failed",
+                    title="Knowledge consumption failed",
+                    summary=exc.error_code,
+                    severity="error",
+                    metadata={
+                        "node_id": exc.node_id,
+                        "error_code": exc.error_code,
+                    },
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to update workflow knowledge failure status",
+                    exc_info=True,
+                )
+            try:
+                workflow_execution_store.fail(task_id, error=failure_error)
+                workflow_execution_store.append_event(
+                    task_id,
+                    {
+                        "event": "error",
+                        "task_id": task_id,
+                        "run_id": workflow_run.run_id,
+                        "node_id": exc.node_id,
+                        "code": exc.error_code,
+                        "message": exc.safe_message,
+                    },
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to persist workflow knowledge failure",
+                    exc_info=True,
+                )
+            yield sse_payload(
+                {
+                    "event": "error",
+                    "task_id": task_id,
+                    "run_id": workflow_run.run_id,
+                    "node_id": exc.node_id,
+                    "code": exc.error_code,
+                    "message": exc.safe_message,
+                }
+            )
         except WorkflowDocumentFatalError as exc:
             failure_error = f"{exc.error_code}: {exc.safe_message}"
             logger.warning(

--- a/server/meta_agent/capabilities.py
+++ b/server/meta_agent/capabilities.py
@@ -88,11 +88,13 @@ def build_capability_snapshot(
                     "tags": list(item.get("tags") or [])[:12],
                     "planner": {
                         "enabled": True,
+                        "support": planner.get("support", "full"),
                         "default_data": dict(planner.get("default_data") or {}),
                         "config_constraints": dict(
                             planner.get("config_constraints") or {}
                         ),
                     },
+                    "contracts": dict(item.get("contracts") or {}),
                 }
             )
     for item in node_payload.get("knowledge_pipeline", {}).get("items", []):
@@ -107,11 +109,13 @@ def build_capability_snapshot(
                     "tags": list(item.get("tags") or [])[:12],
                     "planner": {
                         "enabled": True,
+                        "support": planner.get("support", "full"),
                         "default_data": dict(planner.get("default_data") or {}),
                         "config_constraints": dict(
                             planner.get("config_constraints") or {}
                         ),
                     },
+                    "contracts": dict(item.get("contracts") or {}),
                 }
             )
     nodes.sort(key=lambda item: item["kind"])

--- a/server/rag/rag_service.py
+++ b/server/rag/rag_service.py
@@ -4128,8 +4128,18 @@ class RagService:
             top_k=top_k,
             retrieval=retrieval,
         )
+        return self.citation_anchors_from_search_result(result)
+
+    def citation_anchors_from_search_result(
+        self,
+        result: dict[str, Any],
+    ) -> list[dict[str, Any]]:
+        """Build stable citation anchors without issuing a second retrieval."""
+
         citations: list[dict[str, Any]] = []
         for source in result.get("sources", []):
+            if not isinstance(source, dict):
+                continue
             chunk_id = str(source.get("chunk_id", ""))
             doc_id = str(source.get("source_document_id") or source.get("doc_id", ""))
             citations.append(

--- a/server/tests/test_workflow_knowledge_retrieval_v2.py
+++ b/server/tests/test_workflow_knowledge_retrieval_v2.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from server.main import app
+from server.rag.api import set_rag_service_for_tests
+from server.rag.embedder import EmbeddingClient
+from server.rag.rag_service import RagService
+from server.rag.vector_store import LocalJsonVectorStore
+from server.xpert_runtime.workflow_knowledge import (
+    WorkflowKnowledgeContractError,
+    execute_workflow_knowledge_retrieval,
+    resolve_workflow_knowledge_base,
+)
+
+
+class _FakeKnowledgeService:
+    def __init__(self, knowledge_bases: list[dict[str, Any]]) -> None:
+        self.knowledge_bases = knowledge_bases
+        self.search_calls = 0
+
+    def list_knowledge_bases(self) -> list[dict[str, Any]]:
+        return list(self.knowledge_bases)
+
+    async def search_knowledge(
+        self,
+        kb_id: str,
+        question: str,
+        *,
+        top_k: int = 5,
+    ) -> dict[str, Any]:
+        self.search_calls += 1
+        return {
+            "kb_id": kb_id,
+            "version_id": "version_2",
+            "answer": "ignored generated answer",
+            "sources": [
+                {
+                    "chunk_id": "chunk_1",
+                    "source_document_id": "doc_1",
+                    "document_name": "manual.md",
+                    "text": "A" * 2_500,
+                    "matched_text": "relevant context",
+                    "score": 0.88,
+                    "source_block_id": "block_1",
+                }
+            ],
+            "retrieval": {"mode": "hybrid", "top_k": top_k},
+            "warnings": ["hash embedding fallback"],
+        }
+
+    def citation_anchors_from_search_result(
+        self,
+        result: dict[str, Any],
+    ) -> list[dict[str, Any]]:
+        source = result["sources"][0]
+        return [
+            {
+                "citation_id": "citation_chunk_1",
+                "chunk_id": source["chunk_id"],
+                "document_id": source["source_document_id"],
+                "document_name": source["document_name"],
+                "score": source["score"],
+                "snippet": source["matched_text"],
+                "source_block_id": source["source_block_id"],
+            }
+        ]
+
+
+def test_resolve_legacy_knowledge_base_only_allows_one_available_kb() -> None:
+    service = _FakeKnowledgeService([{"id": "kb_one"}])
+
+    kb_id, warnings = resolve_workflow_knowledge_base(
+        service,
+        "",
+        allow_legacy_fallback=True,
+    )
+
+    assert kb_id == "kb_one"
+    assert warnings == [
+        "Legacy node omitted knowledgeBaseId; the only available knowledge base was used."
+    ]
+
+    service.knowledge_bases.append({"id": "kb_two"})
+    with pytest.raises(WorkflowKnowledgeContractError) as exc_info:
+        resolve_workflow_knowledge_base(
+            service,
+            "",
+            allow_legacy_fallback=True,
+        )
+    assert exc_info.value.error_code == "workflow_knowledge_base_ambiguous"
+
+
+@pytest.mark.asyncio
+async def test_execute_v2_returns_limited_typed_result_without_rag_answer() -> None:
+    service = _FakeKnowledgeService([{"id": "kb_one"}])
+
+    result, metadata = await execute_workflow_knowledge_retrieval(
+        service,
+        configured_kb_id="kb_one",
+        query="Where is the policy?",
+        top_k=5,
+        contract_version=2,
+        return_mode="result",
+    )
+
+    assert service.search_calls == 1
+    assert result["knowledge_base_id"] == "kb_one"
+    assert result["version_id"] == "version_2"
+    assert result["context"] == "A" * 2_000
+    assert result["sources"][0]["text_length"] == 2_500
+    assert result["sources"][0]["text_truncated"] is True
+    assert result["citations"][0]["source_block_id"] == "block_1"
+    assert "answer" not in result
+    assert metadata == {
+        "kb_id": "kb_one",
+        "version_id": "version_2",
+        "hit_count": 1,
+        "citation_count": 1,
+        "context_length": 2_000,
+        "warning_count": 1,
+        "contract_version": 2,
+        "return_mode": "result",
+    }
+
+
+@pytest_asyncio.fixture
+async def client(tmp_path: Path):
+    service = RagService(
+        storage_dir=tmp_path / "storage",
+        uploads_dir=tmp_path / "uploads",
+        embedder=EmbeddingClient(api_key="", dimension=128),
+        vector_store=LocalJsonVectorStore(tmp_path / "storage" / "vectors.json"),
+        llm_enabled=False,
+    )
+    set_rag_service_for_tests(service)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://testserver",
+    ) as async_client:
+        yield async_client
+    set_rag_service_for_tests(None)
+
+
+async def _create_kb(client: httpx.AsyncClient, name: str, text: bytes) -> str:
+    kb_response = await client.post(
+        "/api/rag/knowledge_bases",
+        json={"name": name},
+    )
+    assert kb_response.status_code == 200, kb_response.text
+    kb_id = kb_response.json()["id"]
+    upload_response = await client.post(
+        f"/api/rag/knowledge_bases/{kb_id}/documents",
+        files={"file": (f"{name}.txt", text, "text/plain")},
+    )
+    assert upload_response.status_code == 200, upload_response.text
+    return kb_id
+
+
+def _workflow(kb_id: str, *, contract_version: int | None = 2) -> dict[str, Any]:
+    data: dict[str, Any] = {
+        "kind": "knowledge_retrieval",
+        "queryVariable": "user_input",
+        "knowledgeBaseId": kb_id,
+        "top_k": "3",
+        "outputVariable": "knowledge_result",
+    }
+    if contract_version is not None:
+        data.update({"contractVersion": contract_version, "returnMode": "result"})
+    return {
+        "id": "knowledge-retrieval-v2-workflow",
+        "title": "Knowledge retrieval V2",
+        "nodes": [
+            {
+                "id": "input",
+                "type": "input",
+                "data": {"kind": "input", "variableName": "user_input"},
+            },
+            {"id": "retrieval", "type": "knowledge_retrieval", "data": data},
+            {
+                "id": "output",
+                "type": "output",
+                "data": {"kind": "output", "outputVariable": "knowledge_result"},
+            },
+        ],
+        "edges": [
+            {"id": "e1", "source": "input", "target": "retrieval"},
+            {"id": "e2", "source": "retrieval", "target": "output"},
+        ],
+    }
+
+
+def _parse_sse_events(sse_text: str) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    for line in sse_text.splitlines():
+        if not line.startswith("data:"):
+            continue
+        try:
+            payload = json.loads(line[5:].strip())
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            events.append(payload)
+    return events
+
+
+@pytest.mark.asyncio
+async def test_workflow_retrieval_v2_preserves_typed_variable(
+    client: httpx.AsyncClient,
+) -> None:
+    kb_id = await _create_kb(
+        client,
+        "retrieval-v2",
+        b"The blue protocol requires a signed approval record before deployment.",
+    )
+
+    response = await client.post(
+        "/api/workflow/run",
+        json={
+            "workflow": _workflow(kb_id),
+            "inputs": {"user_input": "What does the blue protocol require?"},
+        },
+    )
+    assert response.status_code == 200, response.text
+    events = _parse_sse_events(response.text)
+    node_end = next(
+        event
+        for event in events
+        if event.get("event") == "node_end" and event.get("node_id") == "retrieval"
+    )
+    result = node_end["variables"]["knowledge_result"]
+    assert isinstance(result, dict)
+    assert result["knowledge_base_id"] == kb_id
+    assert result["sources"]
+    assert result["citations"]
+    assert "signed approval record" in result["context"]
+
+
+@pytest.mark.asyncio
+async def test_legacy_retrieval_without_kb_fails_when_multiple_exist(
+    client: httpx.AsyncClient,
+) -> None:
+    await _create_kb(client, "first", b"First knowledge base content.")
+    await _create_kb(client, "second", b"Second knowledge base content.")
+    workflow = _workflow("", contract_version=None)
+
+    response = await client.post(
+        "/api/workflow/run",
+        json={"workflow": workflow, "inputs": {"user_input": "content"}},
+    )
+    assert response.status_code == 200, response.text
+    events = _parse_sse_events(response.text)
+    error = next(event for event in events if event.get("event") == "error")
+    assert error["code"] == "workflow_knowledge_base_ambiguous"
+    assert "multiple" in error["message"].lower()

--- a/server/tests/test_workflow_native_validate.py
+++ b/server/tests/test_workflow_native_validate.py
@@ -400,6 +400,45 @@ async def test_validate_knowledge_retrieval_top_k(client: httpx.AsyncClient) -> 
 
 
 @pytest.mark.asyncio
+async def test_validate_knowledge_retrieval_v2_contract(
+    client: httpx.AsyncClient,
+) -> None:
+    workflow = linear_workflow()
+    workflow["nodes"][1] = {
+        "id": "retrieval",
+        "type": "knowledge_retrieval",
+        "data": {
+            "kind": "knowledge_retrieval",
+            "contractVersion": 2,
+            "knowledgeBaseId": "kb_test",
+            "queryVariable": "user_input",
+            "top_k": "5",
+            "returnMode": "result",
+            "outputVariable": "knowledge_result",
+        },
+    }
+    workflow["nodes"][2]["data"]["outputVariable"] = "knowledge_result"
+    workflow["edges"] = [
+        {"id": "e1", "source": "input", "target": "retrieval"},
+        {"id": "e2", "source": "retrieval", "target": "output"},
+    ]
+
+    data = await validate(client, workflow)
+    assert data["valid"] is True
+
+    workflow["nodes"][1]["data"]["knowledgeBaseId"] = ""
+    data = await validate(client, workflow)
+    assert data["valid"] is False
+    assert "missing_knowledge_retrieval_knowledge_base_id" in issue_codes(data)
+
+    workflow["nodes"][1]["data"]["knowledgeBaseId"] = "kb_test"
+    workflow["nodes"][1]["data"]["returnMode"] = "answer"
+    data = await validate(client, workflow)
+    assert data["valid"] is False
+    assert "invalid_knowledge_retrieval_return_mode" in issue_codes(data)
+
+
+@pytest.mark.asyncio
 async def test_validate_knowledge_citation_node_ok(client: httpx.AsyncClient) -> None:
     workflow = linear_workflow()
     workflow["nodes"][1] = {

--- a/server/tests/test_workflow_resource_nodes.py
+++ b/server/tests/test_workflow_resource_nodes.py
@@ -143,6 +143,47 @@ def _with_bound_resources(
     return NativeWorkflowDefinition.model_validate(result)
 
 
+def _with_knowledge_retrieval(
+    workflow: NativeWorkflowDefinition,
+    *,
+    knowledge_base_id: str,
+) -> NativeWorkflowDefinition:
+    result = workflow.model_dump(mode="json")
+    result["nodes"].append(
+        {
+            "id": "knowledge-retrieval-1",
+            "type": "knowledge_retrieval",
+            "data": {
+                "kind": "knowledge_retrieval",
+                "contractVersion": 2,
+                "knowledgeBaseId": knowledge_base_id,
+                "queryVariable": "user_input",
+                "top_k": "5",
+                "returnMode": "result",
+                "outputVariable": "knowledge_result",
+            },
+        }
+    )
+    result["edges"] = [
+        {
+            "id": "edge-input-retrieval",
+            "source": "input-1",
+            "target": "knowledge-retrieval-1",
+        },
+        {
+            "id": "edge-retrieval-agent",
+            "source": "knowledge-retrieval-1",
+            "target": "workflow-agent-1",
+        },
+        {
+            "id": "edge-agent-output",
+            "source": "workflow-agent-1",
+            "target": "output-1",
+        },
+    ]
+    return NativeWorkflowDefinition.model_validate(result)
+
+
 def test_resource_bindings_are_valid_and_do_not_enter_control_flow(
     resource_stores,
 ) -> None:
@@ -308,6 +349,55 @@ async def test_publish_pins_external_xpert_version_and_app_blocks_it(
     )
     assert "app_external_xpert_forbidden" in {
         issue["code"] for issue in preflight["issues"]
+    }
+
+
+@pytest.mark.asyncio
+async def test_publish_validates_explicit_knowledge_retrieval_resource(
+    client: httpx.AsyncClient,
+    resource_stores,
+) -> None:
+    xpert_store, rag_service = resource_stores
+    knowledge_base = rag_service.create_knowledge_base("Published Knowledge")
+    xpert = xpert_store.create_xpert(name="Knowledge Consumer")
+    draft = xpert.draft.model_copy(deep=True)
+    draft.workflow = _with_knowledge_retrieval(
+        draft.workflow,
+        knowledge_base_id=knowledge_base["id"],
+    )
+    xpert = xpert_store.update_xpert(
+        xpert.id,
+        {"draft": draft.model_dump(mode="json")},
+    )
+
+    response = await client.post(f"/api/xperts/{xpert.id}/publish", json={})
+    assert response.status_code == 200, response.text
+    published = xpert_store.get_version(xpert.id, 1)
+    retrieval = next(
+        node
+        for node in published.workflow.nodes
+        if str(node.data.get("kind") or node.type) == "knowledge_retrieval"
+    )
+    assert retrieval.data["knowledgeBaseId"] == knowledge_base["id"]
+    assert retrieval.data["contractVersion"] == 2
+
+    missing = xpert_store.create_xpert(name="Missing Knowledge Consumer")
+    missing_draft = missing.draft.model_copy(deep=True)
+    missing_draft.workflow = _with_knowledge_retrieval(
+        missing_draft.workflow,
+        knowledge_base_id="kb_missing",
+    )
+    missing = xpert_store.update_xpert(
+        missing.id,
+        {"draft": missing_draft.model_dump(mode="json")},
+    )
+    rejected = await client.post(
+        f"/api/xperts/{missing.id}/publish",
+        json={},
+    )
+    assert rejected.status_code == 422, rejected.text
+    assert "xpert_knowledge_base_not_found" in {
+        issue["code"] for issue in rejected.json()["detail"]["issues"]
     }
 
 

--- a/server/tests/test_xpert_runtime_workflow_node_registry.py
+++ b/server/tests/test_xpert_runtime_workflow_node_registry.py
@@ -31,10 +31,25 @@ def _registry() -> WorkflowNodeRegistry:
 def test_workflow_node_registry_returns_workflow_and_knowledge_tabs() -> None:
     payload = _registry().to_payload()
 
-    assert payload["version"] == "xpert-workflow-node-registry-v1"
+    assert payload["version"] == "xpert-workflow-node-registry-v2"
     assert {tab["id"] for tab in payload["tabs"]} == {"workflow", "knowledge"}
     assert payload["sections"]
-    assert payload["knowledge_pipeline"]["items"]
+    knowledge_items = payload["knowledge_pipeline"]["items"]
+    assert [item["kind"] for item in knowledge_items] == [
+        "knowledge_base",
+        "knowledge_retrieval",
+    ]
+    assert payload["knowledge_pipeline"]["placeholders"] == []
+
+    knowledge_base, retrieval = knowledge_items
+    assert knowledge_base["planner"]["support"] == "binding_only"
+    assert knowledge_base["contracts"]["resources"] == ["knowledge_base"]
+    assert retrieval["planner"]["enabled"] is False
+    assert retrieval["planner"]["support"] == "unsupported"
+    assert retrieval["contracts"]["outputs"] == {
+        "context": "string",
+        "result": "object",
+    }
 
 
 def test_enabled_workflow_node_kinds_are_supported() -> None:
@@ -89,7 +104,6 @@ def test_placeholders_are_disabled_and_do_not_declare_kind() -> None:
         placeholders.extend(section["placeholders"])
     placeholders.extend(payload["knowledge_pipeline"]["placeholders"])
 
-    assert placeholders
     assert all(item["enabled"] is False for item in placeholders)
     assert all("kind" not in item for item in placeholders)
     assert all(item["statusLabel"] for item in placeholders)
@@ -103,8 +117,15 @@ async def test_workflow_node_registry_api_returns_stable_shape(
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload["version"] == "xpert-workflow-node-registry-v1"
+    assert payload["version"] == "xpert-workflow-node-registry-v2"
     assert isinstance(payload["tabs"], list)
     assert isinstance(payload["sections"], list)
     assert isinstance(payload["knowledge_pipeline"], dict)
-    assert payload["knowledge_pipeline"]["items"][0]["kind"] == "knowledge_citation"
+    assert [
+        item["kind"] for item in payload["knowledge_pipeline"]["items"]
+    ] == ["knowledge_base", "knowledge_retrieval"]
+    assert all(
+        item["kind"] != "knowledge_citation"
+        for section in payload["sections"]
+        for item in section["items"]
+    )

--- a/server/workflow_native/validate.py
+++ b/server/workflow_native/validate.py
@@ -937,7 +937,8 @@ def validate_node_configuration(
             )
 
     if kind == "knowledge_retrieval":
-        if not str(data.get("queryVariable") or "").strip():
+        query_variable = str(data.get("queryVariable") or "").strip()
+        if not query_variable:
             issues.append(
                 ValidationIssue(
                     code="missing_knowledge_retrieval_query_variable",
@@ -945,16 +946,63 @@ def validate_node_configuration(
                     node_id=node.id,
                 )
             )
+        elif not is_variable_name(query_variable):
+            issues.append(
+                ValidationIssue(
+                    code="invalid_knowledge_retrieval_query_variable",
+                    message="Knowledge retrieval queryVariable must be an identifier.",
+                    node_id=node.id,
+                )
+            )
+        raw_contract_version = data.get("contractVersion")
+        contract_version = 1
+        if raw_contract_version is not None:
+            try:
+                contract_version = int(raw_contract_version)
+            except (TypeError, ValueError):
+                contract_version = 0
+            if contract_version != 2:
+                issues.append(
+                    ValidationIssue(
+                        code="invalid_knowledge_retrieval_contract_version",
+                        message="Knowledge retrieval contractVersion must be 2 when set.",
+                        node_id=node.id,
+                    )
+                )
+        if contract_version == 2:
+            if not str(data.get("knowledgeBaseId") or "").strip():
+                issues.append(
+                    ValidationIssue(
+                        code="missing_knowledge_retrieval_knowledge_base_id",
+                        message="Knowledge retrieval V2 needs data.knowledgeBaseId.",
+                        node_id=node.id,
+                    )
+                )
+            return_mode = str(data.get("returnMode") or "result").strip()
+            if return_mode not in {"context", "result"}:
+                issues.append(
+                    ValidationIssue(
+                        code="invalid_knowledge_retrieval_return_mode",
+                        message=(
+                            "Knowledge retrieval returnMode must be context or result."
+                        ),
+                        node_id=node.id,
+                    )
+                )
         top_k = str(data.get("top_k") or "3").strip()
         try:
             top_k_int = int(top_k)
         except ValueError:
             top_k_int = 0
-        if top_k_int < 1 or top_k_int > 20:
+        top_k_max = 10 if contract_version == 2 else 20
+        if top_k_int < 1 or top_k_int > top_k_max:
             issues.append(
                 ValidationIssue(
                     code="invalid_knowledge_retrieval_top_k",
-                    message="Knowledge retrieval top_k must be an integer between 1 and 20.",
+                    message=(
+                        "Knowledge retrieval top_k must be an integer between "
+                        f"1 and {top_k_max}."
+                    ),
                     node_id=node.id,
                 )
             )

--- a/server/xpert_runtime/workflow_knowledge.py
+++ b/server/xpert_runtime/workflow_knowledge.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+
+MAX_CONTEXT_LENGTH = 20_000
+MAX_SOURCE_TEXT_LENGTH = 2_000
+MAX_MATCHED_TEXT_LENGTH = 1_000
+
+
+class WorkflowKnowledgeService(Protocol):
+    def list_knowledge_bases(self) -> list[dict[str, Any]]: ...
+
+    async def search_knowledge(
+        self,
+        kb_id: str,
+        question: str,
+        *,
+        top_k: int = 5,
+        retrieval: dict[str, Any] | None = None,
+        version_id: str | None = None,
+    ) -> dict[str, Any]: ...
+
+    def citation_anchors_from_search_result(
+        self,
+        result: dict[str, Any],
+    ) -> list[dict[str, Any]]: ...
+
+
+class WorkflowKnowledgeContractError(RuntimeError):
+    """Stable, content-free failure for workflow knowledge consumption."""
+
+    def __init__(self, error_code: str, safe_message: str) -> None:
+        super().__init__(safe_message)
+        self.error_code = error_code
+        self.safe_message = safe_message
+
+
+def resolve_workflow_knowledge_base(
+    service: WorkflowKnowledgeService,
+    configured_id: str,
+    *,
+    allow_legacy_fallback: bool,
+) -> tuple[str, list[str]]:
+    knowledge_bases = service.list_knowledge_bases()
+    available_ids = {
+        str(item.get("id") or "").strip()
+        for item in knowledge_bases
+        if isinstance(item, dict) and str(item.get("id") or "").strip()
+    }
+    requested_id = str(configured_id or "").strip()
+    if requested_id:
+        if requested_id not in available_ids:
+            raise WorkflowKnowledgeContractError(
+                "workflow_knowledge_base_not_found",
+                "The configured knowledge base is unavailable.",
+            )
+        return requested_id, []
+
+    if not allow_legacy_fallback:
+        raise WorkflowKnowledgeContractError(
+            "workflow_knowledge_base_required",
+            "Select a knowledge base before running this node.",
+        )
+    if len(available_ids) == 1:
+        return next(iter(available_ids)), [
+            "Legacy node omitted knowledgeBaseId; the only available knowledge base was used."
+        ]
+    if not available_ids:
+        raise WorkflowKnowledgeContractError(
+            "workflow_knowledge_base_unavailable",
+            "No knowledge base is available for this legacy node.",
+        )
+    raise WorkflowKnowledgeContractError(
+        "workflow_knowledge_base_ambiguous",
+        "This legacy node does not identify a knowledge base and multiple choices exist.",
+    )
+
+
+def _limited_source(source: dict[str, Any]) -> dict[str, Any]:
+    text = str(source.get("text") or "")
+    matched_text = str(source.get("matched_text") or "")
+    return {
+        "chunk_id": str(source.get("chunk_id") or ""),
+        "document_id": str(
+            source.get("source_document_id") or source.get("doc_id") or ""
+        ),
+        "document_name": str(source.get("document_name") or "")[:500],
+        "text": text[:MAX_SOURCE_TEXT_LENGTH],
+        "text_length": len(text),
+        "text_truncated": len(text) > MAX_SOURCE_TEXT_LENGTH,
+        "matched_text": matched_text[:MAX_MATCHED_TEXT_LENGTH],
+        "score": source.get("score"),
+        "vector_score": source.get("vector_score"),
+        "fulltext_score": source.get("fulltext_score"),
+        "fused_score": source.get("fused_score"),
+        "rerank_score": source.get("rerank_score"),
+        "parent_chunk_id": source.get("parent_chunk_id"),
+        "parent_lifted": bool(source.get("parent_lifted")),
+        "chunk_type": str(source.get("chunk_type") or "standard"),
+        "start_char": source.get("start_char"),
+        "end_char": source.get("end_char"),
+        "page_number": source.get("page_number"),
+        "slide": source.get("slide"),
+        "heading_path": list(source.get("heading_path") or [])[:20],
+        "sheet": source.get("sheet"),
+        "row_range": source.get("row_range"),
+        "visual_kind": source.get("visual_kind"),
+        "source_block_id": source.get("source_block_id"),
+    }
+
+
+def _limited_context(sources: list[dict[str, Any]]) -> tuple[str, bool]:
+    parts = [str(source.get("text") or "") for source in sources]
+    context = "\n---\n".join(part for part in parts if part)
+    return context[:MAX_CONTEXT_LENGTH], len(context) > MAX_CONTEXT_LENGTH
+
+
+async def execute_workflow_knowledge_retrieval(
+    service: WorkflowKnowledgeService,
+    *,
+    configured_kb_id: str,
+    query: str,
+    top_k: int,
+    contract_version: int,
+    return_mode: str,
+) -> tuple[str | dict[str, Any], dict[str, Any]]:
+    is_v2 = contract_version >= 2
+    knowledge_base_id, compatibility_warnings = resolve_workflow_knowledge_base(
+        service,
+        configured_kb_id,
+        allow_legacy_fallback=not is_v2,
+    )
+    result = await service.search_knowledge(
+        knowledge_base_id,
+        query,
+        top_k=max(1, min(int(top_k), 10)),
+    )
+    raw_sources = result.get("sources")
+    sources = [
+        _limited_source(source)
+        for source in raw_sources
+        if isinstance(source, dict)
+    ] if isinstance(raw_sources, list) else []
+    context, context_truncated = _limited_context(sources)
+    warnings = [
+        *compatibility_warnings,
+        *[
+            str(item)[:1_000]
+            for item in (result.get("warnings") or [])
+            if str(item).strip()
+        ],
+    ]
+    citations = service.citation_anchors_from_search_result(result)
+    diagnostics = dict(result.get("retrieval") or {})
+    metadata = {
+        "kb_id": knowledge_base_id,
+        "version_id": result.get("version_id"),
+        "hit_count": len(sources),
+        "context_length": len(context),
+        "citation_count": len(citations),
+        "warning_count": len(warnings),
+        "contract_version": contract_version,
+        "return_mode": return_mode,
+    }
+    if not is_v2 or return_mode == "context":
+        return context, metadata
+    return {
+        "knowledge_base_id": knowledge_base_id,
+        "version_id": result.get("version_id"),
+        "context": context,
+        "context_truncated": context_truncated,
+        "sources": sources,
+        "citations": citations,
+        "citation_count": len(citations),
+        "retrieval": diagnostics,
+        "warnings": warnings,
+    }, metadata

--- a/server/xpert_runtime/workflow_node_registry.py
+++ b/server/xpert_runtime/workflow_node_registry.py
@@ -6,6 +6,12 @@ from typing import Any, Literal
 
 
 WorkflowNodeRegistryTab = Literal["workflow", "knowledge"]
+WorkflowPlannerSupport = Literal[
+    "full",
+    "binding_only",
+    "metadata_only",
+    "unsupported",
+]
 WorkflowNodeCategory = Literal[
     "logic",
     "transform",
@@ -36,8 +42,14 @@ class WorkflowPaletteItem:
     enabled: bool = True
     metadata: dict[str, Any] = field(default_factory=dict)
     planner_enabled: bool = True
+    planner_support: WorkflowPlannerSupport = "full"
     planner_default_data: dict[str, Any] = field(default_factory=dict)
     planner_config_constraints: dict[str, Any] = field(default_factory=dict)
+    input_contract: dict[str, Any] = field(default_factory=dict)
+    output_contract: dict[str, Any] = field(default_factory=dict)
+    resource_requirements: list[str] = field(default_factory=list)
+    deprecated: bool = False
+    replacement_kind: str | None = None
 
     def to_payload(self) -> dict[str, Any]:
         return {
@@ -49,8 +61,16 @@ class WorkflowPaletteItem:
             "tags": list(self.tags),
             "enabled": self.enabled,
             "metadata": dict(self.metadata),
+            "contracts": {
+                "inputs": dict(self.input_contract),
+                "outputs": dict(self.output_contract),
+                "resources": list(self.resource_requirements),
+                "deprecated": self.deprecated,
+                "replacement_kind": self.replacement_kind,
+            },
             "planner": {
                 "enabled": self.enabled and self.planner_enabled,
+                "support": self.planner_support,
                 "default_data": {
                     "kind": self.kind,
                     "title": self.title,
@@ -123,7 +143,7 @@ class WorkflowNodeRegistry:
     """Xpert-style metadata registry for classic workflow palette nodes."""
 
     def __init__(self) -> None:
-        self.version = "xpert-workflow-node-registry-v1"
+        self.version = "xpert-workflow-node-registry-v2"
         self._tabs: list[WorkflowPaletteTab] = []
         self._sections: list[WorkflowPaletteSection] = []
         self._knowledge_pipeline = KnowledgePipelinePalette()
@@ -259,14 +279,6 @@ def register_builtin_workflow_nodes(registry: WorkflowNodeRegistry) -> None:
                     tags=["classifier", "question"],
                 ),
                 WorkflowPaletteItem(
-                    kind="knowledge_retrieval",
-                    icon="RAG",
-                    title="知识检索",
-                    description="查询本地 RAG 资料库，把相关段落写入变量。",
-                    category="transform",
-                    tags=["rag", "knowledge"],
-                ),
-                WorkflowPaletteItem(
                     kind="code",
                     icon="</>",
                     title="代码执行",
@@ -385,19 +397,6 @@ def register_builtin_workflow_nodes(registry: WorkflowNodeRegistry) -> None:
                     planner_config_constraints={
                         "required": ["xpertId", "toolName"],
                         "target_handle": "expert",
-                    },
-                ),
-                WorkflowPaletteItem(
-                    kind="knowledge_base",
-                    icon="KB",
-                    title="知识库",
-                    description="Bind one knowledge base to the agent's read-only knowledge tools.",
-                    category="resource",
-                    tags=["knowledge", "rag", "resource", "binding"],
-                    planner_default_data={"topK": "5", "scoreThreshold": "0"},
-                    planner_config_constraints={
-                        "required": ["knowledgeBaseId"],
-                        "target_handle": "knowledge",
                     },
                 ),
                 WorkflowPaletteItem(
@@ -664,48 +663,59 @@ def register_builtin_workflow_nodes(registry: WorkflowNodeRegistry) -> None:
         KnowledgePipelinePalette(
             items=[
                 WorkflowPaletteItem(
-                    kind="knowledge_citation",
-                    icon="CITE",
-                    title="知识引用锚点",
-                    description="查询本地 RAG，输出 CitationAnchor JSON。",
+                    kind="knowledge_base",
+                    icon="KB",
+                    title="知识库",
+                    description="将一个知识库绑定到工作流智能体的只读知识工具。",
+                    category="resource",
+                    tags=["knowledge", "rag", "resource", "binding"],
+                    planner_support="binding_only",
+                    planner_default_data={"topK": "5", "scoreThreshold": "0"},
+                    planner_config_constraints={
+                        "required": ["knowledgeBaseId"],
+                        "target_handle": "knowledge",
+                    },
+                    input_contract={"binding": "knowledge_base"},
+                    output_contract={"control_flow": False},
+                    resource_requirements=["knowledge_base"],
+                ),
+                WorkflowPaletteItem(
+                    kind="knowledge_retrieval",
+                    icon="RAG",
+                    title="知识检索",
+                    description="检索指定知识库的活动版本并输出文本或类型化结果。",
                     category="transform",
-                    tags=["citation", "rag", "knowledge-pipeline"],
-                )
-            ],
-            placeholders=[
-                WorkflowPalettePlaceholder(
-                    id="pipeline_source_default",
-                    icon="TXT",
-                    title="默认数据源",
-                    description="从知识流水线数据源读取文件。",
-                    category="other",
-                    tags=["source", "data"],
-                ),
-                WorkflowPalettePlaceholder(
-                    id="pipeline_processor",
-                    icon="PX",
-                    title="处理器",
-                    description="清洗、解析和转换文档内容。",
-                    category="other",
-                    tags=["processor"],
-                ),
-                WorkflowPalettePlaceholder(
-                    id="pipeline_splitter",
-                    icon="SPLIT",
-                    title="分块器",
-                    description="递归字符、Markdown 或父子分块。",
-                    category="other",
-                    tags=["splitter", "chunk"],
-                ),
-                WorkflowPalettePlaceholder(
-                    id="pipeline_vision",
-                    icon="VISION",
-                    title="图像理解",
-                    description="使用视觉语言模型处理图片内容。",
-                    category="other",
-                    tags=["vision", "image"],
+                    tags=["rag", "knowledge", "retrieval"],
+                    planner_enabled=False,
+                    planner_support="unsupported",
+                    planner_default_data={
+                        "contractVersion": 2,
+                        "knowledgeBaseId": "",
+                        "queryVariable": "user_input",
+                        "top_k": "5",
+                        "returnMode": "result",
+                        "outputVariable": "knowledge_result",
+                    },
+                    planner_config_constraints={
+                        "required": [
+                            "knowledgeBaseId",
+                            "queryVariable",
+                            "outputVariable",
+                        ],
+                        "return_mode": ["context", "result"],
+                    },
+                    input_contract={
+                        "queryVariable": "string",
+                        "knowledgeBaseId": "resource:knowledge_base",
+                    },
+                    output_contract={
+                        "context": "string",
+                        "result": "object",
+                    },
+                    resource_requirements=["knowledge_base"],
                 ),
             ],
+            placeholders=[],
         )
     )
 

--- a/server/xperts/api.py
+++ b/server/xperts/api.py
@@ -344,13 +344,46 @@ def _prepare_published_resource_snapshot(
                     )
                 )
             continue
-        if kind == "knowledge_base":
+        if kind in {"knowledge_base", "knowledge_retrieval", "knowledge_citation"}:
             kb_id = str(data.get("knowledgeBaseId") or "").strip()
+            rag_service = get_rag_service()
             if not kb_id:
-                continue
+                is_legacy_consumer = kind in {
+                    "knowledge_retrieval",
+                    "knowledge_citation",
+                } and data.get("contractVersion") is None
+                if is_legacy_consumer:
+                    knowledge_bases = rag_service.list_knowledge_bases()
+                    if len(knowledge_bases) == 1:
+                        kb_id = str(knowledge_bases[0].get("id") or "").strip()
+                        issues.append(
+                            ValidationIssue(
+                                code="xpert_knowledge_legacy_base_resolved",
+                                message=(
+                                    "Legacy knowledge node omitted knowledgeBaseId; "
+                                    "the only available knowledge base will be used."
+                                ),
+                                severity="warning",
+                                node_id=node.id,
+                            )
+                        )
+                    else:
+                        issues.append(
+                            ValidationIssue(
+                                code="xpert_knowledge_base_required",
+                                message=(
+                                    "Legacy knowledge nodes without knowledgeBaseId "
+                                    "require exactly one available knowledge base."
+                                ),
+                                node_id=node.id,
+                            )
+                        )
+                        continue
+                else:
+                    continue
             try:
-                get_rag_service().get_pipeline_draft(kb_id)
-                active = get_rag_service().get_active_pipeline_version(kb_id)
+                rag_service.get_pipeline_draft(kb_id)
+                active = rag_service.get_active_pipeline_version(kb_id)
                 if active is None:
                     issues.append(
                         ValidationIssue(
@@ -371,6 +404,7 @@ def _prepare_published_resource_snapshot(
                         node_id=node.id,
                     )
                 )
+            continue
         if kind != "external_xpert":
             continue
         reference = str(data.get("xpertId") or "").strip()


### PR DESCRIPTION
## Summary

- 收口工作流知识分类，只展示知识库绑定与知识检索
- 新增 knowledge_retrieval V2 类型化结果与显式知识库选择
- 保留旧 Citation 和单知识库旧图的执行兼容，同时对多知识库隐式选择 fail-closed
- 统一通过 RagService.search_knowledge 执行确定性检索并补齐发布预检、Registry 契约与文档

## Validation

- Focused backend: 108 passed
- Frontend palette tests: 3 passed
- Frontend production build: passed
- git diff --check: passed
- Full backend: 2787 passed, 30 skipped, 11 unrelated baseline/environment failures (Agency Worker image, Coding Project host identity, Skill Finder subprocess)
- Independent preview manual acceptance: passed

## Scope

Round 1 only. Generic workflow vision understanding remains a separate follow-up PR.