### PR TITLE
feature: 刷新 OpenRouter 模型并完善 Grok 图片费用

### DIFF
--- a/client/src/components/ImageGenerationWorkspace.tsx
+++ b/client/src/components/ImageGenerationWorkspace.tsx
@@ -7,6 +7,11 @@ import {
 } from "react";
 import { Link } from "react-router-dom";
 import type { Model } from "../data/models";
+import {
+  estimateImageCost,
+  GROK_IMAGINE_IMAGE_2_PRICING,
+  type ImagePricingItem,
+} from "../utils/imageCostEstimate";
 import BrandLogo from "./BrandLogo";
 import ResourceNav from "./ResourceNav";
 
@@ -26,6 +31,7 @@ interface ImageModelProfile {
   operation: "analyze_image" | "generate_image";
   invocable: boolean;
   supported_parameters: Record<string, ParameterProfile>;
+  pricing: ImagePricingItem[];
   interaction_status: "ready" | "planned" | "disabled";
   status_reason: string | null;
 }
@@ -73,6 +79,10 @@ function extensionFor(mediaType: string) {
   return "png";
 }
 
+function formatUsd(value: number) {
+  return `$${value.toFixed(value < 0.01 ? 4 : 2)}`;
+}
+
 export default function ImageGenerationWorkspace({
   model,
 }: ImageGenerationWorkspaceProps) {
@@ -116,6 +126,35 @@ export default function ImageGenerationWorkspace({
     0,
     Number(supported.input_references?.max ?? 0),
   );
+  const costEstimate = useMemo(
+    () => {
+      if (!profile) return null;
+      const pricing = profile.pricing?.length
+        ? profile.pricing
+        : model.id === "x-ai/grok-imagine-image-2.0"
+          ? GROK_IMAGINE_IMAGE_2_PRICING
+          : [];
+      return estimateImageCost(pricing, {
+        outputCount: Number(parameters.n || 1),
+        referenceCount: references.length,
+        resolution: parameters.resolution,
+        quality: parameters.quality,
+      });
+    },
+    [
+      model.id,
+      parameters.n,
+      parameters.quality,
+      parameters.resolution,
+      profile,
+      references.length,
+    ],
+  );
+  const costLabel = costEstimate
+    ? costEstimate.exact
+      ? formatUsd(costEstimate.minUsd)
+      : `${formatUsd(costEstimate.minUsd)}–${formatUsd(costEstimate.maxUsd)}`
+    : null;
 
   function selectValue(key: string, value: string) {
     setParameters((current) => ({ ...current, [key]: value }));
@@ -276,13 +315,41 @@ export default function ImageGenerationWorkspace({
               </div>
             ) : null}
 
+            {costEstimate && costLabel ? (
+              <div
+                aria-live="polite"
+                className="flex flex-wrap items-center justify-between gap-3 border-y border-white/10 py-4"
+              >
+                <div>
+                  <p className="text-sm font-semibold text-white">
+                    预估费用 {costLabel}
+                  </p>
+                  <p className="mt-1 text-xs leading-5 text-slate-400">
+                    {costEstimate.inputUsd > 0
+                      ? `已包含 ${references.length} 张参考图 ${formatUsd(costEstimate.inputUsd)}。`
+                      : costEstimate.exact
+                        ? "按当前分辨率、质量和生成数量估算。"
+                        : "选择分辨率和质量后可缩小估算区间。"}
+                    最终费用以 OpenRouter 网关结算为准。
+                  </p>
+                </div>
+                <span className="rounded-full border border-fuchsia-300/25 px-3 py-1.5 text-xs font-semibold text-fuchsia-100">
+                  目录估算
+                </span>
+              </div>
+            ) : null}
+
             {error ? <p className="rounded-lg border border-rose-300/25 bg-rose-300/10 px-4 py-3 text-sm text-rose-100">{error}</p> : null}
             <button
               className="w-full rounded-lg bg-fuchsia-300 px-4 py-3 text-sm font-semibold text-ink-950 disabled:cursor-not-allowed disabled:opacity-50"
               disabled={busy || !prompt.trim() || profile?.interaction_status !== "ready"}
               type="submit"
             >
-              {busy ? "正在生成并校验完整图片…" : "生成图片 · 费用以网关结算为准"}
+              {busy
+                ? "正在生成并校验完整图片…"
+                : costLabel
+                  ? `生成图片 · 预计 ${costLabel}`
+                  : "生成图片 · 费用以网关结算为准"}
             </button>
           </form>
         </section>

--- a/client/src/data/models.ts
+++ b/client/src/data/models.ts
@@ -1,7 +1,9 @@
 ﻿// Merged with OpenRouter model catalog on 2026-08-06T08:31:09.233Z.
 // Refreshed with entries published through 2026-08-05T23:51:37.000Z.
 // Source: https://openrouter.ai/api/v1/models?output_modalities=all&sort=newest
-// Supplemental OpenRouter refresh: 2026-08-11 (five newly listed models).
+// Supplemental OpenRouter refresh: 2026-08-12 (three general catalog records
+// plus xAI Grok Imagine Image 2.0 from the dedicated image-model catalog).
+// Image source: https://openrouter.ai/api/v1/images/models
 // Prices are stored as USD per 1M tokens and CNY per 1M tokens.
 export const USD_TO_CNY = 6.77;
 
@@ -123,9 +125,129 @@ interface RawCatalogModel {
   created: number;
   expiration_date: number | null;
   model_author: string;
+  note?: string;
 }
 
 const rawCatalogModels: RawCatalogModel[] = [
+  {
+    id: "x-ai/grok-imagine-image-2.0",
+    canonical_slug: "x-ai/grok-imagine-image-2.0",
+    name: "xAI: Grok Imagine Image 2.0",
+    raw_description:
+      "Grok Imagine Image 2.0 is an image generation and editing model from xAI. It is suited for creating images from text prompts and editing images from references, with low and medium quality modes at 1K or 2K resolution.",
+    context_length: 0,
+    pricing: { input: -1, output: -1 },
+    input_modalities: ["text", "image"],
+    output_modalities: ["image"],
+    tokenizer: "Other",
+    supported_parameters: [
+      "resolution",
+      "aspect_ratio",
+      "quality",
+      "n",
+      "input_references",
+    ],
+    created: 1786486044,
+    expiration_date: null,
+    model_author: "xAI",
+    note:
+      "OpenRouter 专用图片 API：非流式返回完整 base64 图片；每次输出 1 张，最多 3 张参考图。参考图约 $0.01/张，输出按 low/medium 与 1K/2K 约 $0.04–$0.08/张。",
+  },
+  {
+    id: "liquid/lfm-2.5-2.6b:free",
+    canonical_slug: "liquid/lfm-2.5-2.6b-20260811",
+    name: "LiquidAI: LFM2.5-2.6B (free)",
+    raw_description:
+      "LFM2.5-2.6B is a compact reasoning model from Liquid AI. It is suited for agent workflows, data extraction, RAG, and long-context processing. Liquid advises against using it for agentic coding.",
+    context_length: 128000,
+    pricing: { input: 0, output: 0 },
+    input_modalities: ["text"],
+    output_modalities: ["text"],
+    tokenizer: "Other",
+    supported_parameters: [
+      "frequency_penalty",
+      "include_reasoning",
+      "logprobs",
+      "max_completion_tokens",
+      "max_tokens",
+      "min_p",
+      "presence_penalty",
+      "reasoning",
+      "repetition_penalty",
+      "response_format",
+      "seed",
+      "stop",
+      "structured_outputs",
+      "temperature",
+      "tool_choice",
+      "tools",
+      "top_k",
+      "top_logprobs",
+      "top_p",
+    ],
+    created: 1786470519,
+    expiration_date: null,
+    model_author: "LiquidAI",
+  },
+  {
+    id: "nvidia/nemotron-3.5-lightning",
+    canonical_slug: "nvidia/nemotron-3.5-lightning-20260807",
+    name: "NVIDIA: Nemotron 3.5 Lightning",
+    raw_description:
+      "NVIDIA Nemotron 3.5 Lightning is an open mixture-of-experts model from NVIDIA, with 3B active parameters out of 30B total. It is suited for high-throughput agentic workloads and specialized tasks.",
+    context_length: 262144,
+    pricing: { input: 0.1, output: 0.25 },
+    input_modalities: ["text"],
+    output_modalities: ["text"],
+    tokenizer: "Other",
+    supported_parameters: [
+      "frequency_penalty",
+      "include_reasoning",
+      "logit_bias",
+      "logprobs",
+      "max_tokens",
+      "min_p",
+      "presence_penalty",
+      "reasoning",
+      "repetition_penalty",
+      "response_format",
+      "seed",
+      "stop",
+      "structured_outputs",
+      "temperature",
+      "top_k",
+      "top_logprobs",
+      "top_p",
+    ],
+    created: 1786452751,
+    expiration_date: null,
+    model_author: "NVIDIA",
+  },
+  {
+    id: "nvidia/nemotron-3.5-lightning:free",
+    canonical_slug: "nvidia/nemotron-3.5-lightning-20260807",
+    name: "NVIDIA: Nemotron 3.5 Lightning (free)",
+    raw_description:
+      "NVIDIA Nemotron 3.5 Lightning is an open mixture-of-experts model from NVIDIA, with 3B active parameters out of 30B total. This free route exposes an OpenRouter-listed 1M-token context window.",
+    context_length: 1000000,
+    pricing: { input: 0, output: 0 },
+    input_modalities: ["text"],
+    output_modalities: ["text"],
+    tokenizer: "Other",
+    supported_parameters: [
+      "include_reasoning",
+      "max_tokens",
+      "reasoning",
+      "seed",
+      "temperature",
+      "tool_choice",
+      "tools",
+      "top_p",
+    ],
+    created: 1786452751,
+    expiration_date: null,
+    model_author: "NVIDIA",
+  },
   {
     id: "bytedance/seedance-2.5",
     canonical_slug: "bytedance/seedance-2.5-20260807",
@@ -18486,6 +18608,7 @@ function enrichModel(raw: RawCatalogModel): Model {
       active,
       pricing_status,
     ),
+    note: raw.note,
   };
 }
 
@@ -18675,14 +18798,24 @@ const MID_CATALOG_MODEL_IDS = [
   "meta/muse-glimmer-30b",
   "inclusionai/ling-3.0-tiny:free",
 ];
+const LATEST_REFRESH_MODEL_IDS = [
+  "x-ai/grok-imagine-image-2.0",
+  "liquid/lfm-2.5-2.6b:free",
+  "nvidia/nemotron-3.5-lightning",
+  "nvidia/nemotron-3.5-lightning:free",
+];
 const reservedCatalogModelIds = new Set([
   SEEDANCE_2_5_MODEL_ID,
   ...MID_CATALOG_MODEL_IDS,
+  ...LATEST_REFRESH_MODEL_IDS,
 ]);
 const seedance25Model = sortedCatalogModels.find(
   (model) => model.id === SEEDANCE_2_5_MODEL_ID,
 );
 const midCatalogModels = MID_CATALOG_MODEL_IDS.map((modelId) =>
+  sortedCatalogModels.find((model) => model.id === modelId),
+).filter((model): model is Model => Boolean(model));
+const latestRefreshModels = LATEST_REFRESH_MODEL_IDS.map((modelId) =>
   sortedCatalogModels.find((model) => model.id === modelId),
 ).filter((model): model is Model => Boolean(model));
 const normallyOrderedCatalogModels = sortedCatalogModels.filter(
@@ -18701,10 +18834,66 @@ const primaryCatalogModels: Model[] = [
 ];
 const catalogMidpoint = Math.floor(primaryCatalogModels.length / 2);
 
-const assembledModels: Model[] = [
+const baseCatalogModels: Model[] = [
   ...primaryCatalogModels.slice(0, catalogMidpoint),
   ...midCatalogModels,
   ...primaryCatalogModels.slice(catalogMidpoint),
+];
+
+function stableCatalogHash(value: string) {
+  let hash = 2166136261;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+function scatterCatalogModels(
+  baseModels: Model[],
+  additions: Model[],
+  minimumIndex: number,
+) {
+  if (additions.length === 0) return [...baseModels];
+
+  const lowerBound = Math.min(minimumIndex, baseModels.length);
+  const tailSlots = Math.max(1, baseModels.length - lowerBound + 1);
+  const placements = additions
+    .map((model, additionIndex) => {
+      const bucketStart = Math.floor(
+        (tailSlots * additionIndex) / additions.length,
+      );
+      const bucketEnd = Math.floor(
+        (tailSlots * (additionIndex + 1)) / additions.length,
+      );
+      const bucketSize = Math.max(1, bucketEnd - bucketStart);
+      return {
+        model,
+        index:
+          lowerBound +
+          bucketStart +
+          (stableCatalogHash(model.id) % bucketSize),
+      };
+    })
+    .sort((left, right) => left.index - right.index);
+
+  const result = [...baseModels];
+  placements.forEach((placement, offset) => {
+    result.splice(placement.index + offset, 0, placement.model);
+  });
+  return result;
+}
+
+// The list page renders two spotlight cards, then a three-column gallery.
+// Keep this refresh below the first six complete gallery rows and scatter it
+// deterministically so cards do not jump between renders.
+const LATEST_REFRESH_MIN_INDEX = 2 + 6 * 3;
+const assembledModels: Model[] = [
+  ...scatterCatalogModels(
+    baseCatalogModels,
+    latestRefreshModels,
+    LATEST_REFRESH_MIN_INDEX,
+  ),
   worldModelEntry,
 ];
 

--- a/client/src/utils/imageCostEstimate.test.ts
+++ b/client/src/utils/imageCostEstimate.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  estimateImageCost,
+  GROK_IMAGINE_IMAGE_2_PRICING,
+} from "./imageCostEstimate";
+
+describe("estimateImageCost", () => {
+  it("returns the exact Grok output and reference-image estimate", () => {
+    expect(
+      estimateImageCost(GROK_IMAGINE_IMAGE_2_PRICING, {
+        outputCount: 1,
+        referenceCount: 3,
+        resolution: "2K",
+        quality: "medium",
+      }),
+    ).toEqual({
+      minUsd: 0.11,
+      maxUsd: 0.11,
+      inputUsd: 0.03,
+      exact: true,
+    });
+  });
+
+  it("returns an honest range while model defaults are selected", () => {
+    expect(
+      estimateImageCost(GROK_IMAGINE_IMAGE_2_PRICING, {
+        outputCount: 1,
+        referenceCount: 0,
+      }),
+    ).toEqual({
+      minUsd: 0.04,
+      maxUsd: 0.08,
+      inputUsd: 0,
+      exact: false,
+    });
+  });
+
+  it("does not understate reference-image cost when its rate is absent", () => {
+    expect(
+      estimateImageCost(GROK_IMAGINE_IMAGE_2_PRICING.slice(1), {
+        outputCount: 1,
+        referenceCount: 1,
+        resolution: "1K",
+        quality: "low",
+      }),
+    ).toBeNull();
+  });
+});

--- a/client/src/utils/imageCostEstimate.ts
+++ b/client/src/utils/imageCostEstimate.ts
@@ -1,0 +1,84 @@
+export interface ImagePricingItem {
+  billable: "input_image" | "output_image";
+  unit: "image";
+  cost_usd: number;
+  variant?: string | null;
+}
+
+export interface ImageCostEstimateInput {
+  outputCount: number;
+  referenceCount: number;
+  resolution?: string;
+  quality?: string;
+}
+
+export interface ImageCostEstimate {
+  minUsd: number;
+  maxUsd: number;
+  inputUsd: number;
+  exact: boolean;
+}
+
+// Verified against OpenRouter's dedicated image endpoint on 2026-08-12.
+// Live profile pricing takes precedence; this keeps the snapshot usable when
+// the optional pricing-detail request is temporarily unavailable.
+export const GROK_IMAGINE_IMAGE_2_PRICING: ImagePricingItem[] = [
+  { billable: "input_image", unit: "image", cost_usd: 0.01 },
+  { billable: "output_image", unit: "image", cost_usd: 0.04, variant: "low_1k" },
+  { billable: "output_image", unit: "image", cost_usd: 0.06, variant: "low_2k" },
+  { billable: "output_image", unit: "image", cost_usd: 0.06, variant: "medium_1k" },
+  { billable: "output_image", unit: "image", cost_usd: 0.08, variant: "medium_2k" },
+];
+
+function normalized(value?: string) {
+  return value?.trim().toLowerCase() ?? "";
+}
+
+export function estimateImageCost(
+  pricing: ImagePricingItem[],
+  input: ImageCostEstimateInput,
+): ImageCostEstimate | null {
+  const outputCount = Math.max(1, Math.floor(input.outputCount));
+  const referenceCount = Math.max(0, Math.floor(input.referenceCount));
+  const resolution = normalized(input.resolution);
+  const quality = normalized(input.quality);
+  const inputRates = pricing
+    .filter((item) => item.billable === "input_image")
+    .map((item) => item.cost_usd)
+    .filter((value) => Number.isFinite(value) && value >= 0);
+  let outputRates = pricing
+    .filter((item) => item.billable === "output_image")
+    .filter((item) => {
+      const variant = normalized(item.variant ?? undefined);
+      if (!variant) return true;
+      if (quality && !variant.startsWith(`${quality}_`)) return false;
+      if (resolution && !variant.endsWith(`_${resolution}`)) return false;
+      return true;
+    })
+    .map((item) => item.cost_usd)
+    .filter((value) => Number.isFinite(value) && value >= 0);
+
+  if (!outputRates.length && (quality || resolution)) {
+    outputRates = pricing
+      .filter(
+        (item) =>
+          item.billable === "output_image" && !normalized(item.variant ?? undefined),
+      )
+      .map((item) => item.cost_usd)
+      .filter((value) => Number.isFinite(value) && value >= 0);
+  }
+  if (!outputRates.length || (referenceCount > 0 && !inputRates.length)) {
+    return null;
+  }
+
+  const inputRate = inputRates.length ? Math.max(...inputRates) : 0;
+  const inputUsd = referenceCount * inputRate;
+  const minUsd = inputUsd + outputCount * Math.min(...outputRates);
+  const maxUsd = inputUsd + outputCount * Math.max(...outputRates);
+  return {
+    minUsd,
+    maxUsd,
+    inputUsd,
+    exact: Math.abs(minUsd - maxUsd) < 1e-9,
+  };
+}

--- a/server/multimodal/image_catalog.py
+++ b/server/multimodal/image_catalog.py
@@ -21,6 +21,9 @@ from .readiness import OperationReadiness
 
 IMAGE_CATALOG_TTL_SECONDS = 300.0
 IMAGE_CATALOG_STALE_SECONDS = 1_800.0
+IMAGE_PRICING_DETAIL_MODEL_IDS = frozenset(
+    {"x-ai/grok-imagine-image-2.0"}
+)
 
 
 class ImageParameterProfile(BaseModel):
@@ -28,6 +31,13 @@ class ImageParameterProfile(BaseModel):
     values: list[str] = Field(default_factory=list)
     min: int | float | None = None
     max: int | float | None = None
+
+
+class ImagePricingItem(BaseModel):
+    billable: Literal["input_image", "output_image"]
+    unit: Literal["image"]
+    cost_usd: float = Field(ge=0)
+    variant: str | None = None
 
 
 class ImageModelProfile(BaseModel):
@@ -40,6 +50,7 @@ class ImageModelProfile(BaseModel):
     supported_parameters: dict[str, ImageParameterProfile] = Field(
         default_factory=dict
     )
+    pricing: list[ImagePricingItem] = Field(default_factory=list)
     supports_streaming: bool = False
     interaction_status: Literal["ready", "planned", "disabled"] = "ready"
     status_reason: str | None = None
@@ -228,6 +239,11 @@ class ImageCatalogService:
                 outputs = self._modalities(item, "output_modalities")
                 if "image" not in outputs:
                     continue
+                pricing = (
+                    await self._fetch_pricing(target, model_id)
+                    if model_id in IMAGE_PRICING_DETAIL_MODEL_IDS
+                    else []
+                )
                 profiles.append(
                     ImageModelProfile(
                         model_id=model_id,
@@ -238,6 +254,7 @@ class ImageCatalogService:
                         supported_parameters=self._parameters(
                             item.get("supported_parameters")
                         ),
+                        pricing=pricing,
                         supports_streaming=bool(
                             item.get("supports_streaming")
                         ),
@@ -252,6 +269,64 @@ class ImageCatalogService:
                     )
                 )
         return profiles
+
+    async def _fetch_pricing(
+        self,
+        target: OpenRouterTarget,
+        model_id: str,
+    ) -> list[ImagePricingItem]:
+        try:
+            async with self.client_factory() as client:
+                response = await client.get(
+                    self._api_url(
+                        target.base_url,
+                        f"images/models/{model_id}/endpoints",
+                    ),
+                    headers={"Authorization": f"Bearer {target.api_key}"},
+                )
+            if response.status_code >= 400:
+                return []
+            payload = response.json()
+        except (httpx.HTTPError, ValueError):
+            return []
+
+        endpoints = (
+            payload.get("endpoints") if isinstance(payload, dict) else None
+        )
+        result: list[ImagePricingItem] = []
+        if not isinstance(endpoints, list):
+            return result
+        for endpoint in endpoints:
+            raw_pricing = (
+                endpoint.get("pricing")
+                if isinstance(endpoint, dict)
+                else None
+            )
+            if not isinstance(raw_pricing, list):
+                continue
+            for raw in raw_pricing:
+                if not isinstance(raw, dict):
+                    continue
+                billable = str(raw.get("billable") or "")
+                unit = str(raw.get("unit") or "")
+                cost = raw.get("cost_usd")
+                if (
+                    billable not in {"input_image", "output_image"}
+                    or unit != "image"
+                    or not isinstance(cost, (int, float))
+                    or cost < 0
+                ):
+                    continue
+                variant = str(raw.get("variant") or "").strip() or None
+                result.append(
+                    ImagePricingItem(
+                        billable=billable,
+                        unit="image",
+                        cost_usd=float(cost),
+                        variant=variant,
+                    )
+                )
+        return result
 
     def resolve_target(self) -> OpenRouterTarget:
         connections = [

--- a/server/tests/test_multimodal_image.py
+++ b/server/tests/test_multimodal_image.py
@@ -239,6 +239,183 @@ async def test_image_generation_validates_capabilities_and_complete_output(
 
 
 @pytest.mark.asyncio
+async def test_grok_imagine_image_2_uses_dedicated_openrouter_contract(
+    tmp_path: Path,
+) -> None:
+    def catalog_handler(request: Request) -> Response:
+        if request.url.path.endswith(
+            "/images/models/x-ai/grok-imagine-image-2.0/endpoints"
+        ):
+            return Response(
+                200,
+                json={
+                    "id": "x-ai/grok-imagine-image-2.0",
+                    "endpoints": [
+                        {
+                            "provider_name": "SpaceXAI",
+                            "pricing": [
+                                {
+                                    "billable": "input_image",
+                                    "unit": "image",
+                                    "cost_usd": 0.01,
+                                },
+                                {
+                                    "billable": "output_image",
+                                    "unit": "image",
+                                    "cost_usd": 0.04,
+                                    "variant": "low_1k",
+                                },
+                                {
+                                    "billable": "output_image",
+                                    "unit": "image",
+                                    "cost_usd": 0.08,
+                                    "variant": "medium_2k",
+                                },
+                            ],
+                        }
+                    ],
+                },
+            )
+        if request.url.path.endswith("/images/models"):
+            return Response(
+                200,
+                json={
+                    "data": [
+                        {
+                            "id": "x-ai/grok-imagine-image-2.0",
+                            "name": "xAI: Grok Imagine Image 2.0",
+                            "architecture": {
+                                "input_modalities": ["text", "image"],
+                                "output_modalities": ["image"],
+                            },
+                            "supported_parameters": {
+                                "resolution": {
+                                    "type": "enum",
+                                    "values": ["1K", "2K"],
+                                },
+                                "aspect_ratio": {
+                                    "type": "enum",
+                                    "values": ["1:1", "16:9", "auto"],
+                                },
+                                "quality": {
+                                    "type": "enum",
+                                    "values": ["low", "medium"],
+                                },
+                                "n": {"type": "range", "min": 1, "max": 1},
+                                "input_references": {
+                                    "type": "range",
+                                    "min": 0,
+                                    "max": 3,
+                                },
+                            },
+                            "supports_streaming": False,
+                        }
+                    ]
+                },
+            )
+        return Response(200, json={"data": []})
+
+    catalog = ImageCatalogService(
+        openrouter_service(tmp_path),
+        client_factory=lambda: httpx.AsyncClient(
+            transport=MockTransport(catalog_handler)
+        ),
+    )
+    catalog_result = await catalog.get_catalog()
+    profile = next(
+        item
+        for item in catalog_result.profiles
+        if item.model_id == "x-ai/grok-imagine-image-2.0"
+    )
+    assert profile.operation == "generate_image"
+    assert profile.supports_streaming is False
+    assert profile.supported_parameters["quality"].values == ["low", "medium"]
+    assert profile.supported_parameters["n"].max == 1
+    assert profile.supported_parameters["input_references"].max == 3
+    assert [item.model_dump() for item in profile.pricing] == [
+        {
+            "billable": "input_image",
+            "unit": "image",
+            "cost_usd": 0.01,
+            "variant": None,
+        },
+        {
+            "billable": "output_image",
+            "unit": "image",
+            "cost_usd": 0.04,
+            "variant": "low_1k",
+        },
+        {
+            "billable": "output_image",
+            "unit": "image",
+            "cost_usd": 0.08,
+            "variant": "medium_2k",
+        },
+    ]
+
+    submitted: list[tuple[str, dict[str, object]]] = []
+
+    def generation_handler(request: Request) -> Response:
+        submitted.append(
+            (
+                request.url.path,
+                httpx.Response(200, content=request.content).json(),
+            )
+        )
+        return Response(
+            200,
+            headers={"x-request-id": "req_grok_image_2"},
+            json={
+                "model": "x-ai/grok-imagine-image-2.0",
+                "data": [
+                    {"b64_json": base64.b64encode(PNG_BYTES).decode()}
+                ],
+                "usage": {"cost": 0.08},
+            },
+        )
+
+    service = ImageGenerationService(
+        catalog,
+        client_factory=lambda: httpx.AsyncClient(
+            transport=MockTransport(generation_handler)
+        ),
+    )
+    result = await service.generate(
+        model_id="x-ai/grok-imagine-image-2.0",
+        prompt="一座霓虹城市",
+        n=1,
+        resolution="2K",
+        aspect_ratio="16:9",
+        quality="medium",
+        reference_filenames=["one.png", "two.png", "three.png"],
+        reference_content_types=["image/png", "image/png", "image/png"],
+        reference_contents=[PNG_BYTES, PNG_BYTES, PNG_BYTES],
+    )
+
+    assert result.request_id == "req_grok_image_2"
+    assert result.usage.cost_usd == 0.08
+    assert submitted[0][0].endswith("/images")
+    assert submitted[0][1]["model"] == "x-ai/grok-imagine-image-2.0"
+    assert submitted[0][1]["resolution"] == "2K"
+    assert submitted[0][1]["aspect_ratio"] == "16:9"
+    assert submitted[0][1]["quality"] == "medium"
+    assert "stream" not in submitted[0][1]
+    assert len(submitted[0][1]["input_references"]) == 3
+
+    with pytest.raises(MultimodalServiceError) as error:
+        await service.generate(
+            model_id="x-ai/grok-imagine-image-2.0",
+            prompt="测试数量限制",
+            n=2,
+            reference_filenames=[],
+            reference_content_types=[],
+            reference_contents=[],
+        )
+    assert error.value.code == "invalid_image_parameter"
+    assert len(submitted) == 1
+
+
+@pytest.mark.asyncio
 async def test_image_generation_rejects_unsupported_parameter_before_request(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
# 变更摘要

## 目标与事实依据

- 单一目标：在最新基线中加入指定的四个 OpenRouter 模型，并完成 Grok Imagine Image 2.0 专用图片契约、统一 UI 与费用估算。
- 事实证据：OpenRouter 通用模型目录、专用图片模型目录与 Grok 端点价格目录；现有 ImageGenerationWorkspace 与多模态图片服务代码。
- 待确认项：本轮全量目录审计发现不纳入此 PR，后续单独规划。

## 变更内容

- 加入 nvidia/nemotron-3.5-lightning、nvidia/nemotron-3.5-lightning:free、liquid/lfm-2.5-2.6b:free、x-ai/grok-imagine-image-2.0 四个快照。
- 将四个新模型确定性散列到模型列表第六行以后，不占据首页顶部。
- 复用统一图片生成工作台处理 Grok 的非流式专用图片 API。
- 从专用端点读取参考图与输出图价格；按分辨率、质量、数量和参考图数量展示费用估算。
- 实时价格不可用时使用本次已核实的 Grok 定价快照安全降级。
- 增加 Grok 参数限制、完整图片响应和费用计算测试。

## 范围声明

- 允许修改：模型静态目录、图片生成工作台、图片目录价格资料、费用估算工具及聚焦测试。
- 明确不改：本轮 OpenRouter 全量审计发现、其他模型快照、聊天文本流、工作流、RAG、持久化数据和 Docker 配置。
- 公共 API/SSE 变化：图片模型 profile 新增可选 pricing 数组；无 SSE 变化。
- 持久化/迁移影响：无。
- 新增或升级依赖：无。

影响类型：

- [x] 前端页面或交互
- [x] 后端 API
- [x] Chat / Workflow / Xpert 执行
- [ ] MCP / Toolset / 子进程
- [ ] RAG / Knowledge / Data X
- [ ] 持久化数据或迁移
- [ ] Docker / Sidecar / 网络
- [ ] 公开 App/API 或凭据
- [ ] 纯文档

## 验收标准

### 正常路径

- Given：OpenRouter 实时目录包含四个指定模型。
- When：用户从模型页进入 Grok 图片生成工作台并选择分辨率、质量或参考图。
- Then：页面使用统一图片生成 UI，显示相应费用估算，并按专用图片 API 契约提交。

### 失败路径

- Given：Grok 价格详情请求暂时不可用，或用户提交超出目录限制的参数。
- When：页面读取费用或后端校验请求。
- Then：费用使用已核实快照降级；非法参数在调用上游前被拒绝。

## 验证证据

状态只允许：通过 / 失败 / 未运行 / 不适用。

| 检查 | 状态 | 实际命令或人工步骤 | 结果摘要 |
| --- | --- | --- | --- |
| 前端生产构建 | 通过 | cd client && npm.cmd run build | Vite 生产构建完成；仅有既有大 chunk 警告 |
| 后端语法 | 通过 | 图片聚焦 pytest 收集并执行变更模块 | 无导入或语法错误 |
| 目标测试 | 通过 | npm.cmd run test:run -- src/utils/imageCostEstimate.test.ts | 3/3 通过 |
| 目标测试 | 通过 | python -m pytest server/tests/test_multimodal_image.py -q（现有 ModelMirror 镜像） | 6/6 通过 |
| 全量测试 | 未运行 | python -m pytest server/tests/ -q | 本 PR 运行聚焦测试与前端生产构建 |
| Docker/健康检查 | 不适用 | 未重建共享栈 | 未修改部署配置 |
| 人工验收 | 通过 | 独立预览器检查默认及 2K + medium 参数 | 默认 $0.04–$0.08；2K + medium 为 $0.08 |
| 敏感信息扫描 | 通过 | 审查完整 Diff 与暂存范围 | 六个预期文件，无凭据或运行数据 |

## Harness 与安全检查

- [x] 已阅读 AGENTS.md、任务相关文档和测试。
- [x] 已检查工作树，未覆盖或回滚用户改动。
- [x] 实际变更没有超出声明范围；六个文件分别承担快照、契约、UI、费用计算及测试职责。
- [x] 未提交 .env、密钥、token、日志、运行存储、上传、索引、构建产物或 APK。
- [x] 本次未新增依赖。
- [x] 已按适用范围验证正常路径、错误参数与价格详情降级。
- [x] 已执行 git diff --check 并审查完整 Diff。
- [x] 本轮行为说明已纳入 PR 描述；全量目录审计留待后续规划。

## 风险、未完成项与回退

- 剩余风险：未消耗真实额度执行生产图片生成；实际结算仍以上游网关为准。
- 未运行/未完成：全量后端测试、真实计费生成。
- 停止条件或后续人工决定：OpenRouter 全量审计发现不得在本 PR 内顺带修改。

回退步骤：

1. 回退提交 7be17628。
2. 确认图片 profile 不再暴露 pricing，模型目录恢复原顺序。
3. 重跑图片聚焦测试与前端生产构建。

## 截图 / 录屏

已在本地独立预览器完成可见 UI 与费用联动验收；本 PR 未附本地预览截图。
